### PR TITLE
Replace links to docs.microsoft.com with learn.microsoft.com

### DIFF
--- a/docs/csharp/asynchronous-programming/snippets/cancel-task-after-period-of-time/Program.cs
+++ b/docs/csharp/asynchronous-programming/snippets/cancel-task-after-period-of-time/Program.cs
@@ -11,25 +11,25 @@ class Program
 
     static readonly IEnumerable<string> s_urlList = new string[]
     {
-            "https://docs.microsoft.com",
-            "https://docs.microsoft.com/aspnet/core",
-            "https://docs.microsoft.com/azure",
-            "https://docs.microsoft.com/azure/devops",
-            "https://docs.microsoft.com/dotnet",
-            "https://docs.microsoft.com/dynamics365",
-            "https://docs.microsoft.com/education",
-            "https://docs.microsoft.com/enterprise-mobility-security",
-            "https://docs.microsoft.com/gaming",
-            "https://docs.microsoft.com/graph",
-            "https://docs.microsoft.com/microsoft-365",
-            "https://docs.microsoft.com/office",
-            "https://docs.microsoft.com/powershell",
-            "https://docs.microsoft.com/sql",
-            "https://docs.microsoft.com/surface",
-            "https://docs.microsoft.com/system-center",
-            "https://docs.microsoft.com/visualstudio",
-            "https://docs.microsoft.com/windows",
-            "https://docs.microsoft.com/xamarin"
+            "https://learn.microsoft.com",
+            "https://learn.microsoft.com/aspnet/core",
+            "https://learn.microsoft.com/azure",
+            "https://learn.microsoft.com/azure/devops",
+            "https://learn.microsoft.com/dotnet",
+            "https://learn.microsoft.com/dynamics365",
+            "https://learn.microsoft.com/education",
+            "https://learn.microsoft.com/enterprise-mobility-security",
+            "https://learn.microsoft.com/gaming",
+            "https://learn.microsoft.com/graph",
+            "https://learn.microsoft.com/microsoft-365",
+            "https://learn.microsoft.com/office",
+            "https://learn.microsoft.com/powershell",
+            "https://learn.microsoft.com/sql",
+            "https://learn.microsoft.com/surface",
+            "https://learn.microsoft.com/system-center",
+            "https://learn.microsoft.com/visualstudio",
+            "https://learn.microsoft.com/windows",
+            "https://learn.microsoft.com/xamarin"
     };
 
     static async Task Main()


### PR DESCRIPTION
I was reading the docs and noticed that some URLs in source code examples still point to docs.microsoft.com. There are more instances like this and I'd be happy to replace them as well, just wanted to check that this is desired first.