### PR TITLE
Add section about `Orleans.Concurrency.ReadOnlyAttribute`

### DIFF
--- a/.openpublishing.redirection.orleans.json
+++ b/.openpublishing.redirection.orleans.json
@@ -11,6 +11,10 @@
         {
             "source_path_from_root": "/docs/orleans/whats-new-in-orleans.md",
             "redirect_url": "/dotnet/orleans/migration-guide"
+        },
+        {
+            "source_path_from_root": "/docs/orleans/grains/reentrancy.md",
+            "redirect_url": "/dotnet/orleans/grains/request-scheduling"
         }
     ]
 }

--- a/docs/orleans/grains/request-scheduling.md
+++ b/docs/orleans/grains/request-scheduling.md
@@ -105,7 +105,7 @@ With reentrancy, the following case becomes a valid execution and the possibilit
 
 ### Case 3: the grain or method is reentrant
 
-:::image type="content" source="grain-persistence/media/reentrancy-scheduling-diagram-03.png" alt-text="Reentrancy scheduling diagram with re-entrant grain or method." lightbox="grain-persistence/media/reentrancy-scheduling-diagram-03.png":::
+:::image type="content" source="grain-persistence/media/reentrancy-scheduling-diagram-03.png" alt-text="Re-entrancy scheduling diagram with re-entrant grain or method." lightbox="grain-persistence/media/reentrancy-scheduling-diagram-03.png":::
 
 In this example, grains *A* and *B* can call each other simultaneously without any potential for request scheduling deadlocks because both grains are *re-entrant*. The following sections provide more details on reentrancy.
 
@@ -142,7 +142,7 @@ That is, the turns from different requests interleave.
 
 If the grain wasn't reentrant, the only possible executions would be: line 1, line 2, line 3, line 4 OR: line 3, line 4, line 1, line 2 (a new request can't start before the previous one finished).
 
-The main tradeoff in choosing between reentrant and non-reentrant grains is the code complexity of making interleaving work correctly, and the difficulty to reason about it.
+The main tradeoff in choosing between reentrant and nonreentrant grains is the code complexity of making interleaving work correctly, and the difficulty to reason about it.
 
 In a trivial case when the grains are stateless and the logic is simple, fewer (but not too few, so that all the hardware threads are used) re-entrant grains should, in general, be slightly more efficient.
 
@@ -207,7 +207,7 @@ public interface IMyGrain : IGrainWithIntegerKey
 }
 ```
 
-The `GetCount` method doesn't modify the grain state, as such it's marked with `ReadOnly`. Callers awaiting this method invocation aren't blocked by other requests to the grain, and the method returns immediately.
+The `GetCount` method doesn't modify the grain state, so it's marked with `ReadOnly`. Callers awaiting this method invocation aren't blocked by other requests to the grain, and the method returns immediately.
 
 ### Reentrancy using a predicate
 

--- a/docs/orleans/grains/request-scheduling.md
+++ b/docs/orleans/grains/request-scheduling.md
@@ -140,7 +140,7 @@ For example, the following order of execution is possible:
 Line 1, line 3, line 2 and line 4.
 That is, the turns from different requests interleave.
 
-If the grain wasn't reentrant, the only possible executions would be: line 1, line 2, line 3, line 4 OR: line 3, line 4, line 1, line 2 (a new request can't start before the previous one finished).
+If the grain wasn't re-entrant, the only possible executions would be: line 1, line 2, line 3, line 4 OR: line 3, line 4, line 1, line 2 (a new request can't start before the previous one finished).
 
 The main tradeoff in choosing between reentrant and nonreentrant grains is the code complexity of making interleaving work correctly, and the difficulty to reason about it.
 

--- a/docs/orleans/grains/request-scheduling.md
+++ b/docs/orleans/grains/request-scheduling.md
@@ -6,7 +6,7 @@ ms.date: 03/16/2022
 
 # Request scheduling
 
-Grain activations have a *single-threaded* execution model and, by default, process each request from beginning to completion before the next request can begin processing. In some circumstances, it may be desirable for activation to process other requests while one request is waiting for an asynchronous operation to complete. For this and other reasons, Orleans gives the developer some control over the request interleaving behavior, as described below in the [Reentrancy](#reentrancy) section. What follows is an example of non-reentrant request scheduling, which is the default behavior in Orleans.
+Grain activations have a *single-threaded* execution model and, by default, process each request from beginning to completion before the next request can begin processing. In some circumstances, it may be desirable for activation to process other requests while one request is waiting for an asynchronous operation to complete. For this and other reasons, Orleans gives the developer some control over the request interleaving behavior, as described in the [Reentrancy](#reentrancy) section. What follows is an example of non-reentrant request scheduling, which is the default behavior in Orleans.
 
 Consider the following `PingGrain` definition:
 
@@ -50,7 +50,7 @@ The flow of execution is as follows:
 1. *B* returns immediately from `Ping()` back to *A*.
 1. *A* logs `"2"` and returns back to the original caller.
 
-While *A* is awaiting the call to *B*, it cannot process any incoming requests. Because of this, if *A* and *B* were to call each other simultaneously, they may *deadlock* while waiting for those calls to complete. Here is an example, based on the client issuing the following call:
+While *A* is awaiting the call to *B*, it can't process any incoming requests. As a result, if *A* and *B* were to call each other simultaneously, they may *deadlock* while waiting for those calls to complete. Here's an example, based on the client issuing the following call:
 
 ```csharp
 var a = grainFactory.GetGrain("A");
