### PR TITLE
Update garbage-collector.md

### DIFF
--- a/docs/core/runtime-config/garbage-collector.md
+++ b/docs/core/runtime-config/garbage-collector.md
@@ -12,8 +12,8 @@ Settings are arranged into groups on this page. The settings within each group a
 
 > [!NOTE]
 >
-> - These settings can also be changed dynamically by the app as it's running, so any configuration options you set may be overridden.
-> - Some settings, such as [latency level](../../standard/garbage-collection/latency.md), are typically set only through the API at design time. Such settings are omitted from this page.
+> - These configurations are only read by the runtime when the GC is initialize (usually this means during the process startup time). So if you change an environment variable when a  process is already running, that change will not be reflected in that process. Settings that can be changed through APIs during at run time such as [latency level](../../standard/garbage-collection/latency.md), are omitted from this page.
+> - Because GC is per process, it rarely ever makes sense to set these configurations on the machine level. For example, you would not want to set every .NET process to use Server GC, or the same heap hard limit on a machine.
 > - For number values, use decimal notation for settings in the *runtimeconfig.json* file and hexadecimal notation for environment variable settings. For hexadecimal values, you can specify them with or without the "0x" prefix.
 > - If you're using the environment variables, .NET 6 standardizes on the prefix `DOTNET_` instead of `COMPlus_`. However, the `COMPlus_` prefix will continue to work. If you're using a previous version of the .NET runtime, you should still use the `COMPlus_` prefix, for example, `COMPlus_gcServer`.
 

--- a/docs/core/runtime-config/garbage-collector.md
+++ b/docs/core/runtime-config/garbage-collector.md
@@ -13,7 +13,7 @@ Settings are arranged into groups on this page. The settings within each group a
 > [!NOTE]
 >
 > - These configurations are only read by the runtime when the GC is initialized (usually this means during the process startup time). If you change an environment variable when a process is already running, the change won't be reflected in that process. Settings that can be changed through APIs at run time, such as [latency level](../../standard/garbage-collection/latency.md), are omitted from this page.
-> - Because GC is per process, it rarely ever makes sense to set these configurations on the machine level. For example, you would not want to set every .NET process to use Server GC, or the same heap hard limit on a machine.
+> - Because GC is per process, it rarely ever makes sense to set these configurations at the machine level. For example, you wouldn't want every .NET process on a machine to use server GC or the same heap hard limit.
 > - For number values, use decimal notation for settings in the *runtimeconfig.json* file and hexadecimal notation for environment variable settings. For hexadecimal values, you can specify them with or without the "0x" prefix.
 > - If you're using the environment variables, .NET 6 standardizes on the prefix `DOTNET_` instead of `COMPlus_`. However, the `COMPlus_` prefix will continue to work. If you're using a previous version of the .NET runtime, you should still use the `COMPlus_` prefix, for example, `COMPlus_gcServer`.
 

--- a/docs/core/runtime-config/garbage-collector.md
+++ b/docs/core/runtime-config/garbage-collector.md
@@ -12,7 +12,7 @@ Settings are arranged into groups on this page. The settings within each group a
 
 > [!NOTE]
 >
-> - These configurations are only read by the runtime when the GC is initialize (usually this means during the process startup time). So if you change an environment variable when a  process is already running, that change will not be reflected in that process. Settings that can be changed through APIs during at run time such as [latency level](../../standard/garbage-collection/latency.md), are omitted from this page.
+> - These configurations are only read by the runtime when the GC is initialized (usually this means during the process startup time). If you change an environment variable when a process is already running, the change won't be reflected in that process. Settings that can be changed through APIs at run time, such as [latency level](../../standard/garbage-collection/latency.md), are omitted from this page.
 > - Because GC is per process, it rarely ever makes sense to set these configurations on the machine level. For example, you would not want to set every .NET process to use Server GC, or the same heap hard limit on a machine.
 > - For number values, use decimal notation for settings in the *runtimeconfig.json* file and hexadecimal notation for environment variable settings. For hexadecimal values, you can specify them with or without the "0x" prefix.
 > - If you're using the environment variables, .NET 6 standardizes on the prefix `DOTNET_` instead of `COMPlus_`. However, the `COMPlus_` prefix will continue to work. If you're using a previous version of the .NET runtime, you should still use the `COMPlus_` prefix, for example, `COMPlus_gcServer`.


### PR DESCRIPTION
## Summary

clarifies that GC configs are rarely ever set per machine based on feedback from a customer. also made another clarification on when the configs are read.