### PR TITLE
Remove single-file links for macOS binaries

### DIFF
--- a/docs/core/diagnostics/dotnet-counters.md
+++ b/docs/core/diagnostics/dotnet-counters.md
@@ -27,7 +27,6 @@ There are two ways to download and install `dotnet-counters`:
   | OS  | Platform |
   | --- | -------- |
   | Windows | [x86](https://aka.ms/dotnet-counters/win-x86) \| [x64](https://aka.ms/dotnet-counters/win-x64) \| [Arm](https://aka.ms/dotnet-counters/win-arm) \| [Arm-x64](https://aka.ms/dotnet-counters/win-arm64) |
-  | macOS   | [x64](https://aka.ms/dotnet-counters/osx-x64) |
   | Linux   | [x64](https://aka.ms/dotnet-counters/linux-x64) \| [Arm](https://aka.ms/dotnet-counters/linux-arm) \| [Arm64](https://aka.ms/dotnet-counters/linux-arm64) \| [musl-x64](https://aka.ms/dotnet-counters/linux-musl-x64) \| [musl-Arm64](https://aka.ms/dotnet-counters/linux-musl-arm64) |
 
 > [!NOTE]

--- a/docs/core/diagnostics/dotnet-dump.md
+++ b/docs/core/diagnostics/dotnet-dump.md
@@ -30,7 +30,6 @@ There are two ways to download and install `dotnet-dump`:
   | OS  | Platform |
   | --- | -------- |
   | Windows | [x86](https://aka.ms/dotnet-dump/win-x86) \| [x64](https://aka.ms/dotnet-dump/win-x64) \| [Arm](https://aka.ms/dotnet-dump/win-arm) \| [Arm-x64](https://aka.ms/dotnet-dump/win-arm64) |
-  | macOS   | [x64](https://aka.ms/dotnet-dump/osx-x64) |
   | Linux   | [x64](https://aka.ms/dotnet-dump/linux-x64) \| [Arm](https://aka.ms/dotnet-dump/linux-arm) \| [Arm64](https://aka.ms/dotnet-dump/linux-arm64) \| [musl-x64](https://aka.ms/dotnet-dump/linux-musl-x64) \| [musl-Arm64](https://aka.ms/dotnet-dump/linux-musl-arm64) |
 
 > [!NOTE]

--- a/docs/core/diagnostics/dotnet-gcdump.md
+++ b/docs/core/diagnostics/dotnet-gcdump.md
@@ -27,7 +27,6 @@ There are two ways to download and install `dotnet-gcdump`:
   | OS  | Platform |
   | --- | -------- |
   | Windows | [x86](https://aka.ms/dotnet-gcdump/win-x86) \| [x64](https://aka.ms/dotnet-gcdump/win-x64) \| [Arm](https://aka.ms/dotnet-gcdump/win-arm) \| [Arm-x64](https://aka.ms/dotnet-gcdump/win-arm64) |
-  | macOS   | [x64](https://aka.ms/dotnet-gcdump/osx-x64) |
   | Linux   | [x64](https://aka.ms/dotnet-gcdump/linux-x64) \| [Arm](https://aka.ms/dotnet-gcdump/linux-arm) \| [Arm64](https://aka.ms/dotnet-gcdump/linux-arm64) \| [musl-x64](https://aka.ms/dotnet-gcdump/linux-musl-x64) \| [musl-Arm64](https://aka.ms/dotnet-gcdump/linux-musl-arm64) |
 
 > [!NOTE]

--- a/docs/core/diagnostics/dotnet-sos.md
+++ b/docs/core/diagnostics/dotnet-sos.md
@@ -27,7 +27,6 @@ There are two ways to download and install `dotnet-sos`:
   | OS  | Platform |
   | --- | -------- |
   | Windows | [x86](https://aka.ms/dotnet-sos/win-x86) \| [x64](https://aka.ms/dotnet-sos/win-x64) \| [Arm](https://aka.ms/dotnet-sos/win-arm) \| [Arm-x64](https://aka.ms/dotnet-sos/win-arm64) |
-  | macOS   | [x64](https://aka.ms/dotnet-sos/osx-x64) |
   | Linux   | [x64](https://aka.ms/dotnet-sos/linux-x64) \| [Arm](https://aka.ms/dotnet-sos/linux-arm) \| [Arm64](https://aka.ms/dotnet-sos/linux-arm64) \| [musl-x64](https://aka.ms/dotnet-sos/linux-musl-x64) \| [musl-Arm64](https://aka.ms/dotnet-sos/linux-musl-arm64) |
 
 ## Synopsis

--- a/docs/core/diagnostics/dotnet-stack.md
+++ b/docs/core/diagnostics/dotnet-stack.md
@@ -26,7 +26,6 @@ There are two ways to download and install `dotnet-stack`:
   | OS  | Platform |
   | --- | -------- |
   | Windows | [x86](https://aka.ms/dotnet-stack/win-x86) \| [x64](https://aka.ms/dotnet-stack/win-x64) \| [Arm](https://aka.ms/dotnet-stack/win-arm) \| [Arm-x64](https://aka.ms/dotnet-stack/win-arm64) |
-  | macOS   | [x64](https://aka.ms/dotnet-stack/osx-x64) |
   | Linux   | [x64](https://aka.ms/dotnet-stack/linux-x64) \| [Arm](https://aka.ms/dotnet-stack/linux-arm) \| [Arm64](https://aka.ms/dotnet-stack/linux-arm64) \| [musl-x64](https://aka.ms/dotnet-stack/linux-musl-x64) \| [musl-Arm64](https://aka.ms/dotnet-stack/linux-musl-arm64) |
 
 ## Synopsis

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -27,7 +27,6 @@ There are two ways to download and install `dotnet-trace`:
   | OS  | Platform |
   | --- | -------- |
   | Windows | [x86](https://aka.ms/dotnet-trace/win-x86) \| [x64](https://aka.ms/dotnet-trace/win-x64) \| [Arm](https://aka.ms/dotnet-trace/win-arm) \| [Arm-x64](https://aka.ms/dotnet-trace/win-arm64) |
-  | macOS   | [x64](https://aka.ms/dotnet-trace/osx-x64) |
   | Linux   | [x64](https://aka.ms/dotnet-trace/linux-x64) \| [Arm](https://aka.ms/dotnet-trace/linux-arm) \| [Arm64](https://aka.ms/dotnet-trace/linux-arm64) \| [musl-x64](https://aka.ms/dotnet-trace/linux-musl-x64) \| [musl-Arm64](https://aka.ms/dotnet-trace/linux-musl-arm64) |
 
 > [!NOTE]


### PR DESCRIPTION
## Summary

There's a fair amount of overhead to create signed and entitled binaries. These were meant for scenarios where getting the SDK installed was non-trivial. However, macOS devices are considered development client devices and global tools are still preferred for those. Given that we don't plan to support arm64 standalone tools and x64 is unsigned, it's better to have them symmetrically unsupported.