### PR TITLE
Update cpp-cli.md

### DIFF
--- a/docs/core/porting/cpp-cli.md
+++ b/docs/core/porting/cpp-cli.md
@@ -5,7 +5,7 @@ author: mjrousos
 ms.date: 03/29/2022
 ---
 
-# How to port a C++/CLI project to .NET Core or .NET 5
+# How to port a C++/CLI project to .NET Core or .NET 5+
 
 Beginning with .NET Core 3.1 and Visual Studio 2019, [C++/CLI projects](/cpp/dotnet/dotnet-programming-with-cpp-cli-visual-cpp) can target .NET Core. This support makes it possible to port Windows desktop applications with C++/CLI interop layers to .NET Core/.NET 5+. This article describes how to port C++/CLI projects from .NET Framework to .NET Core 3.1.
 


### PR DESCRIPTION
Make if clear that C++/CLI support extends past .NET 5.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/porting/cpp-cli.md](https://github.com/dotnet/docs/blob/1dd80f752e5718dc603b123e08aa5a2641e3a046/docs/core/porting/cpp-cli.md) | [How to port a C++/CLI project to .NET Core or .NET 5](https://review.learn.microsoft.com/en-us/dotnet/core/porting/cpp-cli?branch=pr-en-us-35838) |

<!-- PREVIEW-TABLE-END -->