### PR TITLE
Mention the `value` as problematic keywords for function param's name

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/local-functions.md
+++ b/docs/csharp/programming-guide/classes-and-structs/local-functions.md
@@ -33,6 +33,10 @@ A local function is defined as a nested method inside a containing member. Its d
 <modifiers> <return-type> <method-name> <parameter-list>
 ```
 
+> [!NOTE]
+> The `<parameter-list>` shouldn't contain the parameters named with reserved keyword `value`.
+> The compiler creates the temporary variable "value", which contains the referenced outter variables, which later causes ambiguity and may also cause an unexpected behaviour.
+
 You can use the following modifiers with a local function:
 
 - [`async`](../../language-reference/keywords/async.md)

--- a/docs/csharp/programming-guide/classes-and-structs/local-functions.md
+++ b/docs/csharp/programming-guide/classes-and-structs/local-functions.md
@@ -34,7 +34,7 @@ A local function is defined as a nested method inside a containing member. Its d
 ```
 
 > [!NOTE]
-> The `<parameter-list>` shouldn't contain the parameters named with [contextual keyword](../../language-reference/keywords/index#contextual-keywords) `value`.
+> The `<parameter-list>` shouldn't contain the parameters named with [contextual keyword](../../language-reference/keywords/index.md#contextual-keywords) `value`.
 > The compiler creates the temporary variable "value", which contains the referenced outter variables, which later causes ambiguity and may also cause an unexpected behaviour.
 
 You can use the following modifiers with a local function:

--- a/docs/csharp/programming-guide/classes-and-structs/local-functions.md
+++ b/docs/csharp/programming-guide/classes-and-structs/local-functions.md
@@ -34,7 +34,7 @@ A local function is defined as a nested method inside a containing member. Its d
 ```
 
 > [!NOTE]
-> The `<parameter-list>` shouldn't contain the parameters named with [contextual keyword](../../language-reference/keywords/index.md/#contextual-keywords) `value`.
+> The `<parameter-list>` shouldn't contain the parameters named with [contextual keyword](../../language-reference/keywords/index#contextual-keywords) `value`.
 > The compiler creates the temporary variable "value", which contains the referenced outter variables, which later causes ambiguity and may also cause an unexpected behaviour.
 
 You can use the following modifiers with a local function:

--- a/docs/csharp/programming-guide/classes-and-structs/local-functions.md
+++ b/docs/csharp/programming-guide/classes-and-structs/local-functions.md
@@ -34,7 +34,7 @@ A local function is defined as a nested method inside a containing member. Its d
 ```
 
 > [!NOTE]
-> The `<parameter-list>` shouldn't contain the parameters named with reserved keyword `value`.
+> The `<parameter-list>` shouldn't contain the parameters named with [contextual keyword](../../language-reference/keywords/index.md/#contextual-keywords) `value`.
 > The compiler creates the temporary variable "value", which contains the referenced outter variables, which later causes ambiguity and may also cause an unexpected behaviour.
 
 You can use the following modifiers with a local function:


### PR DESCRIPTION
This pull request fixes #35078 
It adds a simple NOTE to the "Local function syntax" section of local functions to warn dev/user about the `value` name of parameter that may lead to undefined behavior due to ambiguity.

Some parts of this small note are taken directly from the issue as it already is a sufficient explanation.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/classes-and-structs/local-functions.md](https://github.com/dotnet/docs/blob/b3c62fd97a8e1b53e80b0f186df86e04a34033e8/docs/csharp/programming-guide/classes-and-structs/local-functions.md) | [Local functions (C# Programming Guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/local-functions?branch=pr-en-us-35509) |


<!-- PREVIEW-TABLE-END -->