### PR TITLE
Update basicbinding-with-transport-security.md

### DIFF
--- a/docs/framework/wcf/samples/basicbinding-with-transport-security.md
+++ b/docs/framework/wcf/samples/basicbinding-with-transport-security.md
@@ -6,7 +6,7 @@ ms.assetid: f49b1de6-0254-4362-8ef2-fccd8ff9688b
 ---
 # BasicBinding with Transport Security
 
-The [TransportSecurity sample](https://github.com/dotnet/samples/tree/main/framework/wcf) demonstrates the use of SSL transport security with the basic binding. This sample is based on the [Getting Started](getting-started-sample.md) that implements a calculator service.
+The [TransportSecurity sample](https://github.com/dotnet/samples/tree/main/framework/wcf/Basic/Binding/Basic/TransportSecurity/CS) demonstrates the use of SSL transport security with the basic binding. This sample is based on the [Getting Started](getting-started-sample.md) that implements a calculator service.
 
 ## Sample Details
 


### PR DESCRIPTION
Fix link to point to actual sample

## Summary

-> Changed link to point to https://github.com/dotnet/samples/tree/main/framework/wcf/Basic/Binding/Basic/TransportSecurity/CS as per the other sample pages


| File | Preview |
|:--|:--|
| 📄 _docs/framework/wcf/samples/basicbinding-with-transport-security.md_ | 🔗 [Preview: docs/framework/wcf/samples/basicbinding-with-transport-security](https://review.learn.microsoft.com/en-us/dotnet/framework/wcf/samples/basicbinding-with-transport-security?branch=pr-en-us-34409) |
