### PR TITLE
Dotnet new details command

### DIFF
--- a/docs/core/tools/dotnet-new-details.md
+++ b/docs/core/tools/dotnet-new-details.md
@@ -1,11 +1,11 @@
 ---
 title: dotnet new details
 description: The dotnet new details command displays template package metadata.
-ms.date: 04/15/2022
+ms.date: 06/07/2023
 ---
 # dotnet new details
 
-**This article applies to:** ✔️ .NET Core ??? SDK and later versions
+**This article applies to:** ✔️ .NET 8 preview 6
 
 ## Name
 
@@ -14,7 +14,7 @@ ms.date: 04/15/2022
 ## Synopsis
 
 ```dotnetcli
-dotnet new details [<PACKAGE_NAME>] [--version <VERSION>] [--interactive] [--add-source|--nuget-source <SOURCE>] 
+dotnet new details [<PACKAGE_NAME>] [--interactive] [--add-source|--nuget-source <SOURCE>] 
     [--force] [-d|--diagnostics] [-h|--help]
 ```
 
@@ -30,10 +30,6 @@ If the package is installed locally or is found on the official NuGet website, i
  The package identifier to display the details for.
 
 ## Options
-
-- **`--version <VERSION>`**
-
- Specifies the version of the package. If none is passed, the command displays information from the latest package version.
 
 - **`--add-source|--nuget-source <SOURCE>`**
   

--- a/docs/core/tools/dotnet-new-details.md
+++ b/docs/core/tools/dotnet-new-details.md
@@ -1,0 +1,62 @@
+---
+title: dotnet new details
+description: The dotnet new details command displays template package metadata.
+ms.date: 04/15/2022
+---
+# dotnet new details
+
+**This article applies to:** ✔️ .NET Core ??? SDK and later versions
+
+## Name
+
+`dotnet new details` - Displays template package metadata.
+
+## Synopsis
+
+```
+add the thingS
+```
+
+## Description
+
+The `dotnet new details` command displays the metdata of the template package from the package name provided. For information on a specific version specify the version in with the `--version (check if this is correct)` option. By default, the command searches for the latest available version.
+If the package is installed locally or is found on the official NuGet website, it also displays the templates that the package contains, otherwise it will only display basic package metadata.
+
+## Arguments
+
+- **`PACKAGE NAME`**
+
+Name of the package being searched for metadata.
+
+
+## Options
+
+- **`--version <VERSION>`**
+Specific version of the package being searched. If this is not specified, the command will look for the latest version.
+
+- **`--add-source|--nuget-source <SOURCE>`**
+  
+  By default, `dotnet new details` uses the hierarchy of NuGet configuration files from the current directory to determine the NuGet source the package can be installed from. If `--nuget-source` is specified, the source will be added to the list of sources to be checked.  
+  To check the configured sources for the current directory use [`dotnet nuget list source`](dotnet-nuget-list-source.md). For more information, see [Common NuGet Configurations](/nuget/consume-packages/configuring-nuget-behavior)
+
+[!INCLUDE [interactive](../../../includes/cli-interactive-5-0.md)]
+
+- **`-d|--diagnostics`**
+
+  Enables diagnostic output. Available since .NET SDK 7.0.100.
+
+- **`-h|--help`**
+
+  Prints out help for the search command. Available since .NET SDK 7.0.100.
+
+
+## Examples
+
+
+## See also
+
+- [dotnet new command](dotnet-new.md)
+- [dotnet new uninstall command](dotnet-new-uninstall.md)
+- [dotnet new list command](dotnet-new-list.md)
+- [dotnet new search command](dotnet-new-search.md)
+- [Custom templates for dotnet new](custom-templates.md)

--- a/docs/core/tools/dotnet-new-details.md
+++ b/docs/core/tools/dotnet-new-details.md
@@ -32,7 +32,7 @@ If the package is installed locally or is found on the official NuGet website, i
 ## Options
 
 - **`--version <VERSION>`**
