### PR TITLE
Update runtime-callable-wrapper.md

### DIFF
--- a/docs/standard/native-interop/runtime-callable-wrapper.md
+++ b/docs/standard/native-interop/runtime-callable-wrapper.md
@@ -28,7 +28,7 @@ The following image shows the process for accessing COM objects through the runt
   
 ## Marshalling selected interfaces  
 
- The primary goal of the [runtime callable wrapper](runtime-callable-wrapper.md) (RCW) is to hide the differences between the managed and unmanaged programming models. To create a seamless transition, the RCW consumes selected COM interfaces without exposing them to the .NET client, as shown in the following illustration.
+ The primary goal of the runtime callable wrapper (RCW) is to hide the differences between the managed and unmanaged programming models. To create a seamless transition, the RCW consumes selected COM interfaces without exposing them to the .NET client, as shown in the following illustration.
 
  The following image shows COM interfaces and the runtime callable wrapper:
   


### PR DESCRIPTION
Removing link to same page.

Fixes #29800

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/native-interop/runtime-callable-wrapper.md](https://github.com/dotnet/docs/blob/1e24cc478f9036aec1795d9abbcc2f4cf8704a79/docs/standard/native-interop/runtime-callable-wrapper.md) | [Runtime Callable Wrapper](https://review.learn.microsoft.com/en-us/dotnet/standard/native-interop/runtime-callable-wrapper?branch=pr-en-us-35035) |

<!-- PREVIEW-TABLE-END -->