### PR TITLE
Add SYSLIB0053

### DIFF
--- a/docs/core/compatibility/core-libraries/8.0/obsolete-apis-with-custom-diagnostics.md
+++ b/docs/core/compatibility/core-libraries/8.0/obsolete-apis-with-custom-diagnostics.md
@@ -2,7 +2,7 @@
 title: "Breaking change: .NET 8 obsoletions with custom IDs"
 titleSuffix: ""
 description: Learn about the .NET 8 breaking change in core .NET libraries where some APIs have been marked as obsolete with a custom diagnostic ID.
-ms.date: 05/05/2023
+ms.date: 06/08/2023
 ---
 # API obsoletions with non-default diagnostic IDs (.NET 8)
 
@@ -19,6 +19,7 @@ The following table lists the custom diagnostic IDs and their corresponding warn
 | [SYSLIB0048](../../../../fundamentals/syslib-diagnostics/syslib0048.md) | <xref:System.Security.Cryptography.RSA.EncryptValue(System.Byte[])?displayProperty=nameWithType> and <xref:System.Security.Cryptography.RSA.DecryptValue(System.Byte[])?displayProperty=nameWithType> are obsolete. Use <xref:System.Security.Cryptography.RSA.Encrypt%2A?displayProperty=nameWithType> and <xref:System.Security.Cryptography.RSA.Decrypt%2A?displayProperty=nameWithType> instead. | Warning |
 | [SYSLIB0050](../../../../fundamentals/syslib-diagnostics/syslib0050.md) | Formatter-based serialization is obsolete and should not be used. | Warning |
 | [SYSLIB0051](../../../../fundamentals/syslib-diagnostics/syslib0051.md) | APIs that support obsolete formatter-based serialization are obsolete. They should not be called or extended by application code. | Warning |
+| [SYSLIB0053](../../../../fundamentals/syslib-diagnostics/syslib0053.md) | <xref:System.Security.Cryptography.AesGcm> should indicate the required tag size for encryption and decryption. Use a constructor that accepts the tag size. | Warning |
 
 ## Version introduced
 
@@ -530,6 +531,11 @@ The `SYSLIB0051` API obsoletions are organized here by namespace.
 - <xref:System.Xml.Xsl.XsltCompileException.GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)?displayProperty=fullName>
 - <xref:System.Xml.Xsl.XsltException.%23ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)?displayProperty=fullName>
 - <xref:System.Xml.Xsl.XsltException.GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)?displayProperty=fullName>
+
+### SYSLIB0053
+
+- <xref:System.Security.Cryptography.AesGcm.%23ctor(System.Byte[])>
+- <xref:System.Security.Cryptography.AesGcm.%23ctor(System.ReadOnlySpan{System.Byte})>
 
 ## See also
 

--- a/docs/fundamentals/syslib-diagnostics/obsoletions-overview.md
+++ b/docs/fundamentals/syslib-diagnostics/obsoletions-overview.md
@@ -2,7 +2,7 @@
 title: Obsolete features in .NET 5+
 titleSuffix: ""
 description: Learn about APIs that are marked as obsolete in .NET 5 and later versions that produce SYSLIB compiler warnings.
-ms.date: 05/05/2023
+ms.date: 06/08/2023
 ---
 
 # Obsolete features in .NET 5+
@@ -71,6 +71,7 @@ The following table provides an index to the `SYSLIB0XXX` obsoletions in .NET 5+
 | [SYSLIB0048](syslib0048.md) | Warning | <xref:System.Security.Cryptography.RSA.EncryptValue(System.Byte[])?displayProperty=nameWithType> and <xref:System.Security.Cryptography.RSA.DecryptValue(System.Byte[])?displayProperty=nameWithType> are obsolete. Use <xref:System.Security.Cryptography.RSA.Encrypt%2A?displayProperty=nameWithType> and <xref:System.Security.Cryptography.RSA.Decrypt%2A?displayProperty=nameWithType> instead. |
 | [SYSLIB0050](syslib0050.md) | Warning | Formatter-based serialization is obsolete and should not be used. |
 | [SYSLIB0051](syslib0051.md) | Warning | APIs that support obsolete formatter-based serialization are obsolete. They should not be called or extended by application code. |
