### PR TITLE
Deprecate CA2109

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca2109.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2109.md
@@ -24,6 +24,11 @@ ms.author: gewarren
 
 A public or protected event-handling method was detected.
 
+> [!NOTE]
+> This rule has been deprecated. It last shipped with Microsoft.CodeAnalysis.NetAnalyzers 7.0.0 NuGet package and the .NET 7 SDK.
+>
+> The rule was removed because the threat that the analyzer warned about (an untrusted intermediary hooking a privileged event handler to a privileged event invoker) hasn't existed since .NET Framework 4.5.
+
 ## Rule description
 
 An externally visible event-handling method presents a security issue that requires review.


### PR DESCRIPTION
**~Please wait until https://github.com/dotnet/roslyn-analyzers/pull/6198 is merged.~**

This PR gets #31797 back with correction of package name and version.