### PR TITLE
Update `--verbosity` parameter to be displayed as a list item

### DIFF
--- a/docs/core/tools/dotnet-build.md
+++ b/docs/core/tools/dotnet-build.md
@@ -136,7 +136,7 @@ The project or solution file to build. If a project or solution file isn't speci
 
   The URI of the NuGet package source to use during the restore operation.
 
-**`-v|--verbosity <LEVEL>`**
+- **`-v|--verbosity <LEVEL>`**
 
   Sets the verbosity level of the command. Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`. The default is `minimal`. By default, MSBuild displays warnings and errors at all verbosity levels. To exclude warnings, use `/property:WarningLevel=0`. For more information, see <xref:Microsoft.Build.Framework.LoggerVerbosity> and [WarningLevel](../../csharp/language-reference/compiler-options/errors-warnings.md#warninglevel).
 


### PR DESCRIPTION
## Summary

`--verbosity` was the only argument that is not displayed as a list item.

<!-- PREVIEW-TABLE-START -->
#### Internal previews

| 📄 File(s) | 🔗 Preview link(s) |
|:--|:--|
| _docs/core/tools/dotnet-build.md_ | [Preview: docs/core/tools/dotnet-build](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-build?branch=pr-en-us-34518) |

<!-- PREVIEW-TABLE-END -->