### PR TITLE
Add limitation to Native AOT doc

### DIFF
--- a/docs/core/deploying/native-aot/index.md
+++ b/docs/core/deploying/native-aot/index.md
@@ -103,7 +103,7 @@ Native AOT applications come with a few fundamental limitations and compatibilit
 - Requires trimming, which has [limitations](../trimming/incompatibilities.md).
 - Implies compilation into a single file, which has known [incompatibilities](../single-file/overview.md#api-incompatibility).
 - Apps include required runtime libraries (just like [self-contained apps](../index.md#publish-self-contained), increasing their size as compared to framework-dependent apps).
-- <xref:System.Linq.Expressions> are interpreted, not compiled, and therefore are much slower than in CoreCLR
+- <xref:System.Linq.Expressions> always use interpreted form, that is much slower than run-time generated compiled code.
 
 The publish process analyzes the entire project and its dependencies and produces warnings whenever the limitations could potentially be hit by the published application at run time.
 

--- a/docs/core/deploying/native-aot/index.md
+++ b/docs/core/deploying/native-aot/index.md
@@ -103,6 +103,7 @@ Native AOT applications come with a few fundamental limitations and compatibilit
 - Requires trimming, which has [limitations](../trimming/incompatibilities.md).
 - Implies compilation into a single file, which has known [incompatibilities](../single-file/overview.md#api-incompatibility).
 - Apps include required runtime libraries (just like [self-contained apps](../index.md#publish-self-contained), increasing their size as compared to framework-dependent apps).
+- [System.Linq.Expressions](https://learn.microsoft.com/en-us/dotnet/api/system.linq.expressions?view=net-7.0) are interpreted, not compiled, and therefore are much slower than in CoreCLR
 
 The publish process analyzes the entire project and its dependencies and produces warnings whenever the limitations could potentially be hit by the published application at run time.
 

--- a/docs/core/deploying/native-aot/index.md
+++ b/docs/core/deploying/native-aot/index.md
@@ -103,7 +103,7 @@ Native AOT applications come with a few fundamental limitations and compatibilit
 - Requires trimming, which has [limitations](../trimming/incompatibilities.md).
 - Implies compilation into a single file, which has known [incompatibilities](../single-file/overview.md#api-incompatibility).
 - Apps include required runtime libraries (just like [self-contained apps](../index.md#publish-self-contained), increasing their size as compared to framework-dependent apps).
-- [System.Linq.Expressions](https://learn.microsoft.com/en-us/dotnet/api/system.linq.expressions?view=net-7.0) are interpreted, not compiled, and therefore are much slower than in CoreCLR
+- <xref:System.Linq.Expressions> are interpreted, not compiled, and therefore are much slower than in CoreCLR
 
 The publish process analyzes the entire project and its dependencies and produces warnings whenever the limitations could potentially be hit by the published application at run time.
 


### PR DESCRIPTION
Note that expression trees are interpreted, not compiled, and therefore are much slower.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/deploying/native-aot/index.md](https://github.com/dotnet/docs/blob/718502dba534ebeeaed083609019d5dec1caeb6d/docs/core/deploying/native-aot/index.md) | [Native AOT deployment](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/index?branch=pr-en-us-35483) |


<!-- PREVIEW-TABLE-END -->