### PR TITLE
Update oop.md

### DIFF
--- a/docs/csharp/fundamentals/tutorials/oop.md
+++ b/docs/csharp/fundamentals/tutorials/oop.md
@@ -130,7 +130,7 @@ This implementation calls `MakeDeposit` only if the initial balance is greater t
 Now that the `BankAccount` class has a read-only field for the minimum balance, the final change is to change the hard code `0` to `minimumBalance` in the `MakeWithdrawal` method:
 
 ```csharp
-if (Balance - amount < minimumBalance)
+if (Balance - amount < _minimumBalance)
 ```
 
 After extending the `BankAccount` class, you can modify the `LineOfCreditAccount` constructor to call the new base constructor, as shown in the following code:
@@ -157,7 +157,7 @@ public void MakeWithdrawal(decimal amount, DateTime date, string note)
         throw new InvalidOperationException("Not sufficient funds for this withdrawal");
     }
     var withdrawal = new Transaction(-amount, date, note);
-    allTransactions.Add(withdrawal);
+    _allTransactions.Add(withdrawal);
 }
 ```
 


### PR DESCRIPTION
## Summary

minimumBlance is defined as "private readonly decimal _minimumBalance;" inside the guide
So the MakeWithdrawal method should implement if (Balance - amount < _minimumBalance)

I had proposed a change to add a _ prefix to allTransactions in classes.md and BankAccount.cs
https://github.com/dotnet/docs/pull/36138
https://github.com/dotnet/docs/pull/36139

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/fundamentals/tutorials/oop.md](https://github.com/dotnet/docs/blob/ca83ea731c4c501eb38b276f6fb5f4dd23df3e53/docs/csharp/fundamentals/tutorials/oop.md) | [Object-Oriented programming (C#)](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/tutorials/oop?branch=pr-en-us-36140) |

<!-- PREVIEW-TABLE-END -->