### PR TITLE
.NET Framework troubleshooting article: Update intro based on discussion

### DIFF
--- a/docs/framework/install/application-not-started.md
+++ b/docs/framework/install/application-not-started.md
@@ -3,7 +3,7 @@ title: Fix .NET Framework 'This application could not be started'
 description: Learn what to do if you see a 'This application could not be started' dialog box when running a .NET Framework application.
 ms.date: 02/13/2023
 ---
-# "This application could not be started" error when running .NET Framework application
+# "This application could not be started" error when running a .NET Framework application
 
 When you attempt to run a .NET Framework application, you may receive the "This application could not be started" error message. This error may be caused by several factors, such as:
 

--- a/docs/framework/install/application-not-started.md
+++ b/docs/framework/install/application-not-started.md
@@ -5,25 +5,11 @@ ms.date: 02/13/2023
 ---
 # "This application could not be started" error when running a .NET Framework application
 
-When you attempt to run a .NET Framework application, you may receive the "This application could not be started" error message. This error may be caused by several factors, such as:
-
-- Missing or corrupted .NET framework installation.
-- Missing dependencies.
-- A corrupted file system.
-- Some other problem.
+When you attempt to run a .NET Framework application, you may receive the "This application could not be started" error message. When this error is caused by an installed version of .NET Framework not being detected, or by .NET Framework being corrupted, use this article to try to solve that problem.
 
 :::image type="content" source="media/application-not-started/app-could-not-be-started.png" alt-text="This application could not be started dialog box.":::
 
-## Error causes
-
-If the application you're trying to run is developed for .NET Framework, the error message may be caused by one of the following conditions:
-
-- A .NET Framework installation on your system has become corrupted.
-- The version of .NET Framework needed by the application can't be detected.
-
-If so, follow the steps in this article to try to fix the problem.
-
-If you still can't run the application after completing all the steps, then the issue may be caused by some other reason, like a corrupted file system, missing dependencies, or a problem with the application. In that case, you can try contacting the app publisher or post a question to [Microsoft Support Community](https://answers.microsoft.com/) or [Microsoft Q&A](/answers/tags/97/dotnet) for more help.
+If you still can't run the application after completing all the steps in this article, then the issue may be caused by some other reason, like a corrupted file system, missing dependencies, or a problem with the application. In that case, you can try contacting the app publisher or post a question to [Microsoft Support Community](https://answers.microsoft.com/) or [Microsoft Q&A](/answers/tags/97/dotnet) for more help.
 
 ## How to fix the error
 

--- a/docs/framework/install/application-not-started.md
+++ b/docs/framework/install/application-not-started.md
@@ -1,21 +1,29 @@
 ---
-title: Troubleshooting 'This application could not be started'
-description: Learn what to do if you see a 'This application could not be started' dialog box.
-ms.date: 10/06/2021
+title: Fix .NET Framework 'This application could not be started'
+description: Learn what to do if you see a 'This application could not be started' dialog box when running a .NET Framework application.
+ms.date: 02/13/2023
 ---
-# Troubleshooting a 'This application could not be started' error message
+# "This application could not be started" error when running .NET Framework application
 
-Applications that are developed for .NET Framework typically require that a specific version of .NET Framework be installed on your system. In some cases, you may attempt to run an application without either an installed version or the expected version of .NET Framework present. This often produces an error dialog box like the following:
+When you attempt to run a .NET Framework application, you may receive the "This application could not be started" error message. This error may be caused by several factors, such as:
+
+- Missing or corrupted .NET framework installation.
+- Missing dependencies.
+- A corrupted file system.
+- Some other problem.
 
 ![This application could not be started](media/application-not-started/app-could-not-be-started.png)
 
 ## Error causes
 
-This error typically indicates one of the following conditions:
+If the application you're trying to run is developed for .NET Framework, the error message may be caused by one of the following conditions:
 
 - A .NET Framework installation on your system has become corrupted.
+- The version of .NET Framework needed by the application can't be detected.
 
-- The version of .NET Framework needed by your application cannot be detected.
+If so, follow the steps in this article to try to fix the problem.
+
+If you still can't run the application after completing all the steps, then the issue may be caused by some other reason, like a corrupted file system, missing dependencies, or a problem with the application. In that case, you can try contacting the app publisher or post a question to [Microsoft Support Community](https://answers.microsoft.com/) or [Microsoft Q&A](https://learn.microsoft.com/answers/tags/97/dotnet) for more help.
 
 ## How to fix the error
 

