### PR TITLE
Http everywhere change

### DIFF
--- a/docs/core/tools/dotnet-new-install.md
+++ b/docs/core/tools/dotnet-new-install.md
@@ -57,7 +57,7 @@ Starting with .NET SDK 6.0.100, installed template packages are available in lat
   To check the configured sources for the current directory use [`dotnet nuget list source`](dotnet-nuget-list-source.md). For more information, see [Common NuGet Configurations](/nuget/consume-packages/configuring-nuget-behavior)
 
   > [!NOTE]
-  > Following NuGet's [Https Everywhere](https://devblogs.microsoft.com/nuget/https-everywhere/) initiative, `dotnet new` is phasing out `http` feeds. If an `http` feed is passed, it will not be queried for packages and a warning will be displayed. The `--force` option can be used to override this behaviour if necessary.
+  > Following NuGet's [Https Everywhere](https://devblogs.microsoft.com/nuget/https-everywhere/) initiative, `dotnet new` is phasing out `http` feeds. If an `http` feed is passed, it isn't queried for packages and a warning is displayed. The `--force` option can be used to override this behavior if necessary.
 
 - **`-d|--diagnostics`**
 

--- a/docs/core/tools/dotnet-new-install.md
+++ b/docs/core/tools/dotnet-new-install.md
@@ -55,6 +55,11 @@ Starting with .NET SDK 6.0.100, installed template packages are available in lat
   
   By default, `dotnet new install` uses the hierarchy of NuGet configuration files from the current directory to determine the NuGet source the package can be installed from. If `--nuget-source` is specified, the source will be added to the list of sources to be checked.  
   To check the configured sources for the current directory use [`dotnet nuget list source`](dotnet-nuget-list-source.md). For more information, see [Common NuGet Configurations](/nuget/consume-packages/configuring-nuget-behavior)
+  
+  > [!NOTE]
+  > Following NuGet's Https Everywhere initiative, `dotnet new` is phasing out `http` feeds. If an `http` feed is passed by the user it will not be queried for packages and a warning will be displayed. The `--force` option can be used to override this behaviour if necessary.
+
+
 
 - **`-d|--diagnostics`**
 

--- a/docs/core/tools/dotnet-new-install.md
+++ b/docs/core/tools/dotnet-new-install.md
@@ -57,7 +57,7 @@ Starting with .NET SDK 6.0.100, installed template packages are available in lat
   To check the configured sources for the current directory use [`dotnet nuget list source`](dotnet-nuget-list-source.md). For more information, see [Common NuGet Configurations](/nuget/consume-packages/configuring-nuget-behavior)
 
   > [!NOTE]
-  > Following NuGet's Https Everywhere initiative, `dotnet new` is phasing out `http` feeds. If an `http` feed is passed, it will not be queried for packages and a warning will be displayed. The `--force` option can be used to override this behaviour if necessary.
+  > Following NuGet's [Https Everywhere](https://devblogs.microsoft.com/nuget/https-everywhere/) initiative, `dotnet new` is phasing out `http` feeds. If an `http` feed is passed, it will not be queried for packages and a warning will be displayed. The `--force` option can be used to override this behaviour if necessary.
 
 
 

--- a/docs/core/tools/dotnet-new-install.md
+++ b/docs/core/tools/dotnet-new-install.md
@@ -55,9 +55,9 @@ Starting with .NET SDK 6.0.100, installed template packages are available in lat
   
   By default, `dotnet new install` uses the hierarchy of NuGet configuration files from the current directory to determine the NuGet source the package can be installed from. If `--nuget-source` is specified, the source will be added to the list of sources to be checked.  
   To check the configured sources for the current directory use [`dotnet nuget list source`](dotnet-nuget-list-source.md). For more information, see [Common NuGet Configurations](/nuget/consume-packages/configuring-nuget-behavior)
-  
+
   > [!NOTE]
-  > Following NuGet's Https Everywhere initiative, `dotnet new` is phasing out `http` feeds. If an `http` feed is passed by the user it will not be queried for packages and a warning will be displayed. The `--force` option can be used to override this behaviour if necessary.
+  > Following NuGet's Https Everywhere initiative, `dotnet new` is phasing out `http` feeds. If an `http` feed is passed, it will not be queried for packages and a warning will be displayed. The `--force` option can be used to override this behaviour if necessary.
 
 
 

--- a/docs/core/tools/dotnet-new-install.md
+++ b/docs/core/tools/dotnet-new-install.md
@@ -59,8 +59,6 @@ Starting with .NET SDK 6.0.100, installed template packages are available in lat
   > [!NOTE]
   > Following NuGet's [Https Everywhere](https://devblogs.microsoft.com/nuget/https-everywhere/) initiative, `dotnet new` is phasing out `http` feeds. If an `http` feed is passed, it will not be queried for packages and a warning will be displayed. The `--force` option can be used to override this behaviour if necessary.
 
-
-
 - **`-d|--diagnostics`**
 
   Enables diagnostic output. Available since .NET SDK 7.0.100.


### PR DESCRIPTION
## Summary

Adds a note about the changes to http behavior in `dotnet new`. The changes are associated with this PR: https://github.com/dotnet/templating/pull/6313

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-new-install.md](https://github.com/dotnet/docs/blob/85f682c95c5f796003cadc8294cb58553d717729/docs/core/tools/dotnet-new-install.md) | [dotnet new install](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-new-install?branch=pr-en-us-35913) |


<!-- PREVIEW-TABLE-END -->