### PR TITLE
Update arithmetic-operators.md

### DIFF
--- a/docs/csharp/language-reference/operators/arithmetic-operators.md
+++ b/docs/csharp/language-reference/operators/arithmetic-operators.md
@@ -100,7 +100,7 @@ The division operator `/` divides its left-hand operand by its right-hand operan
 
 ### Integer division
 
-For the operands of integer types, the result of the `/` operator is of an integer type and equals the quotient of the two operands rounded towards zero:
+For the operands of integer types, the result of the `/` operator is of an integer type and equals the quotient of the two operands rounded down:
 
 :::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ArithmeticOperators.cs" id="IntegerDivision":::
 


### PR DESCRIPTION
It stated that integer division was rounded.

Now it says that it is rounded down.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/arithmetic-operators.md](https://github.com/dotnet/docs/blob/770f960d04f75bb30fc149ae6a2c688b90a4a613/docs/csharp/language-reference/operators/arithmetic-operators.md) | [Arithmetic operators (C# reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/arithmetic-operators?branch=pr-en-us-35310) |

<!-- PREVIEW-TABLE-END -->