### PR TITLE
Update breaking change doc with details about 201

### DIFF
--- a/docs/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid.md
+++ b/docs/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid.md
@@ -17,9 +17,11 @@ In the 7.0.200 SDK, there was [a change](https://github.com/dotnet/sdk/pull/2906
 
 This is because the semantics of the `OutputPath` property, which is controlled by the `--output`/`-o` option, aren't well defined for solutions. Projects built in this way will have their output placed in the same directory, which is inconsistent and has led to a number of user-reported issues.
 
+This change was reduced to a warning level of severity in the 7.0.201 SDK, and `pack` was removed from the list of commands that are affected.
+
 ## Version introduced
 
-.NET 7.0.200 SDK
+.NET 7.0.200 SDK, reduced to a warning only in the 7.0.201 SDK.
 
 ## Previous behavior
 
@@ -27,7 +29,7 @@ Previously, if you specified `--output`/`-o` when using a solution file, the out
 
 ## New behavior
 
-The `dotnet` CLI will error if the `--output`/`-o` option is used with a solution file.
+The `dotnet` CLI will error if the `--output`/`-o` option is used with a solution file. Starting in the 7.0.201 SDK, a warning will be emitted instead, and in the case of `dotnet pack` no behavior change at all will occur.
 
 ## Type of breaking change
 
@@ -37,7 +39,33 @@ This breaking change may require modifications to build scripts and continuous i
 
 This change was made because the semantics of the `OutputPath` property, which is controlled by the `--output`/`-o` option, aren't well defined for solutions. Projects built in this way will have their output placed in the same directory, which is inconsistent and has led to a number of user-reported issues.
 
-For examples of how this presents in practice, see the discussion on [dotnet/sdk#15607](https://github.com/dotnet/sdk/issues/15607).
+When a solution is built, any properties passed in (either explicitly via the `--property` option to MSBuild or implicitly via `dotnet` CLI options like `-r` or `-c`, which are translated to MSBuild properties) are applied globally to all projects that are part of that solution's chosen build configuration. This means that the `OutputPath` property is set to the same value for all projects, which means that all projects will have their output placed in the same directory. Depending on the complexity of the projects in the solution, different and inconsistent results may occur. Let's take a look at some examples of different project shapes and how they are affected by a shared `OutputPath`.
+
+### Single project, single TargetFramework
+
+Imagine a solution that contains a single project targeting a single `TargetFramework`, `net7.0`. In this case, providing the `--output` option is equivalent to setting the `OutputPath` property in the project file. During a build (or other commands, but let's scope the discussion to build for now), all of the outputs for the project will be placed in the specified directory.
+
+### Single project, multiple TargetFrameworks
+
+Now imagine a solution that contains a single project with multiple `TargetFrameworks`, `net6.0` and `net7.0`. Because of multi-targeting, the project will be build twice, once for each `TargetFramework`. For each of these 'inner' builds the `OutputPath` will be set to the same value, and so the outputs for each of the inner builds will be placed in the same directory. This means that whichever build completes last will overwrite the outputs of the other build, and in a parallel-build system like MSBuild operates in by default, 'last' is indeterminate.
+
+### Library => Console => Test, single TargetFramework
+
+Now imagine a solution that contains a library project, a console project that references the library project, and a test project that references the console project. All of these projects target a single `TargetFramework`, `net7.0`. In this case, the library project will be built first, and then the console project will be built. The test project will be built last, and will reference the console project. For each built project, the outputs of each build will be copied into the directory specified by the `OutputPath`, and so the final directory will contain assets from all three projects. This works for testing, but for publishing may result in test assets being sent to production.
+
+### Library => Console => Test, multiple TargetFrameworks
+
+Now take the same chain of projects and add a `net6.0` `TargetFramework` build to them in addition to the `net7.0` build. The same problem as the single-project, multi-targeted build occurs - inconsistent copying of TFM-specific assets to the specified directory.
+
+### Multiple apps
+
+So far we have been looking at scenarios with a linear dependency graph - but many solutions may contain multiple related applications. This raises a new way to get inconsistent outputs in the `OutputPath` - inconsistent resolution of `PackageReference`s across projects.  NuGet helps ensure that within a project and its' `ProjectReference`s, any `PackageReference`s and transitive dependencies (meaning dependencies of `PackageReference`s declared in a project file) are unified to the same version. Because the unification is done within the context of a single project and its dependent projects, this means it is possible to resolve different versions of a package when two separate top-level projects are built. If the versions resolved in this case are different enough, then runtime errors can occur.
+
+This can also happen if you have different explicit versions of `PackageReference`s in the top-level projects of the solution. Because a solution-level build or publish will copy all assets into a single directory, whatever project was copied last will decide what version of the `PackageReference` is actually in use, especially if the entire `OutputPath` is then deployed to a production environment.
+
+## Other examples
+
+For more examples of how this underlying error presents in practice, see the discussion on [dotnet/sdk#15607](https://github.com/dotnet/sdk/issues/15607).
 
 ## Recommended action
 
@@ -47,9 +75,12 @@ If you want to maintain the existing behavior exactly, then you can use the `--p
 
 | Command | Property | Example |
 | -- | -- | -- |
-| `build` | `OutputPath` | `dotnet build --property OutputPath=DESIRED_PATH` |
-| `clean` | `OutputPath` | `dotnet clean --property OutputPath=DESIRED_PATH` |
-| `pack` | `PackageOutputPath` | `dotnet pack --property PackageOutputPath=DESIRED_PATH` |
-| `publish` | `PublishDir` | `dotnet publish --property PublishDir=DESIRED_PATH` |
-| `store` | `OutputPath` | `dotnet store --property OutputPath=DESIRED_PATH` |
-| `test` | `TestResultsDirectory` | `dotnet test --property OutputPath=DESIRED_PATH` |
+| `build` | `OutputPath` | `dotnet build --property:OutputPath=DESIRED_PATH` |
+| `clean` | `OutputPath` | `dotnet clean --property:OutputPath=DESIRED_PATH` |
+| `pack` | `PackageOutputPath` | `dotnet pack --property:PackageOutputPath=DESIRED_PATH` |
+| `publish` | `PublishDir` | `dotnet publish --property:PublishDir=DESIRED_PATH` |
+| `store` | `OutputPath` | `dotnet store --property:OutputPath=DESIRED_PATH` |
+| `test` | `TestResultsDirectory` | `dotnet test --property:OutputPath=DESIRED_PATH` |
+
+**NOTE**
+For best results, the DESIRED_PATH should be an absolute path. Relative paths will be 'anchored' (i.e. made absolute) in ways that you may not expect, and may not work the same with all commands.

--- a/docs/core/tools/dotnet-build.md
+++ b/docs/core/tools/dotnet-build.md
@@ -120,7 +120,7 @@ The project or solution file to build. If a project or solution file isn't speci
 
   - .NET 7.0.200 SDK and later
 
-    If you specify the `--output` option when running this command on a solution, the CLI will emit a warning (an error in 7.0.200) due to the unclear semantics of the output path. The `--output` option is disallowed because all outputs of all built projects would be copied into the specified directory, which isn't compatible with multi-targeted projects, as well as projects that have different versions of direct and transitive dependencies.
+    If you specify the `--output` option when running this command on a solution, the CLI will emit a warning (an error in 7.0.200) due to the unclear semantics of the output path. The `--output` option is disallowed because all outputs of all built projects would be copied into the specified directory, which isn't compatible with multi-targeted projects, as well as projects that have different versions of direct and transitive dependencies. For more information, see [Solution-level `--output` option no longer valid for build-related commands](../compatibility/sdk/7.0/solution-level-output-no-longer-valid.md).
 
 [!INCLUDE [os](../../../includes/cli-os.md)]
 

--- a/docs/core/tools/dotnet-build.md
+++ b/docs/core/tools/dotnet-build.md
@@ -120,7 +120,7 @@ The project or solution file to build. If a project or solution file isn't speci
 
   - .NET 7.0.200 SDK and later
 
-    If you specify the `--output` option when running this command on a solution, the CLI will emit an error due to the unclear semantics of the output path. The `--output` option is disallowed because all outputs of all built projects would be copied into the specified directory, which isn't compatible with multi-targeted projects, as well as projects that have different versions of direct and transitive dependencies.
+    If you specify the `--output` option when running this command on a solution, the CLI will emit a warning (an error in 7.0.200) due to the unclear semantics of the output path. The `--output` option is disallowed because all outputs of all built projects would be copied into the specified directory, which isn't compatible with multi-targeted projects, as well as projects that have different versions of direct and transitive dependencies.
 
 [!INCLUDE [os](../../../includes/cli-os.md)]
 

--- a/docs/core/tools/dotnet-clean.md
+++ b/docs/core/tools/dotnet-clean.md
@@ -54,7 +54,7 @@ The MSBuild project or solution to clean. If a project or solution file is not s
 
   - .NET 7.0.200 SDK and later
 
-    If you specify the `--output` option when running this command on a solution, the CLI will emit a warning (an error in 7.0.200) due to the unclear semantics of the output path. The `--output` option is disallowed because all outputs of all built projects would be copied into the specified directory, which isn't compatible with multi-targeted projects, as well as projects that have different versions of direct and transitive dependencies.
+    If you specify the `--output` option when running this command on a solution, the CLI will emit a warning (an error in 7.0.200) due to the unclear semantics of the output path. The `--output` option is disallowed because all outputs of all built projects would be copied into the specified directory, which isn't compatible with multi-targeted projects, as well as projects that have different versions of direct and transitive dependencies. For more information, see [Solution-level `--output` option no longer valid for build-related commands](../compatibility/sdk/7.0/solution-level-output-no-longer-valid.md).
 
 * **`-r|--runtime <RUNTIME_IDENTIFIER>`**
 

--- a/docs/core/tools/dotnet-clean.md
+++ b/docs/core/tools/dotnet-clean.md
@@ -54,7 +54,7 @@ The MSBuild project or solution to clean. If a project or solution file is not s
 
   - .NET 7.0.200 SDK and later
 
-    If you specify the `--output` option when running this command on a solution, the CLI will emit an error due to the unclear semantics of the output path. The `--output` option is disallowed because all outputs of all built projects would be copied into the specified directory, which isn't compatible with multi-targeted projects, as well as projects that have different versions of direct and transitive dependencies.
+    If you specify the `--output` option when running this command on a solution, the CLI will emit a warning (an error in 7.0.200) due to the unclear semantics of the output path. The `--output` option is disallowed because all outputs of all built projects would be copied into the specified directory, which isn't compatible with multi-targeted projects, as well as projects that have different versions of direct and transitive dependencies.
 
 * **`-r|--runtime <RUNTIME_IDENTIFIER>`**
 

--- a/docs/core/tools/dotnet-pack.md
+++ b/docs/core/tools/dotnet-pack.md
@@ -99,7 +99,7 @@ You can provide MSBuild properties to the `dotnet pack` command for the packing 
 
   - .NET 7.0.200 SDK
 
-    If you specify the `--output` option when running this command on a solution, the CLI will emit an error due to the unclear semantics of the output path. This is a regression and was removed in 7.0.201 and above versions of the .NET SDK.
+    In the 7.0.200 SDK, if you specify the `--output` option when running this command on a solution, the CLI will emit an error. This is a regression and was fixed in 7.0.201 and later versions of the .NET SDK.
 
 - **`--runtime <RUNTIME_IDENTIFIER>`**
 

--- a/docs/core/tools/dotnet-pack.md
+++ b/docs/core/tools/dotnet-pack.md
@@ -97,9 +97,9 @@ You can provide MSBuild properties to the `dotnet pack` command for the packing 
 
   Places the built packages in the directory specified.
 
-  - .NET 7.0.200 SDK and later
+  - .NET 7.0.200 SDK
 
-    If you specify the `--output` option when running this command on a solution, the CLI will emit an error due to the unclear semantics of the output path. The `--output` option is disallowed because all outputs of all built projects would be copied into the specified directory, which isn't compatible with multi-targeted projects, as well as projects that have different versions of direct and transitive dependencies.
+    If you specify the `--output` option when running this command on a solution, the CLI will emit an error due to the unclear semantics of the output path. This is a regression and was removed in 7.0.201 and above versions of the .NET SDK.
 
 - **`--runtime <RUNTIME_IDENTIFIER>`**
 

--- a/docs/core/tools/dotnet-publish.md
+++ b/docs/core/tools/dotnet-publish.md
@@ -157,7 +157,7 @@ For more information, see the following resources:
 
   - .NET 7.0.200 SDK and later
 
-    If you specify the `--output` option when running this command on a solution, the CLI will emit an error due to the unclear semantics of the output path. The `--output` option is disallowed because all outputs of all built projects would be copied into the specified directory, which isn't compatible with multi-targeted projects, as well as projects that have different versions of direct and transitive dependencies.
+    If you specify the `--output` option when running this command on a solution, the CLI will emit a warning (an error in 7.0.200) due to the unclear semantics of the output path. The `--output` option is disallowed because all outputs of all built projects would be copied into the specified directory, which isn't compatible with multi-targeted projects, as well as projects that have different versions of direct and transitive dependencies.
 
   - .NET Core 3.x SDK and later
 

--- a/docs/core/tools/dotnet-publish.md
+++ b/docs/core/tools/dotnet-publish.md
@@ -157,7 +157,7 @@ For more information, see the following resources:
 
   - .NET 7.0.200 SDK and later
 
-    If you specify the `--output` option when running this command on a solution, the CLI will emit a warning (an error in 7.0.200) due to the unclear semantics of the output path. The `--output` option is disallowed because all outputs of all built projects would be copied into the specified directory, which isn't compatible with multi-targeted projects, as well as projects that have different versions of direct and transitive dependencies.
+    If you specify the `--output` option when running this command on a solution, the CLI will emit a warning (an error in 7.0.200) due to the unclear semantics of the output path. The `--output` option is disallowed because all outputs of all built projects would be copied into the specified directory, which isn't compatible with multi-targeted projects, as well as projects that have different versions of direct and transitive dependencies. For more information, see [Solution-level `--output` option no longer valid for build-related commands](../compatibility/sdk/7.0/solution-level-output-no-longer-valid.md).
 
   - .NET Core 3.x SDK and later
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -198,7 +198,7 @@ Where `Microsoft.NET.Test.Sdk` is the test host, `xunit` is the test framework. 
 
   - .NET 7.0.200 SDK and later
 
-    If you specify the `--output` option when running this command on a solution, the CLI will emit an error due to the unclear semantics of the output path. The `--output` option is disallowed because all outputs of all built projects would be copied into the specified directory, which isn't compatible with multi-targeted projects, as well as projects that have different versions of direct and transitive dependencies.
+    If you specify the `--output` option when running this command on a solution, the CLI will emit a warning (an error in 7.0.200) due to the unclear semantics of the output path. The `--output` option is disallowed because all outputs of all built projects would be copied into the specified directory, which isn't compatible with multi-targeted projects, as well as projects that have different versions of direct and transitive dependencies.
 
 [!INCLUDE [os](../../../includes/cli-os.md)]
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -198,7 +198,7 @@ Where `Microsoft.NET.Test.Sdk` is the test host, `xunit` is the test framework. 
 
   - .NET 7.0.200 SDK and later
 
-    If you specify the `--output` option when running this command on a solution, the CLI will emit a warning (an error in 7.0.200) due to the unclear semantics of the output path. The `--output` option is disallowed because all outputs of all built projects would be copied into the specified directory, which isn't compatible with multi-targeted projects, as well as projects that have different versions of direct and transitive dependencies.
+    If you specify the `--output` option when running this command on a solution, the CLI will emit a warning (an error in 7.0.200) due to the unclear semantics of the output path. The `--output` option is disallowed because all outputs of all built projects would be copied into the specified directory, which isn't compatible with multi-targeted projects, as well as projects that have different versions of direct and transitive dependencies. For more information, see [Solution-level `--output` option no longer valid for build-related commands](../compatibility/sdk/7.0/solution-level-output-no-longer-valid.md).
 
 [!INCLUDE [os](../../../includes/cli-os.md)]
 


### PR DESCRIPTION
## Summary

For the .NET SDK 7.0.201 we've reverted the error portion of the `--output` flag changes for solution-level usage of the build, clean, test, publish, and store commands, as well as removed the logic entirely for the pack command. These changes dig into the errors users may see when using this pattern, as well as clarify when to expect warnings instead of errors.

pinging @dsplaisted for content review - I think covered all the scenarios we spoke of.