### PR TITLE
Remove the link to the unpublished feature spec

### DIFF
--- a/docs/csharp/language-reference/statements/fixed.md
+++ b/docs/csharp/language-reference/statements/fixed.md
@@ -52,8 +52,6 @@ For more information, see the following sections of the [C# language specificati
 - [The fixed statement](~/_csharpstandard/standard/unsafe-code.md#227-the-fixed-statement)
 - [Fixed and moveable variables](~/_csharpstandard/standard/unsafe-code.md#224-fixed-and-moveable-variables)
 
-For information about the pattern-based `fixed` statement, see the [Pattern-based `fixed` statement](~/_csharplang/proposals/csharp-7.3/pattern-based-fixed.md) feature proposal note.
-
 ## See also
 
 - [C# reference](../index.md)


### PR DESCRIPTION
Follows #34904 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/statements/fixed.md](https://github.com/dotnet/docs/blob/c7be4de8df897be1f267da43fbf9593ef5347db1/docs/csharp/language-reference/statements/fixed.md) | [fixed statement - safely access memory underlying a variable](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/statements/fixed?branch=pr-en-us-34927) |

<!-- PREVIEW-TABLE-END -->