### PR TITLE
Revert "Update version to Preview 6"

### DIFF
--- a/docs/core/compatibility/deployment/8.0/rid-asset-list.md
+++ b/docs/core/compatibility/deployment/8.0/rid-asset-list.md
@@ -49,7 +49,7 @@ For non-portable builds of the host or runtime, the build might also set a non-p
 
 ## Version introduced
 
-.NET 8 Preview 6
+.NET 8 Preview 5
 
 ## Type of breaking change
 


### PR DESCRIPTION
Reverts dotnet/docs#35923 based on @elinor-fung 's [comment](https://github.com/dotnet/docs/pull/35923#issuecomment-1608077462).

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/deployment/8.0/rid-asset-list.md](https://github.com/dotnet/docs/blob/454f16400a1d0030eb0c866c5bd9c6015f82727f/docs/core/compatibility/deployment/8.0/rid-asset-list.md) | [Host determines RID-specific assets](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/deployment/8.0/rid-asset-list?branch=pr-en-us-35976) |

<!-- PREVIEW-TABLE-END -->