### PR TITLE
Don't recommend FormattableString.Invariant

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1305.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1305.md
@@ -1,7 +1,7 @@
 ---
 title: "CA1305: Specify IFormatProvider (code analysis)"
 description: "Learn about code analysis rule CA1305: Specify IFormatProvider"
-ms.date: 06/30/2018
+ms.date: 07/17/2023
 ms.topic: reference
 f1_keywords:
 - SpecifyIFormatProvider
@@ -25,7 +25,7 @@ dev_langs:
 
 ## Cause
 
-A call is made to a method that has an overload that accepts a <xref:System.IFormatProvider?displayProperty=fullName> parameter, and that overload isn't called.
+A call is made to a method that has an overload that accepts a <xref:System.IFormatProvider?displayProperty=fullName> argument, and that overload isn't called.
 
 This rule ignores calls to .NET methods that are documented as ignoring the <xref:System.IFormatProvider> parameter. The rule also ignores the following methods:
 
@@ -38,19 +38,23 @@ This rule ignores calls to .NET methods that are documented as ignoring the <xre
 
 ## Rule description
 
-When a <xref:System.Globalization.CultureInfo?displayProperty=nameWithType> or <xref:System.IFormatProvider> object is not supplied, the default value that is supplied by the overloaded member might not have the effect that you want in all locales. Also, .NET members choose default culture and formatting based on assumptions that might not be correct for your code. To make sure that the code works as expected for your scenarios, you should supply culture-specific information according to the following guidelines:
+When a <xref:System.Globalization.CultureInfo?displayProperty=nameWithType> or <xref:System.IFormatProvider> object is not supplied, the default value that's supplied by the overloaded member might not have the effect that you want in all locales. Also, .NET members choose default culture and formatting based on assumptions that might not be correct for your code. To make sure that the code works as expected for your scenarios, you should supply culture-specific information according to the following guidelines:
 
 - If the value will be displayed to the user, use the current culture. See <xref:System.Globalization.CultureInfo.CurrentCulture%2A?displayProperty=nameWithType>.
 
 - If the value will be stored and accessed by software (persisted to a file or database), use the invariant culture. See <xref:System.Globalization.CultureInfo.InvariantCulture%2A?displayProperty=nameWithType>.
 
-- If you do not know the destination of the value, have the data consumer or provider specify the culture.
+- If you don't know the destination of the value, have the data consumer or provider specify the culture.
 
-Even if the default behavior of the overloaded member is appropriate for your needs, it is better to explicitly call the culture-specific overload so that your code is self-documenting and more easily maintained.
+Even if the default behavior of the overloaded member is appropriate for your needs, it's better to explicitly call the culture-specific overload so that your code is self-documenting and more easily maintained.
 
 ## How to fix violations
 
