### PR TITLE
Update coding guidelines

### DIFF
--- a/docs/csharp/fundamentals/coding-style/coding-conventions.md
+++ b/docs/csharp/fundamentals/coding-style/coding-conventions.md
@@ -9,7 +9,7 @@ helpviewer_keyword:
 ---
 # Common C# code conventions
 
-A code standard is essential for maintaining code readability, consistency, and collaboration within a development team. Following industry practices and established guidelines helps ensure that code is easier to understand, maintain, and extend. Most projects enforce a consistent style through code conventions. The [`dotnet/docs`](https//github.com/dotnet/docs) and [`dotnet/samples`](https://github.com/dotnet/samples) projects are no exception. In this series of articles, you learn our coding conventions and the tools we use to enforce them. You can take our conventions as-is, or modify them to suit your team.
+A code standard is essential for maintaining code readability, consistency, and collaboration within a development team. Following industry practices and established guidelines helps ensure that code is easier to understand, maintain, and extend. Most projects enforce a consistent style through code conventions. The [`dotnet/docs`](https://github.com/dotnet/docs) and [`dotnet/samples`](https://github.com/dotnet/samples) projects are no exception. In this series of articles, you learn our coding conventions and the tools we use to enforce them. You can take our conventions as-is, or modify them to suit your team.
 
 We chose our conventions based on the following goals:
 
@@ -27,7 +27,7 @@ This article explains our guidelines. The guidelines have evolved over time, and
 
 ## Tools and analyzers
 
-Tools can help your team enforce your standards. You can enable any of the [Code analysis tools](../../../fundamentals/code-analysis/overview.md) to enforce the rules you prefer. You can also create an [editorconfig](~/visualstudio/ide/create-portable-custom-editor-options.md) so that Visual Studio automatically enforces your style guidelines. You can start by using [the dotnet/docs](https://github.com/dotnet/docs/blob/main/.editorconfig) to use our style as a starting point.
+Tools can help your team enforce your standards. You can enable any of the [Code analysis tools](../../../fundamentals/code-analysis/overview.md) to enforce the rules you prefer. You can also create an [editorconfig](/visualstudio/ide/create-portable-custom-editor-options) so that Visual Studio automatically enforces your style guidelines. You can start by using [the dotnet/docs](https://github.com/dotnet/docs/blob/main/.editorconfig) to use our style as a starting point.
 
 These tools make it easier for your team to adopt your preferred guidelines. Visual Studio applies the rules in all `.editorconfig` files in scope to format your code. You can use multiple rule sets to enforce corporate-wide standards, team standards, and even granular project standards.
 

--- a/docs/csharp/fundamentals/coding-style/coding-conventions.md
+++ b/docs/csharp/fundamentals/coding-style/coding-conventions.md
@@ -1,98 +1,96 @@
 ---
 title: ".NET documentation C# Coding Conventions"
 description: Learn about commonly used coding conventions in C#. Coding conventions create a consistent look to the code and facilitate copying, changing, and maintaining the code. This article also includes the docs repo coding guidelines
-ms.date: 07/24/2023
+ms.date: 07/27/2023
 helpviewer_keyword:
   - "coding conventions, C#"
   - "Visual C#, coding conventions"
   - "C# language, coding conventions"
 ---
+# Common C# code conventions
 
-# Common C# coding conventions
+A code standard is essential for maintaining code readability, consistency, and collaboration within a development team. Following industry practices and established guidelines helps ensure that code is easier to understand, maintain, and extend. Most projects enforce a consistent style through code conventions. The [`dotnet/docs`](https//github.com/dotnet/docs) and [`dotnet/samples`](https://github.com/dotnet/samples) projects are no exception. In this series of articles, you learn our coding conventions and the tools we use to enforce them. You can take our conventions as-is, or modify them to suit your team.
+
+We chose our conventions based on the following goals:
+
+1. *Correctness*: Our samples are copied and pasted into your applications. We expect that, so we need to make code that's resilient and correct, even after multiple edits.
+1. *Teaching*: The purpose of our samples is to teach all of .NET and C#. For that reason, we don't place restrictions on any language feature or API. Instead, those samples teach when a feature is a good choice.
+1. *Consistency*: Readers expect a consistent experience across our content. All samples should conform to the same style.
+1. *Adoption*: We aggressively update our samples to use new language features. That practice raises awareness of new features, and makes them more familiar to all C# developers.
 
 > [!IMPORTANT]
-> The guidelines in this article are used by Microsoft to develop samples and documentation. They were adopted from the [.NET Runtime, C# Coding Style](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/coding-style.md) guidelines. You can use them, or adapt them to your needs. They are meant to be an example of common C# conventions, and not an authoritative list (see [Framework Design Guidelines](../../../standard/design-guidelines/index.md) for that). The primary objectives are consistency and readability within your project, team, organization, or company source code.
+> These guidelines are used by Microsoft to develop samples and documentation. They were adopted from the [.NET Runtime, C# Coding Style](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/coding-style.md) and [C# compiler (roslyn)](https://github.com/dotnet/roslyn/blob/main/CONTRIBUTING.md#csharp) guidelines. We chose those guidelines because they have been tested over several years of Open Source development. They've helped community members participate in the runtime and compiler projects. They are meant to be an example of common C# conventions, and not an authoritative list (see [Framework Design Guidelines](../../../standard/design-guidelines/index.md) for that).
+>
+> The *teaching* and *adoption* goals are why the docs coding convention differs from the runtime and compiler conventions. Both the runtime and compiler have strict performance metrics for hot paths. Many other applications don't. Our *teaching* goal mandates that we don't prohibit any construct. Instead, samples show when constructs should be used. We update samples more aggressively than most production applications do. Our *adoption* goal mandates that we show code you should write today, even when code written last year doesn't need changes.
+
+This article explains our guidelines. The guidelines have evolved over time, and you'll find samples that don't follow our guidelines. We welcome PRs that bring those samples into compliance, or issues that draw our attention to samples we should update. Our guidelines are Open Source and we welcome PRs and issues. However, if your submission would change these recommendations, open an issue for discussion first. You're welcome to use our guidelines, or adapt them to your needs.
+
+## Tools and analyzers
+
+Tools can help your team enforce your standards. You can enable any of the [Code analysis tools](../../../fundamentals/code-analysis/overview.md) to enforce the rules you prefer. You can also create an [editorconfig](~/visualstudio/ide/create-portable-custom-editor-options.md) so that Visual Studio automatically enforces your style guidelines. You can start by using [the dotnet/docs](https://github.com/dotnet/docs/blob/main/.editorconfig) to use our style as a starting point.
+
+These tools make it easier for your team to adopt your preferred guidelines. Visual Studio applies the rules in all `.editorconfig` files in scope to format your code. You can use multiple rule sets to enforce corporate-wide standards, team standards, and even granular project standards.
+
+Any configured code analysis tools produce warnings and diagnostics when its rules are violated. You configure the rules you want applied to your project. Then, each CI build notifies developers when they violate any of the rules.
 
 ## Language guidelines
 
-The following sections describe practices that the C# team follows to prepare code examples and samples.
+The following sections describe practices that the .NET docs team follows to prepare code examples and samples. In general, follow these practices:
 
-### String data type
+- Utilize modern language features and C# versions whenever possible.
+- Avoid obsolete or outdated language constructs.
+- Only catch exceptions that can be properly handled; avoid catching generic exceptions.
+- Use specific exception types to provide meaningful error messages.
+- Use LINQ queries and methods for collection manipulation to improve code readability.
+- Use asynchronous programming with async and await for I/O-bound operations.
+- Be cautious of deadlocks and use <xref:System.Threading.Tasks.Task.ConfigureAwait%2A?DisplayProperty=nameWithType> when appropriate.
+- Use the language keywords for data types instead of the runtime types. For example, use `string` instead of <xref:System.String?DisplayProperty=fullName>, or `int` instead of <xref:System.Int32?displayProperty=fullName>.
+- Use `int` rather than unsigned types. The use of `int` is common throughout C#, and it's easier to interact with other libraries when you use `int`. Exceptions are for documentation specific to unsigned data types.
+- Use `var` only when a reader can infer the type from the expression. Readers view our samples on the docs platform. They don't have hover or tool tips that display the type of variables.
+- Write code with clarity and simplicity in mind.
+- Avoid overly complex and convoluted code logic.
+
+More specific guidelines follow.
+
+### String data
 
 - Use [string interpolation](../../language-reference/tokens/interpolated.md) to concatenate short strings, as shown in the following code.
 
   :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet6":::
 
-- To append strings in loops, especially when you're working with large amounts of text, use a <xref:System.Text.StringBuilder> object.
+- To append strings in loops, especially when you're working with large amounts of text, use a <xref:System.Text.StringBuilder?DisplayProperty=nameWithType> object.
 
   :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet7":::
 
-### Implicitly typed local variables
-
-
-
-- Use [implicit typing](../../programming-guide/classes-and-structs/implicitly-typed-local-variables.md) for local variables when the type of the variable is obvious from the right side of the assignment, or when the precise type is not important.
-
-  :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet8":::
-
-- Don't use [var](../../language-reference/statements/declarations.md#implicitly-typed-local-variables) when the type is not apparent from the right side of the assignment. Don't assume the type is clear from a method name. A variable type is considered clear if it's a `new` operator or an explicit cast.
-
-  :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet9":::
-
-- Don't rely on the variable name to specify the type of the variable. It might not be correct. In the following example, the variable name `inputInt` is misleading. It's a string.
-
-  :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet10":::
-
-- Avoid the use of `var` in place of [dynamic](../../language-reference/builtin-types/reference-types.md). Use `dynamic` when you want run-time type inference. For more information, see [Using type dynamic (C# Programming Guide)](../../advanced-topics/interop/using-type-dynamic.md).
-
-- Use implicit typing to determine the type of the loop variable in [`for`](../../language-reference/statements/iteration-statements.md#the-for-statement) loops.
-
-  The following example uses implicit typing in a `for` statement.
-
-    :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet7":::
-
-- Don't use implicit typing to determine the type of the loop variable in [`foreach`](../../language-reference/statements/iteration-statements.md#the-foreach-statement) loops. In most cases, the type of elements in the collection isn't immediately obvious. The collection's name shouldn't be solely relied upon for inferring the type of its elements.
-
-  The following example uses explicit typing in a `foreach` statement.
-
-  :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet12":::
-
-  > [!NOTE]
-  > Be careful not to accidentally change a type of an element of the iterable collection. For example, it is easy to switch from <xref:System.Linq.IQueryable?displayProperty=nameWithType> to <xref:System.Collections.IEnumerable?displayProperty=nameWithType> in a `foreach` statement, which changes the execution of a query.
-
-### Unsigned data types
-
-In general, use `int` rather than unsigned types. The use of `int` is common throughout C#, and it is easier to interact with other libraries when you use `int`.
-
 ### Arrays
 
-Use the concise syntax when you initialize arrays on the declaration line. In the following example, note that you can't use `var` instead of `string[]`.
+- Use the concise syntax when you initialize arrays on the declaration line. In the following example, you can't use `var` instead of `string[]`.
 
 :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet13a":::
 
-If you use explicit instantiation, you can use `var`.
+- If you use explicit instantiation, you can use `var`.
 
 :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet13b":::
 
 ### Delegates
 
-Use [`Func<>` and `Action<>`](../../../standard/delegates-lambdas.md) instead of defining delegate types. In a class, define the delegate method.
+- Use [`Func<>` and `Action<>`](../../../standard/delegates-lambdas.md) instead of defining delegate types. In a class, define the delegate method.
 
 :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet14a":::
 
-Call the method using the signature defined by the `Func<>` or `Action<>` delegate.
+- Call the method using the signature defined by the `Func<>` or `Action<>` delegate.
 
 :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet15a":::
 
-If you create instances of a delegate type, use the concise syntax. In a class, define the delegate type and a method that has a matching signature.
+- If you create instances of a delegate type, use the concise syntax. In a class, define the delegate type and a method that has a matching signature.
 
   :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet14b":::
 
-Create an instance of the delegate type and call it. The following declaration shows the condensed syntax.
+- Create an instance of the delegate type and call it. The following declaration shows the condensed syntax.
 
   :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet15b":::
 
-The following declaration uses the full syntax.
+- The following declaration uses the full syntax.
 
   :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet15c":::
 
@@ -118,7 +116,7 @@ The following declaration uses the full syntax.
 
 ### `&&` and `||` operators
 
-To avoid exceptions and increase performance by skipping unnecessary comparisons, use [`&&`](../../language-reference/operators/boolean-logical-operators.md#conditional-logical-and-operator-) instead of [`&`](../../language-reference/operators/boolean-logical-operators.md#logical-and-operator-) and [`||`](../../language-reference/operators/boolean-logical-operators.md#conditional-logical-or-operator-) instead of [`|`](../../language-reference/operators/boolean-logical-operators.md#logical-or-operator-) when you perform comparisons, as shown in the following example.
+- Use [`&&`](../../language-reference/operators/boolean-logical-operators.md#conditional-logical-and-operator-) instead of [`&`](../../language-reference/operators/boolean-logical-operators.md#logical-and-operator-) and [`||`](../../language-reference/operators/boolean-logical-operators.md#conditional-logical-or-operator-) instead of [`|`](../../language-reference/operators/boolean-logical-operators.md#logical-or-operator-) when you perform comparisons, as shown in the following example.
 
   :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet18":::
 
@@ -148,7 +146,7 @@ If the divisor is 0, the second clause in the `if` statement would cause a run-t
 
 ### Event handling
 
-If you're defining an event handler that you don't need to remove later, use a lambda expression.
+- Use a lambda expression to define an event handler that you don't need to remove later:
 
 :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet22":::
 
@@ -188,13 +186,42 @@ Call [static](../../language-reference/keywords/static.md) members by using the 
 
   :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet30":::
 
-## Security
+### Implicitly typed local variables
 
-Follow the guidelines in [Secure Coding Guidelines](../../../standard/security/secure-coding-guidelines.md).
+- Use [implicit typing](../../programming-guide/classes-and-structs/implicitly-typed-local-variables.md) for local variables when the type of the variable is obvious from the right side of the assignment.
 
-## Place the using directives outside the namespace declaration
+  :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet8":::
 
-When a `using` directive is outside a namespace declaration, that imported namespace is its fully qualified name. That's more clear. When the `using` directive is inside the namespace, it could be either relative to that namespace or it's fully qualified name. That's ambiguous.
+- Don't use [var](../../language-reference/statements/declarations.md#implicitly-typed-local-variables) when the type isn't apparent from the right side of the assignment. Don't assume the type is clear from a method name. A variable type is considered clear if it's a `new` operator, an explicit cast or assignment to a literal value.
+
+  :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet9":::
+
+- Don't use variable names to specify the type of the variable. It might not be correct. In the following example, the variable name `inputInt` is misleading. It's a string.
+
+  :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet10":::
+
+- Avoid the use of `var` in place of [dynamic](../../language-reference/builtin-types/reference-types.md). Use `dynamic` when you want run-time type inference. For more information, see [Using type dynamic (C# Programming Guide)](../../advanced-topics/interop/using-type-dynamic.md).
+
+- Use implicit typing to determine the type of the loop variable in [`for`](../../language-reference/statements/iteration-statements.md#the-for-statement) loops.
+
+  The following example uses implicit typing in a `for` statement.
+
+    :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet7":::
+
+- Don't use implicit typing to determine the type of the loop variable in [`foreach`](../../language-reference/statements/iteration-statements.md#the-foreach-statement) loops. In most cases, the type of elements in the collection isn't immediately obvious. The collection's name shouldn't be solely relied upon for inferring the type of its elements.
+
+  The following example uses explicit typing in a `foreach` statement.
+
+  :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet12":::
+
+  > [!NOTE]
+  > Be careful not to accidentally change a type of an element of the iterable collection. For example, it is easy to switch from <xref:System.Linq.IQueryable?displayProperty=nameWithType> to <xref:System.Collections.IEnumerable?displayProperty=nameWithType> in a `foreach` statement, which changes the execution of a query.
+
+Some of our samples explain the *natural type* of an expression. Those samples must use `var` so that the compiler picks the natural type. Even though those examples are less obvious, the use of `var` is required for the sample. The text should explain the behavior.
+
+### Place the using directives outside the namespace declaration
+
+When a `using` directive is outside a namespace declaration, that imported namespace is its fully qualified name. The fully qualified name is clearer. When the `using` directive is inside the namespace, it could be either relative to that namespace, or its fully qualified name.
 
 ```csharp
 using Azure;
@@ -212,7 +239,7 @@ namespace CoolStuff.AwesomeFeature
 }
 ```
 
-Assuming there is a reference (direct, or indirect) to the <xref:Azure.WaitUntil> class.
+Assuming there's a reference (direct, or indirect) to the <xref:Azure.WaitUntil> class.
 
 Now, let's change it slightly:
 
@@ -232,7 +259,7 @@ namespace CoolStuff.AwesomeFeature
 }
 ```
 
-And it compiles today. And tomorrow. But then sometime next week this (untouched) code fails with two errors:
+And it compiles today. And tomorrow. But then sometime next week the preceding (untouched) code fails with two errors:
 
 ```console
 - error CS0246: The type or namespace name 'WaitUntil' could not be found (are you missing a using directive or an assembly reference?)
@@ -275,8 +302,21 @@ namespace CoolStuff.AwesomeFeature
 }
 ```
 
-## Commenting conventions
+## Style guidelines
 
+In general, use the following format for code samples:
+
+- Use four spaces for indentation. Don't use tabs.
+- Align code consistently to improve readability.
+- Limit lines to 65 characters to enhance code readability on docs, especially on mobile screens.
+- Break long statements into multiple lines to improve clarity.
+- Use the "Allman" style for braces: open and closing brace its own new line. Braces line up with current indentation level.
+- Line breaks should occur before binary operators, if necessary.
+
+### Comment style
+
+- Use single-line comments (`//`) for brief explanations.
+- Avoid multi-line comments (`/* */`) for longer explanations. Comments aren't localized. Instead, longer explanations are in the companion article.
 - Place the comment on a separate line, not at the end of a line of code.
 - Begin comment text with an uppercase letter.
 - End comment text with a period.
@@ -284,25 +324,21 @@ namespace CoolStuff.AwesomeFeature
 
   :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet3":::
 
-- Don't create formatted blocks of asterisks around comments.
-- Ensure all public members have the necessary XML comments providing appropriate descriptions about their behavior.
-
-## Layout conventions
+### Layout conventions
 
 Good layout uses formatting to emphasize the structure of your code and to make the code easier to read. Microsoft examples and samples conform to the following conventions:
 
 - Use the default Code Editor settings (smart indenting, four-character indents, tabs saved as spaces). For more information, see [Options, Text Editor, C#, Formatting](/visualstudio/ide/reference/options-text-editor-csharp-formatting).
-
 - Write only one statement per line.
 - Write only one declaration per line.
-- If continuation lines are not indented automatically, indent them one tab stop (four spaces).
+- If continuation lines aren't indented automatically, indent them one tab stop (four spaces).
 - Add at least one blank line between method definitions and property definitions.
 - Use parentheses to make clauses in an expression apparent, as shown in the following code.
 
   :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet2":::
-  
-## See also
 
-- [.NET runtime coding guidelines](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/coding-style.md)
-- [Visual Basic Coding Conventions](../../../visual-basic/programming-guide/program-structure/coding-conventions.md)
-- [Secure Coding Guidelines](../../../standard/security/secure-coding-guidelines.md)
+Exceptions are when the sample explains operator or expression precedence.
+
+## Security
+
+Follow the guidelines in [Secure Coding Guidelines](../../../standard/security/secure-coding-guidelines.md).

--- a/docs/csharp/fundamentals/coding-style/coding-conventions.md
+++ b/docs/csharp/fundamentals/coding-style/coding-conventions.md
@@ -172,7 +172,7 @@ Call [static](../../language-reference/keywords/static.md) members by using the 
 
   :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet27":::
 
-- Use implicit typing in the declaration of query variables and range variables.
+- Use implicit typing in the declaration of query variables and range variables. This guidance on implicit typing in LINQ queries overrides the general rules for [implicitly typed local variables](#implicitly-typed-local-variables). LINQ queries often use projections that create anonymous types. Other query expressions create results with nested generic types. Implicit typed variables are often more readable.
 
   :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet25":::
 
@@ -196,13 +196,13 @@ Call [static](../../language-reference/keywords/static.md) members by using the 
 
   :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet9":::
 
-- Don't use variable names to specify the type of the variable. It might not be correct. In the following example, the variable name `inputInt` is misleading. It's a string.
+- Don't use variable names to specify the type of the variable. It might not be correct. Instead, use the type to specify the type, and use the variable name to indicate the semantic information of the variable. The following example should use `string` for the type and something like `iterations` to indicate the meaning of the information read from the console.
 
   :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet10":::
 
 - Avoid the use of `var` in place of [dynamic](../../language-reference/builtin-types/reference-types.md). Use `dynamic` when you want run-time type inference. For more information, see [Using type dynamic (C# Programming Guide)](../../advanced-topics/interop/using-type-dynamic.md).
 
-- Use implicit typing to determine the type of the loop variable in [`for`](../../language-reference/statements/iteration-statements.md#the-for-statement) loops.
+- Use implicit typing for the loop variable in [`for`](../../language-reference/statements/iteration-statements.md#the-for-statement) loops.
 
   The following example uses implicit typing in a `for` statement.
 
@@ -213,6 +213,8 @@ Call [static](../../language-reference/keywords/static.md) members by using the 
   The following example uses explicit typing in a `foreach` statement.
 
   :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet12":::
+
+- use implicit type for the result sequences in LINQ queries. The section on [LINQ](#linq-queries) explains that many LINQ queries result in anonymous types where implicit types must be used. Other queries result in nested generic types where `var` is more readable.
 
   > [!NOTE]
   > Be careful not to accidentally change a type of an element of the iterable collection. For example, it is easy to switch from <xref:System.Linq.IQueryable?displayProperty=nameWithType> to <xref:System.Collections.IEnumerable?displayProperty=nameWithType> in a `foreach` statement, which changes the execution of a query.

--- a/docs/csharp/fundamentals/coding-style/coding-conventions.md
+++ b/docs/csharp/fundamentals/coding-style/coding-conventions.md
@@ -1,253 +1,17 @@
 ---
-title: "Common C# Coding Conventions"
-description: Learn about commonly used coding conventions in C#. Coding conventions create a consistent look to the code and facilitate copying, changing, and maintaining the code.
-ms.date: 07/16/2021
-helpviewer_keywords:
+title: ".NET documentation C# Coding Conventions"
+description: Learn about commonly used coding conventions in C#. Coding conventions create a consistent look to the code and facilitate copying, changing, and maintaining the code. This article also includes the docs repo coding guidelines
+ms.date: 07/24/2023
+helpviewer_keyword:
   - "coding conventions, C#"
   - "Visual C#, coding conventions"
   - "C# language, coding conventions"
 ---
 
-# Common C# Coding Conventions
-
-Coding conventions serve the following purposes:
-
-> [!div class="checklist"]
->
-> - They create a consistent look to the code, so that readers can focus on content, not layout.
-> - They enable readers to understand the code more quickly by making assumptions based on previous experience.
-> - They facilitate copying, changing, and maintaining the code.
-> - They demonstrate C# best practices.
+# Common C# coding conventions
 
 > [!IMPORTANT]
 > The guidelines in this article are used by Microsoft to develop samples and documentation. They were adopted from the [.NET Runtime, C# Coding Style](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/coding-style.md) guidelines. You can use them, or adapt them to your needs. They are meant to be an example of common C# conventions, and not an authoritative list (see [Framework Design Guidelines](../../../standard/design-guidelines/index.md) for that). The primary objectives are consistency and readability within your project, team, organization, or company source code.
-
-## Naming conventions
-
-There are several naming conventions to consider when writing C# code.
-
-In the following examples, any of the guidance pertaining to elements marked `public` is also applicable when working with `protected` and `protected internal` elements, all of which are  intended to be visible to external callers.
-
-### Pascal case
-
-Use pascal casing ("PascalCasing") when naming a `class`, `record`, or `struct`.
-
-```csharp
-public class DataService
-{
-}
-```
-
-```csharp
-public record PhysicalAddress(
-    string Street,
-    string City,
-    string StateOrProvince,
-    string ZipCode);
-```
-
-```csharp
-public struct ValueCoordinate
-{
-}
-```
-
-When naming an `interface`, use pascal casing in addition to prefixing the name with an `I`. This clearly indicates to consumers that it's an `interface`.
-
-```csharp
-public interface IWorkerQueue
-{
-}
-```
-
-When naming `public` members of types, such as fields, properties, events, methods, and local functions, use pascal casing.
-
-```csharp
-public class ExampleEvents
-{
-    // A public field, these should be used sparingly
-    public bool IsValid;
-
-    // An init-only property
-    public IWorkerQueue WorkerQueue { get; init; }
-
-    // An event
-    public event Action EventProcessing;
-
-    // Method
-    public void StartEventProcessing()
-    {
-        // Local function
-        static int CountQueueItems() => WorkerQueue.Count;
-        // ...
-    }
-}
-```
-
-When writing positional records, use pascal casing for parameters as they're the public properties of the record.
-
-```csharp
-public record PhysicalAddress(
-    string Street,
-    string City,
-    string StateOrProvince,
-    string ZipCode);
-```
-
-For more information on positional records, see [Positional syntax for property definition](../../language-reference/builtin-types/record.md#positional-syntax-for-property-definition).
-
-### Camel case
-
-Use camel casing ("camelCasing") when naming `private` or `internal` fields, and prefix them with `_`.
-
-```csharp
-public class DataService
-{
-    private IWorkerQueue _workerQueue;
-}
-```
-
-> [!TIP]
-> When editing C# code that follows these naming conventions in an IDE that supports statement completion, typing `_` will show all of the object-scoped members.
-
-When working with `static` fields that are `private` or `internal`, use the `s_` prefix and for thread static use `t_`.
-
-```csharp
-public class DataService
-{
-    private static IWorkerQueue s_workerQueue;
-
-    [ThreadStatic]
-    private static TimeSpan t_timeSpan;
-}
-```
-
-When writing method parameters, use camel casing.
-
-```csharp
-public T SomeMethod<T>(int someNumber, bool isValid)
-{
-}
-```
-
-For more information on C# naming conventions, see [C# Coding Style](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/coding-style.md).
-
-### Additional naming conventions
-
-- Examples that don't include [using directives](../../language-reference/keywords/using-directive.md), use namespace qualifications. If you know that a namespace is imported by default in a project, you don't have to fully qualify the names from that namespace. Qualified names can be broken after a dot (.) if they are too long for a single line, as shown in the following example.
-
-  :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet1":::
-
-- You don't have to change the names of objects that were created by using the Visual Studio designer tools to make them fit other guidelines.
-
-## Layout conventions
-
-Good layout uses formatting to emphasize the structure of your code and to make the code easier to read. Microsoft examples and samples conform to the following conventions:
-
-- Use the default Code Editor settings (smart indenting, four-character indents, tabs saved as spaces). For more information, see [Options, Text Editor, C#, Formatting](/visualstudio/ide/reference/options-text-editor-csharp-formatting).
-
-- Write only one statement per line.
-- Write only one declaration per line.
-- If continuation lines are not indented automatically, indent them one tab stop (four spaces).
-- Add at least one blank line between method definitions and property definitions.
-- Use parentheses to make clauses in an expression apparent, as shown in the following code.
-
-  :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet2":::
-  
-## Place the using directives outside the namespace declaration
-
-When a `using` directive is outside a namespace declaration, that imported namespace is its fully qualified name. That's more clear. When the `using` directive is inside the namespace, it could be either relative to that namespace or it's fully qualified name. That's ambiguous.
-
-```csharp
-using Azure;
-
-namespace CoolStuff.AwesomeFeature
-{
-    public class Awesome
-    {
-        public void Stuff()
-        {
-            WaitUntil wait = WaitUntil.Completed;
-            …
-        }
-    }
-}
-```
-
-Assuming there is a reference (direct, or indirect) to the <xref:Azure.WaitUntil> class.
-
-Now, let's change it slightly:
-
-```csharp
-namespace CoolStuff.AwesomeFeature
-{
-    using Azure;
-    
-    public class Awesome
-    {
-        public void Stuff()
-        {
-            WaitUntil wait = WaitUntil.Completed;
-            …
-        }
-    }
-}
-```
-
-And it compiles today. And tomorrow. But then sometime next week this (untouched) code fails with two errors:
-
-```console
-- error CS0246: The type or namespace name 'WaitUntil' could not be found (are you missing a using directive or an assembly reference?)
-- error CS0103: The name 'WaitUntil' does not exist in the current context
-```
-
-One of the dependencies has introduced this class in a namespace then ends with `.Azure`:
-
-```csharp
-namespace CoolStuff.Azure
-{
-    public class SecretsManagement
-    {
-        public string FetchFromKeyVault(string vaultId, string secretId) { return null; }
-    }
-}
-```
-
-A `using` directive placed inside a namespace is context-sensitive and complicates name resolution. In this example, it's the first namespace that it finds.
-
-- `CoolStuff.AwesomeFeature.Azure`
-- `CoolStuff.Azure`
-- `Azure`
-
-Adding a new namespace that matches either `CoolStuff.Azure` or `CoolStuff.AwesomeFeature.Azure` would match before the global `Azure` namespace. You could resolve it by adding the `global::` modifier to the `using` declaration. However, it's easier to place `using` declarations outside the namespace instead.
-
-```csharp
-namespace CoolStuff.AwesomeFeature
-{
-    using global::Azure;
-    
-    public class Awesome
-    {
-        public void Stuff()
-        {
-            WaitUntil wait = WaitUntil.Completed;
-            …
-        }
-    }
-}
-```
-
-## Commenting conventions
-
-- Place the comment on a separate line, not at the end of a line of code.
-- Begin comment text with an uppercase letter.
-- End comment text with a period.
-- Insert one space between the comment delimiter (//) and the comment text, as shown in the following example.
-
-  :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet3":::
-
-- Don't create formatted blocks of asterisks around comments.
-- Ensure all public members have the necessary XML comments providing appropriate descriptions about their behavior.
 
 ## Language guidelines
 
@@ -264,6 +28,8 @@ The following sections describe practices that the C# team follows to prepare co
   :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet7":::
 
 ### Implicitly typed local variables
+
+
 
 - Use [implicit typing](../../programming-guide/classes-and-structs/implicitly-typed-local-variables.md) for local variables when the type of the variable is obvious from the right side of the assignment, or when the precise type is not important.
 
@@ -426,6 +192,115 @@ Call [static](../../language-reference/keywords/static.md) members by using the 
 
 Follow the guidelines in [Secure Coding Guidelines](../../../standard/security/secure-coding-guidelines.md).
 
+## Place the using directives outside the namespace declaration
+
+When a `using` directive is outside a namespace declaration, that imported namespace is its fully qualified name. That's more clear. When the `using` directive is inside the namespace, it could be either relative to that namespace or it's fully qualified name. That's ambiguous.
+
+```csharp
+using Azure;
+
+namespace CoolStuff.AwesomeFeature
+{
+    public class Awesome
+    {
+        public void Stuff()
+        {
+            WaitUntil wait = WaitUntil.Completed;
+            …
+        }
+    }
+}
+```
+
+Assuming there is a reference (direct, or indirect) to the <xref:Azure.WaitUntil> class.
+
+Now, let's change it slightly:
+
+```csharp
+namespace CoolStuff.AwesomeFeature
+{
+    using Azure;
+    
+    public class Awesome
+    {
+        public void Stuff()
+        {
+            WaitUntil wait = WaitUntil.Completed;
+            …
+        }
+    }
+}
+```
+
+And it compiles today. And tomorrow. But then sometime next week this (untouched) code fails with two errors:
+
+```console
+- error CS0246: The type or namespace name 'WaitUntil' could not be found (are you missing a using directive or an assembly reference?)
+- error CS0103: The name 'WaitUntil' does not exist in the current context
+```
+
+One of the dependencies has introduced this class in a namespace then ends with `.Azure`:
+
+```csharp
+namespace CoolStuff.Azure
+{
+    public class SecretsManagement
+    {
+        public string FetchFromKeyVault(string vaultId, string secretId) { return null; }
+    }
+}
+```
+
+A `using` directive placed inside a namespace is context-sensitive and complicates name resolution. In this example, it's the first namespace that it finds.
+
+- `CoolStuff.AwesomeFeature.Azure`
+- `CoolStuff.Azure`
+- `Azure`
+
+Adding a new namespace that matches either `CoolStuff.Azure` or `CoolStuff.AwesomeFeature.Azure` would match before the global `Azure` namespace. You could resolve it by adding the `global::` modifier to the `using` declaration. However, it's easier to place `using` declarations outside the namespace instead.
+
+```csharp
+namespace CoolStuff.AwesomeFeature
+{
+    using global::Azure;
+    
+    public class Awesome
+    {
+        public void Stuff()
+        {
+            WaitUntil wait = WaitUntil.Completed;
+            …
+        }
+    }
+}
+```
+
+## Commenting conventions
+
+- Place the comment on a separate line, not at the end of a line of code.
+- Begin comment text with an uppercase letter.
+- End comment text with a period.
+- Insert one space between the comment delimiter (//) and the comment text, as shown in the following example.
+
+  :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet3":::
+
+- Don't create formatted blocks of asterisks around comments.
+- Ensure all public members have the necessary XML comments providing appropriate descriptions about their behavior.
+
+## Layout conventions
+
+Good layout uses formatting to emphasize the structure of your code and to make the code easier to read. Microsoft examples and samples conform to the following conventions:
+
+- Use the default Code Editor settings (smart indenting, four-character indents, tabs saved as spaces). For more information, see [Options, Text Editor, C#, Formatting](/visualstudio/ide/reference/options-text-editor-csharp-formatting).
+
+- Write only one statement per line.
+- Write only one declaration per line.
+- If continuation lines are not indented automatically, indent them one tab stop (four spaces).
+- Add at least one blank line between method definitions and property definitions.
+- Use parentheses to make clauses in an expression apparent, as shown in the following code.
+
+  :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet2":::
+  
 ## See also
 
 - [.NET runtime coding guidelines](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/coding-style.md)

--- a/docs/csharp/fundamentals/coding-style/coding-conventions.md
+++ b/docs/csharp/fundamentals/coding-style/coding-conventions.md
@@ -9,7 +9,7 @@ helpviewer_keyword:
 ---
 # Common C# code conventions
 
-A code standard is essential for maintaining code readability, consistency, and collaboration within a development team. Following industry practices and established guidelines helps ensure that code is easier to understand, maintain, and extend. Most projects enforce a consistent style through code conventions. The [`dotnet/docs`](https://github.com/dotnet/docs) and [`dotnet/samples`](https://github.com/dotnet/samples) projects are no exception. In this series of articles, you learn our coding conventions and the tools we use to enforce them. You can take our conventions as-is, or modify them to suit your team.
+A code standard is essential for maintaining code readability, consistency, and collaboration within a development team. Following industry practices and established guidelines helps ensure that code is easier to understand, maintain, and extend. Most projects enforce a consistent style through code conventions. The [`dotnet/docs`](https://github.com/dotnet/docs) and [`dotnet/samples`](https://github.com/dotnet/samples) projects are no exception. In this series of articles, you learn our coding conventions and the tools we use to enforce them. You can take our conventions as-is, or modify them to suit your team's needs.
 
 We chose our conventions based on the following goals:
 
@@ -235,7 +235,7 @@ namespace CoolStuff.AwesomeFeature
         public void Stuff()
         {
             WaitUntil wait = WaitUntil.Completed;
-            …
+            // ...
         }
     }
 }
@@ -255,7 +255,7 @@ namespace CoolStuff.AwesomeFeature
         public void Stuff()
         {
             WaitUntil wait = WaitUntil.Completed;
-            …
+            // ...
         }
     }
 }
@@ -298,7 +298,7 @@ namespace CoolStuff.AwesomeFeature
         public void Stuff()
         {
             WaitUntil wait = WaitUntil.Completed;
-            …
+            // ...
         }
     }
 }

--- a/docs/csharp/fundamentals/coding-style/identifier-names.md
+++ b/docs/csharp/fundamentals/coding-style/identifier-names.md
@@ -163,15 +163,15 @@ The following guidelines apply to type parameters on generic type parameters. Th
 
 - **Do** name generic type parameters with descriptive names, unless a single letter name is completely self explanatory and a descriptive name would not add value.
 
-   :::code language="./snippets/coding-conventions" source="Program.cs" id="TypeParametersOne":::
+   :::code language="./snippets/coding-conventions" source="./snippets/coding-conventions/Program.cs" id="TypeParametersOne":::
 
 - **Consider** using T as the type parameter name for types with one single letter type parameter.
 
-   :::code language="./snippets/coding-conventions" source="Program.cs" id="TypeParametersTwo":::
+   :::code language="./snippets/coding-conventions" source="./snippets/coding-conventions/Program.cs" id="TypeParametersTwo":::
 
 - **Do** prefix descriptive type parameter names with "T".
 
-   :::code language="./snippets/coding-conventions" source="Program.cs" id="TypeParametersThree":::
+   :::code language="./snippets/coding-conventions" source="./snippets/coding-conventions/Program.cs" id="TypeParametersThree":::
 
 - **Consider** indicating constraints placed on a type parameter in the name of parameter. For example, a parameter constrained to `ISession` may be called `TSession`.
 

--- a/docs/csharp/fundamentals/coding-style/identifier-names.md
+++ b/docs/csharp/fundamentals/coding-style/identifier-names.md
@@ -165,7 +165,7 @@ The following guidelines apply to type parameters on generic type parameters. Th
 
    :::code language="./snippets/coding-conventions" source="./snippets/coding-conventions/Program.cs" id="TypeParametersOne":::
 
-- **Consider** using T as the type parameter name for types with one single letter type parameter.
+- **Consider** using `T` as the type parameter name for types with one single letter type parameter.
 
    :::code language="./snippets/coding-conventions" source="./snippets/coding-conventions/Program.cs" id="TypeParametersTwo":::
 

--- a/docs/csharp/fundamentals/coding-style/identifier-names.md
+++ b/docs/csharp/fundamentals/coding-style/identifier-names.md
@@ -157,6 +157,26 @@ public T SomeMethod<T>(int someNumber, bool isValid)
 
 For more information on C# naming conventions, see [C# Coding Style](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/coding-style.md).
 
+### Type parameter naming guidelines
+
+The following guidelines apply to type parameters on generic type parameters. These are the placeholders for arguments in a generic type or a generic method. You can read more about [generic type parameters](../../programming-guide/generics/generic-type-parameters.md) in the C# programming guide.
+
+- **Do** name generic type parameters with descriptive names, unless a single letter name is completely self explanatory and a descriptive name would not add value.
+
+   :::code language="./snippets/coding-conventions" source="Program.cs" id="TypeParametersOne":::
+
+- **Consider** using T as the type parameter name for types with one single letter type parameter.
+
+   :::code language="./snippets/coding-conventions" source="Program.cs" id="TypeParametersTwo":::
+
+- **Do** prefix descriptive type parameter names with "T".
+
+   :::code language="./snippets/coding-conventions" source="Program.cs" id="TypeParametersThree":::
+
+- **Consider** indicating constraints placed on a type parameter in the name of parameter. For example, a parameter constrained to `ISession` may be called `TSession`.
+
+The code analysis rule [CA1715](/visualstudio/code-quality/ca1715) can be used to ensure that type parameters are named appropriately.
+
 ### Extra naming conventions
 
 - Examples that don't include [using directives](../../language-reference/keywords/using-directive.md), use namespace qualifications. If you know that a namespace is imported by default in a project, you don't have to fully qualify the names from that namespace. Qualified names can be broken after a dot (.) if they're too long for a single line, as shown in the following example.

--- a/docs/csharp/fundamentals/coding-style/identifier-names.md
+++ b/docs/csharp/fundamentals/coding-style/identifier-names.md
@@ -31,7 +31,9 @@ In addition to the rules, there are many identifier [naming conventions](../../.
 - Prefer clarity over brevity.
 - Use PascalCase for class names and method names.
 - Use camelCase for method arguments, local variables, and private fields.
-- Use ALL_CAPS for constant names.
+- Use PascalCase for constant names, both fields and local constants.
+- Instance fields start with an underscore (`_`).
+- Static fields start with `s_`. Note that this isn't the default Visual Studio behavior, nor part of the [Framework design guidelines](../../../standard/design-guidelines/names-of-type-members.md#names-of-fields), but is configurable in editorconfig.
 - Avoid using abbreviations or acronyms in names, except for widely known and accepted abbreviations.
 - Use meaningful and descriptive namespaces that follow the reverse domain name notation.
 - Choose assembly names that represent the primary purpose of the assembly.
@@ -49,7 +51,7 @@ In the following examples, guidance pertaining to elements marked `public` is ap
 
 ### Pascal case
 
-Use pascal casing ("PascalCasing") when naming a `class`, `Interface` or `struct`.
+Use pascal casing ("PascalCasing") when naming a `class`, `Interface`, `struct`, or `delegate` type.
 
 ```csharp
 public class DataService
@@ -69,6 +71,10 @@ public record PhysicalAddress(
 public struct ValueCoordinate
 {
 }
+```
+
+```csharp
+public delegate void DelegateType(string message);
 ```
 
 When naming an `interface`, use pascal casing in addition to prefixing the name with an `I`. This prefix clearly indicates to consumers that it's an `interface`.
@@ -117,7 +123,7 @@ For more information on positional records, see [Positional syntax for property 
 
 ### Camel case
 
-Use camel casing ("camelCasing") when naming `private` or `internal` fields, and prefix them with `_`.
+Use camel casing ("camelCasing") when naming `private` or `internal` fields and prefix them with `_`. Use camel casing when naming local variables, including instances of a delegate type.
 
 ```csharp
 public class DataService

--- a/docs/csharp/fundamentals/coding-style/identifier-names.md
+++ b/docs/csharp/fundamentals/coding-style/identifier-names.md
@@ -1,7 +1,7 @@
 ---
-title: "C# identifier names"
-description: "Learn the rules for valid identifier names in the C# programming language."
-ms.date: 03/23/2022
+title: "C# identifier names - rules and conventions"
+description: "Learn the rules for valid identifier names in the C# programming language. In addition, learn the common naming conventions used by the .NET runtime team and the .NET docs team."
+ms.date: 07/24/2023
 ---
 # C# identifier naming rules and conventions
 
@@ -26,18 +26,116 @@ In addition to the rules, there are many identifier [naming conventions](../../.
 - Enum types use a singular noun for non-flags, and a plural noun for flags.
 - Identifiers shouldn't contain two consecutive underscore (`_`) characters. Those names are reserved for compiler-generated identifiers.
 
-For more information, see [Naming conventions](coding-conventions.md#naming-conventions).
+In the following examples, any of the guidance pertaining to elements marked `public` is also applicable when working with `protected` and `protected internal` elements, all of which are intended to be visible to external callers.
 
-## C# Language Specification
+### Pascal case
 
-[!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
-  
-## See also
+Use pascal casing ("PascalCasing") when naming a `class`, `record`, or `struct`.
 
-- [C# Programming Guide](../../programming-guide/index.md)
-- [C# Reference](../../language-reference/index.md)
-- [Classes](../types/classes.md)
-- [Structure types](../../language-reference/builtin-types/struct.md)
-- [Namespaces](../types/namespaces.md)
-- [Interfaces](../types/interfaces.md)
-- [Delegates](../../programming-guide/delegates/index.md)
+```csharp
+public class DataService
+{
+}
+```
+
+```csharp
+public record PhysicalAddress(
+    string Street,
+    string City,
+    string StateOrProvince,
+    string ZipCode);
+```
+
+```csharp
+public struct ValueCoordinate
+{
+}
+```
+
+When naming an `interface`, use pascal casing in addition to prefixing the name with an `I`. This clearly indicates to consumers that it's an `interface`.
+
+```csharp
+public interface IWorkerQueue
+{
+}
+```
+
+When naming `public` members of types, such as fields, properties, events, methods, and local functions, use pascal casing.
+
+```csharp
+public class ExampleEvents
+{
+    // A public field, these should be used sparingly
+    public bool IsValid;
+
+    // An init-only property
+    public IWorkerQueue WorkerQueue { get; init; }
+
+    // An event
+    public event Action EventProcessing;
+
+    // Method
+    public void StartEventProcessing()
+    {
+        // Local function
+        static int CountQueueItems() => WorkerQueue.Count;
+        // ...
+    }
+}
+```
+
+When writing positional records, use pascal casing for parameters as they're the public properties of the record.
+
+```csharp
+public record PhysicalAddress(
+    string Street,
+    string City,
+    string StateOrProvince,
+    string ZipCode);
+```
+
+For more information on positional records, see [Positional syntax for property definition](../../language-reference/builtin-types/record.md#positional-syntax-for-property-definition).
+
+### Camel case
+
+Use camel casing ("camelCasing") when naming `private` or `internal` fields, and prefix them with `_`.
+
+```csharp
+public class DataService
+{
+    private IWorkerQueue _workerQueue;
+}
+```
+
+> [!TIP]
+> When editing C# code that follows these naming conventions in an IDE that supports statement completion, typing `_` will show all of the object-scoped members.
+
+When working with `static` fields that are `private` or `internal`, use the `s_` prefix and for thread static use `t_`.
+
+```csharp
+public class DataService
+{
+    private static IWorkerQueue s_workerQueue;
+
+    [ThreadStatic]
+    private static TimeSpan t_timeSpan;
+}
+```
+
+When writing method parameters, use camel casing.
+
+```csharp
+public T SomeMethod<T>(int someNumber, bool isValid)
+{
+}
+```
+
+For more information on C# naming conventions, see [C# Coding Style](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/coding-style.md).
+
+### Additional naming conventions
+
+- Examples that don't include [using directives](../../language-reference/keywords/using-directive.md), use namespace qualifications. If you know that a namespace is imported by default in a project, you don't have to fully qualify the names from that namespace. Qualified names can be broken after a dot (.) if they are too long for a single line, as shown in the following example.
+
+  :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet1":::
+
+- You don't have to change the names of objects that were created by using the Visual Studio designer tools to make them fit other guidelines.

--- a/docs/csharp/fundamentals/coding-style/identifier-names.md
+++ b/docs/csharp/fundamentals/coding-style/identifier-names.md
@@ -1,11 +1,11 @@
 ---
 title: "C# identifier names - rules and conventions"
 description: "Learn the rules for valid identifier names in the C# programming language. In addition, learn the common naming conventions used by the .NET runtime team and the .NET docs team."
-ms.date: 07/24/2023
+ms.date: 07/27/2023
 ---
 # C# identifier naming rules and conventions
 
-An **identifier** is the name you assign to a type (class, interface, struct, record, delegate, or enum), member, variable, or namespace.
+An **identifier** is the name you assign to a type (class, interface, struct, delegate, or enum), member, variable, or namespace.
 
 ## Naming rules
 
@@ -13,9 +13,10 @@ Valid identifiers must follow these rules:
 
 - Identifiers must start with a letter or underscore (`_`).
 - Identifiers may contain Unicode letter characters, decimal digit characters, Unicode connecting characters, Unicode combining characters, or Unicode formatting characters. For more information on Unicode categories, see the [Unicode Category Database](https://www.unicode.org/reports/tr44/).
-You can declare identifiers that match C# keywords by using the `@` prefix on the identifier. The `@` is not part of the identifier name. For example, `@if` declares an identifier named `if`. These [verbatim identifiers](../../language-reference/tokens/verbatim.md) are primarily for interoperability with identifiers declared in other languages.
 
-For a complete definition of valid identifiers, see the [Identifiers topic in the C# Language Specification](~/_csharpstandard/standard/lexical-structure.md#643-identifiers).
+You can declare identifiers that match C# keywords by using the `@` prefix on the identifier. The `@` isn't part of the identifier name. For example, `@if` declares an identifier named `if`. These [verbatim identifiers](../../language-reference/tokens/verbatim.md) are primarily for interoperability with identifiers declared in other languages.
+
+For a complete definition of valid identifiers, see the [Identifiers article in the C# Language Specification](~/_csharpstandard/standard/lexical-structure.md#643-identifiers).
 
 ## Naming conventions
 
@@ -23,14 +24,32 @@ In addition to the rules, there are many identifier [naming conventions](../../.
 
 - Interface names start with a capital `I`.
 - Attribute types end with the word `Attribute`.
-- Enum types use a singular noun for non-flags, and a plural noun for flags.
+- Enum types use a singular noun for nonflags, and a plural noun for flags.
 - Identifiers shouldn't contain two consecutive underscore (`_`) characters. Those names are reserved for compiler-generated identifiers.
+- Use meaningful and descriptive names for variables, methods, and classes.
+- Avoid using single-letter names, except for simple loop counters. See exceptions for syntax examples noted in the following section.
+- Prefer clarity over brevity.
+- Use PascalCase for class names and method names.
+- Use camelCase for method arguments, local variables, and private fields.
+- Use ALL_CAPS for constant names.
+- Avoid using abbreviations or acronyms in names, except for widely known and accepted abbreviations.
+- Use meaningful and descriptive namespaces that follow the reverse domain name notation.
+- Choose assembly names that represent the primary purpose of the assembly.
 
-In the following examples, any of the guidance pertaining to elements marked `public` is also applicable when working with `protected` and `protected internal` elements, all of which are intended to be visible to external callers.
+The examples that describe the syntax of C# constructs often use single letter names that match the convention used in the [C# language specification](~/_csharpstandard/standard/readme.md):
+
+- Use `S` for structs, `C` for classes.
+- Use `M` for methods.
+- Use `v` for variables, `p` for parameters.
+- Use `r` for `ref` parameters.
+
+The preceding single-letter names are allowed only in the language reference section.
+
+In the following examples, guidance pertaining to elements marked `public` is applicable when working with `protected` and `protected internal` elements, all of which are intended to be visible to external callers.
 
 ### Pascal case
 
-Use pascal casing ("PascalCasing") when naming a `class`, `record`, or `struct`.
+Use pascal casing ("PascalCasing") when naming a `class`, `Interface` or `struct`.
 
 ```csharp
 public class DataService
@@ -52,7 +71,7 @@ public struct ValueCoordinate
 }
 ```
 
-When naming an `interface`, use pascal casing in addition to prefixing the name with an `I`. This clearly indicates to consumers that it's an `interface`.
+When naming an `interface`, use pascal casing in addition to prefixing the name with an `I`. This prefix clearly indicates to consumers that it's an `interface`.
 
 ```csharp
 public interface IWorkerQueue
@@ -60,7 +79,7 @@ public interface IWorkerQueue
 }
 ```
 
-When naming `public` members of types, such as fields, properties, events, methods, and local functions, use pascal casing.
+When naming `public` members of types, such as fields, properties, events, use pascal casing. Also, use pascal casing for all methods and local functions.
 
 ```csharp
 public class ExampleEvents
@@ -132,9 +151,9 @@ public T SomeMethod<T>(int someNumber, bool isValid)
 
 For more information on C# naming conventions, see [C# Coding Style](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/coding-style.md).
 
-### Additional naming conventions
+### Extra naming conventions
 
-- Examples that don't include [using directives](../../language-reference/keywords/using-directive.md), use namespace qualifications. If you know that a namespace is imported by default in a project, you don't have to fully qualify the names from that namespace. Qualified names can be broken after a dot (.) if they are too long for a single line, as shown in the following example.
+- Examples that don't include [using directives](../../language-reference/keywords/using-directive.md), use namespace qualifications. If you know that a namespace is imported by default in a project, you don't have to fully qualify the names from that namespace. Qualified names can be broken after a dot (.) if they're too long for a single line, as shown in the following example.
 
   :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet1":::
 

--- a/docs/csharp/fundamentals/coding-style/identifier-names.md
+++ b/docs/csharp/fundamentals/coding-style/identifier-names.md
@@ -20,7 +20,7 @@ For a complete definition of valid identifiers, see the [Identifiers article in 
 
 ## Naming conventions
 
-In addition to the rules, there are many identifier [naming conventions](../../../standard/design-guidelines/naming-guidelines.md) used throughout the .NET APIs. By convention, C# programs use `PascalCase` for type names, namespaces, and all public members. In addition, the following conventions are common:
+In addition to the rules, there are many identifier [naming conventions](../../../standard/design-guidelines/naming-guidelines.md) used throughout the .NET APIs. By convention, C# programs use `PascalCase` for type names, namespaces, and all public members. In addition, the `dotnet/docs` team uses the following conventions, adopted from the [.NET Runtime team coding style](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/coding-style.md):
 
 - Interface names start with a capital `I`.
 - Attribute types end with the word `Attribute`.

--- a/docs/csharp/fundamentals/coding-style/snippets/coding-conventions/program.cs
+++ b/docs/csharp/fundamentals/coding-style/snippets/coding-conventions/program.cs
@@ -439,3 +439,31 @@ namespace Coding_Conventions_WF2
         }
     }
 }
+
+namespace GenericTypeParameters
+{
+    public class WrapParameters
+    {
+        //<TypeParametersOne>
+        public interface ISessionChannel<TSession> { /*...*/ }
+        public delegate TOutput Converter<TInput, TOutput>(TInput from);
+        public class List<T> { /*...*/ }
+        //</TypeParametersOne>
+
+        //<TypeParametersTwo>
+        public int IComparer<T>() { return 0; }
+        public delegate bool Predicate<T>(T item);
+        public struct Nullable<T> where T : struct { /*...*/ }
+        //</TypeParametersTwo>
+
+        class wrap
+        {
+            //<TypeParametersThree>
+            public interface ISessionChannel<TSession>
+            {
+                TSession Session { get; }
+            }
+            //</TypeParametersThree>
+        }
+    }//WrapParameters
+}

--- a/docs/csharp/fundamentals/coding-style/snippets/coding-conventions/program.cs
+++ b/docs/csharp/fundamentals/coding-style/snippets/coding-conventions/program.cs
@@ -5,14 +5,14 @@ namespace Coding_Conventions_Examples
     class Program
     {
         //<snippet14a>
-        public static Action<string> ActionExample1 = x => Console.WriteLine($"x is: {x}");
+        public static Action<string> actionExample1 = x => Console.WriteLine($"x is: {x}");
 
-        public static Action<string, string> ActionExample2 = (x, y) =>
+        public static Action<string, string> actionExample2 = (x, y) =>
             Console.WriteLine($"x is: {x}, y is {y}");
 
-        public static Func<string, int> FuncExample1 = x => Convert.ToInt32(x);
+        public static Func<string, int> funcExample1 = x => Convert.ToInt32(x);
 
-        public static Func<int, int, int> FuncExample2 = (x, y) => x + y;
+        public static Func<int, int, int> funcExample2 = (x, y) => x + y;
         //</snippet14a>
         //<snippet14b>
         public delegate void Del(string message);

--- a/docs/csharp/fundamentals/coding-style/snippets/coding-conventions/program.cs
+++ b/docs/csharp/fundamentals/coding-style/snippets/coding-conventions/program.cs
@@ -276,15 +276,15 @@ namespace Coding_Conventions_Examples
         }
 
         //<snippet16>
-        static string GetValueFromArray(string[] array, int index)
+        static double ComputeDistance(double x1, double y1, double x2, double y2)
         {
             try
             {
-                return array[index];
+                return Math.SquareRoot((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2));
             }
-            catch (System.IndexOutOfRangeException ex)
+            catch (System.ArithmeticException ex)
             {
-                Console.WriteLine("Index is out of range: {0}", index);
+                Console.WriteLine($"Arithmetic overflow or underflow: {ex}");
                 throw;
             }
         }

--- a/docs/csharp/fundamentals/coding-style/snippets/coding-conventions/program.cs
+++ b/docs/csharp/fundamentals/coding-style/snippets/coding-conventions/program.cs
@@ -114,13 +114,13 @@ namespace Coding_Conventions_Examples
             //</snippet13b>
 
             //<snippet15a>
-            ActionExample1("string for x");
+            actionExample1("string for x");
 
-            ActionExample2("string for x", "string for y");
+            actionExample2("string for x", "string for y");
 
-            Console.WriteLine($"The value is {FuncExample1("1")}");
+            Console.WriteLine($"The value is {funcExample1("1")}");
 
-            Console.WriteLine($"The sum is {FuncExample2(1, 2)}");
+            Console.WriteLine($"The sum is {funcExample2(1, 2)}");
             //</snippet15a>
             //<snippet15b>
             Del exampleDel2 = DelMethod;
@@ -133,7 +133,7 @@ namespace Coding_Conventions_Examples
 
 
             // #16 is below Main.
-            Console.WriteLine(GetValueFromArray(vowels1, 1));
+            Console.WriteLine(ComputeDistance(1,2,3,4));
 
             // 17 requires System.Drawing
             //<snippet17a>
@@ -146,7 +146,7 @@ namespace Coding_Conventions_Examples
             {
                 if (bodyStyle != null)
                 {
-                    ((IDisposable)arialFont).Dispose();
+                    ((IDisposable)bodyStyle).Dispose();
                 }
             }
             //</snippet17a>
@@ -280,7 +280,7 @@ namespace Coding_Conventions_Examples
         {
             try
             {
-                return Math.SquareRoot((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2));
+                return Math.Sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2));
             }
             catch (System.ArithmeticException ex)
             {

--- a/docs/csharp/fundamentals/coding-style/snippets/coding-conventions/program.cs
+++ b/docs/csharp/fundamentals/coding-style/snippets/coding-conventions/program.cs
@@ -31,11 +31,11 @@ namespace Coding_Conventions_Examples
                 PerformanceCounterCategory();
             //</snippet1>
 
-            int val1 = 1;
-            int val2 = 2;
-            int val3 = 3;
+            int startX = 1;
+            int endX = 2;
+            int previousX = 3;
             //<snippet2>
-            if ((val1 > val2) && (val1 > val3))
+            if ((startX > endX) && (startX > previousX))
             {
                 // Take appropriate action.
             }
@@ -71,13 +71,13 @@ namespace Coding_Conventions_Examples
             //</snippet7>
 
             //<snippet8>
-            var var1 = "This is clearly a string.";
-            var var2 = 27;
+            var message = "This is clearly a string.";
+            var currentTemperature = 27;
             //</snippet8>
 
             //<snippet9>
-            int var3 = Convert.ToInt32(Console.ReadLine());
-            int var4 = ExampleClass.ResultSoFar();
+            int numberOfIterations = Convert.ToInt32(Console.ReadLine());
+            int currentMaximum = ExampleClass.ResultSoFar();
             //</snippet9>
 
             //<snippet10>
@@ -137,28 +137,28 @@ namespace Coding_Conventions_Examples
 
             // 17 requires System.Drawing
             //<snippet17a>
-            Font font1 = new Font("Arial", 10.0f);
+            Font bodyStyle = new Font("Arial", 10.0f);
             try
             {
-                byte charset = font1.GdiCharSet;
+                byte charset = bodyStyle.GdiCharSet;
             }
             finally
             {
-                if (font1 != null)
+                if (bodyStyle != null)
                 {
-                    ((IDisposable)font1).Dispose();
+                    ((IDisposable)arialFont).Dispose();
                 }
             }
             //</snippet17a>
             //<snippet17b>
-            using (Font font2 = new Font("Arial", 10.0f))
+            using (Font arial = new Font("Arial", 10.0f))
             {
-                byte charset2 = font2.GdiCharSet;
+                byte charset2 = arial.GdiCharSet;
             }
             //</snippet17b>
             //<snippet17c>
-            using Font font3 = new Font("Arial", 10.0f);
-            byte charset3 = font3.GdiCharSet;
+            using Font normalStyle = new Font("Arial", 10.0f);
+            byte charset3 = normalStyle.GdiCharSet;
             //</snippet17c>
 
             //<snippet18>
@@ -180,24 +180,24 @@ namespace Coding_Conventions_Examples
 
 
             //<snippet19>
-            var instance1 = new ExampleClass();
+            var firstExample = new ExampleClass();
             //</snippet19>
             // Can't show `ExampleClass instance1 = new()` because this project targets net48.
 
             //<snippet20>
-            ExampleClass instance2 = new ExampleClass();
+            ExampleClass secondExample = new ExampleClass();
             //</snippet20>
 
             //<snippet21a>
-            var instance3 = new ExampleClass { Name = "Desktop", ID = 37414,
+            var thirdExample = new ExampleClass { Name = "Desktop", ID = 37414,
                 Location = "Redmond", Age = 2.3 };
             //</snippet21a>
             //<snippet21b>
-            var instance4 = new ExampleClass();
-            instance4.Name = "Desktop";
-            instance4.ID = 37414;
-            instance4.Location = "Redmond";
-            instance4.Age = 2.3;
+            var fourthExample = new ExampleClass();
+            fourthExample.Name = "Desktop";
+            fourthExample.ID = 37414;
+            fourthExample.Location = "Redmond";
+            fourthExample.Age = 2.3;
             //</snippet21b>
 
             // #22 and #23 are in Coding_Conventions_WF, below.

--- a/docs/csharp/fundamentals/coding-style/snippets/coding-conventions/program.cs
+++ b/docs/csharp/fundamentals/coding-style/snippets/coding-conventions/program.cs
@@ -5,14 +5,14 @@ namespace Coding_Conventions_Examples
     class Program
     {
         //<snippet14a>
-        public static Action<string> actionExample1 = x => Console.WriteLine($"x is: {x}");
+        public static Action<string> ActionExample1 = x => Console.WriteLine($"x is: {x}");
 
-        public static Action<string, string> actionExample2 = (x, y) =>
+        public static Action<string, string> ActionExample2 = (x, y) =>
             Console.WriteLine($"x is: {x}, y is {y}");
 
-        public static Func<string, int> funcExample1 = x => Convert.ToInt32(x);
+        public static Func<string, int> FuncExample1 = x => Convert.ToInt32(x);
 
-        public static Func<int, int, int> funcExample2 = (x, y) => x + y;
+        public static Func<int, int, int> FuncExample2 = (x, y) => x + y;
         //</snippet14a>
         //<snippet14b>
         public delegate void Del(string message);
@@ -114,13 +114,13 @@ namespace Coding_Conventions_Examples
             //</snippet13b>
 
             //<snippet15a>
-            actionExample1("string for x");
+            ActionExample1("string for x");
 
-            actionExample2("string for x", "string for y");
+            ActionExample2("string for x", "string for y");
 
-            Console.WriteLine($"The value is {funcExample1("1")}");
+            Console.WriteLine($"The value is {FuncExample1("1")}");
 
-            Console.WriteLine($"The sum is {funcExample2(1, 2)}");
+            Console.WriteLine($"The sum is {FuncExample2(1, 2)}");
             //</snippet15a>
             //<snippet15b>
             Del exampleDel2 = DelMethod;

--- a/docs/csharp/programming-guide/generics/generic-type-parameters.md
+++ b/docs/csharp/programming-guide/generics/generic-type-parameters.md
@@ -15,23 +15,7 @@ In a generic type or method definition, a type parameter is a placeholder for a 
 
 In each of these instances of `GenericList<T>`, every occurrence of `T` in the class is substituted at run time with the type argument. By means of this substitution, we have created three separate type-safe and efficient objects using a single class definition. For more information on how this substitution is performed by the CLR, see [Generics in the Runtime](./generics-in-the-run-time.md).
 
-## Type parameter naming guidelines
-
-- **Do** name generic type parameters with descriptive names, unless a single letter name is completely self explanatory and a descriptive name would not add value.
-
-   [!code-csharp[csProgGuideGenerics#8](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideGenerics/CS/Generics.cs#8)]
-
-- **Consider** using T as the type parameter name for types with one single letter type parameter.
-
-   [!code-csharp[csProgGuideGenerics#9](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideGenerics/CS/Generics.cs#9)]
-
-- **Do** prefix descriptive type parameter names with "T".
-
-   [!code-csharp[csProgGuideGenerics#10](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideGenerics/CS/Generics.cs#10)]
-
-- **Consider** indicating constraints placed on a type parameter in the name of parameter. For example, a parameter constrained to `ISession` may be called `TSession`.
-
-The code analysis rule [CA1715](/visualstudio/code-quality/ca1715) can be used to ensure that type parameters are named appropriately.
+You can learn the naming conventions for generic type parameters in the article on [naming conventions](../../fundamentals/coding-style/identifier-names.md#type-parameter-naming-guidelines).
 
 ## See also
 

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideGenerics/CS/Generics.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideGenerics/CS/Generics.cs
@@ -118,31 +118,6 @@ namespace CsCsrefProgrammingGenerics
         }
     }
 
-    //---------------------------------------------------------------------------
-    public class WrapParameters
-    {
-        //<Snippet8>
-        public interface ISessionChannel<TSession> { /*...*/ }
-        public delegate TOutput Converter<TInput, TOutput>(TInput from);
-        public class List<T> { /*...*/ }
-        //</Snippet8>
-
-        //<Snippet9>
-        public int IComparer<T>() { return 0; }
-        public delegate bool Predicate<T>(T item);
-        public struct Nullable<T> where T : struct { /*...*/ }
-        //</Snippet9>
-
-        class wrap
-        {
-            //<Snippet10>
-            public interface ISessionChannel<TSession>
-            {
-                TSession Session { get; }
-            }
-            //</Snippet10>
-        }
-    }//WrapParameters
 
     //---------------------------------------------------------------------------
     public class WrapConstraints


### PR DESCRIPTION
There are a number of issues related to our coding standards used in .NET docs. 

Many of the issues arise because readers conflate *our* style with *Microsoft recommended style*. The first commits made that distinction much more clear.

This may be easier to review commit-by-commit:

1. Rearrange the content. Some naming conventions were used in both files, clearly separate them. Rearrange the order. 
1. Rework the content. Make it clear that these are our team guidelines. Point to the source for the runtime and roslyn repos. Add appropriate disclaimers that readers should feel free to modify the guidelines to suit their team's needs. Finally, add a section to explain the tools where readers can use editorconfig or analyzers to enforce the rules they want.
1. Fix issues related to `var`:
   - Fixes #26787: clarify "obvious"
   - Fixes #32633: add explanation, update variable names.
   - Fixes #34940: Explain that `var` is preferred in LINQ queries, despite other rules.
1. Fix issues related to naming conventions:
   - Fixes #30626: Clarify (again) that these are our guidelines, not yours. Point out that it's not the VS default, but a configuration option.
   - Fixes #30642: Again, our style.
   - Fixes #30799: Change constant style from ALL_CAPS to PascalCase to match runtime repo.
   - Fixes #33959: Update variable names so delegate types are PascalCased and instances of a delegate are camelCase. Add clarifying text for the same.
1. Fixes [#31951](https://github.com/dotnet/docs/issues/31951) : Rewrite the exception example so that it's still obvious what can fail, but couldn't be easily anticipated before making the computation.
1. Fixes #30897: Move the Generic type parameter naming conventions to the general naming conventions.
1. Fix build issues.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/fundamentals/coding-style/coding-conventions.md](https://github.com/dotnet/docs/blob/a8a3e9d0c7d34574511e22dd62cc93c617d15a6d/docs/csharp/fundamentals/coding-style/coding-conventions.md) | [Common C# Coding Conventions](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions?branch=pr-en-us-36428) |
| [docs/csharp/fundamentals/coding-style/identifier-names.md](https://github.com/dotnet/docs/blob/a8a3e9d0c7d34574511e22dd62cc93c617d15a6d/docs/csharp/fundamentals/coding-style/identifier-names.md) | ["C# identifier names"](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/identifier-names?branch=pr-en-us-36428) |
| [docs/csharp/programming-guide/generics/generic-type-parameters.md](https://github.com/dotnet/docs/blob/a8a3e9d0c7d34574511e22dd62cc93c617d15a6d/docs/csharp/programming-guide/generics/generic-type-parameters.md) | [Generic type parameters (C# Programming Guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/generics/generic-type-parameters?branch=pr-en-us-36428) |


<!-- PREVIEW-TABLE-END -->