### PR TITLE
Update Linux installation dependencies

### DIFF
--- a/docs/core/docker/introduction.md
+++ b/docs/core/docker/introduction.md
@@ -37,9 +37,9 @@ The [Microsoft Container Registry (MCR)](/azure/container-registry) is the offic
 
 A **Dockerfile** is a file that defines a set of instructions that creates an image. Each instruction in the **Dockerfile** creates a layer in the image. For the most part, when you rebuild the image, only the layers that have changed are rebuilt. The **Dockerfile** can be distributed to others and allows them to recreate a new image in the same manner you created it. While this allows you to distribute the *instructions* on how to create the image, the main way to distribute your image is to publish it to a registry.
 
-## .NET Core images
+## .NET images
 
-Official .NET Core Docker images are published to the Microsoft Container Registry (MCR) and are discoverable at the [Microsoft .NET Core Docker Hub repository](https://hub.docker.com/_/microsoft-dotnet/). Each repository contains images for different combinations of the .NET (SDK or Runtime) and OS that you can use.
+Official .NET Docker images are published to the Microsoft Container Registry (MCR) and are discoverable at the [Microsoft .NET Docker Hub repository](https://hub.docker.com/_/microsoft-dotnet/). Each repository contains images for different combinations of the .NET (SDK or Runtime) and OS that you can use.
 
 Microsoft provides images that are tailored for specific scenarios. For example, the [ASP.NET Core repository](https://hub.docker.com/_/microsoft-dotnet-aspnet/) provides images that are built for running ASP.NET Core apps in production.
 

--- a/docs/core/install/includes/linux-libgdiplus-general.md
+++ b/docs/core/install/includes/linux-libgdiplus-general.md
@@ -1,4 +1,8 @@
+---
+author: adegeo
+ms.author: adegeo
+ms.date: 12/27/2022
+ms.topic: include
+---
 
-If the .NET app uses the *System.Drawing.Common* assembly, libgdiplus will also need to be installed.
-Because [*System.Drawing.Common* is no longer supported on Linux](../../compatibility/core-libraries/6.0/system-drawing-common-windows-only.md),
-this only works on .NET 6 and requires setting the `System.Drawing.EnableUnixSupport` runtime configuration switch.
+If the .NET app uses the *System.Drawing.Common* assembly, libgdiplus will also need to be installed. Because [*System.Drawing.Common* is no longer supported on Linux](../../compatibility/core-libraries/6.0/system-drawing-common-windows-only.md), this only works on .NET 6 and requires setting the `System.Drawing.EnableUnixSupport` runtime configuration switch.

--- a/docs/core/install/includes/linux-libgdiplus-general.md
+++ b/docs/core/install/includes/linux-libgdiplus-general.md
@@ -1,0 +1,4 @@
+
+If the .NET app uses the *System.Drawing.Common* assembly, libgdiplus will also need to be installed.
+Because [*System.Drawing.Common* is no longer supported on Linux](../compatibility/core-libraries/6.0/system-drawing-common-windows-only.md),
+this only works on .NET 6 and requires setting the `System.Drawing.EnableUnixSupport` runtime configuration switch.

--- a/docs/core/install/includes/linux-libgdiplus-general.md
+++ b/docs/core/install/includes/linux-libgdiplus-general.md
@@ -1,4 +1,4 @@
 
 If the .NET app uses the *System.Drawing.Common* assembly, libgdiplus will also need to be installed.
-Because [*System.Drawing.Common* is no longer supported on Linux](../compatibility/core-libraries/6.0/system-drawing-common-windows-only.md),
+Because [*System.Drawing.Common* is no longer supported on Linux](../../compatibility/core-libraries/6.0/system-drawing-common-windows-only.md),
 this only works on .NET 6 and requires setting the `System.Drawing.EnableUnixSupport` runtime configuration switch.

--- a/docs/core/install/includes/linux-rpm-install-dependencies.md
+++ b/docs/core/install/includes/linux-rpm-install-dependencies.md
@@ -1,5 +1,5 @@
 
-When you install with a package manager, these libraries are installed for you. But, if you manually install .NET Core or you publish a self-contained app, you'll need to make sure these libraries are installed:
+When you install with a package manager, these libraries are installed for you. But, if you manually install .NET or you publish a self-contained app, you'll need to make sure these libraries are installed:
 
 - krb5-libs
 - libicu
@@ -10,9 +10,6 @@ If the target runtime environment's OpenSSL version is 1.1 or newer, you'll need
 
 For more information about the dependencies, see [Self-contained Linux apps](https://github.com/dotnet/core/blob/main/Documentation/self-contained-linux-apps.md).
 
-For .NET Core apps that use the *System.Drawing.Common* assembly, you'll also need the following dependency:
+[!INCLUDE [linux-libgdiplus-general](includes/linux-libgdiplus-general.md)]
 
-- [libgdiplus (version 6.0.1 or later)](https://www.mono-project.com/docs/gui/libgdiplus/)
-
-  > [!WARNING]
-  > You can install a recent version of *libgdiplus* by adding the Mono repository to your system. For more information, see <https://www.mono-project.com/download/stable/>.
+You can install a recent version of *libgdiplus* by [adding the Mono repository to your system](https://www.mono-project.com/download/stable/#download-lin).

--- a/docs/core/install/includes/linux-rpm-install-dependencies.md
+++ b/docs/core/install/includes/linux-rpm-install-dependencies.md
@@ -10,6 +10,6 @@ If the target runtime environment's OpenSSL version is 1.1 or newer, you'll need
 
 For more information about the dependencies, see [Self-contained Linux apps](https://github.com/dotnet/core/blob/main/Documentation/self-contained-linux-apps.md).
 
-[!INCLUDE [linux-libgdiplus-general](includes/linux-libgdiplus-general.md)]
+[!INCLUDE [linux-libgdiplus-general](linux-libgdiplus-general.md)]
 
 You can install a recent version of *libgdiplus* by [adding the Mono repository to your system](https://www.mono-project.com/download/stable/#download-lin).

--- a/docs/core/install/linux-alpine.md
+++ b/docs/core/install/linux-alpine.md
@@ -10,7 +10,7 @@ ms.date: 11/22/2022
 
 .NET is supported on Alpine and this article describes how to install .NET on Alpine. When an Alpine version falls out of support, .NET is no longer supported with that version.
 
-If you're using Docker, consider using [official .NET Docker images](../docker/introduction.md#net-core-images) instead of installing .NET yourself.
+If you're using Docker, consider using [official .NET Docker images](../docker/introduction.md#net-images) instead of installing .NET yourself.
 
 [!INCLUDE [linux-intro-sdk-vs-runtime](includes/linux-intro-sdk-vs-runtime.md)]
 

--- a/docs/core/install/linux-alpine.md
+++ b/docs/core/install/linux-alpine.md
@@ -10,6 +10,8 @@ ms.date: 11/22/2022
 
 .NET is supported on Alpine and this article describes how to install .NET on Alpine. When an Alpine version falls out of support, .NET is no longer supported with that version.
 
+If you're using Docker, consider using [official .NET Docker images](../docker/introduction.md#net-core-images) instead of installing .NET yourself.
+
 [!INCLUDE [linux-intro-sdk-vs-runtime](includes/linux-intro-sdk-vs-runtime.md)]
 
 The Alpine package manager supports installing some versions of .NET. If the .NET package is unavailable, you'll need to install .NET in one of the following alternative ways:
@@ -62,15 +64,14 @@ The following table is a list of currently supported .NET releases and the versi
 
 ## Dependencies
 
-.NET on Alpine Linux requires the following dependencies installed:
+When you install with a package manager, these libraries are installed for you. But, if you manually install .NET or you publish a self-contained app, you'll need to make sure these libraries are installed:
 
 - icu-libs
 - krb5-libs
 - libgcc
 - libgdiplus (if the .NET app requires the *System.Drawing.Common* assembly)
 - libintl
-- libssl1.1 (Alpine v3.9 or greater)
-- libssl1.0 (Alpine v3.8 or lower)
+- libssl1.1
 - libstdc++
 - zlib
 
@@ -80,10 +81,12 @@ To install the needed requirements, run the following command:
 apk add bash icu-libs krb5-libs libgcc libintl libssl1.1 libstdc++ zlib
 ```
 
-To install **libgdiplus**, you may need to specify a repository:
+[!INCLUDE [linux-libgdiplus-general](includes/linux-libgdiplus-general.md)]
+
+To install libgdiplus on Alpine 3.16 or newer (older versions don't include the package), run:
 
 ```bash
-apk add libgdiplus --repository https://dl-3.alpinelinux.org/alpine/edge/testing/
+apk add libgdiplus
 ```
 
 ## Next steps

--- a/docs/core/install/linux-debian.md
+++ b/docs/core/install/linux-debian.md
@@ -102,26 +102,20 @@ sudo apt-get update && \
 
 ## Dependencies
 
-When you install with a package manager, these libraries are installed for you. But, if you manually install .NET Core or you publish a self-contained app, you'll need to make sure these libraries are installed:
+When you install with a package manager, these libraries are installed for you. But, if you manually install .NET or you publish a self-contained app, you'll need to make sure these libraries are installed:
 
 - libc6
 - libgcc-s1
 - libgssapi-krb5-2
-- libicu52 (for 8.x)
-- libicu57 (for 9.x)
 - libicu63 (for 10.x)
 - libicu67 (for 11.x)
-- libssl1.0.0 (for 8.x)
-- libssl1.1 (for 9.x-11.x)
+- libssl1.1 (for 10.x-11.x)
 - libstdc++6
 - zlib1g
 
-For .NET Core apps that use the *System.Drawing.Common* assembly, you also need the following dependency:
+[!INCLUDE [linux-libgdiplus-general](includes/linux-libgdiplus-general.md)]
 
-- libgdiplus (version 6.0.1 or later)
-
-  > [!WARNING]
-  > You can install a recent version of *libgdiplus* by adding the Mono repository to your system. For more information, see <https://www.mono-project.com/download/stable/>.
+You can install a recent version of *libgdiplus* by [adding the Mono repository to your system](https://www.mono-project.com/download/stable/#download-lin-debian).
 
 ## Next steps
 

--- a/docs/core/install/linux-debian.md
+++ b/docs/core/install/linux-debian.md
@@ -109,7 +109,7 @@ When you install with a package manager, these libraries are installed for you. 
 - libgssapi-krb5-2
 - libicu63 (for 10.x)
 - libicu67 (for 11.x)
-- libssl1.1 (for 10.x-11.x)
+- libssl1.1
 - libstdc++6
 - zlib1g
 

--- a/docs/core/install/linux-opensuse.md
+++ b/docs/core/install/linux-opensuse.md
@@ -74,12 +74,7 @@ If the target runtime environment's OpenSSL version is 1.1 or newer, you'll need
 
 For more information about the dependencies, see [Self-contained Linux apps](https://github.com/dotnet/core/blob/main/Documentation/self-contained-linux-apps.md).
 
-For .NET apps that use the *System.Drawing.Common* assembly, you'll also need the following dependency:
-
-- [libgdiplus (version 6.0.1 or later)](https://www.mono-project.com/docs/gui/libgdiplus/)
-
-  > [!WARNING]
-  > You can install a recent version of *libgdiplus* by adding the Mono repository to your system. For more information, see <https://www.mono-project.com/download/stable/>.
+[!INCLUDE [linux-libgdiplus-general](includes/linux-libgdiplus-general.md)]
 
 ## Next steps
 

--- a/docs/core/install/linux-scripted-manual.md
+++ b/docs/core/install/linux-scripted-manual.md
@@ -68,12 +68,9 @@ If your distribution wasn't previously listed, and is debian-based, you may need
 
 ### Common dependencies
 
-For .NET apps that use the *System.Drawing.Common* assembly, you'll also need the following dependency:
+[!INCLUDE [linux-libgdiplus-general](includes/linux-libgdiplus-general.md)]
 
-- [libgdiplus (version 6.0.1 or later)](https://www.mono-project.com/docs/gui/libgdiplus/)
-
-  > [!WARNING]
-  > You can install a recent version of *libgdiplus* by adding the Mono repository to your system. For more information, see <https://www.mono-project.com/download/stable/>.
+You can usually install a recent version of *libgdiplus* by [adding the Mono repository to your system](https://www.mono-project.com/download/stable/#download-lin).
 
 ## Scripted install
 

--- a/docs/core/install/linux-sles.md
+++ b/docs/core/install/linux-sles.md
@@ -83,12 +83,7 @@ If the target runtime environment's OpenSSL version is 1.1 or newer, you'll need
 
 For more information about the dependencies, see [Self-contained Linux apps](https://github.com/dotnet/core/blob/main/Documentation/self-contained-linux-apps.md).
 
-For .NET apps that use the *System.Drawing.Common* assembly, you'll also need the following dependency:
-
-- [libgdiplus (version 6.0.1 or later)](https://www.mono-project.com/docs/gui/libgdiplus/)
-
-  > [!WARNING]
-  > You can install a recent version of *libgdiplus* by adding the Mono repository to your system. For more information, see <https://www.mono-project.com/download/stable/>.
+[!INCLUDE [linux-libgdiplus-general](includes/linux-libgdiplus-general.md)]
 
 ## Next steps
 

--- a/docs/core/install/linux-ubuntu.md
+++ b/docs/core/install/linux-ubuntu.md
@@ -235,26 +235,22 @@ When you install with a package manager, these libraries are installed for you. 
 - libgcc1
 - libgcc-s1 (for 22.x)
 - libgssapi-krb5-2
-- libicu52 (for 14.x)
 - libicu55 (for 16.x)
 - libicu60 (for 18.x)
 - libicu66 (for 20.x)
 - libicu70 (for 22.04)
 - libicu71 (for 22.10)
 - liblttng-ust1 (for 22.x)
-- libssl1.0.0 (for 14.x, 16.x)
+- libssl1.0.0 (for 16.x)
 - libssl1.1 (for 18.x, 20.x)
 - libssl3 (for 22.x)
 - libstdc++6
 - libunwind8 (for 22.x)
 - zlib1g
 
-For .NET apps that use the *System.Drawing.Common* assembly, you also need the following dependency:
+[!INCLUDE [linux-libgdiplus-general](includes/linux-libgdiplus-general.md)]
 
-- libgdiplus (version 6.0.1 or later)
-
-  > [!WARNING]
-  > You can install a recent version of *libgdiplus* by adding the Mono repository to your system. For more information, see <https://www.mono-project.com/download/stable/>.
+You can install a recent version of *libgdiplus* by [adding the Mono repository to your system](https://www.mono-project.com/download/stable/#download-lin-ubuntu).
 
 ## Next steps
 

--- a/docs/core/install/linux.md
+++ b/docs/core/install/linux.md
@@ -14,7 +14,7 @@ ms.date: 11/08/2022
 > - [Install on macOS](macos.md)
 > - [Install on Linux](linux.md)
 
-This article details how to install .NET on various Linux distributions either manually, via a package manager, or via a [container](../docker/introduction.md#net-core-images).
+This article details how to install .NET on various Linux distributions either manually, via a package manager, or via a [container](../docker/introduction.md#net-images).
 
 ## Manual installation
 


### PR DESCRIPTION
Inspired by https://github.com/dotnet/docs/issues/33101, the installation instructions for Alpine and libgdiplus could use some improvements.

Specifically:

* Explain that dependencies don't have to be manually installed when using .Net Docker images or package managers. (Other distros already mention package managers here.)
* Add an explanation about support status of System.Drawing.Common on Linux. This should make it clear that most people don't need to install `libgdiplus`.
* Update `libgdiplus` install instructions; there is no need to use a scary WARNING.
* Remove dependencies for outdated distros.

Regarding `libgdiplus` on Alpine, it is now included in the `community` repository on 3.16 and 3.17. And since `community` seems to be enabled by default, specifying a repository shouldn't be necessary anymore.

Fixes https://github.com/dotnet/docs/issues/33101.