### PR TITLE
Fix RT_MANIFEST order in .rc file

### DIFF
--- a/docs/framework/interop/configure-net-framework-based-com-components-for-reg.md
+++ b/docs/framework/interop/configure-net-framework-based-com-components-for-reg.md
@@ -153,7 +153,7 @@ You can install an application manifest in the same directory as the COM applica
 
 1. Create a resource script that contains the following statement:
 
-     `RT_MANIFEST 1 myManagedComp.manifest`
+     `1 RT_MANIFEST myManagedComp.manifest`
 
      In this statement, `myManagedComp.manifest` is the name of the component manifest being embedded. For this example, the script file name is `myresource.rc`.
 


### PR DESCRIPTION
Fixes #36341 

Seems correct based on https://learn.microsoft.com/en-us/previous-versions/windows/desktop/ms775308(v=vs.85).

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/interop/configure-net-framework-based-com-components-for-reg.md](https://github.com/dotnet/docs/blob/2a8001a74eee3508783ecc869c7a568ed9e6d3c1/docs/framework/interop/configure-net-framework-based-com-components-for-reg.md) | [How to: Configure .NET Framework-Based COM Components for Registration-Free Activation](https://review.learn.microsoft.com/en-us/dotnet/framework/interop/configure-net-framework-based-com-components-for-reg?branch=pr-en-us-36343) |

<!-- PREVIEW-TABLE-END -->