### PR TITLE
Add docs on native AOT optimization options

### DIFF
--- a/docs/core/deploying/native-aot/optimizing.md
+++ b/docs/core/deploying/native-aot/optimizing.md
@@ -1,0 +1,32 @@
+---
+title: Optimizing AOT deployments
+description: Learn about optimizing the outputs of AOT compilation for size and speed.
+author: MichalStrehovsky
+ms.author: michals
+ms.date: 04/21/2023
+---
+# Optimizing AOT deployments
+
+The native AOT publishing process generates a self-contained executable with a subset of the runtime libraries that are tailored specifically for your app. The compilation generally relies on static analysis of the application to generate the best possible output. However, the term "best possible" can have many meanings and sometimes the output of the compilation can be greatly improved by providing hints to the publish process.
+
+## Optimizing for size or speed
+
+During the compilation, the publishing process needs to make various decisions and tradeoffs between generating theoretically the fastest possible executable and the size of such executable. By default, the compiler chooses a blended approach: generate fast code, but be mindful of the size of the application.
+
+The `<OptimizationPreference>` MSBuild property can be used to communicate a general optimization goal instead of the blended default approach:
+
+```xml
+<OptimizationPreference>Size</OptimizationPreference>
+```
+
+Setting `OptimizationPreference` to `Size` instructs the publishing process to favor the size of the executable instead of other performance metrics. The peak throughput of the app is expected to be lower with this setting and startup time may also be impacted.
+
+```xml
+<OptimizationPreference>Speed</OptimizationPreference>
+```
+
+Setting `OptimizationPreference` to `Speed` instructs the publishing process to favor code execution speed. The peak througput of the app is expected to be higher, but other performance metrics might be affected.
+
+## Further size optimization options
+
+Since native AOT deployments imply the use of trimming, it's possible to further improve the size of the application by specifying more [trimming options](../trimming/trimming-options.md). For example, the Trimming framework library features section discusses how to disable library features such as globalization.

--- a/docs/core/deploying/native-aot/optimizing.md
+++ b/docs/core/deploying/native-aot/optimizing.md
@@ -19,7 +19,7 @@ The `<OptimizationPreference>` MSBuild property can be used to communicate a gen
 <OptimizationPreference>Size</OptimizationPreference>
 ```
 
-Setting `OptimizationPreference` to `Size` instructs the publishing process to favor the size of the executable instead of other performance metrics. The peak throughput of the app is expected to be lower with this setting and startup time may also be impacted.
+Setting `OptimizationPreference` to `Size` instructs the publishing process to favor the size of the executable instead of other performance metrics. The size of the app is expected to be smaller, but other performance metrics might be affected.
 
 ```xml
 <OptimizationPreference>Speed</OptimizationPreference>

--- a/docs/core/deploying/native-aot/optimizing.md
+++ b/docs/core/deploying/native-aot/optimizing.md
@@ -4,13 +4,10 @@ description: Learn about optimizing the outputs of AOT compilation for size and 
 author: MichalStrehovsky
 ms.author: michals
 ms.date: 04/21/2023
-zone_pivot_groups: dotnet-version
 ---
 # Optimizing AOT deployments
 
 The native AOT publishing process generates a self-contained executable with a subset of the runtime libraries that are tailored specifically for your app. The compilation generally relies on static analysis of the application to generate the best possible output. However, the term "best possible" can have many meanings and sometimes the output of the compilation can be greatly improved by providing hints to the publish process.
-
-:::zone pivot="dotnet-8-0"
 
 ## Optimizing for size or speed
 
@@ -29,8 +26,6 @@ Setting `OptimizationPreference` to `Size` instructs the publishing process to f
 ```
 
 Setting `OptimizationPreference` to `Speed` instructs the publishing process to favor code execution speed. The peak througput of the app is expected to be higher, but other performance metrics might be affected.
-
-:::zone-end
 
 ## Further size optimization options
 

--- a/docs/core/deploying/native-aot/optimizing.md
+++ b/docs/core/deploying/native-aot/optimizing.md
@@ -4,10 +4,13 @@ description: Learn about optimizing the outputs of AOT compilation for size and 
 author: MichalStrehovsky
 ms.author: michals
 ms.date: 04/21/2023
+zone_pivot_groups: dotnet-version
 ---
 # Optimizing AOT deployments
 
 The native AOT publishing process generates a self-contained executable with a subset of the runtime libraries that are tailored specifically for your app. The compilation generally relies on static analysis of the application to generate the best possible output. However, the term "best possible" can have many meanings and sometimes the output of the compilation can be greatly improved by providing hints to the publish process.
+
+:::zone pivot="dotnet-8-0"
 
 ## Optimizing for size or speed
 
@@ -26,6 +29,8 @@ Setting `OptimizationPreference` to `Size` instructs the publishing process to f
 ```
 
 Setting `OptimizationPreference` to `Speed` instructs the publishing process to favor code execution speed. The peak througput of the app is expected to be higher, but other performance metrics might be affected.
