### PR TITLE
Move scrape_interval to a scrape_config section

### DIFF
--- a/docs/core/diagnostics/observability-with-otel.md
+++ b/docs/core/diagnostics/observability-with-otel.md
@@ -262,13 +262,13 @@ Modify the Prometheus YAML configuration file to specify the port for your HTTP 
   scrape_configs:
   # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
   - job_name: "prometheus"
+    - scrape_interval: 1s # poll very quickly for a more responsive demo
 
     # metrics_path defaults to '/metrics'
     # scheme defaults to 'http'.
 
     static_configs:
       - targets: ["localhost:5212"]
-      - scrape_interval: 1s # poll very quickly for a more responsive demo
 ```
 
 Start Prometheus, and look in the output for the port it's running on, typically 9090:


### PR DESCRIPTION
## Summary

As stated in the prometheus docs, a [static_config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#static_config) allows specifying only a list of targets and a common label set for them, but a scrape_interval should be specified in a [scrape_config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config). This is also how it is specified in the [getting_started](https://prometheus.io/docs/prometheus/latest/getting_started/#configuring-prometheus-to-monitor-itself) guide.

Otherwise, it leads to an error like:
```
2023-08-02 20:21:13 ts=2023-08-02T18:21:13.524Z caller=main.go:489 level=error msg="Error loading config (--config.file=/etc/prometheus/prometheus.yml)" file=/etc/prometheus/prometheus.yml err="parsing YAML file /etc/prometheus/prometheus.yml: yaml: unmarshal errors:\n  line 10: field scrape_interval not found in type struct { Targets []string \"yaml:\\\"targets\\\"\"; Labels model.LabelSet \"yaml:\\\"labels\\\"\" }"
```


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/observability-with-otel.md](https://github.com/dotnet/docs/blob/2549e8b14204b2dde13bf8b0bac985cf6f957653/docs/core/diagnostics/observability-with-otel.md) | [.NET observability with OpenTelemetry](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/observability-with-otel?branch=pr-en-us-36498) |

<!-- PREVIEW-TABLE-END -->