### PR TITLE
Fixes typo in doc

### DIFF
--- a/docs/core/install/linux-ubuntu.md
+++ b/docs/core/install/linux-ubuntu.md
@@ -170,7 +170,7 @@ If you want to install an unsupported version of .NET, check the [Supported dist
 > [!TIP]
 > If you're not creating .NET apps, install the ASP.NET Core runtime as it includes the .NET runtime and also supports ASP.NET Core apps.
 
-Some enviornment variables affect how .NET is run after it's installed. For more information, see [.NET SDK and CLI environment variables](../tools/dotnet-environment-variables.md#net-sdk-and-cli-environment-variables).
+Some environment variables affect how .NET is run after it's installed. For more information, see [.NET SDK and CLI environment variables](../tools/dotnet-environment-variables.md#net-sdk-and-cli-environment-variables).
 
 ## Uninstall .NET
 


### PR DESCRIPTION
Fixes typo in doc

## Summary
There's a typo in documentation from enviornment to environment

Fixes #35653


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/linux-ubuntu.md](https://github.com/dotnet/docs/blob/68a53728ff56e7c1727ad09a5d0132db83e68130/docs/core/install/linux-ubuntu.md) | [Install the .NET SDK or the .NET Runtime on Ubuntu](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu?branch=pr-en-us-35851) |

<!-- PREVIEW-TABLE-END -->