### PR TITLE
Update "Tutorial: Create a minimal Orleans application"

### DIFF
--- a/docs/orleans/tutorials-and-samples/snippets/minimal/Client/Program.cs
+++ b/docs/orleans/tutorials-and-samples/snippets/minimal/Client/Program.cs
@@ -17,8 +17,8 @@ try
 }
 catch (Exception e)
 {
-    Console.WriteLine($$"""
-        Exception while trying to run client: {{e.Message}}
+    Console.WriteLine($"""
+        Exception while trying to run client: {e.Message}
         Make sure the silo the client is trying to connect to is running.
         Press any key to exit.
         """);

--- a/docs/orleans/tutorials-and-samples/snippets/minimal/Grains/HelloGrain.cs
+++ b/docs/orleans/tutorials-and-samples/snippets/minimal/Grains/HelloGrain.cs
@@ -11,12 +11,14 @@ public class HelloGrain : Grain, IHello
 
     ValueTask<string> IHello.SayHello(string greeting)
     {
-        _logger.LogInformation(
-            "SayHello message received: greeting = '{Greeting}'", greeting);
+        _logger.LogInformation("""
+            SayHello message received: greeting = "{Greeting}"
+            """,
+            greeting);
         
-        return ValueTask.FromResult(
-            $"""
-            Client said: '{greeting}', so HelloGrain says: Hello!
+        return ValueTask.FromResult($"""
+
+            Client said: "{greeting}", so HelloGrain says: Hello!
             """);
     }
 }

--- a/docs/orleans/tutorials-and-samples/snippets/minimal/Silo/Program.cs
+++ b/docs/orleans/tutorials-and-samples/snippets/minimal/Silo/Program.cs
@@ -1,33 +1,14 @@
 ﻿using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
-try
-{
-    using IHost host = await StartSiloAsync();
-    Console.WriteLine("\n\n Press Enter to terminate...\n\n");
-    Console.ReadLine();
+IHostBuilder builder = Host.CreateDefaultBuilder(args)
+    .UseOrleans(silo =>
+    {
+        silo.UseLocalhostClustering()
+            .ConfigureLogging(logging => logging.AddConsole());
+    })
+    .UseConsoleLifetime();
 
-    await host.StopAsync();
+using IHost host = builder.Build();
 
-    return 0;
-}
-catch (Exception ex)
-{
-    Console.WriteLine(ex);
-    return 1;
-}
-
-static async Task<IHost> StartSiloAsync()
-{
-    var builder = new HostBuilder()
-        .UseOrleans(silo =>
-        {
-            silo.UseLocalhostClustering()
-                .ConfigureLogging(logging => logging.AddConsole());
-        });
-
-    var host = builder.Build();
-    await host.StartAsync();
-
-    return host;
-}
+await host.RunAsync();

--- a/docs/orleans/tutorials-and-samples/tutorial-1.md
+++ b/docs/orleans/tutorials-and-samples/tutorial-1.md
@@ -12,7 +12,7 @@ This tutorial lacks appropriate error handling and other essential code that wou
 
 ## Prerequisites
 
