### PR TITLE
Two ASP.NET breaking changes for .NET 8

### DIFF
--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -15,6 +15,12 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 >
 > This article is a work in progress. It's not a complete list of breaking changes in .NET 8. To query breaking changes that are still pending publication, see [Issues of .NET](https://issuesof.net/?q=%20is:open%20-label:Documented%20is:issue%20(label:%22Breaking%20Change%22%20or%20label:breaking-change)%20(repo:dotnet/docs%20or%20repo:aspnet/Announcements)%20group:repo%20(label:%22:checkered_flag:%20Release:%20.NET%208%22%20or%20label:8.0.0)%20sort:created-desc).
 
+## ASP.NET Core
+
+| Title                                                                                                 | Type of change      | Introduced |
+| ----------------------------------------------------------------------------------------------------- | ------------------- | ---------- |
+| [ConcurrencyLimiterMiddleware is obsolete](aspnet-core/8.0/concurrencylimitermiddleware-obsolete.md)  | Source incompatible | Preview 4  |
+
 ## Core .NET libraries
 
 | Title                                                                                                 | Type of change      | Introduced |

--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -20,6 +20,7 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 | Title                                                                                                 | Type of change      | Introduced |
 | ----------------------------------------------------------------------------------------------------- | ------------------- | ---------- |
 | [ConcurrencyLimiterMiddleware is obsolete](aspnet-core/8.0/concurrencylimitermiddleware-obsolete.md)  | Source incompatible | Preview 4  |
+| [Custom converters for serialization removed](aspnet-core/8.0/problemdetails-custom-converters.md)    | Behavioral change   | Preview 2  |
 
 ## Core .NET libraries
 

--- a/docs/core/compatibility/aspnet-core/7.0/api-controller-action-parameters-di.md
+++ b/docs/core/compatibility/aspnet-core/7.0/api-controller-action-parameters-di.md
@@ -10,7 +10,7 @@ The mechanism to infer binding sources of API controller action parameters now m
 
 ## Version introduced
 
-ASP.NET Core 7.0 Preview 2
+ASP.NET Core 7.0
 
 ## Previous behavior
 

--- a/docs/core/compatibility/aspnet-core/7.0/default-authentication-scheme.md
+++ b/docs/core/compatibility/aspnet-core/7.0/default-authentication-scheme.md
@@ -23,7 +23,7 @@ This change might expose unintended behavior changes in applications, such as au
 
 ## Version introduced
 
-ASP.NET Core 7.0 Preview 7
+ASP.NET Core 7.0
 
 ## Previous behavior
 

--- a/docs/core/compatibility/aspnet-core/7.0/https-binding-kestrel.md
+++ b/docs/core/compatibility/aspnet-core/7.0/https-binding-kestrel.md
@@ -9,7 +9,7 @@ The default HTTPS address and port have been removed from Kestrel in .NET 7. Thi
 
 ## Version introduced
 
-ASP.NET Core 7.0 Preview 6
+ASP.NET Core 7.0
 
 ## Previous behavior
 

--- a/docs/core/compatibility/aspnet-core/7.0/libuv-transport-dll-removed.md
+++ b/docs/core/compatibility/aspnet-core/7.0/libuv-transport-dll-removed.md
@@ -10,7 +10,7 @@ Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv and libuv.dll have been remo
 
 ## Version introduced
 
-ASP.NET Core 7.0 Preview 1
+ASP.NET Core 7.0
 
 ## Previous behavior
 

--- a/docs/core/compatibility/aspnet-core/7.0/microsoft-aspnetcore-mvc-core-log-event-ids.md
+++ b/docs/core/compatibility/aspnet-core/7.0/microsoft-aspnetcore-mvc-core-log-event-ids.md
@@ -10,7 +10,7 @@ As part of updating the `Microsoft.AspNetcore.Mvc.Core` assembly to use <xref:Mi
 
 ## Version introduced
 
-ASP.NET Core 7.0 Preview 3
+ASP.NET Core 7.0
 
 ## Previous behavior
 

--- a/docs/core/compatibility/aspnet-core/7.0/microsoft-data-sqlclient-updated-to-4-0-1.md
+++ b/docs/core/compatibility/aspnet-core/7.0/microsoft-data-sqlclient-updated-to-4-0-1.md
@@ -10,7 +10,7 @@ The `Microsoft.Data.SqlClient` package has been updated to 4.0.1.
 
 ## Version introduced
 
-ASP.NET Core 7.0 Preview 2
+ASP.NET Core 7.0
 
 ## Previous behavior
 

--- a/docs/core/compatibility/aspnet-core/7.0/middleware-null-requestdelegate.md
+++ b/docs/core/compatibility/aspnet-core/7.0/middleware-null-requestdelegate.md
@@ -9,7 +9,7 @@ As detailed in <https://github.com/dotnet/aspnetcore/issues/42413>, the file-ser
 
 ## Version introduced
 
