### PR TITLE
New console encoding breaking change

### DIFF
--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -125,6 +125,7 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 | [Automatic RuntimeIdentifier for certain projects](sdk/7.0/automatic-runtimeidentifier.md) | ✔️ | ❌ | 7.0.100 |
 | [Automatic RuntimeIdentifier for publish only](sdk/7.0/automatic-rid-publish-only.md) | ❌ | ❌ | 7.0.200 |
 | [CLI console output uses UTF-8](sdk/8.0/console-encoding.md) | ❌ | ❌ | 7.0.3xx |
+| [Console encoding not UTF-8 after completion](sdk/8.0/console-encoding-fix.md) | ❌ | ✔️ | 7.0.300 |
 | [MSBuild serialization of custom types in .NET 7](sdk/7.0/custom-serialization.md) | ❌ | ❌ | 7.0.100 |
 | [Side-by-side SDK installations](sdk/7.0/side-by-side-install.md) | ❌ | ❌ | 7.0.100 |
 | [Version requirements for .NET 7 SDK](sdk/7.0/vs-msbuild-version.md) | ✔️ | ✔️ | 7.0.100 |

--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -60,6 +60,7 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 | Title                                                                           | Type of change                                   | Introduced |
 | ------------------------------------------------------------------------------- | ------------------------------------------------ | ---------- |
 | [CLI console output uses UTF-8](sdk/8.0/console-encoding.md)                    | Behavioral change/Source and binary incompatible | Preview 1  |
+| [Console encoding not UTF-8 after completion](sdk/8.0/console-encoding-fix.md)  | Behavioral change/Binary incompatible            | Preview 3  |
 | ['dotnet pack' uses Release configuration](sdk/8.0/dotnet-pack-config.md)       | Behavioral change/Source incompatible            | Preview 1  |
 | ['dotnet publish' uses Release configuration](sdk/8.0/dotnet-publish-config.md) | Behavioral change/Source incompatible            | Preview 1  |
 

