### PR TITLE
Orleans Server Configuration doc improvement

### DIFF
--- a/docs/orleans/host/configuration-guide/server-configuration.md
+++ b/docs/orleans/host/configuration-guide/server-configuration.md
@@ -65,9 +65,10 @@ Here you specify two options:
 - Set the `ClusterId` to `"my-first-cluster"`: this is a unique ID for the Orleans cluster. All clients and silos that use this ID will be able to talk directly to each other. You can choose to use a different `ClusterId` for different deployments, though.
 - Set the `ServiceId` to `"SampleApp"`: this is a unique ID for your application that will be used by some providers, such as persistence providers. **This ID should remain stable and not change across deployments**.
 
-By default, Orleans will use a value of `"default"` for both the `ServiceId` and the `ClusterId`. These values do not need to be changed in most cases. `ServiceId` is the more significant of the two, and is used to distinguish different logical services from each other so that they can share backend storage systems without interfering with each other. `ClusterId` is used to determine which hosts will connect to each other and form a cluster.
-Within each cluster, all hosts must use the same `ServiceId`.
-Multiple clusters can share a `ServiceId`, however. This enables blue/green deployment scenarios where a new deployment (cluster) is started before another is shutdown. This is typical for systems hosted in Azure App Service.
+By default, Orleans will use a value of `"default"` for both the `ServiceId` and the `ClusterId`. These values don't need to be changed in most cases. `ServiceId` is the more significant of the two, and is used to distinguish different logical services from each other so that they can share backend storage systems without interfering with each other. `ClusterId` is used to determine which hosts will connect to each other and form a cluster.
+
+Within each cluster, all hosts must use the same `ServiceId`. Multiple clusters can share a `ServiceId`, however. This enables blue/green deployment scenarios where a new deployment (cluster) is started before another is shut down. This is typical for systems hosted in Azure App Service.
+
 The more common case is that `ServiceId` and `ClusterId` remain fixed for the lifetime of the application and a rolling deployment strategy is used. This is typical for systems hosted in Kubernetes and Service Fabric.
 
 ## Endpoints
@@ -176,9 +177,10 @@ Here we do two things:
 - Set the `ClusterId` to `"my-first-cluster"`: this is a unique ID for the Orleans cluster. All clients and silos that use this ID will be able to talk directly to each other. You can choose to use a different `ClusterId` for different deployments, though.
 - Set the `ServiceId` to `"AspNetSampleApp"`: this is a unique ID for your application that will be used by some providers, such as persistence providers. **This ID should remain stable and not change across deployments**.
 
-By default, Orleans will use a value of `"default"` for both the `ServiceId` and the `ClusterId`. These values do not need to be changed in most cases. `ServiceId` is the more significant of the two, and is used to distinguish different logical services from each other so that they can share backend storage systems without interfering with each other. `ClusterId` is used to determine which hosts will connect to each other and form a cluster.
-Within each cluster, all hosts must use the same `ServiceId`.
-Multiple clusters can share a `ServiceId`, however. This enables blue/green deployment scenarios where a new deployment (cluster) is started before another is shutdown. This is typical for systems hosted in Azure App Service.
+By default, Orleans will use a value of `"default"` for both the `ServiceId` and the `ClusterId`. These values don't need to be changed in most cases. `ServiceId` is the more significant of the two, and is used to distinguish different logical services from each other so that they can share backend storage systems without interfering with each other. `ClusterId` is used to determine which hosts will connect to each other and form a cluster.
+
+Within each cluster, all hosts must use the same `ServiceId`. Multiple clusters can share a `ServiceId`, however. This enables blue/green deployment scenarios where a new deployment (cluster) is started before another is shut down. This is typical for systems hosted in Azure App Service.
+
 The more common case is that `ServiceId` and `ClusterId` remain fixed for the lifetime of the application and a rolling deployment strategy is used. This is typical for systems hosted in Kubernetes and Service Fabric.
 
 ## Endpoints

--- a/docs/orleans/host/configuration-guide/server-configuration.md
+++ b/docs/orleans/host/configuration-guide/server-configuration.md
@@ -22,13 +22,13 @@ There are several key aspects of silo configuration:
 This is an example of a silo configuration that defines cluster information, uses Azure clustering, and configures the application parts:
 
 ```csharp
-// using IHost host = Host.CreateDefaultBuilder(args) could be used instead
-using IHost host = new HostBuilder()
+using IHost host = Host.CreateDefaultBuilder(args)
     .UseOrleans(builder =>
     {
         builder.UseAzureStorageClustering(
             options => options.ConfigureTableServiceClient(connectionString));
     })
+    .UseConsoleLifetime()
     .Build();
 ```
 
