### PR TITLE
Update RFC 2617 hyperlink in selecting-a-credential-type.md

### DIFF
--- a/docs/framework/wcf/feature-details/selecting-a-credential-type.md
+++ b/docs/framework/wcf/feature-details/selecting-a-credential-type.md
@@ -23,8 +23,8 @@ ms.assetid: bf707063-3f30-4304-ab53-0e63413728a8
 |Setting|Description|  
 |-------------|-----------------|  
 |None|Specifies that the client does not need to present any credential. This translates to an anonymous client.|  
-|Basic|Specifies basic authentication for the client. For additional information, see RFC2617—[HTTP Authentication: Basic and Digest Authentication](ftp://ftp.rfc-editor.org/in-notes/rfc2617.txt).|  
-|Digest|Specifies digest authentication for the client. For additional information, see RFC2617—[HTTP Authentication: Basic and Digest Authentication](ftp://ftp.rfc-editor.org/in-notes/rfc2617.txt).|  
+|Basic|Specifies basic authentication for the client. For additional information, see RFC2617—[HTTP Authentication: Basic and Digest Authentication](https://www.rfc-editor.org/rfc/rfc2617).|  
+|Digest|Specifies digest authentication for the client. For additional information, see RFC2617—[HTTP Authentication: Basic and Digest Authentication](https://www.rfc-editor.org/rfc/rfc2617).|  
 |Ntlm|Specifies NT LAN Manager (NTLM) authentication. This is used when you cannot use Kerberos authentication for some reason. You can also disable its use as a fallback by setting the <xref:System.ServiceModel.Security.WindowsClientCredential.AllowNtlm%2A> property to `false`, which causes WCF to make a best-effort to throw an exception if NTLM is used. Note that setting this property to `false` may not prevent NTLM credentials from being sent over the wire.|  
 |Windows|Specifies Windows authentication. To specify only the Kerberos protocol on a Windows domain, set the <xref:System.ServiceModel.Security.WindowsClientCredential.AllowNtlm%2A> property to `false` (the default is `true`).|  
 |Certificate|Performs client authentication using an X.509 certificate.|  


### PR DESCRIPTION
## Summary

The current hyperlink for the RFC 2617 spec is `ftp://ftp.rfc-editor.org/in-notes/rfc2617.txt`, which does not lead to a viewable page. A correct URL is `https://www.rfc-editor.org/rfc/rfc2617`.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/wcf/feature-details/selecting-a-credential-type.md](https://github.com/dotnet/docs/blob/5a43c20d530376874e3d00744aa931f82516aa53/docs/framework/wcf/feature-details/selecting-a-credential-type.md) | [Selecting a Credential Type](https://review.learn.microsoft.com/en-us/dotnet/framework/wcf/feature-details/selecting-a-credential-type?branch=pr-en-us-35121) |

<!-- PREVIEW-TABLE-END -->