### PR TITLE
CentOS8 should use the MS repository

### DIFF
--- a/docs/core/install/linux-rhel.md
+++ b/docs/core/install/linux-rhel.md
@@ -107,9 +107,12 @@ As an alternative to the ASP.NET Core Runtime, you can install the .NET Runtime 
 
 ## CentOS Stream 8 ✔️
 
-.NET is included in the AppStream repositories for CentOS Stream 8.
+Use the Microsoft repository to install .NET:
 
-[!INCLUDE [linux-dnf-install-70](includes/linux-install-70-dnf.md)]
+```bash
+sudo rpm -Uvh https://packages.microsoft.com/config/centos/8/packages-microsoft-prod.rpm
+sudo yum install dotnet-sdk-7.0
+```
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary

Add MS package repository guidance for CentOS8

Fixes #35835

@BillWagner 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/linux-rhel.md](https://github.com/dotnet/docs/blob/b33d250630d16c61ed75a79ee40e7490708b1416/docs/core/install/linux-rhel.md) | [Install the .NET SDK or the .NET Runtime on RHEL and CentOS Stream](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-rhel?branch=pr-en-us-36142) |

<!-- PREVIEW-TABLE-END -->