### PR TITLE
Clarify How to: Determine if a file is an assembly

### DIFF
--- a/docs/standard/assembly/identify.md
+++ b/docs/standard/assembly/identify.md
@@ -37,7 +37,7 @@ The <xref:System.Reflection.AssemblyName.GetAssemblyName%2A> method loads the te
 
 ### Using the PEReader class
 
-1. When targeting .NET Standard or .NET Framework, install the [System.Reflection.Metadata](https://www.nuget.org/packages/System.Reflection.Metadata/) NuGet package. When targeting .NET Core or .NET 5+, this step is not required, because this library is included in the shared framework.
+1. When targeting .NET Standard or .NET Framework, install the [System.Reflection.Metadata](https://www.nuget.org/packages/System.Reflection.Metadata/) NuGet package. When targeting .NET Core or .NET 5+, this step isn't required because this library is included in the shared framework.
 
 2. Create a <xref:System.IO.FileStream?displayProperty=nameWithType> instance to read data from the file you're testing.
 

--- a/docs/standard/assembly/identify.md
+++ b/docs/standard/assembly/identify.md
@@ -37,7 +37,7 @@ The <xref:System.Reflection.AssemblyName.GetAssemblyName%2A> method loads the te
 
 ### Using the PEReader class
 
-1. When targeting .NET Standard or .NET Framework, install the [System.Reflection.Metadata](https://www.nuget.org/packages/System.Reflection.Metadata/) NuGet package. When targeting .NET Core or .NET 5+, this step isn't required because this library is included in the shared framework.
+1. If you're targeting .NET Standard or .NET Framework, install the [System.Reflection.Metadata](https://www.nuget.org/packages/System.Reflection.Metadata/) NuGet package. (When targeting .NET Core or .NET 5+, this step isn't required because this library is included in the shared framework.)
 
 2. Create a <xref:System.IO.FileStream?displayProperty=nameWithType> instance to read data from the file you're testing.
 

--- a/docs/standard/assembly/identify.md
+++ b/docs/standard/assembly/identify.md
@@ -37,7 +37,7 @@ The <xref:System.Reflection.AssemblyName.GetAssemblyName%2A> method loads the te
 
 ### Using the PEReader class
 
-1. Install the [System.Reflection.Metadata](https://www.nuget.org/packages/System.Reflection.Metadata/) NuGet package.
+1. When targeting .NET Standard or .NET Framework, install the [System.Reflection.Metadata](https://www.nuget.org/packages/System.Reflection.Metadata/) NuGet package. When targeting .NET Core or .NET 5+, this step is not required, because this library is included in the shared framework.
 
 2. Create a <xref:System.IO.FileStream?displayProperty=nameWithType> instance to read data from the file you're testing.
 


### PR DESCRIPTION
Clarify that installing System.Reflection.Metadata as NuGet package is not required on .NET Core and .NET 5+
