### PR TITLE
Update to ReadOnlyProperty  Counter

### DIFF
--- a/docs/csharp/language-reference/builtin-types/snippets/shared/StructType.cs
+++ b/docs/csharp/language-reference/builtin-types/snippets/shared/StructType.cs
@@ -75,12 +75,7 @@ namespace builtin_types
         public struct Example
         {
             // <SnippetReadonlyProperty>
-            private int counter;
-            public int Counter
-            {
-                readonly get => counter;
-                set => counter = value;
-            }
+            public readonly int Counter;
             // </SnippetReadonlyProperty>
 
             // <ReadonlyWithInit>


### PR DESCRIPTION
The following code snippet results in the error "The modifier 'readonly' is not valid for this item" in VS2022
```private int counter;
public int Counter
{
    readonly get => counter;
    set => counter = value;
}
```
Removing both the getter and the setter makes the error go away

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
