### PR TITLE
Doc for distribution of analyzer config in nuget

### DIFF
--- a/docs/fundamentals/code-analysis/configuration-files.md
+++ b/docs/fundamentals/code-analysis/configuration-files.md
@@ -99,6 +99,17 @@ Consider the following naming recommendations:
 > [!NOTE]
 > The top-level entry `is_global = true` is not required when the file is named `.globalconfig`, but it is recommended for clarity.
 
+### Distribution in NuGet packages
+
+As mentionned above, `GlobalAnalyzerConfigFiles` can be distributed with NuGet packages. To do so, [add a `.props`](https://learn.microsoft.com/en-us/nuget/concepts/msbuild-props-and-targets) file to the nuget, and include the `GlobalAnalyzerConfigFiles` directly under the `Project` node, like so:
+```xml
+<Project>
+  <ItemGroup>
+    <GlobalAnalyzerConfigFiles Include="Relative/Path/to/PackageName.globalconfig" />
+  </ItemGroup>
+</Project>
+```
+
 ### Example
 
 Following is an example global AnalyzerConfig file to configure options and rule severity at the project level:

--- a/docs/fundamentals/code-analysis/configuration-files.md
+++ b/docs/fundamentals/code-analysis/configuration-files.md
@@ -102,6 +102,7 @@ Consider the following naming recommendations:
 ### Distribution in NuGet packages
 
 Global AnalyzerConfig files can be distributed with NuGet packages. To do so, add a [*.props* file](/nuget/concepts/msbuild-props-and-targets) to the NuGet package. In the *.props* file, add a `GlobalAnalyzerConfigFiles` item under the `Project` node:
+
 ```xml
 <Project>
   <ItemGroup>

--- a/docs/fundamentals/code-analysis/configuration-files.md
+++ b/docs/fundamentals/code-analysis/configuration-files.md
@@ -101,7 +101,7 @@ Consider the following naming recommendations:
 
 ### Distribution in NuGet packages
 
-As mentionned above, `GlobalAnalyzerConfigFiles` can be distributed with NuGet packages. To do so, [add a `.props`](https://learn.microsoft.com/nuget/concepts/msbuild-props-and-targets) file to the nuget, and include the `GlobalAnalyzerConfigFiles` directly under the `Project` node, like so:
+Global AnalyzerConfig files can be distributed with NuGet packages. To do so, add a [*.props* file](/nuget/concepts/msbuild-props-and-targets) to the NuGet package. In the *.props* file, add a `GlobalAnalyzerConfigFiles` item under the `Project` node:
 ```xml
 <Project>
   <ItemGroup>

--- a/docs/fundamentals/code-analysis/configuration-files.md
+++ b/docs/fundamentals/code-analysis/configuration-files.md
@@ -101,7 +101,7 @@ Consider the following naming recommendations:
 
 ### Distribution in NuGet packages
 
-As mentionned above, `GlobalAnalyzerConfigFiles` can be distributed with NuGet packages. To do so, [add a `.props`](https://learn.microsoft.com/en-us/nuget/concepts/msbuild-props-and-targets) file to the nuget, and include the `GlobalAnalyzerConfigFiles` directly under the `Project` node, like so:
+As mentionned above, `GlobalAnalyzerConfigFiles` can be distributed with NuGet packages. To do so, [add a `.props`](https://learn.microsoft.com/nuget/concepts/msbuild-props-and-targets) file to the nuget, and include the `GlobalAnalyzerConfigFiles` directly under the `Project` node, like so:
 ```xml
 <Project>
   <ItemGroup>


### PR DESCRIPTION
## Summary

This commit adds documentation for the distribution of `.globalconfig` files with nugets.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/configuration-files.md](https://github.com/dotnet/docs/blob/09cbc03c47ec8895c24b78c70218641e7cdb73cc/docs/fundamentals/code-analysis/configuration-files.md) | [Configuration files for code analysis rules](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/configuration-files?branch=pr-en-us-35719) |


<!-- PREVIEW-TABLE-END -->