### PR TITLE
Fix spacing in RecordType.cs

### DIFF
--- a/docs/csharp/language-reference/builtin-types/snippets/shared/RecordType.cs
+++ b/docs/csharp/language-reference/builtin-types/snippets/shared/RecordType.cs
@@ -49,9 +49,9 @@ namespace builtin_types
         // <ImmutableRecordStruct>
         public record struct Point
         {
-            public double X {  get; init; }
-            public double Y {  get; init; }
-            public double Z {  get; init; }
+            public double X { get; init; }
+            public double Y { get; init; }
+            public double Z { get; init; }
         }
         // </ImmutableRecordStruct>
     }
@@ -105,8 +105,8 @@ namespace builtin_types
         /// map to the JSON elements "firstName" and "lastName" when
         /// serialized or deserialized.
         /// </remarks>
-        public record Person([property: JsonPropertyName("firstName")]string FirstName, 
-            [property: JsonPropertyName("lastName")]string LastName);
+        public record Person([property: JsonPropertyName("firstName")] string FirstName, 
+            [property: JsonPropertyName("lastName")] string LastName);
         // </PositionalAttributes>
 
     }


### PR DESCRIPTION
## Summary

Removes a double space in the property getters/initters found in the `ImmutableRecordStruct` type. Additionally adds a space after the property attributes found in the `PositionalAttributes.Person` record.