### PR TITLE
Remove ellipsis

### DIFF
--- a/docs/core/porting/upgrade-assistant-overview.md
+++ b/docs/core/porting/upgrade-assistant-overview.md
@@ -11,7 +11,7 @@ New versions of .NET are released throughout the year, with a major release once
 
 The .NET Upgrade Assistant is a Visual Studio extension and command-line tool that's designed to assist with upgrading apps to the latest version of .NET.
 
-Issues related to the .NET Upgrade Assistant can be filed within Visual Studio by selecting **Help** > **Send Feedback** > **Report a Problem...**
+Issues related to the .NET Upgrade Assistant can be filed within Visual Studio by selecting **Help** > **Send Feedback** > **Report a Problem**.
 
 ## Install the Upgrade Assistant
 


### PR DESCRIPTION
## Summary

https://learn.microsoft.com/en-us/style-guide/procedures-instructions/formatting-text-in-instructions
If an option label ends with a colon or an ellipsis, don't include that end punctuation in instructions.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/porting/upgrade-assistant-overview.md](https://github.com/dotnet/docs/blob/d5689763f23687fcec1a491eb7ff79374120e50c/docs/core/porting/upgrade-assistant-overview.md) | [Overview of the .NET Upgrade Assistant](https://review.learn.microsoft.com/en-us/dotnet/core/porting/upgrade-assistant-overview?branch=pr-en-us-35512) |

<!-- PREVIEW-TABLE-END -->