### PR TITLE
Document machine readable json output for dotnet list package report

### DIFF
--- a/docs/core/tools/dotnet-list-package.md
+++ b/docs/core/tools/dotnet-list-package.md
@@ -20,6 +20,8 @@ dotnet list [<PROJECT>|<SOLUTION>] package [--config <SOURCE>]
     [--include-prerelease] [--include-transitive] [--interactive]
     [--outdated] [--source <SOURCE>] [-v|--verbosity <LEVEL>]
     [--vulnerable]
+    [--format <console|json>]
+    [--output-version <VERSION>]
 
 dotnet list package -h|--help
 ```
@@ -118,6 +120,14 @@ The project or solution file to operate on. If not specified, the command search
 
   Lists packages that have known vulnerabilities. Cannot be combined with `--deprecated` or `--outdated` options. Nuget.org is the source of information about vulnerabilities. For more information, see [Vulnerabilities](/nuget/api/registration-base-url-resource) and [How to Scan NuGet Packages for Security Vulnerabilities](https://devblogs.microsoft.com/nuget/how-to-scan-nuget-packages-for-security-vulnerabilities/).
 
+- **`--format <console|json>`**
+
+  Sets the report output format. Allowed values are `console`, `json`.  Defaults to `console`.
+
+- **`--output-version <VERSION>`**
+
+  Sets the report output version. Allowed value is `1`. Defaults to `1`. Requires the `--format json` option. When a new JSON version is available, the command will produce the new format by default. This option will let you specify that the command should produce an earlier format.
+
 ## Examples
 
 - List package references of a specific project:
@@ -136,4 +146,28 @@ The project or solution file to operate on. If not specified, the command search
 
   ```dotnetcli
   dotnet list package --framework netcoreapp3.0
+  ```
+
+- List package references in machine readable json output format:
+
+  ```dotnetcli
+  dotnet list package --format json
+  ```
+
+- List package references for a specific target framework in machine readable json output format:
+
+  ```dotnetcli
+   dotnet list package --framework netcoreapp3.0 --format json
+  ```
+
+- Save machine readable json output of package references, including transitive dependency and vulnerability details into a file:
+
+  ```dotnetcli
+  dotnet list package --include-transitive --vulnerable --format json >> dependencyReport.json
+  ```
+
+- List package references in machine readable json output format with output version 1:
+
+  ```dotnetcli
+  dotnet list package --format json --output-version 1
   ```


### PR DESCRIPTION
**!!! Don't merge before .NET sdk 7.2.xx version release**

Fixes: https://github.com/NuGet/docs.microsoft.com-nuget/issues/2922
Related to: https://github.com/dotnet/sdk/pull/29367, https://github.com/NuGet/Home/issues/7752

Spec is [here](https://github.com/NuGet/Home/blob/557f5dfdcdaf21f7a83dab6d30a35d05d33d489b/proposed/2022/DotnetListPackageMachineReadableJsonOutput.md). New command option can be used like below:
`dotnet list package --format json`
`dotnet list package --format json --output-version 1`

**!!! Don't merge before we verify it's available in GA .NET sdk 7.2.xx version.**

This one already had [approval before](https://github.com/dotnet/docs/pull/32855#issuecomment-1380707717).