### PR TITLE
Update worker snippets to use `Host.CreateApplicationBuilder`

### DIFF
--- a/docs/core/extensions/cloud-service.md
+++ b/docs/core/extensions/cloud-service.md
@@ -3,7 +3,7 @@ title: Deploy a Worker Service to Azure
 description: Learn how to deploy a .NET Worker Service to Azure.
 author: IEvangelist
 ms.author: dapine
-ms.date: 09/10/2021
+ms.date: 03/06/2023
 ms.topic: tutorial
 zone_pivot_groups: development-environment-one
 ---

--- a/docs/core/extensions/queue-service.md
+++ b/docs/core/extensions/queue-service.md
@@ -68,7 +68,7 @@ Replace the existing `Program` contents with the following C# code:
 
 :::code source="snippets/workers/queue-service/Program.cs" highlight="4-14":::
 
-The services are registered in `IHostBuilder.ConfigureServices` (*Program.cs*). The hosted service is registered with the `AddHostedService` extension method. `MonitorLoop` is started in *Program.cs* top-level statement:
+The services are registered in (*Program.cs*). The hosted service is registered with the `AddHostedService` extension method. `MonitorLoop` is started in *Program.cs* top-level statement:
 
 :::code source="snippets/workers/queue-service/Program.cs" range="18-19":::
 

--- a/docs/core/extensions/queue-service.md
+++ b/docs/core/extensions/queue-service.md
@@ -3,7 +3,7 @@ title: Create a Queue Service
 description: Learn how to create a queue service subclass of BackgroundService in .NET.
 author: IEvangelist
 ms.author: dapine
-ms.date: 11/12/2021
+ms.date: 03/06/2023
 ms.topic: tutorial
 ---
 
@@ -66,11 +66,11 @@ A `MonitorLoop` service handles enqueuing tasks for the hosted service whenever 
 
 Replace the existing `Program` contents with the following C# code:
 
-:::code source="snippets/workers/queue-service/Program.cs" highlight="6-16":::
+:::code source="snippets/workers/queue-service/Program.cs" highlight="4-14":::
 
 The services are registered in `IHostBuilder.ConfigureServices` (*Program.cs*). The hosted service is registered with the `AddHostedService` extension method. `MonitorLoop` is started in *Program.cs* top-level statement:
 
-:::code source="snippets/workers/queue-service/Program.cs" range="20-21":::
+:::code source="snippets/workers/queue-service/Program.cs" range="18-19":::
 
 For more information on registering services, see [Dependency injection in .NET](dependency-injection.md).
 

--- a/docs/core/extensions/scoped-service.md
+++ b/docs/core/extensions/scoped-service.md
@@ -3,7 +3,7 @@ title: Use scoped services within a BackgroundService
 description: Learn how to use scoped services within a BackgroundService in .NET.
 author: IEvangelist
 ms.author: dapine
-ms.date: 11/12/2021
+ms.date: 03/06/2023
 ms.topic: tutorial
 ---
 
