### PR TITLE
Fix extremely minor typo I found

### DIFF
--- a/docs/architecture/grpc-for-wcf-developers/protobuf-data-types.md
+++ b/docs/architecture/grpc-for-wcf-developers/protobuf-data-types.md
@@ -99,7 +99,7 @@ For values that require explicit null, such as using `int?` in your C# code, Pro
 ```protobuf  
 syntax = "proto3"
 
-import "google/protobuf/wrappers.proto"
+import "google/protobuf/wrappers.proto";
 
 message Person {
 


### PR DESCRIPTION
## Summary

Fixes a very minor typo I found while using this document.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/architecture/grpc-for-wcf-developers/protobuf-data-types.md](https://github.com/dotnet/docs/blob/49bb39dd1c4abd76a87c75e5185372a2ae6b4d73/docs/architecture/grpc-for-wcf-developers/protobuf-data-types.md) | [docs/architecture/grpc-for-wcf-developers/protobuf-data-types](https://review.learn.microsoft.com/en-us/dotnet/architecture/grpc-for-wcf-developers/protobuf-data-types?branch=pr-en-us-34896) |

<!-- PREVIEW-TABLE-END -->