### PR TITLE
Add contextual TOC links

### DIFF
--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -2788,25 +2788,23 @@ items:
       href: ../standard/parallel-programming/task-parallel-library-tpl.md
       items:
       - name: Data parallelism
+        href: ../standard/parallel-programming/data-parallelism-task-parallel-library.md
         items:
-        - name: Overview
-          displayName: data parallelism
-          href: ../standard/parallel-programming/data-parallelism-task-parallel-library.md
-        - name: Write a simple Parallel.For loop
+        - name: "How to: Write a Simple Parallel.For Loop"
           href: ../standard/parallel-programming/how-to-write-a-simple-parallel-for-loop.md
-        - name: Write a simple Parallel.ForEach loop
+        - name: "How to: Write a Simple Parallel.ForEach Loop"
           href: ../standard/parallel-programming/how-to-write-a-simple-parallel-foreach-loop.md
-        - name: Write a Parallel.For loop with thread-local variables
+        - name: "How to: Write a Parallel.For Loop with Thread-Local Variables"
           href: ../standard/parallel-programming/how-to-write-a-parallel-for-loop-with-thread-local-variables.md
-        - name: Write a Parallel.ForEach loop with partition-local variables
+        - name: "How to: Write a Parallel.ForEach Loop with Partition-Local Variables"
           href: ../standard/parallel-programming/how-to-write-a-parallel-foreach-loop-with-partition-local-variables.md
-        - name: Cancel a Parallel.For or ForEach loop
+        - name: "How to: Cancel a Parallel.For or ForEach Loop"
           href: ../standard/parallel-programming/how-to-cancel-a-parallel-for-or-foreach-loop.md
-        - name: Handle exceptions in parallel loops
+        - name: "How to: Handle Exceptions in Parallel Loops"
           href: ../standard/parallel-programming/how-to-handle-exceptions-in-parallel-loops.md
-        - name: Speed up small loop bodies
+        - name: "How to: Speed Up Small Loop Bodies"
           href: ../standard/parallel-programming/how-to-speed-up-small-loop-bodies.md
-        - name: Iterate file directories with the Parallel class
+        - name: "How to: Iterate File Directories with the Parallel Class"
           href: ../standard/parallel-programming/how-to-iterate-file-directories-with-the-parallel-class.md
       - name: Task-based asynchronous programming
         href: ../standard/parallel-programming/task-based-asynchronous-programming.md
@@ -2870,37 +2868,37 @@ items:
         href: ../standard/parallel-programming/potential-pitfalls-in-data-and-task-parallelism.md
     - name: Parallel LINQ (PLINQ)
       items:
-      - name: Introduction
+      - name: Introduction to PLINQ
         href: ../standard/parallel-programming/introduction-to-plinq.md
-      - name: Optimize queries for speedup
+      - name: Understanding Speedup in PLINQ
         href: ../standard/parallel-programming/understanding-speedup-in-plinq.md
-      - name: Order preservation
+      - name: Order Preservation in PLINQ
         href: ../standard/parallel-programming/order-preservation-in-plinq.md
-      - name: Merge options
+      - name: Merge Options in PLINQ
         href: ../standard/parallel-programming/merge-options-in-plinq.md
-      - name: Potential pitfalls
+      - name: Potential Pitfalls with PLINQ
         href: ../standard/parallel-programming/potential-pitfalls-with-plinq.md
-      - name:  Create and Execute a Simple Query
+      - name: "How to: Create and Execute a Simple PLINQ Query"
         href: ../standard/parallel-programming/how-to-create-and-execute-a-simple-plinq-query.md
-      - name:  Control Ordering in a Query
+      - name: "How to: Control Ordering in a PLINQ Query"
         href: ../standard/parallel-programming/how-to-control-ordering-in-a-plinq-query.md
-      - name:  Combine Parallel and Sequential LINQ Queries
+      - name: "How to: Combine Parallel and Sequential LINQ Queries"
         href: ../standard/parallel-programming/how-to-combine-parallel-and-sequential-linq-queries.md
-      - name:  Handle Exceptions in a Query
+      - name: "How to: Handle Exceptions in a PLINQ Query"
         href: ../standard/parallel-programming/how-to-handle-exceptions-in-a-plinq-query.md
