### PR TITLE
Fix typo in with-expression.md

### DIFF
--- a/docs/csharp/language-reference/operators/with-expression.md
+++ b/docs/csharp/language-reference/operators/with-expression.md
@@ -10,7 +10,7 @@ helpviewer_keywords:
 ---
 # with expression - Nondestructive mutation creates a new object with modified properties
 
-Available in C# 9.0 and later, a `with` expression produces a copy of its operand with the specified properties and fields modified. you use [object initializer](../../programming-guide/classes-and-structs/object-and-collection-initializers.md) syntax to specify what members to modify and their new values:
+Available in C# 9.0 and later, a `with` expression produces a copy of its operand with the specified properties and fields modified. You use the [object initializer](../../programming-guide/classes-and-structs/object-and-collection-initializers.md) syntax to specify what members to modify and their new values:
 
 :::code language="csharp" source="snippets/with-expression/BasicExample.cs" :::
 


### PR DESCRIPTION
This commit fixes a tiny grammar issue introduced by 89050169e9b1f8bacae3c8deb8d57391de7cace4.

## Summary

This commit changes two words to fix grammar.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/with-expression.md](https://github.com/dotnet/docs/blob/d9fbabaf39bd67fc678bab30230e621c95c241ee/docs/csharp/language-reference/operators/with-expression.md) | [docs/csharp/language-reference/operators/with-expression](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/with-expression?branch=pr-en-us-34666) |

<!-- PREVIEW-TABLE-END -->