### PR TITLE
Grains 7.0

### DIFF
--- a/docs/orleans/grains/grain-persistence/index.md
+++ b/docs/orleans/grains/grain-persistence/index.md
@@ -1,7 +1,7 @@
 ---
 title: Grain persistence
 description: Learn about persistence in .NET Orleans.
-ms.date: 12/07/2022
+ms.date: 12/09/2022
 zone_pivot_groups: orleans-version
 ---
 
@@ -11,7 +11,7 @@ Grains can have multiple named persistent data objects associated with them. The
 
 :::image type="content" source="media/grain-state-diagram.png" alt-text="Grain persistence diagram" lightbox="media/grain-state-diagram.png":::
 
-In the above diagram, UserGrain has a *Profile- state and a*Cart- state, each of which is stored in a separate storage system.
+In the above diagram, UserGrain has a *Profile* state and a *Cart* state, each of which is stored in a separate storage system.
 
 ## Goals
 
@@ -91,7 +91,7 @@ public async Task SetNameAsync(string name)
 }
 ```
 
-Conceptually, the Orleans Runtime will take a deep copy of the grain state data object for its use during any write operations. Under the covers, the runtime *may- use optimization rules and heuristics to avoid performing some or all of the deep copy in some circumstances, provided that the expected logical isolation semantics are preserved.
+Conceptually, the Orleans Runtime will take a deep copy of the grain state data object for its use during any write operations. Under the covers, the runtime *may* use optimization rules and heuristics to avoid performing some or all of the deep copy in some circumstances, provided that the expected logical isolation semantics are preserved.
 
 See the [Failure Modes](#FailureModes) section below for details of error handling mechanisms.
 
@@ -203,7 +203,7 @@ public class UserGrain : Grain, IUserGrain
 
 ### Failure modes for read operations
 
-Failures returned by the storage provider during the initial read of state data for that particular grain will fail the activate operation for that grain; in such case, there will *not- be any call to that grain's `OnActivateAsync()` life cycle callback method. The original request to the grain which caused the activation will be faulted back to the caller, the same way as any other failure during grain activation. Failures encountered by the storage provider when reading state data for a particular grain will result in an exception from `ReadStateAsync()` `Task`. The grain can choose to handle or ignore the `Task` exception, just like any other `Task` in Orleans.
+Failures returned by the storage provider during the initial read of state data for that particular grain will fail the activate operation for that grain; in such case, there will *not* be any call to that grain's `OnActivateAsync()` life cycle callback method. The original request to the grain which caused the activation will be faulted back to the caller, the same way as any other failure during grain activation. Failures encountered by the storage provider when reading state data for a particular grain will result in an exception from `ReadStateAsync()` `Task`. The grain can choose to handle or ignore the `Task` exception, just like any other `Task` in Orleans.
 
 Any attempt to send a message to a grain that failed to load at silo startup time due to a missing/bad storage provider config will return the permanent error <xref:Orleans.Storage.BadProviderConfigException>.
 
@@ -211,18 +211,18 @@ Any attempt to send a message to a grain that failed to load at silo startup tim
 
 Failures encountered by the storage provider when writing state data for a particular grain will result in an exception thrown by `WriteStateAsync()` `Task`. Usually, this means that the grain call exception will be thrown back to the client caller, provided the `WriteStateAsync()` `Task` is correctly chained into the final return `Task` for this grain method. However, it is possible in certain advanced scenarios to write grain code to specifically handle such write errors, just like they can handle any other faulted `Task`.
 
-Grains that execute error-handling / recovery code *must- catch exceptions / faulted `WriteStateAsync()` `Task`s and not re-throw them, to signify that they have successfully handled the write error.
+Grains that execute error-handling / recovery code *must* catch exceptions / faulted `WriteStateAsync()` `Task`s and not re-throw them, to signify that they have successfully handled the write error.
 
 ## Recommendations
 
 ### Use JSON serialization or another version-tolerant serialization format
 
-Code evolves and this often includes storage types, too. To accommodate these changes, an appropriate serializer should be configured. For most storage providers, a `UseJson` option or similar is available to use JSON as a serialization format. Ensure that when evolving data contracts that already-stored data will still be loadable.
+Code evolves and this often includes storage types, too. To accommodate these changes, an appropriate serializer should be configured. For most storage providers, a `UseJson` option or similar is available to use JSON as a serialization format. Ensure that when evolving data contracts already-stored data will still be loadable.
 
 ## Using Grain&lt;TState&gt; to add storage to a grain
 
 > [!IMPORTANT]
-> Using `Grain<T>` to add storage to a grain is considered *legacy- functionality: grain storage should be added using `IPersistentState<T>` as previously described.
+> Using `Grain<T>` to add storage to a grain is considered *legacy* functionality: grain storage should be added using `IPersistentState<T>` as previously described.
 
 Grain classes that inherit from `Grain<T>` (where `T` is an application-specific state data type that needs to be persisted) will have their state loaded automatically from specified storage.
 
@@ -286,9 +286,9 @@ Create a custom storage provider by implementing this interface and [registering
 
 ### Storage provider semantics
 
-An opaque provider-specific <xref:Orleans.GrainState.Etag%2A> value (`string`) *may- be set by a storage provider as part of the grain state metadata populated when the state was read. Some providers may choose to leave this as `null` if they do not use `Etag`s.
+An opaque provider-specific <xref:Orleans.GrainState.Etag%2A> value (`string`) *may* be set by a storage provider as part of the grain state metadata populated when the state was read. Some providers may choose to leave this as `null` if they do not use `Etag`s.
 
-Any attempt to perform a write operation when the storage provider detects an `Etag` constraint violation *should- cause the write `Task` to be faulted with transient error <xref:Orleans.Storage.InconsistentStateException> and wrapping the underlying storage exception.
+Any attempt to perform a write operation when the storage provider detects an `Etag` constraint violation *should* cause the write `Task` to be faulted with transient error <xref:Orleans.Storage.InconsistentStateException> and wrapping the underlying storage exception.
 
 ```csharp
 public class InconsistentStateException : OrleansException
