### PR TITLE
Add headings

### DIFF
--- a/docs/csharp/tour-of-csharp/tutorials/hello-world.yml
+++ b/docs/csharp/tour-of-csharp/tutorials/hello-world.yml
@@ -130,6 +130,8 @@ items:
   content: |
     You've been using a *method*, <xref:System.Console.WriteLine%2A?displayProperty=nameWithType>, to print messages. A *method* is a block of code that implements some action. It has a name, so you can access it.
 
+    ## Trim
+
     Suppose your strings have leading or trailing spaces that you don't want to display. You want to **trim** the spaces from the strings.
     The <xref:System.String.Trim%2A> method and related methods <xref:System.String.TrimStart%2A> and <xref:System.String.TrimEnd%2A> do that work. You can just use those methods to remove leading and trailing spaces. Try the following code:
 
@@ -151,6 +153,8 @@ items:
 
     This sample reinforces a couple of important concepts for working with strings. The methods that manipulate strings return new string objects rather than making modifications in place. You can see that each call to any of the `Trim` methods returns a new string but doesn't change the original message.
 
+    ## Replace
+    
     There are other methods available to work with a string. For example, you've probably used a search and replace command in an editor or word processor before. The <xref:System.String.Replace%2A> method does something similar in a string. It searches for a substring and replaces it with different text. The <xref:System.String.Replace%2A> method takes two **parameters**. These are the strings between the parentheses. The first string is the text to search for. The second string is the text to replace it with. Try it for yourself. Add this code. Type it in to see the hints as you start typing `.Re` after the `sayHello` variable:
 
     ```csharp


### PR DESCRIPTION
Fixes microsoft/studentambassadors#112

Add headings in the longer online tutorial page. I reviewed the other tutorials, and none of the other pages have similar layout, where multiple distinct concepts are covered.
