### PR TITLE
Add breaking change doc for --output when used with solutions

### DIFF
--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -130,6 +130,7 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 | [dotnet test: switch `-a` to alias `--arch` instead of `--test-adapter-path`](https://github.com/dotnet/sdk/issues/21389) | ❌ | ❌ | Preview 1 |
 | [dotnet test: switch `-r` to alias `--runtime` instead of `--results-dir`](https://github.com/dotnet/sdk/issues/21952) | ❌ | ❌ | Preview 1 |
 | [`--output` option no longer is valid for solution-level commands](sdk/7.0/solution-level-output-no-longer-valid.md) | ❌ | ❌ | 7.0.200 |
+
 ## Serialization
 
 | Title | Binary compatible | Source compatible | Introduced |

--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -129,7 +129,7 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 | [Version requirements for .NET 7 SDK](sdk/7.0/vs-msbuild-version.md) | ✔️ | ✔️ | 7.0.100 |
 | [dotnet test: switch `-a` to alias `--arch` instead of `--test-adapter-path`](https://github.com/dotnet/sdk/issues/21389) | ❌ | ❌ | Preview 1 |
 | [dotnet test: switch `-r` to alias `--runtime` instead of `--results-dir`](https://github.com/dotnet/sdk/issues/21952) | ❌ | ❌ | Preview 1 |
-
+| [`--output` option no longer is valid for solution-level commands](sdk/7.0/solution-level-output-no-longer-valid.md) | ❌ | ❌ | 7.0.200 |
 ## Serialization
 
 | Title | Binary compatible | Source compatible | Introduced |

--- a/docs/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid.md
+++ b/docs/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid.md
@@ -1,0 +1,44 @@
+---
+title: "Solution-level `--output` option no longer valid for build-related commands"
+description: Learn about a breaking change in the .NET 7.0.200 SDK where using the `--output` option is no longer valid when using a solution file
+ms.date: 02/15/2023
+---
+# Solution-level `--output` option no longer valid for build-related commands
+
+In the 7.0.200 SDK, there was [a change]([automatic-runtimeidentifier.md](https://github.com/dotnet/sdk/pull/29065)) to no longer accept the `--output`/`-o` option when using a solution file with the following commands:
+
+* build
+* clean
+* pack
+* publish
+* store
+* test
+* vstest
+
+This is because the semantics of the `OutputPath` property, which is controlled by the `--output`/`-o` option, are not well-defined for solutions - projects built in this way will have their output placed in the same directory, which is not consistent and has lead to a number of user-reported issues in the past.
+
+## Version introduced
+
+.NET 7.0.200 SDK
+
+## Previous behavior
+
+Previously, if you specified `--output`/`-o` when using a solution file, the output for all built projects would be placed in the specified directory in an undefined and inconsistent order.
+
+## New behavior
+
+The `dotnet` CLI will error if the `--output`/`-o` option is used with a solution file.
+
+## Type of breaking change
+
+This change requires changes to build scripts and Continuous Integration pipelines.
+
+## Reason for change
+
+This change was taken because the semantics of the `OutputPath` property, which is controlled by the `--output`/`-o` option, are not well-defined for solutions - projects built in this way will have their output placed in the same directory, which is not consistent and has lead to a number of user-reported issues in the past.
+
+For examples of how this presents in practice, see the discussion on [dotnet/sdk#15607](https://github.com/dotnet/sdk/issues/15607).
+
+## Recommended action
+
+The general recommendation is to perform the action that you previously took _without_ the `--output`/`-o` option, and then move the output to the desired location after the command has completed. It is also possible to perform the action at a more specific level (i.e. at a specific project) and still apply the `--output`/`-o` option, as that has more well-defined semantics.

--- a/docs/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid.md
+++ b/docs/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid.md
@@ -15,7 +15,7 @@ In the 7.0.200 SDK, there was [a change](https://github.com/dotnet/sdk/pull/2906
 * test
 * vstest
 
-This is because the semantics of the `OutputPath` property, which is controlled by the `--output`/`-o` option, are not well-defined for solutions - projects built in this way will have their output placed in the same directory, which is not consistent and has lead to a number of user-reported issues in the past.
+This is because the semantics of the `OutputPath` property, which is controlled by the `--output`/`-o` option, are not well-defined for solutions - projects built in this way will have their output placed in the same directory, which is not consistent and has led to a number of user-reported issues in the past.
 
 ## Version introduced
 
@@ -35,10 +35,10 @@ This change requires changes to build scripts and Continuous Integration pipelin
 
 ## Reason for change
 
-This change was taken because the semantics of the `OutputPath` property, which is controlled by the `--output`/`-o` option, are not well-defined for solutions - projects built in this way will have their output placed in the same directory, which is not consistent and has lead to a number of user-reported issues in the past.
+This change was taken because the semantics of the `OutputPath` property, which is controlled by the `--output`/`-o` option, are not well-defined for solutions - projects built in this way will have their output placed in the same directory, which is not consistent and has led to a number of user-reported issues in the past.
 
 For examples of how this presents in practice, see the discussion on [dotnet/sdk#15607](https://github.com/dotnet/sdk/issues/15607).
 
 ## Recommended action
 
-The general recommendation is to perform the action that you previously took _without_ the `--output`/`-o` option, and then move the output to the desired location after the command has completed. It is also possible to perform the action at a more specific level (i.e. at a specific project) and still apply the `--output`/`-o` option, as that has more well-defined semantics.
+The general recommendation is to perform the action that you previously took _without_ the `--output`/`-o` option, and then move the output to the desired location after the command has completed. It is also possible to perform the action at a specific project and still apply the `--output`/`-o` option, as that has more well-defined semantics.

--- a/docs/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid.md
+++ b/docs/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid.md
@@ -31,7 +31,7 @@ The `dotnet` CLI will error if the `--output`/`-o` option is used with a solutio
 
 ## Type of breaking change
 
-This breaking change may require modifications to build scripts and continuous integration pipelines.
+This breaking change may require modifications to build scripts and continuous integration pipelines. As a result it affects both binary and source compatibility.
 
 ## Reason for change
 

--- a/docs/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid.md
+++ b/docs/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid.md
@@ -42,3 +42,5 @@ For examples of how this presents in practice, see the discussion on [dotnet/sdk
 ## Recommended action
 
 The general recommendation is to perform the action that you previously took _without_ the `--output`/`-o` option, and then move the output to the desired location after the command has completed. It's also possible to perform the action at a specific project and still apply the `--output`/`-o` option, as that has more well-defined semantics.
+
+If you were using `dotnet pack` with a solution file, you can workaround this issue by using `-p PackageOutputPath=DESIRED_PATH` instead of `--output`/`-o`.

--- a/docs/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid.md
+++ b/docs/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid.md
@@ -43,4 +43,13 @@ For examples of how this presents in practice, see the discussion on [dotnet/sdk
 
 The general recommendation is to perform the action that you previously took _without_ the `--output`/`-o` option, and then move the output to the desired location after the command has completed. It's also possible to perform the action at a specific project and still apply the `--output`/`-o` option, as that has more well-defined semantics.
 
-If you were using `dotnet pack` with a solution file, you can workaround this issue by using `-p PackageOutputPath=DESIRED_PATH` instead of `--output`/`-o`.
+If you want to maintain the existing behavior exactly, then you can use the `--property` flag to set a MSBuild property to the desired directory. The property to use varies based on the command:
+
+| Command | Property | Example |
+| -- | -- | -- |
+| `build` | `OutputPath` | `dotnet build --property OutputPath=DESIRED_PATH` |
+| `clean` | `OutputPath` | `dotnet clean --property OutputPath=DESIRED_PATH` |
+| `pack` | `PackageOutputPath` | `dotnet pack --property PackageOutputPath=DESIRED_PATH` |
+| `publish` | `PublishDir` | `dotnet publish --property PublishDir=DESIRED_PATH` |
+| `store` | `OutputPath` | `dotnet store --property OutputPath=DESIRED_PATH` |
+| `test` | `TestResultsDirectory` | `dotnet test --property OutputPath=DESIRED_PATH` |

--- a/docs/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid.md
+++ b/docs/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid.md
@@ -15,7 +15,7 @@ In the 7.0.200 SDK, there was [a change](https://github.com/dotnet/sdk/pull/2906
 * test
 * vstest
 
-This is because the semantics of the `OutputPath` property, which is controlled by the `--output`/`-o` option, are not well-defined for solutions - projects built in this way will have their output placed in the same directory, which is not consistent and has led to a number of user-reported issues in the past.
+This is because the semantics of the `OutputPath` property, which is controlled by the `--output`/`-o` option, aren't well defined for solutions. Projects built in this way will have their output placed in the same directory, which is inconsistent and has led to a number of user-reported issues.
 
 ## Version introduced
 
@@ -31,14 +31,14 @@ The `dotnet` CLI will error if the `--output`/`-o` option is used with a solutio
 
 ## Type of breaking change
 
-This change requires changes to build scripts and Continuous Integration pipelines.
+This breaking change may require modifications to build scripts and continuous integration pipelines.
 
 ## Reason for change
 
-This change was taken because the semantics of the `OutputPath` property, which is controlled by the `--output`/`-o` option, are not well-defined for solutions - projects built in this way will have their output placed in the same directory, which is not consistent and has led to a number of user-reported issues in the past.
+This change was made because the semantics of the `OutputPath` property, which is controlled by the `--output`/`-o` option, aren't well defined for solutions. Projects built in this way will have their output placed in the same directory, which is inconsistent and has led to a number of user-reported issues.
 
 For examples of how this presents in practice, see the discussion on [dotnet/sdk#15607](https://github.com/dotnet/sdk/issues/15607).
 
 ## Recommended action
 
-The general recommendation is to perform the action that you previously took _without_ the `--output`/`-o` option, and then move the output to the desired location after the command has completed. It is also possible to perform the action at a specific project and still apply the `--output`/`-o` option, as that has more well-defined semantics.
+The general recommendation is to perform the action that you previously took _without_ the `--output`/`-o` option, and then move the output to the desired location after the command has completed. It's also possible to perform the action at a specific project and still apply the `--output`/`-o` option, as that has more well-defined semantics.

--- a/docs/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid.md
+++ b/docs/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid.md
@@ -5,7 +5,7 @@ ms.date: 02/15/2023
 ---
 # Solution-level `--output` option no longer valid for build-related commands
 
-In the 7.0.200 SDK, there was [a change]([automatic-runtimeidentifier.md](https://github.com/dotnet/sdk/pull/29065)) to no longer accept the `--output`/`-o` option when using a solution file with the following commands:
+In the 7.0.200 SDK, there was [a change](https://github.com/dotnet/sdk/pull/29065) to no longer accept the `--output`/`-o` option when using a solution file with the following commands:
 
 * build
 * clean

--- a/docs/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid.md
+++ b/docs/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid.md
@@ -7,13 +7,13 @@ ms.date: 02/15/2023
 
 In the 7.0.200 SDK, there was [a change](https://github.com/dotnet/sdk/pull/29065) to no longer accept the `--output`/`-o` option when using a solution file with the following commands:
 
-* build
-* clean
-* pack
-* publish
-* store
-* test
-* vstest
+* `build`
+* `clean`
+* `pack`
+* `publish`
+* `store`
+* `test`
+* `vstest`
 
 This is because the semantics of the `OutputPath` property, which is controlled by the `--output`/`-o` option, aren't well defined for solutions. Projects built in this way will have their output placed in the same directory, which is inconsistent and has led to a number of user-reported issues.
 

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -196,6 +196,8 @@ items:
         href: sdk/7.0/custom-serialization.md
       - name: Side-by-side SDK installations
         href: sdk/7.0/side-by-side-install.md
+      - name: --output option no longer is valid for solution-level commands
+        href: sdk/7.0/solution-level-output-no-longer-valid.md
     - name: Serialization
       items:
       - name: DataContractSerializer retains sign when deserializing -0
@@ -1266,6 +1268,8 @@ items:
         href: sdk/7.0/custom-serialization.md
       - name: Side-by-side SDK installations
         href: sdk/7.0/side-by-side-install.md
+      - name: --output option no longer is valid for solution-level commands
+        href: sdk/7.0/solution-level-output-no-longer-valid.md
     - name: .NET 6
       items:
       - name: -p option for `dotnet run` is deprecated

--- a/docs/core/tools/dotnet-build.md
+++ b/docs/core/tools/dotnet-build.md
@@ -120,7 +120,7 @@ The project or solution file to build. If a project or solution file isn't speci
 
   - .NET 7.0.200 SDK and later
 
-    If you specify the `--output` option the CLI will emit an error due to the unclear semantics of the output path (as described below).
+    If you specify the `--output` option the CLI will emit an error due to the unclear semantics of the output path. All outputs of all built projects will be copied into the specified directory, which isn't compatible with multi-targeted projects, as well as projects that have different versions of direct and transitive dependencies.
 
 [!INCLUDE [os](../../../includes/cli-os.md)]
 

--- a/docs/core/tools/dotnet-build.md
+++ b/docs/core/tools/dotnet-build.md
@@ -120,7 +120,7 @@ The project or solution file to build. If a project or solution file isn't speci
 
   - .NET 7.0.200 SDK and later
 
-    If you specify the `--output` option the CLI will emit an error due to the unclear semantics of the output path. All outputs of all built projects will be copied into the specified directory, which isn't compatible with multi-targeted projects, as well as projects that have different versions of direct and transitive dependencies.
+    If you specify the `--output` option when running this command on a solution, the CLI will emit an error due to the unclear semantics of the output path. The `--output` option is disallowed because all outputs of all built projects would be copied into the specified directory, which isn't compatible with multi-targeted projects, as well as projects that have different versions of direct and transitive dependencies.
 
 [!INCLUDE [os](../../../includes/cli-os.md)]
 

--- a/docs/core/tools/dotnet-build.md
+++ b/docs/core/tools/dotnet-build.md
@@ -118,6 +118,10 @@ The project or solution file to build. If a project or solution file isn't speci
 
   Directory in which to place the built binaries. If not specified, the default path is `./bin/<configuration>/<framework>/`.  For projects with multiple target frameworks (via the `TargetFrameworks` property), you also need to define `--framework` when you specify this option.
 
+  - .NET 7.0.200 SDK and later
+
+    If you specify the `--output` option the CLI will emit an error due to the unclear semantics of the output path (as described below).
+
 [!INCLUDE [os](../../../includes/cli-os.md)]
 
 - **`-r|--runtime <RUNTIME_IDENTIFIER>`**

--- a/docs/core/tools/dotnet-clean.md
+++ b/docs/core/tools/dotnet-clean.md
@@ -54,7 +54,7 @@ The MSBuild project or solution to clean. If a project or solution file is not s
 
   - .NET 7.0.200 SDK and later
 
-    If you specify the `--output` option the CLI will emit an error due to the unclear semantics of the output path (as described below).
+    If you specify the `--output` option the CLI will emit an error due to the unclear semantics of the output path. All outputs of all built projects will be copied into the specified directory, which isn't compatible with multi-targeted projects, as well as projects that have different versions of direct and transitive dependencies.
 
 * **`-r|--runtime <RUNTIME_IDENTIFIER>`**
 

--- a/docs/core/tools/dotnet-clean.md
+++ b/docs/core/tools/dotnet-clean.md
@@ -54,7 +54,7 @@ The MSBuild project or solution to clean. If a project or solution file is not s
 
   - .NET 7.0.200 SDK and later
 
-    If you specify the `--output` option the CLI will emit an error due to the unclear semantics of the output path. All outputs of all built projects will be copied into the specified directory, which isn't compatible with multi-targeted projects, as well as projects that have different versions of direct and transitive dependencies.
+    If you specify the `--output` option when running this command on a solution, the CLI will emit an error due to the unclear semantics of the output path. The `--output` option is disallowed because all outputs of all built projects would be copied into the specified directory, which isn't compatible with multi-targeted projects, as well as projects that have different versions of direct and transitive dependencies.
 
 * **`-r|--runtime <RUNTIME_IDENTIFIER>`**
 

--- a/docs/core/tools/dotnet-clean.md
+++ b/docs/core/tools/dotnet-clean.md
@@ -52,6 +52,10 @@ The MSBuild project or solution to clean. If a project or solution file is not s
 
   The directory that contains the build artifacts to clean. Specify the `-f|--framework <FRAMEWORK>` switch with the output directory switch if you specified the framework when the project was built.
 
+  - .NET 7.0.200 SDK and later
+
+    If you specify the `--output` option the CLI will emit an error due to the unclear semantics of the output path (as described below).
+
 * **`-r|--runtime <RUNTIME_IDENTIFIER>`**
 
   Cleans the output folder of the specified runtime. This is used when a [self-contained deployment](../deploying/index.md#publish-self-contained) was created.

--- a/docs/core/tools/dotnet-pack.md
+++ b/docs/core/tools/dotnet-pack.md
@@ -99,7 +99,7 @@ You can provide MSBuild properties to the `dotnet pack` command for the packing 
 
   - .NET 7.0.200 SDK and later
 
-    If you specify the `--output` option the CLI will emit an error due to the unclear semantics of the output path. All outputs of all built projects will be copied into the specified directory, which isn't compatible with multi-targeted projects, as well as projects that have different versions of direct and transitive dependencies.
+    If you specify the `--output` option when running this command on a solution, the CLI will emit an error due to the unclear semantics of the output path. The `--output` option is disallowed because all outputs of all built projects would be copied into the specified directory, which isn't compatible with multi-targeted projects, as well as projects that have different versions of direct and transitive dependencies.
 
 - **`--runtime <RUNTIME_IDENTIFIER>`**
 

--- a/docs/core/tools/dotnet-pack.md
+++ b/docs/core/tools/dotnet-pack.md
@@ -97,6 +97,10 @@ You can provide MSBuild properties to the `dotnet pack` command for the packing 
 
   Places the built packages in the directory specified.
 
+  - .NET 7.0.200 SDK and later
+
+    If you specify the `--output` option the CLI will emit an error due to the unclear semantics of the output path.
+
 - **`--runtime <RUNTIME_IDENTIFIER>`**
 
   Specifies the target runtime to restore packages for. For a list of Runtime Identifiers (RIDs), see the [RID catalog](../rid-catalog.md).

--- a/docs/core/tools/dotnet-pack.md
+++ b/docs/core/tools/dotnet-pack.md
@@ -99,7 +99,7 @@ You can provide MSBuild properties to the `dotnet pack` command for the packing 
 
   - .NET 7.0.200 SDK and later
 
-    If you specify the `--output` option the CLI will emit an error due to the unclear semantics of the output path.
+    If you specify the `--output` option the CLI will emit an error due to the unclear semantics of the output path. All outputs of all built projects will be copied into the specified directory, which isn't compatible with multi-targeted projects, as well as projects that have different versions of direct and transitive dependencies.
 
 - **`--runtime <RUNTIME_IDENTIFIER>`**
 

--- a/docs/core/tools/dotnet-publish.md
+++ b/docs/core/tools/dotnet-publish.md
@@ -155,6 +155,10 @@ For more information, see the following resources:
   <DefaultItemExcludes>$(DefaultItemExcludes);publishoutput**</DefaultItemExcludes>
   ```
 
+  - .NET 7.0.200 SDK and later
+
+    If you specify the `--output` option the CLI will emit an error due to the unclear semantics of the output path (as described below).
+
   - .NET Core 3.x SDK and later
 
     If you specify a relative path when publishing a project, the generated output directory is relative to the current working directory, not to the project file location.

--- a/docs/core/tools/dotnet-publish.md
+++ b/docs/core/tools/dotnet-publish.md
@@ -157,7 +157,7 @@ For more information, see the following resources:
 
   - .NET 7.0.200 SDK and later
 
-    If you specify the `--output` option the CLI will emit an error due to the unclear semantics of the output path (as described below).
+    If you specify the `--output` option when running this command on a solution, the CLI will emit an error due to the unclear semantics of the output path. The `--output` option is disallowed because all outputs of all built projects would be copied into the specified directory, which isn't compatible with multi-targeted projects, as well as projects that have different versions of direct and transitive dependencies.
 
   - .NET Core 3.x SDK and later
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -198,7 +198,7 @@ Where `Microsoft.NET.Test.Sdk` is the test host, `xunit` is the test framework. 
 
   - .NET 7.0.200 SDK and later
 
-    If you specify the `--output` option the CLI will emit an error due to the unclear semantics of the output path. All outputs of all built projects will be copied into the specified directory, which isn't compatible with multi-targeted projects, as well as projects that have different versions of direct and transitive dependencies.
+    If you specify the `--output` option when running this command on a solution, the CLI will emit an error due to the unclear semantics of the output path. The `--output` option is disallowed because all outputs of all built projects would be copied into the specified directory, which isn't compatible with multi-targeted projects, as well as projects that have different versions of direct and transitive dependencies.
 
 [!INCLUDE [os](../../../includes/cli-os.md)]
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -198,7 +198,7 @@ Where `Microsoft.NET.Test.Sdk` is the test host, `xunit` is the test framework. 
 
   - .NET 7.0.200 SDK and later
 
-    If you specify the `--output` option the CLI will emit an error due to the unclear semantics of the output path (as described below).
+    If you specify the `--output` option the CLI will emit an error due to the unclear semantics of the output path. All outputs of all built projects will be copied into the specified directory, which isn't compatible with multi-targeted projects, as well as projects that have different versions of direct and transitive dependencies.
 
 [!INCLUDE [os](../../../includes/cli-os.md)]
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -196,6 +196,10 @@ Where `Microsoft.NET.Test.Sdk` is the test host, `xunit` is the test framework. 
 
   Directory in which to find the binaries to run. If not specified, the default path is `./bin/<configuration>/<framework>/`.  For projects with multiple target frameworks (via the `TargetFrameworks` property), you also need to define `--framework` when you specify this option. `dotnet test` always runs tests from the output directory. You can use <xref:System.AppDomain.BaseDirectory%2A?displayProperty=nameWithType> to consume test assets in the output directory.
 
+  - .NET 7.0.200 SDK and later
+
+    If you specify the `--output` option the CLI will emit an error due to the unclear semantics of the output path (as described below).
+
 [!INCLUDE [os](../../../includes/cli-os.md)]
 
 - **`--results-directory <RESULTS_DIR>`**


### PR DESCRIPTION
## Summary

We introduced a breaking change to the CLI in 7.0.2000 around the use of `--output` with solution files. This documents the break so users have a source of truth to figure out next steps.
