### PR TITLE
Rename orelans roles

### DIFF
--- a/docs/orleans/deployment/kubernetes.md
+++ b/docs/orleans/deployment/kubernetes.md
@@ -117,7 +117,7 @@ For RBAC-enabled clusters, the Kubernetes service account for the pods may also 
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: orleans-clustering
+  name: orleans-hosting
 rules:
 - apiGroups: [ "" ]
   resources: ["pods"]
@@ -126,14 +126,14 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: orleans-clustering-binding
+  name: orleans-hosting-binding
 subjects:
 - kind: ServiceAccount
   name: default
   apiGroup: ''
 roleRef:
   kind: Role
-  name: orleans-clustering
+  name: orleans-hosting
   apiGroup: ''
 ```
 

--- a/docs/orleans/deployment/kubernetes.md
+++ b/docs/orleans/deployment/kubernetes.md
@@ -117,7 +117,7 @@ For RBAC-enabled clusters, the Kubernetes service account for the pods may also 
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: pod-reader
+  name: orleans-clustering
 rules:
 - apiGroups: [ "" ]
   resources: ["pods"]
@@ -126,14 +126,14 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: pod-reader-binding
+  name: orleans-clustering-binding
 subjects:
 - kind: ServiceAccount
   name: default
   apiGroup: ''
 roleRef:
   kind: Role
-  name: pod-reader
+  name: orleans-clustering
   apiGroup: ''
 ```
 


### PR DESCRIPTION
## Summary

"pod-reader" does not reflect the role as it contains the "delete" verb

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/deployment/kubernetes.md](https://github.com/dotnet/docs/blob/cc9ea12132c0779a878166ff043055e1041a78d9/docs/orleans/deployment/kubernetes.md) | [Kubernetes hosting](https://review.learn.microsoft.com/en-us/dotnet/orleans/deployment/kubernetes?branch=pr-en-us-35664) |

<!-- PREVIEW-TABLE-END -->