### PR TITLE
Fix up parallel programming TOC sections

### DIFF
--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -2794,15 +2794,15 @@ items:
         - name: Overview
           displayName: data parallelism
           href: ../standard/parallel-programming/data-parallelism-task-parallel-library.md
-        - name: Write a simple Parallel.For loop
+        - name: Write a Parallel.For loop
           href: ../standard/parallel-programming/how-to-write-a-simple-parallel-for-loop.md
-        - name: Write a simple Parallel.ForEach loop
+        - name: Write a Parallel.ForEach loop
           href: ../standard/parallel-programming/how-to-write-a-simple-parallel-foreach-loop.md
         - name: Write a Parallel.For loop with thread-local variables
           href: ../standard/parallel-programming/how-to-write-a-parallel-for-loop-with-thread-local-variables.md
         - name: Write a Parallel.ForEach loop with partition-local variables
           href: ../standard/parallel-programming/how-to-write-a-parallel-foreach-loop-with-partition-local-variables.md
-        - name: Cancel a Parallel.For or ForEach loop
+        - name: Cancel a parallel loop
           href: ../standard/parallel-programming/how-to-cancel-a-parallel-for-or-foreach-loop.md
         - name: Handle exceptions in parallel loops
           href: ../standard/parallel-programming/how-to-handle-exceptions-in-parallel-loops.md
@@ -2813,62 +2813,62 @@ items:
       - name: Task-based asynchronous programming
         href: ../standard/parallel-programming/task-based-asynchronous-programming.md
         items:
-        - name: Chaining Tasks by Using Continuation Tasks
+        - name: Chain tasks by using continuation tasks
           href: ../standard/parallel-programming/chaining-tasks-by-using-continuation-tasks.md
-        - name: Attached and Detached Child Tasks
+        - name: Attached and detached child tasks
           href: ../standard/parallel-programming/attached-and-detached-child-tasks.md
-        - name: Task Cancellation
+        - name: Task cancellation
           href: ../standard/parallel-programming/task-cancellation.md
-        - name: Exception Handling
+        - name: Exception handling
           href: ../standard/parallel-programming/exception-handling-task-parallel-library.md
-        - name: "How to: Use Parallel.Invoke to Execute Parallel Operations"
+        - name: Use Parallel.Invoke to execute parallel operations
           href: ../standard/parallel-programming/how-to-use-parallel-invoke-to-execute-parallel-operations.md
-        - name: "How to: Return a Value from a Task"
+        - name: Return a value from a task
           href: ../standard/parallel-programming/how-to-return-a-value-from-a-task.md
-        - name: "How to: Cancel a Task and Its Children"
+        - name: Cancel a task and its children
           href: ../standard/parallel-programming/how-to-cancel-a-task-and-its-children.md
-        - name: "How to: Create Pre-Computed Tasks"
+        - name: Create pre-computed tasks
           href: ../standard/parallel-programming/how-to-create-pre-computed-tasks.md
-        - name: "How to: Traverse a Binary Tree with Parallel Tasks"
+        - name: Traverse a binary tree with parallel tasks
           href: ../standard/parallel-programming/how-to-traverse-a-binary-tree-with-parallel-tasks.md
-        - name: "How to: Unwrap a Nested Task"
+        - name: Unwrap a nested task
           href: ../standard/parallel-programming/how-to-unwrap-a-nested-task.md
-        - name: "How to: Prevent a Child Task from Attaching to its Parent"
+        - name: Prevent a child task from attaching to its parent
           href: ../standard/parallel-programming/how-to-prevent-a-child-task-from-attaching-to-its-parent.md
       - name: Dataflow
         href: ../standard/parallel-programming/dataflow-task-parallel-library.md
         items:
-        - name: "How to: Write Messages to and Read Messages from a Dataflow Block"
+        - name: Write messages to and read messages from a dataflow block
           href: ../standard/parallel-programming/how-to-write-messages-to-and-read-messages-from-a-dataflow-block.md
-        - name: "How to: Implement a Producer-Consumer Dataflow Pattern"
+        - name: Implement a producer-consumer dataflow pattern
           href: ../standard/parallel-programming/how-to-implement-a-producer-consumer-dataflow-pattern.md
-        - name: "How to: Perform Action When a Dataflow Block Receives Data"
+        - name: Perform an action when a dataflow block receives data
           href: ../standard/parallel-programming/how-to-perform-action-when-a-dataflow-block-receives-data.md
