### PR TITLE
Add an example of suppressing CS0067, when event is unused intentionally

### DIFF
--- a/docs/csharp/misc/cs0067.md
+++ b/docs/csharp/misc/cs0067.md
@@ -37,4 +37,21 @@ class MyClass
    {  
    }  
 }  
+```  
+  
+If the event is unused intentionaly (for example when it's part of an interface a class implements) then one way to suppress the warning is:  
+  
+```csharp  
+using System;  
+  
+public interface IThing  
+{  
+   event Action? E;  
+}  
+  
+public class Thing : IThing  
+{  
+   // no CS0067 though the event is left unused  
+   public event Action? E { add { } remove { } }  
+}  
 ```

--- a/docs/csharp/misc/cs0067.md
+++ b/docs/csharp/misc/cs0067.md
@@ -39,7 +39,7 @@ class MyClass
 }  
 ```  
   
-If the event is unused intentionaly (for example when it's part of an interface a class implements) then one way to suppress the warning is:  
+If the event is unused intentionally, for example, when it's part of an interface implementation, then you can avoid emitting an unnecessary field as follows:  
   
 ```csharp  
 using System;  


### PR DESCRIPTION
This pull request closes #33495
It adds the example of a situation where the event is left unused intentionally and shows a way of suppressing the warning.

This example leaves the original part intact. The example is added as a part below so it's treated as additional detail worth mentioning.
The example is taken from [this comment](https://github.com/dotnet/docs/issues/33495#issuecomment-1380344707) added by @Youssef1313