### PR TITLE
Change the title and first section heading

### DIFF
--- a/docs/csharp/language-reference/xmldoc/index.md
+++ b/docs/csharp/language-reference/xmldoc/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Documentation comments - document APIs using /// comments"
-description: Learn about XML documentation comments. You can create documentation for your code by including XML elements in special comment fields. You can use other tools to build documentation layouts from comments.
+description: Learn about documentation comments. You can create documentation for your code by including XML elements in special comment fields. You can use other tools to build documentation layouts from comments.
 ms.date: 06/17/2021
 f1_keywords:
   - "cs.xml"

--- a/docs/csharp/language-reference/xmldoc/index.md
+++ b/docs/csharp/language-reference/xmldoc/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Documentation comments | Microsoft Learn"
+title: "Documentation comments - document APIs using /// comments"
 description: Learn about XML documentation comments. You can create documentation for your code by including XML elements in special comment fields. You can use other tools to build documentation layouts from comments.
 ms.date: 06/17/2021
 f1_keywords:

--- a/docs/csharp/language-reference/xmldoc/index.md
+++ b/docs/csharp/language-reference/xmldoc/index.md
@@ -1,5 +1,5 @@
 ---
-title: "XML documentation comments - document APIs using /// comments"
+title: "Documentation comments | Microsoft Learn"
 description: Learn about XML documentation comments. You can create documentation for your code by including XML elements in special comment fields. You can use other tools to build documentation layouts from comments.
 ms.date: 06/17/2021
 f1_keywords:
@@ -13,7 +13,7 @@ helpviewer_keywords:
   - "XML documentation comments [C#]"
 ms.assetid: 803b7f7b-7428-4725-b5db-9a6cff273199
 ---
-# XML documentation comments
+# Documentation comments
 
 C# source files can have structured comments that produce API documentation for the types defined in those files. The C# compiler produces an *XML* file that contains structured data representing the comments and the API signatures. Other tools can process that XML output to create human-readable documentation in the form of web pages or PDF files, for example.
 


### PR DESCRIPTION
Changed the title to "Documentation comments | Microsoft Learn" for consistency with other Microsoft docs. The previous title didn't make it as obvious that this was part of Microsoft's beginner-friendly tutorial series.

Changed the first section heading to "Documentation comments", for similar reasons. (The placement of "XML" before "Documentation comments" only makes things more confusing for the reader, in my opinion, since it suggests that non-XML documentation comments also exist.)

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
