### PR TITLE
Update ca1802.md

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1802.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1802.md
@@ -11,6 +11,7 @@ helpviewer_keywords:
 - CA1802
 author: gewarren
 ms.author: gewarren
+author: gewarren, dickbaker
 dev_langs:
 - CSharp
 - VB
@@ -89,6 +90,12 @@ You can configure this rule to override the required field modifiers. By default
 | `static` or `Shared` | Must be declared as 'static' ('Shared' in Visual Basic). |
 | `const`              | Must be declared as 'const'.                             |
 | `readonly`           | Must be declared as 'readonly'.                          |
+| `abstract`           | Must be declared as `abstract`                           |
+| `virtual`            | Must be declared as `virtual`                            |
+| `override`           | Must be declared as `override`                           |
+| `sealed`             | Must be declared as `sealed`                             |
+| `extern`             | Must be declared as `extern`                             |
+| `async`              | Must be declared as `async`                              |
 
 For example, to specify that the rule should run against both static and instance fields, add the following key-value pair to an *.editorconfig* file in your project:
 


### PR DESCRIPTION
option values missing, now copied from ../code-quality-rule-options.md


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1802.md](https://github.com/dotnet/docs/blob/0a898207d11007da10233f1fa16b2a5fdf65da4d/docs/fundamentals/code-analysis/quality-rules/ca1802.md) | [CA1802: Use Literals Where Appropriate](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1802?branch=pr-en-us-35716) |

<!-- PREVIEW-TABLE-END -->