### PR TITLE
Remove the closing parenthesis without matching opening pair in comment

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs
@@ -228,7 +228,7 @@ namespace CsProgGuideTypes
                 // The following statement causes a compiler error: Operator
                 // '*' cannot be applied to operands of type 'object' and
                 // 'object'.
-                //sum += mixedList[j] * mixedList[j]);
+                //sum += mixedList[j] * mixedList[j];
 
                 // After the list elements are unboxed, the computation does
                 // not cause a compiler error.


### PR DESCRIPTION
## Summary

Removed closing parenthesis which didn't have an opening pair. If the line was uncommented, the program wouldn't build.