### PR TITLE
Distributed Tracing Walkthrough/Activity links - use correct type signature in code example

### DIFF
--- a/docs/core/diagnostics/distributed-tracing-instrumentation-walkthroughs.md
+++ b/docs/core/diagnostics/distributed-tracing-instrumentation-walkthroughs.md
@@ -445,7 +445,7 @@ void DoBatchWork(ActivityContext[] requestContexts)
     // Assume each context in requestContexts encodes the trace-id that was sent with a request
     using(Activity activity = s_source.StartActivity(name: "BigBatchOfWork",
                                                      kind: ActivityKind.Internal,
-                                                     parentContext: null,
+                                                     parentContext: default,
                                                      links: requestContexts.Select(ctx => new ActivityLink(ctx))
     {
         // do the batch of work here


### PR DESCRIPTION
## Summary
The `StartActivity` method ([docs](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activitysource.startactivity?view=net-7.0)) does not allow `parentContext` to be null, so the code as was would not compile.
Instead it requires `parentContext` to be not null. With that in mind I have replaced `null` with `default` which I think captures the author's intention while being compilable. `default` would mean that a new trace would be started with the activity, which makes sense in the context of the batch processing example where there is not one single context which it makes sense for this to exist under, and so we would expect a new trace with the linked spans.


Also sorry this is my first contribution and I thought I had followed the [quick edits to documentation](https://learn.microsoft.com/en-gb/contribute/#quick-edits-to-documentation) bit, but I'm not sure I did it correctly as this PR description doesn't seem to be in the right format