### PR TITLE
Add a note about differences in Dictionary initialization methods when it comes to multiplied keys

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-a-dictionary-with-a-collection-initializer.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-a-dictionary-with-a-collection-initializer.md
@@ -13,10 +13,12 @@ ms.assetid: 25283922-f8ee-40dc-a639-fac30804ec71
 A <xref:System.Collections.Generic.Dictionary%602> contains a collection of key/value pairs. Its <xref:System.Collections.Generic.Dictionary%602.Add%2A> method takes two parameters, one for the key and one for the value. One way to initialize a <xref:System.Collections.Generic.Dictionary%602>, or any collection whose `Add` method takes multiple parameters, is to enclose each set of parameters in braces as shown in the following example. Another option is to use an index initializer, also shown in the following example.
 
 > NOTE: The major difference between these two ways of initializing the collection is that in case of having multiplied keys, for example:
+>
 > ```csharp  
 > { 111, new StudentName { FirstName="Sachin", LastName="Karnik", ID=211 } },
 > { 111, new StudentName { FirstName="Dina", LastName="Salimzianova", ID=317 } }, 
 >  ```
+>
 > <xref:System.Collections.Generic.Dictionary%602.Add%2A> method will throw <xref:System.ArgumentException>: `'An item with the same key has already been added. Key: 111'`,
 > while the second part of example, the public read / write indexer method, will quietly overwrite the already existing entry with the same key.
 

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-a-dictionary-with-a-collection-initializer.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-a-dictionary-with-a-collection-initializer.md
@@ -18,7 +18,7 @@ A <xref:System.Collections.Generic.Dictionary%602> contains a collection of key/
 > { 111, new StudentName { FirstName="Dina", LastName="Salimzianova", ID=317 } }, 
 >  ```
 > <xref:System.Collections.Generic.Dictionary%602.Add%2A> method will throw <xref:System.ArgumentException>: `'An item with the same key has already been added. Key: 111'`,
-> while the public read / write indexer method will quietly overwrite the already existing entry with the same key.
+> while the second part of example, the public read / write indexer method, will quietly overwrite the already existing entry with the same key.
 
 ## Example
 

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-a-dictionary-with-a-collection-initializer.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-a-dictionary-with-a-collection-initializer.md
@@ -12,7 +12,7 @@ ms.assetid: 25283922-f8ee-40dc-a639-fac30804ec71
 
 A <xref:System.Collections.Generic.Dictionary%602> contains a collection of key/value pairs. Its <xref:System.Collections.Generic.Dictionary%602.Add%2A> method takes two parameters, one for the key and one for the value. One way to initialize a <xref:System.Collections.Generic.Dictionary%602>, or any collection whose `Add` method takes multiple parameters, is to enclose each set of parameters in braces as shown in the following example. Another option is to use an index initializer, also shown in the following example.
 
-> NOTE: The major difference between these two ways of initializing the collection is that in case of having multiplied keys, for example:
+> NOTE: The major difference between these two ways of initializing the collection is that in case of having duplicated keys, for example:
 >
 > ```csharp  
 > { 111, new StudentName { FirstName="Sachin", LastName="Karnik", ID=211 } },

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-a-dictionary-with-a-collection-initializer.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-a-dictionary-with-a-collection-initializer.md
@@ -12,6 +12,14 @@ ms.assetid: 25283922-f8ee-40dc-a639-fac30804ec71
 
 A <xref:System.Collections.Generic.Dictionary%602> contains a collection of key/value pairs. Its <xref:System.Collections.Generic.Dictionary%602.Add%2A> method takes two parameters, one for the key and one for the value. One way to initialize a <xref:System.Collections.Generic.Dictionary%602>, or any collection whose `Add` method takes multiple parameters, is to enclose each set of parameters in braces as shown in the following example. Another option is to use an index initializer, also shown in the following example.
 
+> NOTE: The major difference between these two ways of initializing the collection is that in case of having multiplied keys, for example:
+> ```csharp  
+> { 111, new StudentName { FirstName="Sachin", LastName="Karnik", ID=211 } },
+> { 111, new StudentName { FirstName="Dina", LastName="Salimzianova", ID=317 } }, 
+>  ```
+> <xref:System.Collections.Generic.Dictionary%602.Add%2A> method will throw <xref:System.ArgumentException>: `'An item with the same key has already been added. Key: 111'`,
+> while the public read / write indexer method will quietly overwrite the already existing entry with the same key.
+
 ## Example
 
 In the following code example, a <xref:System.Collections.Generic.Dictionary%602> is initialized with instances of type `StudentName`.  The first initialization uses the `Add` method with two arguments. The compiler generates a call to `Add` for each of the pairs of `int` keys and `StudentName` values. The second uses a public read / write indexer method of the `Dictionary` class:

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-a-dictionary-with-a-collection-initializer.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-a-dictionary-with-a-collection-initializer.md
@@ -12,7 +12,8 @@ ms.assetid: 25283922-f8ee-40dc-a639-fac30804ec71
 
 A <xref:System.Collections.Generic.Dictionary%602> contains a collection of key/value pairs. Its <xref:System.Collections.Generic.Dictionary%602.Add%2A> method takes two parameters, one for the key and one for the value. One way to initialize a <xref:System.Collections.Generic.Dictionary%602>, or any collection whose `Add` method takes multiple parameters, is to enclose each set of parameters in braces as shown in the following example. Another option is to use an index initializer, also shown in the following example.
 
-> NOTE: The major difference between these two ways of initializing the collection is that in case of having duplicated keys, for example:
+> [!NOTE]
+> The major difference between these two ways of initializing the collection is that in case of having duplicated keys, for example:
 >
 > ```csharp  
 > { 111, new StudentName { FirstName="Sachin", LastName="Karnik", ID=211 } },


### PR DESCRIPTION
This pull request closes #35654.

It adds the `NOTE` emphasizing that in case of multiplied keys (with the embedded example of such) the behavior of both ways will differ.
The note links to the `System.ArgumentException` and gives the example message of such exception.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/classes-and-structs/how-to-initialize-a-dictionary-with-a-collection-initializer.md](https://github.com/dotnet/docs/blob/9b243971869005e219f90e39046b7c6e9894cab3/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-a-dictionary-with-a-collection-initializer.md) | [How to initialize a dictionary with a collection initializer (C# Programming Guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/how-to-initialize-a-dictionary-with-a-collection-initializer?branch=pr-en-us-35944) |


<!-- PREVIEW-TABLE-END -->