### PR TITLE
Refactoring the diagnostic docs and TOC to put the emphasis in the right places

### DIFF
--- a/docs/core/diagnostics/index.md
+++ b/docs/core/diagnostics/index.md
@@ -39,20 +39,20 @@ For most cases, whether adding logging to an existing project or creating a new 
 
 [Distributed Tracing](./distributed-tracing.md) is a specialized form of logging that helps you localize failures and performance issues within applications distributed across multiple machines or processes. This technique tracks requests through an application correlating together work done by different application components and separating it from other work the application may be doing for concurrent requests. It is possible to trace every request and sampling can be optionally employed to bound the performance overhead.
 
-### Collecting Instrumentation
+### Collect instrumentation
 
 There are multiple ways that the instrumentation data can be egressed from the application, including:
 
-- [Open Telemetry](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/docs/trace/getting-started-console/README.md) - a cross platform, vendor neutral standard for collecting and exporting telemetry
+- [Open Telemetry](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/docs/trace/getting-started-console/README.md) - a cross-platform, vendor-neutral standard for collecting and exporting telemetry
 - [.NET CLI tools](./tools-overview.md) such as [dotnet-counters](./dotnet-counters.md)
 - [dotnet-monitor](./dotnet-monitor.md) - an agent for collecting traces and telemetry
-- 3rd party libraries or app code can read the information from the <xref:System.Diagnostics.Metrics?displayProperty=nameWithType>, <xref:Microsoft.Extensions.Logging.ILogger%601> and <xref:System.Diagnostics.Activity?displayProperty=nameWithType> APIs.
+- Third-party libraries or app code can read the information from the <xref:System.Diagnostics.Metrics?displayProperty=nameWithType>, <xref:Microsoft.Extensions.Logging.ILogger%601>, and <xref:System.Diagnostics.Activity?displayProperty=nameWithType> APIs.
 
-## Specialized Diagnostics
+## Specialized diagnostics
 
-If debugging or observability is not sufficient, .NET supports additional diagnostic mechanisms such as EventSource, Dumps & DiagnosticSource. The [specialized diagnostics](./specialized-diagnostics-overview.md) section provides more details.
+If debugging or observability is not sufficient, .NET supports additional diagnostic mechanisms such as EventSource, Dumps, DiagnosticSource. For more information, see the [specialized diagnostics](./specialized-diagnostics-overview.md) article.
 
-## Diagnostics Tools
+## Diagnostics tools
 
 .NET supports a number of [CLI tools](./tools-overview.md) that can be used to diagnose your applications.
 

--- a/docs/core/diagnostics/index.md
+++ b/docs/core/diagnostics/index.md
@@ -21,7 +21,7 @@ This article helps you find the various tools you need.
 
 ## Instrumentation for observability
 
-.NET supports industry standard instrumentation techniques using metrics, logs, and distributed traces, commonly known as the *three pillars of observability*. 
+.NET supports industry standard instrumentation techniques using metrics, logs, and distributed traces, commonly known as the *three pillars of observability*.
 
 Instrumentation is code that is added to a software project to record what it is doing. This information can then be collected in files, databases, or in-memory and analyzed to understand how a software program is operating. This is often used in production environments to monitor for problems and diagnose them. The .NET runtime has built-in instrumentation that can be optionally enabled and APIs that allow you to add custom instrumentation specialized for your application.
 
@@ -42,6 +42,7 @@ For most cases, whether adding logging to an existing project or creating a new 
 ### Collecting Instrumentation
 
 There are multiple ways that the instrumentation data can be egressed from the application, including:
+
 - [Open Telemetry](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/docs/trace/getting-started-console/README.md) - a cross platform, vendor neutral standard for collecting and exporting telemetry
 - [.NET CLI tools](./tools-overview.md) such as [dotnet-counters](./dotnet-counters.md)
 - [dotnet-monitor](./dotnet-monitor.md) - an agent for collecting traces and telemetry

--- a/docs/core/diagnostics/index.md
+++ b/docs/core/diagnostics/index.md
@@ -21,69 +21,39 @@ This article helps you find the various tools you need.
 
 ## Instrumentation for observability
 
-.NET supports industry standard instrumentation techniques using metrics, logs, and distributed traces. Instrumentation is code that is added to a software project to record what it is doing. This information can then be collected in files, databases, or in-memory and analyzed to understand how a software program is operating. This is often used in production environments to monitor for problems and diagnose them. The .NET runtime has built-in instrumentation that can be optionally enabled and APIs that allow you to add custom instrumentation specialized for your application.
+.NET supports industry standard instrumentation techniques using metrics, logs, and distributed traces, commonly known as the *three pillars of observability*. 
 
-### Metrics
-
-[Metrics](metrics.md) are numerical measurements recorded over time to monitor application performance and health. Metrics are often used to generate alerts when potential problems are detected. Metrics have very low performance overhead and many services configure them as always-on telemetry.
+Instrumentation is code that is added to a software project to record what it is doing. This information can then be collected in files, databases, or in-memory and analyzed to understand how a software program is operating. This is often used in production environments to monitor for problems and diagnose them. The .NET runtime has built-in instrumentation that can be optionally enabled and APIs that allow you to add custom instrumentation specialized for your application.
 
 ### Logs
 
 [Logging](logging-tracing.md) is a technique where code is instrumented to produce a log, a record of interesting events that occurred while the program was running. Often a baseline set of log events are configured on by default and more extensive logging can be enabled on-demand to diagnose particular problems. Performance overhead is variable depending on how much data is being logged.
 
