### PR TITLE
Config binding to dictionary (.NET 7)

### DIFF
--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -87,6 +87,7 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 
 | Title | Binary compatible | Source compatible |
 | - | :-: | :-: |
+| [Binding config to dictionary extends values](extensions/7.0/config-bind-dictionary.md) | ✔️ | ✔️ |
 | [ContentRootPath for apps launched by Windows Shell](extensions/7.0/contentrootpath-hosted-app.md) | ❌ | ✔️ |
 | [Environment variable prefixes](extensions/7.0/environment-variable-prefix.md) | ❌ | ✔️ |
 

--- a/docs/core/compatibility/extensions/7.0/config-bind-dictionary.md
+++ b/docs/core/compatibility/extensions/7.0/config-bind-dictionary.md
@@ -1,0 +1,67 @@
+---
+title: "Breaking change: Binding config to dictionary extends values"
+description: Learn about the .NET 7 breaking change in .NET extensions where binding a configuration to a dictionary extends collection values instead of replacing the entire collection for a key.
+ms.date: 08/02/2023
+---
+# Binding config to dictionary extends values
+
+When binding a configuration using a <xref:System.Collections.Generic.Dictionary%602> object where the value is a mutable collection type, binding to the same key more than once now extends the values collection instead of replacing the whole collection with the new value.
+
+## Version introduced
+
+.NET 7
+
+## Previous behavior
+
+Consider the following code that binds a configuration that has a single key named `Key` to a dictionary multiple times.
+
+```csharp
+using Microsoft.Extensions.Configuration;
+
+IConfiguration config = new ConfigurationBuilder()
+    .AddInMemoryCollection()
+    .Build();
+
+config["Key:0"] = "NewValue";
+var dict = new Dictionary<string, string[]>() { { "Key", new[] { "InitialValue" } } };
+
+Console.WriteLine($"Initially: {String.Join(", ", dict["Key"])}");
+config.Bind(dict);
+Console.WriteLine($"Bind: {String.Join(", ", dict["Key"])}");
+config.Bind(dict);
+Console.WriteLine($"Bind again: {String.Join(", ", dict["Key"])}");
+```
+
+Prior to .NET 7, the value for `Key` was overwritten one each bind. The code produced the following output:
+
+```output
+Initially: InitialValue
+Bind: NewValue
+Bind again: NewValue
+```
+
+## New behavior
+
+Consider the same code from the [Previous behavior](#previous-behavior) section. Starting in .NET 7, the dictionary value is extended each time the same key is bound, adding the new value but also keeping any existing values in the array. The code produces the following output:
+
+```output
+Initially: InitialValue
+Bind: InitialValue, NewValue
+Bind again: InitialValue, NewValue, NewValue
+```
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+This change improves binding behavior by not overriding previously added values in dictionary value arrays.
+
+## Recommended action
+
+If the new behavior is not satisfactory, you can manually manipulate the values inside the array after binding.
+
+## Affected APIs
+
+- [ConfigurationBinder methods](xref:Microsoft.Extensions.Configuration.ConfigurationBinder#methods)

--- a/docs/core/compatibility/extensions/7.0/config-bind-dictionary.md
+++ b/docs/core/compatibility/extensions/7.0/config-bind-dictionary.md
@@ -42,7 +42,7 @@ Bind again: NewValue
 
 ## New behavior
 
-Consider the same code from the [Previous behavior](#previous-behavior) section. Starting in .NET 7, the dictionary value is extended each time the same key is bound, adding the new value but also keeping any existing values in the array. The code produces the following output:
+Starting in .NET 7, the dictionary value is extended each time the same key is bound, adding the new value but also keeping any existing values in the array. The same code from the [Previous behavior](#previous-behavior) section produces the following output:
 
 ```output
 Initially: InitialValue

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -248,6 +248,8 @@ items:
         href: globalization/7.0/icu-globalization-api.md
     - name: Extensions
       items:
+      - name: Binding config to dictionary extends values
+        href: extensions/7.0/config-bind-dictionary.md
       - name: ContentRootPath for apps launched by Windows Shell
         href: extensions/7.0/contentrootpath-hosted-app.md
       - name: Environment variable prefixes
@@ -1308,6 +1310,8 @@ items:
         href: extensions/8.0/hostapplicationbuilder-ctor.md
     - name: .NET 7
       items:
+      - name: Binding config to dictionary extends values
+        href: extensions/7.0/config-bind-dictionary.md
       - name: ContentRootPath for apps launched by Windows Shell
         href: extensions/7.0/contentrootpath-hosted-app.md
       - name: Environment variable prefixes


### PR DESCRIPTION
Fixes #33685.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/7.0.md](https://github.com/dotnet/docs/blob/5303799179fc70373a921197b5729e3347af9f41/docs/core/compatibility/7.0.md) | [Breaking changes in .NET 7](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/7.0?branch=pr-en-us-36500) |
| [docs/core/compatibility/extensions/7.0/config-bind-dictionary.md](https://github.com/dotnet/docs/blob/5303799179fc70373a921197b5729e3347af9f41/docs/core/compatibility/extensions/7.0/config-bind-dictionary.md) | [docs/core/compatibility/extensions/7.0/config-bind-dictionary](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/extensions/7.0/config-bind-dictionary?branch=pr-en-us-36500) |


<!-- PREVIEW-TABLE-END -->