### PR TITLE
Use the Quest cron job

### DIFF
--- a/.github/workflows/quest-bulk.yml
+++ b/.github/workflows/quest-bulk.yml
@@ -1,5 +1,7 @@
 name: "bulk quest import"
 on:
+  schedule:
+    - cron: '0 10 * * *' # UTC time, that's 5:00 am EST, 2:00 am PTC.
   workflow_dispatch:
     inputs:
       reason:

--- a/.github/workflows/quest-bulk.yml
+++ b/.github/workflows/quest-bulk.yml
@@ -1,7 +1,7 @@
 name: "bulk quest import"
 on:
   schedule:
-    - cron: '0 10 * * *' # UTC time, that's 5:00 am EST, 2:00 am PTC.
+    - cron: '0 10 * * *' # UTC time, that's 5:00 am EST, 2:00 am PST.
   workflow_dispatch:
     inputs:
       reason:

--- a/.github/workflows/quest.yml
+++ b/.github/workflows/quest.yml
@@ -1,8 +1,5 @@
 name: "quest import"
 on:
-  issues:
-    types:
-      [ labeled, closed, reopened, assigned, unassigned ]
   workflow_dispatch:
     inputs:
       reason:


### PR DESCRIPTION
This does a couple things.

First, run the quest bulk action every night, at a time when it's likely that none of us are working. Second, run the single issue quest *only* as a workflow_dispatch to run when needed.
