### PR TITLE
Fix sample code

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs1612.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1612.md
@@ -15,14 +15,14 @@ Cannot modify the return value of 'expression' because it is not a variable
  An attempt was made to modify a value type that is produced as the result of an intermediate expression but is not stored in a variable. This error can occur when you attempt to directly modify a struct in a generic collection, as shown in the following example:  
   
 ```csharp  
-List<myStruct> list = {…};  
+List<MyStruct> list = {…};  
 list[0].Name = "MyStruct42"; //CS1612  
 ```  
   
  To modify the struct, first assign it to a local variable, modify the variable, then assign the variable back to the item in the collection.  
   
 ```csharp  
-List<myStruct> list = {…};  
+List<MyStruct> list = {…};  
 MyStruct ms = list[0];  
 ms.Name = "MyStruct42";  
 list[0] = ms;  


### PR DESCRIPTION
The capitalisation of the sample code was non-idiomatic, and self-inconsistent.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-messages/cs1612.md](https://github.com/dotnet/docs/blob/ff75150675b78463227a65253159146d0182651f/docs/csharp/language-reference/compiler-messages/cs1612.md) | [docs/csharp/language-reference/compiler-messages/cs1612](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs1612?branch=pr-en-us-34773) |

<!-- PREVIEW-TABLE-END -->