### PR TITLE
Redirect What's new in C# to C# 12, not 11

### DIFF
--- a/.openpublishing.redirection.csharp.json
+++ b/.openpublishing.redirection.csharp.json
@@ -3130,7 +3130,7 @@
         },
         {
             "source_path_from_root": "/docs/csharp/whats-new.md",
-            "redirect_url": "/dotnet/csharp/whats-new/csharp-11",
+            "redirect_url": "/dotnet/csharp/whats-new/csharp-12
             "redirect_document_id": true
         },
         {

--- a/.openpublishing.redirection.csharp.json
+++ b/.openpublishing.redirection.csharp.json
@@ -3130,7 +3130,7 @@
         },
         {
             "source_path_from_root": "/docs/csharp/whats-new.md",
-            "redirect_url": "/dotnet/csharp/whats-new/csharp-12"
+            "redirect_url": "/dotnet/csharp/whats-new/csharp-12",
             "redirect_document_id": true
         },
         {

--- a/.openpublishing.redirection.csharp.json
+++ b/.openpublishing.redirection.csharp.json
@@ -3130,7 +3130,7 @@
         },
         {
             "source_path_from_root": "/docs/csharp/whats-new.md",
-            "redirect_url": "/dotnet/csharp/whats-new/csharp-12
+            "redirect_url": "/dotnet/csharp/whats-new/csharp-12"
             "redirect_document_id": true
         },
         {


### PR DESCRIPTION
We've got preview content now

