### PR TITLE
Add brief explanation of what MVID is to deterministic docs

### DIFF
--- a/docs/csharp/language-reference/compiler-options/code-generation.md
+++ b/docs/csharp/language-reference/compiler-options/code-generation.md
@@ -62,7 +62,7 @@ Causes the compiler to produce an assembly whose byte-for-byte output is identic
 <Deterministic>true</Deterministic>
 ```
 
-By default, compiler output from a given set of inputs is unique, since the compiler adds a timestamp and an MVID (a "Module Version ID". Basically it is a GUID that uniquely identifies the module and version.) that is generated from random numbers. You use the `<Deterministic>` option to produce a *deterministic assembly*, one whose binary content is identical across compilations as long as the input remains the same. In such a build, the timestamp and MVID fields will be replaced with values derived from a hash of all the compilation inputs. The compiler considers the following inputs that affect determinism:
+By default, compiler output from a given set of inputs is unique, since the compiler adds a timestamp and an MVID (a <xref:System.Reflection.Module.ModuleVersionId%2A?displayProperty=nameWithType>. Basically it is a GUID that uniquely identifies the module and version.) that is generated from random numbers. You use the `<Deterministic>` option to produce a *deterministic assembly*, one whose binary content is identical across compilations as long as the input remains the same. In such a build, the timestamp and MVID fields will be replaced with values derived from a hash of all the compilation inputs. The compiler considers the following inputs that affect determinism:
 
 - The sequence of command-line parameters.
 - The contents of the compiler's .rsp response file.

--- a/docs/csharp/language-reference/compiler-options/code-generation.md
+++ b/docs/csharp/language-reference/compiler-options/code-generation.md
@@ -62,7 +62,7 @@ Causes the compiler to produce an assembly whose byte-for-byte output is identic
 <Deterministic>true</Deterministic>
 ```
 
-By default, compiler output from a given set of inputs is unique, since the compiler adds a timestamp and an MVID that is generated from random numbers. You use the `<Deterministic>` option to produce a *deterministic assembly*, one whose binary content is identical across compilations as long as the input remains the same. In such a build, the timestamp and MVID fields will be replaced with values derived from a hash of all the compilation inputs. The compiler considers the following inputs that affect determinism:
+By default, compiler output from a given set of inputs is unique, since the compiler adds a timestamp and an MVID (a "Module Version ID". Basically it is a GUID that uniquely identifies the module and version.) that is generated from random numbers. You use the `<Deterministic>` option to produce a *deterministic assembly*, one whose binary content is identical across compilations as long as the input remains the same. In such a build, the timestamp and MVID fields will be replaced with values derived from a hash of all the compilation inputs. The compiler considers the following inputs that affect determinism:
 
 - The sequence of command-line parameters.
 - The contents of the compiler's .rsp response file.


### PR DESCRIPTION
This pull request fixes #34256
It adds the brief explanation of what is the MVID abbreviation for, so that developer or user who reads this can further search for it, knowing what to search for and have more context.
I didn't add any longer explanation, trying to avoid making an off-topic out from it and changing the context too much.

**NOTE:** It would be good to add some kind of link, or information of where to read more
(so it would be something like: "*(...) more here*")
but I couldn't find anything in the docs repo about it, nor in the other .NET docs that would describe it in much details except for direct API documentation [like this](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.module.moduleversionid?view=net-7.0). So if there's anything that comes to a reviewer's mind that can be linked here I will happily add this to the PR 🙏 
