### PR TITLE
Address feedback from #35660

### DIFF
--- a/docs/standard/garbage-collection/implementing-disposeasync.md
+++ b/docs/standard/garbage-collection/implementing-disposeasync.md
@@ -106,6 +106,8 @@ In the `Dispose(bool)` overload method, the <xref:System.IDisposable> instance i
 
 With the `DisposeAsyncCore()` method, the same logical approach is followed. If the <xref:System.IAsyncDisposable> instance isn't `null`, its call to `DisposeAsync().ConfigureAwait(false)` is awaited. If the <xref:System.IDisposable> instance is also an implementation of <xref:System.IAsyncDisposable>, it's also disposed of asynchronously. Both instances are then assigned to `null`.
 
+Each implementation strives to dispose of all possible disposable objects. This ensures that the cleanup is cascaded properly.
+
 ## Using async disposable
 
 To properly consume an object that implements the <xref:System.IAsyncDisposable> interface, you use the [await](../../csharp/language-reference/operators/await.md) and [using](../../csharp/language-reference/statements/using.md) keywords together. Consider the following example, where the `ExampleAsyncDisposable` class is instantiated and then wrapped in an `await using` statement.

--- a/docs/standard/garbage-collection/snippets/dispose-async/ExampleConjunctiveDisposable.cs
+++ b/docs/standard/garbage-collection/snippets/dispose-async/ExampleConjunctiveDisposable.cs
@@ -22,9 +22,13 @@
         if (disposing)
         {
             _disposableResource?.Dispose();
-            (_asyncDisposableResource as IDisposable)?.Dispose();
             _disposableResource = null;
-            _asyncDisposableResource = null;
+
+            if (_asyncDisposableResource is IDisposable disposable)
+            {
+                disposable.Dispose();
+                _asyncDisposableResource = null;
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #35660, only assign the `IAsyncDisposable` instance to `null` if it disposed synchronously.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/garbage-collection/implementing-disposeasync.md](https://github.com/dotnet/docs/blob/67359b5ce611297ef86dbddf8b9c1eb18b433017/docs/standard/garbage-collection/implementing-disposeasync.md) | [Implement a DisposeAsync method](https://review.learn.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-disposeasync?branch=pr-en-us-35669) |

<!-- PREVIEW-TABLE-END -->