### PR TITLE
Add reference page for raw string literal tokens

### DIFF
--- a/docs/csharp/language-reference/builtin-types/reference-types.md
+++ b/docs/csharp/language-reference/builtin-types/reference-types.md
@@ -10,7 +10,6 @@ f1_keywords:
   - "dynamic_CSharpKeyword"
   - "string"
   - "string_CSharpKeyword"
-  - "RawStringLiteral_CSharpKeyword"
   - "Utf8StringLiteral_CSharpKeyword"
 helpviewer_keywords: 
   - "object keyword [C#]"

--- a/docs/csharp/language-reference/tokens/raw-string.md
+++ b/docs/csharp/language-reference/tokens/raw-string.md
@@ -1,0 +1,37 @@
+---
+description: "Raw string literals can contain any arbitrary text without the need for special escape sequences.You begin and end a raw string literal with a minimum of three double-quote characters."
+title: "Raw string literals = \"\"\""
+ms.date: 12/08/2022
+---
+# Raw string literal text - `"""` in string literals
+
+A raw string literal starts and ends with a minimum of three double quote (`"`) characters:
+
+:::code language="csharp" source="./snippets/raw-string-literal.cs" id="SingleLine":::
+
+Raw string literals can span multiple lines:
+
+:::code language="csharp" source="./snippets/raw-string-literal.cs" id="MultiLine":::
+
+The following rules govern the interpretation of a multi-line raw string literal:
+
+- Both opening and closing quote characters must be on their own line.
+- Any whitespace to the left of the closing quotes is removed from all lines of the raw string literal.
+- Whitespace following the opening quote on the same line is ignored.
+- Whitespace only lines following the opening quote are included in the string literal.
+
+You may need to create a raw string literal that has three or consecutive double-quote characters. Raw string literals can start and end with a sequence of at least three double-quote characters. When you string literal contains three consecutive double-quotes, you start and end the raw string literal with four double quote characters:
+
+:::code language="csharp" source="./snippets/raw-string-literal.cs" id="MoarQuotes":::
+
+If you need to start or end a raw string literal with quote characters, use the multi-line format:
+
+:::code language="csharp" source="./snippets/raw-string-literal.cs" id="InitialQuotes":::
+
+Raw strings can also be combined with [interpolated strings](./interpolated.md#special-characters) to embed ther `{` and `}` characters in the output string.
+
+## See also
+
+- [C# interpolated strings](./interpolated.md)
+- [C# Special Characters](./index.md)
+- [Raw string literals feature specification](~/_csharplang/proposals/csharp-11.0/raw-string-literal.md)

--- a/docs/csharp/language-reference/tokens/raw-string.md
+++ b/docs/csharp/language-reference/tokens/raw-string.md
@@ -20,7 +20,7 @@ The following rules govern the interpretation of a multi-line raw string literal
 - Whitespace following the opening quote on the same line is ignored.
 - Whitespace only lines following the opening quote are included in the string literal.
 
-You may need to create a raw string literal that has three or consecutive double-quote characters. Raw string literals can start and end with a sequence of at least three double-quote characters. When you string literal contains three consecutive double-quotes, you start and end the raw string literal with four double quote characters:
+You may need to create a raw string literal that has three or more consecutive double-quote characters. Raw string literals can start and end with a sequence of at least three double-quote characters. When your string literal contains three consecutive double-quotes, you start and end the raw string literal with four double quote characters:
 
 :::code language="csharp" source="./snippets/raw-string-literal.cs" id="MoarQuotes":::
 

--- a/docs/csharp/language-reference/tokens/raw-string.md
+++ b/docs/csharp/language-reference/tokens/raw-string.md
@@ -1,6 +1,8 @@
 ---
 description: "Raw string literals can contain any arbitrary text without the need for special escape sequences.You begin and end a raw string literal with a minimum of three double-quote characters."
-title: "Raw string literals = \"\"\""
+title: "Raw string literals - \"\"\""
+f1_keywords: 
+  - "RawStringLiteral_CSharpKeyword"
 ms.date: 12/08/2022
 ---
 # Raw string literal text - `"""` in string literals
@@ -28,7 +30,7 @@ If you need to start or end a raw string literal with quote characters, use the 
 
 :::code language="csharp" source="./snippets/raw-string-literal.cs" id="InitialQuotes":::
 
-Raw strings can also be combined with [interpolated strings](./interpolated.md#special-characters) to embed ther `{` and `}` characters in the output string.
+Raw strings can also be combined with [interpolated strings](./interpolated.md#special-characters) to embed ther `{` and `}` characters in the output string. You use multiple `$` characters in an interpolated raw string literal to embed `{` and `}` characters in the output string without escaping them.
 
 ## See also
 

--- a/docs/csharp/language-reference/tokens/snippets/raw-string-literal.cs
+++ b/docs/csharp/language-reference/tokens/snippets/raw-string-literal.cs
@@ -1,0 +1,35 @@
+
+using System;
+
+public static class RawStrings
+{
+    internal static void Examples()
+    {
+        // <SingleLine>
+        var singleLine = """This is a "raw string literal". It can contain characters like \, ' and ".""";
+        // </SingleLine>
+        Console.WriteLine(singleLine);
+
+        // <MultiLine>
+        var xml = """
+                <element attr="content">
+                    <body>
+                    </body>
+                </element>
+                """;
+        // </MultiLine>
+        Console.WriteLine(xml);
+
+        // <MoarQuotes>
+        var moreQuotes = """" As you can see,"""Raw string literals""" can start and end with more than three double-quotes when needed."""";
+        // </MoarQuotes>
+        Console.WriteLine(moreQuotes);
+
+        // <InitialQuotes>
+        var moreQuotes = """"
+                       """Raw string literals""" can start and end with more than three double-quotes when needed.
+                       """";
+        // </InitialQuotes>
+        Console.WriteLine(moreQuotes);
+    }
+}

--- a/docs/csharp/language-reference/tokens/snippets/raw-string-literal.cs
+++ b/docs/csharp/language-reference/tokens/snippets/raw-string-literal.cs
@@ -26,10 +26,10 @@ public static class RawStrings
         Console.WriteLine(moreQuotes);
 
         // <InitialQuotes>
-        var moreQuotes = """"
+        var MultiLineQuotes = """"
                        """Raw string literals""" can start and end with more than three double-quotes when needed.
                        """";
         // </InitialQuotes>
-        Console.WriteLine(moreQuotes);
+        Console.WriteLine(MultiLineQuotes);
     }
 }

--- a/docs/csharp/language-reference/tokens/snippets/string-interpolation.cs
+++ b/docs/csharp/language-reference/tokens/snippets/string-interpolation.cs
@@ -14,6 +14,8 @@ public class StringInterpolation
         Console.WriteLine();
         MultiLineExpression();
         Console.WriteLine();
+        RawStrings.Examples();
+        Console.WriteLine();
     }
 
     private static void CompareWithCompositeFormatting()
@@ -125,6 +127,5 @@ public class StringInterpolation
         Console.WriteLine(pointMessage);
         // output:  The point {2, 3} is 3.605551275463989 from the origin.
         // </RawInterpolatedLiteralStringWithBraces>
-
     }
 }

--- a/docs/csharp/programming-guide/strings/index.md
+++ b/docs/csharp/programming-guide/strings/index.md
@@ -56,7 +56,9 @@ Beginning with C# 11, you can use *raw string literals* to more easily create st
 - Starts and ends with a sequence of at least three double quote characters (`"""`). You're allowed more than three consecutive characters to start and end the sequence in order to support string literals that contain three (or more) repeated quote characters.
 - Single line raw string literals require the opening and closing quote characters on the same line.
 - Multi-line raw string literals require both opening and closing quote characters on their own line.
-- In multi-line raw string literals, any whitespace to the left of the closing quotes is removed.
+- In multi-line raw string literals, any whitespace to the left of the closing quotes is removed from all lines of the raw string literal.
+- In multi-line raw string literals, whitespace following the opening quote on the same line is ignored.
+- In multi-line raw string literals, whitespace only lines following the opening quote are included in the string literal.
 
 The following examples demonstrate these rules:
 

--- a/docs/csharp/programming-guide/strings/snippets/StringLiterals.cs
+++ b/docs/csharp/programming-guide/strings/snippets/StringLiterals.cs
@@ -6,26 +6,9 @@ public class Literals
 {
     public static void StringLiterals()
     {
-        //<EscapeSequences>
-        string columns = "Column 1\tColumn 2\tColumn 3";
-        //Output: Column 1        Column 2        Column 3
-
-        string rows = "Row 1\r\nRow 2\r\nRow 3";
-        /* Output:
-            Row 1
-            Row 2
-            Row 3
-        */
-
+        //<VerbatimLiterals>
         string title = "\"The \u00C6olean Harp\", by Samuel Taylor Coleridge";
         //Output: "The Æolean Harp", by Samuel Taylor Coleridge
-        //</EscapeSequences>
-
-        System.Console.WriteLine(columns);
-        System.Console.WriteLine(rows);
-        System.Console.WriteLine(title);
-
-        //<VerbatimLiterals>
         string filePath = @"C:\Users\scoleridge\Documents\";
         //Output: C:\Users\scoleridge\Documents\
 

--- a/docs/csharp/programming-guide/strings/snippets/StringLiterals.cs
+++ b/docs/csharp/programming-guide/strings/snippets/StringLiterals.cs
@@ -6,9 +6,22 @@ public class Literals
 {
     public static void StringLiterals()
     {
+        //<EscapeSequences>
+        string columns = "Column 1\tColumn 2\tColumn 3";
+        //Output: Column 1        Column 2        Column 3
+
+        string rows = "Row 1\r\nRow 2\r\nRow 3";
+        /* Output:
+            Row 1
+            Row 2
+            Row 3
+        */
+
         //<VerbatimLiterals>
         string title = "\"The \u00C6olean Harp\", by Samuel Taylor Coleridge";
         //Output: "The Æolean Harp", by Samuel Taylor Coleridge
+        //</EscapeSequences>
+
         string filePath = @"C:\Users\scoleridge\Documents\";
         //Output: C:\Users\scoleridge\Documents\
 
@@ -24,6 +37,10 @@ public class Literals
         string quote = @"Her name was ""Sara.""";
         //Output: Her name was "Sara."
         //</VerbatimLiterals>
+        System.Console.WriteLine(columns);
+        System.Console.WriteLine(rows);
+        System.Console.WriteLine(title);
+
         System.Console.WriteLine(filePath);
         System.Console.WriteLine(text);
         System.Console.WriteLine(quote);

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1211,6 +1211,8 @@ items:
       href: language-reference/tokens/interpolated.md
     - name: "@ -- verbatim identifier"
       href: language-reference/tokens/verbatim.md
+    - name: "\"\"\" -- raw string literal"
+      href: language-reference/tokens/raw-string.md
   - name: Attributes read by the compiler
     items:
     - name: Global attributes


### PR DESCRIPTION
Fixes #32771 - Add reference page for the raw string literal token (`"""``).

Fixes #32215 - Add notes on the multi-line string literal syntax to answer questions.

Fixes #30757 - move attribution to example with text.

Internal review site: 

- [Language reference - raw string literals](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/raw-string?branch=pr-en-us-32952)
- [Programming guide / strings](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/strings/?branch=pr-en-us-32952)
