### PR TITLE
Boolean overloads removed

### DIFF
--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -49,6 +49,7 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 | [IndexOfAnyValues renamed to SearchValues](core-libraries/8.0/indexofanyvalues-renamed.md)                | Source/binary incompatible | Preview 5 |
 | [ITypeDescriptorContext nullable annotations](core-libraries/8.0/itypedescriptorcontext-props.md)         | Source incompatible | Preview 1    |
 | [Legacy Console.ReadKey removed](core-libraries/8.0/console-readkey-legacy.md)                            | Behavioral change   | Preview 1    |
+| [Removed overloads of ToFrozenDictionary/ToFrozenSet](core-libraries/8.0/optimizeforreading-arg.md)       | Source/binary incompatible | Preview 7 |
 
 ## Cryptography
 

--- a/docs/core/compatibility/core-libraries/8.0/optimizeforreading-arg.md
+++ b/docs/core/compatibility/core-libraries/8.0/optimizeforreading-arg.md
@@ -1,0 +1,39 @@
+---
+title: ".NET 8 breaking change: Removed Boolean-based overloads of ToFrozenDictionary/ToFrozenSet"
+description: Learn about the .NET 8 breaking change in core .NET libraries where the ToFrozenSet and ToFrozenDictionary overloads with a Boolean parameter have been removed.
+ms.date: 08/01/2023
+---
+# Removed Boolean-based overloads of ToFrozenDictionary/ToFrozenSet
+
+Overloads of <xref:System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary%2A> and <xref:System.Collections.Frozen.FrozenSet.ToFrozenSet%2A> previously allowed for a Boolean `optimizeForReading` argument to be supplied. These overloads have been removed in .NET 8 Preview 7.
+
+## Previous behavior
+
+In .NET 8 Preview 1 through Preview 6, you could call overloads of <xref:System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary%2A> and <xref:System.Collections.Frozen.FrozenSet.ToFrozenSet%2A> that had an `optimizeForReading` parameter. If you passed `true`, the implementations constructed instances of <xref:System.Collections.Frozen.FrozenDictionary%602> and <xref:System.Collections.Frozen.FrozenSet%601> that were optimized for performing lookups and reading data from the collections, at the expense of potentially much more time spent in the `ToFrozenDictionary()` and `ToFrozenSet()` calls.
+
+## New behavior
+
+Starting in .NET 8 Preview 7, the [affected overloads](#affected-apis) have been removed. Now all of the <xref:System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary%2A> and <xref:System.Collections.Frozen.FrozenSet.ToFrozenSet%2A> overloads spend extra time to construct a collection that's optimized for reading.
+
+## Version introduced
+
+.NET 8 Preview 7
+
+## Type of breaking change
+
+This change can affect [binary compatibility](../../categories.md#binary-compatibility) and [source compatibility](../../categories.md#source-compatibility).
+
+## Reason for change
+
+Construction performance has been optimized such that it now no longer makes sense to differentiate modes. `ToFrozenDictionary()` and `ToFrozenSet()` now always produce implementations optimized for reading, regardless of which overload is used.
+
+## Recommended action
+
+If you called the overloads that had a Boolean parameter, remove the Boolean argument from the call site.
+
+## Affected APIs
+
+- <xref:System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary%60%602(System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{%60%600,%60%601}},System.Boolean)?displayProperty=fullName>
+- <xref:System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary%60%602(System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{%60%600,%60%601}},System.Collections.Generic.IEqualityComparer{%60%600},System.Boolean)?displayProperty=fullName>
+- <xref:System.Collections.Frozen.FrozenSet.ToFrozenSet%60%601(System.Collections.Generic.IEnumerable{%60%600},System.Boolean)?displayProperty=fullName>
+- <xref:System.Collections.Frozen.FrozenSet.ToFrozenSet%60%601(System.Collections.Generic.IEnumerable{%60%600},System.Collections.Generic.IEqualityComparer{%60%600},System.Boolean)?displayProperty=fullName>

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -54,6 +54,8 @@ items:
         href: core-libraries/8.0/itypedescriptorcontext-props.md
       - name: Legacy Console.ReadKey removed
         href: core-libraries/8.0/console-readkey-legacy.md
+      - name: Removed overloads of ToFrozenDictionary/ToFrozenSet
+        href: core-libraries/8.0/optimizeforreading-arg.md
     - name: Cryptography
       items:
       - name: AesGcm authentication tag size on macOS
@@ -1056,6 +1058,8 @@ items:
         href: core-libraries/8.0/itypedescriptorcontext-props.md
       - name: Legacy Console.ReadKey removed
         href: core-libraries/8.0/console-readkey-legacy.md
+      - name: Removed overloads of ToFrozenDictionary/ToFrozenSet
+        href: core-libraries/8.0/optimizeforreading-arg.md
     - name: .NET 7
       items:
       - name: API obsoletions with default diagnostic ID


### PR DESCRIPTION
Fixes #35960 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/8.0.md](https://github.com/dotnet/docs/blob/a988e7561934276347c037ec25bfc103a8309462/docs/core/compatibility/8.0.md) | [Breaking changes in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/8.0?branch=pr-en-us-36483) |
| [docs/core/compatibility/core-libraries/8.0/optimizeforreading-arg.md](https://github.com/dotnet/docs/blob/a988e7561934276347c037ec25bfc103a8309462/docs/core/compatibility/core-libraries/8.0/optimizeforreading-arg.md) | [docs/core/compatibility/core-libraries/8.0/optimizeforreading-arg](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/8.0/optimizeforreading-arg?branch=pr-en-us-36483) |

<!-- PREVIEW-TABLE-END -->