### PR TITLE
Clarify all default components for C++ workload

### DIFF
--- a/docs/core/deploying/native-aot/index.md
+++ b/docs/core/deploying/native-aot/index.md
@@ -22,7 +22,7 @@ There are some limitations in the .NET native AOT deployment model, with the mai
 
 The following prerequisites need to be installed before publishing .NET projects with native AOT.
 
-On Windows, install [Visual Studio 2022](https://visualstudio.microsoft.com/vs/), including Desktop development with C++ workload.
+On Windows, install Windows SDK and [Visual Studio 2022](https://visualstudio.microsoft.com/vs/), including Desktop development with C++ workload.
 
 On Linux, install compiler toolchain and developer packages for libraries that .NET runtime depends on.
 

--- a/docs/core/deploying/native-aot/index.md
+++ b/docs/core/deploying/native-aot/index.md
@@ -22,7 +22,7 @@ There are some limitations in the .NET native AOT deployment model, with the mai
 
 The following prerequisites need to be installed before publishing .NET projects with native AOT.
 
-On Windows, install Windows SDK and [Visual Studio 2022](https://visualstudio.microsoft.com/vs/), including Desktop development with C++ workload.
+On Windows, install [Visual Studio 2022](https://visualstudio.microsoft.com/vs/), including Desktop development with C++ workload with all default components.
 
 On Linux, install compiler toolchain and developer packages for libraries that .NET runtime depends on.
 


### PR DESCRIPTION
## Summary

NativeAOT on Windows requires some static libraries from Windows SDK (such as `advapi32.lib`), which may or may not be (implicitly) installed. This change explicitly mentions it to guide user about the requirement.

Fixes https://github.com/dotnet/runtime/issues/81584

cc @jkotas, @MichalStrehovsky, @Varorbc