@@ -320,7 +320,7 @@ public class InconsistentStateException : OrleansException
 }
 ```
 
-Any other failure conditions from a storage operation *must- cause the returned `Task` to be broken with an exception indicating the underlying storage issue. In many cases, this exception may be thrown back to the caller which triggered the storage operation by calling a method on the grain. It is important to consider whether or not the caller will be able to deserialize this exception. For example, the client might not have loaded the specific persistence library containing the exception type. For this reason, it is advisable to convert exceptions into exceptions that can be propagated back to the caller.
+Any other failure conditions from a storage operation *must* cause the returned `Task` to be broken with an exception indicating the underlying storage issue. In many cases, this exception may be thrown back to the caller which triggered the storage operation by calling a method on the grain. It is important to consider whether or not the caller will be able to deserialize this exception. For example, the client might not have loaded the specific persistence library containing the exception type. For this reason, it is advisable to convert exceptions into exceptions that can be propagated back to the caller.
 
 ### Data mapping
 

--- a/docs/orleans/grains/grain-persistence/index.md
+++ b/docs/orleans/grains/grain-persistence/index.md
@@ -1,7 +1,7 @@
 ---
 title: Grain persistence
 description: Learn about persistence in .NET Orleans.
-ms.date: 12/01/2022
+ms.date: 12/07/2022
 ---
 
 # Grain persistence
@@ -10,22 +10,22 @@ Grains can have multiple named persistent data objects associated with them. The
 
 :::image type="content" source="media/grain-state-diagram.png" alt-text="Grain persistence diagram" lightbox="media/grain-state-diagram.png":::
 
-In the above diagram, UserGrain has a *Profile* state and a *Cart* state, each of which is stored in a separate storage system.
+In the above diagram, UserGrain has a *Profile- state and a*Cart- state, each of which is stored in a separate storage system.
 
 ## Goals
 
 1. Multiple named persistent data objects per grain.
-2. Multiple configured storage providers, each of which can have a different configuration and be backed by a different storage system.
-3. Storage providers can be developed and published by the community.
-4. Storage providers have complete control over how they store grain state data in the persistent backing store. Corollary: Orleans is not providing a comprehensive ORM storage solution, but instead allows custom storage providers to support specific ORM requirements as and when required.
+1. Multiple configured storage providers, each of which can have a different configuration and be backed by a different storage system.
+1. Storage providers can be developed and published by the community.
+1. Storage providers have complete control over how they store grain state data in the persistent backing store. Corollary: Orleans is not providing a comprehensive ORM storage solution, but instead allows custom storage providers to support specific ORM requirements as and when required.
 
 ## Packages
 
 Orleans grain storage providers can be found on [NuGet](https://www.nuget.org/packages?q=Orleans+Persistence). Officially maintained packages include:
 
-* [Microsoft.Orleans.Persistence.AdoNet](https://www.nuget.org/packages/Microsoft.Orleans.Persistence.AdoNet) is for SQL databases and other storage systems supported by ADO.NET. For more information, see [ADO.NET Grain Persistence](relational-storage.md).
-* [Microsoft.Orleans.Persistence.AzureStorage](https://www.nuget.org/packages/Microsoft.Orleans.Persistence.AzureStorage) is for Azure Storage, including Azure Blob Storage, Azure Table Storage, and Azure CosmosDB, via the Azure Table Storage API. For more information, see [Azure Storage Grain Persistence](azure-storage.md).
-* [Microsoft.Orleans.Persistence.DynamoDB](https://www.nuget.org/packages/Microsoft.Orleans.Persistence.DynamoDB) is for Amazon DynamoDB. For more information, see [Amazon DynamoDB Grain Persistence](dynamodb-storage.md).
+- [Microsoft.Orleans.Persistence.AdoNet](https://www.nuget.org/packages/Microsoft.Orleans.Persistence.AdoNet) is for SQL databases and other storage systems supported by ADO.NET. For more information, see [ADO.NET Grain Persistence](relational-storage.md).
+- [Microsoft.Orleans.Persistence.AzureStorage](https://www.nuget.org/packages/Microsoft.Orleans.Persistence.AzureStorage) is for Azure Storage, including Azure Blob Storage, Azure Table Storage, and Azure CosmosDB, via the Azure Table Storage API. For more information, see [Azure Storage Grain Persistence](azure-storage.md).
+- [Microsoft.Orleans.Persistence.DynamoDB](https://www.nuget.org/packages/Microsoft.Orleans.Persistence.DynamoDB) is for Amazon DynamoDB. For more information, see [Amazon DynamoDB Grain Persistence](dynamodb-storage.md).
 
 ## API
 
@@ -90,7 +90,7 @@ public async Task SetNameAsync(string name)
 }
 ```
 
