### PR TITLE
Add previews 2 and 3 into the table

### DIFF
--- a/docs/core/porting/versioning-sdk-msbuild-vs.md
+++ b/docs/core/porting/versioning-sdk-msbuild-vs.md
@@ -86,11 +86,11 @@ Major versions of the .NET SDK are typically released within a few days of a Vis
 
 | SDK preview version | Visual Studio version |
 |-|-|
-| 7.0.100 Preview 7 | 17.4 Preview 1 |
-| 7.0.100 RC 1 | 17.4 Preview 2 |
 | 7.0.100 RC 2 | 17.4 Preview 3 |
 | 7.0.100 | 17.4.0 |
 | 8.0.100 Preview 1 | 17.6 Preview 1 |
+| 8.0.100 Preview 2 | 17.6 Preview 2 |
+| 8.0.100 Preview 3 | 17.6 Preview 3 |
 
 ## Reference
 


### PR DESCRIPTION
## Summary

Add the next two previews of .net 8 into the matching VS table.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/porting/versioning-sdk-msbuild-vs.md](https://github.com/dotnet/docs/blob/69c555b39f560c50bc5bd0e2a7d6e9472e66bcbb/docs/core/porting/versioning-sdk-msbuild-vs.md) | [docs/core/porting/versioning-sdk-msbuild-vs](https://review.learn.microsoft.com/en-us/dotnet/core/porting/versioning-sdk-msbuild-vs?branch=pr-en-us-34697) |

<!-- PREVIEW-TABLE-END -->