### PR TITLE
DateTime.Add precision breaking change

### DIFF
--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -45,6 +45,7 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 | [C++/CLI projects in Visual Studio](core-libraries/7.0/cpluspluscli-compiler-version.md) | ✔️ | ❌ | Preview 3 |
 | [Changes to reflection invoke API exceptions](core-libraries/7.0/reflection-invoke-exceptions.md) | ❌ | ✔️ | Preview 4 |
 | [Collectible Assembly in non-collectible AssemblyLoadContext](core-libraries/7.0/collectible-assemblies.md) | ❌ | ✔️ | Preview 5 |
+| [DateTime addition methods precision change](core-libraries/7.0/datetime-add-precision.md) | ✔️ | ✔️ |
 | [Equals method behavior change for NaN](core-libraries/7.0/equals-nan.md) | ❌ | ✔️ | Preview 5 |
 | [Generic type constraint on PatternContext\<T>](core-libraries/7.0/patterncontext-generic-constraint.md) | ❌ | ❌ | Preview 3 |
 | [Legacy FileStream strategy removed](core-libraries/7.0/filestream-compat-switch.md) | ❌ | ✔️ | Preview 1 |

--- a/docs/core/compatibility/core-libraries/7.0/datetime-add-precision.md
+++ b/docs/core/compatibility/core-libraries/7.0/datetime-add-precision.md
@@ -1,0 +1,41 @@
+---
+title: ".NET 7 breaking change: DateTime addition methods precision change"
+description: Learn about the .NET 7 breaking change in core .NET libraries where the precision of the value that's added in DateTime addition methods has increased.
+ms.date: 02/01/2023
+---
+# DateTime addition methods precision change
+
+In .NET 6 and earlier versions, the value parameter of the `DateTime` addition methods was rounded to the nearest millisecond. In .NET 7 and later versions, the full <xref:System.Double> precision of the value parameter is used. However, due to the inherent imprecision of floating-point math, the resulting precision will vary.
+
+## Previous behavior
+
+Previously, the `double` value parameter of the <xref:System.DateTime> `Add*` methods, for example, <xref:System.DateTime.AddDays(System.Double)?displayProperty=nameWithType>, was rounded to the nearest millisecond.
+
+## New behavior
+
+Starting in .NET 7, the full precision of the `double` value parameter is used, improving the precision of the [affected methods](#affected-apis).
+
+## Version introduced
+
+.NET 7
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+This change was made in response to a community request to improve the precision in <xref:System.DateTime>.
+
+## Recommended action
+
+No specific action unless you have code that depends on the precision of the `Add*` methods. In that case, review your code and retest it to avoid any surprises with the precision change.
+
+## Affected APIs
+
+- <xref:System.DateTime.AddDays(System.Double)?displayProperty=fullName>
+- <xref:System.DateTime.AddHours(System.Double)?displayProperty=fullName>
+- <xref:System.DateTime.AddMicroseconds(System.Double)?displayProperty=fullName>
+- <xref:System.DateTime.AddMilliseconds(System.Double)?displayProperty=fullName>
+- <xref:System.DateTime.AddMinutes(System.Double)?displayProperty=fullName>
+- <xref:System.DateTime.AddSeconds(System.Double)?displayProperty=fullName>

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -90,6 +90,8 @@ items:
         href: core-libraries/7.0/cpluspluscli-compiler-version.md
       - name: Collectible Assembly in non-collectible AssemblyLoadContext
         href: core-libraries/7.0/collectible-assemblies.md
+      - name: DateTime addition methods precision change
+        href: core-libraries/7.0/datetime-add-precision.md
       - name: Equals method behavior change for NaN
         href: core-libraries/7.0/equals-nan.md
       - name: Generic type constraint on PatternContext<T>
@@ -922,6 +924,8 @@ items:
         href: core-libraries/7.0/cpluspluscli-compiler-version.md
       - name: Collectible Assembly in non-collectible AssemblyLoadContext
         href: core-libraries/7.0/collectible-assemblies.md
+      - name: DateTime addition methods precision change
+        href: core-libraries/7.0/datetime-add-precision.md
       - name: Equals method behavior change for NaN
         href: core-libraries/7.0/equals-nan.md
       - name: Generic type constraint on PatternContext<T>


### PR DESCRIPTION
Fixes #33492.

[Preview](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/7.0/datetime-add-precision?branch=pr-en-us-33833)