### PR TITLE
Fix Description

### DIFF
--- a/docs/core/porting/index.md
+++ b/docs/core/porting/index.md
@@ -1,6 +1,6 @@
 ---
 title: Port from .NET Framework to .NET 7
-description: Understand the porting process and discover tools you may find helpful when porting a .NET Framework project to .NET 6.
+description: Understand the porting process and discover tools you may find helpful when porting a .NET Framework project to .NET 7.
 author: adegeo
 ms.date: 02/28/2023
 ms.custom: devdivchpfy22


### PR DESCRIPTION
There is an inconsistency with the .NET version between this doc's title and description.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/porting/index.md](https://github.com/dotnet/docs/blob/768e00a8a99f28e6a719be61827f2a4740a06340/docs/core/porting/index.md) | [Overview of porting from .NET Framework to .NET](https://review.learn.microsoft.com/en-us/dotnet/core/porting/index?branch=pr-en-us-34991) |

<!-- PREVIEW-TABLE-END -->