@@ -61,7 +61,7 @@ var b = grainFactory.GetGrain("B");
 await Task.WhenAll(a.CallOther(b), b.CallOther(a));
 ```
 
-## Case 1: the calls do not deadlock
+## Case 1: the calls don't deadlock
 
 :::image type="content" source="grain-persistence/media/reentrancy-scheduling-diagram-01.png" alt-text="Reentrancy scheduling diagram without deadlock." lightbox="grain-persistence/media/reentrancy-scheduling-diagram-01.png":::
 
@@ -70,10 +70,10 @@ In this example:
 1. The `Ping()` call from *A* arrives at *B* before the `CallOther(a)` call arrives at *B*.
 1. Therefore, *B* processes the `Ping()` call before the `CallOther(a)` call.
 1. Because *B* processes the `Ping()` call, *A* is able to return back to the caller.
-1. When *B* issues its `Ping()` call to *A*, *A* is still busy logging its message (`"2"`), so the call has to wait for a short duration, but it is soon able to be processed.
-1. *A* processes the `Ping()` call and returns to *B* which returns to the original caller.
+1. When *B* issues its `Ping()` call to *A*, *A* is still busy logging its message (`"2"`), so the call has to wait for a short duration, but it's soon able to be processed.
+1. *A* processes the `Ping()` call and returns to *B*, which returns to the original caller.
 
-Now, we will examine a less fortunate series of events: one in which the same code results in a *deadlock* due to slightly different timing.
+Consider a less fortunate series of events: one in which the same code results in a *deadlock* due to slightly different timing.
 
 ## Case 2: the calls deadlock
 
@@ -83,19 +83,17 @@ In this example:
 
 1. The `CallOther` calls arrive at their respective grains and are processed simultaneously.
 1. Both grains log `"1"` and proceed to `await other.Ping()`.
-1. Since both grains are still *busy* (processing the `CallOther` request, which has not finished yet), the `Ping()` requests wait
-1. After some period of time, Orleans determines that the call has **timed out** and each `Ping()` call results in an exception being thrown.
-1. This exception is not handled by the `CallOther` method body and so it bubbles up to the original caller.
+1. Since both grains are still *busy* (processing the `CallOther` request, which hasn't finished yet), the `Ping()` requests wait
+1. After a while, Orleans determines that the call has **timed out** and each `Ping()` call results in an exception being thrown.
+1. The `CallOther` method body doesn't handle the exception and it bubbles up to the original caller.
 
 The following section describes how to prevent deadlocks by allowing multiple requests to interleave their execution with each other.
 
 ## Reentrancy
 
-Orleans defaults to choosing a safe execution flow: one in which the internal state of a grain is not modified concurrently by multiple requests.
-Concurrent modification of the internal state complicates logic and puts a greater burden on the developer. This protection against those kinds of concurrency bugs has a cost which we saw above, primarily *liveness*: certain call patterns can lead to deadlocks. One way to avoid deadlocks is to ensure that grain calls never form a cycle. Oftentimes, it is difficult to write code that is cycle-free and cannot deadlock. Waiting for each request to run from beginning to completion before processing the next request can also hurt performance. For example, by default, if a grain method performs some asynchronous request to a database service then the grain will pause request execution until the response from the database arrives at the grain.
+Orleans defaults to choosing a safe execution flow: one in which the internal state of a grain isn't modified concurrently during multiple requests. Concurrent modification of the internal state complicates logic and puts a greater burden on the developer. This protection against those kinds of concurrency bugs has a cost, which was previously discussed, primarily *liveness*: certain call patterns can lead to deadlocks. One way to avoid deadlocks is to ensure that grain calls never result in a cycle. Often, it's difficult to write code that is cycle-free and can't deadlock. Waiting for each request to run from beginning to completion before processing the next request can also hurt performance. For example, by default, if a grain method performs some asynchronous request to a database service then the grain pauses request execution until the response from the database arrives at the grain.
 
-Each of those cases is discussed in the sections which follow. For these reasons, Orleans provides developers with options to allow some or all requests to be executed *concurrently*, interleaving their execution with each other. In Orleans, this is called *reentrancy* or *interleaving*.
-By executing requests concurrently, grains that perform asynchronous operations can process more requests in a shorter period.
+Each of those cases is discussed in the sections that follow. For these reasons, Orleans provides developers with options to allow some or all requests to be executed *concurrently*, interleaving their execution with each other. In Orleans, such concerns are referred to as *reentrancy* or *interleaving*. By executing requests concurrently, grains that perform asynchronous operations can process more requests in a shorter period.
 
 Multiple requests may be interleaved in the following cases:
 
@@ -107,20 +105,19 @@ With reentrancy, the following case becomes a valid execution and the possibilit
 
 ### Case 3: the grain or method is reentrant
 
-:::image type="content" source="grain-persistence/media/reentrancy-scheduling-diagram-03.png" alt-text="Reentrancy scheduling diagram with reentrant grain or method." lightbox="grain-persistence/media/reentrancy-scheduling-diagram-03.png":::
+:::image type="content" source="grain-persistence/media/reentrancy-scheduling-diagram-03.png" alt-text="Reentrancy scheduling diagram with re-entrant grain or method." lightbox="grain-persistence/media/reentrancy-scheduling-diagram-03.png":::
 
-In this example, grains *A* and *B* can call each other simultaneously without any potential for request scheduling deadlocks because both grains are *reentrant*. The following sections provide more details on reentrancy.
+In this example, grains *A* and *B* can call each other simultaneously without any potential for request scheduling deadlocks because both grains are *re-entrant*. The following sections provide more details on reentrancy.
 
-### Reentrant grains
+### Re-entrant grains
 
 The <xref:Orleans.Grain> implementation classes may be marked with the <xref:Orleans.Concurrency.ReentrantAttribute> to indicate that different requests may be freely interleaved.
 
-In other words, a reentrant activation may start executing another request while a previous request has not finished processing. Execution is still limited to a single thread, so the activation is still executing one turn at a time, and each turn is executing on behalf of only one of the activation's requests.
+In other words, a re-entrant activation may start executing another request while a previous request hasn't finished processing. Execution is still limited to a single thread, so the activation is still executing one turn at a time, and each turn is executing on behalf of only one of the activation's requests.
 
-Reentrant grain code will never run multiple pieces of grain code in parallel (execution of grain code will always be single-threaded), but reentrant grains **may** see the execution of code for different requests interleaving.
-That is, the continuation turns from different requests may interleave.
+Re-entrant grain code never runs multiple pieces of grain code in parallel (execution of grain code is always single-threaded), but re-entrant grains **may** see the execution of code for different requests interleaving. That is, the continuation turns from different requests may interleave.
 
-For example, with the pseudo-code below, when Foo and Bar are 2 methods of the same grain class:
+For example, as shown in the following pseudo-code, consider that `Foo` and `Bar` are two methods of the same grain class:
 
 ```csharp
 Task Foo()