-        - name: "Walkthrough: Creating a Dataflow Pipeline"
+        - name: Create a dataflow pipeline
           href: ../standard/parallel-programming/walkthrough-creating-a-dataflow-pipeline.md
-        - name: "How to: Unlink Dataflow Blocks"
+        - name: Unlink dataflow blocks
           href: ../standard/parallel-programming/how-to-unlink-dataflow-blocks.md
-        - name: "Walkthrough: Using Dataflow in a Windows Forms Application"
+        - name: Use dataflow in a Windows Forms app
           href: ../standard/parallel-programming/walkthrough-using-dataflow-in-a-windows-forms-application.md
-        - name: "How to: Cancel a Dataflow Block"
+        - name: Cancel a dataflow block
           href: ../standard/parallel-programming/how-to-cancel-a-dataflow-block.md
-        - name: "Walkthrough: Creating a Custom Dataflow Block Type"
+        - name: Create a custom dataflow block type
           href: ../standard/parallel-programming/walkthrough-creating-a-custom-dataflow-block-type.md
-        - name: "How to: Use JoinBlock to Read Data From Multiple Sources"
+        - name: Use JoinBlock to read data from multiple sources
           href: ../standard/parallel-programming/how-to-use-joinblock-to-read-data-from-multiple-sources.md
-        - name: "How to: Specify the Degree of Parallelism in a Dataflow Block"
+        - name: Specify the degree of parallelism in a dataflow block
           href: ../standard/parallel-programming/how-to-specify-the-degree-of-parallelism-in-a-dataflow-block.md
-        - name: "How to: Specify a Task Scheduler in a Dataflow Block"
+        - name: Specify a task scheduler in a dataflow block
           href: ../standard/parallel-programming/how-to-specify-a-task-scheduler-in-a-dataflow-block.md
-        - name: "Walkthrough: Using BatchBlock and BatchedJoinBlock to Improve Efficiency"
+        - name: Use BatchBlock and BatchedJoinBlock to improve efficiency
           href: ../standard/parallel-programming/walkthrough-using-batchblock-and-batchedjoinblock-to-improve-efficiency.md
-      - name: Use TPL with Other Asynchronous Patterns
+      - name: Use TPL with other asynchronous patterns
         items:
-        - name: TPL and Traditional .NET Asynchronous Programming
+        - name: TPL and traditional .NET asynchronous programming
           href: ../standard/parallel-programming/tpl-and-traditional-async-programming.md
-        - name: "How to: Wrap EAP Patterns in a Task"
+        - name: Wrap EAP patterns in a task
           href: ../standard/parallel-programming/how-to-wrap-eap-patterns-in-a-task.md
-      - name: Potential Pitfalls in Data and Task Parallelism
+      - name: Potential pitfalls in data and task parallelism
         href: ../standard/parallel-programming/potential-pitfalls-in-data-and-task-parallelism.md
     - name: Parallel LINQ (PLINQ)
       items:
@@ -2882,27 +2882,27 @@ items:
         href: ../standard/parallel-programming/merge-options-in-plinq.md
       - name: Potential pitfalls
         href: ../standard/parallel-programming/potential-pitfalls-with-plinq.md
-      - name: Create and Execute a Simple Query
+      - name: Create and execute a query
         href: ../standard/parallel-programming/how-to-create-and-execute-a-simple-plinq-query.md
-      - name: Control Ordering in a Query
+      - name: Control ordering in a query
         href: ../standard/parallel-programming/how-to-control-ordering-in-a-plinq-query.md
-      - name: Combine Parallel and Sequential LINQ Queries
+      - name: Combine parallel and sequential LINQ queries
         href: ../standard/parallel-programming/how-to-combine-parallel-and-sequential-linq-queries.md
-      - name: Handle Exceptions in a Query
+      - name: Handle exceptions in a query
         href: ../standard/parallel-programming/how-to-handle-exceptions-in-a-plinq-query.md
-      - name: Cancel a Query
+      - name: Cancel a query
         href: ../standard/parallel-programming/how-to-cancel-a-plinq-query.md
-      - name: Write a Custom Aggregate Function
+      - name: Write a custom aggregate function
         href: ../standard/parallel-programming/how-to-write-a-custom-plinq-aggregate-function.md
-      - name: Specify the Execution Mode
+      - name: Specify the execution mode
         href: ../standard/parallel-programming/how-to-specify-the-execution-mode-in-plinq.md
