### PR TITLE
Describe the example of user-defined types used as fields declarations of anonymous types

### DIFF
--- a/docs/csharp/fundamentals/types/anonymous-types.md
+++ b/docs/csharp/fundamentals/types/anonymous-types.md
@@ -37,6 +37,10 @@ If you don't specify member names in the anonymous type, the compiler gives the 
 > [!TIP]
 > You can use .NET style rule [IDE0037](../../../fundamentals/code-analysis/style-rules/ide0037.md) to enforce whether inferred or explicit member names are preferred.
 
+It is also possible to define a field by object of another type: class, struct or even another anonymous type. It is done by using the variable holding this object just like in the following example, where two anonymous types are created using already instantiated user-defined types. In both cases the `product` field in the anonymous type `shipment` and `shipmentWithBonus` will be of type `Product` containing it's default values of each field. And the `bonus` field will be of anonymous type created by the compiler.
+
+:::code language="csharp" source="snippets/anonymous-types/Program.cs" ID="snippet03":::
+
 Typically, when you use an anonymous type to initialize a variable, you declare the variable as an implicitly typed local variable by using [var](../../language-reference/statements/declarations.md#implicitly-typed-local-variables). The type name cannot be specified in the variable declaration because only the compiler has access to the underlying name of the anonymous type. For more information about `var`, see [Implicitly Typed Local Variables](../../programming-guide/classes-and-structs/implicitly-typed-local-variables.md).
 
 You can create an array of anonymously typed elements by combining an implicitly typed local variable and an implicitly typed array, as shown in the following example.

--- a/docs/csharp/fundamentals/types/snippets/anonymous-types/Program.cs
+++ b/docs/csharp/fundamentals/types/snippets/anonymous-types/Program.cs
@@ -38,6 +38,13 @@ namespace anonymous_types
             Console.WriteLine(apple);
             Console.WriteLine(onSale);
             // </Snippet02>
+
+            // <Snippet03>
+            var product = new Product();
+            var bonus = new { note = "You won!" };
+            var shipment = new { address = "Nowhere St.", product };
+            var shipmentWithBonus = new { address = "Somewhere St.", product, bonus };
+            // </Snippet03>
         }
     }
 }


### PR DESCRIPTION
This pull request fixes #33918 
It adds the explanation of what happens when a variable holding object of user-defined type is used as a declaration of anonymous types field.

The code snippet presents both class case as well as another anonymous type case used.
The `product` var is of type `Product` which is already defined in the `anonymous_types` namespace, but it is not mentioned in the additional text, as the same assumption about `Product` type already existing is already made in the same article.

**NOTE:** I'm not sure about the linking of `ID="snippet03"` and `<Snippet03>` when it comes to capital letter - I can see that the same case is for `ID="snippet02"` linking correctly with `<Snippet02>` so I decided to stick with that approach, but I'll be super happy for reviewers to correct me if there might be any issue with linking. 🙏 