### PR TITLE
ObserverManager.UnSubscribe has only observers id as argument.

### DIFF
--- a/docs/orleans/grains/observers.md
+++ b/docs/orleans/grains/observers.md
@@ -76,7 +76,7 @@ class HelloGrain : Grain, IHello
     //Clients use this to unsubscribe and no longer receive messages.
     public Task UnSubscribe(IChat observer)
     {
-        _subsManager.Unsubscribe(observer, observer);
+        _subsManager.Unsubscribe(observer);
 
         return Task.CompletedTask;
     }


### PR DESCRIPTION
## Summary

Fixed parameterns in code sample for Grains Observers

Fixes #Issue_Number (if available)
No Issue available


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/grains/observers.md](https://github.com/dotnet/docs/blob/45ae0ea85566669efccaba74fa62f1eae54823a4/docs/orleans/grains/observers.md) | [Observers](https://review.learn.microsoft.com/en-us/dotnet/orleans/grains/observers?branch=pr-en-us-35265) |

<!-- PREVIEW-TABLE-END -->