### PR TITLE
Change IGrainIdentity to GrainId.

### DIFF
--- a/docs/orleans/grains/grainservices.md
+++ b/docs/orleans/grains/grainservices.md
@@ -36,7 +36,7 @@ A <xref:Orleans.Runtime.GrainService> is a special grain; one that has no stable
 
         public DataService(
             IServiceProvider services,
-            IGrainIdentity id,
+            GrainId id,
             Silo silo,
             ILoggerFactory loggerFactory,
             IGrainFactory grainFactory)


### PR DESCRIPTION
## Summary

In the example ``DataService`` type - the constructor is using ``IGrainIdentity`` when it should be using ``GrainId`` - this small changes updates that - so that others don't get confused like it did :)


