### PR TITLE
ResolvePackageDependencies no longer called

### DIFF
--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -134,6 +134,7 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 | [dotnet test: switch `-a` to alias `--arch` instead of `--test-adapter-path`](https://github.com/dotnet/sdk/issues/21389) | ❌ | ❌ |
 | [dotnet test: switch `-r` to alias `--runtime` instead of `--results-dir`](https://github.com/dotnet/sdk/issues/21952) | ❌ | ❌ |
 | [`--output` option no longer is valid for solution-level commands](sdk/7.0/solution-level-output-no-longer-valid.md) | ❌ | ❌ |
+| [SDK no longer calls ResolvePackageDependencies](sdk/7.0/resolvepackagedependencies.md) | ✔️ | ❌ |
 
 ## Serialization
 

--- a/docs/core/compatibility/sdk/7.0/resolvepackagedependencies.md
+++ b/docs/core/compatibility/sdk/7.0/resolvepackagedependencies.md
@@ -21,7 +21,7 @@ An existing .NET SDK target was called to get information on packages that were 
 
 ## New behavior
 
-Package information is added from `PreprocessPackageDependenciesDesignTime` into the design-time build cache. If you depended on `PackageDependencies` and `PackageDefinitions` in your build, you'll see build errors.
+Package information is added from `PreprocessPackageDependenciesDesignTime` into the design-time build cache. If you depended on `PackageDependencies` and `PackageDefinitions` in your build, you'll see build errors such as **No dependencies found**.
 
 ## Reason for change
 

--- a/docs/core/compatibility/sdk/7.0/resolvepackagedependencies.md
+++ b/docs/core/compatibility/sdk/7.0/resolvepackagedependencies.md
@@ -1,0 +1,38 @@
+---
+title: "Breaking change: ResolvePackageDependencies no longer called"
+description: Learn about a breaking change in SDK for .NET 7 where the .NET SDK no longer calls the ResolvePackageDependencies target to get package information.
+ms.date: 07/14/2023
+---
+# SDK no longer calls ResolvePackageDependencies
+
+Previously, the .NET SDK called the `ResolvePackageDependencies` target in order to generate `PackageDependencies` and `PackageDefinitions`. However, that data was already available from a different target. Instead, those two items are now added from `PreprocessPackageDependenciesDesignTime` into the design-time build cache and the prior target isn't called.
+
+## Version introduced
+
+.NET SDK 7.0.200
+
+## Type of change
+
+This change can affect [source compatibility](../../categories.md#source-compatibility).
+
+## Previous behavior
+
+An existing .NET SDK target was called to get information on packages that were already available.
+
+## New behavior
+
+Package information is added from `PreprocessPackageDependenciesDesignTime` into the design-time build cache. If you depended on `PackageDependencies` and `PackageDefinitions` in your build, you'll see build errors.
+
+## Reason for change
+
+In some situations, performance was particularly slow for the prior target. Solutions that have large NuGet dependency graphs will see faster IntelliSense after solution loads, branch switches, or when making solution-wide changes while using the Central Package Management feature.
+
+## Recommended action
+
+If your build depends on the previous behavior, add the `<EmitLegacyAssetsFileItems>true</EmitLegacyAssetsFileItems>` property to your project to return to the legacy behavior. We expect this to only impact a small number of users.
+
+```xml
+<PropertyGroup>
+  <EmitLegacyAssetsFileItems>true</EmitLegacyAssetsFileItems>
+</PropertyGroup>
+```

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -274,6 +274,8 @@ items:
         href: sdk/8.0/console-encoding.md
       - name: Version requirements for .NET 7 SDK
         href: sdk/7.0/vs-msbuild-version.md
+      - name: SDK no longer calls ResolvePackageDependencies
+        href: sdk/7.0/resolvepackagedependencies.md
       - name: Serialization of custom types in .NET 7
         href: sdk/7.0/custom-serialization.md
       - name: Side-by-side SDK installations
@@ -1430,6 +1432,8 @@ items:
         href: sdk/8.0/console-encoding.md
       - name: Version requirements for .NET 7 SDK
         href: sdk/7.0/vs-msbuild-version.md
+      - name: SDK no longer calls ResolvePackageDependencies
+        href: sdk/7.0/resolvepackagedependencies.md
       - name: Serialization of custom types in .NET 7
         href: sdk/7.0/custom-serialization.md
       - name: Side-by-side SDK installations


### PR DESCRIPTION
Fixes #34493 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/7.0.md](https://github.com/dotnet/docs/blob/1ca4ce701233d6f45d94df946b1a9ac71dc9466e/docs/core/compatibility/7.0.md) | [Breaking changes in .NET 7](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/7.0?branch=pr-en-us-36266) |
| [docs/core/compatibility/sdk/7.0/resolvepackagedependencies.md](https://github.com/dotnet/docs/blob/1ca4ce701233d6f45d94df946b1a9ac71dc9466e/docs/core/compatibility/sdk/7.0/resolvepackagedependencies.md) | [docs/core/compatibility/sdk/7.0/resolvepackagedependencies](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/7.0/resolvepackagedependencies?branch=pr-en-us-36266) |

<!-- PREVIEW-TABLE-END -->