@@ -136,26 +133,28 @@ Task Bar()
 }
 ```
 
-If this grain is marked <xref:Orleans.Concurrency.ReentrantAttribute>, the execution of Foo and Bar may interleave.
+If this grain is marked <xref:Orleans.Concurrency.ReentrantAttribute>, the execution of `Foo` and `Bar` may interleave.
 
 For example, the following order of execution is possible:
 
 Line 1, line 3, line 2 and line 4.
 That is, the turns from different requests interleave.
 
-If the grain was not reentrant, the only possible executions would be: line 1, line 2, line 3, line 4 OR: line 3, line 4, line 1, line 2 (a new request cannot start before the previous one finished).
+If the grain wasn't reentrant, the only possible executions would be: line 1, line 2, line 3, line 4 OR: line 3, line 4, line 1, line 2 (a new request can't start before the previous one finished).
 
-The main tradeoff in choosing between reentrant and non-reentrant grains is the code complexity to make interleaving work correctly, and the difficulty to reason about it.
+The main tradeoff in choosing between reentrant and non-reentrant grains is the code complexity of making interleaving work correctly, and the difficulty to reason about it.
 
-In a trivial case when the grains are stateless and the logic is simple, fewer (but not too few, so that all the hardware threads are used) reentrant grains should, in general, be slightly more efficient.
+In a trivial case when the grains are stateless and the logic is simple, fewer (but not too few, so that all the hardware threads are used) re-entrant grains should, in general, be slightly more efficient.
 
-If the code is more complex, then a larger number of non-reentrant grains, even if slightly less efficient overall, should save you a lot of grief of figuring out non-obvious interleaving issues.
+If the code is more complex, then a larger number of non-reentrant grains, even if slightly less efficient overall, should save you much grief in figuring out nonobvious interleaving issues.
 
-In the end, the answer will depend on the specifics of the application.
+In the end, the answer depends on the specifics of the application.
 
 ### Interleaving methods
 
-Grain interface methods marked with <xref:Orleans.Concurrency.AlwaysInterleaveAttribute> will always interleave any other request and may always be interleaved by any other request, even requests for non-`[AlwaysInterleave]` methods. This is true regardless of whether the grain is reentrant or not. Consider the following example:
+Grain interface methods marked with <xref:Orleans.Concurrency.AlwaysInterleaveAttribute>, always interleaves any other request and may always be interleaved with any other request, even requests for non-[AlwaysInterleave] methods.
+
+Consider the following example:
 
 ```csharp
 public interface ISlowpokeGrain : IGrainWithIntegerKey
