### PR TITLE
Add docs for inline arrays in C# 12

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -467,7 +467,7 @@
                 "_csharplang/proposals/csharp-9.0/*.md": "07/29/2020",
                 "_csharplang/proposals/csharp-10.0/*.md": "08/07/2021",
                 "_csharplang/proposals/csharp-11.0/*.md": "09/30/2022",
-                "_csharplang/proposals/*.md": "04/03/2023",
+                "_csharplang/proposals/*.md": "07/06/2023",
                 "_roslyn/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md": "11/08/2022",
                 "_vblang/spec/*.md": "07/21/2017"
             },
@@ -669,6 +669,8 @@
                 "_csharplang/proposals/primary-constructors.md": "Primary constructors",
                 "_csharplang/proposals/using-alias-types.md": "Alias any type",
                 "_csharplang/proposals/lambda-method-group-defaults.md": "Optional and parameter array parameters for lambdas and method groups",
+                "_csharplang/proposals/inline-arrays.md": "Inline arrays, or fixed sized buffers",
+                
 
                 "_roslyn/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md": "C# compiler breaking changes since C# 10",
                 "_vblang/spec/introduction.md": "Introduction",
@@ -778,8 +780,9 @@
 
                 "_csharplang/proposals/primary-constructors.md": "Primary constructors put the parameters of one constructor in scope for the whole class or struct to be used for initialization or directly as object state. The trade-off is that any other constructors must call through the primary constructor.",
                 "_csharplang/proposals/using-alias-types.md": "Using directives can alias any type, not just named types. You can create aliases for tuple types, generics and more.",
-                "_csharplang/proposals/lambda-method-group-defaults.md": "Lambda expressions can now declare default parameters and params arrays parameters.",
-
+                "_csharplang/proposals/lambda-method-group-defaults.md": "Optional and parameter array parameters for lambdas and method groups",
+                "_csharplang/proposals/inline-arrays.md": "Inline arrays provide a general-purpose and safe mechanism for declaring inline arrays within C# classes, structs, and interfaces.",
+                
                 "_roslyn/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md": "Learn about any breaking changes since the initial release of C# 10",
                 "_vblang/spec/introduction.md": "This chapter provides and introduction to the Visual Basic language.",
                 "_vblang/spec/lexical-grammar.md": "This chapter defines the lexical grammar for Visual Basic.",

--- a/docs/csharp/language-reference/builtin-types/snippets/shared/StructType.cs
+++ b/docs/csharp/language-reference/builtin-types/snippets/shared/StructType.cs
@@ -259,4 +259,15 @@
             // </WithExpression>
         }
     }
+
+    namespace InlineArrays
+    {
+        // <DeclareInlineArray>
+        [System.Runtime.CompilerServices.InlineArray(10)]
+        public struct CharBuffer
+        {
+            private char _firstElement;
+        }
+        // </DeclareInlineArray>
+    }
 }

--- a/docs/csharp/language-reference/builtin-types/struct.md
+++ b/docs/csharp/language-reference/builtin-types/struct.md
@@ -95,10 +95,10 @@ An inline array is a structure that contains a contiguous block of N elements of
 
 In addition, the compiler validates the <xref:System.Runtime.CompilerServices.InlineArrayAttribute?displayProperty=fullName> attribute:
 
-- The length must be > 0
+- The length must be greater than zero (`> 0`).
 - The target type must be a struct.
 
