### PR TITLE
Standardized sample code

### DIFF
--- a/docs/csharp/tour-of-csharp/tutorials/list-collection.yml
+++ b/docs/csharp/tour-of-csharp/tutorials/list-collection.yml
@@ -82,8 +82,9 @@ items:
     ```csharp
     var index = names.IndexOf("Felipe");
     if (index != -1)
+    {
       Console.WriteLine($"The name {names[index]} is at index {index}");
-
+    }
     var notFound = names.IndexOf("Not Found");
     Console.WriteLine($"When an item is not found, IndexOf returns {notFound}");
     ```


### PR DESCRIPTION
Added braces in the sample code.

## Summary

According tip "Through the rest of this tutorial, the code samples all include the braces, following accepted practices." in C# guide -> Get started -> Branches and loops -> Make if and else work together(https://learn.microsoft.com/en-us/dotnet/csharp/tour-of-csharp/tutorials/branches-and-loops?tutorial-step=2), the sample code should include braces if there are branches. However, there is no braces before this pull request. Braces have been added to this pull request to standardize the sample code.

Note: This is the first pull request I submitted. If there are any mistakes, please correct them, thanks.
