### PR TITLE
Update reference-cells.md

### DIFF
--- a/docs/fsharp/language-reference/reference-cells.md
+++ b/docs/fsharp/language-reference/reference-cells.md
@@ -31,7 +31,7 @@ Reference cells are instances of the `Ref` generic record type, which is declare
 
 ```fsharp
 type Ref<'a> =
-{ mutable contents: 'a }
+    { mutable contents: 'a }
 ```
 
 The type `'a ref` is a synonym for `Ref<'a>`. The compiler and IntelliSense in the IDE display the former for this type, but the underlying definition is the latter.
@@ -46,13 +46,9 @@ The following table shows the features that are available on the reference cell.
 
 |Operator, member, or field|Description|Type|Definition|
 |--------------------------|-----------|----|----------|
-|`!` (dereference operator)|Returns the underlying value.|`'a ref -> 'a`|`let (!) r = r.contents`|
-|`:=` (assignment operator)|Changes the underlying value.|`'a ref -> 'a -> unit`|`let (:=) r x = r.contents <- x`|
 |`ref` (operator)|Encapsulates a value into a new reference cell.|`'a -> 'a ref`|`let ref x = { contents = x }`|
 |`Value` (property)|Gets or sets the underlying value.|`unit -> 'a`|`member x.Value = x.contents`|
 |`contents` (record field)|Gets or sets the underlying value.|`'a`|`let ref x = { contents = x }`|
-
-There are several ways to access the underlying value. The value returned by the dereference operator (`!`) is not an assignable value. Therefore, if you are modifying the underlying value, you must use the assignment operator (`:=`) instead.
 
 Both the `Value` property and the `contents` field are assignable values. Therefore, you can use these to either access or change the underlying value, as shown in the following code.
 
@@ -66,6 +62,13 @@ The output is as follows.
 11
 12
 ```
+
+The following operators are deprecated and the direct use of `.Value` is preferred instead:
+
+|Operator, member, or field|Description|Type|Definition|
+|--------------------------|-----------|----|----------|
+|`!` (dereference operator, deprecated)|Returns the underlying value.|`'a ref -> 'a`|`let (!) r = r.contents`|
+|`:=` (assignment operator, deprecated)|Changes the underlying value.|`'a ref -> 'a -> unit`|`let (:=) r x = r.contents <- x`|
 
 The field `contents` is provided for compatibility with other versions of ML and will produce a warning during compilation. To disable the warning, use the `--mlcompatibility` compiler option. For more information, see [Compiler Options](compiler-options.md).
 

--- a/docs/fsharp/language-reference/reference-cells.md
+++ b/docs/fsharp/language-reference/reference-cells.md
@@ -15,17 +15,18 @@ ref expression
 
 ## Remarks
 
-You use the `ref` operator before an expression to create a new reference cell that encapsulates the value of the expression. You can then change the underlying value because it is mutable.
-
-A reference cell holds an actual value; it is not just an address. When you create a reference cell by using the `ref` operator, you create a copy of the underlying value as an encapsulated mutable value.
-
-You can dereference a reference cell by using the `!` (bang) operator.
+You use the `ref` function to create a new reference cell with an initial value. You can then change the underlying value because it is mutable. A reference cell holds an actual value; it is not just an address.
 
 The following code example illustrates the declaration and use of reference cells.
 
-[!code-fsharp[Main](~/samples/snippets/fsharp/lang-ref-1/snippet2201.fs)]
+[!code-fsharp[Main](~/samples/snippets/fsharp/lang-ref-1/snippet2203.fs)]
 
-The output is `50`.
+The output is as follows.
+
+```console
+10
+11
+```
 
 Reference cells are instances of the `Ref` generic record type, which is declared as follows.
 
@@ -50,19 +51,6 @@ The following table shows the features that are available on the reference cell.
 |`Value` (property)|Gets or sets the underlying value.|`unit -> 'a`|`member x.Value = x.contents`|
 |`contents` (record field)|Gets or sets the underlying value.|`'a`|`let ref x = { contents = x }`|
 
