### PR TITLE
Fix access control blurb (it was incorrect)

### DIFF
--- a/docs/fsharp/language-reference/access-control.md
+++ b/docs/fsharp/language-reference/access-control.md
@@ -20,7 +20,7 @@ In F#, the access control specifiers `public`, `internal`, and `private` can be 
 > [!NOTE]
 > The access specifier `protected` is not used in F#, although it is acceptable if you are using types authored in languages that do support `protected` access. Therefore, if you override a protected method, your method remains accessible only within the class and its descendents.
 
-In general, the specifier is put in front of the name of the entity, except when a `mutable` or `inline` specifier is used, which appear after the access control specifier.
+The access specifier is put in front of the name of the entity.
 
 If no access specifier is used, the default is `public`, except for `let` bindings in a type, which are always `private` to the type.
 


### PR DESCRIPTION
fixes https://github.com/dotnet/docs/issues/22778


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/access-control.md](https://github.com/dotnet/docs/blob/d7b2477b052ade1d64ac6d80f0c3fd72dd271bc0/docs/fsharp/language-reference/access-control.md) | [Access Control](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/access-control?branch=pr-en-us-35523) |

<!-- PREVIEW-TABLE-END -->