### PR TITLE
Correct typo of generation number in large object collection conditions

### DIFF
--- a/docs/standard/garbage-collection/large-object-heap.md
+++ b/docs/standard/garbage-collection/large-object-heap.md
@@ -61,7 +61,7 @@ Figure 3: The LOH after a generation 2 GC
 
 In general, a GC occurs under one of the following three conditions:
 
-- Allocation exceeds the generation 0 or large object threshold.
+- Allocation exceeds the generation 2 or large object threshold.
 
   The threshold is a property of a generation. A threshold for a generation is set when the garbage collector allocates objects into it. When the threshold is exceeded, a GC is triggered on that generation. When you allocate small or large objects, you consume generation 0 and the LOH's thresholds, respectively. When the garbage collector allocates into generation 1 and 2, it consumes their thresholds. These thresholds are dynamically tuned as the program runs.
 


### PR DESCRIPTION
This pull request fixes #36088
It replaces 0 number of generation with 2 when it comes to large objects collection conditions mentioned in this docs.
According to the other articles and the content of the page the issue is valid - gen 2 should be there.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/garbage-collection/large-object-heap.md](https://github.com/dotnet/docs/blob/f000d14a98b3d508f6a54c3934eeb7cde50b1f6e/docs/standard/garbage-collection/large-object-heap.md) | [The large object heap on Windows systems](https://review.learn.microsoft.com/en-us/dotnet/standard/garbage-collection/large-object-heap?branch=pr-en-us-36147) |

<!-- PREVIEW-TABLE-END -->