### PR TITLE
fix grammar on slice / list pattern

### DIFF
--- a/docs/csharp/language-reference/operators/patterns.md
+++ b/docs/csharp/language-reference/operators/patterns.md
@@ -1,7 +1,7 @@
 ---
 title: "Patterns - Pattern matching using the is and switch expressions."
 description: "Learn about the patterns supported by the `is` and `switch` expressions. Combine multiple patterns using the `and`, `or`, and `not` operators."
-ms.date: 11/28/2022
+ms.date: 01/30/2023
 f1_keywords: 
   - "and_CSharpKeyword"
   - "or_CSharpKeyword"

--- a/docs/csharp/language-reference/operators/patterns.md
+++ b/docs/csharp/language-reference/operators/patterns.md
@@ -267,11 +267,11 @@ As the preceding example shows, a list pattern is matched when each nested patte
 
 :::code language="csharp" source="snippets/patterns/ListPattern.cs" id="MatchAnyElement":::
 
-The preceding examples match a whole input sequence against a list pattern. To match elements only at the start or/and the end of an input sequence, use the *slice pattern* `..` within a list pattern, as the following example shows:
+The preceding examples match a whole input sequence against a list pattern. To match elements only at the start or/and the end of an input sequence, use the *slice pattern* `..`, as the following example shows:
 
 :::code language="csharp" source="snippets/patterns/ListPattern.cs" id="UseSlice":::
 
-A slice pattern matches zero or more elements. You can use at most one slice pattern in a list pattern.
+A slice pattern matches zero or more elements. You can use at most one slice pattern in a list pattern. The slice pattern can only appear in a list pattern.
 
 You can also nest a subpattern within a slice pattern, as the following example shows:
 


### PR DESCRIPTION
Fixes #32966

Update the language for the description of a slice pattern. Clarify that it can only be used in a list pattern.

