### PR TITLE
Expanded init explanation when using nullability

### DIFF
--- a/docs/csharp/language-reference/keywords/init.md
+++ b/docs/csharp/language-reference/keywords/init.md
@@ -28,6 +28,9 @@ var john = new Person_InitExample
 
 john.YearOfBirth = 1926; //Not allowed, as its value can only be set once in the constructor
 ```
+Do note, that this behavior does not change when nullablity is used. `init` properties do not force the values to be initialized. What `init` does is that, if the property is to be initialized, it must be done at construction time in an object initializer (or in the constructor if you have one). So the behavior is the same for this example:
+
+[!code-csharp[init#4](snippets/InitNullablityExample.cs)]
 
 The `init` accessor can be used as an expression-bodied member. Example:
 

--- a/docs/csharp/language-reference/keywords/init.md
+++ b/docs/csharp/language-reference/keywords/init.md
@@ -28,9 +28,10 @@ var john = new Person_InitExample
 
 john.YearOfBirth = 1926; //Not allowed, as its value can only be set once in the constructor
 ```
-Do note, that this behavior does not change when nullablity is used. `init` properties do not force the values to be initialized. What `init` does is that, if the property is to be initialized, it must be done at construction time in an object initializer (or in the constructor if you have one). So the behavior is the same for this example:
 
-[!code-csharp[init#4](snippets/InitNullablityExample.cs)]
+An `init` accessor doesn't force callers to set the property. Instead, it allows an object initializer to set the initial value while prohibiting later modification. You can add the `required` modifier to force callers to set a property. The following example shows the same behavior:
+
+:::code language="csharp" source="./snippets/InitNullablityExample.cs" id="Snippet4":::
 
 The `init` accessor can be used as an expression-bodied member. Example:
 

--- a/docs/csharp/language-reference/keywords/snippets/InitNullablityExample.cs
+++ b/docs/csharp/language-reference/keywords/snippets/InitNullablityExample.cs
@@ -11,3 +11,5 @@ class Person_InitExampleNullability
         init => _yearOfBirth = value;
     }
 }
+// </Snippet4>
+

--- a/docs/csharp/language-reference/keywords/snippets/InitNullablityExample.cs
+++ b/docs/csharp/language-reference/keywords/snippets/InitNullablityExample.cs
@@ -1,7 +1,7 @@
 namespace InitExample;
 
 // <Snippet4>
-class Person_InitExampleExpressionBodied
+class Person_InitExampleNullability
 {
     private int? _yearOfBirth;
 

--- a/docs/csharp/language-reference/keywords/snippets/InitNullablityExample.cs
+++ b/docs/csharp/language-reference/keywords/snippets/InitNullablityExample.cs
@@ -1,0 +1,10 @@
+class Person_InitExampleExpressionBodied
+{
+    private int? _yearOfBirth;
+
+    public int? YearOfBirth
+    {
+        get => _yearOfBirth;
+        init => _yearOfBirth = value;
+    }
+}

--- a/docs/csharp/language-reference/keywords/snippets/InitNullablityExample.cs
+++ b/docs/csharp/language-reference/keywords/snippets/InitNullablityExample.cs
@@ -1,3 +1,6 @@
+namespace InitExample;
+
+// <Snippet4>
 class Person_InitExampleExpressionBodied
 {
     private int? _yearOfBirth;


### PR DESCRIPTION
## Summary

I expanded the init explanation when using nullability as that wasn't mentioned but the behavior may be interesting for developers

It helps a bit with #27738


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/init.md](https://github.com/dotnet/docs/blob/727b1e0cf825b52c17155d3e3f7346536b5e4894/docs/csharp/language-reference/keywords/init.md) | [init (C# Reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/init?branch=pr-en-us-35872) |


<!-- PREVIEW-TABLE-END -->