### PR TITLE
Update interpolated-strings.md [RFC FS-1132]

### DIFF
--- a/docs/fsharp/language-reference/interpolated-strings.md
+++ b/docs/fsharp/language-reference/interpolated-strings.md
@@ -124,10 +124,10 @@ Note that the type annotation must be on the interpolated string expression itse
 
 ## Extended syntax for string interpolation
 
-When working with text containing multiple `{`, `}` or `%` characters already, extended string interpolation syntax can be used to remove the need for escaping.
+When you work with text containing multiple `{`, `}` or `%` characters already, you can use extended string interpolation syntax to remove the need for escaping.
 
 Triple quote string literals can start with multiple `$` characters, which changes how many braces are required to open and close interpolation.
-In these string literals, `{` and `}` characters do not need to be escaped:
+In these string literals, `{` and `}` characters don't need to be escaped:
 
 ```fsharp
 let str = $$"""A string containing some {curly braces} and an {{"F#" + " " + "expression"}}."""
@@ -136,7 +136,7 @@ let another = $$$"""A string with pairs of {{ and }} characters and {{{ "an F# e
 // "A string with pairs of {{ and }} characters and an F# expression."""
 ```
 
-Number of `%` characters needed for format specifiers is affected in the same way:
+The number of `%` characters needed for format specifiers is affected in the same way:
 
 ```fsharp
 let percent = $$"""50% of 20 is %%.1f{{20m * 0.5m}}"""

--- a/docs/fsharp/language-reference/interpolated-strings.md
+++ b/docs/fsharp/language-reference/interpolated-strings.md
@@ -137,6 +137,7 @@ let another = $$$"""A string with pairs of {{ and }} characters and {{{ "an F# e
 ```
 
 Number of `%` characters needed for format specifiers is affected in the same way:
+
 ```fsharp
 let percent = $$"""50% of 20 is %%.1f{{20m * 0.5m}}"""
 // "50% of 20 is 10.0"

--- a/docs/fsharp/language-reference/interpolated-strings.md
+++ b/docs/fsharp/language-reference/interpolated-strings.md
@@ -14,6 +14,7 @@ Interpolated strings are [strings](strings.md) that allow you to embed F# expres
 $"string-text {expr}"
 $"string-text %format-specifier{expr}"
 $"""string-text {"embedded string literal"}"""
+$$"""string-text %%format-specifier{{expr}}"""
 ```
 
 ## Remarks
@@ -121,7 +122,28 @@ let frmtStr = $"The speed of light is {speedOfLight:N3} km/s." : FormattableStri
 
 Note that the type annotation must be on the interpolated string expression itself. F# does not implicitly convert an interpolated string into a <xref:System.FormattableString>.
 
+## Extended syntax for string interpolation
+
+When working with text containing multiple `{`, `}` or `%` characters already, extended string interpolation syntax can be used to remove the need for escaping.
+
+Triple quote string literals can start with multiple `$` characters, which changes how many braces are required to open and close interpolation.
+In these string literals, `{` and `}` characters do not need to be escaped:
+
+```fsharp
+let str = $$"""A string containing some {curly braces} and an {{"F#" + " " + "expression"}}."""
+// "A string containing some {curly braces} and an F# expression."
+let another = $$$"""A string with pairs of {{ and }} characters and {{{ "an F# expression" }}}."""
+// "A string with pairs of {{ and }} characters and an F# expression."""
+```
+
+Number of `%` characters needed for format specifiers is affected in the same way:
+```fsharp
+let percent = $$"""50% of 20 is %%.1f{{20m * 0.5m}}"""
+// "50% of 20 is 10.0"
+```
+
 ## See also
 
 * [Strings](strings.md)
 * [F# RFC FS-1001 - Interpolated strings](https://github.com/fsharp/fslang-design/blob/main/FSharp-5.0/FS-1001-StringInterpolation.md)
+* [F# RFC FS-1132 - Extended syntax for interpolated strings](https://github.com/fsharp/fslang-design/blob/main/RFCs/FS-1132-better-interpolated-triple-quoted-strings.md)


### PR DESCRIPTION
Update language reference for interpolated strings to include changes described in [RFC FS-1132](https://github.com/fsharp/fslang-design/blob/main/RFCs/FS-1132-better-interpolated-triple-quoted-strings.md)

## Summary

RFC FS-1132 introduces new syntax for interpolated strings in F#, allowing for literals to start with multiple `$` characters to remove the need for escaping `{`, `}` and `%` characters in the string content.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/interpolated-strings.md](https://github.com/dotnet/docs/blob/9b74f221f0a0f6a39521e2a86d80398724783955/docs/fsharp/language-reference/interpolated-strings.md) | [Interpolated strings](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/interpolated-strings?branch=pr-en-us-35195) |


<!-- PREVIEW-TABLE-END -->