### PR TITLE
add specific branch name to the PR branch

### DIFF
--- a/.github/workflows/whats-new.yml
+++ b/.github/workflows/whats-new.yml
@@ -36,6 +36,7 @@ jobs:
       - name: create-pull-request
         uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04
         with:
+          branch: create-whatsnew-pull-request/patch
           title: "What's new article"
           commit-message: 'Bot 🤖 generated "What''s new article"'
           body: "Automated creation of What's new article."


### PR DESCRIPTION
If our tools run when a PR branch is already created, the branches collide.

Use a specific branch name for each workflow.