### PR TITLE
Add reference docs for preview features

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -15,7 +15,7 @@ on:
         default: "Manual run"
 
 env:
-  DOTNET_INSTALLER_CHANNEL: "7.0"
+  DOTNET_INSTALLER_CHANNEL: "8.0"
   DOTNET_DO_INSTALL: "true" # True to install preview versions, False to use the pre-installed (released) SDK
   EnableNuGetPackageRestore: "True"
   repo: "docs"

--- a/.openpublishing.redirection.csharp.json
+++ b/.openpublishing.redirection.csharp.json
@@ -3151,7 +3151,7 @@
         },
         {
             "source_path_from_root": "/docs/csharp/whats-new/index.md",
-            "redirect_url": "/dotnet/csharp/whats-new/csharp-11",
+            "redirect_url": "/dotnet/csharp/whats-new/csharp-12",
             "ms.custom": "updateeachrelease"
         },
         {

--- a/docfx.json
+++ b/docfx.json
@@ -512,7 +512,8 @@
                 "_csharplang/proposals/csharp-9.0/*.md": "07/29/2020",
                 "_csharplang/proposals/csharp-10.0/*.md": "08/07/2021",
                 "_csharplang/proposals/csharp-11.0/*.md": "09/30/2022",
-                "_roslyn/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md": "09/30/2022",
+                "_csharplang/proposals/*.md": "04/03/2023",
+                "_roslyn/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md": "11/08/2022",
                 "_vblang/spec/*.md": "07/21/2017"
             },
             "ms.technology": {
@@ -716,6 +717,9 @@
                 "_csharplang/proposals/csharp-11.0/static-abstracts-in-interfaces.md": "Static abstract methods in interfaces",
                 "_csharplang/proposals/csharp-11.0/unsigned-right-shift-operator.md": "Unsigned right shift operator",
                 "_csharplang/proposals/csharp-11.0/utf8-string-literals.md": "UTF-8 string literals",
+
+                "_csharplang/proposals/primary-constructors.md": "Primary constructors",
+
                 "_roslyn/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md": "C# compiler breaking changes since C# 10",
                 "_vblang/spec/introduction.md": "Introduction",
                 "_vblang/spec/lexical-grammar.md": "Lexical grammar",
@@ -828,6 +832,9 @@
                 "_csharplang/proposals/csharp-11.0/static-abstracts-in-interfaces.md": "This feature enables an interface to define static members. This enables interfaces to define operators that must be provided by implementing types.",
                 "_csharplang/proposals/csharp-11.0/unsigned-right-shift-operator.md": "This feature defines a logical right-shift operator, `>>>`. The logical right shift operator always shifts in 0 values in the left-most bits during a shift.",
                 "_csharplang/proposals/csharp-11.0/utf8-string-literals.md": "This feature enables the `u8` suffix on a string literal. The `u8` suffix instructs the compiler to convert the UTF-8 string literal to a `ReadOnlySpan<byte>`.",
+
+                "_csharplang/proposals/primary-constructors.md": "Primary constructors put the parameters of one constructor in scope for the whole class or struct to be used for initialization or directly as object state. The trade-off is that any other constructors must call through the primary constructor.",
+
                 "_roslyn/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md": "Learn about any breaking changes since the initial release of C# 10",
                 "_vblang/spec/introduction.md": "This chapter provides and introduction to the Visual Basic language.",
                 "_vblang/spec/lexical-grammar.md": "This chapter defines the lexical grammar for Visual Basic.",
@@ -853,6 +860,7 @@
                 "_csharplang/proposals/csharp-9.0/*.md": "C# 9.0 draft feature specifications",
                 "_csharplang/proposals/csharp-10.0/*.md": "C# 10.0 draft feature specifications",
                 "_csharplang/proposals/csharp-11.0/*.md": "C# 11.0 draft feature specifications",
+                "_csharplang/proposals/*.md": "C# preview feature specifications",
                 "docs/framework/**/**.md": ".NET Framework",
                 "docs/framework/data/adonet/**/**.md": "ADO.NET",
                 "docs/framework/wcf/**/**.md": "WCF",

--- a/docfx.json
+++ b/docfx.json
@@ -55,7 +55,9 @@
                     "csharp-9.0/*.md",
                     "csharp-10.0/*.md",
                     "csharp-11.0/*.md",
-                    "primary-constructors.md"
+                    "primary-constructors.md",
+                    "using-alias-types.md",
+                    "lambda-method-group-defaults.md"
                 ],
                 "src": "_csharplang/proposals",
                 "dest": "csharp/language-reference/proposals",
@@ -720,6 +722,8 @@
                 "_csharplang/proposals/csharp-11.0/utf8-string-literals.md": "UTF-8 string literals",
 
                 "_csharplang/proposals/primary-constructors.md": "Primary constructors",
+                "_csharplang/proposals/using-alias-types.md": "Alias any type",
+                "_csharplang/proposals/lambda-method-group-defaults.md": "Optional and parameter array parameters for lambdas and method groups",
 
                 "_roslyn/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md": "C# compiler breaking changes since C# 10",
                 "_vblang/spec/introduction.md": "Introduction",
@@ -835,6 +839,8 @@
                 "_csharplang/proposals/csharp-11.0/utf8-string-literals.md": "This feature enables the `u8` suffix on a string literal. The `u8` suffix instructs the compiler to convert the UTF-8 string literal to a `ReadOnlySpan<byte>`.",
 
                 "_csharplang/proposals/primary-constructors.md": "Primary constructors put the parameters of one constructor in scope for the whole class or struct to be used for initialization or directly as object state. The trade-off is that any other constructors must call through the primary constructor.",
+                "_csharplang/proposals/using-alias-types.md": "Using directives can alias any type, not just named types. You can create aliases for tuple types, generics and more.",
+                "_csharplang/proposals/lambda-method-group-defaults.md": "Lambda expressions can now declare default parameters and params arrays parameters.",
 
                 "_roslyn/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md": "Learn about any breaking changes since the initial release of C# 10",
                 "_vblang/spec/introduction.md": "This chapter provides and introduction to the Visual Basic language.",

--- a/docfx.json
+++ b/docfx.json
@@ -54,7 +54,8 @@
                     "csharp-8.0/*.md",
                     "csharp-9.0/*.md",
                     "csharp-10.0/*.md",
-                    "csharp-11.0/*.md"
+                    "csharp-11.0/*.md",
+                    "primary-constructors.md"
                 ],
                 "src": "_csharplang/proposals",
                 "dest": "csharp/language-reference/proposals",

