### PR TITLE
fix: well-known-event-providers.md SampleProfiler sampling rate

### DIFF
--- a/docs/core/diagnostics/well-known-event-providers.md
+++ b/docs/core/diagnostics/well-known-event-providers.md
@@ -17,7 +17,7 @@ This provider emits various events from the .NET runtime, including GC, loader, 
 
 ### "Microsoft-DotNETCore-SampleProfiler" provider
 
-This provider is a .NET runtime event provider that is used for CPU sampling for managed callstacks. When enabled, it captures a snapshot of each thread's managed callstack every 10 milliseconds. To enable this capture, you must specify an <xref:System.Diagnostics.Tracing.EventLevel> of `Informational` or higher.
+This provider is a .NET runtime event provider that is used for CPU sampling for managed callstacks. When enabled, it captures a snapshot of each thread's managed callstack every millisecond. To enable this capture, you must specify an <xref:System.Diagnostics.Tracing.EventLevel> of `Informational` or higher.
 
 ## Framework libraries
 


### PR DESCRIPTION
## Summary

I've just noticed the docs say the SampleProfiler samples every 10 milliseconds but that is not true, see https://github.com/dotnet/runtime/issues/82939 for context

<!-- PREVIEW-TABLE-START -->
#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| _docs/core/diagnostics/well-known-event-providers.md_ | [Preview: docs/core/diagnostics/well-known-event-providers](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/well-known-event-providers?branch=pr-en-us-34549) |

<!-- PREVIEW-TABLE-END -->