### PR TITLE
Provide `Perform inner joins` article with method-based syntax examples

### DIFF
--- a/docs/csharp/linq/perform-inner-joins.md
+++ b/docs/csharp/linq/perform-inner-joins.md
@@ -81,7 +81,7 @@ The same results can be achieved using <xref:System.Linq.Enumerable.GroupJoin%2A
 
 :::code language="csharp" source="../../../samples/snippets/csharp/concepts/linq/LinqSamples/InnerJoins.cs" id="inner_joins_method_syntax_4":::
 
-note that this approach requires chaining the query results with <xref:System.Linq.Enumerable.SelectMany%2A> which creates the final list of Owner - Pet relation based on the results of group join. To avoid chaining, the single <xref:System.Linq.Enumerable.Join%2A> method can be used as presented below:
+Note that this approach requires chaining the query results with <xref:System.Linq.Enumerable.SelectMany%2A> to create the final list of Owner - Pet relation based on the results of group join. To avoid chaining, the single <xref:System.Linq.Enumerable.Join%2A> method can be used as presented below:
 
 :::code language="csharp" source="../../../samples/snippets/csharp/concepts/linq/LinqSamples/InnerJoins.cs" id="inner_joins_method_syntax_5":::
 

--- a/docs/csharp/linq/perform-inner-joins.md
+++ b/docs/csharp/linq/perform-inner-joins.md
@@ -31,7 +31,7 @@ The following example creates two collections that contain objects of two user-d
 
 :::code language="csharp" source="../../../samples/snippets/csharp/concepts/linq/LinqSamples/InnerJoins.cs" id="inner_joins_1":::
 
-The same results can be achieved using the <xref:System.Linq.Enumerable.Join%2A> method syntax:
+You achieve the same results using the <xref:System.Linq.Enumerable.Join%2A> method syntax:
 
 :::code language="csharp" source="../../../samples/snippets/csharp/concepts/linq/LinqSamples/InnerJoins.cs" id="inner_joins_method_syntax_1":::
 
@@ -45,7 +45,7 @@ The following example uses a list of `Employee` objects and a list of `Student` 
 
 :::code language="csharp" source="../../../samples/snippets/csharp/concepts/linq/LinqSamples/InnerJoins.cs" id="inner_joins_2":::
 
-And when using the <xref:System.Linq.Enumerable.Join%2A> method, solution would be:
+You can use the <xref:System.Linq.Enumerable.Join%2A> method, as shown in the following example:
 
 :::code language="csharp" source="../../../samples/snippets/csharp/concepts/linq/LinqSamples/InnerJoins.cs" id="inner_joins_method_syntax_2":::
 

--- a/docs/csharp/linq/perform-inner-joins.md
+++ b/docs/csharp/linq/perform-inner-joins.md
@@ -31,6 +31,10 @@ The following example creates two collections that contain objects of two user-d
 
 :::code language="csharp" source="../../../samples/snippets/csharp/concepts/linq/LinqSamples/InnerJoins.cs" id="inner_joins_1":::
 
+The same results can be achieved using the <xref:System.Linq.Enumerable.Join%2A> method syntax:
+
+:::code language="csharp" source="../../../samples/snippets/csharp/concepts/linq/LinqSamples/InnerJoins.cs" id="inner_joins_method_syntax_1":::
+
 Note that the `Person` object whose `LastName` is "Huff" does not appear in the result set because there is no `Pet` object that has `Pet.Owner` equal to that `Person`.
 
 ## Example - Composite key join
@@ -40,6 +44,10 @@ Instead of correlating elements based on just one property, you can use a compos
 The following example uses a list of `Employee` objects and a list of `Student` objects to determine which employees are also students. Both of these types have a `FirstName` and a `LastName` property of type <xref:System.String>. The functions that create the join keys from each list's elements return an anonymous type that consists of the `FirstName` and `LastName` properties of each element. The join operation compares these composite keys for equality and returns pairs of objects from each list where both the first name and the last name match.
 
 :::code language="csharp" source="../../../samples/snippets/csharp/concepts/linq/LinqSamples/InnerJoins.cs" id="inner_joins_2":::
+
+And when using the <xref:System.Linq.Enumerable.Join%2A> method, solution would be:
+
+:::code language="csharp" source="../../../samples/snippets/csharp/concepts/linq/LinqSamples/InnerJoins.cs" id="inner_joins_method_syntax_2":::
 
 ## Example - Multiple join
 
