### PR TITLE
Automatically add reQUEST label

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -564,6 +564,62 @@
           }
         ]
       }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isPartOfProject",
+              "parameters": {}
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "hasLabel",
+                  "parameters": {
+                    "label": ":pushpin: seQUESTered"
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "hasLabel",
+                  "parameters": {
+                    "label": ":world_map: reQUEST"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "isAssignedToSomeone",
+              "parameters": {}
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": ":world_map: reQUEST"
+            }
+          }
+        ]
+      }
     }
   ],
   "userGroups": []


### PR DESCRIPTION
Automatically add reQUEST label to assigned issues that are part of a project that don't already have a reQUEST or seQUESTered label.