### PR TITLE
Remove 3rd paramter from constructor

### DIFF
--- a/docs/orleans/grains/observers.md
+++ b/docs/orleans/grains/observers.md
@@ -61,7 +61,7 @@ class HelloGrain : Grain, IHello
     {
         _subsManager =
             new ObserverManager<IChat>(
-                TimeSpan.FromMinutes(5), logger, "subs");
+                TimeSpan.FromMinutes(5), logger);
     }
 
     // Clients call this to subscribe.


### PR DESCRIPTION
https://learn.microsoft.com/en-us/dotnet/api/orleans.utilities.observermanager-1?view=orleans-7.0

The third parameter passed to the constructor doesn't exist.

@ReubenBond @IEvangelist