### PR TITLE
add new preview options

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-feature-csharp.yml
+++ b/.github/ISSUE_TEMPLATE/new-feature-csharp.yml
@@ -15,9 +15,11 @@ body:
       label: Visual Studio release
       description: What Visual Studio (preview) contains this feature?
       options:
-        - 17.6p1
-        - 17.6p2
-        - 17.6p3
+        - "17.6"
+        - 17.7p1
+        - 17.7p2
+        - 17.7p3
+        - 17.7p4s
         - Other (please put exact version in description textbox)
     validations:
       required: true


### PR DESCRIPTION
The C# 12 new feature template doesn't include the latest preview options.

