### PR TITLE
dotnet tool install: add arch option

### DIFF
--- a/docs/core/tools/global-tools-how-to-use.md
+++ b/docs/core/tools/global-tools-how-to-use.md
@@ -28,14 +28,14 @@ This tutorial teaches you how to install and use a global tool. You use a tool t
 
    The `--add-source` parameter tells the .NET CLI to temporarily use the *./nupkg* directory as an additional source feed for NuGet packages. You gave your package a unique name to make sure that it will only be found in the *./nupkg* directory, not on the Nuget.org site.
 
-   [!INCLUDE[](~/includes/dotnet-tool-install-arch-options.md)]
-
    The output shows the command used to call the tool and the version installed:
 
    ```console
    You can invoke the tool using the following command: botsay
    Tool 'microsoft.botsay' (version '1.0.0') was successfully installed.
    ```
+
+   [!INCLUDE[](~/includes/dotnet-tool-install-arch-options.md)]
 
 1. Invoke the tool:
 

--- a/docs/core/tools/global-tools-how-to-use.md
+++ b/docs/core/tools/global-tools-how-to-use.md
@@ -2,7 +2,7 @@
 title: "Tutorial: Install and use a .NET global tool"
 description: Learn how to install and use a .NET tool as a global tool.
 ms.topic: tutorial
-ms.date: 02/12/2020
+ms.date: 07/25/2023
 recommendations: false
 ---
 
@@ -27,6 +27,8 @@ This tutorial teaches you how to install and use a global tool. You use a tool t
    The `--global` parameter tells the .NET CLI to install the tool binaries in a default location that is automatically added to the PATH environment variable.
 
    The `--add-source` parameter tells the .NET CLI to temporarily use the *./nupkg* directory as an additional source feed for NuGet packages. You gave your package a unique name to make sure that it will only be found in the *./nupkg* directory, not on the Nuget.org site.
+
+   [!INCLUDE[](~/includes/dotnet-tool-install-arch-options.md)]
 
    The output shows the command used to call the tool and the version installed:
 

--- a/docs/core/tools/global-tools.md
+++ b/docs/core/tools/global-tools.md
@@ -3,7 +3,7 @@ title: .NET tools
 description: How to install, use, update, and remove .NET tools. Covers global tools, tool-path tools, and local tools. 
 author: KathleenDollard
 ms.topic: how-to
-ms.date: 08/10/2022
+ms.date: 07/25/2023
 ms.custom: devdivchpfy22
 ---
 # How to manage .NET tools
@@ -53,6 +53,8 @@ To install a tool as a global tool, use the `-g` or `--global` option of [dotnet
 ```dotnetcli
 dotnet tool install -g dotnetsay
 ```
+
+[!INCLUDE[](~/includes/dotnet-tool-install-arch-options.md)]
 
 The output shows the command used to invoke the tool and the version installed, similar to the following example:
 

--- a/docs/core/tools/global-tools.md
+++ b/docs/core/tools/global-tools.md
@@ -54,14 +54,14 @@ To install a tool as a global tool, use the `-g` or `--global` option of [dotnet
 dotnet tool install -g dotnetsay
 ```
 
-[!INCLUDE[](~/includes/dotnet-tool-install-arch-options.md)]
-
 The output shows the command used to invoke the tool and the version installed, similar to the following example:
 
 ```output
 You can invoke the tool using the following command: dotnetsay
 Tool 'dotnetsay' (version '2.1.4') was successfully installed.
 ```
+
+[!INCLUDE[](~/includes/dotnet-tool-install-arch-options.md)]
 
 The default location for a tool's binaries depends on the operating system:
 

--- a/includes/dotnet-tool-install-arch-options.md
+++ b/includes/dotnet-tool-install-arch-options.md
@@ -1,2 +1,2 @@
 > [!NOTE]
-> By default the architecture of the .NET binaries to install represents the currently running OS architecture. To specify a different OS architecture, see [dotnet tool install, --arch option](../docs/core/tools/dotnet-tool-install#options).
+> By default the architecture of the .NET binaries to install represents the currently running OS architecture. To specify a different OS architecture, see [dotnet tool install, --arch option](../docs/core/tools/dotnet-tool-install.md#options).

--- a/includes/dotnet-tool-install-arch-options.md
+++ b/includes/dotnet-tool-install-arch-options.md
@@ -1,0 +1,2 @@
+> [!NOTE]
+> By default the architecture of the .NET binaries to install represents the currently running OS architecture. To specify a different OS architecture, see [dotnet tool install, --arch option](dotnet/core/tools/dotnet-tool-install#options).

--- a/includes/dotnet-tool-install-arch-options.md
+++ b/includes/dotnet-tool-install-arch-options.md
@@ -1,2 +1,2 @@
 > [!NOTE]
-> By default the architecture of the .NET binaries to install represents the currently running OS architecture. To specify a different OS architecture, see [dotnet tool install, --arch option](dotnet/core/tools/dotnet-tool-install#options).
+> By default the architecture of the .NET binaries to install represents the currently running OS architecture. To specify a different OS architecture, see [dotnet tool install, --arch option](../docs/core/tools/dotnet-tool-install#options).


### PR DESCRIPTION
## Summary

- Adding a note mentioning the architecture options for dotnet tool install
- Created a new include file for the note & link.

Fixes #36393

Related to issue #dotnet/AspNetCore.Docs#29262


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/global-tools-how-to-use.md](https://github.com/dotnet/docs/blob/1f6f6f3d32ba916fe21953970b4552e0b469acf7/docs/core/tools/global-tools-how-to-use.md) | [Tutorial: Install and use a .NET global tool using the .NET CLI](https://review.learn.microsoft.com/en-us/dotnet/core/tools/global-tools-how-to-use?branch=pr-en-us-36395) |
| [docs/core/tools/global-tools.md](https://github.com/dotnet/docs/blob/1f6f6f3d32ba916fe21953970b4552e0b469acf7/docs/core/tools/global-tools.md) | [.NET tools](https://review.learn.microsoft.com/en-us/dotnet/core/tools/global-tools?branch=pr-en-us-36395) |


<!-- PREVIEW-TABLE-END -->