### PR TITLE
Remove incorrect semicolon in CS0501, fix spelling

### DIFF
--- a/docs/csharp/misc/cs0501.md
+++ b/docs/csharp/misc/cs0501.md
@@ -40,15 +40,18 @@ This could be fixed by declaring a body (by adding brackets):
 ```csharp  
 public class MyClass
 {  
-   public void MethodWithNoBody() { };   // No error; compiler now interprets as an empty method
+   public void MethodWithNoBody() { }   // No error; compiler now interprets as an empty method
 }  
 ```
+
+> [!NOTE]
+> When defining a method body with brackets, do not add a semicolon. Doing so will trigger [compiler error CS1597](./cs1597.md).
 
 Or, using an appropriate keyword, such as defining an `abstract` method:
 
 ```csharp
-abstract class MyClass // class is abstract; classes that inherit from it will have to deifne MyAbstractMethod
+abstract class MyClass // class is abstract; classes that inherit from it will have to define MyAbstractMethod
 {  
-   public abstract void MyAbstractMethod();   // Compiler now knows that this method must be deinfed by inheriting classes.
+   public abstract void MyAbstractMethod();   // Compiler now knows that this method must be defined by inheriting classes.
 }  
 ```


### PR DESCRIPTION
## Summary

This PR removes an unnecessary/incorrect semicolon in one of the examples for resolving compiler error CS0501.

A semicolon after a curly-braced method body will instead trigger compiler error CS1597.

Some spelling corrections are included as well.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/misc/cs0501.md](https://github.com/dotnet/docs/blob/d0f94077c19645bfc09129286caa58ab59c256b9/docs/csharp/misc/cs0501.md) | [Compiler Error CS0501](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/cs0501?branch=pr-en-us-35607) |

<!-- PREVIEW-TABLE-END -->