--- a/docs/breadcrumb/toc.yml
+++ b/docs/breadcrumb/toc.yml
@@ -385,33 +385,9 @@ items:
                   - name: C# 7.0 draft specification
                     tocHref: /dotnet/csharp/language-reference/language-specification/
                     topicHref: /dotnet/csharp/language-reference/language-specification/index
-                  - name: C# 7.0 feature specifications
-                    tocHref: /dotnet/csharp/language-reference/proposals/csharp-7.0/
-                    topicHref: /dotnet/csharp/language-reference/proposals/csharp-7.0/index
-                  - name: C# 7.1 feature specifications
-                    tocHref: /dotnet/csharp/language-reference/proposals/csharp-7.1/
-                    topicHref: /dotnet/csharp/language-reference/proposals/csharp-7.1/infer-tuple-names
-                  - name: C# 7.2 feature specifications
-                    tocHref: /dotnet/csharp/language-reference/proposals/csharp-7.2/
-                    topicHref: /dotnet/csharp/language-reference/proposals/csharp-7.2/index
-                  - name: C# 7.3 feature specifications
-                    tocHref: /dotnet/csharp/language-reference/proposals/csharp-7.3/
-                    topicHref: /dotnet/csharp/language-reference/proposals/csharp-7.3/index
-                  - name: C# 8.0 feature specifications
-                    tocHref: /dotnet/csharp/language-reference/proposals/csharp-8.0/
-                    topicHref: /dotnet/csharp/language-reference/proposals/csharp-8.0/index
-                  - name: C# 9.0 feature specifications
-                    tocHref: /dotnet/csharp/language-reference/proposals/csharp-9.0/
-                    topicHref: /dotnet/csharp/language-reference/proposals/csharp-9.0/index
-                  - name: C# 10 feature specifications
-                    tocHref: /dotnet/csharp/language-reference/proposals/csharp-10.0/
-                    topicHref: /dotnet/csharp/language-reference/proposals/csharp-10.0/index
-                  - name: C# 11 feature specifications
-                    tocHref: /dotnet/csharp/language-reference/proposals/csharp-11.0/
-                    topicHref: /dotnet/csharp/language-reference/proposals/csharp-11.0/index
-                  - name: C# preview feature specifications
+                  - name: C# feature specifications
                     tocHref: /dotnet/csharp/language-reference/proposals
-                    topicHref: /dotnet/csharp/language-reference/proposals/primary-constructors
+                    topicHref: /dotnet/csharp/language-reference/proposals/csharp-11.0/index
           - name: F# guide
             tocHref: /dotnet/fsharp/
             topicHref: /dotnet/fsharp/index

--- a/docs/breadcrumb/toc.yml
+++ b/docs/breadcrumb/toc.yml
@@ -409,6 +409,9 @@ items:
                   - name: C# 11 feature specifications
                     tocHref: /dotnet/csharp/language-reference/proposals/csharp-11.0/
                     topicHref: /dotnet/csharp/language-reference/proposals/csharp-11.0/index
+                  - name: C# preview feature specifications
+                    tocHref: /dotnet/csharp/language-reference/proposals
+                    topicHref: /dotnet/csharp/language-reference/proposals/primary-constructors
           - name: F# guide
             tocHref: /dotnet/fsharp/
             topicHref: /dotnet/fsharp/index

--- a/docs/breadcrumb/toc.yml
+++ b/docs/breadcrumb/toc.yml
@@ -409,9 +409,6 @@ items:
                   - name: C# 11 feature specifications
                     tocHref: /dotnet/csharp/language-reference/proposals/csharp-11.0/
                     topicHref: /dotnet/csharp/language-reference/proposals/csharp-11.0/index
-                  - name: C# preview feature specifications
-                    tocHref: /dotnet/csharp/language-reference/proposals
-                    topicHref: /dotnet/csharp/language-reference/proposals/primary-constructors
           - name: F# guide
             tocHref: /dotnet/fsharp/
             topicHref: /dotnet/fsharp/index

--- a/docs/csharp/index.yml
+++ b/docs/csharp/index.yml
@@ -7,7 +7,7 @@ metadata:
   title: "C# docs - get started, tutorials, reference."
   description: "Learn C# programming - for beginning developers, developers new to C#, and experienced C# / .NET developers"
   ms.topic: landing-page # Required
-  ms.date: 11/19/2019
+  ms.date: 04/05/2023
 
 landingContent:
   - title: "Learn to program in C#"
@@ -114,14 +114,14 @@ landingContent:
     linkLists:
       - linkListType: whats-new
         links:
+          - text: "What's new in C# 12"
+            url: whats-new/csharp-12.md
           - text: "What's new in C# 11"
             url: whats-new/csharp-11.md
           - text: "What's new in C# 10"
             url: whats-new/csharp-10.md
           - text: "What's new in C# 9.0"
             url: whats-new/csharp-9.md
-          - text: "What's new in C# 8.0"
-            url: whats-new/csharp-8.md
       - linkListType: tutorial
         links:
           - text: Explore record types

--- a/docs/csharp/language-reference/builtin-types/record.md
+++ b/docs/csharp/language-reference/builtin-types/record.md
@@ -78,7 +78,7 @@ A record type doesn't have to declare any positional properties. You can declare
 
 If you define properties by using standard property syntax but omit the access modifier, the properties are implicitly `private`.
 
-Beginning with C# 12, you can declare primary constructors in classes and structs, as well as records. The only difference is that positional parameters in records generate properties. Positional parameters in classes and structs don't. You can learn more in the article on [constructors](../../programming-guide/classes-and-structs/constructors.md).
+Beginning with C# 12, you can declare primary constructors in classes and structs, as well as records. The only difference is that positional parameters in records generate properties. Positional parameters in classes and structs don't. You can learn more in the article on [constructors](../../programming-guide/classes-and-structs/instance-constructors.md).
 
 ## Immutability
 

--- a/docs/csharp/language-reference/builtin-types/record.md
+++ b/docs/csharp/language-reference/builtin-types/record.md
@@ -1,7 +1,7 @@
 ---
 title: "Records - C# reference"
 description: Learn about the record type in C#
-ms.date: 07/23/2022
+ms.date: 04/05/2023
 f1_keywords: 
   - "record_CSharpKeyword"
 helpviewer_keywords: 
