### PR TITLE
dotnet install: Add arch options

### DIFF
--- a/docs/core/tools/dotnet-tool-install.md
+++ b/docs/core/tools/dotnet-tool-install.md
@@ -89,7 +89,7 @@ For more information, see [Install a local tool](global-tools.md#install-a-local
 
 - **`-a|--arch <ARCHITECTURE>`**
 
- Specifies the target architecture. This is a shorthand syntax for setting the [Runtime Identifier (RID)](../docs/core/rid-catalog.md), where the provided value is combined with the default RID. For example, on a `win-x64` machine, specifying `--arch x86` sets the RID to `win-x86`.
+  Specifies the target architecture. This is a shorthand syntax for setting the [Runtime Identifier (RID)](../docs/core/rid-catalog.md), where the provided value is combined with the default RID. For example, on a `win-x64` machine, specifying `--arch x86` sets the RID to `win-x86`.
 
 [!INCLUDE [add-source](../../../includes/cli-add-source.md)]
 

--- a/docs/core/tools/dotnet-tool-install.md
+++ b/docs/core/tools/dotnet-tool-install.md
@@ -1,7 +1,7 @@
 ---
 title: dotnet tool install command
 description: The dotnet tool install command installs the specified .NET tool on your machine.
-ms.date: 05/16/2023
+ms.date: 07/19/2023
 ---
 # dotnet tool install
 
@@ -15,6 +15,8 @@ ms.date: 05/16/2023
 
 ```dotnetcli
 dotnet tool install <PACKAGE_NAME> -g|--global
+    [-a|--arch <ARCHITECTURE>]
+    [--add-source <SOURCE>] [--configfile <FILE>] [--disable-parallel]
     [--add-source <SOURCE>] [--configfile <FILE>] [--disable-parallel]
     [--framework <FRAMEWORK>] [--ignore-failed-sources] [--interactive]
     [--no-cache] [--prerelease]
@@ -22,6 +24,7 @@ dotnet tool install <PACKAGE_NAME> -g|--global
     [--version <VERSION_NUMBER>]
 
 dotnet tool install <PACKAGE_NAME> --tool-path <PATH>
+    [-a|--arch <ARCHITECTURE>]
     [--add-source <SOURCE>] [--configfile <FILE>] [--disable-parallel]
     [--framework <FRAMEWORK>] [--ignore-failed-sources] [--interactive]
     [--no-cache] [--prerelease]
@@ -29,6 +32,7 @@ dotnet tool install <PACKAGE_NAME> --tool-path <PATH>
     [--version <VERSION_NUMBER>]
 
 dotnet tool install <PACKAGE_NAME> [--local]
+    [-a|--arch <ARCHITECTURE>]
     [--add-source <SOURCE>] [--configfile <FILE>]
     [--create-manifest-if-needed] [--disable-parallel]
     [--framework <FRAMEWORK>] [--ignore-failed-sources] [--interactive]
@@ -87,6 +91,10 @@ For more information, see [Install a local tool](global-tools.md#install-a-local
 [!INCLUDE [add-source](../../../includes/cli-add-source.md)]
 
 [!INCLUDE [configfile](../../../includes/cli-configfile.md)]
+
+- **`-a|--arch <ARCHITECTURE>`**
+
+Architecture of the .NET binaries to install. Possible values are <auto>, amd64, x64, x86, arm64, arm, s390x, and ppc64le. The default value is <auto>, which represents the currently running OS architecture.
 
 - **`--create-manifest-if-needed`**
 

--- a/docs/core/tools/dotnet-tool-install.md
+++ b/docs/core/tools/dotnet-tool-install.md
@@ -17,7 +17,6 @@ ms.date: 07/19/2023
 dotnet tool install <PACKAGE_NAME> -g|--global
     [-a|--arch <ARCHITECTURE>]
     [--add-source <SOURCE>] [--configfile <FILE>] [--disable-parallel]
-    [--add-source <SOURCE>] [--configfile <FILE>] [--disable-parallel]
     [--framework <FRAMEWORK>] [--ignore-failed-sources] [--interactive]
     [--no-cache] [--prerelease]
     [--tool-manifest <PATH>] [-v|--verbosity <LEVEL>]

--- a/docs/core/tools/dotnet-tool-install.md
+++ b/docs/core/tools/dotnet-tool-install.md
@@ -93,7 +93,7 @@ For more information, see [Install a local tool](global-tools.md#install-a-local
 
 - **`-a|--arch <ARCHITECTURE>`**
 
-Architecture of the .NET binaries to install. Possible values are <auto>, amd64, x64, x86, arm64, arm, s390x, and ppc64le. The default value is <auto>, which represents the currently running OS architecture.
+  Architecture of the .NET binaries to install. Possible values are `<auto>`, `amd64`, `x64`, `x86`, `arm64`, `arm`, `s390x`, and `ppc64le`. The default value is `<auto>`, which represents the currently running OS architecture.
 
 - **`--create-manifest-if-needed`**
 

--- a/docs/core/tools/dotnet-tool-install.md
+++ b/docs/core/tools/dotnet-tool-install.md
@@ -89,7 +89,7 @@ For more information, see [Install a local tool](global-tools.md#install-a-local
 
 - **`-a|--arch <ARCHITECTURE>`**
 
-  Architecture of the .NET binaries to install. Possible values are `<auto>`, `amd64`, `x64`, `x86`, `arm64`, `arm`, `s390x`, and `ppc64le`. The default value is `<auto>`, which represents the currently running OS architecture.
+ Specifies the target architecture. This is a shorthand syntax for setting the [Runtime Identifier (RID)](../docs/core/rid-catalog.md), where the provided value is combined with the default RID. For example, on a `win-x64` machine, specifying `--arch x86` sets the RID to `win-x86`.
 
 [!INCLUDE [add-source](../../../includes/cli-add-source.md)]
 

--- a/docs/core/tools/dotnet-tool-install.md
+++ b/docs/core/tools/dotnet-tool-install.md
@@ -89,7 +89,7 @@ For more information, see [Install a local tool](global-tools.md#install-a-local
 
 - **`-a|--arch <ARCHITECTURE>`**
 
-  Specifies the target architecture. This is a shorthand syntax for setting the [Runtime Identifier (RID)](../docs/core/rid-catalog.md), where the provided value is combined with the default RID. For example, on a `win-x64` machine, specifying `--arch x86` sets the RID to `win-x86`.
+  Specifies the target architecture. This is a shorthand syntax for setting the [Runtime Identifier (RID)](../../../docs/core/rid-catalog.md), where the provided value is combined with the default RID. For example, on a `win-x64` machine, specifying `--arch x86` sets the RID to `win-x86`.
 
 [!INCLUDE [add-source](../../../includes/cli-add-source.md)]
 

--- a/docs/core/tools/dotnet-tool-install.md
+++ b/docs/core/tools/dotnet-tool-install.md
@@ -87,13 +87,13 @@ For more information, see [Install a local tool](global-tools.md#install-a-local
 
 ## Options
 
-[!INCLUDE [add-source](../../../includes/cli-add-source.md)]
-
-[!INCLUDE [configfile](../../../includes/cli-configfile.md)]
-
 - **`-a|--arch <ARCHITECTURE>`**
 
   Architecture of the .NET binaries to install. Possible values are `<auto>`, `amd64`, `x64`, `x86`, `arm64`, `arm`, `s390x`, and `ppc64le`. The default value is `<auto>`, which represents the currently running OS architecture.
+
+[!INCLUDE [add-source](../../../includes/cli-add-source.md)]
+
+[!INCLUDE [configfile](../../../includes/cli-configfile.md)]
 
 - **`--create-manifest-if-needed`**
 


### PR DESCRIPTION
## Summary

Updating dotnet-tool-install.md to include architecture options `-a` and `--arch`

Fixes #36334 and contributes a first step required before this topic can be referenced in a fix for issue dotnet/AspNetCore.Docs#29262


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-tool-install.md](https://github.com/dotnet/docs/blob/39e0758c6aa20d2fa5e44f1b8af6fb54e01fcafd/docs/core/tools/dotnet-tool-install.md) | [dotnet tool install](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-install?branch=pr-en-us-36345) |


<!-- PREVIEW-TABLE-END -->