### PR TITLE
Minor rephrasing to improve readability

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1802.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1802.md
@@ -33,7 +33,7 @@ By default, this rule only looks at externally visible, static, readonly fields,
 
 The value of a `static readonly` field is computed at run time when the static constructor for the declaring type is called. If the `static readonly` field is initialized when it is declared and a static constructor is not declared explicitly, the compiler emits a static constructor to initialize the field.
 
-The value of a `const` field is computed at compile time and stored in the metadata, which increases run-time performance when it is compared to a `static readonly` field.
+The value of a `const` field is computed at compile time and stored in the metadata, which improves run-time performance when it is compared to a `static readonly` field.
 
 Because the value assigned to the targeted field is computable at compile time, change the declaration to a `const` field so that the value is computed at compile time instead of at run time.
 


### PR DESCRIPTION
## Summary

Rephrase from increases run-time performance_ to _improves run-time performance_. When skimming through this text, one might parse that this change will increase the run-time, when it in fact will decrease it. This change decreases ambiguity when skimming through the text.

![image](https://user-images.githubusercontent.com/12127271/210513979-bb8acb4d-c7d3-40fc-bc7e-edd229955aeb.png)

