### PR TITLE
Update linux-scripted-manual.md - fix setting up environment variable…

### DIFF
--- a/docs/core/install/linux-scripted-manual.md
+++ b/docs/core/install/linux-scripted-manual.md
@@ -162,7 +162,7 @@ Set the following two environment variables in your shell profile:
   This variable should include both the `DOTNET_ROOT` folder and the user's _.dotnet/tools_ folder:
 
   ```bash
-  export PATH=$PATH:$HOME/.dotnet:$HOME/.dotnet/tools
+  export PATH=$PATH:$DOTNET_ROOT:$DOTNET_ROOT/tools
   ```
 
 ## Next steps


### PR DESCRIPTION
## Summary

In the `Set environment variables system-wide` portion the setting up of an environment variable path creates issues in the shell. I fixed it using another microsoft docs page as reference -> https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script




<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/linux-scripted-manual.md](https://github.com/dotnet/docs/blob/cfd93ede90013a6d127ba3a5cd26303ba22b891f/docs/core/install/linux-scripted-manual.md) | [Install .NET on Linux by using an install script or by extracting binaries](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-scripted-manual?branch=pr-en-us-35730) |

<!-- PREVIEW-TABLE-END -->