### PR TITLE
Add docs on native AOT interop details

### DIFF
--- a/docs/core/deploying/native-aot/interop.md
+++ b/docs/core/deploying/native-aot/interop.md
@@ -71,7 +71,7 @@ Examples:
   <LinkerArg Include="/DEPENDENTLOADFLAG:0x800" Condition="$(RuntimeIdentifier.StartsWith('win'))" />
 
   <!-- Native AOT invokes clang/gcc as the linker, so arguments need to be prefixed with "-Wl," -->
-  <LinkerArg Include="-Wl,--build-id=sha1" Condition="$(RuntimeIdentifier.StartsWith('linux'))" />
+  <LinkerArg Include="-Wl,-rpath,'/bin/'" Condition="$(RuntimeIdentifier.StartsWith('linux'))" />
 </ItemGroup>
 ```
 

--- a/docs/core/deploying/native-aot/interop.md
+++ b/docs/core/deploying/native-aot/interop.md
@@ -1,0 +1,81 @@
+---
+title: Native code interop
+description: Learn about native code interop with native AOT.
+author: MichalStrehovsky
+ms.author: michals
+ms.date: 05/17/2023
+---
+# Native code interop
+
+Native code interop is a technology that allows you to access structs and functions in unmanaged libraries from managed code, or expose structs and functions in managed libraries to unmanaged code (the opposite direction).
+
+While native code interop works similarly to non-AOT deployments, there are some specifics that differ when publishing as native AOT.
+
+## Direct P/Invoke calls
+
+The P/Invoke calls in AOT compiled binaries are bound lazily at runtime by default for better compatibility. The AOT compiler can be configured to generate direct calls for selected P/Invoke methods that are bound during startup by the dynamic loader that comes with the operating system. The unmanaged libraries and entry points referenced via direct calls always have to be available at runtime, otherwise the native binary fails to start.
+
+The benefits of direct PInvoke calls are:
+- Direct PInvoke calls have *better steady state performance*
+- Direct PInvoke calls make it possible to *link the unmanaged dependencies statically*
+
+The direct PInvoke generation can be configured using `<DirectPInvoke>` items in the project file. The item name can be either `modulename`, which enables direct calls for all module entry points, or `modulename!entrypointname`, which enables a direct call for the specific module and entry point only.
+
+`<DirectPInvokeList>filename</DirectPInvokeList>` items in the project file allow specifying a list of entry points in an external file. This is useful when the specification of direct PInvoke calls is long and it is not practical to specify them using individual `<DirectPInvoke>` items. The file can contain empty lines and comments starting with `#`.
+
+Examples:
+
+```xml
+<ItemGroup>
+  <!-- Generate direct PInvoke calls for everything in __Internal -->
+  <!-- This option replicates Mono AOT behavior that generates direct PInvoke calls for __Internal -->
+  <DirectPInvoke Include="__Internal" />
+  <!-- Generate direct PInvoke calls for everything in libc (also matches libc.so on Linux or libc.dylib on macOS) --> 
+  <DirectPInvoke Include="libc" />
+  <!-- Generate direct PInvoke calls for Sleep in kernel32 (also matches kernel32.dll on Windows) -->
+  <DirectPInvoke Include="kernel32!Sleep" />
+  <!-- Generate direct PInvoke for all APIs listed in DirectXAPIs.txt -->
+  <DirectPInvokeList Include="DirectXAPIs.txt" />
+</ItemGroup>
+```
+
+On Windows, native AOT uses a pre-populated list of direct P/Invoke methods that are available on all supported versions of Windows.
+
+> [!WARNING]
+> Because direct P/Invoke methods are resolved by the operating system dynamic loader and not by the native AOT runtime library, direct P/Invoke methods will not respect the <xref:System.Runtime.InteropServices.DefaultDllImportSearchPathsAttribute>. The library search order will follow the dynamic loader rules as defined by the operating system. Some operating systems and loaders offer ways to control dynamic loading through linker flags (such as `/DEPENDENTLOADFLAG` on Windows or `-rpath` on Linux). See details below on how to specify linker flags.
+
+### Linking
+
+To statically link against an unmanaged library, you'll need to specify `<NativeLibrary Include="filename" />` pointing to a `.lib` file on Windows and a `.a` file on Unix.
+
+Examples:
+
+```xml
+<ItemGroup>
+  <!-- Generate direct PInvokes for Dependency -->
+  <DirectPInvoke Include="Dependency" />
+  <!-- Specify library to link against -->
+  <NativeLibrary Include="Dependency.lib" Condition="$(RuntimeIdentifier.StartsWith('win'))" />
+  <NativeLibrary Include="Dependency.a" Condition="!$(RuntimeIdentifier.StartsWith('win'))" />
+</ItemGroup>
+```
+
+To specify additional flags to the native linker, use the `<LinkerArg Include="-argument" />` item.
+
+Examples:
+
+```xml
+<ItemGroup>
+  <!-- link.exe is used as the linker on Windows -->
+  <LinkerArg Include="/DEPENDENTLOADFLAG:0x800" Condition="$(RuntimeIdentifier.StartsWith('win'))" />
+
+  <!-- Native AOT invokes clang/gcc as the linker, so arguments need to be prefixed with "-Wl," -->
+  <LinkerArg Include="-Wl,--build-id=sha1" Condition="$(RuntimeIdentifier.StartsWith('linux'))" />
+</ItemGroup>
+```
+
+## Native Exports
+
+The native AOT compiler will export methods annotated with `UnmanagedCallersOnlyAttribute` and an explicitly specified name as
+public C entry points. This makes it possible to either dynamically or statically link the AOT compiled modules into external
+programs. More details can be found in [NativeLibrary Sample](https://github.com/dotnet/samples/tree/main/core/nativeaot/NativeLibrary/README.md).

--- a/docs/core/deploying/native-aot/interop.md
+++ b/docs/core/deploying/native-aot/interop.md
@@ -7,7 +7,7 @@ ms.date: 05/17/2023
 ---
 # Native code interop
 
-Native code interop is a technology that allows you to access structs and functions in unmanaged libraries from managed code, or expose structs and functions in managed libraries to unmanaged code (the opposite direction).
+Native code interop is a technology that allows you to access unmanaged libraries from managed code, or expose managed libraries to unmanaged code (the opposite direction).
 
 While native code interop works similarly to non-AOT deployments, there are some specifics that differ when publishing as native AOT.
 

--- a/docs/core/deploying/native-aot/interop.md
+++ b/docs/core/deploying/native-aot/interop.md
@@ -1,28 +1,28 @@
 ---
-title: Native code interop
+title: Native code interop with native AOT
 description: Learn about native code interop with native AOT.
 author: MichalStrehovsky
 ms.author: michals
 ms.date: 05/17/2023
 ---
-# Native code interop
+# Native code interop with native AOT
 
 Native code interop is a technology that allows you to access unmanaged libraries from managed code, or expose managed libraries to unmanaged code (the opposite direction).
 
-While native code interop works similarly to non-AOT deployments, there are some specifics that differ when publishing as native AOT.
+While native code interop works similarly in native AOT and non-AOT deployments, there are some specifics that differ when publishing as native AOT.
 
 ## Direct P/Invoke calls
 
-The P/Invoke calls in AOT compiled binaries are bound lazily at runtime by default for better compatibility. The AOT compiler can be configured to generate direct calls for selected P/Invoke methods that are bound during startup by the dynamic loader that comes with the operating system. The unmanaged libraries and entry points referenced via direct calls always have to be available at runtime, otherwise the native binary fails to start.
+The P/Invoke calls in AOT-compiled binaries are bound lazily at run time by default, for better compatibility. You can configure the AOT compiler to generate direct calls for selected P/Invoke methods that are bound during startup by the dynamic loader that comes with the operating system. The unmanaged libraries and entry points referenced via direct calls must always be available at run time, otherwise the native binary fails to start.
 
-The benefits of direct PInvoke calls are:
+The benefits of direct P/Invoke calls are:
 
-- Direct PInvoke calls have *better steady state performance*
-- Direct PInvoke calls make it possible to *link the unmanaged dependencies statically*
+- They have *better steady state performance*.
+- They make it possible to *link the unmanaged dependencies statically*.
 
-The direct PInvoke generation can be configured using `<DirectPInvoke>` items in the project file. The item name can be either `modulename`, which enables direct calls for all module entry points, or `modulename!entrypointname`, which enables a direct call for the specific module and entry point only.
+You can configure the direct P/Invoke generation using `<DirectPInvoke>` items in the project file. The item name can be either *\<modulename>*, which enables direct calls for all entry points in the module, or *\<modulename!entrypointname>*, which enables a direct call for the specific module and entry point only.
 
-`<DirectPInvokeList>filename</DirectPInvokeList>` items in the project file allow specifying a list of entry points in an external file. This is useful when the specification of direct PInvoke calls is long and it is not practical to specify them using individual `<DirectPInvoke>` items. The file can contain empty lines and comments starting with `#`.
+To specify a list of entry points in an external file, use `<DirectPInvokeList>filename</DirectPInvokeList>` items in the project file. A list is useful when the number of direct P/Invoke calls is large and it's unpractical to specify them using individual `<DirectPInvoke>` items. The file can contain empty lines and comments starting with `#`.
 
 Examples:
 
@@ -43,7 +43,7 @@ Examples:
 On Windows, native AOT uses a pre-populated list of direct P/Invoke methods that are available on all supported versions of Windows.
 
 > [!WARNING]
-> Because direct P/Invoke methods are resolved by the operating system dynamic loader and not by the native AOT runtime library, direct P/Invoke methods will not respect the <xref:System.Runtime.InteropServices.DefaultDllImportSearchPathsAttribute>. The library search order will follow the dynamic loader rules as defined by the operating system. Some operating systems and loaders offer ways to control dynamic loading through linker flags (such as `/DEPENDENTLOADFLAG` on Windows or `-rpath` on Linux). See details below on how to specify linker flags.
+> Because direct P/Invoke methods are resolved by the operating system dynamic loader and not by the native AOT runtime library, direct P/Invoke methods will not respect the <xref:System.Runtime.InteropServices.DefaultDllImportSearchPathsAttribute>. The library search order will follow the dynamic loader rules as defined by the operating system. Some operating systems and loaders offer ways to control dynamic loading through linker flags (such as `/DEPENDENTLOADFLAG` on Windows or `-rpath` on Linux). For more information on how to specify linker flags, see the [Linking](#linking) section.
 
 ### Linking
 
@@ -75,8 +75,8 @@ Examples:
 </ItemGroup>
 ```
 
-## Native Exports
+## Native exports
 
 The native AOT compiler will export methods annotated with `UnmanagedCallersOnlyAttribute` and an explicitly specified name as
-public C entry points. This makes it possible to either dynamically or statically link the AOT compiled modules into external
-programs. More details can be found in [NativeLibrary Sample](https://github.com/dotnet/samples/tree/main/core/nativeaot/NativeLibrary/README.md).
+public C entry points (that is, set `EntryPoint`). This makes it possible to either dynamically or statically link the AOT compiled modules into external
+programs. For more information, see [NativeLibrary sample](https://github.com/dotnet/samples/tree/main/core/nativeaot/NativeLibrary/README.md).

--- a/docs/core/deploying/native-aot/interop.md
+++ b/docs/core/deploying/native-aot/interop.md
@@ -16,6 +16,7 @@ While native code interop works similarly to non-AOT deployments, there are some
 The P/Invoke calls in AOT compiled binaries are bound lazily at runtime by default for better compatibility. The AOT compiler can be configured to generate direct calls for selected P/Invoke methods that are bound during startup by the dynamic loader that comes with the operating system. The unmanaged libraries and entry points referenced via direct calls always have to be available at runtime, otherwise the native binary fails to start.
 
 The benefits of direct PInvoke calls are:
+
 - Direct PInvoke calls have *better steady state performance*
 - Direct PInvoke calls make it possible to *link the unmanaged dependencies statically*
 

--- a/docs/core/deploying/native-aot/interop.md
+++ b/docs/core/deploying/native-aot/interop.md
@@ -22,7 +22,7 @@ The benefits of direct P/Invoke calls are:
 
 You can configure the direct P/Invoke generation using `<DirectPInvoke>` items in the project file. The item name can be either *\<modulename>*, which enables direct calls for all entry points in the module, or *\<modulename!entrypointname>*, which enables a direct call for the specific module and entry point only.
 
-To specify a list of entry points in an external file, use `<DirectPInvokeList>filename</DirectPInvokeList>` items in the project file. A list is useful when the number of direct P/Invoke calls is large and it's unpractical to specify them using individual `<DirectPInvoke>` items. The file can contain empty lines and comments starting with `#`.
+To specify a list of entry points in an external file, use `<DirectPInvokeList>` items in the project file. A list is useful when the number of direct P/Invoke calls is large and it's unpractical to specify them using individual `<DirectPInvoke>` items. The file can contain empty lines and comments starting with `#`.
 
 Examples:
 
@@ -47,7 +47,7 @@ On Windows, native AOT uses a pre-populated list of direct P/Invoke methods that
 
 ### Linking
 
-To statically link against an unmanaged library, you'll need to specify `<NativeLibrary Include="filename" />` pointing to a `.lib` file on Windows and a `.a` file on Unix.
+To statically link against an unmanaged library, you'll need to specify `<NativeLibrary Include="filename" />` pointing to a `.lib` file on Windows and a `.a` file on Unix-like systems.
 
 Examples:
 
@@ -61,7 +61,7 @@ Examples:
 </ItemGroup>
 ```
 
-To specify additional flags to the native linker, use the `<LinkerArg Include="-argument" />` item.
+To specify additional flags to the native linker, use the `<LinkerArg>` item.
 
 Examples:
 
@@ -77,6 +77,6 @@ Examples:
 
 ## Native exports
 
-The native AOT compiler will export methods annotated with `UnmanagedCallersOnlyAttribute` and an explicitly specified name as
-public C entry points (that is, set `EntryPoint`). This makes it possible to either dynamically or statically link the AOT compiled modules into external
+The native AOT compiler will export methods annotated with <xref:System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute> with a non-empty `EntryPoint` property as
+public C entry points. This makes it possible to either dynamically or statically link the AOT compiled modules into external
 programs. For more information, see [NativeLibrary sample](https://github.com/dotnet/samples/tree/main/core/nativeaot/NativeLibrary/README.md).

--- a/docs/navigate/devops-testing/toc.yml
+++ b/docs/navigate/devops-testing/toc.yml
@@ -329,6 +329,8 @@ items:
             href: ../../core/deploying/native-aot/index.md
           - name: Optimize AOT deployments
             href: ../../core/deploying/native-aot/optimizing.md
+          - name: Native code interop
+            href: ../../core/deploying/native-aot/interop.md
           - name: Intro to AOT warnings
             href: ../../core/deploying/native-aot/fixing-warnings.md
           - name: AOT warnings


### PR DESCRIPTION
## Summary

Document native AOT interop specifics.

Cc @elinor-fung @AaronRobinsonMSFT @jkoritzinsky @dotnet/ilc-contrib

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/deploying/native-aot/interop.md](https://github.com/dotnet/docs/blob/97af7c2588a56b562bc677de004a35f718b8a5c1/docs/core/deploying/native-aot/interop.md) | [docs/core/deploying/native-aot/interop](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/interop?branch=pr-en-us-35352) |


<!-- PREVIEW-TABLE-END -->