### PR TITLE
Fix typo in configuration.md

### DIFF
--- a/docs/core/extensions/configuration.md
+++ b/docs/core/extensions/configuration.md
@@ -187,7 +187,7 @@ The following table shows the configuration providers available to .NET Core app
 | [App secrets (Secret Manager)](/aspnet/core/security/app-secrets)                                                      | File in the user profile directory |
 
 > [!TIP]
-> The order in which configuration providers are added matters. When multiple configuration providers are used and more than one provided specifies the same key, the last one added is used.
+> The order in which configuration providers are added matters. When multiple configuration providers are used and more than one provider specifies the same key, the last one added is used.
 
 For more information on various configuration providers, see [Configuration providers in .NET](configuration-providers.md).
 


### PR DESCRIPTION
The sentence:

> ...and more than one **provided** specifies...

Should read:

> ...and more than one **provider** specifies...


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/configuration.md](https://github.com/dotnet/docs/blob/a38f7a60ae96b08fa264cb4bc0ed949bed4b5e08/docs/core/extensions/configuration.md) | [Configuration in .NET](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/configuration?branch=pr-en-us-35068) |


<!-- PREVIEW-TABLE-END -->