### PR TITLE
Update enable-tab-autocomplete.md

### DIFF
--- a/docs/core/tools/enable-tab-autocomplete.md
+++ b/docs/core/tools/enable-tab-autocomplete.md
@@ -109,16 +109,28 @@ complete -f -c dotnet -a "(dotnet complete (commandline -cp))"
 
 ## nushell
 
-To add tab completion to your **nushell** for .NET CLI, add the following to your `config.nu` file:
-
+To add tab completion to your **nushell** for .NET CLI, add the following to the beginning of your `config.nu` file:
 ```nu
-# completion for the .NET CLI
-
-def "nu-cmp dotnet" [context: string] {
-    ^dotnet complete ($context | split words | skip 1 | str join " ") | lines
+let external_completer = { |spans|
+	{
+		dotnet: { || 
+			dotnet complete (
+				$spans | skip 1 | str join " "
+			) | lines
+		}
+	} | get $spans.0 | each { || do $in }
 }
-
-export extern "dotnet" [ 
-    ...args: any@"nu-cmp dotnet"
-]
+```
+And then in the `config` record find the `completions` section and add the defined earlier `external_completer` to `external` like that:
+```nu
+let-env config = {
+    # your options here
+    completions: {
+        # your options here
+        external: {
+            # your options here
+            completer: $external_completer # add it here
+        }
+    }
+}
 ```

--- a/docs/core/tools/enable-tab-autocomplete.md
+++ b/docs/core/tools/enable-tab-autocomplete.md
@@ -110,18 +110,21 @@ complete -f -c dotnet -a "(dotnet complete (commandline -cp))"
 ## nushell
 
 To add tab completion to your **nushell** for .NET CLI, add the following to the beginning of your `config.nu` file:
+
 ```nu
 let external_completer = { |spans|
-	{
-		dotnet: { || 
-			dotnet complete (
-				$spans | skip 1 | str join " "
-			) | lines
-		}
-	} | get $spans.0 | each { || do $in }
+    {
+        dotnet: { || 
+            dotnet complete (
+                $spans | skip 1 | str join " "
+            ) | lines
+        }
+    } | get $spans.0 | each { || do $in }
 }
 ```
+
 And then in the `config` record find the `completions` section and add the defined earlier `external_completer` to `external` like that:
+
 ```nu
 let-env config = {
     # your options here


### PR DESCRIPTION
Contributes to #34944 

## Summary
Change the nushell completion method because the prior one couldn't complete dash options

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/enable-tab-autocomplete.md](https://github.com/dotnet/docs/blob/29fd4b28f804dda22cde6325f8357eb58a42f896/docs/core/tools/enable-tab-autocomplete.md) | [How to enable tab completion for the .NET CLI](https://review.learn.microsoft.com/en-us/dotnet/core/tools/enable-tab-autocomplete?branch=pr-en-us-35198) |


<!-- PREVIEW-TABLE-END -->