### PR TITLE
IndexOfAnyValues type name change

### DIFF
--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -2,7 +2,7 @@
 title: Breaking changes in .NET 8
 titleSuffix: ""
 description: Navigate to the breaking changes in .NET 8.
-ms.date: 05/05/2023
+ms.date: 06/05/2023
 no-loc: [Blazor, Razor, Kestrel]
 ---
 # Breaking changes in .NET 8
@@ -35,6 +35,7 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 | [FileStream writes when pipe is closed](core-libraries/8.0/filestream-disposed-pipe.md)                   | Behavioral change   | Preview 1    |
 | [GC.GetGeneration might return Int32.MaxValue](core-libraries/8.0/getgeneration-return-value.md)          | Behavioral change   | Preview 4    |
 | [GetFolderPath behavior on Unix](core-libraries/8.0/getfolderpath-unix.md)                                | Behavioral change   | Preview 1    |
+| [IndexOfAnyValues renamed to SearchValues](core-libraries/8.0/indexofanyvalues-renamed.md)                | Source/binary incompatible | Preview 5 |
 | [ITypeDescriptorContext nullable annotations](core-libraries/8.0/itypedescriptorcontext-props.md)         | Source incompatible | Preview 1    |
 | [Legacy Console.ReadKey removed](core-libraries/8.0/console-readkey-legacy.md)                            | Behavioral change   | Preview 1    |
 

--- a/docs/core/compatibility/core-libraries/8.0/indexofanyvalues-renamed.md
+++ b/docs/core/compatibility/core-libraries/8.0/indexofanyvalues-renamed.md
@@ -5,15 +5,15 @@ ms.date: 06/05/2023
 ---
 # IndexOfAnyValues renamed to SearchValues
 
-.NET 8 Preview 1 introduced a new <xref:System.Buffers.IndexOfAnyValues%601> type to speed up `IndexOfAny`-like operations. In .NET 8 Preview 5, the type has been renamed to `SearchValues<T>`.
+.NET 8 Preview 1 introduced a new `System.Buffers.IndexOfAnyValues<T>` type to speed up `IndexOfAny`-like operations. In .NET 8 Preview 5, the type has been renamed to <xref:System.Buffers.SearchValues%601>.
 
 ## Previous behavior
 
-The affected types were named <xref:System.Buffers.IndexOfAnyValues> and <xref:System.Buffers.IndexOfAnyValues%601>.
+In previous preview versions of .NET 8, the affected types were named `IndexOfAnyValues` and `System.Buffers.IndexOfAnyValues<T>`.
 
 ## New behavior
 
-<xref:System.Buffers.IndexOfAnyValues> and <xref:System.Buffers.IndexOfAnyValues%601> are now named <xref:System.Buffers.SearchValues> and <xref:System.Buffers.SearchValues%601>.
+`IndexOfAnyValues` and `System.Buffers.IndexOfAnyValues<T>` are now named <xref:System.Buffers.SearchValues> and <xref:System.Buffers.SearchValues%601>.
 
 ## Version introduced
 
@@ -34,9 +34,9 @@ This should be as simple as a text-based find-and-replace of "IndexOfAnyValues" 
 
 ## Affected APIs
 
-- <xref:System.Buffers.IndexOfAnyValues%601?displayProperty=fullName>
-- <xref:System.Buffers.IndexOfAnyValues.Create%2A?displayProperty=fullName>
-- <xref:System.MemoryExtensions.IndexOfAny%60%601(System.ReadOnlySpan{%60%600},System.Buffers.IndexOfAnyValues{%60%600})?displayProperty=fullName>
-- <xref:System.MemoryExtensions.IndexOfAny%60%601(System.Span{%60%600},System.Buffers.IndexOfAnyValues{%60%600})?displayProperty=fullName>
-- <xref:System.MemoryExtensions.IndexOfAnyExcept%60%601(System.ReadOnlySpan{%60%600},System.Buffers.IndexOfAnyValues{%60%600})?displayProperty=fullName>
-- <xref:System.MemoryExtensions.IndexOfAnyExcept%60%601(System.Span{%60%600},System.Buffers.IndexOfAnyValues{%60%600})?displayProperty=fullName>
+- `System.Buffers.IndexOfAnyValues<T>`
+- `System.Buffers.IndexOfAnyValues.Create()`
+- `System.MemoryExtensions.IndexOfAny<T>(ReadOnlySpan<T>, IndexOfAnyValues<T>)`
+- `System.MemoryExtensions.IndexOfAny<T>(Span<T>, IndexOfAnyValues<T>)`
+- `System.MemoryExtensions.IndexOfAnyExcept<T>(ReadOnlySpan<T>, IndexOfAnyValues<T>)`
+- `System.MemoryExtensions.IndexOfAnyExcept<T>(Span<T>, IndexOfAnyValues<T>)`

