### PR TITLE
Add using statement to snippet

### DIFF
--- a/docs/standard/commandline/snippets/dependency-injection/csharp/Program.cs
+++ b/docs/standard/commandline/snippets/dependency-injection/csharp/Program.cs
@@ -40,7 +40,7 @@ class Program
 
         ILogger GetLogger(BindingContext bindingContext)
         {
-            ILoggerFactory loggerFactory = LoggerFactory.Create(
+            using ILoggerFactory loggerFactory = LoggerFactory.Create(
                 builder => builder.AddConsole());
             ILogger logger = loggerFactory.CreateLogger("LoggerCategory");
             return logger;


### PR DESCRIPTION
## Summary

Adding using statement to ensure that the logs get flushed properly.

If L30 and L32 would be removed, no output would show up in the console - the process would exit before the logs would be flushed.