--- a/docs/framework/install/application-not-started.md
+++ b/docs/framework/install/application-not-started.md
@@ -12,7 +12,7 @@ When you attempt to run a .NET Framework application, you may receive the "This 
 - A corrupted file system.
 - Some other problem.
 
-![This application could not be started](media/application-not-started/app-could-not-be-started.png)
+:::image type="content" source="media/application-not-started/app-could-not-be-started.png" alt-text="This application could not be started dialog box.":::
 
 ## Error causes
 
@@ -33,17 +33,17 @@ To address this issue so that you can run your application, do the following:
 
 1. If the .NET Framework Repair Tool recommends any additional action, such as those shown in the following figure, select **Next**.
 
-   ![Repair tool recommended changes](media/application-not-started/repair-tool-recommended-changes.png)
+   :::image type="content" source="media/application-not-started/repair-tool-recommended-changes.png" alt-text="Repair tool recommended changes.":::
 
 1. The .NET Framework Repair Tools displays a dialog box shown in the following figure to indicate that changes are complete. Leave the dialog box open while you to try rerun your application. This should succeed if the .NET Framework Repair Tool has identified and corrected a corrupted .NET Framework installation.
 
-   ![Repair tool changes complete](media/application-not-started/repair-tool-changes-complete.png)
+   :::image type="content" source="media/application-not-started/repair-tool-changes-complete.png" alt-text="Repair tool changes complete.":::
 
 1. If your application runs successfully, select the **Finish** button. Otherwise, select the **Next** button.
 
 1. If you selected the **Next** button, the .NET Framework Repair Tool displays a dialog box like the following. Select the **Finish** button to send diagnostic information to Microsoft.
 
-   ![Unable to resolve the problem](media/application-not-started/repair-tool-no-resolution.png)
+   :::image type="content" source="media/application-not-started/repair-tool-no-resolution.png" alt-text="Unable to resolve the problem with the repair tool.":::
 
 1. If you still cannot run the application, install the latest version of .NET Framework that's supported by your version of Windows, as shown in the following table.
 
@@ -63,7 +63,7 @@ To address this issue so that you can run your application, do the following:
 
 1. In some cases, you may see a dialog box like the following, which asks you to install .NET Framework 3.5. Select **Download and install this feature** to install .NET Framework 3.5, then launch the application again.
 
-   ![Windows Features dialog box suggesting to install .NET Framework 3.5](media/application-not-started/install-3-5.png)
+   :::image type="content" source="media/application-not-started/install-3-5.png" alt-text="Windows Features dialog box suggesting to install .NET Framework 3.5.":::
 
 ## See also
 

--- a/docs/framework/install/application-not-started.md
+++ b/docs/framework/install/application-not-started.md
@@ -23,7 +23,7 @@ If the application you're trying to run is developed for .NET Framework, the err
 
 If so, follow the steps in this article to try to fix the problem.
 
-If you still can't run the application after completing all the steps, then the issue may be caused by some other reason, like a corrupted file system, missing dependencies, or a problem with the application. In that case, you can try contacting the app publisher or post a question to [Microsoft Support Community](https://answers.microsoft.com/) or [Microsoft Q&A](https://learn.microsoft.com/answers/tags/97/dotnet) for more help.
+If you still can't run the application after completing all the steps, then the issue may be caused by some other reason, like a corrupted file system, missing dependencies, or a problem with the application. In that case, you can try contacting the app publisher or post a question to [Microsoft Support Community](https://answers.microsoft.com/) or [Microsoft Q&A](/answers/tags/97/dotnet) for more help.
 
 ## How to fix the error
 


### PR DESCRIPTION
## Summary

- Update the web search title metadata. Only 3 chars longer and still gets .NET Framework name directly in it.
- Update H1
- Stuff .NET Framework into the search description metadata
- Clearer intro paragraph and merged the error section into the intro
- Add another conditional "If .NET Framework" in the Error causes section
- Links to support communities

[Internal preview link](https://review.learn.microsoft.com/en-us/dotnet/framework/install/application-not-started?branch=pr-en-us-34004)

Fixes #34002