### PR TITLE
Exclude .MD from triggering snippets system

### DIFF
--- a/.github/workflows/snippets5000.yml
+++ b/.github/workflows/snippets5000.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches: [ main ]
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - '**/*.md'
   workflow_dispatch:
     inputs:
       reason:


### PR DESCRIPTION
## Summary

I believe this will prevent PRs that are simply editing MD files from triggering the workflow. This will save time and CPU cycles for every PR
