### PR TITLE
CS0156: Correct the error message

### DIFF
--- a/docs/csharp/misc/cs0156.md
+++ b/docs/csharp/misc/cs0156.md
@@ -10,7 +10,7 @@ ms.assetid: 32026b1b-bcd7-4464-b63f-3b38c00452a6
 ---
 # Compiler Error CS0156
 
-A throw statement with no arguments is not allowed in a finally clause that is nested inside the nearest enclosing catch clause  
+A throw statement with no arguments is not allowed outside of a catch clause  
   
  A [throw](../language-reference/keywords/throw.md) statement with no parameters can only appear in a **catch** clause that takes no parameters.  
   


### PR DESCRIPTION
For example, in sharplab.io:
https://sharplab.io/#v2:EYLgtghglgdgNAExAagD4AEBMBGAsAKHQGYACLEgYRIG8CT6zT0AWEgWQAoBKGuh/gC4AnAJ59+9WvgkySAgBZCA9gHcA3OIkBfTfwDGEAXvk0d02f01mtQA


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/misc/cs0156.md](https://github.com/dotnet/docs/blob/ede927cb3bcedc5e9f5a360d27c4ea3a7541b871/docs/csharp/misc/cs0156.md) | [Compiler Error CS0156](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/cs0156?branch=pr-en-us-35011) |

<!-- PREVIEW-TABLE-END -->