-To fix a violation of this rule, use the overload that takes an <xref:System.IFormatProvider> argument. Or, use a [C# interpolated string](../../../csharp/tutorials/string-interpolation.md) and pass it to the <xref:System.FormattableString.Invariant%2A?displayProperty=nameWithType> method.
+To fix a violation of this rule, use the overload that takes an <xref:System.IFormatProvider> argument. Or, to use the invariant culture, use a [C# interpolated string](../../../csharp/tutorials/string-interpolation.md) and pass it to <xref:System.String.Create(System.IFormatProvider,System.Runtime.CompilerServices.DefaultInterpolatedStringHandler@)?displayProperty=nameWithType> along with <xref:System.Globalization.CultureInfo.InvariantCulture?displayProperty=nameWithType>, for example:
+
+```csharp
+string.Create(CultureInfo.InvariantCulture, $"{major}.{minor}.{build}.{revision}");
+```
 
 ## When to suppress warnings
 

--- a/docs/standard/base-types/best-practices-display-data.md
+++ b/docs/standard/base-types/best-practices-display-data.md
@@ -36,10 +36,15 @@ To explicitly specify that a string should be formatted by using the conventions
   [!code-csharp[Explicit String Conversion](./snippets/best-practices-display-data/csharp/tostring/Program.cs#2)]
   [!code-vb[Implicit String Conversion](./snippets/best-practices-display-data/vb/tostring/Program.vb#2)]
 
-- For string interpolation, rather than assigning an interpolated string to a <xref:System.String> instance, assign it to a <xref:System.FormattableString>. You can then call its <xref:System.FormattableString.ToString?displayProperty=nameWithType> method produce a result string that reflects the conventions of the current culture, or you can call the <xref:System.FormattableString.ToString(System.IFormatProvider)?displayProperty=nameWithType> method to produce a result string that reflects the conventions of a specified culture. You can also pass the formattable string to the static <xref:System.FormattableString.Invariant%2A?displayProperty=nameWithType> method to produce a result string that reflects the conventions of the invariant culture. The following example illustrates this approach. (The output from the example reflects a current culture of en-US.)
+- For string interpolation, rather than assigning an interpolated string to a <xref:System.String> instance, assign it to a <xref:System.FormattableString>. You can then call its <xref:System.FormattableString.ToString?displayProperty=nameWithType> method to produce a result string that reflects the conventions of the current culture, or you can call the <xref:System.FormattableString.ToString(System.IFormatProvider)?displayProperty=nameWithType> method to produce a result string that reflects the conventions of a specified culture.
+
+  You can also pass the formattable string to the static <xref:System.FormattableString.Invariant%2A?displayProperty=nameWithType> method to produce a result string that reflects the conventions of the invariant culture. The following example illustrates this approach. (The output from the example reflects a current culture of `en-US`.)
 
   [!code-csharp[String interpolation](./snippets/best-practices-display-data/csharp/formattable/Program.cs)]
   [!code-vb[String interpolation](./snippets/best-practices-display-data/vb/formattable/Program.vb)]
+
+  > [!NOTE]
+  > If you're using C# and formatting using the invariant culture, it's more performant to call <xref:System.String.Create(System.IFormatProvider,System.Runtime.CompilerServices.DefaultInterpolatedStringHandler@)?displayProperty=nameWithType> and pass <xref:System.Globalization.CultureInfo.InvariantCulture?displayProperty=nameWithType> for the first parameter. For more information, see [String interpolation in C# 10 and .NET 6](https://devblogs.microsoft.com/dotnet/string-interpolation-in-c-10-and-net-6/).
 
 ## Persist formatted data
 

--- a/docs/standard/serialization/system-text-json/snippets/how-to-5-0/csharp/CustomConverterUnixEpochDate.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to-5-0/csharp/CustomConverterUnixEpochDate.cs
@@ -61,7 +61,8 @@ namespace CustomConverterUnixEpochDate
             long unixTime = Convert.ToInt64((value - s_epoch).TotalMilliseconds);
             TimeSpan utcOffset = value.Offset;
 
-            string formatted = FormattableString.Invariant($"/Date({unixTime}{(utcOffset >= TimeSpan.Zero ? "+" : "-")}{utcOffset:hhmm})/");
+            string formatted = string.Create(CultureInfo.InvariantCulture, $"/Date({unixTime}{(utcOffset >= TimeSpan.Zero ? "+" : "-")}{utcOffset:hhmm})/");
+
             writer.WriteStringValue(formatted);
         }
     }

--- a/docs/standard/serialization/system-text-json/snippets/how-to-5-0/csharp/CustomConverterUnixEpochDateNoZone.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to-5-0/csharp/CustomConverterUnixEpochDateNoZone.cs
@@ -55,7 +55,7 @@ namespace CustomConverterUnixEpochDateNoZone
         {
             long unixTime = Convert.ToInt64((value - s_epoch).TotalMilliseconds);
 
-            string formatted = FormattableString.Invariant($"/Date({unixTime})/");
+            string formatted = string.Create(CultureInfo.InvariantCulture, $"/Date({unixTime})/");
             writer.WriteStringValue(formatted);
         }
     }


### PR DESCRIPTION
Contributes to #36256 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1305.md](https://github.com/dotnet/docs/blob/85e5c638be2d2ee83c60aa3de4004b57f74d3c18/docs/fundamentals/code-analysis/quality-rules/ca1305.md) | [CA1305: Specify IFormatProvider](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1305?branch=pr-en-us-36285) |
| [docs/standard/base-types/best-practices-display-data.md](https://github.com/dotnet/docs/blob/85e5c638be2d2ee83c60aa3de4004b57f74d3c18/docs/standard/base-types/best-practices-display-data.md) | [Best practices for displaying and persisting formatted data in .NET](https://review.learn.microsoft.com/en-us/dotnet/standard/base-types/best-practices-display-data?branch=pr-en-us-36285) |

<!-- PREVIEW-TABLE-END -->