### PR TITLE
Fix the issue where 'caller' should have been 'callee'

### DIFF
--- a/docs/orleans/grains/oneway.md
+++ b/docs/orleans/grains/oneway.md
@@ -1,14 +1,14 @@
 ---
 title: One-way requests
 description: Learn about one-way requests in .NET Orleans.
-ms.date: 03/16/2022
+ms.date: 06/26/2023
 ---
 
 # One-way requests
 
-Grains execute requests (method calls) asynchronously and so all grain interface methods must return an asynchronous type, such as <xref:System.Threading.Tasks.Task>. By awaiting the completion of a task returned from a grain call, the caller is notified that the request has been completed and any exceptions or return values can be propagated back to the caller so that they can be handled. There are cases where a caller merely wants to *notify* a grain that some event has happened and doesn't need to be informed of any exceptions or receive a completion signal. For these cases, Orleans supports *one-way requests*.
+Grains perform asynchronous request execution, requiring all grain interface methods to return an asynchronous type, like <xref:System.Threading.Tasks.Task>. Awaiting the completion of a task returned from a grain call notifies the caller that the request has finished, allowing them to handle any exceptions or receive return values. Orleans also supports *one-way requests*, enabling callers to notify a grain about an event without expecting exceptions or completion signals.
 
-One-way requests return to the caller immediately and do not signal failure or completion. A one-way request does not even guarantee that the caller received the request. The primary benefit of a one-way request is that they save messaging costs associated with sending a response back to the caller and can therefore improve performance in some specialized cases. One-way requests are an advanced performance feature and should be used with care and only when a developer has determined that a one-way request is beneficial. It is recommended to prefer regular bi-directional requests, which signal completion and propagate errors back to callers.
+One-way requests return to the caller immediately and don't signal failure or completion. A one-way request doesn't even guarantee that the callee received the request. The primary benefit of a one-way request is that they save messaging costs associated with sending a response back to the caller and can therefore improve performance in some specialized cases. One-way requests are an advanced performance feature and should be used with care and only when a developer has determined that a one-way request is beneficial. It's recommended to prefer regular bi-directional requests, which signal completion and propagate errors back to callers.
 
 A request can be made one way by marking the grain interface method with the <xref:Orleans.Concurrency.OneWayAttribute>, like so:
 


### PR DESCRIPTION
## Summary

- Fix the issue where 'caller' should have been 'callee'
- Edit pass

@ReubenBond @bradygaster

Fixes #35948


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/grains/oneway.md](https://github.com/dotnet/docs/blob/c935ce6caf9dc9e838e4e389f2c2202a7c355632/docs/orleans/grains/oneway.md) | [One-way requests](https://review.learn.microsoft.com/en-us/dotnet/orleans/grains/oneway?branch=pr-en-us-35952) |

<!-- PREVIEW-TABLE-END -->