### PR TITLE
Fix broken windbg link on dump analysis page

### DIFF
--- a/docs/core/diagnostics/debug-windows-dumps.md
+++ b/docs/core/diagnostics/debug-windows-dumps.md
@@ -10,4 +10,4 @@ ms.date: 01/11/2023
 
 ## Analyze dumps on Windows
 
-Windows dumps can be analyzed on Windows with [Visual Studio](/visualstudio/debugger/using-dump-files), [Windbg](https://github.com/dotnet/docs/blob/main/windows-hardware/drivers/debugger/analyzing-a-user-mode-dump-file), or the [`dotnet-dump`](dotnet-dump.md) CLI tool. Visual Studio and Windbg can access both managed and native code and are the recommended tools for a Windows environment. dotnet-dump can only access managed code.
+Windows dumps can be analyzed on Windows with [Visual Studio](/visualstudio/debugger/using-dump-files), [Windbg](https://learn.microsoft.com/windows-hardware/drivers/debugger/debugger-download-tools), or the [`dotnet-dump`](dotnet-dump.md) CLI tool. Visual Studio and Windbg can access both managed and native code and are the recommended tools for a Windows environment. dotnet-dump can only access managed code.

--- a/docs/core/diagnostics/debug-windows-dumps.md
+++ b/docs/core/diagnostics/debug-windows-dumps.md
@@ -10,4 +10,4 @@ ms.date: 01/11/2023
 
 ## Analyze dumps on Windows
 
-Windows dumps can be analyzed on Windows with [Visual Studio](/visualstudio/debugger/using-dump-files), [Windbg](https://learn.microsoft.com/windows-hardware/drivers/debugger/debugger-download-tools), or the [`dotnet-dump`](dotnet-dump.md) CLI tool. Visual Studio and Windbg can access both managed and native code and are the recommended tools for a Windows environment. dotnet-dump can only access managed code.
+Windows dumps can be analyzed on Windows with [Visual Studio](/visualstudio/debugger/using-dump-files), [Windbg](/windows-hardware/drivers/debugger/debugger-download-tools), or the [`dotnet-dump`](dotnet-dump.md) CLI tool. Visual Studio and Windbg can access both managed and native code and are the recommended tools for a Windows environment. dotnet-dump can only access managed code.


### PR DESCRIPTION
## Summary

Fix broken windbg link on dump analysis page

Fixes #34660


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/debug-windows-dumps.md](https://github.com/dotnet/docs/blob/0bd4c966ca20bab364c85cac56f03ab336a55e89/docs/core/diagnostics/debug-windows-dumps.md) | [docs/core/diagnostics/debug-windows-dumps](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/debug-windows-dumps?branch=pr-en-us-34662) |


<!-- PREVIEW-TABLE-END -->