### PR TITLE
Update link to WASM ICU filters

### DIFF
--- a/docs/core/extensions/globalization-icu.md
+++ b/docs/core/extensions/globalization-icu.md
@@ -208,4 +208,4 @@ The following APIs are supported with limitations:
 - <xref:System.String.Normalize(System.Text.NormalizationForm)?displayProperty=nameWithType> and <xref:System.String.IsNormalized(System.Text.NormalizationForm)?displayProperty=nameWithType> don't support the rarely used <xref:System.Text.NormalizationForm.FormKC> and <xref:System.Text.NormalizationForm.FormKD> forms.
 - <xref:System.Globalization.RegionInfo.CurrencyNativeName?displayProperty=nameWithType> returns the same value as <xref:System.Globalization.RegionInfo.CurrencyEnglishName?displayProperty=nameWithType>.
 
-In addition, a list of supported locales is reduced and can be found on the [dotnet/icu repo](https://github.com/dotnet/icu/blob/dotnet/main/icu-filters/icudt_wasm.json#L7-L195).
+In addition, fewer locales are supported. The supported list can be found in the [dotnet/icu repo](https://github.com/dotnet/icu/blob/dotnet/main/icu-filters/icudt_wasm.json#L7-L195).

--- a/docs/core/extensions/globalization-icu.md
+++ b/docs/core/extensions/globalization-icu.md
@@ -208,4 +208,4 @@ The following APIs are supported with limitations:
 - <xref:System.String.Normalize(System.Text.NormalizationForm)?displayProperty=nameWithType> and <xref:System.String.IsNormalized(System.Text.NormalizationForm)?displayProperty=nameWithType> don't support the rarely used <xref:System.Text.NormalizationForm.FormKC> and <xref:System.Text.NormalizationForm.FormKD> forms.
 - <xref:System.Globalization.RegionInfo.CurrencyNativeName?displayProperty=nameWithType> returns the same value as <xref:System.Globalization.RegionInfo.CurrencyEnglishName?displayProperty=nameWithType>.
 
-In addition, a list of supported locales is reduced and can be found on the [dotnet/icu repo](https://github.com/dotnet/icu/blob/5667bcd34fd5edab2ce2e01fdb9533306b8fcf61/icu-filters/icudt_wasm.json#L7-L195).
+In addition, a list of supported locales is reduced and can be found on the [dotnet/icu repo](https://github.com/dotnet/icu/blob/dotnet/main/icu-filters/icudt_wasm.json#L7-L195).

--- a/docs/core/extensions/globalization-icu.md
+++ b/docs/core/extensions/globalization-icu.md
@@ -208,4 +208,4 @@ The following APIs are supported with limitations:
 - <xref:System.String.Normalize(System.Text.NormalizationForm)?displayProperty=nameWithType> and <xref:System.String.IsNormalized(System.Text.NormalizationForm)?displayProperty=nameWithType> don't support the rarely used <xref:System.Text.NormalizationForm.FormKC> and <xref:System.Text.NormalizationForm.FormKD> forms.
 - <xref:System.Globalization.RegionInfo.CurrencyNativeName?displayProperty=nameWithType> returns the same value as <xref:System.Globalization.RegionInfo.CurrencyEnglishName?displayProperty=nameWithType>.
 
-In addition, a list of supported locales can be found on the [dotnet/icu repo](https://github.com/dotnet/icu/blob/0f49268ddfd3331ca090f1c51d2baa2f75f6c6c0/icu-filters/optimal.json#L6-L54).
+In addition, a list of supported locales is reduced and can be found on the [dotnet/icu repo](https://github.com/dotnet/icu/blob/5667bcd34fd5edab2ce2e01fdb9533306b8fcf61/icu-filters/icudt_wasm.json#L7-L195).


### PR DESCRIPTION
## Summary

We are getting questions from confused users that expect the locales listed in the doc to work on WASM but they don't. The locales list is 2 years old and lists e.g. "es", a family that contains "es-PE" that is currently not supported (issue: https://github.com/dotnet/runtime/issues/54486).
I exchanged the old link to the currently valid + underlined that the locales set is reduced.
