### PR TITLE
Add syntax reference for comments

### DIFF
--- a/docs/csharp/language-reference/tokens/comments.md
+++ b/docs/csharp/language-reference/tokens/comments.md
@@ -5,7 +5,7 @@ ms.date: 12/12/2022
 ---
 # Code comments - `//` and `/*`. `*/`
 
-C# supports two different forms of comments. Single line comments start with `//` and end at the end of that line of code. Multiline comments start with `/*` and end with `*/`. The following example shows an example of each:
+C# supports two different forms of comments. Single line comments start with `//` and end at the end of that line of code. Multiline comments start with `/*` and end with `*/`. The following code shows an example of each:
 
 :::code language="csharp" source="./snippets/comments.cs" id="ExampleComments":::
 

--- a/docs/csharp/language-reference/tokens/comments.md
+++ b/docs/csharp/language-reference/tokens/comments.md
@@ -1,0 +1,20 @@
+---
+title: "// and /* */ - comments in C#"
+description: You use \"//\" for single-line comments. You use \"/*\" to start multi-line comments that end with \"*/\". You add comments to explain your code.
+ms.date: 12/12/2022
+---
+# Code comments - `//` and `/*`. `*/`
+
+C# supports two different forms of comments. Single line comments start with `//` and end at the end of that line of code. Multiline comments start with `/*` and end with `*/`. The following example shows an example of each:
+
+:::code language="csharp" source="./snippets/comments.cs" id="ExampleComments":::
+
+The multi-line comment can also be used to insert text in a line of code. Because these comments have an explicit closing character, you can include more executable code after the comment:
+
+:::code language="csharp" source="./snippets/comments.cs" id="InlineComment":::
+
+The single line comment can appear after executable code on the same line. The comment ends at the end of the text line:
+
+:::code language="csharp" source="./snippets/comments.cs" id="LineEndingComment":::
+
+Some comments start with three slashes: `///`. *Triple-slash comments* are *XML documentation comments*. The compiler reads these to produce human documentation. You can read more about [XML doc comments](../xmldoc/index.md) in the section on triple-slash comments.

--- a/docs/csharp/language-reference/tokens/snippets/comments.cs
+++ b/docs/csharp/language-reference/tokens/snippets/comments.cs
@@ -1,0 +1,32 @@
+
+
+public class C
+{
+    // <ExampleComments>
+    // This is a single line comment.
+
+    /* This could be a summary of all the
+       code that's in this class.
+       You might add multiple paragraphs, or links to pages
+       like https://learn.microsoft.com/dotnet/csharp.
+       
+       You could even include emojis. This example is 🔥
+       Then, when you're done, close with
+       */
+    // </ExampleComments>
+
+    // <InlineComment>
+    public static int Add(int left, int right)
+    {
+        return left /* first operand */ + right /* second operand */;
+    }
+    // </InlineComment>
+
+    public static int Increment(int source)
+    {
+        // <LineEndingComment>
+        return source++; // increment the source.
+        // </LineEndingComment>
+    }
+
+}

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1207,6 +1207,9 @@ items:
     - name: Overview
       displayName: special characters
       href: language-reference/tokens/index.md
+    - name: Comments
+      displayName: /* */, //
+      href: language-reference/tokens/comments.md
     - name: $ -- string interpolation
       href: language-reference/tokens/interpolated.md
     - name: "@ -- verbatim identifier"

--- a/docs/csharp/tour-of-csharp/index.md
+++ b/docs/csharp/tour-of-csharp/index.md
@@ -34,11 +34,11 @@ The "Hello, World" program is traditionally used to introduce a programming lang
 
 :::code language="csharp" interactive="try-dotnet" source="./snippets/shared/HelloWorld.cs":::
 
-The "Hello, World" program starts with a `using` directive that references the `System` namespace. Namespaces provide a hierarchical means of organizing C# programs and libraries. Namespaces contain types and other namespaces—for example, the `System` namespace contains a number of types, such as the `Console` class referenced in the program, and a number of other namespaces, such as `IO` and `Collections`. A `using` directive that references a given namespace enables unqualified use of the types that are members of that namespace. Because of the `using` directive, the program can use `Console.WriteLine` as shorthand for `System.Console.WriteLine`.
+The "Hello, World" program starts with a `using` directive that references the `System` namespace. Namespaces provide a hierarchical means of organizing C# programs and libraries. Namespaces contain types and other namespaces—for example, the `System` namespace contains a number of types, such as the `Console` class referenced in the program, and many other namespaces, such as `IO` and `Collections`. A `using` directive that references a given namespace enables unqualified use of the types that are members of that namespace. Because of the `using` directive, the program can use `Console.WriteLine` as shorthand for `System.Console.WriteLine`.
 
 The `Hello` class declared by the "Hello, World" program has a single member, the method named `Main`. The `Main` method is declared with the `static` modifier. While instance methods can reference a particular enclosing object instance using the keyword `this`, static methods operate without reference to a particular object. By convention, a static method named `Main` serves as the entry point of a C# program.
 
-The output of the program is produced by the `WriteLine` method of the `Console` class in the `System` namespace. This class is provided by the standard class libraries, which, by default, are automatically referenced by the compiler.
+The line starting with `//` is a *single line comment*. C# single line comments start with  `//` continue to the end of the current line. C# also supports *multi-line comments*. Multi-line comments start with `/*` and end with `*/`. The output of the program is produced by the `WriteLine` method of the `Console` class in the `System` namespace. This class is provided by the standard class libraries, which, by default, are automatically referenced by the compiler.
 
 ## Types and variables
 

--- a/docs/csharp/tour-of-csharp/snippets/shared/HelloWorld.cs
+++ b/docs/csharp/tour-of-csharp/snippets/shared/HelloWorld.cs
@@ -4,6 +4,7 @@ class Hello
 {
     static void Main()
     {
+        // This line prints "Hello, World" 
         Console.WriteLine("Hello, World");
     }
 }


### PR DESCRIPTION
Fixes #32817

Add a syntax reference page for C# comment characters.

Oddly, we didn't have one. It appears to have been assumed throughout the guide.
