### PR TITLE
Minor grammar fix

### DIFF
--- a/docs/csharp/language-reference/operators/operator-overloading.md
+++ b/docs/csharp/language-reference/operators/operator-overloading.md
@@ -38,7 +38,7 @@ The following table shows the operators that can be overloaded:
 
 ## Non overloadable operators
 
-The following table shows the operators that can't be overloaded:
+The following table shows the operators that cannot be overloaded:
 
 | Operators | Alternatives |
 | :---------: | --------------- |


### PR DESCRIPTION
## Summary

"can't" is considered an informal contraction which should be avoided in more formal writing. "cannot" is the standard form.
