### PR TITLE
Add link to the list of available run-time objects

### DIFF
--- a/docs/visual-basic/programming-guide/program-structure/me-my-mybase-and-myclass.md
+++ b/docs/visual-basic/programming-guide/program-structure/me-my-mybase-and-myclass.md
@@ -48,7 +48,7 @@ ChangeFormColor(Me)
   
 ## My  
 
- The `My` feature provides easy and intuitive access to a number of .NET Framework classes, enabling the Visual Basic user to interact with the computer, application, settings, resources, and so on.  
+ The `My` feature provides easy and intuitive access to a number of .NET Framework classes, enabling the Visual Basic user to interact with the computer, application, settings, resources, and so on. For a list of these classes, see the [Visual Basic Run-time Objects](../../language-reference/objects/#visual-basic-run-time-objects) reference.  
   
 ## MyBase  
 

--- a/docs/visual-basic/programming-guide/program-structure/me-my-mybase-and-myclass.md
+++ b/docs/visual-basic/programming-guide/program-structure/me-my-mybase-and-myclass.md
@@ -48,7 +48,7 @@ ChangeFormColor(Me)
   
 ## My  
 
- The `My` feature provides easy and intuitive access to a number of .NET Framework classes, enabling the Visual Basic user to interact with the computer, application, settings, resources, and so on. For a list of these classes, see the [Visual Basic Run-time Objects](../../language-reference/objects/#visual-basic-run-time-objects) reference.  
+ The `My` feature provides easy and intuitive access to a number of .NET Framework classes, enabling the Visual Basic user to interact with the computer, application, settings, resources, and so on. For a list of these classes, see the [Visual Basic Run-time Objects](../../language-reference/objects/index.md#visual-basic-run-time-objects) reference.  
   
 ## MyBase  
 


### PR DESCRIPTION
## Summary

That list contains (amongst others) all links to My.Xyz such as My.Computer, My.Application, etc.

Fixes #34734


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/visual-basic/programming-guide/program-structure/me-my-mybase-and-myclass.md](https://github.com/dotnet/docs/blob/fe686ffd7a57d1eb7f9ec18eea4dc05866fb237d/docs/visual-basic/programming-guide/program-structure/me-my-mybase-and-myclass.md) | [docs/visual-basic/programming-guide/program-structure/me-my-mybase-and-myclass](https://review.learn.microsoft.com/en-us/dotnet/visual-basic/programming-guide/program-structure/me-my-mybase-and-myclass?branch=pr-en-us-34854) |

<!-- PREVIEW-TABLE-END -->