### PR TITLE
Add framework target on net-6-0 pivot version

### DIFF
--- a/docs/core/tutorials/library-with-visual-studio-code.md
+++ b/docs/core/tutorials/library-with-visual-studio-code.md
@@ -268,8 +268,10 @@ Add a new .NET class library project named "StringLibrary" to the solution.
 1. In the terminal, run the following command to create the library project:
 
    ```dotnetcli
-   dotnet new classlib -o StringLibrary
+   dotnet new classlib -f net6.0 -o StringLibrary
    ```
+
+   The `-f` or `--framework` command changes the default target framework to `net6.0` version.
 
    The `-o` or `--output` command specifies the location to place the generated output.
 
@@ -347,7 +349,7 @@ Add a console application that uses the class library. The app will prompt the u
 1. In the terminal, run the following command to create the console app project:
 
    ```dotnetcli
-   dotnet new console -o ShowCase
+   dotnet new console -f net6.0 -o ShowCase
    ```
 
    The terminal output looks like the following example:

--- a/docs/core/tutorials/testing-library-with-visual-studio-code.md
+++ b/docs/core/tutorials/testing-library-with-visual-studio-code.md
@@ -210,8 +210,12 @@ Unit tests provide automated software testing during your development and publis
 1. Create a unit test project named "StringLibraryTest".
 
    ```dotnetcli
-   dotnet new mstest -o StringLibraryTest
+   dotnet new mstest -f net6.0 -o StringLibraryTest
    ```
+
+   The `-f net6.0` command changes the default target framework to `net6.0` version.
+
+   The `-o` or `--output` command specifies the location to place the generated output.
 
    The project template creates a UnitTest1.cs file with the following code:
 


### PR DESCRIPTION
## Summary

Added framework option in some dotnet6.0 commands docs to avoid creation with the default version.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tutorials/library-with-visual-studio-code.md](https://github.com/dotnet/docs/blob/9dc67593d4352fa55033c749c18f64de1ab4c1ca/docs/core/tutorials/library-with-visual-studio-code.md) | [Tutorial: Create a .NET class library using Visual Studio Code](https://review.learn.microsoft.com/en-us/dotnet/core/tutorials/library-with-visual-studio-code?branch=pr-en-us-36535) |
| [docs/core/tutorials/testing-library-with-visual-studio-code.md](https://github.com/dotnet/docs/blob/9dc67593d4352fa55033c749c18f64de1ab4c1ca/docs/core/tutorials/testing-library-with-visual-studio-code.md) | [Test a .NET class library using Visual Studio Code](https://review.learn.microsoft.com/en-us/dotnet/core/tutorials/testing-library-with-visual-studio-code?branch=pr-en-us-36535) |

<!-- PREVIEW-TABLE-END -->