### PR TITLE
Rid-specific app breaking change

### DIFF
--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -85,6 +85,7 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 | [Console encoding not UTF-8 after completion](sdk/8.0/console-encoding-fix.md)  | Behavioral change/Binary incompatible            | Preview 3  |
 | ['dotnet pack' uses Release configuration](sdk/8.0/dotnet-pack-config.md)       | Behavioral change/Source incompatible            | Preview 1  |
 | ['dotnet publish' uses Release configuration](sdk/8.0/dotnet-publish-config.md) | Behavioral change/Source incompatible            | Preview 1  |
+| [Runtime-specific apps not self-contained](sdk/8.0/runtimespecific-app-default.md) | Source/binary incompatible            | Preview 5  |
 
 ## Serialization
 

--- a/docs/core/compatibility/sdk/8.0/runtimespecific-app-default.md
+++ b/docs/core/compatibility/sdk/8.0/runtimespecific-app-default.md
@@ -1,0 +1,61 @@
+---
+title: "Breaking change: Runtime-specific apps no longer self-contained"
+description: Learn about a breaking change in the .NET 8 SDK where apps that specify a runtime identifier are no longer self-contained by default.
+ms.date: 03/09/2023
+---
+# Runtime-specific apps no longer self-contained
+
+Runtime-specific apps, or .NET apps with a `RuntimeIdentifier`, are no longer [self-contained](../../../deploying/index.md#publish-self-contained) by default. Instead, they are [framework-dependent](../../../deploying/index.md#publish-framework-dependent) by default.
+
+This is a breaking change in the following situations:
+
+- If you deployed, distributed, or published your app and didn't explicitly add the `SelfContained` property, but also didn't require that the .NET runtime be installed on the machine for it to work. In this case, you may have relied on the previous behavior to produce a non-framework-dependent app by default.
+
+- If you rely on the IL Link tool. In this case, you'll have to take the steps described under [Recommended action](#recommended-action) to use IL Link again.
+
+  > [!NOTE]
+  > Some publish properties, like `PublishTrimmed`, `PublishSingleFile`, and `PublishAot`, currently require `SelfContained` to work. If you use these properties, you'll need to add the `SelfContained` property.
+
+- For Blazor WebAssembly apps, because they relied on the previous behavior. However, the Blazor WASM team may side-step this breaking change in their SDK by adding `SelfContained` automatically for all apps, so Blazor customers shouldn't be affected.
+
+## Previous behavior
+
+Previously, if a runtime identifier (RID) was specified (via [RuntimeIdentifier](../../../project-sdk/msbuild-props.md#runtimeidentifier)), the app was published as self-contained, even if `SelfContained` wasn't explicitly specified.
+
+## New behavior
+
+Starting in .NET 8, for apps that target .NET 8 or a later version, `RuntimeIdentifier` no longer implies `SelfContained` by default. Instead, apps that specify a runtime identifier will be dependent on the .NET runtime by default (framework-dependent). Apps that target .NET 7 or earlier versions aren't affected.
+
+## Version introduced
+
+.NET 8 Preview 2
+
+## Type of breaking change
+
+This change can affect [source compatibility](../../categories.md#source-compatibility) and [binary compatibility](../../categories.md#binary-compatibility).
+
+## Reason for change
+
+- The new .NET SDK behavior aligns with Visual Studio behavior.
+- Framework-dependent apps are now smaller by default, since there aren't copies of .NET stored in each app.
+- Ideally, command-line options are orthogonal. In this case, the tooling supports both RID-specific self-contained deployment (SCD) and RID-specific framework-dependent deployment (FDD). So it didn't make sense that no RID defaulted to FDD and RID defaulted to SCD. This behavior was often confusing for users.
+
+.NET 6 alerted users to this breaking change with the following warning:
+
+**warning NETSDK1179: One of '--self-contained' or '--no-self-contained' options are required when '--runtime' is used.**
+
+Now that customers have had time to add `SelfContained` explicitly, we felt we could introduce the break.
+
+## Recommended action
+
+If you're using .NET 7 or an earlier version and relied on the previous behavior where `SelfContained` was inferred, you'll see this warning:
+
+**For projects with TargetFrameworks >= 8.0, RuntimeIdentifier no longer automatically gives a SelfContained app. To continue creating a .NET framework independent app after upgrading to 8.0, consider setting SelfContained explicitly.**
+
+Follow the guidance of the warning if you want to continue to produce self-contained apps. If you want to move to the new default, set `SelfContained` to `false` in the project file (`<SelfContained>false</SelfContained>`) or as a command-line argument, for example, `dotnet publish --no-self-contained`.
+
+If you're using .NET 8, you don't need to do anything unless you want to keep the previous behavior. In that case, set `SelfContained` to `true`.
+
+## See also
+
+- [.NET application publishing overview](../../../deploying/index.md)

--- a/docs/core/compatibility/sdk/8.0/runtimespecific-app-default.md
+++ b/docs/core/compatibility/sdk/8.0/runtimespecific-app-default.md
@@ -1,7 +1,7 @@
 ---
 title: "Breaking change: Runtime-specific apps no longer self-contained"
 description: Learn about a breaking change in the .NET 8 SDK where apps that specify a runtime identifier are no longer self-contained by default.
-ms.date: 03/09/2023
+ms.date: 06/05/2023
 ---
 # Runtime-specific apps no longer self-contained
 
@@ -22,13 +22,25 @@ This is a breaking change in the following situations:
 
 Previously, if a runtime identifier (RID) was specified (via [RuntimeIdentifier](../../../project-sdk/msbuild-props.md#runtimeidentifier)), the app was published as self-contained, even if `SelfContained` wasn't explicitly specified.
 
+In addition:
+
+- The publish properties `PublishTrimmed`, `PublishSingleFile`, and `PublishAot` implied `PublishSelfContained` and therefore `SelfContained` during operations including build, restore, and publish.
+- The `PublishTrimmed` property did not imply `SelfContained`.
+- The `PublishReadyToRun` property implied `SelfContained` if `SelfContained` wasn't specified.
+
 ## New behavior
 
 Starting in .NET 8, for apps that target .NET 8 or a later version, `RuntimeIdentifier` no longer implies `SelfContained` by default. Instead, apps that specify a runtime identifier will be dependent on the .NET runtime by default (framework-dependent). Apps that target .NET 7 or earlier versions aren't affected.
 
+In addition:
+
+- The publish properties `PublishTrimmed`, `PublishSingleFile`, and `PublishAot` now imply `SelfContained` during a publish operation only (that is, not for build or restore).
+- The `PublishTrimmed` property also now implies `SelfContained` during publish.
+- The `PublishReadyToRun` property no longer implies `SelfContained` if the project targets .NET 8 or later.
+
 ## Version introduced
 
-.NET 8 Preview 2
+.NET 8 Preview 5
 
 ## Type of breaking change
 
@@ -44,7 +56,7 @@ This change can affect [source compatibility](../../categories.md#source-compati
 
 **warning NETSDK1179: One of '--self-contained' or '--no-self-contained' options are required when '--runtime' is used.**
 
-Now that customers have had time to add `SelfContained` explicitly, we felt we could introduce the break.
+Now that customers have had time to add `SelfContained` explicitly, it's okay to introduce the break.
 
 ## Recommended action
 

--- a/docs/core/compatibility/sdk/8.0/runtimespecific-app-default.md
+++ b/docs/core/compatibility/sdk/8.0/runtimespecific-app-default.md
@@ -19,7 +19,7 @@ Previously, if a runtime identifier (RID) was specified (via [RuntimeIdentifier]
 
 In addition:
 
-- If `PublishSelfContained` wasn't explicitly set to `false`, the publish properties `PublishSingleFile` and `PublishAot` implied `PublishSelfContained` and therefore `SelfContained` (if it wasn't specified) during operations including `dotnet build`, `dotnet restore`, and `dotnet publish`.
+- If `PublishSelfContained` wasn't explicitly set to `false`, the publish properties `PublishSingleFile` and `PublishAot` implied a `RuntimeIdentifier` and therefore `SelfContained` (if it wasn't specified) during operations including `dotnet build`, `dotnet restore`, and `dotnet publish`.
 - The `PublishTrimmed` property did not imply `SelfContained`.
 - The `PublishReadyToRun` property implied `SelfContained` if `SelfContained` wasn't specified.
 

--- a/docs/core/compatibility/sdk/8.0/runtimespecific-app-default.md
+++ b/docs/core/compatibility/sdk/8.0/runtimespecific-app-default.md
@@ -34,7 +34,7 @@ In addition:
 - The `PublishReadyToRun` property no longer implies `SelfContained` if the project targets .NET 8 or later.
 
 > [!NOTE]
-> If you publish using `msbuild t:/Publish`, the listed publish properties don't imply `SelfContained`.
+>If you publish using `msbuild /t:Publish`, you must explicitly specify `SelfContained` if you want your app to be self-contained, even if your project has one of the listed publish properties.
 
 ## Version introduced
 

--- a/docs/core/compatibility/sdk/8.0/runtimespecific-app-default.md
+++ b/docs/core/compatibility/sdk/8.0/runtimespecific-app-default.md
@@ -13,10 +13,7 @@ This is a breaking change in the following situations:
 
 - If you rely on the IL Link tool. In this case, you'll have to take the steps described under [Recommended action](#recommended-action) to use IL Link again.
 
-  > [!NOTE]
-  > Some publish properties, like `PublishTrimmed`, `PublishSingleFile`, and `PublishAot`, currently require `SelfContained` to work. If you use these properties, you'll need to add the `SelfContained` property.
-
-- For Blazor WebAssembly apps, because they relied on the previous behavior. However, the Blazor WASM team may side-step this breaking change in their SDK by adding `SelfContained` automatically for all apps, so Blazor customers shouldn't be affected.
+Blazor WebAssembly apps relied on the previous behavior. However, the Blazor SDK now adds `SelfContained` automatically for all apps, so Blazor customers shouldn't be affected.
 
 ## Previous behavior
 
@@ -24,7 +21,7 @@ Previously, if a runtime identifier (RID) was specified (via [RuntimeIdentifier]
 
 In addition:
 
-- The publish properties `PublishTrimmed`, `PublishSingleFile`, and `PublishAot` implied `PublishSelfContained` and therefore `SelfContained` during operations including build, restore, and publish.
+- If `PublishSelfContained` wasn't explicitly set to `false`, the publish properties `PublishSingleFile` and `PublishAot` implied `PublishSelfContained` and therefore `SelfContained` during operations including `dotnet build`, `dotnet restore`, and `dotnet publish`.
 - The `PublishTrimmed` property did not imply `SelfContained`.
 - The `PublishReadyToRun` property implied `SelfContained` if `SelfContained` wasn't specified.
 
@@ -34,9 +31,12 @@ Starting in .NET 8, for apps that target .NET 8 or a later version, `RuntimeIden
 
 In addition:
 
-- The publish properties `PublishTrimmed`, `PublishSingleFile`, and `PublishAot` now imply `SelfContained` during a publish operation only (that is, not for build or restore).
-- The `PublishTrimmed` property also now implies `SelfContained` during publish.
+- If `PublishSelfContained` isn't explicitly set to `false`, the publish properties `PublishTrimmed`, `PublishSingleFile`, and `PublishAot` now imply `SelfContained` during `dotnet publish` only (that is, not for `dotnet build` or `dotnet restore`).
+- The `PublishTrimmed` property also now implies `SelfContained` during `dotnet publish`.
 - The `PublishReadyToRun` property no longer implies `SelfContained` if the project targets .NET 8 or later.
+
+> [!NOTE]
+> If you publish using `msbuild t:/Publish`, the publish properties don't imply `SelfContained`.
 
 ## Version introduced
 
@@ -50,6 +50,7 @@ This change can affect [source compatibility](../../categories.md#source-compati
 
 - The new .NET SDK behavior aligns with Visual Studio behavior.
 - Framework-dependent apps are now smaller by default, since there aren't copies of .NET stored in each app.
+- When .NET is managed outside of the app (that is, for framework-dependent deployments), .NET stays more secure and up-to-date. Apps that have their own copy of the runtime don't get security updates. This change makes more apps framework-dependent by default.
 - Ideally, command-line options are orthogonal. In this case, the tooling supports both RID-specific self-contained deployment (SCD) and RID-specific framework-dependent deployment (FDD). So it didn't make sense that no RID defaulted to FDD and RID defaulted to SCD. This behavior was often confusing for users.
 
 .NET 6 alerted users to this breaking change with the following warning:

--- a/docs/core/compatibility/sdk/8.0/runtimespecific-app-default.md
+++ b/docs/core/compatibility/sdk/8.0/runtimespecific-app-default.md
@@ -13,15 +13,13 @@ This is a breaking change in the following situations:
 
 - If you rely on the IL Link tool. In this case, you'll have to take the steps described under [Recommended action](#recommended-action) to use IL Link again.
 
-Blazor WebAssembly apps relied on the previous behavior. However, the Blazor SDK now adds `SelfContained` automatically for all apps, so Blazor customers shouldn't be affected.
-
 ## Previous behavior
 
 Previously, if a runtime identifier (RID) was specified (via [RuntimeIdentifier](../../../project-sdk/msbuild-props.md#runtimeidentifier)), the app was published as self-contained, even if `SelfContained` wasn't explicitly specified.
 
 In addition:
 
-- If `PublishSelfContained` wasn't explicitly set to `false`, the publish properties `PublishSingleFile` and `PublishAot` implied `PublishSelfContained` and therefore `SelfContained` during operations including `dotnet build`, `dotnet restore`, and `dotnet publish`.
+- If `PublishSelfContained` wasn't explicitly set to `false`, the publish properties `PublishSingleFile` and `PublishAot` implied `PublishSelfContained` and therefore `SelfContained` (if it wasn't specified) during operations including `dotnet build`, `dotnet restore`, and `dotnet publish`.
 - The `PublishTrimmed` property did not imply `SelfContained`.
 - The `PublishReadyToRun` property implied `SelfContained` if `SelfContained` wasn't specified.
 
@@ -31,12 +29,12 @@ Starting in .NET 8, for apps that target .NET 8 or a later version, `RuntimeIden
 
 In addition:
 
-- If `PublishSelfContained` isn't explicitly set to `false`, the publish properties `PublishSingleFile` and `PublishAot` now imply `SelfContained` during `dotnet publish` only (that is, not for `dotnet build` or `dotnet restore`).
+- If `PublishSelfContained` isn't explicitly set to `false`, the publish properties `PublishSingleFile` and `PublishAot` now imply `SelfContained` (if it's not specified) during `dotnet publish` only (that is, not for `dotnet build` or `dotnet restore`).
 - The `PublishTrimmed` property also now implies `SelfContained` during `dotnet publish`.
 - The `PublishReadyToRun` property no longer implies `SelfContained` if the project targets .NET 8 or later.
 
 > [!NOTE]
-> If you publish using `msbuild t:/Publish`, the publish properties don't imply `SelfContained`.
+> If you publish using `msbuild t:/Publish`, the listed publish properties don't imply `SelfContained`.
 
 ## Version introduced
 
@@ -61,13 +59,13 @@ Now that customers have had time to add `SelfContained` explicitly, it's okay to
 
 ## Recommended action
 
-If you're using .NET 7 or an earlier version and relied on the previous behavior where `SelfContained` was inferred, you'll see this warning:
+- If you're using .NET 7 or an earlier version and relied on the previous behavior where `SelfContained` was inferred, you'll see this warning:
 
-**For projects with TargetFrameworks >= 8.0, RuntimeIdentifier no longer automatically gives a SelfContained app. To continue creating a .NET framework independent app after upgrading to 8.0, consider setting SelfContained explicitly.**
+  **For projects with TargetFrameworks >= 8.0, RuntimeIdentifier no longer automatically gives a SelfContained app. To continue creating a .NET framework independent app after upgrading to 8.0, consider setting SelfContained explicitly.**
 
-Follow the guidance of the warning if you want to continue to produce self-contained apps. If you want to move to the new default, set `SelfContained` to `false` in the project file (`<SelfContained>false</SelfContained>`) or as a command-line argument, for example, `dotnet publish --no-self-contained`.
+  Follow the guidance of the warning and set `SelfContained` to `true` in the project file (`<SelfContained>true</SelfContained>`) or as a command-line argument, for example, `dotnet publish --self-contained`.
 
-If you're using .NET 8, you don't need to do anything unless you want to keep the previous behavior. In that case, set `SelfContained` to `true`.
+- If you're using .NET 8 and want to keep the previous behavior, set `SelfContained` to `true`.
 
 ## See also
 

--- a/docs/core/compatibility/sdk/8.0/runtimespecific-app-default.md
+++ b/docs/core/compatibility/sdk/8.0/runtimespecific-app-default.md
@@ -9,7 +9,7 @@ Runtime-specific apps, or .NET apps with a `RuntimeIdentifier`, are no longer [s
 
 This is a breaking change in the following situations:
 
-- If you deployed, distributed, or published your app and didn't explicitly add the `SelfContained` property, but also didn't require that the .NET runtime be installed on the machine for it to work. In this case, you may have relied on the previous behavior to produce a non-framework-dependent app by default.
+- If you deployed, distributed, or published your app and didn't explicitly add the `SelfContained` property, but also didn't require that the .NET runtime be installed on the machine for it to work. In this case, you may have relied on the previous behavior to produce a self-contained app by default.
 
 - If you rely on the IL Link tool. In this case, you'll have to take the steps described under [Recommended action](#recommended-action) to use IL Link again.
 
@@ -31,7 +31,7 @@ Starting in .NET 8, for apps that target .NET 8 or a later version, `RuntimeIden
 
 In addition:
 
-- If `PublishSelfContained` isn't explicitly set to `false`, the publish properties `PublishTrimmed`, `PublishSingleFile`, and `PublishAot` now imply `SelfContained` during `dotnet publish` only (that is, not for `dotnet build` or `dotnet restore`).
+- If `PublishSelfContained` isn't explicitly set to `false`, the publish properties `PublishSingleFile` and `PublishAot` now imply `SelfContained` during `dotnet publish` only (that is, not for `dotnet build` or `dotnet restore`).
 - The `PublishTrimmed` property also now implies `SelfContained` during `dotnet publish`.
 - The `PublishReadyToRun` property no longer implies `SelfContained` if the project targets .NET 8 or later.
 
@@ -49,7 +49,7 @@ This change can affect [source compatibility](../../categories.md#source-compati
 ## Reason for change
 
 - The new .NET SDK behavior aligns with Visual Studio behavior.
-- Framework-dependent apps are now smaller by default, since there aren't copies of .NET stored in each app.
+- Framework-dependent apps are smaller by default, since there aren't copies of .NET stored in each app.
 - When .NET is managed outside of the app (that is, for framework-dependent deployments), .NET stays more secure and up-to-date. Apps that have their own copy of the runtime don't get security updates. This change makes more apps framework-dependent by default.
 - Ideally, command-line options are orthogonal. In this case, the tooling supports both RID-specific self-contained deployment (SCD) and RID-specific framework-dependent deployment (FDD). So it didn't make sense that no RID defaulted to FDD and RID defaulted to SCD. This behavior was often confusing for users.
 

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -80,6 +80,8 @@ items:
         href: sdk/8.0/dotnet-pack-config.md
       - name: "'dotnet publish' uses Release configuration"
         href: sdk/8.0/dotnet-publish-config.md
+      - name: Runtime-specific apps not self-contained
+        href: sdk/8.0/runtimespecific-app-default.md
     - name: Serialization
       items:
       - name: BinaryFormatter disabled for most projects
@@ -1352,6 +1354,8 @@ items:
         href: sdk/8.0/dotnet-pack-config.md
       - name: "'dotnet publish' uses Release configuration"
         href: sdk/8.0/dotnet-publish-config.md
+      - name: Runtime-specific apps not self-contained
+        href: sdk/8.0/runtimespecific-app-default.md
     - name: .NET 7
       items:
       - name: Automatic RuntimeIdentifier for certain projects


### PR DESCRIPTION
Fixes #33726

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/8.0.md](https://github.com/dotnet/docs/blob/6ecb9cfac6074a1489773e148171e810553a388b/docs/core/compatibility/8.0.md) | [Breaking changes in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/8.0?branch=pr-en-us-35656) |
| [docs/core/compatibility/sdk/8.0/runtimespecific-app-default.md](https://github.com/dotnet/docs/blob/6ecb9cfac6074a1489773e148171e810553a388b/docs/core/compatibility/sdk/8.0/runtimespecific-app-default.md) | [docs/core/compatibility/sdk/8.0/runtimespecific-app-default](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/runtimespecific-app-default?branch=pr-en-us-35656) |


<!-- PREVIEW-TABLE-END -->