### PR TITLE
Expand warnings in compare-strings.md

### DIFF
--- a/docs/csharp/how-to/compare-strings.md
+++ b/docs/csharp/how-to/compare-strings.md
@@ -55,12 +55,13 @@ When performing a case-insensitive ordinal comparison, these methods use the cas
 
 ## Linguistic comparisons
 
-Strings can also be ordered using linguistic rules for the current culture.
+Unless overridden, many string comparison methods (such as <xref:System.String.StartsWith%2A?displayProperty=nameWithType>) default to using linguistic rules for the _current culture_ to order their inputs.
 This is sometimes referred to as "word sort order." When you perform a
 linguistic comparison, some nonalphanumeric Unicode characters might have
 special weights assigned. For example, the hyphen "-" may have a small
 weight assigned to it so that "co-op" and "coop" appear next to each other
-in sort order. In addition, some Unicode characters may be equivalent to a
+in sort order, while some non-printing control characters might be completely ignored.
+In addition, some Unicode characters may be equivalent to a
 sequence of <xref:System.Char> instances. The following example uses the phrase
 "They dance in the street." in German with the "ss" (U+0073 U+0073) in one string and 'ß' (U+00DF) in another. Linguistically
 (in Windows), "ss" is equal to the German Esszet: 'ß' character in both the "en-US"

--- a/docs/csharp/how-to/compare-strings.md
+++ b/docs/csharp/how-to/compare-strings.md
@@ -55,7 +55,7 @@ When performing a case-insensitive ordinal comparison, these methods use the cas
 
 ## Linguistic comparisons
 
-Unless overridden, many string comparison methods (such as <xref:System.String.StartsWith%2A?displayProperty=nameWithType>) default to using linguistic rules for the _current culture_ to order their inputs.
+Many string comparison methods (such as <xref:System.String.StartsWith%2A?displayProperty=nameWithType>) use linguistic rules for the _current culture_ by default to order their inputs.
 This is sometimes referred to as "word sort order." When you perform a
 linguistic comparison, some nonalphanumeric Unicode characters might have
 special weights assigned. For example, the hyphen "-" may have a small


### PR DESCRIPTION
## Summary

Add two sentences in the "Linguistic Comparison" section of the "How to compare strings" documentation, noting that this is in fact the default behaviour for many methods and noting one particularly common way people discover this fact as having created a bug in their code.

(Related to https://github.com/dotnet/docs/pull/35069; raised off the back of https://github.com/dotnet/dotnet-api-docs/issues/8973 .)

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/how-to/compare-strings.md](https://github.com/dotnet/docs/blob/0f98541c20a490e24d26db1f023ddb8fbc916a9d/docs/csharp/how-to/compare-strings.md) | [How to compare strings in C\#](https://review.learn.microsoft.com/en-us/dotnet/csharp/how-to/compare-strings?branch=pr-en-us-35171) |


<!-- PREVIEW-TABLE-END -->