### PR TITLE
Add compiler messages for inline arrays

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/feature-version-errors.md
+++ b/docs/csharp/language-reference/compiler-messages/feature-version-errors.md
@@ -42,6 +42,7 @@ f1_keywords:
   - "CS9016" # WRN_UseDefViolationPropertyUnsupportedVersion  Use of possibly unassigned property
   - "CS9017" # WRN_UseDefViolationFieldUnsupportedVersion  Use of possibly unassigned field
   - "CS8967" # ERR_NewlinesAreNotAllowedInsideANonVerbatimInterpolatedString  Newlines inside a non-verbatim interpolated string are not supported in C#
+  - "CS9171"
 helpviewer_keywords:
   - "CS0171"
   - "CS0188"
@@ -83,7 +84,8 @@ helpviewer_keywords:
   - "CS9016"
   - "CS9017"
   - "CS8967"
-ms.date: 01/30/2023
+  - "CS9171"
+ms.date: 07/11/2023
 ---
 # Resolve warnings related to language features and versions
 
@@ -115,6 +117,7 @@ That's be design. The text closely matches the text of the compiler error / warn
 - **CS9015** - *Error: Use of possibly unassigned field. Upgrade to auto-default the field.*
 - **CS9016** - *Warning: Use of possibly unassigned property. Upgrade to auto-default the property.*
 - **CS9017** - *Warning: Use of possibly unassigned field. Upgrade to auto-default the field.*
+- **CS9171** - *Target runtime doesn't support inline array types.*
 
 In addition, the following errors and warnings relate to struct initialization changes in recent versions:
 