-      - name:  Cancel a Query
+      - name: "How to: Cancel a PLINQ Query"
         href: ../standard/parallel-programming/how-to-cancel-a-plinq-query.md
-      - name:  Write a Custom Aggregate Function
+      - name: "How to: Write a Custom PLINQ Aggregate Function"
         href: ../standard/parallel-programming/how-to-write-a-custom-plinq-aggregate-function.md
-      - name:  Specify the Execution Mode
+      - name: "How to: Specify the Execution Mode in PLINQ"
         href: ../standard/parallel-programming/how-to-specify-the-execution-mode-in-plinq.md
-      - name:  Specify Merge Options
+      - name: "How to: Specify Merge Options in PLINQ"
         href: ../standard/parallel-programming/how-to-specify-merge-options-in-plinq.md
-      - name:  Iterate File Directories
+      - name: "How to: Iterate File Directories with PLINQ"
         href: ../standard/parallel-programming/how-to-iterate-file-directories-with-plinq.md
-      - name: Measure Query Performance
+      - name: "How to: Measure PLINQ Query Performance"
         href: ../standard/parallel-programming/how-to-measure-plinq-query-performance.md
-      - name: Data Sample
+      - name: PLINQ Data Sample
         href: ../standard/parallel-programming/plinq-data-sample.md
     - name: Data structures for parallel programming
       href: ../standard/parallel-programming/data-structures-for-parallel-programming.md

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -93,10 +93,10 @@ items:
         href: ../core/tutorials/testing-library-with-visual-studio.md
         displayName: tutorials, visual studio, vs
       - name: Install and use a package
-        href: /nuget/quickstart/install-and-use-a-package-in-visual-studio
+        href: /nuget/quickstart/install-and-use-a-package-in-visual-studio?toc=/dotnet/fundamentals/toc.json&bc=/dotnet/breadcrumb/toc.json
         displayName: tutorials, visual studio, vs
       - name: Create and publish a package
-        href: /nuget/quickstart/create-and-publish-a-package-using-visual-studio
+        href: /nuget/quickstart/create-and-publish-a-package-using-visual-studio?toc=/dotnet/fundamentals/toc.json&bc=/dotnet/breadcrumb/toc.json
         displayName: tutorials, visual studio, vs
     - name: Use Visual Studio Code
       items:
@@ -116,10 +116,10 @@ items:
         href: ../core/tutorials/testing-library-with-visual-studio-code.md
         displayName: tutorials, visual studio code, vs code
       - name: Install and use a package
-        href: /nuget/quickstart/install-and-use-a-package-using-the-dotnet-cli
+        href: /nuget/quickstart/install-and-use-a-package-using-the-dotnet-cli?toc=/dotnet/fundamentals/toc.json&bc=/dotnet/breadcrumb/toc.json
         displayName: tutorials, cli
       - name: Create and publish a package
-        href: /nuget/quickstart/create-and-publish-a-package-using-the-dotnet-cli
+        href: /nuget/quickstart/create-and-publish-a-package-using-the-dotnet-cli?toc=/dotnet/fundamentals/toc.json&bc=/dotnet/breadcrumb/toc.json
         displayName: tutorials
     - name: Use Visual Studio for Mac
       items:
@@ -139,7 +139,7 @@ items:
         href: ../core/tutorials/testing-library-with-visual-studio-mac.md
         displayName: tutorials, visual studio for mac, vs for mac
       - name: Install and use a package
-        href: /nuget/quickstart/install-and-use-a-package-in-visual-studio-mac
+        href: /nuget/quickstart/install-and-use-a-package-in-visual-studio-mac?toc=/dotnet/fundamentals/toc.json&bc=/dotnet/breadcrumb/toc.json
         displayName: tutorials, visual studio for mac, vs for mac
     - name: More tutorials
       href: ../core/tutorials/index.md
@@ -636,10 +636,10 @@ items:
     items:
     - name: Visual Studio
       displayName: ide,integrated development environment,vs
-      href: /visualstudio/windows/
+      href: /visualstudio/windows/?toc=/dotnet/fundamentals/toc.json&bc=/dotnet/breadcrumb/toc.json
     - name: Visual Studio for Mac
       displayName: ide,integrated development environment,vs for mac,macOS,Mac
