### PR TITLE
Fix Orleans samples links

### DIFF
--- a/docs/orleans/tutorials-and-samples/index.md
+++ b/docs/orleans/tutorials-and-samples/index.md
@@ -166,7 +166,7 @@ They include an interactive counter, a TODO list, and a Weather service.
 * How to integrate ASP.NET Core Blazor Server with Orleans
 * How to integrate ASP.NET Core Blazor WebAssembly (WASM) with Orleans
 
-## [Stocks](/samples/dotnet/samples/orleans-streaming-samples)
+## [Stocks](/samples/dotnet/samples/orleans-stocks-sample-app)
 
 :::image type="content" source="https://raw.githubusercontent.com/dotnet/samples/main/orleans/Stocks/screenshot.png" alt-text="Output from the running Stocks client sample Orleans app.":::
 

--- a/docs/orleans/tutorials-and-samples/index.md
+++ b/docs/orleans/tutorials-and-samples/index.md
@@ -180,7 +180,7 @@ A stock price application that fetches prices from a remote service using an HTT
 
 ## [Transport Layer Security](/samples/dotnet/samples/orleans-transport-layer-security-tls)
 
-:::image type="content" source="https://github.com/dotnet/samples/blob/main/orleans/TransportLayerSecurity/screenshot.png" alt-text="Output from the running TLS sample Orleans app.":::
+:::image type="content" source="https://raw.githubusercontent.com/dotnet/samples/main/orleans/TransportLayerSecurity/screenshot.png" alt-text="Output from the running TLS sample Orleans app.":::
 
 A *Hello, World!* application configured to use mutual [*Transport Layer Security*](https://en.wikipedia.org/wiki/Transport_Layer_Security) to secure network communication between every server.
 


### PR DESCRIPTION
* Updated the image source of the TLS screenshot to point to the correct URL
* Fix the link to the Stocks sample app