### PR TITLE
Rework STJ bits for `DateOnly` and `TimeOnly`

### DIFF
--- a/docs/standard/datetime/how-to-use-dateonly-timeonly.md
+++ b/docs/standard/datetime/how-to-use-dateonly-timeonly.md
@@ -1,7 +1,7 @@
 ---
 title: How to use DateOnly and TimeOnly
 description: Learn about the DateOnly and TimeOnly structures in .NET.
-ms.date: 12/28/2022
+ms.date: 01/11/2023
 dev_langs: 
   - "csharp"
   - "vb"
@@ -124,6 +124,12 @@ Because `TimeOnly` only represents a 24-hour period, it rolls over forwards or b
 
 :::code language="csharp" source="./snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="time_parse":::
 :::code language="vb" source="./snippets/how-to-use-dateonly-timeonly/vb/Program.vb" id="time_parse":::
+
+### Serialize DateOnly and TimeOnly types
+
+[!INCLUDE [dateonly-and-timeonly-serialization](includes/dateonly-and-timeonly-serialization.md)]
+
+For more information, see [How to serialize and deserialize (marshal and unmarshal) JSON in .NET](../serialization/system-text-json/how-to.md#how-to-serialize-and-deserialize-marshal-and-unmarshal-json-in-net).
 
 ### Work with TimeSpan and DateTime
 

--- a/docs/standard/datetime/includes/dateonly-and-timeonly-serialization-cs.md
+++ b/docs/standard/datetime/includes/dateonly-and-timeonly-serialization-cs.md
@@ -12,7 +12,7 @@ With .NET 7+, `System.Text.Json` supports serializing and deserializing <xref:Sy
 
 The following example serializes an `Appointment` object, displays the resulting JSON, and then deserializes it back into a new instance of the `Appointment` type. Finally, the original and newly deserialized instances are compared for equality and the results are written to the console:
 
-:::code source="snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="serialization":::
+:::code source="../snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="serialization":::
 
 In the preceding code:
 

--- a/docs/standard/datetime/includes/dateonly-and-timeonly-serialization-cs.md
+++ b/docs/standard/datetime/includes/dateonly-and-timeonly-serialization-cs.md
@@ -1,0 +1,24 @@
+---
+author: IEvangelist
+ms.author: dapine
+ms.date: 01/11/2023
+ms.topic: include
+recommendations: false
+---
+
+With .NET 7+, `System.Text.Json` supports serializing and deserializing <xref:System.DateOnly> and <xref:System.TimeOnly> types. Consider the following object:
+
+:::code source="../snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="appointment":::
+
+The following example serializes an `Appointment` object, displays the resulting JSON, and then deserializes it back into a new instance of the `Appointment` type. Finally, the original and newly deserialized instances are compared for equality and the results are written to the console:
+
+:::code source="snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="serialization":::
+
+In the preceding code:
+
+- An `Appointment` object is instantiated and assigned to the `appointment` variable.
+- The `appointment` instance is serialized to JSON using <xref:System.Text.Json.JsonSerializer.Serialize%2A?displayProperty=nameWithType>.
+- The resulting JSON is written to the console.
+- The JSON is deserialized back into a new instance of the `Appointment` type using <xref:System.Text.Json.JsonSerializer.Deserialize%2A?displayProperty=nameWithType>.
+- The original and newly deserialized instances are compared for equality.
+- The result of the comparison is written to the console.

--- a/docs/standard/datetime/includes/dateonly-and-timeonly-serialization.md
+++ b/docs/standard/datetime/includes/dateonly-and-timeonly-serialization.md
@@ -13,8 +13,8 @@ With .NET 7+, `System.Text.Json` supports serializing and deserializing <xref:Sy
 
 The following example serializes an `Appointment` object, displays the resulting JSON, and then deserializes it back into a new instance of the `Appointment` type. Finally, the original and newly deserialized instances are compared for equality and the results are written to the console:
 
-:::code source="snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="serialization":::
-:::code source="snippets/how-to-use-dateonly-timeonly/vb/Program.vb" id="serialization":::
+:::code source="../snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="serialization":::
+:::code source="../snippets/how-to-use-dateonly-timeonly/vb/Program.vb" id="serialization":::
 
 In the preceding code:
 

--- a/docs/standard/datetime/includes/dateonly-and-timeonly-serialization.md
+++ b/docs/standard/datetime/includes/dateonly-and-timeonly-serialization.md
@@ -1,0 +1,26 @@
+---
+author: IEvangelist
+ms.author: dapine
+ms.date: 01/11/2023
+ms.topic: include
+recommendations: false
+---
+
+With .NET 7+, `System.Text.Json` supports serializing and deserializing <xref:System.DateOnly> and <xref:System.TimeOnly> types. Consider the following object:
+
+:::code source="../snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="appointment":::
+:::code source="../snippets/how-to-use-dateonly-timeonly/vb/Program.vb" id="appointment":::
+
+The following example serializes an `Appointment` object, displays the resulting JSON, and then deserializes it back into a new instance of the `Appointment` type. Finally, the original and newly deserialized instances are compared for equality and the results are written to the console:
+
+:::code source="snippets/how-to-use-dateonly-timeonly/csharp/Program.cs" id="serialization":::
+:::code source="snippets/how-to-use-dateonly-timeonly/vb/Program.vb" id="serialization":::
+
+In the preceding code:
+
+- An `Appointment` object is instantiated and assigned to the `appointment` variable.
+- The `appointment` instance is serialized to JSON using <xref:System.Text.Json.JsonSerializer.Serialize%2A?displayProperty=nameWithType>.
+- The resulting JSON is written to the console.
+- The JSON is deserialized back into a new instance of the `Appointment` type using <xref:System.Text.Json.JsonSerializer.Deserialize%2A?displayProperty=nameWithType>.
+- The original and newly deserialized instances are compared for equality.
+- The result of the comparison is written to the console.

--- a/docs/standard/datetime/snippets/how-to-use-dateonly-timeonly/csharp/Program.cs
+++ b/docs/standard/datetime/snippets/how-to-use-dateonly-timeonly/csharp/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using System.Text.Json;
 
 Console.WriteLine("---------- Date Hebrew Calendar");
 Date_HebrewCalendar();
@@ -25,6 +26,9 @@ Console.WriteLine("\n---------- Time Convert DateTime");
 Time_DateTime();
 Console.WriteLine("\n---------- Time Use TimeSpan");
 Time_TimeSpan();
+
+Console.WriteLine("\n---------- DateOnly and TimeOnly Serialization");
+DateOnlyAndTimeOnlySerialization();
 
 
 void Date_HebrewCalendar()
@@ -277,3 +281,35 @@ void Time_DateTime()
     */
     //</time_datetime>
 }
