### PR TITLE
Add how to for DateOnly and TimeOnly

### DIFF
--- a/docs/standard/datetime/choosing-between-datetime.md
+++ b/docs/standard/datetime/choosing-between-datetime.md
@@ -1,6 +1,6 @@
 ---
-title: Compare DateTime, DateTimeOffset, TimeSpan, and TimeZoneInfo
-description: Learn about differences between the DateTime, DateTimeOffset, TimeSpan, and TimeZoneInfo types to represent date and time information in .NET.
+title: Compare types related to date and time
+description: Learn about differences between the DateTime, DateOnly, DateTimeOffset, TimeSpan, TimeOnly and TimeZoneInfo types to represent date and time information in .NET.
 ms.date: "04/10/2017"
 dev_langs: 
   - "csharp"
@@ -14,7 +14,7 @@ helpviewer_keywords:
   - "DateTime structure"
 ms.assetid: 07f17aad-3571-4014-9ef3-b695a86f3800
 ---
-# Choose between DateTime, DateTimeOffset, TimeSpan, and TimeZoneInfo
+# Choose between DateTime, DateOnly, DateTimeOffset, TimeSpan, TimeOnly, and TimeZoneInfo
 
 .NET applications can use date and time information in several ways. The more common uses of date and time information include:
 
@@ -32,7 +32,7 @@ ms.assetid: 07f17aad-3571-4014-9ef3-b695a86f3800
 
 - To perform date and time arithmetic, possibly with a result that uniquely and unambiguously identifies a single point in time.
 
-.NET includes the <xref:System.DateTime>, <xref:System.DateTimeOffset>, <xref:System.TimeSpan>, and <xref:System.TimeZoneInfo> types, all of which can be used to build applications that work with dates and times.
+.NET includes the <xref:System.DateTime>, <xref:System.DateOnly>, <xref:System.DateTimeOffset>, <xref:System.TimeSpan>, <xref:System.TimeOnly>, and <xref:System.TimeZoneInfo> types, all of which can be used to build applications that work with dates and times.
 
 > [!NOTE]
 > This topic doesn't discuss <xref:System.TimeZone> because its functionality is almost entirely incorporated in the <xref:System.TimeZoneInfo> class. Whenever possible, use the <xref:System.TimeZoneInfo> class instead of the <xref:System.TimeZone> class.

--- a/docs/standard/datetime/choosing-between-datetime.md
+++ b/docs/standard/datetime/choosing-between-datetime.md
@@ -86,15 +86,15 @@ Unless a particular <xref:System.DateTime> value represents UTC, that date and t
 
 ## The DateOnly structure
 
-The <xref:System.DateOnly> structure represents the specific date, without time. Since it has no time component, it represents a date from the start of the day to the end of the day. This structure is ideal for storing specific dates, such as a birth date, anniversary date, or business-related dates.
+The <xref:System.DateOnly> structure represents a specific date, without time. Since it has no time component, it represents a date from the start of the day to the end of the day. This structure is ideal for storing specific dates, such as a birth date, an anniversary date, or business-related dates.
 
-You may wonder why you shouldn't just use `DateTime` while ignoring the time component. There are a few benefits to using `DateOnly` over `DateTime`:
+Although you could use `DateTime` while ignoring the time component, there are a few benefits to using `DateOnly` over `DateTime`:
 
-- The `DateTime` structure may roll into the previous or next day if it's offset by a timezone. `DateOnly` can't be offset by a timezone, and it always represents the date that was set.
+- The `DateTime` structure may roll into the previous or next day if it's offset by a time zone. `DateOnly` can't be offset by a time zone, and it always represents the date that was set.
 
 - Serializing a `DateTime` structure includes the time component, which may obscure the intent of the data. Also, `DateOnly` serializes less data.
 
-- When code interacts with a database, such as SQL Server, whole dates are generally stored as the **date** data type, which doesn't include a time. `DateOnly` is better matched to the database's type.
+- When code interacts with a database, such as SQL Server, whole dates are generally stored as the `date` data type, which doesn't include a time. `DateOnly` matches the database type better.
 
 For more information about `DateOnly`, see [How to use the DateOnly and TimeOnly structures](how-to-use-dateonly-timeonly.md).
 
@@ -123,15 +123,15 @@ The `StoreInfo` structure can then be used by client code like the following.
 
 ## The TimeOnly structure
 
-The <xref:System.TimeOnly> structure represents a time-of-day value, such as an alarm for when to wake up a daily wake up time or what time you eat lunch each day. `TimeOnly` is limited to range of **00:00:00.0000000** to **23:59:59.9999999**, a specific time of day.
+The <xref:System.TimeOnly> structure represents a time-of-day value, such as a daily alarm clock or what time you eat lunch each day. `TimeOnly` is limited to the range of **00:00:00.0000000** - **23:59:59.9999999**, a specific time of day.
 
-Prior to the `TimeOnly` type being introduced, programmers typically used either the <xref:System.DateTime> structure or the <xref:System.TimeSpan> structure to represent a specific time. However, using these structures to simulate a "time only" structure has some drawbacks, which `TimeOnly` solves:
+Prior to the `TimeOnly` type being introduced, programmers typically used either the <xref:System.DateTime> type or the <xref:System.TimeSpan> type to represent a specific time. However, using these structures to simulate a time without a date may introduce some problems, which `TimeOnly` solves:
 
-- `TimeSpan` represents elapsed time, such as time measured with a stopwatch. The upper range is more than 29,000 years, and its value can be negative to indicate moving backwards in time.
+- `TimeSpan` represents elapsed time, such as time measured with a stopwatch. The upper range is more than 29,000 years, and its value can be negative to indicate moving backwards in time. A negative `TimeSpan` doesn't indicate a specific time of the day.
 
 - If `TimeSpan` is used as a time of day, there's a risk that it could be manipulated to a value outside of the 24-hour day. `TimeOnly` doesn't have this risk. For example, if an employee's work shift starts at 18:00 and lasts for 8 hours, adding 8 hours to the `TimeOnly` structure rolls over to 2:00
 
-- Using `DateTime` for a time of day, requires that an arbitrary date be associated with the time, and later disregarded. It's common practice to choose `DateTime.MinValue` (0001-01-01) as the date, however, if hours are subtracted from the `DateTime` value, an `OutOfRange` exception may occur. `TimeOnly` doesn't have this problem as the time rolls forwards and backwards around the 24-hour time span.
+- Using `DateTime` for a time of day requires that an arbitrary date be associated with the time, and then later disregarded. It's common practice to choose `DateTime.MinValue` (0001-01-01) as the date, however, if hours are subtracted from the `DateTime` value, an `OutOfRange` exception might occur. `TimeOnly` doesn't have this problem as the time rolls forwards and backwards around the 24-hour timeframe.
 
 - Serializing a `DateTime` structure includes the date component, which may obscure the intent of the data. Also, `TimeOnly` serializes less data.
 

--- a/docs/standard/datetime/choosing-between-datetime.md
+++ b/docs/standard/datetime/choosing-between-datetime.md
@@ -1,6 +1,6 @@
 ---
 title: Compare types related to date and time
-description: Learn about differences between the DateTime, DateOnly, DateTimeOffset, TimeSpan, TimeOnly and TimeZoneInfo types to represent date and time information in .NET.
+description: Learn about differences between the DateTime, DateOnly, DateTimeOffset, TimeSpan, TimeOnly, and TimeZoneInfo types to represent date and time information in .NET.
 ms.date: "04/10/2017"
 dev_langs: 
   - "csharp"

--- a/docs/standard/datetime/choosing-between-datetime.md
+++ b/docs/standard/datetime/choosing-between-datetime.md
@@ -84,6 +84,23 @@ Unless a particular <xref:System.DateTime> value represents UTC, that date and t
 > [!IMPORTANT]
 > When saving or sharing <xref:System.DateTime> data, UTC should be used and the <xref:System.DateTime> value's <xref:System.DateTime.Kind%2A> property should be set to <xref:System.DateTimeKind.Utc?displayProperty=nameWithType>.
 
+## The DateOnly structure
+
+The <xref:System.DateOnly> structure represents the specific date, without time. Since it has no time component, it represents a date from the start of the day to the end of the day. This structure is ideal for storing specific dates, such as a birth date, anniversary date, or business-related dates.
+
+You may wonder why you shouldn't just use `DateTime` while ignoring the time component. There are a few benefits to using `DateOnly` over `DateTime`:
+
+- The `DateTime` structure may roll into the previous or next day if it's offset by a timezone. `DateOnly` can't be offset by a timezone, and it always represents the date that was set.
+
+- Serializing a `DateTime` structure includes the time component, which may obscure the intent of the data. Also, `DateOnly` serializes less data.
+
+- When code interacts with a database, such as SQL Server, whole dates are generally stored as the **date** data type, which doesn't include a time. `DateOnly` is better matched to the database's type.
+
+For more information about `DateOnly`, see [How to use the DateOnly and TimeOnly structures](how-to-use-dateonly-timeonly.md).
+
+> [!IMPORTANT]
+> `DateOnly` isn't available in .NET Framework.
+
 ## The TimeSpan structure
 
 The <xref:System.TimeSpan> structure represents a time interval. Its two typical uses are:
