### PR TITLE
Update ca5405.md header preamble

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca5405.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5405.md
@@ -3,7 +3,7 @@ title: "CA5405: Do not always skip token validation in delegates (code analysis)
 description: Provides information about code analysis rule CA5405, including causes, how to fix violations, and when to suppress it.
 ms.date: 09/01/2021
 ms.topic: reference
-ms.author: timhann, dickbaker
+ms.author: timhann
 f1_keywords:
   - "CA5405"
 ---

--- a/docs/fundamentals/code-analysis/quality-rules/ca5405.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5405.md
@@ -1,9 +1,9 @@
 ---
-title: "CA5045: Do not always skip token validation in delegates (code analysis)"
+title: "CA5405: Do not always skip token validation in delegates (code analysis)"
 description: Provides information about code analysis rule CA5405, including causes, how to fix violations, and when to suppress it.
 ms.date: 09/01/2021
 ms.topic: reference
-ms.author: timhann
+ms.author: timhann, dickbaker
 f1_keywords:
   - "CA5405"
 ---


### PR DESCRIPTION
I just raised an anonymous feedback before I realised I could edit in-place and PR the typo

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca5405.md](https://github.com/dotnet/docs/blob/d6caf73209bde623edfd27ca74b4aa64997517b8/docs/fundamentals/code-analysis/quality-rules/ca5405.md) | [CA5405: Do not always skip token validation in delegates](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca5405?branch=pr-en-us-35513) |


<!-- PREVIEW-TABLE-END -->