### PR TITLE
Remove trailing backslash in default-values.md

### DIFF
--- a/docs/csharp/language-reference/builtin-types/default-values.md
+++ b/docs/csharp/language-reference/builtin-types/default-values.md
@@ -54,7 +54,7 @@ At run time, if the <xref:System.Type?displayProperty=nameWithType> instance rep
 For more information, see the following sections of the [C# language specification](~/_csharpstandard/standard/README.md):
 
 - [Default values](~/_csharpstandard/standard/variables.md#93-default-values)
-- [Default constructors](~/_csharpstandard/standard/types.md#833-default-constructors)\
+- [Default constructors](~/_csharpstandard/standard/types.md#833-default-constructors)
 - [C# 10 - Parameterless struct constructors](~/_csharplang/proposals/csharp-10.0/parameterless-struct-constructors.md)
 - [C# 11 - Auto default structs](~/_csharplang/proposals/csharp-11.0/auto-default-structs.md)
 


### PR DESCRIPTION
This PR removes a trailing backslash after the "Default constructors" link in the default values documentation.