### PR TITLE
Adding preview 7 - rc2 to the table

### DIFF
--- a/docs/core/porting/versioning-sdk-msbuild-vs.md
+++ b/docs/core/porting/versioning-sdk-msbuild-vs.md
@@ -98,7 +98,7 @@ Major versions of the .NET SDK are typically released within a few days of a Vis
 | 8.0.100 Preview 6 | 17.7 Preview 3 |
 | 8.0.100 Preview 7 | 17.8 Preview 1 |
 | 8.0.100 Preview RC 1 | 17.8 Preview 2 |
-| 8.0.100 Preview RC 2 | 17.7 Preview 3 |
+| 8.0.100 Preview RC 2 | 17.8 Preview 3 |
 
 ## Reference
 

--- a/docs/core/porting/versioning-sdk-msbuild-vs.md
+++ b/docs/core/porting/versioning-sdk-msbuild-vs.md
@@ -90,14 +90,15 @@ Major versions of the .NET SDK are typically released within a few days of a Vis
 
 | SDK preview version | Visual Studio version |
 |-|-|
-| 7.0.100 RC 2 | 17.4 Preview 3 |
-| 7.0.100 | 17.4.0 |
 | 8.0.100 Preview 1 | 17.6 Preview 1 |
 | 8.0.100 Preview 2 | 17.6 Preview 2 |
 | 8.0.100 Preview 3 | 17.6 Preview 3 |
 | 8.0.100 Preview 4 | 17.7 Preview 1 |
 | 8.0.100 Preview 5 | 17.7 Preview 2 |
 | 8.0.100 Preview 6 | 17.7 Preview 3 |
+| 8.0.100 Preview 7 | 17.8 Preview 1 |
+| 8.0.100 Preview RC 1 | 17.8 Preview 2 |
+| 8.0.100 Preview RC 2 | 17.7 Preview 3 |
 
 ## Reference
 


### PR DESCRIPTION
Adding additional preview and rcs to the mapping to VS table

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/porting/versioning-sdk-msbuild-vs.md](https://github.com/dotnet/docs/blob/4cfd3704903427f1b96105da78133d2ecc60971a/docs/core/porting/versioning-sdk-msbuild-vs.md) | [Overview of .NET, MSBuild, and Visual Studio versioning](https://review.learn.microsoft.com/en-us/dotnet/core/porting/versioning-sdk-msbuild-vs?branch=pr-en-us-36635) |

<!-- PREVIEW-TABLE-END -->