### PR TITLE
Remove some more 3.1 references; clean a few things

### DIFF
--- a/docs/core/install/includes/package-manager-failed-to-find-deb.md
+++ b/docs/core/install/includes/package-manager-failed-to-find-deb.md
@@ -4,7 +4,7 @@ If you receive an error message similar to **Unable to locate package {dotnet-pa
 There are two placeholders in the following set of commands.
 
 - `{dotnet-package}`\
-This represents the .NET package you're installing, such as `aspnetcore-runtime-3.1`. This is used in the following `sudo apt-get install` command.
+This represents the .NET package you're installing, such as `aspnetcore-runtime-7.0`. This is used in the following `sudo apt-get install` command.
 
 - `{os-version}`\
 This represents the distribution version you're on. This is used in the `wget` command below. The distribution version is the numerical value, such as `20.04` on Ubuntu or `10` on Debian.

--- a/docs/core/install/includes/package-manager-heading-hack-pkgname.md
+++ b/docs/core/install/includes/package-manager-heading-hack-pkgname.md
@@ -18,20 +18,20 @@ Chooses the SDK or the runtime. Valid options are:
 - **version**\
 The version of the SDK or runtime to install. This article will always give the instructions for the latest supported version. Valid options are any released version, such as:
 
+  - 7.0
   - 5.0
   - 3.1
-  - 3.0
   - 2.1
 
   It's possible the SDK/runtime you're trying to download is not available for your Linux distribution. For a list of supported distributions, see [Install .NET on Linux](../linux.md).
 
 ### Examples
 
-- Install the ASP.NET Core 5.0 runtime: `aspnetcore-runtime-5.0`
+- Install the ASP.NET Core 7.0 runtime: `aspnetcore-runtime-7.0`
 - Install the .NET Core 2.1 runtime: `dotnet-runtime-2.1`
 - Install the .NET 5 SDK: `dotnet-sdk-5.0`
 - Install the .NET Core 3.1 SDK: `dotnet-sdk-3.1`
 
 ### Package missing
 
-If the package-version combination doesn't work, it's not available. For example, there isn't an ASP.NET Core SDK, the SDK components are included with the .NET SDK. The value `aspnetcore-sdk-2.2` is incorrect and should be `dotnet-sdk-2.2`. For a list of Linux distributions supported by .NET, see [.NET dependencies and requirements](../linux.md).
+If the package-version combination doesn't work, it's not available. For example, there isn't an ASP.NET Core SDK, the SDK components are included with the .NET SDK. The value `aspnetcore-sdk-7.0` is incorrect and should be `dotnet-sdk-7.0`. For a list of Linux distributions supported by .NET, see [.NET dependencies and requirements](../linux.md).

--- a/docs/core/install/linux-rhel.md
+++ b/docs/core/install/linux-rhel.md
@@ -95,50 +95,6 @@ source scl_source enable rh-dotnet60
 
 As an alternative to the ASP.NET Core Runtime, you can install the .NET Runtime that doesn't include ASP.NET Core support: replace `rh-dotnet60-aspnetcore-runtime-6.0` in the preceding command with `rh-dotnet60-dotnet-runtime-6.0`.
 
-## RHEL 7 ✔️ .NET Core 3.1
-
-[!INCLUDE [linux-prep-intro-generic](includes/linux-prep-intro-generic.md)]
-
-The following command installs the `scl-utils` package:
-
-```bash
-sudo yum install scl-utils
-```
-
-### Install the SDK
-
-.NET SDK allows you to develop apps with .NET Core. If you install .NET SDK, you don't need to install the corresponding runtime. To install .NET SDK, run the following commands:
-
-```bash
-subscription-manager repos --enable=rhel-7-server-dotnet-rpms
-yum install rh-dotnet31 -y
-scl enable rh-dotnet31 bash
-```
-
-Red Hat does not recommend permanently enabling `rh-dotnet31` because it may affect other programs. For example, `rh-dotnet31` includes a version of `libcurl` that differs from the base RHEL version. This may lead to issues in programs that do not expect a different version of `libcurl`. If you want to enable `rh-dotnet` permanently, add the following line to your _~/.bashrc_ file.
-
-```bash
-source scl_source enable rh-dotnet31
-```
-
-### Install the runtime
-
-The .NET Core Runtime allows you to run apps that were made with .NET Core that didn't include the runtime. The commands below install the ASP.NET Core Runtime, which is the most compatible runtime for .NET Core. In your terminal, run the following commands.
-
-```bash
-subscription-manager repos --enable=rhel-7-server-dotnet-rpms
-yum install rh-dotnet31-aspnetcore-runtime-3.1 -y
-scl enable rh-dotnet31 bash
-```
-
-Red Hat does not recommend permanently enabling `rh-dotnet31` because it may affect other programs. For example, `rh-dotnet31` includes a version of `libcurl` that differs from the base RHEL version. This may lead to issues in programs that do not expect a different version of `libcurl`. If you want to enable `rh-dotnet31` permanently, add the following line to your _~/.bashrc_ file.
-
-```bash
-source scl_source enable rh-dotnet31
-```
-
-As an alternative to the ASP.NET Core Runtime, you can install the .NET Core Runtime which doesn't include ASP.NET Core support. To install .NET Core Runtime, replace `rh-dotnet31-aspnetcore-runtime-3.1` in the commands above with `rh-dotnet31-dotnet-runtime-3.1`.
-
 ## CentOS Stream 9 ✔️
 
 .NET is included in the AppStream repositories for CentOS Stream 9.

--- a/docs/core/install/linux-scripted-manual.md
+++ b/docs/core/install/linux-scripted-manual.md
@@ -119,7 +119,6 @@ First, download a **binary** release for either the SDK or the runtime from one 
 
 - ✔️ [.NET 7 downloads](https://dotnet.microsoft.com/download/dotnet/7.0)
 - ✔️ [.NET 6 downloads](https://dotnet.microsoft.com/download/dotnet/6.0)
-- ✔️ [.NET Core 3.1 downloads](https://dotnet.microsoft.com/download/dotnet/3.1)
 - [All .NET Core downloads](https://dotnet.microsoft.com/download/dotnet)
 
 Next, extract the downloaded file and use the `export` command to set `DOTNET_ROOT` to the extracted folder's location and then ensure .NET is in PATH. This should make the .NET CLI commands available at the terminal.

--- a/docs/core/install/linux-snap.md
+++ b/docs/core/install/linux-snap.md
@@ -51,8 +51,6 @@ Snap packages for the .NET SDK are all published under the same identifier: `dot
 |--------------|--------------------------|
 | 7 (STS)      | `7.0` or `latest/stable` |
 | 6 (LTS)      | `6.0` or `lts/stable`    |
-| 5            | `5.0` |
-| 3.1 (LTS)    | `3.1` |
 
 Use the `snap install` command to install a .NET SDK snap package. Use the `--channel` parameter to indicate which version to install. If this parameter is omitted, `latest/stable` is used. In this example, `7.0` is specified:
 
@@ -77,7 +75,7 @@ Snap packages for the .NET Runtime are each published under their own package id
 | 7 (STS)           | `dotnet-runtime-70` |
 | 6 (LTS)           | `dotnet-runtime-60` |
 | 5                 | `dotnet-runtime-50` |
-| 3.1 (LTS)         | `dotnet-runtime-31` |
+| 3.1               | `dotnet-runtime-31` |
 | 3.0               | `dotnet-runtime-30` |
 | 2.2               | `dotnet-runtime-22` |
 | 2.1               | `dotnet-runtime-21` |

--- a/docs/core/install/localized-intellisense.md
+++ b/docs/core/install/localized-intellisense.md
@@ -1,6 +1,6 @@
 ---
 title: Install localized IntelliSense files
-description: Learn how to set up your development machine to use localized IntelliSense files for .NET 5 projects (including .NET Core) in Visual Studio.
+description: Learn how to set up your development machine to use localized IntelliSense files for .NET projects (including .NET Core) in Visual Studio.
 ms.date: 11/09/2022
 ---
 # How to install localized IntelliSense files for .NET
@@ -15,7 +15,7 @@ ms.date: 11/09/2022
 
 ## Prerequisites
 
-- [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download/dotnet) or [.NET 5 SDK](https://dotnet.microsoft.com/download/dotnet/5.0).
+- [.NET SDK](https://dotnet.microsoft.com/download/dotnet/).
 - [Visual Studio 2019 version 16.3](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019) or a later version.
 
 ## Download and install the localized IntelliSense files
@@ -36,7 +36,7 @@ ms.date: 11/09/2022
 
       | SDK type              | Path                               |
       |-----------------------|------------------------------------|
-      | .NET 5 and .NET Core  | *Microsoft.NETCore.App.Ref*        |
+      | .NET 6 and later      | *Microsoft.NETCore.App.Ref*        |
       | Windows Desktop       | *Microsoft.WindowsDesktop.App.Ref* |
       | .NET Standard         | *NETStandard.Library.Ref*          |
 

--- a/docs/core/install/templates.md
+++ b/docs/core/install/templates.md
@@ -182,12 +182,14 @@ The .NET templates are available on NuGet, and you can install them like any oth
 | .NET Core 3.1    | [`Microsoft.DotNet.Common.ProjectTemplates.3.1`](https://www.nuget.org/packages/Microsoft.DotNet.Common.ProjectTemplates.3.1) |
 | .NET 5.0         | [`Microsoft.DotNet.Common.ProjectTemplates.5.0`](https://www.nuget.org/packages/Microsoft.DotNet.Common.ProjectTemplates.5.0) |
 | .NET 6.0         | [`Microsoft.DotNet.Common.ProjectTemplates.6.0`](https://www.nuget.org/packages/Microsoft.DotNet.Common.ProjectTemplates.6.0) |
+| .NET 7.0         | [`Microsoft.DotNet.Common.ProjectTemplates.7.0`](https://www.nuget.org/packages/Microsoft.DotNet.Common.ProjectTemplates.7.0) |
 | ASP.NET Core 2.1 | [`Microsoft.DotNet.Web.ProjectTemplates.2.1`](https://www.nuget.org/packages/Microsoft.DotNet.Web.ProjectTemplates.2.1)       |
 | ASP.NET Core 2.2 | [`Microsoft.DotNet.Web.ProjectTemplates.2.2`](https://www.nuget.org/packages/Microsoft.DotNet.Web.ProjectTemplates.2.2)       |
 | ASP.NET Core 3.0 | [`Microsoft.DotNet.Web.ProjectTemplates.3.0`](https://www.nuget.org/packages/Microsoft.DotNet.Web.ProjectTemplates.3.0)       |
 | ASP.NET Core 3.1 | [`Microsoft.DotNet.Web.ProjectTemplates.3.1`](https://www.nuget.org/packages/Microsoft.DotNet.Web.ProjectTemplates.3.1)       |
 | ASP.NET Core 5.0 | [`Microsoft.DotNet.Web.ProjectTemplates.5.0`](https://www.nuget.org/packages/Microsoft.DotNet.Web.ProjectTemplates.5.0)       |
 | ASP.NET Core 6.0 | [`Microsoft.DotNet.Web.ProjectTemplates.6.0`](https://www.nuget.org/packages/Microsoft.DotNet.Web.ProjectTemplates.6.0)       |
+| ASP.NET Core 7.0 | [`Microsoft.DotNet.Web.ProjectTemplates.7.0`](https://www.nuget.org/packages/Microsoft.DotNet.Web.ProjectTemplates.7.0)       |
 
 For example, the .NET 7 SDK includes templates for a console app targeting .NET 7. If you wanted to target .NET Core 3.1, you would need to install the 3.1 template package.
 
@@ -199,7 +201,7 @@ For example, the .NET 7 SDK includes templates for a console app targeting .NET 
 
     If you see an error message, you need to install the templates.
 
-01. Install the .NET Core 3.0 project templates.
+01. Install the .NET Core 3.1 project templates.
 
     ```dotnetcli
     dotnet new install Microsoft.DotNet.Common.ProjectTemplates.3.1


### PR DESCRIPTION
## Summary

- Removed RHEL 7 .NET Core 3.1 instructions
- Tweaks to a few examples that had too many references to unsupported versions
- Other minor changes related to 3.1

@davidbritch Please review