### PR TITLE
Update Observers docs

### DIFF
--- a/docs/orleans/grains/observers.md
+++ b/docs/orleans/grains/observers.md
@@ -9,9 +9,9 @@ ms.date: 03/16/2022
 There are situations in which a simple message/response pattern is not enough, and the client needs to receive asynchronous notifications.
 For example, a user might want to be notified when a new instant message has been published by a friend.
 
-Client observers is a mechanism that allows notifying clients asynchronously. An observer is a one-way asynchronous interface that inherits from <xref:Orleans.IGrainObserver>, and all its methods must be void. The grain sends a notification to the observer by invoking it like a grain interface method, except that it has no return value, and so the grain need not depend on the result. The Orleans runtime will ensure one-way delivery of the notifications. A grain that publishes such notifications should provide an API to add or remove observers. In addition, it is usually convenient to expose a method that allows an existing subscription to be cancelled.
+Client observers is a mechanism that allows notifying clients asynchronously. An observer is a one-way asynchronous interface that inherits from <xref:Orleans.IGrainObserver>, and all its methods must return `void` or <xref:System.Threading.Tasks.Task>. The grain sends a notification to the observer by invoking it like a grain interface method, except that it has no return value, and so the grain need not depend on the result. The Orleans runtime will ensure one-way delivery of the notifications. A grain that publishes such notifications should provide an API to add or remove observers. In addition, it is usually convenient to expose a method that allows an existing subscription to be cancelled.
 
-Grain developers may use a utility class such as [`ObserverManager<T>`](https://github.com/dotnet/orleans/blob/e997335d2d689bb39e67f6bcf6fd70862a22c02f/test/Grains/TestGrains/ObserverManager.cs#L12) to simplify development of observed grain types. Unlike grains, which are automatically reactivated as-needed after failure, clients are not fault-tolerant: a client which fails may never recover.
+Grain developers may use a utility class such as <xref:Orleans.Utilities.ObserverManager%601> to simplify development of observed grain types. Unlike grains, which are automatically reactivated as-needed after failure, clients are not fault-tolerant: a client which fails may never recover.
 For this reason, the `ObserverManager<T>` utility removes subscriptions after a configured duration. Clients which are active should resubscribe on a timer to keep their subscription active.
 
 To subscribe to a notification, the client must first create a local object that implements the observer interface. It then calls a method on the observer factory, <xref:Orleans.IGrainFactory.CreateObjectReference%2A>`, to turn the object into a grain reference, which can then be passed to the subscription method on the notifying grain.
@@ -47,7 +47,10 @@ public class Chat : IChat
 }
 ```
 
-On the server, we should next have a Grain that sends these chat messages to clients. The Grain should also have a mechanism for clients to subscribe and unsubscribe themselves for notifications. For subscriptions, the grain can use a copy of the utility class [`ObserverManager<T>`](https://github.com/dotnet/orleans/blob/e997335d2d689bb39e67f6bcf6fd70862a22c02f/test/Grains/TestGrains/ObserverManager.cs#L12).
+On the server, we should next have a Grain that sends these chat messages to clients. The Grain should also have a mechanism for clients to subscribe and unsubscribe themselves for notifications. For subscriptions, the grain can use an instance of the utility class <xref:Orleans.Utilities.ObserverManager%601>.
+    
+> [!NOTE]
+> <xref:Orleans.Utilities.ObserverManager%601> is part of Orleans since version 7.0. For older versions, the following [implementation](https://github.com/dotnet/orleans/blob/e997335d2d689bb39e67f6bcf6fd70862a22c02f/test/Grains/TestGrains/ObserverManager.cs#L12) can be copied.
 
 ```csharp
 class HelloGrain : Grain, IHello

--- a/docs/orleans/grains/observers.md
+++ b/docs/orleans/grains/observers.md
@@ -48,7 +48,7 @@ public class Chat : IChat
 ```
 
 On the server, we should next have a Grain that sends these chat messages to clients. The Grain should also have a mechanism for clients to subscribe and unsubscribe themselves for notifications. For subscriptions, the grain can use an instance of the utility class <xref:Orleans.Utilities.ObserverManager%601>.
-    
+
 > [!NOTE]
 > <xref:Orleans.Utilities.ObserverManager%601> is part of Orleans since version 7.0. For older versions, the following [implementation](https://github.com/dotnet/orleans/blob/e997335d2d689bb39e67f6bcf6fd70862a22c02f/test/Grains/TestGrains/ObserverManager.cs#L12) can be copied.
 


### PR DESCRIPTION

## Summary

- ObserverManager now part of Orleans.
- Clarify that IGrainObserver also can return Task