### PR TITLE
System.Drawing.Common config switch removal

### DIFF
--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -13,37 +13,37 @@ If you're migrating an app to .NET 6, the breaking changes listed here might aff
 
 ## ASP.NET Core
 
-| Title | Binary compatible | Source compatible |
+| Title | Binary compatible | Source compatible | Introduced |
 | - | :-: | :-: | - |
-| [ActionResult\<T> sets StatusCode to 200](aspnet-core/6.0/actionresult-statuscode.md) | ✔️ | ❌ |
-| [AddDataAnnotationsValidation method made obsolete](aspnet-core/6.0/adddataannotationsvalidation-obsolete.md) | ✔️ | ❌ |
-| [Assemblies removed from Microsoft.AspNetCore.App shared framework](aspnet-core/6.0/assemblies-removed-from-shared-framework.md) | ❌ | ✔️ |
-| [Blazor: Parameter name changed in RequestImageFileAsync method](aspnet-core/6.0/blazor-parameter-name-changed-in-method.md) | ✔️ | ❌ |
-| [Blazor: WebEventDescriptor.EventArgsType property replaced](aspnet-core/6.0/blazor-eventargstype-property-replaced.md) | ❌ | ❌ |
-| [Blazor: Byte array interop](aspnet-core/6.0/byte-array-interop.md) | ✔️ | ❌ |
-| [Changed MessagePack library in @microsoft/signalr-protocol-msgpack](aspnet-core/6.0/messagepack-library-change.md) | ❌ | ✔️ |
-| [ClientCertificate property doesn't trigger renegotiation for HttpSys](aspnet-core/6.0/clientcertificate-doesnt-trigger-renegotiation.md) | ✔️ | ❌ |
-| [EndpointName metadata not set automatically](aspnet-core/6.0/endpointname-metadata.md) | ✔️ | ❌ |
-| [Identity: Default Bootstrap version of UI changed](aspnet-core/6.0/identity-bootstrap4-to-5.md) | ❌ | ❌
-| [Kestrel: Log message attributes changed](aspnet-core/6.0/kestrel-log-message-attributes-changed.md) | ✔️ | ❌ |
-| [Microsoft.AspNetCore.Http.Features split](aspnet-core/6.0/microsoft-aspnetcore-http-features-package-split.md) | ❌ | ✔️ |
-| [Middleware: HTTPS Redirection Middleware throws exception on ambiguous HTTPS ports](aspnet-core/6.0/middleware-ambiguous-https-ports-exception.md) | ✔️ | ❌ |
-| [Middleware: New Use overload](aspnet-core/6.0/middleware-new-use-overload.md) | ✔️ | ❌ |
-| [Minimal API renames in RC 1](aspnet-core/6.0/rc1-minimal-api-renames.md) | ❌ | ❌ |
-| [Minimal API renames in RC 2](aspnet-core/6.0/rc2-minimal-api-renames.md) | ❌ | ❌ |
-| [MVC doesn't buffer IAsyncEnumerable types when using System.Text.Json](aspnet-core/6.0/iasyncenumerable-not-buffered-by-mvc.md) | ✔️ | ❌ |
-| [Nullable reference type annotations changed](aspnet-core/6.0/nullable-reference-type-annotations-changed.md) | ✔️ | ❌ |
-| [Obsoleted and removed APIs](aspnet-core/6.0/obsolete-removed-apis.md) | ✔️ | ❌ |
-| [PreserveCompilationContext not configured by default](aspnet-core/6.0/preservecompilationcontext-not-set-by-default.md) | ❌ | ✔️ |
-| [Razor: Compiler no longer produces a Views assembly](aspnet-core/6.0/razor-compiler-doesnt-produce-views-assembly.md) | ✔️ | ❌ |
-| [Razor: Logging ID changes](aspnet-core/6.0/razor-pages-logging-ids.md) | ❌ | ✔️ |
-| [Razor: RazorEngine APIs marked obsolete](aspnet-core/6.0/razor-engine-apis-obsolete.md) | ✔️ | ❌ |
-| [SignalR: Java Client updated to RxJava3](aspnet-core/6.0/signalr-java-client-updated.md) | ❌ | ✔️ |
-| [TryParse and BindAsync methods are validated](aspnet-core/6.0/tryparse-bindasync-validation.md) | ❌ | ❌ |
+| [ActionResult\<T> sets StatusCode to 200](aspnet-core/6.0/actionresult-statuscode.md) | ✔️ | ❌ |  |
+| [AddDataAnnotationsValidation method made obsolete](aspnet-core/6.0/adddataannotationsvalidation-obsolete.md) | ✔️ | ❌ |  |
+| [Assemblies removed from Microsoft.AspNetCore.App shared framework](aspnet-core/6.0/assemblies-removed-from-shared-framework.md) | ❌ | ✔️ |  |
+| [Blazor: Parameter name changed in RequestImageFileAsync method](aspnet-core/6.0/blazor-parameter-name-changed-in-method.md) | ✔️ | ❌ | Preview 1 |
+| [Blazor: WebEventDescriptor.EventArgsType property replaced](aspnet-core/6.0/blazor-eventargstype-property-replaced.md) | ❌ | ❌ |  |
+| [Blazor: Byte array interop](aspnet-core/6.0/byte-array-interop.md) | ✔️ | ❌ | Preview 6 |
+| [Changed MessagePack library in @microsoft/signalr-protocol-msgpack](aspnet-core/6.0/messagepack-library-change.md) | ❌ | ✔️ |  |
+| [ClientCertificate property doesn't trigger renegotiation for HttpSys](aspnet-core/6.0/clientcertificate-doesnt-trigger-renegotiation.md) | ✔️ | ❌ |  |
+| [EndpointName metadata not set automatically](aspnet-core/6.0/endpointname-metadata.md) | ✔️ | ❌ | RC 2 |
+| [Identity: Default Bootstrap version of UI changed](aspnet-core/6.0/identity-bootstrap4-to-5.md) | ❌ | ❌  |  |
+| [Kestrel: Log message attributes changed](aspnet-core/6.0/kestrel-log-message-attributes-changed.md) | ✔️ | ❌ |  |
+| [Microsoft.AspNetCore.Http.Features split](aspnet-core/6.0/microsoft-aspnetcore-http-features-package-split.md) | ❌ | ✔️ |  |
+| [Middleware: HTTPS Redirection Middleware throws exception on ambiguous HTTPS ports](aspnet-core/6.0/middleware-ambiguous-https-ports-exception.md) | ✔️ | ❌ |  |
+| [Middleware: New Use overload](aspnet-core/6.0/middleware-new-use-overload.md) | ✔️ | ❌ | Preview 4 |
+| [Minimal API renames in RC 1](aspnet-core/6.0/rc1-minimal-api-renames.md) | ❌ | ❌ | RC 1 |
+| [Minimal API renames in RC 2](aspnet-core/6.0/rc2-minimal-api-renames.md) | ❌ | ❌ | RC 2 |
+| [MVC doesn't buffer IAsyncEnumerable types when using System.Text.Json](aspnet-core/6.0/iasyncenumerable-not-buffered-by-mvc.md) | ✔️ | ❌ | Preview 4 |
+| [Nullable reference type annotations changed](aspnet-core/6.0/nullable-reference-type-annotations-changed.md) | ✔️ | ❌ |  |
+| [Obsoleted and removed APIs](aspnet-core/6.0/obsolete-removed-apis.md) | ✔️ | ❌ | Preview 1 |
+| [PreserveCompilationContext not configured by default](aspnet-core/6.0/preservecompilationcontext-not-set-by-default.md) | ❌ | ✔️ |  |
+| [Razor: Compiler no longer produces a Views assembly](aspnet-core/6.0/razor-compiler-doesnt-produce-views-assembly.md) | ✔️ | ❌ | Preview 3 |
+| [Razor: Logging ID changes](aspnet-core/6.0/razor-pages-logging-ids.md) | ❌ | ✔️ | RC1 |
+| [Razor: RazorEngine APIs marked obsolete](aspnet-core/6.0/razor-engine-apis-obsolete.md) | ✔️ | ❌ | Preview 1 |
+| [SignalR: Java Client updated to RxJava3](aspnet-core/6.0/signalr-java-client-updated.md) | ❌ | ✔️ | Preview 4 |
+| [TryParse and BindAsync methods are validated](aspnet-core/6.0/tryparse-bindasync-validation.md) | ❌ | ❌ | RC 2 |
 
 ## Containers
 
-| Title | Binary compatible | Source compatible |
+| Title | Binary compatible | Source compatible | Introduced |
 | - | :-: | :-: | - |
 | [Default console logger formatting in container images](containers/6.0/console-formatter-default.md) | ✔️ | ❌ | Servicing 6.0.6 |
 
@@ -51,42 +51,42 @@ For information on other breaking changes for containers in .NET 6, see [.NET 6 
 
 ## Core .NET libraries
 
-| Title | Binary compatible | Source compatible |
+| Title | Binary compatible | Source compatible | Introduced |
 | - | :-: | :-: | - |
-| [API obsoletions with non-default diagnostic IDs](core-libraries/6.0/obsolete-apis-with-custom-diagnostics.md) | ✔️ | ❌ |
-| [Changes to nullable reference type annotations](core-libraries/6.0/nullable-ref-type-annotation-changes.md) | ✔️ | ❌ |
-| [Conditional string evaluation in Debug methods](core-libraries/6.0/debug-assert-conditional-evaluation.md) | ✔️ | ❌ |
-| [Environment.ProcessorCount behavior on Windows](core-libraries/6.0/environment-processorcount-on-windows.md) | ✔️ | ❌ |
-| [File.Replace on Unix throws exceptions to match Windows](core-libraries/6.0/file-replace-exceptions-on-unix.md) | ✔️ | ❌ |
-| [FileStream locks files with shared lock on Unix](core-libraries/6.0/filestream-file-locks-unix.md) | ❌ | ✔️ |
-| [FileStream no longer synchronizes file offset with OS](core-libraries/6.0/filestream-doesnt-sync-offset-with-os.md) | ❌ | ❌ |
-| [FileStream.Position updates after ReadAsync or WriteAsync completes](core-libraries/6.0/filestream-position-updates-after-readasync-writeasync-completion.md) | ❌ | ❌ |
-| [New diagnostic IDs for obsoleted APIs](core-libraries/6.0/diagnostic-id-change-for-obsoletions.md) | ✔️ | ❌ |
-| [New nullable annotation in AssociatedMetadataTypeTypeDescriptionProvider](core-libraries/6.0/nullable-ref-type-annotations-added.md) | ✔️ | ❌ |
-| [New System.Linq.Queryable method overloads](core-libraries/6.0/additional-linq-queryable-method-overloads.md) | ✔️ | ❌ |
-| [Older framework versions dropped from package](core-libraries/6.0/older-framework-versions-dropped.md) | ❌ | ✔️ |
-| [Parameter names changed](core-libraries/6.0/parameter-name-changes.md) | ✔️ | ❌ |
-| [Parameter names in Stream-derived types](core-libraries/6.0/parameters-renamed-on-stream-derived-types.md) | ✔️ | ❌ |
-| [Partial and zero-byte reads in DeflateStream, GZipStream, and CryptoStream](core-libraries/6.0/partial-byte-reads-in-streams.md) | ✔️ | ❌ |
-| [Set timestamp on read-only file on Windows](core-libraries/6.0/set-timestamp-readonly-file.md) | ❌ | ✔️ |
-| [Standard numeric format parsing precision](core-libraries/6.0/numeric-format-parsing-handles-higher-precision.md) | ✔️ | ❌ |
-| [Static abstract members in interfaces](core-libraries/6.0/static-abstract-interface-methods.md) | ❌ | ✔️ |
-| [StringBuilder.Append overloads and evaluation order](core-libraries/6.0/stringbuilder-append-evaluation-order.md) | ❌ | ✔️ |
-| [Strong-name APIs throw PlatformNotSupportedException](core-libraries/6.0/strong-name-signing-exceptions.md) | ❌ | ✔️ |
-| [System.Drawing.Common only supported on Windows](core-libraries/6.0/system-drawing-common-windows-only.md) | ❌ | ❌ |
-| [System.Security.SecurityContext is marked obsolete](core-libraries/6.0/securitycontext-obsolete.md) | ✔️ | ❌ |
-| [Task.FromResult may return singleton](core-libraries/6.0/task-fromresult-returns-singleton.md) | ❌ | ✔️ |
-| [Unhandled exceptions from a BackgroundService](core-libraries/6.0/hosting-exception-handling.md) | ✔️ | ❌ |
+| [API obsoletions with non-default diagnostic IDs](core-libraries/6.0/obsolete-apis-with-custom-diagnostics.md) | ✔️ | ❌ | Preview 1 |
+| [Changes to nullable reference type annotations](core-libraries/6.0/nullable-ref-type-annotation-changes.md) | ✔️ | ❌ | Preview 1-2 |
+| [Conditional string evaluation in Debug methods](core-libraries/6.0/debug-assert-conditional-evaluation.md) | ✔️ | ❌ | RC 1 |
+| [Environment.ProcessorCount behavior on Windows](core-libraries/6.0/environment-processorcount-on-windows.md) | ✔️ | ❌ | Preview 2 |
+| [File.Replace on Unix throws exceptions to match Windows](core-libraries/6.0/file-replace-exceptions-on-unix.md) | ✔️ | ❌ | Preview 7 |
+| [FileStream locks files with shared lock on Unix](core-libraries/6.0/filestream-file-locks-unix.md) | ❌ | ✔️ | Preview 1 |
+| [FileStream no longer synchronizes file offset with OS](core-libraries/6.0/filestream-doesnt-sync-offset-with-os.md) | ❌ | ❌ | Preview 4 |
+| [FileStream.Position updates after ReadAsync or WriteAsync completes](core-libraries/6.0/filestream-position-updates-after-readasync-writeasync-completion.md) | ❌ | ❌ | Preview 4 |
+| [New diagnostic IDs for obsoleted APIs](core-libraries/6.0/diagnostic-id-change-for-obsoletions.md) | ✔️ | ❌ | Preview 5 |
+| [New nullable annotation in AssociatedMetadataTypeTypeDescriptionProvider](core-libraries/6.0/nullable-ref-type-annotations-added.md) | ✔️ | ❌ | RC 2 |
+| [New System.Linq.Queryable method overloads](core-libraries/6.0/additional-linq-queryable-method-overloads.md) | ✔️ | ❌ | Preview 3-4 |
+| [Older framework versions dropped from package](core-libraries/6.0/older-framework-versions-dropped.md) | ❌ | ✔️ | Preview 5 |
+| [Parameter names changed](core-libraries/6.0/parameter-name-changes.md) | ✔️ | ❌ | Preview 1 |
+| [Parameter names in Stream-derived types](core-libraries/6.0/parameters-renamed-on-stream-derived-types.md) | ✔️ | ❌ | Preview 1 |
+| [Partial and zero-byte reads in DeflateStream, GZipStream, and CryptoStream](core-libraries/6.0/partial-byte-reads-in-streams.md) | ✔️ | ❌ | Preview 6 |
+| [Set timestamp on read-only file on Windows](core-libraries/6.0/set-timestamp-readonly-file.md) | ❌ | ✔️ | Servicing 6.0.2 |
+| [Standard numeric format parsing precision](core-libraries/6.0/numeric-format-parsing-handles-higher-precision.md) | ✔️ | ❌ | Preview 2 |
+| [Static abstract members in interfaces](core-libraries/6.0/static-abstract-interface-methods.md) | ❌ | ✔️ | Preview 7 |
+| [StringBuilder.Append overloads and evaluation order](core-libraries/6.0/stringbuilder-append-evaluation-order.md) | ❌ | ✔️ | RC 1 |
+| [Strong-name APIs throw PlatformNotSupportedException](core-libraries/6.0/strong-name-signing-exceptions.md) | ❌ | ✔️ |  Preview 4 |
+| [System.Drawing.Common only supported on Windows](core-libraries/6.0/system-drawing-common-windows-only.md) | ❌ | ❌ | Preview 7 |
+| [System.Security.SecurityContext is marked obsolete](core-libraries/6.0/securitycontext-obsolete.md) | ✔️ | ❌ | RC 1 |
+| [Task.FromResult may return singleton](core-libraries/6.0/task-fromresult-returns-singleton.md) | ❌ | ✔️ | Preview 1 |
+| [Unhandled exceptions from a BackgroundService](core-libraries/6.0/hosting-exception-handling.md) | ✔️ | ❌ | Preview 4 |
 
 ## Cryptography
 
-| Title | Binary compatible | Source compatible |
+| Title | Binary compatible | Source compatible | Introduced |
 | - | :-: | :-: | - |
-| [CreateEncryptor methods throw exception for incorrect feedback size](cryptography/6.0/cfb-mode-feedback-size-exception.md) | ❌ | ✔️ |
+| [CreateEncryptor methods throw exception for incorrect feedback size](cryptography/6.0/cfb-mode-feedback-size-exception.md) | ❌ | ✔️ | Preview 7 |
 
 ## Deployment
 
-| Title | Binary compatible | Source compatible |
+| Title | Binary compatible | Source compatible | Introduced |
 | - | :-: | :-: | - |
 | [x86 host path on 64-bit Windows](deployment/7.0/x86-host-path.md) | ✔️ | ✔️ | Servicing release |
 
@@ -96,88 +96,88 @@ For information on other breaking changes for containers in .NET 6, see [.NET 6 
 
 ## Extensions
 
-| Title | Binary compatible | Source compatible |
+| Title | Binary compatible | Source compatible | Introduced |
 | - | :-: | :-: | - |
-| [AddProvider checks for non-null provider](extensions/6.0/addprovider-null-check.md) | ✔️ | ❌ |
-| [FileConfigurationProvider.Load throws InvalidDataException](extensions/6.0/filename-in-load-exception.md) | ✔️ | ❌ |
+| [AddProvider checks for non-null provider](extensions/6.0/addprovider-null-check.md) | ✔️ | ❌ | RC 1 |
+| [FileConfigurationProvider.Load throws InvalidDataException](extensions/6.0/filename-in-load-exception.md) | ✔️ | ❌ | RC 1 |
 | [Repeated XML elements include index](extensions/6.0/repeated-xml-elements.md) | ❌ | ✔️ | |
-| [Resolving disposed ServiceProvider throws exception](extensions/6.0/service-provider-disposed.md) | ✔️ | ❌ |
+| [Resolving disposed ServiceProvider throws exception](extensions/6.0/service-provider-disposed.md) | ✔️ | ❌ | RC 1 |
 
 ## Globalization
 
-| Title | Binary compatible | Source compatible |
+| Title | Binary compatible | Source compatible | Introduced |
 | - | :-: | :-: | - |
-| [Culture creation and case mapping in globalization-invariant mode](globalization/6.0/culture-creation-invariant-mode.md) |
+| [Culture creation and case mapping in globalization-invariant mode](globalization/6.0/culture-creation-invariant-mode.md) |  |  | Preview 7 |
 
 ## Interop
 
-| Title | Binary compatible | Source compatible |
+| Title | Binary compatible | Source compatible | Introduced |
 | - | :-: | :-: | - |
-| [Static abstract members in interfaces](core-libraries/6.0/static-abstract-interface-methods.md) | ❌ | ✔️ |
+| [Static abstract members in interfaces](core-libraries/6.0/static-abstract-interface-methods.md) | ❌ | ✔️ | Preview 7 |
 
 ## JIT compiler
 
-| Title | Binary compatible | Source compatible |
+| Title | Binary compatible | Source compatible | Introduced |
 | - | :-: | :-: | - |
-| [Coerce call arguments according to ECMA-335](jit/6.0/coerce-call-arguments-ecma-335.md) | ✔️ | ✔️ |
+| [Coerce call arguments according to ECMA-335](jit/6.0/coerce-call-arguments-ecma-335.md) | ✔️ | ✔️ | Preview 1 |
 
 ## Networking
 
-| Title | Binary compatible | Source compatible |
+| Title | Binary compatible | Source compatible | Introduced |
 | - | :-: | :-: | - |
-| [Port removed from SPN for Kerberos and Negotiate](networking/6.0/httpclient-port-lookup.md) | ❌ | ✔️ |
-| [WebRequest, WebClient, and ServicePoint are obsolete](networking/6.0/webrequest-deprecated.md) | ✔️ | ❌ |
+| [Port removed from SPN for Kerberos and Negotiate](networking/6.0/httpclient-port-lookup.md) | ❌ | ✔️ | RC 1 |
+| [WebRequest, WebClient, and ServicePoint are obsolete](networking/6.0/webrequest-deprecated.md) | ✔️ | ❌ | Preview 1 |
 
 ## SDK
 
-| Title | Binary compatible | Source compatible |
+| Title | Binary compatible | Source compatible | Introduced |
 | - | :-: | :-: | - |
-| [`-p` option for `dotnet run` is deprecated](sdk/6.0/deprecate-p-option-dotnet-run.md) | ✔️ | ❌ |
-| [C# code in templates not supported by earlier versions](sdk/6.0/csharp-template-code.md) | ✔️ | ✔️ |
+| [`-p` option for `dotnet run` is deprecated](sdk/6.0/deprecate-p-option-dotnet-run.md) | ✔️ | ❌ | Preview 6 |
+| [C# code in templates not supported by earlier versions](sdk/6.0/csharp-template-code.md) | ✔️ | ✔️ | Preview 7 |
 | [EditorConfig files implicitly included](sdk/6.0/editorconfig-additional-files.md) | ✔️ | ❌ | |
-| [Generate apphost for macOS](sdk/6.0/apphost-generated-for-macos.md) | ✔️ | ❌ |
-| [Generate error for duplicate files in publish output](sdk/6.0/duplicate-files-in-output.md) | ❌ | ✔️ |
-| [GetTargetFrameworkProperties and GetNearestTargetFramework removed from ProjectReference protocol](sdk/6.0/gettargetframeworkproperties-and-getnearesttargetframework-removed.md) | ❌ | ✔️ |
-| [Install location for x64 emulated on Arm64](sdk/6.0/path-x64-emulated.md) | ✔️ | ❌ |
-| [MSBuild no longer supports calling GetType()](sdk/6.0/calling-gettype-property-functions.md) | | |
-| [OutputType not automatically set to WinExe](sdk/6.0/outputtype-not-set-automatically.md) | ✔️ | ❌ |
-| [Publish ReadyToRun with --no-restore requires changes](sdk/6.0/publish-readytorun-requires-restore-change.md) | ✔️ | ❌ |
-| [runtimeconfig.dev.json file not generated](sdk/6.0/runtimeconfigdev-file.md) | ❌ | ✔️ |
-| [RuntimeIdentifier warning if self-contained is unspecified](sdk/6.0/runtimeidentifier-self-contained.md) | ✔️ | ❌ |
-| [Version requirements for .NET 6 SDK](sdk/6.0/vs-msbuild-version.md) | ✔️ | ✔️ |
+| [Generate apphost for macOS](sdk/6.0/apphost-generated-for-macos.md) | ✔️ | ❌ | Preview 6 |
+| [Generate error for duplicate files in publish output](sdk/6.0/duplicate-files-in-output.md) | ❌ | ✔️ | Preview 1 |
+| [GetTargetFrameworkProperties and GetNearestTargetFramework removed from ProjectReference protocol](sdk/6.0/gettargetframeworkproperties-and-getnearesttargetframework-removed.md) | ❌ | ✔️ | Preview 1 |
+| [Install location for x64 emulated on Arm64](sdk/6.0/path-x64-emulated.md) | ✔️ | ❌ | RC 2 |
+| [MSBuild no longer supports calling GetType()](sdk/6.0/calling-gettype-property-functions.md) | | | RC 1 |
+| [OutputType not automatically set to WinExe](sdk/6.0/outputtype-not-set-automatically.md) | ✔️ | ❌ | RC 1 |
+| [Publish ReadyToRun with --no-restore requires changes](sdk/6.0/publish-readytorun-requires-restore-change.md) | ✔️ | ❌ | 6.0.100 |
+| [runtimeconfig.dev.json file not generated](sdk/6.0/runtimeconfigdev-file.md) | ❌ | ✔️ | 6.0.100 |
+| [RuntimeIdentifier warning if self-contained is unspecified](sdk/6.0/runtimeidentifier-self-contained.md) | ✔️ | ❌ | RC 1 |
+| [Version requirements for .NET 6 SDK](sdk/6.0/vs-msbuild-version.md) | ✔️ | ✔️ | 6.0.300 |
 | [.version file includes build version](sdk/6.0/version-file-entries.md) | ✔️ | ✔️ | 6.0.401 |
-| [Write reference assemblies to IntermediateOutputPath](sdk/6.0/write-reference-assemblies-to-obj.md) | ❌ | ✔️ |
+| [Write reference assemblies to IntermediateOutputPath](sdk/6.0/write-reference-assemblies-to-obj.md) | ❌ | ✔️ | 6.0.200 |
 
 ## Serialization
 
-| Title | Binary compatible | Source compatible |
+| Title | Binary compatible | Source compatible | Introduced |
 | - | :-: | :-: | - |
 | [DataContractSerializer retains sign when deserializing -0](serialization/7.0/datacontractserializer-negative-sign.md) | ❌ | ✔️ | Servicing 6.0.11 |
-| [Default serialization format for TimeSpan](serialization/6.0/timespan-serialization-format.md) | ❌ | ✔️ |
-| [IAsyncEnumerable serialization](serialization/6.0/iasyncenumerable-serialization.md) | ✔️ | ❌ |
-| [JSON source-generation API refactoring](serialization/6.0/json-source-gen-api-refactor.md) | ❌ | ✔️ |
-| [JsonNumberHandlingAttribute on collection properties](serialization/6.0/jsonnumberhandlingattribute-behavior.md) | ❌ | ✔️ |
-| [New JsonSerializer source generator overloads](serialization/6.0/jsonserializer-source-generator-overloads.md) | ❌ | ✔️ |
+| [Default serialization format for TimeSpan](serialization/6.0/timespan-serialization-format.md) | ❌ | ✔️ | Servicing 6.0.2 |
+| [IAsyncEnumerable serialization](serialization/6.0/iasyncenumerable-serialization.md) | ✔️ | ❌ | Preview 4 |
+| [JSON source-generation API refactoring](serialization/6.0/json-source-gen-api-refactor.md) | ❌ | ✔️ | RC 2 |
+| [JsonNumberHandlingAttribute on collection properties](serialization/6.0/jsonnumberhandlingattribute-behavior.md) | ❌ | ✔️ | RC 1 |
+| [New JsonSerializer source generator overloads](serialization/6.0/jsonserializer-source-generator-overloads.md) | ❌ | ✔️ | Preview 6 |
 
 ## Windows Forms
 
-| Title | Binary compatible | Source compatible |
+| Title | Binary compatible | Source compatible | Introduced |
 | - | :-: | :-: | - |
-| [C# templates use application bootstrap](windows-forms/6.0/application-bootstrap.md) | ✔️ | ❌ |
-| [Selected TableLayoutSettings properties throw InvalidEnumArgumentException](windows-forms/6.0/tablelayoutsettings-apis-throw-invalidenumargumentexception.md) | ❌ | ✔️ |
-| [DataGridView-related APIs now throw InvalidOperationException](windows-forms/6.0/null-owner-causes-invalidoperationexception.md) | ❌ | ✔️ |
-| [ListViewGroupCollection methods throw new InvalidOperationException](windows-forms/6.0/listview-invalidoperationexception.md) | ❌ | ✔️ |
-| [NotifyIcon.Text maximum text length increased](windows-forms/6.0/notifyicon-text-max-text-length-increased.md) | ❌ | ✔️ |
-| [ScaleControl called only when needed](windows-forms/6.0/optimize-scalecontrol-calls.md) | ✔️ | ❌ |
-| [Some APIs throw ArgumentNullException](windows-forms/6.0/apis-throw-argumentnullexception.md) | ❌ | ✔️ |
-| [TreeNodeCollection.Item throws exception if node is assigned elsewhere](windows-forms/6.0/treenodecollection-item-throws-argumentexception.md) | ❌ | ✔️ |
+| [C# templates use application bootstrap](windows-forms/6.0/application-bootstrap.md) | ✔️ | ❌ | RC 1 |
+| [Selected TableLayoutSettings properties throw InvalidEnumArgumentException](windows-forms/6.0/tablelayoutsettings-apis-throw-invalidenumargumentexception.md) | ❌ | ✔️ | Preview 1 |
+| [DataGridView-related APIs now throw InvalidOperationException](windows-forms/6.0/null-owner-causes-invalidoperationexception.md) | ❌ | ✔️ | Preview 4 |
+| [ListViewGroupCollection methods throw new InvalidOperationException](windows-forms/6.0/listview-invalidoperationexception.md) | ❌ | ✔️ | RC 2 |
+| [NotifyIcon.Text maximum text length increased](windows-forms/6.0/notifyicon-text-max-text-length-increased.md) | ❌ | ✔️ | Preview 1 |
+| [ScaleControl called only when needed](windows-forms/6.0/optimize-scalecontrol-calls.md) | ✔️ | ❌ | Servicing 6.0.101 |
+| [Some APIs throw ArgumentNullException](windows-forms/6.0/apis-throw-argumentnullexception.md) | ❌ | ✔️ | Preview 1-4 |
+| [TreeNodeCollection.Item throws exception if node is assigned elsewhere](windows-forms/6.0/treenodecollection-item-throws-argumentexception.md) | ❌ | ✔️ | Preview 1 |
 
 ## XML and XSLT
 
-| Title | Binary compatible | Source compatible |
+| Title | Binary compatible | Source compatible | Introduced |
 | - | :-: | :-: | - |
-| [XmlDocument.XmlResolver nullability change](core-libraries/6.0/xmlresolver-nullable.md) | ❌ | ✔️ |
-| [XNodeReader.GetAttribute behavior for invalid index](core-libraries/6.0/xnodereader-getattribute.md) | ✔️ | ❌ |
+| [XmlDocument.XmlResolver nullability change](core-libraries/6.0/xmlresolver-nullable.md) | ❌ | ✔️ | RC 1 |
+| [XNodeReader.GetAttribute behavior for invalid index](core-libraries/6.0/xnodereader-getattribute.md) | ✔️ | ❌ | Preview 2 |
 
 ## See also
 

--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -13,37 +13,37 @@ If you're migrating an app to .NET 6, the breaking changes listed here might aff
 
 ## ASP.NET Core
 
-| Title | Binary compatible | Source compatible | Introduced |
+| Title | Binary compatible | Source compatible |
 | - | :-: | :-: | - |
-| [ActionResult\<T> sets StatusCode to 200](aspnet-core/6.0/actionresult-statuscode.md) | ✔️ | ❌ |  |
-| [AddDataAnnotationsValidation method made obsolete](aspnet-core/6.0/adddataannotationsvalidation-obsolete.md) | ✔️ | ❌ |  |
-| [Assemblies removed from Microsoft.AspNetCore.App shared framework](aspnet-core/6.0/assemblies-removed-from-shared-framework.md) | ❌ | ✔️ |  |
-| [Blazor: Parameter name changed in RequestImageFileAsync method](aspnet-core/6.0/blazor-parameter-name-changed-in-method.md) | ✔️ | ❌ | Preview 1 |
-| [Blazor: WebEventDescriptor.EventArgsType property replaced](aspnet-core/6.0/blazor-eventargstype-property-replaced.md) | ❌ | ❌ |  |
-| [Blazor: Byte array interop](aspnet-core/6.0/byte-array-interop.md) | ✔️ | ❌ | Preview 6 |
-| [Changed MessagePack library in @microsoft/signalr-protocol-msgpack](aspnet-core/6.0/messagepack-library-change.md) | ❌ | ✔️ |  |
-| [ClientCertificate property doesn't trigger renegotiation for HttpSys](aspnet-core/6.0/clientcertificate-doesnt-trigger-renegotiation.md) | ✔️ | ❌ |  |
-| [EndpointName metadata not set automatically](aspnet-core/6.0/endpointname-metadata.md) | ✔️ | ❌ | RC 2 |
-| [Identity: Default Bootstrap version of UI changed](aspnet-core/6.0/identity-bootstrap4-to-5.md) | ❌ | ❌  |  |
-| [Kestrel: Log message attributes changed](aspnet-core/6.0/kestrel-log-message-attributes-changed.md) | ✔️ | ❌ |  |
-| [Microsoft.AspNetCore.Http.Features split](aspnet-core/6.0/microsoft-aspnetcore-http-features-package-split.md) | ❌ | ✔️ |  |
-| [Middleware: HTTPS Redirection Middleware throws exception on ambiguous HTTPS ports](aspnet-core/6.0/middleware-ambiguous-https-ports-exception.md) | ✔️ | ❌ |  |
-| [Middleware: New Use overload](aspnet-core/6.0/middleware-new-use-overload.md) | ✔️ | ❌ | Preview 4 |
-| [Minimal API renames in RC 1](aspnet-core/6.0/rc1-minimal-api-renames.md) | ❌ | ❌ | RC 1 |
-| [Minimal API renames in RC 2](aspnet-core/6.0/rc2-minimal-api-renames.md) | ❌ | ❌ | RC 2 |
-| [MVC doesn't buffer IAsyncEnumerable types when using System.Text.Json](aspnet-core/6.0/iasyncenumerable-not-buffered-by-mvc.md) | ✔️ | ❌ | Preview 4 |
-| [Nullable reference type annotations changed](aspnet-core/6.0/nullable-reference-type-annotations-changed.md) | ✔️ | ❌ |  |
-| [Obsoleted and removed APIs](aspnet-core/6.0/obsolete-removed-apis.md) | ✔️ | ❌ | Preview 1 |
-| [PreserveCompilationContext not configured by default](aspnet-core/6.0/preservecompilationcontext-not-set-by-default.md) | ❌ | ✔️ |  |
-| [Razor: Compiler no longer produces a Views assembly](aspnet-core/6.0/razor-compiler-doesnt-produce-views-assembly.md) | ✔️ | ❌ | Preview 3 |
-| [Razor: Logging ID changes](aspnet-core/6.0/razor-pages-logging-ids.md) | ❌ | ✔️ | RC1 |
-| [Razor: RazorEngine APIs marked obsolete](aspnet-core/6.0/razor-engine-apis-obsolete.md) | ✔️ | ❌ | Preview 1 |
-| [SignalR: Java Client updated to RxJava3](aspnet-core/6.0/signalr-java-client-updated.md) | ❌ | ✔️ | Preview 4 |
-| [TryParse and BindAsync methods are validated](aspnet-core/6.0/tryparse-bindasync-validation.md) | ❌ | ❌ | RC 2 |
+| [ActionResult\<T> sets StatusCode to 200](aspnet-core/6.0/actionresult-statuscode.md) | ✔️ | ❌ |
+| [AddDataAnnotationsValidation method made obsolete](aspnet-core/6.0/adddataannotationsvalidation-obsolete.md) | ✔️ | ❌ |
+| [Assemblies removed from Microsoft.AspNetCore.App shared framework](aspnet-core/6.0/assemblies-removed-from-shared-framework.md) | ❌ | ✔️ |
+| [Blazor: Parameter name changed in RequestImageFileAsync method](aspnet-core/6.0/blazor-parameter-name-changed-in-method.md) | ✔️ | ❌ |
+| [Blazor: WebEventDescriptor.EventArgsType property replaced](aspnet-core/6.0/blazor-eventargstype-property-replaced.md) | ❌ | ❌ |
+| [Blazor: Byte array interop](aspnet-core/6.0/byte-array-interop.md) | ✔️ | ❌ |
+| [Changed MessagePack library in @microsoft/signalr-protocol-msgpack](aspnet-core/6.0/messagepack-library-change.md) | ❌ | ✔️ |
+| [ClientCertificate property doesn't trigger renegotiation for HttpSys](aspnet-core/6.0/clientcertificate-doesnt-trigger-renegotiation.md) | ✔️ | ❌ |
+| [EndpointName metadata not set automatically](aspnet-core/6.0/endpointname-metadata.md) | ✔️ | ❌ |
+| [Identity: Default Bootstrap version of UI changed](aspnet-core/6.0/identity-bootstrap4-to-5.md) | ❌ | ❌
+| [Kestrel: Log message attributes changed](aspnet-core/6.0/kestrel-log-message-attributes-changed.md) | ✔️ | ❌ |
+| [Microsoft.AspNetCore.Http.Features split](aspnet-core/6.0/microsoft-aspnetcore-http-features-package-split.md) | ❌ | ✔️ |
+| [Middleware: HTTPS Redirection Middleware throws exception on ambiguous HTTPS ports](aspnet-core/6.0/middleware-ambiguous-https-ports-exception.md) | ✔️ | ❌ |
+| [Middleware: New Use overload](aspnet-core/6.0/middleware-new-use-overload.md) | ✔️ | ❌ |
+| [Minimal API renames in RC 1](aspnet-core/6.0/rc1-minimal-api-renames.md) | ❌ | ❌ |
+| [Minimal API renames in RC 2](aspnet-core/6.0/rc2-minimal-api-renames.md) | ❌ | ❌ |
+| [MVC doesn't buffer IAsyncEnumerable types when using System.Text.Json](aspnet-core/6.0/iasyncenumerable-not-buffered-by-mvc.md) | ✔️ | ❌ |
+| [Nullable reference type annotations changed](aspnet-core/6.0/nullable-reference-type-annotations-changed.md) | ✔️ | ❌ |
+| [Obsoleted and removed APIs](aspnet-core/6.0/obsolete-removed-apis.md) | ✔️ | ❌ |
+| [PreserveCompilationContext not configured by default](aspnet-core/6.0/preservecompilationcontext-not-set-by-default.md) | ❌ | ✔️ |
+| [Razor: Compiler no longer produces a Views assembly](aspnet-core/6.0/razor-compiler-doesnt-produce-views-assembly.md) | ✔️ | ❌ |
+| [Razor: Logging ID changes](aspnet-core/6.0/razor-pages-logging-ids.md) | ❌ | ✔️ |
+| [Razor: RazorEngine APIs marked obsolete](aspnet-core/6.0/razor-engine-apis-obsolete.md) | ✔️ | ❌ |
+| [SignalR: Java Client updated to RxJava3](aspnet-core/6.0/signalr-java-client-updated.md) | ❌ | ✔️ |
+| [TryParse and BindAsync methods are validated](aspnet-core/6.0/tryparse-bindasync-validation.md) | ❌ | ❌ |
 
 ## Containers
 
-| Title | Binary compatible | Source compatible | Introduced |
+| Title | Binary compatible | Source compatible |
 | - | :-: | :-: | - |
 | [Default console logger formatting in container images](containers/6.0/console-formatter-default.md) | ✔️ | ❌ | Servicing 6.0.6 |
 
@@ -51,42 +51,42 @@ For information on other breaking changes for containers in .NET 6, see [.NET 6 
 
 ## Core .NET libraries
 
-| Title | Binary compatible | Source compatible | Introduced |
+| Title | Binary compatible | Source compatible |
 | - | :-: | :-: | - |
-| [API obsoletions with non-default diagnostic IDs](core-libraries/6.0/obsolete-apis-with-custom-diagnostics.md) | ✔️ | ❌ | Preview 1 |
-| [Changes to nullable reference type annotations](core-libraries/6.0/nullable-ref-type-annotation-changes.md) | ✔️ | ❌ | Preview 1-2 |
-| [Conditional string evaluation in Debug methods](core-libraries/6.0/debug-assert-conditional-evaluation.md) | ✔️ | ❌ | RC 1 |
-| [Environment.ProcessorCount behavior on Windows](core-libraries/6.0/environment-processorcount-on-windows.md) | ✔️ | ❌ | Preview 2 |
-| [File.Replace on Unix throws exceptions to match Windows](core-libraries/6.0/file-replace-exceptions-on-unix.md) | ✔️ | ❌ | Preview 7 |
-| [FileStream locks files with shared lock on Unix](core-libraries/6.0/filestream-file-locks-unix.md) | ❌ | ✔️ | Preview 1 |
-| [FileStream no longer synchronizes file offset with OS](core-libraries/6.0/filestream-doesnt-sync-offset-with-os.md) | ❌ | ❌ | Preview 4 |
-| [FileStream.Position updates after ReadAsync or WriteAsync completes](core-libraries/6.0/filestream-position-updates-after-readasync-writeasync-completion.md) | ❌ | ❌ | Preview 4 |
-| [New diagnostic IDs for obsoleted APIs](core-libraries/6.0/diagnostic-id-change-for-obsoletions.md) | ✔️ | ❌ | Preview 5 |
-| [New nullable annotation in AssociatedMetadataTypeTypeDescriptionProvider](core-libraries/6.0/nullable-ref-type-annotations-added.md) | ✔️ | ❌ | RC 2 |
-| [New System.Linq.Queryable method overloads](core-libraries/6.0/additional-linq-queryable-method-overloads.md) | ✔️ | ❌ | Preview 3-4 |
-| [Older framework versions dropped from package](core-libraries/6.0/older-framework-versions-dropped.md) | ❌ | ✔️ | Preview 5 |
-| [Parameter names changed](core-libraries/6.0/parameter-name-changes.md) | ✔️ | ❌ | Preview 1 |
-| [Parameter names in Stream-derived types](core-libraries/6.0/parameters-renamed-on-stream-derived-types.md) | ✔️ | ❌ | Preview 1 |
-| [Partial and zero-byte reads in DeflateStream, GZipStream, and CryptoStream](core-libraries/6.0/partial-byte-reads-in-streams.md) | ✔️ | ❌ | Preview 6 |
-| [Set timestamp on read-only file on Windows](core-libraries/6.0/set-timestamp-readonly-file.md) | ❌ | ✔️ | Servicing 6.0.2 |
-| [Standard numeric format parsing precision](core-libraries/6.0/numeric-format-parsing-handles-higher-precision.md) | ✔️ | ❌ | Preview 2 |
-| [Static abstract members in interfaces](core-libraries/6.0/static-abstract-interface-methods.md) | ❌ | ✔️ | Preview 7 |
-| [StringBuilder.Append overloads and evaluation order](core-libraries/6.0/stringbuilder-append-evaluation-order.md) | ❌ | ✔️ | RC 1 |
-| [Strong-name APIs throw PlatformNotSupportedException](core-libraries/6.0/strong-name-signing-exceptions.md) | ❌ | ✔️ |  Preview 4 |
-| [System.Drawing.Common only supported on Windows](core-libraries/6.0/system-drawing-common-windows-only.md) | ❌ | ❌ | Preview 7 |
-| [System.Security.SecurityContext is marked obsolete](core-libraries/6.0/securitycontext-obsolete.md) | ✔️ | ❌ | RC 1 |
-| [Task.FromResult may return singleton](core-libraries/6.0/task-fromresult-returns-singleton.md) | ❌ | ✔️ | Preview 1 |
-| [Unhandled exceptions from a BackgroundService](core-libraries/6.0/hosting-exception-handling.md) | ✔️ | ❌ | Preview 4 |
+| [API obsoletions with non-default diagnostic IDs](core-libraries/6.0/obsolete-apis-with-custom-diagnostics.md) | ✔️ | ❌ |
+| [Changes to nullable reference type annotations](core-libraries/6.0/nullable-ref-type-annotation-changes.md) | ✔️ | ❌ |
+| [Conditional string evaluation in Debug methods](core-libraries/6.0/debug-assert-conditional-evaluation.md) | ✔️ | ❌ |
+| [Environment.ProcessorCount behavior on Windows](core-libraries/6.0/environment-processorcount-on-windows.md) | ✔️ | ❌ |
+| [File.Replace on Unix throws exceptions to match Windows](core-libraries/6.0/file-replace-exceptions-on-unix.md) | ✔️ | ❌ |
+| [FileStream locks files with shared lock on Unix](core-libraries/6.0/filestream-file-locks-unix.md) | ❌ | ✔️ |
+| [FileStream no longer synchronizes file offset with OS](core-libraries/6.0/filestream-doesnt-sync-offset-with-os.md) | ❌ | ❌ |
+| [FileStream.Position updates after ReadAsync or WriteAsync completes](core-libraries/6.0/filestream-position-updates-after-readasync-writeasync-completion.md) | ❌ | ❌ |
+| [New diagnostic IDs for obsoleted APIs](core-libraries/6.0/diagnostic-id-change-for-obsoletions.md) | ✔️ | ❌ |
+| [New nullable annotation in AssociatedMetadataTypeTypeDescriptionProvider](core-libraries/6.0/nullable-ref-type-annotations-added.md) | ✔️ | ❌ |
+| [New System.Linq.Queryable method overloads](core-libraries/6.0/additional-linq-queryable-method-overloads.md) | ✔️ | ❌ |
+| [Older framework versions dropped from package](core-libraries/6.0/older-framework-versions-dropped.md) | ❌ | ✔️ |
+| [Parameter names changed](core-libraries/6.0/parameter-name-changes.md) | ✔️ | ❌ |
+| [Parameter names in Stream-derived types](core-libraries/6.0/parameters-renamed-on-stream-derived-types.md) | ✔️ | ❌ |
+| [Partial and zero-byte reads in DeflateStream, GZipStream, and CryptoStream](core-libraries/6.0/partial-byte-reads-in-streams.md) | ✔️ | ❌ |
+| [Set timestamp on read-only file on Windows](core-libraries/6.0/set-timestamp-readonly-file.md) | ❌ | ✔️ |
+| [Standard numeric format parsing precision](core-libraries/6.0/numeric-format-parsing-handles-higher-precision.md) | ✔️ | ❌ |
+| [Static abstract members in interfaces](core-libraries/6.0/static-abstract-interface-methods.md) | ❌ | ✔️ |
+| [StringBuilder.Append overloads and evaluation order](core-libraries/6.0/stringbuilder-append-evaluation-order.md) | ❌ | ✔️ |
+| [Strong-name APIs throw PlatformNotSupportedException](core-libraries/6.0/strong-name-signing-exceptions.md) | ❌ | ✔️ |
+| [System.Drawing.Common only supported on Windows](core-libraries/6.0/system-drawing-common-windows-only.md) | ❌ | ❌ |
+| [System.Security.SecurityContext is marked obsolete](core-libraries/6.0/securitycontext-obsolete.md) | ✔️ | ❌ |
+| [Task.FromResult may return singleton](core-libraries/6.0/task-fromresult-returns-singleton.md) | ❌ | ✔️ |
+| [Unhandled exceptions from a BackgroundService](core-libraries/6.0/hosting-exception-handling.md) | ✔️ | ❌ |
 
 ## Cryptography
 
-| Title | Binary compatible | Source compatible | Introduced |
+| Title | Binary compatible | Source compatible |
 | - | :-: | :-: | - |
-| [CreateEncryptor methods throw exception for incorrect feedback size](cryptography/6.0/cfb-mode-feedback-size-exception.md) | ❌ | ✔️ | Preview 7 |
+| [CreateEncryptor methods throw exception for incorrect feedback size](cryptography/6.0/cfb-mode-feedback-size-exception.md) | ❌ | ✔️ |
 
 ## Deployment
 
-| Title | Binary compatible | Source compatible | Introduced |
+| Title | Binary compatible | Source compatible |
 | - | :-: | :-: | - |
 | [x86 host path on 64-bit Windows](deployment/7.0/x86-host-path.md) | ✔️ | ✔️ | Servicing release |
 
@@ -96,88 +96,88 @@ For information on other breaking changes for containers in .NET 6, see [.NET 6 
 
 ## Extensions
 
-| Title | Binary compatible | Source compatible | Introduced |
+| Title | Binary compatible | Source compatible |
 | - | :-: | :-: | - |
-| [AddProvider checks for non-null provider](extensions/6.0/addprovider-null-check.md) | ✔️ | ❌ | RC 1 |
-| [FileConfigurationProvider.Load throws InvalidDataException](extensions/6.0/filename-in-load-exception.md) | ✔️ | ❌ | RC 1 |
+| [AddProvider checks for non-null provider](extensions/6.0/addprovider-null-check.md) | ✔️ | ❌ |
+| [FileConfigurationProvider.Load throws InvalidDataException](extensions/6.0/filename-in-load-exception.md) | ✔️ | ❌ |
 | [Repeated XML elements include index](extensions/6.0/repeated-xml-elements.md) | ❌ | ✔️ | |
-| [Resolving disposed ServiceProvider throws exception](extensions/6.0/service-provider-disposed.md) | ✔️ | ❌ | RC 1 |
+| [Resolving disposed ServiceProvider throws exception](extensions/6.0/service-provider-disposed.md) | ✔️ | ❌ |
 
 ## Globalization
 
-| Title | Binary compatible | Source compatible | Introduced |
+| Title | Binary compatible | Source compatible |
 | - | :-: | :-: | - |
-| [Culture creation and case mapping in globalization-invariant mode](globalization/6.0/culture-creation-invariant-mode.md) |  |  | Preview 7 |
+| [Culture creation and case mapping in globalization-invariant mode](globalization/6.0/culture-creation-invariant-mode.md) |
 
 ## Interop
 
-| Title | Binary compatible | Source compatible | Introduced |
+| Title | Binary compatible | Source compatible |
 | - | :-: | :-: | - |
-| [Static abstract members in interfaces](core-libraries/6.0/static-abstract-interface-methods.md) | ❌ | ✔️ | Preview 7 |
+| [Static abstract members in interfaces](core-libraries/6.0/static-abstract-interface-methods.md) | ❌ | ✔️ |
 
 ## JIT compiler
 
-| Title | Binary compatible | Source compatible | Introduced |
+| Title | Binary compatible | Source compatible |
 | - | :-: | :-: | - |
-| [Coerce call arguments according to ECMA-335](jit/6.0/coerce-call-arguments-ecma-335.md) | ✔️ | ✔️ | Preview 1 |
+| [Coerce call arguments according to ECMA-335](jit/6.0/coerce-call-arguments-ecma-335.md) | ✔️ | ✔️ |
 
 ## Networking
 
-| Title | Binary compatible | Source compatible | Introduced |
+| Title | Binary compatible | Source compatible |
 | - | :-: | :-: | - |
-| [Port removed from SPN for Kerberos and Negotiate](networking/6.0/httpclient-port-lookup.md) | ❌ | ✔️ | RC 1 |
-| [WebRequest, WebClient, and ServicePoint are obsolete](networking/6.0/webrequest-deprecated.md) | ✔️ | ❌ | Preview 1 |
+| [Port removed from SPN for Kerberos and Negotiate](networking/6.0/httpclient-port-lookup.md) | ❌ | ✔️ |
+| [WebRequest, WebClient, and ServicePoint are obsolete](networking/6.0/webrequest-deprecated.md) | ✔️ | ❌ |
 
 ## SDK
 
-| Title | Binary compatible | Source compatible | Introduced |
+| Title | Binary compatible | Source compatible |
 | - | :-: | :-: | - |
-| [`-p` option for `dotnet run` is deprecated](sdk/6.0/deprecate-p-option-dotnet-run.md) | ✔️ | ❌ | Preview 6 |
-| [C# code in templates not supported by earlier versions](sdk/6.0/csharp-template-code.md) | ✔️ | ✔️ | Preview 7 |
+| [`-p` option for `dotnet run` is deprecated](sdk/6.0/deprecate-p-option-dotnet-run.md) | ✔️ | ❌ |
+| [C# code in templates not supported by earlier versions](sdk/6.0/csharp-template-code.md) | ✔️ | ✔️ |
 | [EditorConfig files implicitly included](sdk/6.0/editorconfig-additional-files.md) | ✔️ | ❌ | |
-| [Generate apphost for macOS](sdk/6.0/apphost-generated-for-macos.md) | ✔️ | ❌ | Preview 6 |
-| [Generate error for duplicate files in publish output](sdk/6.0/duplicate-files-in-output.md) | ❌ | ✔️ | Preview 1 |
-| [GetTargetFrameworkProperties and GetNearestTargetFramework removed from ProjectReference protocol](sdk/6.0/gettargetframeworkproperties-and-getnearesttargetframework-removed.md) | ❌ | ✔️ | Preview 1 |
-| [Install location for x64 emulated on Arm64](sdk/6.0/path-x64-emulated.md) | ✔️ | ❌ | RC 2 |
-| [MSBuild no longer supports calling GetType()](sdk/6.0/calling-gettype-property-functions.md) | | | RC 1 |
-| [OutputType not automatically set to WinExe](sdk/6.0/outputtype-not-set-automatically.md) | ✔️ | ❌ | RC 1 |
-| [Publish ReadyToRun with --no-restore requires changes](sdk/6.0/publish-readytorun-requires-restore-change.md) | ✔️ | ❌ | 6.0.100 |
-| [runtimeconfig.dev.json file not generated](sdk/6.0/runtimeconfigdev-file.md) | ❌ | ✔️ | 6.0.100 |
-| [RuntimeIdentifier warning if self-contained is unspecified](sdk/6.0/runtimeidentifier-self-contained.md) | ✔️ | ❌ | RC 1 |
-| [Version requirements for .NET 6 SDK](sdk/6.0/vs-msbuild-version.md) | ✔️ | ✔️ | 6.0.300 |
+| [Generate apphost for macOS](sdk/6.0/apphost-generated-for-macos.md) | ✔️ | ❌ |
+| [Generate error for duplicate files in publish output](sdk/6.0/duplicate-files-in-output.md) | ❌ | ✔️ |
+| [GetTargetFrameworkProperties and GetNearestTargetFramework removed from ProjectReference protocol](sdk/6.0/gettargetframeworkproperties-and-getnearesttargetframework-removed.md) | ❌ | ✔️ |
+| [Install location for x64 emulated on Arm64](sdk/6.0/path-x64-emulated.md) | ✔️ | ❌ |
+| [MSBuild no longer supports calling GetType()](sdk/6.0/calling-gettype-property-functions.md) | | |
+| [OutputType not automatically set to WinExe](sdk/6.0/outputtype-not-set-automatically.md) | ✔️ | ❌ |
+| [Publish ReadyToRun with --no-restore requires changes](sdk/6.0/publish-readytorun-requires-restore-change.md) | ✔️ | ❌ |
+| [runtimeconfig.dev.json file not generated](sdk/6.0/runtimeconfigdev-file.md) | ❌ | ✔️ |
+| [RuntimeIdentifier warning if self-contained is unspecified](sdk/6.0/runtimeidentifier-self-contained.md) | ✔️ | ❌ |
+| [Version requirements for .NET 6 SDK](sdk/6.0/vs-msbuild-version.md) | ✔️ | ✔️ |
 | [.version file includes build version](sdk/6.0/version-file-entries.md) | ✔️ | ✔️ | 6.0.401 |
-| [Write reference assemblies to IntermediateOutputPath](sdk/6.0/write-reference-assemblies-to-obj.md) | ❌ | ✔️ | 6.0.200 |
+| [Write reference assemblies to IntermediateOutputPath](sdk/6.0/write-reference-assemblies-to-obj.md) | ❌ | ✔️ |
 
 ## Serialization
 
-| Title | Binary compatible | Source compatible | Introduced |
+| Title | Binary compatible | Source compatible |
 | - | :-: | :-: | - |
 | [DataContractSerializer retains sign when deserializing -0](serialization/7.0/datacontractserializer-negative-sign.md) | ❌ | ✔️ | Servicing 6.0.11 |
-| [Default serialization format for TimeSpan](serialization/6.0/timespan-serialization-format.md) | ❌ | ✔️ | Servicing 6.0.2 |
-| [IAsyncEnumerable serialization](serialization/6.0/iasyncenumerable-serialization.md) | ✔️ | ❌ | Preview 4 |
-| [JSON source-generation API refactoring](serialization/6.0/json-source-gen-api-refactor.md) | ❌ | ✔️ | RC 2 |
-| [JsonNumberHandlingAttribute on collection properties](serialization/6.0/jsonnumberhandlingattribute-behavior.md) | ❌ | ✔️ | RC 1 |
-| [New JsonSerializer source generator overloads](serialization/6.0/jsonserializer-source-generator-overloads.md) | ❌ | ✔️ | Preview 6 |
+| [Default serialization format for TimeSpan](serialization/6.0/timespan-serialization-format.md) | ❌ | ✔️ |
+| [IAsyncEnumerable serialization](serialization/6.0/iasyncenumerable-serialization.md) | ✔️ | ❌ |
+| [JSON source-generation API refactoring](serialization/6.0/json-source-gen-api-refactor.md) | ❌ | ✔️ |
+| [JsonNumberHandlingAttribute on collection properties](serialization/6.0/jsonnumberhandlingattribute-behavior.md) | ❌ | ✔️ |
+| [New JsonSerializer source generator overloads](serialization/6.0/jsonserializer-source-generator-overloads.md) | ❌ | ✔️ |
 
 ## Windows Forms
 
-| Title | Binary compatible | Source compatible | Introduced |
+| Title | Binary compatible | Source compatible |
 | - | :-: | :-: | - |
-| [C# templates use application bootstrap](windows-forms/6.0/application-bootstrap.md) | ✔️ | ❌ | RC 1 |
-| [Selected TableLayoutSettings properties throw InvalidEnumArgumentException](windows-forms/6.0/tablelayoutsettings-apis-throw-invalidenumargumentexception.md) | ❌ | ✔️ | Preview 1 |
-| [DataGridView-related APIs now throw InvalidOperationException](windows-forms/6.0/null-owner-causes-invalidoperationexception.md) | ❌ | ✔️ | Preview 4 |
-| [ListViewGroupCollection methods throw new InvalidOperationException](windows-forms/6.0/listview-invalidoperationexception.md) | ❌ | ✔️ | RC 2 |
-| [NotifyIcon.Text maximum text length increased](windows-forms/6.0/notifyicon-text-max-text-length-increased.md) | ❌ | ✔️ | Preview 1 |
-| [ScaleControl called only when needed](windows-forms/6.0/optimize-scalecontrol-calls.md) | ✔️ | ❌ | Servicing 6.0.101 |
-| [Some APIs throw ArgumentNullException](windows-forms/6.0/apis-throw-argumentnullexception.md) | ❌ | ✔️ | Preview 1-4 |
-| [TreeNodeCollection.Item throws exception if node is assigned elsewhere](windows-forms/6.0/treenodecollection-item-throws-argumentexception.md) | ❌ | ✔️ | Preview 1 |
+| [C# templates use application bootstrap](windows-forms/6.0/application-bootstrap.md) | ✔️ | ❌ |
+| [Selected TableLayoutSettings properties throw InvalidEnumArgumentException](windows-forms/6.0/tablelayoutsettings-apis-throw-invalidenumargumentexception.md) | ❌ | ✔️ |
+| [DataGridView-related APIs now throw InvalidOperationException](windows-forms/6.0/null-owner-causes-invalidoperationexception.md) | ❌ | ✔️ |
+| [ListViewGroupCollection methods throw new InvalidOperationException](windows-forms/6.0/listview-invalidoperationexception.md) | ❌ | ✔️ |
+| [NotifyIcon.Text maximum text length increased](windows-forms/6.0/notifyicon-text-max-text-length-increased.md) | ❌ | ✔️ |
+| [ScaleControl called only when needed](windows-forms/6.0/optimize-scalecontrol-calls.md) | ✔️ | ❌ |
+| [Some APIs throw ArgumentNullException](windows-forms/6.0/apis-throw-argumentnullexception.md) | ❌ | ✔️ |
+| [TreeNodeCollection.Item throws exception if node is assigned elsewhere](windows-forms/6.0/treenodecollection-item-throws-argumentexception.md) | ❌ | ✔️ |
 
 ## XML and XSLT
 
-| Title | Binary compatible | Source compatible | Introduced |
+| Title | Binary compatible | Source compatible |
 | - | :-: | :-: | - |
-| [XmlDocument.XmlResolver nullability change](core-libraries/6.0/xmlresolver-nullable.md) | ❌ | ✔️ | RC 1 |
-| [XNodeReader.GetAttribute behavior for invalid index](core-libraries/6.0/xnodereader-getattribute.md) | ✔️ | ❌ | Preview 2 |
+| [XmlDocument.XmlResolver nullability change](core-libraries/6.0/xmlresolver-nullable.md) | ❌ | ✔️ |
+| [XNodeReader.GetAttribute behavior for invalid index](core-libraries/6.0/xnodereader-getattribute.md) | ✔️ | ❌ |
 
 ## See also
 

--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -2,7 +2,7 @@
 title: Breaking changes in .NET 7
 titleSuffix: ""
 description: Navigate to the breaking changes in .NET 7.
-ms.date: 01/04/2022
+ms.date: 05/18/2023
 no-loc: [Blazor, Razor, Kestrel]
 ---
 # Breaking changes in .NET 7
@@ -13,88 +13,89 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 
 ## ASP.NET Core
 
-| Title | Binary compatible | Source compatible | Introduced |
+| Title | Binary compatible | Source compatible |
 | - | :-: | :-: | - |
-| [API controller actions try to infer parameters from DI](aspnet-core/7.0/api-controller-action-parameters-di.md) | ✔️ | ❌ | Preview 2 |
-| [ASPNET-prefixed environment variable precedence](aspnet-core/7.0/environment-variable-precedence.md) | ✔️ | ✔️ | Preview 3 |
-| [AuthenticateAsync for remote auth providers](aspnet-core/7.0/authenticateasync-anonymous-request.md) | ✔️ | ❌ | RC 1 |
-| [Authentication in WebAssembly apps](aspnet-core/7.0/wasm-app-authentication.md) | ❌ | ✔️ | RC 1 |
-| [Default authentication scheme](aspnet-core/7.0/default-authentication-scheme.md) | ❌ | ✔️ | Preview 7 |
-| [Event IDs for some Microsoft.AspNetCore.Mvc.Core log messages changed](aspnet-core/7.0/microsoft-aspnetcore-mvc-core-log-event-ids.md) | ❌ | ✔️ | Preview 3 |
-| [Fallback file endpoints](aspnet-core/7.0/fallback-file-endpoints.md) | ❌ | ✔️ | RC 2 |
+| [API controller actions try to infer parameters from DI](aspnet-core/7.0/api-controller-action-parameters-di.md) | ✔️ | ❌ |
+| [ASPNET-prefixed environment variable precedence](aspnet-core/7.0/environment-variable-precedence.md) | ✔️ | ✔️ |
+| [AuthenticateAsync for remote auth providers](aspnet-core/7.0/authenticateasync-anonymous-request.md) | ✔️ | ❌ |
+| [Authentication in WebAssembly apps](aspnet-core/7.0/wasm-app-authentication.md) | ❌ | ✔️ |
+| [Default authentication scheme](aspnet-core/7.0/default-authentication-scheme.md) | ❌ | ✔️ |
+| [Event IDs for some Microsoft.AspNetCore.Mvc.Core log messages changed](aspnet-core/7.0/microsoft-aspnetcore-mvc-core-log-event-ids.md) | ❌ | ✔️ |
+| [Fallback file endpoints](aspnet-core/7.0/fallback-file-endpoints.md) | ❌ | ✔️ |
 | [IHubClients and IHubCallerClients hide members](aspnet-core/7.0/ihubclients-ihubcallerclients.md) | ✔️ | ❌ | |
-| [Kestrel: Default HTTPS binding removed](aspnet-core/7.0/https-binding-kestrel.md) | ❌ | ✔️ | Preview 6 |
-| [Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv and libuv.dll removed](aspnet-core/7.0/libuv-transport-dll-removed.md) | ❌ | ❌ | Preview 1 |
-| [Microsoft.Data.SqlClient updated to 4.0.1](aspnet-core/7.0/microsoft-data-sqlclient-updated-to-4-0-1.md) | ✔️ | ❌ | Preview 2 |
-| [Middleware no longer defers to endpoint with null request delegate](aspnet-core/7.0/middleware-null-requestdelegate.md) | ❌ | ✔️ | Preview 7 |
-| [MVC's detection of an empty body in model binding changed](aspnet-core/7.0/mvc-empty-body-model-binding.md) | ❌ | ✔️ | Preview 3 |
-| [Output caching API changes](aspnet-core/7.0/output-caching-renames.md) | ❌ | ❌ | RC 2 |
-| [SignalR Hub methods try to resolve parameters from DI](aspnet-core/7.0/signalr-hub-method-parameters-di.md) | ✔️ | ❌ | Preview 2 |
+| [Kestrel: Default HTTPS binding removed](aspnet-core/7.0/https-binding-kestrel.md) | ❌ | ✔️ |
+| [Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv and libuv.dll removed](aspnet-core/7.0/libuv-transport-dll-removed.md) | ❌ | ❌ |
+| [Microsoft.Data.SqlClient updated to 4.0.1](aspnet-core/7.0/microsoft-data-sqlclient-updated-to-4-0-1.md) | ✔️ | ❌ |
+| [Middleware no longer defers to endpoint with null request delegate](aspnet-core/7.0/middleware-null-requestdelegate.md) | ❌ | ✔️ |
+| [MVC's detection of an empty body in model binding changed](aspnet-core/7.0/mvc-empty-body-model-binding.md) | ❌ | ✔️ |
+| [Output caching API changes](aspnet-core/7.0/output-caching-renames.md) | ❌ | ❌ |
+| [SignalR Hub methods try to resolve parameters from DI](aspnet-core/7.0/signalr-hub-method-parameters-di.md) | ✔️ | ❌ |
 
 ## Core .NET libraries
 
-| Title | Binary compatible | Source compatible | Introduced |
+| Title | Binary compatible | Source compatible |
 | - | :-: | :-: | - |
-| [API obsoletions with default diagnostic ID](core-libraries/7.0/obsolete-apis-with-default-diagnostic.md) | ✔️ | ❌ | Preview 3 |
-| [API obsoletions with non-default diagnostic IDs](core-libraries/7.0/obsolete-apis-with-custom-diagnostics.md) | ✔️ | ❌ | Preview 1 |
-| [BinaryFormatter serialization APIs produce compiler errors](serialization/7.0/binaryformatter-apis-produce-errors.md) | ✔️ | ❌ | RC 1 |
-| [BrotliStream no longer allows undefined CompressionLevel values](core-libraries/7.0/brotlistream-ctor.md) | ❌ | ✔️ | |
-| [C++/CLI projects in Visual Studio](core-libraries/7.0/cpluspluscli-compiler-version.md) | ✔️ | ❌ | Preview 3 |
-| [Changes to reflection invoke API exceptions](core-libraries/7.0/reflection-invoke-exceptions.md) | ❌ | ✔️ | Preview 4 |
-| [Collectible Assembly in non-collectible AssemblyLoadContext](core-libraries/7.0/collectible-assemblies.md) | ❌ | ✔️ | Preview 5 |
+| [API obsoletions with default diagnostic ID](core-libraries/7.0/obsolete-apis-with-default-diagnostic.md) | ✔️ | ❌ |
+| [API obsoletions with non-default diagnostic IDs](core-libraries/7.0/obsolete-apis-with-custom-diagnostics.md) | ✔️ | ❌ |
+| [BinaryFormatter serialization APIs produce compiler errors](serialization/7.0/binaryformatter-apis-produce-errors.md) | ✔️ | ❌ |
+| [BrotliStream no longer allows undefined CompressionLevel values](core-libraries/7.0/brotlistream-ctor.md) | ❌ | ✔️ |
+| [C++/CLI projects in Visual Studio](core-libraries/7.0/cpluspluscli-compiler-version.md) | ✔️ | ❌ |
+| [Changes to reflection invoke API exceptions](core-libraries/7.0/reflection-invoke-exceptions.md) | ❌ | ✔️ |
+| [Collectible Assembly in non-collectible AssemblyLoadContext](core-libraries/7.0/collectible-assemblies.md) | ❌ | ✔️ |
 | [DateTime addition methods precision change](core-libraries/7.0/datetime-add-precision.md) | ✔️ | ✔️ |
-| [Equals method behavior change for NaN](core-libraries/7.0/equals-nan.md) | ❌ | ✔️ | Preview 5 |
-| [Generic type constraint on PatternContext\<T>](core-libraries/7.0/patterncontext-generic-constraint.md) | ❌ | ❌ | Preview 3 |
-| [Legacy FileStream strategy removed](core-libraries/7.0/filestream-compat-switch.md) | ❌ | ✔️ | Preview 1 |
-| [Library support for older frameworks](core-libraries/7.0/old-framework-support.md) | ❌ | ❌ | Preview 1 |
-| [Maximum precision for numeric format strings](core-libraries/7.0/max-precision-numeric-format-strings.md) | ❌ | ✔️ | RC 1 |
-| [SerializationFormat.Binary is obsolete](serialization/7.0/serializationformat-binary.md) | ❌ | ❌ | Preview 2 |
-| [System.Runtime.CompilerServices.Unsafe NuGet package](core-libraries/7.0/unsafe-package.md) | ✔️ | ✔️ | Preview 3 |
-| [Time fields on symbolic links](core-libraries/7.0/symbolic-link-timestamps.md) | ❌ | ✔️ | Preview 1 |
-| [Tracking linked cache entries](core-libraries/7.0/memorycache-tracking.md) | ❌ | ✔️ | Preview 1 |
-| [Validate CompressionLevel for BrotliStream](core-libraries/7.0/compressionlevel-validation.md) | ❌ | ✔️ | Preview 1 |
+| [Equals method behavior change for NaN](core-libraries/7.0/equals-nan.md) | ❌ | ✔️ |
+| [Generic type constraint on PatternContext\<T>](core-libraries/7.0/patterncontext-generic-constraint.md) | ❌ | ❌ |
+| [Legacy FileStream strategy removed](core-libraries/7.0/filestream-compat-switch.md) | ❌ | ✔️ |
+| [Library support for older frameworks](core-libraries/7.0/old-framework-support.md) | ❌ | ❌ |
+| [Maximum precision for numeric format strings](core-libraries/7.0/max-precision-numeric-format-strings.md) | ❌ | ✔️ |
+| [SerializationFormat.Binary is obsolete](serialization/7.0/serializationformat-binary.md) | ❌ | ❌ |
+| [System.Drawing.Common config switch removed](core-libraries/7.0/system-drawing.md) | ✔️ | ✔️ |
+| [System.Runtime.CompilerServices.Unsafe NuGet package](core-libraries/7.0/unsafe-package.md) | ✔️ | ✔️ |
+| [Time fields on symbolic links](core-libraries/7.0/symbolic-link-timestamps.md) | ❌ | ✔️ |
+| [Tracking linked cache entries](core-libraries/7.0/memorycache-tracking.md) | ❌ | ✔️ |
+| [Validate CompressionLevel for BrotliStream](core-libraries/7.0/compressionlevel-validation.md) | ❌ | ✔️ |
 
 ## Configuration
 
-| Title | Binary compatible | Source compatible | Introduced |
+| Title | Binary compatible | Source compatible |
 | - | :-: | :-: | - |
-| [System.diagnostics entry in app.config](configuration/7.0/diagnostics-config-section.md) | ❌ | ✔️ | RC 1 |
+| [System.diagnostics entry in app.config](configuration/7.0/diagnostics-config-section.md) | ❌ | ✔️ |
 
 ## Cryptography
 
-| Title | Binary compatible | Source compatible | Introduced |
+| Title | Binary compatible | Source compatible |
 | - | :-: | :-: | - |
-| [Decrypting EnvelopedCms doesn't double unwrap](cryptography/7.0/decrypt-envelopedcms.md) | ❌ | ✔️  | Preview 5 |
-| [Dynamic X509ChainPolicy verification time](cryptography/7.0/x509chainpolicy-verification-time.md) | ❌ | ✔️  | Preview 7 |
-| [X500DistinguishedName parsing of friendly names](cryptography/7.0/x500-distinguished-names.md) | ❌ | ✔️  | Preview 5 |
+| [Decrypting EnvelopedCms doesn't double unwrap](cryptography/7.0/decrypt-envelopedcms.md) | ❌ | ✔️  |
+| [Dynamic X509ChainPolicy verification time](cryptography/7.0/x509chainpolicy-verification-time.md) | ❌ | ✔️  |
+| [X500DistinguishedName parsing of friendly names](cryptography/7.0/x500-distinguished-names.md) | ❌ | ✔️  |
 
 ## Deployment
 
-| Title | Binary compatible | Source compatible | Introduced |
+| Title | Binary compatible | Source compatible |
 | - | :-: | :-: | - |
-| [All assemblies trimmed by default](deployment/7.0/trim-all-assemblies.md) | ✔️ | ❌ | Preview 7 |
-| [Multi-level lookup is disabled](deployment/7.0/multilevel-lookup.md) | ❌ | ✔️ | Preview 4 |
-| [x86 host path on 64-bit Windows](deployment/7.0/x86-host-path.md) | ✔️ | ✔️ | Preview 6 |
-| [TrimmerDefaultAction is deprecated](deployment/7.0/deprecated-trimmer-default-action.md) | ✔️ | ❌ | Preview 7 |
+| [All assemblies trimmed by default](deployment/7.0/trim-all-assemblies.md) | ✔️ | ❌ |
+| [Multi-level lookup is disabled](deployment/7.0/multilevel-lookup.md) | ❌ | ✔️ |
+| [x86 host path on 64-bit Windows](deployment/7.0/x86-host-path.md) | ✔️ | ✔️ |
+| [TrimmerDefaultAction is deprecated](deployment/7.0/deprecated-trimmer-default-action.md) | ✔️ | ❌ |
 
 ## Extensions
 
-| Title | Binary compatible | Source compatible | Introduced |
+| Title | Binary compatible | Source compatible |
 | - | :-: | :-: | - |
-| [ContentRootPath for apps launched by Windows Shell](extensions/7.0/contentrootpath-hosted-app.md) | ❌ | ✔️ | Preview 6 |
-| [Environment variable prefixes](extensions/7.0/environment-variable-prefix.md) | ❌ | ✔️ | Preview 4 |
+| [ContentRootPath for apps launched by Windows Shell](extensions/7.0/contentrootpath-hosted-app.md) | ❌ | ✔️ |
+| [Environment variable prefixes](extensions/7.0/environment-variable-prefix.md) | ❌ | ✔️ |
 
 ## Globalization
 
-| Title | Binary compatible | Source compatible | Introduced |
+| Title | Binary compatible | Source compatible |
 | - | :-: | :-: | - |
-| [Globalization APIs use ICU libraries on Windows Server](globalization/7.0/icu-globalization-api.md) | ❌ | ✔️ | RC 1 |
+| [Globalization APIs use ICU libraries on Windows Server](globalization/7.0/icu-globalization-api.md) | ❌ | ✔️ |
 
 ## Interop
 
-| Title | Binary compatible | Source compatible | Introduced |
+| Title | Binary compatible | Source compatible |
 | - | :-: | :-: | - |
-| [RuntimeInformation.OSArchitecture under emulation](interop/7.0/osarchitecture-emulation.md) | ❌ | ✔️ | RC 1 |
+| [RuntimeInformation.OSArchitecture under emulation](interop/7.0/osarchitecture-emulation.md) | ❌ | ✔️ |
 
 ## .NET MAUI
 
@@ -108,49 +109,49 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 
 ## Networking
 
-| Title | Binary compatible | Source compatible | Introduced |
+| Title | Binary compatible | Source compatible |
 | - | :-: | :-: | - |
-| [AllowRenegotiation default is false](networking/7.0/allowrenegotiation-default.md) | ❌ | ❌ | Preview 3 |
-| [Custom ping payloads on Linux](networking/7.0/ping-custom-payload-linux.md) | ❌ | ✔️ | Preview 2 |
-| [Socket.End methods don't throw ObjectDisposedException](networking/7.0/socket-end-closed-sockets.md) | ❌ | ✔️ | Preview 7 |
+| [AllowRenegotiation default is false](networking/7.0/allowrenegotiation-default.md) | ❌ | ❌ |
+| [Custom ping payloads on Linux](networking/7.0/ping-custom-payload-linux.md) | ❌ | ✔️ |
+| [Socket.End methods don't throw ObjectDisposedException](networking/7.0/socket-end-closed-sockets.md) | ❌ | ✔️ |
 
 ## SDK and MSBuild
 
-| Title | Binary compatible | Source compatible | Introduced |
+| Title | Binary compatible | Source compatible |
 | - | :-: | :-: | - |
-| [Automatic RuntimeIdentifier for certain projects](sdk/7.0/automatic-runtimeidentifier.md) | ✔️ | ❌ | 7.0.100 |
-| [Automatic RuntimeIdentifier for publish only](sdk/7.0/automatic-rid-publish-only.md) | ❌ | ❌ | 7.0.200 |
+| [Automatic RuntimeIdentifier for certain projects](sdk/7.0/automatic-runtimeidentifier.md) | ✔️ | ❌ |
+| [Automatic RuntimeIdentifier for publish only](sdk/7.0/automatic-rid-publish-only.md) | ❌ | ❌ |
 | [CLI console output uses UTF-8](sdk/8.0/console-encoding.md) | ❌ | ❌ | 7.0.3xx |
-| [Console encoding not UTF-8 after completion](sdk/8.0/console-encoding-fix.md) | ❌ | ✔️ | 7.0.300 |
-| [MSBuild serialization of custom types in .NET 7](sdk/7.0/custom-serialization.md) | ❌ | ❌ | 7.0.100 |
-| [Side-by-side SDK installations](sdk/7.0/side-by-side-install.md) | ❌ | ❌ | 7.0.100 |
-| [Version requirements for .NET 7 SDK](sdk/7.0/vs-msbuild-version.md) | ✔️ | ✔️ | 7.0.100 |
-| [dotnet test: switch `-a` to alias `--arch` instead of `--test-adapter-path`](https://github.com/dotnet/sdk/issues/21389) | ❌ | ❌ | Preview 1 |
-| [dotnet test: switch `-r` to alias `--runtime` instead of `--results-dir`](https://github.com/dotnet/sdk/issues/21952) | ❌ | ❌ | Preview 1 |
-| [`--output` option no longer is valid for solution-level commands](sdk/7.0/solution-level-output-no-longer-valid.md) | ❌ | ❌ | 7.0.200 |
+| [Console encoding not UTF-8 after completion](sdk/8.0/console-encoding-fix.md) | ❌ | ✔️ |
+| [MSBuild serialization of custom types in .NET 7](sdk/7.0/custom-serialization.md) | ❌ | ❌ |
+| [Side-by-side SDK installations](sdk/7.0/side-by-side-install.md) | ❌ | ❌ |
+| [Version requirements for .NET 7 SDK](sdk/7.0/vs-msbuild-version.md) | ✔️ | ✔️ |
+| [dotnet test: switch `-a` to alias `--arch` instead of `--test-adapter-path`](https://github.com/dotnet/sdk/issues/21389) | ❌ | ❌ |
+| [dotnet test: switch `-r` to alias `--runtime` instead of `--results-dir`](https://github.com/dotnet/sdk/issues/21952) | ❌ | ❌ |
+| [`--output` option no longer is valid for solution-level commands](sdk/7.0/solution-level-output-no-longer-valid.md) | ❌ | ❌ |
 
 ## Serialization
 
-| Title | Binary compatible | Source compatible | Introduced |
+| Title | Binary compatible | Source compatible |
 | - | :-: | :-: | - |
-| [DataContractSerializer retains sign when deserializing -0](serialization/7.0/datacontractserializer-negative-sign.md) | ❌ | ✔️ | RC 1 |
-| [Deserialize Version type with leading or trailing whitespace](serialization/7.0/deserialize-version-with-whitespace.md) | ❌ | ✔️ | Preview 1 |
-| [JsonSerializerOptions copy constructor includes JsonSerializerContext](serialization/7.0/jsonserializeroptions-copy-constructor.md) | ❌ | ✔️ | Preview 7 |
-| [Polymorphic serialization for object types](serialization/7.0/polymorphic-serialization.md) | ❌ | ✔️ | RC 1 |
-| [System.Text.Json source generator fallback](serialization/7.0/reflection-fallback.md) | ❌ | ✔️ | Preview 7 |
+| [DataContractSerializer retains sign when deserializing -0](serialization/7.0/datacontractserializer-negative-sign.md) | ❌ | ✔️ |
+| [Deserialize Version type with leading or trailing whitespace](serialization/7.0/deserialize-version-with-whitespace.md) | ❌ | ✔️ |
+| [JsonSerializerOptions copy constructor includes JsonSerializerContext](serialization/7.0/jsonserializeroptions-copy-constructor.md) | ❌ | ✔️ |
+| [Polymorphic serialization for object types](serialization/7.0/polymorphic-serialization.md) | ❌ | ✔️ |
+| [System.Text.Json source generator fallback](serialization/7.0/reflection-fallback.md) | ❌ | ✔️ |
 
 ## Windows Forms
 
-| Title | Binary compatible | Source compatible | Introduced |
+| Title | Binary compatible | Source compatible |
 | - | :-: | :-: | - |
-| [Obsoletions and warnings](windows-forms/7.0/obsolete-apis.md) | ✔️ | ❌ | Preview 1 and RC 1 |
-| [Some APIs throw ArgumentNullException](windows-forms/7.0/apis-throw-argumentnullexception.md) | ❌ | ✔️ | Preview 1 |
+| [Obsoletions and warnings](windows-forms/7.0/obsolete-apis.md) | ✔️ | ❌ |
+| [Some APIs throw ArgumentNullException](windows-forms/7.0/apis-throw-argumentnullexception.md) | ❌ | ✔️ |
 
 ## XML and XSLT
 
-| Title | Binary compatible | Source compatible | Introduced |
+| Title | Binary compatible | Source compatible |
 | - | :-: | :-: | - |
-| [XmlSecureResolver is obsolete](xml/7.0/xmlsecureresolver-obsolete.md) | ❌ | ❌ | RC 1 |
+| [XmlSecureResolver is obsolete](xml/7.0/xmlsecureresolver-obsolete.md) | ❌ | ❌ |
 
 ## See also
 

--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -14,7 +14,7 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 ## ASP.NET Core
 
 | Title | Binary compatible | Source compatible |
-| - | :-: | :-: | - |
+| - | :-: | :-: |
 | [API controller actions try to infer parameters from DI](aspnet-core/7.0/api-controller-action-parameters-di.md) | ✔️ | ❌ |
 | [ASPNET-prefixed environment variable precedence](aspnet-core/7.0/environment-variable-precedence.md) | ✔️ | ✔️ |
 | [AuthenticateAsync for remote auth providers](aspnet-core/7.0/authenticateasync-anonymous-request.md) | ✔️ | ❌ |
@@ -22,7 +22,7 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 | [Default authentication scheme](aspnet-core/7.0/default-authentication-scheme.md) | ❌ | ✔️ |
 | [Event IDs for some Microsoft.AspNetCore.Mvc.Core log messages changed](aspnet-core/7.0/microsoft-aspnetcore-mvc-core-log-event-ids.md) | ❌ | ✔️ |
 | [Fallback file endpoints](aspnet-core/7.0/fallback-file-endpoints.md) | ❌ | ✔️ |
-| [IHubClients and IHubCallerClients hide members](aspnet-core/7.0/ihubclients-ihubcallerclients.md) | ✔️ | ❌ | |
+| [IHubClients and IHubCallerClients hide members](aspnet-core/7.0/ihubclients-ihubcallerclients.md) | ✔️ | ❌ |
 | [Kestrel: Default HTTPS binding removed](aspnet-core/7.0/https-binding-kestrel.md) | ❌ | ✔️ |
 | [Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv and libuv.dll removed](aspnet-core/7.0/libuv-transport-dll-removed.md) | ❌ | ❌ |
 | [Microsoft.Data.SqlClient updated to 4.0.1](aspnet-core/7.0/microsoft-data-sqlclient-updated-to-4-0-1.md) | ✔️ | ❌ |
@@ -34,7 +34,7 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 ## Core .NET libraries
 
 | Title | Binary compatible | Source compatible |
-| - | :-: | :-: | - |
+| - | :-: | :-: |
 | [API obsoletions with default diagnostic ID](core-libraries/7.0/obsolete-apis-with-default-diagnostic.md) | ✔️ | ❌ |
 | [API obsoletions with non-default diagnostic IDs](core-libraries/7.0/obsolete-apis-with-custom-diagnostics.md) | ✔️ | ❌ |
 | [BinaryFormatter serialization APIs produce compiler errors](serialization/7.0/binaryformatter-apis-produce-errors.md) | ✔️ | ❌ |
@@ -58,13 +58,13 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 ## Configuration
 
 | Title | Binary compatible | Source compatible |
-| - | :-: | :-: | - |
+| - | :-: | :-: |
 | [System.diagnostics entry in app.config](configuration/7.0/diagnostics-config-section.md) | ❌ | ✔️ |
 
 ## Cryptography
 
 | Title | Binary compatible | Source compatible |
-| - | :-: | :-: | - |
+| - | :-: | :-: |
 | [Decrypting EnvelopedCms doesn't double unwrap](cryptography/7.0/decrypt-envelopedcms.md) | ❌ | ✔️  |
 | [Dynamic X509ChainPolicy verification time](cryptography/7.0/x509chainpolicy-verification-time.md) | ❌ | ✔️  |
 | [X500DistinguishedName parsing of friendly names](cryptography/7.0/x500-distinguished-names.md) | ❌ | ✔️  |
@@ -72,7 +72,7 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 ## Deployment
 
 | Title | Binary compatible | Source compatible |
-| - | :-: | :-: | - |
+| - | :-: | :-: |
 | [All assemblies trimmed by default](deployment/7.0/trim-all-assemblies.md) | ✔️ | ❌ |
 | [Multi-level lookup is disabled](deployment/7.0/multilevel-lookup.md) | ❌ | ✔️ |
 | [x86 host path on 64-bit Windows](deployment/7.0/x86-host-path.md) | ✔️ | ✔️ |
@@ -81,20 +81,20 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 ## Extensions
 
 | Title | Binary compatible | Source compatible |
-| - | :-: | :-: | - |
+| - | :-: | :-: |
 | [ContentRootPath for apps launched by Windows Shell](extensions/7.0/contentrootpath-hosted-app.md) | ❌ | ✔️ |
 | [Environment variable prefixes](extensions/7.0/environment-variable-prefix.md) | ❌ | ✔️ |
 
 ## Globalization
 
 | Title | Binary compatible | Source compatible |
-| - | :-: | :-: | - |
+| - | :-: | :-: |
 | [Globalization APIs use ICU libraries on Windows Server](globalization/7.0/icu-globalization-api.md) | ❌ | ✔️ |
 
 ## Interop
 
 | Title | Binary compatible | Source compatible |
-| - | :-: | :-: | - |
+| - | :-: | :-: |
 | [RuntimeInformation.OSArchitecture under emulation](interop/7.0/osarchitecture-emulation.md) | ❌ | ✔️ |
 
 ## .NET MAUI
@@ -110,7 +110,7 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 ## Networking
 
 | Title | Binary compatible | Source compatible |
-| - | :-: | :-: | - |
+| - | :-: | :-: |
 | [AllowRenegotiation default is false](networking/7.0/allowrenegotiation-default.md) | ❌ | ❌ |
 | [Custom ping payloads on Linux](networking/7.0/ping-custom-payload-linux.md) | ❌ | ✔️ |
 | [Socket.End methods don't throw ObjectDisposedException](networking/7.0/socket-end-closed-sockets.md) | ❌ | ✔️ |
@@ -118,10 +118,10 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 ## SDK and MSBuild
 
 | Title | Binary compatible | Source compatible |
-| - | :-: | :-: | - |
+| - | :-: | :-: |
 | [Automatic RuntimeIdentifier for certain projects](sdk/7.0/automatic-runtimeidentifier.md) | ✔️ | ❌ |
 | [Automatic RuntimeIdentifier for publish only](sdk/7.0/automatic-rid-publish-only.md) | ❌ | ❌ |
-| [CLI console output uses UTF-8](sdk/8.0/console-encoding.md) | ❌ | ❌ | 7.0.3xx |
+| [CLI console output uses UTF-8](sdk/8.0/console-encoding.md) | ❌ | ❌ |
 | [Console encoding not UTF-8 after completion](sdk/8.0/console-encoding-fix.md) | ❌ | ✔️ |
 | [MSBuild serialization of custom types in .NET 7](sdk/7.0/custom-serialization.md) | ❌ | ❌ |
 | [Side-by-side SDK installations](sdk/7.0/side-by-side-install.md) | ❌ | ❌ |
@@ -133,7 +133,7 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 ## Serialization
 
 | Title | Binary compatible | Source compatible |
-| - | :-: | :-: | - |
+| - | :-: | :-: |
 | [DataContractSerializer retains sign when deserializing -0](serialization/7.0/datacontractserializer-negative-sign.md) | ❌ | ✔️ |
 | [Deserialize Version type with leading or trailing whitespace](serialization/7.0/deserialize-version-with-whitespace.md) | ❌ | ✔️ |
 | [JsonSerializerOptions copy constructor includes JsonSerializerContext](serialization/7.0/jsonserializeroptions-copy-constructor.md) | ❌ | ✔️ |
@@ -143,14 +143,14 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 ## Windows Forms
 
 | Title | Binary compatible | Source compatible |
-| - | :-: | :-: | - |
+| - | :-: | :-: |
 | [Obsoletions and warnings](windows-forms/7.0/obsolete-apis.md) | ✔️ | ❌ |
 | [Some APIs throw ArgumentNullException](windows-forms/7.0/apis-throw-argumentnullexception.md) | ❌ | ✔️ |
 
 ## XML and XSLT
 
 | Title | Binary compatible | Source compatible |
-| - | :-: | :-: | - |
+| - | :-: | :-: |
 | [XmlSecureResolver is obsolete](xml/7.0/xmlsecureresolver-obsolete.md) | ❌ | ❌ |
 
 ## See also

--- a/docs/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only.md
+++ b/docs/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only.md
@@ -85,7 +85,7 @@ Alternatively, you can enable support for non-Windows platforms in .NET 6 by set
 > [!NOTE]
 >
 > - This configuration switch was added to give cross-platform apps that depend heavily on this package time to migrate to more modern libraries. However, non-Windows bugs will not be fixed.
-> - This switch is only available in .NET 6 and was removed in .NET 7.
+> - This switch is only available in .NET 6 and was removed in .NET 7. For more information, see [System.Drawing.Common config switch removed](../7.0/system-drawing.md).
 
 ## Affected APIs
 

--- a/docs/core/compatibility/core-libraries/7.0/system-drawing.md
+++ b/docs/core/compatibility/core-libraries/7.0/system-drawing.md
@@ -5,7 +5,7 @@ ms.date: 05/18/2023
 ---
 # System.Drawing.Common config switch removed
 
-The [System.Drawing.Common](https://www.nuget.org/packages/System.Drawing.Common/) NuGet package has been attributed as a Windows-specific library since .NET 6. On non-Windows operating systems, a <xref:System.TypeInitializationException> exception is thrown with <xref:System.PlatformNotSupportedException> as the inner exception. The runtime configuration switch to re-enable usage of the package on non-Windows operating systems has been removed in .NET 7.
+The [System.Drawing.Common](https://www.nuget.org/packages/System.Drawing.Common/) NuGet package has been attributed as a Windows-specific library since .NET 6 and using it resulted in compile-time warnings and run-time exceptions. The runtime configuration switch to re-enable usage of the package on non-Windows operating systems has been removed in .NET 7.
 
 ## Old behavior
 

--- a/docs/core/compatibility/core-libraries/7.0/system-drawing.md
+++ b/docs/core/compatibility/core-libraries/7.0/system-drawing.md
@@ -1,0 +1,45 @@
+---
+title: "Breaking change: System.Drawing.Common config switch removed"
+description: Learn about the .NET 7 breaking change where the EnableUnixSupport switch to enable System.Drawing.Common support on non-Windows operating systems was removed.
+ms.date: 05/18/2023
+---
+# System.Drawing.Common config switch removed
+
+The [System.Drawing.Common](https://www.nuget.org/packages/System.Drawing.Common/) NuGet package has been attributed as a Windows-specific library since .NET 6. On non-Windows operating systems, a <xref:System.TypeInitializationException> exception is thrown with <xref:System.PlatformNotSupportedException> as the inner exception. The runtime configuration switch to re-enable usage of the package on non-Windows operating systems has been removed in .NET 7.
+
+## Old behavior
+
+Prior to .NET 6, using the System.Drawing.Common package did not produce any compile-time warnings, and no run-time exceptions were thrown. In .NET 6, you could set the `System.Drawing.EnableUnixSupport` runtime configuration setting to re-enable non-Windows support.
+
+## New behavior
+
+Starting in .NET 7, the `System.Drawing.EnableUnixSupport` switch has been removed and you can no longer use the [System.Drawing.Common](https://www.nuget.org/packages/System.Drawing.Common/) package on non-Windows operating systems.
+
+## Version introduced
+
+.NET 7
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+The switch to re-enable functionality on non-Windows operating systems was added in .NET 6 to give customers time to migrate to an alternative, modern library. Now that .NET 7 has been released, the switch has been removed. For more information, see [Reason for change (.NET 6 breaking change)](../6.0/system-drawing-common-windows-only.md#reason-for-change).
+
+## Recommended action
+
+To use these APIs for cross-platform apps, migrate to one of the following libraries:
+
+- [ImageSharp](https://sixlabors.com/products/imagesharp)
+- [SkiaSharp](https://github.com/mono/SkiaSharp)
+- [Microsoft.Maui.Graphics](/dotnet/maui/user-interface/graphics/)
+
+## Affected APIs
+
+See [Affected APIs (.NET 6 breaking change)](../6.0/system-drawing-common-windows-only.md#affected-apis).
+
+## See also
+
+- [System.Drawing.Common only supported on Windows (.NET 6)](../6.0/system-drawing-common-windows-only.md)
+- [`System.Drawing.Common` only supported on Windows - dotnet/designs](https://github.com/dotnet/designs/blob/main/accepted/2021/system-drawing-win-only/system-drawing-win-only.md)

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -158,6 +158,8 @@ items:
         href: core-libraries/7.0/max-precision-numeric-format-strings.md
       - name: Reflection invoke API exceptions
         href: core-libraries/7.0/reflection-invoke-exceptions.md
+      - name: System.Drawing.Common config switch removed
+        href: core-libraries/7.0/system-drawing.md
       - name: System.Runtime.CompilerServices.Unsafe NuGet package
         href: core-libraries/7.0/unsafe-package.md
       - name: Time fields on symbolic links
@@ -1008,6 +1010,8 @@ items:
         href: core-libraries/7.0/max-precision-numeric-format-strings.md
       - name: Reflection invoke API exceptions
         href: core-libraries/7.0/reflection-invoke-exceptions.md
+      - name: System.Drawing.Common config switch removed
+        href: core-libraries/7.0/system-drawing.md
       - name: System.Runtime.CompilerServices.Unsafe NuGet package
         href: core-libraries/7.0/unsafe-package.md
       - name: Time fields on symbolic links


### PR DESCRIPTION
Fixes #33653.
Fixes #32878.

Also removes "introduced version" column from .NET 7 overview page.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/7.0.md](https://github.com/dotnet/docs/blob/381121cf58c7d81676bca779a6727340b64d85b6/docs/core/compatibility/7.0.md) | [Breaking changes in .NET 7](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/7.0?branch=pr-en-us-35401) |
| [docs/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only.md](https://github.com/dotnet/docs/blob/381121cf58c7d81676bca779a6727340b64d85b6/docs/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only.md) | [System.Drawing.Common only supported on Windows](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only?branch=pr-en-us-35401) |
| [docs/core/compatibility/core-libraries/7.0/system-drawing.md](https://github.com/dotnet/docs/blob/381121cf58c7d81676bca779a6727340b64d85b6/docs/core/compatibility/core-libraries/7.0/system-drawing.md) | [docs/core/compatibility/core-libraries/7.0/system-drawing](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/7.0/system-drawing?branch=pr-en-us-35401) |


<!-- PREVIEW-TABLE-END -->