### PR TITLE
fix commandline/model-binding.md update references of 8 -> 16

### DIFF
--- a/docs/standard/commandline/dependency-injection.md
+++ b/docs/standard/commandline/dependency-injection.md
@@ -13,7 +13,7 @@ ms.topic: how-to
 
 [!INCLUDE [scl-preview](../../../includes/scl-preview.md)]
 
-Use a [custom binder](model-binding.md#parameter-binding-more-than-8-options-and-arguments) to inject custom types into a command handler.
+Use a [custom binder](model-binding.md#parameter-binding-more-than-16-options-and-arguments) to inject custom types into a command handler.
 
 We recommend handler-specific dependency injection (DI) for the following reasons:
 

--- a/docs/standard/commandline/model-binding.md
+++ b/docs/standard/commandline/model-binding.md
@@ -66,11 +66,11 @@ The variables that follow the lambda represent the option and argument objects t
 * If the out-of-order options or arguments are of different types, a run-time exception is thrown. For example, an `int` might appear where a `string` should be in the list of sources.
 * If the out-of-order options or arguments are of the same type, the handler silently gets the wrong values in the parameters provided to it. For example, `string` option `x` might appear where `string` option `y` should be in the list of sources. In that case, the variable for the option `y` value gets the option `x` value.
 
-There are overloads of <xref:System.CommandLine.Handler.SetHandler%2A> that support up to 8 parameters, with both synchronous and asynchronous signatures.
+There are overloads of <xref:System.CommandLine.Handler.SetHandler%2A> that support up to 16 parameters, with both synchronous and asynchronous signatures.
 
-## Parameter binding more than 8 options and arguments
+## Parameter binding more than 16 options and arguments
 
-To handle more than 8 options, or to construct a custom type from multiple options, you can use `InvocationContext` or a custom binder.
+To handle more than 16 options, or to construct a custom type from multiple options, you can use `InvocationContext` or a custom binder.
 
 ### Use `InvocationContext`
 


### PR DESCRIPTION
since in System.CommandLine.Handler.SetHandler, there are overloads that take 16 parameters

## Summary

in https://learn.microsoft.com/en-us/dotnet/standard/commandline/model-binding , it incorrectly says in a few spots that you can only use 8 Options (or IValueDescriptor ) to a a Command using SetHandler, when it is actually 16. I wonder if it used to be 8 and then was upped to 16 and this docs page was just never fully updated.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/commandline/dependency-injection.md](https://github.com/dotnet/docs/blob/755e60cb4731eefaba6647e00e5a4d6dd7d1d3ee/docs/standard/commandline/dependency-injection.md) | [How to configure dependency injection in System.CommandLine](https://review.learn.microsoft.com/en-us/dotnet/standard/commandline/dependency-injection?branch=pr-en-us-35304) |
| [docs/standard/commandline/model-binding.md](https://github.com/dotnet/docs/blob/755e60cb4731eefaba6647e00e5a4d6dd7d1d3ee/docs/standard/commandline/model-binding.md) | [docs/standard/commandline/model-binding](https://review.learn.microsoft.com/en-us/dotnet/standard/commandline/model-binding?branch=pr-en-us-35304) |


<!-- PREVIEW-TABLE-END -->