@@ -77,7 +77,8 @@ A record type doesn't have to declare any positional properties. You can declare
 :::code language="csharp" source="snippets/shared/RecordType.cs" id="MixedSyntax":::
 
 If you define properties by using standard property syntax but omit the access modifier, the properties are implicitly `private`.
-<!-- Todo -- Explain issues surrounding use of attributes on positional properties. -->
+
+Beginning with C# 12, you can declare primary constructors in classes and structs, as well as records. The only difference is that positional parameters in records generate properties. Positional parameters in classes and structs don't. You can learn more in the article on [constructors](../../programming-guide/classes-and-structs/constructors.md).
 
 ## Immutability
 

--- a/docs/csharp/language-reference/builtin-types/struct.md
+++ b/docs/csharp/language-reference/builtin-types/struct.md
@@ -1,14 +1,13 @@
 ---
 title: "Structure types - C# reference"
 description: Learn about the struct type in C#
-ms.date: 09/15/2022
+ms.date: 04/05/2023
 f1_keywords: 
   - "struct_CSharpKeyword"
 helpviewer_keywords: 
   - "struct keyword [C#]"
   - "struct type [C#]"
   - "structure type [C#]"
-ms.assetid: ff3dd9b7-dc93-4720-8855-ef5558f65c7c
 ---
 # Structure types (C# reference)
 
@@ -108,6 +107,8 @@ Beginning with C# 11, if you don't initialize all fields in a struct, the compil
 :::code language="csharp" source="snippets/shared/StructType.cs" id="FieldInitializer":::
 
 Every `struct` has a `public` parameterless constructor. If you write a parameterless constructor, it must be public. If a struct declares any field initializers, it must explicitly declare a constructor. That constructor need not be parameterless. If a struct declares a field initializer but no constructors, the compiler reports an error. Any explicitly declared constructor (with parameters, or parameterless) executes all field initializers for that struct. All fields without a field initializer or an assignment in a constructor are set to the [default value](default-values.md). For more information, see the [Parameterless struct constructors](~/_csharplang/proposals/csharp-10.0/parameterless-struct-constructors.md) feature proposal note.
+
+Beginning with C# 12, `struct` types can define a [primary constructor](../../programming-guide/classes-and-structs/constructors.md#primary-constructors) as part of its declaration. This provides a concise syntax for constructor parameters that can be used throughout the `struct` body, in any member declaration for that struct.
 
 If all instance fields of a structure type are accessible, you can also instantiate it without the `new` operator. In that case you must initialize all instance fields before the first use of the instance. The following example shows how to do that:
 

--- a/docs/csharp/language-reference/builtin-types/struct.md
+++ b/docs/csharp/language-reference/builtin-types/struct.md
@@ -108,7 +108,7 @@ Beginning with C# 11, if you don't initialize all fields in a struct, the compil
 
 Every `struct` has a `public` parameterless constructor. If you write a parameterless constructor, it must be public. If a struct declares any field initializers, it must explicitly declare a constructor. That constructor need not be parameterless. If a struct declares a field initializer but no constructors, the compiler reports an error. Any explicitly declared constructor (with parameters, or parameterless) executes all field initializers for that struct. All fields without a field initializer or an assignment in a constructor are set to the [default value](default-values.md). For more information, see the [Parameterless struct constructors](~/_csharplang/proposals/csharp-10.0/parameterless-struct-constructors.md) feature proposal note.
 
-Beginning with C# 12, `struct` types can define a [primary constructor](../../programming-guide/classes-and-structs/constructors.md#primary-constructors) as part of its declaration. This provides a concise syntax for constructor parameters that can be used throughout the `struct` body, in any member declaration for that struct.
+Beginning with C# 12, `struct` types can define a [primary constructor](../../programming-guide/classes-and-structs/instance-constructors.md#primary-constructors) as part of its declaration. This provides a concise syntax for constructor parameters that can be used throughout the `struct` body, in any member declaration for that struct.
 
 If all instance fields of a structure type are accessible, you can also instantiate it without the `new` operator. In that case you must initialize all instance fields before the first use of the instance. The following example shows how to do that:
 

--- a/docs/csharp/language-reference/keywords/using-directive.md
+++ b/docs/csharp/language-reference/keywords/using-directive.md
@@ -158,7 +158,7 @@ The following example shows how to define a `using` directive and a `using` alia
 
 :::code language="csharp" source="./snippets/csrefKeywordsNamespace2.cs" id="Snippet9":::
 
-Beginning with C# 12, you can create aliases for types that were previously restricted, including tuple types, pointer types, and other unsafe types. For more information on the udpated rules, see the [feature spec](~/csharplang/proposals/using-alias-types.md).
+Beginning with C# 12, you can create aliases for types that were previously restricted, including tuple types, pointer types, and other unsafe types. For more information on the udpated rules, see the [feature spec](~/_csharplang/proposals/using-alias-types.md).
 
 ## How to use the Visual Basic `My` namespace
 

--- a/docs/csharp/language-reference/keywords/using-directive.md
+++ b/docs/csharp/language-reference/keywords/using-directive.md
@@ -158,6 +158,8 @@ The following example shows how to define a `using` directive and a `using` alia
 
 :::code language="csharp" source="./snippets/csrefKeywordsNamespace2.cs" id="Snippet9":::
 
+Beginning with C# 12, you can create aliases for types that were previously restricted, including tuple types, pointer types, and other unsafe types. For more information on the udpated rules, see the [feature spec](~/csharplang/proposals/using-alias-types.md).
+
 ## How to use the Visual Basic `My` namespace
 
 The <xref:Microsoft.VisualBasic.MyServices> namespace (`My` in Visual Basic) provides easy and intuitive access to a number of .NET classes, enabling you to write code that interacts with the computer, application, settings, resources, and so on. Although originally designed for use with Visual Basic, the `MyServices` namespace can be used in C# applications.

