### PR TITLE
Fix comments pertaining to code explanations

### DIFF
--- a/docs/standard/garbage-collection/implementing-disposeasync.md
+++ b/docs/standard/garbage-collection/implementing-disposeasync.md
@@ -16,7 +16,7 @@ ms.topic: how-to
 
 The <xref:System.IAsyncDisposable?displayProperty=nameWithType> interface was introduced as part of C# 8.0. You implement the <xref:System.IAsyncDisposable.DisposeAsync?displayProperty=nameWithType> method when you need to perform resource cleanup, just as you would when [implementing a Dispose method](implementing-dispose.md). One of the key differences, however, is that this implementation allows for asynchronous cleanup operations. The <xref:System.IAsyncDisposable.DisposeAsync> returns a <xref:System.Threading.Tasks.ValueTask> represents the asynchronous disposal operation.
 
-It is typical when implementing the <xref:System.IAsyncDisposable> interface that classes will also implement the <xref:System.IDisposable> interface. A good implementation pattern of the <xref:System.IAsyncDisposable> interface is to be prepared for either synchronous or asynchronous disposal, however, this isn't a requirement. If no synchronous disposable of your class is possible, having only <xref:System.IAsyncDisposable> is acceptable. All of the guidance for implementing the dispose pattern also applies to the asynchronous implementation. This article assumes that you're already familiar with how to [implement a Dispose method](implementing-dispose.md).
+It's typical when implementing the <xref:System.IAsyncDisposable> interface that classes also implement the <xref:System.IDisposable> interface. A good implementation pattern of the <xref:System.IAsyncDisposable> interface is to be prepared for either synchronous or asynchronous disposal, however, it's not a requirement. If no synchronous disposable of your class is possible, having only <xref:System.IAsyncDisposable> is acceptable. All of the guidance for implementing the disposal pattern also applies to the asynchronous implementation. This article assumes that you're already familiar with how to [implement a Dispose method](implementing-dispose.md).
 
 > [!CAUTION]
 > If you implement the <xref:System.IAsyncDisposable> interface but not the <xref:System.IDisposable> interface, your app can potentially leak resources. If a class implements <xref:System.IAsyncDisposable>, but not <xref:System.IDisposable>, and a consumer only calls `Dispose`, your implementation would never call `DisposeAsync`. This would result in a resource leak.
@@ -25,7 +25,7 @@ It is typical when implementing the <xref:System.IAsyncDisposable> interface tha
 
 ## Explore `DisposeAsync` and `DisposeAsyncCore` methods
 
-The <xref:System.IAsyncDisposable> interface declares a single parameterless method, <xref:System.IAsyncDisposable.DisposeAsync>. Any non-sealed class should have an additional `DisposeAsyncCore()` method that also returns a <xref:System.Threading.Tasks.ValueTask>.
+The <xref:System.IAsyncDisposable> interface declares a single parameterless method, <xref:System.IAsyncDisposable.DisposeAsync>. Any nonsealed class should define a `DisposeAsyncCore()` method that also returns a <xref:System.Threading.Tasks.ValueTask>.
 
 - A `public` <xref:System.IAsyncDisposable.DisposeAsync?displayProperty=nameWithType> implementation that has no parameters.
 - A `protected virtual ValueTask DisposeAsyncCore()` method whose signature is:
@@ -59,28 +59,28 @@ public async ValueTask DisposeAsync()
 
 ### The `DisposeAsyncCore` method
 
-The `DisposeAsyncCore()` method is intended to perform the asynchronous cleanup of managed resources or for cascading calls to `DisposeAsync()`. It encapsulates the common asynchronous cleanup operations when a subclass inherits a base class that is an implementation of <xref:System.IAsyncDisposable>. The `DisposeAsyncCore()` method is `virtual` so that derived classes can define additional cleanup in their overrides.
+The `DisposeAsyncCore()` method is intended to perform the asynchronous cleanup of managed resources or for cascading calls to `DisposeAsync()`. It encapsulates the common asynchronous cleanup operations when a subclass inherits a base class that is an implementation of <xref:System.IAsyncDisposable>. The `DisposeAsyncCore()` method is `virtual` so that derived classes can define custom cleanup in their overrides.
 
 > [!TIP]
 > If an implementation of <xref:System.IAsyncDisposable> is `sealed`, the `DisposeAsyncCore()` method is not needed, and the asynchronous cleanup can be performed directly in the <xref:System.IAsyncDisposable.DisposeAsync?displayProperty=nameWithType> method.
 
 ## Implement the async dispose pattern
 
