### PR TITLE
EventSource breaking change

### DIFF
--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -57,6 +57,7 @@ For information on other breaking changes for containers in .NET 6, see [.NET 6 
 | [Changes to nullable reference type annotations](core-libraries/6.0/nullable-ref-type-annotation-changes.md) | ✔️ | ❌ | Preview 1-2 |
 | [Conditional string evaluation in Debug methods](core-libraries/6.0/debug-assert-conditional-evaluation.md) | ✔️ | ❌ | RC 1 |
 | [Environment.ProcessorCount behavior on Windows](core-libraries/6.0/environment-processorcount-on-windows.md) | ✔️ | ❌ | Preview 2 |
+| [EventSource callback behavior](core-libraries/6.0/eventsource-callback.md) | ✔️ | ✔️ | Servicing |
 | [File.Replace on Unix throws exceptions to match Windows](core-libraries/6.0/file-replace-exceptions-on-unix.md) | ✔️ | ❌ | Preview 7 |
 | [FileStream locks files with shared lock on Unix](core-libraries/6.0/filestream-file-locks-unix.md) | ❌ | ✔️ | Preview 1 |
 | [FileStream no longer synchronizes file offset with OS](core-libraries/6.0/filestream-doesnt-sync-offset-with-os.md) | ❌ | ❌ | Preview 4 |

--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -44,6 +44,7 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 | [Collectible Assembly in non-collectible AssemblyLoadContext](core-libraries/7.0/collectible-assemblies.md) | ❌ | ✔️ |
 | [DateTime addition methods precision change](core-libraries/7.0/datetime-add-precision.md) | ✔️ | ✔️ |
 | [Equals method behavior change for NaN](core-libraries/7.0/equals-nan.md) | ❌ | ✔️ |
+| [EventSource callback behavior](core-libraries/6.0/eventsource-callback.md) | ✔️ | ✔️ |
 | [Generic type constraint on PatternContext\<T>](core-libraries/7.0/patterncontext-generic-constraint.md) | ❌ | ❌ |
 | [Legacy FileStream strategy removed](core-libraries/7.0/filestream-compat-switch.md) | ❌ | ✔️ |
 | [Library support for older frameworks](core-libraries/7.0/old-framework-support.md) | ❌ | ❌ |

--- a/docs/core/compatibility/core-libraries/6.0/eventsource-callback.md
+++ b/docs/core/compatibility/core-libraries/6.0/eventsource-callback.md
@@ -1,0 +1,41 @@
+---
+title: ".NET 6 breaking change: EventSource callback behavior"
+description: Learn about the .NET 6 servicing breaking change in core .NET libraries where the 'EventSource' is marked as disabled before the callback is issue for an 'EventCommand.Disable'.
+ms.date: 06/15/2023
+---
+# EventSource callback behavior
+
+For an <xref:System.Diagnostics.Tracing.EventCommand.Disable?displayProperty=nameWithType>, the <xref:System.Diagnostics.Tracing.EventSource> is now marked as disabled *before* the callback is issued.
+
+## Previous behavior
+
+Previously, the <xref:System.Diagnostics.Tracing.EventSource.OnEventCommand(System.Diagnostics.Tracing.EventCommandEventArgs)?displayProperty=nameWithType> callback was issued for an <xref:System.Diagnostics.Tracing.EventCommand.Disable?displayProperty=nameWithType> prior to setting `m_eventSourceEnabled=false`.
+
+This meant that <xref:System.Diagnostics.Tracing.EventSource.IsEnabled?displayProperty=nameWithType> returned `true` in the <xref:System.Diagnostics.Tracing.EventSource.OnEventCommand(System.Diagnostics.Tracing.EventCommandEventArgs)> callback for a user <xref:System.Diagnostics.Tracing.EventSource>, even if the command led to the `EventSource` being disabled. The callback happened after the ability to dispatch events was turned off though, so even if an `EventSource` tried to fire an event, it wasn't written.
+
+## New behavior
+
+Now, the <xref:System.Diagnostics.Tracing.EventSource> is marked as disabled *before* the callback is issued for an <xref:System.Diagnostics.Tracing.EventCommand.Disable?displayProperty=nameWithType>.
+
+## Version introduced
+
+- .NET 6 servicing
+- .NET 7 servicing
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+This change was necessary to support multiple <xref:System.Diagnostics.Tracing.EventCounter> instances. The ability to have multiple instances has been requested by multiple customers.
+
+In addition, <xref:System.Diagnostics.Tracing.EventCommand.Enable?displayProperty=nameWithType> has always issued a consistent view: <xref:System.Diagnostics.Tracing.EventSource.IsEnabled?displayProperty=nameWithType> accurately reports the enabled status, and `EventSource` can write events from the `OnEventCommand` callback. This change makes the `EventCommand.Disable` behavior consistent with `EventCommand.Enable`.
+
+## Recommended action
+
+It's unlikely that there's a scenario where the previous behavior is desired, and there's no way to revert the behavior.
+
+## Affected APIs
+
+-

--- a/docs/core/compatibility/core-libraries/6.0/eventsource-callback.md
+++ b/docs/core/compatibility/core-libraries/6.0/eventsource-callback.md
@@ -38,4 +38,4 @@ It's unlikely that there's a scenario where the previous behavior is desired, an
 
 ## Affected APIs
 
--
+- <xref:System.Diagnostics.Tracing.EventCommand.Disable?displayProperty=fullName>

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -172,6 +172,8 @@ items:
         href: core-libraries/7.0/datetime-add-precision.md
       - name: Equals method behavior change for NaN
         href: core-libraries/7.0/equals-nan.md
+      - name: EventSource callback behavior
+        href: core-libraries/6.0/eventsource-callback.md
       - name: Generic type constraint on PatternContext<T>
         href: core-libraries/7.0/patterncontext-generic-constraint.md
       - name: Legacy FileStream strategy removed
@@ -362,6 +364,8 @@ items:
         href: core-libraries/6.0/debug-assert-conditional-evaluation.md
       - name: Environment.ProcessorCount behavior on Windows
         href: core-libraries/6.0/environment-processorcount-on-windows.md
+      - name: EventSource callback behavior
+        href: core-libraries/6.0/eventsource-callback.md
       - name: File.Replace on Unix throws exceptions to match Windows
         href: core-libraries/6.0/file-replace-exceptions-on-unix.md
       - name: FileStream locks files with shared lock on Unix
@@ -1034,6 +1038,8 @@ items:
         href: core-libraries/7.0/datetime-add-precision.md
       - name: Equals method behavior change for NaN
         href: core-libraries/7.0/equals-nan.md
+      - name: EventSource callback behavior
+        href: core-libraries/6.0/eventsource-callback.md
       - name: Generic type constraint on PatternContext<T>
         href: core-libraries/7.0/patterncontext-generic-constraint.md
       - name: Legacy FileStream strategy removed
@@ -1062,6 +1068,8 @@ items:
         href: core-libraries/6.0/debug-assert-conditional-evaluation.md
       - name: Environment.ProcessorCount behavior on Windows
         href: core-libraries/6.0/environment-processorcount-on-windows.md
+      - name: EventSource callback behavior
+        href: core-libraries/6.0/eventsource-callback.md
       - name: File.Replace on Unix throws exceptions to match Windows
         href: core-libraries/6.0/file-replace-exceptions-on-unix.md
       - name: FileStream locks files with shared lock on Unix


### PR DESCRIPTION
Fixes #35313 
Fixes #35314 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/6.0.md](https://github.com/dotnet/docs/blob/c84d244b4e3a3254013c4fea02a483178ef6835d/docs/core/compatibility/6.0.md) | [Breaking changes in .NET 6](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/6.0?branch=pr-en-us-35841) |
| [docs/core/compatibility/7.0.md](https://github.com/dotnet/docs/blob/c84d244b4e3a3254013c4fea02a483178ef6835d/docs/core/compatibility/7.0.md) | [Breaking changes in .NET 7](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/7.0?branch=pr-en-us-35841) |
| [docs/core/compatibility/core-libraries/6.0/eventsource-callback.md](https://github.com/dotnet/docs/blob/c84d244b4e3a3254013c4fea02a483178ef6835d/docs/core/compatibility/core-libraries/6.0/eventsource-callback.md) | [docs/core/compatibility/core-libraries/6.0/eventsource-callback](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/eventsource-callback?branch=pr-en-us-35841) |


<!-- PREVIEW-TABLE-END -->