### PR TITLE
Remove FormattableString.Invariant example

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1305.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1305.md
@@ -94,19 +94,19 @@ You can configure these options for just this rule, for all rules it applies to,
 
 ## Example
 
-In the following code, the `example1` string violates rule CA1305. The `example2` string satisfies rule CA1305 by passing <xref:System.Globalization.CultureInfo.CurrentCulture%2A?displayProperty=nameWithType>, which implements <xref:System.IFormatProvider>, to <xref:System.String.Format(System.IFormatProvider,System.String,System.Object)?displayProperty=nameWithType>. The `example3` string satisfies rule CA1305 by passing an interpolated string to <xref:System.FormattableString.Invariant%2A?displayProperty=fullName]>.
+In the following code, the `example1` string violates rule CA1305. The `example2` string satisfies rule CA1305 by passing <xref:System.Globalization.CultureInfo.CurrentCulture%2A?displayProperty=nameWithType>, which implements <xref:System.IFormatProvider>, to <xref:System.String.Format(System.IFormatProvider,System.String,System.Object)?displayProperty=nameWithType>. The `example3` string satisfies rule CA1305 by passing an interpolated string to <xref:System.String.Create(System.IFormatProvider,System.Runtime.CompilerServices.DefaultInterpolatedStringHandler@)?displayProperty=nameWithType> along with <xref:System.Globalization.CultureInfo.InvariantCulture?displayProperty=nameWithType>.
 
 ```csharp
 string name = "Georgette";
 
 // Violates CA1305
-string example1 = String.Format("Hello {0}", name);
+string example1 = string.Format("Hello {0}", name);
 
 // Satisfies CA1305
-string example2 = String.Format(CultureInfo.CurrentCulture, "Hello {0}", name);
+string example2 = string.Format(CultureInfo.CurrentCulture, "Hello {0}", name);
 
 // Satisfies CA1305
-string example3 = FormattableString.Invariant($"Hello {name}");
+string example3 = string.Create(CultureInfo.InvariantCulture, $"Hello {name}");
 ```
 
 ## Related rules


### PR DESCRIPTION
Follow-up to #36256.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1305.md](https://github.com/dotnet/docs/blob/e412e19688f8663105330d17ac16d3d00d458865/docs/fundamentals/code-analysis/quality-rules/ca1305.md) | [CA1305: Specify IFormatProvider](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1305?branch=pr-en-us-36371) |

<!-- PREVIEW-TABLE-END -->