-Conceptually, the Orleans Runtime will take a deep copy of the grain state data object for its use during any write operations. Under the covers, the runtime *may* use optimization rules and heuristics to avoid performing some or all of the deep copy in some circumstances, provided that the expected logical isolation semantics are preserved.
+Conceptually, the Orleans Runtime will take a deep copy of the grain state data object for its use during any write operations. Under the covers, the runtime *may- use optimization rules and heuristics to avoid performing some or all of the deep copy in some circumstances, provided that the expected logical isolation semantics are preserved.
 
 See the [Failure Modes](#FailureModes) section below for details of error handling mechanisms.
 
@@ -202,7 +202,7 @@ public class UserGrain : Grain, IUserGrain
 
 ### Failure modes for read operations
 
-Failures returned by the storage provider during the initial read of state data for that particular grain will fail the activate operation for that grain; in such case, there will *not* be any call to that grain's `OnActivateAsync()` life cycle callback method. The original request to the grain which caused the activation will be faulted back to the caller, the same way as any other failure during grain activation. Failures encountered by the storage provider when reading state data for a particular grain will result in an exception from `ReadStateAsync()` `Task`. The grain can choose to handle or ignore the `Task` exception, just like any other `Task` in Orleans.
+Failures returned by the storage provider during the initial read of state data for that particular grain will fail the activate operation for that grain; in such case, there will *not- be any call to that grain's `OnActivateAsync()` life cycle callback method. The original request to the grain which caused the activation will be faulted back to the caller, the same way as any other failure during grain activation. Failures encountered by the storage provider when reading state data for a particular grain will result in an exception from `ReadStateAsync()` `Task`. The grain can choose to handle or ignore the `Task` exception, just like any other `Task` in Orleans.
 
 Any attempt to send a message to a grain that failed to load at silo startup time due to a missing/bad storage provider config will return the permanent error <xref:Orleans.Storage.BadProviderConfigException>.
 
@@ -210,7 +210,7 @@ Any attempt to send a message to a grain that failed to load at silo startup tim
 
 Failures encountered by the storage provider when writing state data for a particular grain will result in an exception thrown by `WriteStateAsync()` `Task`. Usually, this means that the grain call exception will be thrown back to the client caller, provided the `WriteStateAsync()` `Task` is correctly chained into the final return `Task` for this grain method. However, it is possible in certain advanced scenarios to write grain code to specifically handle such write errors, just like they can handle any other faulted `Task`.
 
-Grains that execute error-handling / recovery code *must* catch exceptions / faulted `WriteStateAsync()` `Task`s and not re-throw them, to signify that they have successfully handled the write error.
+Grains that execute error-handling / recovery code *must- catch exceptions / faulted `WriteStateAsync()` `Task`s and not re-throw them, to signify that they have successfully handled the write error.
 
 ## Recommendations
 
@@ -221,7 +221,7 @@ Code evolves and this often includes storage types, too. To accommodate these ch
 ## Using Grain&lt;TState&gt; to add storage to a grain
 
 > [!IMPORTANT]
-> Using `Grain<T>` to add storage to a grain is considered *legacy* functionality: grain storage should be added using `IPersistentState<T>` as previously described.
+> Using `Grain<T>` to add storage to a grain is considered *legacy- functionality: grain storage should be added using `IPersistentState<T>` as previously described.
 
 Grain classes that inherit from `Grain<T>` (where `T` is an application-specific state data type that needs to be persisted) will have their state loaded automatically from specified storage.
 
@@ -285,9 +285,9 @@ Create a custom storage provider by implementing this interface and [registering
 
 ### Storage provider semantics
 
-An opaque provider-specific <xref:Orleans.GrainState.Etag%2A> value (`string`) *may* be set by a storage provider as part of the grain state metadata populated when the state was read. Some providers may choose to leave this as `null` if they do not use `Etag`s.
+An opaque provider-specific <xref:Orleans.GrainState.Etag%2A> value (`string`) *may- be set by a storage provider as part of the grain state metadata populated when the state was read. Some providers may choose to leave this as `null` if they do not use `Etag`s.
 
-Any attempt to perform a write operation when the storage provider detects an `Etag` constraint violation *should* cause the write `Task` to be faulted with transient error <xref:Orleans.Storage.InconsistentStateException> and wrapping the underlying storage exception.
+Any attempt to perform a write operation when the storage provider detects an `Etag` constraint violation *should- cause the write `Task` to be faulted with transient error <xref:Orleans.Storage.InconsistentStateException> and wrapping the underlying storage exception.
 
 ```csharp
 public class InconsistentStateException : OrleansException
@@ -319,7 +319,7 @@ public class InconsistentStateException : OrleansException
 }
 ```
 
-Any other failure conditions from a storage operation *must* cause the returned `Task` to be broken with an exception indicating the underlying storage issue. In many cases, this exception may be thrown back to the caller which triggered the storage operation by calling a method on the grain. It is important to consider whether or not the caller will be able to deserialize this exception. For example, the client might not have loaded the specific persistence library containing the exception type. For this reason, it is advisable to convert exceptions into exceptions that can be propagated back to the caller.
+Any other failure conditions from a storage operation *must- cause the returned `Task` to be broken with an exception indicating the underlying storage issue. In many cases, this exception may be thrown back to the caller which triggered the storage operation by calling a method on the grain. It is important to consider whether or not the caller will be able to deserialize this exception. For example, the client might not have loaded the specific persistence library containing the exception type. For this reason, it is advisable to convert exceptions into exceptions that can be propagated back to the caller.
 
 ### Data mapping
 

--- a/docs/orleans/grains/grain-persistence/index.md
+++ b/docs/orleans/grains/grain-persistence/index.md
@@ -324,6 +324,50 @@ The behavior of these methods corresponds to their counterparts on `IPersistentS
 
 There are two parts to the state persistence APIs: the API exposed to the grain via `IPersistentState<T>` or `Grain<T>`, and the storage provider API, which is centered around `IGrainStorage` — the interface which storage providers must implement:
 
+<!-- markdownlint-disable MD044 -->
+:::zone target="docs" pivot="orleans-7-0"
+<!-- markdownlint-enable MD044 -->
+
+```csharp
+/// <summary>
+/// Interface to be implemented for a storage able to read and write Orleans grain state data.
+/// </summary>
+public interface IGrainStorage
+{
+    /// <summary>Read data function for this storage instance.</summary>
+    /// <param name="stateName">Name of the state for this grain</param>
+    /// <param name="grainId">Grain ID</param>
+    /// <param name="grainState">State data object to be populated for this grain.</param>
+    /// <typeparam name="T">The grain state type.</typeparam>
+    /// <returns>Completion promise for the Read operation on the specified grain.</returns>
+    Task ReadStateAsync<T>(
+        string stateName, GrainId grainId, IGrainState<T> grainState);
+
+    /// <summary>Write data function for this storage instance.</summary>
+    /// <param name="stateName">Name of the state for this grain</param>
+    /// <param name="grainId">Grain ID</param>
+    /// <param name="grainState">State data object to be written for this grain.</param>
+    /// <typeparam name="T">The grain state type.</typeparam>
+    /// <returns>Completion promise for the Write operation on the specified grain.</returns>
+    Task WriteStateAsync<T>(
+        string stateName, GrainId grainId, IGrainState<T> grainState);
+
+    /// <summary>Delete / Clear data function for this storage instance.</summary>
+    /// <param name="stateName">Name of the state for this grain</param>
+    /// <param name="grainId">Grain ID</param>
+    /// <param name="grainState">Copy of last-known state data object for this grain.</param>
+    /// <typeparam name="T">The grain state type.</typeparam>
+    /// <returns>Completion promise for the Delete operation on the specified grain.</returns>
+    Task ClearStateAsync<T>(
+        string stateName, GrainId grainId, IGrainState<T> grainState);
+}
+```
+
+:::zone-end
+<!-- markdownlint-disable MD044 -->
+:::zone target="docs" pivot="orleans-3-x"
+<!-- markdownlint-enable MD044 -->
+
 ```csharp
 /// <summary>
 /// Interface to be implemented for a storage able to read and write Orleans grain state data.
@@ -355,6 +399,8 @@ public interface IGrainStorage
         string grainType, GrainReference grainReference, IGrainState grainState);
 }
 ```
+
+:::zone-end
 
 Create a custom storage provider by implementing this interface and [registering](#register-a-storage-provider) that implementation. For an example of an existing storage provider implementation, see [`AzureBlobGrainStorage`](https://github.com/dotnet/orleans/blob/af974d37864f85bfde5dc02f2f60bba997f2162d/src/Azure/Orleans.Persistence.AzureStorage/Providers/Storage/AzureBlobStorage.cs).
 

--- a/docs/orleans/grains/grain-persistence/index.md
+++ b/docs/orleans/grains/grain-persistence/index.md
@@ -2,6 +2,7 @@
 title: Grain persistence
 description: Learn about persistence in .NET Orleans.
 ms.date: 12/07/2022
+zone_pivot_groups: orleans-version
 ---
 
 # Grain persistence

--- a/docs/orleans/tutorials-and-samples/custom-grain-storage.md
+++ b/docs/orleans/tutorials-and-samples/custom-grain-storage.md
@@ -13,7 +13,7 @@ In this tutorial, we'll walk through how to write simple file-based grain storag
 
 ## Get started
 
-An Orleans grain storage is a class that implements `IGrainStorage` which is included in [Microsoft.Orleans.Core](https://www.nuget.org/packages/Microsoft.Orleans.Core) NuGet package. It will also inherit from `ILifecycleParticipant<ISiloLifecycle>` which will allow you to subscribe to a particular event in the lifecycle of the silo. You start by creating a class named `FileGrainStorage`.
+An Orleans grain storage is a class that implements `IGrainStorage`, which is included in [Microsoft.Orleans.Core](https://www.nuget.org/packages/Microsoft.Orleans.Core) NuGet package. It will also inherit from `ILifecycleParticipant<ISiloLifecycle>`, which will allow you to subscribe to a particular event in the lifecycle of the silo. You start by creating a class named `FileGrainStorage`.
 
 <!-- markdownlint-disable MD044 -->
 :::zone target="docs" pivot="orleans-7-0"
@@ -110,7 +110,7 @@ Writing the state is similar to reading the state.
 
 :::code source="snippets/custom-grain-storage/FileGrainStorage.cs" id="writestateasync":::
 
-Similar to reading state, you use the <xref:Orleans.Storage.IStorageProviderSerializerOptions.GrainStorageSerializer?displayProperty=nameWithType> to write the state. The current `ETag` is used to check against the last updated time in the UTC of the file. If the date is different, it means that another activation of the same grain changed the state concurrently. In this situation, you'll throw an `InconsistentStateException` which will result in the current activation being killed to prevent overwriting the state previously saved by the other activated grain.
+Similar to reading state, you use the <xref:Orleans.Storage.IStorageProviderSerializerOptions.GrainStorageSerializer?displayProperty=nameWithType> to write the state. The current `ETag` is used to check against the last updated time in the UTC of the file. If the date is different, it means that another activation of the same grain changed the state concurrently. In this situation, you'll throw an `InconsistentStateException`, which will result in the current activation being killed to prevent overwriting the state previously saved by the other activated grain.
 
 ## Clear state
 
@@ -118,7 +118,7 @@ Clearing the state would be deleting the file if the file exists.
 
 :::code source="snippets/custom-grain-storage/FileGrainStorage.cs" id="clearstateasync":::
 
-For the same reason as `WriteState`, you check for inconsistency before proceeding to delete the file and reset the `ETag`, you check if the current `ETag` is the same as the last write time UTC.
+For the same reason as `WriteState`, you check for inconsistency. Before proceeding to delete the file and reset the `ETag`, you check if the current `ETag` is the same as the last write time UTC.
 
 ## Put it all together
 
@@ -130,7 +130,7 @@ Lastly, to register the grain storage, you create an extension on the `ISiloBuil
 
 :::code source="snippets/custom-grain-storage/FileSiloBuilderExtensions.cs":::
 
