### PR TITLE
Improve and extend the page about `CS0453`

### DIFF
--- a/docs/csharp/misc/cs0453.md
+++ b/docs/csharp/misc/cs0453.md
@@ -28,3 +28,9 @@ public class H3<S> : HV<S> where S : class { }     // CS0453
 public class H4 : HV<int?> { }                     // CS0453  
 public class H5 : HV<Nullable<Nullable<int>>> { }  // CS0453  
 ```
+
+## See also
+
+- [Built-in reference types](../language-reference/builtin-types/reference-types.md)
+- [Value types](../language-reference/builtin-types/value-types.md)
+- [Constraints on type parameters](../programming-guide/generics/constraints-on-type-parameters.md)

--- a/docs/csharp/misc/cs0453.md
+++ b/docs/csharp/misc/cs0453.md
@@ -12,7 +12,7 @@ ms.assetid: a1bbd09e-6313-4bfd-84bf-bc15a8d214a6
 
 The type 'Type Name' must be a non-nullable value type in order to use it as parameter 'Parameter Name' in the generic type or method 'Generic Identifier'  
   
- This error occurs when you use a non-value type argument in instantiating a generic type or method that has the **value** constraint on it. It can also occur when you use a nullable value type argument. See the last two lines of code in the following example.  
+ This error occurs when you use a [non-value type](../language-reference/builtin-types/value-types.md) argument in instantiating a generic type or method that has the [**value** constraint](../programming-guide/generics/constraints-on-type-parameters.md) on it. It can also occur when you use a nullable value type argument. See the last two lines of code in the following example.  
   
 ## Example  
 

--- a/docs/csharp/misc/cs0453.md
+++ b/docs/csharp/misc/cs0453.md
@@ -21,12 +21,23 @@ The type 'Type Name' must be a non-nullable value type in order to use it as par
 ```csharp  
 // CS0453.cs  
 using System;  
-public class HV<S> where S : struct { }  
-public class H1 : HV<string> { }                   // CS0453  
-public class H2 : HV<H1> { }                       // CS0453  
-public class H3<S> : HV<S> where S : class { }     // CS0453  
-public class H4 : HV<int?> { }                     // CS0453  
-public class H5 : HV<Nullable<Nullable<int>>> { }  // CS0453  
+public class HV<S> where S : struct { }
+
+// CS0453: string is not a value type
+public class H1 : HV<string> { }
+
+// CS0453: H1 is a class, not a struct
+public class H2 : HV<H1> { }
+
+// CS0453: HV is based on a class, not a struct
+public class H3<S> : HV<S> where S : class { }
+public class H4<S> : HV<S> where S : struct { } // OK
+
+// CS0453: HV accepts a nullable int type
+public class H4 : HV<int?> { }
+
+// CS0453: HV is based on Nullable type of int
+public class H5 : HV<Nullable<Nullable<int>>> { }
 ```
 
 ## See also


### PR DESCRIPTION
This pull request fixes #36359

It extends the description of `CS0453` error by following:
* turns mentions of "non-value type" and "**value** constraints" into links to proper pages,
* introduces "See also" section with links to further readings,
Two are already linked in the description, still I decided to put them here explicitly. "Built-in reference types" is additional one, added there as a contrary to linked "Value types"
* Adds very brief comments to each example of `CS0453` error in the code snippet, explaining why such line of code has that error


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/misc/cs0453.md](https://github.com/dotnet/docs/blob/9d1688ca4b499ac9c82c35a42b801ff620bfaac6/docs/csharp/misc/cs0453.md) | [Compiler Error CS0453](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/cs0453?branch=pr-en-us-36482) |

<!-- PREVIEW-TABLE-END -->