+For most cases, whether adding logging to an existing project or creating a new project, the [ILogger infrastructure](../extensions/logging.md) is a good default choice. `ILogger` supports fast structured logging, flexible configuration, and a collection of [common sinks](../extensions/logging-providers.md#built-in-logging-providers) including the console, which is what you see when running an ASP.NET app. Additionally, the `ILogger` interface can also serve as a facade over many [third party logging implementations](../extensions/logging-providers.md#third-party-logging-providers) that offer rich functionality and extensibility.
+
+### Metrics
+
+[Metrics](metrics.md) are numerical measurements recorded over time to monitor application performance and health. Metrics are often used to generate alerts when potential problems are detected. Metrics have very low performance overhead and many services configure them as always-on telemetry.
+
 ### Distributed traces
 
 [Distributed Tracing](./distributed-tracing.md) is a specialized form of logging that helps you localize failures and performance issues within applications distributed across multiple machines or processes. This technique tracks requests through an application correlating together work done by different application components and separating it from other work the application may be doing for concurrent requests. It is possible to trace every request and sampling can be optionally employed to bound the performance overhead.
 
-## Dumps
+### Collecting Instrumentation
 
-A [dump](./dumps.md) is a file that contains a snapshot of the process at the time of creation. These can be useful for examining the state of your application for debugging purposes.
+There are multiple ways that the instrumentation data can be egressed from the application, including:
+- [Open Telemetry](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/docs/trace/getting-started-console/README.md) - a cross platform, vendor neutral standard for collecting and exporting telemetry
+- [.NET CLI tools](./tools-overview.md) such as [dotnet-counters](./dotnet-counters.md)
+- [dotnet-monitor](./dotnet-monitor.md) - an agent for collecting traces and telemetry
+- 3rd party libraries or app code can read the information from the <xref:System.Diagnostics.Metrics?displayProperty=nameWithType>, <xref:Microsoft.Extensions.Logging.ILogger%601> and <xref:System.Diagnostics.Activity?displayProperty=nameWithType> APIs.
 
-## Symbols
+## Specialized Diagnostics
 
-[Symbols](./symbols.md) are a mapping between the source code and the binary produced by the compiler. These are commonly used by .NET debuggers to resolve source line numbers, local variable names, and other types of diagnostic information.
+If debugging or observability is not sufficient, .NET supports additional diagnostic mechanisms such as EventSource, Dumps & DiagnosticSource. The [specialized diagnostics](./specialized-diagnostics-overview.md) section provides more details.
 
-## Collect diagnostics in containers
+## Diagnostics Tools
 
-The same diagnostics tools that are used in non-containerized Linux environments can also be used to [collect diagnostics in containers](diagnostics-in-containers.md). There are just a few usage changes needed to make sure the tools work in a Docker container.
-
-## .NET Core diagnostic global tools
-
-### dotnet-counters
-
-[dotnet-counters](dotnet-counters.md) is a performance monitoring tool for first-level health monitoring and performance investigation. It observes performance counter values published via the <xref:System.Diagnostics.Tracing.EventCounter> API. For example, you can quickly monitor things like the CPU usage or the rate of exceptions being thrown in your .NET Core application.
-
-### dotnet-dump
-
-The [dotnet-dump](dotnet-dump.md) tool is a way to collect and analyze Windows and Linux core dumps without a native debugger.
-
-### dotnet-gcdump
-
-The [dotnet-gcdump](dotnet-gcdump.md) tool is a way to collect GC (Garbage Collector) dumps of live .NET processes.
-
-### dotnet-monitor
-
-The [dotnet-monitor](dotnet-monitor.md) tool is a way to monitor .NET applications in production environments and to collect diagnostic artifacts (for example, dumps, traces, logs, and metrics) on-demand or using automated rules for collecting under specified conditions.
-
-### dotnet-trace
-
-.NET Core includes what is called the `EventPipe` through which diagnostics data is exposed. The [dotnet-trace](dotnet-trace.md) tool allows you to consume interesting profiling data from your app that can help in scenarios where you need to root cause apps running slow.
-
-### dotnet-stack
-
-The [dotnet-stack](dotnet-stack.md) tool allows you to quickly print the managed stacks for all threads in a running .NET process.
-
-### dotnet-symbol
-
-[dotnet-symbol](dotnet-symbol.md) downloads files (symbols, DAC/DBI, host files, etc.) needed to open a core dump or minidump. Use this tool if you need symbols and modules to debug a dump file captured on a different machine.
-
-### dotnet-sos
-
-[dotnet-sos](dotnet-sos.md) installs the [SOS debugging extension](sos-debugging-extension.md) on Linux and macOS (and on Windows if you're using [Windbg/cdb](/windows-hardware/drivers/debugger/debugger-download-tools)).
-
-### PerfCollect
-
-[PerfCollect](trace-perfcollect-lttng.md) is a bash script you can use to collect traces with `perf` and `LTTng` for a more in-depth performance analysis of .NET apps running on Linux distributions.
+.NET supports a number of [CLI tools](./tools-overview.md) that can be used to diagnose your applications.
 
 ## .NET Core diagnostics tutorials
 

--- a/docs/core/diagnostics/logging-tracing.md
+++ b/docs/core/diagnostics/logging-tracing.md
@@ -7,9 +7,9 @@ ms.date: 4/29/2022
 
 Code can be instrumented to produce a log, which serves as a record of interesting events that occurred while the program was running. To understand the application's behavior, logs can be reviewed. Logging and tracing both encapsulate this technique. .NET has accumulated several different logging APIs over its history and this article will help you understand what options are available.
 
-The terms logging and tracing are commonly synonymous, the distinction we usually take is that logging output is expected to be collected all the time, and so should have a low overhead. Tracing is typically more invasive and collects more information from deeper parts of the application and .NET runtime, so is either used when diagnosing specific problems, or automatically for short periods of time as part of deeper performance analysis systems.
+The terms "logging" and "tracing" are commonly synonymous. The distinction is that logging output is expected to be collected all the time, and so it should have a low overhead. Tracing is typically more invasive and collects more information from deeper parts of the application and .NET runtime. It's either used when diagnosing specific problems, or automatically for short periods of time as part of deeper performance-analysis systems.
 
-Another pivot on the tracing term is [Distributed Tracing](./distributed-tracing.md) - which collects high-level activity & timing data for request based systems, and correlates the requests across services to give a view of how each request is processed  by the complete system.
+Another pivot on the tracing term is [Distributed tracing](./distributed-tracing.md). Distributed tracing collects high-level activity and timing data for request-based systems and correlates the requests across services to give a view of how each request is processed by the complete system.
 
 ## Key distinctions in logging APIs
 
@@ -36,11 +36,11 @@ Most logging APIs allow log messages to be sent to different destinations called
 
 For most cases, whether adding logging to an existing project or creating a new project, the [ILogger infrastructure](../extensions/logging.md) is a good default choice. `ILogger` supports fast structured logging, flexible configuration, and a collection of [common sinks](../extensions/logging-providers.md#built-in-logging-providers) including the console, which is what you see when running an ASP.NET app. Additionally, the `ILogger` interface can also serve as a facade over many [third party logging implementations](../extensions/logging-providers.md#third-party-logging-providers) that offer rich functionality and extensibility.
 
-ILogger provides the logging story for the Open Telemetry implementation for .NET, which enables egress of logs from you application to a variety of APM systems for further analysis.
+ILogger provides the logging story for the Open Telemetry implementation for .NET, which enables egress of logs from your application to a variety of APM systems for further analysis.
 
 ### EventSource
 
-[EventSource](./eventsource.md) is an older high performance tracing API with structured logging. It was originally designed to integrate well with [Event Tracing for Windows (ETW)](/windows/win32/etw/event-tracing-portal), but was later extended to support [EventPipe](./eventpipe.md) cross-platform tracing and <xref:System.Diagnostics.Tracing.EventListener> for custom sinks. In comparison to `ILogger`, `EventSource` has relatively few pre-made logging sinks and there is no built-in support to configure via separate configuration files. `EventSource` is excellent if you want tighter control over [ETW](/windows/win32/etw/event-tracing-portal) or [EventPipe](./eventpipe.md) integration, but for general purpose logging, `ILogger` is more flexible and easier to use.
+[EventSource](./eventsource.md) is an older, high-performance tracing API with structured logging. It was originally designed to integrate well with [Event Tracing for Windows (ETW)](/windows/win32/etw/event-tracing-portal), but was later extended to support [EventPipe](./eventpipe.md) cross-platform tracing and <xref:System.Diagnostics.Tracing.EventListener> for custom sinks. In comparison to `ILogger`, `EventSource` has relatively few premade logging sinks and there's no built-in support to configure via separate configuration files. `EventSource` is excellent if you want tighter control over [ETW](/windows/win32/etw/event-tracing-portal) or [EventPipe](./eventpipe.md) integration, but for general purpose logging, `ILogger` is more flexible and easier to use.
 
 ### Trace
 

--- a/docs/core/diagnostics/logging-tracing.md
+++ b/docs/core/diagnostics/logging-tracing.md
@@ -5,7 +5,11 @@ ms.date: 4/29/2022
 ---
 # .NET logging and tracing
 
-Code can be instrumented to produce a log, which serves as a record of interesting events that occurred while the program was running. To understand the application's behavior, logs are reviewed. Logging and tracing both encapsulate this technique. .NET has accumulated several different logging APIs over its history and this article will help you understand what options are available.
+Code can be instrumented to produce a log, which serves as a record of interesting events that occurred while the program was running. To understand the application's behavior, logs can be reviewed. Logging and tracing both encapsulate this technique. .NET has accumulated several different logging APIs over its history and this article will help you understand what options are available.
+
+The terms logging and tracing are commonly synonymous, the distinction we usually take is that logging output is expected to be collected all the time, and so should have a low overhead. Tracing is typically more invasive and collects more information from deeper parts of the application and .NET runtime, so is either used when diagnosing specific problems, or automatically for short periods of time as part of deeper performance analysis systems.
+
+Another pivot on the tracing term is [Distributed Tracing](./distributed-tracing.md) - which collects high-level activity & timing data for request based systems, and correlates the requests across services to give a view of how each request is processed  by the complete system.
 
 ## Key distinctions in logging APIs
 
@@ -30,15 +34,17 @@ Most logging APIs allow log messages to be sent to different destinations called
 
 ### ILogger
 
-For most cases, whether adding logging to an existing project or creating a new project, the [ILogger](../extensions/logging.md) interface is a good default choice. `ILogger` supports fast structured logging, flexible configuration, and a collection of [common sinks](../extensions/logging-providers.md#built-in-logging-providers). Additionally, the `ILogger` interface can also serve as a facade over many [third party logging implementations](../extensions/logging-providers.md#third-party-logging-providers) that offer more functionality and extensibility.
+For most cases, whether adding logging to an existing project or creating a new project, the [ILogger infrastructure](../extensions/logging.md) is a good default choice. `ILogger` supports fast structured logging, flexible configuration, and a collection of [common sinks](../extensions/logging-providers.md#built-in-logging-providers) including the console, which is what you see when running an ASP.NET app. Additionally, the `ILogger` interface can also serve as a facade over many [third party logging implementations](../extensions/logging-providers.md#third-party-logging-providers) that offer rich functionality and extensibility.
+
+ILogger provides the logging story for the Open Telemetry implementation for .NET, which enables egress of logs from you application to a variety of APM systems for further analysis.
 
 ### EventSource
 
-[EventSource](./eventsource.md) is an older high performance structured logging API. It was originally designed to integrate well with [Event Tracing for Windows (ETW)](/windows/win32/etw/event-tracing-portal), but was later extended to support [EventPipe](./eventpipe.md) cross-platform tracing and <xref:System.Diagnostics.Tracing.EventListener> for custom sinks. In comparison to `ILogger`, `EventSource` has relatively few pre-made logging sinks and there is no built-in support to configure via separate configuration files. `EventSource` is excellent if you want tighter control over [ETW](/windows/win32/etw/event-tracing-portal) or [EventPipe](./eventpipe.md) integration, but for general purpose logging, `ILogger` is more flexible and easier to use.
+[EventSource](./eventsource.md) is an older high performance tracing API with structured logging. It was originally designed to integrate well with [Event Tracing for Windows (ETW)](/windows/win32/etw/event-tracing-portal), but was later extended to support [EventPipe](./eventpipe.md) cross-platform tracing and <xref:System.Diagnostics.Tracing.EventListener> for custom sinks. In comparison to `ILogger`, `EventSource` has relatively few pre-made logging sinks and there is no built-in support to configure via separate configuration files. `EventSource` is excellent if you want tighter control over [ETW](/windows/win32/etw/event-tracing-portal) or [EventPipe](./eventpipe.md) integration, but for general purpose logging, `ILogger` is more flexible and easier to use.
 
 ### Trace
 
-<xref:System.Diagnostics.Trace?displayProperty=nameWithType> and <xref:System.Diagnostics.Debug?displayProperty=nameWithType> are .NET's oldest logging APIs. These classes have flexible configuration APIs and a large ecosystem of sinks, but only support unstructured logging. On .NET Framework they can be configured via an app.config file, but in .NET Core, there's no built-in, file-based configuration mechanism. The .NET team continues to support these APIs for backward-compatibility purposes, but no new functionality will be added. These APIs are a fine choice for applications that are already using them. For newer apps that haven't already committed to a logging API, `ILogger` may offer better functionality.
+<xref:System.Diagnostics.Trace?displayProperty=nameWithType> and <xref:System.Diagnostics.Debug?displayProperty=nameWithType> are .NET's oldest logging APIs. These classes have flexible configuration APIs and a large ecosystem of sinks, but only support unstructured logging. On .NET Framework they can be configured via an app.config file, but in .NET Core, there's no built-in, file-based configuration mechanism. They are typically used to produce diagnostics output for the developer while running under the debugger. The .NET team continues to support these APIs for backward-compatibility purposes, but no new functionality will be added. These APIs are a fine choice for applications that are already using them. For newer apps that haven't already committed to a logging API, `ILogger` may offer better functionality.
 
 ## Specialized logging APIs
 

--- a/docs/core/diagnostics/specialized-diagnostics-overview.md
+++ b/docs/core/diagnostics/specialized-diagnostics-overview.md
@@ -3,47 +3,47 @@ title: Specialized Diagnostics
 description: A guide to more advanced diagnostics support in .NET
 ms.date: 05/19/2023
 ---
-# Specialized Diagnostics
+# Specialized diagnostics
 
 If debugging or observability is not sufficient, .NET supports additional diagnostic mechanisms.
 
 ## Tracing with Event Source
 
-[Event Source](./eventsource.md)) provides the ability to collect detailed diagnostic information about what is happening inside .NET processes, and includes telemetry information for the Runtime, GC, Libraries and application code.
+[Event Source](./eventsource.md)) provides the ability to collect detailed diagnostic information about what's happening inside .NET processes. It includes telemetry information for the runtime, GC, libraries, and application code.
 
-Event Source data can be collected in-process using the <xref:System.Diagnostics.Tracing.EventListener?displayProperty=nameWithType> API or with external diagostics tools such as [Visual Studio](/visualstudio/profiling), [dotnet-monitor](./dotnet-monitor.md), [dotnet-trace](./dotnet-trace.md), [PerfView](https://github.com/microsoft/perfview) and the [Perfcollect](./trace-perfcollect-lttng.md) scripts. Using the external tools to collect eventsource data in traces is commonly used for perforance analysis.
+Event Source data can be collected in-process using the <xref:System.Diagnostics.Tracing.EventListener?displayProperty=nameWithType> API or with external diagostics tools such as [Visual Studio](/visualstudio/profiling), [dotnet-monitor](./dotnet-monitor.md), [dotnet-trace](./dotnet-trace.md), [PerfView](https://github.com/microsoft/perfview), and the [Perfcollect](./trace-perfcollect-lttng.md) scripts. Using the external tools to collect event source data in traces is commonly used for performance analysis.
 
-### Collecting diagnostics in containers
+### Collect diagnostics in containers
 
 The same diagnostics tools that are used in non-containerized Linux environments can also be used to [collect diagnostics in containers](diagnostics-in-containers.md). There are just a few usage changes needed to make sure the tools work in a Docker container.
 
 ### EventPipe
 
-[EventPipe](./eventpipe.md) is a runtime component that can be used to collect tracing data, similar to ETW or LTTng. The goal of EventPipe is to allow .NET developers to easily trace their .NET applications without having to rely on platform-specific OS-native components such as ETW or LTTng.
+[EventPipe](./eventpipe.md) is a runtime component that can be used to collect tracing data, similar to ETW or LTTng. The goal of EventPipe is to allow .NET developers to easily trace their .NET applications without having to rely on platform-specific, OS-native components, such as ETW or LTTng.
 
-EventPipe is the mechanism behind many of the diagnostic tools and can be used for consuming events emitted by the runtime as well as custom events written with [EventSource](xref:System.Diagnostics.Tracing.EventSource).
+EventPipe is the mechanism behind many of the diagnostic tools. It can be used for consuming events emitted by the runtime as well as custom events written with [EventSource](xref:System.Diagnostics.Tracing.EventSource).
 
 ## Dumps
 
-A [dump](./dumps.md) is a file that contains a snapshot of the process at the time of dump creation. These can be useful for examining the state of your application for debugging purposes.
+A [dump](./dumps.md) is a file that contains a snapshot of the process at the time of dump creation. Dumps can be useful for examining the state of your application for debugging purposes.
 
 ## Symbols
 
-[Symbols](./symbols.md) are a mapping between the source code and the binary produced by the compiler. These are commonly used by .NET debuggers & tracing tools to resolve source line numbers, local variable names, and other types of diagnostic information.
+[Symbols](./symbols.md) are a mapping between the source code and the binary produced by the compiler. These are commonly used by .NET debuggers and tracing tools to resolve source line numbers, local variable names, and other types of diagnostic information.
 
 ## Diagnostic port
 
-The .NET Core runtime exposes a service endpoint that allows other processes to send diagnostic commands and receive responses over an [IPC channel](https://en.wikipedia.org/wiki/Inter-process_communication). This endpoint is called a *diagnostic port*. Commands can be sent to the diagnostic port to:
+The .NET runtime exposes a service endpoint that allows other processes to send diagnostic commands and receive responses over an [IPC channel](https://en.wikipedia.org/wiki/Inter-process_communication). This endpoint is called a *diagnostic port*. Commands can be sent to the diagnostic port to:
 
 - Capture a memory dump.
 - Start an EventPipe trace.
-- Request the command-line used to launch the app.
+- Request the command line used to launch the app.
 
 ## DiagnosticSource & DiagnosticListener
 
-[DiagnosticSource](./diagnosticsource-diagnosticlistener.md) is a module that allows code to be instrumented for production-time logging of rich data payloads for consumption within the process that was instrumented. At run time, consumers can dynamically discover data sources and subscribe to the ones of interest. <xref:System.Diagnostics.DiagnosticSource?displayProperty=nameWithType> was designed to allow in-process tools to access rich data such as by [Open Telemetry instrumentation libraries](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Instrumentation.AspNetCore/README.md). DiagnosticSource data can also be egressed via EventPipe enabling rich diagnostic data to be collected by dedicated tools. |
+[DiagnosticSource](./diagnosticsource-diagnosticlistener.md) is a module that allows code to be instrumented for production-time logging of rich data payloads for consumption within the process that was instrumented. At run time, consumers can dynamically discover data sources and subscribe to the ones of interest. <xref:System.Diagnostics.DiagnosticSource?displayProperty=nameWithType> was designed to allow in-process tools to access rich data, such as by [Open Telemetry instrumentation libraries](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Instrumentation.AspNetCore/README.md). DiagnosticSource data can also be egressed via EventPipe, which enables rich diagnostic data to be collected by dedicated tools. |
 
-## See Also
+## See also
 
-[Debug high CPU usage](./debug-highcpu.md)
-[Collect a performance trace in Linux with PerfCollect](./trace-perfcollect-lttng.md)
+- [Debug high CPU usage](./debug-highcpu.md)
+- [Collect a performance trace in Linux with PerfCollect](./trace-perfcollect-lttng.md)

--- a/docs/core/diagnostics/specialized-diagnostics-overview.md
+++ b/docs/core/diagnostics/specialized-diagnostics-overview.md
@@ -1,0 +1,48 @@
+---
+title: Specialized Diagnostics
+description: A guide to more advanced diagnostics support in .NET
+ms.date: 05/19/2023
+---
+# Specialized Diagnostics
+
+If debugging or observability is not sufficient, .NET supports additional diagnostic mechanisms.
+
+## Tracing with Event Source
+
+[Event Source](./eventsource.md)) provides the ability to collect detailed diagnostic information about what is happening inside .NET processes, and includes telemetry information for the Runtime, GC, Libraries and application code.
+
+Event Source data can be collected in-process using the <xref:System.Diagnostics.Tracing.EventListener?displayProperty=nameWithType> API or with external diagostics tools such as [Visual Studio](https://learn.microsoft.com/visualstudio/profiling), [dotnet-monitor](./dotnet-monitor.md), [dotnet-trace](./dotnet-trace.md), [PerfView](https://github.com/microsoft/perfview) and the [Perfcollect](./trace-perfcollect-lttng.md) scripts. Using the external tools to collect eventsource data in traces is commonly used for perforance analysis.
+
+### Collecting diagnostics in containers
+
+The same diagnostics tools that are used in non-containerized Linux environments can also be used to [collect diagnostics in containers](diagnostics-in-containers.md). There are just a few usage changes needed to make sure the tools work in a Docker container.
+
+### EventPipe 
+
+[EventPipe](./eventpipe.md) is a runtime component that can be used to collect tracing data, similar to ETW or LTTng. The goal of EventPipe is to allow .NET developers to easily trace their .NET applications without having to rely on platform-specific OS-native components such as ETW or LTTng.
+
+EventPipe is the mechanism behind many of the diagnostic tools and can be used for consuming events emitted by the runtime as well as custom events written with [EventSource](xref:System.Diagnostics.Tracing.EventSource).
+
+## Dumps
+
+A [dump](./dumps.md) is a file that contains a snapshot of the process at the time of dump creation. These can be useful for examining the state of your application for debugging purposes.
+
+## Symbols
+
+[Symbols](./symbols.md) are a mapping between the source code and the binary produced by the compiler. These are commonly used by .NET debuggers & tracing tools to resolve source line numbers, local variable names, and other types of diagnostic information.
+
+## Diagnostic port
+
+The .NET Core runtime exposes a service endpoint that allows other processes to send diagnostic commands and receive responses over an [IPC channel](https://en.wikipedia.org/wiki/Inter-process_communication). This endpoint is called a *diagnostic port*. Commands can be sent to the diagnostic port to:
+
+- Capture a memory dump.
+- Start an EventPipe trace.
+- Request the command-line used to launch the app.
+
+## DiagnosticSource & DiagnosticListener
+[DiagnosticSource](./diagnosticsource-diagnosticlistener.md) is a module that allows code to be instrumented for production-time logging of rich data payloads for consumption within the process that was instrumented. At run time, consumers can dynamically discover data sources and subscribe to the ones of interest. <xref:System.Diagnostics.DiagnosticSource?displayProperty=nameWithType> was designed to allow in-process tools to access rich data such as by [Open Telemetry instrumentation libraries](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Instrumentation.AspNetCore/README.md). DiagnosticSource data can also be egressed via EventPipe enabling rich diagnostic data to be collected by dedicated tools. |
+
+## See Also
+
+[Debug high CPU usage](./debug-highcpu.md)
+[Collect a performance trace in Linux with PerfCollect](./trace-perfcollect-lttng.md)

--- a/docs/core/diagnostics/specialized-diagnostics-overview.md
+++ b/docs/core/diagnostics/specialized-diagnostics-overview.md
@@ -11,7 +11,7 @@ If debugging or observability is not sufficient, .NET supports additional diagno
 
 [Event Source](./eventsource.md)) provides the ability to collect detailed diagnostic information about what is happening inside .NET processes, and includes telemetry information for the Runtime, GC, Libraries and application code.
 
-Event Source data can be collected in-process using the <xref:System.Diagnostics.Tracing.EventListener?displayProperty=nameWithType> API or with external diagostics tools such as [Visual Studio](https://learn.microsoft.com/visualstudio/profiling), [dotnet-monitor](./dotnet-monitor.md), [dotnet-trace](./dotnet-trace.md), [PerfView](https://github.com/microsoft/perfview) and the [Perfcollect](./trace-perfcollect-lttng.md) scripts. Using the external tools to collect eventsource data in traces is commonly used for perforance analysis.
+Event Source data can be collected in-process using the <xref:System.Diagnostics.Tracing.EventListener?displayProperty=nameWithType> API or with external diagostics tools such as [Visual Studio](/visualstudio/profiling), [dotnet-monitor](./dotnet-monitor.md), [dotnet-trace](./dotnet-trace.md), [PerfView](https://github.com/microsoft/perfview) and the [Perfcollect](./trace-perfcollect-lttng.md) scripts. Using the external tools to collect eventsource data in traces is commonly used for perforance analysis.
 
 ### Collecting diagnostics in containers
 

--- a/docs/core/diagnostics/specialized-diagnostics-overview.md
+++ b/docs/core/diagnostics/specialized-diagnostics-overview.md
@@ -17,7 +17,7 @@ Event Source data can be collected in-process using the <xref:System.Diagnostics
 
 The same diagnostics tools that are used in non-containerized Linux environments can also be used to [collect diagnostics in containers](diagnostics-in-containers.md). There are just a few usage changes needed to make sure the tools work in a Docker container.
 
-### EventPipe 
+### EventPipe
 
 [EventPipe](./eventpipe.md) is a runtime component that can be used to collect tracing data, similar to ETW or LTTng. The goal of EventPipe is to allow .NET developers to easily trace their .NET applications without having to rely on platform-specific OS-native components such as ETW or LTTng.
 
@@ -40,6 +40,7 @@ The .NET Core runtime exposes a service endpoint that allows other processes to 
 - Request the command-line used to launch the app.
 
 ## DiagnosticSource & DiagnosticListener
+
 [DiagnosticSource](./diagnosticsource-diagnosticlistener.md) is a module that allows code to be instrumented for production-time logging of rich data payloads for consumption within the process that was instrumented. At run time, consumers can dynamically discover data sources and subscribe to the ones of interest. <xref:System.Diagnostics.DiagnosticSource?displayProperty=nameWithType> was designed to allow in-process tools to access rich data such as by [Open Telemetry instrumentation libraries](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Instrumentation.AspNetCore/README.md). DiagnosticSource data can also be egressed via EventPipe enabling rich diagnostic data to be collected by dedicated tools. |
 
 ## See Also

--- a/docs/core/diagnostics/tools-overview.md
+++ b/docs/core/diagnostics/tools-overview.md
@@ -1,0 +1,59 @@
+---
+title: .NET Diagnostic tools overview
+description: An overview of the tools available to diagnose .NET Core applications.
+ms.date: 06/8/2023
+ms.topic: overview
+#Customer intent: As a .NET Core developer I want to find the best tools to help me diagnose problems so that I can be productive.
+---
+
+# .NET Core diagnostic tools
+
+.NET supports a number of tools that can be used to diagnose your applications.
+
+## IDE / Editors
+
+### Visual Studio
+[Visual Studio](https://visualstudio.microsoft.com/#vs-section) is the most comprehensive IDE for .NET developers on Windows. It includes [debugging](https://learn.microsoft.com/visualstudio/debugger/) and [performance profiling](https://learn.microsoft.com/visualstudio/profiling) tools to aid .NET developers in diagnosing their applications.
+
+### Visual Studio Code
+[Visual Studio Code](https://visualstudio.microsoft.com/#vscode-section) is a lightweight but powerful source code editor which runs on your desktop and is available for Windows, macOS and Linux. It supports local and remote [debugging](https://code.visualstudio.com/docs/csharp/debugging) for .NET.
+
+## CLI Tools
+
+### dotnet-counters
+
+[dotnet-counters](dotnet-counters.md) is a performance monitoring tool for first-level health monitoring and performance investigation. It observes performance counter values published via the <xref:System.Diagnostics.Tracing.EventCounter> API. For example, you can quickly monitor things like the CPU usage or the rate of exceptions being thrown in your .NET Core application.
+
+### dotnet-dump
+
+The [dotnet-dump](dotnet-dump.md) tool is a way to collect and analyze Windows and Linux core dumps without a native debugger.
+
+### dotnet-gcdump
+
+The [dotnet-gcdump](dotnet-gcdump.md) tool is a way to collect GC (Garbage Collector) dumps of live .NET processes.
+
+### dotnet-monitor
+
+The [dotnet-monitor](dotnet-monitor.md) tool is a way to monitor .NET applications in production environments and to collect diagnostic artifacts (for example, dumps, traces, logs, and metrics) on-demand or using automated rules for collecting under specified conditions.
+
+### dotnet-trace
+
+.NET Core includes what is called the `EventPipe` through which diagnostics data is exposed. The [dotnet-trace](dotnet-trace.md) tool allows you to consume interesting profiling data from your app that can help in scenarios where you need to root cause apps running slow.
+
+### dotnet-stack
+
+The [dotnet-stack](dotnet-stack.md) tool allows you to quickly print the managed stacks for all threads in a running .NET process.
+
+### dotnet-symbol
+
+[dotnet-symbol](dotnet-symbol.md) downloads files (symbols, DAC/DBI, host files, etc.) needed to open a core dump or minidump. Use this tool if you need symbols and modules to debug a dump file captured on a different machine.
+
+### dotnet-sos
+
+[dotnet-sos](dotnet-sos.md) installs the [SOS debugging extension](sos-debugging-extension.md) on Linux and macOS (and on Windows if you're using [Windbg/cdb](/windows-hardware/drivers/debugger/debugger-download-tools)).
+
+## Other Tools
+
+### PerfCollect
+
+[PerfCollect](trace-perfcollect-lttng.md) is a bash script you can use to collect traces with `perf` and `LTTng` for a more in-depth performance analysis of .NET apps running on Linux distributions.

--- a/docs/core/diagnostics/tools-overview.md
+++ b/docs/core/diagnostics/tools-overview.md
@@ -13,9 +13,11 @@ ms.topic: overview
 ## IDE / Editors
 
 ### Visual Studio
+
 [Visual Studio](https://visualstudio.microsoft.com/#vs-section) is the most comprehensive IDE for .NET developers on Windows. It includes [debugging](https://learn.microsoft.com/visualstudio/debugger/) and [performance profiling](https://learn.microsoft.com/visualstudio/profiling) tools to aid .NET developers in diagnosing their applications.
 
 ### Visual Studio Code
+
 [Visual Studio Code](https://visualstudio.microsoft.com/#vscode-section) is a lightweight but powerful source code editor which runs on your desktop and is available for Windows, macOS and Linux. It supports local and remote [debugging](https://code.visualstudio.com/docs/csharp/debugging) for .NET.
 
 ## CLI Tools

--- a/docs/core/diagnostics/tools-overview.md
+++ b/docs/core/diagnostics/tools-overview.md
@@ -6,11 +6,11 @@ ms.topic: overview
 #Customer intent: As a .NET Core developer I want to find the best tools to help me diagnose problems so that I can be productive.
 ---
 
-# .NET Core diagnostic tools
+# .NET diagnostic tools
 
 .NET supports a number of tools that can be used to diagnose your applications.
 
-## IDE / Editors
+## IDEs and editors
 
 ### Visual Studio
 
@@ -18,9 +18,9 @@ ms.topic: overview
 
 ### Visual Studio Code
 
-[Visual Studio Code](https://visualstudio.microsoft.com/#vscode-section) is a lightweight but powerful source code editor which runs on your desktop and is available for Windows, macOS and Linux. It supports local and remote [debugging](https://code.visualstudio.com/docs/csharp/debugging) for .NET.
+[Visual Studio Code](https://visualstudio.microsoft.com/#vscode-section) is a lightweight but powerful source code editor that runs on your desktop and is available for Windows, macOS, and Linux. It supports local and remote [debugging](https://code.visualstudio.com/docs/csharp/debugging) for .NET.
 
-## CLI Tools
+## CLI tools
 
 ### dotnet-counters
 
@@ -32,7 +32,7 @@ The [dotnet-dump](dotnet-dump.md) tool is a way to collect and analyze Windows a
 
 ### dotnet-gcdump
 
-The [dotnet-gcdump](dotnet-gcdump.md) tool is a way to collect GC (Garbage Collector) dumps of live .NET processes.
+The [dotnet-gcdump](dotnet-gcdump.md) tool is a way to collect garbage collector (GC) dumps of live .NET processes.
 
 ### dotnet-monitor
 
@@ -40,7 +40,7 @@ The [dotnet-monitor](dotnet-monitor.md) tool is a way to monitor .NET applicatio
 
 ### dotnet-trace
 
-.NET Core includes what is called the `EventPipe` through which diagnostics data is exposed. The [dotnet-trace](dotnet-trace.md) tool allows you to consume interesting profiling data from your app that can help in scenarios where you need to root cause apps running slow.
+.NET Core includes `EventPipe`, which exposes diagnostics data. The [dotnet-trace](dotnet-trace.md) tool allows you to consume interesting profiling data from your app that can help in scenarios where you need to root-cause apps running that are running slowly.
 
 ### dotnet-stack
 
@@ -48,13 +48,13 @@ The [dotnet-stack](dotnet-stack.md) tool allows you to quickly print the managed
 
 ### dotnet-symbol
 
-[dotnet-symbol](dotnet-symbol.md) downloads files (symbols, DAC/DBI, host files, etc.) needed to open a core dump or minidump. Use this tool if you need symbols and modules to debug a dump file captured on a different machine.
+[dotnet-symbol](dotnet-symbol.md) downloads files (for example, symbols, DAC/DBI, and host files) needed to open a core dump or minidump. Use this tool if you need symbols and modules to debug a dump file captured on a different machine.
 
 ### dotnet-sos
 
 [dotnet-sos](dotnet-sos.md) installs the [SOS debugging extension](sos-debugging-extension.md) on Linux and macOS (and on Windows if you're using [Windbg/cdb](/windows-hardware/drivers/debugger/debugger-download-tools)).
 
-## Other Tools
+## Other tools
 
 ### PerfCollect
 

--- a/docs/core/diagnostics/tools-overview.md
+++ b/docs/core/diagnostics/tools-overview.md
@@ -14,7 +14,7 @@ ms.topic: overview
 
 ### Visual Studio
 
-[Visual Studio](https://visualstudio.microsoft.com/#vs-section) is the most comprehensive IDE for .NET developers on Windows. It includes [debugging](https://learn.microsoft.com/visualstudio/debugger/) and [performance profiling](https://learn.microsoft.com/visualstudio/profiling) tools to aid .NET developers in diagnosing their applications.
+[Visual Studio](https://visualstudio.microsoft.com/#vs-section) is the most comprehensive IDE for .NET developers on Windows. It includes [debugging](/visualstudio/debugger/) and [performance profiling](/visualstudio/profiling) tools to aid .NET developers in diagnosing their applications.
 
 ### Visual Studio Code
 

--- a/docs/core/tools/global-tools.md
+++ b/docs/core/tools/global-tools.md
@@ -38,7 +38,7 @@ Here are some ways to find tools:
 * Use the [dotnet tool search](dotnet-tool-search.md) command to find a tool that's published to NuGet.org.
 * Use the ".NET tool" package type filter to search for the [NuGet](https://www.nuget.org) website. For more information, see [Finding and choosing packages](/nuget/consume-packages/finding-and-choosing-packages).
 * See the source code for the tools the ASP.NET Core team created in the [Tools directory of the dotnet/aspnetcore GitHub repository](https://github.com/dotnet/aspnetcore/tree/main/src/Tools).
-* Learn about diagnostic tools at [.NET diagnostic tools](../diagnostics/index.md#net-core-diagnostic-global-tools).
+* Learn about diagnostic tools at [.NET diagnostic tools](../diagnostics/tools-overview.md).
 
 ## Check the author and statistics
 

--- a/docs/navigate/tools-diagnostics/toc.yml
+++ b/docs/navigate/tools-diagnostics/toc.yml
@@ -305,7 +305,7 @@ items:
   - name: Diagnostics and instrumentation
     items:
     - name: Overview
-    - displayName: diagnostics, instrumentation
+      displayName: diagnostics, instrumentation
       href: ../../core/diagnostics/index.md
     - name: Managed debuggers
       href: ../../core/diagnostics/managed-debuggers.md

--- a/docs/navigate/tools-diagnostics/toc.yml
+++ b/docs/navigate/tools-diagnostics/toc.yml
@@ -304,149 +304,150 @@ items:
         href: ../../core/additional-tools/xml-serializer-generator.md
   - name: Diagnostics and instrumentation
     items:
+    - name: Overview
+      href: ../core/diagnostics/index.md
+    - name: Managed debuggers
+      href: ../core/diagnostics/managed-debuggers.md
+    - name: Logging & Tracing options
+      href: ../core/diagnostics/logging-tracing.md
+    - name: ILogger Logging
+      href: ../core/extensions/logging.md  
+    - name: Metrics
+      items:
       - name: Overview
-        href: ../../core/diagnostics/index.md
-      - name: Managed debuggers
-        href: ../../core/diagnostics/managed-debuggers.md
-      - name: Diagnostic port
-        href: ../../core/diagnostics/diagnostic-port.md
+        displayName: metrics
+        href: ../core/diagnostics/metrics.md
+      - name: Instrumentation
+        href: ../core/diagnostics/metrics-instrumentation.md
+      - name: Collection
+        href: ../core/diagnostics/metrics-collection.md
+      - name: EventCounters
+        items:
+        - name: Overview
+          displayName: eventcounter
+          href: ../core/diagnostics/event-counters.md
+        - name: Well-known counters
+          href: ../core/diagnostics/available-counters.md
+        - name: "Tutorial: Measure performance with EventCounters"
+          href: ../core/diagnostics/event-counter-perf.md
+      - name: Compare metric APIs
+        href: ../core/diagnostics/compare-metric-apis.md
+    - name: Distributed tracing
+      items:
+      - name: Overview
+        href: ../core/diagnostics/distributed-tracing.md
+      - name: Concepts
+        href: ../core/diagnostics/distributed-tracing-concepts.md
+      - name: Instrumentation
+        href: ../core/diagnostics/distributed-tracing-instrumentation-walkthroughs.md
+      - name: Collection
+        href: ../core/diagnostics/distributed-tracing-collection-walkthroughs.md
+    - name: Specialized Diagnostics
+      items:
+      - name: Overview
+        href: specialized-diagnostics-overview.md    
+      - name: Event Source
+        items:
+        - name: Overview
+          href: ../core/diagnostics/eventsource.md
+        - name: Getting started
+          href: ../core/diagnostics/eventsource-getting-started.md
+        - name: Instrumentation
+          href: ../core/diagnostics/eventsource-instrumentation.md
+        - name: Collection
+          href: ../core/diagnostics/eventsource-collect-and-view-traces.md
+        - name: Activity IDs
+          href: ../core/diagnostics/eventsource-activity-ids.md
+        - name: Well-known event providers
+          href: ../core/diagnostics/well-known-event-providers.md
+        - name: Runtime event Reference
+          items:
+          - name: Overview
+            href: ../fundamentals/diagnostics/runtime-events.md
+          - name: Contention events
+            href: ../fundamentals/diagnostics/runtime-contention-events.md
+          - name: Exception events
+            href: ../fundamentals/diagnostics/runtime-exception-events.md
+          - name: Garbage collection events
+            href: ../fundamentals/diagnostics/runtime-garbage-collection-events.md
+          - name: Interop events
+            href: ../fundamentals/diagnostics/runtime-interop-events.md
+          - name: Loader and binder events
+            href: ../fundamentals/diagnostics/runtime-loader-binder-events.md
+          - name: Method events
+            href: ../fundamentals/diagnostics/runtime-method-events.md
+          - name: ThreadPool events
+            href: ../fundamentals/diagnostics/runtime-thread-events.md
+          - name: Type-system events
+            href: ../fundamentals/diagnostics/runtime-type-events.md
+      - name: Collect diagnostics in containers
+        href: ../core/diagnostics/diagnostics-in-containers.md   
       - name: Dumps
         items:
-          - name: Overview
-            displayName: dumps
-            href: ../../core/diagnostics/dumps.md
-          - name: Linux dumps
-            href: ../../core/diagnostics/debug-linux-dumps.md
-          - name: SOS debugger extension
-            href: ../../core/diagnostics/sos-debugging-extension.md
-          - name: Dumps FAQ - .NET
-            href: ../../core/diagnostics/faq-dumps.yml
-          - name: Debug Windows dumps
-            href: ../../core/diagnostics/debug-windows-dumps.md
-          - name: Collect dumps on crash
-            href: ../../core/diagnostics/collect-dumps-crash.md
-      - name: Logging and tracing
-        items:
-          - name: Overview
-            displayName: logging tracing
-            href: ../../core/diagnostics/logging-tracing.md
-          - name: Well-known event providers
-            href: ../../core/diagnostics/well-known-event-providers.md
-          - name: Event Source
-            items:
-              - name: Overview
-                href: ../../core/diagnostics/eventsource.md
-              - name: Getting started
-                href: ../../core/diagnostics/eventsource-getting-started.md
-              - name: Instrumentation
-                href: ../../core/diagnostics/eventsource-instrumentation.md
-              - name: Collection
-                href: ../../core/diagnostics/eventsource-collect-and-view-traces.md
-              - name: Activity IDs
-                href: ../../core/diagnostics/eventsource-activity-ids.md
-          - name: DiagnosticSource and DiagnosticListener
-            items:
-              - name: Getting started
-                href: ../../core/diagnostics/diagnosticsource-diagnosticlistener.md
-          - name: EventPipe
-            href: ../../core/diagnostics/eventpipe.md
-      - name: Metrics
-        items:
-          - name: Overview
-            displayName: metrics
-            href: ../../core/diagnostics/metrics.md
-          - name: Instrumentation
-            href: ../../core/diagnostics/metrics-instrumentation.md
-          - name: Collection
-            href: ../../core/diagnostics/metrics-collection.md
-          - name: EventCounters
-            items:
-              - name: Overview
-                displayName: eventcounter
-                href: ../../core/diagnostics/event-counters.md
-              - name: Well-known counters
-                href: ../../core/diagnostics/available-counters.md
-              - name: "Tutorial: Measure performance with EventCounters"
-                href: ../../core/diagnostics/event-counter-perf.md
-          - name: Compare metric APIs
-            href: ../../core/diagnostics/compare-metric-apis.md
-      - name: Distributed tracing
-        items:
-          - name: Overview
-            href: ../../core/diagnostics/distributed-tracing.md
-          - name: Concepts
-            href: ../../core/diagnostics/distributed-tracing-concepts.md
-          - name: Instrumentation
-            href: ../../core/diagnostics/distributed-tracing-instrumentation-walkthroughs.md
-          - name: Collection
-            href: ../../core/diagnostics/distributed-tracing-collection-walkthroughs.md
+        - name: Overview
+          displayName: dumps
+          href: ../core/diagnostics/dumps.md
+        - name: Linux dumps
+          href: ../core/diagnostics/debug-linux-dumps.md
+        - name: SOS debugger extension
+          href: ../core/diagnostics/sos-debugging-extension.md
       - name: Symbols
-        href: ../../core/diagnostics/symbols.md
-      - name: Microsoft.Diagnostics.NETCore.Client library
+        href: ../core/diagnostics/symbols.md    
+      - name: EventPipe
+        href: ../core/diagnostics/eventpipe.md    
+      - name: Diagnostic port
         items:
+        - name: Overview
+          href: ../core/diagnostics/diagnostic-port.md
+        - name: Microsoft.Diagnostics.NETCore.Client library
+          items:
           - name: Overview and examples
             displayName: diagnostics client library
-            href: ../../core/diagnostics/diagnostics-client-library.md
+            href: ../core/diagnostics/diagnostics-client-library.md
           - name: API reference
-            href: ../../core/diagnostics/microsoft-diagnostics-netcore-client.md
-      - name: Runtime events
+            href: ../core/diagnostics/microsoft-diagnostics-netcore-client.md
+      - name: DiagnosticSource and DiagnosticListener
         items:
-          - name: Overview
-            href: ../../fundamentals/diagnostics/runtime-events.md
-          - name: Contention events
-            href: ../../fundamentals/diagnostics/runtime-contention-events.md
-          - name: Exception events
-            href: ../../fundamentals/diagnostics/runtime-exception-events.md
-          - name: Garbage collection events
-            href: ../../fundamentals/diagnostics/runtime-garbage-collection-events.md
-          - name: Interop events
-            href: ../../fundamentals/diagnostics/runtime-interop-events.md
-          - name: Loader and binder events
-            href: ../../fundamentals/diagnostics/runtime-loader-binder-events.md
-          - name: Method events
-            href: ../../fundamentals/diagnostics/runtime-method-events.md
-          - name: ThreadPool events
-            href: ../../fundamentals/diagnostics/runtime-thread-events.md
-          - name: Type-system events
-            href: ../../fundamentals/diagnostics/runtime-type-events.md
-      - name: Collect diagnostics in containers
-        href: ../../core/diagnostics/diagnostics-in-containers.md
-      - name: .NET CLI global tools
-        items:
-          - name: dotnet-counters
-            href: ../../core/diagnostics/dotnet-counters.md
-          - name: dotnet-coverage
-            href: ../../core/additional-tools/dotnet-coverage.md
-          - name: dotnet-dump
-            href: ../../core/diagnostics/dotnet-dump.md
-          - name: dotnet-gcdump
-            href: ../../core/diagnostics/dotnet-gcdump.md
-          - name: dotnet-monitor
-            href: ../../core/diagnostics/dotnet-monitor.md
-          - name: dotnet-trace
-            href: ../../core/diagnostics/dotnet-trace.md
-          - name: dotnet-stack
-            href: ../../core/diagnostics/dotnet-stack.md
-          - name: dotnet-symbol
-            href: ../../core/diagnostics/dotnet-symbol.md
-          - name: dotnet-sos
-            href: ../../core/diagnostics/dotnet-sos.md
-          - name: dotnet-dsrouter
-            href: ../../core/diagnostics/dotnet-dsrouter.md
-      - name: .NET diagnostics tutorials
-        items:
-          - name: Collect performance trace in Linux with PerfCollect
-            href: ../../core/diagnostics/trace-perfcollect-lttng.md
-          - name: Debug a memory leak
-            href: ../../core/diagnostics/debug-memory-leak.md
-          - name: Debug high CPU usage
-            href: ../../core/diagnostics/debug-highcpu.md
-          - name: Debug deadlock
-            href: ../../core/diagnostics/debug-deadlock.md
-          - name: Debug thread-pool starvation
-            href: ../../core/diagnostics/debug-threadpool-starvation.md
-          - name: Debug a stack overflow
-            href: ../../core/diagnostics/debug-stackoverflow.md
+        - name: Getting started
+          href: ../core/diagnostics/diagnosticsource-diagnosticlistener.md                
+    - name: .NET CLI global tools
+      items:
+      - name: Overview
+        href: ../core/diagnostics/tools-overview.md
+      - name: dotnet-counters
+        href: ../core/diagnostics/dotnet-counters.md
+      - name: dotnet-coverage
+        href: ../core/additional-tools/dotnet-coverage.md
+      - name: dotnet-dump
+        href: ../core/diagnostics/dotnet-dump.md
+      - name: dotnet-gcdump
+        href: ../core/diagnostics/dotnet-gcdump.md
+      - name: dotnet-monitor
+        href: ../core/diagnostics/dotnet-monitor.md
+      - name: dotnet-trace
+        href: ../core/diagnostics/dotnet-trace.md
+      - name: dotnet-stack
+        href: ../core/diagnostics/dotnet-stack.md
+      - name: dotnet-symbol
+        href: ../core/diagnostics/dotnet-symbol.md
+      - name: dotnet-sos
+        href: ../core/diagnostics/dotnet-sos.md
+      - name: dotnet-dsrouter
+        href: ../core/diagnostics/dotnet-dsrouter.md
+    - name: .NET diagnostics tutorials
+      items:
+      - name: Collect performance trace in Linux with PerfCollect
+        href: ../core/diagnostics/trace-perfcollect-lttng.md
+      - name: Debug a memory leak
+        href: ../core/diagnostics/debug-memory-leak.md
+      - name: Debug high CPU usage
+        href: ../core/diagnostics/debug-highcpu.md
+      - name: Debug deadlock
+        href: ../core/diagnostics/debug-deadlock.md
+      - name: Debug ThreadPool starvation
+        href: ../core/diagnostics/debug-threadpool-starvation.md
+      - name: Debug a StackOverflow
+        href: ../core/diagnostics/debug-stackoverflow.md
   - name: Code analysis
     items:
       - name: Overview

--- a/docs/navigate/tools-diagnostics/toc.yml
+++ b/docs/navigate/tools-diagnostics/toc.yml
@@ -305,61 +305,61 @@ items:
   - name: Diagnostics and instrumentation
     items:
     - name: Overview
-      href: ../core/diagnostics/index.md
+      href: ../../core/diagnostics/index.md
     - name: Managed debuggers
-      href: ../core/diagnostics/managed-debuggers.md
+      href: ../../core/diagnostics/managed-debuggers.md
     - name: Logging & Tracing options
-      href: ../core/diagnostics/logging-tracing.md
+      href: ../../core/diagnostics/logging-tracing.md
     - name: ILogger Logging
-      href: ../core/extensions/logging.md  
+      href: ../../core/extensions/logging.md  
     - name: Metrics
       items:
       - name: Overview
         displayName: metrics
-        href: ../core/diagnostics/metrics.md
+        href: ../../core/diagnostics/metrics.md
       - name: Instrumentation
-        href: ../core/diagnostics/metrics-instrumentation.md
+        href: ../../core/diagnostics/metrics-instrumentation.md
       - name: Collection
-        href: ../core/diagnostics/metrics-collection.md
+        href: ../../core/diagnostics/metrics-collection.md
       - name: EventCounters
         items:
         - name: Overview
           displayName: eventcounter
-          href: ../core/diagnostics/event-counters.md
+          href: ../../core/diagnostics/event-counters.md
         - name: Well-known counters
-          href: ../core/diagnostics/available-counters.md
+          href: ../../core/diagnostics/available-counters.md
         - name: "Tutorial: Measure performance with EventCounters"
-          href: ../core/diagnostics/event-counter-perf.md
+          href: ../../core/diagnostics/event-counter-perf.md
       - name: Compare metric APIs
-        href: ../core/diagnostics/compare-metric-apis.md
+        href: ../../core/diagnostics/compare-metric-apis.md
     - name: Distributed tracing
       items:
       - name: Overview
-        href: ../core/diagnostics/distributed-tracing.md
+        href: ../../core/diagnostics/distributed-tracing.md
       - name: Concepts
-        href: ../core/diagnostics/distributed-tracing-concepts.md
+        href: ../../core/diagnostics/distributed-tracing-concepts.md
       - name: Instrumentation
-        href: ../core/diagnostics/distributed-tracing-instrumentation-walkthroughs.md
+        href: ../../core/diagnostics/distributed-tracing-instrumentation-walkthroughs.md
       - name: Collection
-        href: ../core/diagnostics/distributed-tracing-collection-walkthroughs.md
+        href: ../../core/diagnostics/distributed-tracing-collection-walkthroughs.md
     - name: Specialized Diagnostics
       items:
       - name: Overview
-        href: specialized-diagnostics-overview.md    
+        href: ../../core/diagnostics/specialized-diagnostics-overview.md    
       - name: Event Source
         items:
         - name: Overview
-          href: ../core/diagnostics/eventsource.md
+          href: ../../core/diagnostics/eventsource.md
         - name: Getting started
-          href: ../core/diagnostics/eventsource-getting-started.md
+          href: ../../core/diagnostics/eventsource-getting-started.md
         - name: Instrumentation
-          href: ../core/diagnostics/eventsource-instrumentation.md
+          href: ../../core/diagnostics/eventsource-instrumentation.md
         - name: Collection
-          href: ../core/diagnostics/eventsource-collect-and-view-traces.md
+          href: ../../core/diagnostics/eventsource-collect-and-view-traces.md
         - name: Activity IDs
-          href: ../core/diagnostics/eventsource-activity-ids.md
+          href: ../../core/diagnostics/eventsource-activity-ids.md
         - name: Well-known event providers
-          href: ../core/diagnostics/well-known-event-providers.md
+          href: ../../core/diagnostics/well-known-event-providers.md
         - name: Runtime event Reference
           items:
           - name: Overview
@@ -381,73 +381,73 @@ items:
           - name: Type-system events
             href: ../fundamentals/diagnostics/runtime-type-events.md
       - name: Collect diagnostics in containers
-        href: ../core/diagnostics/diagnostics-in-containers.md   
+        href: ../../core/diagnostics/diagnostics-in-containers.md   
       - name: Dumps
         items:
         - name: Overview
           displayName: dumps
-          href: ../core/diagnostics/dumps.md
+          href: ../../core/diagnostics/dumps.md
         - name: Linux dumps
-          href: ../core/diagnostics/debug-linux-dumps.md
+          href: ../../core/diagnostics/debug-linux-dumps.md
         - name: SOS debugger extension
-          href: ../core/diagnostics/sos-debugging-extension.md
+          href: ../../core/diagnostics/sos-debugging-extension.md
       - name: Symbols
-        href: ../core/diagnostics/symbols.md    
+        href: ../../core/diagnostics/symbols.md    
       - name: EventPipe
-        href: ../core/diagnostics/eventpipe.md    
+        href: ../../core/diagnostics/eventpipe.md    
       - name: Diagnostic port
         items:
         - name: Overview
-          href: ../core/diagnostics/diagnostic-port.md
+          href: ../../core/diagnostics/diagnostic-port.md
         - name: Microsoft.Diagnostics.NETCore.Client library
           items:
           - name: Overview and examples
             displayName: diagnostics client library
-            href: ../core/diagnostics/diagnostics-client-library.md
+            href: ../../core/diagnostics/diagnostics-client-library.md
           - name: API reference
-            href: ../core/diagnostics/microsoft-diagnostics-netcore-client.md
+            href: ../../core/diagnostics/microsoft-diagnostics-netcore-client.md
       - name: DiagnosticSource and DiagnosticListener
         items:
         - name: Getting started
-          href: ../core/diagnostics/diagnosticsource-diagnosticlistener.md                
+          href: ../../core/diagnostics/diagnosticsource-diagnosticlistener.md                
     - name: .NET CLI global tools
       items:
       - name: Overview
-        href: ../core/diagnostics/tools-overview.md
+        href: ../../core/diagnostics/tools-overview.md
       - name: dotnet-counters
-        href: ../core/diagnostics/dotnet-counters.md
+        href: ../../core/diagnostics/dotnet-counters.md
       - name: dotnet-coverage
-        href: ../core/additional-tools/dotnet-coverage.md
+        href: ../../core/additional-tools/dotnet-coverage.md
       - name: dotnet-dump
-        href: ../core/diagnostics/dotnet-dump.md
+        href: ../../core/diagnostics/dotnet-dump.md
       - name: dotnet-gcdump
-        href: ../core/diagnostics/dotnet-gcdump.md
+        href: ../../core/diagnostics/dotnet-gcdump.md
       - name: dotnet-monitor
-        href: ../core/diagnostics/dotnet-monitor.md
+        href: ../../core/diagnostics/dotnet-monitor.md
       - name: dotnet-trace
-        href: ../core/diagnostics/dotnet-trace.md
+        href: ../../core/diagnostics/dotnet-trace.md
       - name: dotnet-stack
-        href: ../core/diagnostics/dotnet-stack.md
+        href: ../../core/diagnostics/dotnet-stack.md
       - name: dotnet-symbol
-        href: ../core/diagnostics/dotnet-symbol.md
+        href: ../../core/diagnostics/dotnet-symbol.md
       - name: dotnet-sos
-        href: ../core/diagnostics/dotnet-sos.md
+        href: ../../core/diagnostics/dotnet-sos.md
       - name: dotnet-dsrouter
-        href: ../core/diagnostics/dotnet-dsrouter.md
+        href: ../../core/diagnostics/dotnet-dsrouter.md
     - name: .NET diagnostics tutorials
       items:
       - name: Collect performance trace in Linux with PerfCollect
-        href: ../core/diagnostics/trace-perfcollect-lttng.md
+        href: ../../core/diagnostics/trace-perfcollect-lttng.md
       - name: Debug a memory leak
-        href: ../core/diagnostics/debug-memory-leak.md
+        href: ../../core/diagnostics/debug-memory-leak.md
       - name: Debug high CPU usage
-        href: ../core/diagnostics/debug-highcpu.md
+        href: ../../core/diagnostics/debug-highcpu.md
       - name: Debug deadlock
-        href: ../core/diagnostics/debug-deadlock.md
+        href: ../../core/diagnostics/debug-deadlock.md
       - name: Debug ThreadPool starvation
-        href: ../core/diagnostics/debug-threadpool-starvation.md
+        href: ../../core/diagnostics/debug-threadpool-starvation.md
       - name: Debug a StackOverflow
-        href: ../core/diagnostics/debug-stackoverflow.md
+        href: ../../core/diagnostics/debug-stackoverflow.md
   - name: Code analysis
     items:
       - name: Overview

--- a/docs/navigate/tools-diagnostics/toc.yml
+++ b/docs/navigate/tools-diagnostics/toc.yml
@@ -392,9 +392,9 @@ items:
         - name: SOS debugger extension
           href: ../../core/diagnostics/sos-debugging-extension.md
         - name: Debug Windows dumps
-            href: ../../core/diagnostics/debug-windows-dumps.md
+          href: ../../core/diagnostics/debug-windows-dumps.md
         - name: Collect dumps on crash
-            href: ../../core/diagnostics/collect-dumps-crash.md
+          href: ../../core/diagnostics/collect-dumps-crash.md
       - name: Symbols
         href: ../../core/diagnostics/symbols.md    
       - name: EventPipe

--- a/docs/navigate/tools-diagnostics/toc.yml
+++ b/docs/navigate/tools-diagnostics/toc.yml
@@ -363,23 +363,23 @@ items:
         - name: Runtime event Reference
           items:
           - name: Overview
-            href: ../fundamentals/diagnostics/runtime-events.md
+            href: ../../fundamentals/diagnostics/runtime-events.md
           - name: Contention events
-            href: ../fundamentals/diagnostics/runtime-contention-events.md
+            href: ../../fundamentals/diagnostics/runtime-contention-events.md
           - name: Exception events
-            href: ../fundamentals/diagnostics/runtime-exception-events.md
+            href: ../../fundamentals/diagnostics/runtime-exception-events.md
           - name: Garbage collection events
-            href: ../fundamentals/diagnostics/runtime-garbage-collection-events.md
+            href: ../../fundamentals/diagnostics/runtime-garbage-collection-events.md
           - name: Interop events
-            href: ../fundamentals/diagnostics/runtime-interop-events.md
+            href: ../../fundamentals/diagnostics/runtime-interop-events.md
           - name: Loader and binder events
-            href: ../fundamentals/diagnostics/runtime-loader-binder-events.md
+            href: ../../fundamentals/diagnostics/runtime-loader-binder-events.md
           - name: Method events
-            href: ../fundamentals/diagnostics/runtime-method-events.md
+            href: ../../fundamentals/diagnostics/runtime-method-events.md
           - name: ThreadPool events
-            href: ../fundamentals/diagnostics/runtime-thread-events.md
+            href: ../../fundamentals/diagnostics/runtime-thread-events.md
           - name: Type-system events
-            href: ../fundamentals/diagnostics/runtime-type-events.md
+            href: ../../fundamentals/diagnostics/runtime-type-events.md
       - name: Collect diagnostics in containers
         href: ../../core/diagnostics/diagnostics-in-containers.md   
       - name: Dumps

--- a/docs/navigate/tools-diagnostics/toc.yml
+++ b/docs/navigate/tools-diagnostics/toc.yml
@@ -391,6 +391,10 @@ items:
           href: ../../core/diagnostics/debug-linux-dumps.md
         - name: SOS debugger extension
           href: ../../core/diagnostics/sos-debugging-extension.md
+        - name: Debug Windows dumps
+            href: ../../core/diagnostics/debug-windows-dumps.md
+        - name: Collect dumps on crash
+            href: ../../core/diagnostics/collect-dumps-crash.md
       - name: Symbols
         href: ../../core/diagnostics/symbols.md    
       - name: EventPipe

--- a/docs/navigate/tools-diagnostics/toc.yml
+++ b/docs/navigate/tools-diagnostics/toc.yml
@@ -305,10 +305,11 @@ items:
   - name: Diagnostics and instrumentation
     items:
     - name: Overview
+    - displayName: diagnostics, instrumentation
       href: ../../core/diagnostics/index.md
     - name: Managed debuggers
       href: ../../core/diagnostics/managed-debuggers.md
-    - name: Logging & Tracing options
+    - name: Logging & tracing options
       href: ../../core/diagnostics/logging-tracing.md
     - name: ILogger Logging
       href: ../../core/extensions/logging.md  
@@ -336,6 +337,7 @@ items:
       items:
       - name: Overview
         href: ../../core/diagnostics/distributed-tracing.md
+        displayName: distributed tracing
       - name: Concepts
         href: ../../core/diagnostics/distributed-tracing-concepts.md
       - name: Instrumentation
@@ -350,6 +352,7 @@ items:
         items:
         - name: Overview
           href: ../../core/diagnostics/eventsource.md
+          displayName: event source, eventsource
         - name: Get started
           href: ../../core/diagnostics/eventsource-getting-started.md
         - name: Instrumentation
@@ -450,7 +453,7 @@ items:
         href: ../../core/diagnostics/debug-deadlock.md
       - name: Debug ThreadPool starvation
         href: ../../core/diagnostics/debug-threadpool-starvation.md
-      - name: Debug a StackOverflow
+      - name: Debug a stack overflow
         href: ../../core/diagnostics/debug-stackoverflow.md
   - name: Code analysis
     items:

--- a/docs/navigate/tools-diagnostics/toc.yml
+++ b/docs/navigate/tools-diagnostics/toc.yml
@@ -342,7 +342,7 @@ items:
         href: ../../core/diagnostics/distributed-tracing-instrumentation-walkthroughs.md
       - name: Collection
         href: ../../core/diagnostics/distributed-tracing-collection-walkthroughs.md
-    - name: Specialized Diagnostics
+    - name: Specialized diagnostics
       items:
       - name: Overview
         href: ../../core/diagnostics/specialized-diagnostics-overview.md    
@@ -350,7 +350,7 @@ items:
         items:
         - name: Overview
           href: ../../core/diagnostics/eventsource.md
-        - name: Getting started
+        - name: Get started
           href: ../../core/diagnostics/eventsource-getting-started.md
         - name: Instrumentation
           href: ../../core/diagnostics/eventsource-instrumentation.md
@@ -360,7 +360,7 @@ items:
           href: ../../core/diagnostics/eventsource-activity-ids.md
         - name: Well-known event providers
           href: ../../core/diagnostics/well-known-event-providers.md
-        - name: Runtime event Reference
+        - name: Runtime event reference
           items:
           - name: Overview
             href: ../../fundamentals/diagnostics/runtime-events.md
@@ -408,7 +408,7 @@ items:
             href: ../../core/diagnostics/microsoft-diagnostics-netcore-client.md
       - name: DiagnosticSource and DiagnosticListener
         items:
-        - name: Getting started
+        - name: Get started
           href: ../../core/diagnostics/diagnosticsource-diagnosticlistener.md                
     - name: .NET CLI global tools
       items:


### PR DESCRIPTION
##Summary

Refactoring diagnostics docs and the TOC to put emphasis on the right places.

Fixes #35589
Replaces #35444


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/index.md](https://github.com/dotnet/docs/blob/ad2ba517b772300c2631f662cc990a44d02c2f0b/docs/core/diagnostics/index.md) | [What diagnostic tools are available in .NET Core?](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/index?branch=pr-en-us-35727) |
| [docs/core/diagnostics/logging-tracing.md](https://github.com/dotnet/docs/blob/ad2ba517b772300c2631f662cc990a44d02c2f0b/docs/core/diagnostics/logging-tracing.md) | [Logging and tracing - .NET](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/logging-tracing?branch=pr-en-us-35727) |
| [docs/core/diagnostics/specialized-diagnostics-overview.md](https://github.com/dotnet/docs/blob/ad2ba517b772300c2631f662cc990a44d02c2f0b/docs/core/diagnostics/specialized-diagnostics-overview.md) | [docs/core/diagnostics/specialized-diagnostics-overview](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/specialized-diagnostics-overview?branch=pr-en-us-35727) |
| [docs/core/diagnostics/tools-overview.md](https://github.com/dotnet/docs/blob/ad2ba517b772300c2631f662cc990a44d02c2f0b/docs/core/diagnostics/tools-overview.md) | [docs/core/diagnostics/tools-overview](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/tools-overview?branch=pr-en-us-35727) |
| [docs/core/tools/global-tools.md](https://github.com/dotnet/docs/blob/ad2ba517b772300c2631f662cc990a44d02c2f0b/docs/core/tools/global-tools.md) | [How to manage .NET tools](https://review.learn.microsoft.com/en-us/dotnet/core/tools/global-tools?branch=pr-en-us-35727) |


<!-- PREVIEW-TABLE-END -->