### PR TITLE
snippet fix: need 'ref' passing Utf8JsonReader

### DIFF
--- a/docs/standard/serialization/system-text-json/snippets/system-text-json-how-to/csharp/Utf8ReaderPartialRead.cs
+++ b/docs/standard/serialization/system-text-json/snippets/system-text-json-how-to/csharp/Utf8ReaderPartialRead.cs
@@ -37,7 +37,7 @@ namespace SystemTextJsonSamples
                 if (!reader.Read())
                 {
                     // Not enough of the JSON is in the buffer to complete a read.
-                    GetMoreBytesFromStream(stream, buffer, reader);
+                    GetMoreBytesFromStream(stream, buffer, ref reader);
                 }
             }
 

--- a/docs/standard/serialization/system-text-json/snippets/system-text-json-how-to/csharp/Utf8ReaderPartialRead.cs
+++ b/docs/standard/serialization/system-text-json/snippets/system-text-json-how-to/csharp/Utf8ReaderPartialRead.cs
@@ -46,14 +46,14 @@ namespace SystemTextJsonSamples
             while (!reader.Read())
             {
                 // Not enough of the JSON is in the buffer to complete a read.
-                GetMoreBytesFromStream(stream, buffer, reader);
+                GetMoreBytesFromStream(stream, buffer, ref reader);
             }
             // Display value of Summary property, that is, "Hot".
             Console.WriteLine($"Got property value: {reader.GetString()}");
         }
 
         private static void GetMoreBytesFromStream(
-            MemoryStream stream, byte[] buffer, Utf8JsonReader reader)
+            MemoryStream stream, byte[] buffer, ref Utf8JsonReader reader)
         {
             int bytesRead;
             if (reader.BytesConsumed < buffer.Length)


### PR DESCRIPTION
The existing snippet code is obviously incorrect (since `Utf8JsonReader` is a `ref struct`), but in the example as shown it doesn't matter because `GetMoreBytesFromStream` is never called, since the json string in the demo is less than 4096 bytes.

This PR would fix the C# version, but note that I did not test it.

I assume there is a similar error in the VB version of this code but I don't know how to fix it.

Please feel free to process this PR as desired without my further participation.