### PR TITLE
Add note about VS to the .NET Framework ref assemblies article

### DIFF
--- a/docs/framework/migration-guide/reference-assemblies.md
+++ b/docs/framework/migration-guide/reference-assemblies.md
@@ -53,4 +53,4 @@ After adding the **Microsoft.NETFramework.ReferenceAssemblies** NuGet package to
 - If your project is an SDK-style project, you don't need to do anything. The NuGet restore action is automatically run when the project is built.
 
 > [!IMPORTANT]
-> Using reference assemblies makes it possible to build projects that target unsupported versions of .NET Framework from the command line. However, you still can't load these projects in newer versions of Visual Studio. To continue building these apps in Visual Studio, the only workaround is to use an older version of Visual Studio.
+> Using reference assemblies makes it possible to build projects that target unsupported versions of .NET Framework from the command line. However, you still can't load these projects in newer versions of Visual Studio. To continue building these apps in Visual Studio, the only workaround is to use [an older version of Visual Studio](https://visualstudio.microsoft.com/vs/older-downloads/).

--- a/docs/framework/migration-guide/reference-assemblies.md
+++ b/docs/framework/migration-guide/reference-assemblies.md
@@ -51,3 +51,8 @@ After adding the **Microsoft.NETFramework.ReferenceAssemblies** NuGet package to
   01. Run _msbuild /t:restore_.
 
 - If your project is an SDK-style project, you don't need to do anything. The NuGet restore action is automatically run when the project is built.
+
+> [!IMPORTANT]
+> While using reference assemblies makes it possible to build the project on the command line, it still doesn't allow loading it in Visual Studio.
+To continue building apps that target unsupported versions of .NET Framework in Visual Studio, the only workaround is to use an older version of
+Visual Studio.

--- a/docs/framework/migration-guide/reference-assemblies.md
+++ b/docs/framework/migration-guide/reference-assemblies.md
@@ -53,6 +53,4 @@ After adding the **Microsoft.NETFramework.ReferenceAssemblies** NuGet package to
 - If your project is an SDK-style project, you don't need to do anything. The NuGet restore action is automatically run when the project is built.
 
 > [!IMPORTANT]
-> While using reference assemblies makes it possible to build the project on the command line, it still doesn't allow loading it in Visual Studio.
-To continue building apps that target unsupported versions of .NET Framework in Visual Studio, the only workaround is to use an older version of
-Visual Studio.
+> Using reference assemblies makes it possible to build projects that target unsupported versions of .NET Framework from the command line. However, you still can't load these projects in newer versions of Visual Studio. To continue building these apps in Visual Studio, the only workaround is to use an older version of Visual Studio.


### PR DESCRIPTION
## Summary

Since many users are taken to the SDK downloads page from the VS "Target framework not supported" dialog and then land on this article, it is important to create the right expectation with respect to Visual Studio.

This proposed doc change was prompted by external user feedback.

<!-- PREVIEW-TABLE-START -->

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/migration-guide/reference-assemblies.md](https://github.com/dotnet/docs/blob/fa7d7e39bd85338fb38231a0498614405fa891a8/docs/framework/migration-guide/reference-assemblies.md) | [docs/framework/migration-guide/reference-assemblies](https://review.learn.microsoft.com/en-us/dotnet/framework/migration-guide/reference-assemblies?branch=pr-en-us-34600) |


<!-- PREVIEW-TABLE-END -->