### PR TITLE
Fedora 36 is EOL

### DIFF
--- a/docs/core/install/linux-fedora.md
+++ b/docs/core/install/linux-fedora.md
@@ -25,7 +25,6 @@ The following table is a list of currently supported .NET releases and the versi
 |--------|-----------|
 | 38     | 7, 6      |
 | 37     | 7, 6      |
-| 36     | 7, 6      |
 
 [!INCLUDE [versions-not-supported](includes/versions-not-supported.md)]
 


### PR DESCRIPTION
## Summary

Fedora 36 is EOL and should be removed.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/linux-fedora.md](https://github.com/dotnet/docs/blob/76a10a4781f8bc16d842306787837f1b8a6ce773/docs/core/install/linux-fedora.md) | [Install the .NET SDK or the .NET Runtime on Fedora](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-fedora?branch=pr-en-us-35915) |

<!-- PREVIEW-TABLE-END -->