-      - name: Specify Merge Options
+      - name: Specify merge options
         href: ../standard/parallel-programming/how-to-specify-merge-options-in-plinq.md
-      - name: Iterate File Directories
+      - name: Iterate file directories
         href: ../standard/parallel-programming/how-to-iterate-file-directories-with-plinq.md
-      - name: Measure Query Performance
+      - name: Measure query performance
         href: ../standard/parallel-programming/how-to-measure-plinq-query-performance.md
-      - name: Data Sample
+      - name: Data sample
         href: ../standard/parallel-programming/plinq-data-sample.md
     - name: Data structures for parallel programming
       href: ../standard/parallel-programming/data-structures-for-parallel-programming.md
@@ -2913,9 +2913,9 @@ items:
       - name: Overview
         href: ../standard/parallel-programming/custom-partitioners-for-plinq-and-tpl.md
         displayName: custom partitioners
-      - name: "How to: Implement Dynamic Partitions"
+      - name: Implement dynamic partitions
         href: ../standard/parallel-programming/how-to-implement-dynamic-partitions.md
-      - name: "How to: Implement a Partitioner for Static Partitioning"
+      - name: Implement a partitioner for static partitioning
         href: ../standard/parallel-programming/how-to-implement-a-partitioner-for-static-partitioning.md
     - name: Lambda expressions in PLINQ and TPL
       href: ../standard/parallel-programming/lambda-expressions-in-plinq-and-tpl.md

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -2882,23 +2882,23 @@ items:
         href: ../standard/parallel-programming/merge-options-in-plinq.md
       - name: Potential pitfalls
         href: ../standard/parallel-programming/potential-pitfalls-with-plinq.md
-      - name:  Create and Execute a Simple Query
+      - name: Create and Execute a Simple Query
         href: ../standard/parallel-programming/how-to-create-and-execute-a-simple-plinq-query.md
-      - name:  Control Ordering in a Query
+      - name: Control Ordering in a Query
         href: ../standard/parallel-programming/how-to-control-ordering-in-a-plinq-query.md
-      - name:  Combine Parallel and Sequential LINQ Queries
+      - name: Combine Parallel and Sequential LINQ Queries
         href: ../standard/parallel-programming/how-to-combine-parallel-and-sequential-linq-queries.md
-      - name:  Handle Exceptions in a Query
+      - name: Handle Exceptions in a Query
         href: ../standard/parallel-programming/how-to-handle-exceptions-in-a-plinq-query.md
-      - name:  Cancel a Query
+      - name: Cancel a Query
         href: ../standard/parallel-programming/how-to-cancel-a-plinq-query.md
-      - name:  Write a Custom Aggregate Function
+      - name: Write a Custom Aggregate Function
         href: ../standard/parallel-programming/how-to-write-a-custom-plinq-aggregate-function.md
-      - name:  Specify the Execution Mode
+      - name: Specify the Execution Mode
         href: ../standard/parallel-programming/how-to-specify-the-execution-mode-in-plinq.md
-      - name:  Specify Merge Options
+      - name: Specify Merge Options
         href: ../standard/parallel-programming/how-to-specify-merge-options-in-plinq.md
-      - name:  Iterate File Directories
+      - name: Iterate File Directories
         href: ../standard/parallel-programming/how-to-iterate-file-directories-with-plinq.md
       - name: Measure Query Performance
         href: ../standard/parallel-programming/how-to-measure-plinq-query-performance.md

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -2790,23 +2790,25 @@ items:
       href: ../standard/parallel-programming/task-parallel-library-tpl.md
       items:
       - name: Data parallelism
-        href: ../standard/parallel-programming/data-parallelism-task-parallel-library.md
         items:
-        - name: "How to: Write a Simple Parallel.For Loop"
+        - name: Overview
+          displayName: data parallelism
+          href: ../standard/parallel-programming/data-parallelism-task-parallel-library.md
+        - name: Write a simple Parallel.For loop
           href: ../standard/parallel-programming/how-to-write-a-simple-parallel-for-loop.md
-        - name: "How to: Write a Simple Parallel.ForEach Loop"
+        - name: Write a simple Parallel.ForEach loop
           href: ../standard/parallel-programming/how-to-write-a-simple-parallel-foreach-loop.md
-        - name: "How to: Write a Parallel.For Loop with Thread-Local Variables"
+        - name: Write a Parallel.For loop with thread-local variables
           href: ../standard/parallel-programming/how-to-write-a-parallel-for-loop-with-thread-local-variables.md
