### PR TITLE
Document DOTNET_WATCH_RESTART_ON_RUDE_EDIT

### DIFF
--- a/docs/core/tools/dotnet-watch.md
+++ b/docs/core/tools/dotnet-watch.md
@@ -146,6 +146,10 @@ As an alternative to disabling response compression, manually add the browser re
 - **`DOTNET_WATCH_SUPPRESS_STATIC_FILE_HANDLING`**
 
   When set to `1` or `true`, `dotnet watch` won't do special handling for static content files. `dotnet watch` sets MSBuild property `DotNetWatchContentFiles` to `false`.
+  
+- **`DOTNET_WATCH_RESTART_ON_RUDE_EDIT`**
+
+  When set to `1` or `true`, `dotnet watch` will always restart on rude edits instead of asking.
 
 ## Files watched by default
 


### PR DESCRIPTION
This PR adds missing documentation for the environment setting `DOTNET_WATCH_RESTART_ON_RUDE_EDIT`.

Fixes #34716

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-watch.md](https://github.com/dotnet/docs/blob/f457f0a4f64fbd039961cda7aa67a2a8099241d6/docs/core/tools/dotnet-watch.md) | [docs/core/tools/dotnet-watch](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-watch?branch=pr-en-us-34715) |

<!-- PREVIEW-TABLE-END -->