### PR TITLE
Assembly name is default command

### DIFF
--- a/docs/core/tools/global-tools-how-to-create.md
+++ b/docs/core/tools/global-tools-how-to-create.md
@@ -176,7 +176,7 @@ Before you can pack and distribute the application as a tool, you need to modify
    <PackageOutputPath>./nupkg</PackageOutputPath>
    ```
 
-   `<ToolCommandName>` is an optional element that specifies the command that will invoke the tool after it's installed. If this element isn't provided, the command name for the tool is the assembly name, typically project file name without the *.csproj* extension.
+   `<ToolCommandName>` is an optional element that specifies the command that will invoke the tool after it's installed. If this element isn't provided, the command name for the tool is the assembly name, typically the project file name without the *.csproj* extension.
 
    `<PackageOutputPath>` is an optional element that determines where the NuGet package will be produced. The NuGet package is what the .NET CLI uses to install your tool.
 

--- a/docs/core/tools/global-tools-how-to-create.md
+++ b/docs/core/tools/global-tools-how-to-create.md
@@ -176,7 +176,7 @@ Before you can pack and distribute the application as a tool, you need to modify
    <PackageOutputPath>./nupkg</PackageOutputPath>
    ```
 
-   `<ToolCommandName>` is an optional element that specifies the command that will invoke the tool after it's installed. If this element isn't provided, the command name for the tool is the project file name without the *.csproj* extension.
+   `<ToolCommandName>` is an optional element that specifies the command that will invoke the tool after it's installed. If this element isn't provided, the command name for the tool is the assembly name, typically project file name without the *.csproj* extension.
 
    `<PackageOutputPath>` is an optional element that determines where the NuGet package will be produced. The NuGet package is what the .NET CLI uses to install your tool.
 

--- a/docs/core/tools/global-tools-how-to-create.md
+++ b/docs/core/tools/global-tools-how-to-create.md
@@ -176,7 +176,7 @@ Before you can pack and distribute the application as a tool, you need to modify
    <PackageOutputPath>./nupkg</PackageOutputPath>
    ```
 
-   `<ToolCommandName>` is an optional element that specifies the command that will invoke the tool after it's installed. If this element isn't provided, the command name for the tool is the assembly name, typically the project file name without the *.csproj* extension.
+   `<ToolCommandName>` is an optional element that specifies the command that will invoke the tool after it's installed. If this element isn't provided, the command name for the tool is the assembly name, which is typically the project file name without the *.csproj* extension.
 
    `<PackageOutputPath>` is an optional element that determines where the NuGet package will be produced. The NuGet package is what the .NET CLI uses to install your tool.
 


### PR DESCRIPTION
Fixes #35871 



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/global-tools-how-to-create.md](https://github.com/dotnet/docs/blob/c585cd09bbdf803b026e6fc3857561519d4486e3/docs/core/tools/global-tools-how-to-create.md) | [Tutorial: Create a .NET tool using the .NET CLI](https://review.learn.microsoft.com/en-us/dotnet/core/tools/global-tools-how-to-create?branch=pr-en-us-35875) |


<!-- PREVIEW-TABLE-END -->