### PR TITLE
Update .NET Standard 2.1 UWP table

### DIFF
--- a/includes/net-standard-2.1.md
+++ b/includes/net-standard-2.1.md
@@ -8,12 +8,14 @@
 | Xamarin.iOS                 | 12.16                   |
 | Xamarin.Mac                 | 5.16                    |
 | Xamarin.Android             | 10.0                    |
-| Universal Windows Platform  | TBD                     |
+| Universal Windows Platform  | N/A<sup>3</sup>         |
 | Unity                       | 2021.2                  |
 
 <sup>1</sup> The versions listed for .NET Framework apply to .NET Core 2.0 SDK and later versions of the tooling. Older versions used a different mapping for .NET Standard 1.5 and higher. You can [download tooling for .NET Core tools for Visual Studio 2015](https://github.com/dotnet/core/blob/main/release-notes/download-archives) if you cannot upgrade to Visual Studio 2017 or a later version.
 
 <sup>2</sup> .NET Framework doesn't support .NET Standard 2.1. For more information, see the [announcement of .NET Standard 2.1](https://devblogs.microsoft.com/dotnet/announcing-net-standard-2-1/).
+
+<sup>3</sup> UWP does not support .NET Standard 2.1.
 
 For more information, see [.NET Standard 2.1][2.1]. For an interactive table, see [.NET Standard versions](https://dotnet.microsoft.com/platform/dotnet-standard#versions).
 

--- a/includes/net-standard-2.1.md
+++ b/includes/net-standard-2.1.md
@@ -15,7 +15,7 @@
 
 <sup>2</sup> .NET Framework doesn't support .NET Standard 2.1. For more information, see the [announcement of .NET Standard 2.1](https://devblogs.microsoft.com/dotnet/announcing-net-standard-2-1/).
 
-<sup>3</sup> UWP does not support .NET Standard 2.1.
+<sup>3</sup> UWP doesn't support .NET Standard 2.1.
 
 For more information, see [.NET Standard 2.1][2.1]. For an interactive table, see [.NET Standard versions](https://dotnet.microsoft.com/platform/dotnet-standard#versions).
 


### PR DESCRIPTION
## Summary

UWP does not support .NET Standard 2.1, and there are no plans for it to get support for this.
This PR updates the table to remove that "TBD", which was a bit misleading.


<!-- PREVIEW-TABLE-START -->

#### Internal previews

| 📄 File(s) | 🔗 Preview link(s) |
|:--|:--|
| _includes/net-standard-2.1.md_ | [Preview: includes/net-standard-2.1](https://review.learn.microsoft.com/en-us/dotnet/includes/net-standard-2.1?branch=pr-en-us-34512) |


<!-- PREVIEW-TABLE-END -->