### PR TITLE
Update observers.md

### DIFF
--- a/docs/orleans/grains/observers.md
+++ b/docs/orleans/grains/observers.md
@@ -118,7 +118,7 @@ Now whenever our grain on the server calls the `SendUpdateMessage` method, all s
 Users should maintain a reference for each observer which they do not want to be collected.
 
 > [!NOTE]
-> Observers are inherently unreliable since you don't get any response back to know if the message is received and processed or simply failed due to any condition which might arise in a distributed system. Because of that, your observers should poll the grain periodically or use any other mechanism to ensure that they received all messages which they should have received. In some situations, you can afford to lose some messages and you don't need an additional mechanism, but if you need to make sure that all observers are always receiving the messages and are receiving all of them, both periodic resubscription and polling the observer grain can help to ensure eventual processing of all messages.
+> Observers are inherently unreliable since a client which hosts an observer may fail and observers created after recovery have different (randomized) identities. <xref:Orleans.Utilities.ObserverManager%601> relies on periodic resubscription by observers, as discussed above, so that inactive observers can be removed.
 
 ## Execution model
 


### PR DESCRIPTION
## Summary

Observers no longer only support one-way messaging.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/grains/observers.md](https://github.com/dotnet/docs/blob/de746c4046b6936b2a9ac1bf7c90f0fde30fbb32/docs/orleans/grains/observers.md) | [Observers](https://review.learn.microsoft.com/en-us/dotnet/orleans/grains/observers?branch=pr-en-us-35345) |

<!-- PREVIEW-TABLE-END -->