### PR TITLE
C# 11: explicitly mention dotnet version

### DIFF
--- a/docs/csharp/whats-new/csharp-11.md
+++ b/docs/csharp/whats-new/csharp-11.md
@@ -24,7 +24,9 @@ The following features were added in C# 11:
 - [Improved method group conversion to delegate](#improved-method-group-conversion-to-delegate)
 - [Warning wave 7](../language-reference/compiler-messages/warning-waves.md#cs8981---the-type-name-only-contains-lower-cased-ascii-characters)
 
-You can download the latest [Visual Studio 2022](https://visualstudio.microsoft.com/vs/). You can also try all these features with the .NET 7 SDK, which can be downloaded from the [.NET downloads](https://dotnet.microsoft.com/download/dotnet) page.
+C# 11 is supported on **.NET 7**. For more information, see [C# language versioning](../language-reference/configure-language-version.md).
+
+You can download the latest .NET 7 SDK from the [.NET downloads page](https://dotnet.microsoft.com/download). You can also download [Visual Studio 2022](https://visualstudio.microsoft.com/vs/), which includes the .NET 7 SDK.
 
 [!INCLUDE [released-version-feedback](./includes/released-feedback.md)]
 


### PR DESCRIPTION
Use the same template as the what's new pages for C# 9 and C# 10.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/whats-new/csharp-11.md](https://github.com/dotnet/docs/blob/10c9351e8be884d6459419a30da41c0abc881978/docs/csharp/whats-new/csharp-11.md) | [What's new in C# 11](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-11?branch=pr-en-us-36362) |

<!-- PREVIEW-TABLE-END -->