### PR TITLE
Improve SEO for null-conditional

### DIFF
--- a/docs/csharp/language-reference/operators/member-access-operators.md
+++ b/docs/csharp/language-reference/operators/member-access-operators.md
@@ -1,6 +1,6 @@
 ---
-title: "Member access operators and expressions"
-description: "C# operators that you use to access type members. These operators include the dot operator - `.`, indexers - `[`, `]`, `^` and `..`, and invocation - `(`, `)`."
+title: "Member access and null-conditional operators and expressions:"
+description: "C# operators that you use to access type members or null-conditionally access type members. These operators include the dot operator - `.`, indexers - `[`, `]`, `^` and `..`, and invocation - `(`, `)`."
 ms.date: 11/28/2022
 author: pkulikov
 f1_keywords:
@@ -35,7 +35,7 @@ helpviewer_keywords:
 ---
 # Member access operators and expressions - the dot, indexer, and invocation operators.
 
-You use several operators and expressions to access a type member. These operators include member access (`.`), array element or indexer access (`[]`), index-from-end (`^`), range (`..`), null-conditional operators (`?.` and `?[]`), and method invocation (`()`).
+You use several operators and expressions to access a type member. These operators include member access (`.`), array element or indexer access (`[]`), index-from-end (`^`), range (`..`), null-conditional operators (`?.` and `?[]`), and method invocation (`()`). These include the *null-conditional* member access (`.?`), and indexer access (`?[]`) operators.
 
 - [`.` (member access)](#member-access-expression-): to access a member of a namespace or a type
 - [`[]` (array element or indexer access)](#indexer-operator-): to access an array element or a type indexer

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1101,7 +1101,7 @@ items:
     - name: Comparison operators
       href: language-reference/operators/comparison-operators.md
       displayName: ">, <, >=, <=, greater, less"
-    - name: Member access operators and expressions
+    - name: Member access and null-conditional operators and expressions
       href: language-reference/operators/member-access-operators.md
       displayName: "., [], ?., ?[], (), indexer, null-conditional, Elvis, invocation, ^, index from end, hat, .., range"
     - name: Type-testing operators and cast expression


### PR DESCRIPTION
Fixes #33064

Operators are hard to search for. So, add the null-conditional phrase to the title and description. Add the null conditional variants of the operators to the first paragraph so they show up in the search result details.