--- a/docs/core/compatibility/sdk/8.0/console-encoding-fix.md
+++ b/docs/core/compatibility/sdk/8.0/console-encoding-fix.md
@@ -1,0 +1,45 @@
+---
+title: "Breaking change: SDK no longer changes console encoding after completion"
+description: Learn about a breaking change where the .NET 8 SDK no longer changes the console encoding after running a command.
+ms.date: 04/04/2023
+---
+# Console encoding doesn't remain UTF-8 after completion
+
+The bug mentioned in the [CLI console output uses UTF-8](console-encoding.md) breaking change, where the .NET SDK changed the encoding of the entire console, has been fixed. The console encoding no longer remains UTF-8 after the .NET SDK executes a command. It's possible that users came to rely on that behavior, hence this is a breaking change.
+
+In addition, the .NET SDK no longer changes the encoding to UTF-8 on older Windows 10 versions that don't fully support it.
+
+## Previous behavior
+
+- The SDK changed the encoding of a terminal after running a command such as `dotnet build`.
+- The SDK used the UTF-8 encoding to correctly render non-English characters, even on versions of windows 10 that did not officially support UTF-8. The behavior was undefined on those versions.
+
+## New behavior
+
+- The SDK doesn't change the terminal encoding after exit for other programs.
+- By default, the SDK no longer uses UTF-8 for Windows versions that don't support it.
+
+## Version introduced
+
+7.0.3xx
+.NET 8 Preview 3
+
+## Type of breaking change
+
+This change can affect [binary compatibility](../../categories.md#binary-compatibility). It's also a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+There was an existing bug where the .NET SDK affected the encoding on the console for other programs. That was a bug that was fixed, resulting in this breaking change.
+
+Older versions of Windows 10 (that is, versions before the November 2019 update) didn't support UTF-8, so the default behavior shouldn't be to use UTF-8 encoding. Instead, an opt-in is now available.
+
+## Recommended action
+
+If your app needs to change the code page on Windows, it can run a process to invoke the `chcp` command. Your app shouldn't rely on the .NET SDK to change the encoding.
+
+For older Windows 10 versions that don't officially support UTF-8 where you want the .NET SDK to continue to change the encoding to UTF-8 for non-English languages, can you set the environment variable [`DOTNET_CLI_FORCE_UTF8_ENCODING`](../../../tools/dotnet-environment-variables.md#dotnet_cli_force_utf8_encoding) to `true` or 1.
+
+## See also
+
+- [SDK no longer changes console encoding after completion](console-encoding-fix.md)

--- a/docs/core/compatibility/sdk/8.0/console-encoding.md
+++ b/docs/core/compatibility/sdk/8.0/console-encoding.md
@@ -1,7 +1,7 @@
 ---
 title: "Breaking change: CLI console output uses UTF-8"
 description: Learn about a breaking change in the .NET 8 SDK where the encoding for console input and output is now UTF-8.
-ms.date: 03/03/2023
+ms.date: 04/04/2023
 ---
 # CLI console output uses UTF-8
 
@@ -29,9 +29,9 @@ MSBuild version 17.3.0-preview[...] for .NET
   正在确定要还原的项目…
 ```
 
-Versions of Windows older than Windows 10 1909 don't fully support UTF-8 and may experience issues after this change.
+Versions of Windows older than Windows 10 1909 don't fully support UTF-8 and may experience issues after this change. (Starting in .NET 8 Preview 3 and .NET 7.0.300 SDK, the .NET SDK no longer changes the encoding to UTF-8 on these versions, by default. To opt back into using UTF-8 even on Windows 10 versions that don't support it, use the [`DOTNET_CLI_FORCE_UTF8_ENCODING`](../../../tools/dotnet-environment-variables.md#dotnet_cli_force_utf8_encoding) environment variable.)
 
-In addition, there's [an existing bug](https://github.com/dotnet/sdk/issues/30170) where the SDK can affect the encoding of other commands and programs called in the same command prompt after the SDK has finished execution. Now that the SDK more frequently changes the encoding, the impact of this bug may increase.
+In addition, there was [an existing bug](https://github.com/dotnet/sdk/issues/30170) where the SDK can affect the encoding of other commands and programs called in the same command prompt after the SDK has finished execution. Now that the SDK more frequently changes the encoding, the impact of this bug may increase. However, the bug was fixed in .NET 8 Preview 3 and .NET 7.0.300 SDK. For more information, see [SDK no longer changes console encoding after completion](console-encoding-fix.md).
 
 ## Version introduced
 
@@ -54,3 +54,7 @@ The legacy scenarios are already less likely to support the broken languages, so
 
 - If you're using an older version of windows 10, upgrade to version 1909 or later.
 - If you want to use a legacy console or are facing build issues or others due to the encoding change, unset `VSLANG` and `DOTNET_CLI_UI_LANGUAGE` to disable this change.
+
+## See also
+
+- [SDK no longer changes console encoding when finished](console-encoding-fix.md)

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -52,6 +52,8 @@ items:
       items:
       - name: CLI console output uses UTF-8
         href: sdk/8.0/console-encoding.md
+      - name: Console encoding not UTF-8 after completion
+        href: sdk/8.0/console-encoding-fix.md
       - name: "'dotnet pack' uses Release configuration"
         href: sdk/8.0/dotnet-pack-config.md
       - name: "'dotnet publish' uses Release configuration"
@@ -1294,6 +1296,8 @@ items:
       items:
       - name: CLI console output uses UTF-8
         href: sdk/8.0/console-encoding.md
+      - name: Console encoding not UTF-8 after completion
+        href: sdk/8.0/console-encoding-fix.md
       - name: "'dotnet pack' uses Release configuration"
         href: sdk/8.0/dotnet-pack-config.md
       - name: "'dotnet publish' uses Release configuration"

--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -1,7 +1,7 @@
 ---
 title: .NET environment variables
 description: Learn about the environment variables that you can use to configure the .NET SDK, .NET CLI, and .NET runtime.
-ms.date: 03/30/2023
+ms.date: 04/04/2023
 ---
 
 # .NET environment variables
@@ -183,9 +183,9 @@ See [EventPipe environment variables](../diagnostics/eventpipe.md#trace-using-en
 
 Specifies the location of the .NET runtimes, if they are not installed in the default location. The default location on Windows is `C:\Program Files\dotnet`. The default location on macOS is `/usr/local/share/dotnet`. The default location on Linux varies depending on distro and installment method. The default location on Ubuntu 22.04 is `/usr/share/dotnet` (when installed from `packages.microsoft.com`) or `/usr/lib/dotnet` (when installed from Jammy feed). For more information, see the following resources:
 
-* [Troubleshoot app launch failures](../runtime-discovery/troubleshoot-app-launch.md?pivots=os-linux)
-* GitHub issue [dotnet/core#7699](https://github.com/dotnet/core/issues/7699)
-* GitHub issue [dotnet/runtime#79237](https://github.com/dotnet/runtime/issues/79237)
+- [Troubleshoot app launch failures](../runtime-discovery/troubleshoot-app-launch.md?pivots=os-linux)
+- GitHub issue [dotnet/core#7699](https://github.com/dotnet/core/issues/7699)
+- GitHub issue [dotnet/runtime#79237](https://github.com/dotnet/runtime/issues/79237)
 
 This environment variable is used only when running apps via generated executables (apphosts). `DOTNET_ROOT(x86)` is used instead when running a 32-bit executable on a 64-bit OS.
 
@@ -242,6 +242,10 @@ For more information, see [the `--roll-forward` option for the `dotnet` command]
 
 Disables minor version roll forward, if set to `0`. This setting is superseded in .NET Core 3.0 by `DOTNET_ROLL_FORWARD`. The new settings should be used instead.
 
+### `DOTNET_CLI_FORCE_UTF8_ENCODING`
+
+Forces the use of UTF-8 encoding in the console, even for older versions of Windows 10 that don't fully support UTF-8. For more information, see [SDK no longer changes console encoding when finished](../compatibility/sdk/8.0/console-encoding-fix.md).
+
 ### `DOTNET_CLI_UI_LANGUAGE`
 
 Sets the language of the CLI UI using a locale value such as `en-us`. The supported values are the same as for Visual Studio. For more information, see the section on changing the installer language in the [Visual Studio installation documentation](/visualstudio/install/install-visual-studio). The .NET resource manager rules apply, so you don't have to pick an exact match&mdash;you can also pick descendants in the `CultureInfo` tree. For example, if you set it to `fr-CA`, the CLI will find and use the `fr` translations. If you set it to a language that is not supported, the CLI falls back to English.
@@ -289,14 +293,14 @@ Specifies the minimum number of hours between background downloads of advertisin
 
 Controls diagnostics tracing from the hosting components, such as `dotnet.exe`, `hostfxr`, and `hostpolicy`.
 
-* `COREHOST_TRACE=[0/1]` - default is `0` - tracing disabled. If set to `1`, diagnostics tracing is enabled.
-* `COREHOST_TRACEFILE=<file path>` - has an effect only if tracing is enabled by setting `COREHOST_TRACE=1`. When set, the tracing information is written to the specified file; otherwise, the trace information is written to `stderr`.
-* `COREHOST_TRACE_VERBOSITY=[1/2/3/4]` - default is `4`. The setting is used only when tracing is enabled via `COREHOST_TRACE=1`.
+- `COREHOST_TRACE=[0/1]` - default is `0` - tracing disabled. If set to `1`, diagnostics tracing is enabled.
+- `COREHOST_TRACEFILE=<file path>` - has an effect only if tracing is enabled by setting `COREHOST_TRACE=1`. When set, the tracing information is written to the specified file; otherwise, the trace information is written to `stderr`.
+- `COREHOST_TRACE_VERBOSITY=[1/2/3/4]` - default is `4`. The setting is used only when tracing is enabled via `COREHOST_TRACE=1`.
 
-  * `4` - all tracing information is written
-  * `3` - only informational, warning, and error messages are written
-  * `2` - only warning and error messages are written
-  * `1` - only error messages are written
+  - `4` - all tracing information is written
+  - `3` - only informational, warning, and error messages are written
+  - `2` - only warning and error messages are written
+  - `1` - only error messages are written
 
 The typical way to get detailed trace information about application startup is to set `COREHOST_TRACE=1` and`COREHOST_TRACEFILE=host_trace.txt` and then run the application. A new file `host_trace.txt` will be created in the current directory with the detailed information.
 


### PR DESCRIPTION
Fixes #34471.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/7.0.md](https://github.com/dotnet/docs/blob/665fa155d73d94f60015841138c1f23a4fa37d27/docs/core/compatibility/7.0.md) | [docs/core/compatibility/7.0](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/7.0?branch=pr-en-us-34878) |
| [docs/core/compatibility/8.0.md](https://github.com/dotnet/docs/blob/665fa155d73d94f60015841138c1f23a4fa37d27/docs/core/compatibility/8.0.md) | [docs/core/compatibility/8.0](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/8.0?branch=pr-en-us-34878) |
| [docs/core/compatibility/sdk/8.0/console-encoding-fix.md](https://github.com/dotnet/docs/blob/665fa155d73d94f60015841138c1f23a4fa37d27/docs/core/compatibility/sdk/8.0/console-encoding-fix.md) | [docs/core/compatibility/sdk/8.0/console-encoding-fix](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/console-encoding-fix?branch=pr-en-us-34878) |
| [docs/core/compatibility/sdk/8.0/console-encoding.md](https://github.com/dotnet/docs/blob/665fa155d73d94f60015841138c1f23a4fa37d27/docs/core/compatibility/sdk/8.0/console-encoding.md) | [docs/core/compatibility/sdk/8.0/console-encoding](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/console-encoding?branch=pr-en-us-34878) |
| [docs/core/tools/dotnet-environment-variables.md](https://github.com/dotnet/docs/blob/665fa155d73d94f60015841138c1f23a4fa37d27/docs/core/tools/dotnet-environment-variables.md) | [docs/core/tools/dotnet-environment-variables](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables?branch=pr-en-us-34878) |

<!-- PREVIEW-TABLE-END -->