### PR TITLE
Update formatting.md

### DIFF
--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -505,7 +505,7 @@ let useAddEntry () =
          // foo
          bar ()
 
-// ❌ Not OK, code formatters will reformat to the above to avoid the vanity alignment.
+// ❌ Not OK, code formatters will reformat to the above to avoid reliance on whitespace alignment that is contingent to length of an identifier.
 let useAddEntry () =
     fun (input: {| name: string
                    amount: Amount


### PR DESCRIPTION
Disroot the conception that "vanity" is the reason code may use whitespace alignment. It may be for other reasons (readability).

Despite the guideline discourages formatting that relies on length of identifiers, and that some diff tools will show whitespace changes as if the whole line changed, I think it is better to not carry judgement through "vanity" adjective.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/style-guide/formatting.md](https://github.com/dotnet/docs/blob/e64e36406eabe9ac98ba29cab544ce7d47e00fbd/docs/fsharp/style-guide/formatting.md) | [F# code formatting guidelines](https://review.learn.microsoft.com/en-us/dotnet/fsharp/style-guide/formatting?branch=pr-en-us-36143) |

<!-- PREVIEW-TABLE-END -->