### PR TITLE
sqlite: do not recommend usage of shared cache

### DIFF
--- a/docs/standard/data/sqlite/async.md
+++ b/docs/standard/data/sqlite/async.md
@@ -7,7 +7,7 @@ description: Explains the limitations of the async APIs and some alternatives th
 
 SQLite doesn't support asynchronous I/O. Async ADO.NET methods will execute synchronously in Microsoft.Data.Sqlite. Avoid calling them.
 
-Instead, use a [shared cache](connection-strings.md#cache) and [write-ahead logging](https://www.sqlite.org/wal.html) to improve performance and concurrency.
+Instead, use [write-ahead logging](https://www.sqlite.org/wal.html) to improve performance and concurrency.
 
 [!code-csharp[](../../../../samples/snippets/standard/data/sqlite/AsyncSample/Program.cs?name=snippet_WAL)]
 

--- a/docs/standard/data/sqlite/async.md
+++ b/docs/standard/data/sqlite/async.md
@@ -1,6 +1,6 @@
 ---
 title: Async limitations
-ms.date: 09/04/2020
+ms.date: 06/01/2023
 description: Explains the limitations of the async APIs and some alternatives that you can use instead.
 ---
 # Async limitations

--- a/docs/standard/data/sqlite/connection-strings.md
+++ b/docs/standard/data/sqlite/connection-strings.md
@@ -1,6 +1,6 @@
 ---
 title: Connection strings
-ms.date: 06/01/2023
+ms.date: 06/06/2023
 no-loc: Command Timeout,Default Timeout,Data Source,Recursive Triggers,Pooling
 description: The supported keywords and values of connection strings.
 ---
@@ -118,10 +118,13 @@ You can use <xref:Microsoft.Data.Sqlite.SqliteConnectionStringBuilder> as a stro
 
 ### Basic
 
-A basic connection string.
+A basic connection string with a shared cache for improved concurrency.
+
+> [!CAUTION]
+> Mixing shared-cache mode and write-ahead logging is discouraged. For optimal performance, remove `Cache=Shared` when the database is configured to use write-ahead logging.
 
 ```connectionstring
-Data Source=Application.db
+Data Source=Application.db;Cache=Shared
 ```
 
 ### Encrypted

--- a/docs/standard/data/sqlite/connection-strings.md
+++ b/docs/standard/data/sqlite/connection-strings.md
@@ -118,10 +118,10 @@ You can use <xref:Microsoft.Data.Sqlite.SqliteConnectionStringBuilder> as a stro
 
 ### Basic
 
-A basic connection string with a shared cache for improved concurrency.
+A basic connection string.
 
 ```connectionstring
-Data Source=Application.db;Cache=Shared
+Data Source=Application.db
 ```
 
 ### Encrypted

--- a/docs/standard/data/sqlite/connection-strings.md
+++ b/docs/standard/data/sqlite/connection-strings.md
@@ -1,6 +1,6 @@
 ---
 title: Connection strings
-ms.date: 07/14/2021
+ms.date: 06/01/2023
 no-loc: Command Timeout,Default Timeout,Data Source,Recursive Triggers,Pooling
 description: The supported keywords and values of connection strings.
 ---

--- a/docs/standard/data/sqlite/database-errors.md
+++ b/docs/standard/data/sqlite/database-errors.md
@@ -1,6 +1,6 @@
 ---
 title: Database errors
-ms.date: 12/13/2019
+ms.date: 06/06/2023
 description: Describes how database errors and retires are handled by the library.
 ---
 # Database errors
@@ -18,7 +18,7 @@ Consider carefully how your app will handle these errors.
 
 ## Locking, retries, and timeouts
 
-SQLite is aggressive when it comes to locking tables and database files. If your app enables any concurrent database access, you'll likely encounter busy and locked errors. You can mitigate many errors by using a [shared cache](connection-strings.md#cache) and [write-ahead logging](async.md).
+SQLite is aggressive when it comes to locking tables and database files. If your app enables any concurrent database access, you'll likely encounter busy and locked errors. You can mitigate many errors by using [write-ahead logging](async.md).
 
 Whenever Microsoft.Data.Sqlite encounters a busy or locked error, it will automatically retry until it succeeds or the command timeout is reached.
 

--- a/samples/snippets/standard/data/sqlite/AsyncSample/Program.cs
+++ b/samples/snippets/standard/data/sqlite/AsyncSample/Program.cs
@@ -16,7 +16,7 @@ namespace AsyncSample
             // Microsoft.Data.Sqlite.
 
             #region snippet_WAL
-            var connection = new SqliteConnection("Data Source=AsyncSample.db;Cache=Shared");
+            var connection = new SqliteConnection("Data Source=AsyncSample.db");
             connection.Open();
 
             // Enable write-ahead logging


### PR DESCRIPTION
## Summary

This reverts parts of #20467.

SQLite Shared Cache Mode should not be used, as explained [here](https://www.sqlite.org/sharedcache.html) by the devs themselves.
Enabling shared cache together with WAL leads to worse performance and locking issues. Having `Cache=Shared` in the default connection string is a massive footgun for anyone just copy-pasting it.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/data/sqlite/async.md](https://github.com/dotnet/docs/blob/cf7244b028cc85fcd9052105143a692721c41e6c/docs/standard/data/sqlite/async.md) | [Async limitations](https://review.learn.microsoft.com/en-us/dotnet/standard/data/sqlite/async?branch=pr-en-us-35584) |
| [docs/standard/data/sqlite/connection-strings.md](https://github.com/dotnet/docs/blob/cf7244b028cc85fcd9052105143a692721c41e6c/docs/standard/data/sqlite/connection-strings.md) | [Connection strings](https://review.learn.microsoft.com/en-us/dotnet/standard/data/sqlite/connection-strings?branch=pr-en-us-35584) |
| [docs/standard/data/sqlite/database-errors.md](https://github.com/dotnet/docs/blob/cf7244b028cc85fcd9052105143a692721c41e6c/docs/standard/data/sqlite/database-errors.md) | [Database errors](https://review.learn.microsoft.com/en-us/dotnet/standard/data/sqlite/database-errors?branch=pr-en-us-35584) |


<!-- PREVIEW-TABLE-END -->