-All non-sealed classes should be considered a potential base class, because they could be inherited. If you implement the async dispose pattern for any potential base class, you must provide the `protected virtual ValueTask DisposeAsyncCore()` method. Some of the following examples use a `NoopAsyncDisposable` class that is defined as follows:
+All nonsealed classes should be considered a potential base class, because they could be inherited. If you implement the async dispose pattern for any potential base class, you must provide the `protected virtual ValueTask DisposeAsyncCore()` method. Some of the following examples use a `NoopAsyncDisposable` class that is defined as follows:
 
 :::code language="csharp" source="snippets/dispose-async/NoopAsyncDisposable.cs":::
 
-Here is an example implementation of the async dispose pattern that uses the `NoopAsyncDisposable` type that implements `DisposeAsync` by returning <xref:System.Threading.Tasks.ValueTask.CompletedTask?displayProperty=nameWithType>.
+Here's an example implementation of the async dispose pattern that uses the `NoopAsyncDisposable` type that implements `DisposeAsync` by returning <xref:System.Threading.Tasks.ValueTask.CompletedTask?displayProperty=nameWithType>.
 
 :::code language="csharp" source="snippets/dispose-async/ExampleAsyncDisposable.cs":::
 
 In the preceding example:
 
-- The `ExampleAsyncDisposable` is a non-sealed class that implements the <xref:System.IAsyncDisposable> interface.
-- It contains a private `IAsyncDisposable` field, `_example`, that is initialized in the constructor.
+- The `ExampleAsyncDisposable` is a nonsealed class that implements the <xref:System.IAsyncDisposable> interface.
+- It contains a private `IAsyncDisposable` field, `_example` that is initialized in the constructor.
 - The `DisposeAsync` method delegates to the `DisposeAsyncCore` method and calls <xref:System.GC.SuppressFinalize%2A?displayProperty=nameWithType> to notify the garbage collector that the finalizer doesn't have to run.
 - It contains a `DisposeAsyncCore()` method that calls the `_example.DisposeAsync()` method, and sets the field to `null`.
-- The `DisposeAsyncCore()` method is `virtual` allowing it to be overridden by subclasses.
+- The `DisposeAsyncCore()` method is `virtual` allowing subclasses to override it with custom behavior.
 
 ### Sealed alternative async dispose pattern
 
@@ -96,15 +96,15 @@ In the preceding example:
 
 ## Implement both dispose and async dispose patterns
 
-You may need to implement both the <xref:System.IDisposable> and <xref:System.IAsyncDisposable> interfaces, especially when your class scope contains instances of these implementations. Doing so ensures that you can properly cascade clean up calls. Here is an example class that implements both interfaces and demonstrates the proper guidance for cleanup.
+You may need to implement both the <xref:System.IDisposable> and <xref:System.IAsyncDisposable> interfaces, especially when your class scope contains instances of these implementations. Doing so ensures that you can properly cascade clean up calls. Here's an example class that implements both interfaces and demonstrates the proper guidance for cleanup.
 
 :::code language="csharp" source="snippets/dispose-async/ExampleConjunctiveDisposable.cs":::
 
 The <xref:System.IDisposable.Dispose?displayProperty=nameWithType> and <xref:System.IAsyncDisposable.DisposeAsync?displayProperty=nameWithType> implementations are both simple boilerplate code.
 
-In the `Dispose(bool)` overload method, the <xref:System.IDisposable> instance is conditionally disposed of if it is not `null`. The <xref:System.IAsyncDisposable> instance is cast as <xref:System.IDisposable>, and if it is also not `null`, it is disposed of as well. Both instances are then assigned to `null`.
+In the `Dispose(bool)` overload method, the <xref:System.IDisposable> instance is conditionally disposed of if it isn't `null`. The <xref:System.IAsyncDisposable> instance is cast as <xref:System.IDisposable>, and if it's also not `null`, it's disposed of as well. Both instances are then assigned to `null`.
 
-With the `DisposeAsyncCore()` method, the same logical approach is followed. If the <xref:System.IAsyncDisposable> instance is not `null`, its call to `DisposeAsync().ConfigureAwait(false)` is awaited. If the <xref:System.IDisposable> instance is also an implementation of <xref:System.IAsyncDisposable>, it's also disposed of asynchronously. Both instances are then assigned to `null`.
+With the `DisposeAsyncCore()` method, the same logical approach is followed. If the <xref:System.IAsyncDisposable> instance isn't `null`, its call to `DisposeAsync().ConfigureAwait(false)` is awaited. If the <xref:System.IDisposable> instance is also an implementation of <xref:System.IAsyncDisposable>, it's also disposed of asynchronously. Both instances are then assigned to `null`.
 
 ## Using async disposable
 
