### PR TITLE
Changed TargetType to OutputType

### DIFF
--- a/docs/csharp/language-reference/compiler-options/output.md
+++ b/docs/csharp/language-reference/compiler-options/output.md
@@ -21,7 +21,7 @@ The following options control compiler output generation.
 | **OutputAssembly** | `-out:` | Specify the output assembly file. |
 | **PlatformTarget** | `-platform:` | Specify the target platform CPU. |
 | **ProduceReferenceAssembly** | `-refout:` | Generate a reference assembly. |
-| **TargetType** | `-target:` | Specify the type of the output assembly. |
+| **OutputType** | `-target:` | Specify the type of the output assembly. |
 
 ## DocumentationFile
 
@@ -100,9 +100,9 @@ You generally don't need to work directly with reference assembly files. By defa
 
 .NET SDK 6.0.200 made a [change](../../../core/compatibility/sdk/6.0/write-reference-assemblies-to-obj.md) that moved reference assemblies from the output directory to the intermediate directory by default.
 
-## TargetType
+## OutputType
 
-The **TargetType** compiler option can be specified in one of the following forms:  
+The **OutputType** compiler option can be specified in one of the following forms:  
   
 - **library**: to create a code library. **library** is the default value.
 - **exe**: to create an .exe file.  


### PR DESCRIPTION
There doesn't seem to be a `TargetType` property available, or if it does it neither auto-completes in Visual Studio nor affects a build's output type.

There IS however the property `OutputType`, which can be set to the same values as listed here under `TargetType`.

It's worth investigating other options listed in this documentation set. `OutputAssembly` also doesn't seem to exist. This probably refers to the `OutputPath` and `AssemblyName` properties. Furthermore, the example does not indicate that a trailing slash is needed after the folder name. 

The document also has "Specify the full name and extension of the file you want to create". However, it's unclear whether this simply means the base file name (i.e. the file name without the extension) or the fully qualified filename. I suspect this is meant to simply be "the name and extension of the file". As well, the documentation does not indicate whether or not the "folder" can be relative. 

This is not the only documentation that appears to be incorrect in this set. For example, [MainEntryPoint or StartupObject](https://github.com/dotnet/docs/blob/main/docs/csharp/language-reference/compiler-options/advanced.md#mainentrypoint-or-startupobject) references a `MainEntryPoint` property which does not seem to exist or work. It also incorrectly states that `StartupObject` must be a fully qualified class name.

I hope I didn't read this entire section incorrectly.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-options/output.md](https://github.com/dotnet/docs/blob/14634df8bd3dc79565b0f5b90274579674e1b30b/docs/csharp/language-reference/compiler-options/output.md) | [C# Compiler Options that control compiler output](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/output?branch=pr-en-us-35941) |

<!-- PREVIEW-TABLE-END -->