### PR TITLE
Add object reference for some functions

### DIFF
--- a/docs/machine-learning/tutorials/image-classification-api-transfer-learning.md
+++ b/docs/machine-learning/tutorials/image-classification-api-transfer-learning.md
@@ -189,7 +189,7 @@ When training and validation data do not change often, it is good practice to ca
 The images are stored in two subdirectories. Before loading the data, it needs to be formatted into a list of `ImageData` objects. To do so, create the `LoadImagesFromDirectory` method.
 
 ```csharp
-IEnumerable<ImageData> LoadImagesFromDirectory(string folder, bool useFolderNameAsLabel = true)
+public static IEnumerable<ImageData> LoadImagesFromDirectory(string folder, bool useFolderNameAsLabel = true)
 {
 
 }
@@ -295,7 +295,7 @@ Create a new utility method called `OutputPrediction` to display prediction info
 1. Create a new method called `ClassifySingleImage` to make and output a single image prediction.
 
     ```csharp
-    void ClassifySingleImage(MLContext mlContext, IDataView data, ITransformer trainedModel)
+    public static void ClassifySingleImage(MLContext mlContext, IDataView data, ITransformer trainedModel)
     {
 
     }
@@ -326,7 +326,7 @@ Create a new utility method called `OutputPrediction` to display prediction info
 1. Add a new method called `ClassifyImages` below the `ClassifySingleImage` method to make and output multiple image predictions.
 
     ```csharp
-    void ClassifyImages(MLContext mlContext, IDataView data, ITransformer trainedModel)
+    public static void ClassifyImages(MLContext mlContext, IDataView data, ITransformer trainedModel)
     {
 
     }


### PR DESCRIPTION
## Summary
Add public static for methods.
Without the public static, would get an error that requires the object reference. Also the proposed changes are already on the official sample in GitHub: https://github.com/dotnet/machinelearning-samples/blob/main/samples/csharp/getting-started/DeepLearning_ImageClassification_Binary/DeepLearning_ImageClassification/Program.cs


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/machine-learning/tutorials/image-classification-api-transfer-learning.md](https://github.com/dotnet/docs/blob/8a7076924f7d06542df47d8998dc041d3e9ba779/docs/machine-learning/tutorials/image-classification-api-transfer-learning.md) | [docs/machine-learning/tutorials/image-classification-api-transfer-learning](https://review.learn.microsoft.com/en-us/dotnet/machine-learning/tutorials/image-classification-api-transfer-learning?branch=pr-en-us-34746) |

<!-- PREVIEW-TABLE-END -->