### PR TITLE
Remove inaccessible variable (col) from example

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_Misc/cancellation/cs/cancellationex11.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/cancellation/cs/cancellationex11.cs
@@ -53,7 +53,7 @@ class CancelByPolling
 
       if (token.IsCancellationRequested) {
          // Cleanup or undo here if necessary...
-         Console.WriteLine("\r\nCancelling before column {0}.", col);
+         Console.WriteLine("\r\nOperation canceled");
          Console.WriteLine("Press any key to exit.");
 
          // If using Task:

--- a/samples/snippets/visualbasic/VS_Snippets_Misc/cancellation/vb/cancellationex11.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_Misc/cancellation/vb/cancellationex11.vb
@@ -55,7 +55,7 @@ Class CancelByPolling
 
         If token.IsCancellationRequested = True Then
             ' Cleanup or undo here if necessary...
-            Console.WriteLine(vbCrLf + "Cancelling before column 0'.", col)
+            Console.WriteLine(vbCrLf + "Operation canceled")
             Console.WriteLine("Press any key to exit.")
 
             ' If using Task:


### PR DESCRIPTION
## Summary

Remove the inaccessible variable (col) from example

Fixes #33404
