### PR TITLE
Add note for packagereference stating when it's needed

### DIFF
--- a/docs/core/docker/publish-as-container.md
+++ b/docs/core/docker/publish-as-container.md
@@ -73,7 +73,10 @@ The worker template loops indefinitely. Use the cancel command <kbd>Ctrl+C</kbd>
 
 ## Add NuGet package
 
-The [Microsoft.NET.Build.Containers NuGet package](https://libraries.io/nuget/Microsoft.NET.Build.Containers) package is currently required to publish an app as a container. To add the `Microsoft.NET.Build.Containers` NuGet package to the worker template, run the following [dotnet add package](../tools/dotnet-add-package.md) command:
+> [!IMPORTANT]
+> If you are building a Web application and using .NET SDK 7.0.300 or greater then the package isn't required - the SDK contains the same functionality out of the box! All non-web projects should continue to use this package for now. We hope to remove this limitation [in the future](https://github.com/dotnet/sdk-container-builds/issues/402).
+
+The [Microsoft.NET.Build.Containers NuGet package](https://libraries.io/nuget/Microsoft.NET.Build.Containers) package is currently required to publish non-Web projects as a container. To add the `Microsoft.NET.Build.Containers` NuGet package to the worker template, run the following [dotnet add package](../tools/dotnet-add-package.md) command:
 
 ```dotnetcli
 dotnet add package Microsoft.NET.Build.Containers

--- a/docs/core/docker/publish-as-container.md
+++ b/docs/core/docker/publish-as-container.md
@@ -74,9 +74,9 @@ The worker template loops indefinitely. Use the cancel command <kbd>Ctrl+C</kbd>
 ## Add NuGet package
 
 > [!IMPORTANT]
-> If you are building a Web application and using .NET SDK 7.0.300 or greater then the package isn't required - the SDK contains the same functionality out of the box! All non-web projects should continue to use this package for now. We hope to remove this limitation [in the future](https://github.com/dotnet/sdk-container-builds/issues/402).
+> If you are building a Web application and using .NET SDK 7.0.300 or greater than the package isn't required—the SDK contains the same functionality out of the box! All non-web projects should continue to use this package for now. We hope to remove this limitation [in the future](https://github.com/dotnet/sdk-container-builds/issues/402).
 
-The [Microsoft.NET.Build.Containers NuGet package](https://libraries.io/nuget/Microsoft.NET.Build.Containers) package is currently required to publish non-Web projects as a container. To add the `Microsoft.NET.Build.Containers` NuGet package to the worker template, run the following [dotnet add package](../tools/dotnet-add-package.md) command:
+The [Microsoft.NET.Build.Containers](https://www.nuget.org/packages/Microsoft.NET.Build.Containers) NuGet package is currently required to publish non-Web projects as a container. To add the `Microsoft.NET.Build.Containers` NuGet package to the worker template, run the following [dotnet add package](../tools/dotnet-add-package.md) command:
 
 ```dotnetcli
 dotnet add package Microsoft.NET.Build.Containers


### PR DESCRIPTION
Non-web projects need the package, but Web SDK projects enjoy built-in support from 7.0.3xx onwards.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/docker/publish-as-container.md](https://github.com/dotnet/docs/blob/a1224f2e5c659b6fc5f23bd8b0561846af71305e/docs/core/docker/publish-as-container.md) | [Containerize a .NET app with dotnet publish](https://review.learn.microsoft.com/en-us/dotnet/core/docker/publish-as-container?branch=pr-en-us-36144) |


<!-- PREVIEW-TABLE-END -->