### PR TITLE
fix redirection and breadcrumb

### DIFF
--- a/.openpublishing.redirection.csharp.json
+++ b/.openpublishing.redirection.csharp.json
@@ -1328,7 +1328,7 @@
         },
         {
             "source_path_from_root": "/docs/csharp/programming-guide/concepts/attributes/index.md",
-            "redirect_url": "/dotnet/csharp/advanced-concepts/reflection-and-attributes"
+            "redirect_url": "/dotnet/csharp/advanced-concepts/reflection-and-attributes/"
         },
         {
             "source_path_from_root": "/docs/csharp/programming-guide/concepts/attributes/attributeusage.md",

--- a/.openpublishing.redirection.csharp.json
+++ b/.openpublishing.redirection.csharp.json
@@ -1328,7 +1328,7 @@
         },
         {
             "source_path_from_root": "/docs/csharp/programming-guide/concepts/attributes/index.md",
-            "redirect_url": "/dotnet/csharp/advanced-concepts/reflection-and-attributes/"
+            "redirect_url": "/dotnet/csharp/advanced-topics/reflection-and-attributes/"
         },
         {
             "source_path_from_root": "/docs/csharp/programming-guide/concepts/attributes/attributeusage.md",
@@ -1340,15 +1340,15 @@
         },
         {
             "source_path_from_root": "/docs/csharp/programming-guide/concepts/attributes/creating-custom-attributes.md",
-            "redirect_url": "/dotnet/csharp/advanced-concepts/reflection-and-attributes/creating-custom-attributes"
+            "redirect_url": "/dotnet/csharp/advanced-topics/reflection-and-attributes/creating-custom-attributes"
         },
         {
             "source_path_from_root": "/docs/csharp/programming-guide/concepts/attributes/accessing-attributes-by-using-reflection.md",
-            "redirect_url": "/dotnet/csharp/advanced-concepts/reflection-and-attributes/accessing-attributes-by-using-reflection"
+            "redirect_url": "/dotnet/csharp/advanced-topics/reflection-and-attributes/accessing-attributes-by-using-reflection"
         },
         {
             "source_path_from_root": "/docs/csharp/programming-guide/concepts/attributes/how-to-create-a-c-cpp-union-by-using-attributes.md",
-            "redirect_url": "/dotnet/csharp/advanced-concepts/reflection-and-attributes/how-to-create-a-c-cpp-union-by-using-attributes"
+            "redirect_url": "/dotnet/csharp/advanced-topics/reflection-and-attributes/how-to-create-a-c-cpp-union-by-using-attributes"
         },
         {
             "source_path_from_root": "/docs/csharp/programming-guide/concepts/caller-information.md",

--- a/docs/breadcrumb/toc.yml
+++ b/docs/breadcrumb/toc.yml
@@ -288,7 +288,7 @@ items:
                 topicHref: /dotnet/csharp/asynchronous-programming/index
               - name: Advanced concepts
                 tocHref: /dotnet/csharp/advanced-topics
-                topicHref: /dotnet/csharp/advanced-topics/index
+                topicHref: /dotnet/csharp/advanced-topics/reflection-and-attributes/index
                
               - name: Tutorials
                 tocHref: /dotnet/csharp/tutorials/

--- a/docs/csharp/language-reference/compiler-messages/cs0592.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0592.md
@@ -39,4 +39,4 @@ public class A
 
 ## See also
 
-- [Attributes](/dotnet/csharp/advanced-topics/reflections-and-attributes)
+- [Attributes](/dotnet/csharp/advanced-topics/reflection-and-attributes)

--- a/docs/csharp/language-reference/compiler-messages/cs0592.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0592.md
@@ -39,4 +39,4 @@ public class A
 
 ## See also
 
-- [Attributes](/dotnet/csharp/advanced-concepts/reflection-and-attributes)
+- [Attributes](/dotnet/csharp/advanced-topics/reflections-and-attributes)

--- a/docs/csharp/language-reference/operators/member-access-operators.md
+++ b/docs/csharp/language-reference/operators/member-access-operators.md
@@ -94,7 +94,7 @@ For more information about indexers, see [Indexers](../../programming-guide/inde
 
 For information about pointer element access, see the [Pointer element access operator []](pointer-related-operators.md#pointer-element-access-operator-) section of the [Pointer related operators](pointer-related-operators.md) article.
 
-You also use square brackets to specify [attributes](/dotnet/csharp/advanced-topics/reflections-and-attributes):
+You also use square brackets to specify [attributes](/dotnet/csharp/advanced-topics/reflection-and-attributes):
 
 ```csharp
 [System.Diagnostics.Conditional("DEBUG")]

--- a/docs/csharp/language-reference/operators/member-access-operators.md
+++ b/docs/csharp/language-reference/operators/member-access-operators.md
@@ -94,7 +94,7 @@ For more information about indexers, see [Indexers](../../programming-guide/inde
 
 For information about pointer element access, see the [Pointer element access operator []](pointer-related-operators.md#pointer-element-access-operator-) section of the [Pointer related operators](pointer-related-operators.md) article.
 
-You also use square brackets to specify [attributes](/dotnet/csharp/advanced-concepts/reflection-and-attributes):
+You also use square brackets to specify [attributes](/dotnet/csharp/advanced-topics/reflections-and-attributes):
 
 ```csharp
 [System.Diagnostics.Conditional("DEBUG")]

--- a/docs/csharp/language-reference/operators/nameof.md
+++ b/docs/csharp/language-reference/operators/nameof.md
@@ -24,7 +24,7 @@ You can use a `nameof` expression to make the argument-checking code more mainta
 
 [!code-csharp[nameof and argument check](snippets/shared/NameOfOperator.cs#ExceptionMessage)]
 
-Beginning with C# 11, you can use a `nameof` expression with a method parameter inside an [attribute](/dotnet/csharp/advanced-topics/reflections-and-attributes) on a method or its parameter. The following code shows how to do that for an attribute on a method, a local function, and the parameter of a lambda expression:
+Beginning with C# 11, you can use a `nameof` expression with a method parameter inside an [attribute](/dotnet/csharp/advanced-topics/reflection-and-attributes) on a method or its parameter. The following code shows how to do that for an attribute on a method, a local function, and the parameter of a lambda expression:
 
 :::code language="csharp" source="snippets/shared/NameOfOperator.cs" id="SnippetNameOfParameter":::
 

--- a/docs/csharp/language-reference/operators/nameof.md
+++ b/docs/csharp/language-reference/operators/nameof.md
@@ -24,7 +24,7 @@ You can use a `nameof` expression to make the argument-checking code more mainta
 
 [!code-csharp[nameof and argument check](snippets/shared/NameOfOperator.cs#ExceptionMessage)]
 
-Beginning with C# 11, you can use a `nameof` expression with a method parameter inside an [attribute](/dotnet/csharp/advanced-concepts/reflection-and-attributes) on a method or its parameter. The following code shows how to do that for an attribute on a method, a local function, and the parameter of a lambda expression:
+Beginning with C# 11, you can use a `nameof` expression with a method parameter inside an [attribute](/dotnet/csharp/advanced-topics/reflections-and-attributes) on a method or its parameter. The following code shows how to do that for an attribute on a method, a local function, and the parameter of a lambda expression:
 
 :::code language="csharp" source="snippets/shared/NameOfOperator.cs" id="SnippetNameOfParameter":::
 

--- a/docs/csharp/misc/cs0182.md
+++ b/docs/csharp/misc/cs0182.md
@@ -24,7 +24,7 @@ Certain restrictions apply to what kinds of arguments may be used with attribute
   
 - [decimal](../language-reference/builtin-types/floating-point-numeric-types.md)  
   
-For more information, see [Attributes](/dotnet/csharp/advanced-topics/reflections-and-attributes).  
+For more information, see [Attributes](/dotnet/csharp/advanced-topics/reflection-and-attributes).  
   
 ## Example  
 

--- a/docs/csharp/misc/cs0182.md
+++ b/docs/csharp/misc/cs0182.md
@@ -24,7 +24,7 @@ Certain restrictions apply to what kinds of arguments may be used with attribute
   
 - [decimal](../language-reference/builtin-types/floating-point-numeric-types.md)  
   
-For more information, see [Attributes](/dotnet/csharp/advanced-concepts/reflection-and-attributes).  
+For more information, see [Attributes](/dotnet/csharp/advanced-topics/reflections-and-attributes).  
   
 ## Example  
 

--- a/docs/csharp/misc/cs0643.md
+++ b/docs/csharp/misc/cs0643.md
@@ -12,7 +12,7 @@ ms.assetid: beae30ff-15c2-413f-8f5c-504cdba2e57a
 
 'arg' duplicate named attribute argument  
   
- A parameter, `arg`, on a user-defined attribute was specified twice. For more information, see [Attributes](/dotnet/csharp/advanced-topics/reflections-and-attributes).  
+ A parameter, `arg`, on a user-defined attribute was specified twice. For more information, see [Attributes](/dotnet/csharp/advanced-topics/reflection-and-attributes).  
   
 ## Example  
 

--- a/docs/csharp/misc/cs0643.md
+++ b/docs/csharp/misc/cs0643.md
@@ -12,7 +12,7 @@ ms.assetid: beae30ff-15c2-413f-8f5c-504cdba2e57a
 
 'arg' duplicate named attribute argument  
   
- A parameter, `arg`, on a user-defined attribute was specified twice. For more information, see [Attributes](/dotnet/csharp/advanced-concepts/reflection-and-attributes).  
+ A parameter, `arg`, on a user-defined attribute was specified twice. For more information, see [Attributes](/dotnet/csharp/advanced-topics/reflections-and-attributes).  
   
 ## Example  
 

--- a/docs/csharp/misc/cs0655.md
+++ b/docs/csharp/misc/cs0655.md
@@ -12,7 +12,7 @@ ms.assetid: 8ce340e2-eeeb-476a-8609-ab4bbaf10c44
 
 'parameter' is not a valid named attribute argument because it is not a valid attribute parameter type  
   
- See [Attributes](/dotnet/csharp/advanced-topics/reflections-and-attributes) for a discussion of valid parameter types for an attribute.  
+ See [Attributes](/dotnet/csharp/advanced-topics/reflection-and-attributes) for a discussion of valid parameter types for an attribute.  
   
 ## Example  
 

--- a/docs/csharp/misc/cs0655.md
+++ b/docs/csharp/misc/cs0655.md
@@ -12,7 +12,7 @@ ms.assetid: 8ce340e2-eeeb-476a-8609-ab4bbaf10c44
 
 'parameter' is not a valid named attribute argument because it is not a valid attribute parameter type  
   
- See [Attributes](/dotnet/csharp/advanced-concepts/reflection-and-attributes) for a discussion of valid parameter types for an attribute.  
+ See [Attributes](/dotnet/csharp/advanced-topics/reflections-and-attributes) for a discussion of valid parameter types for an attribute.  
   
 ## Example  
 

--- a/docs/csharp/misc/cs0657.md
+++ b/docs/csharp/misc/cs0657.md
@@ -12,7 +12,7 @@ ms.assetid: d12d2efc-f44e-40e6-b825-5a66ead0c08e
 
 'attribute modifier' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'locations'. All attributes in this block will be ignored.  
   
- The compiler found an attribute modifier in an invalid location. See [Attribute Targets](/dotnet/csharp/advanced-concepts/reflection-and-attributes#attribute-targets) for more information.  
+ The compiler found an attribute modifier in an invalid location. See [Attribute Targets](/dotnet/csharp/advanced-topics/reflections-and-attributes#attribute-targets) for more information.  
   
  The following sample generates CS0657:  
   

--- a/docs/csharp/misc/cs0657.md
+++ b/docs/csharp/misc/cs0657.md
@@ -12,7 +12,7 @@ ms.assetid: d12d2efc-f44e-40e6-b825-5a66ead0c08e
 
 'attribute modifier' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'locations'. All attributes in this block will be ignored.  
   
- The compiler found an attribute modifier in an invalid location. See [Attribute Targets](/dotnet/csharp/advanced-topics/reflections-and-attributes#attribute-targets) for more information.  
+ The compiler found an attribute modifier in an invalid location. See [Attribute Targets](/dotnet/csharp/advanced-topics/reflection-and-attributes#attribute-targets) for more information.  
   
  The following sample generates CS0657:  
   

--- a/docs/csharp/misc/cs0658.md
+++ b/docs/csharp/misc/cs0658.md
@@ -12,7 +12,7 @@ ms.assetid: 0309074c-741a-492c-9370-73b4bbfd3c1a
 
 'attribute modifier' is not a recognized attribute location. All attributes in this block will be ignored.  
   
- An invalid attribute modifier was specified. See [Attribute Targets](/dotnet/csharp/advanced-concepts/reflection-and-attributes#attribute-targets) for more information.  
+ An invalid attribute modifier was specified. See [Attribute Targets](/dotnet/csharp/advanced-topics/reflections-and-attributes#attribute-targets) for more information.  
   
  The following sample generates CS0658:  
   

--- a/docs/csharp/misc/cs0658.md
+++ b/docs/csharp/misc/cs0658.md
@@ -12,7 +12,7 @@ ms.assetid: 0309074c-741a-492c-9370-73b4bbfd3c1a
 
 'attribute modifier' is not a recognized attribute location. All attributes in this block will be ignored.  
   
- An invalid attribute modifier was specified. See [Attribute Targets](/dotnet/csharp/advanced-topics/reflections-and-attributes#attribute-targets) for more information.  
+ An invalid attribute modifier was specified. See [Attribute Targets](/dotnet/csharp/advanced-topics/reflection-and-attributes#attribute-targets) for more information.  
   
  The following sample generates CS0658:  
   

--- a/docs/csharp/misc/cs1730.md
+++ b/docs/csharp/misc/cs1730.md
@@ -32,4 +32,4 @@ class Test
   
 ## See also
 
-- [Attributes](/dotnet/csharp/advanced-concepts/reflection-and-attributes)
+- [Attributes](/dotnet/csharp/advanced-topics/reflections-and-attributes)

--- a/docs/csharp/misc/cs1730.md
+++ b/docs/csharp/misc/cs1730.md
@@ -32,4 +32,4 @@ class Test
   
 ## See also
 
-- [Attributes](/dotnet/csharp/advanced-topics/reflections-and-attributes)
+- [Attributes](/dotnet/csharp/advanced-topics/reflection-and-attributes)

--- a/docs/csharp/programming-guide/concepts/index.md
+++ b/docs/csharp/programming-guide/concepts/index.md
@@ -12,7 +12,7 @@ This section explains programming concepts in the C# language.
 |Title|Description|  
 |-----------|-----------------|  
 |[Assemblies in .NET](../../../standard/assembly/index.md)|Describes how to create and use assemblies.|  
-|[Attributes (C#)](/dotnet/csharp/advanced-concepts/reflection-and-attributes)|Discusses how to provide additional information about programming elements such as types, fields, methods, and properties by using attributes.|  
+|[Attributes (C#)](/dotnet/csharp/advanced-topics/reflections-and-attributes)|Discusses how to provide additional information about programming elements such as types, fields, methods, and properties by using attributes.|  
 |[Collections (C#)](./collections.md)|Describes some of the types of collections provided by .NET. Demonstrates how to use simple collections and collections of key/value pairs.|  
 |[Covariance and Contravariance (C#)](./covariance-contravariance/index.md)|Shows how to enable implicit conversion of generic type parameters in interfaces and delegates.|  
 |[Expression Trees (C#)](../../advanced-topics/expression-trees/index.md)|Explains how you can use expression trees to enable dynamic modification of executable code.|  

--- a/docs/csharp/programming-guide/concepts/index.md
+++ b/docs/csharp/programming-guide/concepts/index.md
@@ -12,7 +12,7 @@ This section explains programming concepts in the C# language.
 |Title|Description|  
 |-----------|-----------------|  
 |[Assemblies in .NET](../../../standard/assembly/index.md)|Describes how to create and use assemblies.|  
-|[Attributes (C#)](/dotnet/csharp/advanced-topics/reflections-and-attributes)|Discusses how to provide additional information about programming elements such as types, fields, methods, and properties by using attributes.|  
+|[Attributes (C#)](/dotnet/csharp/advanced-topics/reflection-and-attributes)|Discusses how to provide additional information about programming elements such as types, fields, methods, and properties by using attributes.|  
 |[Collections (C#)](./collections.md)|Describes some of the types of collections provided by .NET. Demonstrates how to use simple collections and collections of key/value pairs.|  
 |[Covariance and Contravariance (C#)](./covariance-contravariance/index.md)|Shows how to enable implicit conversion of generic type parameters in interfaces and delegates.|  
 |[Expression Trees (C#)](../../advanced-topics/expression-trees/index.md)|Explains how you can use expression trees to enable dynamic modification of executable code.|  

--- a/docs/csharp/programming-guide/index.md
+++ b/docs/csharp/programming-guide/index.md
@@ -71,7 +71,7 @@ This section provides detailed information on key C# language features and featu
   
  [Assemblies in .NET](../../standard/assembly/index.md)  
   
- [Attributes](/dotnet/csharp/advanced-concepts/reflection-and-attributes)  
+ [Attributes](/dotnet/csharp/advanced-topics/reflections-and-attributes)  
   
  [Collections](./concepts/collections.md)  
   

--- a/docs/csharp/programming-guide/index.md
+++ b/docs/csharp/programming-guide/index.md
@@ -71,7 +71,7 @@ This section provides detailed information on key C# language features and featu
   
  [Assemblies in .NET](../../standard/assembly/index.md)  
   
- [Attributes](/dotnet/csharp/advanced-topics/reflections-and-attributes)  
+ [Attributes](/dotnet/csharp/advanced-topics/reflection-and-attributes)  
   
  [Collections](./concepts/collections.md)  
   

--- a/docs/csharp/tour-of-csharp/features.md
+++ b/docs/csharp/tour-of-csharp/features.md
@@ -94,7 +94,7 @@ This small sample shows the major features for asynchronous programming:
 
 ## Attributes
 
-Types, members, and other entities in a C# program support modifiers that control certain aspects of their behavior. For example, the accessibility of a method is controlled using the `public`, `protected`, `internal`, and `private` modifiers. C# generalizes this capability such that user-defined types of declarative information can be attached to program entities and retrieved at run-time. Programs specify this declarative information by defining and using [***attributes***](/dotnet/csharp/advanced-topics/reflections-and-attributes).
+Types, members, and other entities in a C# program support modifiers that control certain aspects of their behavior. For example, the accessibility of a method is controlled using the `public`, `protected`, `internal`, and `private` modifiers. C# generalizes this capability such that user-defined types of declarative information can be attached to program entities and retrieved at run-time. Programs specify this declarative information by defining and using [***attributes***](/dotnet/csharp/advanced-topics/reflection-and-attributes).
 
 The following example declares a `HelpAttribute` attribute that can be placed on program entities to provide links to their associated documentation.
 

--- a/docs/csharp/tour-of-csharp/features.md
+++ b/docs/csharp/tour-of-csharp/features.md
@@ -94,7 +94,7 @@ This small sample shows the major features for asynchronous programming:
 
 ## Attributes
 
-Types, members, and other entities in a C# program support modifiers that control certain aspects of their behavior. For example, the accessibility of a method is controlled using the `public`, `protected`, `internal`, and `private` modifiers. C# generalizes this capability such that user-defined types of declarative information can be attached to program entities and retrieved at run-time. Programs specify this declarative information by defining and using [***attributes***](/dotnet/csharp/advanced-concepts/reflection-and-attributes).
+Types, members, and other entities in a C# program support modifiers that control certain aspects of their behavior. For example, the accessibility of a method is controlled using the `public`, `protected`, `internal`, and `private` modifiers. C# generalizes this capability such that user-defined types of declarative information can be attached to program entities and retrieved at run-time. Programs specify this declarative information by defining and using [***attributes***](/dotnet/csharp/advanced-topics/reflections-and-attributes).
 
 The following example declares a `HelpAttribute` attribute that can be placed on program entities to provide links to their associated documentation.
 

--- a/docs/csharp/whats-new/csharp-11.md
+++ b/docs/csharp/whats-new/csharp-11.md
@@ -166,7 +166,7 @@ You've been able to test if a `string` had a specific constant value using patte
 
 ## Extended nameof scope
 
-Type parameter names and parameter names are now in scope when used in a `nameof` expression in an [attribute declaration](/dotnet/csharp/advanced-topics/reflections-and-attributes#using-attributes) on that method. This feature means you can use the `nameof` operator to specify the name of a method parameter in an attribute on the method or parameter declaration. This feature is most often useful to add attributes for [nullable analysis](../language-reference/attributes/nullable-analysis.md).
+Type parameter names and parameter names are now in scope when used in a `nameof` expression in an [attribute declaration](/dotnet/csharp/advanced-topics/reflection-and-attributes#using-attributes) on that method. This feature means you can use the `nameof` operator to specify the name of a method parameter in an attribute on the method or parameter declaration. This feature is most often useful to add attributes for [nullable analysis](../language-reference/attributes/nullable-analysis.md).
 
 ## UTF-8 string literals
 

--- a/docs/csharp/whats-new/csharp-11.md
+++ b/docs/csharp/whats-new/csharp-11.md
@@ -166,7 +166,7 @@ You've been able to test if a `string` had a specific constant value using patte
 
 ## Extended nameof scope
 
-Type parameter names and parameter names are now in scope when used in a `nameof` expression in an [attribute declaration](/dotnet/csharp/advanced-concepts/reflection-and-attributes#using-attributes) on that method. This feature means you can use the `nameof` operator to specify the name of a method parameter in an attribute on the method or parameter declaration. This feature is most often useful to add attributes for [nullable analysis](../language-reference/attributes/nullable-analysis.md).
+Type parameter names and parameter names are now in scope when used in a `nameof` expression in an [attribute declaration](/dotnet/csharp/advanced-topics/reflections-and-attributes#using-attributes) on that method. This feature means you can use the `nameof` operator to specify the name of a method parameter in an attribute on the method or parameter declaration. This feature is most often useful to add attributes for [nullable analysis](../language-reference/attributes/nullable-analysis.md).
 
 ## UTF-8 string literals
 

--- a/docs/csharp/whats-new/csharp-version-history.md
+++ b/docs/csharp/whats-new/csharp-version-history.md
@@ -375,6 +375,6 @@ The major features of C# 1.0 included:
 - [Delegates](../delegates-overview.md)
 - [Operators and expressions](../language-reference/operators/index.md)
 - [Statements](../programming-guide/statements-expressions-operators/statements.md)
-- [Attributes](/dotnet/csharp/advanced-topics/reflections-and-attributes)
+- [Attributes](/dotnet/csharp/advanced-topics/reflection-and-attributes)
 
 _Article_ [_originally published on the NDepend blog_](https://blog.ndepend.com/c-versions-look-language-history/)_, courtesy of Erik Dietrich and Patrick Smacchia._

--- a/docs/csharp/whats-new/csharp-version-history.md
+++ b/docs/csharp/whats-new/csharp-version-history.md
@@ -375,6 +375,6 @@ The major features of C# 1.0 included:
 - [Delegates](../delegates-overview.md)
 - [Operators and expressions](../language-reference/operators/index.md)
 - [Statements](../programming-guide/statements-expressions-operators/statements.md)
-- [Attributes](/dotnet/csharp/advanced-concepts/reflection-and-attributes)
+- [Attributes](/dotnet/csharp/advanced-topics/reflections-and-attributes)
 
 _Article_ [_originally published on the NDepend blog_](https://blog.ndepend.com/c-versions-look-language-history/)_, courtesy of Erik Dietrich and Patrick Smacchia._

--- a/docs/standard/attributes/applying-attributes.md
+++ b/docs/standard/attributes/applying-attributes.md
@@ -52,5 +52,5 @@ Use the following process to apply an attribute to an element of your code.
 - [Attributes](index.md)
 - [Retrieving Information Stored in Attributes](retrieving-information-stored-in-attributes.md)
 - [Concepts](/cpp/windows/attributed-programming-concepts)
-- [Attributes (C#)](/dotnet/csharp/advanced-topics/reflections-and-attributes)
+- [Attributes (C#)](/dotnet/csharp/advanced-topics/reflection-and-attributes)
 - [Attributes overview (Visual Basic)](../../visual-basic/programming-guide/concepts/attributes/index.md)

--- a/docs/standard/attributes/applying-attributes.md
+++ b/docs/standard/attributes/applying-attributes.md
@@ -52,5 +52,5 @@ Use the following process to apply an attribute to an element of your code.
 - [Attributes](index.md)
 - [Retrieving Information Stored in Attributes](retrieving-information-stored-in-attributes.md)
 - [Concepts](/cpp/windows/attributed-programming-concepts)
-- [Attributes (C#)](/dotnet/csharp/advanced-concepts/reflection-and-attributes)
+- [Attributes (C#)](/dotnet/csharp/advanced-topics/reflections-and-attributes)
 - [Attributes overview (Visual Basic)](../../visual-basic/programming-guide/concepts/attributes/index.md)


### PR DESCRIPTION
Fix the breadcrumb for the C# "advanced topics" section. There isn't an index in that folder, so defer to the first sub-section and it's overview article.

Fixes #34604

Also, fix the redirection to this same article: The destination must include the trailing "/" to redirect to the (default) `index` in that folder.


<!-- PREVIEW-TABLE-START -->

#### Internal previews

<details><summary><strong>Toggle Expand/Collapse</strong></summary><br/>

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-messages/cs0592.md](https://github.com/dotnet/docs/blob/3d45d53b6fe272e9741023c5a9f31860cf30d458/docs/csharp/language-reference/compiler-messages/cs0592.md) | [docs/csharp/language-reference/compiler-messages/cs0592](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0592?branch=pr-en-us-34624) |
| [docs/csharp/language-reference/operators/member-access-operators.md](https://github.com/dotnet/docs/blob/3d45d53b6fe272e9741023c5a9f31860cf30d458/docs/csharp/language-reference/operators/member-access-operators.md) | [docs/csharp/language-reference/operators/member-access-operators](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/member-access-operators?branch=pr-en-us-34624) |
| [docs/csharp/language-reference/operators/nameof.md](https://github.com/dotnet/docs/blob/3d45d53b6fe272e9741023c5a9f31860cf30d458/docs/csharp/language-reference/operators/nameof.md) | [docs/csharp/language-reference/operators/nameof](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/nameof?branch=pr-en-us-34624) |
| [docs/csharp/misc/cs0182.md](https://github.com/dotnet/docs/blob/3d45d53b6fe272e9741023c5a9f31860cf30d458/docs/csharp/misc/cs0182.md) | [docs/csharp/misc/cs0182](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/cs0182?branch=pr-en-us-34624) |
| [docs/csharp/misc/cs0643.md](https://github.com/dotnet/docs/blob/3d45d53b6fe272e9741023c5a9f31860cf30d458/docs/csharp/misc/cs0643.md) | [docs/csharp/misc/cs0643](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/cs0643?branch=pr-en-us-34624) |
| [docs/csharp/misc/cs0655.md](https://github.com/dotnet/docs/blob/3d45d53b6fe272e9741023c5a9f31860cf30d458/docs/csharp/misc/cs0655.md) | [docs/csharp/misc/cs0655](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/cs0655?branch=pr-en-us-34624) |
| [docs/csharp/misc/cs0657.md](https://github.com/dotnet/docs/blob/3d45d53b6fe272e9741023c5a9f31860cf30d458/docs/csharp/misc/cs0657.md) | [docs/csharp/misc/cs0657](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/cs0657?branch=pr-en-us-34624) |
| [docs/csharp/misc/cs0658.md](https://github.com/dotnet/docs/blob/3d45d53b6fe272e9741023c5a9f31860cf30d458/docs/csharp/misc/cs0658.md) | [docs/csharp/misc/cs0658](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/cs0658?branch=pr-en-us-34624) |
| [docs/csharp/misc/cs1730.md](https://github.com/dotnet/docs/blob/3d45d53b6fe272e9741023c5a9f31860cf30d458/docs/csharp/misc/cs1730.md) | [docs/csharp/misc/cs1730](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/cs1730?branch=pr-en-us-34624) |
| [docs/csharp/programming-guide/concepts/index.md](https://github.com/dotnet/docs/blob/3d45d53b6fe272e9741023c5a9f31860cf30d458/docs/csharp/programming-guide/concepts/index.md) | [docs/csharp/programming-guide/concepts/index](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/concepts/index?branch=pr-en-us-34624) |
| [docs/csharp/programming-guide/index.md](https://github.com/dotnet/docs/blob/3d45d53b6fe272e9741023c5a9f31860cf30d458/docs/csharp/programming-guide/index.md) | [docs/csharp/programming-guide/index](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/index?branch=pr-en-us-34624) |
| [docs/csharp/tour-of-csharp/features.md](https://github.com/dotnet/docs/blob/3d45d53b6fe272e9741023c5a9f31860cf30d458/docs/csharp/tour-of-csharp/features.md) | [docs/csharp/tour-of-csharp/features](https://review.learn.microsoft.com/en-us/dotnet/csharp/tour-of-csharp/features?branch=pr-en-us-34624) |
| [docs/csharp/whats-new/csharp-11.md](https://github.com/dotnet/docs/blob/3d45d53b6fe272e9741023c5a9f31860cf30d458/docs/csharp/whats-new/csharp-11.md) | [docs/csharp/whats-new/csharp-11](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-11?branch=pr-en-us-34624) |
| [docs/csharp/whats-new/csharp-version-history.md](https://github.com/dotnet/docs/blob/3d45d53b6fe272e9741023c5a9f31860cf30d458/docs/csharp/whats-new/csharp-version-history.md) | [docs/csharp/whats-new/csharp-version-history](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-version-history?branch=pr-en-us-34624) |
| [docs/standard/attributes/applying-attributes.md](https://github.com/dotnet/docs/blob/3d45d53b6fe272e9741023c5a9f31860cf30d458/docs/standard/attributes/applying-attributes.md) | [docs/standard/attributes/applying-attributes](https://review.learn.microsoft.com/en-us/dotnet/standard/attributes/applying-attributes?branch=pr-en-us-34624) |

</details>


<!-- PREVIEW-TABLE-END -->