### PR TITLE
Fix typo

### DIFF
--- a/docs/core/whats-new/dotnet-8.md
+++ b/docs/core/whats-new/dotnet-8.md
@@ -545,7 +545,7 @@ MyOptions options0 = section.Get<MyOptions>();
 
 // !! Bind call - to be replaced with source-gen'd implementation
 MyOptions options1 = new MyOptions();
-section.Bind(myOptions1);
+section.Bind(options1);
 
 WebApplication app = builder.Build();
 app.MapGet("/", () => "Hello World!");


### PR DESCRIPTION
## Summary

Fix typo in "Source generator for configuration binding" section from core/whats-new/dotnet-8.md.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/whats-new/dotnet-8.md](https://github.com/dotnet/docs/blob/f7ba8d3a40a69a4b575ec7f41838c9ebc1951c07/docs/core/whats-new/dotnet-8.md) | [What's new in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-8?branch=pr-en-us-35717) |

<!-- PREVIEW-TABLE-END -->