+
+void DateOnlyAndTimeOnlySerialization()
+{
+    // <serialization>
+    Appointment originalAppointment = new(
+        Id: Guid.NewGuid(),
+        Description: "Take dog to veterinarian.",
+        Date: new DateOnly(2002, 1, 13),
+        StartTime: new TimeOnly(5,15),
+        EndTime: new TimeOnly(5, 45));
+    string serialized = JsonSerializer.Serialize(originalAppointment);
+
+    Console.WriteLine($"Resulting JSON: {serialized}");
+
+    Appointment deserializedAppointment =
+        JsonSerializer.Deserialize<Appointment>(serialized)!;
+
+    bool valuesAreTheSame = originalAppointment == deserializedAppointment;
+    Console.WriteLine($"""
+        Original record has the same values as the deserialized record: {valuesAreTheSame}
+        """);
+    // </serialization>
+}
+
+// <appointment>
+sealed file record Appointment(
+    Guid Id,
+    string Description,
+    DateOnly Date,
+    TimeOnly StartTime,
+    TimeOnly EndTime);
+// </appointment>

--- a/docs/standard/datetime/snippets/how-to-use-dateonly-timeonly/vb/Program.vb
+++ b/docs/standard/datetime/snippets/how-to-use-dateonly-timeonly/vb/Program.vb
@@ -1,5 +1,6 @@
 ﻿Imports System
 Imports System.Globalization
+Imports System.Text.Json
 
 Module Program
     Sub Main(args As String())
@@ -28,6 +29,9 @@ Module Program
         Time_DateTime()
         Console.WriteLine(vbCrLf + "---------- Time Use TimeSpan")
         Time_TimeSpan()
+
+        Console.WriteLine(vbCrLf + "---------- DateOnly and TimeOnly Serialization")
+        DateOnlyAndTimeOnlySerialization()
     End Sub
 
     Sub Date_HebrewCalendar()
