### PR TITLE
Fix a small grammar issue

### DIFF
--- a/docs/csharp/language-reference/compiler-options/advanced.md
+++ b/docs/csharp/language-reference/compiler-options/advanced.md
@@ -297,7 +297,7 @@ The diagnostics are enabled if the element content is `true`, disabled if `false
 **ReportIVTs** reports the following information when enabled:
 
 1. Any inaccessible member diagnostics include their source assembly, if different than the current assembly.
-1. The compiler prints the assembly identity of the project being compiled, its assembly name, and public key.
+1. The compiler prints the assembly identity of the project being compiled, its assembly name and public key.
 1. For every reference passed to the compiler, it prints;
    1. The assembly identity of the reference
    1. Whether the reference grants the current project `InternalsVisibleTo`

--- a/docs/csharp/language-reference/compiler-options/advanced.md
+++ b/docs/csharp/language-reference/compiler-options/advanced.md
@@ -296,8 +296,8 @@ The diagnostics are enabled if the element content is `true`, disabled if `false
 
 **ReportIVTs** reports the following information when enabled:
 
-1. Any inaccessible member diagnostics include their source assembly, if if different than the current assembly.
-1. The compiler prints the assembly identity of the project being compiled, its assembly name and public key.
+1. Any inaccessible member diagnostics include their source assembly, if different than the current assembly.
+1. The compiler prints the assembly identity of the project being compiled, its assembly name, and public key.
 1. For every reference passed to the compiler, it prints;
    1. The assembly identity of the reference
    1. Whether the reference grants the current project `InternalsVisibleTo`


### PR DESCRIPTION
Double if


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-options/advanced.md](https://github.com/dotnet/docs/blob/e3946014ac64601050d9f5ae75615e3b0cf03ee6/docs/csharp/language-reference/compiler-options/advanced.md) | [Advanced C# compiler options](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/advanced?branch=pr-en-us-36297) |


<!-- PREVIEW-TABLE-END -->