### PR TITLE
Rename role and role binding

### DIFF
--- a/docs/orleans/deployment/kubernetes.md
+++ b/docs/orleans/deployment/kubernetes.md
@@ -117,7 +117,7 @@ For RBAC-enabled clusters, the Kubernetes service account for the pods may also 
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: pod-reader
+  name: orleans-clustering
 rules:
 - apiGroups: [ "" ]
   resources: ["pods"]
@@ -126,14 +126,14 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: pod-reader-binding
+  name: orleans-clustering-binding
 subjects:
 - kind: ServiceAccount
   name: default
   apiGroup: ''
 roleRef:
   kind: Role
-  name: pod-reader
+  name: orleans-clustering
   apiGroup: ''
 ```
 


### PR DESCRIPTION
## Summary

"pod-reader" does not reflect the role as it contains the "delete" verb



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/deployment/kubernetes.md](https://github.com/dotnet/docs/blob/8ed3f1ae3d29f1ffd8edee3906af01c4af44be50/docs/orleans/deployment/kubernetes.md) | [Kubernetes hosting](https://review.learn.microsoft.com/en-us/dotnet/orleans/deployment/kubernetes?branch=pr-en-us-35497) |

<!-- PREVIEW-TABLE-END -->