### PR TITLE
Lock the Moq version

### DIFF
--- a/docs/azure/sdk/snippets/unit-testing/UnitTestingSampleApp.csproj
+++ b/docs/azure/sdk/snippets/unit-testing/UnitTestingSampleApp.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Azure.Core" Version="1.34.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="Moq" Version="[4.18.4]" /> <!-- Context: https://github.com/Azure/azure-sdk-for-net/issues/38111 -->
     <PackageReference Include="NSubstitute" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">


### PR DESCRIPTION
Related to https://github.com/Azure/azure-sdk-for-net/issues/38111

Locks the Moq package version used in the accompanying sample app at https://learn.microsoft.com/dotnet/azure/sdk/unit-testing-mocking