@@ -202,7 +206,7 @@ Module Program
 
         '<time_now>
         Dim now = TimeOnly.FromDateTime(DateTime.Now)
-        Console.WriteLine($"It is {Now} right now")
+        Console.WriteLine($"It is {now} right now")
 
         ' This example produces output similar to the following
         ' 
@@ -283,5 +287,43 @@ Module Program
         '</time_datetime>
 
     End Sub
+
+    Sub DateOnlyAndTimeOnlySerialization()
+        '<serialization>
+        Dim originalAppointment As New Appointment With {
+            .Id = Guid.NewGuid(),
+            .Description = "Take dog to veterinarian.",
+            .DateValue = New DateOnly(2002, 1, 13),
+            .StartTime = New TimeOnly(5, 3, 1),
+            .EndTime = New TimeOnly(5, 3, 1)
+}
+        Dim serialized As String = JsonSerializer.Serialize(originalAppointment)
+
+        Console.WriteLine($"Resulting JSON: {serialized}")
+
+        Dim deserializedAppointment As Appointment =
+            JsonSerializer.Deserialize(Of Appointment)(serialized)
+
+        Dim valuesAreTheSame As Boolean =
+            (originalAppointment.DateValue = deserializedAppointment.DateValue AndAlso
+            originalAppointment.StartTime = deserializedAppointment.StartTime AndAlso
+            originalAppointment.EndTime = deserializedAppointment.EndTime AndAlso
+            originalAppointment.Id = deserializedAppointment.Id AndAlso
+            originalAppointment.Description = deserializedAppointment.Description)
+
+        Console.WriteLine(
+            $"Original object has the same values as the deserialized object: {valuesAreTheSame}")
+        '</serialization>
+    End Sub
+
+    '<appointment>
+    Public NotInheritable Class Appointment
+        Public Property Id As Guid
+        Public Property Description As String
+        Public Property DateValue As DateOnly?
+        Public Property StartTime As TimeOnly?
+        Public Property EndTime As TimeOnly?
+    End Class
+    '</appointment>
 
 End Module

--- a/docs/standard/datetime/system-text-json-support.md
+++ b/docs/standard/datetime/system-text-json-support.md
@@ -3,8 +3,9 @@ title: DateTime and DateTimeOffset support in System.Text.Json
 description: An overview of how DateTime and DateTimeOffset types are supported in the System.Text.Json library.
 author: layomia
 ms.author: laakinri
-ms.date: 08/09/2022
+ms.date: 01/11/2023
 ms.custom: devdivchpfy22
+zone_pivot_groups: dotnet-version
 helpviewer_keywords:
   - "JSON, Serializer, Utf8"
   - "JSON DateTime, JSON DateTimeOffset"
@@ -59,6 +60,14 @@ The lower level <xref:System.Text.Json.Utf8JsonWriter> writes <xref:System.DateT
 Attempting to read non-compliant formats with <xref:System.Text.Json.Utf8JsonReader> will cause it to throw a <xref:System.FormatException>:
 
 :::code language="csharp" source="snippets/system-text-json-support/csharp/reading-with-utf8jsonreader-error/Program.cs":::
+
+::: zone pivot="dotnet-7-0"
+
+## Serialize DateOnly and TimeOnly properties
+
+[!INCLUDE [dateonly-and-timeonly-serialization-cs](includes/dateonly-and-timeonly-serialization-cs.md)]
+
+::: zone-end
 
 ## Custom support for <xref:System.DateTime> and <xref:System.DateTimeOffset>
 

--- a/docs/standard/datetime/system-text-json-support.md
+++ b/docs/standard/datetime/system-text-json-support.md
@@ -22,6 +22,8 @@ The `System.Text.Json` library parses and writes <xref:System.DateTime> and <xre
 
 ## Support for the ISO 8601-1:2019 format
 
+::: zone pivot="dotnet-6-0,dotnet-7-0,dotnet-5-0,dotnet-core-3-1"
+
 The <xref:System.Text.Json.JsonSerializer>, <xref:System.Text.Json.Utf8JsonReader>, <xref:System.Text.Json.Utf8JsonWriter>,
 and <xref:System.Text.Json.JsonElement> types parse and write <xref:System.DateTime> and <xref:System.DateTimeOffset>
 text representations according to the extended profile of the ISO 8601-1:2019 format. For example, `2019-07-26T16:59:57-05:00`.
