### PR TITLE
Use `required` keyword to avoid `null` as default when instantiating record types

### DIFF
--- a/docs/csharp/language-reference/builtin-types/snippets/shared/RecordType.cs
+++ b/docs/csharp/language-reference/builtin-types/snippets/shared/RecordType.cs
@@ -41,8 +41,8 @@ namespace builtin_types
         // <ImmutableRecord>
         public record Person
         {
-            public string FirstName { get; init; } = default!;
-            public string LastName { get; init; } = default!;
+            public required string FirstName { get; init; }
+            public required string LastName { get; init; }
         };
         // </ImmutableRecord>
 
@@ -61,8 +61,8 @@ namespace builtin_types
         // <MutableRecord>
         public record Person
         {
-            public string FirstName { get; set; } = default!;
-            public string LastName { get; set; } = default!;
+            public required string FirstName { get; set; }
+            public required string LastName { get; set; }
         };
         // </MutableRecord>
 


### PR DESCRIPTION
This pull request fixes #33851

It changes the way the fields and properties are declared within the `record` classes.
The structs in these examples are left intact, because the `double` type will get 0 by default comparing to `null` for strings.