### PR TITLE
Fix request labeler

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -187,41 +187,6 @@
           "operator": "and",
           "operands": [
             {
-              "name": "prMatchesPattern",
-              "parameters": {
-                "matchRegex": "docs\\/[A-z\\/\\d\\-]*\\/[A-z\\-\\d]*\\.md"
-              }
-            }
-          ]
-        },
-        "eventType": "pull_request",
-        "eventNames": [
-          "pull_request",
-          "issues",
-          "project_card"
-        ],
-        "taskName": "Insert preview link",
-        "actions": [
-          {
-            "name": "addReply",
-            "parameters": {
-              "comment": "[Internal preview link](https://review.docs.microsoft.com/dotnet/fundamentals/?branch=pr-en-us-${number})"
-            }
-          }
-        ]
-      },
-      "disabled": true
-    },
-    {
-      "taskType": "trigger",
-      "capabilityId": "IssueResponder",
-      "subCapability": "PullRequestResponder",
-      "version": "1.0",
-      "config": {
-        "conditions": {
-          "operator": "and",
-          "operands": [
-            {
               "name": "isActivitySender",
               "parameters": {
                 "user": "azure-sdk"
@@ -575,8 +540,10 @@
           "operator": "and",
           "operands": [
             {
-              "name": "isPartOfProject",
-              "parameters": {}
+              "name": "isAction",
+              "parameters": {
+                "action": "created"
+              }
             },
             {
               "operator": "not",
@@ -618,7 +585,8 @@
               "label": ":world_map: reQUEST"
             }
           }
-        ]
+        ],
+        "taskName": "Add reQUEST label to issues"
       }
     }
   ],


### PR DESCRIPTION
Tries two different things:

- adds name to task
- uses action = project card created instead of "is part of any project"

(Also removes insert preview link task that was disabled anyway.)