-      href: /visualstudio/mac/
+      href: /visualstudio/mac/?toc=/dotnet/fundamentals/toc.json&bc=/dotnet/breadcrumb/toc.json
     - name: Visual Studio Code
       displayName: ide,integrated development environment,code,vs code,oss ide,
       href: https://code.visualstudio.com/docs
@@ -841,9 +841,9 @@ items:
         href: ../core/diagnostics/debug-highcpu.md
       - name: Debug deadlock
         href: ../core/diagnostics/debug-deadlock.md
-      - name: Debug ThreadPool starvation
+      - name: Debug thread-pool starvation
         href: ../core/diagnostics/debug-threadpool-starvation.md
-      - name: Debug a StackOverflow
+      - name: Debug a stack overflow
         href: ../core/diagnostics/debug-stackoverflow.md
   - name: Code analysis
     items:
@@ -1790,15 +1790,13 @@ items:
       - name: Create a .NET application with plugins
         href: ../core/tutorials/creating-app-with-plugin-support.md
       - name: How to use and debug assembly unloadability
-        href: ../core/../standard/assembly/unloadability.md
+        href: ../standard/assembly/unloadability.md
   - name: Versioning
     items:
     - name: Overview
       href: ../core/versions/index.md
     - name: .NET version selection
       href: ../core/versions/selection.md
-    - name: Compatibility
-      href: ../core/compatibility/breaking-changes.md
   - name: Configure .NET Runtime
     items:
     - name: Settings
@@ -2103,7 +2101,7 @@ items:
     - name: Publish app as container image
       href: ../core/docker/publish-as-container.md
     - name: Container tools in Visual Studio
-      href: /visualstudio/containers/overview
+      href: /visualstudio/containers/overview?toc=/dotnet/fundamentals/toc.json&bc=/dotnet/breadcrumb/toc.json
 - name: DevOps
   items:
   - name: GitHub Actions and .NET
@@ -2777,7 +2775,7 @@ items:
   - name: Microsoft.Data.Sqlite
     href: ../standard/data/sqlite/
   - name: Entity Framework Core
-    href: "/ef/core/"
+    href: /ef/core/?toc=/dotnet/fundamentals/toc.json&bc=/dotnet/breadcrumb/toc.json
 - name: Parallel processing, concurrency, and async
   items:
   - name: Asynchronous programming patterns
@@ -2790,23 +2788,25 @@ items:
       href: ../standard/parallel-programming/task-parallel-library-tpl.md
       items:
       - name: Data parallelism
-        href: ../standard/parallel-programming/data-parallelism-task-parallel-library.md
         items:
-        - name: "How to: Write a Simple Parallel.For Loop"
+        - name: Overview
+          displayName: data parallelism
+          href: ../standard/parallel-programming/data-parallelism-task-parallel-library.md
+        - name: Write a simple Parallel.For loop
           href: ../standard/parallel-programming/how-to-write-a-simple-parallel-for-loop.md
-        - name: "How to: Write a Simple Parallel.ForEach Loop"
+        - name: Write a simple Parallel.ForEach loop
           href: ../standard/parallel-programming/how-to-write-a-simple-parallel-foreach-loop.md
-        - name: "How to: Write a Parallel.For Loop with Thread-Local Variables"
+        - name: Write a Parallel.For loop with thread-local variables
           href: ../standard/parallel-programming/how-to-write-a-parallel-for-loop-with-thread-local-variables.md
-        - name: "How to: Write a Parallel.ForEach Loop with Partition-Local Variables"
+        - name: Write a Parallel.ForEach loop with partition-local variables
           href: ../standard/parallel-programming/how-to-write-a-parallel-foreach-loop-with-partition-local-variables.md
-        - name: "How to: Cancel a Parallel.For or ForEach Loop"
+        - name: Cancel a Parallel.For or ForEach loop
           href: ../standard/parallel-programming/how-to-cancel-a-parallel-for-or-foreach-loop.md
-        - name: "How to: Handle Exceptions in Parallel Loops"
+        - name: Handle exceptions in parallel loops
           href: ../standard/parallel-programming/how-to-handle-exceptions-in-parallel-loops.md
