### PR TITLE
GetGeneration breaking change

### DIFF
--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -23,6 +23,7 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 | [AnonymousPipeServerStream.Dispose behavior](core-libraries/8.0/anonymouspipeserverstream-dispose.md) | Behavioral change   | Preview 1  |
 | [Backslash mapping in Unix file paths](core-libraries/8.0/file-path-backslash.md)                     | Behavioral change   | Preview 1  |
 | [FileStream writes when pipe is closed](core-libraries/8.0/filestream-disposed-pipe.md)               | Behavioral change   | Preview 1  |
+| [GC.GetGeneration might return Int32.MaxValue](core-libraries/8.0/getgeneration-return-value.md)      | Behavioral change   | Preview 4  |
 | [GetFolderPath behavior on Unix](core-libraries/8.0/getfolderpath-unix.md)                            | Behavioral change   | Preview 1  |
 | [ITypeDescriptorContext nullable annotations](core-libraries/8.0/itypedescriptorcontext-props.md)     | Source incompatible | Preview 1  |
 | [Legacy Console.ReadKey removed](core-libraries/8.0/console-readkey-legacy.md)                        | Behavioral change   | Preview 1  |

--- a/docs/core/compatibility/core-libraries/8.0/getgeneration-return-value.md
+++ b/docs/core/compatibility/core-libraries/8.0/getgeneration-return-value.md
@@ -1,0 +1,41 @@
+---
+title: ".NET 8 breaking change: GC.GetGeneration might return Int32.MaxValue"
+description: Learn about the .NET 8 breaking change in core .NET libraries where GC.GetGeneration might return Int32.MaxValue for certain object types.
+ms.date: 05/02/2023
+---
+# GC.GetGeneration might return Int32.MaxValue
+
+Starting in .NET 8, <xref:System.GC.GetGeneration%2A?displayProperty=nameWithType> might return <xref:System.Int32.MaxValue?displayProperty=nameWithType> for objects allocated on non-GC heaps (also referred as "frozen" heaps), where previously it returned 2. When and how the runtime allocates objects on non-GC heaps is an internal implementation detail. String literals, for example, are allocated on a non-GC heap, and the following method call might return <xref:System.Int32.MaxValue?displayProperty=nameWithType>.
+
+```csharp
+int gen = int GetGeneration("string");
+```
+
+## Previous behavior
+
+Previously, <xref:System.GC.GetGeneration%2A?displayProperty=nameWithType> returned integer values in the range of 0-2.
+
+## New behavior
+
+Starting in .NET 8, <xref:System.GC.GetGeneration%2A?displayProperty=nameWithType> can return a value of 0, 1, 2, or <xref:System.Int32.MaxValue?displayProperty=nameWithType>.
+
+## Version introduced
+
+.NET 8 Preview 4
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+.NET introduced a new, non-GC kind of heap that's slightly different from the existing heaps, which are large object heap (LOH), small object heap (SOH), and pinned object heap (POH).
+
+## Recommended action
+
+Make sure you're not using the return value from `GC.GetGeneration()` as an array indexer or for anything else where <xref:System.Int32.MaxValue?displayProperty=nameWithType> is unexpected.
+
+## Affected APIs
+
+- <xref:System.GC.GetGeneration(System.Object)?displayProperty=fullName>
+- <xref:System.GC.GetGeneration(System.WeakReference)?displayProperty=fullName>

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -18,6 +18,8 @@ items:
         href: core-libraries/8.0/file-path-backslash.md
       - name: FileStream writes when pipe is closed
         href: core-libraries/8.0/filestream-disposed-pipe.md
+      - name: GC.GetGeneration might return Int32.MaxValue
+        href: core-libraries/8.0/getgeneration-return-value.md
       - name: GetFolderPath behavior on Unix
         href: core-libraries/8.0/getfolderpath-unix.md
       - name: ITypeDescriptorContext nullable annotations
@@ -946,6 +948,8 @@ items:
         href: core-libraries/8.0/file-path-backslash.md
       - name: FileStream writes when pipe is closed
         href: core-libraries/8.0/filestream-disposed-pipe.md
+      - name: GC.GetGeneration might return Int32.MaxValue
+        href: core-libraries/8.0/getgeneration-return-value.md
       - name: GetFolderPath behavior on Unix
         href: core-libraries/8.0/getfolderpath-unix.md
       - name: ITypeDescriptorContext nullable annotations


### PR DESCRIPTION
Fixes #35105 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/8.0.md](https://github.com/dotnet/docs/blob/d1c57386dbfa7c7e23bdc4af1694be310bbd7ebd/docs/core/compatibility/8.0.md) | [Breaking changes in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/8.0?branch=pr-en-us-35228) |
| [docs/core/compatibility/core-libraries/8.0/getgeneration-return-value.md](https://github.com/dotnet/docs/blob/d1c57386dbfa7c7e23bdc4af1694be310bbd7ebd/docs/core/compatibility/core-libraries/8.0/getgeneration-return-value.md) | [docs/core/compatibility/core-libraries/8.0/getgeneration-return-value](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/8.0/getgeneration-return-value?branch=pr-en-us-35228) |

<!-- PREVIEW-TABLE-END -->