### PR TITLE
Fix LDM link

### DIFF
--- a/docs/csharp/tour-of-csharp/strategy.md
+++ b/docs/csharp/tour-of-csharp/strategy.md
@@ -29,4 +29,4 @@ We respect that there is a massive amount of C# code in use today. Any potential
 
 > "maintaining stewardship"
 
-[C# language design](https://github.com/dotnet/csharplang/tree/main/meetings) takes place in the open with community participation. Anyone can propose new C# features in our [GitHub repos](https://github.com/dotnet/csharplang). The [Language Design Team](https://github.com/orgs/dotnet/teams/ldm) makes the final decisions after weighing community input.
+[C# language design](https://github.com/dotnet/csharplang/tree/main/meetings) takes place in the open with community participation. Anyone can propose new C# features in our [GitHub repos](https://github.com/dotnet/csharplang). The [Language Design Team](https://github.com/dotnet/csharplang/tree/main/meetings) makes the final decisions after weighing community input.


### PR DESCRIPTION
The original link was scoped to members of the `dotnet` GitHub org. That wasn't intended. Replace that link with a link to the LDM meeting minutes.

Fixes #33884
