### PR TITLE
Fix unclear wording in BinaryFormatter security guide

### DIFF
--- a/docs/standard/serialization/binaryformatter-security-guide.md
+++ b/docs/standard/serialization/binaryformatter-security-guide.md
@@ -41,7 +41,7 @@ As a simpler analogy, assume that calling `BinaryFormatter.Deserialize` over a p
 
 `BinaryFormatter.Deserialize` may be vulnerable to other attack categories, such as information disclosure or remote code execution. Utilizing features such as a custom <xref:System.Runtime.Serialization.SerializationBinder> may be insufficient to properly mitigate these risks. The possibility exists that a novel vulnerability will be discovered for which .NET cannot practically publish a security update. Consumers should assess their individual scenarios and consider their potential exposure to these risks.
 
-We recommend that `BinaryFormatter` consumers perform individual risk assessments on their apps. It is the consumer's sole responsibility to determine whether to utilize `BinaryFormatter`. Consumers should risk assess the security, technical, reputation, legal, and regulatory consequences of using `BinaryFormatter`.
+We recommend that `BinaryFormatter` consumers perform individual risk assessments on their apps. It is the consumer's sole responsibility to determine whether to utilize `BinaryFormatter`. If you're considering using it, you should risk-assess the security, technical, reputation, legal, and regulatory consequences.
 
 ## Preferred alternatives
 

--- a/docs/standard/serialization/binaryformatter-security-guide.md
+++ b/docs/standard/serialization/binaryformatter-security-guide.md
@@ -41,7 +41,7 @@ As a simpler analogy, assume that calling `BinaryFormatter.Deserialize` over a p
 
 `BinaryFormatter.Deserialize` may be vulnerable to other attack categories, such as information disclosure or remote code execution. Utilizing features such as a custom <xref:System.Runtime.Serialization.SerializationBinder> may be insufficient to properly mitigate these risks. The possibility exists that a novel vulnerability will be discovered for which .NET cannot practically publish a security update. Consumers should assess their individual scenarios and consider their potential exposure to these risks.
 
-We recommend that `BinaryFormatter` consumers perform individual risk assessments on their apps. It is the consumer's sole responsibility to determine whether to utilize `BinaryFormatter`. Consumers should risk assess the security, technical, reputation, legal, and regulatory requirements of using `BinaryFormatter`.
+We recommend that `BinaryFormatter` consumers perform individual risk assessments on their apps. It is the consumer's sole responsibility to determine whether to utilize `BinaryFormatter`. Consumers should risk assess the security, technical, reputation, legal, and regulatory consequences of using `BinaryFormatter`.
 
 ## Preferred alternatives
 


### PR DESCRIPTION
## Summary

The word "requirements" is confusing in context. Recommending a change:

> Consumers should risk assess the security, technical, reputation, legal, and regulatory ~~requirements~~ **consequences** of using BinaryFormatter.

The word "impact" could probably serve as a good substitute as well.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/serialization/binaryformatter-security-guide.md](https://github.com/dotnet/docs/blob/a0ceaec67881bc9b9f6d564604d4e4c4597c5cbb/docs/standard/serialization/binaryformatter-security-guide.md) | [Deserialization risks in use of BinaryFormatter and related types](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/binaryformatter-security-guide?branch=pr-en-us-34939) |


<!-- PREVIEW-TABLE-END -->