### PR TITLE
- fixes required vs version for dotnet 7.0.200

### DIFF
--- a/docs/core/compatibility/sdk/7.0/vs-msbuild-version.md
+++ b/docs/core/compatibility/sdk/7.0/vs-msbuild-version.md
@@ -18,7 +18,7 @@ The following table shows the minimum version of Visual Studio and MSBuild you n
 | NET SDK version   | Minimum Visual Studio and MSBuild version |
 | ----------------- | ----------------------------------------- |
 | 7.0.100           | 17.4                                      |
-| 7.0.200           | 17.4                                      |
+| 7.0.200           | 17.5                                      |
 
 <sup>1</sup>In addition, scenarios that use a source generator could fail when using a Visual Studio or MSBuild version earlier than version 17.2.
 


### PR DESCRIPTION
## Summary

The required visual studio version for dotnet 7.0.20X was wrong. This PR fixes that.
When looking at [the download page](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) all 200 versions document requiring 17.5 and all 100 17.4.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/sdk/7.0/vs-msbuild-version.md](https://github.com/dotnet/docs/blob/9633ba948f038ad858b7b89e4585c090804e0293/docs/core/compatibility/sdk/7.0/vs-msbuild-version.md) | [docs/core/compatibility/sdk/7.0/vs-msbuild-version](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/7.0/vs-msbuild-version?branch=pr-en-us-34688) |

<!-- PREVIEW-TABLE-END -->