### PR TITLE
Update ClassesObjects.cs

### DIFF
--- a/docs/csharp/tour-of-csharp/snippets/shared/ClassesObjects.cs
+++ b/docs/csharp/tour-of-csharp/snippets/shared/ClassesObjects.cs
@@ -205,8 +205,10 @@ namespace TourOfCsharp
             get => _items[index];
             set
             {
-                _items[index] = value;
-                OnChanged();
+                if (!object.Equals(_items[index], value)) {
+                    _items[index] = value;
+                    OnChanged();
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

My suggestion is to modify the indexer `set` accessor code of the `MyList<T>` class to only assign a value to an item at a specific index and call the `OnChange()` virtual method if the value of the item has really been changed. This modification will make the code more confident with the event name.