### PR TITLE
Disposed pipe and Console.ReadKey breaking changes

### DIFF
--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -16,10 +16,11 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 
 ## Core .NET libraries
 
-| Title                                                                              | Type of change    | Introduced |
-| ---------------------------------------------------------------------------------- | ----------------- | ---------- |
-| [Activity operation name when null](core-libraries/8.0/activity-operation-name.md) | Behavioral change | Preview 1  |
-| [GetFolderPath behavior on Unix](core-libraries/8.0/getfolderpath-unix.md)         | Behavioral change | Preview 1  |
+| Title                                                                               | Type of change    | Introduced |
+| ----------------------------------------------------------------------------------- | ----------------- | ---------- |
+| [Activity operation name when null](core-libraries/8.0/activity-operation-name.md)  | Behavioral change | Preview 1  |
+| [FileStream write to disposed pipe](core-libraries/8.0/filestream-disposed-pipe.md) | Behavioral change | Preview 1  |
+| [GetFolderPath behavior on Unix](core-libraries/8.0/getfolderpath-unix.md)          | Behavioral change | Preview 1  |
 
 ## Cryptography
 

--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -16,11 +16,12 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 
 ## Core .NET libraries
 
-| Title                                                                               | Type of change    | Introduced |
-| ----------------------------------------------------------------------------------- | ----------------- | ---------- |
-| [Activity operation name when null](core-libraries/8.0/activity-operation-name.md)  | Behavioral change | Preview 1  |
-| [FileStream write to disposed pipe](core-libraries/8.0/filestream-disposed-pipe.md) | Behavioral change | Preview 1  |
-| [GetFolderPath behavior on Unix](core-libraries/8.0/getfolderpath-unix.md)          | Behavioral change | Preview 1  |
+| Title                                                                                   | Type of change    | Introduced |
+| --------------------------------------------------------------------------------------- | ----------------- | ---------- |
+| [Activity operation name when null](core-libraries/8.0/activity-operation-name.md)      | Behavioral change | Preview 1  |
+| [FileStream writes when pipe is closed](core-libraries/8.0/filestream-disposed-pipe.md) | Behavioral change | Preview 1  |
+| [GetFolderPath behavior on Unix](core-libraries/8.0/getfolderpath-unix.md)              | Behavioral change | Preview 1  |
+| [Legacy Console.ReadKey removed](core-libraries/8.0/console-readkey-legacy.md)          | Behavioral change | Preview 1  |
 
 ## Cryptography
 

--- a/docs/core/compatibility/core-libraries/8.0/console-readkey-legacy.md
+++ b/docs/core/compatibility/core-libraries/8.0/console-readkey-legacy.md
@@ -1,0 +1,36 @@
+---
+title: ".NET 8 breaking change: Legacy Console.ReadKey removed"
+description: Learn about the .NET 8 breaking change in core .NET libraries where the legacy Console.ReadKey implementation has been removed.
+ms.date: 01/27/2023
+---
+# Legacy Console.ReadKey removed
+
+The ability to use the legacy <xref:System.Console.ReadKey%2A?displayProperty=nameWithType> implementation exposed via the `System.Console.UseNet6CompatReadKey` JSON setting and the `DOTNET_SYSTEM_CONSOLE_USENET6COMPATREADKEY` environment variable has been removed.
+
+## Previous behavior
+
+Previously, you could request the .NET 6 console key parsing logic via a runtime configuration switch.
+
+## New behavior
+
+Starting in .NET 8, you can't request the .NET 6 compatibility mode for <xref:System.Console.ReadKey%2A?displayProperty=nameWithType>.
+
+## Version introduced
+
+.NET 8 Preview 1
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+The compatibility mode was introduced as a safety switch in case the <xref:System.Console.ReadKey%2A?displayProperty=nameWithType> implementation rewrite introduced any bugs. Only one bug was reported, and it was fixed in .NET 7, so there's no need to keep the previous implementation anymore.
+
+## Recommended action
+
+If the new implementation doesn't work as expected, open a bug at <https://github.com/dotnet/runtime/issues> so it can be fixed.
+
+## Affected APIs
+
+- <xref:System.Console.ReadKey%2A?displayProperty=fullName>

--- a/docs/core/compatibility/core-libraries/8.0/filestream-disposed-pipe.md
+++ b/docs/core/compatibility/core-libraries/8.0/filestream-disposed-pipe.md
@@ -1,9 +1,9 @@
 ---
-title: ".NET 8 breaking change: "
-description: Learn about the .NET 8 breaking change in core .NET libraries where ...
+title: ".NET 8 breaking change: FileStream writes when pipe is closed"
+description: Learn about the .NET 8 breaking change in core .NET libraries where an exception is thrown if you write to a FileStream whose underlying pipe is closed.
 ms.date: 01/27/2023
 ---