-Our `FileGrainStorage` implements two interfaces, `IGrainStorage` and `ILifecycleParticipant<ISiloLifecycle>` therefore we need to register two named services for each interface:
+Our `FileGrainStorage` implements two interfaces, `IGrainStorage` and `ILifecycleParticipant<ISiloLifecycle>`, therefore we need to register two named services for each interface:
 
 ```csharp
 return services.AddSingletonNamedService(providerName, FileGrainStorageFactory.Create)

--- a/docs/orleans/tutorials-and-samples/custom-grain-storage.md
+++ b/docs/orleans/tutorials-and-samples/custom-grain-storage.md
@@ -1,7 +1,7 @@
 ---
 title: Custom grain storage sample project
 description: Explore a custom grain storage sample project written with .NET Orleans.
-ms.date: 02/04/2022
+ms.date: 12/07/2022
 ---
 
 # Custom Grain Storage

--- a/docs/orleans/tutorials-and-samples/custom-grain-storage.md
+++ b/docs/orleans/tutorials-and-samples/custom-grain-storage.md
@@ -1,7 +1,8 @@
 ---
 title: Custom grain storage sample project
 description: Explore a custom grain storage sample project written with .NET Orleans.
-ms.date: 12/07/2022
+ms.date: 12/08/2022
+zone_pivot_groups: orleans-version
 ---
 
 # Custom Grain Storage
@@ -14,12 +15,74 @@ In this tutorial, we'll walk through how to write simple file-based grain storag
 
 An Orleans grain storage is a class that implements `IGrainStorage` which is included in [Microsoft.Orleans.Core](https://www.nuget.org/packages/Microsoft.Orleans.Core) NuGet package. We also inherit from `ILifecycleParticipant<ISiloLifecycle>` which will allow us to subscribe to a particular event in the lifecycle of the silo. We start by creating a class named `FileGrainStorage`.
 
+<!-- markdownlint-disable MD044 -->
+:::zone target="docs" pivot="orleans-7-0"
+<!-- markdownlint-enable MD044 -->
+
 ```csharp
