### PR TITLE
Update publishing article to remove out-of-date versions and clarify cross-plat

### DIFF
--- a/docs/core/deploying/index.md
+++ b/docs/core/deploying/index.md
@@ -1,7 +1,7 @@
 ---
 title: Application publishing
 description: Learn about the ways to publish a .NET application. .NET can publish platform-specific or cross-platform apps. You can publish an app as self-contained or as framework-dependent. Each mode affects how a user runs your app.
-ms.date: 03/30/2022
+ms.date: 12/23/2022
 ---
 # .NET application publishing overview
 
@@ -17,26 +17,26 @@ When an executable is produced, you can specify the target platform with a runti
 
 The following table outlines the commands used to publish an app as framework-dependent or self-contained, per SDK version:
 
-| Type                                                                                     | SDK 2.1 | SDK 3.1 | SDK 5.0 | SDK 6.0 | Command |
-| ---------------------------------------------------------------------------------------  | ------- | ------- | ------- | ------- | ------- |
-| [framework-dependent executable](#publish-framework-dependent) for the current platform. |         | ✔️      | ✔️      |  ✔️     | [`dotnet publish`](../tools/dotnet-publish.md) |
-| [framework-dependent executable](#publish-framework-dependent) for a specific platform.  |         | ✔️      | ✔️      |  ✔️     | [`dotnet publish -r <RID> --self-contained false`](../tools/dotnet-publish.md) |
-| [framework-dependent cross-platform binary](#publish-framework-dependent).               | ✔️      | ✔️      | ✔️      |  ✔️     | [`dotnet publish`](../tools/dotnet-publish.md) |
-| [self-contained executable](#publish-self-contained).                                    | ✔️      | ✔️      | ✔️      |  ✔️     | [`dotnet publish -r <RID>`](../tools/dotnet-publish.md) |
+| Type                                                                                     | Command                                                                        |
+|------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------|
+| [framework-dependent executable](#publish-framework-dependent) for the current platform. | [`dotnet publish`](../tools/dotnet-publish.md)                                 |
+| [framework-dependent executable](#publish-framework-dependent) for a specific platform.  | [`dotnet publish -r <RID> --self-contained false`](../tools/dotnet-publish.md) |
+| [framework-dependent binary](#publish-framework-dependent).                              | [`dotnet publish`](../tools/dotnet-publish.md)                                 |
+| [self-contained executable](#publish-self-contained).                                    | [`dotnet publish -r <RID>`](../tools/dotnet-publish.md)                        |
 
 For more information, see [.NET dotnet publish command](../tools/dotnet-publish.md).
 
 ## Produce an executable
 
-Executables aren't cross-platform. They're specific to an operating system and CPU architecture. When publishing your app and creating an executable, you can publish the app as [self-contained](#publish-self-contained) or [framework-dependent](#publish-framework-dependent). Publishing an app as self-contained includes the .NET runtime with the app, and users of the app don't have to worry about installing .NET before running the app. Apps published as framework-dependent don't include the .NET runtime and libraries; only the app and 3rd-party dependencies are included.
+Executables aren't cross-platform, they're specific to an operating system and CPU architecture. When publishing your app and creating an executable, you can publish the app as [self-contained](#publish-self-contained) or [framework-dependent](#publish-framework-dependent). Publishing an app as self-contained includes the .NET runtime with the app, and users of the app don't have to worry about installing .NET before running the app. Publishing an app as framework-dependent doesn't include the .NET runtime; only the app and 3rd-party dependencies are included.
 
 The following commands produce an executable:
 
-| Type                                                                                     | SDK 2.1 | SDK 3.1 | SDK 5.0 | SDK 6.0 | Command |
-| ---------------------------------------------------------------------------------------- | ------- | ------- | ------- | ------- | ------- |
-| [framework-dependent executable](#publish-framework-dependent) for the current platform. |         | ✔️      | ✔️      |  ✔️   |  [`dotnet publish`](../tools/dotnet-publish.md) |
-| [framework-dependent executable](#publish-framework-dependent) for a specific platform.  |         | ✔️      | ✔️      |  ✔️   |  [`dotnet publish -r <RID> --self-contained false`](../tools/dotnet-publish.md) |
-| [self-contained executable](#publish-self-contained).                                    | ✔️      | ✔️      | ✔️      |  ✔️   |  [`dotnet publish -r <RID>`](../tools/dotnet-publish.md) |
+| Type                                                                                     | Command |
+| ---------------------------------------------------------------------------------------- | ------- |
+| [framework-dependent executable](#publish-framework-dependent) for the current platform. |  [`dotnet publish`](../tools/dotnet-publish.md) |
+| [framework-dependent executable](#publish-framework-dependent) for a specific platform.  |  [`dotnet publish -r <RID> --self-contained false`](../tools/dotnet-publish.md) |
+| [self-contained executable](#publish-self-contained).                                    |  [`dotnet publish -r <RID>`](../tools/dotnet-publish.md) |
 
 ## Produce a cross-platform binary
 
@@ -46,22 +46,25 @@ Cross-platform binaries can be run on any operating system as long as the target
 
 The following command produces a cross-platform binary:
 
-| Type                                                                                 | SDK 2.1 | SDK 3.x | SDK 5.0 | SDK 6.0 | Command |
-| -----------------------------------------------------------------------------------  | ------- | ------- | ------- | ------- | ------- |
-| [framework-dependent cross-platform binary](#publish-framework-dependent).           | ✔️      | ✔️      | ✔️      | ✔️      | [`dotnet publish`](../tools/dotnet-publish.md) |
+| Type                                                                                | Command |
+| ----------------------------------------------------------------------------------- | ------- |
+| [framework-dependent cross-platform binary](#publish-framework-dependent).          | [`dotnet publish`](../tools/dotnet-publish.md) |
 
 ## Publish framework-dependent
 
 Apps published as framework-dependent are cross-platform and don't include the .NET runtime. The user of your app is required to install the .NET runtime.
 
-Publishing an app as framework-dependent produces a [cross-platform binary](#produce-a-cross-platform-binary) as a *dll* file, and a [platform-specific executable](#produce-an-executable) that targets your current platform. The *dll* is cross-platform while the executable isn't. For example, if you publish an app named **word_reader** and target Windows, a *word_reader.exe* executable is created along with *word_reader.dll*. When targeting Linux or macOS, a *word_reader* executable is created along with *word_reader.dll*. For more information about RIDs, see [.NET RID Catalog](../rid-catalog.md).
+Publishing an app as framework-dependent produces a [cross-platform binary](#produce-a-cross-platform-binary) as a *dll* file, and a [platform-specific executable](#produce-an-executable) that targets your current platform. The *dll* is cross-platform while the executable isn't. For example, if you publish an app named **word_reader** and target Windows, a *word_reader.exe* executable is created along with *word_reader.dll*. When targeting Linux or macOS, a *word_reader* executable is created along with *word_reader.dll*. If the app uses a NuGet package that has platform-specific implementations, all platforms' dependencies are copied to the *publish\\runtimes\\{platform}* folder.
 
-> [!IMPORTANT]
-> .NET SDK 2.1 doesn't produce platform-specific executables when you publish an app framework-dependent.
+The cross-platform binary of your app can be run with the `dotnet <filename.dll>` command, and can be run on any platform.
 
-The cross-platform binary of your app can be run with the `dotnet <filename.dll>` command, and can be run on any platform. If the app uses a NuGet package that has platform-specific implementations, all platforms' dependencies are copied to the publish folder along with the app.
+### Platform-specific framework-dependent
 
-You can create an executable for a specific platform by passing the `-r <RID> --self-contained false` parameters to the [`dotnet publish`](../tools/dotnet-publish.md) command. When the `-r` parameter is omitted, an executable is created for your current platform. Any NuGet packages that have platform-specific dependencies for the targeted platform are copied to the publish folder. If you don't need a platform-specific executable, you can specify `<UseAppHost>False</UseAppHost>` in the project file. For more information, see [MSBuild reference for .NET SDK projects](../project-sdk/msbuild-props.md#useapphost).
+You can publish a framework-dependent app that is platform-specific by passing the `-r <RID> --self-contained false` parameters to the [`dotnet publish`](../tools/dotnet-publish.md) command. Publishing in this way is the same as [publish framework-dependent](#publish-framework-dependent), except that platform-specific dependencies are handled differently. If the app uses a NuGet package that has platform-specific implementations, only the targeted platform's dependencies are copied. These dependencies are copied directly to the *publish* folder.
+
+While technically the binary produced is cross-platform, by targeting a specific platform, your app isn't guaranteed to run cross-platform. So you can run `dotnet <filename.dll>`, but the app may crash once it tries to access platform-specific dependencies that are missing.
+
+For more information about RIDs, see [.NET RID Catalog](../rid-catalog.md).
 
 ### Advantages
 
@@ -82,20 +85,15 @@ Your app can run only if the version of .NET your app targets is already install
 - **.NET may change**\
 It's possible for the .NET runtime and libraries to be updated on the machine where the app is run. In rare cases, this may change the behavior of your app if you use the .NET libraries, which most apps do. You can configure how your app uses newer versions of .NET. For more information, see [framework-dependent apps roll forward](../versions/selection.md#framework-dependent-apps-roll-forward).
 
-The following disadvantage only applies to .NET Core 2.1 SDK.
-
-- **Use the `dotnet` command to start the app**\
-Users must run the `dotnet <filename.dll>` command to start your app. .NET Core 2.1 SDK doesn't produce platform-specific executables for apps published framework-dependent.
-
 ### Examples
 
-Publish an app cross-platform framework-dependent. An executable that targets your current platform is created along with the *dll* file.
+Publish an app cross-platform framework-dependent. An executable that targets your current platform is created along with the *dll* file. Any platform-specific dependencies are published with the app.
 
 ```dotnetcli
 dotnet publish
 ```
 
-Publish an app cross-platform framework-dependent. A Linux 64-bit executable is created along with the *dll* file. This command doesn't work with .NET Core SDK 2.1.
+Publish an app platform-specific framework-dependent. A Linux 64-bit executable is created along with the *dll* file. Only the targeted platform's dependencies are published with the app.
 
 ```dotnetcli
 dotnet publish -r linux-x64 --self-contained false
@@ -147,7 +145,7 @@ dotnet publish -r win-x64
 
 ## Publish with ReadyToRun images
 
-Publishing with ReadyToRun images will improve the startup time of your application at the cost of increasing the size of your application. In order to publish with ReadyToRun see [ReadyToRun](ready-to-run.md) for more details.
+Publishing with ReadyToRun images will improve the startup time of your application at the cost of increasing the size of your application. For more information, see [ReadyToRun](ready-to-run.md).
 
 ### Advantages
 

--- a/docs/core/deploying/index.md
+++ b/docs/core/deploying/index.md
@@ -15,7 +15,7 @@ Both publishing modes produce a platform-specific executable by default. Framewo
 
 When an executable is produced, you can specify the target platform with a runtime identifier (RID). For more information about RIDs, see [.NET RID Catalog](../rid-catalog.md).
 
-The following table outlines the commands used to publish an app as framework-dependent or self-contained, per SDK version:
+The following table outlines the commands used to publish an app as framework-dependent or self-contained:
 
 | Type                                                                                     | Command                                                                        |
 |------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------|
@@ -28,7 +28,7 @@ For more information, see [.NET dotnet publish command](../tools/dotnet-publish.
 
 ## Produce an executable
 
-Executables aren't cross-platform, they're specific to an operating system and CPU architecture. When publishing your app and creating an executable, you can publish the app as [self-contained](#publish-self-contained) or [framework-dependent](#publish-framework-dependent). Publishing an app as self-contained includes the .NET runtime with the app, and users of the app don't have to worry about installing .NET before running the app. Publishing an app as framework-dependent doesn't include the .NET runtime; only the app and 3rd-party dependencies are included.
+Executables aren't cross-platform, they're specific to an operating system and CPU architecture. When publishing your app and creating an executable, you can publish the app as [self-contained](#publish-self-contained) or [framework-dependent](#publish-framework-dependent). Publishing an app as self-contained includes the .NET runtime with the app, and users of the app don't have to worry about installing .NET before running the app. Publishing an app as framework-dependent doesn't include the .NET runtime; only the app and third-party dependencies are included.
 
 The following commands produce an executable:
 
@@ -54,15 +54,15 @@ The following command produces a cross-platform binary:
 
 Apps published as framework-dependent are cross-platform and don't include the .NET runtime. The user of your app is required to install the .NET runtime.
 
-Publishing an app as framework-dependent produces a [cross-platform binary](#produce-a-cross-platform-binary) as a *dll* file, and a [platform-specific executable](#produce-an-executable) that targets your current platform. The *dll* is cross-platform while the executable isn't. For example, if you publish an app named **word_reader** and target Windows, a *word_reader.exe* executable is created along with *word_reader.dll*. When targeting Linux or macOS, a *word_reader* executable is created along with *word_reader.dll*. If the app uses a NuGet package that has platform-specific implementations, all platforms' dependencies are copied to the *publish\\runtimes\\{platform}* folder.
+Publishing an app as framework-dependent produces a [cross-platform binary](#produce-a-cross-platform-binary) as a *dll* file, and a [platform-specific executable](#produce-an-executable) that targets your current platform. The *dll* is cross-platform while the executable isn't. For example, if you publish an app named **word_reader** and target Windows, a *word_reader.exe* executable is created along with *word_reader.dll*. When targeting Linux or macOS, a *word_reader* executable is created along with *word_reader.dll*. If the app uses a NuGet package that has platform-specific implementations, dependencies for all platforms are copied to the *publish\\runtimes\\{platform}* folder.
 
 The cross-platform binary of your app can be run with the `dotnet <filename.dll>` command, and can be run on any platform.
 
-### Platform-specific framework-dependent
+### Platform-specific and framework-dependent
 
-You can publish a framework-dependent app that is platform-specific by passing the `-r <RID> --self-contained false` parameters to the [`dotnet publish`](../tools/dotnet-publish.md) command. Publishing in this way is the same as [publish framework-dependent](#publish-framework-dependent), except that platform-specific dependencies are handled differently. If the app uses a NuGet package that has platform-specific implementations, only the targeted platform's dependencies are copied. These dependencies are copied directly to the *publish* folder.
+You can publish a framework-dependent app that's platform-specific by passing the `-r <RID> --self-contained false` parameters to the [`dotnet publish`](../tools/dotnet-publish.md) command. Publishing in this way is the same as [publish framework-dependent](#publish-framework-dependent), except that platform-specific dependencies are handled differently. If the app uses a NuGet package that has platform-specific implementations, only the targeted platform's dependencies are copied. These dependencies are copied directly to the *publish* folder.
 
-While technically the binary produced is cross-platform, by targeting a specific platform, your app isn't guaranteed to run cross-platform. So you can run `dotnet <filename.dll>`, but the app may crash once it tries to access platform-specific dependencies that are missing.
+While technically the binary produced is cross-platform, by targeting a specific platform, your app isn't guaranteed to run cross-platform. You can run `dotnet <filename.dll>`, but the app may crash when it tries to access platform-specific dependencies that are missing.
 
 For more information about RIDs, see [.NET RID Catalog](../rid-catalog.md).
 
@@ -87,13 +87,13 @@ It's possible for the .NET runtime and libraries to be updated on the machine wh
 
 ### Examples
 
-Publish an app cross-platform framework-dependent. An executable that targets your current platform is created along with the *dll* file. Any platform-specific dependencies are published with the app.
+Publish an app as cross-platform and framework-dependent. An executable that targets your current platform is created along with the *dll* file. Any platform-specific dependencies are published with the app.
 
 ```dotnetcli
 dotnet publish
 ```
 
-Publish an app platform-specific framework-dependent. A Linux 64-bit executable is created along with the *dll* file. Only the targeted platform's dependencies are published with the app.
+Publish an app as platform-specific and framework-dependent. A Linux 64-bit executable is created along with the *dll* file. Only the targeted platform's dependencies are published with the app.
 
 ```dotnetcli
 dotnet publish -r linux-x64 --self-contained false
@@ -145,7 +145,7 @@ dotnet publish -r win-x64
 
 ## Publish with ReadyToRun images
 
-Publishing with ReadyToRun images will improve the startup time of your application at the cost of increasing the size of your application. For more information, see [ReadyToRun](ready-to-run.md).
+Publishing with ReadyToRun images improves the startup time of your application at the cost of increasing the size of your application. For more information, see [ReadyToRun](ready-to-run.md).
 
 ### Advantages
 


### PR DESCRIPTION
## Summary

- Remove old versions from the table. Considering the commands have been stable for the last 3 versions, there isn't a point in calling it out anymore.
- Clarified the example used (the issue that generated this PR)
- Clarified the descriptions of framework-dependent publishing when a platform is specified.

[Internal preview](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/?branch=pr-en-us-33193)

Fixes #31964
