### PR TITLE
Fix the recommended action on how to set the roll-forward policy of .NET tools

### DIFF
--- a/docs/core/compatibility/sdk/8.0/tool-rollforward.md
+++ b/docs/core/compatibility/sdk/8.0/tool-rollforward.md
@@ -29,8 +29,8 @@ A .NET (local) tool is a specific kind of .NET application that's intended to be
 
 ## Recommended action
 
-If this change is undesirable, you can explicitly set the roll-forward policy to `latestPatch` in the [global.json](../../../tools/global-json.md) file.
+If this change is undesirable, you can explicitly set the roll-forward policy to `latestPatch` in the `RollForward` MSBuild property or the `rollForward` property of the runtime configuration file.
 
 ## See also
 
-- [rollForward](../../../tools/global-json.md#rollforward)
+- [rollForward](https://github.com/dotnet/designs/blob/main/accepted/2019/runtime-binding.md#rollforward)


### PR DESCRIPTION
Changing the roll-forward policy in the `global.json` file will only affect the _SDK_ used, not the _runtime_ used.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/sdk/8.0/tool-rollforward.md](https://github.com/dotnet/docs/blob/f5f6756cee5c410629e28a6f15409af7257391e2/docs/core/compatibility/sdk/8.0/tool-rollforward.md) | [.NET tool roll-forward behavior](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/tool-rollforward?branch=pr-en-us-35775) |

<!-- PREVIEW-TABLE-END -->