-using Orleans;
+public class FileGrainStorage : IGrainStorage, ILifecycleParticipant<ISiloLifecycle>
+{
+    private readonly string _storageName;
+    private readonly FileGrainStorageOptions _options;
+    private readonly ClusterOptions _clusterOptions;
+
+    public FileGrainStorage(
+        string storageName,
+        FileGrainStorageOptions options,
+        IOptions<ClusterOptions> clusterOptions)
+    {
+        _storageName = storageName;
+        _options = options;
+        _clusterOptions = clusterOptions.Value;
+    }
+
+    public Task ClearStateAsync<T>(
+        string stateName,
+        GrainId grainId,
+        IGrainState<T> grainState)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task ReadStateAsync<T>(
+        string stateName,
+        GrainId grainId,
+        IGrainState<T> grainState)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task WriteStateAsync<T>(
+        string stateName,
+        GrainId grainId,
+        IGrainState<T> grainState)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Participate(ISiloLifecycle lifecycle) =>
+        throw new NotImplementedException();
+    
+    public BinaryData Serialize<T>(T input) =>
+        throw new NotImplementedException();
+
+    public T Deserialize<T>(BinaryData input) =>
+        throw new NotImplementedException();
+}
+```
+
+:::zone-end
+
+<!-- markdownlint-disable MD044 -->
+:::zone target="docs" pivot="orleans-3-x"
+<!-- markdownlint-enable MD044 -->
+
+```csharp
 using System;
+using System.Threading.Tasks;
+using Orleans;
 using Orleans.Storage;
 using Orleans.Runtime;
-using System.Threading.Tasks;
 
 namespace GrainStorage;
 
@@ -79,7 +142,21 @@ public class FileGrainStorage
 }
 ```
 
+:::zone-end
+
 Before starting the implementation, we create an option class containing the root directory where the grains states files will be stored. For that we will create an options file `FileGrainStorageOptions`:
+
+<!-- markdownlint-disable MD044 -->
+:::zone target="docs" pivot="orleans-7-0"
+<!-- markdownlint-enable MD044 -->
+
+:::code source="snippets/custom-grain-storage/FileGrainStorageOptions.cs":::
+
+:::zone-end
+
+<!-- markdownlint-disable MD044 -->
+:::zone target="docs" pivot="orleans-3-x"
+<!-- markdownlint-enable MD044 -->
 
 ```csharp
 public class FileGrainStorageOptions