-        - name: "How to: Speed Up Small Loop Bodies"
+        - name: Speed up small loop bodies
           href: ../standard/parallel-programming/how-to-speed-up-small-loop-bodies.md
-        - name: "How to: Iterate File Directories with the Parallel Class"
+        - name: Iterate file directories with the Parallel class
           href: ../standard/parallel-programming/how-to-iterate-file-directories-with-the-parallel-class.md
       - name: Task-based asynchronous programming
         href: ../standard/parallel-programming/task-based-asynchronous-programming.md
@@ -2870,37 +2870,37 @@ items:
         href: ../standard/parallel-programming/potential-pitfalls-in-data-and-task-parallelism.md
     - name: Parallel LINQ (PLINQ)
       items:
-      - name: Introduction to PLINQ
+      - name: Introduction
         href: ../standard/parallel-programming/introduction-to-plinq.md
-      - name: Understanding Speedup in PLINQ
+      - name: Optimize queries for speedup
         href: ../standard/parallel-programming/understanding-speedup-in-plinq.md
-      - name: Order Preservation in PLINQ
+      - name: Order preservation
         href: ../standard/parallel-programming/order-preservation-in-plinq.md
-      - name: Merge Options in PLINQ
+      - name: Merge options
         href: ../standard/parallel-programming/merge-options-in-plinq.md
-      - name: Potential Pitfalls with PLINQ
+      - name: Potential pitfalls
         href: ../standard/parallel-programming/potential-pitfalls-with-plinq.md
-      - name: "How to: Create and Execute a Simple PLINQ Query"
+      - name:  Create and Execute a Simple Query
         href: ../standard/parallel-programming/how-to-create-and-execute-a-simple-plinq-query.md
-      - name: "How to: Control Ordering in a PLINQ Query"
+      - name:  Control Ordering in a Query
         href: ../standard/parallel-programming/how-to-control-ordering-in-a-plinq-query.md
-      - name: "How to: Combine Parallel and Sequential LINQ Queries"
+      - name:  Combine Parallel and Sequential LINQ Queries
         href: ../standard/parallel-programming/how-to-combine-parallel-and-sequential-linq-queries.md
-      - name: "How to: Handle Exceptions in a PLINQ Query"
+      - name:  Handle Exceptions in a Query
         href: ../standard/parallel-programming/how-to-handle-exceptions-in-a-plinq-query.md
-      - name: "How to: Cancel a PLINQ Query"
+      - name:  Cancel a Query
         href: ../standard/parallel-programming/how-to-cancel-a-plinq-query.md
-      - name: "How to: Write a Custom PLINQ Aggregate Function"
+      - name:  Write a Custom Aggregate Function
         href: ../standard/parallel-programming/how-to-write-a-custom-plinq-aggregate-function.md
-      - name: "How to: Specify the Execution Mode in PLINQ"
+      - name:  Specify the Execution Mode
         href: ../standard/parallel-programming/how-to-specify-the-execution-mode-in-plinq.md
-      - name: "How to: Specify Merge Options in PLINQ"
+      - name:  Specify Merge Options
         href: ../standard/parallel-programming/how-to-specify-merge-options-in-plinq.md
-      - name: "How to: Iterate File Directories with PLINQ"
+      - name:  Iterate File Directories
         href: ../standard/parallel-programming/how-to-iterate-file-directories-with-plinq.md
-      - name: "How to: Measure PLINQ Query Performance"
+      - name: Measure Query Performance
         href: ../standard/parallel-programming/how-to-measure-plinq-query-performance.md
-      - name: PLINQ Data Sample
+      - name: Data Sample
         href: ../standard/parallel-programming/plinq-data-sample.md
     - name: Data structures for parallel programming
       href: ../standard/parallel-programming/data-structures-for-parallel-programming.md
@@ -2964,7 +2964,7 @@ items:
   - name: Unit test published output
     href: ../core/testing/unit-testing-published-output.md
   - name: Live unit test .NET projects with Visual Studio
-    href: /visualstudio/test/live-unit-testing-start
+    href: /visualstudio/test/live-unit-testing-start?toc=/dotnet/fundamentals/toc.json&bc=/dotnet/breadcrumb/toc.json
 - name: Security
   href: ../standard/security/
 - name: Advanced topics
