### PR TITLE
.NET 7 is available in Fedora

### DIFF
--- a/docs/core/install/linux-fedora.md
+++ b/docs/core/install/linux-fedora.md
@@ -99,7 +99,7 @@ For more information on installing .NET without a package manager, see one of th
 
 [!INCLUDE [package-manager-failed-to-fetch-rpm](includes/package-manager-failed-to-fetch-rpm.md)]
 
-### Errors related to missing `fxr`, `libhostfxr.so`, `FrameworkList.xml` or `/usr/share/dotnet`
+### Errors related to missing `fxr`, `libhostfxr.so`, `FrameworkList.xml`, or `/usr/share/dotnet`
 
 For more information about solving these problems, see [Troubleshoot `fxr`, `libhostfxr.so`, and `FrameworkList.xml` errors](linux-package-mixup.md).
 

--- a/docs/core/install/linux-fedora.md
+++ b/docs/core/install/linux-fedora.md
@@ -24,14 +24,14 @@ The following table is a list of currently supported .NET releases and the versi
 
 | Fedora | .NET      |
 |--------|-----------|
-| 37     | 6         |
-| 36     | 6         |
-| 35     | 6         |
-
-> [!IMPORTANT]
-> .NET 7 isn't yet ready for Fedora. This article will be updated when it's available.
+| 37     | 7, 6      |
+| 36     | 7, 6      |
 
 [!INCLUDE [versions-not-supported](includes/versions-not-supported.md)]
+
+## Install .NET 7
+
+[!INCLUDE [linux-dnf-install-70](includes/linux-install-70-dnf.md)]
 
 ## Install .NET 6
 
@@ -63,6 +63,8 @@ Older versions of Fedora don't contain .NET Core in the default package reposito
 
     | Fedora Version | Package repository |
     | -------------- | ------- |
+    | 35             | `https://packages.microsoft.com/config/fedora/35/prod.repo` |
+    | 34             | `https://packages.microsoft.com/config/fedora/34/prod.repo` |
     | 33             | `https://packages.microsoft.com/config/fedora/33/prod.repo` |
     | 32             | `https://packages.microsoft.com/config/fedora/32/prod.repo` |
     | 31             | `https://packages.microsoft.com/config/fedora/31/prod.repo` |
@@ -75,7 +77,7 @@ Older versions of Fedora don't contain .NET Core in the default package reposito
     sudo wget -O /etc/yum.repos.d/microsoft-prod.repo https://packages.microsoft.com/config/fedora/31/prod.repo
     ```
 
-[!INCLUDE [linux-dnf-install-60](./includes/linux-install-60-dnf.md)]
+[!INCLUDE [linux-dnf-install-70](./includes/linux-install-70-dnf.md)]
 
 ## How to install other versions
 
@@ -97,7 +99,7 @@ For more information on installing .NET without a package manager, see one of th
 
 [!INCLUDE [package-manager-failed-to-fetch-rpm](includes/package-manager-failed-to-fetch-rpm.md)]
 
-### Errors related to missing `fxr`, `libhostfxr.so`, or `FrameworkList.xml`
+### Errors related to missing `fxr`, `libhostfxr.so`, `FrameworkList.xml` or `/usr/share/dotnet`
 
 For more information about solving these problems, see [Troubleshoot `fxr`, `libhostfxr.so`, and `FrameworkList.xml` errors](linux-package-mixup.md).
 

--- a/docs/core/install/remove-runtime-sdk-versions.md
+++ b/docs/core/install/remove-runtime-sdk-versions.md
@@ -45,7 +45,7 @@ There's no need to first uninstall the .NET SDK when upgrading it using a packag
 If you installed .NET using a package manager, use that same package manager to uninstall the .NET SDK or runtime. .NET installations support most popular package managers. Consult the documentation for your distribution's package manager for the precise syntax in your environment:
 
 - [apt-get(8)](https://linux.die.net/man/8/apt-get) is used by Debian based systems, including Ubuntu.
-- [yum(8)](https://linux.die.net/man/8/yum) is used on Fedora, CentOS, and Oracle Linux.
+- [yum(8)](https://linux.die.net/man/8/yum) is used on Fedora, CentOS, Oracle Linux and RHEL.
 - [zypper(8)](https://en.opensuse.org/SDB:Zypper_manual_(plain)) is used on openSUSE and SUSE Linux Enterprise System (SLES).
 - [dnf(8)](https://dnf.readthedocs.io/en/latest/command_ref.html) is used on Fedora.
 

--- a/docs/core/install/remove-runtime-sdk-versions.md
+++ b/docs/core/install/remove-runtime-sdk-versions.md
@@ -45,7 +45,7 @@ There's no need to first uninstall the .NET SDK when upgrading it using a packag
 If you installed .NET using a package manager, use that same package manager to uninstall the .NET SDK or runtime. .NET installations support most popular package managers. Consult the documentation for your distribution's package manager for the precise syntax in your environment:
 
 - [apt-get(8)](https://linux.die.net/man/8/apt-get) is used by Debian based systems, including Ubuntu.
-- [yum(8)](https://linux.die.net/man/8/yum) is used on Fedora, CentOS, Oracle Linux and RHEL.
+- [yum(8)](https://linux.die.net/man/8/yum) is used on Fedora, CentOS, Oracle Linux, and RHEL.
 - [zypper(8)](https://en.opensuse.org/SDB:Zypper_manual_(plain)) is used on openSUSE and SUSE Linux Enterprise System (SLES).
 - [dnf(8)](https://dnf.readthedocs.io/en/latest/command_ref.html) is used on Fedora.
 


### PR DESCRIPTION
## Summary

.NET 7 packages are (almost) available for Fedora, 36 and later.
