### PR TITLE
Duplicate line removed

### DIFF
--- a/docs/csharp/language-reference/operators/snippets/shared/NullCoalescingOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/NullCoalescingOperator.cs
@@ -58,7 +58,7 @@ public static class NullCoalescingOperator
         int? a = null;
 
         Console.WriteLine((numbers is null)); // expected: true
-        // if numbers is null add 5 to numbers
+        // if numbers is null, initialize it. Then, add 5 to numbers
         (numbers ??= new List<int>()).Add(5);
         Console.WriteLine(string.Join(" ", numbers));  // output: 5
         Console.WriteLine((numbers is null)); // expected: false        

--- a/docs/csharp/language-reference/operators/snippets/shared/NullCoalescingOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/NullCoalescingOperator.cs
@@ -60,9 +60,8 @@ public static class NullCoalescingOperator
         (numbers ??= new List<int>()).Add(5);
         Console.WriteLine(string.Join(" ", numbers));  // output: 5
 
-        numbers.Add(a ??= 0);
-        Console.WriteLine(string.Join(" ", numbers));  // output: 5 0
-        Console.WriteLine(a);  // output: 0
+        numbers.Add(a ??= 3);
+        Console.WriteLine(a);  // output: 3
         // </SnippetAssignment>
     }
 }

--- a/docs/csharp/language-reference/operators/snippets/shared/NullCoalescingOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/NullCoalescingOperator.cs
@@ -57,11 +57,20 @@ public static class NullCoalescingOperator
         List<int> numbers = null;
         int? a = null;
 
+        Console.WriteLine((numbers is null)); // expected: true
+        // if numbers is null add 5 to numbers
         (numbers ??= new List<int>()).Add(5);
         Console.WriteLine(string.Join(" ", numbers));  // output: 5
+        Console.WriteLine((numbers is null)); // expected: false        
 
-        numbers.Add(a ??= 3);
-        Console.WriteLine(a);  // output: 3
+        
+        Console.WriteLine((a is null)); // expected: true
+        Console.WriteLine((a ?? 3)); // expected: 3 since a is still null 
+        // if a is null then assign 0 to a and add a to the list
+        numbers.Add(a ??= 0);
+        Console.WriteLine((a is null)); // expected: false        
+        Console.WriteLine(string.Join(" ", numbers));  // output: 5 0
+        Console.WriteLine(a);  // output: 0	        
         // </SnippetAssignment>
     }
 }


### PR DESCRIPTION
The current line 61 `Console.WriteLine(string.Join(" ", numbers));  // output: 5 0` was repeated on line 64. I removed 64. 

The line 63 was `numbers.Add(a ??= 0);` i changed it to `numbers.Add(a ??= 3);` because in my opinion an int > 0 conveys clearly that it is not `null`.  On a side note in dutch / flemish and german zero `0` is called  `Nul` or `Null` which is pretty close to `null`

## Summary

Duplicate line removed, integer changed from 0 to 3

Fixes #Issue_Number (if available)
