### PR TITLE
Update wcf-web-service-reference-guide.md

### DIFF
--- a/docs/core/additional-tools/wcf-web-service-reference-guide.md
+++ b/docs/core/additional-tools/wcf-web-service-reference-guide.md
@@ -27,7 +27,7 @@ The screenshots in this article are from Visual Studio 2022.
 
 Using the **ASP.NET Core Web Application** project template as an example, this article walks you through adding a WCF service reference to the project.
 
-1. In Solution Explorer, double-click the **Connected Services** node of the project. (For a .NET Core or .NET Standard project, this option is available when you right-click on the **Dependencies** node of the project in Solution Explorer and choose **Manage Connected Services**.)
+1. In Solution Explorer, double-click the **Connected Services** node of the project. (For a .NET Core or .NET Standard project, this option is available when you right-click on the project, select Add option and choose **Manage Connected Services**.)
 
    The **Connected Services** page appears as shown in the following image:
 


### PR DESCRIPTION
dotnet core applications ( console applications ) do not have the options connected service beneath the project as aspnet core projects have. Its important to make it more explicit that its currently is. For now this is the fix of the issue

## Summary

Describe your changes here.

Fixes #33729 (if available)
