### PR TITLE
Fix: Replace 'Create' with 'Initialize' in Delegates example

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDelegates/CS/Delegates.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDelegates/CS/Delegates.cs
@@ -428,11 +428,11 @@ namespace WrapContravariance
                 // want to and use Action<string> instead.
                 //Action<string> hiDel, byeDel, multiDel, multiMinusHiDel;
 
-                // Create the delegate object hiDel that references the
+                // Initialize the delegate object hiDel that references the
                 // method Hello.
                 hiDel = Hello;
 
-                // Create the delegate object byeDel that references the
+                // Initialize the delegate object byeDel that references the
                 // method Goodbye.
                 byeDel = Goodbye;
 


### PR DESCRIPTION
This pull request fixes #33077 
It corrects the comments of initializing delegates, so instead of 'Create' there is now 'Initialize' to avoid misleading.