### PR TITLE
Refactor CS0433 description to better present the Aliases solution

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs0433.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0433.md
@@ -26,8 +26,8 @@ This error can also occur if:
  This code creates the DLL with the first copy of the ambiguous type.  
   
 ```csharp  
-// CS0433_1.cs  
-// compile with: /target:library  
+// CS0433_1.cs in CS0433_1.csproj  
+// or compile with: /target:library  
 namespace TypeBindConflicts
 {  
    public class AggPubImpAggPubImp {}  
@@ -37,19 +37,25 @@ namespace TypeBindConflicts
  This code creates the DLL with the second copy of the ambiguous type.  
   
 ```csharp  
-// CS0433_2.cs  
-// compile with: /target:library  
+// CS0433_2.cs in CS0433_2.csproj  
+// or compile with: /target:library  
 namespace TypeBindConflicts
 {  
    public class AggPubImpAggPubImp {}  
 }  
 ```  
   
- The following example generates CS0433.  
+ So, when consuming these two libraries (`CS0433_1.dll` and `CS0433_2.dll`) in the project, using the `AggPubImpAddPubImp` type will be ambiguous and will lead to compiler error `CS0433`.
+  
+```xml  
+<!-- CS0433_3.csproj -->
+<ProjectReference Include="..\CS0433_1\CS0433_1.csproj" />  
+<ProjectReference Include="..\CS0433_2\CS0433_2.csproj" />  
+```  
   
 ```csharp  
-// CS0433_3.cs  
-// compile with: /reference:cs0433_1.dll /reference:cs0433_2.dll  
+// CS0433_3.cs in CS0433_3.csproj  
+// or compile with: /reference:cs0433_1.dll /reference:cs0433_2.dll  
 using TypeBindConflicts;  
 public class Test
 {  
@@ -60,17 +66,27 @@ public class Test
 }  
 ```  
   
- The following example shows how you can use the alias feature of the **/reference** compiler option to resolve this CS0433 error.  
+ The following example shows how you can use the alias feature of the **/reference** compiler option or `<Aliases>` feature in `<ProjectReference>` to resolve this CS0433 error.  
+  
+```xml  
+<!-- CS0433_4.csproj -->  
+<ProjectReference Include="..\CS0433_1\CS0433_1.csproj">  
+  <Aliases>CustomTypes</Aliases>  
+<ProjectReference Include="..\CS0433_2\CS0433_2.csproj" />  
+```  
   
 ```csharp  
-// CS0433_4.cs  
-// compile with: /reference:cs0433_1.dll /reference:TypeBindConflicts=cs0433_2.dll  
+// CS0433_4.cs in CS0433_4.csproj  
+// compile with: /reference:cs0433_1.dll /reference:CustomTypes=cs0433_2.dll  
+extern alias CustomTypes;  
 using TypeBindConflicts;  
+
 public class Test
 {  
    public static void Main()
    {  
-      AggPubImpAggPubImp n6 = new AggPubImpAggPubImp();  
+      AggPubImpAggPubImp n6 = new AggPubImpAggPubImp();   // AggPubImpAggPubImp taken from CS0433_1.dll  
+      CustomTypes.TypeBindConflicts.AggPubImpAggPubImp n7 = new CustomTypes.TypeBindConflicts.AggPubImpAggPubImp();  // AggPubImpAggPubImp taken from CS0433_2.dll
    }  
 }  
 ```


### PR DESCRIPTION
This pull request fixes #33334 

It clarifies the solution of the CS0433 error basically by:
* introducing the XML code showing the `<Aliases/>` feature and the more "modern" approach to building projects
* extending the `CS0433_4.cs` file's example to show that with the fix for CS0433 both `AggPubImpAggPubImp` can be used even with the same name and namespace.
* rephrases the problem a bit (in line 48) to better show why does the CS0433 pops up.

I have tested it locally and it works. Still, I'm bit worry about the dotnet/sdk#15443 when it comes to `extern alias CustomTypes` I used in the example. Is this issue really fixed, by any means?


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-messages/cs0433.md](https://github.com/dotnet/docs/blob/00b1d112e071125e597789728a11d62f1bb0c3f7/docs/csharp/language-reference/compiler-messages/cs0433.md) | [Compiler Error CS0433](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0433?branch=pr-en-us-35281) |

<!-- PREVIEW-TABLE-END -->