### PR TITLE
Add .NET 7 to Fedora Docs

### DIFF
--- a/docs/core/install/linux-fedora.md
+++ b/docs/core/install/linux-fedora.md
@@ -3,7 +3,7 @@ title: Install .NET on Fedora
 description: Demonstrates the various ways to install .NET SDK and .NET Runtime on Fedora.
 author: adegeo
 ms.author: adegeo
-ms.date: 12/21/2022
+ms.date: 01/21/2023
 ---
 
 # Install the .NET SDK or the .NET Runtime on Fedora
@@ -24,18 +24,14 @@ The following table is a list of currently supported .NET releases and the versi
 
 | Fedora | .NET      |
 |--------|-----------|
-| 37     | 6         |
-| 36     | 6         |
-| 35     | 6         |
-
-> [!IMPORTANT]
-> .NET 7 isn't yet ready for Fedora. This article will be updated when it's available.
+| 37     | 7         |
+| 36     | 7         |
 
 [!INCLUDE [versions-not-supported](includes/versions-not-supported.md)]
 
-## Install .NET 6
+## Install .NET 7
 
-[!INCLUDE [linux-dnf-install-60](includes/linux-install-60-dnf.md)]
+[!INCLUDE [linux-dnf-install-70](includes/linux-install-70-dnf.md)]
 
 ## Install preview versions
 
@@ -75,7 +71,7 @@ Older versions of Fedora don't contain .NET Core in the default package reposito
     sudo wget -O /etc/yum.repos.d/microsoft-prod.repo https://packages.microsoft.com/config/fedora/31/prod.repo
     ```
 
-[!INCLUDE [linux-dnf-install-60](./includes/linux-install-60-dnf.md)]
+[!INCLUDE [linux-dnf-install-70](./includes/linux-install-70-dnf.md)]
 
 ## How to install other versions
 


### PR DESCRIPTION
Added instructions on how to install .NET 7.

Removed the poster, which talks about the lack of .NET 7 in Fedora.

Fedora 35 was removed from the list, as this version is no longer supported by the Fedora team.