-# FileStream write to disposed pipe
+# FileStream writes when pipe is closed
 
 <xref:System.IO.FileStream> error handling on Windows has been updated to be consistent with <xref:System.IO.Pipes.NamedPipeServerStream>, <xref:System.IO.Pipes.NamedPipeClientStream>, <xref:System.IO.Pipes.AnonymousPipeServerStream>, and <xref:System.IO.Pipes.AnonymousPipeClientStream>.
 

--- a/docs/core/compatibility/core-libraries/8.0/filestream-disposed-pipe.md
+++ b/docs/core/compatibility/core-libraries/8.0/filestream-disposed-pipe.md
@@ -1,0 +1,38 @@
+---
+title: ".NET 8 breaking change: "
+description: Learn about the .NET 8 breaking change in core .NET libraries where ...
+ms.date: 01/27/2023
+---
+# FileStream write to disposed pipe
+
+<xref:System.IO.FileStream> error handling on Windows has been updated to be consistent with <xref:System.IO.Pipes.NamedPipeServerStream>, <xref:System.IO.Pipes.NamedPipeClientStream>, <xref:System.IO.Pipes.AnonymousPipeServerStream>, and <xref:System.IO.Pipes.AnonymousPipeClientStream>.
+
+## Previous behavior
+
+Previously, when writing to a <xref:System.IO.FileStream> that represented a closed or disconnected pipe, the underlying operating system error was ignored and the write was reported as successful. However, nothing was written to the pipe.
+
+## New behavior
+
+Starting in .NET 8, when writing to a <xref:System.IO.FileStream> whose underlying pipe is closed or disconnected, the write fails and an <xref:System.IO.IOException> is thrown.
+
+## Version introduced
+
+.NET 8 Preview 1
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+This change was made to unify the handling of edge cases and avoid silent errors that are difficult to diagnose.
+
+## Recommended action
+
+Close or disconnect the pipe after everything has been written.
+
+## Affected APIs
+
+- <xref:System.IO.FileStream.WriteByte(System.Byte)?displayProperty=fullName>
+- <xref:System.IO.FileStream.Write%2A?displayProperty=fullName>
+- <xref:System.IO.FileStream.WriteAsync%2A?displayProperty=fullName>

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -12,6 +12,8 @@ items:
       items:
       - name: Activity operation name when null
         href: core-libraries/8.0/activity-operation-name.md
+      - name: FileStream write to disposed pipe
+        href: core-libraries/8.0/filestream-disposed-pipe.md
       - name: GetFolderPath behavior on Unix
         href: core-libraries/8.0/getfolderpath-unix.md
     - name: Cryptography
@@ -888,6 +890,8 @@ items:
       items:
       - name: Activity operation name when null
         href: core-libraries/8.0/activity-operation-name.md
+      - name: FileStream write to disposed pipe
+        href: core-libraries/8.0/filestream-disposed-pipe.md
       - name: GetFolderPath behavior on Unix
         href: core-libraries/8.0/getfolderpath-unix.md
     - name: .NET 7

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -12,10 +12,12 @@ items:
       items:
       - name: Activity operation name when null
         href: core-libraries/8.0/activity-operation-name.md
-      - name: FileStream write to disposed pipe
+      - name: FileStream writes when pipe is closed
         href: core-libraries/8.0/filestream-disposed-pipe.md
       - name: GetFolderPath behavior on Unix
         href: core-libraries/8.0/getfolderpath-unix.md
+      - name: Legacy Console.ReadKey removed
+        href: core-libraries/8.0/console-readkey-legacy.md
     - name: Cryptography
       items:
       - name: AesGcm authentication tag size on macOS
@@ -890,10 +892,12 @@ items:
       items:
       - name: Activity operation name when null
         href: core-libraries/8.0/activity-operation-name.md
-      - name: FileStream write to disposed pipe
+      - name: FileStream writes when pipe is closed
         href: core-libraries/8.0/filestream-disposed-pipe.md
       - name: GetFolderPath behavior on Unix
         href: core-libraries/8.0/getfolderpath-unix.md
+      - name: Legacy Console.ReadKey removed
+        href: core-libraries/8.0/console-readkey-legacy.md
     - name: .NET 7
       items:
       - name: API obsoletions with default diagnostic ID


### PR DESCRIPTION
Fixes #32224 
Fixes #32225 

Previews:

- [Legacy Console.ReadKey](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/8.0/console-readkey-legacy?branch=pr-en-us-33741)
- [FileStream write to a disposed pipe](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/8.0/filestream-disposed-pipe?branch=pr-en-us-33741)