### PR TITLE
Create deprecating-api-port.md

### DIFF
--- a/docs/core/porting/porting-approaches.md
+++ b/docs/core/porting/porting-approaches.md
@@ -7,6 +7,10 @@ ms.date: 06/10/2021
 ---
 # Create a porting plan
 
+We recommend using the Visual Studio [.NET Upgrade Assistant](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.upgradeassistant) to update .NET Framework code to the latest .NET versions. For more information see the blog [Upgrading your .NET projects with Visual Studio](https://devblogs.microsoft.com/dotnet/upgrade-assistant-now-in-visual-studio/).
+
+[!INCLUDE[](~/includes/deprecating-api-port.md)]
+
 Before you jump straight into the code, take the time to go through the recommended pre-migration steps. This article gives you insight into the kinds of issues you may come across, and helps you decide on an approach that makes the most sense.
 
 ## Port your code

--- a/docs/standard/analyzers/portability-analyzer.md
+++ b/docs/standard/analyzers/portability-analyzer.md
@@ -7,8 +7,7 @@ ms.assetid: 0375250f-5704-4993-a6d5-e21c499cea1e
 
 # The .NET Portability Analyzer
 
-> [!NOTE]
-> We're in the process of deprecating API Port in favor of integrating binary analysis directly into [.NET Upgrade Assistant](https://github.com/dotnet/upgrade-assistant). In the upcoming months, we're going to shut down the backend service of API Port, which will require using the tool offline. For more information, see [GitHub: .NET API Port repository](https://github.com/microsoft/dotnet-apiport/blob/dev/docs/Console/README.md#run-the-tool-in-an-offline-mode).*
+[!INCLUDE[](~/includes/deprecating-api-port.md)]
 
 Want to make your libraries support multi-platform? Want to see how much work is required to make your .NET Framework application run on .NET Core? The [.NET Portability Analyzer](https://github.com/microsoft/dotnet-apiport) is a tool that analyzes assemblies and provides a detailed report on .NET APIs that are missing for the applications or libraries to be portable on your specified targeted .NET platforms. The Portability Analyzer is offered as a [Visual Studio Extension](https://marketplace.visualstudio.com/items?itemName=ConnieYau.NETPortabilityAnalyzer), which analyzes one assembly per project, and as an [ApiPort console app](https://aka.ms/apiportdownload), which analyzes assemblies by specified files or directory.
 

--- a/includes/deprecating-api-port.md
+++ b/includes/deprecating-api-port.md
@@ -1,0 +1,2 @@
+> [!NOTE]
+> We're in the process of deprecating API Port in favor of integrating binary analysis directly into [.NET Upgrade Assistant](https://github.com/dotnet/upgrade-assistant). In the upcoming months, we're going to shut down the backend service of API Port, which will require using the tool offline. For more information, see [GitHub: .NET API Port repository](https://github.com/microsoft/dotnet-apiport/blob/dev/docs/Console/README.md#run-the-tool-in-an-offline-mode).*


### PR DESCRIPTION
Move common text to include.  This is a band-aid fix until someone has time to update these docs. 

Fixes https://github.com/dotnet/AspNetCore.Docs/issues/28667

<!-- PREVIEW-TABLE-START -->

#### Internal previews

| 📄 File(s) | 🔗 Preview link(s) |
|:--|:--|
| _docs/core/porting/porting-approaches.md_ | [Preview: docs/core/porting/porting-approaches](https://review.learn.microsoft.com/en-us/dotnet/core/porting/porting-approaches?branch=pr-en-us-34545) |
| _docs/standard/analyzers/portability-analyzer.md_ | [Preview: docs/standard/analyzers/portability-analyzer](https://review.learn.microsoft.com/en-us/dotnet/standard/analyzers/portability-analyzer?branch=pr-en-us-34545) |


<!-- PREVIEW-TABLE-END -->