### PR TITLE
Increase visibility of target-typed new

### DIFF
--- a/docs/csharp/language-reference/operators/new-operator.md
+++ b/docs/csharp/language-reference/operators/new-operator.md
@@ -22,6 +22,8 @@ You can use an [object or collection initializer](../../programming-guide/classe
 
 [!code-csharp-interactive[constructor with initializer](snippets/shared/NewOperator.cs#ConstructorWithInitializer)]
 
+### Target-typed `new`
+
 Beginning with C# 9.0, constructor invocation expressions are target-typed. That is, if a target type of an expression is known, you can omit a type name, as the following example shows:
 
 :::code language="csharp" source="snippets/shared/NewOperator.cs" id="SnippetTargetTyped":::


### PR DESCRIPTION
From #33829 it looks like the new feature description is not very visible. Let's make it into the separate section to make it stand out more.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/new-operator.md](https://github.com/dotnet/docs/blob/179373123c64e29a54f42d8fefe3d48672c939d9/docs/csharp/language-reference/operators/new-operator.md) | [new operator - The `new` operator creates a new instance of a type](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/new-operator?branch=pr-en-us-35179) |

<!-- PREVIEW-TABLE-END -->