### PR TITLE
Annotate R formatter example for datetime

### DIFF
--- a/docs/standard/base-types/standard-date-and-time-format-strings.md
+++ b/docs/standard/base-types/standard-date-and-time-format-strings.md
@@ -1,7 +1,7 @@
 ---
 title: "Standard date and time format strings"
 description: Learn how to use a standard date and time format string to define the text representation of a date and time value in .NET.
-ms.date: 01/25/2021
+ms.date: 04/05/2023
 dev_langs:
   - "csharp"
   - "vb"
@@ -43,7 +43,7 @@ A standard date and time format string uses a single character as the format spe
 |"G"|General date/time pattern (long time).<br /><br /> More information: [The general date long time ("G") format specifier](#GeneralDateLongTime).|2009-06-15T13:45:30 -> 6/15/2009 1:45:30 PM (en-US)<br /><br /> 2009-06-15T13:45:30 -> 15/06/2009 13:45:30 (es-ES)<br /><br /> 2009-06-15T13:45:30 -> 2009/6/15 13:45:30 (zh-CN)|
 |"M", "m"|Month/day pattern.<br /><br /> More information: [The month ("M", "m") format specifier](#MonthDay).|2009-06-15T13:45:30 -> June 15 (en-US)<br /><br /> 2009-06-15T13:45:30 -> 15. juni (da-DK)<br /><br /> 2009-06-15T13:45:30 -> 15 Juni (id-ID)|
 |"O", "o"|round-trip date/time pattern.<br /><br /> More information: [The round-trip ("O", "o") format specifier](#Roundtrip).|<xref:System.DateTime> values:<br /><br /> 2009-06-15T13:45:30 (DateTimeKind.Local) --> 2009-06-15T13:45:30.0000000-07:00<br /><br /> 2009-06-15T13:45:30 (DateTimeKind.Utc) --> 2009-06-15T13:45:30.0000000Z<br /><br /> 2009-06-15T13:45:30 (DateTimeKind.Unspecified) --> 2009-06-15T13:45:30.0000000<br /><br /> <xref:System.DateTimeOffset> values:<br /><br /> 2009-06-15T13:45:30-07:00 --> 2009-06-15T13:45:30.0000000-07:00|
-|"R", "r"|RFC1123 pattern.<br /><br /> More information: [The RFC1123 ("R", "r") format specifier](#RFC1123).|2009-06-15T13:45:30 -> Mon, 15 Jun 2009 20:45:30 GMT|
+|"R", "r"|RFC1123 pattern.<br /><br /> More information: [The RFC1123 ("R", "r") format specifier](#RFC1123).|<xref:System.DateTimeOffset> input: 2009-06-15T13:45:30 -> Mon, 15 Jun 2009 20:45:30 GMT<br/><xref:System.DateTime> input: 2009-06-15T13:45:30 -> Mon, 15 Jun 2009 13:45:30 GMT |
 |"s"|Sortable date/time pattern.<br /><br /> More information: [The sortable ("s") format specifier](#Sortable).|2009-06-15T13:45:30 (DateTimeKind.Local) -> 2009-06-15T13:45:30<br /><br /> 2009-06-15T13:45:30 (DateTimeKind.Utc) -> 2009-06-15T13:45:30|
 |"t"|Short time pattern.<br /><br /> More information: [The short time ("t") format specifier](#ShortTime).|2009-06-15T13:45:30 -> 1:45 PM (en-US)<br /><br /> 2009-06-15T13:45:30 -> 13:45 (hr-HR)<br /><br /> 2009-06-15T13:45:30 -> 01:45 م (ar-EG)|
 |"T"|Long time pattern.<br /><br /> More information: [The long time ("T") format specifier](#LongTime).|2009-06-15T13:45:30 -> 1:45:30 PM (en-US)<br /><br /> 2009-06-15T13:45:30 -> 13:45:30 (hr-HR)<br /><br /> 2009-06-15T13:45:30 -> 01:45:30 م (ar-EG)|
@@ -287,7 +287,7 @@ The following example uses the "o" format specifier to create a formatted string
 
 ### The RFC1123 ("R", "r") format specifier
 
-The "R" or "r" standard format specifier represents a custom date and time format string that is defined by the <xref:System.Globalization.DateTimeFormatInfo.RFC1123Pattern%2A?displayProperty=nameWithType> property. The pattern reflects a defined standard, and the property is read-only. Therefore, it is always the same, regardless of the culture used or the format provider supplied. The custom format string is "ddd, dd MMM yyyy HH':'mm':'ss 'GMT'". When this standard format specifier is used, the formatting or parsing operation always uses the invariant culture.
+The "R" or "r" standard format specifier represents a custom date and time format string that's defined by the <xref:System.Globalization.DateTimeFormatInfo.RFC1123Pattern%2A?displayProperty=nameWithType> property. The pattern reflects a defined standard, and the property is read-only. Therefore, it is always the same, regardless of the culture used or the format provider supplied. The custom format string is "ddd, dd MMM yyyy HH':'mm':'ss 'GMT'". When this standard format specifier is used, the formatting or parsing operation always uses the invariant culture.
 
 The result string is affected by the following properties of the <xref:System.Globalization.DateTimeFormatInfo> object returned by the <xref:System.Globalization.DateTimeFormatInfo.InvariantInfo%2A?displayProperty=nameWithType> property that represents the invariant culture.
 
@@ -297,7 +297,7 @@ The result string is affected by the following properties of the <xref:System.Gl
 |<xref:System.Globalization.DateTimeFormatInfo.AbbreviatedDayNames%2A>|Defines the abbreviated day names that can appear in the result string.|
 |<xref:System.Globalization.DateTimeFormatInfo.AbbreviatedMonthNames%2A>|Defines the abbreviated month names that can appear in the result string.|
 
-Although the RFC 1123 standard expresses a time as Coordinated Universal Time (UTC), the formatting operation does not modify the value of the <xref:System.DateTime> object that is being formatted. Therefore, you must convert the <xref:System.DateTime> value to UTC by calling the <xref:System.DateTime.ToUniversalTime%2A?displayProperty=nameWithType> method before you perform the formatting operation. In contrast, <xref:System.DateTimeOffset> values perform this conversion automatically; there is no need to call the <xref:System.DateTimeOffset.ToUniversalTime%2A?displayProperty=nameWithType> method before the formatting operation.
+Although the RFC 1123 standard expresses a time as Coordinated Universal Time (UTC), the formatting operation does not modify the value of the <xref:System.DateTime> object that's being formatted. Therefore, you must convert the <xref:System.DateTime> value to UTC by calling the <xref:System.DateTime.ToUniversalTime%2A?displayProperty=nameWithType> method before you perform the formatting operation. In contrast, <xref:System.DateTimeOffset> values perform this conversion automatically; there's no need to call the <xref:System.DateTimeOffset.ToUniversalTime%2A?displayProperty=nameWithType> method before the formatting operation.
 
 The following example uses the "r" format specifier to display a <xref:System.DateTime> and a <xref:System.DateTimeOffset> value on a system in the U.S. Pacific Time zone.
 

--- a/docs/standard/datetime/choosing-between-datetime.md
+++ b/docs/standard/datetime/choosing-between-datetime.md
@@ -1,7 +1,7 @@
 ---
 title: Compare types related to date and time
 description: Learn about differences between the DateTime, DateOnly, DateTimeOffset, TimeSpan, TimeOnly, and TimeZoneInfo types to represent date and time information in .NET.
-ms.date: "04/10/2017"
+ms.date: 04/05/2023
 dev_langs: 
   - "csharp"
   - "vb"
@@ -19,23 +19,17 @@ ms.assetid: 07f17aad-3571-4014-9ef3-b695a86f3800
 .NET applications can use date and time information in several ways. The more common uses of date and time information include:
 
 - To reflect a date only, so that time information is not important.
-
 - To reflect a time only, so that date information is not important.
-
-- To reflect an abstract date and time that is not tied to a specific time and place (for example, most stores in an international chain open on weekdays at 9:00 A.M.).
-
+- To reflect an abstract date and time that's not tied to a specific time and place (for example, most stores in an international chain open on weekdays at 9:00 A.M.).
 - To retrieve date and time information from sources outside of .NET, typically where date and time information is stored in a simple data type.
-
 - To uniquely and unambiguously identify a single point in time. Some applications require that a date and time be unambiguous only on the host system. Other apps require that it be unambiguous across systems (that is, a date serialized on one system can be meaningfully deserialized and used on another system anywhere in the world).
-
-- To preserve multiple related times (such as the requestor's local time and the server's time of receipt for a Web request).
-
+- To preserve multiple related times (such as the requestor's local time and the server's time of receipt for a web request).
 - To perform date and time arithmetic, possibly with a result that uniquely and unambiguously identifies a single point in time.
 
 .NET includes the <xref:System.DateTime>, <xref:System.DateOnly>, <xref:System.DateTimeOffset>, <xref:System.TimeSpan>, <xref:System.TimeOnly>, and <xref:System.TimeZoneInfo> types, all of which can be used to build applications that work with dates and times.
 
 > [!NOTE]
-> This topic doesn't discuss <xref:System.TimeZone> because its functionality is almost entirely incorporated in the <xref:System.TimeZoneInfo> class. Whenever possible, use the <xref:System.TimeZoneInfo> class instead of the <xref:System.TimeZone> class.
+> This article doesn't discuss <xref:System.TimeZone> because its functionality is almost entirely incorporated in the <xref:System.TimeZoneInfo> class. Whenever possible, use the <xref:System.TimeZoneInfo> class instead of the <xref:System.TimeZone> class.
 
 ## The DateTimeOffset structure
 
@@ -44,9 +38,7 @@ The <xref:System.DateTimeOffset> structure represents a date and time value, tog
 The <xref:System.DateTimeOffset> type includes all of the functionality of the <xref:System.DateTime> type along with time zone awareness. This makes it suitable for applications that:
 
 - Uniquely and unambiguously identify a single point in time. The <xref:System.DateTimeOffset> type can be used to unambiguously define the meaning of "now", to log transaction times, to log the times of system or application events, and to record file creation and modification times.
-
 - Perform general date and time arithmetic.
-
 - Preserve multiple related times, as long as those times are stored as two separate values or as two members of a structure.
 
 > [!NOTE]
@@ -65,35 +57,24 @@ A <xref:System.DateTime> value defines a particular date and time. It includes a
 
 The <xref:System.DateTime> structure is suitable for applications with one or more of the following characteristics:
 
-- Work with dates only.
-
-- Work with times only.
-
 - Work with abstract dates and times.
-
 - Work with dates and times for which time zone information is missing.
-
 - Work with UTC dates and times only.
-
-- Retrieve date and time information from sources outside of .NET, such as SQL databases. Typically, these sources store date and time information in a simple format that is compatible with the <xref:System.DateTime> structure.
-
 - Perform date and time arithmetic, but are concerned with general results. For example, in an addition operation that adds six months to a particular date and time, it is often not important whether the result is adjusted for daylight saving time.
 
-Unless a particular <xref:System.DateTime> value represents UTC, that date and time value is often ambiguous or limited in its portability. For example, if a <xref:System.DateTime> value represents the local time, it is portable within that local time zone (that is, if the value is deserialized on another system in the same time zone, that value still unambiguously identifies a single point in time). Outside the local time zone, that <xref:System.DateTime> value can have multiple interpretations. If the value's <xref:System.DateTime.Kind%2A> property is <xref:System.DateTimeKind.Unspecified?displayProperty=nameWithType>, it is even less portable: it is now ambiguous within the same time zone and possibly even on the same system on which it was first serialized. Only if a <xref:System.DateTime> value represents UTC does that value unambiguously identify a single point in time regardless of the system or time zone in which the value is used.
+Unless a particular <xref:System.DateTime> value represents UTC, that date and time value is often ambiguous or limited in its portability. For example, if a <xref:System.DateTime> value represents the local time, it's portable within that local time zone (that is, if the value is deserialized on another system in the same time zone, that value still unambiguously identifies a single point in time). Outside the local time zone, that <xref:System.DateTime> value can have multiple interpretations. If the value's <xref:System.DateTime.Kind%2A> property is <xref:System.DateTimeKind.Unspecified?displayProperty=nameWithType>, it's even less portable: it is now ambiguous within the same time zone and possibly even on the same system where it was first serialized. Only if a <xref:System.DateTime> value represents UTC does that value unambiguously identify a single point in time regardless of the system or time zone in which the value is used.
 
 > [!IMPORTANT]
-> When saving or sharing <xref:System.DateTime> data, UTC should be used and the <xref:System.DateTime> value's <xref:System.DateTime.Kind%2A> property should be set to <xref:System.DateTimeKind.Utc?displayProperty=nameWithType>.
+> When saving or sharing <xref:System.DateTime> data, use UTC and set the <xref:System.DateTime> value's <xref:System.DateTime.Kind%2A> property to <xref:System.DateTimeKind.Utc?displayProperty=nameWithType>.
 
 ## The DateOnly structure
 
-The <xref:System.DateOnly> structure represents a specific date, without time. Since it has no time component, it represents a date from the start of the day to the end of the day. This structure is ideal for storing specific dates, such as a birth date, an anniversary date, or business-related dates.
+The <xref:System.DateOnly> structure represents a specific date, without time. Since it has no time component, it represents a date from the start of the day to the end of the day. This structure is ideal for storing specific dates, such as a birth date, an anniversary date, a holiday, or a business-related date.
 
 Although you could use `DateTime` while ignoring the time component, there are a few benefits to using `DateOnly` over `DateTime`:
 
 - The `DateTime` structure may roll into the previous or next day if it's offset by a time zone. `DateOnly` can't be offset by a time zone, and it always represents the date that was set.
-
 - Serializing a `DateTime` structure includes the time component, which may obscure the intent of the data. Also, `DateOnly` serializes less data.
-
 - When code interacts with a database, such as SQL Server, whole dates are generally stored as the `date` data type, which doesn't include a time. `DateOnly` matches the database type better.
 
 For more information about `DateOnly`, see [How to use the DateOnly and TimeOnly structures](how-to-use-dateonly-timeonly.md).
@@ -106,7 +87,6 @@ For more information about `DateOnly`, see [How to use the DateOnly and TimeOnly
 The <xref:System.TimeSpan> structure represents a time interval. Its two typical uses are:
 
 - Reflecting the time interval between two date and time values. For example, subtracting one <xref:System.DateTime> value from another returns a <xref:System.TimeSpan> value.
-
 - Measuring elapsed time. For example, the <xref:System.Diagnostics.Stopwatch.Elapsed%2A?displayProperty=nameWithType> property returns a <xref:System.TimeSpan> value that reflects the time interval that has elapsed since the call to one of the <xref:System.Diagnostics.Stopwatch> methods that begins to measure elapsed time.
 
 A <xref:System.TimeSpan> value can also be used as a replacement for a <xref:System.DateTime> value when that value reflects a time without reference to a particular day. This usage is similar to the <xref:System.DateTime.TimeOfDay%2A?displayProperty=nameWithType> and <xref:System.DateTimeOffset.TimeOfDay%2A?displayProperty=nameWithType> properties, which return a <xref:System.TimeSpan> value that represents the time without reference to a date. For example, the <xref:System.TimeSpan> structure can be used to reflect a store's daily opening or closing time, or it can be used to represent the time at which any regular event occurs.
@@ -128,11 +108,8 @@ The <xref:System.TimeOnly> structure represents a time-of-day value, such as a d
 Prior to the `TimeOnly` type being introduced, programmers typically used either the <xref:System.DateTime> type or the <xref:System.TimeSpan> type to represent a specific time. However, using these structures to simulate a time without a date may introduce some problems, which `TimeOnly` solves:
 
 - `TimeSpan` represents elapsed time, such as time measured with a stopwatch. The upper range is more than 29,000 years, and its value can be negative to indicate moving backwards in time. A negative `TimeSpan` doesn't indicate a specific time of the day.
-
-- If `TimeSpan` is used as a time of day, there's a risk that it could be manipulated to a value outside of the 24-hour day. `TimeOnly` doesn't have this risk. For example, if an employee's work shift starts at 18:00 and lasts for 8 hours, adding 8 hours to the `TimeOnly` structure rolls over to 2:00
-
+- If `TimeSpan` is used as a time of day, there's a risk that it could be manipulated to a value outside of the 24-hour day. `TimeOnly` doesn't have this risk. For example, if an employee's work shift starts at 18:00 and lasts for 8 hours, adding 8 hours to the `TimeOnly` structure rolls over to 2:00.
 - Using `DateTime` for a time of day requires that an arbitrary date be associated with the time, and then later disregarded. It's common practice to choose `DateTime.MinValue` (0001-01-01) as the date, however, if hours are subtracted from the `DateTime` value, an `OutOfRange` exception might occur. `TimeOnly` doesn't have this problem as the time rolls forwards and backwards around the 24-hour timeframe.
-
 - Serializing a `DateTime` structure includes the date component, which may obscure the intent of the data. Also, `TimeOnly` serializes less data.
 
 For more information about `TimeOnly`, see [How to use the DateOnly and TimeOnly structures](how-to-use-dateonly-timeonly.md).


### PR DESCRIPTION
Fixes #30764.

Also updates recommended use of DateTime (removed database use in favor of DateOnly).

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/base-types/standard-date-and-time-format-strings.md](https://github.com/dotnet/docs/blob/fe0b1ec1b72edb7e8a0a396e7fff4c34790ece69/docs/standard/base-types/standard-date-and-time-format-strings.md) | [Standard date and time format strings](https://review.learn.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings?branch=pr-en-us-34898) |
| [docs/standard/datetime/choosing-between-datetime.md](https://github.com/dotnet/docs/blob/fe0b1ec1b72edb7e8a0a396e7fff4c34790ece69/docs/standard/datetime/choosing-between-datetime.md) | [Choose between DateTime, DateOnly, DateTimeOffset, TimeSpan, TimeOnly, and TimeZoneInfo](https://review.learn.microsoft.com/en-us/dotnet/standard/datetime/choosing-between-datetime?branch=pr-en-us-34898) |


<!-- PREVIEW-TABLE-END -->