-In most cases, and inline array can be accessed like an array, both to read and write values. In addition, you can use the [range](../operators/member-access-operators.md#range-operator-) and [index](../operators/member-access-operators.md#indexer-access) operators.
+In most cases, an inline array can be accessed like an array, both to read and write values. In addition, you can use the [range](../operators/member-access-operators.md#range-operator-) and [index](../operators/member-access-operators.md#indexer-access) operators.
 
 There are minimal restrictions on the type of the single field. It can't be a pointer type, but it can be any reference type, or any value type. You can use inline arrays with almost any C# data structure.
 

--- a/docs/csharp/language-reference/builtin-types/struct.md
+++ b/docs/csharp/language-reference/builtin-types/struct.md
@@ -43,7 +43,7 @@ The following code defines a `readonly` struct with init-only property setters, 
 
 You can also use the `readonly` modifier to declare that an instance member doesn't modify the state of a struct. If you can't declare the whole structure type as `readonly`, use the `readonly` modifier to mark the instance members that don't modify the state of the struct.
 
-Within a `readonly` instance member, you can't assign to structure's instance fields. However, a `readonly` member can call a non-`readonly` member. In that case the compiler creates a copy of the structure instance and calls the non-`readonly` member on that copy. As a result, the original structure instance isn't modified.
+Within a `readonly` instance member, you can't assign to structure's instance fields. However, a `readonly` member can call a non-`readonly` member. In that case, the compiler creates a copy of the structure instance and calls the non-`readonly` member on that copy. As a result, the original structure instance isn't modified.
 
 Typically, you apply the `readonly` modifier to the following kinds of instance members:
 
@@ -82,6 +82,26 @@ Beginning with C# 10, you can use the [`with` expression](../operators/with-expr
 
 Beginning with C# 10, you can define record structure types. Record types provide built-in functionality for encapsulating data. You can define both `record struct` and `readonly record struct` types. A record struct can't be a [`ref struct`](ref-struct.md). For more information and examples, see [Records](record.md).
 
+## Inline arrays
+
+Beginning with C# 12, you can declare *inline arrays* as a `struct` type:
+
+:::code language="csharp" source="snippets/shared/StructType.cs" id="DeclareInlineArray":::
+
+An inline array is a structure that contains a contiguous block of N elements of the same type. It's a safe-code equivalent of the [fixed buffer](../unsafe-code.md#fixed-size-buffers) declaration available only in unsafe code. An inline array is a `struct` with the following characteristics:
+
+- It contains a single field.
+- The struct doesn't specify an explicit layout.
+
+In addition, the compiler validates the <xref:System.Runtime.CompilerServices.InlineArrayAttribute?displayProperty=fullName> attribute:
+
+- The length must be > 0
+- The target type must be a struct.
+
+In most cases, and inline array can be accessed like an array, both to read and write values. In addition, you can use the [range](../operators/member-access-operators.md#range-operator) and [index](../operators/member-access-operators.md#indexer-access) operators.
+
+Inline arrays are an advanced language feature. They're intended for high-performance scenarios where an inline, contiguous block of elements is faster than other alternative data structures. You can learn more about inline arrays from the [feature speclet](~/_csharplang/proposals/inline-arrays.md)
+
 ## Struct initialization and default values
 
 A variable of a `struct` type directly contains the data for that `struct`. That creates a distinction between an uninitialized `struct`, which has its default value and an initialized `struct`, which stores values set by constructing it. For example consider the following code:
@@ -108,7 +128,7 @@ Beginning with C# 11, if you don't initialize all fields in a struct, the compil
 
 Every `struct` has a `public` parameterless constructor. If you write a parameterless constructor, it must be public. If a struct declares any field initializers, it must explicitly declare a constructor. That constructor need not be parameterless. If a struct declares a field initializer but no constructors, the compiler reports an error. Any explicitly declared constructor (with parameters, or parameterless) executes all field initializers for that struct. All fields without a field initializer or an assignment in a constructor are set to the [default value](default-values.md). For more information, see the [Parameterless struct constructors](~/_csharplang/proposals/csharp-10.0/parameterless-struct-constructors.md) feature proposal note.
 
-Beginning with C# 12, `struct` types can define a [primary constructor](../../programming-guide/classes-and-structs/instance-constructors.md#primary-constructors) as part of its declaration. This provides a concise syntax for constructor parameters that can be used throughout the `struct` body, in any member declaration for that struct.
+Beginning with C# 12, `struct` types can define a [primary constructor](../../programming-guide/classes-and-structs/instance-constructors.md#primary-constructors) as part of its declaration. Primary constructors provides a concise syntax for constructor parameters that can be used throughout the `struct` body, in any member declaration for that struct.
 
 If all instance fields of a structure type are accessible, you can also instantiate it without the `new` operator. In that case you must initialize all instance fields before the first use of the instance. The following example shows how to do that:
 

--- a/docs/csharp/language-reference/builtin-types/struct.md
+++ b/docs/csharp/language-reference/builtin-types/struct.md
@@ -98,7 +98,9 @@ In addition, the compiler validates the <xref:System.Runtime.CompilerServices.In
 - The length must be > 0
 - The target type must be a struct.
 
-In most cases, and inline array can be accessed like an array, both to read and write values. In addition, you can use the [range](../operators/member-access-operators.md#range-operator) and [index](../operators/member-access-operators.md#indexer-access) operators.
+In most cases, and inline array can be accessed like an array, both to read and write values. In addition, you can use the [range](../operators/member-access-operators.md#range-operator-) and [index](../operators/member-access-operators.md#indexer-access) operators.
+
+There are minimal restrictions on the type of the single field. It can't be a pointer type, but it can be any reference type, or any value type. You can use inline arrays with almost any C# data structure.
 
 Inline arrays are an advanced language feature. They're intended for high-performance scenarios where an inline, contiguous block of elements is faster than other alternative data structures. You can learn more about inline arrays from the [feature speclet](~/_csharplang/proposals/inline-arrays.md)
 

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1426,3 +1426,5 @@ items:
         href: ../../_csharplang/proposals/using-alias-types.md
       - name: Optional Lambda expression parameters
         href: ../../_csharplang/proposals/lambda-method-group-defaults.md
+      - name: Inline arrays
+        href: ../../_csharplang/proposals/inline-arrays.md

--- a/docs/csharp/whats-new/csharp-12.md
+++ b/docs/csharp/whats-new/csharp-12.md
@@ -10,6 +10,7 @@ Some C# 12 features have been introduced in previews. You can try these features
 - [Primary constructors](#primary-constructors) - Introduced in Visual Studio 17.6 preview 2.
 - [Optional parameters in lambda expressions](#default-lambda-parameters) - Introduced in Visual Studio 17.5 preview 2.
 - [Alias any type](#alias-any-type) - Introduced in Visual Studio 17.6 preview 3.
+- [Inline arrays](#inline-arrays) - 
 - [Interceptors](#interceptors) - *Preview feature* Introduced in Visual Studio 17.7, preview 3.
 
 ## Primary constructors
@@ -29,6 +30,10 @@ You can learn more about default parameters on lambda expressions in the article
 ## Alias any type
 
 You can use the `using` alias directive to alias any type, not just named types. That means you can create semantic aliases for tuple types, array types, pointer types, or other unsafe types. For more information, see the [feature specification](~/_csharplang/proposals/using-alias-types.md)
+
+## Inline arrays
+
+Inline arrays are used by the runtime team and other library authors to improve performance in your application. Inline arrays enable a developer to create an array of fixed size in a `struct` type. A struct with an inline buffer should provide performance characteristics similar to an unsafe fixed size buffer. You likely won't eclare your own inline arrays, but you'll use them transparently when they are exposes as <xref:System.Span%601?displayProperty=nameWithType> or <xref:System.ReadOnlySpan%601?displayProperty=nameWithType> objects from runtime APIs.
 
 ## Interceptors
 

--- a/docs/csharp/whats-new/csharp-12.md
+++ b/docs/csharp/whats-new/csharp-12.md
@@ -10,7 +10,7 @@ Some C# 12 features have been introduced in previews. You can try these features
 - [Primary constructors](#primary-constructors) - Introduced in Visual Studio 17.6 preview 2.
 - [Optional parameters in lambda expressions](#default-lambda-parameters) - Introduced in Visual Studio 17.5 preview 2.
 - [Alias any type](#alias-any-type) - Introduced in Visual Studio 17.6 preview 3.
-- [Inline arrays](#inline-arrays) - 
+- [Inline arrays](#inline-arrays) - Introduced in Visual Studio 17.7 preview 3.
 - [Interceptors](#interceptors) - *Preview feature* Introduced in Visual Studio 17.7, preview 3.
 
 ## Primary constructors
@@ -33,7 +33,34 @@ You can use the `using` alias directive to alias any type, not just named types.
 
 ## Inline arrays
 
-Inline arrays are used by the runtime team and other library authors to improve performance in your application. Inline arrays enable a developer to create an array of fixed size in a `struct` type. A struct with an inline buffer should provide performance characteristics similar to an unsafe fixed size buffer. You likely won't eclare your own inline arrays, but you'll use them transparently when they are exposes as <xref:System.Span%601?displayProperty=nameWithType> or <xref:System.ReadOnlySpan%601?displayProperty=nameWithType> objects from runtime APIs.
+Inline arrays are used by the runtime team and other library authors to improve performance in your application. Inline arrays enable a developer to create an array of fixed size in a `struct` type. A struct with an inline buffer should provide performance characteristics similar to an unsafe fixed size buffer. You likely won't declare your own inline arrays, but you'll use them transparently when they're exposed as <xref:System.Span%601?displayProperty=nameWithType> or <xref:System.ReadOnlySpan%601?displayProperty=nameWithType> objects from runtime APIs.
+
+An *inline array* is declared similar to the following `struct`:
+
+```csharp
+[System.Runtime.CompilerServices.InlineArray(10)]
+public struct Buffer
+{
+    private int _element0;
+}
+```
+
+You could use them like any other array:
+
+```csharp
+var b = new Buffer();
+for(int i = 0; i < 10; i++)
+{
+    b[i] = i;
+}
+
+foreach(var i in b)
+{
+    Console.WriteLine(i);
+}
+```
+
+The difference is that the compiler can take advantage of known information about an inline array. You'll likely consume inline arrays as you would any other array. For more information on how to declare inline arrays, see the language reference on [`struct` types](../language-reference/builtin-types/struct.md#inline-arrays).
 
 ## Interceptors
 
@@ -42,11 +69,11 @@ Inline arrays are used by the runtime team and other library authors to improve 
 >
 > In order to use interceptors, you'll need to set the `<Features>InterceptorsPreview<Features>` element in your project file. Without this flag, interceptors are disabled, even when other C# 12 features are enabled.
 
-An *interceptor* is a method which can declaratively substitute a call to an *interceptable* method with a call to itself at compile time. This substitution occurs by having the interceptor declare the source locations of the calls that it intercepts. This provides a limited facility to change the semantics of existing code by adding new code to a compilation, for example in a source generator.
+An *interceptor* is a method that can declaratively substitute a call to an *interceptable* method with a call to itself at compile time. This substitution occurs by having the interceptor declare the source locations of the calls that it intercepts. Interceptors provides a limited facility to change the semantics of existing code by adding new code to a compilation, for example in a source generator.
 
 You use an *interceptor* as part of a source generator to modify, rather than add code to an existing source compilation. The source generator substitutes calls to an interceptable method with a call to the *interceptor* method.
 
-If you are interested in experimenting with interceptors, you can learn more by reading the [feature specification](https://github.com/dotnet/roslyn/blob/main/docs/features/interceptors.md). If you use the feature, make sure to stay current with any changes in the feature specification for this preview feature. Once the feature is finalized, we'll add more guidance on this site.
+If you're interested in experimenting with interceptors, you can learn more by reading the [feature specification](https://github.com/dotnet/roslyn/blob/main/docs/features/interceptors.md). If you use the feature, make sure to stay current with any changes in the feature specification for this preview feature. Once the feature is finalized, we'll add more guidance on this site.
 
 ## See also
 

--- a/docs/csharp/whats-new/csharp-12.md
+++ b/docs/csharp/whats-new/csharp-12.md
@@ -33,7 +33,7 @@ You can use the `using` alias directive to alias any type, not just named types.
 
 ## Inline arrays
 
-Inline arrays are used by the runtime team and other library authors to improve performance in your application. Inline arrays enable a developer to create an array of fixed size in a `struct` type. A struct with an inline buffer should provide performance characteristics similar to an unsafe fixed size buffer. You likely won't declare your own inline arrays, but you'll use them transparently when they're exposed as <xref:System.Span%601?displayProperty=nameWithType> or <xref:System.ReadOnlySpan%601?displayProperty=nameWithType> objects from runtime APIs.
+Inline arrays are used by the runtime team and other library authors to improve performance in your apps. Inline arrays enable a developer to create an array of fixed size in a `struct` type. A struct with an inline buffer should provide performance characteristics similar to an unsafe fixed size buffer. You likely won't declare your own inline arrays, but you'll use them transparently when they're exposed as <xref:System.Span%601?displayProperty=nameWithType> or <xref:System.ReadOnlySpan%601?displayProperty=nameWithType> objects from runtime APIs.
 
 An *inline array* is declared similar to the following `struct`:
 
@@ -45,16 +45,16 @@ public struct Buffer
 }
 ```
 
-You could use them like any other array:
+You use them like any other array:
 
 ```csharp
-var b = new Buffer();
-for(int i = 0; i < 10; i++)
+var buffer = new Buffer();
+for (int i = 0; i < 10; i++)
 {
-    b[i] = i;
+    buffer[i] = i;
 }
 
-foreach(var i in b)
+foreach (var i in buffer)
 {
     Console.WriteLine(i);
 }

--- a/docs/csharp/whats-new/csharp-12.md
+++ b/docs/csharp/whats-new/csharp-12.md
@@ -29,7 +29,7 @@ You can learn more about default parameters on lambda expressions in the article
 
 ## Alias any type
 
-You can use the `using` alias directive to alias any type, not just named types. That means you can create semantic aliases for tuple types, array types, pointer types, or other unsafe types. For more information, see the [feature specification](~/_csharplang/proposals/using-alias-types.md)
+You can use the `using` alias directive to alias any type, not just named types. That means you can create semantic aliases for tuple types, array types, pointer types, or other unsafe types. For more information, see the [feature specification](~/_csharplang/proposals/using-alias-types.md).
 
 ## Inline arrays
 


### PR DESCRIPTION
Contributes to #36066
Fixes #36134 

- Publish the feature speclet.
- Add new paragraphs in the What's new in C# 12 for the new feature.
- Fix grammar nit reported while editing these files.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/builtin-types/struct.md](https://github.com/dotnet/docs/blob/d8852b873f5c437b16ab69feb45e6685e216b4fa/docs/csharp/language-reference/builtin-types/struct.md) | [Structure types (C# reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/struct?branch=pr-en-us-36114) |
| [docs/csharp/whats-new/csharp-12.md](https://github.com/dotnet/docs/blob/d8852b873f5c437b16ab69feb45e6685e216b4fa/docs/csharp/whats-new/csharp-12.md) | [What's new in C# 12 - C# Guide](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-12?branch=pr-en-us-36114) |


<!-- PREVIEW-TABLE-END -->