@@ -180,19 +179,19 @@ public class SlowpokeGrain : Grain, ISlowpokeGrain
 }
 ```
 
-Now consider the call flow initiated by the following client request:
+Consider the call flow initiated by the following client request:
 
 ```csharp
 var slowpoke = client.GetGrain<ISlowpokeGrain>(0);
 
-// A) This will take around 20 seconds
+// A. This will take around 20 seconds.
 await Task.WhenAll(slowpoke.GoSlow(), slowpoke.GoSlow());
 
-// B) This will take around 10 seconds.
+// B. This will take around 10 seconds.
 await Task.WhenAll(slowpoke.GoFast(), slowpoke.GoFast(), slowpoke.GoFast());
 ```
 
-Calls to `GoSlow` will not be interleaved, so the execution of the two `GoSlow()` calls will take around 20 seconds. On the other hand, `GoFast` is marked <xref:Orleans.Concurrency.AlwaysInterleaveAttribute>, and the three calls to it will be executed concurrently, completing in approximately 10 seconds total instead of requiring at least 30 seconds to complete.
+Calls to `GoSlow` aren't interleaved, so the total execution time of the two `GoSlow` calls takes around 20 seconds. On the other hand, `GoFast` is marked <xref:Orleans.Concurrency.AlwaysInterleaveAttribute>, and the three calls to it are executed concurrently, completing in approximately 10 seconds total instead of requiring at least 30 seconds to complete.
 
 ### Readonly methods
 
@@ -208,13 +207,13 @@ public interface IMyGrain : IGrainWithIntegerKey
 }
 ```
 
-The `GetCount` method doesn't modify the grain state, as such it is marked with `ReadOnly`. Callers that await this method invocation will not be blocked by other requests to the grain.
+The `GetCount` method doesn't modify the grain state, as such it's marked with `ReadOnly`. Callers awaiting this method invocation aren't blocked by other requests to the grain, and the method returns immediately.
 
 ### Reentrancy using a predicate
 
 Grain classes can specify a predicate to determine interleaving on a call-by-call basis by inspecting the request. The `[MayInterleave(string methodName)]` attribute provides this functionality. The argument to the attribute is the name of a static method within the grain class that accepts an <xref:Orleans.CodeGeneration.InvokeMethodRequest> object and returns a `bool` indicating whether or not the request should be interleaved.
 
-Here is an example that allows interleaving if the request argument type has the `[Interleave]` attribute:
+Here's an example that allows interleaving if the request argument type has the `[Interleave]` attribute:
 
 ```csharp
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]

--- a/docs/orleans/grains/request-scheduling.md
+++ b/docs/orleans/grains/request-scheduling.md
@@ -1,6 +1,6 @@
 ---
 title: Request scheduling
-description: Learn about reentrancy in .NET Orleans.
+description: Learn about request scheduling in .NET Orleans.
 ms.date: 03/16/2022
 ---
 
@@ -195,7 +195,7 @@ Calls to `GoSlow` aren't interleaved, so the total execution time of the two `Go
 
 ### Readonly methods
 
