### PR TITLE
Update NuGet documentation for .NET 8 SDK

### DIFF
--- a/docs/core/tools/nuget-signed-package-verification.md
+++ b/docs/core/tools/nuget-signed-package-verification.md
@@ -28,7 +28,9 @@ NuGet uses the default root store on Windows, which already supports general-pur
 
 ## Linux
 
-Verification is disabled by default during package restore operations. To opt in, set the environment variable `DOTNET_NUGET_SIGNATURE_VERIFICATION` to `true`.
+Prior to .NET 8 SDK, verification is disabled by default during package restore operations. To opt in, set the environment variable `DOTNET_NUGET_SIGNATURE_VERIFICATION` to `true`.
+
+Starting with .NET 8 SDK, verification is enabled by default. To opt out, set the environment variable `DOTNET_NUGET_SIGNATURE_VERIFICATION` to `false`.
 
 NuGet uses .NET SDK fallback certificate bundles by default. You can override the code signing fallback certificate bundle by providing a certificate bundle valid for code signing at the following probe path:
 


### PR DESCRIPTION
## Summary

This change updates documentation to account for NuGet signed package verification being enabled by default on Linux in .NET 8 SDK.

Fixes https://github.com/dotnet/docs/issues/33502
