### PR TITLE
Fix <xref> in diagnosticsource-diagnosticlistener.md

### DIFF
--- a/docs/core/diagnostics/diagnosticsource-diagnosticlistener.md
+++ b/docs/core/diagnostics/diagnosticsource-diagnosticlistener.md
@@ -180,7 +180,7 @@ To decode the payload more fully, you could replace the `listener.Subscribe()` c
 Note that using reflection is relatively expensive. However, using reflection is the only
 option if the payloads were generated using anonymous types. This overhead can be reduced by
 making fast, specialized property fetchers using either [PropertyInfo.GetMethod.CreateDelegate()](xref:System.Reflection.MethodInfo.CreateDelegate%2A) or
-xref<System.Reflection.Emit> namespace, but that's beyond the scope of this article.
+<xref:System.Reflection.Emit> namespace, but that's beyond the scope of this article.
 (For an example of a fast, delegate-based property fetcher, see the [PropertySpec](https://github.com/dotnet/runtime/blob/6de7147b9266d7730b0d73ba67632b0c198cb11e/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs#L1235)
 class used in the `DiagnosticSourceEventSource`.)
 


### PR DESCRIPTION
## Summary

This PR fixes an invalid <xref> reference in https://learn.microsoft.com/en-us/dotnet/core/diagnostics/diagnosticsource-diagnosticlistener#decode-payloads.

Here's a screenshot of the issue:
<img width="657" alt="image" src="https://user-images.githubusercontent.com/6381023/233130696-7f00add0-2ff0-42e9-976c-361b3bb41654.png">



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/diagnosticsource-diagnosticlistener.md](https://github.com/dotnet/docs/blob/f1a81fbd990b52a01447269e66721eef3fb31536/docs/core/diagnostics/diagnosticsource-diagnosticlistener.md) | [DiagnosticSource and DiagnosticListener](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/diagnosticsource-diagnosticlistener?branch=pr-en-us-35063) |

<!-- PREVIEW-TABLE-END -->