### PR TITLE
Rename confusing generics class and methods

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Locate projects for PR
         env:
           GitHubKey: ${{ secrets.GITHUB_TOKEN }}
-          LocateExts: ".cs;.vb;.fs;.cpp;.h;.xaml;.razor;.cshtml;.vbhtml;.csproj;.fsproj;.vbproj;.vcxproj;.sln"
+          LocateExts: ".cs;.vb;.fs;.cpp;.h;.xaml;.razor;.cshtml;.vbhtml;.csproj;.fsproj;.vbproj;.vcxproj;.sln;makefile"
         run: |
           ./.github/workflows/dependencies/Get-MSBuildResults.ps1 "${{ github.workspace }}" -PullRequest ${{ github.event.number }} -RepoOwner ${{ github.repository_owner }} -RepoName ${{ github.event.repository.name }}
 

--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Locate projects for PR
         env:
           GitHubKey: ${{ secrets.GITHUB_TOKEN }}
-          LocateExts: ".cs;.vb;.fs;.cpp;.h;.xaml;.razor;.cshtml;.vbhtml;.csproj;.fsproj;.vbproj;.vcxproj;.sln;makefile"
+          LocateExts: ".cs;.vb;.fs;.cpp;.h;.xaml;.razor;.cshtml;.vbhtml;.csproj;.fsproj;.vbproj;.vcxproj;.sln"
         run: |
           ./.github/workflows/dependencies/Get-MSBuildResults.ps1 "${{ github.workspace }}" -PullRequest ${{ github.event.number }} -RepoOwner ${{ github.repository_owner }} -RepoName ${{ github.event.repository.name }}
 

--- a/samples/snippets/cpp/VS_Snippets_CLR/conceptual.generics.overview/cpp/makefile
+++ b/samples/snippets/cpp/VS_Snippets_CLR/conceptual.generics.overview/cpp/makefile
@@ -1,0 +1,7 @@
+all: source.exe source2.exe
+
+source.exe: source.cpp
+    cl /clr:pure source.cpp
+
+source2.exe: source2.cpp
+    cl /clr:pure source2.cpp

--- a/samples/snippets/cpp/VS_Snippets_CLR/conceptual.generics.overview/cpp/source.cpp
+++ b/samples/snippets/cpp/VS_Snippets_CLR/conceptual.generics.overview/cpp/source.cpp
@@ -5,7 +5,7 @@ namespace GenericsExample1
 {
     //<snippet2>
     generic<typename T>
-    public ref class Generics
+    public ref class SimpleGenericClass
     {
     public:
         T Field;
@@ -18,17 +18,17 @@ namespace GenericsExample1
         //<snippet3>
         static void Main()
         {
-            Generics<String^>^ g = gcnew Generics<String^>();
+            SimpleGenericClass<String^>^ g = gcnew SimpleGenericClass<String^>();
             g->Field = "A string";
             //...
-            Console::WriteLine("Generics.Field           = \"{0}\"", g->Field);
-            Console::WriteLine("Generics.Field.GetType() = {0}", g->Field->GetType()->FullName);
+            Console::WriteLine("SimpleGenericClass.Field           = \"{0}\"", g->Field);
+            Console::WriteLine("SimpleGenericClass.Field.GetType() = {0}", g->Field->GetType()->FullName);
         }
         //</snippet3>
 
        //<snippet4>
         generic<typename T>
-        T Generic(T arg)
+        T MyGenericMethod(T arg)
         {
             T temp = arg;
             //...
@@ -53,7 +53,7 @@ namespace GenericsExample2
         }
     };
     generic<typename T>
-    ref class Generic
+    ref class MyGenericClass
     {
         T M(T arg)
         {

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.generics.overview/cs/source.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.generics.overview/cs/source.cs
@@ -4,7 +4,7 @@ using System;
 namespace GenericsExample1
 {
     //<snippet2>
-    public class Generic<T>
+    public class SimpleGenericClass<T>
     {
         public T Field;
     }
@@ -15,16 +15,16 @@ namespace GenericsExample1
         //<snippet3>
         public static void Main()
         {
-            Generic<string> g = new Generic<string>();
+            SimpleGenericClass<string> g = new SimpleGenericClass<string>();
             g.Field = "A string";
             //...
-            Console.WriteLine("Generic.Field           = \"{0}\"", g.Field);
-            Console.WriteLine("Generic.Field.GetType() = {0}", g.Field.GetType().FullName);
+            Console.WriteLine("SimpleGenericClass.Field           = \"{0}\"", g.Field);
+            Console.WriteLine("SimpleGenericClass.Field.GetType() = {0}", g.Field.GetType().FullName);
         }
         //</snippet3>
 
        //<snippet4>
-        T Generic<T>(T arg)
+        T MyGenericMethod<T>(T arg)
         {
             T temp = arg;
             //...
@@ -46,7 +46,7 @@ namespace GenericsExample2
             return temp;
         }
     }
-    class Generic<T>
+    class MyGenericClass<T>
     {
         T M(T arg)
         {

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.generics.overview/vb/Project.vbproj
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.generics.overview/vb/Project.vbproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+  </PropertyGroup>
+
+</Project>

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.generics.overview/vb/source.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.generics.overview/vb/source.vb
@@ -1,7 +1,7 @@
 ﻿'<snippet1>
 Namespace GenericsExample1
     '<snippet2>
-    Public Class Generic(Of T)
+    Public Class SimpleGenericClass(Of T)
         Public Field As T
 
     End Class
@@ -10,16 +10,16 @@ Namespace GenericsExample1
     Public Class GenTest
         '<snippet3>
         Public Shared Sub Main()
-            Dim g As New Generic(Of String)
+            Dim g As New SimpleGenericClass(Of String)
             g.Field = "A string"
             '...
-            Console.WriteLine("Generic.Field           = ""{0}""", g.Field)
-            Console.WriteLine("Generic.Field.GetType() = {0}", g.Field.GetType().FullName)
+            Console.WriteLine("SimpleGenericClass.Field           = ""{0}""", g.Field)
+            Console.WriteLine("SimpleGenericClass.Field.GetType() = {0}", g.Field.GetType().FullName)
         End Sub
         '</snippet3>
 
         '<snippet4>
-        Function Generic(Of T)(ByVal arg As T) As T
+        Function MyGenericMethod(Of T)(ByVal arg As T) As T
             Dim temp As T = arg
             '...
             Return temp
@@ -38,7 +38,7 @@ Namespace GenericsExample2
             Return temp
         End Function
     End Class
-    Class Generic(Of T)
+    Class MyGenericClass(Of T)
         Function M(ByVal arg As T) As T
             Dim temp As T = arg
             '...


### PR DESCRIPTION
This pull request fixes #30380 
It renames all generics methods and classes in the generics overview examples so that they can't confuse about naming conventions or requirements.
I decided to go with naming that either relates to the article or is rather safe and commonly spotted in many learning resources.