### PR TITLE
Improve doc for CA1861 to avoid breaking change

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1861.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1861.md
@@ -26,60 +26,32 @@ dev_langs:
 
 ## Cause
 
-A constant array, of literal values, passed to a method via regular invocation or extension method invocation.
+A constant array of literal values, passed to a method via regular invocation or extension method invocation.
 
 ## Rule description
 
-Constant arrays passed as arguments aren't reused, which implies a performance overhead. Consider extracting them to `static readonly` fields to improve performance.
+Constant arrays passed as arguments are not reused when called repeatedly, which implies a new array is created each time. Consider extracting them to `static readonly` fields to improve performance if the passed array is not mutated within the called method.
+
+  > [!NOTE]
+  >  In case the called method mutates the passed array or if you are not sure if the method would mutate the array do not apply the suggestion as it could be a breaking change, better to suppress the warning instead.
 
 ## How to fix violations
 
-Extract constant arrays as `static readonly` arrays.
+Extract constant arrays to `static readonly` fields if the passed array is not mutated within the called method.  
 
-## When to suppress warnings
-
-Suppress a violation of this rule if you're not concerned about the performance impact of using constant arrays.
-
-## Suppress a warning
-
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
-
-```csharp
-#pragma warning disable CA1861
-// The code that's violating the rule is on this line.
-#pragma warning restore CA1861
-```
-
-To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
-
-```ini
-[*.{cs,vb}]
-dotnet_diagnostic.CA1861.severity = none
-```
-
-For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
-
-## Example
-
-The following examples show violations of the rule:
+The following example show violations of the rule:
 
 ```csharp
 // A method argument
 string message = string.Join(" ", new[] { "Hello", "world!" });
-// An extension method argument, as with LINQ
-bool firstResponse = new[] { false, true, false, false }.First();
 ```
 
 ```vb
 ' A method argument
 Dim message As String = String.Join(" ", {"Hello", "world!"})
-' An extension method argument, as with LINQ
-Dim firstResponse As Bool = { false, true, false, false }.First()
 ```
 
-### Fix by extracting with a `static readonly` modifier
-
-The following examples show how to fix a violation of this rule by extracting an argument as a `static readonly` field.
+The following example show how the violation of this rule fixed by extracting the argument to a `static readonly` field.
 
 ```csharp
 private static readonly string[] array = new[] { "Hello" , "world!" };
@@ -99,6 +71,30 @@ End Function
 ```
 
 Now, the value of the array is resolved at compile time rather than at run time, making code more performant.
+
+
+## When to suppress warnings
+
+Suppress a violation of this rule if the invocation only runs once, or if the array could be mutated within the invoked method or if the you're not concerned about the performance impact of creating constant arrays for each invocation.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1861
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1861
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.CA1861.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1861.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1861.md
@@ -26,20 +26,20 @@ dev_langs:
 
 ## Cause
 
-A constant array of literal values, passed to a method via regular invocation or extension method invocation.
+A constant array of literal values is passed to a method via regular invocation or extension method invocation.
 
 ## Rule description
 
-Constant arrays passed as arguments are not reused when called repeatedly, which implies a new array is created each time. Consider extracting them to `static readonly` fields to improve performance if the passed array is not mutated within the called method.
+Constant arrays passed as arguments are not reused when called repeatedly, which implies a new array is created each time. If the passed array is not mutated within the called method, consider extracting it to a `static readonly` field to improve performance.
 
   > [!NOTE]
-  > In case the called method mutates the passed array or if you are not sure if the method would mutate the array do not apply the suggestion as it could be a breaking change, better to suppress the warning instead.
+  > If the called method mutates the passed array or if you're not sure if the method would mutate the array, don't extract the array to a `static readonly` field. Doing so could be a breaking change. In this case, it's better to suppress the warning instead.
 
 ## How to fix violations
 
 Extract constant arrays to `static readonly` fields if the passed array is not mutated within the called method.  
 
-The following example show violations of the rule:
+The following example shows a violation of the rule:
 
 ```csharp
 // A method argument
@@ -51,7 +51,7 @@ string message = string.Join(" ", new[] { "Hello", "world!" });
 Dim message As String = String.Join(" ", {"Hello", "world!"})
 ```
 
-The following example show how the violation of this rule fixed by extracting the argument to a `static readonly` field.
+The following example show how the violation of this rule is fixed by extracting the argument to a `static readonly` field.
 
 ```csharp
 private static readonly string[] array = new[] { "Hello" , "world!" };
@@ -74,7 +74,11 @@ Now, the value of the array is resolved at compile time rather than at run time,
 
 ## When to suppress warnings
 
-Suppress a violation of this rule if the invocation only runs once, or if the array could be mutated within the invoked method or if the you're not concerned about the performance impact of creating constant arrays for each invocation.
+Suppress a violation of this rule if:
+
+- The invocation only runs once.
+- The array could be mutated within the invoked method, or you aren't sure if it would mutated.
+- You're not concerned about the performance impact of creating a constant array for each invocation.
 
 ## Suppress a warning
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1861.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1861.md
@@ -33,7 +33,7 @@ A constant array of literal values, passed to a method via regular invocation or
 Constant arrays passed as arguments are not reused when called repeatedly, which implies a new array is created each time. Consider extracting them to `static readonly` fields to improve performance if the passed array is not mutated within the called method.
 
   > [!NOTE]
-  >  In case the called method mutates the passed array or if you are not sure if the method would mutate the array do not apply the suggestion as it could be a breaking change, better to suppress the warning instead.
+  > In case the called method mutates the passed array or if you are not sure if the method would mutate the array do not apply the suggestion as it could be a breaking change, better to suppress the warning instead.
 
 ## How to fix violations
 
@@ -71,7 +71,6 @@ End Function
 ```
 
 Now, the value of the array is resolved at compile time rather than at run time, making code more performant.
-
 
 ## When to suppress warnings
 


### PR DESCRIPTION
## Summary

CA1861 Avoid constant arrays as arguments analyzer does not check if the array is mutated within the called method. As per https://github.com/dotnet/runtime/pull/86229#issuecomment-1548844377 applying the fix for method arguments that mutates the passed array is a breaking change. We need to document that aspect well to avoid developers making unwanted changes

Related to https://github.com/dotnet/runtime/pull/86229#issuecomment-1552360091

Fixes https://github.com/dotnet/runtime/issues/86414

CC @jkotas @stephentoub 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1861.md](https://github.com/dotnet/docs/blob/d58c54de14c87f25a0acacaef6bf132c563b7f54/docs/fundamentals/code-analysis/quality-rules/ca1861.md) | [CA1861: Avoid constant arrays as arguments](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1861?branch=pr-en-us-35455) |


<!-- PREVIEW-TABLE-END -->