### PR TITLE
Update link to Microsoft.Maui.Graphics library

### DIFF
--- a/docs/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only.md
+++ b/docs/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only.md
@@ -56,7 +56,7 @@ To use these APIs for cross-platform apps, migrate to one of the following libra
 
 - [ImageSharp](https://sixlabors.com/products/imagesharp)
 - [SkiaSharp](https://github.com/mono/SkiaSharp)
-- [Microsoft.Maui.Graphics](https://github.com/dotnet/Microsoft.Maui.Graphics)
+- [Microsoft.Maui.Graphics](https://learn.microsoft.com/en-us/dotnet/maui/user-interface/graphics/?view=net-maui-7.0)
 
 Alternatively, you can enable support for non-Windows platforms in .NET 6 by setting the `System.Drawing.EnableUnixSupport` [runtime configuration switch](../../../runtime-config/index.md) to `true` in the *runtimeconfig.json* file.
 

--- a/docs/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only.md
+++ b/docs/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only.md
@@ -56,7 +56,7 @@ To use these APIs for cross-platform apps, migrate to one of the following libra
 
 - [ImageSharp](https://sixlabors.com/products/imagesharp)
 - [SkiaSharp](https://github.com/mono/SkiaSharp)
-- [Microsoft.Maui.Graphics](https://learn.microsoft.com/en-us/dotnet/maui/user-interface/graphics/?view=net-maui-7.0)
+- [Microsoft.Maui.Graphics](https://learn.microsoft.com/dotnet/maui/user-interface/graphics/)
 
 Alternatively, you can enable support for non-Windows platforms in .NET 6 by setting the `System.Drawing.EnableUnixSupport` [runtime configuration switch](../../../runtime-config/index.md) to `true` in the *runtimeconfig.json* file.
 


### PR DESCRIPTION
## Summary

The dotnet/Microsoft.Maui.Graphics repository is not currently maintained and is not the right place to find the current version of the Microsoft.Maui.Graphics package, as it has been merged into the dotnet/maui repository. I have edited the link to point to the documentation of the maintained package (since it lacks any other landing page). See issue dotnet/Microsoft.Maui.Graphics#500

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only.md](https://github.com/dotnet/docs/blob/9ccf6553da5ad1b422f89da7750a3a6e91fea5fb/docs/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only.md) | [System.Drawing.Common only supported on Windows](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only?branch=pr-en-us-35015) |


<!-- PREVIEW-TABLE-END -->