### PR TITLE
Fix typo in properties.md

### DIFF
--- a/docs/csharp/properties.md
+++ b/docs/csharp/properties.md
@@ -92,7 +92,7 @@ The preceding example allows a caller to create a `Person` using the default con
 
 :::code language="csharp" source="./snippets/properties/Person.cs" id="Snippet9.2":::
 
-The preceding code makes two addition to the `Person` class. First, the `FirstName` property declaration includes the `required` modifier. That means any code that creates a new `Person` must set this property. Second, the constructor that takes a `firstName` parameter has the <xref:System.Diagnostics.CodeAnalysis.SetsRequiredMembersAttribute?displayProperty=fullName> attribute. This attribute informs the compiler that this constructor sets *all* `required` members.
+The preceding code makes two additions to the `Person` class. First, the `FirstName` property declaration includes the `required` modifier. That means any code that creates a new `Person` must set this property. Second, the constructor that takes a `firstName` parameter has the <xref:System.Diagnostics.CodeAnalysis.SetsRequiredMembersAttribute?displayProperty=fullName> attribute. This attribute informs the compiler that this constructor sets *all* `required` members.
 
 > [!IMPORTANT]
 > Don't confuse `required` with *non-nullable*. It's valid to set a `required` property to `null` or `default`. If the type is non-nullable, such as `string` in these examples, the compiler issues a warning.


### PR DESCRIPTION
The sentence:

> The preceding code makes two **addition** to...

Should read:

> The preceding code makes two **additions** to...

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/properties.md](https://github.com/dotnet/docs/blob/da7296a55b8aae8b1efebd92b9afebd3785b1f52/docs/csharp/properties.md) | [Properties](https://review.learn.microsoft.com/en-us/dotnet/csharp/properties?branch=pr-en-us-36137) |

<!-- PREVIEW-TABLE-END -->