-        - name: "How to: Write a Parallel.ForEach Loop with Partition-Local Variables"
+        - name: Write a Parallel.ForEach loop with partition-local variables
           href: ../standard/parallel-programming/how-to-write-a-parallel-foreach-loop-with-partition-local-variables.md
-        - name: "How to: Cancel a Parallel.For or ForEach Loop"
+        - name: Cancel a Parallel.For or ForEach loop
           href: ../standard/parallel-programming/how-to-cancel-a-parallel-for-or-foreach-loop.md
-        - name: "How to: Handle Exceptions in Parallel Loops"
+        - name: Handle exceptions in parallel loops
           href: ../standard/parallel-programming/how-to-handle-exceptions-in-parallel-loops.md
-        - name: "How to: Speed Up Small Loop Bodies"
+        - name: Speed up small loop bodies
           href: ../standard/parallel-programming/how-to-speed-up-small-loop-bodies.md
-        - name: "How to: Iterate File Directories with the Parallel Class"
+        - name: Iterate file directories with the Parallel class
           href: ../standard/parallel-programming/how-to-iterate-file-directories-with-the-parallel-class.md
       - name: Task-based asynchronous programming
         href: ../standard/parallel-programming/task-based-asynchronous-programming.md
@@ -2870,37 +2872,37 @@ items:
         href: ../standard/parallel-programming/potential-pitfalls-in-data-and-task-parallelism.md
     - name: Parallel LINQ (PLINQ)
       items:
-      - name: Introduction to PLINQ
+      - name: Introduction
         href: ../standard/parallel-programming/introduction-to-plinq.md
-      - name: Understanding Speedup in PLINQ
+      - name: Optimize queries for speedup
         href: ../standard/parallel-programming/understanding-speedup-in-plinq.md
-      - name: Order Preservation in PLINQ
+      - name: Order preservation
         href: ../standard/parallel-programming/order-preservation-in-plinq.md
-      - name: Merge Options in PLINQ
+      - name: Merge options
         href: ../standard/parallel-programming/merge-options-in-plinq.md
-      - name: Potential Pitfalls with PLINQ
+      - name: Potential pitfalls
         href: ../standard/parallel-programming/potential-pitfalls-with-plinq.md
-      - name: "How to: Create and Execute a Simple PLINQ Query"
+      - name:  Create and Execute a Simple Query
         href: ../standard/parallel-programming/how-to-create-and-execute-a-simple-plinq-query.md
-      - name: "How to: Control Ordering in a PLINQ Query"
+      - name:  Control Ordering in a Query
         href: ../standard/parallel-programming/how-to-control-ordering-in-a-plinq-query.md
-      - name: "How to: Combine Parallel and Sequential LINQ Queries"
+      - name:  Combine Parallel and Sequential LINQ Queries
         href: ../standard/parallel-programming/how-to-combine-parallel-and-sequential-linq-queries.md
-      - name: "How to: Handle Exceptions in a PLINQ Query"
+      - name:  Handle Exceptions in a Query
         href: ../standard/parallel-programming/how-to-handle-exceptions-in-a-plinq-query.md
-      - name: "How to: Cancel a PLINQ Query"
+      - name:  Cancel a Query
         href: ../standard/parallel-programming/how-to-cancel-a-plinq-query.md
-      - name: "How to: Write a Custom PLINQ Aggregate Function"
+      - name:  Write a Custom Aggregate Function
         href: ../standard/parallel-programming/how-to-write-a-custom-plinq-aggregate-function.md
-      - name: "How to: Specify the Execution Mode in PLINQ"
+      - name:  Specify the Execution Mode
         href: ../standard/parallel-programming/how-to-specify-the-execution-mode-in-plinq.md
-      - name: "How to: Specify Merge Options in PLINQ"
+      - name:  Specify Merge Options
         href: ../standard/parallel-programming/how-to-specify-merge-options-in-plinq.md
-      - name: "How to: Iterate File Directories with PLINQ"
+      - name:  Iterate File Directories
         href: ../standard/parallel-programming/how-to-iterate-file-directories-with-plinq.md
-      - name: "How to: Measure PLINQ Query Performance"
+      - name: Measure Query Performance
         href: ../standard/parallel-programming/how-to-measure-plinq-query-performance.md
