### PR TITLE
Corrected typo in documentation

### DIFF
--- a/docs/csharp/language-reference/keywords/base.md
+++ b/docs/csharp/language-reference/keywords/base.md
@@ -26,7 +26,7 @@ The base class that is accessed is the base class specified in the class declara
 
 ## Example 1
 
-In this example, both the base class `Person` and the derived class `Employee` have a method named `Getinfo`. By using the `base` keyword, it is possible to call the `Getinfo` method of the base class from within the derived class.
+In this example, both the base class `Person` and the derived class `Employee` have a method named `GetInfo`. By using the `base` keyword, it is possible to call the `GetInfo` method of the base class from within the derived class.
 
 [!code-csharp[csrefKeywordsAccess#1](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsAccess/CS/csrefKeywordsAccess.cs#1)]
 


### PR DESCRIPTION
## Summary

Aligned method names used in documentation with the method names used inside the code snippets.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/base.md](https://github.com/dotnet/docs/blob/22cdac0352a0d37b89e23c89c7ce7e0eebc18f07/docs/csharp/language-reference/keywords/base.md) | [docs/csharp/language-reference/keywords/base](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/base?branch=pr-en-us-34682) |

<!-- PREVIEW-TABLE-END -->