### PR TITLE
Fixes issue number #35206

### DIFF
--- a/docs/csharp/language-reference/operators/lambda-expressions.md
+++ b/docs/csharp/language-reference/operators/lambda-expressions.md
@@ -108,7 +108,7 @@ Lambda expressions with default parameters or `params` arrays as parameters don'
 
 :::code language="csharp" source="snippets/lambda-expressions/GeneralExamples.cs" id="DelegateDeclarations":::
 
-Or, you can use implicitly typed variables with `var` declarations to define the delegate type. The compile synthesizes the correct delegate type.
+Or, you can use implicitly typed variables with `var` declarations to define the delegate type. The compiler synthesizes the correct delegate type.
 
 For more information on see the feature spec for [default parameters on lambda expressions](~/_csharplang/proposals/lambda-method-group-defaults.md).
 


### PR DESCRIPTION
## Summary

I have fixed the typo in https://github.com/dotnet/docs/blob/main/docs/csharp/language-reference/operators/lambda-expressions.md file. The correction was the word compiler in the line given below-

```
Or, you can use implicitly typed variables with var declarations to define the delegate type. The compile synthesizes the correct delegate type.
```

Fixes #Issue_Number - #35206


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/lambda-expressions.md](https://github.com/dotnet/docs/blob/40166abb366fdc1e5fccc37f48df6be6494ebd19/docs/csharp/language-reference/operators/lambda-expressions.md) | [Lambda expressions and anonymous functions](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/lambda-expressions?branch=pr-en-us-35264) |

<!-- PREVIEW-TABLE-END -->