### PR TITLE
Fix GCTriggered event ID

### DIFF
--- a/docs/fundamentals/diagnostics/runtime-garbage-collection-events.md
+++ b/docs/fundamentals/diagnostics/runtime-garbage-collection-events.md
@@ -386,7 +386,7 @@ The following table shows the event information:
 
 |Event|Event ID|Raised when|
 |-----------|--------------|-----------------|
-|`GCTriggered`|33|A GC has been triggered.|
+|`GCTriggered`|35|A GC has been triggered.|
 
 The following table shows the event data:
 


### PR DESCRIPTION
The suggestion in #35175 seems correct based on https://github.com/dotnet/runtime/blob/6cd933a568f90842daec2f1f45389465b5e8c3a9/src/coreclr/nativeaot/Runtime/EtwEvents.h#L341.

Fixes #35175 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/diagnostics/runtime-garbage-collection-events.md](https://github.com/dotnet/docs/blob/c139a00c8622fc9d0138db3fed37605d72c50f72/docs/fundamentals/diagnostics/runtime-garbage-collection-events.md) | [.NET runtime garbage collection events](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/diagnostics/runtime-garbage-collection-events?branch=pr-en-us-36300) |

<!-- PREVIEW-TABLE-END -->