### PR TITLE
Fixes wrong wording in interfaces

### DIFF
--- a/docs/fsharp/language-reference/interfaces.md
+++ b/docs/fsharp/language-reference/interfaces.md
@@ -48,7 +48,7 @@ You can optionally give each method parameter a name using normal F# syntax:
 
 In the above `ISprintable` example, the `Print` method has a single parameter of the type `string` with the name `format`.
 
-There are two ways to implement interfaces: by using object expressions, and by using class types. In either case, the class type or object expression provides method bodies for abstract methods of the interface. Implementations are specific to each type that implements the interface. Therefore, interface methods on different types might be different from each other.
+There are two ways to implement interfaces: by using object expressions, and by using types. In either case, the type or object expression provides method bodies for abstract methods of the interface. Implementations are specific to each type that implements the interface. Therefore, interface methods on different types might be different from each other.
 
 The keywords `interface` and `end`, which mark the start and end of the definition, are optional when you use lightweight syntax. If you do not use these keywords, the compiler attempts to infer whether the type is a class or an interface by analyzing the constructs that you use. If you define a member or use other class syntax, the type is interpreted as a class.
 


### PR DESCRIPTION
Simple fixes https://github.com/dotnet/docs/issues/33827 -- doesn't need anything else TBH


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/interfaces.md](https://github.com/dotnet/docs/blob/102b4aca0f8742ade827159dd9e1c6f619f00415/docs/fsharp/language-reference/interfaces.md) | [Interfaces (F#)](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/interfaces?branch=pr-en-us-35527) |

<!-- PREVIEW-TABLE-END -->