### PR TITLE
Clarify the x86 path removal on upgrade

### DIFF
--- a/docs/core/compatibility/deployment/7.0/x86-host-path.md
+++ b/docs/core/compatibility/deployment/7.0/x86-host-path.md
@@ -7,6 +7,8 @@ ms.date: 06/22/2022
 
 The x86 versions of .NET installers for Windows have been modified to no longer add the x86 host location (*Program Files (x86)\dotnet*) to the `PATH` environment variable on 64-bit Windows systems.
 
+With this change, if the x86 host location was added to the PATH by a prior version of .NET, the x86 versions of .NET installers and .NET updates will remove it on upgrade.
+
 This change affects .NET Core 3.1, .NET 6, .NET 7, and future versions.
 
 This change only affects the `dotnet` host. It doesn't affect 32-bit/x86 application hosts, like *myapp.exe*. Those hosts will continue to find the x86 runtime correctly (assuming it's installed).

--- a/docs/core/compatibility/deployment/7.0/x86-host-path.md
+++ b/docs/core/compatibility/deployment/7.0/x86-host-path.md
@@ -7,7 +7,7 @@ ms.date: 06/22/2022
 
 The x86 versions of .NET installers for Windows have been modified to no longer add the x86 host location (*Program Files (x86)\dotnet*) to the `PATH` environment variable on 64-bit Windows systems.
 
-With this change, if the x86 host location was added to the PATH by a prior version of .NET, the x86 versions of .NET installers and .NET updates will remove it on upgrade.
+With this change, if the x86 host location was added to `PATH` by a prior version of .NET, the x86 versions of .NET installers and .NET updates will remove it on upgrade.
 
 This change affects .NET Core 3.1, .NET 6, .NET 7, and future versions.
 
@@ -19,7 +19,7 @@ The x86 host location was added to `PATH`, even on x64/Arm64 systems. Depending 
 
 ## New behavior
 
-Going forward, the x86 host location is only added to the `PATH` environment variable on x86 systems.
+Going forward, the x86 host location is only added to the `PATH` environment variable on x86 systems and will be removed on upgrade of .NET or Visual Studio on any x64 and arm64 systems.
 
 ## Version introduced
 


### PR DESCRIPTION
## Summary

I've gotten customer feedback that they didn't realize that the upgrade of .NET from an older version that was setting the path to a newer version that is not would remove the x86 PATH. I've gotten a request to add this to the breaking change documentation.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/deployment/7.0/x86-host-path.md](https://github.com/dotnet/docs/blob/a1b803917eb5fefffd84f97e0faa1cff4641b854/docs/core/compatibility/deployment/7.0/x86-host-path.md) | [x86 host path on 64-bit Windows](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/deployment/7.0/x86-host-path?branch=pr-en-us-35595) |


<!-- PREVIEW-TABLE-END -->