-When a grain method doesn't modify the grain state, it's safe to execute concurrently with other requests. The <xref:Orleans.Concurrency.ReadOnlyAttribute> indicates that a method doesn't modify the state of a grain. Marking methods as `ReadOnly` allows Orleans to perform several optimizations that may significantly improve the performance of your app. Consider the following example:
+When a grain method doesn't modify the grain state, it's safe to execute concurrently with other requests. The <xref:Orleans.Concurrency.ReadOnlyAttribute> indicates that a method doesn't modify the state of a grain. Marking methods as `ReadOnly` allows Orleans to process your request concurrently with other `ReadOnly` requests, which may significantly improve the performance of your app. Consider the following example:
 
 ```csharp
 public interface IMyGrain : IGrainWithIntegerKey
@@ -207,7 +207,7 @@ public interface IMyGrain : IGrainWithIntegerKey
 }
 ```
 
-The `GetCount` method doesn't modify the grain state, so it's marked with `ReadOnly`. Callers awaiting this method invocation aren't blocked by other requests to the grain, and the method returns immediately.
+The `GetCount` method doesn't modify the grain state, so it's marked with `ReadOnly`. Callers awaiting this method invocation aren't blocked by other `ReadOnly` requests to the grain, and the method returns immediately.
 
 ### Reentrancy using a predicate
 

--- a/docs/orleans/implementation/scheduler.md
+++ b/docs/orleans/implementation/scheduler.md
@@ -8,7 +8,7 @@ ms.date: 03/17/2022
 
 There are two forms of scheduling in Orleans which are relevant to grains:
 
-1. Request scheduling, the scheduling of incoming grain calls for execution according to scheduling rules discussed [in Reentrancy](../grains/request-scheduling.md).
+1. Request scheduling, the scheduling of incoming grain calls for execution according to scheduling rules discussed [in Request scheduling](../grains/request-scheduling.md).
 1. Task scheduling, the scheduling of synchronous blocks of code to be executed in a *single-threaded* manner
 
 All grain code is executed on the grain's task scheduler, which means that requests are also executed on the grain's task scheduler.

--- a/docs/orleans/implementation/scheduler.md
+++ b/docs/orleans/implementation/scheduler.md
@@ -8,7 +8,7 @@ ms.date: 03/17/2022
 
 There are two forms of scheduling in Orleans which are relevant to grains:
 
-1. Request scheduling, the scheduling of incoming grain calls for execution according to scheduling rules discussed [in Reentrancy](../grains/reentrancy.md).
+1. Request scheduling, the scheduling of incoming grain calls for execution according to scheduling rules discussed [in Reentrancy](../grains/request-scheduling.md).
 1. Task scheduling, the scheduling of synchronous blocks of code to be executed in a *single-threaded* manner
 
 All grain code is executed on the grain's task scheduler, which means that requests are also executed on the grain's task scheduler.

--- a/docs/orleans/toc.yml
+++ b/docs/orleans/toc.yml
@@ -31,7 +31,7 @@ items:
       - name: Observers
         href: grains/observers.md
       - name: Request scheduling
-        href: grains/reentrancy.md
+        href: grains/request-scheduling.md
       - name: Request context
         href: grains/request-context.md
       - name: Code generation


### PR DESCRIPTION
## Summary

In this PR:

- Renamed _reentrancy.md_ to _request-scheduling.md_
- Adjust title accordingly
- Add section about `ReadOnly` attribute usage
- Edit pass/acrolinx

Fixes #33985, @ReubenBond @bradygaster 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/grains/request-scheduling.md](https://github.com/dotnet/docs/blob/7a7a9edbcf4e488b95889b5c9c2166cfbab33c26/docs/orleans/grains/request-scheduling.md) | [docs/orleans/grains/request-scheduling](https://review.learn.microsoft.com/en-us/dotnet/orleans/grains/request-scheduling?branch=pr-en-us-35765) |
| [docs/orleans/implementation/scheduler.md](https://github.com/dotnet/docs/blob/7a7a9edbcf4e488b95889b5c9c2166cfbab33c26/docs/orleans/implementation/scheduler.md) | [Scheduling overview](https://review.learn.microsoft.com/en-us/dotnet/orleans/implementation/scheduler?branch=pr-en-us-35765) |


<!-- PREVIEW-TABLE-END -->