### PR TITLE
fixed minor spelling error

### DIFF
--- a/docs/csharp/linq/index.md
+++ b/docs/csharp/linq/index.md
@@ -9,7 +9,7 @@ ms.assetid: 007cc736-f5cf-4919-b99b-0c00ab2814ce
 
 Language-Integrated Query (LINQ) is the name for a set of technologies based on the integration of query capabilities directly into the C# language. Traditionally, queries against data are expressed as simple strings without type checking at compile time or IntelliSense support. Furthermore, you have to learn a different query language for each type of data source: SQL databases, XML documents, various Web services, and so on. With LINQ, a query is a first-class language construct, just like classes, methods, events.
 
-For a developer who writes queries, the most visible "language-integrated" part of LINQ is the query expression. Query expressions are written in a declarative *query syntax*. By using query syntax, you can perform filtering, ordering, and grouping operations on data sources with a minimum of code. You use the same basic query expression patterns to query and transform data in SQL databases, ADO .NET Datasets, XML documents and streams, and .NET collections.
+For a developer who writes queries, the most visible "language-integrated" part of LINQ is the query expression. Query expressions are written in a declarative *query syntax*. By using query syntax, you can perform filtering, ordering, and grouping operations on data sources with a minimum of code. You use the same basic query expression patterns to query and transform data in SQL databases, ADO.NET Datasets, XML documents and streams, and .NET collections.
 
 The following example shows the complete query operation. The complete operation includes creating a data source, defining the query expression, and executing the query in a `foreach` statement.
 


### PR DESCRIPTION
removed space from "ADO .NET"

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/linq/index.md](https://github.com/dotnet/docs/blob/3598ee86df74e2313aba64187a80e747e500fddb/docs/csharp/linq/index.md) | [docs/csharp/linq/index](https://review.learn.microsoft.com/en-us/dotnet/csharp/linq/index?branch=pr-en-us-34825) |

<!-- PREVIEW-TABLE-END -->