### PR TITLE
Add instructions for loading COM component in default ALC

### DIFF
--- a/docs/core/native-interop/expose-components-to-com.md
+++ b/docs/core/native-interop/expose-components-to-com.md
@@ -104,7 +104,7 @@ For example, the following code block adds the `Server.tlb` type library at inde
 
 During activation, the assembly containing the COM component is loaded in a separate <xref:System.Runtime.Loader.AssemblyLoadContext> based on the assembly path. If there is one assembly providing multiple COM servers, the `AssemblyLoadContext` is reused such that all of the servers from that assembly reside in the same load context. If there are multiple assemblies providing COM servers, a new `AssemblyLoadContext` is created for each assembly, and each server resides in the load context that corresponds to its assembly.
 
-In .NET 8 and later versions, the assembly can specify that it should be loaded in the default `AssemblyLoadContext`. To enable loading in the default context, add the following [RuntimeHostConfigurationOption](../runtime-config/index.md#msbuild-properties) to the project:
+In .NET 8 and later versions, the assembly can specify that it should be loaded in the default `AssemblyLoadContext`. To enable loading in the default context, add the following [RuntimeHostConfigurationOption](../runtime-config/index.md#msbuild-properties) item to the project:
 
 ```xml
 <ItemGroup>

--- a/docs/core/native-interop/expose-components-to-com.md
+++ b/docs/core/native-interop/expose-components-to-com.md
@@ -100,6 +100,18 @@ For example, the following code block adds the `Server.tlb` type library at inde
 </ItemGroup>
 ```
 
+## Loading in the default `AssemblyLoadContext`
+
+During activation, the assembly containing the COM component is loaded in a separate <xref:System.Runtime.Loader.AssemblyLoadContext> based on the assembly path. If there is one assembly providing multiple COM servers, the `AssemblyLoadContext` is reused such that all of the servers from that assembly reside in the same load context. If there are multiple assemblies providing COM servers, a new `AssemblyLoadContext` is created for each assembly, and each server resides in the load context that corresponds to its assembly.
+
+In .NET 8 and later versions, the assembly can specify that it should be loaded in the default `AssemblyLoadContext`. To enable loading in the default context, add the following [RuntimeHostConfigurationOption](../runtime-config/index.md#msbuild-properties) to the project:
+
+```xml
+<ItemGroup>
+  <RuntimeHostConfigurationOption Include="System.Runtime.InteropServices.COM.LoadComponentInDefaultContext" Value="true" />
+</ItemGroup>
+```
+
 ## Sample
 
 There is a fully functional [COM server sample](https://github.com/dotnet/samples/tree/main/core/extensions/COMServerDemo) in the dotnet/samples repository on GitHub.
@@ -108,8 +120,6 @@ There is a fully functional [COM server sample](https://github.com/dotnet/sample
 
 > [!IMPORTANT]
 > In .NET Framework, an "Any CPU" assembly can be consumed by both 32-bit and 64-bit clients. By default, in .NET Core, .NET 5, and later versions, "Any CPU" assemblies are accompanied by a 64-bit *\*.comhost.dll*. Because of this, they can only be consumed by 64-bit clients. That is the default because that is what the SDK represents. This behavior is identical to how the "self-contained" feature is published: by default it uses what the SDK provides. The `NETCoreSdkRuntimeIdentifier` MSBuild property determines the bitness of *\*.comhost.dll*. The managed part is actually bitness agnostic as expected, but the accompanying native asset defaults to the targeted SDK.
-
-During activation, the assembly containing the COM component is loaded in a separate <xref:System.Runtime.Loader.AssemblyLoadContext> based on the assembly path. If there is one assembly providing multiple COM servers, the `AssemblyLoadContext` is reused such that all of the servers from that assembly reside in the same load context. If there are multiple assemblies providing COM servers, a new `AssemblyLoadContext` is created for each assembly, and each server resides in the load context that corresponds to its assembly.
 
 [Self-contained deployments](../deploying/index.md#publish-self-contained) of COM components are not supported. Only [framework-dependent deployments](../deploying/index.md#publish-framework-dependent) of COM components are supported.
 


### PR DESCRIPTION
The ability to specify loading a COM component in the default ALC was added in .NET 8. Update the doc with the configuration option that enables it.

cc @AaronRobinsonMSFT @vitek-karas 