### PR TITLE
Remove the include file

### DIFF
--- a/docs/csharp/includes/speclet-disclaimer.md
+++ b/docs/csharp/includes/speclet-disclaimer.md
@@ -1,9 +1,0 @@
----
-author: BillWagner
-ms.author: wiwagn
-ms.topic: include
-ms.date: 06/19/2023
----
-
-> [!NOTE]
-> This article is a feature specification. The specification represents the *proposed* feature specification. There may be some discrepancies between the feature specification and the completed implementation. Those differences are captured in the pertinent [language design meeting (LDM) notes](https://github.com/dotnet/csharplang/tree/main/meetings). Links to pertinent meetings are included at the bottom of the spec. You can learn more about the process for merging feature speclets into the C# language standard in the article on the [specifications](/dotnet/csharp/language-reference/specifications).


### PR DESCRIPTION
It's now in the csharplang repo so that the links resolve when people are looking at the speclets on the csharplang repo.
