### PR TITLE
Update tour.md due to "Try F# in Fable" link leads to a non-functioni…

### DIFF
--- a/docs/fsharp/tour.md
+++ b/docs/fsharp/tour.md
@@ -11,7 +11,7 @@ There are two primary concepts in F#: functions and types. This tour emphasizes 
 
 ## Executing the code online
 
-If you don't have F# installed on your machine, you can execute all of the samples in your browser with [Try F# in Fable](https://fable.io/repl3/). Fable is a dialect of F# that executes directly in your browser. To view the samples that follow in the REPL, check out **Samples > Learn > Tour of F#** in the left-hand menu bar of the Fable REPL.
+If you don't have F# installed on your machine, you can execute all of the samples in your browser with [Try F# in Fable](https://fable.io/repl/). Fable is a dialect of F# that executes directly in your browser. To view the samples that follow in the REPL, check out **Samples > Learn > Tour of F#** in the left-hand menu bar of the Fable REPL.
 
 ## Functions and Modules
 


### PR DESCRIPTION
…ng playground

Changed the link to direct users to the working playground as shown in fable.io homepage

## Summary

Simply removed the 3 in the Fable link to direct users to a working playground. 
The current link leads to an identical playground, but there are errors with the playground that prevents code from running.

## Error messages in Console

```
[FABLE WORKER] Cannot decode: Error at: `$`
The following `failure` occurred with the decoder: Expected 3 union fields but got 2
```

```
workbox-d9851aed.js:1 Uncaught (in promise) bad-precaching-response: bad-precaching-response :: [{"url":"https://fable.io/repl3/js/repl/fable-library/.fable/compiler_info.txt","status":404}]
    at y.u (https://fable.io/repl3/workbox-d9851aed.js:1:5420)
    at async Promise.all (index 1)
    at async y.install (https://fable.io/repl3/workbox-d9851aed.js:1:4833)
```

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/tour.md](https://github.com/dotnet/docs/blob/f7a9c8f8f967e4052f8bf8f31f64c274100ef5b2/docs/fsharp/tour.md) | [Tour of F\#](https://review.learn.microsoft.com/en-us/dotnet/fsharp/tour?branch=pr-en-us-36388) |

<!-- PREVIEW-TABLE-END -->