### PR TITLE
Add a scenario to netsdk1005.md

### DIFF
--- a/docs/core/tools/sdk-errors/netsdk1005.md
+++ b/docs/core/tools/sdk-errors/netsdk1005.md
@@ -25,3 +25,5 @@ Here are some actions you can take that may resolve the error:
 * Make sure that the missing target value is included in the `TargetFrameworks` property of your project.
 
 * If you're building a Docker image, make sure the *.dockerignore* file ignores the *bin* and *obj* directories. For more information, see GitHub pull request [dotnet/docs #29530](https://github.com/dotnet/docs/pull/29530).
+
+* If you're trying to run a Maui App on an Android Simulator, open the Android SDKs and Tools, and add the missing platforms under both the Platforms and the Tools tab.


### PR DESCRIPTION
Fixes #35285 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/sdk-errors/netsdk1005.md](https://github.com/dotnet/docs/blob/cd4fe6715525cd8d3fced28afcec212c7ae00560/docs/core/tools/sdk-errors/netsdk1005.md) | [NETSDK1005 and NETSDK1047: Asset file is missing target](https://review.learn.microsoft.com/en-us/dotnet/core/tools/sdk-errors/netsdk1005?branch=pr-en-us-35706) |

<!-- PREVIEW-TABLE-END -->