-- [Visual Studio 2022](https://visualstudio.microsoft.com/downloads/) or [Visual Studio Code](https://code.visualstudio.com/download) with the [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) installed.
+- [Visual Studio 2022](https://visualstudio.microsoft.com/downloads)
 - [.NET 7.0 SDK or later](https://dotnet.microsoft.com/download/dotnet/7.0)
 
 ## Project setup
@@ -28,7 +28,7 @@ For this tutorial you're going to create four projects as part of the same solut
 
 Replace the default code with the code given for each project.
 
-1. Start by creating a Console App project in a new solution. Call the project part `Silo` and name the solution `OrleansHelloWorld`. For more information on creating a console app, see [Tutorial: Create a .NET console application using Visual Studio](../../core/tutorials/with-visual-studio.md).
+1. Start by creating a Console App project in a new solution. Call the project part silo and name the solution `OrleansHelloWorld`. For more information on creating a console app, see [Tutorial: Create a .NET console application using Visual Studio](../../core/tutorials/with-visual-studio.md).
 1. Add another Console App project and name it `Client`.
 1. Add a Class Library and name it `GrainInterfaces`. For information on creating a class library, see [Tutorial: Create a .NET class library using Visual Studio](../../core/tutorials/library-with-visual-studio.md).
 1. Add another Class Library and name it `Grains`.

--- a/docs/orleans/tutorials-and-samples/tutorial-1.md
+++ b/docs/orleans/tutorials-and-samples/tutorial-1.md
@@ -1,22 +1,23 @@
 ---
 title: Minimal Orleans app sample project
 description: Explore the minimal Orleans app sample project.
-ms.date: 12/06/2022
+ms.date: 06/05/2023
 ---
 
 # Tutorial: Create a minimal Orleans application
 
-This tutorial provides step-by-step instructions for creating a basic functioning Orleans application. It is designed to be self-contained and minimalistic, with the following traits:
-
-- It relies only on NuGet packages.
-- It has been tested in Visual Studio 2022 using Orleans 7.0.
-- It has no reliance on external storage.
+In this tutorial, you follow step-by-step instructions to create a basic functioning Orleans application. It's designed to be self-contained and minimalistic.
 
 Keep in mind this is a tutorial and lacks appropriate error handling and other essential code that would be useful for a production environment. However, it should help readers get a hands-on understanding of the common app structure for Orleans and allow them to focus their continued learning on the parts most relevant to them.
 
+## Prerequisites
+
+- [Visual Studio 2022](https://visualstudio.microsoft.com/downloads/) or [Visual Studio Code](https://code.visualstudio.com/download) with the [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) installed.
+- [.NET 7.0 SDK or later](https://dotnet.microsoft.com/download/dotnet/7.0)
+
 ## Project setup
 
-For this tutorial we're going to create four projects:
+For this tutorial you're going to create four projects in the same solution:
 
 - Library to contain the grain interfaces.
 - Library to contain the grain classes.
@@ -25,7 +26,7 @@ For this tutorial we're going to create four projects:
 
 ### Create the structure in Visual Studio
 
-You will replace the default code with the code given for each project, below. You will also probably need to add `using` statements.
+You replace the default code with the code given for each project, below. You'll also probably need to add `using` statements.
 
 1. Start by creating a Console App project in a new solution. Call the project part `Silo` and name the solution `OrleansHelloWorld`.
 2. Add another Console App project and name it `Client`.
@@ -52,7 +53,7 @@ You will replace the default code with the code given for each project, below. Y
 | Grain Interfaces | `Microsoft.Orleans.Sdk` |
 | Grains | `Microsoft.Orleans.Sdk`<br>`Microsoft.Extensions.Logging.Abstractions` |
 
-`Microsoft.Orleans.Server`, `Microsoft.Orleans.Client` and `Microsoft.Orleans.Sdk` are meta-packages that bring dependency that you will most likely need on the Silo and client-side. For more information on adding package references, see [dotnet add package](../../core/tools/dotnet-add-package.md) or [Install and manage packages in Visual Studio using the NuGet Package Manage](/nuget/consume-packages/install-use-packages-visual-studio).
+`Microsoft.Orleans.Server`, `Microsoft.Orleans.Client` and `Microsoft.Orleans.Sdk` are meta-packages that bring dependency that you'll most likely need on the Silo and client-side. For more information on adding package references, see [dotnet add package](../../core/tools/dotnet-add-package.md) or [Install and manage packages in Visual Studio using the NuGet Package Manage](/nuget/consume-packages/install-use-packages-visual-studio).
 
 ## Define a Grain Interface
 
@@ -68,7 +69,7 @@ In the **Grains** project, add a _HelloGrain.cs_ code file and define the follow
 
 ### Create the Silo
 
-At this step, we add code to initialize a server that will host and run our grains&mdash;a silo. We will use the development clustering provider here, so that we can run everything locally, without a dependency on external storage systems. For more information, see [Local Development Configuration](../host/configuration-guide/local-development-configuration.md). In this example, you'll run a cluster with a single Silo in it.
+At this step, you add code to initialize a server that will host and run our grains&mdash;a silo. You use the development clustering provider here, so that you can run everything locally, without a dependency on external storage systems. For more information, see [Local Development Configuration](../host/configuration-guide/local-development-configuration.md). In this example, you run a cluster with a single Silo in it.
 
 Add the following code to _Program.cs_ of the **Silo** project:
 
@@ -76,7 +77,7 @@ Add the following code to _Program.cs_ of the **Silo** project:
 
 ### Create the client
 
-Finally, we need to configure a client for communicating with our grains, connect it to the cluster (with a single silo in it), and invoke the grain. Note that the clustering configuration must match the one we used for the silo. For more information, see [Clusters and Clients](../host/client.md)
+Finally, you need to configure a client for communicating with our grains, connect it to the cluster (with a single silo in it), and invoke the grain. The clustering configuration must match the one you used for the silo. For more information, see [Clusters and Clients](../host/client.md)
 
 :::code source="snippets/minimal/Client/Program.cs":::
 

--- a/docs/orleans/tutorials-and-samples/tutorial-1.md
+++ b/docs/orleans/tutorials-and-samples/tutorial-1.md
@@ -1,14 +1,14 @@
 ---
 title: Minimal Orleans app sample project
 description: Explore the minimal Orleans app sample project.
-ms.date: 06/05/2023
+ms.date: 06/06/2023
 ---
 
 # Tutorial: Create a minimal Orleans application
 
-In this tutorial, you follow step-by-step instructions to create a basic functioning Orleans application. It's designed to be self-contained and minimalistic.
+In this tutorial, you follow step-by-step instructions to create foundational moving parts common to most Orleans applications. It's designed to be self-contained and minimalistic.
 
-Keep in mind this is a tutorial and lacks appropriate error handling and other essential code that would be useful for a production environment. However, it should help readers get a hands-on understanding of the common app structure for Orleans and allow them to focus their continued learning on the parts most relevant to them.
+This tutorial lacks appropriate error handling and other essential code that would be useful for a production environment. However, it should help readers get a hands-on understanding of the common app structure for Orleans and allow them to focus their continued learning on the parts most relevant to them.
 
 ## Prerequisites
 
@@ -17,7 +17,7 @@ Keep in mind this is a tutorial and lacks appropriate error handling and other e
 
 ## Project setup
 
-For this tutorial you're going to create four projects in the same solution:
+For this tutorial you're going to create four projects as part of the same solution:
 
 - Library to contain the grain interfaces.
 - Library to contain the grain classes.
@@ -26,12 +26,12 @@ For this tutorial you're going to create four projects in the same solution:
 
 ### Create the structure in Visual Studio
 
-You replace the default code with the code given for each project, below. You'll also probably need to add `using` statements.
+Replace the default code with the code given for each project.
 
-1. Start by creating a Console App project in a new solution. Call the project part `Silo` and name the solution `OrleansHelloWorld`.
-2. Add another Console App project and name it `Client`.
-3. Add a Class Library and name it `GrainInterfaces`.
-4. Add another Class Library and name it `Grains`.
+1. Start by creating a Console App project in a new solution. Call the project part `Silo` and name the solution `OrleansHelloWorld`. For more information on creating a console app, see [Tutorial: Create a .NET console application using Visual Studio](../../core/tutorials/with-visual-studio.md).
+1. Add another Console App project and name it `Client`.
+1. Add a Class Library and name it `GrainInterfaces`. For information on creating a class library, see [Tutorial: Create a .NET class library using Visual Studio](../../core/tutorials/library-with-visual-studio.md).
+1. Add another Class Library and name it `Grains`.
 
 #### Delete default source files
 
@@ -53,9 +53,9 @@ You replace the default code with the code given for each project, below. You'll
 | Grain Interfaces | `Microsoft.Orleans.Sdk` |
 | Grains | `Microsoft.Orleans.Sdk`<br>`Microsoft.Extensions.Logging.Abstractions` |
 
-`Microsoft.Orleans.Server`, `Microsoft.Orleans.Client` and `Microsoft.Orleans.Sdk` are meta-packages that bring dependency that you'll most likely need on the Silo and client-side. For more information on adding package references, see [dotnet add package](../../core/tools/dotnet-add-package.md) or [Install and manage packages in Visual Studio using the NuGet Package Manage](/nuget/consume-packages/install-use-packages-visual-studio).
+`Microsoft.Orleans.Server`, `Microsoft.Orleans.Client` and `Microsoft.Orleans.Sdk` are meta-packages that bring dependencies that you'll most likely need on the Silo and client. For more information on adding package references, see [dotnet add package](../../core/tools/dotnet-add-package.md) or [Install and manage packages in Visual Studio using the NuGet Package Manage](/nuget/consume-packages/install-use-packages-visual-studio).
 
-## Define a Grain Interface
+## Define a grain interface
 
 In the **GrainInterfaces** project, add an _IHello.cs_ code file and define the following `IHello` interface in it:
 
@@ -69,24 +69,50 @@ In the **Grains** project, add a _HelloGrain.cs_ code file and define the follow
 
 ### Create the Silo
 
-At this step, you add code to initialize a server that will host and run our grains&mdash;a silo. You use the development clustering provider here, so that you can run everything locally, without a dependency on external storage systems. For more information, see [Local Development Configuration](../host/configuration-guide/local-development-configuration.md). In this example, you run a cluster with a single Silo in it.
+To create the Silo project, add code to initialize a server that hosts and runs the grains&mdash;a silo. You use the localhost clustering provider, which allows you to run everything locally, without a dependency on external storage systems. For more information, see [Local Development Configuration](../host/configuration-guide/local-development-configuration.md). In this example, you run a cluster with a single Silo in it.
 
 Add the following code to _Program.cs_ of the **Silo** project:
 
 :::code source="snippets/minimal/Silo/Program.cs":::
 
+The preceding code:
+
+- Configures the <xref:Microsoft.Extensions.Hosting.IHost> to use Orleans with the <xref:Microsoft.Extensions.Hosting.GenericHostExtensions.UseOrleans%2A>.
+- Specifies that the localhost clustering provider should be used with the <xref:Orleans.Hosting.CoreHostingExtensions.UseLocalhostClustering(Orleans.Hosting.ISiloBuilder,System.Int32,System.Int32,System.Net.IPEndPoint,System.String,System.String)> method.
+- Runs the `host` and waits for the process to terminate, by listening for <kbd>Ctrl</kbd>+<kbd>C</kbd> or `SIGTERM`.
+
 ### Create the client
 
-Finally, you need to configure a client for communicating with our grains, connect it to the cluster (with a single silo in it), and invoke the grain. The clustering configuration must match the one you used for the silo. For more information, see [Clusters and Clients](../host/client.md)
+Finally, you need to configure a client for communicating with the grains, connect it to the cluster (with a single silo in it), and invoke the grain. The clustering configuration must match the one you used for the silo. For more information, see [Clusters and Clients](../host/client.md)
 
 :::code source="snippets/minimal/Client/Program.cs":::
 
 ## Run the application
 
-Build the solution and run the **Silo**. After you get the confirmation message that the **Silo** is running ("Press enter to terminate..."), run the **Client**. For more information, see [How to: Set multiple startup projects](/visualstudio/ide/how-to-set-multiple-startup-projects).
+Build the solution and run the **Silo**. After you get the confirmation message that the **Silo** is running, run the **Client**.
+
+To start the Silo from the command line, run the following command from the directory containing the Silo's project file:
+
+```dotnetcli
+dotnet run
+```
+
+You'll see numerous outputs as part of the startup of the Silo, after seeing the following message you're ready to run the client:
+
+```Output
+Application started. Press Ctrl+C to shut down.
+```
+
+From the client project directory, run the same .NET CLI command in a separate terminal window to start the client:
+
+```dotnetcli
+dotnet run
+```
+
+For more information on running .NET apps, see [dotnet run](../../core/tools/dotnet-run.md). If you're using Visual Studio, you can [configure multiple startup projects](/visualstudio/ide/how-to-set-multiple-startup-projects).
 
 ## See also
 
-- [List of Orleans Packages](../resources/nuget-packages.md)
-- [Orleans Configuration Guide](../host/configuration-guide/index.md)
-- [Orleans Best Practices](https://www.microsoft.com/research/publication/orleans-best-practices)
+- [List of Orleans packages](../resources/nuget-packages.md)
+- [Orleans configuration guide](../host/configuration-guide/index.md)
+- [Orleans best practices](https://www.microsoft.com/research/publication/orleans-best-practices)

--- a/docs/orleans/tutorials-and-samples/tutorial-1.md
+++ b/docs/orleans/tutorials-and-samples/tutorial-1.md
@@ -8,7 +8,7 @@ ms.date: 06/06/2023
 
 In this tutorial, you follow step-by-step instructions to create foundational moving parts common to most Orleans applications. It's designed to be self-contained and minimalistic.
 
-This tutorial lacks appropriate error handling and other essential code that would be useful for a production environment. However, it should help readers get a hands-on understanding of the common app structure for Orleans and allow them to focus their continued learning on the parts most relevant to them.
+This tutorial lacks appropriate error handling and other essential code that would be useful for a production environment. However, it should help you get a hands-on understanding of the common app structure for Orleans and allow you to focus your continued learning on the parts most relevant to you.
 
 ## Prerequisites
 
@@ -53,7 +53,7 @@ Replace the default code with the code given for each project.
 | Grain Interfaces | `Microsoft.Orleans.Sdk` |
 | Grains | `Microsoft.Orleans.Sdk`<br>`Microsoft.Extensions.Logging.Abstractions` |
 
-`Microsoft.Orleans.Server`, `Microsoft.Orleans.Client` and `Microsoft.Orleans.Sdk` are meta-packages that bring dependencies that you'll most likely need on the Silo and client. For more information on adding package references, see [dotnet add package](../../core/tools/dotnet-add-package.md) or [Install and manage packages in Visual Studio using the NuGet Package Manage](/nuget/consume-packages/install-use-packages-visual-studio).
+`Microsoft.Orleans.Server`, `Microsoft.Orleans.Client` and `Microsoft.Orleans.Sdk` are metapackages that bring dependencies that you'll most likely need on the Silo and client. For more information on adding package references, see [dotnet add package](../../core/tools/dotnet-add-package.md) or [Install and manage packages in Visual Studio using the NuGet Package Manager](/nuget/consume-packages/install-use-packages-visual-studio).
 
 ## Define a grain interface
 
@@ -69,7 +69,7 @@ In the **Grains** project, add a _HelloGrain.cs_ code file and define the follow
 
 ### Create the Silo
 
-To create the Silo project, add code to initialize a server that hosts and runs the grains&mdash;a silo. You use the localhost clustering provider, which allows you to run everything locally, without a dependency on external storage systems. For more information, see [Local Development Configuration](../host/configuration-guide/local-development-configuration.md). In this example, you run a cluster with a single Silo in it.
+To create the Silo project, add code to initialize a server that hosts and runs the grains&mdash;a silo. You use the localhost clustering provider, which allows you to run everything locally, without a dependency on external storage systems. For more information, see [Local Development Configuration](../host/configuration-guide/local-development-configuration.md). In this example, you run a cluster with a single silo in it.
 
 Add the following code to _Program.cs_ of the **Silo** project:
 
@@ -77,7 +77,7 @@ Add the following code to _Program.cs_ of the **Silo** project:
 
 The preceding code:
 
-- Configures the <xref:Microsoft.Extensions.Hosting.IHost> to use Orleans with the <xref:Microsoft.Extensions.Hosting.GenericHostExtensions.UseOrleans%2A>.
+- Configures the <xref:Microsoft.Extensions.Hosting.IHost> to use Orleans with the <xref:Microsoft.Extensions.Hosting.GenericHostExtensions.UseOrleans%2A> method.
 - Specifies that the localhost clustering provider should be used with the <xref:Orleans.Hosting.CoreHostingExtensions.UseLocalhostClustering(Orleans.Hosting.ISiloBuilder,System.Int32,System.Int32,System.Net.IPEndPoint,System.String,System.String)> method.
 - Runs the `host` and waits for the process to terminate, by listening for <kbd>Ctrl</kbd>+<kbd>C</kbd> or `SIGTERM`.
 
@@ -97,7 +97,7 @@ To start the Silo from the command line, run the following command from the dire
 dotnet run
 ```
 
-You'll see numerous outputs as part of the startup of the Silo, after seeing the following message you're ready to run the client:
+You'll see numerous outputs as part of the startup of the Silo. After seeing the following message you're ready to run the client:
 
 ```Output
 Application started. Press Ctrl+C to shut down.


### PR DESCRIPTION
## Summary

In this PR:

- Rewrote the minimal Orleans tutorial.
- Edit pass.
- Modernize the sample source to simplify it.

Fixes #33846, @bradygaster @ReubenBond 

As part of this effort, I discovered that Orleans didn't have extensions on the `HostApplicationBuilder` APIs, so I decided to add them - see https://github.com/dotnet/orleans/pull/8466.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/tutorials-and-samples/tutorial-1.md](https://github.com/dotnet/docs/blob/7a43add541e14e88e6d5af33403bcd9f9fe7fd4b/docs/orleans/tutorials-and-samples/tutorial-1.md) | [Tutorial: Create a minimal Orleans application](https://review.learn.microsoft.com/en-us/dotnet/orleans/tutorials-and-samples/tutorial-1?branch=pr-en-us-35663) |


<!-- PREVIEW-TABLE-END -->