### PR TITLE
Added a note to use a legacy CLI version for WCF projects

### DIFF
--- a/docs/core/porting/upgrade-assistant-install.md
+++ b/docs/core/porting/upgrade-assistant-install.md
@@ -52,4 +52,4 @@ dotnet tool update -g upgrade-assistant
 > dotnet tool install -g --ignore-failed-sources upgrade-assistant
 > ```
 
-For upgrading projects with WCF components, use the older version of the CLI tool. See (Install (legacy version))[https://learn.microsoft.com/dotnet/core/porting/upgrade-assistant-install-legacy] for more details.
+For upgrading projects with WCF components, use the older version of the CLI tool. See [Install (legacy version])(https://learn.microsoft.com/dotnet/core/porting/upgrade-assistant-install-legacy) for more details.

--- a/docs/core/porting/upgrade-assistant-install.md
+++ b/docs/core/porting/upgrade-assistant-install.md
@@ -51,3 +51,5 @@ dotnet tool update -g upgrade-assistant
 > ```dotnetcli
 > dotnet tool install -g --ignore-failed-sources upgrade-assistant
 > ```
+
+For upgrading projects with WCF components, use the older version of the CLI tool. See (Install (legacy version))[https://learn.microsoft.com/dotnet/core/porting/upgrade-assistant-install-legacy] for more details.

--- a/docs/core/porting/upgrade-assistant-install.md
+++ b/docs/core/porting/upgrade-assistant-install.md
@@ -52,4 +52,4 @@ dotnet tool update -g upgrade-assistant
 > dotnet tool install -g --ignore-failed-sources upgrade-assistant
 > ```
 
-For upgrading projects with WCF components, use the older version of the CLI tool. See [Install (legacy version])(https://learn.microsoft.com/dotnet/core/porting/upgrade-assistant-install-legacy) for more details.
+For upgrading projects with WCF components, use the older version of the CLI tool. For more information, see [Install (legacy version)](upgrade-assistant-install-legacy.md).


### PR DESCRIPTION
## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/porting/upgrade-assistant-install.md](https://github.com/dotnet/docs/blob/968a5f200e2fbe25c58f7953a7371fa6f049c4ef/docs/core/porting/upgrade-assistant-install.md) | [Install the .NET Upgrade Assistant](https://review.learn.microsoft.com/en-us/dotnet/core/porting/upgrade-assistant-install?branch=pr-en-us-35712) |


<!-- PREVIEW-TABLE-END -->