### PR TITLE
use the oauth keys in sequester

### DIFF
--- a/.github/workflows/quest-bulk.yml
+++ b/.github/workflows/quest-bulk.yml
@@ -28,6 +28,9 @@ jobs:
           ImportOptions__ApiKeys__GitHubToken: ${{ secrets.GITHUB_TOKEN }}
           ImportOptions__ApiKeys__OSPOKey: ${{ secrets.OSPO_KEY }}
           ImportOptions__ApiKeys__QuestKey: ${{ secrets.QUEST_KEY }}
+          ImportOptions__ApiKeys__SequesterPrivateKey: ${{ secrets.SEQUESTER_PRIVATEKEY }}
+          ImportOptions__ApiKeys__SequesterAppID: ${{ secrets.SEQUESTER_SEQUESTER_APPID }}
+          
         with:
           org: ${{ github.repository_owner }}
           repo: ${{ github.repository }}


### PR DESCRIPTION
Update the ApiKeys to use the new org-level oauth keys.
