### PR TITLE
Corrected GetSubscriptionAsync() to GetSubscriptionResource()

### DIFF
--- a/docs/azure/sdk/resource-management.md
+++ b/docs/azure/sdk/resource-management.md
@@ -222,15 +222,19 @@ using System.Threading.Tasks;
 
 // Code omitted for brevity
 
-ResourceIdentifier resourceId = 
+ResourceIdentifier subscriptionId =
+    SubscriptionResource.CreateResourceIdentifier("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+
+ResourceIdentifier resourceId =
     AvailabilitySetResource.CreateResourceIdentifier(
-        "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
-        "resourceGroupName", 
-        "resourceName"); 
+        subscriptionId.SubscriptionId,
+        "resourceGroupName",
+        "resourceName");
+
 // We construct a new armClient to work with
 ArmClient client = new ArmClient(new DefaultAzureCredential());
 // Next we get the specific subscription this resource belongs to
-SubscriptionResource subscription = await client.GetSubscriptionAsync(resourceId.SubscriptionId);
+SubscriptionResource subscription = client.GetSubscriptionResource(subscriptionId);
 // Next we get the specific resource group this resource belongs to
 ResourceGroupResource resourceGroup = await subscription.GetResourceGroupAsync(resourceId.ResourceGroupName);
 // Finally we get the resource itself


### PR DESCRIPTION
GetSubscriptionAsync() does not exist as a method on ArmClient. See https://learn.microsoft.com/en-us/dotnet/api/azure.resourcemanager.armclient?view=azure-dotnet.

## Summary

The  samecode does not compile with Azure.ResourceManager 1.6.0, as method 'GetSubscriptionAsync() does not exist. I;ve corrected to use GetSubscriptionResource, which takes a resource identifier object.

See https://learn.microsoft.com/en-us/dotnet/api/azure.resourcemanager.armclient.getsubscriptionresource?view=azure-dotnet#azure-resourcemanager-armclient-getsubscriptionresource(azure-core-resourceidentifier).

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/azure/sdk/resource-management.md](https://github.com/dotnet/docs/blob/8a1c02f4a75d2572aa80024523d7310cdd2faba0/docs/azure/sdk/resource-management.md) | [Resource management using the Azure SDK for .NET](https://review.learn.microsoft.com/en-us/dotnet/azure/sdk/resource-management?branch=pr-en-us-36126) |

<!-- PREVIEW-TABLE-END -->