### PR TITLE
Update breaking-changes.md

### DIFF
--- a/docs/standard/library-guidance/breaking-changes.md
+++ b/docs/standard/library-guidance/breaking-changes.md
@@ -44,7 +44,7 @@ Because a source breaking change is only harmful when developers recompile their
 
 ### Behavior breaking change
 
-Behavior changes are the most common type of breaking change: almost any change in behavior could break someone. Changes to your library, such as method signatures, exceptions thrown or input or output data formats, could all negatively impact your library consumers. Even a bug fix can qualify as a breaking change if users relied on the previously broken behavior.
+Behavior changes are the most common type of breaking change: almost any change in behavior could cause a logic error for a consumer. Changes to your library, such as method signatures, exceptions thrown or input or output data formats, could all negatively impact your library consumers. Even a bug fix can qualify as a breaking change if users relied on the previously broken behavior.
 
 Adding features and improving bad behaviors is a good thing, but without care it can make it very hard for existing users to upgrade. One approach to helping developers deal with behavior breaking changes is to hide them behind settings. Settings let developers update to the latest version of your library while at the same time choosing to opt in or opt out of breaking changes. This strategy lets developers stay up to date while letting their consuming code adapt over time.
 


### PR DESCRIPTION
changed "almost any change in behavior could result breaking someone" to be "almost any change in behavior could cause a logic error for a consumer". 

## Summary
I think the author intended to convey the idea that a change to behavior in a library can cause breaking changes for the consumer of that library, that's why they wrote 'breaking someone'. However, that doesn't read well nor convey the idea well. It reads as though the 'someone' is the thing that is breaking, not their code. I prefer the change to read "almost any change in behavior could cause a logic error", leaving off the 'for a consumer', but will leave that on the change to keep it as close to what I believe was the authors intent.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->
#### Internal previews

| 📄 File(s) | 🔗 Preview link(s) |
|:--|:--|
| _docs/standard/library-guidance/breaking-changes.md_ | [Preview: docs/standard/library-guidance/breaking-changes](https://review.learn.microsoft.com/en-us/dotnet/standard/library-guidance/breaking-changes?branch=pr-en-us-34544) |

<!-- PREVIEW-TABLE-END -->