### PR TITLE
Add migration section for JsonObjectAttribute

### DIFF
--- a/docs/standard/serialization/system-text-json/supported-collection-types.md
+++ b/docs/standard/serialization/system-text-json/supported-collection-types.md
@@ -18,7 +18,7 @@ This article gives an overview of which collections are supported for serializat
 * Derives from <xref:System.Collections.IEnumerable> or <xref:System.Collections.Generic.IAsyncEnumerable%601>
 * Contains elements that are serializable.
 
-The serializer calls the <xref:System.Collections.IEnumerable.GetEnumerator> method, and writes the elements.
+The serializer calls the <xref:System.Collections.IEnumerable.GetEnumerator> method and writes the elements.
 
 Deserialization is more complicated and is not supported for some collection types.
 


### PR DESCRIPTION
Fixes #35767 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/serialization/system-text-json/migrate-from-newtonsoft.md](https://github.com/dotnet/docs/blob/717414c2e5d18e80bf851318472809d6dda295a6/docs/standard/serialization/system-text-json/migrate-from-newtonsoft.md) | [Compare Newtonsoft.Json to System.Text.Json, and migrate to System.Text.Json](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/migrate-from-newtonsoft?branch=pr-en-us-36247) |
| [docs/standard/serialization/system-text-json/supported-collection-types.md](https://github.com/dotnet/docs/blob/717414c2e5d18e80bf851318472809d6dda295a6/docs/standard/serialization/system-text-json/supported-collection-types.md) | ["Supported collection types in System.Text.Json"](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/supported-collection-types?branch=pr-en-us-36247) |

<!-- PREVIEW-TABLE-END -->