### PR TITLE
Patterns reference: Added the link to the patterns spec

### DIFF
--- a/docs/csharp/language-reference/operators/patterns.md
+++ b/docs/csharp/language-reference/operators/patterns.md
@@ -281,9 +281,10 @@ For more information, see the [List patterns](~/_csharplang/proposals/csharp-11.
 
 ## C# language specification
 
-For more information, see the following feature proposal notes:
+For more information, see the [Patterns and pattern matching](~/_csharpstandard/standard/patterns.md) section of the [C# language specification](~/_csharpstandard/standard/README.md).
 
-- [C# 7 - Pattern matching](~/_csharplang/proposals/csharp-7.0/pattern-matching.md)
+For information about features added in C# 8 and later, see the following feature proposal notes:
+
 - [C# 8 - Recursive pattern matching](~/_csharplang/proposals/csharp-8.0/patterns.md)
 - [C# 9 - Pattern-matching updates](~/_csharplang/proposals/csharp-9.0/patterns3.md)
 - [C# 10 - Extended property patterns](~/_csharplang/proposals/csharp-10.0/extended-property-patterns.md)


### PR DESCRIPTION
Follows #34945 
@BillWagner cool to see the progress on the C# spec updates!!


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/patterns.md](https://github.com/dotnet/docs/blob/bff8e059bb7dd24f4aa5d29c278f35ec4aba39d4/docs/csharp/language-reference/operators/patterns.md) | [Pattern matching - the `is` and `switch` expressions, and operators `and`, `or` and `not` in patterns](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/patterns?branch=pr-en-us-34989) |

<!-- PREVIEW-TABLE-END -->