### PR TITLE
Removing Windows 7 and 8.1 from .NET7 support

### DIFF
--- a/docs/core/install/windows.md
+++ b/docs/core/install/windows.md
@@ -277,7 +277,6 @@ The following Windows versions are supported with .NET 7:
 |---------------------|---------------|-----------------|
 | Windows 11          | 21H2+         | x64, Arm64      |
 | Windows 10 Client   | 1607+         | x64, x86, Arm64 |
-| Windows Client      | 7 SP1+, 8.1   | x64, x86        |
 | Windows Server      | 2012+         | x64, x86        |
 | Windows Server Core | 2012+         | x64, x86        |
 | Nano Server         | 1809+         | x64             |


### PR DESCRIPTION
## Summary

Windows 7 and 8.1 are not supported by .NET7
More details are in the issue below
Fixes #35003 (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/windows.md](https://github.com/dotnet/docs/blob/d655d3d9e084c4f20d455a6f148fa883844e1a00/docs/core/install/windows.md) | [[.NET 6](#tab/net60)](https://review.learn.microsoft.com/en-us/dotnet/core/install/windows?branch=pr-en-us-35004) |

<!-- PREVIEW-TABLE-END -->