### PR TITLE
Update 7.0.md with implicit Required for ASP.NET Core 7 model binding

### DIFF
--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -34,6 +34,7 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 | [MVC's detection of an empty body in model binding changed](aspnet-core/7.0/mvc-empty-body-model-binding.md) | ❌ | ✔️ | Preview 3 |
 | [Output caching API changes](aspnet-core/7.0/output-caching-renames.md) | ❌ | ❌ | RC 2 |
 | [SignalR Hub methods try to resolve parameters from DI](aspnet-core/7.0/signalr-hub-method-parameters-di.md) | ✔️ | ❌ | Preview 2 |
+| [Model binding: Nullability enabled means implicitly Required fields]([aspnet-core/7.0/signalr-hub-method-parameters-di.md](https://learn.microsoft.com/en-us/aspnet/core/mvc/models/validation?view=aspnetcore-6.0#non-nullable-reference-types-and-the-required-attribute)) | ❓ | ❓ | No idea, plz halp |
 
 ## Core .NET libraries
 


### PR DESCRIPTION
## Summary

This hit us when going from ASP.NET Core 6 to 7.

Nullability: enabled

A model sent to an API controller  containing a `string` field was not treated as [Required] in ASP.NET Core 6, but was implicitly [Required] in 7.

Mark: The docs say this is already present in ASP.NET Core 6, but this only hit us after migrating to 7, so something does not add up.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/7.0.md](https://github.com/dotnet/docs/blob/98ab1ecb278e66bd9a693e84d057df35079dc73e/docs/core/compatibility/7.0.md) | [Breaking changes in .NET 7](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/7.0?branch=pr-en-us-35007) |

<!-- PREVIEW-TABLE-END -->