+| [SYSLIB0053](syslib0053.md) | Warning | <xref:System.Security.Cryptography.AesGcm> should indicate the required tag size for encryption and decryption. Use a constructor that accepts the tag size. |
 
 ## Suppress warnings
 

--- a/docs/fundamentals/syslib-diagnostics/syslib0053.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib0053.md
@@ -1,0 +1,50 @@
+---
+title: SYSLIB0053 warning - AesGcm should indicate the required tag size
+description: Learn about the obsoletion of AesGcm constructors that generates compile-time warning SYSLIB0053.
+ms.date: 06/08/2023
+---
+# SYSLIB0053: AesGcm should indicate the required tag size
+
+The <xref:System.Security.Cryptography.AesGcm> constructors that don't accept a tag size are obsolete, starting in .NET 8:
+
+- <xref:System.Security.Cryptography.AesGcm.%23ctor(System.Byte[])>
+- <xref:System.Security.Cryptography.AesGcm.%23ctor(System.ReadOnlySpan{System.Byte})>
+
+Calling them in code generates warning `SYSLIB0053` at compile time.
+
+## Workaround
+
+New constructors that accept a tag size have been added in .NET 8. Use one of these constructors instead:
+
+- <xref:System.Security.Cryptography.AesGcm.%23ctor(System.Byte[],System.Int32)>
+- <xref:System.Security.Cryptography.AesGcm.%23ctor(System.ReadOnlySpan{System.Byte},System.Int32)>
+
+## Suppress a warning
+
+If you must use the obsolete APIs, you can suppress the warning in code or in your project file.
+
+To suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the warning.
+
+```csharp
+// Disable the warning.
+#pragma warning disable SYSLIB0053
+
+// Code that uses obsolete API.
+// ...
+
+// Re-enable the warning.
+#pragma warning restore SYSLIB0053
+```
+
+To suppress all the `SYSLIB0053` warnings in your project, add a `<NoWarn>` property to your project file.
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+   ...
+   <NoWarn>$(NoWarn);SYSLIB0053</NoWarn>
+  </PropertyGroup>
+</Project>
+```
+
+For more information, see [Suppress warnings](obsoletions-overview.md#suppress-warnings).


### PR DESCRIPTION
Fixes #35338 

xref errors will go away once we update the API ref for Preview 5.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/core-libraries/8.0/obsolete-apis-with-custom-diagnostics.md](https://github.com/dotnet/docs/blob/1c4e3e8ae1f86227cac4a169734b82885de0fa3e/docs/core/compatibility/core-libraries/8.0/obsolete-apis-with-custom-diagnostics.md) | [API obsoletions with non-default diagnostic IDs (.NET 8)](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/8.0/obsolete-apis-with-custom-diagnostics?branch=pr-en-us-35729) |
| [docs/fundamentals/syslib-diagnostics/obsoletions-overview.md](https://github.com/dotnet/docs/blob/1c4e3e8ae1f86227cac4a169734b82885de0fa3e/docs/fundamentals/syslib-diagnostics/obsoletions-overview.md) | [Obsolete features in .NET 5+](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/obsoletions-overview?branch=pr-en-us-35729) |
| [docs/fundamentals/syslib-diagnostics/syslib0053.md](https://github.com/dotnet/docs/blob/1c4e3e8ae1f86227cac4a169734b82885de0fa3e/docs/fundamentals/syslib-diagnostics/syslib0053.md) | [docs/fundamentals/syslib-diagnostics/syslib0053](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib0053?branch=pr-en-us-35729) |


<!-- PREVIEW-TABLE-END -->