@@ -87,6 +164,8 @@ public class FileGrainStorageOptions
     public string RootDirectory { get; set; }
 }
 ```
+
+:::zone-end
 
 The create a constructor containing two fields, `storageName` to specify which grains should write using this storage `[StorageProvider(ProviderName = "File")]` and `directory` which would be the directory where the grain states will be saved.
 

--- a/docs/orleans/tutorials-and-samples/custom-grain-storage.md
+++ b/docs/orleans/tutorials-and-samples/custom-grain-storage.md
@@ -5,7 +5,7 @@ ms.date: 12/08/2022
 zone_pivot_groups: orleans-version
 ---
 
-# Custom Grain Storage
+# Custom grain storage
 
 In the tutorial on declarative actor storage, we looked at allowing grains to store their state in an Azure table using one of the built-in storage providers. While Azure is a great place to squirrel away your data, there are many alternatives. There are so many that there was no way to support them all. Instead, Orleans is designed to let you easily add support for your form of storage by writing a grain storage.
 
@@ -20,6 +20,13 @@ An Orleans grain storage is a class that implements `IGrainStorage` which is inc
 <!-- markdownlint-enable MD044 -->
 
 ```csharp
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.Runtime;
+using Orleans.Storage;
+
+namespace GrainStorage;
+
 public sealed class FileGrainStorage : IGrainStorage, ILifecycleParticipant<ISiloLifecycle>
 {
     private readonly string _storageName;
@@ -121,7 +128,7 @@ After that, you will create a factory that will allow you to scope the options t
 
 Lastly, to register the grain storage, you create an extension on the `ISiloBuilder` which internally registers the grain storage as a named service using <xref:Orleans.Runtime.KeyedServiceExtensions.AddSingletonNamedService%2A>, an extension provided by `Orleans.Core`.
 
-:::code source="snippets/custom-grain-storage/FileGrainStorageExtensions.cs":::
+:::code source="snippets/custom-grain-storage/FileSiloBuilderExtensions.cs":::
 
 Our `FileGrainStorage` implements two interfaces, `IGrainStorage` and `ILifecycleParticipant<ISiloLifecycle>` therefore we need to register two named services for each interface:
 
@@ -135,7 +142,9 @@ This enables you to add the file storage using the extension on the `ISiloBuilde
 
 :::code source="snippets/custom-grain-storage/Program.cs":::
 
-Now you will be able to decorate your grains with the provider `[StorageProvider(ProviderName = "File")]` and it will store in the grain state in the root directory set in the options.
+Now you will be able to decorate your grains with the provider `[StorageProvider(ProviderName = "File")]` and it will store in the grain state in the root directory set in the options. Consider the full implementation of the `FileGrainStorage`:
+
+:::code source="snippets/custom-grain-storage/FileGrainStorage.cs":::
 
 :::zone-end
 

--- a/docs/orleans/tutorials-and-samples/snippets/custom-grain-storage/FileGrainStorage.cs
+++ b/docs/orleans/tutorials-and-samples/snippets/custom-grain-storage/FileGrainStorage.cs
@@ -1,0 +1,106 @@
+﻿using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.Runtime;
+using Orleans.Storage;
+
+namespace GrainStorage;
+
+public class FileGrainStorage : IGrainStorage, ILifecycleParticipant<ISiloLifecycle>
+{
+    private readonly string _storageName;
+    private readonly FileGrainStorageOptions _options;
+    private readonly ClusterOptions _clusterOptions;
+
+    public FileGrainStorage(
+        string storageName,
+        FileGrainStorageOptions options,
+        IOptions<ClusterOptions> clusterOptions)
+    {
+        _storageName = storageName;
+        _options = options;
+        _clusterOptions = clusterOptions.Value;
+    }
+
+    public Task ClearStateAsync<T>(
+        string stateName,
+        GrainId grainId,
+        IGrainState<T> grainState)
+    {
+        var fName = grainId.Key.ToString();
+        var path = Path.Combine(_options.RootDirectory, fName!);
+        var fileInfo = new FileInfo(path);
+        if (fileInfo.Exists)
+        {
+            if (fileInfo.LastWriteTimeUtc.ToString() != grainState.ETag)
+            {
+                throw new InconsistentStateException($$"""
+                Version conflict (ClearState): ServiceId={{_clusterOptions.ServiceId}}
+                ProviderName={{_storageName}} GrainType={{typeof(T)}} 
+                GrainReference={{grainId}}.
+                """);
+            }
+
+            grainState.ETag = null;
+            grainState.State = (T)Activator.CreateInstance(typeof(T))!;
+
+            fileInfo.Delete();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public async Task ReadStateAsync<T>(
+        string stateName,
+        GrainId grainId,
+        IGrainState<T> grainState)
+    {
+        var fName = grainId.Key.ToString();
+        var path = Path.Combine(_options.RootDirectory, fName!);        
+        var fileInfo = new FileInfo(path);
+        if (fileInfo is { Exists: false })
+        {
+            grainState.State = (T)Activator.CreateInstance(typeof(T))!;
+            return;
+        }
+
+        using var stream = fileInfo.OpenText();
+        var storedData = await stream.ReadToEndAsync();
+        
+        grainState.State = _options.GrainStorageSerializer.Deserialize<T>(new BinaryData(storedData));
+        grainState.ETag = fileInfo.LastWriteTimeUtc.ToString();
+    }
+
+    public async Task WriteStateAsync<T>(
+        string stateName,
+        GrainId grainId,
+        IGrainState<T> grainState)
+    {
+        var storedData = _options.GrainStorageSerializer.Serialize(grainState.State);
+        var fName = grainId.Key.ToString();
+        var path = Path.Combine(_options.RootDirectory, fName!);
+        var fileInfo = new FileInfo(path);
+        if (fileInfo.Exists && fileInfo.LastWriteTimeUtc.ToString() != grainState.ETag)
+        {
+            throw new InconsistentStateException($$"""
+                Version conflict (WriteState): ServiceId={{_clusterOptions.ServiceId}}
+                ProviderName={{_storageName}} GrainType={{typeof(T)}} 
+                GrainReference={{grainId}}.
+                """);
+        }
+
+        await File.WriteAllBytesAsync(path, storedData.ToArray());
+
+        fileInfo.Refresh();
+        grainState.ETag = fileInfo.LastWriteTimeUtc.ToString();
+    }
+
+    public void Participate(ISiloLifecycle lifecycle) =>
+        lifecycle.Subscribe(
+            OptionFormattingUtilities.Name<FileGrainStorage>(_storageName),
+            ServiceLifecycleStage.ApplicationServices,
+            (ct) =>
+            {
+                Directory.CreateDirectory(_options.RootDirectory);
+                return Task.CompletedTask;
+            });
+}

--- a/docs/orleans/tutorials-and-samples/snippets/custom-grain-storage/FileGrainStorage.cs
+++ b/docs/orleans/tutorials-and-samples/snippets/custom-grain-storage/FileGrainStorage.cs
@@ -35,10 +35,10 @@ public sealed class FileGrainStorage : IGrainStorage, ILifecycleParticipant<ISil
             if (fileInfo.LastWriteTimeUtc.ToString() != grainState.ETag)
             {
                 throw new InconsistentStateException($$"""
-                Version conflict (ClearState): ServiceId={{_clusterOptions.ServiceId}}
-                ProviderName={{_storageName}} GrainType={{typeof(T)}} 
-                GrainReference={{grainId}}.
-                """);
+                    Version conflict (ClearState): ServiceId={{_clusterOptions.ServiceId}}
+                    ProviderName={{_storageName}} GrainType={{typeof(T)}} 
+                    GrainReference={{grainId}}.
+                    """);
             }
 
             grainState.ETag = null;

--- a/docs/orleans/tutorials-and-samples/snippets/custom-grain-storage/FileGrainStorageFactory.cs
+++ b/docs/orleans/tutorials-and-samples/snippets/custom-grain-storage/FileGrainStorageFactory.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration.Overrides;
+using Orleans.Storage;
+
+namespace GrainStorage;
+
+internal static class FileGrainStorageFactory
+{
+    internal static IGrainStorage Create(
+        IServiceProvider services, string name)
+    {
+        var optionsSnapshot =
+            services.GetRequiredService<IOptionsSnapshot<FileGrainStorageOptions>>();
+
+        return ActivatorUtilities.CreateInstance<FileGrainStorage>(
+            services,
+            name,
+            optionsSnapshot.Get(name),
+            services.GetProviderClusterOptions(name));
+    }
+}

--- a/docs/orleans/tutorials-and-samples/snippets/custom-grain-storage/FileGrainStorageOptions.cs
+++ b/docs/orleans/tutorials-and-samples/snippets/custom-grain-storage/FileGrainStorageOptions.cs
@@ -2,7 +2,7 @@
 
 namespace GrainStorage;
 
-public class FileGrainStorageOptions : IStorageProviderSerializerOptions
+public sealed class FileGrainStorageOptions : IStorageProviderSerializerOptions
 {
     public required string RootDirectory { get; set; }
 

--- a/docs/orleans/tutorials-and-samples/snippets/custom-grain-storage/FileGrainStorageOptions.cs
+++ b/docs/orleans/tutorials-and-samples/snippets/custom-grain-storage/FileGrainStorageOptions.cs
@@ -1,0 +1,10 @@
+﻿using Orleans.Storage;
+
+namespace GrainStorage;
+
+public class FileGrainStorageOptions : IStorageProviderSerializerOptions
+{
+    public required string RootDirectory { get; set; }
+
+    public required IGrainStorageSerializer GrainStorageSerializer { get; set; }
+}

--- a/docs/orleans/tutorials-and-samples/snippets/custom-grain-storage/FileSiloBuilderExtensions.cs
+++ b/docs/orleans/tutorials-and-samples/snippets/custom-grain-storage/FileSiloBuilderExtensions.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans.Runtime;
+using Orleans.Storage;
+
+namespace GrainStorage;
+
+public static class FileSiloBuilderExtensions
+{
+    public static ISiloBuilder AddFileGrainStorage(
+        this ISiloBuilder builder,
+        string providerName,
+        Action<FileGrainStorageOptions> options) =>
+        builder.ConfigureServices(
+            services => services.AddFileGrainStorage(
+                providerName, options));
+
+    public static IServiceCollection AddFileGrainStorage(
+        this IServiceCollection services,
+        string providerName,
+        Action<FileGrainStorageOptions> options)
+    {
+        services.AddOptions<FileGrainStorageOptions>(providerName)
+            .Configure(options);
+
+        services.AddTransient<
+            IPostConfigureOptions<FileGrainStorageOptions>,
+            DefaultStorageProviderSerializerOptionsConfigurator<FileGrainStorageOptions>>();
+
+        return services.AddSingletonNamedService(providerName, FileGrainStorageFactory.Create)
+            .AddSingletonNamedService(providerName,
+                (p, n) =>
+                    (ILifecycleParticipant<ISiloLifecycle>)p.GetRequiredServiceByName<IGrainStorage>(n));
+    }
+}

--- a/docs/orleans/tutorials-and-samples/snippets/custom-grain-storage/GrainStorage.csproj
+++ b/docs/orleans/tutorials-and-samples/snippets/custom-grain-storage/GrainStorage.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <OutputType>exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Runtime" Version="7.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/docs/orleans/tutorials-and-samples/snippets/custom-grain-storage/Program.cs
+++ b/docs/orleans/tutorials-and-samples/snippets/custom-grain-storage/Program.cs
@@ -1,15 +1,18 @@
 ﻿using GrainStorage;
 using Microsoft.Extensions.Hosting;
 
-var host = new HostBuilder()
+using IHost host = new HostBuilder()
     .UseOrleans(builder =>
     {
         builder.UseLocalhostClustering()
             .AddFileGrainStorage("File", options =>
             {
-                options.RootDirectory = "C:/TestFiles";
+                string path = Environment.GetFolderPath(
+                    Environment.SpecialFolder.ApplicationData);
+
+                options.RootDirectory = Path.Combine(path, "Orleans/GrainState/v1");
             });
     })
     .Build();
 
-host.Run();
+await host.RunAsync();

--- a/docs/orleans/tutorials-and-samples/snippets/custom-grain-storage/Program.cs
+++ b/docs/orleans/tutorials-and-samples/snippets/custom-grain-storage/Program.cs
@@ -1,0 +1,15 @@
+﻿using GrainStorage;
+using Microsoft.Extensions.Hosting;
+
+var host = new HostBuilder()
+    .UseOrleans(builder =>
+    {
+        builder.UseLocalhostClustering()
+            .AddFileGrainStorage("File", options =>
+            {
+                options.RootDirectory = "C:/TestFiles";
+            });
+    })
+    .Build();
+
+host.Run();

--- a/docs/orleans/whats-new-in-orleans.md
+++ b/docs/orleans/whats-new-in-orleans.md
@@ -1,7 +1,7 @@
 ---
 title: What's new in Orleans
 description: Learn about the various new features introduced in Orleans 7.0.
-ms.date: 11/14/2022
+ms.date: 12/07/2022
 ---
 
 # What's new in Orleans 7.0
@@ -395,7 +395,14 @@ public sealed class MyType
 
 ### Grain storage serializers
 
-Orleans includes a provider-backed persistence model for grains, accessed via the <xref:Orleans.Grain%601.State?displayName=nameWithType> property or by injecting one or more <xref:Orleans.Runtime.IPersistentState%601> values into your grain. Before Orleans 7.0, each provider had a different mechanism for configuring serialization. In Orleans 7.0, there is now a general-purpose grain state serializer interface, <xref:Orleans.Storage.IGrainStorageSerializer>, which offers a consistent way to customize state serialization for each provider. Supported storage providers implement a pattern which involves setting the <xref:Orleans.Storage.IStorageProviderSerializerOptions.GrainStorageSerializer%2A?displayProperty=nameWithType> property on the provider's options class, for example `AzureBlobStorageOptions.GrainStorageSerializer`. This currently defaults to an implementation which uses `Newtonsoft.Json` to serialize state. You can replace this by modifying that property at configuration time. The following example demonstrates this, using [OptionsBuilder\<TOptions\>](../core/extensions/options.md#optionsbuilder-api):
+Orleans includes a provider-backed persistence model for grains, accessed via the <xref:Orleans.Grain%601.State?displayName=nameWithType> property or by injecting one or more <xref:Orleans.Runtime.IPersistentState%601> values into your grain. Before Orleans 7.0, each provider had a different mechanism for configuring serialization. In Orleans 7.0, there is now a general-purpose grain state serializer interface, <xref:Orleans.Storage.IGrainStorageSerializer>, which offers a consistent way to customize state serialization for each provider. Supported storage providers implement a pattern which involves setting the <xref:Orleans.Storage.IStorageProviderSerializerOptions.GrainStorageSerializer%2A?displayProperty=nameWithType> property on the provider's options class, for example:
+
+- <xref:Orleans.Configuration.DynamoDBStorageOptions.GrainStorageSerializer?displayProperty=nameWithType>
+- <xref:Orleans.Configuration.AzureBlobStorageOptions.GrainStorageSerializer?displayProperty=nameWithType>
+- <xref:Orleans.Configuration.AzureTableStorageOptions.GrainStorageSerializer?displayProperty=nameWithType>
+- <xref:Orleans.Configuration.AdoNetGrainStorageOptions.GrainStorageSerializer>
+
+This currently defaults to an implementation which uses `Newtonsoft.Json` to serialize state. You can replace this by modifying that property at configuration time. The following example demonstrates this, using [OptionsBuilder\<TOptions\>](../core/extensions/options.md#optionsbuilder-api):
 
 ```csharp
 siloBuilder.AddAzureBlobGrainStorage(


### PR DESCRIPTION
## Summary

- Use zones in the custom grain storage tutorial.
- Add _snippets_ directory with 7.0 bits.
- Leaves 3.x bits as they were, introduces new 7.0 bits.

Fixes #32737 /cc @ReubenBond @bradygaster 

Previews:

- [Custom Grain Storage](https://review.learn.microsoft.com/en-us/dotnet/orleans/tutorials-and-samples/custom-grain-storage?branch=pr-en-us-32969&pivots=orleans-7-0)
- [Grain persistence](https://review.learn.microsoft.com/en-us/dotnet/orleans/grains/grain-persistence/?branch=pr-en-us-32969&pivots=orleans-7-0)
