### PR TITLE
Small reorganization of docs to move logging up to its own topic, and…

### DIFF
--- a/docs/core/diagnostics/logging-tracing.md
+++ b/docs/core/diagnostics/logging-tracing.md
@@ -9,7 +9,7 @@ Code can be instrumented to produce a log, which serves as a record of interesti
 
 The terms logging and tracing are commonly synonymous, the distinction we usually take is that logging output is expected to be collected all the time, and so should have a low overhead. Tracing is typically more invasive and collects more information from deeper parts of the application and .NET runtime, so is either used when diagnosing specific problems, or automatically for short periods of time as part of deeper performance analysis systems.
 
-Another pivot on the tracing term is [Distributed Tracing](./distributed-tracing.md) - which collects high-level activity & timing data for request based systems, and correlates the requests across services to give a view of how each request is processed  by the complete system.
+Another pivot on the tracing term is [Distributed Tracing](./distributed-tracing.md) - which collects high-level activity & timing data for request based systems, and correlates the requests across services to give a view of how each request is processed by the complete system.
 
 ## Key distinctions in logging APIs
 
@@ -36,7 +36,7 @@ Most logging APIs allow log messages to be sent to different destinations called
 
 For most cases, whether adding logging to an existing project or creating a new project, the [ILogger infrastructure](../extensions/logging.md) is a good default choice. `ILogger` supports fast structured logging, flexible configuration, and a collection of [common sinks](../extensions/logging-providers.md#built-in-logging-providers) including the console, which is what you see when running an ASP.NET app. Additionally, the `ILogger` interface can also serve as a facade over many [third party logging implementations](../extensions/logging-providers.md#third-party-logging-providers) that offer more functionality and extensibility.
 
-ILogger provides the logging story for the Open Telemetry implementation for .NET, which enables egress of logs from you application to a variety of APM systems for further analysis.
+`ILogger` provides the logging story for the Open Telemetry implementation for .NET, which enables egress of logs from you application to a variety of APM systems for further analysis.
 
 ### EventSource
 

--- a/docs/core/diagnostics/logging-tracing.md
+++ b/docs/core/diagnostics/logging-tracing.md
@@ -5,7 +5,11 @@ ms.date: 4/29/2022
 ---
 # .NET logging and tracing
 
-Code can be instrumented to produce a log, which serves as a record of interesting events that occurred while the program was running. To understand the application's behavior, logs are reviewed. Logging and tracing both encapsulate this technique. .NET has accumulated several different logging APIs over its history and this article will help you understand what options are available.
+Code can be instrumented to produce a log, which serves as a record of interesting events that occurred while the program was running. To understand the application's behavior, logs can be reviewed. Logging and tracing both encapsulate this technique. .NET has accumulated several different logging APIs over its history and this article will help you understand what options are available.
+
+The terms logging and tracing are commonly synonymous, the distinction we usually take is that logging output is expected to be collected all the time, and so should have a low overhead. Tracing is typically more invasive and collects more information from deeper parts of the application and .NET runtime, so is either used when diagnosing specific problems, or automatically for short periods of time as part of deeper performance analysis systems.
+
+Another pivot on the tracing term is [Distributed Tracing](./distributed-tracing.md) - which collects high-level activity & timing data for request based systems, and correlates the requests across services to give a view of how each request is processed  by the complete system.
 
 ## Key distinctions in logging APIs
 
@@ -30,15 +34,17 @@ Most logging APIs allow log messages to be sent to different destinations called
 
 ### ILogger
 
-For most cases, whether adding logging to an existing project or creating a new project, the [ILogger](../extensions/logging.md) interface is a good default choice. `ILogger` supports fast structured logging, flexible configuration, and a collection of [common sinks](../extensions/logging-providers.md#built-in-logging-providers). Additionally, the `ILogger` interface can also serve as a facade over many [third party logging implementations](../extensions/logging-providers.md#third-party-logging-providers) that offer more functionality and extensibility.
+For most cases, whether adding logging to an existing project or creating a new project, the [ILogger infrastructure](../extensions/logging.md) is a good default choice. `ILogger` supports fast structured logging, flexible configuration, and a collection of [common sinks](../extensions/logging-providers.md#built-in-logging-providers) including the console, which is what you see when running an ASP.NET app. Additionally, the `ILogger` interface can also serve as a facade over many [third party logging implementations](../extensions/logging-providers.md#third-party-logging-providers) that offer more functionality and extensibility.
+
+ILogger provides the logging story for the Open Telemetry implementation for .NET, which enables egress of logs from you application to a variety of APM systems for further analysis.
 
 ### EventSource
 
-[EventSource](./eventsource.md) is an older high performance structured logging API. It was originally designed to integrate well with [Event Tracing for Windows (ETW)](/windows/win32/etw/event-tracing-portal), but was later extended to support [EventPipe](./eventpipe.md) cross-platform tracing and <xref:System.Diagnostics.Tracing.EventListener> for custom sinks. In comparison to `ILogger`, `EventSource` has relatively few pre-made logging sinks and there is no built-in support to configure via separate configuration files. `EventSource` is excellent if you want tighter control over [ETW](/windows/win32/etw/event-tracing-portal) or [EventPipe](./eventpipe.md) integration, but for general purpose logging, `ILogger` is more flexible and easier to use.
+[EventSource](./eventsource.md) is an older high performance tracing API with structured logging. It was originally designed to integrate well with [Event Tracing for Windows (ETW)](/windows/win32/etw/event-tracing-portal), but was later extended to support [EventPipe](./eventpipe.md) cross-platform tracing and <xref:System.Diagnostics.Tracing.EventListener> for custom sinks. In comparison to `ILogger`, `EventSource` has relatively few pre-made logging sinks and there is no built-in support to configure via separate configuration files. `EventSource` is excellent if you want tighter control over [ETW](/windows/win32/etw/event-tracing-portal) or [EventPipe](./eventpipe.md) integration, but for general purpose logging, `ILogger` is more flexible and easier to use.
 
 ### Trace
 
-<xref:System.Diagnostics.Trace?displayProperty=nameWithType> and <xref:System.Diagnostics.Debug?displayProperty=nameWithType> are .NET's oldest logging APIs. These classes have flexible configuration APIs and a large ecosystem of sinks, but only support unstructured logging. On .NET Framework they can be configured via an app.config file, but in .NET Core, there's no built-in, file-based configuration mechanism. The .NET team continues to support these APIs for backward-compatibility purposes, but no new functionality will be added. These APIs are a fine choice for applications that are already using them. For newer apps that haven't already committed to a logging API, `ILogger` may offer better functionality.
+<xref:System.Diagnostics.Trace?displayProperty=nameWithType> and <xref:System.Diagnostics.Debug?displayProperty=nameWithType> are .NET's oldest logging APIs. These classes have flexible configuration APIs and a large ecosystem of sinks, but only support unstructured logging. On .NET Framework they can be configured via an app.config file, but in .NET Core, there's no built-in, file-based configuration mechanism. They are typically used to produce diagnostics output for the developer while running under the debugger. The .NET team continues to support these APIs for backward-compatibility purposes, but no new functionality will be added. These APIs are a fine choice for applications that are already using them. For newer apps that haven't already committed to a logging API, `ILogger` may offer better functionality.
 
 ## Specialized logging APIs
 

--- a/docs/core/diagnostics/logging-tracing.md
+++ b/docs/core/diagnostics/logging-tracing.md
@@ -5,7 +5,10 @@ ms.date: 4/29/2022
 ---
 # .NET logging and tracing
 
-Code can be instrumented to produce a log, which serves as a record of interesting events that occurred while the program was running. To understand the application's behavior, logs can be reviewed. Logging and tracing both encapsulate this technique. .NET has accumulated several different logging APIs over its history and this article will help you understand what options are available.
+Code can be instrumented to produce a log, which serves as a record of interesting events that occurred while the program was running. To understand the application's behavior, logs can be reviewed. .NET has accumulated several different logging APIs over its history and this article will help you understand what options are available.
+
+> [!NOTE]
+> The term 'tracing' has different meanings and in this article we use to it as a synonym for logging. Historically many developers tended to use 'tracing' when referring to logging that was particularly verbose, used a binary format, or was done as part of performance analysis. More recently 'tracing' has also been adopted as shorthand for [Distributed Tracing](./distributed-tracing.md) - which collects high-level activity & timing data for request based systems, and correlates the requests across services to give a view of how each request is processed  by the complete system.
 
 The terms logging and tracing are commonly synonymous, the distinction we usually take is that logging output is expected to be collected all the time, and so should have a low overhead. Tracing is typically more invasive and collects more information from deeper parts of the application and .NET runtime, so is either used when diagnosing specific problems, or automatically for short periods of time as part of deeper performance analysis systems.
 
@@ -44,7 +47,7 @@ For most cases, whether adding logging to an existing project or creating a new 
 
 ### Trace
 
-<xref:System.Diagnostics.Trace?displayProperty=nameWithType> and <xref:System.Diagnostics.Debug?displayProperty=nameWithType> are .NET's oldest logging APIs. These classes have flexible configuration APIs and a large ecosystem of sinks, but only support unstructured logging. On .NET Framework they can be configured via an app.config file, but in .NET Core, there's no built-in, file-based configuration mechanism. They are typically used to produce diagnostics output for the developer while running under the debugger. The .NET team continues to support these APIs for backward-compatibility purposes, but no new functionality will be added. These APIs are a fine choice for applications that are already using them. For newer apps that haven't already committed to a logging API, `ILogger` may offer better functionality.
+<xref:System.Diagnostics.Trace?displayProperty=nameWithType> and <xref:System.Diagnostics.Debug?displayProperty=nameWithType> are .NET's oldest logging APIs. These classes have flexible configuration APIs and a large ecosystem of sinks, but only support unstructured logging. On .NET Framework they can be configured via an app.config file, but in .NET Core, there's no built-in, file-based configuration mechanism. A common use-case is producing diagnostics output for the developer while running under the debugger. The .NET team continues to support these APIs for backward-compatibility purposes, but no new functionality will be added. These APIs are a fine choice for applications that are already using them. For newer apps that haven't already committed to a logging API, `ILogger` may offer better functionality.
 
 ## Specialized logging APIs
 

--- a/docs/core/diagnostics/performance-tracing.md
+++ b/docs/core/diagnostics/performance-tracing.md
@@ -1,0 +1,46 @@
+---
+title: Performance Tracing
+description: A guide to tracing in .NET
+ms.date: 05/19/2023
+---
+# Performance Tracing Overview
+
+Performance tracing is the ability to collect detailed diagnostic information about what is happening inside .NET processes, and includes telemetry information for the Runtime, GC, Libraries and application code.
+
+There are a number of aspects to performance tracing for .NET, including:
+
+## How events are sourced
+
+There are two main mechanisms within .NET for providing events for use with performance tracing:
+
+| Name | Description |
+| --- | --- |
+| [EventSource](./eventsource.md) | <xref:System.Diagnostics.Tracing.EventSource?displayProperty=nameWithType> is a fast structured logging solution built into the .NET runtime. On .NET Framework EventSource can send events to [Event Tracing for Windows (ETW)](/windows/win32/etw/event-tracing-portal) and <xref:System.Diagnostics.Tracing.EventListener?displayProperty=nameWithType>. On .NET Core EventSource additionally supports [EventPipe](./eventpipe.md), a cross-platform tracing option. Most often developers use EventSource logs for performance analysis, but EventSource can be used for any diagnostic tasks where logs are useful. The .NET runtime is already instrumented with [built-in events](./well-known-event-providers.md) and you can log your own custom events. |
+| [DiagnosticSource](./diagnosticsource-diagnosticlistener.md) | <xref:System.Diagnostics.DiagnosticSource?displayProperty=nameWithType> is a module that allows code to be instrumented for production-time logging of rich data payloads for consumption within the process that was instrumented. At run time, consumers can dynamically discover data sources and subscribe to the ones of interest. <xref:System.Diagnostics.DiagnosticSource?displayProperty=nameWithType> was designed to allow in-process tools to access rich data. DiagnosticSource data can also be egressed via EventPipe enabling rich diagnostic data to be collected by dedicated tools. |
+
+## How Events are collected
+
+Events can be collected:
+
+| Mechanism | Description |
+| --- | --- |
+| In-Process | `EventSource` and `DiagnosticSource` can both be listened to in-process and used by tools such as [Open Telemetry](https://opentelemetry.io/docs/instrumentation/net/) to collect detailed events about features like ASP.NET or HttpClient and then produce metrics based on those events. For example Open Telemetry uses DiagnosticSource to create an [Instumentation Library for ASP.NET](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Instrumentation.AspNetCore/README.md). |
+| Out-of-process | .NET supports rich collection of tracing data via [EventPipe](./eventpipe.md), which can be used by external tools to collect performance tracing data, then can the be analyzed by different tools. |
+
+## Collection tools
+
+The primary collection tools for performance data for .NET are:
+
+| Tool | OS | Description |
+| --- | --- | --- |
+| [dotnet-trace](./dotnet-trace.md) | All | `dotnet-trace` is a command line tool that will collect traces in the .nettrace format. It can also convert traces to the Chromium or Speedscope formats for viewing. |
+| [dotnet-monitor](./dotnet-monitor.md) | All | `dotnet-monitor` is an agent that can be instructed to collect a trace for .NET processes, either by making Web API calls, or by configuring trigger-based rules for CPU or Memory usage thresholds. |
+| [Visual Studio](https://learn.microsoft.com/visualstudio/profiling/events-viewer?view=vs-2022) | Windows | Microsoft Visual Studio supports collecting traces for .NET processes as part of the *Performance Profiler* feature. In addition to being able to collect traces, it also can open `.nettrace` traces collected with the other tools in this table. |
+| [PerfView](https://github.com/Microsoft/perfview) | Windows | PerfView is a tool for collecting and examining perfomance traces on Windows |
+| [PerfCollect](./trace-perfcollect-lttng.md) | Linux | Perfcollect is a collection of scripts that works with the Linux `LTTng` and `perf` tools to collect detailed performance traces for .NET Processes. The resulting traces can be analyzed with a variety of tools include PerfView. |
+| [Windows Performance Analyzer](https://learn.microsoft.com/windows-hardware/test/wpt/wpt-getting-started-portal) | Windows | WPA includes a performance recorder and viewer based on the Windows `ETW` event recorder system. It can record a trace of the complete system, including all processes and how they interact with the OS functionality for Networking, Disk IO etc. |
+
+## See Also
+
+[Debug high CPU usage](./debug-highcpu.md)
+[Collect a performance trace in Linux with PerfCollect](./trace-perfcollect-lttng.md)

--- a/docs/core/diagnostics/performance-tracing.md
+++ b/docs/core/diagnostics/performance-tracing.md
@@ -1,9 +1,10 @@
 ---
-title: Performance Tracing
+title: Performance tracing
 description: A guide to tracing in .NET
 ms.date: 05/19/2023
 ---
-# Performance Tracing Overview
+
+# Performance tracing overview
 
 Performance tracing is the ability to collect detailed diagnostic information about what is happening inside .NET processes, and includes telemetry information for the Runtime, GC, Libraries and application code.
 
@@ -18,7 +19,7 @@ There are two main mechanisms within .NET for providing events for use with perf
 | [EventSource](./eventsource.md) | <xref:System.Diagnostics.Tracing.EventSource?displayProperty=nameWithType> is a fast structured logging solution built into the .NET runtime. On .NET Framework EventSource can send events to [Event Tracing for Windows (ETW)](/windows/win32/etw/event-tracing-portal) and <xref:System.Diagnostics.Tracing.EventListener?displayProperty=nameWithType>. On .NET Core EventSource additionally supports [EventPipe](./eventpipe.md), a cross-platform tracing option. Most often developers use EventSource logs for performance analysis, but EventSource can be used for any diagnostic tasks where logs are useful. The .NET runtime is already instrumented with [built-in events](./well-known-event-providers.md) and you can log your own custom events. |
 | [DiagnosticSource](./diagnosticsource-diagnosticlistener.md) | <xref:System.Diagnostics.DiagnosticSource?displayProperty=nameWithType> is a module that allows code to be instrumented for production-time logging of rich data payloads for consumption within the process that was instrumented. At run time, consumers can dynamically discover data sources and subscribe to the ones of interest. <xref:System.Diagnostics.DiagnosticSource?displayProperty=nameWithType> was designed to allow in-process tools to access rich data. DiagnosticSource data can also be egressed via EventPipe enabling rich diagnostic data to be collected by dedicated tools. |
 
-## How Events are collected
+## How events are collected
 
 Events can be collected:
 
@@ -40,7 +41,7 @@ The primary collection tools for performance data for .NET are:
 | [PerfCollect](./trace-perfcollect-lttng.md) | Linux | Perfcollect is a collection of scripts that works with the Linux `LTTng` and `perf` tools to collect detailed performance traces for .NET Processes. The resulting traces can be analyzed with a variety of tools include PerfView. |
 | [Windows Performance Analyzer](https://learn.microsoft.com/windows-hardware/test/wpt/wpt-getting-started-portal) | Windows | WPA includes a performance recorder and viewer based on the Windows `ETW` event recorder system. It can record a trace of the complete system, including all processes and how they interact with the OS functionality for Networking, Disk IO etc. |
 
-## See Also
+## See also
 
 [Debug high CPU usage](./debug-highcpu.md)
 [Collect a performance trace in Linux with PerfCollect](./trace-perfcollect-lttng.md)

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -640,6 +640,10 @@ items:
     items:
     - name: Overview
       href: ../core/diagnostics/index.md
+    - name: Logging and tracing
+      href: ../core/diagnostics/logging-tracing.md
+    - name: ILogger logging
+      href: ../core/extensions/logging.md  
     - name: Managed debuggers
       href: ../core/diagnostics/managed-debuggers.md
     - name: Diagnostic port
@@ -653,11 +657,11 @@ items:
         href: ../core/diagnostics/debug-linux-dumps.md
       - name: SOS debugger extension
         href: ../core/diagnostics/sos-debugging-extension.md
-    - name: Logging and tracing
+    - name: Performance tracing
       items:
       - name: Overview
-        displayName: logging tracing
-        href: ../core/diagnostics/logging-tracing.md
+        displayName: Performance tracing Overview
+        href: ../core/diagnostics/performance-tracing.md
       - name: Well-known event providers
         href: ../core/diagnostics/well-known-event-providers.md
       - name: Event Source

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -660,7 +660,7 @@ items:
     - name: Performance tracing
       items:
       - name: Overview
-        displayName: Performance tracing Overview
+        displayName: Performance tracing overview
         href: ../core/diagnostics/performance-tracing.md
       - name: Well-known event providers
         href: ../core/diagnostics/well-known-event-providers.md


### PR DESCRIPTION
… adding an overview for tracing that points to all the other topics

## Summary

Moves the logging topic out of tracing, and renames logging and tracing to performance tracing.
Adds a new overview for performance tracing pointing at the APIs and tools that can be used.

Fixes #2911


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/logging-tracing.md](https://github.com/dotnet/docs/blob/e2b0c72c7fa3c151970c718c9cef0d550fc19928/docs/core/diagnostics/logging-tracing.md) | [.NET logging and tracing](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/logging-tracing?branch=pr-en-us-35444) |
| [docs/core/diagnostics/performance-tracing.md](https://github.com/dotnet/docs/blob/e2b0c72c7fa3c151970c718c9cef0d550fc19928/docs/core/diagnostics/performance-tracing.md) | [docs/core/diagnostics/performance-tracing](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/performance-tracing?branch=pr-en-us-35444) |


<!-- PREVIEW-TABLE-END -->