### PR TITLE
derived class has access to all virtual members

### DIFF
--- a/docs/csharp/fundamentals/object-oriented/polymorphism.md
+++ b/docs/csharp/fundamentals/object-oriented/polymorphism.md
@@ -32,7 +32,7 @@ In C#, every type is polymorphic because all types, including user-defined types
 
 ### Virtual members
 
-When a derived class inherits from a base class, it includes all the members of the base class. All the behavior declared in the base class is part of the derived class. That enables objects of the derived class to be treated as objects of the base class. Access modifiers (`public`, `protected`, `private` and so on) determine if those members are accessible from the derived class implementation. Virtual methods gives the designer choice of different behavior of the derived class:
+When a derived class inherits from a base class, it includes all the members of the base class. All the behavior declared in the base class is part of the derived class. That enables objects of the derived class to be treated as objects of the base class. Access modifiers (`public`, `protected`, `private` and so on) determine if those members are accessible from the derived class implementation. Virtual methods gives the designer different choices for the behavior of the derived class:
 
 - The derived class may override virtual members in the base class, defining new behavior.
 - The derived class may inherit the closest base class method without overriding it, preserving the existing behavior but enabling further derived classes to override the method.

--- a/docs/csharp/fundamentals/object-oriented/polymorphism.md
+++ b/docs/csharp/fundamentals/object-oriented/polymorphism.md
@@ -32,7 +32,7 @@ In C#, every type is polymorphic because all types, including user-defined types
 
 ### Virtual members
 
-When a derived class inherits from a base class, it gains all the methods, fields, properties, and events of the base class. The designer of the derived class has different choices for the behavior of virtual methods:
+When a derived class inherits from a base class, it gains all the virtual methods, virtual properties, and virtual events of the base class. The designer of the derived class has different choices for the behavior of virtual methods:
 
 - The derived class may override virtual members in the base class, defining new behavior.
 - The derived class may inherit the closest base class method without overriding it, preserving the existing behavior but enabling further derived classes to override the method.

--- a/docs/csharp/fundamentals/object-oriented/polymorphism.md
+++ b/docs/csharp/fundamentals/object-oriented/polymorphism.md
@@ -32,7 +32,7 @@ In C#, every type is polymorphic because all types, including user-defined types
 
 ### Virtual members
 
-When a derived class inherits from a base class, it gains all the virtual methods, virtual properties, and virtual events of the base class. The designer of the derived class has different choices for the behavior of virtual methods:
+When a derived class inherits from a base class, it includes all the members of the base class. All the behavior declared in the base class is part of the derived class. That enables objects of the derived class to be treated as objects of the base class. Access modifiers (`public`, `protected`, `private` and so on) determine if those members are accessible from the derived class implementation. Virtual methods gives the designer choice of different behavior of the derived class:
 
 - The derived class may override virtual members in the base class, defining new behavior.
 - The derived class may inherit the closest base class method without overriding it, preserving the existing behavior but enabling further derived classes to override the method.


### PR DESCRIPTION
Earlier description was bit confusing as derived class doesn't have access to all the fields or properties. If this is in context to inheritance then it should mention public or protected access modifier. Since this article is related to polymorphism using Virtual keyword is more appropriate

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
