### PR TITLE
C# reference: Add the link to async/await .NET blog post

### DIFF
--- a/docs/csharp/language-reference/keywords/async.md
+++ b/docs/csharp/language-reference/keywords/async.md
@@ -88,3 +88,4 @@ For more information and examples, see [Async Return Types](../../asynchronous-p
 - [await](../operators/await.md)
 - [Asynchronous programming with async and await](../../asynchronous-programming/index.md)
 - [Process asynchronous tasks as they complete](../../asynchronous-programming/start-multiple-async-tasks-and-process-them-as-they-complete.md)
+- [.NET blog: How async/await really works in C#](https://devblogs.microsoft.com/dotnet/how-async-await-really-works/)

--- a/docs/csharp/language-reference/operators/await.md
+++ b/docs/csharp/language-reference/operators/await.md
@@ -50,3 +50,4 @@ For more information, see the [Await expressions](~/_csharpstandard/standard/exp
 - [Asynchronous programming](../../asynchronous-programming/index.md)
 - [Walkthrough: accessing the Web by using async and await](../../asynchronous-programming/async-scenarios.md)
 - [Tutorial: Generate and consume async streams](../../asynchronous-programming/generate-consume-asynchronous-stream.md)
+- [.NET blog: How async/await really works in C#](https://devblogs.microsoft.com/dotnet/how-async-await-really-works/)


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/async.md](https://github.com/dotnet/docs/blob/5661136b1c5a35b3c0edcb03710e4c03ea096aca/docs/csharp/language-reference/keywords/async.md) | [docs/csharp/language-reference/keywords/async](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/async?branch=pr-en-us-34649) |
| [docs/csharp/language-reference/operators/await.md](https://github.com/dotnet/docs/blob/5661136b1c5a35b3c0edcb03710e4c03ea096aca/docs/csharp/language-reference/operators/await.md) | [docs/csharp/language-reference/operators/await](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/await?branch=pr-en-us-34649) |

<!-- PREVIEW-TABLE-END -->