### PR TITLE
Updated `appsetting.json` to `global.json`

### DIFF
--- a/docs/core/tools/global-json.md
+++ b/docs/core/tools/global-json.md
@@ -92,7 +92,7 @@ Type: `object`
 
 Lets you control the project SDK version in one place rather than in each individual project. For more information, see [How project SDKs are resolved](/visualstudio/msbuild/how-to-use-project-sdk#how-project-sdks-are-resolved).
 
-### Comments in appsettings.json
+### Comments in global.json
 
 Comments in *global.json* files are supported using JavaScript or C# style comments. For example:
 


### PR DESCRIPTION
## Summary

I believe this is intended to talk about `global.json` and this is an unintended copy/paste error.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/global-json.md](https://github.com/dotnet/docs/blob/01d91156b54b65758adfbee6bddc31cbd1c7c673/docs/core/tools/global-json.md) | [global.json overview](https://review.learn.microsoft.com/en-us/dotnet/core/tools/global-json?branch=pr-en-us-35173) |

<!-- PREVIEW-TABLE-END -->