### PR TITLE
remove C# 7 speclets.

### DIFF
--- a/.openpublishing.redirection.csharp.json
+++ b/.openpublishing.redirection.csharp.json
@@ -45,7 +45,7 @@
             "redirect_url": "/dotnet/csharp/language-reference/language-specification/patterns"
         },
         {
-            "source_path_from_root": "_csharplang/proposals/csharp-7.2/conditional-ref.md",
+            "source_path_from_root": "/redirections/proposals/csharp-7.2/conditional-ref.md",
             "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions#1218-conditional-operator"
         },
         {
@@ -57,7 +57,7 @@
             "redirect_url": "/dotnet/csharp/language-reference/language-specification/classes#1436-access-modifiers"
         },
         {
-            "source_path_from_root": "/redirections/proposals/sharp-7.2/readonly-ref ",
+            "source_path_from_root": "/redirections/proposals/csharp-7.2/readonly-ref.md",
             "redirect_url": "/dotnet/csharp/language-reference/language-specification/variables#928-input-parameters"
         },
         {

--- a/.openpublishing.redirection.csharp.json
+++ b/.openpublishing.redirection.csharp.json
@@ -10,15 +10,15 @@
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-7.0/local-functions.md",
-            "redirect_url": "/dotnet/csharp/language-reference/language-specification/statements.md#1264-local-function-declarations"
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/statements#1264-local-function-declarations"
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-7.0/throw-expression.md",
-            "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions.md#1115-the-throw-expression-operator"
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions#1115-the-throw-expression-operator"
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-7.0/out-var.md",
-            "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions.md#1117-declaration-expressions"
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions#1117-declaration-expressions"
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-7.0/pattern-matching.md",
@@ -26,7 +26,7 @@
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-7.0/task-types.md",
-            "redirect_url": "/dotnet/csharp/language-reference/language-specification/classes.md#15152-task-type-builder-pattern"
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/classes#15152-task-type-builder-pattern"
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-7.1/async-main.md",
@@ -38,55 +38,75 @@
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-7.1/infer-tuple-names.md",
-            "redirect_url": "/dotnet/csharp/language-reference/language-specification/types.md#8311-tuple-types"
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/types#8311-tuple-types"
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-7.1/generics-pattern-match.md",
-            "redirect_url": "/dotnet/csharp/language-reference/language-specification/patterns.md"
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/patterns"
         },
         {
-            "source_path_from_root": "/redirections/proposals/csharp-7.2/private-protected.md",
-            "redirect_url": "/dotnet/csharp/language-reference/language-specification/classes.md#1436-access-modifiers"
-        },
-        {
-            "source_path_from_root": "/redirections/proposals/csharp-7.2/readonly-struct.md",
-            "redirect_url": "/dotnet/csharp/language-reference/language-specification/structs.md#1524-struct-interfaces"
+            "source_path_from_root": "_csharplang/proposals/csharp-7.2/conditional-ref.md",
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions#1218-conditional-operator"
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-7.2/non-trailing-named-arguments.md",
             "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions#11621-general"
         },
         {
+            "source_path_from_root": "/redirections/proposals/csharp-7.2/private-protected.md",
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/classes#1436-access-modifiers"
+        },
+        {
+            "source_path_from_root": "/redirections/proposals/sharp-7.2/readonly-ref ",
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/variables#928-input-parameters"
+        },
+        {
+            "source_path_from_root": "/redirections/proposals/csharp-7.2/readonly-struct.md",
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/structs#1524-struct-interfaces"
+        },
+        {
+            "source_path_from_root": "/redirections/proposals/csharp-7.2/span-safety.md",
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/variables#97-reference-variables-and-returns"
+        },
+        {
             "source_path_from_root": "/redirections/proposals/csharp-7.3/auto-prop-field-attrs.md",
             "redirect_url": "/dotnet/csharp/language-reference/language-specification/attributes#213-attribute-specification"
-        },
-        {
-            "source_path_from_root": "/redirections/proposals/csharp-7.3/improved-overload-candidates.md",
-            "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions#11642-applicable-function-member"
-        },
-        {
-            "source_path_from_root": "/redirections/proposals/csharp-7.3/leading-digit-separator.md",
-            "redirect_url": "/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals"
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-7.3/blittable.md",
             "redirect_url": "/dotnet/csharp/language-reference/language-specification/classes#1425-type-parameter-constraints"
         },
         {
+            "source_path_from_root": "/redirections/proposals/csharp-7.3/expression-variables-in-initializers.md",
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions#1117-declaration-expressions"
+        },
+        {
+            "source_path_from_root": "/redirections/proposals/csharp-7.3/improved-overload-candidates.md",
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions#11642-applicable-function-member"
+        },
+        {
             "source_path_from_root": "/redirections/proposals/csharp-7.3/indexing-movable-fixed-fields.md",
             "redirect_url": "/dotnet/csharp/language-reference/language-specification/unsafe-code#2283-fixed-size-buffers-in-expressions"
+        },
+        {
+            "source_path_from_root": "/redirections/proposals/csharp-7.3/leading-digit-separator.md",
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals"
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-7.3/pattern-based-fixed.md",
             "redirect_url": "/dotnet/csharp/language-reference/language-specification/unsafe-code#227-the-fixed-statement"
         },
         {
-            "source_path_from_root": "/redirections/proposals/csharp-7.3/expression-variables-in-initializers.md",
-            "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions.md#1117-declaration-expressions"
+            "source_path_from_root": "/redirections/proposals/csharp-7.3/ref-local-reassignment.md",
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/variables#97-reference-variables-and-returns"
+        },
+        {
+            "source_path_from_root": "/redirections/proposals/csharp-7.3/stackalloc-array-initializers.md",
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions#12821-stack-allocation"
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-7.3/tuple-equality.md",
-            "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions.md#111211-tuple-equality-operators"
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions#111211-tuple-equality-operators"
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-10.0/generic-attributes.md",

--- a/docfx.json
+++ b/docfx.json
@@ -61,7 +61,6 @@
                     "**/README.md",
                     "inactive/**",
                     "rejected/**",
-                    "csharp-6.0/enum-base-type.md",
                     "csharp-8.0/alternative-interpolated-verbatim.md",
                     "csharp-8.0/async-using.md",
                     "csharp-8.0/constraints-in-overrides.md",

--- a/docfx.json
+++ b/docfx.json
@@ -47,8 +47,6 @@
             },
             {
                 "files": [
-                    "csharp-7.2/*.md",
-                    "csharp-7.3/*.md",
                     "csharp-8.0/*.md",
                     "csharp-9.0/*.md",
                     "csharp-10.0/*.md",
@@ -64,22 +62,6 @@
                     "inactive/**",
                     "rejected/**",
                     "csharp-6.0/enum-base-type.md",
-                    "csharp-7.2/leading-separator.md",
-                    "csharp-7.2/readonly-struct.md",
-                    "csharp-7.2/ref-struct-and-span.md",
-                    "csharp-7.2/ref-extension-methods.md",
-                    "csharp-7.2/non-trailing-named-arguments.md",
-                    "csharp-7.2/private-protected.md",
-                    "csharp-7.2/private-protected.md",
-                    "csharp-7.3/auto-prop-field-attrs.md",
-                    "csharp-7.3/enum-delegate-constraints.md",
-                    "csharp-7.3/improved-overload-candidates.md",
-                    "csharp-7.3/ref-loops.md",
-                    "csharp-7.3/blittable.md",
-                    "csharp-7.3/indexing-movable-fixed-fields.md",
-                    "csharp-7.3/pattern-based-fixed.md",
-                    "csharp-7.3/expression-variables-in-initializers.md",
-                    "csharp-7.3/tuple-equality.md",
                     "csharp-8.0/alternative-interpolated-verbatim.md",
                     "csharp-8.0/async-using.md",
                     "csharp-8.0/constraints-in-overrides.md",
@@ -132,15 +114,6 @@
             }
         ],
         "externalReference": [],
