### PR TITLE
What's new in Preview 5

### DIFF
--- a/docs/core/whats-new/dotnet-8.md
+++ b/docs/core/whats-new/dotnet-8.md
@@ -794,7 +794,7 @@ For more information, see the [Improving multi-platform container support](https
 
 As part of an effort to improve containerization performance, a new ASP.NET Alpine-based Docker image with a composite version of the runtime is available. This composite is built by compiling multiple MSIL assemblies into a single ready-to-run (R2R) output binary. Because these assemblies are embedded into a single image, jitting takes less time, and the startup performance of apps improves. The other big advantage of the composite over the regular ASP.NET image is that the composite images have a smaller size on disk.
 
-However, all these benefits don't come without a caveat. Since composites have multiple assemblies embedded into one, they have tighter version coupling. Apps can't use custom versions of framework or ASP.NET binaries.
+There is a caveat to be aware of. Since composites have multiple assemblies embedded into one, they have tighter version coupling. Apps can't use custom versions of framework or ASP.NET binaries.
 
 ## .NET on Linux
 

--- a/docs/core/whats-new/dotnet-8.md
+++ b/docs/core/whats-new/dotnet-8.md
@@ -126,7 +126,7 @@ The [template engine](https://github.com/dotnet/templating) provides a more secu
 
 ### Source Link
 
-[Source Link](../../standard/library-guidance/sourcelink.md) is now included in the .NET SDK. The goal is that by bundling Source Link into the SDK, instead of requiring a separate `<PackageReference>` for the package, more packages will include this information by default, resulting in better IDE experiences for developers all up.
+[Source Link](../../standard/library-guidance/sourcelink.md) is now included in the .NET SDK. The goal is that by bundling Source Link into the SDK, instead of requiring a separate `<PackageReference>` for the package, more packages will include this information by default. That information will improve the IDE experience for developers.
 
 ### Source-build SDK
 
@@ -792,7 +792,7 @@ For more information, see the [Improving multi-platform container support](https
 
 ### Alpine ASP.NET Docker composite images
 
-As part of an effort to improve containerization performance, a new ASP.NET Alpine-based Docker image with a composite version of the runtime is available. This composite is built by compiling multiple MSIL assemblies into a single ready-to-run (R2R) output binary. Because these assemblies embedded into a single image, jitting takes less time, and the startup performance of apps improves. The other big advantage of the composite over the regular ASP.NET image is that the composite images have a smaller size on disk.
+As part of an effort to improve containerization performance, a new ASP.NET Alpine-based Docker image with a composite version of the runtime is available. This composite is built by compiling multiple MSIL assemblies into a single ready-to-run (R2R) output binary. Because these assemblies are embedded into a single image, jitting takes less time, and the startup performance of apps improves. The other big advantage of the composite over the regular ASP.NET image is that the composite images have a smaller size on disk.
 
 However, all these benefits don't come without a caveat. Since composites have multiple assemblies embedded into one, they have tighter version coupling. Apps can't use custom versions of framework or ASP.NET binaries.
 

--- a/docs/core/whats-new/dotnet-8.md
+++ b/docs/core/whats-new/dotnet-8.md
@@ -492,7 +492,7 @@ The new APIs include:
 
 - <xref:System.Diagnostics.Metrics.MeterOptions>
 - <xref:System.Diagnostics.Metrics.Meter.%23ctor(System.Diagnostics.Metrics.MeterOptions)>
-- <xref:System.Diagnostics.Metrics.Meter.CreateCounter%601%601(System.String,System.String,System.String,System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.String,System.Object}})>
+- <xref:System.Diagnostics.Metrics.Meter.CreateCounter%60%601(System.String,System.String,System.String,System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.String,System.Object}})>
 
 ## Extension libraries
 

--- a/docs/core/whats-new/dotnet-8.md
+++ b/docs/core/whats-new/dotnet-8.md
@@ -473,8 +473,6 @@ The <xref:System.ComponentModel.DataAnnotations?displayProperty=fullName> namesp
 
 ### Metrics
 
