### PR TITLE
Revert "Update documentation for .NET 8 SDK"

### DIFF
--- a/docs/core/tools/nuget-signed-package-verification.md
+++ b/docs/core/tools/nuget-signed-package-verification.md
@@ -28,9 +28,7 @@ NuGet uses the default root store on Windows, which already supports general-pur
 
 ## Linux
 
-Prior to .NET 8 SDK, verification is disabled by default during package restore operations. To opt in, set the environment variable `DOTNET_NUGET_SIGNATURE_VERIFICATION` to `true`.
-
-Starting with .NET 8 SDK, verification is enabled by default. To opt out, set the environment variable `DOTNET_NUGET_SIGNATURE_VERIFICATION` to `false`.
+Verification is disabled by default during package restore operations. To opt in, set the environment variable `DOTNET_NUGET_SIGNATURE_VERIFICATION` to `true`.
 
 NuGet uses .NET SDK fallback certificate bundles by default. You can override the code signing fallback certificate bundle by providing a certificate bundle valid for code signing at the following probe path:
 


### PR DESCRIPTION
This reverts commit c98f6c15bd5ed3c97accd7d93281002fbc82a1d9.

## Summary

This doc change was intended for .NET 8 SDK Preview 1; however, the code change didn't make it into .NET 8 SDK Preview 1.  It should make it into Preview 2.  For now, I'm reverting this doc change.  I will re-submit it closer to Preview 2 release.
