### PR TITLE
ConvertTo breaking change

### DIFF
--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -52,9 +52,10 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 
 ## Globalization
 
-| Title                                                                           | Type of change    | Introduced |
-| ------------------------------------------------------------------------------- | ----------------- | ---------- |
-| [TwoDigitYearMax default is 2049](globalization/8.0/twodigityearmax-default.md) | Behavioral change | Preview 1  |
+| Title                                                                                             | Type of change    | Introduced |
+|---------------------------------------------------------------------------------------------------|-------------------|------------|
+| [Date and time converters honor culture argument](globalization/8.0/typeconverter-cultureinfo.md) | Behavioral change | Preview 4  |
+| [TwoDigitYearMax default is 2049](globalization/8.0/twodigityearmax-default.md)                   | Behavioral change | Preview 1  |
 
 ## Reflection
 

--- a/docs/core/compatibility/globalization/8.0/typeconverter-cultureinfo.md
+++ b/docs/core/compatibility/globalization/8.0/typeconverter-cultureinfo.md
@@ -25,7 +25,7 @@ Console.WriteLine($"Current culture: {CultureInfo.CurrentCulture}");
 var dt1 = new DateTime(2022, 8, 1);
 
 var frCulture = new CultureInfo("fr-FR");
-frCulture.DateTimeFormat = new DateTimeFormatInfo() { ShortDatePattern = "dd MMMM yyyy" };
+frCulture.DateTimeFormat.ShortDatePattern = "dd MMMM yyyy";
 
 Console.WriteLine(TypeDescriptor.GetConverter(dt1).ConvertTo(null, frCulture, dt1, typeof(string)));
 ```

--- a/docs/core/compatibility/globalization/8.0/typeconverter-cultureinfo.md
+++ b/docs/core/compatibility/globalization/8.0/typeconverter-cultureinfo.md
@@ -1,0 +1,44 @@
+---
+title: "Breaking change: Date and time converters honor culture argument"
+description: Learn about the globalization breaking change in .NET 8 where the type converters for date and time types use the argument-specified culture to format the date and time.
+ms.date: 05/03/2023
+---
+# Date and time converters honor culture argument
+
+The `ConvertTo` methods on the following classes now use the culture from the `culture` parameter to format the date and time instead of <xref:System.Globalization.CultureInfo.CurrentCulture?displayProperty=nameWithType>:
+
+- <xref:System.ComponentModel.DateOnlyConverter>
+- <xref:System.ComponentModel.DateTimeConverter>
+- <xref:System.ComponentModel.DateTimeOffsetConverter>
+- <xref:System.ComponentModel.TimeOnlyConverter>
+
+## Previous behavior
+
+Previously, the [affected APIs](#affected-apis) used <xref:System.Globalization.CultureInfo.CurrentCulture?displayProperty=nameWithType> to format the date and time even though the caller specified a culture in the `culture` parameter.
+
+## New behavior
+
+Starting in .NET 8, the [affected APIs](#affected-apis) use the culture specified by the `culture` parameter to format the date and time.
+
+## Version introduced
+
+.NET 8 Preview 4
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+This change fixes a bug where `ConvertTo` was not consistent with `ConvertFrom`. It used the date format pattern from the input culture and but formatted the date and time with <xref:System.Globalization.CultureInfo.CurrentCulture>.
+
+## Recommended action
+
+If you relied on the previous behavior, pass in <xref:System.Globalization.CultureInfo.CurrentCulture?displayProperty=nameWithType> or a custom culture for the `culture` parameter.
+
+## Affected APIs
+
+- <xref:System.ComponentModel.DateOnlyConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext,System.Globalization.CultureInfo,System.Object,System.Type)?displayProperty=fullName>
+- <xref:System.ComponentModel.DateTimeConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext,System.Globalization.CultureInfo,System.Object,System.Type)?displayProperty=fullName>
+- <xref:System.ComponentModel.DateTimeOffsetConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext,System.Globalization.CultureInfo,System.Object,System.Type)?displayProperty=fullName>
+- <xref:System.ComponentModel.TimeOnlyConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext,System.Globalization.CultureInfo,System.Object,System.Type)?displayProperty=fullName>

--- a/docs/core/compatibility/globalization/8.0/typeconverter-cultureinfo.md
+++ b/docs/core/compatibility/globalization/8.0/typeconverter-cultureinfo.md
@@ -34,7 +34,7 @@ This change fixes a bug where `ConvertTo` was not consistent with `ConvertFrom`.
 
 ## Recommended action
 
-If you relied on the previous behavior, pass in <xref:System.Globalization.CultureInfo.CurrentCulture?displayProperty=nameWithType> or a custom culture for the `culture` parameter.
+If you relied on the previous behavior, pass in <xref:System.Globalization.CultureInfo.CurrentCulture?displayProperty=nameWithType>, `null`, or a custom culture for the `culture` parameter.
 
 ## Affected APIs
 

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -48,6 +48,8 @@ items:
         href: extensions/8.0/hostapplicationbuilder-ctor.md
     - name: Globalization
       items:
+      - name: Date and time converters honor culture argument
+        href: globalization/8.0/typeconverter-cultureinfo.md
       - name: TwoDigitYearMax default is 2049
         href: globalization/8.0/twodigityearmax-default.md
     - name: Reflection
@@ -1206,6 +1208,8 @@ items:
     items:
     - name: .NET 8
       items:
+      - name: Date and time converters honor culture argument
+        href: globalization/8.0/typeconverter-cultureinfo.md
       - name: TwoDigitYearMax default is 2049
         href: globalization/8.0/twodigityearmax-default.md
     - name: .NET 7


### PR DESCRIPTION
Fixes #35201.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/8.0.md](https://github.com/dotnet/docs/blob/0c30a7916026716984bf9c8daf59f78d794f0ab2/docs/core/compatibility/8.0.md) | [Breaking changes in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/8.0?branch=pr-en-us-35256) |
| [docs/core/compatibility/globalization/8.0/typeconverter-cultureinfo.md](https://github.com/dotnet/docs/blob/0c30a7916026716984bf9c8daf59f78d794f0ab2/docs/core/compatibility/globalization/8.0/typeconverter-cultureinfo.md) | [docs/core/compatibility/globalization/8.0/typeconverter-cultureinfo](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/globalization/8.0/typeconverter-cultureinfo?branch=pr-en-us-35256) |


<!-- PREVIEW-TABLE-END -->