### PR TITLE
Added delete permission to pod-reader

### DIFF
--- a/docs/orleans/deployment/kubernetes.md
+++ b/docs/orleans/deployment/kubernetes.md
@@ -121,7 +121,7 @@ metadata:
 rules:
 - apiGroups: [ "" ]
   resources: ["pods"]
-  verbs: ["get", "watch", "list"]
+  verbs: ["get", "watch", "list", "delete"]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Summary

The RBAC yaml is missing the delete permission. This PR fixes that

Fixes dotnet/orleans/issues/8248


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/deployment/kubernetes.md](https://github.com/dotnet/docs/blob/9a4f608ecb3886d37c03e8208874cdb2bad384ad/docs/orleans/deployment/kubernetes.md) | [docs/orleans/deployment/kubernetes](https://review.learn.microsoft.com/en-us/dotnet/orleans/deployment/kubernetes?branch=pr-en-us-33299) |

<!-- PREVIEW-TABLE-END -->