### PR TITLE
Link Managed Threading in Introduction page

### DIFF
--- a/docs/core/introduction.md
+++ b/docs/core/introduction.md
@@ -49,7 +49,7 @@ recommendations: false
 * [Garbage collection](../standard/automatic-memory-management.md)
 * [Generic types](../standard/generics.md)
 * [LINQ (Language Integrated Query)](../standard/linq/index.md).
-* [Parallel programming](../standard/parallel-programming/index.md), [Managed Threading](../standard/threading/managed-threading-basics.md)
+* [Parallel programming](../standard/parallel-programming/index.md) and [Managed threading](../standard/threading/managed-threading-basics.md)
 * Type inference - [C#](../csharp/fundamentals/types/index.md#specifying-types-in-variable-declarations), [F#](../fsharp/language-reference/type-inference.md), [Visual Basic](../visual-basic/programming-guide/language-features/variables/local-type-inference.md).
 * [Type system](../standard/base-types/common-type-system.md)
 * [Unsafe code](../csharp/language-reference/unsafe-code.md)

--- a/docs/core/introduction.md
+++ b/docs/core/introduction.md
@@ -49,7 +49,7 @@ recommendations: false
 * [Garbage collection](../standard/automatic-memory-management.md)
 * [Generic types](../standard/generics.md)
 * [LINQ (Language Integrated Query)](../standard/linq/index.md).
-* [Parallel programming](../standard/parallel-programming/index.md)
+* [Parallel programming](../standard/parallel-programming/index.md), [Managed Threading](../standard/threading/managed-threading-basics.md)
 * Type inference - [C#](../csharp/fundamentals/types/index.md#specifying-types-in-variable-declarations), [F#](../fsharp/language-reference/type-inference.md), [Visual Basic](../visual-basic/programming-guide/language-features/variables/local-type-inference.md).
 * [Type system](../standard/base-types/common-type-system.md)
 * [Unsafe code](../csharp/language-reference/unsafe-code.md)


### PR DESCRIPTION
This pull request fixes #31800.
It adds the link to `Managed Threading` page to Introduction page.

I decided to add this link not as a separate bullet point, but as an additional link right next to `Parallel programming` link. That's because the `Parallel programming` page already contains the link to `Managed Threading`, so it is just to make it easier to find.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/introduction.md](https://github.com/dotnet/docs/blob/ae1755a0340ce901f3dbc51057b298b194f34a94/docs/core/introduction.md) | [What is .NET? Introduction and overview](https://review.learn.microsoft.com/en-us/dotnet/core/introduction?branch=pr-en-us-35676) |


<!-- PREVIEW-TABLE-END -->