### PR TITLE
Update best-practices.md

### DIFF
--- a/docs/standard/native-interop/best-practices.md
+++ b/docs/standard/native-interop/best-practices.md
@@ -224,7 +224,7 @@ A Windows `PVOID`, which is a C `void*`, can be marshalled as either `IntPtr` or
 
 There are rare instances when built-in support for a type is removed.
 
-The [`UnmanagedType.HString`](xref:System.Runtime.InteropServices.UnmanagedType) built-in marshal support was removed in the .NET 5 release. You must recompile binaries that use this marshalling type and that target a previous framework. It's still possible to marshal this type, but you must marshal it manually, as the following code example shows. This code will work moving forward and is also compatible with previous frameworks.
+The [`UnmanagedType.HString`](xref:System.Runtime.InteropServices.UnmanagedType) and [`UnmanagedType.IInspectable`](xref:System.Runtime.InteropServices.UnmanagedType) built-in marshal support was removed in the .NET 5 release. You must recompile binaries that use this marshalling type and that target a previous framework. It's still possible to marshal this type, but you must marshal it manually, as the following code example shows. This code will work moving forward and is also compatible with previous frameworks.
 
 ```csharp
 public sealed class HStringMarshaler : ICustomMarshaler
@@ -284,11 +284,11 @@ public sealed class HStringMarshaler : ICustomMarshaler
 }
 
 // Example usage:
-[DllImport("combase.dll", PreserveSig = true)]
+[DllImport("api-ms-win-core-winrt-l1-1-0.dll", PreserveSig = true)]
 internal static extern int RoGetActivationFactory(
     /*[MarshalAs(UnmanagedType.HString)]*/[MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(HStringMarshaler))] string activatableClassId,
     [In] ref Guid iid,
-    [Out, MarshalAs(UnmanagedType.IUnknown)] out Object factory);
+    [Out, MarshalAs(UnmanagedType.IUnknown)] out object factory);
 ```
 
 ## Cross-platform data type considerations

--- a/docs/standard/native-interop/best-practices.md
+++ b/docs/standard/native-interop/best-practices.md
@@ -288,7 +288,7 @@ public sealed class HStringMarshaler : ICustomMarshaler
 internal static extern int RoGetActivationFactory(
     /*[MarshalAs(UnmanagedType.HString)]*/[MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(HStringMarshaler))] string activatableClassId,
     [In] ref Guid iid,
-    [Out, MarshalAs(UnmanagedType.IInspectable)] out Object factory);
+    [Out, MarshalAs(UnmanagedType.IUnknown)] out Object factory);
 ```
 
 ## Cross-platform data type considerations

--- a/docs/standard/native-interop/best-practices.md
+++ b/docs/standard/native-interop/best-practices.md
@@ -272,7 +272,7 @@ public sealed class HStringMarshaler : ICustomMarshaler
 
     [DllImport("api-ms-win-core-winrt-string-l1-1-0.dll")]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    private static extern int WindowsCreateString([MarshalAs(UnmanagedType.LPWStr)] string sourceString, int length, out IntPtr @string);
+    private static extern int WindowsCreateString([MarshalAs(UnmanagedType.LPWStr)] string sourceString, int length, out IntPtr hstring);
 
     [DllImport("api-ms-win-core-winrt-string-l1-1-0.dll")]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]

--- a/docs/standard/native-interop/best-practices.md
+++ b/docs/standard/native-interop/best-practices.md
@@ -280,7 +280,7 @@ public sealed class HStringMarshaler : ICustomMarshaler
 
     [DllImport("api-ms-win-core-winrt-string-l1-1-0.dll")]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    private static extern IntPtr WindowsGetStringRawBuffer(IntPtr @string, out int length);
+    private static extern IntPtr WindowsGetStringRawBuffer(IntPtr hstring, out int length);
 }
 
 // Example usage:

--- a/docs/standard/native-interop/best-practices.md
+++ b/docs/standard/native-interop/best-practices.md
@@ -276,7 +276,7 @@ public sealed class HStringMarshaler : ICustomMarshaler
 
     [DllImport("api-ms-win-core-winrt-string-l1-1-0.dll")]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    private static extern int WindowsDeleteString(IntPtr @string);
+    private static extern int WindowsDeleteString(IntPtr hstring);
 
     [DllImport("api-ms-win-core-winrt-string-l1-1-0.dll")]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]


### PR DESCRIPTION
## Summary

Add custom marshaller example that could be used inplace instead of `[MarshalAs(UnmanagedType.HString)]` attribute.