### PR TITLE
Specify where to actually set assembly attributes

### DIFF
--- a/docs/standard/assembly/set-attributes.md
+++ b/docs/standard/assembly/set-attributes.md
@@ -15,7 +15,7 @@ dev_langs:
 
 # Set assembly attributes
 
-Assembly attributes are values that provide information about an assembly. The attributes are divided into the following sets of information:
+Assembly attributes are values that provide information about an assembly. They are usually set in a `AssemblyInfo.cs` file. The attributes are divided into the following sets of information:
 
 - Assembly identity attributes
 - Informational attributes

--- a/docs/standard/assembly/set-attributes.md
+++ b/docs/standard/assembly/set-attributes.md
@@ -15,7 +15,7 @@ dev_langs:
 
 # Set assembly attributes
 
-Assembly attributes are values that provide information about an assembly. They are usually set in a `AssemblyInfo.cs` file. The attributes are divided into the following sets of information:
+Assembly attributes are values that provide information about an assembly. They're usually set in an _AssemblyInfo.cs_ file. The attributes are divided into the following sets of information:
 
 - Assembly identity attributes
 - Informational attributes


### PR DESCRIPTION
"Set assembly attributes" page ironically doesn't say where to set assembly attributes. Ha.