### PR TITLE
Clean up the docs to call out that DOTNETHOME is no longer supported

### DIFF
--- a/docs/core/install/windows.md
+++ b/docs/core/install/windows.md
@@ -97,11 +97,7 @@ While Visual Studio Code doesn't come with an automated .NET Core installer like
 
 The [download page](https://dotnet.microsoft.com/download/dotnet) for .NET provides Windows Installer executables.
 
-When you use the Windows installers to install .NET, you can customize the installation path by setting the `DOTNETHOME_X64` and `DOTNETHOME_X86` parameters:
-
-```console
-dotnet-sdk-7.0.100-win-x64.exe DOTNETHOME_X64="F:\dotnet\x64" DOTNETHOME_X86="F:\dotnet\x86"
-```
+With the release of arm64 support in 2021 November releases of .NET 3.1 and newer, custom msi install locations on Windows are no longer allowed and the `DOTNETHOME` environment variables are no longer supported. To install to a custom location, use the [dotnet-install scripts](../tools/dotnet-install-script.md).
 
 If you want to install .NET silently, such as in a production environment or to support continuous integration, use the following switches:
 

--- a/docs/core/install/windows.md
+++ b/docs/core/install/windows.md
@@ -97,7 +97,8 @@ While Visual Studio Code doesn't come with an automated .NET Core installer like
 
 The [download page](https://dotnet.microsoft.com/download/dotnet) for .NET provides Windows Installer executables.
 
-With the release of arm64 support in 2021 November releases of .NET 3.1 and newer, custom msi install locations on Windows are no longer allowed and the `DOTNETHOME` environment variables are no longer supported. To install to a custom location, use the [dotnet-install scripts](../tools/dotnet-install-script.md).
+> [IMPORTANT]
+> Starting in November 2021, you can't change the installation path of .NET with the Windows Installer package. To install .NET to a different path, use the [dotnet-install scripts](../tools/dotnet-install-script.md).
 
 If you want to install .NET silently, such as in a production environment or to support continuous integration, use the following switches:
 


### PR DESCRIPTION
This support was removed when we introduced arm64 support back in 2021. https://github.com/dotnet/core/issues/4819#issuecomment-913057837

@dotnet/compat let me know if ya'll think we'd also need a breaking change doc for it. Not sure what we documented or not back when that change rolled out. CC @ericstj @joeloff



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/windows.md](https://github.com/dotnet/docs/blob/69b8f5d990a5c2678110ae53d86327681f710be3/docs/core/install/windows.md) | [docs/core/install/windows](https://review.learn.microsoft.com/en-us/dotnet/core/install/windows?branch=pr-en-us-34717) |


<!-- PREVIEW-TABLE-END -->