### PR TITLE
Fix incorrect endpoint

### DIFF
--- a/docs/framework/wcf/how-to-host-and-run-a-basic-wcf-service.md
+++ b/docs/framework/wcf/how-to-host-and-run-a-basic-wcf-service.md
@@ -192,7 +192,7 @@ Make the following changes to the code:
 
     The service must be run with administrator privileges. Because you opened Visual Studio with administrator privileges, when you run **GettingStartedHost** in Visual Studio, the application is run with administrator privileges as well. As an alternative, you can open a new command prompt as an administrator (select **More** > **Run as administrator** from the shortcut menu) and run **GettingStartedHost.exe** within it.
 
-2. Open a web browser and browse to the service's page at `http://localhost:8000/GettingStarted/CalculatorService`.
+2. Open a web browser and browse to the service's page at `http://localhost:8000/GettingStarted/`.
 
    > [!NOTE]
    > Services such as this one require the proper permission to register HTTP addresses on the machine for listening. Administrator accounts have this permission, but non-administrator accounts must be granted permission for HTTP namespaces. For more information about how to configure namespace reservations, see [Configuring HTTP and HTTPS](feature-details/configuring-http-and-https.md).


### PR DESCRIPTION
## Summary

The incorrect endpoint is provided in step 2 of "Verify the service is working" - propose to either change the endpoint there, or update on line 13 in Program.cs.


Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/wcf/how-to-host-and-run-a-basic-wcf-service.md](https://github.com/dotnet/docs/blob/a61b9a074466c0875aad1fef2417083593e130ac/docs/framework/wcf/how-to-host-and-run-a-basic-wcf-service.md) | [Tutorial: Host and run a basic Windows Communication Foundation service](https://review.learn.microsoft.com/en-us/dotnet/framework/wcf/how-to-host-and-run-a-basic-wcf-service?branch=pr-en-us-34933) |


<!-- PREVIEW-TABLE-END -->