--- a/docs/csharp/language-reference/operators/lambda-expressions.md
+++ b/docs/csharp/language-reference/operators/lambda-expressions.md
@@ -49,7 +49,7 @@ A lambda expression with an expression on the right side of the `=>` operator is
 (input-parameters) => expression
 ```
 
-The body of an expression lambda can consist of a method call. However, if you're creating [expression trees](../../advanced-topics/expression-trees/index.md) that are evaluated outside the context of the .NET Common Language Runtime (CLR), such as in SQL Server, you shouldn't use method calls in lambda expressions. The methods will have no meaning outside the context of the .NET Common Language Runtime (CLR).
+The body of an expression lambda can consist of a method call. However, if you're creating [expression trees](../../advanced-topics/expression-trees/index.md) that are evaluated outside the context of the .NET Common Language Runtime (CLR), such as in SQL Server, you shouldn't use method calls in lambda expressions. The methods have no meaning outside the context of the .NET Common Language Runtime (CLR).
 
 ## Statement lambdas
 
@@ -93,6 +93,24 @@ Lambda discard parameters may be useful when you use a lambda expression to [pro
 
 > [!NOTE]
 > For backwards compatibility, if only a single input parameter is named `_`, then, within a lambda expression, `_` is treated as the name of that parameter.
+
+Beginning with C# 12, you can provide *default values* for parameters on lambda expressions. The syntax and the restrictions on default parameter values are the same as for methods and local functions. The following example declares a lambda expression with a default parameter, then calls it once using the default and once with two explicit parameters:
+
+:::code language="csharp" source="snippets/lambda-expressions/GeneralExamples.cs" id="SnippetDefaultParameters":::
+
+You can also declare lambda expressions with `params` arrays as parameters:
+
+:::code language="csharp" source="snippets/lambda-expressions/GeneralExamples.cs" id="SnippetParamsArray":::
+
+As part of these updates, when a method group that has a default parameter is assigned to a lambda expression, that lambda expression also has the same default parameter. A method group with a `params` array parameter can also be assigned to a lambda expression.
+
+Lambda expressions with default parameters or `params` arrays as parameters don't have natural types that correspond to `Func<>` or `Action<>` types. However, you can define delegate types that include default parameter values:
+
+:::code language="csharp" source="snippets/lambda-expressions/GeneralExamples.cs" id="DelegateDeclarations":::
+
+Or, you can use implicitly typed variables with `var` declarations to define the delegate type. The compile synthesizes the correct delegate type.
+
+For more information on see the feature spec for [default parameters on lambda expressions](~/_csharplang/proposals/lambda-method-group-defaults.md).
 
 ## Async lambdas
 

--- a/docs/csharp/language-reference/operators/snippets/lambda-expressions/GeneralExamples.cs
+++ b/docs/csharp/language-reference/operators/snippets/lambda-expressions/GeneralExamples.cs
@@ -52,7 +52,14 @@ namespace lambda_expressions
             // </SnippetDefaultParameters>
 
             // <SnippetParamsArray>
-            var sum = (params int[] values) => { int sum = 0; foreach (var value in values) sum += value; return sum; };
+            var sum = (params int[] values) =>
+            {
+                int sum = 0;
+                foreach (var value in values) 
+                    sum += value;
+                
+                return sum;
+            };
 
             var empty = sum();
             Console.WriteLine(empty); // 0

--- a/docs/csharp/language-reference/operators/snippets/lambda-expressions/GeneralExamples.cs
+++ b/docs/csharp/language-reference/operators/snippets/lambda-expressions/GeneralExamples.cs
@@ -41,5 +41,32 @@ namespace lambda_expressions
             Func<double, double> square = static x => x * x;
             // </SnippetStatic>
         }
+
+        public static void DefaultParmExamples()
+        {
+            // <SnippetDefaultParameters>
+            var IncrementBy = (int source, int increment = 1) => source + increment;
+
+            Console.WriteLine(IncrementBy(5)); // 6
+            Console.WriteLine(IncrementBy(5, 2)); // 7
+            // </SnippetDefaultParameters>
+
+            // <SnippetParamsArray>
+            var sum = (params int[] values) => { int sum = 0; foreach (var value in values) sum += value; return sum; };
+
+            var empty = sum();
+            Console.WriteLine(empty); // 0
+
+            var sequence = new[] { 1, 2, 3, 4, 5 };
+            var total = sum(sequence);
+            Console.WriteLine(total); // 15
+            // </SnippetParamsArray>
+        }
+
+        // <DelegateDeclarations>
+        delegate int IncrementByDelegate(int source, int increment = 1);
+        delegate int SumDelegate(params int[] values);
+        // </DelegateDeclarations>
+
     }
 }

--- a/docs/csharp/language-reference/operators/snippets/lambda-expressions/Program.cs
+++ b/docs/csharp/language-reference/operators/snippets/lambda-expressions/Program.cs
@@ -11,6 +11,7 @@ namespace lambda_expressions
             LambdasAndTuples.Examples();
             LambdasWithQueryMethods.Examples();
             VariableScopeWithLambdas.Main();
+            GeneralExamples.DefaultParmExamples();
         }
     }
 }

--- a/docs/csharp/language-reference/operators/snippets/lambda-expressions/lambda-expressions.csproj
+++ b/docs/csharp/language-reference/operators/snippets/lambda-expressions/lambda-expressions.csproj
@@ -2,9 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>preview</LangVersion>
     <RootNamespace>lambda_expressions</RootNamespace>
     <StartupObject>lambda_expressions.Program</StartupObject>
   </PropertyGroup>

--- a/docs/csharp/programming-guide/classes-and-structs/constructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/constructors.md
@@ -52,7 +52,6 @@ For more information and examples, see [Static Constructors](./static-constructo
 
 - [Using constructors](./using-constructors.md)
 - [Instance constructors](./instance-constructors.md)
-- [Primary constructors](./primary-constructors.md)
 - [Private constructors](./private-constructors.md)
 - [Static constructors](./static-constructors.md)
 - [How to write a copy constructor](./how-to-write-a-copy-constructor.md)

--- a/docs/csharp/programming-guide/classes-and-structs/constructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/constructors.md
@@ -1,7 +1,7 @@
 ---
 title: "Constructors - C# programming guide"
 description: A constructor in C# is called when a class or struct is created. Use constructors to set defaults, limit instantiation, and write flexible, easy-to-read code.
-ms.date: 01/30/2023
+ms.date: 04/06/2023
 helpviewer_keywords: 
   - "constructors [C#]"
   - "classes [C#], constructors"
@@ -28,11 +28,11 @@ If the [static constructor](static-constructors.md) hasn't run, the static const
 
 A constructor is a method whose name is the same as the name of its type. Its method signature includes only an optional [access modifier](./access-modifiers.md), the method name and its parameter list; it does not include a return type. The following example shows the constructor for a class named `Person`.
 
-[!code-csharp[constructors](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/constructors1.cs#1)]  
+[!code-csharp[constructors](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/constructors1.cs#1)]
 
 If a constructor can be implemented as a single statement, you can use an [expression body definition](../statements-expressions-operators/expression-bodied-members.md). The following example defines a `Location` class whose constructor has a single string parameter named *name*. The expression body definition assigns the argument to the `locationName` field.
 
-[!code-csharp[expression-bodied-constructor](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/expr-bodied-ctor.cs#1)]  
+[!code-csharp[expression-bodied-constructor](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/expr-bodied-ctor.cs#1)]
 
 ## Static constructors
 
@@ -40,26 +40,23 @@ The previous examples have all shown instance constructors, which create a new o
 
 The following example uses a static constructor to initialize a static field.
 
-[!code-csharp[constructors](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/constructors1.cs#2)]  
+[!code-csharp[constructors](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/constructors1.cs#2)]
 
 You can also define a static constructor with an expression body definition, as the following example shows.
 
-[!code-csharp[constructors](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/constructors1.cs#3)]  
+[!code-csharp[constructors](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/constructors1.cs#3)]
 
-For more information and examples, see [Static Constructors](./static-constructors.md).  
-  
-## In This Section  
+For more information and examples, see [Static Constructors](./static-constructors.md).
 
- [Using Constructors](./using-constructors.md)  
-  
- [Instance Constructors](./instance-constructors.md)  
-  
- [Private Constructors](./private-constructors.md)  
-  
- [Static Constructors](./static-constructors.md)  
-  
- [How to write a copy constructor](./how-to-write-a-copy-constructor.md)  
-  
+## In This Section
+
+- [Using constructors](./using-constructors.md)
+- [Instance constructors](./instance-constructors.md)
+- [Primary constructors](./primary-constructors.md)
+- [Private constructors](./private-constructors.md)
+- [Static constructors](./static-constructors.md)
+- [How to write a copy constructor](./how-to-write-a-copy-constructor.md)
+
 ## See also
 
 - [C# Programming Guide](../index.md)

--- a/docs/csharp/programming-guide/classes-and-structs/instance-constructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/instance-constructors.md
@@ -45,9 +45,9 @@ A primary constructor indicates that these parameters are necessary for any inst
 
 :::code language="csharp" source="./snippets/instance-constructors/widgets/Program.cs" id="DerivedPrimaryConstructor":::
 
-For non-`record` types, if a primary constructor is read or written in the body of the type, the compiler captures the parameter in a private field. This private field has a compiler generate name that is different from the primary constructor parameter. That ensures the private field name doesn't conflict with other variable names. It's also harder to find using Reflection. If a primary constructor parameter isn't used in the body of the type, no private field is captured. This prevents accidentally allocating two copies of a primary constructor parameter that is passed to a base constructor.
+For non-`record` types, if a primary constructor is read or written in the body of the type, the compiler captures the parameter in a private field. This private field has a compiler-generated name that is different from the primary constructor parameter. That ensures the private field name doesn't conflict with other variable names. It's also harder to find using reflection. If a primary constructor parameter isn't used in the body of the type, no private field is captured. This prevents accidentally allocating two copies of a primary constructor parameter that is passed to a base constructor.
 
-For `record` types (`record class`, and `record struct`), the compiler generates public properties for each of the positional parameters in the primary constructor. For `record class` types, if a primary constructor parameter uses the same name as a base primary constructor, that property is a public property of the base `record class` type. It is not duplicated in the derived `record class` type. These properties aren't generated for non-`record` types.
+For `record` types (`record class` and `record struct`), the compiler generates public properties for each of the positional parameters in the primary constructor. For `record class` types, if a primary constructor parameter uses the same name as a base primary constructor, that property is a public property of the base `record class` type. It is not duplicated in the derived `record class` type. These properties aren't generated for non-`record` types.
 
 ## See also
 

--- a/docs/csharp/programming-guide/classes-and-structs/instance-constructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/instance-constructors.md
@@ -37,13 +37,13 @@ A *structure* type always provides a parameterless constructor as follows:
 
 Beginning in C# 12, you can declare a *primary constructor* in classes and structs. You place any parameters in parentheses following the type name:
 
-:::code language="csharp" source="./snippets/widgets/Program.cs" id="BasePrimaryConstructor":::
+:::code language="csharp" source="./snippets/instance-constructors/widgets/Program.cs" id="BasePrimaryConstructor":::
 
 The parameters to a primary constructor are in scope in the entire body of the declaring type. They can initialize properties or fields. They can be used as variables in methods or local functions. They can be passed to a base constructor.
 
 A primary constructor indicates that these parameters are necessary for any instance of a type. Any explicitly written constructor must use the `this(...)` initializer syntax to invoke the primary constructor. That ensures that the primary constructor parameters are definitely assigned by all constructors. For any `class` type, including `record class` types, the implicit parameterless constructor isn't emitted when a primary constructor is present. For any `struct` type, including `record struct` types, the implicit parameterless constructor is always emitted, and always initializes all fields, including primary constructor parameters, to the 0-bit pattern. If you write an explicit parameterless constructor, it must invoke the primary constructor. In that case, you can specify a different value for the primary constructor parameters. The following code shows examples of primary constructors.
 
-:::code language="csharp" source="./snippets/widgets/Program.cs" id="DerivedPrimaryConstructor":::
+:::code language="csharp" source="./snippets/instance-constructors/widgets/Program.cs" id="DerivedPrimaryConstructor":::
 
 For non-`record` types, if a primary constructor is read or written in the body of the type, the compiler captures the parameter in a private field. This private field has a compiler generate name that is different from the primary constructor parameter. That ensures the private field name doesn't conflict with other variable names. It's also harder to find using Reflection. If a primary constructor parameter isn't used in the body of the type, no private field is captured. This prevents accidentally allocating two copies of a primary constructor parameter that is passed to a base constructor.
 

--- a/docs/csharp/programming-guide/classes-and-structs/instance-constructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/instance-constructors.md
@@ -1,15 +1,14 @@
 ---
-title: "Instance constructors - C# programming guide"
+title: "Instance constructors"
 description: Instance constructors in C# create and initialize any instance member variables when you use the new expression to create an instance of a type.
-ms.date: 09/27/2021
+ms.date: 04/06/2023
 helpviewer_keywords: 
   - "constructors [C#], instance constructors"
   - "instance constructors [C#]"
-ms.assetid: 24663779-c1e5-4af4-a942-ca554e4c542d
 ---
 # Instance constructors (C# programming guide)
 
-You declare an instance constructor to specify the code that is executed when you create a new instance of a type with the [`new` expression](../../language-reference/operators/new-operator.md). To initialize a [static](../../language-reference/keywords/static.md) class or static variables in a non-static class, you can define a [static constructor](static-constructors.md).
+You declare an instance constructor to specify the code that is executed when you create a new instance of a type with the [`new` expression](../../language-reference/operators/new-operator.md). To initialize a [static](../../language-reference/keywords/static.md) class or static variables in a nonstatic class, you can define a [static constructor](static-constructors.md).
 
 As the following example shows, you can declare several instance constructors in one type:
 
@@ -34,6 +33,22 @@ A *structure* type always provides a parameterless constructor as follows:
 - In C# 9.0 and earlier, that is an implicit parameterless constructor that produces the [default value](../../language-reference/builtin-types/default-values.md) of a type.
 - In C# 10 and later, that is either an implicit parameterless constructor that produces the default value of a type or an explicitly declared parameterless constructor. For more information, see the [Struct initialization and default values](../../language-reference/builtin-types/struct.md#struct-initialization-and-default-values) section of the [Structure types](../../language-reference/builtin-types/struct.md) article.
 
+## Primary constructors
+
+Beginning in C# 12, you can declare a *primary constructor* in classes and structs. You place any parameters in parentheses following the type name:
+
+:::code language="csharp" source="./snippets/widgets/Program.cs" id="BasePrimaryConstructor":::
+
+The parameters to a primary constructor are in scope in the entire body of the declaring type. They can initialize properties or fields. They can be used as variables in methods or local functions. They can be passed to a base constructor.
+
+A primary constructor indicates that these parameters are necessary for any instance of a type. Any explicitly written constructor must use the `this(...)` initializer syntax to invoke the primary constructor. That ensures that the primary constructor parameters are definitely assigned by all constructors. For any `class` type, including `record class` types, the implicit parameterless constructor isn't emitted when a primary constructor is present. For any `struct` type, including `record struct` types, the implicit parameterless constructor is always emitted, and always initializes all fields, including primary constructor parameters, to the 0-bit pattern. If you write an explicit parameterless constructor, it must invoke the primary constructor. In that case, you can specify a different value for the primary constructor parameters. The following code shows examples of primary constructors.
+
+:::code language="csharp" source="./snippets/widgets/Program.cs" id="DerivedPrimaryConstructor":::
+
+For non-`record` types, if a primary constructor is read or written in the body of the type, the compiler captures the parameter in a private field. This private field has a compiler generate name that is different from the primary constructor parameter. That ensures the private field name doesn't conflict with other variable names. It's also harder to find using Reflection. If a primary constructor parameter isn't used in the body of the type, no private field is captured. This prevents accidentally allocating two copies of a primary constructor parameter that is passed to a base constructor.
+
+For `record` types (`record class`, and `record struct`), the compiler generates public properties for each of the positional parameters in the primary constructor. For `record class` types, if a primary constructor parameter uses the same name as a base primary constructor, that property is a public property of the base `record class` type. It is not duplicated in the derived `record class` type. These properties aren't generated for non-`record` types.
+
 ## See also
 
 - [C# programming guide](../index.md)
@@ -42,3 +57,4 @@ A *structure* type always provides a parameterless constructor as follows:
 - [Finalizers](finalizers.md)
 - [base](../../language-reference/keywords/base.md)
 - [this](../../language-reference/keywords/this.md)
+- [Primary constructors feature spec](~/_csharplang/proposals/primary-constructors.md)

--- a/docs/csharp/programming-guide/classes-and-structs/snippets/instance-constructors/widgets/Program.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/snippets/instance-constructors/widgets/Program.cs
@@ -1,0 +1,25 @@
+﻿// See https://aka.ms/new-console-template for more information
+Console.WriteLine("Hello, World!");
+
+
+// <BasePrimaryConstructor>
+public class NamedItem(string name)
+{
+    public string Name => name;
+}
+// <BasePrimaryConstructor>
+
+// <DerivedPrimaryConstructor>
+// name isn't captured in Widget.
+// width, height, and depth are captured as private fields
+public class Widget(string name, int width, int height, int depth) : NamedItem(name)
+{
+    public Widget() : this("N/A", 1,1,1) {} // unnamed unit cube
+
+    public int WidthInCM => width;
+    public int HeightInCM => height;
+    public int DepthInCM => depth;
+
+    public int Volume => width * height * depth;
+}
+// </DerivedPrimaryConstructor>

--- a/docs/csharp/programming-guide/classes-and-structs/snippets/instance-constructors/widgets/Program.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/snippets/instance-constructors/widgets/Program.cs
@@ -7,7 +7,7 @@ public class NamedItem(string name)
 {
     public string Name => name;
 }
-// <BasePrimaryConstructor>
+// </BasePrimaryConstructor>
 
 // <DerivedPrimaryConstructor>
 // name isn't captured in Widget.

--- a/docs/csharp/programming-guide/classes-and-structs/snippets/instance-constructors/widgets/widgets.csproj
+++ b/docs/csharp/programming-guide/classes-and-structs/snippets/instance-constructors/widgets/widgets.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+
+</Project>

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -149,7 +149,6 @@ items:
 - name: What's new in C#
   items:
   - name: C# 12
-    items: New features
     displayName: what's New
     href: whats-new/csharp-12.md
   - name: C# 11

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -148,6 +148,10 @@ items:
       href: fundamentals/exceptions/how-to-execute-cleanup-code-using-finally.md
 - name: What's new in C#
   items:
+  - name: C# 12
+    items: New features
+    displayName: what's New
+    href: whats-new/csharp-12.md
   - name: C# 11
     items:
     - name: New features

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1447,3 +1447,7 @@ items:
       items:
       - name: Primary constructors
         href: ../../_csharplang/proposals/primary-constructors.md
+      - name: Alias any type
+        href: ../../_csharplang/proposals/using-alias-types.md
+      - name: Optional Lambda expression parameters
+        href: ../../_csharplang/proposals/lambda-method-group-defaults.md

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1440,3 +1440,7 @@ items:
         href: ../../_csharplang/proposals/csharp-11.0/file-local-types.md
       - name: Generic attributes
         href: ../../_csharplang/proposals/csharp-11.0/generic-attributes.md
+    - name: C# Preview features
+      items:
+      - name: Primary constructors
+        href: ../../_csharplang/proposals/primary-constructors.md

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -682,13 +682,13 @@ items:
       items:
       - name: Constructors overview
         href: programming-guide/classes-and-structs/constructors.md
-      - name: Using Constructors
+      - name: Using constructors
         href: programming-guide/classes-and-structs/using-constructors.md
-      - name: Instance Constructors
+      - name: Instance constructors
         href: programming-guide/classes-and-structs/instance-constructors.md
-      - name: Private Constructors
+      - name: Private constructors
         href: programming-guide/classes-and-structs/private-constructors.md
-      - name: Static Constructors
+      - name: Static constructors
         href: programming-guide/classes-and-structs/static-constructors.md
       - name: "How to write a copy constructor"
         href: programming-guide/classes-and-structs/how-to-write-a-copy-constructor.md

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1297,7 +1297,7 @@ items:
       href: ../../_csharpstandard/standard/documentation-comments.md
     - name: Bibliography
       href: ../../_csharpstandard/standard/bibliography.md
-  - name: C# 7.0 - 11.0 features
+  - name: C# 7.0 - 12 features
     items:
     - name: C# 7.0 features
       items:

--- a/docs/csharp/whats-new/csharp-11.md
+++ b/docs/csharp/whats-new/csharp-11.md
@@ -1,6 +1,6 @@
 ---
 title: What's new in C# 11 - C# Guide
-description: Get an overview of the new features coming in C# 11.
+description: Get an overview of the new features added in C# 11.
 ms.date: 11/21/2022
 ms.custom: UpdateFrequency1
 ---

--- a/docs/csharp/whats-new/csharp-12.md
+++ b/docs/csharp/whats-new/csharp-12.md
@@ -5,15 +5,28 @@ ms.date: 04/04/2023
 ---
 # What's new in C# 12
 
-The following C# 12 features were introduced in [Visual Studio 17.6 preview 2](https://visualstudio.microsoft.com/vs/preview/). You can also use the latest [.NET 8 preview SDK](https://dotnet.microsoft.com/download/dotnet).
+Some C# 12 features have been introduced in previews. The You can try these features using the latest [Visual Studio preview](https://visualstudio.microsoft.com/vs/preview/) or 
+the latest [.NET 8 preview SDK](https://dotnet.microsoft.com/download/dotnet).
 
-- [Primary constructors](#primary-constructors)
+- [Primary constructors](#primary-constructors) - Introduced in Visual Studio 17.6 preview 2.
+- [Optional parameters in lambda expressions](#default-lambda-parameters) - Introduced in Visual Studio 17.5 preview 2.
+- [Alias any type](#alias-any-type) - Introduced in Visual Studio 17.6 preview 3.
 
 ## Primary constructors
 
-You can now create primary constructors in classes and structs. Primary constructors are no longer restricted to record types.
+You can now create primary constructors in any `class` and `struct`. Primary constructors are no longer restricted to `record` types. Primary constructor parameters are in scope for the entire body of the class. To ensure that all primary constructor parameters are definitely assigned, all explicitly declared constructors must call the primary constructor using `this()` syntax. Adding a primary constructor to a `class` prevents the compiler from declaring an implicit parameterless constructor. In a `struct`, The implicit parameterless constructor initializes all fields, including primary constructor parameters to the 0 bit pattern.
 
-Unlike primary constructors in records, primary constructors in classes and structs don't create properties for each primary constructor parameter. Instead, primary constructor parameters are in scope for the entire body of the class. To ensure that all primary constructor parameters are definitely assigned, all constructors in a class must call the primary constructor using `this()` syntax.
+The compiler generates public properties for primary constructor parameters only in `record` types, either `record class` or `record struct` types. Non-record classes and structs may not always want this behavior for primary constructor parameters.
+
+You can learn more about primary constructors in the article on [instance constructors](../programming-guide/classes-and-structs/instance-constructors.md#primary-constructors).
+
+## Default lambda parameters
+
+You can now define default values for parameters on lambda expressions. The syntax and rules are the same as adding default values for arguments to any method or local function.
+
+## Alias any type
+
+You can use the `using` alias directive to alias any type, not just named types. That means you can create semantic aliases for tuple types, array types, pointer types, or other unsafe types.
 
 ## See also
 

--- a/docs/csharp/whats-new/csharp-12.md
+++ b/docs/csharp/whats-new/csharp-12.md
@@ -5,8 +5,7 @@ ms.date: 04/04/2023
 ---
 # What's new in C# 12
 
-Some C# 12 features have been introduced in previews. The You can try these features using the latest [Visual Studio preview](https://visualstudio.microsoft.com/vs/preview/) or 
-the latest [.NET 8 preview SDK](https://dotnet.microsoft.com/download/dotnet).
+Some C# 12 features have been introduced in previews. The You can try these features using the latest [Visual Studio preview](https://visualstudio.microsoft.com/vs/preview/) or the latest [.NET 8 preview SDK](https://dotnet.microsoft.com/download/dotnet).
 
 - [Primary constructors](#primary-constructors) - Introduced in Visual Studio 17.6 preview 2.
 - [Optional parameters in lambda expressions](#default-lambda-parameters) - Introduced in Visual Studio 17.5 preview 2.
@@ -14,7 +13,7 @@ the latest [.NET 8 preview SDK](https://dotnet.microsoft.com/download/dotnet).
 
 ## Primary constructors
 
-You can now create primary constructors in any `class` and `struct`. Primary constructors are no longer restricted to `record` types. Primary constructor parameters are in scope for the entire body of the class. To ensure that all primary constructor parameters are definitely assigned, all explicitly declared constructors must call the primary constructor using `this()` syntax. Adding a primary constructor to a `class` prevents the compiler from declaring an implicit parameterless constructor. In a `struct`, The implicit parameterless constructor initializes all fields, including primary constructor parameters to the 0 bit pattern.
+You can now create primary constructors in any `class` and `struct`. Primary constructors are no longer restricted to `record` types. Primary constructor parameters are in scope for the entire body of the class. To ensure that all primary constructor parameters are definitely assigned, all explicitly declared constructors must call the primary constructor using `this()` syntax. Adding a primary constructor to a `class` prevents the compiler from declaring an implicit parameterless constructor. In a `struct`, The implicit parameterless constructor initializes all fields, including primary constructor parameters to the 0-bit pattern.
 
 The compiler generates public properties for primary constructor parameters only in `record` types, either `record class` or `record struct` types. Non-record classes and structs may not always want this behavior for primary constructor parameters.
 
@@ -24,9 +23,11 @@ You can learn more about primary constructors in the article on [instance constr
 
 You can now define default values for parameters on lambda expressions. The syntax and rules are the same as adding default values for arguments to any method or local function.
 
+You can learn more about default parameters on lambda expressions in the article on [lambda expressions](../language-reference/operators/lambda-expressions.md#input-parameters-of-a-lambda-expressions)
+
 ## Alias any type
 
-You can use the `using` alias directive to alias any type, not just named types. That means you can create semantic aliases for tuple types, array types, pointer types, or other unsafe types.
+You can use the `using` alias directive to alias any type, not just named types. That means you can create semantic aliases for tuple types, array types, pointer types, or other unsafe types. For more information, see the [feature specification](~/csharplang/proposals/using-alias-types.md)
 
 ## See also
 

--- a/docs/csharp/whats-new/csharp-12.md
+++ b/docs/csharp/whats-new/csharp-12.md
@@ -1,0 +1,20 @@
+---
+title: What's new in C# 12 - C# Guide
+description: Get an overview of the new features in C# 12.
+ms.date: 04/04/2023
+---
+# What's new in C# 12
+
+The following C# 12 features were introduced in [Visual Studio 17.6 preview 2](https://visualstudio.microsoft.com/vs/preview/). You can also use the latest [.NET 8 preview SDK](https://dotnet.microsoft.com/download/dotnet).
+
+- [Primary constructors](#primary-constructors)
+
+## Primary constructors
+
+You can now create primary constructors in classes and structs. Primary constructors are no longer restricted to record types.
+
+Unlike primary constructors in records, primary constructors in classes and structs don't create properties for each primary constructor parameter. Instead, primary constructor parameters are in scope for the entire body of the class. To ensure that all primary constructor parameters are definitely assigned, all constructors in a class must call the primary constructor using `this()` syntax.
+
+## See also
+
+- [What's new in .NET 8](../../core/whats-new/dotnet-8.md)

--- a/docs/csharp/whats-new/csharp-12.md
+++ b/docs/csharp/whats-new/csharp-12.md
@@ -23,11 +23,11 @@ You can learn more about primary constructors in the article on [instance constr
 
 You can now define default values for parameters on lambda expressions. The syntax and rules are the same as adding default values for arguments to any method or local function.
 
-You can learn more about default parameters on lambda expressions in the article on [lambda expressions](../language-reference/operators/lambda-expressions.md#input-parameters-of-a-lambda-expressions)
+You can learn more about default parameters on lambda expressions in the article on [lambda expressions](../language-reference/operators/lambda-expressions.md#input-parameters-of-a-lambda-expression).
 
 ## Alias any type
 
-You can use the `using` alias directive to alias any type, not just named types. That means you can create semantic aliases for tuple types, array types, pointer types, or other unsafe types. For more information, see the [feature specification](~/csharplang/proposals/using-alias-types.md)
+You can use the `using` alias directive to alias any type, not just named types. That means you can create semantic aliases for tuple types, array types, pointer types, or other unsafe types. For more information, see the [feature specification](~/_csharplang/proposals/using-alias-types.md)
 
 ## See also
 


### PR DESCRIPTION
Contributes to: #34529, #34655, #34530

Adding initial content for all three features to make sure some content is live for the upcoming preview. Later PRs will add tutorials and compiler error / warning messages, as needed.

A number of content updates here, covering three features:  *Primary constructors*, *Alias any type*, and *Default lambda parameters*.

- [x] Publish speclets on docs
- [x] Add what's new page for C# 12
- [x] Language reference updates for Primary constructors:
  - Add section on *Instance constructors* describing primary constructors.
  - Link to new section from `struct`, `class`, and `record` pages
- [x] Language reference for alias any type
  - Additional text on `using` aliases. This is small, because the docs didn't explicitly mention what wasn't allowed.
- [x] Language reference for default parameters on lambda expressions
  - Add text on the lambda expressions page to describe the declarations, and their type.
   
<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/builtin-types/record.md](https://github.com/dotnet/docs/blob/64c17455926739f69b9adb21afc0d0bb8cdc083a/docs/csharp/language-reference/builtin-types/record.md) | [Records (C# reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/record?branch=pr-en-us-34876) |
| [docs/csharp/language-reference/builtin-types/struct.md](https://github.com/dotnet/docs/blob/64c17455926739f69b9adb21afc0d0bb8cdc083a/docs/csharp/language-reference/builtin-types/struct.md) | [Structure types (C# reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/struct?branch=pr-en-us-34876) |
| [docs/csharp/language-reference/keywords/using-directive.md](https://github.com/dotnet/docs/blob/64c17455926739f69b9adb21afc0d0bb8cdc083a/docs/csharp/language-reference/keywords/using-directive.md) | [using directive](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-directive?branch=pr-en-us-34876) |
| [docs/csharp/language-reference/operators/lambda-expressions.md](https://github.com/dotnet/docs/blob/64c17455926739f69b9adb21afc0d0bb8cdc083a/docs/csharp/language-reference/operators/lambda-expressions.md) | [Lambda expressions and anonymous functions](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/lambda-expressions?branch=pr-en-us-34876) |
| [docs/csharp/programming-guide/classes-and-structs/constructors.md](https://github.com/dotnet/docs/blob/64c17455926739f69b9adb21afc0d0bb8cdc083a/docs/csharp/programming-guide/classes-and-structs/constructors.md) | [Constructors (C# programming guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/constructors?branch=pr-en-us-34876) |
| [docs/csharp/programming-guide/classes-and-structs/instance-constructors.md](https://github.com/dotnet/docs/blob/64c17455926739f69b9adb21afc0d0bb8cdc083a/docs/csharp/programming-guide/classes-and-structs/instance-constructors.md) | [Instance constructors (C# programming guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/instance-constructors?branch=pr-en-us-34876) |
| [docs/csharp/whats-new/csharp-11.md](https://github.com/dotnet/docs/blob/64c17455926739f69b9adb21afc0d0bb8cdc083a/docs/csharp/whats-new/csharp-11.md) | [What's new in C# 11](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-11?branch=pr-en-us-34876) |
| [docs/csharp/whats-new/csharp-12.md](https://github.com/dotnet/docs/blob/64c17455926739f69b9adb21afc0d0bb8cdc083a/docs/csharp/whats-new/csharp-12.md) | [docs/csharp/whats-new/csharp-12](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-12?branch=pr-en-us-34876) |


<!-- PREVIEW-TABLE-END -->