### PR TITLE
Typo Fix -  update to the unit testing article in Orleans documentation

### DIFF
--- a/docs/orleans/tutorials-and-samples/testing.md
+++ b/docs/orleans/tutorials-and-samples/testing.md
@@ -52,7 +52,7 @@ public class ClusterFixture : IDisposable
     public ClusterFixture()
     {
         var builder = new TestClusterBuilder();
-        var cluster = builder.Build();
+        Cluster = builder.Build();
         Cluster.Deploy();
     }
 


### PR DESCRIPTION
instead of var cluster = builder.Build(); this needed to be Cluster = builder.Build() in the ClusterFixture

## Summary

Describe your changes here.

Fixes #34254
