### PR TITLE
Fix wrong startup project

### DIFF
--- a/docs/framework/wcf/how-to-use-a-wcf-client.md
+++ b/docs/framework/wcf/how-to-use-a-wcf-client.md
@@ -138,9 +138,9 @@ Notice the `using` (for Visual C#) or `Imports` (for Visual Basic) statement tha
 
 1. Save and build the solution.
 
-2. Select the **GettingStartedLib** folder, and then select **Set as Startup Project** from the shortcut menu.
+2. Select the **GettingStartedClient** folder, and then select **Set as Startup Project** from the shortcut menu.
 
-3. From **Startup Projects**, select **GettingStartedLib** from the drop-down list, then select **Run** or press <kbd>F5</kbd>.
+3. From **Startup Projects**, select **GettingStartedClient** from the drop-down list, then select **Run** or press <kbd>F5</kbd>.
 
 ### Test the application from a command prompt
 


### PR DESCRIPTION
## Summary
GettingStartedLib is not the correct startup project for the tutorial to work correctly for this step. GettingStartedClient is the correct project.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/wcf/how-to-use-a-wcf-client.md](https://github.com/dotnet/docs/blob/596fdb586f6be51945e26745b0042e8f4da5da79/docs/framework/wcf/how-to-use-a-wcf-client.md) | [Tutorial: Use a Windows Communication Foundation client](https://review.learn.microsoft.com/en-us/dotnet/framework/wcf/how-to-use-a-wcf-client?branch=pr-en-us-34941) |

<!-- PREVIEW-TABLE-END -->