### PR TITLE
Remove misleading reference

### DIFF
--- a/docs/csharp/fundamentals/exceptions/exception-handling.md
+++ b/docs/csharp/fundamentals/exceptions/exception-handling.md
@@ -49,7 +49,7 @@ The `LogException` method always returns `false`, no `catch` clause using this e
 
 A `finally` block enables you to clean up actions that are performed in a `try` block. If present, the `finally` block executes last, after the `try` block and any matched `catch` block. A `finally` block always runs, whether an exception is thrown or a `catch` block matching the exception type is found.
 
-The `finally` block can be used to release resources such as file streams, database connections, and graphics handles without waiting for the garbage collector in the runtime to finalize the objects. For more information, see the [using statement](../../language-reference/statements/using.md).
+The `finally` block can be used to release resources such as file streams, database connections, and graphics handles without waiting for the garbage collector in the runtime to finalize the objects.
 
 In the following example, the `finally` block is used to close a file that is opened in the `try` block. Notice that the state of the file handle is checked before the file is closed. If the `try` block can't open the file, the file handle still has the value `null` and the `finally` block doesn't try to close it. Instead, if the file is opened successfully in the `try` block, the `finally` block closes the open file.
 


### PR DESCRIPTION
The linked article about `using` statement doesn't provide more information about the matter mentioned in the first sentence. Instead, should the article recommend the use of `using` statement instead of `try-finally` if the resource is disposable?


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/fundamentals/exceptions/exception-handling.md](https://github.com/dotnet/docs/blob/64ed3fc7b46ea4930782c7ab35e2cf60d9929d7e/docs/csharp/fundamentals/exceptions/exception-handling.md) | [docs/csharp/fundamentals/exceptions/exception-handling](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/exceptions/exception-handling?branch=pr-en-us-34762) |

<!-- PREVIEW-TABLE-END -->