--- a/docs/csharp/language-reference/compiler-messages/inline-array-errors.md
+++ b/docs/csharp/language-reference/compiler-messages/inline-array-errors.md
@@ -1,0 +1,78 @@
+---
+title: Resolve errors related to inline arrays
+description: These compiler errors and warnings are generated when you create an inline array struct that is invalid. This article helps you diagnose and fix those issues.
+f1_keywords:
+  - "CS9164"
+  - "CS9165"
+  - "CS9166"
+  - "CS9167"
+  - "CS9168"
+  - "CS9169"
+  - "CS9172"
+  - "CS9173"
+helpviewer_keywords:
+  - "CS9164"
+  - "CS9165"
+  - "CS9166"
+  - "CS9167"
+  - "CS9168"
+  - "CS9169"
+  - "CS9172"
+  - "CS9173"
+ms.date: 07/11/2023
+---
+# Resolve errors and warnings with inline array declarations
+
+This article covers the following compiler errors:
+
+<!-- The text in this list generates issues for Acrolinx, because they don't use contractions.
+That's by design. The text closely matches the text of the compiler error / warning for SEO purposes.
+ -->
+- [**CS9164**](#conversions-to-span) - *Cannot convert expression to `Span<T>` because it is not an assignable variable*
+- [**CS9165**](#conversions-to-span) - *Cannot convert expression to `ReadOnlySpan<T>` because it may not be passed or returned by reference*
+- [**CS9166**](#element-access) - *Index is outside the bounds of the inline array*
+- [**CS9167**](#inline-array-declaration) - *Inline array length must be greater than 0.*
+- [**CS9168**](#inline-array-declaration) - *Inline array struct must not have explicit layout.*
+- [**CS9169**](#inline-array-declaration) - *Inline array struct must declare one and only one instance field which must not be a ref field.*
+- [**CS9172**](#element-access) - *Elements of an inline array type can be accessed only with a single argument implicitly convertible to `int`, `System.Index`, or `System.Range`.*
+- [**CS9173**](#element-access) - *An inline array access may not have a named argument specifier*
+
+## Inline array declaration
+
+You declare inline arrays as a `struct` type with a single field, and an attribute that specifies the length of the array. The compiler generates the following errors for invalid inline array declarations:
+
+- **CS9167** - *Inline array length must be greater than 0.*
+- **CS9168** - *Inline array struct must not have explicit layout.*
+- **CS9169** - *Inline array struct must declare one and only one instance field which must not be a ref field.*
+
+To fix these arrays, ensure the following are true:
+
+- The argument to the <xref:System.Runtime.CompilerServices.InlineArrayAttribute?displayProperty=fullName> is a positive integer.
+- The enclosing `struct` doesn't specify any explicit layout.
+- The enclosing `struct` has a single instance field, and that instance field is not a `ref` field.
+
+## Element access
+
+You access elements of an inline array in the same way as any array. The following errors may be generated from incorrect element access:
+
+- **CS9166** - *Index is outside the bounds of the inline array*
+- **CS9172** - *Elements of an inline array type can be accessed only with a single argument implicitly convertible to `int`, `System.Index`, or `System.Range`.*
+- **CS9173** - *An inline array access may not have a named argument specifier*
+
+The argument to the indexer must be:
+
+- One of these three types: `int`, a `System.Index` or a `System.Range`.
+- Can't be a named argument. The compiler generates the element accessor. The parameter doesn't have a name, so you can't use named arguments.
+- Is included in the bounds of the array. Like all .NET arrays, inline array element access is bounds-checked. The index must be within the bounds of the inline array.
+
+## Conversions to Span
+
+You often use <xref:System.Span%601?displayProperty=nameWithType> or <xref:System.ReadOnlySpan%601?displayProperty=nameWithType> to work with inline arrays. The compiler generates the following errors for invalid conversions:
+
+- **CS9164** - *Cannot convert expression to `Span<T>` because it is not an assignable variable*
+- **CS9165** - *Cannot convert expression to `ReadOnlySpan<T>` because it may not be passed or returned by reference*
+
+An inline array can be implicitly converted to a `Span<T>` or `ReadOnlySpan<T>` to pass an inline array to methods. The compiler enforces restrictions on those conversions:
+
+- The inline array must be writable in order to convert an inline array to a `Span<T>`. If the array is readonly, you can't convert it to a writable `Span<T>`. You can use `ReadOnlySpan<T>` instead.
+- The *safe context* of the inline array must be at least as wide as the *safe context* of the `Span<T>` or `ReadOnlySpan<T>` for the conversion to succeed. You must either limit the context of the span, or expand the scope of the inline array.

--- a/docs/csharp/language-reference/compiler-messages/lambda-expression-errors.md
+++ b/docs/csharp/language-reference/compiler-messages/lambda-expression-errors.md
@@ -29,6 +29,7 @@ f1_keywords:
   - "CS9098" # ERR_ImplicitlyTypedDefaultParameter: Implicitly typed lambda parameter '{0}' cannot have a default value.
   - "CS9099" # WRN_OptionalParamValueMismatch: The default parameter value does not match in the target delegate type.
   - "CS9100" # WRN_ParamsArrayInLambdaOnly: Parameter has params modifier in lambda but not in target delegate type.
+  - "CS9170"
 helpviewer_keywords:
   - "CS0748"
   - "CS0834"
@@ -57,6 +58,7 @@ helpviewer_keywords:
   - "CS9098"
   - "CS9099"
   - "CS9100"
+  - "CS9170"
 ms.date: 05/04/2023
 ---
 # Errors and warnings when using lambda expressions and anonymous functions
@@ -91,6 +93,7 @@ That's by design. The text closely matches the text of the compiler error / warn
 - [**CS8972**](#conversion-to-expression-trees) - *A lambda expression with attributes cannot be converted to an expression tree.*
 - [**CS8975**](#lambda-expression-parameters-and-returns) - *The contextual keyword `var` cannot be used as an explicit lambda return type.*
 - [**CS9098**](#lambda-expression-parameters-and-returns) - *Implicitly typed lambda parameter '...' cannot have a default value.*
+- [**CS9170**](#syntax-limitations-in-lambda-expressions) - *An expression tree may not contain an inline array access or conversion*
 
 In addition, there are several *warnings* related to declaring and using lambda expressions:
 
@@ -108,6 +111,7 @@ Some C# syntax is prohibited in lambda expressions and anonymous methods. Using 
 - **CS1673**: *Anonymous methods, lambda expressions, and query expressions inside structs cannot access instance members of `this`.*
 - **CS1686**: *Local variable or its members cannot have their address taken and be used inside an anonymous method or lambda expression.*
 - **CS8175**: *Cannot use ref local inside an anonymous method, lambda expression, or query expression.*
+- **CS9170** - *An expression tree may not contain an inline array access or conversion*
 
 All the following constructs are disallowed in lambda expressions:
 
@@ -117,6 +121,7 @@ All the following constructs are disallowed in lambda expressions:
 - `break`, `goto`, and `continue` statements
 - `this` access when `this` is a `struct` type
 - Anonymous methods or lambda expressions inside another expression, such as an Attribute constructor.
+- [Inline arrays](../builtin-types/struct.md#inline-arrays).
 
 You can't use any of these constructs in a lambda expression or an anonymous method. Many are allowed in a [local function](../../programming-guide/classes-and-structs/local-functions.md).
 


### PR DESCRIPTION
Fixes #36066

Add a reference pages for all new compiler errors and warnings generated by inline arrays.

Most are in the new page, although one is in the page for expression trees, and one is related to feature flags and a runtime  value.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-messages/feature-version-errors.md](https://github.com/dotnet/docs/blob/8bcc6fdc99d0ca548199075d036952caecefaf9e/docs/csharp/language-reference/compiler-messages/feature-version-errors.md) | [Resolve warnings related to language features and versions](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/feature-version-errors?branch=pr-en-us-36150) |
| [docs/csharp/language-reference/compiler-messages/inline-array-errors.md](https://github.com/dotnet/docs/blob/8bcc6fdc99d0ca548199075d036952caecefaf9e/docs/csharp/language-reference/compiler-messages/inline-array-errors.md) | [docs/csharp/language-reference/compiler-messages/inline-array-errors](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/inline-array-errors?branch=pr-en-us-36150) |
| [docs/csharp/language-reference/compiler-messages/lambda-expression-errors.md](https://github.com/dotnet/docs/blob/8bcc6fdc99d0ca548199075d036952caecefaf9e/docs/csharp/language-reference/compiler-messages/lambda-expression-errors.md) | [Lambda expression warnings](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/lambda-expression-errors?branch=pr-en-us-36150) |

<!-- PREVIEW-TABLE-END -->