### PR TITLE
Clarify CA1860 and CA1827

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1827.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1827.md
@@ -27,7 +27,7 @@ The [Count()](xref:System.Linq.Enumerable.Count%2A) or [LongCount()](xref:System
 
 ## Rule description
 
-This rule flags the <xref:System.Linq.Enumerable.Count%2A>() and <xref:System.Linq.Enumerable.LongCount%2A>() LINQ method calls used to check if the collection has at least one element. These method calls require enumerating the entire collection to compute the count. The same check is faster with the <xref:System.Linq.Enumerable.Any%2A>() method as it avoids enumerating the collection.
+This rule flags [Count()](xref:System.Linq.Enumerable.Count%2A) and [LongCount()](xref:System.Linq.Enumerable.LongCount%2A) LINQ method calls that are used to check if the collection has at least one element. These methods enumerate the entire collection to compute the count. The same check is faster with the [Any()](<xref:System.Linq.Enumerable.Any%2A) method as it avoids enumerating the collection.
 
 ## How to fix violations
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1827.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1827.md
@@ -23,7 +23,7 @@ ms.author: mavasani
 
 ## Cause
 
-The <xref:System.Linq.Enumerable.Count%2A>() or <xref:System.Linq.Enumerable.LongCount%2A>() **method** was used where the <xref:System.Linq.Enumerable.Any%2A>() method would be more efficient.
+The [Count()](xref:System.Linq.Enumerable.Count%2A) or [LongCount()](xref:System.Linq.Enumerable.LongCount%2A) *method* was used where the [Any()](<xref:System.Linq.Enumerable.Any%2A) method would be more efficient.
 
 ## Rule description
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1827.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1827.md
@@ -1,7 +1,7 @@
 ---
 title: "CA1827: Do not use Count/LongCount when Any can be used (code analysis)"
 description: "Learn about code analysis rule CA1827: Do not use Count/LongCount when Any can be used"
-ms.date: 04/24/2020
+ms.date: 07/17/2023
 ms.topic: reference
 f1_keywords:
   - "DoNotUseCountWhenAnyCanBeUsedAnalyzer"
@@ -12,7 +12,7 @@ helpviewer_keywords:
 author: mavasani
 ms.author: mavasani
 ---
-# CA1827: Do not use Count/LongCount when Any can be used
+# CA1827: Do not use Count()/LongCount() when Any() can be used
 
 |                                     | Value                                  |
 | ----------------------------------- | -------------------------------------- |
@@ -23,11 +23,14 @@ ms.author: mavasani
 
 ## Cause
 
-The [Count()](xref:System.Linq.Enumerable.Count%2A) or [LongCount()](xref:System.Linq.Enumerable.LongCount%2A) *method* was used where the [Any()](<xref:System.Linq.Enumerable.Any%2A) method would be more efficient.
+The [Count()](xref:System.Linq.Enumerable.Count%2A) or [LongCount()](xref:System.Linq.Enumerable.LongCount%2A) *method* was used where the [Any()](xref:System.Linq.Enumerable.Any%2A) method would be more efficient.
 
 ## Rule description
 
-This rule flags [Count()](xref:System.Linq.Enumerable.Count%2A) and [LongCount()](xref:System.Linq.Enumerable.LongCount%2A) LINQ method calls that are used to check if the collection has at least one element. These methods enumerate the entire collection to compute the count. The same check is faster with the [Any()](<xref:System.Linq.Enumerable.Any%2A) method as it avoids enumerating the collection.
+This rule flags [Count()](xref:System.Linq.Enumerable.Count%2A) and [LongCount()](xref:System.Linq.Enumerable.LongCount%2A) LINQ method calls that are used to check if the collection has at least one element. These methods enumerate the entire collection to compute the count. The same check is faster with the [Any()](xref:System.Linq.Enumerable.Any%2A) method as it avoids enumerating the collection.
+
+> [!NOTE]
+> This rule is similar to [CA1860: Avoid using 'Enumerable.Any()' extension method](ca1860.md). However that rule suggests using the `Count` *property*, while this rule applies to the Linq `Count()` *extension method*.
 
 ## How to fix violations
 
@@ -61,9 +64,6 @@ class C
 }
 ```
 
-> [!NOTE]
-> This rule is similar to [CA1860: Avoid using 'Enumerable.Any()' extension method](ca1860.md). However that rule suggests using the `Count` *property*, while this rule applies to the Linq `Count()` *extension method*.
-
 > [!TIP]
 > A code fix is available for this rule in Visual Studio. To use it, position the cursor on the violation and press <kbd>Ctrl</kbd>+<kbd>.</kbd> (period). Choose **Do not use Count() or LongCount() when Any() can be used** from the list of options that's presented.
 >
@@ -96,7 +96,7 @@ For more information, see [How to suppress code analysis warnings](../suppress-w
 
 - [CA1826: Use property instead of Linq Enumerable method](ca1826.md)
 - [CA1828: Do not use CountAsync/LongCountAsync when AnyAsync can be used](ca1828.md)
-- [CA1829: Use Length/Count property instead of Enumerable.Count method](ca1829.md)
+- [CA1829: Use Length/Count property instead of Enumerable.Count() method](ca1829.md)
 - [CA1860: Avoid using 'Enumerable.Any()' extension method](ca1860.md)
 
 ## See also

--- a/docs/fundamentals/code-analysis/quality-rules/ca1827.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1827.md
@@ -62,7 +62,7 @@ class C
 ```
 
 > [!NOTE]
