### PR TITLE
Fix typo in `standard/common-type-system.md`

### DIFF
--- a/docs/standard/common-type-system.md
+++ b/docs/standard/common-type-system.md
@@ -39,7 +39,7 @@ CTS also defines all other properties of the types, such as access modifiers, wh
 
 To enable full interoperability scenarios, all objects that are created in code must rely on some commonality in the languages that are consuming them (are their _callers_). Since there are numerous different languages, .NET has specified those commonalities in something called the **Common Language Specification** (CLS). CLS defines a set of features that are needed by many common applications. It also provides a sort of recipe for any language that is implemented on top of .NET on what it needs to support.
 
-CLS is a subset of the CTS. This means that all of the rules in the CTS also apply to the CLS, unless the CLS rules are more strict. If a component is built using only the rules in the CLS, that is, it exposes only the CLS features in its API, it is said to be **CLS-compliant**. For instance, the `<framework-librares>` are CLS-compliant precisely because they need to work across all of the languages that are supported on .NET.
+CLS is a subset of the CTS. This means that all of the rules in the CTS also apply to the CLS, unless the CLS rules are more strict. If a component is built using only the rules in the CLS, that is, it exposes only the CLS features in its API, it is said to be **CLS-compliant**. For instance, the `<framework-libraries>` are CLS-compliant precisely because they need to work across all of the languages that are supported on .NET.
 
 You can consult the documents in the [More Resources](#more-resources) section below to get an overview of all the features in the CLS.
 


### PR DESCRIPTION
## Summary

Fixed typo in documentation for *Common Type System & Common Language Specification*
Replaced `<framework-librares>` with `<framework-libraries>`.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/common-type-system.md](https://github.com/dotnet/docs/blob/7b6aa12dd934dcec7613ae43d3d1e9c473f3b033/docs/standard/common-type-system.md) | [Common Type System & Common Language Specification](https://review.learn.microsoft.com/en-us/dotnet/standard/common-type-system?branch=pr-en-us-35097) |

<!-- PREVIEW-TABLE-END -->