### PR TITLE
Removed the link to the obsoleted proposal about conditional ref

### DIFF
--- a/docs/csharp/language-reference/operators/conditional-operator.md
+++ b/docs/csharp/language-reference/operators/conditional-operator.md
@@ -85,7 +85,6 @@ For more information, see the [Conditional operator](~/_csharpstandard/standard/
 
 Specifications for newer features are:
 
-- [Conditional ref expressions (C# 7.2)](~/_csharplang/proposals/csharp-7.2/conditional-ref.md)
 - [Target-typed conditional expression (C# 9.0)](~/_csharplang/proposals/csharp-9.0/target-typed-conditional-expression.md)
 
 ## See also


### PR DESCRIPTION
The updated published spec now covers conditional ref

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/conditional-operator.md](https://github.com/dotnet/docs/blob/3b605b31070ca4ad2aad67f1e102b431adfbbaae/docs/csharp/language-reference/operators/conditional-operator.md) | [?: operator - the ternary conditional operator](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/conditional-operator?branch=pr-en-us-35771) |

<!-- PREVIEW-TABLE-END -->