### PR TITLE
Typo fix - update to inheritance in C# and .NET article

### DIFF
--- a/docs/csharp/fundamentals/tutorials/inheritance.md
+++ b/docs/csharp/fundamentals/tutorials/inheritance.md
@@ -53,7 +53,7 @@ While all other members of a base class are inherited by derived classes, whethe
 
   [!code-csharp[Inheritance](./snippets/inheritance/basics.cs#1)]
 
-Derived classes can also *override* inherited members by providing an alternate implementation. In order to be able to override a member, the member in the base class must be marked with the [virtual](../../language-reference/keywords/virtual.md) keyword. By default, base class members are not marked as `virtual` and cannot be overridden. Attempting to override a non-virtual member, as the following example does, generates compiler error CS0506: "\<member> cannot override inherited member \<member> because it is not marked virtual, abstract, or override.
+Derived classes can also *override* inherited members by providing an alternate implementation. In order to be able to override a member, the member in the base class must be marked with the [virtual](../../language-reference/keywords/virtual.md) keyword. By default, base class members are not marked as `virtual` and cannot be overridden. Attempting to override a non-virtual member, as the following example does, generates compiler error CS0506: "\<member> cannot override inherited member \<member> because it is not marked virtual, abstract, or override."
 
 ```csharp
 public class A
@@ -184,7 +184,7 @@ In designing your `Publication` class, you need to make several design decisions
 
   The `Publication` class does not have any `abstract` methods, but the class itself is `abstract`.
 
-- Whether a derived class represents the final class in the inheritance hierarchy and cannot itself be used as a base class for additional derived classes. By default, any class can serve as a base class. You can apply the [sealed](../../language-reference/keywords/sealed.md) keyword to indicate that a class cannot serve as a base class for any additional classes. Attempting to derive from a sealed class generated compiler error CS0509, "cannot derive from sealed type \<typeName>".
+- Whether a derived class represents the final class in the inheritance hierarchy and cannot itself be used as a base class for additional derived classes. By default, any class can serve as a base class. You can apply the [sealed](../../language-reference/keywords/sealed.md) keyword to indicate that a class cannot serve as a base class for any additional classes. Attempting to derive from a sealed class generated compiler error CS0509, "cannot derive from sealed type \<typeName>."
 
   For your example, you'll mark your derived class as `sealed`.
 


### PR DESCRIPTION
## Summary

* Add closing quotation mark to ("<member> cannot override inherited member <member> because it is not marked virtual, abstract, or override.").
* Change ( "cannot derive from sealed type <typeName>".) to (...<typeName>."). This moves last dot to inside of quotation mark, as other quoted compiler errors through out the article.