### PR TITLE
Fix all open issues on the patterns language reference.

### DIFF
--- a/docs/csharp/language-reference/operators/patterns.md
+++ b/docs/csharp/language-reference/operators/patterns.md
@@ -145,7 +145,9 @@ As the preceding example shows, you can repeatedly use the pattern combinators i
 
 ### Precedence and order of checking
 
-The following list orders pattern combinators starting from the highest precedence to the lowest:
+A pattern that is part of an `is` expression has *relational* precedence. It's the same precedence as the `is` operator. Pattern expressions in the `case` arms of a `switch` statement have the same precedence as the *conditional logical* operators (`||` and `&&`). Pattern expressions inside a `switch` expression have the same precedence as the coalescing operators (`??` and `throw` expressions).
+
+The individual pattern expressions are evaluated in order, except as noted for the pattern combinators. The pattern combinators are ordered from the highest precedence to the lowest as shown in the following list:
 
 - `not`
 - `and`
@@ -247,7 +249,7 @@ You use a *discard pattern* `_` to match any expression, including `null`, as th
 
 In the preceding example, a discard pattern is used to handle `null` and any integer value that doesn't have the corresponding member of the <xref:System.DayOfWeek> enumeration. That guarantees that a `switch` expression in the example handles all possible input values. If you don't use a discard pattern in a `switch` expression and none of the expression's patterns matches an input, the runtime [throws an exception](switch-expression.md#non-exhaustive-switch-expressions). The compiler generates a warning if a `switch` expression doesn't handle all possible input values.
 
-A discard pattern can't be a pattern in an `is` expression or a `switch` statement. In those cases, to match any expression, use a [`var` pattern](#var-pattern) with a discard: `var _`.
+A discard pattern can't be a pattern in an `is` expression or a `switch` statement. In those cases, to match any expression, use a [`var` pattern](#var-pattern) with a discard: `var _`. The discard pattern can be used in a `switch` expression.
 
 For more information, see the [Discard pattern](~/_csharplang/proposals/csharp-8.0/patterns.md#discard-pattern) section of the feature proposal note.
 

--- a/docs/csharp/language-reference/operators/patterns.md
+++ b/docs/csharp/language-reference/operators/patterns.md
@@ -145,9 +145,9 @@ As the preceding example shows, you can repeatedly use the pattern combinators i
 
 ### Precedence and order of checking
 
-A pattern that is part of an `is` expression has *relational* precedence. It's the same precedence as the `is` operator. Pattern expressions in the `case` arms of a `switch` statement have the same precedence as the *conditional logical* operators (`||` and `&&`). Pattern expressions inside a `switch` expression have the same precedence as the coalescing operators (`??` and `throw` expressions).
+When a logical pattern is a pattern of an `is` expression, the precedence of logical pattern combinators is **higher** than the precedence of logical operators. Otherwise, the precedence of logical pattern combinators is **lower** than the precedence of logical and conditional logical operators.
 
-The individual pattern expressions are evaluated in order, except as noted for the pattern combinators. The pattern combinators are ordered from the highest precedence to the lowest as shown in the following list:
+The pattern combinators are ordered from the highest precedence to the lowest as shown in the following list:
 
 - `not`
 - `and`

--- a/docs/csharp/language-reference/operators/patterns.md
+++ b/docs/csharp/language-reference/operators/patterns.md
@@ -249,7 +249,7 @@ You use a *discard pattern* `_` to match any expression, including `null`, as th
 
 In the preceding example, a discard pattern is used to handle `null` and any integer value that doesn't have the corresponding member of the <xref:System.DayOfWeek> enumeration. That guarantees that a `switch` expression in the example handles all possible input values. If you don't use a discard pattern in a `switch` expression and none of the expression's patterns matches an input, the runtime [throws an exception](switch-expression.md#non-exhaustive-switch-expressions). The compiler generates a warning if a `switch` expression doesn't handle all possible input values.
 
-A discard pattern can't be a pattern in an `is` expression or a `switch` statement. In those cases, to match any expression, use a [`var` pattern](#var-pattern) with a discard: `var _`. The discard pattern can be used in a `switch` expression.
+A discard pattern can't be a pattern in an `is` expression or a `switch` statement. In those cases, to match any expression, use a [`var` pattern](#var-pattern) with a discard: `var _`. A discard pattern can be a pattern in a `switch` expression.
 
 For more information, see the [Discard pattern](~/_csharplang/proposals/csharp-8.0/patterns.md#discard-pattern) section of the feature proposal note.
 


### PR DESCRIPTION
Fixes #33298 
Fixes #33397

First, add more explanation on the discard pattern (`_`). The statement correctly said that the discard pattern isn't allowed in the `is` statement or `switch` statement. This led to confusion because the discard pattern is allowed in a `switch` expression.

Add clarifying notes on the precedence of pattern expressions. This adds where a pattern expression's precedence fits in context when it is a sub-expression of another expression.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/patterns.md](https://github.com/dotnet/docs/blob/c13edb4c04c5e29e7314dad9674d02762c4fc699/docs/csharp/language-reference/operators/patterns.md) | [Pattern matching - the `is` and `switch` expressions, and operators `and`, `or` and `not` in patterns](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/patterns?branch=pr-en-us-36065) |


<!-- PREVIEW-TABLE-END -->