### PR TITLE
Add async delegates to the overall list of migration considerations, and details in the details doc.

### DIFF
--- a/docs/core/porting/index.md
+++ b/docs/core/porting/index.md
@@ -78,6 +78,8 @@ There are a few technologies in .NET Framework that don't exist in .NET:
 
   Remoting is used for communicating across application domains, which are no longer supported. For simple communication across processes, consider inter-process communication (IPC) mechanisms as an alternative to remoting, such as the <xref:System.IO.Pipes> class or the <xref:System.IO.MemoryMappedFiles.MemoryMappedFile> class. For more complex scenarios, consider frameworks such as [StreamJsonRpc](https://github.com/microsoft/vs-streamjsonrpc) or [ASP.NET Core](/aspnet/core) (either using [gRPC](/aspnet/core/grpc) or [RESTful Web API services](/aspnet/core/web-api)).
 
+  Async delegates are not supported. This means that calls to `BeginInvoke()` and `EndInvoke()` on delegate objects will throw an exception.
+
 - [Code access security (CAS)](net-framework-tech-unavailable.md#code-access-security-cas)
 
   CAS was a sandboxing technique supported by .NET Framework but deprecated in .NET Framework 4.0. It was replaced by Security Transparency and it isn't supported in .NET. Instead, use security boundaries provided by the operating system, such as virtualization, containers, or user accounts.

--- a/docs/core/porting/index.md
+++ b/docs/core/porting/index.md
@@ -78,7 +78,7 @@ There are a few technologies in .NET Framework that don't exist in .NET:
 
   Remoting is used for communicating across application domains, which are no longer supported. For simple communication across processes, consider inter-process communication (IPC) mechanisms as an alternative to remoting, such as the <xref:System.IO.Pipes> class or the <xref:System.IO.MemoryMappedFiles.MemoryMappedFile> class. For more complex scenarios, consider frameworks such as [StreamJsonRpc](https://github.com/microsoft/vs-streamjsonrpc) or [ASP.NET Core](/aspnet/core) (either using [gRPC](/aspnet/core/grpc) or [RESTful Web API services](/aspnet/core/web-api)).
 
-  Async delegates are not supported. This means that calls to `BeginInvoke()` and `EndInvoke()` on delegate objects will throw an exception.
+  Because remoting is not supported, calls to `BeginInvoke()` and `EndInvoke()` on delegate objects will throw `PlatformNotSupportedException`.
 
 - [Code access security (CAS)](net-framework-tech-unavailable.md#code-access-security-cas)
 

--- a/docs/core/porting/net-framework-tech-unavailable.md
+++ b/docs/core/porting/net-framework-tech-unavailable.md
@@ -27,6 +27,8 @@ Across machines, use a network-based solution as an alternative. Preferably, use
 
 For more messaging options, see [.NET Open Source Developer Projects: Messaging](https://github.com/Microsoft/dotnet/blob/master/dotnet-developer-projects.md#messaging).
 
+Async delegates are not supported on .NET 6+. This is because they depend on remoting. This means that calls to `BeginInvoke` and `EndInvoke` on delegates will throw a `PlatformNotSupportedException`. For more information, see [Migrating Delegate BeginInvoke Calls For .NET Core](https://devblogs.microsoft.com/dotnet/migrating-delegate-begininvoke-calls-for-net-core/).
+
 ## Code access security (CAS)
 
 Sandboxing, which relies on the runtime or the framework to constrain which resources a managed application or library uses or runs, [isn't supported on .NET Framework](/previous-versions/dotnet/framework/code-access-security/code-access-security) and therefore is also not supported on .NET 6+. CAS is no longer treated as a security boundary, because there are too many cases in .NET Framework and the runtime where an elevation of privileges occurs. Also, CAS makes the implementation more complicated and often has correctness-performance implications for applications that don't intend to use it.

--- a/docs/core/porting/net-framework-tech-unavailable.md
+++ b/docs/core/porting/net-framework-tech-unavailable.md
@@ -27,7 +27,7 @@ Across machines, use a network-based solution as an alternative. Preferably, use
 
 For more messaging options, see [.NET Open Source Developer Projects: Messaging](https://github.com/Microsoft/dotnet/blob/master/dotnet-developer-projects.md#messaging).
 
-Async delegates are not supported on .NET 6+. This is because they depend on remoting. This means that calls to `BeginInvoke` and `EndInvoke` on delegates will throw a `PlatformNotSupportedException`. For more information, see [Migrating Delegate BeginInvoke Calls For .NET Core](https://devblogs.microsoft.com/dotnet/migrating-delegate-begininvoke-calls-for-net-core/).
+Because remoting is not supported, calls to `BeginInvoke()` and `EndInvoke()` on delegate objects will throw `PlatformNotSupportedException`. For more information, see [Migrating Delegate BeginInvoke Calls For .NET Core](https://devblogs.microsoft.com/dotnet/migrating-delegate-begininvoke-calls-for-net-core/).
 
 ## Code access security (CAS)
 


### PR DESCRIPTION
A number of customers have hit this ([eg](https://github.com/dotnet/runtime/issues/16312)) and I learned that an internal service was surprised by this during porting as well. They expected to see it listed in this doc.

cc @wikimonkey @stephentoub 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/porting/index.md](https://github.com/dotnet/docs/blob/8d49bea33b4b78222c78aa9e23e6c9dd06b92a67/docs/core/porting/index.md) | [Overview of porting from .NET Framework to .NET](https://review.learn.microsoft.com/en-us/dotnet/core/porting/index?branch=pr-en-us-34937) |
| [docs/core/porting/net-framework-tech-unavailable.md](https://github.com/dotnet/docs/blob/8d49bea33b4b78222c78aa9e23e6c9dd06b92a67/docs/core/porting/net-framework-tech-unavailable.md) | [.NET Framework technologies unavailable on .NET](https://review.learn.microsoft.com/en-us/dotnet/core/porting/net-framework-tech-unavailable?branch=pr-en-us-34937) |


<!-- PREVIEW-TABLE-END -->