### PR TITLE
Edit pass, and clarifying statements

### DIFF
--- a/docs/core/extensions/channels.md
+++ b/docs/core/extensions/channels.md
@@ -10,7 +10,7 @@ ms.date: 06/26/2023
 
 The <xref:System.Threading.Channels?displayProperty=fullName> namespace provides a set of synchronization data structures for passing data between producers and consumers asynchronously. The library targets .NET Standard and works on all .NET implementations.
 
-This library is available in the [System.Threading.Channels](https://www.nuget.org/packages/System.Threading.Channels) NuGet package, however; if you're using .NET Core 3.0 or later, the package is included as part of the framework.
+This library is available in the [System.Threading.Channels](https://www.nuget.org/packages/System.Threading.Channels) NuGet package. However, if you're using .NET Core 3.0 or later, the package is included as part of the framework.
 
 ## Producer/consumer conceptual programming model
 
@@ -51,7 +51,7 @@ When using a bounded channel, you can specify the behavior the channel adheres t
 
 | Value | Behavior |
 |--|--|
-| <xref:System.Threading.Channels.BoundedChannelFullMode.Wait?displayProperty=nameWithType> | This is the default value. Calls to `WriteAsync`, wait for space to be available in order to complete the write operation. Calls to `TryWrite` return `false` immediately. |
+| <xref:System.Threading.Channels.BoundedChannelFullMode.Wait?displayProperty=nameWithType> | This is the default value. Calls to `WriteAsync` wait for space to be available in order to complete the write operation. Calls to `TryWrite` return `false` immediately. |
 | <xref:System.Threading.Channels.BoundedChannelFullMode.DropNewest?displayProperty=nameWithType> | Removes and ignores the newest item in the channel in order to make room for the item being written. |
 | <xref:System.Threading.Channels.BoundedChannelFullMode.DropOldest?displayProperty=nameWithType> | Removes and ignores the oldest item in the channel in order to make room for the item being written. |
 | <xref:System.Threading.Channels.BoundedChannelFullMode.DropWrite?displayProperty=nameWithType> | Drops the item being written. |
@@ -119,7 +119,7 @@ The preceding code creates a bounded channel with a max capacity of `1`. Other o
 
 In the preceding code, the channel is created as a bounded channel that's limited to 1,000 items, with a single writer but many readers. Its full mode behavior is defined as `DropWrite`, which means that it drops the item being written if the channel is full.
 
-To observe items that are dropped when using bounded channels register an `itemDropped` callback:
+To observe items that are dropped when using bounded channels, register an `itemDropped` callback:
 
 :::code language="csharp" source="snippets/channels/Program.Bounded.cs" id="boundedcallback":::
 

--- a/docs/core/extensions/channels.md
+++ b/docs/core/extensions/channels.md
@@ -3,24 +3,24 @@ title: Channels
 description: Learn the official synchronization data structures in System.Threading.Channels for producers and consumers with .NET.
 author: IEvangelist
 ms.author: dapine
-ms.date: 03/13/2023
+ms.date: 06/26/2023
 ---
 
 # System.Threading.Channels library
 
 The <xref:System.Threading.Channels?displayProperty=fullName> namespace provides a set of synchronization data structures for passing data between producers and consumers asynchronously. The library targets .NET Standard and works on all .NET implementations.
 
-This library is available in the [System.Threading.Channels](https://www.nuget.org/packages/System.Threading.Channels) NuGet package (or included when targeting .NET Core 2.1+).
+This library is available in the [System.Threading.Channels](https://www.nuget.org/packages/System.Threading.Channels) NuGet package, however; if you're using .NET Core 3.0 or later, the package is included as part of the framework.
 
 ## Producer/consumer conceptual programming model
 
-Channels are an implementation of the producer/consumer conceptual programming model. In this programming model, producers asynchronously produce data, and consumers asynchronously consume that data. In other words, this model hands off data from one party to another. Try to think of channels as you would any other common generic collection type, such as a `List<T>`. The primary difference is that this collection manages synchronization and provides various consumption models through factory creation options. These options control the behavior of the channels, such as how many elements they're allowed to store and what happens if that limit is reached, or whether the channel may be accessed by multiple producers or multiple consumers concurrently.
+Channels are an implementation of the producer/consumer conceptual programming model. In this programming model, producers asynchronously produce data, and consumers asynchronously consume that data. In other words, this model hands off data from one party to another. Try to think of channels as you would any other common generic collection type, such as a `List<T>`. The primary difference is that this collection manages synchronization and provides various consumption models through factory creation options. These options control the behavior of the channels, such as how many elements they're allowed to store and what happens if that limit is reached, or whether the channel is accessed by multiple producers or multiple consumers concurrently.
 
 ## Bounding strategies
 
-Depending on how a `Channel<T>` is created, its reader and writer will behave differently.
+Depending on how a `Channel<T>` is created, its reader and writer behave differently.
 
-To create a channel that specifies a maximum capacity, call <xref:System.Threading.Channels.Channel.CreateBounded%2A?displayProperty=nameWithType>. To create a channel that can be used by any number of readers and writers concurrently, call <xref:System.Threading.Channels.Channel.CreateUnbounded%2A?displayProperty=nameWithType>. Each bounding strategy exposes various creator-defined options, either <xref:System.Threading.Channels.BoundedChannelOptions> or <xref:System.Threading.Channels.UnboundedChannelOptions> respectively.
+To create a channel that specifies a maximum capacity, call <xref:System.Threading.Channels.Channel.CreateBounded%2A?displayProperty=nameWithType>. To create a channel that is used by any number of readers and writers concurrently, call <xref:System.Threading.Channels.Channel.CreateUnbounded%2A?displayProperty=nameWithType>. Each bounding strategy exposes various creator-defined options, either <xref:System.Threading.Channels.BoundedChannelOptions> or <xref:System.Threading.Channels.UnboundedChannelOptions> respectively.
 
 > [!NOTE]
 > Regardless of the bounding strategy, a channel will always throw a <xref:System.Threading.Channels.ChannelClosedException> when it's used after it's been closed.
@@ -33,7 +33,7 @@ To create an unbounded channel, call one of the <xref:System.Threading.Channels.
 var channel = Channel.CreateUnbounded<T>();
 ```
 
-When you create an unbounded channel, by default, the channel can be used by any number of readers and writers concurrently. Alternatively, you can specify non-default behavior when creating an unbounded channel by providing an `UnboundedChannelOptions` instance. The channel's capacity is unbounded and all writes are performed synchronously. For additional examples, see [Unbounded creation patterns](#unbounded-creation-patterns).
+When you create an unbounded channel, by default, the channel can be used by any number of readers and writers concurrently. Alternatively, you can specify nondefault behavior when creating an unbounded channel by providing an `UnboundedChannelOptions` instance. The channel's capacity is unbounded and all writes are performed synchronously. For more examples, see [Unbounded creation patterns](#unbounded-creation-patterns).
 
 ### Bounded channels
 
@@ -43,15 +43,15 @@ To create a bounded channel, call one of the <xref:System.Threading.Channels.Cha
 var channel = Channel.CreateBounded<T>(7);
 ```
 
-The preceding code creates a channel that has a maximum capacity of `7` items. When you create a bounded channel, the channel is bound to a maximum capacity. When the bound is reached, the default behavior is that the channel will asynchronously block the producer until space becomes available. You can configure this behavior by specifying an option when you create the channel. Bounded channels can be created with any capacity value greater than zero. For additional examples, see [Bounded creation patterns](#bounded-creation-patterns).
+The preceding code creates a channel that has a maximum capacity of `7` items. When you create a bounded channel, the channel is bound to a maximum capacity. When the bound is reached, the default behavior is that the channel asynchronously blocks the producer until space becomes available. You can configure this behavior by specifying an option when you create the channel. Bounded channels can be created with any capacity value greater than zero. For other examples, see [Bounded creation patterns](#bounded-creation-patterns).
 
 #### Full mode behavior
 
-When using a bounded channel, you can specify the behavior the channel will adhere to when the configured bound is reached. The following table lists the full mode behaviors for each <xref:System.Threading.Channels.BoundedChannelFullMode> value:
+When using a bounded channel, you can specify the behavior the channel adheres to when the configured bound is reached. The following table lists the full mode behaviors for each <xref:System.Threading.Channels.BoundedChannelFullMode> value:
 
 | Value | Behavior |
 |--|--|
-| <xref:System.Threading.Channels.BoundedChannelFullMode.Wait?displayProperty=nameWithType> | This is the default value. When calling `WriteAsync`, waits for space to be available in order to complete the write operation. When calling `TryWrite`, returns `false` immediately. |
+| <xref:System.Threading.Channels.BoundedChannelFullMode.Wait?displayProperty=nameWithType> | This is the default value. Calls to `WriteAsync`, wait for space to be available in order to complete the write operation. Calls to `TryWrite`, return `false` immediately. |
 | <xref:System.Threading.Channels.BoundedChannelFullMode.DropNewest?displayProperty=nameWithType> | Removes and ignores the newest item in the channel in order to make room for the item being written. |
 | <xref:System.Threading.Channels.BoundedChannelFullMode.DropOldest?displayProperty=nameWithType> | Removes and ignores the oldest item in the channel in order to make room for the item being written. |
 | <xref:System.Threading.Channels.BoundedChannelFullMode.DropWrite?displayProperty=nameWithType> | Drops the item being written. |
@@ -65,10 +65,10 @@ The producer functionality is exposed on the <xref:System.Threading.Channels.Cha
 
 | API | Expected behavior |
 |--|--|
-| <xref:System.Threading.Channels.ChannelWriter%601.Complete%2A?displayProperty=nameWithType> | Marks the channel as being complete, meaning no more items will be written to it. |
-| <xref:System.Threading.Channels.ChannelWriter%601.TryComplete%2A?displayProperty=nameWithType> | Attempts to mark the channel as being completed, meaning no more data will be written to it. |
+| <xref:System.Threading.Channels.ChannelWriter%601.Complete%2A?displayProperty=nameWithType> | Marks the channel as being complete, meaning no more items are written to it. |
+| <xref:System.Threading.Channels.ChannelWriter%601.TryComplete%2A?displayProperty=nameWithType> | Attempts to mark the channel as being completed, meaning no more data is written to it. |
 | <xref:System.Threading.Channels.ChannelWriter%601.TryWrite%2A?displayProperty=nameWithType> | Attempts to write the specified item to the channel. When used with an unbounded channel, this always returns `true` unless the channel's writer signals completion with either <xref:System.Threading.Channels.ChannelWriter%601.Complete%2A?displayProperty=nameWithType>, or <xref:System.Threading.Channels.ChannelWriter%601.TryComplete%2A?displayProperty=nameWithType>. |
-| <xref:System.Threading.Channels.ChannelWriter%601.WaitToWriteAsync%2A?displayProperty=nameWithType> | Returns a <xref:System.Threading.Tasks.ValueTask%601> that will complete when space is available to write an item. |
+| <xref:System.Threading.Channels.ChannelWriter%601.WaitToWriteAsync%2A?displayProperty=nameWithType> | Returns a <xref:System.Threading.Tasks.ValueTask%601> that completes when space is available to write an item. |
 | <xref:System.Threading.Channels.ChannelWriter%601.WriteAsync%2A?displayProperty=nameWithType> | Asynchronously writes an item to the channel. |
 
 ## Consumer APIs
@@ -81,7 +81,7 @@ The consumer functionality is exposed on the <xref:System.Threading.Channels.Cha
 | <xref:System.Threading.Channels.ChannelReader%601.ReadAsync%2A?displayProperty=nameWithType> | Asynchronously reads an item from the channel. |
 | <xref:System.Threading.Channels.ChannelReader%601.TryPeek%2A?displayProperty=nameWithType> | Attempts to peek at an item from the channel. |
 | <xref:System.Threading.Channels.ChannelReader%601.TryRead%2A?displayProperty=nameWithType> | Attempts to read an item from the channel. |
-| <xref:System.Threading.Channels.ChannelReader%601.WaitToReadAsync%2A?displayProperty=nameWithType> | Returns a <xref:System.Threading.Tasks.ValueTask%601> that will complete when data is available to read. |
+| <xref:System.Threading.Channels.ChannelReader%601.WaitToReadAsync%2A?displayProperty=nameWithType> | Returns a <xref:System.Threading.Tasks.ValueTask%601> that completes when data is available to read. |
 
 ## Common usage patterns
 
@@ -107,23 +107,23 @@ In this case, all writes are synchronous, even the `WriteAsync`. This is because
 
 #### Bounded creation patterns
 
-When working with bounded channels, the configurability of the channel should be known to the consumer to help ensure proper consumption. That is, the consumer should know what behavior the channel will exhibit when the configured bound is reached. Let's explore some of the common bounded creation patterns.
+With bounded channels, the configurability of the channel should be known to the consumer to help ensure proper consumption. That is, the consumer should know what behavior the channel exhibits when the configured bound is reached. Let's explore some of the common bounded creation patterns.
 
 The simplest way to create a bounded channel is to specify a capacity:
 
 :::code language="csharp" source="snippets/channels/Program.Bounded.cs" id="boundedcapcity":::
 
-The preceding code creates a bounded channel with a max capacity of `1`. Additional options are available, some options are the same as an unbounded channel, while others are specific to unbounded channels:
+The preceding code creates a bounded channel with a max capacity of `1`. Other options are available, some options are the same as an unbounded channel, while others are specific to unbounded channels:
 
 :::code language="csharp" source="snippets/channels/Program.Bounded.cs" id="boundedoptions":::
 
-In the preceding code, the channel is created as a bounded channel that's limited to 1,000 items, with a single writer but many readers. Its full mode behavior is defined as `DropWrite`, which means that it will drop the item being written if the channel is full.
+In the preceding code, the channel is created as a bounded channel that's limited to 1,000 items, with a single writer but many readers. Its full mode behavior is defined as `DropWrite`, which means that it drops the item being written if the channel is full.
 
-When using a bounded channel, to observe items that are dropped register an `itemDropped` callback:
+To observe items that are dropped when using bounded channels register an `itemDropped` callback:
 
 :::code language="csharp" source="snippets/channels/Program.Bounded.cs" id="boundedcallback":::
 
-Whenever the channel is full and a new item is added, the `itemDropped` callback will be invoked. In this example, the provided callback writes the item to the console, but you're free to take any other action you want.
+Whenever the channel is full and a new item is added, the `itemDropped` callback is invoked. In this example, the provided callback writes the item to the console, but you're free to take any other action you want.
 
 ### Producer patterns
 
@@ -140,7 +140,7 @@ An alternative producer might use the `WriteAsync` method:
 
 :::code language="csharp" source="snippets/channels/Program.Producer.cs" id="whilewrite":::
 
-Again, the `Channel<Coordinates>.Writer` is used within a `while` loop. But this time, the <xref:System.Threading.Channels.ChannelWriter%601.WriteAsync%2A> method is called. The method will continue only after the coordinates have been written. When the `while` loop exits, a call to <xref:System.Threading.Channels.ChannelWriter%601.Complete%2A> is made, which signals that no more data will be written to the channel.
+Again, the `Channel<Coordinates>.Writer` is used within a `while` loop. But this time, the <xref:System.Threading.Channels.ChannelWriter%601.WriteAsync%2A> method is called. The method will continue only after the coordinates have been written. When the `while` loop exits, a call to <xref:System.Threading.Channels.ChannelWriter%601.Complete%2A> is made, which signals that no more data is written to the channel.
 
 Another producer pattern is to use the <xref:System.Threading.Channels.ChannelWriter%601.WaitToWriteAsync%2A> method, consider the following code:
 
@@ -150,7 +150,7 @@ As part of the conditional `while`, the result of the `WaitToWriteAsync` call is
 
 ### Consumer patterns
 
-There are several common channel consumer patterns. When a channel is never ending, meaning it will infinitely produce data, the consumer could use a `while (true)` loop, and read data as it becomes available:
+There are several common channel consumer patterns. When a channel is never ending, meaning it produces data indefinitely, the consumer could use a `while (true)` loop, and read data as it becomes available:
 
 :::code language="csharp" source="snippets/channels/Program.Consumer.cs" id="whiletrue":::
 
@@ -161,7 +161,7 @@ An alternative consumer could avoid this concern by using a nested while loop, a
 
 :::code language="csharp" source="snippets/channels/Program.Consumer.cs" id="nestedwhile":::
 
-In the preceding code, the consumer waits to read data. Once the data is available, the consumer tries to read it. These loops will continue to evaluate until the producer of the channel signals that it no longer has data to be read. With that said, when a producer is known to have a finite number of items it will produce and it signals completion, the consumer can use `await foreach` semantics to iterate over the items:
+In the preceding code, the consumer waits to read data. Once the data is available, the consumer tries to read it. These loops continue to evaluate until the producer of the channel signals that it no longer has data to be read. With that said, when a producer is known to have a finite number of items it produces and it signals completion, the consumer can use `await foreach` semantics to iterate over the items:
 
 :::code language="csharp" source="snippets/channels/Program.Consumer.cs" id="awaitforeach":::
 

--- a/docs/core/extensions/channels.md
+++ b/docs/core/extensions/channels.md
@@ -51,7 +51,7 @@ When using a bounded channel, you can specify the behavior the channel adheres t
 
 | Value | Behavior |
 |--|--|
-| <xref:System.Threading.Channels.BoundedChannelFullMode.Wait?displayProperty=nameWithType> | This is the default value. Calls to `WriteAsync`, wait for space to be available in order to complete the write operation. Calls to `TryWrite`, return `false` immediately. |
+| <xref:System.Threading.Channels.BoundedChannelFullMode.Wait?displayProperty=nameWithType> | This is the default value. Calls to `WriteAsync`, wait for space to be available in order to complete the write operation. Calls to `TryWrite` return `false` immediately. |
 | <xref:System.Threading.Channels.BoundedChannelFullMode.DropNewest?displayProperty=nameWithType> | Removes and ignores the newest item in the channel in order to make room for the item being written. |
 | <xref:System.Threading.Channels.BoundedChannelFullMode.DropOldest?displayProperty=nameWithType> | Removes and ignores the oldest item in the channel in order to make room for the item being written. |
 | <xref:System.Threading.Channels.BoundedChannelFullMode.DropWrite?displayProperty=nameWithType> | Drops the item being written. |


### PR DESCRIPTION
## Summary

- Add clarifying statements about NuGet package vs. framework inclusions.
- Edit pass.

Fixes #35945


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/channels.md](https://github.com/dotnet/docs/blob/81662bb77f3aa2f989b64a9d87cbaf807f89a2b0/docs/core/extensions/channels.md) | [System.Threading.Channels library](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/channels?branch=pr-en-us-35954) |


<!-- PREVIEW-TABLE-END -->