### PR TITLE
Links update - update to .NET dependency injection article

### DIFF
--- a/docs/core/extensions/dependency-injection.md
+++ b/docs/core/extensions/dependency-injection.md
@@ -104,7 +104,7 @@ The method `CreateHostBuilder` uses types `IHostBuilder` and `Host`. In order to
 
 It's not unusual to use dependency injection in a chained fashion. Each requested dependency in turn requests its own dependencies. The container resolves the dependencies in the graph and returns the fully resolved service. The collective set of dependencies that must be resolved is typically referred to as a *dependency tree*, *dependency graph*, or *object graph*.
 
-The container resolves `ILogger<TCategoryName>` by taking advantage of [(generic) open types](/dotnet/csharp/language-reference/language-specification/types#open-and-closed-types), eliminating the need to register every [(generic) constructed type](/dotnet/csharp/language-reference/language-specification/types#constructed-types).
+The container resolves `ILogger<TCategoryName>` by taking advantage of [(generic) open types](/dotnet/csharp/language-reference/language-specification/types#843-open-and-closed-types), eliminating the need to register every [(generic) constructed type](/dotnet/csharp/language-reference/language-specification/types#84-constructed-types).
 
 With dependency injection terminology, a service:
 


### PR DESCRIPTION
## Summary

- Change (generic) open types and (generic) constructed type links from (/dotnet/csharp/language-reference/language-specification/types#open-and-closed-types) and (/dotnet/csharp/language-reference/language-specification/types#constructed-types) to (... types#843-open-and-...) and (... types#84-constructed...) respectively. This reflects latest urls in use.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/dependency-injection.md](https://github.com/dotnet/docs/blob/d3c35f4c703910bd6c202dc0e3c3699de5cead83/docs/core/extensions/dependency-injection.md) | [.NET dependency injection](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection?branch=pr-en-us-35507) |

<!-- PREVIEW-TABLE-END -->