### PR TITLE
Fix Ubuntu deps

### DIFF
--- a/docs/core/install/linux-ubuntu-2204.md
+++ b/docs/core/install/linux-ubuntu-2204.md
@@ -59,7 +59,7 @@ When you install with a package manager, these libraries are installed for you. 
 - libgcc1
 - libgcc-s1
 - libgssapi-krb5-2
-- libicu71
+- libicu70
 - liblttng-ust1
 - libssl3
 - libstdc++6


### PR DESCRIPTION
## Summary

- Fix the dependency library version.

Fixes #34707


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/linux-ubuntu-2204.md](https://github.com/dotnet/docs/blob/1ccc412e8fe157edfb98c712a679df5ef3958ad4/docs/core/install/linux-ubuntu-2204.md) | [Install .NET SDK or .NET Runtime on Ubuntu 22.04](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu-2204?branch=pr-en-us-35038) |

<!-- PREVIEW-TABLE-END -->