### PR TITLE
Fix punctuation in titles

### DIFF
--- a/docs/csharp/language-reference/statements/jump-statements.md
+++ b/docs/csharp/language-reference/statements/jump-statements.md
@@ -17,7 +17,7 @@ helpviewer_keywords:
   - "goto statement [C#]"
   - "goto keyword [C#]"
 ---
-# Jump statements - `break`, `continue`, `return` and `goto`
+# Jump statements - `break`, `continue`, `return`, and `goto`
 
 Four C# statements unconditionally transfer control. The `break` [statement](#the-break-statement), terminates the closest enclosing [iteration statement](iteration-statements.md) or `switch` [statement](selection-statements.md#the-switch-statement). The `continue` [statement](#the-continue-statement) starts a new iteration of the closest enclosing [iteration statement](iteration-statements.md). The `return` [statement](#the-return-statement): terminates execution of the function in which it appears and returns control to the caller. The `ref` modifier on a `return` statement indicates the returned expression is returned *by reference*, not *by value*. The `goto` [statement](#the-goto-statement): transfers control to a statement that is marked by a label.
 

--- a/docs/csharp/language-reference/statements/lock.md
+++ b/docs/csharp/language-reference/statements/lock.md
@@ -8,7 +8,7 @@ f1_keywords:
 helpviewer_keywords: 
   - "lock keyword [C#]"
 ---
-# lock statement - ensure exclusive access to a shared resource.
+# lock statement - ensure exclusive access to a shared resource
 
 The `lock` statement acquires the mutual-exclusion lock for a given object, executes a statement block, and then releases the lock. While a lock is held, the thread that holds the lock can again acquire and release the lock. Any other thread is blocked from acquiring the lock and waits until the lock is released. The `lock` statement ensures that a single thread has exclusive access to that object.
 

--- a/docs/csharp/language-reference/statements/selection-statements.md
+++ b/docs/csharp/language-reference/statements/selection-statements.md
@@ -17,7 +17,7 @@ helpviewer_keywords:
   - "case keyword [C#]"
   - "default keyword [C#]"
 ---
-# Selection statements - `if`, `else` and `switch`
+# Selection statements - `if`, `else`, and `switch`
 
 The `if`, `else` and `switch` statements select statements to execute from many possible paths based on the value of an expression. The `if` [statement](#the-if-statement) selects a statement to execute based on the value of a Boolean expression. An `if` statement can be combined with `else` to choose two distinct paths based on the Boolean expression. The `switch` [statement](#the-switch-statement) selects a statement list to execute based on a pattern match with an expression.
 


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->
#### Internal previews

| 📄 File(s) | 🔗 Preview link(s) |
|:--|:--|
| _docs/csharp/language-reference/statements/jump-statements.md_ | [Preview: docs/csharp/language-reference/statements/jump-statements](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/statements/jump-statements?branch=pr-en-us-34537) |
| _docs/csharp/language-reference/statements/lock.md_ | [Preview: docs/csharp/language-reference/statements/lock](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/statements/lock?branch=pr-en-us-34537) |
| _docs/csharp/language-reference/statements/selection-statements.md_ | [Preview: docs/csharp/language-reference/statements/selection-statements](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/statements/selection-statements?branch=pr-en-us-34537) |

<!-- PREVIEW-TABLE-END -->