### PR TITLE
Remove OpenTelemetry.Exporter.Zipkin reference

### DIFF
--- a/docs/core/diagnostics/observability-with-otel.md
+++ b/docs/core/diagnostics/observability-with-otel.md
@@ -120,7 +120,6 @@ Use the NuGet Package Manager or command line to add the following NuGet package
    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.5.0" />
    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.5.0" />
    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.5.0-rc.1" />
-   <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.5.0" />
    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.5.0" />
    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.5.0-beta.1" />
    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.5.0-beta.1" />


### PR DESCRIPTION
## Summary

This package is not used since an example is about OtlpExporter and Jaeger

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/observability-with-otel.md](https://github.com/dotnet/docs/blob/0798fc2d78dfe07d2fcd3be5e2ce8a1bff9f09f2/docs/core/diagnostics/observability-with-otel.md) | [.NET observability with OpenTelemetry](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/observability-with-otel?branch=pr-en-us-36478) |

<!-- PREVIEW-TABLE-END -->