### PR TITLE
Updates to porting from .NET Framework 

### DIFF
--- a/docs/core/porting/index.md
+++ b/docs/core/porting/index.md
@@ -54,7 +54,7 @@ As previously mentioned, the project files for .NET use a different format than 
 </PropertyGroup>
 ```
 
-The SDK-style project uses a different property to identify the target framework, the `<TargetFramework>` property. When targeting .NET Framework, the moniker used starts with `net` and ends with the version of .NET Framework without any periods. The moniker to target .NET Framework 4.7.2 is `net472`:
+An SDK-style project uses a different property to identify the target framework, the `<TargetFramework>` property. When targeting .NET Framework, the moniker starts with `net` and ends with the version of .NET Framework without any periods. For example, the moniker to target .NET Framework 4.7.2 is `net472`:
 
 ```xml
 <PropertyGroup>

--- a/docs/core/porting/index.md
+++ b/docs/core/porting/index.md
@@ -46,7 +46,7 @@ The .NET Framework compatibility mode was introduced in .NET Standard 2.0. The c
 
 ## Target framework changes in SDK-style projects
 
-As previously mentioned, the project files for .NET use a different format than .NET Framework, known as the SDK-style project format. Even if you're not moving from .NET Framework to .NET, you should still upgrade the project file to the latest format. Specifying a target framework in has changed in SDK-style projects. In .NET Framework, the `<TargetFrameworkVersion>` property is used with a moniker that specified the version of .NET Framework. For example, .NET Framework 4.7.2 looks like the following snippet:
+As previously mentioned, the project files for .NET use a different format than .NET Framework, known as the SDK-style project format. Even if you're not moving from .NET Framework to .NET, you should still upgrade the project file to the latest format. The way to specify a target framework is different in SDK-style projects. In .NET Framework, the `<TargetFrameworkVersion>` property is used with a moniker that specifies the version of .NET Framework. For example, .NET Framework 4.7.2 looks like the following snippet:
 
 ```xml
 <PropertyGroup>

--- a/docs/core/porting/index.md
+++ b/docs/core/porting/index.md
@@ -46,7 +46,7 @@ The .NET Framework compatibility mode was introduced in .NET Standard 2.0. The c
 
 ## Target framework changes in SDK-style projects
 
-As previously mentioned, the project files for .NET use a different format than .NET Framework, known as the SDK-style project format. Even if you're not moving from .NET Framework to .NET, you should still upgrade the project file to the latest format. Identifying a target framework in has changed in SDK-style projects. In .NET Framework, the `<TargetFrameworkVersion>` property is used with a moniker that specified the version of .NET Framework. For example, .NET Framework 4.7.2 looks like the following snippet:
+As previously mentioned, the project files for .NET use a different format than .NET Framework, known as the SDK-style project format. Even if you're not moving from .NET Framework to .NET, you should still upgrade the project file to the latest format. Specifying a target framework in has changed in SDK-style projects. In .NET Framework, the `<TargetFrameworkVersion>` property is used with a moniker that specified the version of .NET Framework. For example, .NET Framework 4.7.2 looks like the following snippet:
 
 ```xml
 <PropertyGroup>

--- a/docs/core/porting/index.md
+++ b/docs/core/porting/index.md
@@ -1,8 +1,8 @@
 ---
-title: Port from .NET Framework to .NET 6
+title: Port from .NET Framework to .NET 7
 description: Understand the porting process and discover tools you may find helpful when porting a .NET Framework project to .NET 6.
 author: adegeo
-ms.date: 07/22/2022
+ms.date: 02/28/2023
 ms.custom: devdivchpfy22
 no-loc: ["package.config", PackageReference]
 ---
@@ -25,7 +25,7 @@ Consider the following dependencies before you migrate a Windows Forms or WPF ap
 
 .NET uses the open-source versions of Windows Forms and WPF and includes enhancements over .NET Framework.
 
