### PR TITLE
Removed Instruction to Include System.Threading.Tasks.Extensions in Order to Use ValueTask

### DIFF
--- a/docs/csharp/asynchronous-programming/async-return-types.md
+++ b/docs/csharp/asynchronous-programming/async-return-types.md
@@ -75,7 +75,7 @@ An async method can return any type that has an accessible `GetAwaiter` method t
 
 This feature is the complement to [awaitable expressions](~/_csharpstandard/standard/expressions.md#12982-awaitable-expressions), which describes the requirements for the operand of `await`. Generalized async return types enable the compiler to generate `async` methods that return different types. Generalized async return types enabled performance improvements in the .NET libraries. Because <xref:System.Threading.Tasks.Task> and <xref:System.Threading.Tasks.Task%601> are reference types, memory allocation in performance-critical paths, particularly when allocations occur in tight loops, can adversely affect performance. Support for generalized return types means that you can return a lightweight value type instead of a reference type to avoid additional memory allocations.
 
-.NET provides the <xref:System.Threading.Tasks.ValueTask%601?displayProperty=nameWithType> structure as a lightweight implementation of a generalized task-returning value. To use the <xref:System.Threading.Tasks.ValueTask%601?displayProperty=nameWithType> type, you must add the `System.Threading.Tasks.Extensions` NuGet package to your project. The following example uses the <xref:System.Threading.Tasks.ValueTask%601> structure to retrieve the value of two dice rolls.
+.NET provides the <xref:System.Threading.Tasks.ValueTask%601?displayProperty=nameWithType> structure as a lightweight implementation of a generalized task-returning value. The following example uses the <xref:System.Threading.Tasks.ValueTask%601> structure to retrieve the value of two dice rolls.
 
 :::code language="csharp" source="snippets/async-return-types/async-valuetask.cs":::
 


### PR DESCRIPTION
On the page [Async return types](https://learn.microsoft.com/en-us/dotnet/csharp/asynchronous-programming/async-return-types), the section **[Generalized async return types and ValueTask<TResult>](https://learn.microsoft.com/dotnet/csharp/asynchronous-programming/async-return-types#generalized-async-return-types-and-valuetasktresult)** had:

*"To use the System.Threading.Tasks.ValueTask<TResult> type, you must add the System.Threading.Tasks.Extensions NuGet package to your project."*

This is not true and was removed.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/asynchronous-programming/async-return-types.md](https://github.com/dotnet/docs/blob/3e75d6fda9b5fcd90ddd83916fbafb0977bc54d3/docs/csharp/asynchronous-programming/async-return-types.md) | [Async return types (C#)](https://review.learn.microsoft.com/en-us/dotnet/csharp/asynchronous-programming/async-return-types?branch=pr-en-us-36073) |

<!-- PREVIEW-TABLE-END -->