### PR TITLE
Correct parameter name in code snippet

### DIFF
--- a/docs/standard/asynchronous-programming-patterns/consuming-the-task-based-asynchronous-pattern.md
+++ b/docs/standard/asynchronous-programming-patterns/consuming-the-task-based-asynchronous-pattern.md
@@ -725,7 +725,7 @@ public class AsyncCache<TKey, TValue>
 
     public AsyncCache(Func<TKey, Task<TValue>> valueFactory)
     {
-        if (valueFactory == null) throw new ArgumentNullException("loader");
+        if (valueFactory == null) throw new ArgumentNullException("valueFactory");
         _valueFactory = valueFactory;
         _map = new ConcurrentDictionary<TKey, Lazy<Task<TValue>>>();
     }


### PR DESCRIPTION
## Summary

Fixed typo in parameter name in code snippet.

Fixes #33097 