### PR TITLE
Update prepare-libraries-for-trimming.md

### DIFF
--- a/docs/core/deploying/trimming/prepare-libraries-for-trimming.md
+++ b/docs/core/deploying/trimming/prepare-libraries-for-trimming.md
@@ -141,8 +141,8 @@ public class MyLibrary
 {
     public static void Method()
     {
-        // warning IL2026 : MyLibrary.Method: Using method 'MyLibrary.DynamicBehavior' which has
-        // 'RequiresUnreferencedCodeAttribute' can break functionality
+        // warning IL2026 : MyLibrary.Method: Using method 'MyLibrary.DynamicBehavior'
+        //  which has 'RequiresUnreferencedCodeAttribute' can break functionality
         // when trimming application code.
         DynamicBehavior();
     }

--- a/docs/core/deploying/trimming/prepare-libraries-for-trimming.md
+++ b/docs/core/deploying/trimming/prepare-libraries-for-trimming.md
@@ -50,9 +50,9 @@ To create your sample app, first create a separate console application project w
 - If your app targets .NET 7, [the new default behavior](../../../core/compatibility/deployment/7.0/trim-all-assemblies.md) is what you want, but you can enforce the behavior by adding `<TrimMode>full</TrimMode>` in a `<PropertyGroup>` tag.
   - This ensures that the trimmer only analyzes the parts of the library's dependencies that are used. It tells the trimmer that any code that isn't part of a "root" can be trimmed if it's unused. Without this option, you would see warnings originating from _any_ part of a dependency that doesn't set `[AssemblyMetadata("IsTrimmable", "True")]`, including parts that are unused by your library.
 
-### [.NET 6](#tab/net6)
+##### .csproj file
 
-##### .NET 6 .csproj
+### [.NET 6](#tab/net6)
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
@@ -76,8 +76,6 @@ To create your sample app, first create a separate console application project w
 ```
 
 ### [.NET 7](#tab/net7)
-
-##### .NET 7 .csproj
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">

--- a/docs/core/deploying/trimming/prepare-libraries-for-trimming.md
+++ b/docs/core/deploying/trimming/prepare-libraries-for-trimming.md
@@ -50,6 +50,8 @@ To create your sample app, first create a separate console application project w
 - If your app targets .NET 7, [the new default behavior](../../../core/compatibility/deployment/7.0/trim-all-assemblies.md) is what you want, but you can enforce the behavior by adding `<TrimMode>full</TrimMode>` in a `<PropertyGroup>` tag.
   - This ensures that the trimmer only analyzes the parts of the library's dependencies that are used. It tells the trimmer that any code that isn't part of a "root" can be trimmed if it's unused. Without this option, you would see warnings originating from _any_ part of a dependency that doesn't set `[AssemblyMetadata("IsTrimmable", "True")]`, including parts that are unused by your library.
 
+### [.NET 6](#tab/net6)
+
 ##### .NET 6 .csproj
 
 ```xml
@@ -73,6 +75,8 @@ To create your sample app, first create a separate console application project w
 </Project>
 ```
 
+### [.NET 7](#tab/net7)
+
 ##### .NET 7 .csproj
 
 ```xml
@@ -92,6 +96,28 @@ To create your sample app, first create a separate console application project w
 
 </Project>
 ```
+
+### [.NET 8+](#tab/net8plus)
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <PublishTrimmed>true</PublishTrimmed>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="path/to/MyLibrary.csproj" />
+    <!-- Analyze the whole library -->
+    <TrimmerRootAssembly Include="MyLibrary" />
+  </ItemGroup>
+
+</Project>
+```
+
+---
 
 Once your project file is updated, run `dotnet publish` with the [runtime identifier (RID)](../../rid-catalog.md) you want to target.
 

--- a/docs/core/deploying/trimming/prepare-libraries-for-trimming.md
+++ b/docs/core/deploying/trimming/prepare-libraries-for-trimming.md
@@ -178,8 +178,10 @@ public class MyLibrary
     static void UseMethods(Type type)
     {
         // warning IL2070: MyLibrary.UseMethods(Type): 'this' argument does not satisfy
-        // 'DynamicallyAccessedMemberTypes.PublicMethods' in call to 'System.Type.GetMethods()'.
-        // The parameter 't' of method 'MyLibrary.UseMethods(Type)' does not have matching annotations.
+        // 'DynamicallyAccessedMemberTypes.PublicMethods' in call to
+        // 'System.Type.GetMethods()'.
+        // The parameter 't' of method 'MyLibrary.UseMethods(Type)' doesn't have
+        // matching annotations.
         foreach (var method in type.GetMethods())
         {
             // ...
@@ -210,7 +212,8 @@ static Type type;
 static void UseMethodsHelper()
 {
     // warning IL2077: MyLibrary.UseMethodsHelper(Type): 'type' argument does not satisfy
-    // 'DynamicallyAccessedMemberTypes.PublicMethods' in call to 'MyLibrary.UseMethods(Type)'.
+    // 'DynamicallyAccessedMemberTypes.PublicMethods' in call to
+    // 'MyLibrary.UseMethods(Type)'.
     // The field 'System.Type MyLibrary::type' does not have matching annotations.
     UseMethods(type);
 }


### PR DESCRIPTION
Update to .NET 8

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/deploying/trimming/prepare-libraries-for-trimming.md](https://github.com/dotnet/docs/blob/d021b9de7f9a88eed90ea1240f99f1ee7a3ad55f/docs/core/deploying/trimming/prepare-libraries-for-trimming.md) | [Prepare .NET libraries for trimming](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/prepare-libraries-for-trimming?branch=pr-en-us-36414) |


<!-- PREVIEW-TABLE-END -->