--- a/docs/core/compatibility/core-libraries/8.0/indexofanyvalues-renamed.md
+++ b/docs/core/compatibility/core-libraries/8.0/indexofanyvalues-renamed.md
@@ -1,0 +1,42 @@
+---
+title: ".NET 8 breaking change: IndexOfAnyValues renamed to SearchValues"
+description: Learn about the .NET 8 breaking change in core .NET libraries where the IndexOfAnyValues type was renamed to SearchValues.
+ms.date: 06/05/2023
+---
+# IndexOfAnyValues renamed to SearchValues
+
+.NET 8 Preview 1 introduced a new <xref:System.Buffers.IndexOfAnyValues%601> type to speed up `IndexOfAny`-like operations. In .NET 8 Preview 5, the type has been renamed to `SearchValues<T>`.
+
+## Previous behavior
+
+The affected types were named <xref:System.Buffers.IndexOfAnyValues> and <xref:System.Buffers.IndexOfAnyValues%601>.
+
+## New behavior
+
+<xref:System.Buffers.IndexOfAnyValues> and <xref:System.Buffers.IndexOfAnyValues%601> are now named <xref:System.Buffers.SearchValues> and <xref:System.Buffers.SearchValues%601>.
+
+## Version introduced
+
+.NET 8 Preview 5
+
+## Type of breaking change
+
+This change can affect [source compatibility](../../categories.md#source-compatibility) and [binary compatibility](../../categories.md#binary-compatibility).
+
+## Reason for change
+
+The type was renamed to `SearchValues` to allow us to extend its functionality in the future without making the name of the type misleading. `IndexOfAnyValues` was introduced in a previous preview version of .NET 8 as a way to cache computation associated with preparing any number of values for use in a search. We expected to only use it with `IndexOfAny` and possibly `Contains`. However, there are other places that could benefit from exposing overloads of other operations that would take an `IndexOfAnyValues`, like `Count`, `Replace`, or `Remove`, and in those contexts, the `IndexOfAnyValues` name doesn't make sense.
+
+## Recommended action
+
+If you've written code using `IndexOfAnyValues` in a previous preview version of .NET 8, replace all usages with `SearchValues`.
+This should be as simple as a text-based find-and-replace of "IndexOfAnyValues" with "SearchValues".
+
+## Affected APIs
+
+- <xref:System.Buffers.IndexOfAnyValues%601?displayProperty=fullName>
+- <xref:System.Buffers.IndexOfAnyValues.Create%2A?displayProperty=fullName>
+- <xref:System.MemoryExtensions.IndexOfAny%60%601(System.ReadOnlySpan{%60%600},System.Buffers.IndexOfAnyValues{%60%600})?displayProperty=fullName>
+- <xref:System.MemoryExtensions.IndexOfAny%60%601(System.Span{%60%600},System.Buffers.IndexOfAnyValues{%60%600})?displayProperty=fullName>
+- <xref:System.MemoryExtensions.IndexOfAnyExcept%60%601(System.ReadOnlySpan{%60%600},System.Buffers.IndexOfAnyValues{%60%600})?displayProperty=fullName>
+- <xref:System.MemoryExtensions.IndexOfAnyExcept%60%601(System.Span{%60%600},System.Buffers.IndexOfAnyValues{%60%600})?displayProperty=fullName>

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -34,6 +34,8 @@ items:
         href: core-libraries/8.0/getgeneration-return-value.md
       - name: GetFolderPath behavior on Unix
         href: core-libraries/8.0/getfolderpath-unix.md
+      - name: IndexOfAnyValues renamed to SearchValues
+        href: core-libraries/8.0/indexofanyvalues-renamed.md
       - name: ITypeDescriptorContext nullable annotations
         href: core-libraries/8.0/itypedescriptorcontext-props.md
       - name: Legacy Console.ReadKey removed
@@ -992,6 +994,8 @@ items:
         href: core-libraries/8.0/getgeneration-return-value.md
       - name: GetFolderPath behavior on Unix
         href: core-libraries/8.0/getfolderpath-unix.md
+      - name: IndexOfAnyValues renamed to SearchValues
+        href: core-libraries/8.0/indexofanyvalues-renamed.md
       - name: ITypeDescriptorContext nullable annotations
         href: core-libraries/8.0/itypedescriptorcontext-props.md
       - name: Legacy Console.ReadKey removed


### PR DESCRIPTION
Fixes #35244.

The xref links should resolve once the API reference is updated for Preview 5.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/8.0.md](https://github.com/dotnet/docs/blob/cd0d3776ea6fcafd25d1b3aba5a872de2c59354a/docs/core/compatibility/8.0.md) | [Breaking changes in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/8.0?branch=pr-en-us-35657) |
| [docs/core/compatibility/core-libraries/8.0/indexofanyvalues-renamed.md](https://github.com/dotnet/docs/blob/cd0d3776ea6fcafd25d1b3aba5a872de2c59354a/docs/core/compatibility/core-libraries/8.0/indexofanyvalues-renamed.md) | [docs/core/compatibility/core-libraries/8.0/indexofanyvalues-renamed](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/8.0/indexofanyvalues-renamed?branch=pr-en-us-35657) |


<!-- PREVIEW-TABLE-END -->