### PR TITLE
Update Ubuntu 2204 feed info

### DIFF
--- a/docs/core/install/includes/linux-ubuntu-feed-sdk-note.md
+++ b/docs/core/install/includes/linux-ubuntu-feed-sdk-note.md
@@ -7,4 +7,3 @@ ms.topic: include
 
 > [IMPORTANT]
 > .NET SDKs offered by Canonical remain on the .1xx major version band. If you want to use newer major release, you'll need to use the [Microsoft feed to install the SDK](../linux-ubuntu.md#register-the-microsoft-package-repository).
-

--- a/docs/core/install/includes/linux-ubuntu-feed-sdk-note.md
+++ b/docs/core/install/includes/linux-ubuntu-feed-sdk-note.md
@@ -5,5 +5,5 @@ ms.date: 05/24/2023
 ms.topic: include
 ---
 
-> [IMPORTANT]
+> [!IMPORTANT]
 > .NET SDKs offered by Canonical remain on the .1xx minor version band. If you want to use newer minor release, use the [Microsoft feed to install the SDK](../linux-ubuntu.md#register-the-microsoft-package-repository). Make sure you review the information in the [.NET package mix ups on Linux](../linux-package-mixup.md?pivots=os-linux-ubuntu#whats-going-on) article to understand the implications of switching between repository feeds.

--- a/docs/core/install/includes/linux-ubuntu-feed-sdk-note.md
+++ b/docs/core/install/includes/linux-ubuntu-feed-sdk-note.md
@@ -6,4 +6,4 @@ ms.topic: include
 ---
 
 > [!IMPORTANT]
-> .NET SDKs offered by Canonical remain on the [.1xx feature band](../versions/index#versioning-details). If you want to use a newer feature release, use the [Microsoft feed to install the SDK](../linux-ubuntu.md#register-the-microsoft-package-repository). Make sure you review the information in the [.NET package mix ups on Linux](../linux-package-mixup.md?pivots=os-linux-ubuntu#whats-going-on) article to understand the implications of switching between repository feeds.
+> .NET SDK versions offered by Canonical are always in the [.1xx feature band](../versions/index.md#versioning-details). If you want to use a newer feature band release, use the [Microsoft feed to install the SDK](../linux-ubuntu.md#register-the-microsoft-package-repository). Make sure you review the information in the [.NET package mix ups on Linux](../linux-package-mixup.md?pivots=os-linux-ubuntu#whats-going-on) article to understand the implications of switching between repository feeds.

--- a/docs/core/install/includes/linux-ubuntu-feed-sdk-note.md
+++ b/docs/core/install/includes/linux-ubuntu-feed-sdk-note.md
@@ -6,4 +6,4 @@ ms.topic: include
 ---
 
 > [!IMPORTANT]
-> .NET SDKs offered by Canonical remain on the .1xx minor version band. If you want to use a newer minor release, use the [Microsoft feed to install the SDK](../linux-ubuntu.md#register-the-microsoft-package-repository). Make sure you review the information in the [.NET package mix ups on Linux](../linux-package-mixup.md?pivots=os-linux-ubuntu#whats-going-on) article to understand the implications of switching between repository feeds.
+> .NET SDKs offered by Canonical remain on the [.1xx feature band](../versions/index#versioning-details). If you want to use a newer feature release, use the [Microsoft feed to install the SDK](../linux-ubuntu.md#register-the-microsoft-package-repository). Make sure you review the information in the [.NET package mix ups on Linux](../linux-package-mixup.md?pivots=os-linux-ubuntu#whats-going-on) article to understand the implications of switching between repository feeds.

--- a/docs/core/install/includes/linux-ubuntu-feed-sdk-note.md
+++ b/docs/core/install/includes/linux-ubuntu-feed-sdk-note.md
@@ -6,4 +6,4 @@ ms.topic: include
 ---
 
 > [!IMPORTANT]
-> .NET SDKs offered by Canonical remain on the .1xx minor version band. If you want to use newer minor release, use the [Microsoft feed to install the SDK](../linux-ubuntu.md#register-the-microsoft-package-repository). Make sure you review the information in the [.NET package mix ups on Linux](../linux-package-mixup.md?pivots=os-linux-ubuntu#whats-going-on) article to understand the implications of switching between repository feeds.
+> .NET SDKs offered by Canonical remain on the .1xx minor version band. If you want to use a newer minor release, use the [Microsoft feed to install the SDK](../linux-ubuntu.md#register-the-microsoft-package-repository). Make sure you review the information in the [.NET package mix ups on Linux](../linux-package-mixup.md?pivots=os-linux-ubuntu#whats-going-on) article to understand the implications of switching between repository feeds.

--- a/docs/core/install/includes/linux-ubuntu-feed-sdk-note.md
+++ b/docs/core/install/includes/linux-ubuntu-feed-sdk-note.md
@@ -6,4 +6,4 @@ ms.topic: include
 ---
 
 > [IMPORTANT]
-> .NET SDKs offered by Canonical remain on the .1xx major version band. If you want to use newer major release, you'll need to use the [Microsoft feed to install the SDK](../linux-ubuntu.md#register-the-microsoft-package-repository).
+> .NET SDKs offered by Canonical remain on the .1xx minor version band. If you want to use newer minor release, use the [Microsoft feed to install the SDK](../linux-ubuntu.md#register-the-microsoft-package-repository). Make sure you review the information in the [.NET package mix ups on Linux](../linux-package-mixup.md?pivots=os-linux-ubuntu#whats-going-on) article to understand the implications of switching between repository feeds.

--- a/docs/core/install/includes/linux-ubuntu-feed-sdk-note.md
+++ b/docs/core/install/includes/linux-ubuntu-feed-sdk-note.md
@@ -1,0 +1,10 @@
+---
+author: adegeo
+ms.author: adegeo
+ms.date: 05/24/2023
+ms.topic: include
+---
+
+> [IMPORTANT]
+> .NET SDKs offered by Canonical remain on the .1xx major version band. If you want to use newer major release, you'll need to use the [Microsoft feed to install the SDK](../linux-ubuntu.md#register-the-microsoft-package-repository).
+

--- a/docs/core/install/includes/linux-ubuntu-feed-sdk-note.md
+++ b/docs/core/install/includes/linux-ubuntu-feed-sdk-note.md
@@ -6,4 +6,4 @@ ms.topic: include
 ---
 
 > [!IMPORTANT]
-> .NET SDK versions offered by Canonical are always in the [.1xx feature band](../versions/index.md#versioning-details). If you want to use a newer feature band release, use the [Microsoft feed to install the SDK](../linux-ubuntu.md#register-the-microsoft-package-repository). Make sure you review the information in the [.NET package mix ups on Linux](../linux-package-mixup.md?pivots=os-linux-ubuntu#whats-going-on) article to understand the implications of switching between repository feeds.
+> .NET SDK versions offered by Canonical are always in the [.1xx feature band](../../versions/index.md#versioning-details). If you want to use a newer feature band release, use the [Microsoft feed to install the SDK](../linux-ubuntu.md#register-the-microsoft-package-repository). Make sure you review the information in the [.NET package mix ups on Linux](../linux-package-mixup.md?pivots=os-linux-ubuntu#whats-going-on) article to understand the implications of switching between repository feeds.

--- a/docs/core/install/linux-ubuntu-2204.md
+++ b/docs/core/install/linux-ubuntu-2204.md
@@ -3,7 +3,7 @@ title: Install .NET on Ubuntu 22.04
 description: Demonstrates the various ways to install .NET SDK and .NET Runtime on Ubuntu 22.04.
 author: adegeo
 ms.author: adegeo
-ms.date: 03/01/2023
+ms.date: 05/24/2023
 ---
 
 # Install .NET SDK or .NET Runtime on Ubuntu 22.04

--- a/docs/core/install/linux-ubuntu-2204.md
+++ b/docs/core/install/linux-ubuntu-2204.md
@@ -14,7 +14,7 @@ This article discusses how to install .NET on Ubuntu 22.04; .NET 6 and .NET 7 ar
 
 [!INCLUDE [linux-install-package-manager-x64-vs-arm](includes/linux-install-package-manager-x64-vs-arm.md)]
 
-.NET is available in the Ubuntu package manager feeds, as well as the Microsoft package repository. However, you should only one use or the other to install .NET. If you want to use the Microsoft package repository, see [How to register the Microsoft package repository](linux-ubuntu.md#register-the-microsoft-package-repository).
+.NET is available in the Ubuntu package manager feeds, as well as the Microsoft package repository. However, you should only use one or the other to install .NET. If you want to use the Microsoft package repository, see [How to register the Microsoft package repository](linux-ubuntu.md#register-the-microsoft-package-repository).
 
 ## Supported versions
 

--- a/docs/core/install/linux-ubuntu-2204.md
+++ b/docs/core/install/linux-ubuntu-2204.md
@@ -14,7 +14,7 @@ This article discusses how to install .NET on Ubuntu 22.04; .NET 6 and .NET 7 ar
 
 [!INCLUDE [linux-install-package-manager-x64-vs-arm](includes/linux-install-package-manager-x64-vs-arm.md)]
 
-.NET is available in the Ubuntu package manager feeds, as well as the Microsoft package repository. However, you should only use one or the other to install .NET. If you want to use the Microsoft package repository, see [How to register the Microsoft package repository](linux-ubuntu.md#register-the-microsoft-package-repository).
+.NET is available in the [Ubuntu packages feed](https://packages.ubuntu.com/), as well as the Microsoft package repository. However, you should only use one or the other to install .NET. If you want to use the Microsoft package repository, see [How to register the Microsoft package repository](linux-ubuntu.md#register-the-microsoft-package-repository).
 
 ## Supported versions
 

--- a/docs/core/install/linux-ubuntu-2204.md
+++ b/docs/core/install/linux-ubuntu-2204.md
@@ -22,26 +22,17 @@ The following versions of .NET are supported or available for Ubuntu 22.04:
 
 | Supported .NET versions | Available in Ubuntu feed | [Available in Microsoft feed](linux-ubuntu.md#register-the-microsoft-package-repository) |
 |-------------------------|--------------------------|-----------------------------------|
-| 7.0, 6.0                | 6.0                      | 7.0, 6.0, 3.1                     |
+| 7.0, 6.0                | 7.0, 6.0                 | 7.0, 6.0, 3.1                     |
+
+[!INCLUDE [linux-ubuntu-feed-sdk-note](includes/linux-ubuntu-feed-sdk-note.md)]
 
 When an [Ubuntu version](https://wiki.ubuntu.com/Releases) falls out of support, .NET is no longer supported with that version.
 
 [!INCLUDE [versions-not-supported](includes/versions-not-supported.md)]
 
-## Install .NET 7
+## Install .NET
 
-.NET 7 packages aren't available in the Ubuntu package manager feeds. You must use the Microsoft package repository.
-
-> [!WARNING]
-> If you've previously installed .NET 6 from the Ubuntu feed, you'll run into issues installing .NET 7 from the Microsoft package repository. .NET is installed to different locations and is resolved differently for both package feeds. It's recommended that you uninstall .NET 6 and then install with the Microsoft package repository.
->
-> For more information about how to clean your system and install .NET 7, see [I need a version of .NET that isn't provided by my Linux distribution](linux-package-mixup.md?pivots=os-linux-ubuntu#i-need-a-version-of-net-that-isnt-provided-by-my-linux-distribution).
-
-## Install .NET 6
-
-This section describes how to install .NET 6.
-
-[!INCLUDE [linux-apt-install-60](includes/linux-install-60-apt.md)]
+[!INCLUDE [linux-apt-install-70](includes/linux-install-70-apt.md)]
 
 ## How to install other versions
 

--- a/docs/core/install/linux-ubuntu-2210.md
+++ b/docs/core/install/linux-ubuntu-2210.md
@@ -27,6 +27,8 @@ The following versions of .NET are supported or available for Ubuntu 22.10:
 |-------------------------|--------------------------|-----------------------------------|
 | 7.0, 6.0                | 7.0, 6.0                 | 7.0, 6.0, 3.1                     |
 
+[!INCLUDE [linux-ubuntu-feed-sdk-note](includes/linux-ubuntu-feed-sdk-note.md)]
+
 When an [Ubuntu version](https://wiki.ubuntu.com/Releases) falls out of support, .NET is no longer supported with that version.
 
 [!INCLUDE [versions-not-supported](includes/versions-not-supported.md)]

--- a/docs/core/install/linux-ubuntu-2210.md
+++ b/docs/core/install/linux-ubuntu-2210.md
@@ -14,7 +14,7 @@ This article discusses how to install .NET on Ubuntu 22.10; .NET 6 and .NET 7 ar
 
 [!INCLUDE [linux-install-package-manager-x64-vs-arm](includes/linux-install-package-manager-x64-vs-arm.md)]
 
-.NET is available in the Ubuntu package manager feeds, as well as the Microsoft repository. However, you should only one use or the other to install .NET. Review the [Decide how to install .NET](linux-ubuntu.md#decide-how-to-install-net) section to determine which feed you should use.
+.NET is available in the Ubuntu package manager feeds, as well as the Microsoft package repository. However, you should only use one or the other to install .NET. If you want to use the Microsoft package repository, see [How to register the Microsoft package repository](linux-ubuntu.md#register-the-microsoft-package-repository).
 
 > [!WARNING]
 > Don't use both repositories to manage .NET. If you've previously installed .NET from the Ubuntu feed or the Microsoft feed, you'll run into issues using the other feed. .NET is installed to different locations and is resolved differently for both package feeds. It's recommended that you uninstall previously installed versions of .NET and then install with the Microsoft package repository. For more information, see [How to register the Microsoft package repository](linux-ubuntu.md#register-the-microsoft-package-repository).

--- a/docs/core/install/linux-ubuntu-2210.md
+++ b/docs/core/install/linux-ubuntu-2210.md
@@ -3,7 +3,7 @@ title: Install .NET on Ubuntu 22.10
 description: Demonstrates the various ways to install .NET SDK and .NET Runtime on Ubuntu 22.10.
 author: adegeo
 ms.author: adegeo
-ms.date: 03/01/2023
+ms.date: 05/24/2023
 ---
 
 # Install .NET SDK or .NET Runtime on Ubuntu 22.10

--- a/docs/core/install/linux-ubuntu-2304.md
+++ b/docs/core/install/linux-ubuntu-2304.md
@@ -3,7 +3,7 @@ title: Install .NET on Ubuntu 23.04
 description: Demonstrates the various ways to install .NET SDK and .NET Runtime on Ubuntu 23.04.
 author: adegeo
 ms.author: adegeo
-ms.date: 03/01/2023
+ms.date: 05/24/2023
 ---
 
 # Install .NET SDK or .NET Runtime on Ubuntu 23.04

--- a/docs/core/install/linux-ubuntu-2304.md
+++ b/docs/core/install/linux-ubuntu-2304.md
@@ -24,6 +24,8 @@ The following versions of .NET are supported or available for Ubuntu 23.04:
 |-------------------------|--------------------------|-----------------------------------|
 | 7.0, 6.0                | 7.0, 6.0                 | 7.0, 6.0                          |
 
+[!INCLUDE [linux-ubuntu-feed-sdk-note](includes/linux-ubuntu-feed-sdk-note.md)]
+
 When an [Ubuntu version](https://wiki.ubuntu.com/Releases) falls out of support, .NET is no longer supported with that version.
 
 [!INCLUDE [versions-not-supported](includes/versions-not-supported.md)]

--- a/docs/core/install/linux-ubuntu-2304.md
+++ b/docs/core/install/linux-ubuntu-2304.md
@@ -14,7 +14,7 @@ This article discusses how to install .NET on Ubuntu 23.04; .NET 6 and .NET 7 ar
 
 [!INCLUDE [linux-install-package-manager-x64-vs-arm](includes/linux-install-package-manager-x64-vs-arm.md)]
 
-.NET is available in the Ubuntu package manager feeds, as well as the Microsoft package repository. However, you should only one use or the other to install .NET. If you want to use the Microsoft package repository, see [How to register the Microsoft package repository](linux-ubuntu.md#register-the-microsoft-package-repository).
+.NET is available in the Ubuntu package manager feeds, as well as the Microsoft package repository. However, you should only use one or the other to install .NET. If you want to use the Microsoft package repository, see [How to register the Microsoft package repository](linux-ubuntu.md#register-the-microsoft-package-repository).
 
 ## Supported versions
 

--- a/docs/core/install/linux-ubuntu.md
+++ b/docs/core/install/linux-ubuntu.md
@@ -25,9 +25,7 @@ When your version of Ubuntu supports .NET through the built-in Ubuntu feed, supp
 
 Use the following sections to determine how you should install .NET:
 
-- [I'm using Ubuntu 22.10 or 23.04, and I only need .NET 6.0 or .NET 7.0](#im-using-ubuntu-2210-or-2304-and-i-only-need-net-60-or-net-70)
-- [I'm using Ubuntu 22.04, and I only need .NET 6.0](#im-using-ubuntu-2204-and-i-only-need-net-60)
-- [I'm using Ubuntu 22.04, and I need .NET 7.0](#im-using-ubuntu-2204-and-i-need-net-70)
+- [I'm using Ubuntu 22.04, 22.10, or 23.04, and I only need .NET 6.0 or .NET 7.0](#im-using-ubuntu-2204-2210-or-2304-and-i-only-need-net-60-or-net-70)
 - [I'm using a version of Ubuntu prior to 22.04](#im-using-a-version-of-ubuntu-prior-to-2204)
 - [I'm using other Microsoft packages, such as `powershell`, `mdatp`, or `mssql`](#im-using-other-microsoft-packages-such-as-powershell-mdatp-or-mssql)
 - [I want to create a .NET app](#i-want-to-create-a-net-app)
@@ -37,21 +35,17 @@ Use the following sections to determine how you should install .NET:
 - [I don't want to use APT](#i-dont-want-to-use-apt)
 - [I'm using an Arm-based CPU](#im-using-an-arm-based-cpu)
 
-### I'm using Ubuntu 22.10 or 23.04, and I only need .NET 6.0 or .NET 7.0
+### I'm using Ubuntu 22.04, 22.10, or 23.04, and I only need .NET 6.0 or .NET 7.0
 
-Install .NET through the Ubuntu feed. For more information, see [Install .NET on Ubuntu 22.10](linux-ubuntu-2210.md) or [Install .NET on Ubuntu 23.04](linux-ubuntu-2304.md).
+Install .NET through the Ubuntu feed. For more information, see the following pages:
 
-If you're going to use other Microsoft repository packages, such as `powershell`, `mdatp`, or `mssql`, you'll need to de-prioritize the .NET packages provided by the Microsoft repository. For instructions on how to de-prioritize the packages, see [My Linux distribution provides .NET packages, and I want to use them](linux-package-mixup.md?pivots=os-linux-ubuntu#my-linux-distribution-provides-net-packages-and-i-want-to-use-them).
+- [Install .NET on Ubuntu 22.04](linux-ubuntu-2204.md)
+- [Install .NET on Ubuntu 22.10](linux-ubuntu-2210.md)
+- [Install .NET on Ubuntu 23.04](linux-ubuntu-2304.md).
 
-### I'm using Ubuntu 22.04, and I only need .NET 6.0
+[!INCLUDE [linux-ubuntu-feed-sdk-note](includes/linux-ubuntu-feed-sdk-note.md)]
 
-Install .NET through the Ubuntu feed. For more information, see [Install .NET on Ubuntu 22.04](linux-ubuntu-2204.md).
-
-If you're going to use other Microsoft repository packages, such as `powershell`, `mdatp`, or `mssql`, you'll need to de-prioritize the .NET packages provided by the Microsoft repository. For instructions on how to de-prioritize the packages, see [My Linux distribution provides .NET packages, and I want to use them](linux-package-mixup.md?pivots=os-linux-ubuntu#my-linux-distribution-provides-net-packages-and-i-want-to-use-them).
-
-### I'm using Ubuntu 22.04, and I need .NET 7.0
-
-.NET 7 isn't provided in the default Ubuntu package feed. You'll need to add the Microsoft package repository and then install .NET. For more information, see the [Register and install with the Microsoft package repository](#register-the-microsoft-package-repository) section.
+If you're going to install the Microsoft repository to use other Microsoft packages, such as `powershell`, `mdatp`, or `mssql`, you'll need to de-prioritize the .NET packages provided by the Microsoft repository. For instructions on how to de-prioritize the packages, see [My Linux distribution provides .NET packages, and I want to use them](linux-package-mixup.md?pivots=os-linux-ubuntu#my-linux-distribution-provides-net-packages-and-i-want-to-use-them).
 
 ### I'm using a version of Ubuntu prior to 22.04
 

--- a/docs/core/install/linux-ubuntu.md
+++ b/docs/core/install/linux-ubuntu.md
@@ -3,7 +3,7 @@ title: .NET and Ubuntu overview
 description: Demonstrates the various ways to install .NET SDK and .NET Runtime on Ubuntu.
 author: adegeo
 ms.author: adegeo
-ms.date: 05/05/2023
+ms.date: 05/24/2023
 ---
 
 # Install the .NET SDK or the .NET Runtime on Ubuntu


### PR DESCRIPTION
Ubuntu 22.04's built in feed now includes .NET 6

- Removed the **I'm using Ubuntu 22.04, and I only need .NET 6.0** section
- Removed the **I'm using Ubuntu 22.04, and I only need .NET 7.0** section
- Added a note to Ubuntu pages that support the built in feed. Note states the limitation of the minor SDK version
- Merged the two .NET 6 and .NET 7 sections of 22.04

Fixes #35482

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/linux-ubuntu-2204.md](https://github.com/dotnet/docs/blob/24ad2b4e1bc8d90bc5ae97d846088772c1508365/docs/core/install/linux-ubuntu-2204.md) | [Install .NET SDK or .NET Runtime on Ubuntu 22.04](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu-2204?branch=pr-en-us-35481) |
| [docs/core/install/linux-ubuntu-2210.md](https://github.com/dotnet/docs/blob/24ad2b4e1bc8d90bc5ae97d846088772c1508365/docs/core/install/linux-ubuntu-2210.md) | [Install .NET on Ubuntu 22.10](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu-2210?branch=pr-en-us-35481) |
| [docs/core/install/linux-ubuntu-2304.md](https://github.com/dotnet/docs/blob/24ad2b4e1bc8d90bc5ae97d846088772c1508365/docs/core/install/linux-ubuntu-2304.md) | [Install .NET SDK or .NET Runtime on Ubuntu 23.04](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu-2304?branch=pr-en-us-35481) |
| [docs/core/install/linux-ubuntu.md](https://github.com/dotnet/docs/blob/24ad2b4e1bc8d90bc5ae97d846088772c1508365/docs/core/install/linux-ubuntu.md) | [Get Ubuntu version](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu?branch=pr-en-us-35481) |


<!-- PREVIEW-TABLE-END -->