### PR TITLE
Update function-pointer-reflection.md

### DIFF
--- a/docs/core/compatibility/reflection/8.0/function-pointer-reflection.md
+++ b/docs/core/compatibility/reflection/8.0/function-pointer-reflection.md
@@ -31,7 +31,7 @@ This change is a [behavioral change](../../categories.md#behavioral-change).
 
 ## Reason for change
 
-This change adds the capability to obtain function pointer metadata including parameter types, the return type, and the calling conventions. Function pointer support was added with C# 9 and .NET 6, but reflection support wasn't added at that time.
+This change adds the capability to obtain function pointer metadata including parameter types, the return type, and the calling conventions. Function pointer support was added with C# 9 and .NET 5, but reflection support wasn't added at that time.
 
 ## Recommended action
 


### PR DESCRIPTION
C# 9 came with .NET 5, not 6.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/reflection/8.0/function-pointer-reflection.md](https://github.com/dotnet/docs/blob/91e5c2a4767c5ff0d355b39d7f46aae8e16a6d34/docs/core/compatibility/reflection/8.0/function-pointer-reflection.md) | [IntPtr no longer used for function pointer types](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/reflection/8.0/function-pointer-reflection?branch=pr-en-us-35005) |

<!-- PREVIEW-TABLE-END -->