### PR TITLE
Fix cross-platform MSTest doc

### DIFF
--- a/docs/core/testing/unit-testing-with-mstest.md
+++ b/docs/core/testing/unit-testing-with-mstest.md
@@ -98,7 +98,7 @@ The following outline shows the final solution layout:
 Change to the *unit-testing-using-mstest* directory, and run [`dotnet sln add`](../tools/dotnet-sln.md):
 
 ```dotnetcli
-dotnet sln add .\PrimeService.Tests\PrimeService.Tests.csproj
+dotnet sln add ./PrimeService.Tests/PrimeService.Tests.csproj
 ```
 
 ## Create the first test


### PR DESCRIPTION
## Summary

* Allows command to work out of the box on Windows and UNIX machines
* Makes command consistent with the others in the doc that use forward slashes


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-with-mstest.md](https://github.com/dotnet/docs/blob/0da637ab8298b1854684a27808372c1da8e9e5db/docs/core/testing/unit-testing-with-mstest.md) | [docs/core/testing/unit-testing-with-mstest](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-with-mstest?branch=pr-en-us-33863) |

<!-- PREVIEW-TABLE-END -->