### PR TITLE
Add nushell to enable-tab-autocomplete.md

### DIFF
--- a/docs/core/tools/enable-tab-autocomplete.md
+++ b/docs/core/tools/enable-tab-autocomplete.md
@@ -106,3 +106,18 @@ To add tab completion to your **fish** shell for the .NET CLI, add the following
 ```fish
 complete -f -c dotnet -a "(dotnet complete (commandline -cp))"
 ```
+
+## nushell
+
+To add tab completion to your **nushell** for .NET CLI, add the following to your `config.nu` file:
+```nu
+# completion for the .NET CLI
+
+def "nu-cmp dotnet" [context: string] {
+    ^dotnet complete ($context | split words | skip 1 | str join " ") | lines
+}
+
+export extern "dotnet" [ 
+    ...args: any@"nu-cmp dotnet"
+]
+```

--- a/docs/core/tools/enable-tab-autocomplete.md
+++ b/docs/core/tools/enable-tab-autocomplete.md
@@ -110,8 +110,8 @@ complete -f -c dotnet -a "(dotnet complete (commandline -cp))"
 ## nushell
 
 To add tab completion to your **nushell** for .NET CLI, add the following to your `config.nu` file:
-```nu
 
+```nu
 # completion for the .NET CLI
 
 def "nu-cmp dotnet" [context: string] {

--- a/docs/core/tools/enable-tab-autocomplete.md
+++ b/docs/core/tools/enable-tab-autocomplete.md
@@ -111,6 +111,7 @@ complete -f -c dotnet -a "(dotnet complete (commandline -cp))"
 
 To add tab completion to your **nushell** for .NET CLI, add the following to your `config.nu` file:
 ```nu
+
 # completion for the .NET CLI
 
 def "nu-cmp dotnet" [context: string] {


### PR DESCRIPTION
## Summary
Add instructions for enabling completion of .NET CLI commands in [nushell](https://github.com/nushell/nushell)

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/enable-tab-autocomplete.md](https://github.com/dotnet/docs/blob/a0f7074d24b7774f374b8e5238d971d990953eb6/docs/core/tools/enable-tab-autocomplete.md) | [zsh parameter completion for the dotnet CLI](https://review.learn.microsoft.com/en-us/dotnet/core/tools/enable-tab-autocomplete?branch=pr-en-us-34942) |


<!-- PREVIEW-TABLE-END -->

_tdykstra edit to add link to issue_

Fixes #34944