-#### Meter and Instrument tags
-
 New APIs let you attach key-value pair tags to <xref:System.Diagnostics.Metrics.Meter> and <xref:System.Diagnostics.Metrics.Instrument> objects when you create them. Aggregators of published metric measurements can use the tags to differentiate the aggregated values.
 
 ```csharp

--- a/docs/core/whats-new/dotnet-8.md
+++ b/docs/core/whats-new/dotnet-8.md
@@ -413,7 +413,7 @@ IDataView predictions = model.Transform(split.TestSet);
   }
   ```
 
-- The new <xref:System.Buffers.IndexOfAnyValues%601?displayProperty=fullName> type is designed to be passed to methods that look for the first occurrence of any value in the passed collection. For example, <xref:System.String.IndexOfAny(System.Char[])?displayProperty=nameWithType> looks for the first occurrence of any character in the specified array in the `string` it's called on. NET 8 adds new overloads of methods like <xref:System.String.IndexOfAny%2A?displayProperty=nameWithType> and <xref:System.MemoryExtensions.IndexOfAny%2A?displayProperty=nameWithType> that accept an instance of the new type. When you create an instance of <xref:System.Buffers.IndexOfAnyValues%601?displayProperty=fullName>, all the data that's necessary to optimize subsequent searches is derived *at that time*, meaning the work is done up front.
+- The new <xref:System.Buffers.SearchValues%601?displayProperty=fullName> type is designed to be passed to methods that look for the first occurrence of any value in the passed collection. For example, <xref:System.String.IndexOfAny(System.Char[])?displayProperty=nameWithType> looks for the first occurrence of any character in the specified array in the `string` it's called on. NET 8 adds new overloads of methods like <xref:System.String.IndexOfAny%2A?displayProperty=nameWithType> and <xref:System.MemoryExtensions.IndexOfAny%2A?displayProperty=nameWithType> that accept an instance of the new type. When you create an instance of <xref:System.Buffers.SearchValues%601?displayProperty=fullName>, all the data that's necessary to optimize subsequent searches is derived *at that time*, meaning the work is done up front.
 - The new <xref:System.Text.CompositeFormat?displayProperty=fullName> type is useful for optimizing format strings that aren't known at compile time (for example, if the format string is loaded from a resource file). A little extra time is spent up front to do work such as parsing the string, but it saves the work from being done on each use.
 
   ```csharp
@@ -465,7 +465,6 @@ The <xref:System.ComponentModel.DataAnnotations?displayProperty=fullName> namesp
 
 | New API | Description |
 |--|--|
-| <xref:System.ComponentModel.DataAnnotations.RequiredAttribute.DisallowAllDefaultValues?displayProperty=nameWithType> | Validates that structs don't equal their default values. |
 | <xref:System.ComponentModel.DataAnnotations.RangeAttribute.MinimumIsExclusive?displayProperty=nameWithType><br/><xref:System.ComponentModel.DataAnnotations.RangeAttribute.MaximumIsExclusive?displayProperty=nameWithType> | Specifies whether bounds are included in the allowable range. |
 | <xref:System.ComponentModel.DataAnnotations.LengthAttribute?displayProperty=nameWithType> | Specifies both lower and upper bounds for strings or collections. For example, `[Length(10, 20)]` requires at least 10 elements and at most 20 elements in a collection. |
 | <xref:System.ComponentModel.DataAnnotations.Base64StringAttribute?displayProperty=nameWithType> | Validates that a string is a valid Base64 representation. |


### PR DESCRIPTION
Fixes #34556 

xref warning should go away once the API docs are refreshed.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/whats-new/dotnet-8.md](https://github.com/dotnet/docs/blob/b01976d551fb87485f56f03c87011fd415425fd2/docs/core/whats-new/dotnet-8.md) | [What's new in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-8?branch=pr-en-us-35761) |


<!-- PREVIEW-TABLE-END -->