### PR TITLE
Use better link for `&` in match section of symbol referencef

### DIFF
--- a/docs/fsharp/language-reference/symbol-and-operator-reference/index.md
+++ b/docs/fsharp/language-reference/symbol-and-operator-reference/index.md
@@ -165,7 +165,7 @@ The following table describes symbols related to pattern matching.
 |Symbol or operator|Links|Description|
 |------------------|-----|-----------|
 |`->`|[Match Expressions](../match-expressions.md)|Used in match expressions.|
-|`&`|[Match Expressions](../match-expressions.md)|<ul><li>Computes the address of a mutable value, for use when interoperating with other languages.</li><li>Used in AND patterns.</li></ul>|
+|`&`|[Pattern Matching](../pattern-matching.md)|<ul><li>Computes the address of a mutable value, for use when interoperating with other languages.</li><li>Used in AND patterns.</li></ul>|
 |`_`|[Match Expressions](../match-expressions.md)<br /><br />[Generics](../generics/index.md)|<ul><li>Indicates a wildcard pattern.</li><li>Specifies an anonymous generic parameter.</li></ul>|
 |<code>&#124;</code>|[Match Expressions](../match-expressions.md)|Delimits individual match cases, individual discriminated union cases, and enumeration values.|
 


### PR DESCRIPTION
fixes https://github.com/dotnet/docs/issues/34743


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/symbol-and-operator-reference/index.md](https://github.com/dotnet/docs/blob/e2eb32b0ad63734b124e1d21ec5d71653e86371f/docs/fsharp/language-reference/symbol-and-operator-reference/index.md) | [Symbol and operator reference](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/symbol-and-operator-reference/index?branch=pr-en-us-35526) |

<!-- PREVIEW-TABLE-END -->