-For tutorials on migrating your desktop application to .NET 6, see one of the following articles:
+For tutorials on migrating your desktop application to .NET, see one of the following articles:
 
 - [Migrate .NET Framework WPF apps to .NET](/dotnet/desktop/wpf/migration/convert-project-from-net-framework?view=netdesktop-6.0&preserve-view=true)
 - [Migrate .NET Framework Windows Forms apps to .NET](/dotnet/desktop/winforms/migration/?view=netdesktop-6.0&preserve-view=true)
@@ -42,7 +42,27 @@ For more information, see [Use the Windows Compatibility Pack to port code to .N
 
 ## .NET Framework compatibility mode
 
-The .NET Framework compatibility mode was introduced in .NET Standard 2.0. The compatibility mode allows .NET Standard and .NET (including .NET Core 3.1) projects to reference .NET Framework libraries on Windows only. Referencing .NET Framework libraries doesn't work for all projects, such as if the library uses WPF APIs, but it does unblock many porting scenarios. For more information, see the [Analyze your dependencies to port code from .NET Framework to .NET](third-party-deps.md#net-framework-compatibility-mode).
+The .NET Framework compatibility mode was introduced in .NET Standard 2.0. The compatibility mode allows .NET Standard and .NET projects to reference .NET Framework libraries on Windows only. Referencing .NET Framework libraries doesn't work for all projects, such as if the library uses WPF APIs, but it does unblock many porting scenarios. For more information, see the [Analyze your dependencies to port code from .NET Framework to .NET](third-party-deps.md#net-framework-compatibility-mode).
+
+## Target framework changes in SDK-style projects
+
+As previously mentioned, the project files for .NET use a different format than .NET Framework, known as the SDK-style project format. Even if you're not moving from .NET Framework to .NET, you should still upgrade the project file to the latest format. Identifying a target framework in has changed in SDK-style projects. In .NET Framework, the `<TargetFrameworkVersion>` property is used with a moniker that specified the version of .NET Framework. For example, .NET Framework 4.7.2 looks like the following snippet:
+
+```xml
+<PropertyGroup>
+  <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+</PropertyGroup>
+```
+
+The SDK-style project uses a different property to identify the target framework, the `<TargetFramework>` property. When targeting .NET Framework, the moniker used starts with `net` and ends with the version of .NET Framework without any periods. The moniker to target .NET Framework 4.7.2 is `net472`:
+
+```xml
+<PropertyGroup>
+  <TargetFramework>net472</TargetFramework>
+</PropertyGroup>
+```
+
+For a list of all target monikers, see [Target frameworks in SDK-style projects](../../standard/frameworks.md#supported-target-frameworks).
 
 ## Unavailable technologies
 
@@ -72,7 +92,7 @@ There are a few technologies in .NET Framework that don't exist in .NET:
 
   WF isn't supported in .NET. For an alternative, see [CoreWF](https://github.com/UiPath/corewf).
 
-For more information about these unsupported technologies, see [.NET Framework technologies unavailable on .NET Core and .NET 5+](net-framework-tech-unavailable.md).
+For more information about these unsupported technologies, see [.NET Framework technologies unavailable on .NET 6+](net-framework-tech-unavailable.md).
 
 ## Cross-platform
 
@@ -109,7 +129,7 @@ The [.NET Upgrade Assistant](upgrade-assistant-overview.md) is a command-line to
 - Console
 - Class libraries
 
-This tool uses the other tools listed in this article and guides the migration process. For more information about the tool, see [Overview of the .NET Upgrade Assistant](upgrade-assistant-overview.md).
+This tool uses the other tools listed in this article, such as **try-convert**, and guides the migration process. For more information about the tool, see [Overview of the .NET Upgrade Assistant](upgrade-assistant-overview.md).
 
 ### try-convert
 

--- a/docs/core/porting/net-framework-tech-unavailable.md
+++ b/docs/core/porting/net-framework-tech-unavailable.md
@@ -1,13 +1,13 @@
 ---
-title: .NET Framework technologies unavailable on .NET Core and .NET 5+
+title: .NET Framework technologies unavailable on .NET 6+
 titleSuffix: ""
-description: Learn about .NET Framework technologies that are unavailable on .NET Core and .NET 5 and later versions.
-ms.date: 05/11/2022
+description: Learn about .NET Framework technologies that are unavailable on .NET 6 and later versions.
+ms.date: 02/28/2023
 ms.topic: reference
 ---
-# .NET Framework technologies unavailable on .NET Core and .NET 5+
+# .NET Framework technologies unavailable on .NET
 
-Several technologies available to .NET Framework libraries aren't available for use with .NET 5+ (and .NET Core), such as app domains, remoting, and code access security (CAS). If your libraries rely on one or more of the technologies listed on this page, consider the alternative approaches mentioned.
+Several technologies available to .NET Framework libraries aren't available for use with .NET 6+, such as app domains, remoting, and code access security (CAS). If your libraries rely on one or more of the technologies listed on this page, consider the alternative approaches mentioned.
 
 For more information on API compatibility, see [Breaking changes in .NET](../compatibility/breaking-changes.md).
 
@@ -15,11 +15,11 @@ For more information on API compatibility, see [Breaking changes in .NET](../com
 
 Application domains (AppDomains) isolate apps from one another. AppDomains require runtime support and are resource-expensive. Creating more app domains isn't supported, and there are no plans to add this capability in the future. For code isolation, use separate processes or containers as an alternative. To dynamically load assemblies, use the <xref:System.Runtime.Loader.AssemblyLoadContext> class.
 
-To make code migration from .NET Framework easier, .NET 5+ exposes some of the <xref:System.AppDomain> API surface. Some of the APIs function normally (for example, <xref:System.AppDomain.UnhandledException?displayProperty=nameWithType>), some members do nothing (for example, <xref:System.AppDomain.SetCachePath%2A>), and some of them throw <xref:System.PlatformNotSupportedException> (for example, <xref:System.AppDomain.CreateDomain%2A>). Check the types you use against the [`System.AppDomain` reference source](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/AppDomain.cs) in the [dotnet/runtime GitHub repository](https://github.com/dotnet/runtime). Make sure to select the branch that matches your implemented version.
+To make code migration from .NET Framework easier, .NET 6+ exposes some of the <xref:System.AppDomain> API surface. Some of the APIs function normally (for example, <xref:System.AppDomain.UnhandledException?displayProperty=nameWithType>), some members do nothing (for example, <xref:System.AppDomain.SetCachePath%2A>), and some of them throw <xref:System.PlatformNotSupportedException> (for example, <xref:System.AppDomain.CreateDomain%2A>). Check the types you use against the [`System.AppDomain` reference source](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/AppDomain.cs) in the [dotnet/runtime GitHub repository](https://github.com/dotnet/runtime). Make sure to select the branch that matches your implemented version.
 
 ## Remoting
 
-.NET Remoting isn't supported on .NET 5+ (and .NET Core). .NET remoting was identified as a problematic architecture. It's used for communicating across application domains, which are no longer supported. Also, remoting requires runtime support, which is expensive to maintain.
+.NET Remoting isn't supported on .NET 6+. .NET remoting was identified as a problematic architecture. It's used for communicating across application domains, which are no longer supported. Also, remoting requires runtime support, which is expensive to maintain.
 
 For simple communication across processes, consider inter-process communication (IPC) mechanisms as an alternative to remoting, such as the <xref:System.IO.Pipes> class or the <xref:System.IO.MemoryMappedFiles.MemoryMappedFile> class. For more complex scenarios, the open-source [StreamJsonRpc](https://github.com/microsoft/vs-streamjsonrpc) project provides a cross-platform .NET Standard remoting framework that works on top of existing stream or pipe connections.
 
@@ -29,7 +29,7 @@ For more messaging options, see [.NET Open Source Developer Projects: Messaging]
 
 ## Code access security (CAS)
 
-Sandboxing, which relies on the runtime or the framework to constrain which resources a managed application or library uses or runs, [isn't supported on .NET Framework](/previous-versions/dotnet/framework/code-access-security/code-access-security) and therefore is also not supported on .NET Core and .NET 5+. CAS is no longer treated as a security boundary, because there are too many cases in .NET Framework and the runtime where an elevation of privileges occurs. Also, CAS makes the implementation more complicated and often has correctness-performance implications for applications that don't intend to use it.
+Sandboxing, which relies on the runtime or the framework to constrain which resources a managed application or library uses or runs, [isn't supported on .NET Framework](/previous-versions/dotnet/framework/code-access-security/code-access-security) and therefore is also not supported on .NET 6+. CAS is no longer treated as a security boundary, because there are too many cases in .NET Framework and the runtime where an elevation of privileges occurs. Also, CAS makes the implementation more complicated and often has correctness-performance implications for applications that don't intend to use it.
 
 Use security boundaries provided by the operating system, such as virtualization, containers, or user accounts, for running processes with the minimum set of privileges.
 
@@ -41,18 +41,18 @@ To run processes with the least set of privileges, use security boundaries provi
 
 ## System.EnterpriseServices
 
-<xref:System.EnterpriseServices?displayProperty=fullName> (COM+) isn't supported by .NET Core and .NET 5+.
+<xref:System.EnterpriseServices?displayProperty=fullName> (COM+) isn't supported by .NET 6+.
 
 ## Workflow Foundation
 
-Windows Workflow Foundation (WF) is not supported in .NET 5+ (including .NET Core). For an alternative, see [CoreWF](https://github.com/UiPath/corewf).
+Windows Workflow Foundation (WF) is not supported in .NET 6+. For an alternative, see [CoreWF](https://github.com/UiPath/corewf).
 
 > [!TIP]
-> Windows Communication Foundation (WCF) server can be used in .NET 5+ by using the [CoreWCF NuGet packages](https://www.nuget.org/profiles/corewcf). For more information, see [CoreWCF 1.0 has been Released](https://devblogs.microsoft.com/dotnet/corewcf-v1-released/).
+> Windows Communication Foundation (WCF) server can be used in .NET 6+ by using the [CoreWCF NuGet packages](https://www.nuget.org/profiles/corewcf). For more information, see [CoreWCF 1.0 has been Released](https://devblogs.microsoft.com/dotnet/corewcf-v1-released/).
 
 ## Saving assemblies generated by reflection
 
-.NET 5+ (including .NET Core) does not support saving assemblies that are generated by the <xref:System.Reflection.Emit?displayProperty=fullName> APIs. The <xref:System.Reflection.Emit.AssemblyBuilder.Save%2A?displayProperty=nameWithType> method is not available in .NET 5+ (including .NET Core). In addition, the following fields of the <xref:System.Reflection.Emit.AssemblyBuilderAccess> enumeration aren't available:
+.NET 6+ doesn't support saving assemblies that are generated by the <xref:System.Reflection.Emit?displayProperty=fullName> APIs. The <xref:System.Reflection.Emit.AssemblyBuilder.Save%2A?displayProperty=nameWithType> method is not available in .NET 6+. In addition, the following fields of the <xref:System.Reflection.Emit.AssemblyBuilderAccess> enumeration aren't available:
 
 - <xref:System.Reflection.Emit.AssemblyBuilderAccess.ReflectionOnly>
 - <xref:System.Reflection.Emit.AssemblyBuilderAccess.RunAndSave>
@@ -64,13 +64,13 @@ For more information, see [dotnet/runtime issue 15704](https://github.com/dotnet
 
 ## Loading multi-module assemblies
 
-Assemblies that consist of multiple modules (`OutputType=Module` in MSBuild) are not supported in .NET 5+ (including .NET Core).
+Assemblies that consist of multiple modules (`OutputType=Module` in MSBuild) are not supported in .NET 6+.
 
 As an alternative, consider merging the individual modules into a single assembly file.
 
 ## XSLT script blocks
 
-XSLT [script blocks](../../standard/data/xml/script-blocks-using-msxsl-script.md) are supported only in .NET Framework. They are not supported on .NET Core or .NET 5 or later.
+XSLT [script blocks](../../standard/data/xml/script-blocks-using-msxsl-script.md) are supported only in .NET Framework. They are not supported on .NET 6 or later.
 
 ## See also
 


### PR DESCRIPTION
## Summary

- Add section about monikers
- Update references from .NET 5/Core to .NET or .NET 6+

Fixes #23972
