### PR TITLE
Fix an issue in the native aot deployment page.

### DIFF
--- a/docs/core/deploying/native-aot/index.md
+++ b/docs/core/deploying/native-aot/index.md
@@ -114,4 +114,4 @@ The following table shows supported compilation targets.
 | Linux    | x64, Arm64             |
 | macOS*   | x64, Arm64             |
 
-* Supported starting in .NET 8.
+\* Supported starting in .NET 8.


### PR DESCRIPTION
## Summary

Escape an asterisk at the end of the document which is not supposed to be a bullet.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/deploying/native-aot/index.md](https://github.com/dotnet/docs/blob/5ba487b46f2b50d3fcacc8cebab45664f2ff48e7/docs/core/deploying/native-aot/index.md) | [Native AOT deployment](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/index?branch=pr-en-us-35252) |

<!-- PREVIEW-TABLE-END -->