### PR TITLE
F#: Update string newline source encoding blurb

### DIFF
--- a/docs/fsharp/language-reference/strings.md
+++ b/docs/fsharp/language-reference/strings.md
@@ -50,7 +50,7 @@ let xmlFragment1 = @"<book author=""Milton, John"" title=""Paradise Lost"">"
 let xmlFragment2 = """<book author="Milton, John" title="Paradise Lost">"""
 ```
 
-In code, strings that have line breaks are accepted and the line breaks are interpreted literally as newlines, unless a backslash character is the last character before the line break. Leading white space on the next line is ignored when the backslash character is used. The following code produces a string `str1` that has value `"abc\ndef"` and a string `str2` that has value `"abcdef"`.
+In code, strings that have line breaks are accepted and the line breaks are interpreted as the newline encoding used in source, unless a backslash character is the last character before the line break. Leading white space on the next line is ignored when the backslash character is used. The following code produces a string `str1` that has value `"abc\ndef"` and a string `str2` that has value `"abcdef"`.
 
 [!code-fsharp[Main](~/samples/snippets/fsharp/lang-ref-1/snippet1001.fs)]
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/docs/issues/26359


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/strings.md](https://github.com/dotnet/docs/blob/633c0a716fa6a972403899bd3912b0ca9eca4905/docs/fsharp/language-reference/strings.md) | [Strings](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/strings?branch=pr-en-us-35521) |

<!-- PREVIEW-TABLE-END -->