### PR TITLE
Update the URL of OpenTelemetry Semantic Conventions

### DIFF
--- a/docs/core/diagnostics/distributed-tracing-instrumentation-walkthroughs.md
+++ b/docs/core/diagnostics/distributed-tracing-instrumentation-walkthroughs.md
@@ -250,7 +250,7 @@ if(activity != null)
 ```
 
 - OpenTelemetry provides a set of recommended
-[conventions](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/trace/semantic_conventions)
+[conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/specification/README.md)
 for setting Tags on Activities that represent common types of application work.
 
 - If you are instrumenting functions with high-performance requirements,

--- a/docs/core/diagnostics/distributed-tracing-instrumentation-walkthroughs.md
+++ b/docs/core/diagnostics/distributed-tracing-instrumentation-walkthroughs.md
@@ -250,7 +250,7 @@ if(activity != null)
 ```
 
 - OpenTelemetry provides a set of recommended
-[conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/specification/README.md)
+[conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/README.md)
 for setting Tags on Activities that represent common types of application work.
 
 - If you are instrumenting functions with high-performance requirements,


### PR DESCRIPTION
The previous URL was the obsolete location of conventions.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/distributed-tracing-instrumentation-walkthroughs.md](https://github.com/dotnet/docs/blob/6be2b410e99c8118b7b0ea6943899cdf6474dc6b/docs/core/diagnostics/distributed-tracing-instrumentation-walkthroughs.md) | [Adding distributed tracing instrumentation](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/distributed-tracing-instrumentation-walkthroughs?branch=pr-en-us-36099) |


<!-- PREVIEW-TABLE-END -->