### PR TITLE
[csc.exe cmd line - "response" file] Extra '-' character

### DIFF
--- a/docs/csharp/language-reference/compiler-options/miscellaneous.md
+++ b/docs/csharp/language-reference/compiler-options/miscellaneous.md
@@ -13,7 +13,7 @@ helpviewer_keywords:
 
 The following options control miscellaneous compiler behavior. The new MSBuild syntax is shown in **Bold**. The older *csc.exe* syntax is shown in `code style`.
 
-- **ResponseFiles** / `-@`: Read response file for more options.
+- **ResponseFiles** / `@`: Read response file for more options.
 - **NoLogo** / `-nologo` : Suppress compiler copyright message.
 - **NoConfig** / `-noconfig`: Don't auto include *CSC.RSP* file.
 

--- a/docs/csharp/language-reference/compiler-options/miscellaneous.md
+++ b/docs/csharp/language-reference/compiler-options/miscellaneous.md
@@ -11,9 +11,9 @@ helpviewer_keywords:
 ---
 # Miscellaneous C# Compiler Options
 
-The following options control miscellaneous compiler behavior. The new MSBuild syntax is shown in **Bold**. The older *csc.exe* syntax is shown in `code style`.
+The following options control miscellaneous compiler behavior. The new MSBuild syntax is shown in **Bold**. The older *csc.exe* command-line syntax is shown in `code style`.
 
-- **ResponseFiles** / <code>@&lt;<i>rsp_file</i>&gt;</code> : Read the specified response file for more options.
+- **ResponseFiles** / <code>@*CustomOpts.RSP*</code> : Read the specified response file for more options.
 - **NoLogo** / `-nologo` : Suppress compiler copyright message.
 - **NoConfig** / `-noconfig` : Don't auto include *CSC.RSP* file.
 

--- a/docs/csharp/language-reference/compiler-options/miscellaneous.md
+++ b/docs/csharp/language-reference/compiler-options/miscellaneous.md
@@ -13,9 +13,9 @@ helpviewer_keywords:
 
 The following options control miscellaneous compiler behavior. The new MSBuild syntax is shown in **Bold**. The older *csc.exe* syntax is shown in `code style`.
 
-- **ResponseFiles** / `@`: Read response file for more options.
+- **ResponseFiles** / <code>@&lt;<i>rsp_file</i>&gt;</code> : Read the specified response file for more options.
 - **NoLogo** / `-nologo` : Suppress compiler copyright message.
-- **NoConfig** / `-noconfig`: Don't auto include *CSC.RSP* file.
+- **NoConfig** / `-noconfig` : Don't auto include *CSC.RSP* file.
 
 ## ResponseFiles
 


### PR DESCRIPTION
When specifying a "response" (input) file for `csc.exe` with the `@` character, there mustn't be a dash in front.

![cscrsp](https://user-images.githubusercontent.com/5589855/212535438-3d72ad92-ab72-404d-95bb-53eff0798e14.png)
