### PR TITLE
Generic Pitfall removed

### DIFF
--- a/docs/csharp/nullable-references.md
+++ b/docs/csharp/nullable-references.md
@@ -292,27 +292,6 @@ public static class Program
 
 In the preceding example, there's no warning in `PrintStudent(default)` while the non-nullable reference types `FirstName` and `LastName` are null.
 
-Another more common case is when you deal with generic structs. Consider the following example:
-
-```csharp
-#nullable enable
-
-public struct Foo<T>
-{
-    public T Bar { get; set; }
-}
-
-public static class Program
-{
-    public static void Main()
-    {
-        string s = default(Foo<string>).Bar;
-    }
-}
-```
-
-In the preceding example, the property `Bar` is going to be `null` at run time, and it's assigned to non-nullable string without any warnings.
-
 ### Arrays
 
 Arrays are also a known pitfall in nullable reference types. Consider the following example that doesn't produce any warnings:


### PR DESCRIPTION
Generic example is fixed and delivers warning as I tested  in Visual Studio 17.4




<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/nullable-references.md](https://github.com/dotnet/docs/blob/d96cb0ecb68d00cfc3e6a17ff47cf6a647591858/docs/csharp/nullable-references.md) | [Nullable reference types](https://review.learn.microsoft.com/en-us/dotnet/csharp/nullable-references?branch=pr-en-us-35022) |

<!-- PREVIEW-TABLE-END -->