### PR TITLE
NativeAOT diagnostic documentation

### DIFF
--- a/docs/core/deploying/native-aot/diagnostics.md
+++ b/docs/core/deploying/native-aot/diagnostics.md
@@ -17,7 +17,7 @@ NativeAOT applications have the following characteristics that are important to 
 
 ## Current NativeAOT diagnostic support
 
-Not all diagnostic features in NativeAOT are currently at parity with .NET. The following table summarizes NativeAOT diagnostic feature parity with .NET:
+The following table summarizes diagnostic features supported for native AOT deployments:
 
 | Feature | Fully Supported | Partially Supported | Not Supported |
 | - | - | - | - |
@@ -37,7 +37,7 @@ NativeAOT runtime supports [EventPipe](../../diagnostics/eventpipe.md) which wil
 
 NativeAOT also provides partial support for [OpenTelemetry](../../diagnostics/observability-with-otel.md) and some [well-known event providers](../../diagnostics/well-known-event-providers.md). Not all [runtime events](../../../fundamentals/diagnostics/runtime-events.md) are supported in NativeAOT.
 
-### Profiling support
+### CPU Profiling support
 
 "Microsoft-DotNETCore-SampleProfiler" provider is not currently supported in NativeAOT. Platform specific tools like [PerfView](https://github.com/microsoft/perfview), and [Perf](https://perf.wiki.kernel.org/index.php/Main_Page) can be used to collect CPU samples of a NativeAOT application.
 

--- a/docs/core/deploying/native-aot/diagnostics.md
+++ b/docs/core/deploying/native-aot/diagnostics.md
@@ -11,13 +11,13 @@ The long term goal for NativeAOT application diagnostics is to provide the rich 
 
 NativeAOT applications have the following characteristics that are important to keep in mind in diagnostic scenarios:
 
-- Trimming as a first-class feature in NativeAOT application. Unused code in a NativeAOT application is stripped out of the final binary. Any unbounded reflection used by the application including its dependent libraries will be trimmed. Trimming The IL Compiler will generate warnings in such cases, and it is critical that these warnings are fixed. For example, suppressing any such warnings without careful analysis can lead to hard to debug production failures.
-- Symbol file issues: NativeAOT applications require symbol files to be present at application publish time to create a full application symbol file. In contrast, .NET production debugging experience can rely on symbol files being available postproduction deployment since symbol servers can be used to download library symbol files.
-- NativeAOT application is neither a managed application (for example, no JIT) nor a full native application (for example, has full GC support). The intent is to meet the reasonable diagnostics expectation of a product that is coming out of the .NET family and also the experience should feel familiar to someone who does production diagnostics on a C++ application (with a GC).
+- Trimming as a first-class feature in NativeAOT application. Unused code in a NativeAOT application is stripped out of the final binary. Any unbounded reflection used by the application including its dependent libraries will be trimmed. NativeAOT compiler will generate warnings in such cases, and it is critical that these warnings are fixed. For example, suppressing any such warnings without careful analysis can lead to hard to debug production failures.
+- Symbol file issues: In NativeAOT, symbol-file-dependent diagnostics (debugging, PerfView callstacks, etc) don't work at all unless the diagnostic tool has access to the monolithic PDB that was generated when the application was compiled. In .NET, symbol-file-dependent diagnostics generally work just fine (or even work great) even if the diagnostic tool has no access to any PDBs that were generated when the application was compiled (i.e., symbols for the .NET runtime and the .NET libraries can be pulled from symbol servers, diagnostic tools can still show function names, accurate callstacks, etc even without access to the PDBs generated at application compile time).
+- NativeAOT application is neither a typical managed application (for example, no JIT) nor a typical native application (for example, has full GC support). The intent is to meet the reasonable diagnostics expectation of a product that is coming out of the .NET family and also the experience should feel familiar to someone who does production diagnostics on a C++ application.
 
 ## Current NativeAOT diagnostic support
 
-Not all diagnostic features in NativeAOT are currently compatible with .NET. The following table summarizes NativeAOT diagnostic feature compatibility with .NET:
+Not all diagnostic features in NativeAOT are currently at parity with .NET. The following table summarizes NativeAOT diagnostic feature parity with .NET:
 
 | Feature | Fully Supported | Partially Supported | Not Supported |
 | - | - | - | - |
@@ -33,9 +33,9 @@ Build time (inner-dev-loop experience) diagnostic experience for a NativeAOT app
 
 ### Observability support
 
-NativeAOT runtime supports [EventPipe](../../diagnostics/eventpipe.md) which will allow NativeAOT applications to easily trace their applications. EventPipe support will also allow most .NET diagnsotic tools like [dotnet-trace](../../diagnostics/dotnet-trace.md), [dotnet-counter](../../diagnostics/dotnet-counters.md), and [dotnet-monitor](../../diagnostics/dotnet-monitor.md) to work seamlessly with NativeAOT applications.
+NativeAOT runtime supports [EventPipe](../../diagnostics/eventpipe.md) which will allow NativeAOT applications to easily trace their applications. EventPipe support will also allow most .NET diagnostic tools like [dotnet-trace](../../diagnostics/dotnet-trace.md), [dotnet-counter](../../diagnostics/dotnet-counters.md), and [dotnet-monitor](../../diagnostics/dotnet-monitor.md) to work seamlessly with NativeAOT applications.
 
-NativeAOT also providers partial support for [OpenTelemetry](../../diagnostics/observability-with-otel.md) and some [well-known event providers](../../diagnostics/well-known-event-providers.md). Not all [runtime events](../../../fundamentals/diagnostics/runtime-events.md) are supported in NativeAOT.
+NativeAOT also provides partial support for [OpenTelemetry](../../diagnostics/observability-with-otel.md) and some [well-known event providers](../../diagnostics/well-known-event-providers.md). Not all [runtime events](../../../fundamentals/diagnostics/runtime-events.md) are supported in NativeAOT.
 
 ### Profiling support
 
@@ -45,7 +45,7 @@ NativeAOT also providers partial support for [OpenTelemetry](../../diagnostics/o
 
 A NativeAOT application in production environment is a native application with full GC support and can be debugged by native platform debuggers  (e.g. WinDbg or Visual Studio on Windows, and gdb or lldb on Unix-like systems). It is critical that the corresponding symbol file for the application is available to do production debugging.
 
-The NativeAOT compiler generates information about line numbers, types, locals and parameters. The native debugger will allow inspecting stack trace and variables, stepping into/over source lines, or setting line breakpoints. Additional feature support like debugging around Exceptions, fixing some name mangling, step into virtual calls, hot reload, stepping into runtime library code, property evaluations, expression evaluation are planned in future releases.
+The NativeAOT compiler generates information about line numbers, types, locals and parameters. The native debugger will allow inspecting stack trace and variables, stepping into/over source lines, or setting line breakpoints. Additional feature support like debugging around Exceptions, fixing some name mangling, step into virtual calls, hot reload, stepping into runtime library code, property and expression evaluation are planned in future releases.
 
 Collecting a [dump](../../diagnostics/dumps.md) file for a NativeAOT application would involve some manual steps in .NET8 release.
 

--- a/docs/core/deploying/native-aot/diagnostics.md
+++ b/docs/core/deploying/native-aot/diagnostics.md
@@ -15,11 +15,11 @@ Native AOT applications have the following characteristics that are important to
 
 ### Trimming as a first-class feature
 
-Unused code in a NativeAOT application is stripped out of the final binary. Any unbounded reflection used by the application, including its dependent libraries, is trimmed. The NativeAOT compiler will generate warnings in such cases, and it's critical that these warnings are fixed. For example, if you suppress any warnings without careful analysis, it can lead to hard to debug production failures.
+Unused code in a native AOT application is stripped out of the final binary. Any unbounded reflection used by the application, including its dependent libraries, is trimmed. The native AOT compiler will generate warnings in such cases, and it's critical that these warnings are fixed. For example, if you suppress any warnings without careful analysis, it can lead to hard to debug production failures.
 
 ### Importance of the symbol file
 
-In native AOT, symbol-file-dependent diagnostics (such as debugging, PerfView callstacks) don't work at all unless the diagnostic tool has access to the monolithic PDB that was generated when the application was compiled. In .NET, symbol-file-dependent diagnostics generally work just fine (or even work great) even if the diagnostic tool has no access to any PDBs that were generated when the application was compiled (that is, symbols for the .NET runtime and the .NET libraries can be pulled from symbol servers, diagnostic tools can still show function names and accurate callstacks even without access to the PDBs generated at application compile time)
+In native AOT, symbol-file-dependent diagnostics (such as debugging, [PerfView](https://github.com/microsoft/perfview) callstacks) don't work at all unless the diagnostic tool has access to the monolithic PDB that was generated when the application was compiled. In .NET, symbol-file-dependent diagnostics generally work just fine (or even work great) even if the diagnostic tool has no access to any PDBs that were generated when the application was compiled (that is, symbols for the .NET runtime and the .NET libraries can be pulled from symbol servers, diagnostic tools can still show function names and accurate callstacks even without access to the PDBs generated at application compile time)
 
 ### Application type
 
@@ -51,7 +51,7 @@ The native AOT runtime supports [EventPipe](../../diagnostics/eventpipe.md), whi
 </PropertyGroup>
 ```
 
-[OpenTelemetry](../../diagnostics/observability-with-otel.md) is expected to support native AOT in the key three pillars of observability: logging, tracing, and metrics in .NET 8. Native AOT provides partial support for and some [well-known event providers](../../diagnostics/well-known-event-providers.md). Not all [runtime events](../../../fundamentals/diagnostics/runtime-events.md) are supported in native AOT.
+[OpenTelemetry](../../diagnostics/observability-with-otel.md) is expected to support native AOT in the key three pillars of observability: logging, tracing, and metrics in .NET 8. Native AOT provides partial support for some [well-known event providers](../../diagnostics/well-known-event-providers.md). Not all [runtime events](../../../fundamentals/diagnostics/runtime-events.md) are supported in native AOT.
 
 ### CPU profiling
 

--- a/docs/core/deploying/native-aot/diagnostics.md
+++ b/docs/core/deploying/native-aot/diagnostics.md
@@ -55,7 +55,7 @@ The native AOT runtime supports [EventPipe](../../diagnostics/eventpipe.md), whi
 
 ### CPU profiling
 
-The "Microsoft-DotNETCore-SampleProfiler" provider is not currently supported in native AOT. However, platform-specific tools like [PerfView](https://github.com/microsoft/perfview) and [Perf](https://perf.wiki.kernel.org/index.php/Main_Page) can be used to collect CPU samples of a native AOT application.
+Platform-specific tools like [PerfView](https://github.com/microsoft/perfview) and [Perf](https://perf.wiki.kernel.org/index.php/Main_Page) can be used to collect CPU samples of a native AOT application.
 
 ### Production debugging
 

--- a/docs/core/deploying/native-aot/diagnostics.md
+++ b/docs/core/deploying/native-aot/diagnostics.md
@@ -15,15 +15,15 @@ Native AOT applications have the following characteristics that are important to
 
 ### Trimming as a first-class feature
 
-Unused code in a native AOT application is stripped out of the final binary. Any unbounded reflection used by the application, including its dependent libraries, is trimmed. The native AOT compiler will generate warnings in such cases, and it's critical that these warnings are fixed. For example, if you suppress any warnings without careful analysis, it can lead to hard to debug production failures.
+Unused code in a native AOT application is stripped out of the final binary. Any unbounded reflection used by the application, including its dependent libraries, is trimmed. The native AOT compiler will generate warnings in such cases, and it's critical that these warnings are fixed. For example, if you suppress any warnings without careful analysis, it can lead to hard-to-debug production failures.
 
 ### Importance of the symbol file
 
-In native AOT, symbol-file-dependent diagnostics (such as debugging, [PerfView](https://github.com/microsoft/perfview) callstacks) don't work at all unless the diagnostic tool has access to the monolithic PDB that was generated when the application was compiled. In .NET, symbol-file-dependent diagnostics generally work just fine (or even work great) even if the diagnostic tool has no access to any PDBs that were generated when the application was compiled (that is, symbols for the .NET runtime and the .NET libraries can be pulled from symbol servers, diagnostic tools can still show function names and accurate callstacks even without access to the PDBs generated at application compile time)
+In native AOT, symbol-file-dependent diagnostics (such as debugging [PerfView](https://github.com/microsoft/perfview) callstacks) don't work at all unless the diagnostic tool has access to the monolithic PDB that was generated when the application was compiled. In .NET, symbol-file-dependent diagnostics generally work just fine, or even great, even if the diagnostic tool has no access to any PDBs that were generated when the application was compiled. That is, symbols for the .NET runtime and the .NET libraries can be pulled from symbol servers, and diagnostic tools can still show function names and accurate call stacks even without access to the compile-time PDBs.
 
 ### Application type
 
-Native AOT apps aren't typical managed applications (for example, no JIT). They also aren't typical native applications (for example, they have full GC support). The intent is to meet the reasonable diagnostics expectation of a product in the .NET family, but the experience should also feel familiar to those using production diagnostics on C++ apps.
+Native AOT apps aren't typical managed applications (for example, no JIT). They also aren't typical native applications (for example, they have full GC support). The intent for diagnostics is to meet a reasonable expectation of a product in the .NET family, but the experience should also feel familiar to those using production diagnostics on C++ apps.
 
 ## .NET 8 native AOT diagnostic support
 
@@ -37,13 +37,13 @@ The following table summarizes diagnostic features supported for native AOT depl
 | Production debugging | | <span aria-hidden="true">✔️</span><span class="visually-hidden">Partially supported</span> | |
 | Heap analysis | | | <span aria-hidden="true">❌</span><span class="visually-hidden">Not supported</span> |
 
-### Build (Inner dev loop) diagnostics
+### Build (inner dev loop) diagnostics
 
 Publishing your app as native AOT produces an app that has been ahead-of-time (AOT) compiled to native code. As mentioned above, this means that not all diagnostic tools will work seamlessly with published native AOT applications in .NET 8. However, all .NET diagnostic tools are available for developers during the application building stage. We recommend developing, debugging, and testing the applications as usual and publish the working app with native AOT as one of the last steps.
 
 ### Observability
 
-The native AOT runtime supports [EventPipe](../../diagnostics/eventpipe.md), which allows native AOT apps to easily trace their applications. EventPipe support also allows most .NET diagnostic tools, like [dotnet-trace](../../diagnostics/dotnet-trace.md), [dotnet-counter](../../diagnostics/dotnet-counters.md), and [dotnet-monitor](../../diagnostics/dotnet-monitor.md), to work seamlessly with native AOT applications. EventPipe is an optional component in native AOT and require the `EventSourceSupport` property to be set to `true` to include EventPipe support.
+The native AOT runtime supports [EventPipe](../../diagnostics/eventpipe.md), which allows native AOT apps to easily trace their applications. EventPipe support also allows most .NET diagnostic tools, like [dotnet-trace](../../diagnostics/dotnet-trace.md), [dotnet-counter](../../diagnostics/dotnet-counters.md), and [dotnet-monitor](../../diagnostics/dotnet-monitor.md), to work seamlessly with native AOT applications. EventPipe is an optional component in native AOT. To include EventPipe support, set the `EventSourceSupport` MSBuild property to `true`.
 
 ```xml
 <PropertyGroup>
@@ -51,20 +51,20 @@ The native AOT runtime supports [EventPipe](../../diagnostics/eventpipe.md), whi
 </PropertyGroup>
 ```
 
-[OpenTelemetry](../../diagnostics/observability-with-otel.md) is expected to support native AOT in the key three pillars of observability: logging, tracing, and metrics in .NET 8. Native AOT provides partial support for some [well-known event providers](../../diagnostics/well-known-event-providers.md). Not all [runtime events](../../../fundamentals/diagnostics/runtime-events.md) are supported in native AOT.
+[OpenTelemetry](../../diagnostics/observability-with-otel.md) is expected to support native AOT in the key three pillars of observability&mdash;logging, tracing, and metrics&mdash;in .NET 8. Native AOT provides partial support for some [well-known event providers](../../diagnostics/well-known-event-providers.md). Not all [runtime events](../../../fundamentals/diagnostics/runtime-events.md) are supported in native AOT.
 
 ### CPU profiling
 
-The "Microsoft-DotNETCore-SampleProfiler" provider is not currently supported in native AOT. However, platform-specific tools like [PerfView](https://github.com/microsoft/perfview), and [Perf](https://perf.wiki.kernel.org/index.php/Main_Page) can be used to collect CPU samples of a native AOT application.
+The "Microsoft-DotNETCore-SampleProfiler" provider is not currently supported in native AOT. However, platform-specific tools like [PerfView](https://github.com/microsoft/perfview) and [Perf](https://perf.wiki.kernel.org/index.php/Main_Page) can be used to collect CPU samples of a native AOT application.
 
 ### Production debugging
 
-Typical production debugging scenarios are done through logging and tracing, and will be [supported](#observability) in native AOT. Low-level debugging, using platform debuggers like WinDbg or Visual Studio on Windows, and gdb or lldb on Unix-like systems, can be used in native AOT. For this case, it is critical that the corresponding symbol file for the application is available to do production debugging.
+Typical production debugging scenarios are done through logging and tracing and are [supported](#observability) in native AOT. Low-level debugging, using platform debuggers like WinDbg or Visual Studio on Windows, and gdb or lldb on Unix-like systems, can be used in native AOT. For this case, it's critical that the corresponding symbol file for the application is available.
 
-The native AOT compiler generates information about line numbers, types, locals, and parameters. The native debugger will allow inspecting stack trace and variables, stepping into/over source lines, or setting line breakpoints. Additional feature support like debugging around Exceptions, fixing some name mangling, step into virtual calls, stepping into runtime library code, property and expression evaluation are planned in future releases.
+The native AOT compiler generates information about line numbers, types, locals, and parameters. The native debugger allows inspecting stack trace and variables, stepping into or over source lines, or setting line breakpoints. Additional feature support like debugging around exceptions, fixing some name mangling, stepping into virtual calls, stepping into runtime library code, and property and expression evaluation are planned in future releases.
 
-Collecting a [dump](../../diagnostics/dumps.md) file for a native AOT application would involve some manual steps in .NET8 release.
+Collecting a [dump](../../diagnostics/dumps.md) file for a native AOT application involves some manual steps in .NET 8.
 
 ### Heap analysis
 
-Managed heap analysis is not currently supported in native AOT. Heap analysis tools like, [dotnet-gcdump](../../diagnostics/dotnet-gcdump.md), [PerfView](https://github.com/microsoft/perfview) and Visual Studio heap analysis tools will not work in native AOT in .NET 8.
+Managed heap analysis is not currently supported in native AOT. Heap analysis tools like [dotnet-gcdump](../../diagnostics/dotnet-gcdump.md), [PerfView](https://github.com/microsoft/perfview), and Visual Studio heap analysis tools don't work in native AOT in .NET 8.

--- a/docs/core/deploying/native-aot/diagnostics.md
+++ b/docs/core/deploying/native-aot/diagnostics.md
@@ -1,5 +1,5 @@
 ---
-title: AOT Diagnostics
+title: AOT diagnostics
 description: Learn about diagnostics in native AOT applications
 author: lakshanf
 ms.author: lakshanf
@@ -7,15 +7,15 @@ ms.date: 08/07/2023
 ---
 # Diagnostics in native AOT applications
 
-The long term goal for native AOT application diagnostics is to provide the rich diagnostic experience that developers expect out of a .NET application. .NET diagnostic experience was built over multiple releases and getting customer feedback on diagnostic was a critical part of that journey. native AOT wants to follow a similar path where the right diagnostic experience is built from prioritized customer feedback in multiple releases.
+The long-term goal for native AOT application diagnostics is to provide the rich diagnostic experience that developers expect out of a .NET application. The .NET diagnostic experience was built over multiple releases, and a critical part of that journey was customer feedback. Native AOT diagnostics will follow a similar path where the right diagnostic experience is built from prioritized customer feedback in multiple releases.
 
 ## Native AOT application features
 
-Native AOT applications have the following characteristics that are important to keep in mind in diagnostic scenarios
+Native AOT applications have the following characteristics that are important to keep in mind in diagnostic scenarios.
 
 ### Trimming as a first-class feature
 
-Unused code in a native AOT application is stripped out of the final binary. Any unbounded reflection used by the application including its dependent libraries will be trimmed. native AOT compiler will generate warnings in such cases, and it is critical that these warnings are fixed. For example, suppressing any such warnings without careful analysis can lead to hard to debug production failures.
+Unused code in a NativeAOT application is stripped out of the final binary. Any unbounded reflection used by the application, including its dependent libraries, is trimmed. The NativeAOT compiler will generate warnings in such cases, and it's critical that these warnings are fixed. For example, if you suppress any warnings without careful analysis, it can lead to hard to debug production failures.
 
 ### Importance of the symbol file
 
@@ -23,7 +23,7 @@ In native AOT, symbol-file-dependent diagnostics (such as debugging, PerfView ca
 
 ### Application type
 
-Native AOT application is neither a typical managed application (for example, no JIT) nor a typical native application (for example, has full GC support). The intent is to meet the reasonable diagnostics expectation of a product that is coming out of the .NET family and also the experience should feel familiar to someone who does production diagnostics on a C++ application.
+Native AOT apps aren't typical managed applications (for example, no JIT). They also aren't typical native applications (for example, they have full GC support). The intent is to meet the reasonable diagnostics expectation of a product in the .NET family, but the experience should also feel familiar to those using production diagnostics on C++ apps.
 
 ## .NET 8 native AOT diagnostic support
 
@@ -39,26 +39,26 @@ The following table summarizes diagnostic features supported for native AOT depl
 
 ### Build (Inner dev loop) diagnostics
 
-Publishing your app as native AOT produces an app that has been ahead-of-time (AOT) compiled to native code. However, all .NET diagnostic tools are available for developers during the application building stage. We recommend developing, debugging and testing the applications as usual and publish the working app with native AOT as one of the last steps.
+Publishing your app as native AOT produces an app that has been ahead-of-time (AOT) compiled to native code. As mentioned above, this means that not all diagnostic tools will work seamlessly with published native AOT applications in .NET 8. However, all .NET diagnostic tools are available for developers during the application building stage. We recommend developing, debugging, and testing the applications as usual and publish the working app with native AOT as one of the last steps.
 
 ### Observability
 
-Native AOT runtime supports [EventPipe](../../diagnostics/eventpipe.md) which will allow native AOT applications to easily trace their applications. EventPipe support will also allow most .NET diagnostic tools like [dotnet-trace](../../diagnostics/dotnet-trace.md), [dotnet-counter](../../diagnostics/dotnet-counters.md), and [dotnet-monitor](../../diagnostics/dotnet-monitor.md) to work seamlessly with native AOT applications.
+The native AOT runtime supports [EventPipe](../../diagnostics/eventpipe.md), which allows native AOT apps to easily trace their applications. EventPipe support also allows most .NET diagnostic tools, like [dotnet-trace](../../diagnostics/dotnet-trace.md), [dotnet-counter](../../diagnostics/dotnet-counters.md), and [dotnet-monitor](../../diagnostics/dotnet-monitor.md), to work seamlessly with native AOT applications.
 
-native AOT also provides partial support for [OpenTelemetry](../../diagnostics/observability-with-otel.md) and some [well-known event providers](../../diagnostics/well-known-event-providers.md). Not all [runtime events](../../../fundamentals/diagnostics/runtime-events.md) are supported in native AOT.
+[OpenTelemetry](../../diagnostics/observability-with-otel.md) is expected to support native AOT in the key three pillars of observability: logging, tracing, and metrics in .NET 8. Native AOT provides partial support for and some [well-known event providers](../../diagnostics/well-known-event-providers.md). Not all [runtime events](../../../fundamentals/diagnostics/runtime-events.md) are supported in native AOT.
 
-### CPU Profiling
+### CPU profiling
 
-"Microsoft-DotNETCore-SampleProfiler" provider is not currently supported in native AOT. Platform specific tools like [PerfView](https://github.com/microsoft/perfview), and [Perf](https://perf.wiki.kernel.org/index.php/Main_Page) can be used to collect CPU samples of a native AOT application.
+The "Microsoft-DotNETCore-SampleProfiler" provider is not currently supported in native AOT. However, platform-specific tools like [PerfView](https://github.com/microsoft/perfview), and [Perf](https://perf.wiki.kernel.org/index.php/Main_Page) can be used to collect CPU samples of a native AOT application.
 
 ### Production debugging
 
-A native AOT application in production environment is a native application with full GC support and can be debugged by native platform debuggers  (e.g. WinDbg or Visual Studio on Windows, and gdb or lldb on Unix-like systems). It is critical that the corresponding symbol file for the application is available to do production debugging.
+Typical production debugging scenarios are done through logging and tracing, and will be [supported](#observability) in native AOT. Low-level debugging, using platform debuggers like WinDbg or Visual Studio on Windows, and gdb or lldb on Unix-like systems, can be used in native AOT. For this case, it is critical that the corresponding symbol file for the application is available to do production debugging.
 
-The native AOT compiler generates information about line numbers, types, locals and parameters. The native debugger will allow inspecting stack trace and variables, stepping into/over source lines, or setting line breakpoints. Additional feature support like debugging around Exceptions, fixing some name mangling, step into virtual calls, stepping into runtime library code, property and expression evaluation are planned in future releases.
+The native AOT compiler generates information about line numbers, types, locals, and parameters. The native debugger will allow inspecting stack trace and variables, stepping into/over source lines, or setting line breakpoints. Additional feature support like debugging around Exceptions, fixing some name mangling, step into virtual calls, stepping into runtime library code, property and expression evaluation are planned in future releases.
 
 Collecting a [dump](../../diagnostics/dumps.md) file for a native AOT application would involve some manual steps in .NET8 release.
 
 ### Heap analysis
 
-Heap analysis tool, [dotnet-gcdump](../../diagnostics/dotnet-gcdump.md), is not currently supported in native AOT.
+Managed heap analysis is not currently supported in native AOT. Heap analysis tools like, [dotnet-gcdump](../../diagnostics/dotnet-gcdump.md), [PerfView](https://github.com/microsoft/perfview) and Visual Studio heap analysis tools will not work in native AOT in .NET 8.

--- a/docs/core/deploying/native-aot/diagnostics.md
+++ b/docs/core/deploying/native-aot/diagnostics.md
@@ -1,0 +1,54 @@
+---
+title: AOT Diagnostics
+description: Learn about diagnostics in NativeAOT applications
+author: lakshanf
+ms.author: lakshanf
+ms.date: 08/07/2023
+---
+# Diagnostics in NativeAOT applications
+
+The long term goal for NativeAOT application diagnostics is to provide the rich diagnostic experience that developers expect out of a .NET application. .NET diagnostic experience was built over multiple releases and getting customer feedback on diagnostic was a critical part of that journey. NativeAOT wants to follow a similar path where the right diagnostic experience is built from prioritized customer feedback in multiple releases.
+
+NativeAOT applications have the following characteristics that are important to keep in mind in diagnostic scenarios:
+
+- Trimming as a first-class feature in NativeAOT application. Unused code in a NativeAOT application is stripped out of the final binary. Any unbounded reflection used by the application including its dependent libraries will be trimmed. Trimming The IL Compiler will generate warnings in such cases, and it is critical that these warnings are fixed. For example, suppressing any such warnings without careful analysis can lead to hard to debug production failures.
+- Symbol file issues: NativeAOT applications require symbol files to be present at application publish time to create a full application symbol file. In contrast, .NET production debugging experience can rely on symbol files being available postproduction deployment since symbol servers can be used to download library symbol files.
+- NativeAOT application is neither a managed application (for example, no JIT) nor a full native application (for example, has full GC support). The intent is to meet the reasonable diagnostics expectation of a product that is coming out of the .NET family and also the experience should feel familiar to someone who does production diagnostics on a C++ application (with a GC).
+
+## Current NativeAOT diagnostic support
+
+Not all diagnostic features in NativeAOT are currently compatible with .NET. The following table summarizes NativeAOT diagnostic feature compatibility with .NET:
+
+| Feature | Fully Supported | Partially Supported | Not Supported |
+| - | - | - | - |
+| Build (Inner dev loop) diagnostics | <span aria-hidden="true">✔️</span><span class="visually-hidden">Fully supported</span> | | |
+| Observability | | <span aria-hidden="true">✔️</span><span class="visually-hidden">Partially supported</span> | |
+| Profiling | | <span aria-hidden="true">✔️</span><span class="visually-hidden">Partially supported</span> | |
+| Production debugging | | <span aria-hidden="true">✔️</span><span class="visually-hidden">Partially supported</span> | |
+| Heap analysis | | | <span aria-hidden="true">❌</span><span class="visually-hidden">Not supported</span> |
+
+### Build time diagnostics
+
+Build time (inner-dev-loop experience) diagnostic experience for a NativeAOT application will match exactly the .NET application experience since the application in build-time will run on .NET. Given the challenges in acquiring diagnostics in production environment and the current gap in diagnostic tools in NativeAOT, spending time in build time diagnostic in NativeAOT will be the best solution to build a performant and reliable NativeAOT application.
+
+### Observability support
+
+NativeAOT runtime supports [EventPipe](../../diagnostics/eventpipe.md) which will allow NativeAOT applications to easily trace their applications. EventPipe support will also allow most .NET diagnsotic tools like [dotnet-trace](../../diagnostics/dotnet-trace.md), [dotnet-counter](../../diagnostics/dotnet-counters.md), and [dotnet-monitor](../../diagnostics/dotnet-monitor.md) to work seamlessly with NativeAOT applications.
+
+NativeAOT also providers partial support for [OpenTelemetry](../../diagnostics/observability-with-otel.md) and some [well-known event providers](../../diagnostics/well-known-event-providers.md). Not all [runtime events](../../../fundamentals/diagnostics/runtime-events.md) are supported in NativeAOT.
+
+### Profiling support
+
+"Microsoft-DotNETCore-SampleProfiler" provider is not currently supported in NativeAOT. Platform specific tools like [PerfView](https://github.com/microsoft/perfview), and [Perf](https://perf.wiki.kernel.org/index.php/Main_Page) can be used to collect CPU samples of a NativeAOT application.
+
+### Production debugging
+
+A NativeAOT application in production environment is a native application with full GC support and can be debugged by native platform debuggers  (e.g. WinDbg or Visual Studio on Windows, and gdb or lldb on Unix-like systems). It is critical that the corresponding symbol file for the application is available to do production debugging.
+
+The NativeAOT compiler generates information about line numbers, types, locals and parameters. The native debugger will allow inspecting stack trace and variables, stepping into/over source lines, or setting line breakpoints. Additional feature support like debugging around Exceptions, fixing some name mangling, step into virtual calls, hot reload, stepping into runtime library code, property evaluations, expression evaluation are planned in future releases.
+
+Collecting a [dump](../../diagnostics/dumps.md) file for a NativeAOT application would involve some manual steps in .NET8 release.
+
+### Heap analysis support
+
+Heap analysis tool, [dotnet-gcdump](../../diagnostics/dotnet-gcdump.md), is not currently supported in NativeAOT.

--- a/docs/core/deploying/native-aot/diagnostics.md
+++ b/docs/core/deploying/native-aot/diagnostics.md
@@ -1,21 +1,31 @@
 ---
 title: AOT Diagnostics
-description: Learn about diagnostics in NativeAOT applications
+description: Learn about diagnostics in native AOT applications
 author: lakshanf
 ms.author: lakshanf
 ms.date: 08/07/2023
 ---
-# Diagnostics in NativeAOT applications
+# Diagnostics in native AOT applications
 
-The long term goal for NativeAOT application diagnostics is to provide the rich diagnostic experience that developers expect out of a .NET application. .NET diagnostic experience was built over multiple releases and getting customer feedback on diagnostic was a critical part of that journey. NativeAOT wants to follow a similar path where the right diagnostic experience is built from prioritized customer feedback in multiple releases.
+The long term goal for native AOT application diagnostics is to provide the rich diagnostic experience that developers expect out of a .NET application. .NET diagnostic experience was built over multiple releases and getting customer feedback on diagnostic was a critical part of that journey. native AOT wants to follow a similar path where the right diagnostic experience is built from prioritized customer feedback in multiple releases.
 
-NativeAOT applications have the following characteristics that are important to keep in mind in diagnostic scenarios:
+## Native AOT application features
 
-- Trimming as a first-class feature in NativeAOT application. Unused code in a NativeAOT application is stripped out of the final binary. Any unbounded reflection used by the application including its dependent libraries will be trimmed. NativeAOT compiler will generate warnings in such cases, and it is critical that these warnings are fixed. For example, suppressing any such warnings without careful analysis can lead to hard to debug production failures.
-- Symbol file issues: In NativeAOT, symbol-file-dependent diagnostics (debugging, PerfView callstacks, etc) don't work at all unless the diagnostic tool has access to the monolithic PDB that was generated when the application was compiled. In .NET, symbol-file-dependent diagnostics generally work just fine (or even work great) even if the diagnostic tool has no access to any PDBs that were generated when the application was compiled (i.e., symbols for the .NET runtime and the .NET libraries can be pulled from symbol servers, diagnostic tools can still show function names, accurate callstacks, etc even without access to the PDBs generated at application compile time).
-- NativeAOT application is neither a typical managed application (for example, no JIT) nor a typical native application (for example, has full GC support). The intent is to meet the reasonable diagnostics expectation of a product that is coming out of the .NET family and also the experience should feel familiar to someone who does production diagnostics on a C++ application.
+Native AOT applications have the following characteristics that are important to keep in mind in diagnostic scenarios
 
-## Current NativeAOT diagnostic support
+### Trimming as a first-class feature
+
+Unused code in a native AOT application is stripped out of the final binary. Any unbounded reflection used by the application including its dependent libraries will be trimmed. native AOT compiler will generate warnings in such cases, and it is critical that these warnings are fixed. For example, suppressing any such warnings without careful analysis can lead to hard to debug production failures.
+
+### Importance of the symbol file
+
+In native AOT, symbol-file-dependent diagnostics (such as debugging, PerfView callstacks) don't work at all unless the diagnostic tool has access to the monolithic PDB that was generated when the application was compiled. In .NET, symbol-file-dependent diagnostics generally work just fine (or even work great) even if the diagnostic tool has no access to any PDBs that were generated when the application was compiled (that is, symbols for the .NET runtime and the .NET libraries can be pulled from symbol servers, diagnostic tools can still show function names and accurate callstacks even without access to the PDBs generated at application compile time)
+
+### Application type
+
+Native AOT application is neither a typical managed application (for example, no JIT) nor a typical native application (for example, has full GC support). The intent is to meet the reasonable diagnostics expectation of a product that is coming out of the .NET family and also the experience should feel familiar to someone who does production diagnostics on a C++ application.
+
+## .NET 8 native AOT diagnostic support
 
 The following table summarizes diagnostic features supported for native AOT deployments:
 
@@ -23,32 +33,32 @@ The following table summarizes diagnostic features supported for native AOT depl
 | - | - | - | - |
 | Build (Inner dev loop) diagnostics | <span aria-hidden="true">✔️</span><span class="visually-hidden">Fully supported</span> | | |
 | Observability | | <span aria-hidden="true">✔️</span><span class="visually-hidden">Partially supported</span> | |
-| Profiling | | <span aria-hidden="true">✔️</span><span class="visually-hidden">Partially supported</span> | |
+| CPU Profiling | | <span aria-hidden="true">✔️</span><span class="visually-hidden">Partially supported</span> | |
 | Production debugging | | <span aria-hidden="true">✔️</span><span class="visually-hidden">Partially supported</span> | |
 | Heap analysis | | | <span aria-hidden="true">❌</span><span class="visually-hidden">Not supported</span> |
 
-### Build time diagnostics
+### Build (Inner dev loop) diagnostics
 
-Build time (inner-dev-loop experience) diagnostic experience for a NativeAOT application will match exactly the .NET application experience since the application in build-time will run on .NET. Given the challenges in acquiring diagnostics in production environment and the current gap in diagnostic tools in NativeAOT, spending time in build time diagnostic in NativeAOT will be the best solution to build a performant and reliable NativeAOT application.
+Publishing your app as native AOT produces an app that has been ahead-of-time (AOT) compiled to native code. However, all .NET diagnostic tools are available for developers during the application building stage. We recommend developing, debugging and testing the applications as usual and publish the working app with native AOT as one of the last steps.
 
-### Observability support
+### Observability
 
-NativeAOT runtime supports [EventPipe](../../diagnostics/eventpipe.md) which will allow NativeAOT applications to easily trace their applications. EventPipe support will also allow most .NET diagnostic tools like [dotnet-trace](../../diagnostics/dotnet-trace.md), [dotnet-counter](../../diagnostics/dotnet-counters.md), and [dotnet-monitor](../../diagnostics/dotnet-monitor.md) to work seamlessly with NativeAOT applications.
+Native AOT runtime supports [EventPipe](../../diagnostics/eventpipe.md) which will allow native AOT applications to easily trace their applications. EventPipe support will also allow most .NET diagnostic tools like [dotnet-trace](../../diagnostics/dotnet-trace.md), [dotnet-counter](../../diagnostics/dotnet-counters.md), and [dotnet-monitor](../../diagnostics/dotnet-monitor.md) to work seamlessly with native AOT applications.
 
-NativeAOT also provides partial support for [OpenTelemetry](../../diagnostics/observability-with-otel.md) and some [well-known event providers](../../diagnostics/well-known-event-providers.md). Not all [runtime events](../../../fundamentals/diagnostics/runtime-events.md) are supported in NativeAOT.
+native AOT also provides partial support for [OpenTelemetry](../../diagnostics/observability-with-otel.md) and some [well-known event providers](../../diagnostics/well-known-event-providers.md). Not all [runtime events](../../../fundamentals/diagnostics/runtime-events.md) are supported in native AOT.
 
-### CPU Profiling support
+### CPU Profiling
 
-"Microsoft-DotNETCore-SampleProfiler" provider is not currently supported in NativeAOT. Platform specific tools like [PerfView](https://github.com/microsoft/perfview), and [Perf](https://perf.wiki.kernel.org/index.php/Main_Page) can be used to collect CPU samples of a NativeAOT application.
+"Microsoft-DotNETCore-SampleProfiler" provider is not currently supported in native AOT. Platform specific tools like [PerfView](https://github.com/microsoft/perfview), and [Perf](https://perf.wiki.kernel.org/index.php/Main_Page) can be used to collect CPU samples of a native AOT application.
 
 ### Production debugging
 
-A NativeAOT application in production environment is a native application with full GC support and can be debugged by native platform debuggers  (e.g. WinDbg or Visual Studio on Windows, and gdb or lldb on Unix-like systems). It is critical that the corresponding symbol file for the application is available to do production debugging.
+A native AOT application in production environment is a native application with full GC support and can be debugged by native platform debuggers  (e.g. WinDbg or Visual Studio on Windows, and gdb or lldb on Unix-like systems). It is critical that the corresponding symbol file for the application is available to do production debugging.
 
-The NativeAOT compiler generates information about line numbers, types, locals and parameters. The native debugger will allow inspecting stack trace and variables, stepping into/over source lines, or setting line breakpoints. Additional feature support like debugging around Exceptions, fixing some name mangling, step into virtual calls, hot reload, stepping into runtime library code, property and expression evaluation are planned in future releases.
+The native AOT compiler generates information about line numbers, types, locals and parameters. The native debugger will allow inspecting stack trace and variables, stepping into/over source lines, or setting line breakpoints. Additional feature support like debugging around Exceptions, fixing some name mangling, step into virtual calls, stepping into runtime library code, property and expression evaluation are planned in future releases.
 
-Collecting a [dump](../../diagnostics/dumps.md) file for a NativeAOT application would involve some manual steps in .NET8 release.
+Collecting a [dump](../../diagnostics/dumps.md) file for a native AOT application would involve some manual steps in .NET8 release.
 
-### Heap analysis support
+### Heap analysis
 
-Heap analysis tool, [dotnet-gcdump](../../diagnostics/dotnet-gcdump.md), is not currently supported in NativeAOT.
+Heap analysis tool, [dotnet-gcdump](../../diagnostics/dotnet-gcdump.md), is not currently supported in native AOT.

--- a/docs/core/deploying/native-aot/diagnostics.md
+++ b/docs/core/deploying/native-aot/diagnostics.md
@@ -29,7 +29,7 @@ Native AOT application is neither a typical managed application (for example, no
 
 The following table summarizes diagnostic features supported for native AOT deployments:
 
-| Feature | Fully Supported | Partially Supported | Not Supported |
+| Feature | Fully supported | Partially supported | Not supported |
 | - | - | - | - |
 | Build (Inner dev loop) diagnostics | <span aria-hidden="true">✔️</span><span class="visually-hidden">Fully supported</span> | | |
 | Observability | | <span aria-hidden="true">✔️</span><span class="visually-hidden">Partially supported</span> | |

--- a/docs/core/deploying/native-aot/diagnostics.md
+++ b/docs/core/deploying/native-aot/diagnostics.md
@@ -43,7 +43,13 @@ Publishing your app as native AOT produces an app that has been ahead-of-time (A
 
 ### Observability
 
-The native AOT runtime supports [EventPipe](../../diagnostics/eventpipe.md), which allows native AOT apps to easily trace their applications. EventPipe support also allows most .NET diagnostic tools, like [dotnet-trace](../../diagnostics/dotnet-trace.md), [dotnet-counter](../../diagnostics/dotnet-counters.md), and [dotnet-monitor](../../diagnostics/dotnet-monitor.md), to work seamlessly with native AOT applications.
+The native AOT runtime supports [EventPipe](../../diagnostics/eventpipe.md), which allows native AOT apps to easily trace their applications. EventPipe support also allows most .NET diagnostic tools, like [dotnet-trace](../../diagnostics/dotnet-trace.md), [dotnet-counter](../../diagnostics/dotnet-counters.md), and [dotnet-monitor](../../diagnostics/dotnet-monitor.md), to work seamlessly with native AOT applications. EventPipe is an optional component in native AOT and require the `EventSourceSupport` property to be set to `true` to include EventPipe support.
+
+```xml
+<PropertyGroup>
+    <EventSourceSupport>true</EventSourceSupport>
+</PropertyGroup>
+```
 
 [OpenTelemetry](../../diagnostics/observability-with-otel.md) is expected to support native AOT in the key three pillars of observability: logging, tracing, and metrics in .NET 8. Native AOT provides partial support for and some [well-known event providers](../../diagnostics/well-known-event-providers.md). Not all [runtime events](../../../fundamentals/diagnostics/runtime-events.md) are supported in native AOT.
 

--- a/docs/core/deploying/native-aot/index.md
+++ b/docs/core/deploying/native-aot/index.md
@@ -131,7 +131,7 @@ By default, native AOT publishing produces debug information in a separate file:
 - Windows: *.pdb*
 - macOS: *.dwarf*
 
-The debug file is necessary for running the app under the debugger or inspecting crash dumps. On Unix-like platforms, set the `StripSymbols` property to `false` to include the debug information in the native binary. Including debug information makes the native binary larger.
+The debug file is necessary for running the app under the [debugger or inspecting crash dumps](./diagnostics.md#symbol-file-issues). On Unix-like platforms, set the `StripSymbols` property to `false` to include the debug information in the native binary. Including debug information makes the native binary larger.
 
 ```xml
 <PropertyGroup>
@@ -166,7 +166,7 @@ The publish process analyzes the entire project and its dependencies for possibl
 
 ### [.NET 8+](#tab/net8plus)
 
-- Some limitations on diagnostic support for debugging and profiling.
+- Some limitations on [diagnostic support for debugging and profiling](./diagnostics.md).
 - Support for some ASP.NET Core features. For more information, see [ASP.NET Core support for native AOT](/aspnet/core/fundamentals/native-aot/?view=aspnetcore-8.0&preserve-view=true).
 
 ---

--- a/docs/core/deploying/native-aot/index.md
+++ b/docs/core/deploying/native-aot/index.md
@@ -166,7 +166,7 @@ The publish process analyzes the entire project and its dependencies for possibl
 
 ### [.NET 8+](#tab/net8plus)
 
-- Some limitations on [diagnostic support for debugging and profiling](./diagnostics.md).
+- [Diagnostic support for debugging and profiling](./diagnostics.md) with some limitations.
 - Support for some ASP.NET Core features. For more information, see [ASP.NET Core support for native AOT](/aspnet/core/fundamentals/native-aot/?view=aspnetcore-8.0&preserve-view=true).
 
 ---

--- a/docs/core/deploying/native-aot/index.md
+++ b/docs/core/deploying/native-aot/index.md
@@ -131,7 +131,7 @@ By default, native AOT publishing produces debug information in a separate file:
 - Windows: *.pdb*
 - macOS: *.dwarf*
 
-The debug file is necessary for running the app under the [debugger or inspecting crash dumps](./diagnostics.md#symbol-file-issues). On Unix-like platforms, set the `StripSymbols` property to `false` to include the debug information in the native binary. Including debug information makes the native binary larger.
+The debug file is necessary for running the app under the [debugger or inspecting crash dumps](./diagnostics.md#importance-of-the-symbol-file). On Unix-like platforms, set the `StripSymbols` property to `false` to include the debug information in the native binary. Including debug information makes the native binary larger.
 
 ```xml
 <PropertyGroup>

--- a/docs/core/diagnostics/index.md
+++ b/docs/core/diagnostics/index.md
@@ -9,7 +9,7 @@ ms.topic: overview
 
 Software doesn't always behave as you would expect, but .NET Core has tools and APIs that will help you diagnose these issues quickly and effectively.
 
-[Native AOT deployment](../../core/deploying/native-aot/index.md) is a relatively new application model that has been available since .NET 7 and details on .NET 8 diagnostic support for native AOT applications can be found [here](../../core/deploying/native-aot/diagnostics.md).
+[Native AOT deployment](../../core/deploying/native-aot/index.md) is an application model that's been available since .NET 7. For information about .NET 8 diagnostic support for native AOT apps, see [Native AOT diagnostics](../../core/deploying/native-aot/diagnostics.md).
 
 This article helps you find the various tools you need.
 

--- a/docs/core/diagnostics/index.md
+++ b/docs/core/diagnostics/index.md
@@ -9,6 +9,8 @@ ms.topic: overview
 
 Software doesn't always behave as you would expect, but .NET Core has tools and APIs that will help you diagnose these issues quickly and effectively.
 
+[Native AOT deployment](../../core/deploying/native-aot/index.md) is a relatively new application model that has been available since .NET 7 and details on .NET 8 diagnostic support for native AOT applications can be found [here](../../core/deploying/native-aot/diagnostics.md).
+
 This article helps you find the various tools you need.
 
 ## Debuggers

--- a/docs/navigate/devops-testing/toc.yml
+++ b/docs/navigate/devops-testing/toc.yml
@@ -329,7 +329,7 @@ items:
             href: ../../core/deploying/native-aot/index.md
           - name: Optimize AOT deployments
             href: ../../core/deploying/native-aot/optimizing.md
-          - name: AOT Diagnostics
+          - name: AOT diagnostics
             href: ../../core/deploying/native-aot/diagnostics.md
           - name: Native code interop
             href: ../../core/deploying/native-aot/interop.md

--- a/docs/navigate/devops-testing/toc.yml
+++ b/docs/navigate/devops-testing/toc.yml
@@ -329,6 +329,8 @@ items:
             href: ../../core/deploying/native-aot/index.md
           - name: Optimize AOT deployments
             href: ../../core/deploying/native-aot/optimizing.md
+          - name: AOT Diagnostics
+            href: ../../core/deploying/native-aot/diagnostics.md
           - name: Native code interop
             href: ../../core/deploying/native-aot/interop.md
           - name: Intro to AOT warnings


### PR DESCRIPTION
## Summary

Although diagnostic is not fully at parity with .NET, NativeAOT diagnostic support is significantly expanded in .NET8 release. This document describes the current support. 

Addresses the main documentation described in #[88905](https://github.com/dotnet/runtime/issues/88905)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/deploying/native-aot/diagnostics.md](https://github.com/dotnet/docs/blob/72838e8bd4113f843815b31dcd8f38f27d6e271a/docs/core/deploying/native-aot/diagnostics.md) | [docs/core/deploying/native-aot/diagnostics](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/diagnostics?branch=pr-en-us-36626) |
| [docs/core/deploying/native-aot/index.md](https://github.com/dotnet/docs/blob/72838e8bd4113f843815b31dcd8f38f27d6e271a/docs/core/deploying/native-aot/index.md) | [Native AOT deployment](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/index?branch=pr-en-us-36626) |
| [docs/core/diagnostics/index.md](https://github.com/dotnet/docs/blob/72838e8bd4113f843815b31dcd8f38f27d6e271a/docs/core/diagnostics/index.md) | [What diagnostic tools are available in .NET Core?](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/index?branch=pr-en-us-36626) |


<!-- PREVIEW-TABLE-END -->