### PR TITLE
Fix link for using declaration

### DIFF
--- a/docs/csharp/whats-new/csharp-version-history.md
+++ b/docs/csharp/whats-new/csharp-version-history.md
@@ -140,7 +140,7 @@ C# 8.0 is the first major C# release that specifically targets .NET Core. Some f
   - Property patterns
   - Tuple patterns
   - Positional patterns
-- [Using declarations](../language-reference/keywords/using-directive.md)
+- [Using declarations](../language-reference/statements/using.md)
 - [Static local functions](../programming-guide/classes-and-structs/local-functions.md)
 - [Disposable ref structs](../language-reference/builtin-types/ref-struct.md)
 - [Nullable reference types](../language-reference/builtin-types/nullable-reference-types.md)


### PR DESCRIPTION
Fixes #35886

The using declarations are mentioned, but the link goes to the using directive, not the declaration.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/whats-new/csharp-version-history.md](https://github.com/dotnet/docs/blob/4be9c7da9293807107ad5189b157d5049ea60f47/docs/csharp/whats-new/csharp-version-history.md) | [The history of C\#](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-version-history?branch=pr-en-us-35890) |

<!-- PREVIEW-TABLE-END -->