@@ -103,6 +120,25 @@ The `StoreInfo` structure can then be used by client code like the following.
 
 [!code-csharp[Conceptual.ChoosingDates#2](../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.choosingdates/cs/datetimereplacement1.cs#2)]
 [!code-vb[Conceptual.ChoosingDates#2](../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.choosingdates/vb/datetimereplacement1.vb#2)]
+
+## The TimeOnly structure
+
+The <xref:System.TimeOnly> structure represents a time-of-day value, such as an alarm for when to wake up a daily wake up time or what time you eat lunch each day. `TimeOnly` is limited to range of **00:00:00.0000000** to **23:59:59.9999999**, a specific time of day.
+
+Prior to the `TimeOnly` type being introduced, programmers typically used either the <xref:System.DateTime> structure or the <xref:System.TimeSpan> structure to represent a specific time. However, using these structures to simulate a "time only" structure has some drawbacks, which `TimeOnly` solves:
+
+- `TimeSpan` represents elapsed time, such as time measured with a stopwatch. The upper range is more than 29,000 years, and its value can be negative to indicate moving backwards in time.
+
+- If `TimeSpan` is used as a time of day, there's a risk that it could be manipulated to a value outside of the 24-hour day. `TimeOnly` doesn't have this risk. For example, if an employee's work shift starts at 18:00 and lasts for 8 hours, adding 8 hours to the `TimeOnly` structure rolls over to 2:00
+
+- Using `DateTime` for a time of day, requires that an arbitrary date be associated with the time, and later disregarded. It's common practice to choose `DateTime.MinValue` (0001-01-01) as the date, however, if hours are subtracted from the `DateTime` value, an `OutOfRange` exception may occur. `TimeOnly` doesn't have this problem as the time rolls forwards and backwards around the 24-hour time span.
+
+- Serializing a `DateTime` structure includes the date component, which may obscure the intent of the data. Also, `TimeOnly` serializes less data.
+
+For more information about `TimeOnly`, see [How to use the DateOnly and TimeOnly structures](how-to-use-dateonly-timeonly.md).
+
+> [!IMPORTANT]
+> `TimeOnly` isn't available in .NET Framework.
 
 ## The TimeZoneInfo class
 

--- a/docs/standard/datetime/how-to-use-dateonly-timeonly.md
+++ b/docs/standard/datetime/how-to-use-dateonly-timeonly.md
@@ -1,0 +1,130 @@
+---
+title: How to use DateOnly and TimeOnly
+description: Learn about the DateOnly and TimeOnly structures. DateOnly and TimeOnly 
+ms.date: 12/28/2022
+dev_langs: 
+  - "csharp"
+  - "vb"
+helpviewer_keywords: 
+  - "DateOnly structure"
+  - "TimeOnly structure"
+  - "date and time classes [.NET]"
+---
+
+# How to use the DateOnly and TimeOnly structures
+
+The <xref:System.DateOnly> and <xref:System.TimeOnly> structures were introduced with .NET 6, and represent the specific component of a <xref:System.DateTime>. Prior to .NET 6, and always in .NET Framework, the <xref:System.DateTime> structure was used to represent a specific time, ignoring the date. Or you may have used that structure to represent the date, ignoring the time.
+
+> [!IMPORTANT]
+> <xref:System.DateOnly> and <xref:System.TimeOnly> structures aren't available in .NET Framework.
+
+## The DateOnly structure
+
+The <xref:System.DateOnly> structure represents the specific date, without time. Since it has no time component, it represents a date from the start of the day to the end of the day. This structure is ideal for storing specific dates, such as a birth date, anniversary date, or business-related dates.
+
+You may wonder why you shouldn't just use `DateTime` while ignoring the time component. There are a few benefits to using `DateOnly` over `DateTime`:
+
+- The `DateTime` structure may roll into the previous or next day if it's offset by a timezone. `DateOnly` can't be offset by a timezone, and it always represents the date that was set.
+
+- Serializing a `DateTime` structure includes the time component, which may obscure the intent of the data. Also, `DateOnly` serializes less data.
+
+- When code interacts with a database, such as SQL Server, whole dates are generally stored as the **date** data type, which doesn't include a time. `DateOnly` is better matched to the database's type.
+
+`DateOnly` has a range from 0001-01-01 through 9999-12-31, just like `DateTime`. You can specify a specific calendar in the `DateOnly` constructor. However, just like `DateTime`, a `DateOnly` object always represents a date in the proleptic Gregorian calendar, regardless of which calendar was used to construct it. For example, you can build the date from a Hebrew calendar:
+
+:::code language="csharp" source="./snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="hebrew":::
+
+Use the following examples to learn about `DateOnly`:
+
+- [Convert DateTime to DateOnly](#convert-datetime-to-dateonly)
+- [Add or subtract days, months, years](#add-or-subtract-days-months-years)
+- [Parse and format DateOnly](#parse-and-format-dateonly)
+- [Compare DateOnly](#compare-dateonly)
+
+### Convert DateTime to DateOnly
+
+Use the <xref:System.DateOnly.FromDateTime%2A?displayProperty=nameWithType> static method to create a `DateOnly` type from a `DateTime` type, as demonstrated in the following code:
+
+:::code language="csharp" source="./snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="today":::
+
+### Add or subtract days, months, years
+
+There are three methods used to adjust a <xref:System.DateOnly> structure: <xref:System.DateOnly.AddDays%2A>, <xref:System.DateOnly.AddMonths%2A>, and <xref:System.DateOnly.AddYears%2A>. Each method takes an integer parameter, and increases the date by that measurement. If a negative number is provided, the date is decreased by that measurement. A new instance of `DateOnly` is returned, as the structure is immutable.
+
+:::code language="csharp" source="./snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="date_adjust":::
+
+### Parse and format DateOnly
+
+<xref:System.DateOnly> can be parsed from a string, just like the <xref:System.DateTime> structure. All of the standard .NET date-based parsing tokens work with `DateOnly`. When converting a `DateOnly` type to a string, you can use standard .NET date-based formatting patterns too. For more information about formatting strings, see [Standard date and time format strings](../base-types/standard-date-and-time-format-strings.md).
+
+:::code language="csharp" source="./snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="parse":::
+
+### Compare DateOnly
+
+<xref:System.DateOnly> can be compared with other instances. For example, you can check if a date is before or after another, or if a date today matches a specific date.
+
+:::code language="csharp" source="./snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="date_compare":::
+
+## The TimeOnly structure
+
+The <xref:System.TimeOnly> structure represents a time-of-day value, such as an alarm for when to wake up a daily wake up time or what time you eat lunch each day. `TimeOnly` is limited to range of **00:00:00.0000000** to **23:59:59.9999999**, a specific time of day.
+
+Prior to the `TimeOnly` type being introduced, programmers typically used either the <xref:System.DateTime> structure or the <xref:System.TimeSpan> structure to represent a specific time. However, using these structures to simulate a "time only" structure has some drawbacks, which `TimeOnly` solves:
+
+- `TimeSpan` represents elapsed time, such as time measured with a stopwatch. The upper range is more than 29,000 years, and its value can be negative to indicate moving backwards in time.
+
+- If `TimeSpan` is used as a time of day, there's a risk that it could be manipulated to a value outside of the 24-hour day. `TimeOnly` doesn't have this risk. For example, if an employee's work shift starts at 18:00 and lasts for 8 hours, adding 8 hours to the `TimeOnly` structure rolls over to 2:00
+
+- Using `DateTime` for a time of day, requires that an arbitrary date be associated with the time, and later disregarded. It's common practice to choose `DateTime.MinValue` (0001-01-01) as the date, however, if hours are subtracted from the `DateTime` value, an `OutOfRange` exception may occur. `TimeOnly` doesn't have this problem as the time rolls forwards and backwards around the 24-hour time span.
+
+- Serializing a `DateTime` structure includes the date component, which may obscure the intent of the data. Also, `TimeOnly` serializes less data.
+
+Use the following examples to learn about `TimeOnly`:
+
+- [Convert DateTime to TimeOnly](#convert-datetime-to-timeonly)
+- [Add or subtract time](#add-or-subtract-time)
+- [Parse and format TimeOnly](#parse-and-format-timeonly)
+- [Work with TimeSpan and DateTime](#work-with-timespan-and-datetime)
+- [Arithmetic operators and comparing TimeOnly](#arithmetic-operators-and-comparing-timeonly)
+
+### Convert DateTime to TimeOnly
+
+Use the <xref:System.TimeOnly.FromDateTime%2A?displayProperty=nameWithType> static method to create a `TimeOnly` type from a `DateTime` type, as demonstrated in the following code:
+
+:::code language="csharp" source="./snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="time_now":::
+
+### Add or subtract time
+
+There are three methods used to adjust a <xref:System.TimeOnly> structure: <xref:System.TimeOnly.AddHours%2A>, <xref:System.TimeOnly.AddMinutes%2A>, and <xref:System.TimeOnly.Add%2A>. Both `AddHours` and `AddMinutes` take an integer parameter, and adjust the value accordingly. You can use a negative value to subtract and a positive value to add. A new instance of `TimeOnly` is returned, as the structure is immutable. The `Add` method takes a <xref:System.TimeSpan> parameter and adds or subtracts the value from the `TimeOnly` value.
+
+Because `TimeOnly` only represents a 24-hour period, it rolls over forwards or backwards appropriately when adding values supplied to those three methods. For example, if you use a value of `01:30:00` to represent 1:30 AM, then add -4 hours from that period, it rolls backwards to `21:30:00`, which is 9:30 PM. There are method overloads for `AddHours`, `AddMinutes`, and `Add`, which capture the number of days rolled over.
+
+:::code language="csharp" source="./snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="time_adjust":::
+
+### Parse and format TimeOnly
+
+<xref:System.TimeOnly> can be parsed from a string, just like the <xref:System.DateTime> structure. All of the standard .NET time-based parsing tokens work with `TimeOnly`. When converting a `TimeOnly` type to a string, you can use standard .NET date-based formatting patterns too. For more information about formatting strings, see [Standard date and time format strings](../base-types/standard-date-and-time-format-strings.md).
+
+:::code language="csharp" source="./snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="time_parse":::
+
+### Work with TimeSpan and DateTime
+
+<xref:System.TimeOnly> can be created from and converted to, a <xref:System.TimeSpan>. Also, `TimeOnly` can be used with a <xref:System.DateTime>, either to create the `TimeOnly` instance, or to create a `DateTime` instance as long as a date is provided.
+
+The following example creates a `TimeOnly` object from a `TimeSpan` and then converts it back:
+
+:::code language="csharp" source="./snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="time_timespan":::
+
+The following example creates a `DateTime` from a `TimeOnly` object, with an arbitrary date chosen:
+
+:::code language="csharp" source="./snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="time_datetime":::
+
+### Arithmetic operators and comparing TimeOnly
+
+Two <xref:System.TimeOnly> instances can be compared with one another, and the <xref:System.TimeOnly.IsBetween%2A> method can be used to check if a time is between two other times. When an addition or subtraction operator is used on a `TimeOnly`, a <xref:System.TimeSpan> is returned, representing a duration of time.
+
+:::code language="csharp" source="./snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="time_between":::
+
+## See also
+
+- [Dates, times, and time zones](index.md)

--- a/docs/standard/datetime/how-to-use-dateonly-timeonly.md
+++ b/docs/standard/datetime/how-to-use-dateonly-timeonly.md
@@ -13,7 +13,13 @@ helpviewer_keywords:
 
 # How to use the DateOnly and TimeOnly structures
 
-The <xref:System.DateOnly> and <xref:System.TimeOnly> structures were introduced with .NET 6, and represent the specific component of a <xref:System.DateTime>. Prior to .NET 6, and always in .NET Framework, the <xref:System.DateTime> structure was used to represent a specific time, ignoring the date. Or you may have used that structure to represent the date, ignoring the time.
+The <xref:System.DateOnly> and <xref:System.TimeOnly> structures were introduced with .NET 6, and represent either the date or time portion of a <xref:System.DateTime> structure. Prior to .NET 6, and always in .NET Framework, the <xref:System.DateTime> structure was used to represent one of the following:
+
+- A whole date and time.
+- A date, disregarding the time.
+- A time, disregarding the date.
+
+`DateOnly` and `TimeOnly` are types that represent those particular portions of a `DateTime` type.
 
 > [!IMPORTANT]
 > <xref:System.DateOnly> and <xref:System.TimeOnly> structures aren't available in .NET Framework.
@@ -22,7 +28,7 @@ The <xref:System.DateOnly> and <xref:System.TimeOnly> structures were introduced
 
 The <xref:System.DateOnly> structure represents the specific date, without time. Since it has no time component, it represents a date from the start of the day to the end of the day. This structure is ideal for storing specific dates, such as a birth date, anniversary date, or business-related dates.
 
-You may wonder why you shouldn't just use `DateTime` while ignoring the time component. There are a few benefits to using `DateOnly` over `DateTime`:
+Although you could use `DateTime` while ignoring the time component, there are a few benefits to using `DateOnly` over `DateTime`:
 
 - The `DateTime` structure may roll into the previous or next day if it's offset by a timezone. `DateOnly` can't be offset by a timezone, and it always represents the date that was set.
 
@@ -30,9 +36,10 @@ You may wonder why you shouldn't just use `DateTime` while ignoring the time com
 
 - When code interacts with a database, such as SQL Server, whole dates are generally stored as the **date** data type, which doesn't include a time. `DateOnly` is better matched to the database's type.
 
-`DateOnly` has a range from 0001-01-01 through 9999-12-31, just like `DateTime`. You can specify a specific calendar in the `DateOnly` constructor. However, just like `DateTime`, a `DateOnly` object always represents a date in the proleptic Gregorian calendar, regardless of which calendar was used to construct it. For example, you can build the date from a Hebrew calendar:
+`DateOnly` has a range from 0001-01-01 through 9999-12-31, just like `DateTime`. You can specify a specific calendar in the `DateOnly` constructor. However, a `DateOnly` object always represents a date in the proleptic Gregorian calendar, regardless of which calendar was used to construct it. For example, you can build the date from a Hebrew calendar, but the date is converted to Gregorian:
 
 :::code language="csharp" source="./snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="hebrew":::
+:::code language="vb" source="./snippets/how-to-use-dateonly-timeonly/vb/Program.vb" id="hebrew":::
 
 Use the following examples to learn about `DateOnly`:
 
@@ -46,32 +53,36 @@ Use the following examples to learn about `DateOnly`:
 Use the <xref:System.DateOnly.FromDateTime%2A?displayProperty=nameWithType> static method to create a `DateOnly` type from a `DateTime` type, as demonstrated in the following code:
 
 :::code language="csharp" source="./snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="today":::
+:::code language="vb" source="./snippets/how-to-use-dateonly-timeonly/vb/Program.vb" id="today":::
 
 ### Add or subtract days, months, years
 
 There are three methods used to adjust a <xref:System.DateOnly> structure: <xref:System.DateOnly.AddDays%2A>, <xref:System.DateOnly.AddMonths%2A>, and <xref:System.DateOnly.AddYears%2A>. Each method takes an integer parameter, and increases the date by that measurement. If a negative number is provided, the date is decreased by that measurement. A new instance of `DateOnly` is returned, as the structure is immutable.
 
 :::code language="csharp" source="./snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="date_adjust":::
+:::code language="vb" source="./snippets/how-to-use-dateonly-timeonly/vb/Program.vb" id="date_adjust":::
 
 ### Parse and format DateOnly
 
 <xref:System.DateOnly> can be parsed from a string, just like the <xref:System.DateTime> structure. All of the standard .NET date-based parsing tokens work with `DateOnly`. When converting a `DateOnly` type to a string, you can use standard .NET date-based formatting patterns too. For more information about formatting strings, see [Standard date and time format strings](../base-types/standard-date-and-time-format-strings.md).
 
 :::code language="csharp" source="./snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="parse":::
+:::code language="vb" source="./snippets/how-to-use-dateonly-timeonly/vb/Program.vb" id="parse":::
 
 ### Compare DateOnly
 
 <xref:System.DateOnly> can be compared with other instances. For example, you can check if a date is before or after another, or if a date today matches a specific date.
 
 :::code language="csharp" source="./snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="date_compare":::
+:::code language="vb" source="./snippets/how-to-use-dateonly-timeonly/vb/Program.vb" id="date_compare":::
 
 ## The TimeOnly structure
 
 The <xref:System.TimeOnly> structure represents a time-of-day value, such as an alarm for when to wake up a daily wake up time or what time you eat lunch each day. `TimeOnly` is limited to range of **00:00:00.0000000** to **23:59:59.9999999**, a specific time of day.
 
-Prior to the `TimeOnly` type being introduced, programmers typically used either the <xref:System.DateTime> structure or the <xref:System.TimeSpan> structure to represent a specific time. However, using these structures to simulate a "time only" structure has some drawbacks, which `TimeOnly` solves:
+Prior to the `TimeOnly` type being introduced, programmers typically used either the <xref:System.DateTime> structure or the <xref:System.TimeSpan> structure to represent a specific time. However, using these structures to simulate a "time only" structure may introduce some problems, which `TimeOnly` solves:
 
-- `TimeSpan` represents elapsed time, such as time measured with a stopwatch. The upper range is more than 29,000 years, and its value can be negative to indicate moving backwards in time.
+- `TimeSpan` represents elapsed time, such as time measured with a stopwatch. The upper range is more than 29,000 years, and its value can be negative to indicate moving backwards in time. A negative `TimeSpan` doesn't indicate a specific time of the day.
 
 - If `TimeSpan` is used as a time of day, there's a risk that it could be manipulated to a value outside of the 24-hour day. `TimeOnly` doesn't have this risk. For example, if an employee's work shift starts at 18:00 and lasts for 8 hours, adding 8 hours to the `TimeOnly` structure rolls over to 2:00
 
@@ -92,6 +103,7 @@ Use the following examples to learn about `TimeOnly`:
 Use the <xref:System.TimeOnly.FromDateTime%2A?displayProperty=nameWithType> static method to create a `TimeOnly` type from a `DateTime` type, as demonstrated in the following code:
 
 :::code language="csharp" source="./snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="time_now":::
+:::code language="vb" source="./snippets/how-to-use-dateonly-timeonly/vb/Program.vb" id="time_now":::
 
 ### Add or subtract time
 
@@ -100,12 +112,14 @@ There are three methods used to adjust a <xref:System.TimeOnly> structure: <xref
 Because `TimeOnly` only represents a 24-hour period, it rolls over forwards or backwards appropriately when adding values supplied to those three methods. For example, if you use a value of `01:30:00` to represent 1:30 AM, then add -4 hours from that period, it rolls backwards to `21:30:00`, which is 9:30 PM. There are method overloads for `AddHours`, `AddMinutes`, and `Add`, which capture the number of days rolled over.
 
 :::code language="csharp" source="./snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="time_adjust":::
+:::code language="vb" source="./snippets/how-to-use-dateonly-timeonly/vb/Program.vb" id="time_adjust":::
 
 ### Parse and format TimeOnly
 
 <xref:System.TimeOnly> can be parsed from a string, just like the <xref:System.DateTime> structure. All of the standard .NET time-based parsing tokens work with `TimeOnly`. When converting a `TimeOnly` type to a string, you can use standard .NET date-based formatting patterns too. For more information about formatting strings, see [Standard date and time format strings](../base-types/standard-date-and-time-format-strings.md).
 
 :::code language="csharp" source="./snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="time_parse":::
+:::code language="vb" source="./snippets/how-to-use-dateonly-timeonly/vb/Program.vb" id="time_parse":::
 
 ### Work with TimeSpan and DateTime
 
@@ -114,16 +128,19 @@ Because `TimeOnly` only represents a 24-hour period, it rolls over forwards or b
 The following example creates a `TimeOnly` object from a `TimeSpan` and then converts it back:
 
 :::code language="csharp" source="./snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="time_timespan":::
+:::code language="vb" source="./snippets/how-to-use-dateonly-timeonly/vb/Program.vb" id="time_timespan":::
 
 The following example creates a `DateTime` from a `TimeOnly` object, with an arbitrary date chosen:
 
 :::code language="csharp" source="./snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="time_datetime":::
+:::code language="vb" source="./snippets/how-to-use-dateonly-timeonly/vb/Program.vb" id="time_datetime":::
 
 ### Arithmetic operators and comparing TimeOnly
 
 Two <xref:System.TimeOnly> instances can be compared with one another, and the <xref:System.TimeOnly.IsBetween%2A> method can be used to check if a time is between two other times. When an addition or subtraction operator is used on a `TimeOnly`, a <xref:System.TimeSpan> is returned, representing a duration of time.
 
 :::code language="csharp" source="./snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="time_between":::
+:::code language="vb" source="./snippets/how-to-use-dateonly-timeonly/vb/Program.vb" id="time_between":::
 
 ## See also
 

--- a/docs/standard/datetime/how-to-use-dateonly-timeonly.md
+++ b/docs/standard/datetime/how-to-use-dateonly-timeonly.md
@@ -1,6 +1,6 @@
 ---
 title: How to use DateOnly and TimeOnly
-description: Learn about the DateOnly and TimeOnly structures. DateOnly and TimeOnly 
+description: Learn about the DateOnly and TimeOnly structures in .NET.
 ms.date: 12/28/2022
 dev_langs: 
   - "csharp"
@@ -13,7 +13,7 @@ helpviewer_keywords:
 
 # How to use the DateOnly and TimeOnly structures
 
-The <xref:System.DateOnly> and <xref:System.TimeOnly> structures were introduced with .NET 6, and represent either a specific date and time-of-day, respectively. Prior to .NET 6, and always in .NET Framework, the <xref:System.DateTime> type (or some other alternative) was used to represent one of the following:
+The <xref:System.DateOnly> and <xref:System.TimeOnly> structures were introduced with .NET 6 and represent a specific date or time-of-day, respectively. Prior to .NET 6, and always in .NET Framework, developers used the <xref:System.DateTime> type (or some other alternative) to represent one of the following:
 
 - A whole date and time.
 - A date, disregarding the time.
@@ -26,20 +26,22 @@ The <xref:System.DateOnly> and <xref:System.TimeOnly> structures were introduced
 
 ## The DateOnly structure
 
-The <xref:System.DateOnly> structure represents the specific date, without time. Since it has no time component, it represents a date from the start of the day to the end of the day. This structure is ideal for storing specific dates, such as a birth date, anniversary date, or business-related dates.
+The <xref:System.DateOnly> structure represents a specific date, without time. Since it has no time component, it represents a date from the start of the day to the end of the day. This structure is ideal for storing specific dates, such as a birth date, an anniversary date, or business-related dates.
 
 Although you could use `DateTime` while ignoring the time component, there are a few benefits to using `DateOnly` over `DateTime`:
 
-- The `DateTime` structure may roll into the previous or next day if it's offset by a timezone. `DateOnly` can't be offset by a timezone, and it always represents the date that was set.
+- The `DateTime` structure may roll into the previous or next day if it's offset by a time zone. `DateOnly` can't be offset by a time zone, and it always represents the date that was set.
 
 - Serializing a `DateTime` structure includes the time component, which may obscure the intent of the data. Also, `DateOnly` serializes less data.
 
-- When code interacts with a database, such as SQL Server, whole dates are generally stored as the **date** data type, which doesn't include a time. `DateOnly` is better matched to the database's type.
+- When code interacts with a database, such as SQL Server, whole dates are generally stored as the `date` data type, which doesn't include a time. `DateOnly` matches the database type better.
 
 `DateOnly` has a range from 0001-01-01 through 9999-12-31, just like `DateTime`. You can specify a specific calendar in the `DateOnly` constructor. However, a `DateOnly` object always represents a date in the proleptic Gregorian calendar, regardless of which calendar was used to construct it. For example, you can build the date from a Hebrew calendar, but the date is converted to Gregorian:
 
 :::code language="csharp" source="./snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="hebrew":::
 :::code language="vb" source="./snippets/how-to-use-dateonly-timeonly/vb/Program.vb" id="hebrew":::
+
+## DateOnly examples
 
 Use the following examples to learn about `DateOnly`:
 
@@ -57,7 +59,7 @@ Use the <xref:System.DateOnly.FromDateTime%2A?displayProperty=nameWithType> stat
 
 ### Add or subtract days, months, years
 
-There are three methods used to adjust a <xref:System.DateOnly> structure: <xref:System.DateOnly.AddDays%2A>, <xref:System.DateOnly.AddMonths%2A>, and <xref:System.DateOnly.AddYears%2A>. Each method takes an integer parameter, and increases the date by that measurement. If a negative number is provided, the date is decreased by that measurement. A new instance of `DateOnly` is returned, as the structure is immutable.
+There are three methods used to adjust a <xref:System.DateOnly> structure: <xref:System.DateOnly.AddDays%2A>, <xref:System.DateOnly.AddMonths%2A>, and <xref:System.DateOnly.AddYears%2A>. Each method takes an integer parameter, and increases the date by that measurement. If a negative number is provided, the date is decreased by that measurement. The methods return a new instance of `DateOnly`, as the structure is immutable.
 
 :::code language="csharp" source="./snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="date_adjust":::
 :::code language="vb" source="./snippets/how-to-use-dateonly-timeonly/vb/Program.vb" id="date_adjust":::
@@ -86,9 +88,11 @@ Prior to the `TimeOnly` type being introduced, programmers typically used either
 
 - If `TimeSpan` is used as a time of day, there's a risk that it could be manipulated to a value outside of the 24-hour day. `TimeOnly` doesn't have this risk. For example, if an employee's work shift starts at 18:00 and lasts for 8 hours, adding 8 hours to the `TimeOnly` structure rolls over to 2:00
 
-- Using `DateTime` for a time of day, requires that an arbitrary date be associated with the time, and later disregarded. It's common practice to choose `DateTime.MinValue` (0001-01-01) as the date, however, if hours are subtracted from the `DateTime` value, an `OutOfRange` exception may occur. `TimeOnly` doesn't have this problem as the time rolls forwards and backwards around the 24-hour timeframe.
+- Using `DateTime` for a time of day requires that an arbitrary date be associated with the time, and then later disregarded. It's common practice to choose `DateTime.MinValue` (0001-01-01) as the date, however, if hours are subtracted from the `DateTime` value, an `OutOfRange` exception might occur. `TimeOnly` doesn't have this problem as the time rolls forwards and backwards around the 24-hour timeframe.
 
 - Serializing a `DateTime` structure includes the date component, which may obscure the intent of the data. Also, `TimeOnly` serializes less data.
+
+## TimeOnly examples
 
 Use the following examples to learn about `TimeOnly`:
 
@@ -107,9 +111,9 @@ Use the <xref:System.TimeOnly.FromDateTime%2A?displayProperty=nameWithType> stat
 
 ### Add or subtract time
 
-There are three methods used to adjust a <xref:System.TimeOnly> structure: <xref:System.TimeOnly.AddHours%2A>, <xref:System.TimeOnly.AddMinutes%2A>, and <xref:System.TimeOnly.Add%2A>. Both `AddHours` and `AddMinutes` take an integer parameter, and adjust the value accordingly. You can use a negative value to subtract and a positive value to add. A new instance of `TimeOnly` is returned, as the structure is immutable. The `Add` method takes a <xref:System.TimeSpan> parameter and adds or subtracts the value from the `TimeOnly` value.
+There are three methods used to adjust a <xref:System.TimeOnly> structure: <xref:System.TimeOnly.AddHours%2A>, <xref:System.TimeOnly.AddMinutes%2A>, and <xref:System.TimeOnly.Add%2A>. Both `AddHours` and `AddMinutes` take an integer parameter, and adjust the value accordingly. You can use a negative value to subtract and a positive value to add. The methods return a new instance of `TimeOnly` is returned, as the structure is immutable. The `Add` method takes a <xref:System.TimeSpan> parameter and adds or subtracts the value from the `TimeOnly` value.
 
-Because `TimeOnly` only represents a 24-hour period, it rolls over forwards or backwards appropriately when adding values supplied to those three methods. For example, if you use a value of `01:30:00` to represent 1:30 AM, then add -4 hours from that period, it rolls backwards to `21:30:00`, which is 9:30 PM. There are method overloads for `AddHours`, `AddMinutes`, and `Add`, which capture the number of days rolled over.
+Because `TimeOnly` only represents a 24-hour period, it rolls over forwards or backwards appropriately when adding values supplied to those three methods. For example, if you use a value of `01:30:00` to represent 1:30 AM, then add -4 hours from that period, it rolls backwards to `21:30:00`, which is 9:30 PM. There are method overloads for `AddHours`, `AddMinutes`, and `Add` that capture the number of days rolled over.
 
 :::code language="csharp" source="./snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="time_adjust":::
 :::code language="vb" source="./snippets/how-to-use-dateonly-timeonly/vb/Program.vb" id="time_adjust":::
@@ -123,7 +127,7 @@ Because `TimeOnly` only represents a 24-hour period, it rolls over forwards or b
 
 ### Work with TimeSpan and DateTime
 
-<xref:System.TimeOnly> can be created from and converted to, a <xref:System.TimeSpan>. Also, `TimeOnly` can be used with a <xref:System.DateTime>, either to create the `TimeOnly` instance, or to create a `DateTime` instance as long as a date is provided.
+<xref:System.TimeOnly> can be created from and converted to a <xref:System.TimeSpan>. Also, `TimeOnly` can be used with a <xref:System.DateTime>, either to create the `TimeOnly` instance, or to create a `DateTime` instance as long as a date is provided.
 
 The following example creates a `TimeOnly` object from a `TimeSpan`, and then converts it back:
 
@@ -137,7 +141,7 @@ The following example creates a `DateTime` from a `TimeOnly` object, with an arb
 
 ### Arithmetic operators and comparing TimeOnly
 
-Two <xref:System.TimeOnly> instances can be compared with one another, and the <xref:System.TimeOnly.IsBetween%2A> method can be used to check if a time is between two other times. When an addition or subtraction operator is used on a `TimeOnly`, a <xref:System.TimeSpan> is returned, representing a duration of time.
+Two <xref:System.TimeOnly> instances can be compared with one another, and you can use the <xref:System.TimeOnly.IsBetween%2A> method to check if a time is between two other times. When an addition or subtraction operator is used on a `TimeOnly`, a <xref:System.TimeSpan> is returned, representing a duration of time.
 
 :::code language="csharp" source="./snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="time_between":::
 :::code language="vb" source="./snippets/how-to-use-dateonly-timeonly/vb/Program.vb" id="time_between":::

--- a/docs/standard/datetime/how-to-use-dateonly-timeonly.md
+++ b/docs/standard/datetime/how-to-use-dateonly-timeonly.md
@@ -13,7 +13,7 @@ helpviewer_keywords:
 
 # How to use the DateOnly and TimeOnly structures
 
-The <xref:System.DateOnly> and <xref:System.TimeOnly> structures were introduced with .NET 6, and represent either the date or time portion of a <xref:System.DateTime> structure. Prior to .NET 6, and always in .NET Framework, the <xref:System.DateTime> structure was used to represent one of the following:
+The <xref:System.DateOnly> and <xref:System.TimeOnly> structures were introduced with .NET 6, and represent either a specific date and time-of-day, respectively. Prior to .NET 6, and always in .NET Framework, the <xref:System.DateTime> type (or some other alternative) was used to represent one of the following:
 
 - A whole date and time.
 - A date, disregarding the time.
@@ -22,7 +22,7 @@ The <xref:System.DateOnly> and <xref:System.TimeOnly> structures were introduced
 `DateOnly` and `TimeOnly` are types that represent those particular portions of a `DateTime` type.
 
 > [!IMPORTANT]
-> <xref:System.DateOnly> and <xref:System.TimeOnly> structures aren't available in .NET Framework.
+> <xref:System.DateOnly> and <xref:System.TimeOnly> types aren't available in .NET Framework.
 
 ## The DateOnly structure
 
@@ -78,15 +78,15 @@ There are three methods used to adjust a <xref:System.DateOnly> structure: <xref
 
 ## The TimeOnly structure
 
-The <xref:System.TimeOnly> structure represents a time-of-day value, such as an alarm for when to wake up a daily wake up time or what time you eat lunch each day. `TimeOnly` is limited to range of **00:00:00.0000000** to **23:59:59.9999999**, a specific time of day.
+The <xref:System.TimeOnly> structure represents a time-of-day value, such as a daily alarm clock or what time you eat lunch each day. `TimeOnly` is limited to the range of **00:00:00.0000000** - **23:59:59.9999999**, a specific time of day.
 
-Prior to the `TimeOnly` type being introduced, programmers typically used either the <xref:System.DateTime> structure or the <xref:System.TimeSpan> structure to represent a specific time. However, using these structures to simulate a "time only" structure may introduce some problems, which `TimeOnly` solves:
+Prior to the `TimeOnly` type being introduced, programmers typically used either the <xref:System.DateTime> type or the <xref:System.TimeSpan> type to represent a specific time. However, using these structures to simulate a time without a date may introduce some problems, which `TimeOnly` solves:
 
 - `TimeSpan` represents elapsed time, such as time measured with a stopwatch. The upper range is more than 29,000 years, and its value can be negative to indicate moving backwards in time. A negative `TimeSpan` doesn't indicate a specific time of the day.
 
 - If `TimeSpan` is used as a time of day, there's a risk that it could be manipulated to a value outside of the 24-hour day. `TimeOnly` doesn't have this risk. For example, if an employee's work shift starts at 18:00 and lasts for 8 hours, adding 8 hours to the `TimeOnly` structure rolls over to 2:00
 
-- Using `DateTime` for a time of day, requires that an arbitrary date be associated with the time, and later disregarded. It's common practice to choose `DateTime.MinValue` (0001-01-01) as the date, however, if hours are subtracted from the `DateTime` value, an `OutOfRange` exception may occur. `TimeOnly` doesn't have this problem as the time rolls forwards and backwards around the 24-hour time span.
+- Using `DateTime` for a time of day, requires that an arbitrary date be associated with the time, and later disregarded. It's common practice to choose `DateTime.MinValue` (0001-01-01) as the date, however, if hours are subtracted from the `DateTime` value, an `OutOfRange` exception may occur. `TimeOnly` doesn't have this problem as the time rolls forwards and backwards around the 24-hour timeframe.
 
 - Serializing a `DateTime` structure includes the date component, which may obscure the intent of the data. Also, `TimeOnly` serializes less data.
 
@@ -125,7 +125,7 @@ Because `TimeOnly` only represents a 24-hour period, it rolls over forwards or b
 
 <xref:System.TimeOnly> can be created from and converted to, a <xref:System.TimeSpan>. Also, `TimeOnly` can be used with a <xref:System.DateTime>, either to create the `TimeOnly` instance, or to create a `DateTime` instance as long as a date is provided.
 
-The following example creates a `TimeOnly` object from a `TimeSpan` and then converts it back:
+The following example creates a `TimeOnly` object from a `TimeSpan`, and then converts it back:
 
 :::code language="csharp" source="./snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="time_timespan":::
 :::code language="vb" source="./snippets/how-to-use-dateonly-timeonly/vb/Program.vb" id="time_timespan":::
@@ -141,7 +141,3 @@ Two <xref:System.TimeOnly> instances can be compared with one another, and the <
 
 :::code language="csharp" source="./snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="time_between":::
 :::code language="vb" source="./snippets/how-to-use-dateonly-timeonly/vb/Program.vb" id="time_between":::
-
-## See also
-
-- [Dates, times, and time zones](index.md)

--- a/docs/standard/datetime/index.md
+++ b/docs/standard/datetime/index.md
@@ -30,7 +30,7 @@ Starting with .NET 6, the following types are available:
 
 * <xref:System.DateOnly>
 
-  Use this structure when working with a value that only represents a date. The date represents the entire day, from the start of the day to the end. `DateOnly` has a range of `0001-01-01` through `9999-12-31`. And, this type represents the month, day, and year combination without a specific time. If you previously used a `DateTime` type in your code to represent a date that disregarded the time, use this type in its place.
+  Use this structure when working with a value that only represents a date. The date represents the entire day, from the start of the day to the end. `DateOnly` has a range of `0001-01-01` through `9999-12-31`. And, this type represents the month, day, and year combination without a specific time. If you previously used a `DateTime` type in your code to represent a date that disregarded the time, use this type in its place. For more information, see 
 
 * <xref:System.TimeOnly>
 

--- a/docs/standard/datetime/index.md
+++ b/docs/standard/datetime/index.md
@@ -30,11 +30,11 @@ Starting with .NET 6, the following types are available:
 
 * <xref:System.DateOnly>
 
-  Use this structure when working with a value that only represents a date. The date represents the entire day, from the start of the day to the end. `DateOnly` has a range of `0001-01-01` through `9999-12-31`. And, this type represents the month, day, and year combination without a specific time. If you previously used a `DateTime` type in your code to represent a date that disregarded the time, use this type in its place. For more information, see 
+  Use this structure when working with a value that only represents a date. The date represents the entire day, from the start of the day to the end. `DateOnly` has a range of `0001-01-01` through `9999-12-31`. And, this type represents the month, day, and year combination without a specific time. If you previously used a `DateTime` type in your code to represent a date that disregarded the time, use this type in its place. For more information, see [How to use the DateOnly and TimeOnly structures](how-to-use-dateonly-timeonly.md).
 
 * <xref:System.TimeOnly>
 
-  Use this structure to represent a time without a date. The time represents the hours, minutes, and seconds of a non-specific day. `TimeOnly` has a range of `00:00:00.0000000` to `23:59:59.9999999`. This type can be used to replace `DateTime` and `TimeSpan` types in your code when you used those types to represent a time.
+  Use this structure to represent a time without a date. The time represents the hours, minutes, and seconds of a non-specific day. `TimeOnly` has a range of `00:00:00.0000000` to `23:59:59.9999999`. This type can be used to replace `DateTime` and `TimeSpan` types in your code when you used those types to represent a time. For more information, see [How to use the DateOnly and TimeOnly structures](how-to-use-dateonly-timeonly.md).
 
 The next section provides the information that you need to work with time zones and to create time zone-aware applications that can convert dates and times from one time zone to another.
 

--- a/docs/standard/datetime/snippets/how-to-use-dateonly-timeonly/csharp/Program.cs
+++ b/docs/standard/datetime/snippets/how-to-use-dateonly-timeonly/csharp/Program.cs
@@ -1,0 +1,279 @@
+﻿using System.Globalization;
+
+Console.WriteLine("---------- Date Hebrew Calendar");
+Date_HebrewCalendar();
+Console.WriteLine("\n---------- Date Today");
+Date_Today();
+Console.WriteLine("\n---------- Date Adjust");
+Date_ChangeDays();
+Console.WriteLine("\n---------- Date Leap Year");
+Date_ChangeLeapYear();
+Console.WriteLine("\n---------- Date Parsing");
+Date_Parse();
+Console.WriteLine("\n---------- Date Compare");
+Date_Compare();
+
+Console.WriteLine("\n---------- Time Adjust");
+Time_ChangeTime();
+Console.WriteLine("\n---------- Time Parsing");
+Time_Parse();
+Console.WriteLine("\n---------- Time Now");
+Time_Now();
+Console.WriteLine("\n---------- Time Between");
+Time_Between();
+Console.WriteLine("\n---------- Time Convert DateTime");
+Time_DateTime();
+Console.WriteLine("\n---------- Time Use TimeSpan");
+Time_TimeSpan();
+
+
+void Date_HebrewCalendar()
+{
+    //<hebrew>
+    var hebrewCalendar = new System.Globalization.HebrewCalendar();
+    var theDate = new DateOnly(5776, 2, 8, hebrewCalendar); // 8 Cheshvan 5776
+
+    Console.WriteLine(theDate);
+
+    /* This example produces the following output:
+     *
+     * 10/21/2015
+    */
+    //</hebrew>
+}
+
+void Date_Today()
+{
+    //<today>
+    var today = DateOnly.FromDateTime(DateTime.Now);
+    Console.WriteLine($"Today is {today}");
+
+    /* This example produces output similar to the following:
+     * 
+     * Today is 12/28/2022
+    */
+    //</today>
+}
+
+void Date_ChangeDays()
+{
+    //<date_adjust>
+    var theDate = new DateOnly(2015, 10, 21);
+
+    var nextDay = theDate.AddDays(1);
+    var previousDay = theDate.AddDays(-1);
+    var decadeLater = theDate.AddYears(10);
+    var lastMonth = theDate.AddMonths(-1);
+
+    Console.WriteLine($"Date: {theDate}");
+    Console.WriteLine($" Next day: {nextDay}");
+    Console.WriteLine($" Previous day: {previousDay}");
+    Console.WriteLine($" Decade later: {decadeLater}");
+    Console.WriteLine($" Last month: {lastMonth}");
+
+    /* This example produces the following output:
+     * 
+     * Date: 10/21/2015
+     *  Next day: 10/22/2015
+     *  Previous day: 10/20/2015
+     *  Decade later: 10/21/2025
+     *  Last month: 9/21/2015
+    */
+    //</date_adjust>
+}
+
+void Date_ChangeLeapYear()
+{
+    //<change_leapyear>
+    var theDate = new DateOnly(2024, 02, 29);
+    Console.WriteLine(theDate);
+    Console.WriteLine(theDate.AddYears(-1));
+
+    /* This example produces the following output:
+     * 
+     * 2/29/2024
+     * 2/28/2023
+    */
+    //</change_leapyear>
+}
+
+void Date_Parse()
+{
+    //<parse>
+    var theDate = DateOnly.ParseExact("21 Oct 2015", "dd MMM yyyy", CultureInfo.InvariantCulture);  // Custom format
+    var theDate2 = DateOnly.Parse("October 21, 2015", CultureInfo.InvariantCulture);
+
+    Console.WriteLine(theDate.ToString("m", CultureInfo.InvariantCulture));     // Month day pattern
+    Console.WriteLine(theDate2.ToString("o", CultureInfo.InvariantCulture));    // ISO 8601 format
+    Console.WriteLine(theDate2.ToLongDateString());
+
+    /* This example produces the following output:
+     * 
+     * October 21
+     * 2015-10-21
+     * Wednesday, October 21, 2015
+    */
+    //</parse>
+}
+
+void Date_Compare()
+{
+    //<date_compare>
+    var theDate = DateOnly.ParseExact("21 Oct 2015", "dd MMM yyyy", CultureInfo.InvariantCulture);  // Custom format
+    var theDate2 = DateOnly.Parse("October 21, 2015", CultureInfo.InvariantCulture);
+    var dateLater = theDate.AddMonths(6);
+    var dateBefore = theDate.AddDays(-10);
+
+    Console.WriteLine($"Consider {theDate}...");
+    Console.WriteLine($" Is '{nameof(theDate2)}' equal? {theDate == theDate2}");
+    Console.WriteLine($" Is {dateLater} after? {dateLater > theDate} ");
+    Console.WriteLine($" Is {dateLater} before? {dateLater < theDate} ");
+    Console.WriteLine($" Is {dateBefore} after? {dateBefore > theDate} ");
+    Console.WriteLine($" Is {dateBefore} before? {dateBefore < theDate} ");
+
+    /* This example produces the following output:
+     * 
+     * Consider 10/21/2015
+     *  Is 'theDate2' equal? True
+     *  Is 4/21/2016 after? True
+     *  Is 4/21/2016 before? False
+     *  Is 10/11/2015 after? False
+     *  Is 10/11/2015 before? True
+    */
+    //</date_compare>
+}
+
+void Time_ChangeTime()
+{
+    //<time_adjust>
+    var theTime = new TimeOnly(7, 23, 11);
+
+    var hourLater = theTime.AddHours(1);
+    var minutesBefore = theTime.AddMinutes(-12);
+    var secondsAfter = theTime.Add(TimeSpan.FromSeconds(10));
+    var daysLater = theTime.Add(new TimeSpan(hours: 21, minutes: 200, seconds: 83), out int wrappedDays);
+    var daysBehind = theTime.AddHours(-222, out int wrappedDaysFromHours);
+
+    Console.WriteLine($"Time: {theTime}");
+    Console.WriteLine($" Hour later: {hourLater}");
+    Console.WriteLine($" Minutes before: {minutesBefore}");
+    Console.WriteLine($" Seconds after: {secondsAfter}");
+    Console.WriteLine($" {daysLater} is the time, which is {wrappedDays} days later");
+    Console.WriteLine($" {daysBehind} is the time, which is {wrappedDaysFromHours} days prior");
+
+    /* This example produces the following output:
+     * 
+     * Time: 7:23 AM
+     *  Hour later: 8:23 AM
+     *  Minutes before: 7:11 AM
+     *  Seconds after: 7:23 AM
+     *  7:44 AM is the time, which is 1 days later 
+     *  1:23 AM is the time, which is -9 days prior
+    */
+    //</time_adjust>
+}
+
+void Time_Parse()
+{
+    //<time_parse>
+    var theTime = TimeOnly.ParseExact("5:00 pm", "h:mm tt", CultureInfo.InvariantCulture);  // Custom format
+    var theTime2 = TimeOnly.Parse("17:30:25", CultureInfo.InvariantCulture);
+
+    Console.WriteLine(theTime.ToString("o", CultureInfo.InvariantCulture));     // Round-trip pattern.
+    Console.WriteLine(theTime2.ToString("t", CultureInfo.InvariantCulture));    // Long time format
+    Console.WriteLine(theTime2.ToLongTimeString());
+
+    /* This example produces the following output:
+     * 
+     * 17:00:00.0000000
+     * 17:30
+     * 5:30:25 PM
+    */
+    //</time_parse>
+}
+
+void Time_Now()
+{
+    //<time_now>
+    var now = TimeOnly.FromDateTime(DateTime.Now);
+    Console.WriteLine($"It is {now} right now");
+
+    /* This example produces output similar to the following:
+     * 
+     * It is 2:01 PM right now
+    */
+    //</time_now>
+}
+
+void Time_Between()
+{
+    //<time_between>
+    var start = new TimeOnly(10, 12, 01); // 10:12:01 AM
+    var end = new TimeOnly(14, 00, 53); // 02:00:53 PM
+
+    var outside = start.AddMinutes(-3);
+    var inside = start.AddMinutes(120);
+
+    Console.WriteLine($"Time starts at {start} and ends at {end}");
+    Console.WriteLine($" Is {outside} between the start and end? {outside.IsBetween(start, end)}");
+    Console.WriteLine($" Is {inside} between the start and end? {inside.IsBetween(start, end)}");
+    Console.WriteLine($" Is {start} less than {end}? {start < end}");
+    Console.WriteLine($" Is {start} greater than {end}? {start > end}");
+    Console.WriteLine($" Does {start} equal {end}? {start == end}");
+    Console.WriteLine($" The time between {start} and {end} is {end - start}");
+
+    /* This example produces the following output:
+     * 
+     * Time starts at 10:12 AM and ends at 2:00 PM
+     *  Is 10:09 AM between the start and end? False
+     *  Is 12:12 PM between the start and end? True
+     *  Is 10:12 AM less than 2:00 PM? True
+     *  Is 10:12 AM greater than 2:00 PM? False
+     *  Does 10:12 AM equal 2:00 PM? False
+     *  The time between 10:12 AM and 2:00 PM is 03:48:52
+    */
+    //</time_between>
+}
+
+void Time_TimeSpan()
+{
+    //<time_timespan>
+    // TimeSpan must in the range of 00:00:00.0000000 to 23:59:59.9999999
+    var theTime = TimeOnly.FromTimeSpan(new TimeSpan(23, 59, 59));
+    var theTimeSpan = theTime.ToTimeSpan();
+
+    Console.WriteLine($"Variable '{nameof(theTime)}' is {theTime}");
+    Console.WriteLine($"Variable '{nameof(theTimeSpan)}' is {theTimeSpan}");
+
+    /* This example produces the following output:
+     * 
+     * Variable 'theTime' is 11:59 PM
+     * Variable 'theTimeSpan' is 23:59:59
+    */
+    //</time_timespan>
+}
+
+void Time_DateTime()
+{
+    //<time_datetime>
+    var theTime = new TimeOnly(11, 25, 46);   // 11:25 PM and 46 seconds
+    var theDate = new DateOnly(2015, 10, 21); // October 21, 2015
+    var theDateTime = theDate.ToDateTime(theTime);
+    var reverseTime = TimeOnly.FromDateTime(theDateTime);
+
+    Console.WriteLine($"Date only is {theDate}");
+    Console.WriteLine($"Time only is {theTime}");
+    Console.WriteLine();
+    Console.WriteLine($"Combined to a DateTime type, the value is {theDateTime}");
+    Console.WriteLine($"Converted back from DateTime, the time is {reverseTime}");
+
+    /* This example produces the following output:
+     * 
+     * Date only is 10/21/2015
+     * Time only is 11:25 AM
+     * 
+     * Combined to a DateTime type, the value is 10/21/2015 11:25:46 AM
+     * Converted back from DateTime, the time is 11:25 AM
+    */
+    //</time_datetime>
+}

--- a/docs/standard/datetime/snippets/how-to-use-dateonly-timeonly/csharp/Program.cs
+++ b/docs/standard/datetime/snippets/how-to-use-dateonly-timeonly/csharp/Program.cs
@@ -155,7 +155,7 @@ void Time_ChangeTime()
     var daysBehind = theTime.AddHours(-222, out int wrappedDaysFromHours);
 
     Console.WriteLine($"Time: {theTime}");
-    Console.WriteLine($" Hour later: {hourLater}");
+    Console.WriteLine($" Hours later: {hourLater}");
     Console.WriteLine($" Minutes before: {minutesBefore}");
     Console.WriteLine($" Seconds after: {secondsAfter}");
     Console.WriteLine($" {daysLater} is the time, which is {wrappedDays} days later");
@@ -164,7 +164,7 @@ void Time_ChangeTime()
     /* This example produces the following output:
      * 
      * Time: 7:23 AM
-     *  Hour later: 8:23 AM
+     *  Hours later: 8:23 AM
      *  Minutes before: 7:11 AM
      *  Seconds after: 7:23 AM
      *  7:44 AM is the time, which is 1 days later 

--- a/docs/standard/datetime/snippets/how-to-use-dateonly-timeonly/csharp/dateonlytimeonly.csproj
+++ b/docs/standard/datetime/snippets/how-to-use-dateonly-timeonly/csharp/dateonlytimeonly.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/docs/standard/datetime/snippets/how-to-use-dateonly-timeonly/vb/Program.vb
+++ b/docs/standard/datetime/snippets/how-to-use-dateonly-timeonly/vb/Program.vb
@@ -1,0 +1,7 @@
+Imports System
+
+Module Program
+    Sub Main(args As String())
+        Console.WriteLine("Hello World!")
+    End Sub
+End Module

--- a/docs/standard/datetime/snippets/how-to-use-dateonly-timeonly/vb/Program.vb
+++ b/docs/standard/datetime/snippets/how-to-use-dateonly-timeonly/vb/Program.vb
@@ -1,7 +1,287 @@
-Imports System
+﻿Imports System
+Imports System.Globalization
 
 Module Program
     Sub Main(args As String())
-        Console.WriteLine("Hello World!")
+        Console.WriteLine("---------- Date Hebrew Calendar")
+        Date_HebrewCalendar()
+        Console.WriteLine(vbCrLf + "---------- Date Today")
+        Date_Today()
+        Console.WriteLine(vbCrLf + "---------- Date Adjust")
+        Date_ChangeDays()
+        Console.WriteLine(vbCrLf + "---------- Date Leap Year")
+        Date_ChangeLeapYear()
+        Console.WriteLine(vbCrLf + "---------- Date Parsing")
+        Date_Parse()
+        Console.WriteLine(vbCrLf + "---------- Date Compare")
+        Date_Compare()
+
+        Console.WriteLine(vbCrLf + "---------- Time Adjust")
+        Time_ChangeTime()
+        Console.WriteLine(vbCrLf + "---------- Time Parsing")
+        Time_Parse()
+        Console.WriteLine(vbCrLf + "---------- Time Now")
+        Time_Now()
+        Console.WriteLine(vbCrLf + "---------- Time Between")
+        Time_Between()
+        Console.WriteLine(vbCrLf + "---------- Time Convert DateTime")
+        Time_DateTime()
+        Console.WriteLine(vbCrLf + "---------- Time Use TimeSpan")
+        Time_TimeSpan()
     End Sub
+
+    Sub Date_HebrewCalendar()
+
+        '<hebrew>
+        Dim hebrewCalendar = New System.Globalization.HebrewCalendar()
+        Dim theDate = New DateOnly(5776, 2, 8, hebrewCalendar) ' 8 Cheshvan 5776
+
+        Console.WriteLine(theDate)
+
+        ' This example produces the following output
+        '
+        ' 10/21/2015
+        '</hebrew>
+
+    End Sub
+
+    Sub Date_Today()
+
+        '<today>
+        Dim today = DateOnly.FromDateTime(DateTime.Now)
+        Console.WriteLine($"Today is {today}")
+
+        ' This example produces output similar to the following
+        ' 
+        ' Today is 12/28/2022
+        '</today>
+
+    End Sub
+
+    Sub Date_ChangeDays()
+
+        '<date_adjust>
+        Dim theDate = New DateOnly(2015, 10, 21)
+
+        Dim nextDay = theDate.AddDays(1)
+        Dim previousDay = theDate.AddDays(-1)
+        Dim decadeLater = theDate.AddYears(10)
+        Dim lastMonth = theDate.AddMonths(-1)
+
+        Console.WriteLine($"Date: {theDate}")
+        Console.WriteLine($" Next day: {nextDay}")
+        Console.WriteLine($" Previous day: {previousDay}")
+        Console.WriteLine($" Decade later: {decadeLater}")
+        Console.WriteLine($" Last month: {lastMonth}")
+
+        ' This example produces the following output
+        ' 
+        ' Date: 10/21/2015
+        '  Next day: 10/22/2015
+        '  Previous day: 10/20/2015
+        '  Decade later: 10/21/2025
+        '  Last month: 9/21/2015
+        '</date_adjust>
+
+    End Sub
+
+    Sub Date_ChangeLeapYear()
+
+        '<change_leapyear>
+        Dim theDate = New DateOnly(2024, 2, 29)
+        Console.WriteLine(theDate)
+        Console.WriteLine(theDate.AddYears(-1))
+
+        ' This example produces the following output
+        ' 
+        ' 2/29/2024
+        ' 2/28/2023
+        '</change_leapyear>
+
+    End Sub
+
+    Sub Date_Parse()
+
+        '<parse>
+        Dim theDate = DateOnly.ParseExact("21 Oct 2015", "dd MMM yyyy", CultureInfo.InvariantCulture) ' Custom format
+        Dim theDate2 = DateOnly.Parse("October 21, 2015", CultureInfo.InvariantCulture)
+
+        Console.WriteLine(theDate.ToString("m", CultureInfo.InvariantCulture))     ' Month day pattern
+        Console.WriteLine(theDate2.ToString("o", CultureInfo.InvariantCulture))    ' ISO 8601 format
+        Console.WriteLine(theDate2.ToLongDateString())
+
+        ' This example produces the following output
+        ' 
+        ' October 21
+        ' 2015-10-21
+        ' Wednesday, October 21, 2015
+        '</parse>
+
+    End Sub
+
+    Sub Date_Compare()
+
+        '<date_compare>
+        Dim theDate = DateOnly.ParseExact("21 Oct 2015", "dd MMM yyyy", CultureInfo.InvariantCulture) ' Custom format
+        Dim theDate2 = DateOnly.Parse("October 21, 2015", CultureInfo.InvariantCulture)
+        Dim dateLater = theDate.AddMonths(6)
+        Dim dateBefore = theDate.AddDays(-10)
+
+        Console.WriteLine($"Consider {theDate}...")
+        Console.WriteLine($" Is '{NameOf(theDate2)}' equal? {theDate = theDate2}")
+        Console.WriteLine($" Is {dateLater} after? {dateLater > theDate} ")
+        Console.WriteLine($" Is {dateLater} before? {dateLater < theDate} ")
+        Console.WriteLine($" Is {dateBefore} after? {dateBefore > theDate} ")
+        Console.WriteLine($" Is {dateBefore} before? {dateBefore < theDate} ")
+
+        ' This example produces the following output
+        ' 
+        ' Consider 10/21/2015
+        '  Is 'theDate2' equal? True
+        '  Is 4/21/2016 after? True
+        '  Is 4/21/2016 before? False
+        '  Is 10/11/2015 after? False
+        '  Is 10/11/2015 before? True
+        '</date_compare>
+
+    End Sub
+
+    Sub Time_ChangeTime()
+
+        '<time_adjust>
+        Dim wrappedDays As Integer
+        Dim wrappedDaysFromHours As Integer
+
+        Dim theTime = New TimeOnly(7, 23, 11)
+
+        Dim hourLater = theTime.AddHours(1)
+        Dim minutesBefore = theTime.AddMinutes(-12)
+        Dim secondsAfter = theTime.Add(TimeSpan.FromSeconds(10))
+        Dim daysLater = theTime.Add(New TimeSpan(hours:=21, minutes:=200, seconds:=83), wrappedDays)
+        Dim daysBehind = theTime.AddHours(-222, wrappedDaysFromHours)
+
+        Console.WriteLine($"Time: {theTime}")
+        Console.WriteLine($" Hours later: {hourLater}")
+        Console.WriteLine($" Minutes before: {minutesBefore}")
+        Console.WriteLine($" Seconds after: {secondsAfter}")
+        Console.WriteLine($" {daysLater} is the time, which is {wrappedDays} days later")
+        Console.WriteLine($" {daysBehind} is the time, which is {wrappedDaysFromHours} days prior")
+
+        ' This example produces the following output
+        ' 
+        ' Time: 7:23 AM
+        '  Hours later: 8:23 AM
+        '  Minutes before: 7:11 AM
+        '  Seconds after: 7:23 AM
+        '  7:44 AM is the time, which is 1 days later 
+        '  1:23 AM is the time, which is -9 days prior
+        '</time_adjust>
+
+    End Sub
+
+    Sub Time_Parse()
+
+        '<time_parse>
+        Dim theTime = TimeOnly.ParseExact("5:00 pm", "h:mm tt", CultureInfo.InvariantCulture) ' Custom format
+        Dim theTime2 = TimeOnly.Parse("17:30:25", CultureInfo.InvariantCulture)
+
+        Console.WriteLine(theTime.ToString("o", CultureInfo.InvariantCulture))     ' Round-trip pattern.
+        Console.WriteLine(theTime2.ToString("t", CultureInfo.InvariantCulture))    ' Long time format
+        Console.WriteLine(theTime2.ToLongTimeString())
+
+        ' This example produces the following output
+        ' 
+        ' 17:00:00.0000000
+        ' 17:30
+        ' 5:30:25 PM
+        '</time_parse>
+
+    End Sub
+
+    Sub Time_Now()
+
+        '<time_now>
+        Dim now = TimeOnly.FromDateTime(DateTime.Now)
+        Console.WriteLine($"It is {Now} right now")
+
+        ' This example produces output similar to the following
+        ' 
+        ' It is 2:01 PM right now
+        '</time_now>
+
+    End Sub
+
+    Sub Time_Between()
+
+        '<time_between>
+        Dim startDate = New TimeOnly(10, 12, 1) ' 10:12:01 AM
+        Dim endDate = New TimeOnly(14, 0, 53) ' 02:00:53 PM
+
+        Dim outside = startDate.AddMinutes(-3)
+        Dim inside = startDate.AddMinutes(120)
+
+        Console.WriteLine($"Time starts at {startDate} and ends at {endDate}")
+        Console.WriteLine($" Is {outside} between the start and end? {outside.IsBetween(startDate, endDate)}")
+        Console.WriteLine($" Is {inside} between the start and end? {inside.IsBetween(startDate, endDate)}")
+        Console.WriteLine($" Is {startDate} less than {endDate}? {startDate < endDate}")
+        Console.WriteLine($" Is {startDate} greater than {endDate}? {startDate > endDate}")
+        Console.WriteLine($" Does {startDate} equal {endDate}? {startDate = endDate}")
+        Console.WriteLine($" The time between {startDate} and {endDate} is {endDate - startDate}")
+
+        ' This example produces the following output
+        ' 
+        ' Time starts at 10:12 AM And ends at 2:00 PM
+        '  Is 10:09 AM between the start And end? False
+        '  Is 12:12 PM between the start And end? True
+        '  Is 10:12 AM less than 2:00 PM? True
+        '  Is 10:12 AM greater than 2:00 PM? False
+        '  Does 10:12 AM equal 2:00 PM? False
+        '  The time between 10:12 AM and 2:00 PM is 03:48:52
+        '</time_between>
+
+    End Sub
+
+    Sub Time_TimeSpan()
+
+        '<time_timespan>
+        ' TimeSpan must in the range of 00:00:00.0000000 to 23:59:59.9999999
+        Dim theTime = TimeOnly.FromTimeSpan(New TimeSpan(23, 59, 59))
+        Dim theTimeSpan = theTime.ToTimeSpan()
+
+        Console.WriteLine($"Variable '{NameOf(theTime)}' is {theTime}")
+        Console.WriteLine($"Variable '{NameOf(theTimeSpan)}' is {theTimeSpan}")
+
+        ' This example produces the following output
+        ' 
+        ' Variable 'theTime' is 11:59 PM
+        ' Variable 'theTimeSpan' is 23:59:59
+        '</time_timespan>
+
+    End Sub
+
+    Sub Time_DateTime()
+
+        '<time_datetime>
+        Dim theTime = New TimeOnly(11, 25, 46) ' 11:   25 PM And 46 seconds
+        Dim theDate = New DateOnly(2015, 10, 21) ' October 21, 2015
+        Dim theDateTime = theDate.ToDateTime(theTime)
+        Dim reverseTime = TimeOnly.FromDateTime(theDateTime)
+
+        Console.WriteLine($"Date only is {theDate}")
+        Console.WriteLine($"Time only is {theTime}")
+        Console.WriteLine()
+        Console.WriteLine($"Combined to a DateTime type, the value is {theDateTime}")
+        Console.WriteLine($"Converted back from DateTime, the time is {reverseTime}")
+
+        ' This example produces the following output
+        ' 
+        ' Date only is 10/21/2015
+        ' Time only is 11:25 AM
+        ' 
+        ' Combined to a DateTime type, the value is 10/21/2015 11:25:46 AM
+        ' Converted back from DateTime, the time is 11:25 AM
+        '</time_datetime>
+
+    End Sub
+
 End Module

--- a/docs/standard/datetime/snippets/how-to-use-dateonly-timeonly/vb/dateonlytimeonly.vbproj
+++ b/docs/standard/datetime/snippets/how-to-use-dateonly-timeonly/vb/dateonlytimeonly.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>dateonlytimeonly</RootNamespace>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/docs/standard/datetime/toc.yml
+++ b/docs/standard/datetime/toc.yml
@@ -5,6 +5,8 @@ items:
     href: choosing-between-datetime.md
   - name: Working with calendars
     href: working-with-calendars.md
+  - name: Use the DateOnly and TimeOnly types
+    href: how-to-use-dateonly-timeonly.md
   - name: Performing arithmetic operations with dates and times
     href: performing-arithmetic-operations.md
   - name: "DateTime and DateTimeOffset support in System.Text.Json"


### PR DESCRIPTION
## Summary

- Add new article for DateOnly and TimeOnly.
- Add info to the choosing between the types article.

Fixes #26802

[Internal preview](https://review.learn.microsoft.com/en-us/dotnet/standard/datetime/how-to-use-dateonly-timeonly?branch=pr-en-us-33270)