### PR TITLE
Document Restore UseCurrentRuntime

### DIFF
--- a/docs/core/tools/dotnet-restore.md
+++ b/docs/core/tools/dotnet-restore.md
@@ -19,7 +19,8 @@ dotnet restore [<ROOT>] [--configfile <FILE>] [--disable-parallel]
     [--interactive] [--lock-file-path <LOCK_FILE_PATH>] [--locked-mode]
     [--no-cache] [--no-dependencies] [--packages <PACKAGES_DIRECTORY>]
     [-r|--runtime <RUNTIME_IDENTIFIER>] [-s|--source <SOURCE>]
-    [--use-lock-file] [-v|--verbosity <LEVEL>]
+    [--use-current-runtime, --ucr [true|false]] [--use-lock-file]
+    [-v|--verbosity <LEVEL>]
 
 dotnet restore -h|--help
 ```
@@ -139,6 +140,10 @@ There are three specific settings that `dotnet restore` ignores:
 - **`-s|--source <SOURCE>`**
 
   Specifies the URI of the NuGet package source to use during the restore operation. This setting overrides all of the sources specified in the *nuget.config* files. Multiple sources can be provided by specifying this option multiple times.
+
+- **`--use-current-runtime, --ucr [true|false]`**
+
+  Sets the `RuntimeIdentifier` to a platform portable `RuntimeIdentifier` based on the one of your machine. This happens implicitly with properties that require a `RuntimeIdentifier`, such as `SelfContained`, `PublishAot`, `PublishSelfContained`, `PublishSingleFile`, and `PublishReadyToRun`. If the property is set to false, that implicit resolution will no longer occur.
 
 - **`--use-lock-file`**
 


### PR DESCRIPTION
Document Restore UseCurrentRuntime like we have for Build (https://github.com/dotnet/docs/pull/31970) and Publish (https://github.com/dotnet/docs/pull/32004).

JFYI @richlander 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-restore.md](https://github.com/dotnet/docs/blob/c245847ec1903577cb11c3f05d21349e7fdf3d58/docs/core/tools/dotnet-restore.md) | [dotnet restore](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-restore?branch=pr-en-us-35876) |

<!-- PREVIEW-TABLE-END -->