### PR TITLE
Make actions and funcs local

### DIFF
--- a/docs/csharp/fundamentals/coding-style/snippets/coding-conventions/program.cs
+++ b/docs/csharp/fundamentals/coding-style/snippets/coding-conventions/program.cs
@@ -4,16 +4,29 @@ namespace Coding_Conventions_Examples
 {
     class Program
     {
-        //<snippet14a>
-        public static Action<string> ActionExample1 = x => Console.WriteLine($"x is: {x}");
+        public static void DelegateExamples()
+        {
+            //<snippet14a>
+            Action<string> actionExample1 = x => Console.WriteLine($"x is: {x}");
 
-        public static Action<string, string> ActionExample2 = (x, y) =>
-            Console.WriteLine($"x is: {x}, y is {y}");
+            Action<string, string> actionExample2 = (x, y) =>
+                Console.WriteLine($"x is: {x}, y is {y}");
 
-        public static Func<string, int> FuncExample1 = x => Convert.ToInt32(x);
+            Func<string, int> funcExample1 = x => Convert.ToInt32(x);
 
-        public static Func<int, int, int> FuncExample2 = (x, y) => x + y;
-        //</snippet14a>
+            Func<int, int, int> funcExample2 = (x, y) => x + y;
+            //</snippet14a>
+
+            //<snippet15a>
+            actionExample1("string for x");
+
+            actionExample2("string for x", "string for y");
+
+            Console.WriteLine($"The value is {funcExample1("1")}");
+
+            Console.WriteLine($"The sum is {funcExample2(1, 2)}");
+            //</snippet15a>
+        }
         //<snippet14b>
         public delegate void Del(string message);
 
@@ -113,15 +126,6 @@ namespace Coding_Conventions_Examples
             var vowels2 = new string[] { "a", "e", "i", "o", "u" };
             //</snippet13b>
 
-            //<snippet15a>
-            ActionExample1("string for x");
-
-            ActionExample2("string for x", "string for y");
-
-            Console.WriteLine($"The value is {FuncExample1("1")}");
-
-            Console.WriteLine($"The sum is {FuncExample2(1, 2)}");
-            //</snippet15a>
             //<snippet15b>
             Del exampleDel2 = DelMethod;
             exampleDel2("Hey");


### PR DESCRIPTION
See https://github.com/dotnet/docs/pull/36428#discussion_r1277974331

For the issue involved, it's a better fix to create local variables for the Func and Action objects. That shows readers the distinction between the delegate type and the instance.
