### PR TITLE
Add readonly to rule description

### DIFF
--- a/docs/fundamentals/code-analysis/style-rules/naming-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/naming-rules.md
@@ -167,7 +167,7 @@ The severity value must be `warning` or `error` to be [enforced on build](../ove
 
 ## Example: Public member capitalization
 
-The following *.editorconfig* file contains a naming convention that specifies that public properties, methods, fields, events, and delegates must be capitalized. Notice that this naming convention specifies multiple kinds of symbol to apply the rule to, using a comma to separate the values.
+The following *.editorconfig* file contains a naming convention that specifies that public properties, methods, fields, events, and delegates that are marked `readonly` must be capitalized. This naming convention specifies multiple kinds of symbol to apply the rule to, using a comma to separate the values.
 
 ```ini
 [*.{cs,vb}]


### PR DESCRIPTION
Fixes #33603 

Based on [an older version of this example](https://github.com/MicrosoftDocs/visualstudio-docs/blob/gewarren-patch-1/docs/ide/editorconfig-naming-conventions.md#example), the readonly requirement was intentional, so I just added it into the rule description.