-> This rule is similar to [CA1860: Avoid using 'Enumerable.Any()' extension method](ca1860.md). However and that rule applies suggests using the `Count` **property**, while this rule applies to the , this Linq `Count()` extension **method**.
+> This rule is similar to [CA1860: Avoid using 'Enumerable.Any()' extension method](ca1860.md). However that rule suggests using the `Count` **property**, while this rule applies to the Linq `Count()` extension **method**.
 
 > [!TIP]
 > A code fix is available for this rule in Visual Studio. To use it, position the cursor on the violation and press <kbd>Ctrl</kbd>+<kbd>.</kbd> (period). Choose **Do not use Count() or LongCount() when Any() can be used** from the list of options that's presented.

--- a/docs/fundamentals/code-analysis/quality-rules/ca1827.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1827.md
@@ -62,7 +62,7 @@ class C
 ```
 
 > [!NOTE]
-> This rule is similar to [CA1860: Avoid using 'Enumerable.Any()' extension method](ca1860.md). However that rule suggests using the `Count` **property**, while this rule applies to the Linq `Count()` extension **method**.
+> This rule is similar to [CA1860: Avoid using 'Enumerable.Any()' extension method](ca1860.md). However that rule suggests using the `Count` *property*, while this rule applies to the Linq `Count()` *extension method*.
 
 > [!TIP]
 > A code fix is available for this rule in Visual Studio. To use it, position the cursor on the violation and press <kbd>Ctrl</kbd>+<kbd>.</kbd> (period). Choose **Do not use Count() or LongCount() when Any() can be used** from the list of options that's presented.

--- a/docs/fundamentals/code-analysis/quality-rules/ca1827.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1827.md
@@ -23,11 +23,11 @@ ms.author: mavasani
 
 ## Cause
 
-The <xref:System.Linq.Enumerable.Count%2A> or <xref:System.Linq.Enumerable.LongCount%2A> method was used where the <xref:System.Linq.Enumerable.Any%2A> method would be more efficient.
+The <xref:System.Linq.Enumerable.Count%2A>() or <xref:System.Linq.Enumerable.LongCount%2A>() **method** was used where the <xref:System.Linq.Enumerable.Any%2A>() method would be more efficient.
 
 ## Rule description
 
-This rule flags the <xref:System.Linq.Enumerable.Count%2A> and <xref:System.Linq.Enumerable.LongCount%2A> LINQ method calls used to check if the collection has at least one element. These method calls require enumerating the entire collection to compute the count. The same check is faster with the <xref:System.Linq.Enumerable.Any%2A> method as it avoids enumerating the collection.
+This rule flags the <xref:System.Linq.Enumerable.Count%2A>() and <xref:System.Linq.Enumerable.LongCount%2A>() LINQ method calls used to check if the collection has at least one element. These method calls require enumerating the entire collection to compute the count. The same check is faster with the <xref:System.Linq.Enumerable.Any%2A>() method as it avoids enumerating the collection.
 
 ## How to fix violations
 
@@ -60,6 +60,9 @@ class C
         => list.Any() ? "Not empty" : "Empty";
 }
 ```
