### PR TITLE
Markdown lint fix

### DIFF
--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -73,4 +73,3 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 ## See also
 
 - [What's new in .NET 8](../whats-new/dotnet-8.md)
-


### PR DESCRIPTION
Extra blank line is causing a Markdown lint issue


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/8.0.md](https://github.com/dotnet/docs/blob/165ea1a23913334c01c76aca7a5b27f8d1c1e35e/docs/core/compatibility/8.0.md) | [docs/core/compatibility/8.0](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/8.0?branch=pr-en-us-34641) |

<!-- PREVIEW-TABLE-END -->