### PR TITLE
Updating fedora install to dotnet 7

### DIFF
--- a/docs/core/install/linux-fedora.md
+++ b/docs/core/install/linux-fedora.md
@@ -24,18 +24,16 @@ The following table is a list of currently supported .NET releases and the versi
 
 | Fedora | .NET      |
 |--------|-----------|
-| 37     | 6         |
-| 36     | 6         |
-| 35     | 6         |
+| 37     | 7         |
+| 36     | 7         |
+| 35     | 7         |
 
-> [!IMPORTANT]
-> .NET 7 isn't yet ready for Fedora. This article will be updated when it's available.
 
 [!INCLUDE [versions-not-supported](includes/versions-not-supported.md)]
 
-## Install .NET 6
+## Install .NET 7
 
-[!INCLUDE [linux-dnf-install-60](includes/linux-install-60-dnf.md)]
+[!INCLUDE [linux-dnf-install-70](includes/linux-install-70-dnf.md)]
 
 ## Install preview versions
 


### PR DESCRIPTION
Dotnet 7 is now available on Fedora.
https://packages.fedoraproject.org/pkgs/dotnet7.0/

I changed the docs to reflect this.