@@ -53,6 +61,10 @@ The second `join` clause in C# correlates the anonymous types returned by the fi
 
 :::code language="csharp" source="../../../samples/snippets/csharp/concepts/linq/LinqSamples/InnerJoins.cs" id="inner_joins_3":::
 
+The equivalent using multiple <xref:System.Linq.Enumerable.Join%2A> method uses the same approach with the anonymous type (in the example below it's named `commonOwner`):
+
+:::code language="csharp" source="../../../samples/snippets/csharp/concepts/linq/LinqSamples/InnerJoins.cs" id="inner_joins_method_syntax_3":::
+
 ## Example - Inner join by using grouped join
 
 The following example shows you how to implement an inner join by using a group join.
@@ -64,6 +76,14 @@ By adding a second `from` clause to the query, this sequence of sequences is com
 The result of `query1` is equivalent to the result set that would have been obtained by using the `join` clause without the `into` clause to perform an inner join. The `query2` variable demonstrates this equivalent query.
 
 :::code language="csharp" source="../../../samples/snippets/csharp/concepts/linq/LinqSamples/InnerJoins.cs" id="inner_joins_4":::
+
+The same results can be achieved using <xref:System.Linq.Enumerable.GroupJoin%2A> method, as follows:
+
+:::code language="csharp" source="../../../samples/snippets/csharp/concepts/linq/LinqSamples/InnerJoins.cs" id="inner_joins_method_syntax_4":::
+
+note that this approach requires chaining the query results with <xref:System.Linq.Enumerable.SelectMany%2A> which creates the final list of Owner - Pet relation based on the results of group join. To avoid chaining, the single <xref:System.Linq.Enumerable.Join%2A> method can be used as presented below:
+
+:::code language="csharp" source="../../../samples/snippets/csharp/concepts/linq/LinqSamples/InnerJoins.cs" id="inner_joins_method_syntax_5":::
 
 ## See also
 

--- a/samples/snippets/csharp/concepts/linq/LinqSamples.Test/InnerJoinsTest.cs
+++ b/samples/snippets/csharp/concepts/linq/LinqSamples.Test/InnerJoinsTest.cs
@@ -8,50 +8,54 @@ public class InnerJoinsTest
     [Fact]
     public void BasicTest()
     {
-        var sw = InitTest();
-
-        InnerJoins.Basic();
-        Assert.Equal(
+        const string expectedOutput =
 @"""Daisy"" is owned by Magnus
 ""Barley"" is owned by Terry
 ""Boots"" is owned by Terry
 ""Whiskers"" is owned by Charlotte
 ""Blue Moon"" is owned by Rui
-", sw.ToString());
+";
+
+        var querySyntaxResult = InnerJoins.Basic();
+        Assert.Equal(expectedOutput, querySyntaxResult);
+
+        var methodSyntaxResult = InnerJoins.BasicMethodSyntax();
+        Assert.Equal(methodSyntaxResult, querySyntaxResult);
     }
 
     [Fact]
     public void CompositeKeyTest()
     {
-        var sw = InitTest();
-
-        InnerJoins.CompositeKey();
-        Assert.Equal(
+        const string expectedOutput =
 @"The following people are both employees and students:
 Terry Adams
 Vernette Price
-", sw.ToString());
+";
+        var querySyntaxResult = InnerJoins.CompositeKey();
+        Assert.Equal(expectedOutput, querySyntaxResult);
+
+        var methodSyntaxResult = InnerJoins.CompositeKeyMethodSyntax();
+        Assert.Equal(methodSyntaxResult, querySyntaxResult);
     }
 
     [Fact]
     public void MultipleJoinTest()
     {
-        var sw = InitTest();
-
-        InnerJoins.MultipleJoin();
-        Assert.Equal(
+        const string expectedOutput =
 @"The cat ""Daisy"" shares a house, and the first letter of their name, with ""Duke"".
 The cat ""Whiskers"" shares a house, and the first letter of their name, with ""Wiley"".
-", sw.ToString());
+";
+        var querySyntaxResult = InnerJoins.MultipleJoin();
+        Assert.Equal(expectedOutput, querySyntaxResult);
+
+        var methodSyntaxResult = InnerJoins.MultipleJoinMethodSyntax();
+        Assert.Equal(methodSyntaxResult, querySyntaxResult);
     }
 
     [Fact]
     public void InnerGroupJoinTest()
     {
-        var sw = InitTest();
-
-        InnerJoins.InnerGroupJoin();
-        Assert.Equal(
+        const string expectedOutput =
 @"Inner join using GroupJoin():
 Magnus - Daisy
 Terry - Barley
@@ -65,6 +69,11 @@ Terry - Barley
 Terry - Boots
 Terry - Blue Moon
 Charlotte - Whiskers
-", sw.ToString());
+";
+        var querySyntaxResult = InnerJoins.InnerGroupJoin();
+        Assert.Equal(expectedOutput, querySyntaxResult);
+
+        var methodSyntaxResult = InnerJoins.InnerGroupJoinMethodSyntax();
+        Assert.Equal(methodSyntaxResult, querySyntaxResult);
     }
 }

--- a/samples/snippets/csharp/concepts/linq/LinqSamples/InnerJoins.cs
+++ b/samples/snippets/csharp/concepts/linq/LinqSamples/InnerJoins.cs
@@ -2,7 +2,7 @@
 
 public static class InnerJoins
 {
-    public static void Basic()
+    public static string Basic()
     {
         // <inner_joins_1>
         Person magnus = new(FirstName: "Magnus", LastName: "Hedlund");
@@ -33,10 +33,13 @@ public static class InnerJoins
                 PetName = pet.Name
             };
 
+        string result = "";
         foreach (var ownerAndPet in query)
         {
-            Console.WriteLine($"\"{ownerAndPet.PetName}\" is owned by {ownerAndPet.OwnerName}");
+            result += $"\"{ownerAndPet.PetName}\" is owned by {ownerAndPet.OwnerName}\r\n";
         }
+        Console.Write(result);
+        return result;
 
         /* Output:
              "Daisy" is owned by Magnus
@@ -48,7 +51,7 @@ public static class InnerJoins
         // </inner_joins_1>
     }
 
-    public static void BasicMethodSyntax()
+    public static string BasicMethodSyntax()
     {
         Person magnus = new(FirstName: "Magnus", LastName: "Hedlund");
         Person terry = new("Terry", "Adams");
@@ -74,13 +77,16 @@ public static class InnerJoins
                         (person, pet) =>
                             new { OwnerName = person.FirstName, PetName = pet.Name });
 
+        string result = "";
         foreach (var ownerAndPet in query)
         {
-            Console.WriteLine($"\"{ownerAndPet.PetName}\" is owned by {ownerAndPet.OwnerName}");
+            result += $"\"{ownerAndPet.PetName}\" is owned by {ownerAndPet.OwnerName}\r\n";
         }
+        Console.Write(result);
+        return result;
     }
 
-    public static void CompositeKey()
+    public static string CompositeKey()
     {
         // <inner_joins_2>
         List<Employee> employees = new()
@@ -113,11 +119,14 @@ public static class InnerJoins
             }
             select employee.FirstName + " " + employee.LastName;
 
-        Console.WriteLine("The following people are both employees and students:");
+        string result = "";
+        result += "The following people are both employees and students:\r\n";
         foreach (string name in query)
         {
-            Console.WriteLine(name);
+            result += $"{name}\r\n";
         }
+        Console.Write(result);
+        return result;
 
         /* Output:
             The following people are both employees and students:
@@ -127,7 +136,7 @@ public static class InnerJoins
         // </inner_joins_2>
     }
 
-    public static void CompositeKeyMethodSyntax()
+    public static string CompositeKeyMethodSyntax()
     {
         List<Employee> employees = new()
         {
@@ -151,14 +160,17 @@ public static class InnerJoins
              (employee, student) => $"{employee.FirstName} {employee.LastName}"
          );
 
-        Console.WriteLine("The following people are both employees and students:");
+        string result = "";
+        result += "The following people are both employees and students:\r\n";
         foreach (string name in query)
         {
-            Console.WriteLine(name);
+            result += $"{name}\r\n";
         }
+        Console.Write(result);
+        return result;
     }
 
-    public static void MultipleJoin()
+    public static string MultipleJoin()
     {
         // <inner_joins_3>
         Person magnus = new(FirstName: "Magnus", LastName: "Hedlund");
@@ -210,10 +222,13 @@ public static class InnerJoins
                 DogName = dog.Name
             };
 
+        string result = "";
         foreach (var obj in query)
         {
-            Console.WriteLine($"The cat \"{obj.CatName}\" shares a house, and the first letter of their name, with \"{obj.DogName}\".");
+            result += $"The cat \"{obj.CatName}\" shares a house, and the first letter of their name, with \"{obj.DogName}\".\r\n";
         }
+        Console.Write(result);
+        return result;
 
         /* Output:
              The cat "Daisy" shares a house, and the first letter of their name, with "Duke".
@@ -222,7 +237,7 @@ public static class InnerJoins
         // </inner_joins_3>
     }
 
-    public static void MultipleJoinMethodSyntax()
+    public static string MultipleJoinMethodSyntax()
     {
         Person magnus = new(FirstName: "Magnus", LastName: "Hedlund");
         Person terry = new("Terry", "Adams");
@@ -261,13 +276,16 @@ public static class InnerJoins
                 dog => new { dog.Owner, Letter = dog.Name.Substring(0, 1) },
                 (commonOwner, dog) => new { CatName = commonOwner.cat.Name, DogName = dog.Name });
 
+        string result = "";
         foreach (var obj in query)
         {
-            Console.WriteLine($"The cat \"{obj.CatName}\" shares a house, and the first letter of their name, with \"{obj.DogName}\".");
+            result += $"The cat \"{obj.CatName}\" shares a house, and the first letter of their name, with \"{obj.DogName}\".\r\n";
         }
+        Console.Write(result);
+        return result;
     }
 
-    public static void InnerGroupJoin()
+    public static string InnerGroupJoin()
     {
         // <inner_joins_4>
         Person magnus = new(FirstName: "Magnus", LastName: "Hedlund");
@@ -296,10 +314,11 @@ public static class InnerJoins
                 PetName = subpet.Name
             };
 
-        Console.WriteLine("Inner join using GroupJoin():");
+        string result = "";
+        result += "Inner join using GroupJoin():\r\n";
         foreach (var v in query1)
         {
-            Console.WriteLine($"{v.OwnerName} - {v.PetName}");
+            result += $"{v.OwnerName} - {v.PetName}\r\n";
         }
 
         var query2 =
@@ -311,12 +330,13 @@ public static class InnerJoins
                 PetName = pet.Name
             };
 
-        Console.WriteLine();
-        Console.WriteLine("The equivalent operation using Join():");
+        result += "\r\nThe equivalent operation using Join():\r\n";
         foreach (var v in query2)
         {
-            Console.WriteLine($"{v.OwnerName} - {v.PetName}");
+            result += $"{v.OwnerName} - {v.PetName}\r\n";
         }
+        Console.Write(result);
+        return result;
 
         /* Output:
             Inner join using GroupJoin():
@@ -336,7 +356,7 @@ public static class InnerJoins
         // </inner_joins_4>
     }
 
-    public static void InnerGroupJoinMethodSyntax()
+    public static string InnerGroupJoinMethodSyntax()
     {
         Person magnus = new(FirstName: "Magnus", LastName: "Hedlund");
         Person terry = new("Terry", "Adams");
@@ -361,10 +381,11 @@ public static class InnerJoins
             .SelectMany(pet => pet.gj,
                 (groupJoinPet, subpet) => new { OwnerName = groupJoinPet.person.FirstName, PetName = subpet.Name });
 
-        Console.WriteLine("Inner join using GroupJoin():");
+        string result = "";
+        result += "Inner join using GroupJoin():\r\n";
         foreach (var v in query1)
         {
-            Console.WriteLine($"{v.OwnerName} - {v.PetName}");
+            result += $"{v.OwnerName} - {v.PetName}\r\n";
         }
 
         var query2 = people.Join(pets,
@@ -372,11 +393,12 @@ public static class InnerJoins
             pet => pet.Owner,
             (person, pet) => new { OwnerName = person.FirstName, PetName = pet.Name });
 
-        Console.WriteLine();
-        Console.WriteLine("The equivalent operation using Join():");
+        result += "\r\nThe equivalent operation using Join():\r\n";
         foreach (var v in query2)
         {
-            Console.WriteLine($"{v.OwnerName} - {v.PetName}");
+            result += $"{v.OwnerName} - {v.PetName}\r\n";
         }
+        Console.Write(result);
+        return result;
     }
 }

--- a/samples/snippets/csharp/concepts/linq/LinqSamples/InnerJoins.cs
+++ b/samples/snippets/csharp/concepts/linq/LinqSamples/InnerJoins.cs
@@ -48,6 +48,38 @@ public static class InnerJoins
         // </inner_joins_1>
     }
 
+    public static void BasicMethodSyntax()
+    {
+        Person magnus = new(FirstName: "Magnus", LastName: "Hedlund");
+        Person terry = new("Terry", "Adams");
+        Person charlotte = new("Charlotte", "Weiss");
+        Person arlene = new("Arlene", "Huff");
+        Person rui = new("Rui", "Raposo");
+
+        List<Person> people = new() { magnus, terry, charlotte, arlene, rui };
+
+        List<Pet> pets = new()
+        {
+            new(Name: "Barley", Owner: terry),
+            new("Boots", terry),
+            new("Whiskers", charlotte),
+            new("Blue Moon", rui),
+            new("Daisy", magnus),
+        };
+
+        var query =
+            people.Join(pets,
+                        person => person,
+                        pet => pet.Owner,
+                        (person, pet) =>
+                            new { OwnerName = person.FirstName, PetName = pet.Name });
+
+        foreach (var ownerAndPet in query)
+        {
+            Console.WriteLine($"\"{ownerAndPet.PetName}\" is owned by {ownerAndPet.OwnerName}");
+        }
+    }
+
     public static void CompositeKey()
     {
         // <inner_joins_2>
@@ -93,6 +125,37 @@ public static class InnerJoins
             Vernette Price
          */
         // </inner_joins_2>
+    }
+
+    public static void CompositeKeyMethodSyntax()
+    {
+        List<Employee> employees = new()
+        {
+            new(FirstName: "Terry", LastName: "Adams", EmployeeID: 522459),
+            new("Charlotte", "Weiss", 204467),
+            new("Magnus", "Hedland", 866200),
+            new("Vernette", "Price", 437139)
+        };
+
+        List<Student> students = new()
+        {
+            new(FirstName: "Vernette", LastName: "Price", StudentID: 9562),
+            new("Terry", "Earls", 9870),
+            new("Terry", "Adams", 9913)
+        };
+
+        var query = employees.Join(
+             students,
+             employee => new {FirstName = employee.FirstName, LastName = employee.LastName },
+             student => new { FirstName = student.FirstName, student.LastName },
+             (employee, student) => $"{employee.FirstName} {employee.LastName}"
+         );
+
+        Console.WriteLine("The following people are both employees and students:");
+        foreach (string name in query)
+        {
+            Console.WriteLine(name);
+        }
     }
 
     public static void MultipleJoin()
@@ -149,9 +212,7 @@ public static class InnerJoins
 
         foreach (var obj in query)
         {
-            Console.WriteLine(
-                $"The cat \"{obj.CatName}\" shares a house, and the first letter of their name, with \"{obj.DogName}\"."
-            );
+            Console.WriteLine($"The cat \"{obj.CatName}\" shares a house, and the first letter of their name, with \"{obj.DogName}\".");
         }
 
         /* Output:
@@ -159,6 +220,51 @@ public static class InnerJoins
              The cat "Whiskers" shares a house, and the first letter of their name, with "Wiley".
          */
         // </inner_joins_3>
+    }
+
+    public static void MultipleJoinMethodSyntax()
+    {
+        Person magnus = new(FirstName: "Magnus", LastName: "Hedlund");
+        Person terry = new("Terry", "Adams");
+        Person charlotte = new("Charlotte", "Weiss");
+        Person arlene = new("Arlene", "Huff");
+        Person rui = new("Rui", "Raposo");
+        Person phyllis = new("Phyllis", "Harris");
+
+        List<Person> people = new() { magnus, terry, charlotte, arlene, rui, phyllis };
+
+        List<Cat> cats = new()
+        {
+            new(Name: "Barley", Owner: terry),
+            new("Boots", terry),
+            new("Whiskers", charlotte),
+            new("Blue Moon", rui),
+            new("Daisy", magnus),
+        };
+
+        List<Dog> dogs = new()
+        {
+            new(Name: "Four Wheel Drive", Owner: phyllis),
+            new("Duke", magnus),
+            new("Denim", terry),
+            new("Wiley", charlotte),
+            new("Snoopy", rui),
+            new("Snickers", arlene),
+        };
+
+        var query = people.Join(cats,
+                person => person,
+                cat => cat.Owner,
+                (person, cat) => new { person, cat })
+            .Join(dogs,
+                commonOwner => new { Owner = commonOwner.person, Letter = commonOwner.cat.Name.Substring(0, 1) },
+                dog => new { dog.Owner, Letter = dog.Name.Substring(0, 1) },
+                (commonOwner, dog) => new { CatName = commonOwner.cat.Name, DogName = dog.Name });
+
+        foreach (var obj in query)
+        {
+            Console.WriteLine($"The cat \"{obj.CatName}\" shares a house, and the first letter of their name, with \"{obj.DogName}\".");
+        }
     }
 
     public static void InnerGroupJoin()
@@ -228,5 +334,49 @@ public static class InnerJoins
             Charlotte - Whiskers
         */
         // </inner_joins_4>
+    }
+
+    public static void InnerGroupJoinMethodSyntax()
+    {
+        Person magnus = new(FirstName: "Magnus", LastName: "Hedlund");
+        Person terry = new("Terry", "Adams");
+        Person charlotte = new("Charlotte", "Weiss");
+        Person arlene = new("Arlene", "Huff");
+
+        List<Person> people = new() { magnus, terry, charlotte, arlene };
+
+        List<Pet> pets = new()
+        {
+            new(Name: "Barley", Owner: terry),
+            new("Boots", terry),
+            new("Whiskers", charlotte),
+            new("Blue Moon", terry),
+            new("Daisy", magnus),
+        };
+
+        var query1 = people.GroupJoin(pets,
+                person => person,
+                pet => pet.Owner,
+                (person, gj) => new { person, gj })
+            .SelectMany(pet => pet.gj,
+                (groupJoinPet, subpet) => new { OwnerName = groupJoinPet.person.FirstName, PetName = subpet.Name });
+
+        Console.WriteLine("Inner join using GroupJoin():");
+        foreach (var v in query1)
+        {
+            Console.WriteLine($"{v.OwnerName} - {v.PetName}");
+        }
+
+        var query2 = people.Join(pets,
+            person => person,
+            pet => pet.Owner,
+            (person, pet) => new { OwnerName = person.FirstName, PetName = pet.Name });
+
+        Console.WriteLine();
+        Console.WriteLine("The equivalent operation using Join():");
+        foreach (var v in query2)
+        {
+            Console.WriteLine($"{v.OwnerName} - {v.PetName}");
+        }
     }
 }

--- a/samples/snippets/csharp/concepts/linq/LinqSamples/InnerJoins.cs
+++ b/samples/snippets/csharp/concepts/linq/LinqSamples/InnerJoins.cs
@@ -70,12 +70,14 @@ public static class InnerJoins
             new("Daisy", magnus),
         };
 
+        // <inner_joins_method_syntax_1>
         var query =
             people.Join(pets,
                         person => person,
                         pet => pet.Owner,
                         (person, pet) =>
                             new { OwnerName = person.FirstName, PetName = pet.Name });
+        // </inner_joins_method_syntax_1>
 
         string result = "";
         foreach (var ownerAndPet in query)
@@ -153,12 +155,14 @@ public static class InnerJoins
             new("Terry", "Adams", 9913)
         };
 
+        // <inner_joins_method_syntax_2>
         var query = employees.Join(
              students,
              employee => new {FirstName = employee.FirstName, LastName = employee.LastName },
              student => new { FirstName = student.FirstName, student.LastName },
              (employee, student) => $"{employee.FirstName} {employee.LastName}"
          );
+        // </inner_joins_method_syntax_2>
 
         string result = "";
         result += "The following people are both employees and students:\r\n";
@@ -267,6 +271,7 @@ public static class InnerJoins
             new("Snickers", arlene),
         };
 
+        // <inner_joins_method_syntax_3>
         var query = people.Join(cats,
                 person => person,
                 cat => cat.Owner,
@@ -275,6 +280,7 @@ public static class InnerJoins
                 commonOwner => new { Owner = commonOwner.person, Letter = commonOwner.cat.Name.Substring(0, 1) },
                 dog => new { dog.Owner, Letter = dog.Name.Substring(0, 1) },
                 (commonOwner, dog) => new { CatName = commonOwner.cat.Name, DogName = dog.Name });
+        // </inner_joins_method_syntax_3>
 
         string result = "";
         foreach (var obj in query)
@@ -374,12 +380,14 @@ public static class InnerJoins
             new("Daisy", magnus),
         };
 
+        // <inner_joins_method_syntax_4>
         var query1 = people.GroupJoin(pets,
                 person => person,
                 pet => pet.Owner,
                 (person, gj) => new { person, gj })
             .SelectMany(pet => pet.gj,
                 (groupJoinPet, subpet) => new { OwnerName = groupJoinPet.person.FirstName, PetName = subpet.Name });
+        // </inner_joins_method_syntax_4>
 
         string result = "";
         result += "Inner join using GroupJoin():\r\n";
@@ -388,10 +396,12 @@ public static class InnerJoins
             result += $"{v.OwnerName} - {v.PetName}\r\n";
         }
 
+        // <inner_joins_method_syntax_5>
         var query2 = people.Join(pets,
             person => person,
             pet => pet.Owner,
             (person, pet) => new { OwnerName = person.FirstName, PetName = pet.Name });
+        // </inner_joins_method_syntax_5>
 
         result += "\r\nThe equivalent operation using Join():\r\n";
         foreach (var v in query2)

--- a/samples/snippets/csharp/concepts/linq/LinqSamples/Program.cs
+++ b/samples/snippets/csharp/concepts/linq/LinqSamples/Program.cs
@@ -54,9 +54,13 @@ RuntimeFiltering.RuntimeFiltering1();
 RuntimeFiltering.RuntimeFiltering2();
 
 InnerJoins.Basic();
+InnerJoins.BasicMethodSyntax();
 InnerJoins.CompositeKey();
+InnerJoins.CompositeKeyMethodSyntax();
 InnerJoins.MultipleJoin();
+InnerJoins.MultipleJoinMethodSyntax();
 InnerJoins.InnerGroupJoin();
+InnerJoins.InnerGroupJoinMethodSyntax();
 
 GroupJoins.GroupJoin1();
 GroupJoins.GroupJoinXml();


### PR DESCRIPTION
This pull request closes #31958
It adds examples of how to achieve each query with the `Join` method approach.

---

**Why creating separate methods?**
Adding the examples of method-based syntax in existing methods would not be possible because `inner_joins_method_syntax_2` tags/ids would conflict with existing `inner_joins_2` tags, which would not be possible to link and present them separately in the article. I also targeted for better readability of the whole article by not presenting the example of method-syntax in the same code snippet as the query-syntax, but as a separate paragraph.

**Why changing the return type of all methods?**
My goal was to make 100% sure the examples of method-syntax will give the exact same results as query-syntax implementation. So I wanted to cover new methods with unit tests.
However, it turns out that `InitTest` captures the console output as a single string for each test - so when invoking both (e.g.) `InnerGroupJoin` and `InnerGroupJoinMethodSyntax` methods in the same test the console output captured by `sw` would be a single string with both outputs.
So to avoid capturing combined outputs and implementing hacky division, I decided to go with directly returning the results of query.
Note that this does not affect the console outputs.

**Why removing `sw` usage from the tests?**
Basically the reasoning is explained in previous question ⬆️

**Is there no explanation regarding the presented method-syntax queries?**
Looking at the existing explanations of query-syntax examples I found them to be almost 100% match for the method-syntax as well. So in most cases I decided to stick with existing descriptions finding them sufficient.

**Aren't new methods `(...)MethodSyntax` breaking DRY?**
Yes, they are. Unfortunately each method has it's setup implemented where lists of datasets are created. For every query-syntax method the method-syntax one uses the exact same datasets. I couldn't extract those into separate methods (like for example: `CompositeKeyDatasets()`) because I wanted to keep the datasets creation implementation as an integral part of already existing examples for query-syntax.
Also I decided that after changing the return types, and unit tests refactors, I should somehow reduce the further refactoring to minimize the scope of this pull request.

---

The changes were tested by extended unit tests, and manually by launching the *.\LinqSamples.sln* solution and comparing the console outputs of each method and query.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/linq/perform-inner-joins.md](https://github.com/dotnet/docs/blob/cf4b27a13f43e2add06d16b6208a371666fbefc7/docs/csharp/linq/perform-inner-joins.md) | [Perform inner joins](https://review.learn.microsoft.com/en-us/dotnet/csharp/linq/perform-inner-joins?branch=pr-en-us-36376) |


<!-- PREVIEW-TABLE-END -->