### PR TITLE
Make BinaryFormatter examples more secure

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca2301.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2301.md
@@ -136,9 +136,13 @@ public class BookRecordSerializationBinder : SerializationBinder
 
         ////Console.WriteLine($"BindToType('{assemblyName}', '{typeName}')");
 
-        if (typeName == "BookRecord" || typeName == "AisleLocation")
+        if (typeName == "BookRecord")
         {
-            return null;
+            return typeof(BookRecord);
+        }
+        else if (typeName == "AisleLocation")
+        {
+            return typeof(AisleLocation);
         }
         else
         {
@@ -190,8 +194,10 @@ Public Class BookRecordSerializationBinder
 
         'Console.WriteLine($"BindToType('{assemblyName}', '{typeName}')")
 
-        If typeName = "BinaryFormatterVB.BookRecord" Or typeName = "BinaryFormatterVB.AisleLocation" Then
-            Return Nothing
+        If typeName = "BinaryFormatterVB.BookRecord" Then
+            Return GetType(BookRecord)
+        Else If typeName = "BinaryFormatterVB.AisleLocation" Then
+            Return GetType(AisleLocation)
         Else
             Throw New ArgumentException("Unexpected type", NameOf(typeName))
         End If

--- a/docs/fundamentals/code-analysis/quality-rules/ca2302.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2302.md
@@ -77,9 +77,13 @@ public class BookRecordSerializationBinder : SerializationBinder
 
         ////Console.WriteLine($"BindToType('{assemblyName}', '{typeName}')");
 
-        if (typeName == "BookRecord" || typeName == "AisleLocation")
+        if (typeName == "BookRecord")
         {
-            return null;
+            return typeof(BookRecord);
+        }
+        else if (typeName == "AisleLocation")
+        {
+            return typeof(AisleLocation);
         }
         else
         {
@@ -137,8 +141,10 @@ Public Class BookRecordSerializationBinder
 
         'Console.WriteLine($"BindToType('{assemblyName}', '{typeName}')")
 
-        If typeName = "BinaryFormatterVB.BookRecord" Or typeName = "BinaryFormatterVB.AisleLocation" Then
-            Return Nothing
+        If typeName = "BinaryFormatterVB.BookRecord" Then
+            Return GetType(BookRecord)
+        Else If typeName = "BinaryFormatterVB.AisleLocation" Then
+            Return GetType(AisleLocation)
         Else
             Throw New ArgumentException("Unexpected type", NameOf(typeName))
         End If
@@ -189,9 +195,13 @@ public class BookRecordSerializationBinder : SerializationBinder
 
         ////Console.WriteLine($"BindToType('{assemblyName}', '{typeName}')");
 
-        if (typeName == "BookRecord" || typeName == "AisleLocation")
+        if (typeName == "BookRecord")
         {
-            return null;
+            return typeof(BookRecord);
+        }
+        else if (typeName == "AisleLocation")
+        {
+            return typeof(AisleLocation);
         }
         else
         {
@@ -252,8 +262,10 @@ Public Class BookRecordSerializationBinder
 
         'Console.WriteLine($"BindToType('{assemblyName}', '{typeName}')")
 
-        If typeName = "BinaryFormatterVB.BookRecord" Or typeName = "BinaryFormatterVB.AisleLocation" Then
-            Return Nothing
+        If typeName = "BinaryFormatterVB.BookRecord" Then
+            Return GetType(BookRecord)
+        Else If typeName = "BinaryFormatterVB.AisleLocation" Then
+            Return GetType(AisleLocation)
         Else
             Throw New ArgumentException("Unexpected type", NameOf(typeName))
         End If
@@ -370,9 +382,13 @@ public class BookRecordSerializationBinder : SerializationBinder
 
         ////Console.WriteLine($"BindToType('{assemblyName}', '{typeName}')");
 
-        if (typeName == "BookRecord" || typeName == "AisleLocation")
+        if (typeName == "BookRecord")
         {
-            return null;
+            return typeof(BookRecord);
+        }
+        else if (typeName == "AisleLocation")
+        {
+            return typeof(AisleLocation);
         }
         else
         {
@@ -424,8 +440,10 @@ Public Class BookRecordSerializationBinder
 
         'Console.WriteLine($"BindToType('{assemblyName}', '{typeName}')")
 
-        If typeName = "BinaryFormatterVB.BookRecord" Or typeName = "BinaryFormatterVB.AisleLocation" Then
-            Return Nothing
+        If typeName = "BinaryFormatterVB.BookRecord" Then
+            Return GetType(BookRecord)
+        Else If typeName = "BinaryFormatterVB.AisleLocation" Then
+            Return GetType(AisleLocation)
         Else
             Throw New ArgumentException("Unexpected type", NameOf(typeName))
         End If

--- a/docs/fundamentals/code-analysis/quality-rules/ca2311.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2311.md
@@ -147,9 +147,13 @@ public class BookRecordSerializationBinder : SerializationBinder
 
         ////Console.WriteLine($"BindToType('{assemblyName}', '{typeName}')");
 
-        if (typeName == "BookRecord" || typeName == "AisleLocation")
+        if (typeName == "BookRecord")
         {
-            return null;
+            return typeof(BookRecord);
+        }
+        else if (typeName == "AisleLocation")
+        {
+            return typeof(AisleLocation);
         }
         else
         {
@@ -206,8 +210,10 @@ Public Class BookRecordSerializationBinder
 
         'Console.WriteLine($"BindToType('{assemblyName}', '{typeName}')")
 
-        If typeName = "BinaryFormatterVB.BookRecord" Or typeName = "BinaryFormatterVB.AisleLocation" Then
-            Return Nothing
+        If typeName = "BinaryFormatterVB.BookRecord" Then
+            Return GetType(BookRecord)
+        Else If typeName = "BinaryFormatterVB.AisleLocation" Then
+            Return GetType(AisleLocation)
         Else
             Throw New ArgumentException("Unexpected type", NameOf(typeName))
         End If

--- a/docs/fundamentals/code-analysis/quality-rules/ca2312.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2312.md
@@ -78,9 +78,13 @@ public class BookRecordSerializationBinder : SerializationBinder
 
         ////Console.WriteLine($"BindToType('{assemblyName}', '{typeName}')");
 
-        if (typeName == "BookRecord" || typeName == "AisleLocation")
+        if (typeName == "BookRecord")
         {
-            return null;
+            return typeof(BookRecord);
+        }
+        else if (typeName == "AisleLocation")
+        {
+            return typeof(AisleLocation);
         }
         else
         {
@@ -142,8 +146,10 @@ Public Class BookRecordSerializationBinder
 
         'Console.WriteLine($"BindToType('{assemblyName}', '{typeName}')")
 
-        If typeName = "BinaryFormatterVB.BookRecord" Or typeName = "BinaryFormatterVB.AisleLocation" Then
-            Return Nothing
+        If typeName = "BinaryFormatterVB.BookRecord" Then
+            Return GetType(BookRecord)
+        Else If typeName = "BinaryFormatterVB.AisleLocation" Then
+            Return GetType(AisleLocation)
         Else
             Throw New ArgumentException("Unexpected type", NameOf(typeName))
         End If
@@ -200,9 +206,13 @@ public class BookRecordSerializationBinder : SerializationBinder
 
         ////Console.WriteLine($"BindToType('{assemblyName}', '{typeName}')");
 
-        if (typeName == "BookRecord" || typeName == "AisleLocation")
+        if (typeName == "BookRecord")
         {
-            return null;
+            return typeof(BookRecord);
+        }
+        else if (typeName == "AisleLocation")
+        {
+            return typeof(AisleLocation);
         }
         else
         {
@@ -267,8 +277,10 @@ Public Class BookRecordSerializationBinder
 
         'Console.WriteLine($"BindToType('{assemblyName}', '{typeName}')")
 
-        If typeName = "BinaryFormatterVB.BookRecord" Or typeName = "BinaryFormatterVB.AisleLocation" Then
-            Return Nothing
+        If typeName = "BinaryFormatterVB.BookRecord" Then
+            Return GetType(BookRecord)
+        Else If typeName = "BinaryFormatterVB.AisleLocation" Then
+            Return GetType(AisleLocation)
         Else
             Throw New ArgumentException("Unexpected type", NameOf(typeName))
         End If
@@ -412,9 +424,13 @@ public class BookRecordSerializationBinder : SerializationBinder
 
         ////Console.WriteLine($"BindToType('{assemblyName}', '{typeName}')");
 
-        if (typeName == "BookRecord" || typeName == "AisleLocation")
+        if (typeName == "BookRecord")
         {
-            return null;
+            return typeof(BookRecord);
+        }
+        else if (typeName == "AisleLocation")
+        {
+            return typeof(AisleLocation);
         }
         else
         {
@@ -477,8 +493,10 @@ Public Class BookRecordSerializationBinder
 
         'Console.WriteLine($"BindToType('{assemblyName}', '{typeName}')")
 
-        If typeName = "BinaryFormatterVB.BookRecord" Or typeName = "BinaryFormatterVB.AisleLocation" Then
-            Return Nothing
+        If typeName = "BinaryFormatterVB.BookRecord" Then
+            Return GetType(BookRecord)
+        Else If typeName = "BinaryFormatterVB.AisleLocation" Then
+            Return GetType(AisleLocation)
         Else
             Throw New ArgumentException("Unexpected type", NameOf(typeName))
         End If


### PR DESCRIPTION
## Summary

Per https://liquid.microsoft.com/Web/Object/Read/ms.security/Requirements/Microsoft.Security.SystemsADM.10010#Zguide, `SerializationBinder` subclasses must not return null from their `BindToType` and `BindToName` methods. The PR makes the code snippets compliant with this SDL requirement. The new code is functionally equivalent with the old code.