### PR TITLE
Update coding convention docs

### DIFF
--- a/docs/csharp/fundamentals/coding-style/coding-conventions.md
+++ b/docs/csharp/fundamentals/coding-style/coding-conventions.md
@@ -1,6 +1,6 @@
 ---
-title: "C# Coding Conventions"
-description: Learn about coding conventions in C#. Coding conventions create a consistent look to the code and facilitate copying, changing, and maintaining the code.
+title: "Common C# Coding Conventions"
+description: Learn about commonly used coding conventions in C#. Coding conventions create a consistent look to the code and facilitate copying, changing, and maintaining the code.
 ms.date: 07/16/2021
 helpviewer_keywords:
   - "coding conventions, C#"
@@ -8,7 +8,7 @@ helpviewer_keywords:
   - "C# language, coding conventions"
 ---
 
-# C# Coding Conventions
+# Common C# Coding Conventions
 
 Coding conventions serve the following purposes:
 
@@ -20,7 +20,7 @@ Coding conventions serve the following purposes:
 > - They demonstrate C# best practices.
 
 > [!IMPORTANT]
-> The guidelines in this article are used by Microsoft to develop samples and documentation. They were adopted from the [.NET Runtime, C# Coding Style](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/coding-style.md) guidelines. You can use them, or adapt them to your needs. The primary objectives are consistency and readability within your project, team, organization, or company source code.
+> The guidelines in this article are used by Microsoft to develop samples and documentation. They were adopted from the [.NET Runtime, C# Coding Style](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/coding-style.md) guidelines. You can use them, or adapt them to your needs. They are meant to be an example of common C# conventions, and not an authoritative list (see [Framework Design Guidelines](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/) for that). The primary objectives are consistency and readability within your project, team, organization, or company source code.
 
 ## Naming conventions
 

--- a/docs/csharp/fundamentals/coding-style/coding-conventions.md
+++ b/docs/csharp/fundamentals/coding-style/coding-conventions.md
@@ -20,7 +20,7 @@ Coding conventions serve the following purposes:
 > - They demonstrate C# best practices.
 
 > [!IMPORTANT]
-> The guidelines in this article are used by Microsoft to develop samples and documentation. They were adopted from the [.NET Runtime, C# Coding Style](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/coding-style.md) guidelines. You can use them, or adapt them to your needs. They are meant to be an example of common C# conventions, and not an authoritative list (see [Framework Design Guidelines](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/) for that). The primary objectives are consistency and readability within your project, team, organization, or company source code.
+> The guidelines in this article are used by Microsoft to develop samples and documentation. They were adopted from the [.NET Runtime, C# Coding Style](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/coding-style.md) guidelines. You can use them, or adapt them to your needs. They are meant to be an example of common C# conventions, and not an authoritative list (see [Framework Design Guidelines](../../../standard/design-guidelines/) for that). The primary objectives are consistency and readability within your project, team, organization, or company source code.
 
 ## Naming conventions
 

--- a/docs/csharp/fundamentals/coding-style/coding-conventions.md
+++ b/docs/csharp/fundamentals/coding-style/coding-conventions.md
@@ -20,7 +20,7 @@ Coding conventions serve the following purposes:
 > - They demonstrate C# best practices.
 
 > [!IMPORTANT]
-> The guidelines in this article are used by Microsoft to develop samples and documentation. They were adopted from the [.NET Runtime, C# Coding Style](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/coding-style.md) guidelines. You can use them, or adapt them to your needs. They are meant to be an example of common C# conventions, and not an authoritative list (see [Framework Design Guidelines](../../../standard/design-guidelines/) for that). The primary objectives are consistency and readability within your project, team, organization, or company source code.
+> The guidelines in this article are used by Microsoft to develop samples and documentation. They were adopted from the [.NET Runtime, C# Coding Style](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/coding-style.md) guidelines. You can use them, or adapt them to your needs. They are meant to be an example of common C# conventions, and not an authoritative list (see [Framework Design Guidelines](../../../standard/design-guidelines/index.md) for that). The primary objectives are consistency and readability within your project, team, organization, or company source code.
 
 ## Naming conventions
 


### PR DESCRIPTION
## Summary

The title/description of the C# coding convention docs is incorrectly being authoritative. There is a remark, but the title phrased this way makes it seem like the conventions in the file are "the correct way" to name things in C#, which is not the case. There _are_ authoritative guidelines in C# (see [Framework Design Guidelines](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/)), but they specifically don't cover internal members.

This PR updates the title, description and remarks to clarify this distinction.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/fundamentals/coding-style/coding-conventions.md](https://github.com/dotnet/docs/blob/1722a28146fa8afb4a3a2fc73a0de3663e11e7f3/docs/csharp/fundamentals/coding-style/coding-conventions.md) | [C# Coding Conventions](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions?branch=pr-en-us-35587) |


<!-- PREVIEW-TABLE-END -->