@@ -60,10 +60,15 @@ siloBuilder.Configure<ClusterOptions>(options =>
 })
 ```
 
-Here you specific two options:
+Here you specify two options:
 
 - Set the `ClusterId` to `"my-first-cluster"`: this is a unique ID for the Orleans cluster. All clients and silos that use this ID will be able to talk directly to each other. You can choose to use a different `ClusterId` for different deployments, though.
 - Set the `ServiceId` to `"SampleApp"`: this is a unique ID for your application that will be used by some providers, such as persistence providers. **This ID should remain stable and not change across deployments**.
+
+By default, Orleans will use a value of `"default"` for both the `ServiceId` and the `ClusterId`. These values do not need to be changed in most cases. `ServiceId` is the more significant of the two, and is used to distinguish different logical services from each other so that they can share backend storage systems without interfering with each other. `ClusterId` is used to determine which hosts will connect to each other and form a cluster.
+Within each cluster, all hosts must use the same `ServiceId`.
+Multiple clusters can share a `ServiceId`, however. This enables blue/green deployment scenarios where a new deployment (cluster) is started before another is shutdown. This is typical for systems hosted in Azure App Service.
+The more common case is that `ServiceId` and `ClusterId` remain fixed for the lifetime of the application and a rolling deployment strategy is used. This is typical for systems hosted in Kubernetes and Service Fabric.
 
 ## Endpoints
 
@@ -83,7 +88,8 @@ An Orleans silo has two typical types of endpoint configuration:
 - Silo-to-silo endpoints are used for communication between silos in the same cluster.
 - Client-to-silo (or gateway) endpoints are used for communication between clients and silos in the same cluster.
 
-If you can customize endpoints further, for example, if you need an external IP address with some port-forwarding, consider the following:
+This method should be sufficient in most cases, but you can customize it further if you need to.
+Here is an example of how to use an external IP address with some port-forwarding:
 
 ```csharp
 siloBuilder.Configure<EndpointOptions>(options =>
@@ -121,7 +127,7 @@ There are several key aspects of silo configuration:
 This is an example of a silo configuration that defines cluster information, uses Azure clustering, and configures the application parts:
 
 ```csharp
-var silo = new HostBuilder()
+var silo = Host.CreateDefaultBuiler(args)
     .UseOrleans(builder =>
     {
         builder
@@ -136,6 +142,7 @@ var silo = new HostBuilder()
             .ConfigureApplicationParts(
                 parts => parts.AddApplicationPart(typeof(ValueGrain).Assembly).WithReferences())
     })
+    .UseConsoleLifetime()
     .Build();
 ```
 
@@ -168,6 +175,11 @@ Here we do two things:
 
 - Set the `ClusterId` to `"my-first-cluster"`: this is a unique ID for the Orleans cluster. All clients and silos that use this ID will be able to talk directly to each other. You can choose to use a different `ClusterId` for different deployments, though.
 - Set the `ServiceId` to `"AspNetSampleApp"`: this is a unique ID for your application that will be used by some providers, such as persistence providers. **This ID should remain stable and not change across deployments**.
+
+By default, Orleans will use a value of `"default"` for both the `ServiceId` and the `ClusterId`. These values do not need to be changed in most cases. `ServiceId` is the more significant of the two, and is used to distinguish different logical services from each other so that they can share backend storage systems without interfering with each other. `ClusterId` is used to determine which hosts will connect to each other and form a cluster.
+Within each cluster, all hosts must use the same `ServiceId`.
+Multiple clusters can share a `ServiceId`, however. This enables blue/green deployment scenarios where a new deployment (cluster) is started before another is shutdown. This is typical for systems hosted in Azure App Service.
+The more common case is that `ServiceId` and `ClusterId` remain fixed for the lifetime of the application and a rolling deployment strategy is used. This is typical for systems hosted in Kubernetes and Service Fabric.
 
 ## Endpoints
 


### PR DESCRIPTION
* Use Host.CreateDefaultBuilder in code samples so that logging is enabled by default
* UseConsoleLifetime so that Ctrl+C is hooked up
* Elaborate on ClusterOptions properties - Maybe a spiel about how the developer probably doesn't need to do this should come first and be highlighted, eg using a callout

cc @IEvangelist - [preview](https://review.learn.microsoft.com/en-us/dotnet/orleans/host/configuration-guide/server-configuration?branch=pr-en-us-33747)