@@ -61,6 +63,7 @@ Attempting to read non-compliant formats with <xref:System.Text.Json.Utf8JsonRea
 
 :::code language="csharp" source="snippets/system-text-json-support/csharp/reading-with-utf8jsonreader-error/Program.cs":::
 
+::: zone-end
 ::: zone pivot="dotnet-7-0"
 
 ## Serialize DateOnly and TimeOnly properties

--- a/docs/standard/serialization/system-text-json/how-to.md
+++ b/docs/standard/serialization/system-text-json/how-to.md
@@ -85,6 +85,8 @@ The preceding examples use type inference for the type being serialized. An over
 :::code language="csharp" source="snippets/system-text-json-how-to/csharp/SerializeWithGenericParameter.cs" highlight="23":::
 :::code language="vb" source="snippets/system-text-json-how-to/vb/RoundtripToString.vb" id="SerializeWithGenericParameter":::
 
+[!INCLUDE [dateonly-and-timeonly-serialization](../../datetime/includes/dateonly-and-timeonly-serialization.md)]
+
 ### Serialization example
 
 Here's an example showing how a class that contains collection properties and a user-defined type is serialized:

--- a/docs/standard/serialization/system-text-json/how-to.md
+++ b/docs/standard/serialization/system-text-json/how-to.md
@@ -85,16 +85,6 @@ The preceding examples use type inference for the type being serialized. An over
 :::code language="csharp" source="snippets/system-text-json-how-to/csharp/SerializeWithGenericParameter.cs" highlight="23":::
 :::code language="vb" source="snippets/system-text-json-how-to/vb/RoundtripToString.vb" id="SerializeWithGenericParameter":::
 
-With .NET 7, `System.Text.Json` supports serializing and deserializing <xref:System.DateOnly> and <xref:System.TimeOnly> types. Consider the following object:
-
-:::code source="snippets/system-text-json-how-to/csharp/RoundtripDateOnly.cs" id="SeriesDataPoint":::
-:::code source="snippets/system-text-json-how-to/vb/RoundtripDateOnly.vb" id="SeriesDataPoint":::
-
-The following example serializes the `SeriesDataPoint` object, displays the resulting JSON, and then deserializes it back into a new instance of the `SeriesDataPoint` type. Finally, the original and newly deserialized instances are compared for equality and the results are written to the console:
-
-:::code source="snippets/system-text-json-how-to/csharp/RoundtripDateOnly.cs" id="RoundtripDateOnly":::
-:::code source="snippets/system-text-json-how-to/vb/RoundtripDateOnly.vb" id="RoundtripDateOnly":::
-
 ### Serialization example
 
 Here's an example showing how a class that contains collection properties and a user-defined type is serialized:

--- a/docs/standard/serialization/system-text-json/how-to.md
+++ b/docs/standard/serialization/system-text-json/how-to.md
@@ -85,8 +85,6 @@ The preceding examples use type inference for the type being serialized. An over
 :::code language="csharp" source="snippets/system-text-json-how-to/csharp/SerializeWithGenericParameter.cs" highlight="23":::
 :::code language="vb" source="snippets/system-text-json-how-to/vb/RoundtripToString.vb" id="SerializeWithGenericParameter":::
 
-[!INCLUDE [dateonly-and-timeonly-serialization](../../datetime/includes/dateonly-and-timeonly-serialization.md)]
-
 ### Serialization example
 
 Here's an example showing how a class that contains collection properties and a user-defined type is serialized:


### PR DESCRIPTION
Fixes #33481

- [How to use the `DateOnly` and `TimeOnly` structures: Serialize DateOnly and TimeOnly types](https://review.learn.microsoft.com/en-us/dotnet/standard/datetime/how-to-use-dateonly-timeonly?branch=pr-en-us-33482#serialize-dateonly-and-timeonly-types)
- [`DateTime` and `DateTimeOffset` support in `System.Text.Json`: Serialize `DateOnly` and `TimeOnly` properties](https://review.learn.microsoft.com/en-us/dotnet/standard/datetime/system-text-json-support?branch=pr-en-us-33482&pivots=dotnet-7-0#serialize-dateonly-and-timeonly-properties)
- [How to serialize and deserialize (marshal and unmarshal) JSON in .NET](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/how-to?branch=pr-en-us-33482&pivots=dotnet-7-0)
