### PR TITLE
Bool-backed enum support

### DIFF
--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -46,6 +46,7 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 | [API obsoletions with custom diagnostic IDs](core-libraries/8.0/obsolete-apis-with-custom-diagnostics.md) | Source incompatible | Preview 1, 4 |
 | [Backslash mapping in Unix file paths](core-libraries/8.0/file-path-backslash.md)                         | Behavioral change   | Preview 1    |
 | [Base64.DecodeFromUtf8 methods ignore whitespace](core-libraries/8.0/decodefromutf8-whitespace.md)        | Behavioral change   | Preview 5    |
+| [Boolean-backed enum type support removed](core-libraries/8.0/bool-backed-enum.md)        | Behavioral change   | Preview 1    |
 | [FileStream writes when pipe is closed](core-libraries/8.0/filestream-disposed-pipe.md)                   | Behavioral change   | Preview 1    |
 | [GC.GetGeneration might return Int32.MaxValue](core-libraries/8.0/getgeneration-return-value.md)          | Behavioral change   | Preview 4    |
 | [GetFolderPath behavior on Unix](core-libraries/8.0/getfolderpath-unix.md)                                | Behavioral change   | Preview 1    |

--- a/docs/core/compatibility/core-libraries/8.0/bool-backed-enum.md
+++ b/docs/core/compatibility/core-libraries/8.0/bool-backed-enum.md
@@ -1,0 +1,42 @@
+---
+title: ".NET 8 breaking change: Boolean-backed enum type support removed"
+description: Learn about the .NET 8 breaking change in core .NET libraries where support for parsing, formatting, and conversions of Boolean-backed enumeration types has been removed.
+ms.date: 08/02/2023
+---
+# Boolean-backed enum type support removed
+
+Support for formatting, parsing, and conversions of Boolean-backed enumeration types has been removed.
+
+## Previous behavior
+
+Previously, formatting, parsing, or converting a Boolean-backed enumeration type was somewhat functional.
+
+## New behavior
+
+Starting in .NET 8, an <xref:System.InvalidOperationException> is thrown if you try to format, parse, or convert a Boolean-backed enumeration type.
+
+## Version introduced
+
+.NET 8 Preview 1
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+This change was made to make the .NET runtime simpler, faster, and smaller. Formatting and parsing Boolean-backed enumeration types is never used in practice and complicates the implementation. Also, Boolean-backed enum types aren't expressible in C#.
+
+## Recommended action
+
+If you're using a Boolean-backed enumeration type, use a regular Boolean type or a byte-backed enumeration type instead.
+
+## Affected APIs
+
+- <xref:System.Enum.Parse%2A?displayProperty=fullName>
+- <xref:System.Enum.TryParse%2A?displayProperty=fullName>
+- <xref:System.Enum.Format(System.Type,System.Object,System.String)?displayProperty=fullName>
+- <xref:System.Enum.GetName%2A?displayProperty=fullName>
+- <xref:System.Enum.GetNames%2A?displayProperty=fullName>
+- <xref:System.Enum.GetValues%2A?displayProperty=fullName>
+- <xref:System.Enum.ToObject%2A?displayProperty=fullName>

--- a/docs/core/compatibility/core-libraries/8.0/bool-backed-enum.md
+++ b/docs/core/compatibility/core-libraries/8.0/bool-backed-enum.md
@@ -5,7 +5,7 @@ ms.date: 08/02/2023
 ---
 # Boolean-backed enum type support removed
 
-Support for formatting, parsing, and conversions of Boolean-backed enumeration types has been removed.
+Support for formatting, parsing, and conversions of Boolean-backed [enumeration types](../../../../csharp/language-reference/builtin-types/enum.md) has been removed.
 
 ## Previous behavior
 

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -48,6 +48,8 @@ items:
         href: core-libraries/8.0/file-path-backslash.md
       - name: Base64.DecodeFromUtf8 methods ignore whitespace
         href: core-libraries/8.0/decodefromutf8-whitespace.md
+      - name: Boolean-backed enum type support removed
+        href: core-libraries/8.0/bool-backed-enum.md
       - name: FileStream writes when pipe is closed
         href: core-libraries/8.0/filestream-disposed-pipe.md
       - name: GC.GetGeneration might return Int32.MaxValue
@@ -1060,6 +1062,8 @@ items:
         href: core-libraries/8.0/file-path-backslash.md
       - name: Base64.DecodeFromUtf8 methods ignore whitespace
         href: core-libraries/8.0/decodefromutf8-whitespace.md
+      - name: Boolean-backed enum type support removed
+        href: core-libraries/8.0/bool-backed-enum.md
       - name: FileStream writes when pipe is closed
         href: core-libraries/8.0/filestream-disposed-pipe.md
       - name: GC.GetGeneration might return Int32.MaxValue


### PR DESCRIPTION
Fixes #33647

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/8.0.md](https://github.com/dotnet/docs/blob/ff27ae5a6804ca78ecf1470826e3798b3306a9e4/docs/core/compatibility/8.0.md) | [Breaking changes in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/8.0?branch=pr-en-us-36505) |
| [docs/core/compatibility/core-libraries/8.0/bool-backed-enum.md](https://github.com/dotnet/docs/blob/ff27ae5a6804ca78ecf1470826e3798b3306a9e4/docs/core/compatibility/core-libraries/8.0/bool-backed-enum.md) | [docs/core/compatibility/core-libraries/8.0/bool-backed-enum](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/8.0/bool-backed-enum?branch=pr-en-us-36505) |


<!-- PREVIEW-TABLE-END -->