### PR TITLE
Provide link to assembly documentation

### DIFF
--- a/docs/fsharp/language-reference/access-control.md
+++ b/docs/fsharp/language-reference/access-control.md
@@ -13,7 +13,7 @@ In F#, the access control specifiers `public`, `internal`, and `private` can be 
 
 - `public` indicates that the entity can be accessed by all callers.
 
-- `internal` indicates that the entity can be accessed only from the same assembly.
+- `internal` indicates that the entity can be accessed only from the same [assembly](https://github.com/dotnet/docs/blob/main/docs/standard/assembly/index.md).
 
 - `private` indicates that the entity can be accessed only from the enclosing type or module.
 

--- a/docs/fsharp/language-reference/access-control.md
+++ b/docs/fsharp/language-reference/access-control.md
@@ -13,7 +13,7 @@ In F#, the access control specifiers `public`, `internal`, and `private` can be 
 
 - `public` indicates that the entity can be accessed by all callers.
 
-- `internal` indicates that the entity can be accessed only from the same [assembly](https://github.com/dotnet/docs/blob/main/docs/standard/assembly/index.md).
+- `internal` indicates that the entity can be accessed only from the same [assembly](../../standard/assembly/index.md).
 
 - `private` indicates that the entity can be accessed only from the enclosing type or module.
 


### PR DESCRIPTION
People reading the docs, do not nessecarily know what "assembly" means. 

Particularly people coming from other platforms, will likely appreciate the link.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/access-control.md](https://github.com/dotnet/docs/blob/4e64669dd46e8353f73d45421f184959ca4e55dc/docs/fsharp/language-reference/access-control.md) | [Access Control](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/access-control?branch=pr-en-us-35606) |


<!-- PREVIEW-TABLE-END -->