### PR TITLE
Fix broken in-document link for interpolated strings

### DIFF
--- a/docs/csharp/whats-new/tutorials/interpolated-string-handler.md
+++ b/docs/csharp/whats-new/tutorials/interpolated-string-handler.md
@@ -22,7 +22,7 @@ This tutorial assumes you're familiar with C# and .NET, including either Visual 
 
 ## New outline
 
-C# 10 adds support for a custom [*interpolated string handler*](~/_csharplang/proposals/csharp-10.0/improved-interpolated-strings.md#the-handler-pattern). An interpolated string handler is a type that processes the placeholder expression in an interpolated string. Without a custom handler, placeholders are processed similar to <xref:System.String.Format%2A?displayProperty=nameWithType>. Each placeholder is formatted as text, and then the components are concatenated to form the resulting string.
+C# 10 adds support for a custom [*interpolated string handler*](#implement-the-handler-pattern). An interpolated string handler is a type that processes the placeholder expression in an interpolated string. Without a custom handler, placeholders are processed similar to <xref:System.String.Format%2A?displayProperty=nameWithType>. Each placeholder is formatted as text, and then the components are concatenated to form the resulting string.
 
 You can write a handler for any scenario where you use information about the resulting string. Will it be used? What constraints are on the format? Some examples include:
 


### PR DESCRIPTION
## Summary

Fixes a broken in-document link to a part explaining custom interpolation handlers.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/whats-new/tutorials/interpolated-string-handler.md](https://github.com/dotnet/docs/blob/8b3a68f76fc59d98ada9d374c1506ffb4de75176/docs/csharp/whats-new/tutorials/interpolated-string-handler.md) | [docs/csharp/whats-new/tutorials/interpolated-string-handler](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/tutorials/interpolated-string-handler?branch=pr-en-us-34870) |

<!-- PREVIEW-TABLE-END -->