### PR TITLE
Update Class1.cs so snippets 14 and 15 match docs

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/CsLINQGettingStarted/CS/Class1.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/CsLINQGettingStarted/CS/Class1.cs
@@ -341,16 +341,14 @@ namespace LINQGettingStarted_1
             //</snippet13>
 
             //<snippet14>
-            // studentQuery2 is an IEnumerable<IGrouping<char, Student>>
-            var studentQuery2 =
+            IEnumerable<IGrouping<char, Student>> studentQuery2 =
                 from student in students
                 group student by student.Last[0];
             //</snippet14>
 
             Console.WriteLine("\nExecuting Query 2..............");
             //<snippet15>
-            // studentGroup is a IGrouping<char, Student>
-            foreach (var studentGroup in studentQuery2)
+            foreach (IGrouping<char, Student> studentGroup in studentQuery2)
             {
                 Console.WriteLine(studentGroup.Key);
                 foreach (Student student in studentGroup)


### PR DESCRIPTION
Snippets 14 and 15 are _supposed_ to use the long-form declarations, because the whole point of Snippet 16 is to show replacing those with implicitly typed variables. See the text of the using topic `https://github.com/dotnet/docs/blob/main/docs/csharp/programming-guide/concepts/linq/walkthrough-writing-queries-linq.md`.

## Summary

Modified code to match documentation's explanation (implicitly typed variables are used as explicit education a bit farther down).

Fixes #Issue_Number (N/A - minor edit)
