### PR TITLE
Adding whitespace after 'for' keyword

### DIFF
--- a/docs/csharp/tour-of-csharp/tutorials/branches-and-loops.yml
+++ b/docs/csharp/tour-of-csharp/tutorials/branches-and-loops.yml
@@ -201,7 +201,7 @@ items:
     `for` loop. Try this code in the interactive window:
 
     ```csharp
-    for(int counter = 0; counter < 10; counter++)
+    for (int counter = 0; counter < 10; counter++)
     {
       Console.WriteLine($"Hello World! The counter is {counter}");
     }


### PR DESCRIPTION
## Summary

Style change to respect coding conventions used in the rest of the document.  
Literally only adding a whitespace.