+
+> [!NOTE]
+> This rule is similar to [CA1860: Avoid using 'Enumerable.Any()' extension method](ca1860.md). However and that rule applies suggests using the `Count` **property**, while this rule applies to the , this Linq `Count()` extension **method**.
 
 > [!TIP]
 > A code fix is available for this rule in Visual Studio. To use it, position the cursor on the violation and press <kbd>Ctrl</kbd>+<kbd>.</kbd> (period). Choose **Do not use Count() or LongCount() when Any() can be used** from the list of options that's presented.
@@ -94,6 +97,7 @@ For more information, see [How to suppress code analysis warnings](../suppress-w
 - [CA1826: Use property instead of Linq Enumerable method](ca1826.md)
 - [CA1828: Do not use CountAsync/LongCountAsync when AnyAsync can be used](ca1828.md)
 - [CA1829: Use Length/Count property instead of Enumerable.Count method](ca1829.md)
+- [CA1860: Avoid using 'Enumerable.Any()' extension method](ca1860.md)
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1860.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1860.md
@@ -95,6 +95,7 @@ dotnet_diagnostic.CA1860.severity = none
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
 
 ## Related rules
+
 - [CA1827: Do not use Count/LongCount when Any can be used](ca1827.md)
 - [CA1828: Do not use CountAsync/LongCountAsync when AnyAsync can be used](ca1828.md)
 - [CA1829: Use Length/Count property instead of Enumerable.Count method](ca1829.md)

--- a/docs/fundamentals/code-analysis/quality-rules/ca1860.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1860.md
@@ -24,7 +24,7 @@ dev_langs:
 
 ## Cause
 
-<xref:System.Linq.Enumerable.Any%2A?displayProperty=nameWithType> is called on a type that has a `Length`, `Count`, or `IsEmpty` property.
+<xref:System.Linq.Enumerable.Any%2A?displayProperty=nameWithType> is called on a type that has a `Length`, `Count`, or `IsEmpty` **property**.
 
 ## Rule description
 
@@ -68,6 +68,9 @@ Function HasElements(strings As String()) As Boolean
 End Function
 ```
 
+> [!NOTE]
+> This rule is similar to [CA1827: Do not use Count/LongCount when Any can be used](ca1827.md). However that rule applies to the Linq `Count()` **method**, while this rule suggest the use of the `Count` **property**.
+
 ## When to suppress warnings
 
 It's safe to suppress this warning if performance isn't a concern.
@@ -90,3 +93,8 @@ dotnet_diagnostic.CA1860.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
+## Related rules
+- [CA1827: Do not use Count/LongCount when Any can be used](ca1827.md)
+- [CA1828: Do not use CountAsync/LongCountAsync when AnyAsync can be used](ca1828.md)
+- [CA1829: Use Length/Count property instead of Enumerable.Count method](ca1829.md)

--- a/docs/fundamentals/code-analysis/quality-rules/ca1860.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1860.md
@@ -1,7 +1,7 @@
 ---
 title: "CA1860: Avoid using 'Enumerable.Any()' extension method"
 description: "Learn about code analyzer rule CA1860 - Avoid using 'Enumerable.Any()' extension method"
-ms.date: 03/01/2023
+ms.date: 07/17/2023
 ms.topic: reference
 f1_keywords:
  - CA1860
@@ -28,13 +28,16 @@ dev_langs:
 
 ## Rule description
 
-It's more efficient and clearer to use `Length`, `Count`, or `IsEmpty` (if possible) than to call <xref:System.Linq.Enumerable.Any%2A?displayProperty=nameWithType> to determine whether a collection type has any elements.
+To determine whether a collection type has any elements, it's more efficient and clearer to use the `Length`, `Count`, or `IsEmpty` (if possible) properties than to call the <xref:System.Linq.Enumerable.Any%2A?displayProperty=nameWithType> method.
 
 `Any()`, which is an extension method, uses language integrated query (LINQ). It's more efficient to rely on the collection's own properties, and it also clarifies intent.
 
+> [!NOTE]
+> This rule is similar to [CA1827: Do not use Count()/LongCount() when Any() can be used](ca1827.md). However, that rule applies to the Linq `Count()` *method*, while this rule suggests using the `Count` *property*.
+
 ## How to fix violations
 
-Replace a call to <xref:System.Linq.Enumerable.Any%2A?displayProperty=nameWithType> with a call to the collection's `Length`, `Count`, or `IsEmpty` property.
+Replace a call to [Any()](xref:System.Linq.Enumerable.Any%2A) with a call to the collection's `Length`, `Count`, or `IsEmpty` property.
 
 ## Example
 
@@ -67,9 +70,6 @@ Function HasElements(strings As String()) As Boolean
     Return strings.Length > 0
 End Function
 ```
-
-> [!NOTE]
-> This rule is similar to [CA1827: Do not use Count()/LongCount() when Any() can be used](ca1827.md). However, that rule applies to the Linq `Count()` *method*, while this rule suggests using the `Count` *property*.
 
 ## When to suppress warnings
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1860.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1860.md
@@ -24,7 +24,7 @@ dev_langs:
 
 ## Cause
 
-<xref:System.Linq.Enumerable.Any%2A?displayProperty=nameWithType> is called on a type that has a `Length`, `Count`, or `IsEmpty` **property**.
+<xref:System.Linq.Enumerable.Any%2A?displayProperty=nameWithType> is called on a type that has a `Length`, `Count`, or `IsEmpty` *property*.
 
 ## Rule description
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1860.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1860.md
@@ -69,7 +69,7 @@ End Function
 ```
 
 > [!NOTE]
-> This rule is similar to [CA1827: Do not use Count/LongCount when Any can be used](ca1827.md). However that rule applies to the Linq `Count()` **method**, while this rule suggest the use of the `Count` **property**.
+> This rule is similar to [CA1827: Do not use Count()/LongCount() when Any() can be used](ca1827.md). However, that rule applies to the Linq `Count()` *method*, while this rule suggests using the `Count` *property*.
 
 ## When to suppress warnings
 


### PR DESCRIPTION
## Summary

when #75933 was created [I had brought up ](https://github.com/dotnet/runtime/issues/75933#issuecomment-1330636078)the similarity between the new error (CA1860) and the existing CA1827.

this PR updates the docs for both those analyzers to call out that similarity and reduce the chance of confusion

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1827.md](https://github.com/dotnet/docs/blob/ffd564e624692388c501ebf7e51d2aaf6ef01b68/docs/fundamentals/code-analysis/quality-rules/ca1827.md) | [CA1827: Do not use Count/LongCount when Any can be used](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1827?branch=pr-en-us-36257) |
| [docs/fundamentals/code-analysis/quality-rules/ca1860.md](https://github.com/dotnet/docs/blob/ffd564e624692388c501ebf7e51d2aaf6ef01b68/docs/fundamentals/code-analysis/quality-rules/ca1860.md) | ["CA1860: Avoid using 'Enumerable.Any()' extension method"](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1860?branch=pr-en-us-36257) |


<!-- PREVIEW-TABLE-END -->