-      - name: PLINQ Data Sample
+      - name: Data Sample
         href: ../standard/parallel-programming/plinq-data-sample.md
     - name: Data structures for parallel programming
       href: ../standard/parallel-programming/data-structures-for-parallel-programming.md

--- a/docs/standard/parallel-programming/understanding-speedup-in-plinq.md
+++ b/docs/standard/parallel-programming/understanding-speedup-in-plinq.md
@@ -9,13 +9,15 @@ helpviewer_keywords:
   - "PLINQ queries, performance tuning"
 ms.assetid: 53706c7e-397d-467a-98cd-c0d1fd63ba5e
 ---
-# Understanding Speedup in PLINQ
+# Speedup in PLINQ
 
-The primary purpose of PLINQ is to speed up the execution of LINQ to Objects queries by executing the query delegates in parallel on multi-core computers. PLINQ performs best when the processing of each element in a source collection is independent, with no shared state involved among the individual delegates. Such operations are common in LINQ to Objects and PLINQ, and are often called "*delightfully parallel*" because they lend themselves easily to scheduling on multiple threads. However, not all queries consist entirely of delightfully parallel operations; in most cases, a query involves some operators that either cannot be parallelized, or that slow down parallel execution. And even with queries that are entirely delightfully parallel, PLINQ must still partition the data source and schedule the work on the threads, and usually merge the results when the query completes. All these operations add to the computational cost of parallelization; these costs of adding parallelization are called *overhead*. To achieve optimum performance in a PLINQ query, the goal is to maximize the parts that are delightfully parallel and minimize the parts that require overhead. This article provides information that will help you write PLINQ queries that are as efficient as possible while still yielding correct results.  
+This article provides information that will help you write PLINQ queries that are as efficient as possible while still yielding correct results.
+
+The primary purpose of PLINQ is to speed up the execution of LINQ to Objects queries by executing the query delegates in parallel on multi-core computers. PLINQ performs best when the processing of each element in a source collection is independent, with no shared state involved among the individual delegates. Such operations are common in LINQ to Objects and PLINQ, and are often called "*delightfully parallel*" because they lend themselves easily to scheduling on multiple threads. However, not all queries consist entirely of delightfully parallel operations. In most cases, a query involves some operators that either cannot be parallelized, or that slow down parallel execution. And even with queries that are entirely delightfully parallel, PLINQ must still partition the data source and schedule the work on the threads, and usually merge the results when the query completes. All these operations add to the computational cost of parallelization; these costs of adding parallelization are called *overhead*. To achieve optimum performance in a PLINQ query, the goal is to maximize the parts that are delightfully parallel and minimize the parts that require overhead.
   
 ## Factors that Impact PLINQ Query Performance  
 
- The following sections lists some of the most important factors that impact parallel query performance. These are general statements that by themselves are not sufficient to predict query performance in all cases. As always, it is important to measure actual performance of specific queries on computers with a range of representative configurations and loads.  
+ The following sections lists some of the most important factors that impact parallel query performance. These are general statements that by themselves are not sufficient to predict query performance in all cases. As always, it's important to measure actual performance of specific queries on computers with a range of representative configurations and loads.  
   
 1. Computational cost of the overall work.  
   

--- a/docs/standard/parallel-programming/walkthrough-using-dataflow-in-a-windows-forms-application.md
+++ b/docs/standard/parallel-programming/walkthrough-using-dataflow-in-a-windows-forms-application.md
@@ -10,7 +10,7 @@ ms.topic: tutorial
 ---
 # Walkthrough: Using Dataflow in a Windows Forms Application
 
-This document demonstrates how to create a network of dataflow blocks that perform image processing in a Windows Forms application.  
+This article demonstrates how to create a network of dataflow blocks that perform image processing in a Windows Forms application.  
   
  This example loads image files from the specified folder, creates a composite image, and displays the result. The example uses the dataflow model to route images through the network. In the dataflow model, independent components of a program communicate with one another by sending messages. When a component receives a message, it performs some action and then passes the result to another component. Compare this with the control flow model, in which an application uses control structures, for example, conditional statements, loops, and so on, to control the order of operations in a program.  
   


### PR DESCRIPTION
- Sentence capitalization
- Remove unnecessary words such as "how to:" and "PLINQ" to shorten TOC node titles
- Move sentence up to beginning of article so it's clear what it's about

[Internal preview link](https://review.learn.microsoft.com/en-us/dotnet/standard/parallel-programming/introduction-to-plinq?branch=pr-en-us-33352)