- 
+
  Specifies the version of the package. If none is passed, the command displays information from the latest package version.
 
 - **`--add-source|--nuget-source <SOURCE>`**
@@ -49,7 +49,6 @@ If the package is installed locally or is found on the official NuGet website, i
 - **`-h|--help`**
 
   Prints out help for the search command. Available since .NET SDK 7.0.100.
-
 
 ## Examples
 

--- a/docs/core/tools/dotnet-new-details.md
+++ b/docs/core/tools/dotnet-new-details.md
@@ -20,44 +20,44 @@ dotnet new details [<PACKAGE_NAME>] [--interactive] [--add-source|--nuget-source
 
 ## Description
 
-The `dotnet new details` command displays the metdata of the template package from the package name provided. For information on a specific version specify the version in with the `--version (check if this is correct)` option. By default, the command searches for the latest available version.
-If the package is installed locally or is found on the official NuGet website, it also displays the templates that the package contains, otherwise it will only display basic metadata.
+The `dotnet new details` command displays the metdata of the template package from the package name provided. By default, the command searches for the latest available version.
+If the package is installed locally or is found on the official NuGet website, it also displays the templates that the package contains, otherwise it only displays basic metadata.
 
 ## Arguments
 
-- **`PACKAGE NAME`**
+- **`PACKAGE_NAME`**
 
- The package identifier to display the details for.
+  The package identifier to display the details for.
 
 ## Options
 
 - **`--add-source|--nuget-source <SOURCE>`**
   
-  By default, `dotnet new details` uses the hierarchy of NuGet configuration files from the current directory to determine the NuGet source the package can be installed from. If `--nuget-source` is specified, the source will be added to the list of sources to be checked.  
+  By default, `dotnet new details` uses the hierarchy of NuGet configuration files from the current directory to determine the NuGet source the package can be installed from. If `--nuget-source` is specified, the source is added to the list of sources to be checked.  
   To check the configured sources for the current directory use [`dotnet nuget list source`](dotnet-nuget-list-source.md). For more information, see [Common NuGet Configurations](/nuget/consume-packages/configuring-nuget-behavior)
 
-[!INCLUDE [interactive](../../../includes/cli-interactive-5-0.md)]
+[!INCLUDE [interactive](../../../includes/cli-interactive.md)]
 
 - **`-d|--diagnostics`**
 
-  Enables diagnostic output. Available since .NET SDK 7.0.100.
+  Enables diagnostic output.
 
 - **`-h|--help`**
 
-  Prints out help for the search command. Available since .NET SDK 7.0.100.
+  Prints out help for the search command.
 
 ## Examples
 
-- Displays package data from the latest version of SPA templates for ASP.NET Core:
+- Display package data from the latest version of NUnit templates:
 
    ```dotnetcli
-  dotnet new details Microsoft.DotNet.Web.Spa.ProjectTemplates
+  dotnet new details NUnit3.DotNetNew.Template
   ```
 
-- Displays package data of the SPA templates for ASP.NET Core from a custom NuGet source using interactive mode:
+- Display package data of the NUnit templates from a custom NuGet source using interactive mode:
 
   ```dotnetcli
-  dotnet new details Microsoft.DotNet.Web.Spa.ProjectTemplates --add-source "https://api.my-custom-nuget.com/v3/index.json" --interactive
+  dotnet new details NUnit3.DotNetNew.Template --add-source "https://api.my-custom-nuget.com/v3/index.json" --interactive
   ```
 
 ## See also

--- a/docs/core/tools/dotnet-new-details.md
+++ b/docs/core/tools/dotnet-new-details.md
@@ -54,16 +54,10 @@ If the package is installed locally or is found on the official NuGet website, i
   dotnet new details Microsoft.DotNet.Web.Spa.ProjectTemplates
   ```
 
-- Displays package data from version 2.0 of the SPA templates for ASP.NET Core:
+- Displays package data of the SPA templates for ASP.NET Core from a custom NuGet source using interactive mode:
 
   ```dotnetcli
-  dotnet new install Microsoft.DotNet.Web.Spa.ProjectTemplates --version 2.0.0
-  ```
-
-- Displays package data from version 2.0 of the SPA templates for ASP.NET Core from a custom NuGet source using interactive mode:
-
-  ```dotnetcli
-  dotnet new details Microsoft.DotNet.Web.Spa.ProjectTemplates --version 2.0.0 --add-source "https://api.my-custom-nuget.com/v3/index.json" --interactive
+  dotnet new details Microsoft.DotNet.Web.Spa.ProjectTemplates --add-source "https://api.my-custom-nuget.com/v3/index.json" --interactive
   ```
 
 ## See also

--- a/docs/core/tools/dotnet-new-details.md
+++ b/docs/core/tools/dotnet-new-details.md
@@ -13,26 +13,27 @@ ms.date: 04/15/2022
 
 ## Synopsis
 
-```
-add the thingS
+```dotnetcli
+dotnet new details [<PACKAGE_NAME>] [--version <VERSION>] [--interactive] [--add-source|--nuget-source <SOURCE>] 
+    [--force] [-d|--diagnostics] [-h|--help]
 ```
 
 ## Description
 
 The `dotnet new details` command displays the metdata of the template package from the package name provided. For information on a specific version specify the version in with the `--version (check if this is correct)` option. By default, the command searches for the latest available version.
-If the package is installed locally or is found on the official NuGet website, it also displays the templates that the package contains, otherwise it will only display basic package metadata.
+If the package is installed locally or is found on the official NuGet website, it also displays the templates that the package contains, otherwise it will only display basic metadata.
 
 ## Arguments
 
 - **`PACKAGE NAME`**
 
-Name of the package being searched for metadata.
-
+ The package identifier to display the details for.
 
 ## Options
 
 - **`--version <VERSION>`**
-Specific version of the package being searched. If this is not specified, the command will look for the latest version.
+ 
+ Specifies the version of the package. If none is passed, the command displays information from the latest package version.
 
 - **`--add-source|--nuget-source <SOURCE>`**
   
@@ -52,6 +53,23 @@ Specific version of the package being searched. If this is not specified, the co
 
 ## Examples
 
+- Displays package data from the latest version of SPA templates for ASP.NET Core:
+
+   ```dotnetcli
+  dotnet new details Microsoft.DotNet.Web.Spa.ProjectTemplates
+  ```
+
+- Displays package data from version 2.0 of the SPA templates for ASP.NET Core:
+
+  ```dotnetcli
+  dotnet new install Microsoft.DotNet.Web.Spa.ProjectTemplates --version 2.0.0
+  ```
+
+- Displays package data from version 2.0 of the SPA templates for ASP.NET Core from a custom NuGet source using interactive mode:
+
+  ```dotnetcli
+  dotnet new details Microsoft.DotNet.Web.Spa.ProjectTemplates --version 2.0.0 --add-source "https://api.my-custom-nuget.com/v3/index.json" --interactive
+  ```
 
 ## See also
 

--- a/docs/navigate/tools-diagnostics/toc.yml
+++ b/docs/navigate/tools-diagnostics/toc.yml
@@ -122,6 +122,8 @@ items:
                 href: ../../core/tools/dotnet-new-list.md
               - name: dotnet new search
                 href: ../../core/tools/dotnet-new-search.md
+              - name: dotnet new details
+                href: ../../core/tools/dotnet-new-details.md
               - name: dotnet new install
                 href: ../../core/tools/dotnet-new-install.md
               - name: dotnet new uninstall


### PR DESCRIPTION
## Summary

Added a new page for the `dotnet new details` command that was implemented here: https://github.com/dotnet/sdk/pull/31743.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-new-details.md](https://github.com/dotnet/docs/blob/87e81fe4f4f997682149fea8734665904dcf7bec/docs/core/tools/dotnet-new-details.md) | [docs/core/tools/dotnet-new-details](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-new-details?branch=pr-en-us-35919) |


<!-- PREVIEW-TABLE-END -->