### PR TITLE
Update option-setting scope wording

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1000.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1000.md
@@ -85,7 +85,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules that it applies to, or for all rules in this category ([Design](design-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1001.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1001.md
@@ -70,7 +70,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-These options can be configured for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+These options can be configured for just this rule, for all rules it applies to, or for all rules in this category ([Design](design-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1002.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1002.md
@@ -74,7 +74,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Design](design-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1003.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1003.md
@@ -50,7 +50,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Design](design-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1005.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1005.md
@@ -64,7 +64,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Design](design-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1008.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1008.md
@@ -70,7 +70,7 @@ Use the following option to configure which parts of your codebase to run this r
 - [Include specific API surfaces](#include-specific-api-surfaces)
 - [Additional zero-value field names](#additional-zero-value-field-names)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category (Design) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1010.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1010.md
@@ -75,7 +75,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 - [Additional required generic interfaces](#additional-required-generic-interfaces)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Design](design-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1012.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1012.md
@@ -66,7 +66,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Design](design-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1021.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1021.md
@@ -74,7 +74,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Design](design-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1024.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1024.md
@@ -79,7 +79,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Design](design-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1027.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1027.md
@@ -66,7 +66,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Design](design-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1028.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1028.md
@@ -67,7 +67,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Design](design-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1030.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1030.md
@@ -71,6 +71,6 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Design](design-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]

--- a/docs/fundamentals/code-analysis/quality-rules/ca1031.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1031.md
@@ -51,7 +51,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Disallowed exception type names](#disallowed-exception-type-names)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Design](design-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 ### Disallowed exception type names
 
@@ -75,7 +75,7 @@ Examples:
 |`dotnet_code_quality.CA1031.disallowed_symbol_names = T:NS.ExceptionType` | Matches specific types named 'ExceptionType' with given fully qualified name. |
 |`dotnet_code_quality.CA1031.disallowed_symbol_names = T:NS1.ExceptionType1|T:NS1.ExceptionType2` | Matches types named 'ExceptionType1' and 'ExceptionType2' with respective fully qualified names. |
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Design](design-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 ## Example
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1036.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1036.md
@@ -78,7 +78,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Design](design-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1040.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1040.md
@@ -69,7 +69,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Design](design-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1041.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1041.md
@@ -48,7 +48,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Design](design-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1043.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1043.md
@@ -67,7 +67,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Design](design-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1044.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1044.md
@@ -48,7 +48,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Design](design-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1045.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1045.md
@@ -73,7 +73,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Design](design-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1046.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1046.md
@@ -62,7 +62,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category (Design) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1047.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1047.md
@@ -48,7 +48,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Design](design-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1051.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1051.md
@@ -74,7 +74,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 - [Exclude structs](#exclude-structs)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Design](design-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1052.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1052.md
@@ -75,7 +75,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Design](design-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1054.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1054.md
@@ -69,7 +69,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Design](design-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1055.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1055.md
@@ -69,7 +69,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Design](design-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1056.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1056.md
@@ -69,7 +69,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Design](design-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1058.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1058.md
@@ -103,6 +103,6 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Design](design-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]

--- a/docs/fundamentals/code-analysis/quality-rules/ca1062.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1062.md
@@ -74,7 +74,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude extension method 'this' parameter](#exclude-extension-method-this-parameter)
 - [Null check validation methods](#null-check-validation-methods)
 
-These options can be configured for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+These options can be configured for just this rule, for all rules it applies to, or for all rules in this category ([Design](design-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1063.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1063.md
@@ -86,7 +86,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Design](design-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1068.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1068.md
@@ -89,7 +89,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Design](design-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1070.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1070.md
@@ -71,7 +71,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Design](design-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Design](design-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1303.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1303.md
@@ -86,7 +86,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 - [Use naming heuristic](#use-naming-heuristic)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Globalization](globalization-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Globalization](globalization-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1304.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1304.md
@@ -80,7 +80,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Globalization](globalization-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Globalization](globalization-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1305.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1305.md
@@ -82,7 +82,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Globalization](globalization-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Globalization](globalization-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1501.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1501.md
@@ -101,7 +101,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Inheritance excluded type or namespace names](#inheritance-excluded-type-or-namespace-names)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Maintainability](maintainability-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Maintainability](maintainability-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 ### Inheritance excluded type or namespace names
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1508.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1508.md
@@ -89,7 +89,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Maintainability](maintainability-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Maintainability](maintainability-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1700.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1700.md
@@ -72,7 +72,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Naming](naming-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Naming](naming-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1707.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1707.md
@@ -66,7 +66,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Naming](naming-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Naming](naming-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1708.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1708.md
@@ -45,7 +45,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Naming](naming-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Naming](naming-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1710.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1710.md
@@ -112,7 +112,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude indirect base types](#exclude-indirect-base-types)
 - [Additional required suffixes](#additional-required-suffixes)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Naming](naming-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Naming](naming-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1711.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1711.md
@@ -90,7 +90,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 - [Allow suffixes](#allow-suffixes)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Naming](naming-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Naming](naming-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1712.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1712.md
@@ -78,7 +78,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Enum values prefix trigger](#enum-values-prefix-trigger)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Naming](naming-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Naming](naming-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 ### Enum values prefix trigger
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1714.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1714.md
@@ -66,7 +66,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Naming](naming-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Naming](naming-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1715.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1715.md
@@ -51,7 +51,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 - [Single-character type parameters](#single-character-type-parameters)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Naming](naming-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Naming](naming-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1716.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1716.md
@@ -73,7 +73,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 - [Analyzed symbol kinds](#analyzed-symbol-kinds)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Naming](naming-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Naming](naming-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1717.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1717.md
@@ -68,7 +68,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Naming](naming-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Naming](naming-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1720.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1720.md
@@ -120,7 +120,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Naming](naming-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Naming](naming-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1721.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1721.md
@@ -70,7 +70,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Naming](naming-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Naming](naming-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1725.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1725.md
@@ -64,6 +64,6 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Naming](naming-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Naming](naming-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]

--- a/docs/fundamentals/code-analysis/quality-rules/ca1801.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1801.md
@@ -92,7 +92,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Performance). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category (Performance) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1802.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1802.md
@@ -75,7 +75,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 - [Required modifiers](#required-modifiers)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Performance](performance-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Performance](performance-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1815.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1815.md
@@ -64,7 +64,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Performance](performance-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Performance](performance-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1819.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1819.md
@@ -71,7 +71,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Performance](performance-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Performance](performance-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1822.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1822.md
@@ -62,7 +62,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Performance](performance-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Performance](performance-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2000.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2000.md
@@ -100,7 +100,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Reliability](reliability-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Reliability](reliability-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2007.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2007.md
@@ -92,7 +92,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude async void methods](#exclude-async-void-methods)
 - [Output kind](#output-kind)
 
-You can configure all of these options for just this rule, for all rules, or for all rules in this category ([Reliability](reliability-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure all of these options for just this rule, for all rules it applies to, or for all rules in this category ([Reliability](reliability-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 ### Exclude async void methods
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2100.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2100.md
@@ -99,7 +99,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2208.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2208.md
@@ -91,7 +91,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category (Design). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category (Design) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2217.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2217.md
@@ -48,7 +48,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Usage](usage-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Usage](usage-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2225.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2225.md
@@ -116,7 +116,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Usage](usage-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Usage](usage-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2226.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2226.md
@@ -47,7 +47,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Usage](usage-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Usage](usage-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2231.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2231.md
@@ -84,7 +84,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Usage](usage-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Usage](usage-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2234.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2234.md
@@ -67,7 +67,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Include specific API surfaces](#include-specific-api-surfaces)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Usage](usage-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Usage](usage-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[api-surface](../includes/api-surface.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2301.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2301.md
@@ -51,7 +51,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2302.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2302.md
@@ -53,7 +53,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2311.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2311.md
@@ -51,7 +51,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2312.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2312.md
@@ -55,7 +55,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2321.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2321.md
@@ -68,7 +68,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2322.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2322.md
@@ -69,7 +69,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2327.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2327.md
@@ -78,7 +78,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2328.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2328.md
@@ -84,7 +84,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2329.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2329.md
@@ -71,7 +71,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2330.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2330.md
@@ -77,7 +77,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3001.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3001.md
@@ -70,7 +70,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3002.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3002.md
@@ -77,7 +77,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3003.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3003.md
@@ -59,7 +59,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3004.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3004.md
@@ -70,7 +70,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3005.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3005.md
@@ -76,7 +76,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3006.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3006.md
@@ -71,7 +71,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3007.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3007.md
@@ -76,7 +76,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3008.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3008.md
@@ -74,7 +74,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3009.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3009.md
@@ -55,7 +55,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3010.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3010.md
@@ -51,7 +51,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3011.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3011.md
@@ -51,7 +51,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca3012.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3012.md
@@ -75,7 +75,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5361.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5361.md
@@ -67,7 +67,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5376.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5376.md
@@ -43,7 +43,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5377.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5377.md
@@ -62,7 +62,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5378.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5378.md
@@ -67,7 +67,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5380.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5380.md
@@ -44,7 +44,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5381.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5381.md
@@ -44,7 +44,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5382.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5382.md
@@ -80,7 +80,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5383.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5383.md
@@ -80,7 +80,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5384.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5384.md
@@ -65,7 +65,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5387.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5387.md
@@ -63,7 +63,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5388.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5388.md
@@ -66,7 +66,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5389.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5389.md
@@ -70,7 +70,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5390.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5390.md
@@ -47,7 +47,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5393.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5393.md
@@ -72,7 +72,7 @@ Use the following option to configure which parts of your codebase to run this r
 
 - [Unsafe DllImportSearchPath bits](#unsafe-dllimportsearchpath-bits)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 ### Unsafe DllImportSearchPath bits
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5399.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5399.md
@@ -42,7 +42,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure these options for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5400.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5400.md
@@ -61,7 +61,7 @@ Use the following options to configure which parts of your codebase to run this 
 - [Exclude specific symbols](#exclude-specific-symbols)
 - [Exclude specific types and their derived types](#exclude-specific-types-and-their-derived-types)
 
-You can configure this option for just this rule, for all rules, or for all rules in this category ([Security](security-warnings.md)). For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+You can configure this option for just this rule, for all rules it applies to, or for all rules in this category ([Security](security-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 
 [!INCLUDE[excluded-symbol-names](../includes/excluded-symbol-names.md)]
 


### PR DESCRIPTION
Find/replace change across all files.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

<details><summary><strong>Toggle expand/collapse</strong></summary><br/>

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1000.md](https://github.com/dotnet/docs/blob/cbdb02974802e6535b6a2e24bdd59283606db2c1/docs/fundamentals/code-analysis/quality-rules/ca1000.md) | [CA1000: Do not declare static members on generic types](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1000?branch=pr-en-us-35460) |
| [docs/fundamentals/code-analysis/quality-rules/ca1001.md](https://github.com/dotnet/docs/blob/cbdb02974802e6535b6a2e24bdd59283606db2c1/docs/fundamentals/code-analysis/quality-rules/ca1001.md) | ["CA1001: Types that own disposable fields should be disposable (code analysis)"](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1001?branch=pr-en-us-35460) |
| [docs/fundamentals/code-analysis/quality-rules/ca1002.md](https://github.com/dotnet/docs/blob/cbdb02974802e6535b6a2e24bdd59283606db2c1/docs/fundamentals/code-analysis/quality-rules/ca1002.md) | [CA1002: Do not expose generic lists](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1002?branch=pr-en-us-35460) |
| [docs/fundamentals/code-analysis/quality-rules/ca1003.md](https://github.com/dotnet/docs/blob/cbdb02974802e6535b6a2e24bdd59283606db2c1/docs/fundamentals/code-analysis/quality-rules/ca1003.md) | [CA1003: Use generic event handler instances](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1003?branch=pr-en-us-35460) |
| [docs/fundamentals/code-analysis/quality-rules/ca1005.md](https://github.com/dotnet/docs/blob/cbdb02974802e6535b6a2e24bdd59283606db2c1/docs/fundamentals/code-analysis/quality-rules/ca1005.md) | [docs/fundamentals/code-analysis/quality-rules/ca1005](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1005?branch=pr-en-us-35460) |
| [docs/fundamentals/code-analysis/quality-rules/ca1008.md](https://github.com/dotnet/docs/blob/cbdb02974802e6535b6a2e24bdd59283606db2c1/docs/fundamentals/code-analysis/quality-rules/ca1008.md) | [CA1008: Enums should have zero value](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1008?branch=pr-en-us-35460) |
| [docs/fundamentals/code-analysis/quality-rules/ca1010.md](https://github.com/dotnet/docs/blob/cbdb02974802e6535b6a2e24bdd59283606db2c1/docs/fundamentals/code-analysis/quality-rules/ca1010.md) | [CA1010: Collections should implement generic interface](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1010?branch=pr-en-us-35460) |
| [docs/fundamentals/code-analysis/quality-rules/ca1012.md](https://github.com/dotnet/docs/blob/cbdb02974802e6535b6a2e24bdd59283606db2c1/docs/fundamentals/code-analysis/quality-rules/ca1012.md) | ["CA1012: Abstract types should not have public constructors (code analysis)"](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1012?branch=pr-en-us-35460) |
| [docs/fundamentals/code-analysis/quality-rules/ca1021.md](https://github.com/dotnet/docs/blob/cbdb02974802e6535b6a2e24bdd59283606db2c1/docs/fundamentals/code-analysis/quality-rules/ca1021.md) | [CA1021: Avoid out parameters](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1021?branch=pr-en-us-35460) |
| [docs/fundamentals/code-analysis/quality-rules/ca1024.md](https://github.com/dotnet/docs/blob/cbdb02974802e6535b6a2e24bdd59283606db2c1/docs/fundamentals/code-analysis/quality-rules/ca1024.md) | [CA1024: Use properties where appropriate](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1024?branch=pr-en-us-35460) |
| [docs/fundamentals/code-analysis/quality-rules/ca1027.md](https://github.com/dotnet/docs/blob/cbdb02974802e6535b6a2e24bdd59283606db2c1/docs/fundamentals/code-analysis/quality-rules/ca1027.md) | [docs/fundamentals/code-analysis/quality-rules/ca1027](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1027?branch=pr-en-us-35460) |
| [docs/fundamentals/code-analysis/quality-rules/ca1028.md](https://github.com/dotnet/docs/blob/cbdb02974802e6535b6a2e24bdd59283606db2c1/docs/fundamentals/code-analysis/quality-rules/ca1028.md) | [CA1028: Enum storage should be Int32](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1028?branch=pr-en-us-35460) |
| [docs/fundamentals/code-analysis/quality-rules/ca1030.md](https://github.com/dotnet/docs/blob/cbdb02974802e6535b6a2e24bdd59283606db2c1/docs/fundamentals/code-analysis/quality-rules/ca1030.md) | ["CA1030: Use events where appropriate (code analysis)"](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1030?branch=pr-en-us-35460) |
| [docs/fundamentals/code-analysis/quality-rules/ca1031.md](https://github.com/dotnet/docs/blob/cbdb02974802e6535b6a2e24bdd59283606db2c1/docs/fundamentals/code-analysis/quality-rules/ca1031.md) | [CA1031: Do not catch general exception types](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1031?branch=pr-en-us-35460) |
| [docs/fundamentals/code-analysis/quality-rules/ca1036.md](https://github.com/dotnet/docs/blob/cbdb02974802e6535b6a2e24bdd59283606db2c1/docs/fundamentals/code-analysis/quality-rules/ca1036.md) | [docs/fundamentals/code-analysis/quality-rules/ca1036](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1036?branch=pr-en-us-35460) |
| [docs/fundamentals/code-analysis/quality-rules/ca1040.md](https://github.com/dotnet/docs/blob/cbdb02974802e6535b6a2e24bdd59283606db2c1/docs/fundamentals/code-analysis/quality-rules/ca1040.md) | [CA1040: Avoid empty interfaces](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1040?branch=pr-en-us-35460) |
| [docs/fundamentals/code-analysis/quality-rules/ca1041.md](https://github.com/dotnet/docs/blob/cbdb02974802e6535b6a2e24bdd59283606db2c1/docs/fundamentals/code-analysis/quality-rules/ca1041.md) | [CA1041: Provide ObsoleteAttribute message](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1041?branch=pr-en-us-35460) |
| [docs/fundamentals/code-analysis/quality-rules/ca1043.md](https://github.com/dotnet/docs/blob/cbdb02974802e6535b6a2e24bdd59283606db2c1/docs/fundamentals/code-analysis/quality-rules/ca1043.md) | ["CA1043: Use integral or string argument for indexers (code analysis)"](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1043?branch=pr-en-us-35460) |
| [docs/fundamentals/code-analysis/quality-rules/ca1044.md](https://github.com/dotnet/docs/blob/cbdb02974802e6535b6a2e24bdd59283606db2c1/docs/fundamentals/code-analysis/quality-rules/ca1044.md) | [CA1044: Properties should not be write only](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1044?branch=pr-en-us-35460) |
| [docs/fundamentals/code-analysis/quality-rules/ca1045.md](https://github.com/dotnet/docs/blob/cbdb02974802e6535b6a2e24bdd59283606db2c1/docs/fundamentals/code-analysis/quality-rules/ca1045.md) | [docs/fundamentals/code-analysis/quality-rules/ca1045](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1045?branch=pr-en-us-35460) |
| [docs/fundamentals/code-analysis/quality-rules/ca1046.md](https://github.com/dotnet/docs/blob/cbdb02974802e6535b6a2e24bdd59283606db2c1/docs/fundamentals/code-analysis/quality-rules/ca1046.md) | [CA1046: Do not overload operator equals on reference types](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1046?branch=pr-en-us-35460) |
| [docs/fundamentals/code-analysis/quality-rules/ca1047.md](https://github.com/dotnet/docs/blob/cbdb02974802e6535b6a2e24bdd59283606db2c1/docs/fundamentals/code-analysis/quality-rules/ca1047.md) | ["CA1047: Do not declare protected members in sealed types (code analysis)"](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1047?branch=pr-en-us-35460) |
| [docs/fundamentals/code-analysis/quality-rules/ca1051.md](https://github.com/dotnet/docs/blob/cbdb02974802e6535b6a2e24bdd59283606db2c1/docs/fundamentals/code-analysis/quality-rules/ca1051.md) | [CA1051: Do not declare visible instance fields](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1051?branch=pr-en-us-35460) |
| [docs/fundamentals/code-analysis/quality-rules/ca1052.md](https://github.com/dotnet/docs/blob/cbdb02974802e6535b6a2e24bdd59283606db2c1/docs/fundamentals/code-analysis/quality-rules/ca1052.md) | [CA1052: Static holder types should be Static or NotInheritable](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1052?branch=pr-en-us-35460) |
| [docs/fundamentals/code-analysis/quality-rules/ca1054.md](https://github.com/dotnet/docs/blob/cbdb02974802e6535b6a2e24bdd59283606db2c1/docs/fundamentals/code-analysis/quality-rules/ca1054.md) | [docs/fundamentals/code-analysis/quality-rules/ca1054](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1054?branch=pr-en-us-35460) |
| [docs/fundamentals/code-analysis/quality-rules/ca1055.md](https://github.com/dotnet/docs/blob/cbdb02974802e6535b6a2e24bdd59283606db2c1/docs/fundamentals/code-analysis/quality-rules/ca1055.md) | [CA1055: URI return values should not be strings](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1055?branch=pr-en-us-35460) |
| [docs/fundamentals/code-analysis/quality-rules/ca1056.md](https://github.com/dotnet/docs/blob/cbdb02974802e6535b6a2e24bdd59283606db2c1/docs/fundamentals/code-analysis/quality-rules/ca1056.md) | ["CA1056: URI properties should not be strings (code analysis)"](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1056?branch=pr-en-us-35460) |
| [docs/fundamentals/code-analysis/quality-rules/ca1058.md](https://github.com/dotnet/docs/blob/cbdb02974802e6535b6a2e24bdd59283606db2c1/docs/fundamentals/code-analysis/quality-rules/ca1058.md) | [CA1058: Types should not extend certain base types](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1058?branch=pr-en-us-35460) |
| [docs/fundamentals/code-analysis/quality-rules/ca1062.md](https://github.com/dotnet/docs/blob/cbdb02974802e6535b6a2e24bdd59283606db2c1/docs/fundamentals/code-analysis/quality-rules/ca1062.md) | [docs/fundamentals/code-analysis/quality-rules/ca1062](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1062?branch=pr-en-us-35460) |
| [docs/fundamentals/code-analysis/quality-rules/ca1063.md](https://github.com/dotnet/docs/blob/cbdb02974802e6535b6a2e24bdd59283606db2c1/docs/fundamentals/code-analysis/quality-rules/ca1063.md) | [CA1063: Implement IDisposable correctly](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1063?branch=pr-en-us-35460) |

</details>

> **Note**
> This table shows preview links for the 30 files with the most changes. For preview links for other files in this PR, select <strong>OpenPublishing.Build Details</strong> within [checks](https://github.com/dotnet/docs/pull/35460/checks).

<!-- PREVIEW-TABLE-END -->