### PR TITLE
Cross-link sections about patterns and operators precedence

### DIFF
--- a/docs/csharp/language-reference/operators/index.md
+++ b/docs/csharp/language-reference/operators/index.md
@@ -88,6 +88,8 @@ The following table lists the C# operators starting with the highest precedence 
 | [c ? t : f](conditional-operator.md) | Conditional operator |
 | [x = y](assignment-operator.md), [x += y](arithmetic-operators.md#compound-assignment), [x -= y](arithmetic-operators.md#compound-assignment), [x *= y](arithmetic-operators.md#compound-assignment), [x /= y](arithmetic-operators.md#compound-assignment), [x %= y](arithmetic-operators.md#compound-assignment), [x &= y](boolean-logical-operators.md#compound-assignment), [x &#124;= y](boolean-logical-operators.md#compound-assignment), [x ^= y](boolean-logical-operators.md#compound-assignment), [x <<= y](bitwise-and-shift-operators.md#compound-assignment), [x >>= y](bitwise-and-shift-operators.md#compound-assignment), [x >>>= y](bitwise-and-shift-operators.md#compound-assignment), [x ??= y](null-coalescing-operator.md), [=>](lambda-operator.md) | Assignment and lambda declaration |
 
+For information about the precedence of [logical pattern combinators](patterns.md#logical-patterns), see the [Precedence and order of checking of logical patterns](patterns.md#precedence-and-order-of-checking) section of the [Patterns](patterns.md) article.
+
 ## Operator associativity
 
 When operators have the same precedence, associativity of the operators determines the order in which the operations are performed:

--- a/docs/csharp/language-reference/operators/patterns.md
+++ b/docs/csharp/language-reference/operators/patterns.md
@@ -145,13 +145,13 @@ As the preceding example shows, you can repeatedly use the pattern combinators i
 
 ### Precedence and order of checking
 
-When a logical pattern is a pattern of an `is` expression, the precedence of logical pattern combinators is **higher** than the precedence of logical operators. Otherwise, the precedence of logical pattern combinators is **lower** than the precedence of logical and conditional logical operators.
-
-The pattern combinators are ordered from the highest precedence to the lowest as shown in the following list:
+The pattern combinators are ordered from the highest precedence to the lowest as follows:
 
 - `not`
 - `and`
 - `or`
+
+When a logical pattern is a pattern of an `is` expression, the precedence of logical pattern combinators is **higher** than the precedence of logical operators (both [bitwise logical](bitwise-and-shift-operators.md) and [Boolean logical](boolean-logical-operators.md) operators). Otherwise, the precedence of logical pattern combinators is **lower** than the precedence of logical and conditional logical operators. For the complete list of C# operators ordered by precedence level, see the [Operator precedence](index.md#operator-precedence) section of the [C# operators](index.md) article.
 
 To explicitly specify the precedence, use parentheses, as the following example shows:
 


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/index.md](https://github.com/dotnet/docs/blob/d4217fc03a4d31226c07d5c0e85a052de0347c5f/docs/csharp/language-reference/operators/index.md) | [C# operators and expressions](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/index?branch=pr-en-us-36385) |
| [docs/csharp/language-reference/operators/patterns.md](https://github.com/dotnet/docs/blob/d4217fc03a4d31226c07d5c0e85a052de0347c5f/docs/csharp/language-reference/operators/patterns.md) | [Pattern matching - the `is` and `switch` expressions, and operators `and`, `or` and `not` in patterns](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/patterns?branch=pr-en-us-36385) |

<!-- PREVIEW-TABLE-END -->