### PR TITLE
unpublish unmanaged constraint

### DIFF
--- a/.openpublishing.redirection.csharp.json
+++ b/.openpublishing.redirection.csharp.json
@@ -49,6 +49,10 @@
             "redirect_url": "/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals"
         },
         {
+            "source_path_from_root": "/redirections/proposals/csharp-7.3/blittable.md",
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/classes#1425-type-parameter-constraints"
+        },
+        {
             "source_path_from_root": "/redirections/proposals/csharp-10.0/generic-attributes.md",
             "redirect_url": "/dotnet/csharp/language-reference/proposals/csharp-11.0/generic-attributes"
         },

--- a/docfx.json
+++ b/docfx.json
@@ -75,6 +75,7 @@
                     "csharp-7.3/enum-delegate-constraints.md",
                     "csharp-7.3/improved-overload-candidates.md",
                     "csharp-7.3/ref-loops.md",
+                    "csharp-7.3/blittable.md",
                     "csharp-8.0/alternative-interpolated-verbatim.md",
                     "csharp-8.0/async-using.md",
                     "csharp-8.0/constraints-in-overrides.md",
@@ -128,8 +129,7 @@
                     "_csharplang/proposals/csharp-7.0/throw-expression.md",
                     "_csharplang/proposals/csharp-7.1/target-typed-default.md",
                     "_csharplang/proposals/csharp-7.2/readonly-struct.md",
-                    "_csharplang/proposals/csharp-7.2/non-trailing-named-arguments.md",
-                    "_csharplang/proposals/csharp-7.3/blittable.md"
+                    "_csharplang/proposals/csharp-7.2/non-trailing-named-arguments.md"
                 ]
             }
         },
@@ -637,7 +637,6 @@
                 "_csharplang/proposals/csharp-7.2/conditional-ref.md": "Conditional ref",
                 "_csharplang/proposals/csharp-7.2/leading-separator.md": "Leading digit separator",
 
-                "_csharplang/proposals/csharp-7.3/blittable.md": "Unmanaged generic type constraints",
                 "_csharplang/proposals/csharp-7.3/indexing-movable-fixed-fields.md": "Indexing fixed fields without pinning regardless of context",
                 "_csharplang/proposals/csharp-7.3/pattern-based-fixed.md": "Pattern-based fixed statement",
                 "_csharplang/proposals/csharp-7.3/ref-local-reassignment.md": "Ref local reassignment",
@@ -772,7 +771,6 @@
                 "_csharplang/proposals/csharp-7.2/conditional-ref.md": "This feature specification describes the syntax enhancements for using 'ref' with '?:' expressions",
                 "_csharplang/proposals/csharp-7.2/leading-separator.md": "This feature specification describes syntax enhancements to support a leading digit separator in numeric literals.",
 
-                "_csharplang/proposals/csharp-7.3/blittable.md": "This feature specification describes the 'unmanaged' generic type constraint. That forces the type argument to be an unmanaged type.",
                 "_csharplang/proposals/csharp-7.3/indexing-movable-fixed-fields.md": "This feature specification describes syntax enhancement to support indexing fixed fields without pinning the memory, regardless of context.",
                 "_csharplang/proposals/csharp-7.3/pattern-based-fixed.md": "This feature specification describes syntax enhancements to enable more types to be the target of a fixed statement.",
                 "_csharplang/proposals/csharp-7.3/ref-local-reassignment.md": "This feature specification describes syntax enhancements that enable ref local variables to be assigned to refer to different storage after being initialized.",

--- a/docs/csharp/language-reference/index.md
+++ b/docs/csharp/language-reference/index.md
@@ -51,7 +51,7 @@ The features that have been implemented in C# versions after 6.0, including thos
  [C# 7.2 Specification Proposals](~/_csharplang/proposals/csharp-7.2/readonly-ref.md)  
  C# 7.2 added a number of small features. You can pass arguments by readonly reference using the `in` keyword. There are a number of low-level changes to support compile-time safety for `Span` and related types. You can use named arguments where later arguments are positional, in some situations. The `private protected` access modifier enables you to specify that callers are limited to derived types implemented in the same assembly. The `?:` operator can resolve to a reference to a variable. You can also format hexadecimal and binary numbers using a leading digit separator.
 
- [C# 7.3 Specification Proposals](~/_csharplang/proposals/csharp-7.3/blittable.md)  
+ [C# 7.3 Specification Proposals](~/_csharplang/proposals/csharp-7.3/indexing-movable-fixed-fields.md)  
  C# 7.3 is another point release that includes several small updates. You can use new constraints on generic type parameters. Other changes make it easier to work with `fixed` fields, including using [`stackalloc`](./operators/stackalloc.md) allocations. Local variables declared with the `ref` keyword may be reassigned to refer to new storage. You can place attributes on auto-implemented properties that target the compiler-generated backing field. Expression variables can be used in initializers. Tuples can be compared for equality (or inequality). There have also been some improvements to overload resolution.
   
  [C# 8.0 Specification Proposals](~/_csharplang/proposals/csharp-8.0/nullable-reference-types.md)  

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1367,8 +1367,6 @@ items:
         href: ../../_csharplang/proposals/csharp-7.2/conditional-ref.md
     - name: C# 7.3 features
       items:
-      - name: Unmanaged generic type constraints
-        href: ../../_csharplang/proposals/csharp-7.3/blittable.md
       - name: Indexing `fixed` fields should not require pinning regardless of the movable/unmovable context
         href: ../../_csharplang/proposals/csharp-7.3/indexing-movable-fixed-fields.md
       - name: Pattern-based `fixed` statement


### PR DESCRIPTION
see dotnet/csharpstandard#244

The standard draft language has been updated to add the `unmanaged` generic constraint. Remove the feature speclet from the docs site.
