### PR TITLE
Update dotnet-trace.md with clreventlevel values

### DIFF
--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -98,6 +98,16 @@ dotnet-trace collect [--buffersize <size>] [--clreventlevel <clreventlevel>] [--
 - **`--clreventlevel <clreventlevel>`**
 
   Verbosity of CLR events to be emitted.
+  The table belows show the list of avaiable event levels:
+  
+  | String Value | Numberic Value |
+  | ------------ | ------------------- |
+  | `logalways` | `0` |
+  | `critical` | `1` |
+  | `error` | `2` |
+  | `warning` | `3` |
+  | `informational` | `4` |
+  | `verbose` | `5` |
 
 - **`--clrevents <clrevents>`**
 

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -100,7 +100,7 @@ dotnet-trace collect [--buffersize <size>] [--clreventlevel <clreventlevel>] [--
   Verbosity of CLR events to be emitted.
   The table belows show the list of avaiable event levels:
   
-  | String Value | Numberic Value |
+  | String value | Numeric value |
   | ------------ | ------------------- |
   | `logalways` | `0` |
   | `critical` | `1` |

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -100,14 +100,14 @@ dotnet-trace collect [--buffersize <size>] [--clreventlevel <clreventlevel>] [--
   Verbosity of CLR events to be emitted.
   The following table shows the available event levels.
   
-  | String value | Numeric value |
-  | ------------ | ------------------- |
-  | `logalways` | `0` |
-  | `critical` | `1` |
-  | `error` | `2` |
-  | `warning` | `3` |
-  | `informational` | `4` |
-  | `verbose` | `5` |
+  | String value    | Numeric value |
+  | --------------- | :-----------: |
+  | `logalways`     |      `0`      |
+  | `critical`      |      `1`      |
+  | `error`         |      `2`      |
+  | `warning`       |      `3`      |
+  | `informational` |      `4`      |
+  | `verbose`       |      `5`      |
 
 - **`--clrevents <clrevents>`**
 

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -98,7 +98,7 @@ dotnet-trace collect [--buffersize <size>] [--clreventlevel <clreventlevel>] [--
 - **`--clreventlevel <clreventlevel>`**
 
   Verbosity of CLR events to be emitted.
-  The table belows show the list of avaiable event levels:
+  The following table shows the available event levels.
   
   | String value | Numeric value |
   | ------------ | ------------------- |


### PR DESCRIPTION
## Summary

Adds a table to dotnet-trace-md with possible values for the `--clreventlevel <clreventlevel>` option.

Fixes #36129


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/dotnet-trace.md](https://github.com/dotnet/docs/blob/0c2267a0a84d1c9156c495423c6efbc908f68fdd/docs/core/diagnostics/dotnet-trace.md) | [dotnet-trace performance analysis utility](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-trace?branch=pr-en-us-36375) |


<!-- PREVIEW-TABLE-END -->