-ASP.NET Core 7.0 Preview 7
+ASP.NET Core 7.0
 
 ## Previous behavior
 

--- a/docs/core/compatibility/aspnet-core/7.0/mvc-empty-body-model-binding.md
+++ b/docs/core/compatibility/aspnet-core/7.0/mvc-empty-body-model-binding.md
@@ -21,7 +21,7 @@ The previous behavior performed a minimal validation of `Content-Length = 0`. In
 
 ## Version introduced
 
-ASP.NET Core 7.0 Preview 3
+ASP.NET Core 7.0
 
 ## Previous behavior
 

--- a/docs/core/compatibility/aspnet-core/7.0/signalr-hub-method-parameters-di.md
+++ b/docs/core/compatibility/aspnet-core/7.0/signalr-hub-method-parameters-di.md
@@ -10,7 +10,7 @@ SignalR Hub methods now support injecting services from your Dependency Injectio
 
 ## Version introduced
 
-ASP.NET Core 7.0 Preview 2
+ASP.NET Core 7.0
 
 ## Previous behavior
 

--- a/docs/core/compatibility/aspnet-core/8.0/concurrencylimitermiddleware-obsolete.md
+++ b/docs/core/compatibility/aspnet-core/8.0/concurrencylimitermiddleware-obsolete.md
@@ -1,0 +1,81 @@
+---
+title: "Breaking change: ConcurrencyLimiterMiddleware is obsolete"
+description: Learn about the breaking change in ASP.NET Core 8.0 where ConcurrencyLimiterMiddleware has been obsoleted.
+ms.date: 05/03/2023
+---
+# ConcurrencyLimiterMiddleware is obsolete
+
+<xref:Microsoft.AspNetCore.ConcurrencyLimiter.ConcurrencyLimiterMiddleware> and its associated methods and types have been marked as obsolete.
+
+If you require rate-limiting capabilities, switch to the newer and more capable rate-limiting middleware that was introduced in .NET 7 (for example, <xref:Microsoft.AspNetCore.Builder.RateLimiterApplicationBuilderExtensions.UseRateLimiter%2A?displayProperty=nameWithType>). The .NET 7 rate-limiting API includes a concurrency limiter and several other rate-limiting algorithms that you can apply to your application.
+
+## Version introduced
+
+ASP.NET Core 8.0 Preview 4
+
+## Previous behavior
+
+Developers could use <xref:Microsoft.AspNetCore.ConcurrencyLimiter.ConcurrencyLimiterMiddleware> to control concurrency by adding a policy to dependency injection (DI) and enabling the middleware:
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddStackPolicy<options => {
+    options.MaxConcurrentRequests = 2;
+    options.RequestQueueLimit = 25;
+    });
+
+var app = builder.Build();
+app.UseConcurrencyLimiter();
+// Map endpoints.
+app.Run();
+```
+
+## New behavior
+
+If you use the [Affected APIs](#affected-apis) in your code, you'll get warning [`CS0618`](../../../../csharp/language-reference/compiler-messages/cs0618.md) at compile time.
+
+## Type of breaking change
+
+This change affects [source compatibility](../../categories.md#source-compatibility).
+
+## Reason for change
+
+<xref:Microsoft.AspNetCore.ConcurrencyLimiter.ConcurrencyLimiterMiddleware> is infrequently used and undocumented. The newer rate-limiting API has more extensive functionality.
+
+## Recommended action
+
+If you're using the older <xref:Microsoft.AspNetCore.ConcurrencyLimiter.ConcurrencyLimiterMiddleware>, we recommend moving to the newer rate-limiting middleware. Here's an example usage of the newer API, <xref:Microsoft.AspNetCore.Builder.RateLimiterApplicationBuilderExtensions.UseRateLimiter%2A?displayProperty=nameWithType>:
+
+```csharp
+using Microsoft.AspNetCore.RateLimiting;
+using System.Threading.RateLimiting;
+
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.UseRateLimiter(new RateLimiterOptions()
+    .AddConcurrencyLimiter("only-one-at-a-time-stacked", (options) =>
+    {
+        options.PermitLimit = 2;
+        options.QueueLimit = 25;
+        options.QueueProcessingOrder = QueueProcessingOrder.NewestFirst;
+    }));
+
+app.MapGet("/", async () =>
+{
+    await Task.Delay(10000);
+    return "Hello World";
+}).RequireRateLimiting("only-one-at-a-time-stacked");
+
+app.Run();
+```
+
+## Affected APIs
+
+- <xref:Microsoft.AspNetCore.Builder.ConcurrencyLimiterExtensions.UseConcurrencyLimiter(Microsoft.AspNetCore.Builder.IApplicationBuilder)?displayProperty=fullName>
+- <xref:Microsoft.AspNetCore.ConcurrencyLimiter.ConcurrencyLimiterMiddleware?displayProperty=fullName>
+- <xref:System.Threading.RateLimiting.ConcurrencyLimiterOptions?displayProperty=fullName>
+
+## See also
+
+- [Rate limiting middleware in ASP.NET Core](/aspnet/core/performance/rate-limit)

--- a/docs/core/compatibility/aspnet-core/8.0/problemdetails-custom-converters.md
+++ b/docs/core/compatibility/aspnet-core/8.0/problemdetails-custom-converters.md
@@ -1,0 +1,62 @@
+---
+title: "Breaking change: Custom converters for serialization removed"
+description: Learn about the breaking change in ASP.NET Core 8.0 where 'ValidationProblemDetails' and 'ProblemDetails' no longer use custom converters.
+ms.date: 05/03/2023
+---
+# Custom converters for serialization removed
+
+<xref:Microsoft.AspNetCore.Mvc.ProblemDetails> and <xref:Microsoft.AspNetCore.Mvc.ValidationProblemDetails> previously used custom converters to support JSON serialization due to a lack of built-in support for the `IgnoreNullValues` option. Now that this option is supported by the <xref:System.Text.Json?displayProperty=fullName> APIs, we've removed the custom converters from the framework in favor of the serialization provided by the framework.
+
+As a result of this change, the properties in the <xref:Microsoft.AspNetCore.Mvc.ProblemDetails> and <xref:Microsoft.AspNetCore.Mvc.ValidationProblemDetails> types no longer assume lowercase type names. Developers must specify a <xref:System.Text.Json.JsonNamingPolicy> to get the correct behavior.
+
+## Version introduced
+
+ASP.NET Core 8.0 Preview 2
+
+## Previous behavior
+
+Previously, you could add <xref:System.Text.Json.Serialization.JsonStringEnumConverter> to the serialization options as a custom converter, and deserialization resulted in a 400 status for <xref:Microsoft.AspNetCore.Mvc.ValidationProblemDetails>.
+
+```csharp
+string content = "{\"status\":400,\"detail\":\"HTTP egress is not enabled.\"}";
+using MemoryStream stream = new();
+using StreamWriter writer = new(stream);
+writer.Write(content);
+writer.Flush();
+stream.Position = 0;
+
+JsonSerializerOptions options = new();
+options.Converters.Add(new JsonStringEnumConverter());
+
+ValidationProblemDetails? details = await JsonSerializer.DeserializeAsync<ValidationProblemDetails>(stream, options);
+Console.WriteLine(details.Status); // 400
+```
+
+## New behavior
+
+Starting in .NET 8, the same code results in a null status for <xref:Microsoft.AspNetCore.Mvc.ValidationProblemDetails>.
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+Now that <xref:System.Text.Json.JsonSerializerOptions.IgnoreNullValues?displayProperty=nameWithType> is supported by the `System.Text.Json` APIs, we've removed the custom converters in favor of the serialization provided by the framework.
+
+## Recommended action
+
+Provide a JSON serializer options with the correct details.
+
+```csharp
+JsonSerializerOptions options = new()
+{
+   PropertyNameCaseInsensitive = true
+};
+ValidationProblemDetails? details = await JsonSerializer.DeserializeAsync<ValidationProblemDetails>(stream, options);
+```
+
+## Affected APIs
+
+- <xref:Microsoft.AspNetCore.Mvc.ProblemDetails?displayProperty=fullName>
+- <xref:Microsoft.AspNetCore.Mvc.ValidationProblemDetails?displayProperty=fullName>

--- a/docs/core/compatibility/aspnet-core/8.0/problemdetails-custom-converters.md
+++ b/docs/core/compatibility/aspnet-core/8.0/problemdetails-custom-converters.md
@@ -34,7 +34,22 @@ Console.WriteLine(details.Status); // 400
 
 ## New behavior
 
-Starting in .NET 8, the same code results in a null status for <xref:Microsoft.AspNetCore.Mvc.ValidationProblemDetails>.
+Starting in .NET 8, the same code results in a `null` status for <xref:Microsoft.AspNetCore.Mvc.ValidationProblemDetails>.
+
+```csharp
+string content = "{\"status\":400,\"detail\":\"HTTP egress is not enabled.\"}";
+using MemoryStream stream = new();
+using StreamWriter writer = new(stream);
+writer.Write(content);
+writer.Flush();
+stream.Position = 0;
+
+JsonSerializerOptions options = new();
+options.Converters.Add(new JsonStringEnumConverter());
+
+ValidationProblemDetails? details = await JsonSerializer.DeserializeAsync<ValidationProblemDetails>(stream, options);
+Console.WriteLine(details.Status); // null
+```
 
 ## Type of breaking change
 

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -8,6 +8,10 @@ items:
     items:
     - name: Overview
       href: 8.0.md
+    - name: ASP.NET Core
+      items:
+      - name: ConcurrencyLimiterMiddleware is obsolete
+        href: aspnet-core/8.0/concurrencylimitermiddleware-obsolete.md
     - name: Core .NET libraries
       items:
       - name: Activity operation name when null
@@ -740,6 +744,10 @@ items:
   items:
   - name: ASP.NET Core
     items:
+    - name: .NET 8
+      items:
+      - name: ConcurrencyLimiterMiddleware is obsolete
+        href: aspnet-core/8.0/concurrencylimitermiddleware-obsolete.md
     - name: .NET 7
       items:
       - name: API controller actions try to infer parameters from DI

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -12,6 +12,8 @@ items:
       items:
       - name: ConcurrencyLimiterMiddleware is obsolete
         href: aspnet-core/8.0/concurrencylimitermiddleware-obsolete.md
+      - name: Custom converters for serialization removed
+        href: aspnet-core/8.0/problemdetails-custom-converters.md
     - name: Core .NET libraries
       items:
       - name: Activity operation name when null
@@ -748,6 +750,8 @@ items:
       items:
       - name: ConcurrencyLimiterMiddleware is obsolete
         href: aspnet-core/8.0/concurrencylimitermiddleware-obsolete.md
+      - name: Custom converters for serialization removed
+        href: aspnet-core/8.0/problemdetails-custom-converters.md
     - name: .NET 7
       items:
       - name: API controller actions try to infer parameters from DI

--- a/docs/csharp/language-reference/compiler-messages/cs0618.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0618.md
@@ -1,43 +1,43 @@
 ---
 description: "Compiler Warning (level 2) CS0618"
 title: "Compiler Warning (level 2) CS0618"
-ms.date: 07/20/2015
-f1_keywords: 
+ms.date: 05/03/2023
+f1_keywords:
   - "CS0618"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS0618"
 ms.assetid: b6edf0a9-b186-4ed8-9e16-978659b89205
 ---
 # Compiler Warning (level 2) CS0618
 
-'member' is obsolete: 'text'  
-  
- A class member was marked with the `Obsolete` attribute, such that a warning will be issued when the class member is referenced. For more information, see [Common Attributes](../attributes/global.md).  
-  
- The following sample generates CS0618:  
-  
-```csharp  
-// CS0618.cs  
-// compile with: /W:2  
-using System;  
-  
-public class C  
-{  
-   [Obsolete("Use newMethod instead", false)]   // warn if referenced  
-   public static void m2()  
-   {  
-   }  
-  
-   public static void newMethod()  
-   {  
-   }  
-}  
-  
-class MyClass  
-{  
-   public static void Main()  
-   {  
-      C.m2();  // CS0618  
-   }  
-}  
+'member' is obsolete: 'text'
+
+A class member was marked with the `Obsolete` attribute, such that a warning will be issued when the class member is referenced. For more information, see [Assembly level attributes](../attributes/global.md).
+
+The following sample generates CS0618:
+
+```csharp
+// CS0618.cs
+// compile with: /W:2
+using System;
+
+public class C
+{
+   [Obsolete("Use newMethod instead", false)]   // warn if referenced
+   public static void m2()
+   {
+   }
+
+   public static void newMethod()
+   {
+   }
+}
+
+class MyClass
+{
+   public static void Main()
+   {
+      C.m2();  // CS0618
+   }
+}
 ```


### PR DESCRIPTION
Fixes #34913.
Fixes #35047.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/aspnet-core/8.0/concurrencylimitermiddleware-obsolete.md](https://github.com/dotnet/docs/blob/cd07ebc62b04bce91fe592f41d3975e68af8d0c4/docs/core/compatibility/aspnet-core/8.0/concurrencylimitermiddleware-obsolete.md) | [docs/core/compatibility/aspnet-core/8.0/concurrencylimitermiddleware-obsolete](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/aspnet-core/8.0/concurrencylimitermiddleware-obsolete?branch=pr-en-us-35248) |
| [docs/core/compatibility/aspnet-core/8.0/problemdetails-custom-converters.md](https://github.com/dotnet/docs/blob/cd07ebc62b04bce91fe592f41d3975e68af8d0c4/docs/core/compatibility/aspnet-core/8.0/problemdetails-custom-converters.md) | [docs/core/compatibility/aspnet-core/8.0/problemdetails-custom-converters](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/aspnet-core/8.0/problemdetails-custom-converters?branch=pr-en-us-35248) |

</details>


<!-- PREVIEW-TABLE-END -->