### PR TITLE
Removed the link to an obsoleted proposal about ref assignment

### DIFF
--- a/docs/csharp/language-reference/operators/assignment-operator.md
+++ b/docs/csharp/language-reference/operators/assignment-operator.md
@@ -74,8 +74,6 @@ A user-defined type can't explicitly overload a compound assignment operator. Ho
 
 For more information, see the [Assignment operators](~/_csharpstandard/standard/expressions.md#1221-assignment-operators) section of the [C# language specification](~/_csharpstandard/standard/README.md).
 
-For more information about the ref assignment operator `= ref`, see the [feature proposal note](~/_csharplang/proposals/csharp-7.3/ref-local-reassignment.md).
-
 ## See also
 
 - [C# reference](../index.md)


### PR DESCRIPTION
The spec section about the assignment operators now covers `= ref` as well.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/assignment-operator.md](https://github.com/dotnet/docs/blob/a4c5e7efb4575d99e94576932dd92a568782804c/docs/csharp/language-reference/operators/assignment-operator.md) | [Assignment operators (C# reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/assignment-operator?branch=pr-en-us-35770) |

<!-- PREVIEW-TABLE-END -->