### PR TITLE
Add a note regarding record modifier for accessibility levels

### DIFF
--- a/docs/csharp/language-reference/keywords/accessibility-levels.md
+++ b/docs/csharp/language-reference/keywords/accessibility-levels.md
@@ -38,7 +38,11 @@ Use the access modifiers, `public`, `protected`, `internal`, or `private`, to sp
 |`struct`|`private`|`public`<br /><br /> `internal`<br /><br /> `private`|  
 
 \* An `interface` member with `private` accessibility must have a default implementation.
-
+  
+> [!NOTE]  
+> If a class or struct is modified with the [`record`](../builtin-types/record.md) keyword modifier, then the same access modifiers are allowed.  
+> However, with the [`record`](../builtin-types/record.md) modifier the default member accessibility is `internal` both for class and the struct.  
+  
 The accessibility of a nested type depends on its [accessibility domain](./accessibility-domain.md), which is determined by both the declared accessibility of the member and the accessibility domain of the immediately containing type. However, the accessibility domain of a nested type cannot exceed that of the containing type.  
   
 ## C# Language Specification  

--- a/docs/csharp/language-reference/keywords/accessibility-levels.md
+++ b/docs/csharp/language-reference/keywords/accessibility-levels.md
@@ -41,7 +41,7 @@ Use the access modifiers, `public`, `protected`, `internal`, or `private`, to sp
   
 > [!NOTE]  
 > If a class or struct is modified with the [`record`](../builtin-types/record.md) keyword modifier, then the same access modifiers are allowed.  
-> However, with the [`record`](../builtin-types/record.md) modifier the default member accessibility is `internal` both for class and the struct.  
+> Also, with the [`record`](../builtin-types/record.md) modifier the default member accessibility is still `private` both for class and the struct.  
   
 The accessibility of a nested type depends on its [accessibility domain](./accessibility-domain.md), which is determined by both the declared accessibility of the member and the accessibility domain of the immediately containing type. However, the accessibility domain of a nested type cannot exceed that of the containing type.  
   


### PR DESCRIPTION
This pull request fixes #36248 

It adds the note about the `record` modifier for class and struct keeping the allowed access modifiers intact, but changing the default access levels to `internal` for both struct and class.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/accessibility-levels.md](https://github.com/dotnet/docs/blob/852a3291750b89e6e1d136f16069638e7ef78765/docs/csharp/language-reference/keywords/accessibility-levels.md) | [Accessibility Levels (C# Reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/accessibility-levels?branch=pr-en-us-36641) |


<!-- PREVIEW-TABLE-END -->