@@ -3231,20 +3231,16 @@ items:
         href: ../core/porting/breaking-changes.md
       - name: Breaking changes
         href: ../core/compatibility/fx-core.md
-      - name: Unavailable technologies
-        href: ../core/porting/net-framework-tech-unavailable.md
-      - name: APIs that always throw
-        href: ../core/compatibility/unsupported-apis.md
   - name: Pre-migration
     items:
     - name: Assess the portability of your project
       items:
-      - name: Unsupported Dependencies
+      - name: Unsupported dependencies
         href: ../core/porting/third-party-deps.md
       - name: Use the Windows Compatibility Pack
         href: ../core/porting/windows-compat-pack.md
       - name: Unavailable technologies
-        href: ../core/porting/net-framework-tech-unavailable.md?toc=/dotnet/fundamentals/toc.json&bc=/dotnet/breadcrumb/toc.json
+        href: ../core/porting/net-framework-tech-unavailable.md
       - name: Unsupported APIs
         href: ../core/porting/unsupported-apis.md
     - name: Needed changes before porting code
@@ -3260,8 +3256,8 @@ items:
     - name: Application porting guides
       items:
       - name: Windows Forms
-        href: /dotnet/desktop/winforms/migration/?view=netdesktop-6.0&preserve-view=false
+        href: /dotnet/desktop/winforms/migration/?view=netdesktop-6.0&preserve-view=false&toc=/dotnet/fundamentals/toc.json&bc=/dotnet/breadcrumb/toc.json
       - name: Windows Presentation Foundation
-        href: /dotnet/desktop/wpf/migration/convert-project-from-net-framework?view=netdesktop-6.0&preserve-view=false
+        href: /dotnet/desktop/wpf/migration/convert-project-from-net-framework?view=netdesktop-6.0&preserve-view=false&toc=/dotnet/fundamentals/toc.json&bc=/dotnet/breadcrumb/toc.json
       - name: C++/CLI projects
         href: ../core/porting/cpp-cli.md

--- a/docs/standard/parallel-programming/understanding-speedup-in-plinq.md
+++ b/docs/standard/parallel-programming/understanding-speedup-in-plinq.md
@@ -9,15 +9,13 @@ helpviewer_keywords:
   - "PLINQ queries, performance tuning"
 ms.assetid: 53706c7e-397d-467a-98cd-c0d1fd63ba5e
 ---
-# Speedup in PLINQ
+# Understanding Speedup in PLINQ
 
-This article provides information that will help you write PLINQ queries that are as efficient as possible while still yielding correct results.
-
-The primary purpose of PLINQ is to speed up the execution of LINQ to Objects queries by executing the query delegates in parallel on multi-core computers. PLINQ performs best when the processing of each element in a source collection is independent, with no shared state involved among the individual delegates. Such operations are common in LINQ to Objects and PLINQ, and are often called "*delightfully parallel*" because they lend themselves easily to scheduling on multiple threads. However, not all queries consist entirely of delightfully parallel operations. In most cases, a query involves some operators that either cannot be parallelized, or that slow down parallel execution. And even with queries that are entirely delightfully parallel, PLINQ must still partition the data source and schedule the work on the threads, and usually merge the results when the query completes. All these operations add to the computational cost of parallelization; these costs of adding parallelization are called *overhead*. To achieve optimum performance in a PLINQ query, the goal is to maximize the parts that are delightfully parallel and minimize the parts that require overhead.
+The primary purpose of PLINQ is to speed up the execution of LINQ to Objects queries by executing the query delegates in parallel on multi-core computers. PLINQ performs best when the processing of each element in a source collection is independent, with no shared state involved among the individual delegates. Such operations are common in LINQ to Objects and PLINQ, and are often called "*delightfully parallel*" because they lend themselves easily to scheduling on multiple threads. However, not all queries consist entirely of delightfully parallel operations; in most cases, a query involves some operators that either cannot be parallelized, or that slow down parallel execution. And even with queries that are entirely delightfully parallel, PLINQ must still partition the data source and schedule the work on the threads, and usually merge the results when the query completes. All these operations add to the computational cost of parallelization; these costs of adding parallelization are called *overhead*. To achieve optimum performance in a PLINQ query, the goal is to maximize the parts that are delightfully parallel and minimize the parts that require overhead. This article provides information that will help you write PLINQ queries that are as efficient as possible while still yielding correct results.  
   
 ## Factors that Impact PLINQ Query Performance  
 