-        "rules": {
-            "docs-link-absolute": {
-                "exclude": [
-                    "_csharplang/proposals/csharp-7.1/target-typed-default.md",
-                    "_csharplang/proposals/csharp-7.2/readonly-struct.md",
-                    "_csharplang/proposals/csharp-7.2/non-trailing-named-arguments.md"
-                ]
-            }
-        },
         "globalMetadata": {
             "apiPlatform": "dotnet",
             "author": "dotnet-bot",
@@ -491,8 +464,6 @@
             },
             "ms.date": {
                 "_csharpstandard/standard/*.md": "01/10/2021",
-                "_csharplang/proposals/csharp-7.2/*.md": "01/19/2019",
-                "_csharplang/proposals/csharp-7.3/*.md": "11/25/2018",
                 "_csharplang/proposals/csharp-8.0/*.md": "09/10/2019",
                 "_csharplang/proposals/csharp-9.0/*.md": "07/29/2020",
                 "_csharplang/proposals/csharp-10.0/*.md": "08/07/2021",
@@ -638,11 +609,6 @@
                 "_csharpstandard/standard/standard-library.md": "Standard library",
                 "_csharpstandard/standard/documentation-comments.md": "Documentation comments",
                 "_csharpstandard/standard/Bibliography.md": "Bibliography",
-                "_csharplang/proposals/csharp-7.2/readonly-ref.md": "Readonly references",
-                "_csharplang/proposals/csharp-7.2/span-safety.md": "Compile time safety for ref-like types",
-                "_csharplang/proposals/csharp-7.2/conditional-ref.md": "Conditional ref",
-                "_csharplang/proposals/csharp-7.3/ref-local-reassignment.md": "Ref local reassignment",
-                "_csharplang/proposals/csharp-7.3/stackalloc-array-initializers.md": "Stackalloc array initializers",
                 "_csharplang/proposals/csharp-8.0/nullable-reference-types.md": "Null reference types - proposal",
                 "_csharplang/proposals/csharp-8.0/patterns.md": "Recursive pattern matching",
                 "_csharplang/proposals/csharp-8.0/default-interface-methods.md": "Default interface methods",
@@ -753,11 +719,6 @@
                 "_csharpstandard/standard/standard-library.md": "This appendix lists requirements of the standard library. The C# language relies on these types for some of its behavior.",
                 "_csharpstandard/standard/documentation-comments.md": "This appendix describes XML comments that are used to document your program.",
                 "_csharpstandard/standard/Bibliography.md": "This appendix lists external standards referenced in this specification.",
-                "_csharplang/proposals/csharp-7.2/readonly-ref.md": "This feature specification describes how to create readonly references to variables. This includes the 'readonly' modifier on variables, and the 'in' modifier on parameters and arguments.",
-                "_csharplang/proposals/csharp-7.2/span-safety.md": "This feature specification describes the rules that govern 'ref struct' declarations and their use.",
-                "_csharplang/proposals/csharp-7.2/conditional-ref.md": "This feature specification describes the syntax enhancements for using 'ref' with '?:' expressions",
-                "_csharplang/proposals/csharp-7.3/ref-local-reassignment.md": "This feature specification describes syntax enhancements that enable ref local variables to be assigned to refer to different storage after being initialized.",
-                "_csharplang/proposals/csharp-7.3/stackalloc-array-initializers.md": "This feature specification describes the syntax that enables arrays to be declared using the 'stackalloc' keyword.",
                 "_csharplang/proposals/csharp-8.0/nullable-reference-types.md": "This feature specification describes nullable reference types.",
                 "_csharplang/proposals/csharp-8.0/patterns.md": "This feature specification describes recursive pattern matching, where patterns can nest inside other patterns.",
                 "_csharplang/proposals/csharp-8.0/default-interface-methods.md": "This feature specification describe the syntax updates necessary to support default interface methods. This includes declaring bodies in interface declarations, and supporting modifiers on declarations.",
@@ -837,8 +798,6 @@
             },
             "titleSuffix": {
                 "_csharpstandard/standard/*.md": "C# language specification",
-                "_csharplang/proposals/csharp-7.2/*.md": "C# 7.2 draft feature specifications",
-                "_csharplang/proposals/csharp-7.3/*.md": "C# 7.3 draft feature specifications",
                 "_csharplang/proposals/csharp-8.0/*.md": "C# 8.0 draft feature specifications",
                 "_csharplang/proposals/csharp-9.0/*.md": "C# 9.0 draft feature specifications",
                 "_csharplang/proposals/csharp-10.0/*.md": "C# 10.0 draft feature specifications",

--- a/docs/csharp/language-reference/operators/arithmetic-operators.md
+++ b/docs/csharp/language-reference/operators/arithmetic-operators.md
@@ -286,7 +286,7 @@ For more information, see the following sections of the [C# language specificati
 - [Remainder operator](~/_csharpstandard/standard/expressions.md#12104-remainder-operator)
 - [Addition operator](~/_csharpstandard/standard/expressions.md#12105-addition-operator)
 - [Subtraction operator](~/_csharpstandard/standard/expressions.md#12106-subtraction-operator)
-- [Compound assignment](~/_csharpstandard/standard/expressions.md#12213-compound-assignment)
+- [Compound assignment](~/_csharpstandard/standard/expressions.md#12214-compound-assignment)
 - [The checked and unchecked operators](~/_csharpstandard/standard/expressions.md#12819-the-checked-and-unchecked-operators)
 - [Numeric promotions](~/_csharpstandard/standard/expressions.md#1247-numeric-promotions)
 

--- a/docs/csharp/language-reference/operators/bitwise-and-shift-operators.md
+++ b/docs/csharp/language-reference/operators/bitwise-and-shift-operators.md
@@ -199,7 +199,7 @@ For more information, see the following sections of the [C# language specificati
 - [Bitwise complement operator](~/_csharpstandard/standard/expressions.md#1295-bitwise-complement-operator)
 - [Shift operators](~/_csharpstandard/standard/expressions.md#1211-shift-operators)
 - [Logical operators](~/_csharpstandard/standard/expressions.md#1213-logical-operators)
-- [Compound assignment](~/_csharpstandard/standard/expressions.md#12213-compound-assignment)
+- [Compound assignment](~/_csharpstandard/standard/expressions.md#12214-compound-assignment)
 - [Numeric promotions](~/_csharpstandard/standard/expressions.md#1247-numeric-promotions)
 - [C# 11 - Relaxed shift requirements](~/_csharplang/proposals/csharp-11.0/relaxing_shift_operator_requirements.md)
 - [C# 11 - Logical right-shift operator](~/_csharplang/proposals/csharp-11.0/unsigned-right-shift-operator.md)

--- a/docs/csharp/language-reference/operators/boolean-logical-operators.md
+++ b/docs/csharp/language-reference/operators/boolean-logical-operators.md
@@ -193,7 +193,7 @@ For more information, see the following sections of the [C# language specificati
 - [Logical negation operator](~/_csharpstandard/standard/expressions.md#1294-logical-negation-operator)
 - [Logical operators](~/_csharpstandard/standard/expressions.md#1213-logical-operators)
 - [Conditional logical operators](~/_csharpstandard/standard/expressions.md#1214-conditional-logical-operators)
-- [Compound assignment](~/_csharpstandard/standard/expressions.md#12213-compound-assignment)
+- [Compound assignment](~/_csharpstandard/standard/expressions.md#12214-compound-assignment)
 
 ## See also
 

--- a/docs/csharp/language-reference/operators/nameof.md
+++ b/docs/csharp/language-reference/operators/nameof.md
@@ -32,7 +32,7 @@ When the operand is a [verbatim identifier](../tokens/verbatim.md), the `@` char
 
 ## C# language specification
 
-For more information, see the [Nameof expressions](~/_csharpstandard/standard/expressions.md#12821-nameof-expressions) section of the [C# language specification](~/_csharpstandard/standard/README.md), and the [C# 11 - Extended `nameof` scope](~/_csharplang/proposals/csharp-11.0/extended-nameof-scope.md) feature specification.
+For more information, see the [Nameof expressions](~/_csharpstandard/standard/expressions.md#12822-nameof-expressions) section of the [C# language specification](~/_csharpstandard/standard/README.md), and the [C# 11 - Extended `nameof` scope](~/_csharplang/proposals/csharp-11.0/extended-nameof-scope.md) feature specification.
 
 ## See also
 

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1292,20 +1292,8 @@ items:
       href: ../../_csharpstandard/standard/documentation-comments.md
     - name: Bibliography
       href: ../../_csharpstandard/standard/bibliography.md
-  - name: C# 7.0 - 12 features
+  - name: C# 8.0 - 12 features
     items:
-    - name: C# 7.n features
-      items:
-      - name: Readonly references
-        href: ../../_csharplang/proposals/csharp-7.2/readonly-ref.md
-      - name: Compile-time safety for ref-like types
-        href: ../../_csharplang/proposals/csharp-7.2/span-safety.md
-      - name: Conditional ref
-        href: ../../_csharplang/proposals/csharp-7.2/conditional-ref.md
-      - name: Ref local reassignment
-        href: ../../_csharplang/proposals/csharp-7.3/ref-local-reassignment.md
-      - name: Stackalloc array initializers
-        href: ../../_csharplang/proposals/csharp-7.3/stackalloc-array-initializers.md
     - name: C# 8.0 features
       items:
       - name: Nullable reference types - proposal


### PR DESCRIPTION
with dotnet/csharpstandard#795, all C# 7.n features have been incorporated into the standard.

Some bug fixes remain, but it's feature complete.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/arithmetic-operators.md](https://github.com/dotnet/docs/blob/cd1f406ad169a516d2671fbcb2acad194a92b2cc/docs/csharp/language-reference/operators/arithmetic-operators.md) | [Arithmetic operators (C# reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/arithmetic-operators?branch=pr-en-us-35668) |
| [docs/csharp/language-reference/operators/bitwise-and-shift-operators.md](https://github.com/dotnet/docs/blob/cd1f406ad169a516d2671fbcb2acad194a92b2cc/docs/csharp/language-reference/operators/bitwise-and-shift-operators.md) | [Bitwise and shift operators (C# reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/bitwise-and-shift-operators?branch=pr-en-us-35668) |
| [docs/csharp/language-reference/operators/boolean-logical-operators.md](https://github.com/dotnet/docs/blob/cd1f406ad169a516d2671fbcb2acad194a92b2cc/docs/csharp/language-reference/operators/boolean-logical-operators.md) | ["Boolean logical operators - the boolean and, or, not, and xor operators"](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/boolean-logical-operators?branch=pr-en-us-35668) |
| [docs/csharp/language-reference/operators/nameof.md](https://github.com/dotnet/docs/blob/cd1f406ad169a516d2671fbcb2acad194a92b2cc/docs/csharp/language-reference/operators/nameof.md) | [nameof expression (C# reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/nameof?branch=pr-en-us-35668) |


<!-- PREVIEW-TABLE-END -->