### PR TITLE
Update dotnet-help.md

### DIFF
--- a/docs/core/tools/dotnet-help.md
+++ b/docs/core/tools/dotnet-help.md
@@ -36,5 +36,5 @@ The `dotnet help` command opens up the reference page for more detailed informat
 - Opens the documentation page for the [dotnet new](dotnet-new.md) command:
 
   ```dotnetcli
-  dotnet help new
+  dotnet help new -h
   ```


### PR DESCRIPTION
Testing `dotnet help new` command on .NET version 7.0.201 gives back the following error: 

Specified command 'new' is not a valid SDK command. Specify a valid SDK command. For more information, run dotnet help.

Adding -h or --help seems to resolve this issue.

## Summary

Documentation Correction

Fixes #Issue_Number (if available)
