### PR TITLE
Document the order of initialization actions.

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/constructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/constructors.md
@@ -1,17 +1,27 @@
 ---
 title: "Constructors - C# programming guide"
 description: A constructor in C# is called when a class or struct is created. Use constructors to set defaults, limit instantiation, and write flexible, easy-to-read code.
-ms.date: 09/27/2021
+ms.date: 01/30/2023
 helpviewer_keywords: 
   - "constructors [C#]"
   - "classes [C#], constructors"
   - "C# language, constructors"
-ms.assetid: df2e2e9d-7998-418b-8e7d-890c17ff6c95
 ---
 # Constructors (C# programming guide)
 
-Whenever a [class](../../language-reference/keywords/class.md) or [struct](../../language-reference/builtin-types/struct.md) is created, its constructor is called. A class or struct may have multiple constructors that take different arguments. Constructors enable the programmer to set default values, limit instantiation, and write code that is flexible and easy to read. For more information and examples, see [Instance constructors](instance-constructors.md) and [Using constructors](using-constructors.md).
+Whenever an instance of a [class](../../language-reference/keywords/class.md) or a [struct](../../language-reference/builtin-types/struct.md) is created, its constructor is called. A class or struct may have multiple constructors that take different arguments. Constructors enable the programmer to set default values, limit instantiation, and write code that is flexible and easy to read. For more information and examples, see [Instance constructors](instance-constructors.md) and [Using constructors](using-constructors.md).
 
+There are several actions that are part of initializing a new instance. Those actions take place in the following order:
+
+1. *Instance fields are set to 0*. This is typically done by the runtime.
+1. *Field initializers run*. The field initializers in the most derived type run.
+1. *Base type field initializers run*. Field initializers starting with the direct base through each base type to <xref:System.Object?displayProperty=fullName>.
+1. *Base instance constructors run*. Any instance constructors, starting with <xref:System.Object.%23ctor%2A?displayProperty=nameWithType> through each base class to the direct base class.
+1. *The instance constructor runs*. The instance constructor for the type runs.
+1. *Object initializers run*. If the expression includes any object initializers, those run after the instance constructor runs. Object initializers run in the textual order.
+
+The preceding actions take place when a new instance is initialized. If a new instance of a `struct` is set to its `default` value, all instance fields are set to 0.
+ 
 ## Constructor syntax
 
 A constructor is a method whose name is the same as the name of its type. Its method signature includes only an optional [access modifier](./access-modifiers.md), the method name and its parameter list; it does not include a return type. The following example shows the constructor for a class named `Person`.

--- a/docs/csharp/programming-guide/classes-and-structs/constructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/constructors.md
@@ -21,7 +21,9 @@ There are several actions that are part of initializing a new instance. Those ac
 1. *Object initializers run*. If the expression includes any object initializers, those run after the instance constructor runs. Object initializers run in the textual order.
 
 The preceding actions take place when a new instance is initialized. If a new instance of a `struct` is set to its `default` value, all instance fields are set to 0.
- 
+
+If the [static constructor](static-constructors.md) hasn't run, the static constructor runs before any of the instance constructor actions take place.
+
 ## Constructor syntax
 
 A constructor is a method whose name is the same as the name of its type. Its method signature includes only an optional [access modifier](./access-modifiers.md), the method name and its parameter list; it does not include a return type. The following example shows the constructor for a class named `Person`.

--- a/docs/csharp/programming-guide/classes-and-structs/static-constructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/static-constructors.md
@@ -1,16 +1,24 @@
 ---
 title: "Static Constructors - C# Programming Guide"
 description: A static constructor in C# initializes static data or performs an action done only once. It runs before the first instance is created or static members are referenced.
-ms.date: 12/21/2021
+ms.date: 01/30/2023
 helpviewer_keywords: 
   - "static constructors [C#]"
   - "constructors [C#], static"
 ---
 # Static Constructors (C# Programming Guide)
 
-A static constructor is used to initialize any [static](../../language-reference/keywords/static.md) data, or to perform a particular action that needs to be performed only once. It is called automatically before the first instance is created or any static members are referenced.
+A static constructor is used to initialize any [static](../../language-reference/keywords/static.md) data, or to perform a particular action that needs to be performed only once. It is called automatically before the first instance is created or any static members are referenced. A static constructor will be called at most once.
 
 [!code-csharp[SimpleClass#1](snippets/static-constructors/Program.cs#1)]
+
+There are several actions that are part of static initialization. Those actions take place in the following order:
+
+1. *Static fields are set to 0*. This is typically done by the runtime.
+1. *Static field initializers run*. The static field initializers in the most derived type run.
+1. *Base type static field initializers run*. Static field initializers starting with the direct base through each base type to <xref:System.Object?displayProperty=fullName>.
+1. *Base static constructors run*. Any static constructors, starting with <xref:System.Object.%23ctor%2A?displayProperty=nameWithType> through each base class to the direct base class.
+1. *The static constructor runs*. The static constructor for the type runs.
 
 ## Remarks
 
@@ -21,7 +29,7 @@ Static constructors have the following properties:
 - Static constructors cannot be inherited or overloaded.
 - A static constructor cannot be called directly and is only meant to be called by the common language runtime (CLR). It is invoked automatically.
 - The user has no control on when the static constructor is executed in the program.
-- A static constructor is called automatically. It initializes the [class](../../language-reference/keywords/class.md) before the first instance is created or any static members declared in that class (not its base classes) are referenced. A static constructor runs before an instance constructor. A type's static constructor is called when a static method assigned to an event or a delegate is invoked and not when it is assigned. If static field variable initializers are present in the class of the static constructor, they're executed in the textual order in which they appear in the class declaration. The initializers run immediately prior to the execution of the static constructor.
+- A static constructor is called automatically. It initializes the [class](../../language-reference/keywords/class.md) before the first instance is created or any static members declared in that class (not its base classes) are referenced. A static constructor runs before an instance constructor. If static field variable initializers are present in the class of the static constructor, they're executed in the textual order in which they appear in the class declaration. The initializers run immediately prior to the execution of the static constructor.
 - If you don't provide a static constructor to initialize static fields, all static fields are initialized to their default value as listed in [Default values of C# types](../../language-reference/builtin-types/default-values.md).
 - If a static constructor throws an exception, the runtime doesn't invoke it a second time, and the type will remain uninitialized for the lifetime of the application domain. Most commonly, a <xref:System.TypeInitializationException> exception is thrown when a static constructor is unable to instantiate a type or for an unhandled exception occurring within a static constructor. For static constructors that aren't explicitly defined in source code, troubleshooting may require inspection of the intermediate language (IL) code.
 - The presence of a static constructor prevents the addition of the <xref:System.Reflection.TypeAttributes.BeforeFieldInit> type attribute. This limits runtime optimization.


### PR DESCRIPTION
Fixes [#32809](https://github.com/dotnet/docs/issues/32809)
Fixes [#33704](https://github.com/dotnet/docs/issues/33704)

Specify the order of initialization actions when static constructors run, and when a new instance is created.