### PR TITLE
Use code formatting on regex domain example

### DIFF
--- a/docs/framework/configure-apps/file-schema/network/add-element-for-bypasslist-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/add-element-for-bypasslist-network-settings.md
@@ -56,7 +56,7 @@ Adds an IP address or DNS name to the proxy bypass list.
   
  The value of the `address` attribute should be a regular expression that describes a set of IP addresses or host names.  
   
- You should use caution when specifying a regular expression for this element. The regular expression "[a-z]+\\.contoso\\.com" matches any host in the contoso.com domain, but it also matches any host in the contoso.com.cpandl.com domain. To match only a host in the contoso.com domain, use an anchor ("$"): "[a-z]+\\.contoso\\.com$".  
+ You should use caution when specifying a regular expression for this element. The regular expression `[a-z]+\\.contoso\\.com` matches any host in the contoso.com domain, but it also matches any host in the contoso.com.cpandl.com domain. To match only a host in the contoso.com domain, use an anchor (`$`): `[a-z]+\\.contoso\\.com$`.
   
  For more information about regular expressions, see .[.NET Framework Regular Expressions](../../../../standard/base-types/regular-expressions.md).  
   


### PR DESCRIPTION
## Summary

There  was no code formatting on the example regex for using the end of string anchor. This was causing the regex to render as LaTex due to the enclosing dollar-signs.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/configure-apps/file-schema/network/add-element-for-bypasslist-network-settings.md](https://github.com/dotnet/docs/blob/2caa0d847c78e8874b935095486c5a5664603851/docs/framework/configure-apps/file-schema/network/add-element-for-bypasslist-network-settings.md) | [\<add> Element for bypasslist (Network Settings)](https://review.learn.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/network/add-element-for-bypasslist-network-settings?branch=pr-en-us-36557) |

<!-- PREVIEW-TABLE-END -->