### PR TITLE
Update snippets/caching/memory-worker/CacheWorker.cs

### DIFF
--- a/docs/core/extensions/snippets/caching/memory-worker/CacheWorker.cs
+++ b/docs/core/extensions/snippets/caching/memory-worker/CacheWorker.cs
@@ -53,10 +53,10 @@ public sealed class CacheWorker : BackgroundService
             }
             finally
             {
-                if (initialRun)
+                if (initialCaching)
                 {
                     _cacheSignal.Release();
-                    initialRun = false;
+                    initialCaching = false;
                 }
             }
 

--- a/docs/core/extensions/snippets/caching/memory-worker/CacheWorker.cs
+++ b/docs/core/extensions/snippets/caching/memory-worker/CacheWorker.cs
@@ -28,6 +28,7 @@ public sealed class CacheWorker : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
+        var initialCaching = true;
         while (!stoppingToken.IsCancellationRequested)
         {
             _logger.LogInformation("Updating cache.");
@@ -52,7 +53,11 @@ public sealed class CacheWorker : BackgroundService
             }
             finally
             {
-                _cacheSignal.Release();
+                if (initialRun)
+                {
+                    _cacheSignal.Release();
+                    initialRun = false;
+                }
             }
 
             try


### PR DESCRIPTION
## Summary

`semaphore.Release` will be called multiple times in the background worker loop, while it is acquired by it only once.

Another approach:

```csharp
public sealed class CacheWorker : BackgroundService
{
    private readonly ILogger<CacheWorker> _logger;
    private readonly HttpClient _httpClient;
    private readonly CacheSignal<Photo> _cacheSignal;
    private readonly IMemoryCache _cache;
    private readonly TimeSpan _updateInterval = TimeSpan.FromHours(3);

    private const string Url = "https://jsonplaceholder.typicode.com/photos";

    public CacheWorker(
        ILogger<CacheWorker> logger,
        HttpClient httpClient,
        CacheSignal<Photo> cacheSignal,
        IMemoryCache cache) =>
        (_logger, _httpClient, _cacheSignal, _cache) = (logger, httpClient, cacheSignal, cache);

    public override async Task StartAsync(CancellationToken cancellationToken)
    {
        await _cacheSignal.WaitAsync();
        try
        {
            await FetchAndSetCache(cancellationToken);
        }
        finally
        {
            _cacheSignal.Release();   
        }
        await base.StartAsync(cancellationToken);
    }

    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
    {
        while (!stoppingToken.IsCancellationRequested)
        {
            _logger.LogInformation("Updating cache.");

            await FetchAndSetCache(stoppingToken); 

            try
            {
                _logger.LogInformation(
                    "Will attempt to update the cache in {Hours} hours from now.",
                    _updateInterval.Hours);

                await Task.Delay(_updateInterval, stoppingToken);
            }
            catch (OperationCanceledException)
            {
                _logger.LogWarning("Cancellation acknowledged: shutting down.");
                break;
            }
        }
    }

    private async Task FetchAndSetCache(CancellationToken stoppingToken)
    {
        Photo[]? photos;
        try
        {
            photos = await _httpClient.GetFromJsonAsync<Photo[]>(
                    Url, stoppingToken);
        }
        catch (Exception e)
        {
            photos = new Photo[0];
        }

        if (photos is { Length: > 0 })
        {
            _cache.Set("Photos", photos);
            _logger.LogInformation(
                "Cache updated with {Count:#,#} photos.", photos.Length);
        }
        else
        {
            _logger.LogWarning(
                "Unable to fetch photos to update cache.");
        }
    }
}
```