### PR TITLE
Fix wording

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/local-functions.md
+++ b/docs/csharp/programming-guide/classes-and-structs/local-functions.md
@@ -56,7 +56,7 @@ The preceding example uses a [special attribute](../../language-reference/attrib
 
 ## Local functions and exceptions
 
-One of the useful features of local functions is that they can allow exceptions to surface immediately. For method iterators, exceptions are surfaced only when the returned sequence is enumerated, and not when the iterator is retrieved. For async methods, any exceptions thrown in an async method are observed when the returned task is awaited.
+One of the useful features of local functions is that they can allow exceptions to surface immediately. For iterator methods, exceptions are surfaced only when the returned sequence is enumerated, and not when the iterator is retrieved. For async methods, any exceptions thrown in an async method are observed when the returned task is awaited.
 
 The following example defines an `OddSequence` method that enumerates odd numbers in a specified range. Because it passes a number greater than 100 to the `OddSequence` enumerator method, the method throws an <xref:System.ArgumentOutOfRangeException>. As the output from the example shows, the exception surfaces only when you iterate the numbers, and not when you retrieve the enumerator.
 


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/classes-and-structs/local-functions.md](https://github.com/dotnet/docs/blob/2ee57d23f674dd8b94a7ecd058cfb0f9f2d35d92/docs/csharp/programming-guide/classes-and-structs/local-functions.md) | [Local functions (C# Programming Guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/local-functions?branch=pr-en-us-35025) |

<!-- PREVIEW-TABLE-END -->