### PR TITLE
Orleans update azure-storage.md

### DIFF
--- a/docs/orleans/grains/grain-persistence/azure-storage.md
+++ b/docs/orleans/grains/grain-persistence/azure-storage.md
@@ -1,7 +1,7 @@
 ---
 title: Azure Storage grain persistence
 description: Learn about Azure Storage grain persistence in .NET Orleans.
-ms.date: 03/15/2022
+ms.date: 02/08/2023
 ---
 
 # Azure Storage grain persistence
@@ -19,7 +19,6 @@ siloBuilder.AddAzureTableGrainStorage(
     name: "profileStore",
     configureOptions: options =>
     {
-        options.UseJson = true;
         options.ConfigureTableServiceClient(
             "DefaultEndpointsProtocol=https;AccountName=data1;AccountKey=SOMETHING1");
     });
@@ -36,7 +35,6 @@ siloBuilder.AddAzureBlobGrainStorage(
     name: "profileStore",
     configureOptions: options =>
     {
-        options.UseJson = true;
         options.ConfigureBlobServiceClient(
              "DefaultEndpointsProtocol=https;AccountName=data1;AccountKey=SOMETHING1");
     });


### PR DESCRIPTION
UseJson is no longer necessary or available. JSON storage is the default. It can be customized via the `GrainStorageSerializer` property on the provider options.

Fixes #33931