### PR TITLE
Revert "Exclude .MD from triggering snippets system (#35065)"

### DIFF
--- a/.github/workflows/snippets5000.yml
+++ b/.github/workflows/snippets5000.yml
@@ -7,8 +7,6 @@ on:
   pull_request:
     branches: [ main ]
     types: [opened, synchronize, reopened]
-    paths-ignore:
-      - '**/*.md'
   workflow_dispatch:
     inputs:
       reason:


### PR DESCRIPTION
This reverts commit 390bbd576817d0c99af5a6ec1409b4476f4ab337.

Because we require the snippets build to complete successfully in order to merge a PR, we can't skip it.

Yes, this causes some wasted resources, but otherwise it never completes, and we can't merge PRs.
