### PR TITLE
Add where the method must go

### DIFF
--- a/docs/machine-learning/tutorials/image-classification-api-transfer-learning.md
+++ b/docs/machine-learning/tutorials/image-classification-api-transfer-learning.md
@@ -186,7 +186,7 @@ When training and validation data do not change often, it is good practice to ca
 
 ### Create data loading utility method
 
-The images are stored in two subdirectories. Before loading the data, it needs to be formatted into a list of `ImageData` objects. To do so, create the `LoadImagesFromDirectory` method.
+The images are stored in two subdirectories. Before loading the data, it needs to be formatted into a list of `ImageData` objects. To do so, create the `LoadImagesFromDirectory` method inside the `ImageData` class.
 
 ```csharp
 IEnumerable<ImageData> LoadImagesFromDirectory(string folder, bool useFolderNameAsLabel = true)


### PR DESCRIPTION
## Summary

Mention the method must go in ImageData class. In case someone doesn't understand it's a method of that class


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/machine-learning/tutorials/image-classification-api-transfer-learning.md](https://github.com/dotnet/docs/blob/d3100f28b9b89ccbbcbf9d5b89da8070ae72eef8/docs/machine-learning/tutorials/image-classification-api-transfer-learning.md) | [docs/machine-learning/tutorials/image-classification-api-transfer-learning](https://review.learn.microsoft.com/en-us/dotnet/machine-learning/tutorials/image-classification-api-transfer-learning?branch=pr-en-us-34736) |

<!-- PREVIEW-TABLE-END -->