### PR TITLE
Change comment referring to named client

### DIFF
--- a/docs/core/extensions/snippets/http/typed/Program.cs
+++ b/docs/core/extensions/snippets/http/typed/Program.cs
@@ -10,7 +10,7 @@ using IHost host = Host.CreateDefaultBuilder(args)
         services.AddHttpClient<TodoService>(
             client =>
             {
-                // Set the base address of the named client.
+                // Set the base address of the typed client.
                 client.BaseAddress = new Uri("https://jsonplaceholder.typicode.com/");
 
                 // Add a user-agent default request header.


### PR DESCRIPTION
## Summary

Comment should refer to typed client not named client.
It used to be the same as the named client example, now it's specific for typed client.