@@ -115,7 +115,7 @@ To properly consume an object that implements the <xref:System.IAsyncDisposable>
 > [!IMPORTANT]
 > Use the <xref:System.Threading.Tasks.TaskAsyncEnumerableExtensions.ConfigureAwait(System.IAsyncDisposable,System.Boolean)> extension method of the <xref:System.IAsyncDisposable> interface to configure how the continuation of the task is marshalled on its original context or scheduler. For more information on `ConfigureAwait`, see [ConfigureAwait FAQ](https://devblogs.microsoft.com/dotnet/configureawait-faq/).
 
-For situations where the usage of `ConfigureAwait` is not needed, the `await using` statement could be simplified as follows:
+For situations where the usage of `ConfigureAwait` isn't needed, the `await using` statement could be simplified as follows:
 
 :::code language="csharp" source="snippets/dispose-async/ExampleUsingStatementProgram.cs":::
 
@@ -145,23 +145,23 @@ In situations where you create and use multiple objects that implement <xref:Sys
 
 :::code language="csharp" id="one" source="snippets/dispose-async/ExamplePatterns.cs":::
 
-In the preceding example, each asynchronous clean up operation is explicitly scoped under the `await using` block. The outer scope is defined by how `objOne` sets its braces, enclosing `objTwo`, as such `objTwo` is disposed first, followed by `objOne`. Both `IAsyncDisposable` instances have their <xref:System.IAsyncDisposable.DisposeAsync> method awaited, so each instance performs its asynchronous clean up operation. The calls are nested, not stacked.
+In the preceding example, each asynchronous clean-up operation is explicitly scoped under the `await using` block. The outer scope follows how `objOne` sets its braces, enclosing `objTwo`, as such `objTwo` is disposed first, followed by `objOne`. Both `IAsyncDisposable` instances have their <xref:System.IAsyncDisposable.DisposeAsync> method awaited, so each instance performs its asynchronous clean-up operation. The calls are nested, not stacked.
 
 ### Acceptable pattern two
 
 :::code language="csharp" id="two" source="snippets/dispose-async/ExamplePatterns.cs":::
 
-In the preceding example, each asynchronous clean up operation is explicitly scoped under the `await using` block. At the end of each block, the corresponding `IAsyncDisposable` instance has its <xref:System.IAsyncDisposable.DisposeAsync> method awaited, thus performing its asynchronous clean up operation. The calls are sequential, not stacked. In this scenario `objOne` is disposed first, then `objTwo` is disposed.
+In the preceding example, each asynchronous clean-up operation is explicitly scoped under the `await using` block. At the end of each block, the corresponding `IAsyncDisposable` instance has its <xref:System.IAsyncDisposable.DisposeAsync> method awaited, thus performing its asynchronous clean-up operation. The calls are sequential, not stacked. In this scenario `objOne` is disposed first, then `objTwo` is disposed.
 
 ### Acceptable pattern three
 
 :::code language="csharp" id="three" source="snippets/dispose-async/ExamplePatterns.cs":::
 
-In the preceding example, each asynchronous clean up operation is implicitly scoped with the containing method body. At the end of the enclosing block, the `IAsyncDisposable` instances perform their asynchronous clean up operations. This runs in reverse order from which they were declared, meaning that `objTwo` is disposed before `objOne`.
+In the preceding example, each asynchronous clean-up operation is implicitly scoped with the containing method body. At the end of the enclosing block, the `IAsyncDisposable` instances perform their asynchronous clean-up operations. This example runs in reverse order from which they were declared, meaning that `objTwo` is disposed before `objOne`.
 
 ### Unacceptable pattern
 
-The highlighted lines in the following code show what it means to have "stacked usings". If an exception is thrown from the `AnotherAsyncDisposable` constructor, neither object is properly disposed of. The variable `objTwo` is never assigned because the constructor did not complete successfully. As a result, the constructor for `AnotherAsyncDisposable` is responsible for disposing any resources allocated before it throws an exception. If the `ExampleAsyncDisposable` type has a finalizer, it's eligible for finalization.
+The highlighted lines in the following code show what it means to have "stacked usings". If an exception is thrown from the `AnotherAsyncDisposable` constructor, neither object is properly disposed of. The variable `objTwo` is never assigned because the constructor didn't complete successfully. As a result, the constructor for `AnotherAsyncDisposable` is responsible for disposing any resources allocated before it throws an exception. If the `ExampleAsyncDisposable` type has a finalizer, it's eligible for finalization.
 
 :::code language="csharp" id="dontdothis" source="snippets/dispose-async/ExamplePatterns.cs" highlight="9-10":::
 

--- a/docs/standard/garbage-collection/implementing-disposeasync.md
+++ b/docs/standard/garbage-collection/implementing-disposeasync.md
@@ -3,7 +3,7 @@ title: Implement a DisposeAsync method
 description: Learn how to implement DisposeAsync and DisposeAsyncCore methods to perform asynchronous resource cleanup.
 author: IEvangelist
 ms.author: dapine
-ms.date: 01/02/2023
+ms.date: 05/12/2023
 dev_langs:
   - "csharp"
 helpviewer_keywords:
@@ -14,7 +14,7 @@ ms.topic: how-to
 
 # Implement a DisposeAsync method
 
-The <xref:System.IAsyncDisposable?displayProperty=nameWithType> interface was introduced as part of C# 8.0. You implement the <xref:System.IAsyncDisposable.DisposeAsync?displayProperty=nameWithType> method when you need to perform resource cleanup, just as you would when [implementing a Dispose method](implementing-dispose.md). One of the key differences, however, is that this implementation allows for asynchronous cleanup operations. The <xref:System.IAsyncDisposable.DisposeAsync> returns a <xref:System.Threading.Tasks.ValueTask> representing the asynchronous disposal operation.
+The <xref:System.IAsyncDisposable?displayProperty=nameWithType> interface was introduced as part of C# 8.0. You implement the <xref:System.IAsyncDisposable.DisposeAsync?displayProperty=nameWithType> method when you need to perform resource cleanup, just as you would when [implementing a Dispose method](implementing-dispose.md). One of the key differences, however, is that this implementation allows for asynchronous cleanup operations. The <xref:System.IAsyncDisposable.DisposeAsync> returns a <xref:System.Threading.Tasks.ValueTask> represents the asynchronous disposal operation.
 
 It is typical when implementing the <xref:System.IAsyncDisposable> interface that classes will also implement the <xref:System.IDisposable> interface. A good implementation pattern of the <xref:System.IAsyncDisposable> interface is to be prepared for either synchronous or asynchronous disposal, however, this isn't a requirement. If no synchronous disposable of your class is possible, having only <xref:System.IAsyncDisposable> is acceptable. All of the guidance for implementing the dispose pattern also applies to the asynchronous implementation. This article assumes that you're already familiar with how to [implement a Dispose method](implementing-dispose.md).
 
@@ -70,7 +70,7 @@ All non-sealed classes should be considered a potential base class, because they
 
 :::code language="csharp" source="snippets/dispose-async/NoopAsyncDisposable.cs":::
 
-Here is an example implementation of the async dispose pattern that using a custom `NoopAsyncDisposable` type that implements `DisposeAsync` by returning <xref:System.Threading.Tasks.ValueTask.CompletedTask?displayProperty=nameWithType>.
+Here is an example implementation of the async dispose pattern that uses the `NoopAsyncDisposable` type that implements `DisposeAsync` by returning <xref:System.Threading.Tasks.ValueTask.CompletedTask?displayProperty=nameWithType>.
 
 :::code language="csharp" source="snippets/dispose-async/ExampleAsyncDisposable.cs":::
 
@@ -78,9 +78,9 @@ In the preceding example:
 
 - The `ExampleAsyncDisposable` is a non-sealed class that implements the <xref:System.IAsyncDisposable> interface.
 - It contains a private `IAsyncDisposable` field, `_example`, that is initialized in the constructor.
-- The `DisposeAsync` method delegates to the `DisposeAsyncCore` method, and calls <xref:System.GC.SuppressFinalize%2A?displayProperty=nameWithType> to notify the garbage collector that the finalizer doesn't have to run.
+- The `DisposeAsync` method delegates to the `DisposeAsyncCore` method and calls <xref:System.GC.SuppressFinalize%2A?displayProperty=nameWithType> to notify the garbage collector that the finalizer doesn't have to run.
 - It contains a `DisposeAsyncCore()` method that calls the `_example.DisposeAsync()` method, and sets the field to `null`.
-- The `DisposeAsyncCore()` method is `virtual` and is overridden in the `ExampleAsyncDisposable` class.
+- The `DisposeAsyncCore()` method is `virtual` allowing it to be overridden by subclasses.
 
 ### Sealed alternative async dispose pattern
 

--- a/docs/standard/garbage-collection/implementing-disposeasync.md
+++ b/docs/standard/garbage-collection/implementing-disposeasync.md
@@ -14,7 +14,7 @@ ms.topic: how-to
 
 # Implement a DisposeAsync method
 
-The <xref:System.IAsyncDisposable?displayProperty=nameWithType> interface was introduced as part of C# 8.0. You implement the <xref:System.IAsyncDisposable.DisposeAsync?displayProperty=nameWithType> method when you need to perform resource cleanup, just as you would when [implementing a Dispose method](implementing-dispose.md). One of the key differences, however, is that this implementation allows for asynchronous cleanup operations. The <xref:System.IAsyncDisposable.DisposeAsync> returns a <xref:System.Threading.Tasks.ValueTask> represents the asynchronous disposal operation.
+The <xref:System.IAsyncDisposable?displayProperty=nameWithType> interface was introduced as part of C# 8.0. You implement the <xref:System.IAsyncDisposable.DisposeAsync?displayProperty=nameWithType> method when you need to perform resource cleanup, just as you would when [implementing a Dispose method](implementing-dispose.md). One of the key differences, however, is that this implementation allows for asynchronous cleanup operations. The <xref:System.IAsyncDisposable.DisposeAsync> returns a <xref:System.Threading.Tasks.ValueTask> that represents the asynchronous disposal operation.
 
 It's typical when implementing the <xref:System.IAsyncDisposable> interface that classes also implement the <xref:System.IDisposable> interface. A good implementation pattern of the <xref:System.IAsyncDisposable> interface is to be prepared for either synchronous or asynchronous disposal, however, it's not a requirement. If no synchronous disposable of your class is possible, having only <xref:System.IAsyncDisposable> is acceptable. All of the guidance for implementing the disposal pattern also applies to the asynchronous implementation. This article assumes that you're already familiar with how to [implement a Dispose method](implementing-dispose.md).
 
@@ -70,17 +70,17 @@ All nonsealed classes should be considered a potential base class, because they 
 
 :::code language="csharp" source="snippets/dispose-async/NoopAsyncDisposable.cs":::
 
-Here's an example implementation of the async dispose pattern that uses the `NoopAsyncDisposable` type that implements `DisposeAsync` by returning <xref:System.Threading.Tasks.ValueTask.CompletedTask?displayProperty=nameWithType>.
+Here's an example implementation of the async dispose pattern that uses the `NoopAsyncDisposable` type. The type implements `DisposeAsync` by returning <xref:System.Threading.Tasks.ValueTask.CompletedTask?displayProperty=nameWithType>.
 
 :::code language="csharp" source="snippets/dispose-async/ExampleAsyncDisposable.cs":::
 
 In the preceding example:
 
 - The `ExampleAsyncDisposable` is a nonsealed class that implements the <xref:System.IAsyncDisposable> interface.
-- It contains a private `IAsyncDisposable` field, `_example` that is initialized in the constructor.
+- It contains a private `IAsyncDisposable` field, `_example`, that's initialized in the constructor.
 - The `DisposeAsync` method delegates to the `DisposeAsyncCore` method and calls <xref:System.GC.SuppressFinalize%2A?displayProperty=nameWithType> to notify the garbage collector that the finalizer doesn't have to run.
 - It contains a `DisposeAsyncCore()` method that calls the `_example.DisposeAsync()` method, and sets the field to `null`.
-- The `DisposeAsyncCore()` method is `virtual` allowing subclasses to override it with custom behavior.
+- The `DisposeAsyncCore()` method is `virtual`, which allows subclasses to override it with custom behavior.
 
 ### Sealed alternative async dispose pattern
 


### PR DESCRIPTION
## Summary

- Fix comments pertaining to code explanations, specifically addressing contradictive statements.
- Edit pass and acrolinx (went from 77 to 98 🤓).

Fixes #34478


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/garbage-collection/implementing-disposeasync.md](https://github.com/dotnet/docs/blob/c8cbc601abb0e14d77ae05016154a46f73a13c08/docs/standard/garbage-collection/implementing-disposeasync.md) | [Implement a DisposeAsync method](https://review.learn.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-disposeasync?branch=pr-en-us-35320) |


<!-- PREVIEW-TABLE-END -->