### PR TITLE
Add links to setup and tutorials

### DIFF
--- a/docs/csharp/tour-of-csharp/index.md
+++ b/docs/csharp/tour-of-csharp/index.md
@@ -40,6 +40,8 @@ The `Hello` class declared by the "Hello, World" program has a single member, th
 
 The line starting with `//` is a *single line comment*. C# single line comments start with  `//` continue to the end of the current line. C# also supports *multi-line comments*. Multi-line comments start with `/*` and end with `*/`. The output of the program is produced by the `WriteLine` method of the `Console` class in the `System` namespace. This class is provided by the standard class libraries, which, by default, are automatically referenced by the compiler.
 
+You use the [.NET SDK](https://microsoft.com/dotnet/download) to build your own "Hello, World" program. Once you install the SDK, you run `dotnet new console` to create a basic "Hello, World" program that you can modify. For more information, see the [Hello, World tutorial](../..//core/get-started.md) in the .NET Get started section.
+
 ## Types and variables
 
 A *type* defines the structure and behavior of any data in C#. The declaration of a type may include its members, base type, interfaces it implements, and operations permitted for that type. A *variable* is a label that refers to an instance of a specific type.


### PR DESCRIPTION
Fixes #33542

Readers of the Tour of C# need to find resources to download the SDK and write their own versions of these introductory tutorials.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/tour-of-csharp/index.md](https://github.com/dotnet/docs/blob/133310ec4d15916f7d8c47339c2e68c689da878a/docs/csharp/tour-of-csharp/index.md) | [A tour of the C# language](https://review.learn.microsoft.com/en-us/dotnet/csharp/tour-of-csharp/index?branch=pr-en-us-36063) |

<!-- PREVIEW-TABLE-END -->