@@ -55,9 +55,9 @@ In the preceding code, an explicit scope is created and the `IScopedProcessingSe
 
 Replace the template *Program.cs* file contents with the following C# code:
 
-:::code source="snippets/workers/scoped-service/Program.cs" highlight="6-7":::
+:::code source="snippets/workers/scoped-service/Program.cs" highlight="4-5":::
 
-The services are registered in `IHostBuilder.ConfigureServices` (*Program.cs*). The hosted service is registered with the `AddHostedService` extension method.
+The services are registered in (*Program.cs*). The hosted service is registered with the `AddHostedService` extension method.
 
 For more information on registering services, see [Dependency injection in .NET](dependency-injection.md).
 

--- a/docs/core/extensions/snippets/workers/background-service/Program.cs
+++ b/docs/core/extensions/snippets/workers/background-service/Program.cs
@@ -1,10 +1,7 @@
 ﻿using App.WorkerService;
 
-IHost host = Host.CreateDefaultBuilder(args)
-    .ConfigureServices(services =>
-    {
-        services.AddHostedService<Worker>();
-    })
-    .Build();
+HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
+builder.Services.AddHostedService<Worker>();
 
-await host.RunAsync();
+IHost host = builder.Build();
+host.Run();

--- a/docs/core/extensions/snippets/workers/cloud-service/Program.cs
+++ b/docs/core/extensions/snippets/workers/cloud-service/Program.cs
@@ -1,10 +1,7 @@
 ﻿using App.CloudService;
 
-using IHost host = Host.CreateDefaultBuilder(args)
-    .ConfigureServices((hostContext, services) =>
-    {
-        services.AddHostedService<Worker>();
-    })
-    .Build();
+HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
+builder.Services.AddHostedService<Worker>();
 
-await host.RunAsync();
+IHost host = builder.Build();
+host.Run();

--- a/docs/core/extensions/snippets/workers/scoped-service/Program.cs
+++ b/docs/core/extensions/snippets/workers/scoped-service/Program.cs
@@ -1,11 +1,8 @@
 ﻿using App.ScopedService;
 
-using IHost host = Host.CreateDefaultBuilder(args)
-    .ConfigureServices(services =>
-    {
-        services.AddHostedService<ScopedBackgroundService>();
-        services.AddScoped<IScopedProcessingService, DefaultScopedProcessingService>();
-    })
-    .Build();
+HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
+builder.Services.AddHostedService<ScopedBackgroundService>();
+builder.Services.AddScoped<IScopedProcessingService, DefaultScopedProcessingService>();
 
-await host.RunAsync();
+IHost host = builder.Build();
+host.Run();

--- a/docs/core/extensions/snippets/workers/signal-completion-service/App.SignalCompletionService/Program.cs
+++ b/docs/core/extensions/snippets/workers/signal-completion-service/App.SignalCompletionService/Program.cs
@@ -1,8 +1,7 @@
 ﻿using App.SignalCompletionService;
 
-using IHost host = Host.CreateDefaultBuilder(args)
-    .ConfigureServices(
-        services => services.AddHostedService<Worker>())
-    .Build();
+HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
+builder.Services.AddHostedService<Worker>();
 
-await host.RunAsync();
+IHost host = builder.Build();
+host.Run();

--- a/docs/core/extensions/snippets/workers/timer-service/Program.cs
+++ b/docs/core/extensions/snippets/workers/timer-service/Program.cs
@@ -1,10 +1,7 @@
 ﻿using App.TimerHostedService;
 
-using IHost host = Host.CreateDefaultBuilder(args)
-    .ConfigureServices(services =>
-    {
-        services.AddHostedService<TimerService>();
-    })
-    .Build();
+HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
+builder.Services.AddHostedService<TimerService>();
 
-await host.RunAsync();
+IHost host = builder.Build();
+host.Run();

--- a/docs/core/extensions/snippets/workers/windows-service/Program.cs
+++ b/docs/core/extensions/snippets/workers/windows-service/Program.cs
@@ -2,25 +2,21 @@
 using Microsoft.Extensions.Logging.Configuration;
 using Microsoft.Extensions.Logging.EventLog;
 
-using IHost host = Host.CreateDefaultBuilder(args)
-    .UseWindowsService(options =>
-    {
-        options.ServiceName = ".NET Joke Service";
-    })
-    .ConfigureServices(services =>
-    {
-        LoggerProviderOptions.RegisterProviderOptions<
-            EventLogSettings, EventLogLoggerProvider>(services);
+HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
+builder.Services.AddWindowsService(options =>
+{
+    options.ServiceName = ".NET Joke Service";
+});
 
-        services.AddSingleton<JokeService>();
-        services.AddHostedService<WindowsBackgroundService>();
-    })
-    .ConfigureLogging((context, logging) =>
-    {
-        // See: https://github.com/dotnet/runtime/issues/47303
-        logging.AddConfiguration(
-            context.Configuration.GetSection("Logging"));
-    })
-    .Build();
+LoggerProviderOptions.RegisterProviderOptions<
+    EventLogSettings, EventLogLoggerProvider>(builder.Services);
 
-await host.RunAsync();
+builder.Services.AddSingleton<JokeService>();
+builder.Services.AddHostedService<WindowsBackgroundService>();
+
+// See: https://github.com/dotnet/runtime/issues/47303
+builder.Logging.AddConfiguration(
+    builder.Configuration.GetSection("Logging"));
+
+IHost host = builder.Build();
+host.Run();

--- a/docs/core/extensions/timer-service.md
+++ b/docs/core/extensions/timer-service.md
@@ -50,9 +50,9 @@ When <xref:Microsoft.Extensions.Hosting.IHostedService.StartAsync%2A> is called,
 
 Replace the existing `Program` contents with the following C# code:
 
-:::code source="snippets/workers/timer-service/Program.cs" highlight="6":::
+:::code source="snippets/workers/timer-service/Program.cs" highlight="4":::
 
-The service is registered in `IHostBuilder.ConfigureServices` (*Program.cs*) with the `AddHostedService` extension method. This is the same extension method you use when registering <xref:Microsoft.Extensions.Hosting.BackgroundService> subclasses, as they both implement the <xref:Microsoft.Extensions.Hosting.IHostedService> interface.
+The service is registered in (*Program.cs*) with the `AddHostedService` extension method. This is the same extension method you use when registering <xref:Microsoft.Extensions.Hosting.BackgroundService> subclasses, as they both implement the <xref:Microsoft.Extensions.Hosting.IHostedService> interface.
 
 For more information on registering services, see [Dependency injection in .NET](dependency-injection.md).
 

--- a/docs/core/extensions/windows-service.md
+++ b/docs/core/extensions/windows-service.md
@@ -3,7 +3,7 @@ title: Create a Windows Service using BackgroundService
 description: Learn how to create a Windows Service using the BackgroundService in .NET.
 author: IEvangelist
 ms.author: dapine
-ms.date: 02/27/2023
+ms.date: 03/06/2023
 ms.topic: tutorial
 ---
 
@@ -103,9 +103,9 @@ In the preceding code, the `JokeService` is injected along with an `ILogger`. Bo
 
 Replace the template *Program.cs* file contents with the following C# code:
 
-:::code source="snippets/workers/windows-service/Program.cs" highlight="6-9,15-16":::
+:::code source="snippets/workers/windows-service/Program.cs" highlight="6-9,14-15":::
 
-The <xref:Microsoft.Extensions.Hosting.WindowsServiceLifetimeHostBuilderExtensions.UseWindowsService%2A> extension method configures the app to work as a Windows Service. The service name is set to `".NET Joke Service"`. The hosted service is registered for dependency injection.
+The `AddWindowsService` extension method configures the app to work as a Windows Service. The service name is set to `".NET Joke Service"`. The hosted service is registered for dependency injection.
 
 For more information on registering services, see [Dependency injection in .NET](dependency-injection.md).
 

--- a/docs/core/extensions/workers.md
+++ b/docs/core/extensions/workers.md
@@ -3,7 +3,7 @@ title: Worker Services
 description: Learn how to implement a custom IHostedService and use existing implementations with .NET.
 author: IEvangelist
 ms.author: dapine
-ms.date: 07/20/2022
+ms.date: 03/06/2023
 ms.topic: overview
 ---
 
@@ -39,8 +39,8 @@ The Worker Service template is available to the .NET CLI, and Visual Studio. For
 
 The preceding `Program` class:
 
-- Creates the default <xref:Microsoft.Extensions.Hosting.IHostBuilder>.
-- Calls <xref:Microsoft.Extensions.Hosting.HostBuilder.ConfigureServices%2A> to add the `Worker` class as a hosted service with <xref:Microsoft.Extensions.DependencyInjection.ServiceCollectionHostedServiceExtensions.AddHostedService%2A>.
+- Creates a <xref:Microsoft.Extensions.Hosting.HostApplicationBuilder>.
+- Calls <xref:Microsoft.Extensions.DependencyInjection.ServiceCollectionHostedServiceExtensions.AddHostedService%2A> to register the `Worker` as a hosted service.
 - Builds an <xref:Microsoft.Extensions.Hosting.IHost> from the builder.
 - Calls `Run` on the `host` instance, which runs the app.
 
@@ -54,25 +54,6 @@ The preceding `Program` class:
 > ```
 >
 > For more information regarding performance considerations, see [Server GC](../../standard/garbage-collection/workstation-server-gc.md#server-gc). For more information on configuring server GC, see [Server GC configuration examples](../runtime-config/garbage-collector.md#workstation-vs-server).
-
-The *Program.cs* file from the template can be rewritten using top-level statements:
-
-```csharp
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using App.WorkerService;
-
-using IHost host = Host.CreateDefaultBuilder(args)
-    .ConfigureServices((hostContext, services) =>
-    {
-        services.AddHostedService<Worker>();
-    })
-    .Build();
-
-await host.RunAsync();
-```
-
-This is functionally equivalent to the original template. For more information on C# 9 features, see [What's new in C# 9.0](../../csharp/whats-new/csharp-9.md).
 
 As for the `Worker`, the template provides a simple implementation.
 
@@ -102,13 +83,13 @@ With most modern .NET workloads, containers are a viable option. When creating a
 
 The preceding *Dockerfile* steps include:
 
-- Setting the base image from `mcr.microsoft.com/dotnet/runtime:6.0` as the alias `base`.
+- Setting the base image from `mcr.microsoft.com/dotnet/runtime:7.0` as the alias `base`.
 - Changing the working directory to */app*.
-- Setting the `build` alias from the `mcr.microsoft.com/dotnet/sdk:6.0` image.
+- Setting the `build` alias from the `mcr.microsoft.com/dotnet/sdk:7.0` image.
 - Changing the working directory to */src*.
 - Copying the contents and publishing the .NET app:
   - The app is published using the [`dotnet publish`](../tools/dotnet-publish.md) command.
-- Relayering the .NET SDK image from `mcr.microsoft.com/dotnet/runtime:6.0` (the `base` alias).
+- Relayering the .NET SDK image from `mcr.microsoft.com/dotnet/runtime:7.0` (the `base` alias).
 - Copying the published build output from the */publish*.
 - Defining the entry point, which delegates to [`dotnet App.BackgroundService.dll`](../tools/dotnet.md).
 


### PR DESCRIPTION
## Summary

Update worker snippets to use `Host.CreateApplicationBuilder`

Fixes #34247

Previews:

- [Deploy a Worker Service to Azure](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/cloud-service?branch=pr-en-us-34391&pivots=visualstudio)
- [Create a Queue Service](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/queue-service?branch=pr-en-us-34391)
- [Use scoped services within a `BackgroundService`](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/scoped-service?branch=pr-en-us-34391)
- [Implement the `IHostedService` interface](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/timer-service?branch=pr-en-us-34391)
- [Create a Windows Service using `BackgroundService`](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/windows-service?branch=pr-en-us-34391)
- [Worker Services in .NET](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/workers?branch=pr-en-us-34391)