### PR TITLE
fix build warning

### DIFF
--- a/docs/csharp/language-reference/builtin-types/ref-struct.md
+++ b/docs/csharp/language-reference/builtin-types/ref-struct.md
@@ -63,7 +63,7 @@ The `Span<T>` type stores a reference through which it accesses the contiguous e
 For more information, see the following sections of the [C# language specification](~/_csharpstandard/standard/README.md):
 
 - [Structs: Ref modifier](~/_csharpstandard/standard/structs.md#1623-ref-modifier)
-- [Safe context constraint for ref struct types](~/_csharpstandard/standard/structs.md#16412-safe-context-constraint-for-ref-struct-types)
+- [Safe context constraint for ref struct types](~/_csharpstandard/standard/structs.md#16412-safe-context-constraint)
 
 For more information about `ref` fields, see the [Low-level struct improvements](~/_csharplang/proposals/csharp-11.0/low-level-struct-improvements.md) proposal note.
 


### PR DESCRIPTION
The title for this clause was changed at the July ECMA meeting.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/builtin-types/ref-struct.md](https://github.com/dotnet/docs/blob/7de5a2c01cf4d6e583429df6e2b8ac41c58a6424/docs/csharp/language-reference/builtin-types/ref-struct.md) | [`ref` structure types (C# reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/ref-struct?branch=pr-en-us-36245) |

<!-- PREVIEW-TABLE-END -->