### PR TITLE
Variable naming adds clarity

### DIFF
--- a/docs/standard/parallel-programming/how-to-write-a-parallel-for-loop-with-thread-local-variables.md
+++ b/docs/standard/parallel-programming/how-to-write-a-parallel-for-loop-with-thread-local-variables.md
@@ -1,7 +1,7 @@
 ---
 title: "How to: Write a Parallel.For Loop with Thread-Local Variables"
 description: See an example of how to write a Parallel.For loop in .NET that uses thread-local variables, which store and retrieve state in each separate task in the loop.
-ms.date: "03/30/2017"
+ms.date: 05/22/2023
 dev_langs: 
   - "csharp"
   - "vb"

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_parallel/cs/forandforeach_simple.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_parallel/cs/forandforeach_simple.cs
@@ -1,11 +1,7 @@
-﻿
-
-
-namespace ThreadLocalFor
+﻿namespace ThreadLocalFor
 {
 //<snippet05>
  using System;
- using System.Collections.Generic;
  using System.Linq;
  using System.Threading;
  using System.Threading.Tasks;
@@ -14,7 +10,7 @@ namespace ThreadLocalFor
  {
      static void Main()
      {
-         int[] nums = Enumerable.Range(0, 1000000).ToArray();
+         int[] nums = Enumerable.Range(0, 1_000_000).ToArray();
          long total = 0;
 
          // Use type parameter to make subtotal a long, not an int
@@ -23,7 +19,7 @@ namespace ThreadLocalFor
              subtotal += nums[j];
              return subtotal;
          },
-             (x) => Interlocked.Add(ref total, x)
+             subtotal => Interlocked.Add(ref total, subtotal)
          );
 
          Console.WriteLine("The total is {0:N0}", total);

--- a/samples/snippets/visualbasic/VS_Snippets_Misc/tpl_parallel/vb/forwiththreadlocal.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_Misc/tpl_parallel/vb/forwiththreadlocal.vb
@@ -14,7 +14,7 @@ Module ForWithThreadLocal
         Parallel.For(Of Long)(0, nums.Length, Function() 0, Function(j, [loop], subtotal)
                                                                 subtotal += nums(j)
                                                                 Return subtotal
-                                                            End Function, Function(x) Interlocked.Add(total, x))
+                                                            End Function, Function(subtotal) Interlocked.Add(total, subtotal))
 
         Console.WriteLine("The total is {0:N0}", total)
         Console.WriteLine("Press any key to exit")


### PR DESCRIPTION
Fixes #33823


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/parallel-programming/how-to-write-a-parallel-for-loop-with-thread-local-variables.md](https://github.com/dotnet/docs/blob/fff9c94bbbdaf8d7e21a530d8b5fcb55f2e3f379/docs/standard/parallel-programming/how-to-write-a-parallel-for-loop-with-thread-local-variables.md) | [How to: Write a Parallel.For Loop with Thread-Local Variables](https://review.learn.microsoft.com/en-us/dotnet/standard/parallel-programming/how-to-write-a-parallel-for-loop-with-thread-local-variables?branch=pr-en-us-35437) |

<!-- PREVIEW-TABLE-END -->