-Both the `Value` property and the `contents` field are assignable values. Therefore, you can use these to either access or change the underlying value, as shown in the following code.
-
-[!code-fsharp[Main](~/samples/snippets/fsharp/lang-ref-1/snippet2203.fs)]
-
-The output is as follows.
-
-```console
-10
-10
-11
-12
-```
-
 Since F# 6.0, the following operators are deprecated and their use gives informational warnings:
 
 |Operator, member, or field|Description|Type|Definition|
@@ -84,3 +72,4 @@ Values marked as `mutable`may be automatically promoted to `'a ref` if captured 
 - [Parameters and Arguments](parameters-and-arguments.md)
 - [Symbol and Operator Reference](./symbol-and-operator-reference/index.md)
 - [Values](./values/index.md)
+- [F# RFC FS-1111](https://aka.ms/fsharp-refcell-ops)

--- a/docs/fsharp/language-reference/reference-cells.md
+++ b/docs/fsharp/language-reference/reference-cells.md
@@ -15,7 +15,7 @@ ref expression
 
 ## Remarks
 
-You use the `ref` operator before a value to create a new reference cell that encapsulates the value. You can then change the underlying value because it is mutable.
+You use the `ref` operator before an expression to create a new reference cell that encapsulates the value of the expression. You can then change the underlying value because it is mutable.
 
 A reference cell holds an actual value; it is not just an address. When you create a reference cell by using the `ref` operator, you create a copy of the underlying value as an encapsulated mutable value.
 
@@ -63,12 +63,14 @@ The output is as follows.
 12
 ```
 
-The following operators are deprecated and the direct use of `.Value` is preferred instead:
+Since F# 6.0, the following operators are deprecated and their use gives informational warnings:
 
 |Operator, member, or field|Description|Type|Definition|
 |--------------------------|-----------|----|----------|
 |`!` (dereference operator, deprecated)|Returns the underlying value.|`'a ref -> 'a`|`let (!) r = r.contents`|
 |`:=` (assignment operator, deprecated)|Changes the underlying value.|`'a ref -> 'a -> unit`|`let (:=) r x = r.contents <- x`|
+
+The direct use of `.Value` is preferred instead, see [F# RFC FS-1111](https://aka.ms/fsharp-refcell-ops).
 
 The field `contents` is provided for compatibility with other versions of ML and will produce a warning during compilation. To disable the warning, use the `--mlcompatibility` compiler option. For more information, see [Compiler Options](compiler-options.md).
 

--- a/docs/fsharp/language-reference/reference-cells.md
+++ b/docs/fsharp/language-reference/reference-cells.md
@@ -49,7 +49,12 @@ The following table shows the features that are available on the reference cell.
 |--------------------------|-----------|----|----------|
 |`ref` (operator)|Encapsulates a value into a new reference cell.|`'a -> 'a ref`|`let ref x = { contents = x }`|
 |`Value` (property)|Gets or sets the underlying value.|`unit -> 'a`|`member x.Value = x.contents`|
-|`contents` (record field)|Gets or sets the underlying value.|`'a`|`let ref x = { contents = x }`|
+
+C# programmers should know that `ref` in C# is not the same thing as `ref` in F#. The equivalent constructs in F# are [byrefs](byrefs.md), which are a different concept from reference cells.
+
+Values marked as `mutable`may be automatically promoted to `'a ref` if captured by a closure; see [Values](./values/index.md).
+
+## Deprecated constructs
 
 Since F# 6.0, the following operators are deprecated and their use gives informational warnings:
 
@@ -57,14 +62,11 @@ Since F# 6.0, the following operators are deprecated and their use gives informa
 |--------------------------|-----------|----|----------|
 |`!` (dereference operator, deprecated)|Returns the underlying value.|`'a ref -> 'a`|`let (!) r = r.contents`|
 |`:=` (assignment operator, deprecated)|Changes the underlying value.|`'a ref -> 'a -> unit`|`let (:=) r x = r.contents <- x`|
+|`contents` (record field)|Gets or sets the underlying value.|`'a`|`let ref x = { contents = x }`|
 
 The direct use of `.Value` is preferred instead, see [F# RFC FS-1111](https://aka.ms/fsharp-refcell-ops).
 
 The field `contents` is provided for compatibility with other versions of ML and will produce a warning during compilation. To disable the warning, use the `--mlcompatibility` compiler option. For more information, see [Compiler Options](compiler-options.md).
-
-C# programmers should know that `ref` in C# is not the same thing as `ref` in F#. The equivalent constructs in F# are [byrefs](byrefs.md), which are a different concept from reference cells.
-
-Values marked as `mutable`may be automatically promoted to `'a ref` if captured by a closure; see [Values](./values/index.md).
 
 ## See also
 

--- a/docs/fsharp/language-reference/reference-cells.md
+++ b/docs/fsharp/language-reference/reference-cells.md
@@ -52,7 +52,7 @@ The following table shows the features that are available on the reference cell.
 
 C# programmers should know that `ref` in C# is not the same thing as `ref` in F#. The equivalent constructs in F# are [byrefs](byrefs.md), which are a different concept from reference cells.
 
-Values marked as `mutable`may be automatically promoted to `'a ref` if captured by a closure; see [Values](./values/index.md).
+Values marked as `mutable` may be automatically promoted to `'a ref` if captured by a closure; see [Values](./values/index.md).
 
 ## Deprecated constructs
 

--- a/docs/fsharp/language-reference/reference-cells.md
+++ b/docs/fsharp/language-reference/reference-cells.md
@@ -64,7 +64,7 @@ Since F# 6.0, the following operators are deprecated and their use gives informa
 |`:=` (assignment operator, deprecated)|Changes the underlying value.|`'a ref -> 'a -> unit`|`let (:=) r x = r.contents <- x`|
 |`contents` (record field)|Gets or sets the underlying value.|`'a`|`let ref x = { contents = x }`|
 
-The direct use of `.Value` is preferred instead, see [F# RFC FS-1111](https://aka.ms/fsharp-refcell-ops).
+Instead, the direct use of `.Value` is preferred; see [F# RFC FS-1111](https://aka.ms/fsharp-refcell-ops).
 
 The field `contents` is provided for compatibility with other versions of ML and will produce a warning during compilation. To disable the warning, use the `--mlcompatibility` compiler option. For more information, see [Compiler Options](compiler-options.md).
 

--- a/samples/snippets/fsharp/lang-ref-1/snippet2201.fs
+++ b/samples/snippets/fsharp/lang-ref-1/snippet2201.fs
@@ -1,8 +1,0 @@
-// Declare a reference.
-let refVar = ref 6
-
-// Change the value referred to by the reference.
-refVar := 50
-
-// Dereference by using the ! operator.
-printfn "%d" !refVar

--- a/samples/snippets/fsharp/lang-ref-1/snippet2203.fs
+++ b/samples/snippets/fsharp/lang-ref-1/snippet2203.fs
@@ -1,9 +1,7 @@
-let xRef : int ref = ref 10
+let xRef = ref 10
 
-printfn "%d" (xRef.Value)
-printfn "%d" (xRef.contents)
+printfn "%d" xRef.Value
 
 xRef.Value <- 11
-printfn "%d" (xRef.Value)
-xRef.contents <- 12
-printfn "%d" (xRef.contents)
+
+printfn "%d" xRef.Value


### PR DESCRIPTION

Since F# 6.0 two operators have been deprecated, see https://github.com/fsharp/fslang-design/blob/main/FSharp-6.0/FS-1111-refcell-op-information-messages.md 