### PR TITLE
Fix typo (through → throw)

### DIFF
--- a/docs/core/compatibility/serialization/8.0/binaryformatter-disabled.md
+++ b/docs/core/compatibility/serialization/8.0/binaryformatter-disabled.md
@@ -1,11 +1,11 @@
 ---
 title: "Breaking change: BinaryFormatter disabled across most project types"
-description: Learn about the .NET 7 breaking change in serialization where serialize and deserialize methods on BinaryFormatter now through an exception at run time.
+description: Learn about the .NET 7 breaking change in serialization where serialize and deserialize methods on BinaryFormatter now throw an exception at run time.
 ms.date: 05/01/2023
 ---
 # BinaryFormatter disabled across most project types
 
-The <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter.Serialize(System.IO.Stream,System.Object)?displayProperty=nameWithType> and <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter.Deserialize(System.IO.Stream)?displayProperty=nameWithType> methods now through a <xref:System.NotSupportedException> at run time across nearly all project types, including console applications.
+The <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter.Serialize(System.IO.Stream,System.Object)?displayProperty=nameWithType> and <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter.Deserialize(System.IO.Stream)?displayProperty=nameWithType> methods now throw a <xref:System.NotSupportedException> at run time across nearly all project types, including console applications.
 
 ## Previous behavior
 


### PR DESCRIPTION
## Summary

The **BinaryFormatter disabled across most project types** documentation about .NET 8 breaking changes had a typo.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/serialization/8.0/binaryformatter-disabled.md](https://github.com/dotnet/docs/blob/f931249f8ad82199b637b220dcd2f2642d20c764/docs/core/compatibility/serialization/8.0/binaryformatter-disabled.md) | [BinaryFormatter disabled across most project types](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/serialization/8.0/binaryformatter-disabled?branch=pr-en-us-35774) |

<!-- PREVIEW-TABLE-END -->