- The following sections lists some of the most important factors that impact parallel query performance. These are general statements that by themselves are not sufficient to predict query performance in all cases. As always, it's important to measure actual performance of specific queries on computers with a range of representative configurations and loads.  
+ The following sections lists some of the most important factors that impact parallel query performance. These are general statements that by themselves are not sufficient to predict query performance in all cases. As always, it is important to measure actual performance of specific queries on computers with a range of representative configurations and loads.  
   
 1. Computational cost of the overall work.  
   

--- a/docs/standard/parallel-programming/understanding-speedup-in-plinq.md
+++ b/docs/standard/parallel-programming/understanding-speedup-in-plinq.md
@@ -9,13 +9,15 @@ helpviewer_keywords:
   - "PLINQ queries, performance tuning"
 ms.assetid: 53706c7e-397d-467a-98cd-c0d1fd63ba5e
 ---
-# Understanding Speedup in PLINQ
+# Speedup in PLINQ
 
-The primary purpose of PLINQ is to speed up the execution of LINQ to Objects queries by executing the query delegates in parallel on multi-core computers. PLINQ performs best when the processing of each element in a source collection is independent, with no shared state involved among the individual delegates. Such operations are common in LINQ to Objects and PLINQ, and are often called "*delightfully parallel*" because they lend themselves easily to scheduling on multiple threads. However, not all queries consist entirely of delightfully parallel operations; in most cases, a query involves some operators that either cannot be parallelized, or that slow down parallel execution. And even with queries that are entirely delightfully parallel, PLINQ must still partition the data source and schedule the work on the threads, and usually merge the results when the query completes. All these operations add to the computational cost of parallelization; these costs of adding parallelization are called *overhead*. To achieve optimum performance in a PLINQ query, the goal is to maximize the parts that are delightfully parallel and minimize the parts that require overhead. This article provides information that will help you write PLINQ queries that are as efficient as possible while still yielding correct results.  
+This article provides information that will help you write PLINQ queries that are as efficient as possible while still yielding correct results.
+
+The primary purpose of PLINQ is to speed up the execution of LINQ to Objects queries by executing the query delegates in parallel on multi-core computers. PLINQ performs best when the processing of each element in a source collection is independent, with no shared state involved among the individual delegates. Such operations are common in LINQ to Objects and PLINQ, and are often called "*delightfully parallel*" because they lend themselves easily to scheduling on multiple threads. However, not all queries consist entirely of delightfully parallel operations. In most cases, a query involves some operators that either cannot be parallelized, or that slow down parallel execution. And even with queries that are entirely delightfully parallel, PLINQ must still partition the data source and schedule the work on the threads, and usually merge the results when the query completes. All these operations add to the computational cost of parallelization; these costs of adding parallelization are called *overhead*. To achieve optimum performance in a PLINQ query, the goal is to maximize the parts that are delightfully parallel and minimize the parts that require overhead.
   
 ## Factors that Impact PLINQ Query Performance  
 
- The following sections lists some of the most important factors that impact parallel query performance. These are general statements that by themselves are not sufficient to predict query performance in all cases. As always, it is important to measure actual performance of specific queries on computers with a range of representative configurations and loads.  
+ The following sections lists some of the most important factors that impact parallel query performance. These are general statements that by themselves are not sufficient to predict query performance in all cases. As always, it's important to measure actual performance of specific queries on computers with a range of representative configurations and loads.  
   
 1. Computational cost of the overall work.  
   


### PR DESCRIPTION
Contributes to #33349 

Example link for NuGet tutorial: https://learn.microsoft.com/en-us/nuget/quickstart/install-and-use-a-package-in-visual-studio?toc=%2Fdotnet%2Ffundamentals%2Ftoc.json&bc=%2Fdotnet%2Fbreadcrumb%2Ftoc.json

- Adds contextual TOC links to TOC links that take you to another TOC
- Remove two duplicated links from the migration guide section
- Remove link to compatibility/breaking changes TOC