### PR TITLE
Update int and long sizes

### DIFF
--- a/docs/csharp/advanced-topics/reflection-and-attributes/how-to-create-a-c-cpp-union-by-using-attributes.md
+++ b/docs/csharp/advanced-topics/reflection-and-attributes/how-to-create-a-c-cpp-union-by-using-attributes.md
@@ -16,7 +16,7 @@ The following code is another example where fields start at different explicitly
 
 :::code language="csharp" source="./snippets/conceptual/CStyleUnion.cs" id="ExplicitLayout":::
 
-The two integer fields, `i1` and `i2` combined, share the same memory locations as `lg`. Either `lg` uses the first 4 bytes, or `i1` uses the first 2 bytes and `i2` uses the next 2 bytes. This sort of control over struct layout is useful when using platform invocation.
+The two integer fields, `i1` and `i2` combined, share the same memory locations as `lg`. Either `lg` uses the first 8 bytes, or `i1` uses the first 4 bytes and `i2` uses the next 4 bytes. This sort of control over struct layout is useful when using platform invocation.
 
 ## See also
 


### PR DESCRIPTION
They were incorrectly specified earlier.

Fixes #34827


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/advanced-topics/reflection-and-attributes/how-to-create-a-c-cpp-union-by-using-attributes.md](https://github.com/dotnet/docs/blob/57361cd2a44ceba2911d3619abbbe033c1afcdec/docs/csharp/advanced-topics/reflection-and-attributes/how-to-create-a-c-cpp-union-by-using-attributes.md) | [docs/csharp/advanced-topics/reflection-and-attributes/how-to-create-a-c-cpp-union-by-using-attributes](https://review.learn.microsoft.com/en-us/dotnet/csharp/advanced-topics/reflection-and-attributes/how-to-create-a-c-cpp-union-by-using-attributes?branch=pr-en-us-34833) |

<!-- PREVIEW-TABLE-END -->