+
+:::zone-end
 
 ## Further size optimization options
 

--- a/docs/core/deploying/native-aot/optimizing.md
+++ b/docs/core/deploying/native-aot/optimizing.md
@@ -5,13 +5,13 @@ author: MichalStrehovsky
 ms.author: michals
 ms.date: 04/21/2023
 ---
-# Optimizing AOT deployments
+# Optimize AOT deployments
 
-The native AOT publishing process generates a self-contained executable with a subset of the runtime libraries that are tailored specifically for your app. The compilation generally relies on static analysis of the application to generate the best possible output. However, the term "best possible" can have many meanings and sometimes the output of the compilation can be greatly improved by providing hints to the publish process.
+The native AOT publishing process generates a self-contained executable with a subset of the runtime libraries that are tailored specifically for your app. The compilation generally relies on static analysis of the application to generate the best possible output. However, the term "best possible" can have many meanings. Sometimes, you can improve the output of the compilation by providing hints to the publish process.
 
-## Optimizing for size or speed
+## Optimize for size or speed
 
-During the compilation, the publishing process needs to make various decisions and tradeoffs between generating theoretically the fastest possible executable and the size of such executable. By default, the compiler chooses a blended approach: generate fast code, but be mindful of the size of the application.
+During the compilation, the publishing process makes decisions and tradeoffs between generating the theoretically fastest possible executable and the size of the executable. By default, the compiler chooses a blended approach: generate fast code, but be mindful of the size of the application.
 
 The `<OptimizationPreference>` MSBuild property can be used to communicate a general optimization goal instead of the blended default approach:
 
@@ -25,8 +25,8 @@ Setting `OptimizationPreference` to `Size` instructs the publishing process to f
 <OptimizationPreference>Speed</OptimizationPreference>
 ```
 
-Setting `OptimizationPreference` to `Speed` instructs the publishing process to favor code execution speed. The peak througput of the app is expected to be higher, but other performance metrics might be affected.
+Setting `OptimizationPreference` to `Speed` instructs the publishing process to favor code execution speed. The peak throughput of the app is expected to be higher, but other performance metrics might be affected.
 
 ## Further size optimization options
 
-Since native AOT deployments imply the use of trimming, it's possible to further improve the size of the application by specifying more [trimming options](../trimming/trimming-options.md). For example, the Trimming framework library features section discusses how to disable library features such as globalization.
+Since native AOT deployments imply the use of trimming, it's possible to further improve the size of the application by specifying more [trimming options](../trimming/trimming-options.md). For example, the [Trimming framework library features section](../trimming/trimming-options.md#trimming-framework-library-features) discusses how to disable library features such as globalization.

--- a/docs/navigate/devops-testing/toc.yml
+++ b/docs/navigate/devops-testing/toc.yml
@@ -327,7 +327,7 @@ items:
         items:
           - name: Overview
             href: ../../core/deploying/native-aot/index.md
-          - name: Optimizing AOT deployments
+          - name: Optimize AOT deployments
             href: ../../core/deploying/native-aot/optimizing.md
           - name: Intro to AOT warnings
             href: ../../core/deploying/native-aot/fixing-warnings.md

--- a/docs/navigate/devops-testing/toc.yml
+++ b/docs/navigate/devops-testing/toc.yml
@@ -327,6 +327,8 @@ items:
         items:
           - name: Overview
             href: ../../core/deploying/native-aot/index.md
+          - name: Optimizing AOT deployments
+            href: ../../core/deploying/native-aot/optimizing.md
           - name: Intro to AOT warnings
             href: ../../core/deploying/native-aot/fixing-warnings.md
           - name: AOT warnings


### PR DESCRIPTION
## Summary

Add docs on optimization options in Native AOT.

Cc @dotnet/ilc-contrib 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/deploying/native-aot/optimizing.md](https://github.com/dotnet/docs/blob/2ed2d5b75f33b4f5f144d067348a019b6579cac8/docs/core/deploying/native-aot/optimizing.md) | [docs/core/deploying/native-aot/optimizing](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/optimizing?branch=pr-en-us-35092) |


<!-- PREVIEW-TABLE-END -->