### PR TITLE
Update build-container.md to add missing "cd App" command

### DIFF
--- a/docs/core/docker/build-container.md
+++ b/docs/core/docker/build-container.md
@@ -60,6 +60,7 @@ Your folder tree will look like the following:
 The `dotnet new` command creates a new folder named *App* and generates a "Hello World" console application. Change directories and navigate into the *App* folder, from your terminal session. Use the `dotnet run` command to start the app. The application will run, and print `Hello World!` below the command:
 
 ```dotnetcli
+cd App
 dotnet run
 Hello World!
 ```


### PR DESCRIPTION
Add missing command to change directories and navigate into the *App* folder, from the terminal session

## Summary

In the "Tutorial: Containerize a .NET app", it explains that "_The `dotnet new` command creates a new folder named App_", and tells the reader to "_Change directories and navigate into the App folder, from your terminal session_".

However, the code sample calls `dotnet run` without actually changing to the directory

https://learn.microsoft.com/en-us/dotnet/core/docker/build-container?tabs=windows#create-net-app

![image](https://user-images.githubusercontent.com/177608/215286718-0aab0362-d69d-4987-b705-56825c5ea519.png)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/docker/build-container.md](https://github.com/dotnet/docs/blob/66abb8a107015bfa6be1e9ee4045016d71bc00f5/docs/core/docker/build-container.md) | [docs/core/docker/build-container](https://review.learn.microsoft.com/en-us/dotnet/core/docker/build-container?branch=pr-en-us-33748) |

<!-- PREVIEW-TABLE-END -->