### PR TITLE
Fix F# snippet indentation

### DIFF
--- a/samples/snippets/fsharp/lang-ref-2/snippet5004.fs
+++ b/samples/snippets/fsharp/lang-ref-2/snippet5004.fs
@@ -10,9 +10,9 @@ let (|Float|_|) (str: string) =
 
 let parseNumeric str =
    match str with
-     | Integer i -> printfn "%d : Integer" i
-     | Float f -> printfn "%f : Floating point" f
-     | _ -> printfn "%s : Not matched." str
+   | Integer i -> printfn "%d : Integer" i
+   | Float f -> printfn "%f : Floating point" f
+   | _ -> printfn "%s : Not matched." str
 
 parseNumeric "1.1"
 parseNumeric "0"

--- a/samples/snippets/fsharp/lang-ref-2/snippet5005.fs
+++ b/samples/snippets/fsharp/lang-ref-2/snippet5005.fs
@@ -12,9 +12,9 @@ let (|Cube|_|) (x : int) =
 
 let findSquareCubes x =
    match x with
-       | Cube x & Square _ -> printfn "%d is a cube and a square" x
-       | Cube x -> printfn "%d is a cube" x
-       | _ -> ()
-         
+   | Cube x & Square _ -> printfn "%d is a cube and a square" x
+   | Cube x -> printfn "%d is a cube" x
+   | _ -> ()
+   
 
 [ 1 .. 1000 ] |> List.iter (fun elem -> findSquareCubes elem)

--- a/samples/snippets/fsharp/lang-ref-2/snippet5006.fs
+++ b/samples/snippets/fsharp/lang-ref-2/snippet5006.fs
@@ -15,13 +15,13 @@ let (|ParseRegex|_|) regex str =
 // date is provided, it is an abbreviation, not a year in the first century.
 let parseDate str =
    match str with
-     | ParseRegex "(\d{1,2})/(\d{1,2})/(\d{1,2})$" [Integer m; Integer d; Integer y]
+   | ParseRegex "(\d{1,2})/(\d{1,2})/(\d{1,2})$" [Integer m; Integer d; Integer y]
           -> new System.DateTime(y + 2000, m, d)
-     | ParseRegex "(\d{1,2})/(\d{1,2})/(\d{3,4})" [Integer m; Integer d; Integer y]
+   | ParseRegex "(\d{1,2})/(\d{1,2})/(\d{3,4})" [Integer m; Integer d; Integer y]
           -> new System.DateTime(y, m, d)
-     | ParseRegex "(\d{1,4})-(\d{1,2})-(\d{1,2})" [Integer y; Integer m; Integer d]
+   | ParseRegex "(\d{1,4})-(\d{1,2})-(\d{1,2})" [Integer y; Integer m; Integer d]
           -> new System.DateTime(y, m, d)
-     | _ -> new System.DateTime()
+   | _ -> new System.DateTime()
 
 let dt1 = parseDate "12/22/08"
 let dt2 = parseDate "1/1/2009"


### PR DESCRIPTION
## Summary

This PR is fixing the snippet indentation of some `match .. with` blocks from the Active Patterns page in the F# documentation.
