### PR TITLE
Minor fix to samples in "Cancel list of tasks"

### DIFF
--- a/docs/csharp/asynchronous-programming/cancel-an-async-task-or-a-list-of-tasks.md
+++ b/docs/csharp/asynchronous-programming/cancel-an-async-task-or-a-list-of-tasks.md
@@ -100,21 +100,24 @@ static async Task Main()
         Console.WriteLine("\nENTER key pressed: cancelling downloads.\n");
         s_cts.Cancel();
     });
+    
+    Task sumPageSizesTask = SumPageSizesAsync();
 
-        Task finishedTask = await Task.WhenAny(new[] { cancelTask, sumPageSizesTask });
-        if (finishedTask == cancelTask)
+    Task finishedTask = await Task.WhenAny(new[] { cancelTask, sumPageSizesTask });
+    if (finishedTask == cancelTask)
+    {
+        // wait for the cancellation to take place:
+        try
         {
-            // wait for the cancellation to take place:
-            try
-            {
-                await sumPageSizesTask;
-                Console.WriteLine("Download task completed before cancel request was processed.");
-            }
-            catch (TaskCanceledException)
-            {
-                Console.WriteLine("Download task has been cancelled.");
-            }
+            await sumPageSizesTask;
+            Console.WriteLine("Download task completed before cancel request was processed.");
         }
+        catch (TaskCanceledException)
+        {
+            Console.WriteLine("Download task has been cancelled.");
+        }
+    }
+        
     Console.WriteLine("Application ending.");
 }
 ```


### PR DESCRIPTION
Adds the missing declaration of the variable `sumPageSizesTask` and fixes the indentation in section "Update application entry point".

Fixes #34742


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/asynchronous-programming/cancel-an-async-task-or-a-list-of-tasks.md](https://github.com/dotnet/docs/blob/af1c826f5d986d30b4f6c6ce8975178a76fd673c/docs/csharp/asynchronous-programming/cancel-an-async-task-or-a-list-of-tasks.md) | [Cancel a list of tasks](https://review.learn.microsoft.com/en-us/dotnet/csharp/asynchronous-programming/cancel-an-async-task-or-a-list-of-tasks?branch=pr-en-us-35233) |

<!-- PREVIEW-TABLE-END -->