### PR TITLE
Fix code syntax

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1832.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1832.md
@@ -27,7 +27,9 @@ When using a range-indexer on an array and implicitly assigning the value to <xr
 
 ## Rule description
 
-Using a range-indexer on an array and assigning to a memory or span type: The range indexer on a <xref:System.Span%601> is a non-copying <xref:System.Span%601.Slice%2A?#System_Span_1_Slice_System_Int32_System_Int32_> operation, but for the range indexer on array the method <xref:System.Runtime.CompilerServices.RuntimeHelpers.GetSubArray%2A> will be used instead of <xref:System.Span%601.Slice%2A?#System_Span_1_Slice_System_Int32_System_Int32_>, which produces a copy of requested portion of the array. This copy is usually unnecessary when it is implicitly used as a <xref:System.ReadOnlySpan%601> or <xref:System.ReadOnlyMemory%601> value. If a copy isn't intended, use the <xref:System.MemoryExtensions.AsSpan%2A?#System_MemoryExtensions_AsSpan__1___0___> or <xref:System.MemoryExtensions.AsMemory%2A?#System_MemoryExtensions_AsMemory__1___0___>  method to avoid the unnecessary copy. If the copy is intended, either assign it to a local variable first or add an explicit cast. The analyzer only reports when an implicit cast is used on the result of the range indexer operation.
+The range indexer on a <xref:System.Span%601> is a non-copying <xref:System.Span%601.Slice%2A?#System_Span_1_Slice_System_Int32_System_Int32_> operation. But for the range indexer on an array, the method <xref:System.Runtime.CompilerServices.RuntimeHelpers.GetSubArray%2A> will be used instead of <xref:System.Span%601.Slice%2A?#System_Span_1_Slice_System_Int32_System_Int32_>, which produces a copy of the requested portion of the array. This copy is usually unnecessary when it's implicitly used as a <xref:System.ReadOnlySpan%601> or <xref:System.ReadOnlyMemory%601> value. If a copy isn't intended, use the <xref:System.MemoryExtensions.AsSpan%2A?#System_MemoryExtensions_AsSpan__1___0___> or <xref:System.MemoryExtensions.AsMemory%2A?#System_MemoryExtensions_AsMemory__1___0___>  method to avoid the unnecessary copy. If the copy is intended, either assign it to a local variable first or add an explicit cast.
+
+The analyzer only reports when an implicit cast is used on the result of the range indexer operation.
 
 ### Detects
 
@@ -45,7 +47,7 @@ Explicit conversions:
 
 ## How to fix violations
 
-To fix the violation of this rule: use the <xref:System.MemoryExtensions.AsSpan%2A?#System_MemoryExtensions_AsSpan__1___0___> or <xref:System.MemoryExtensions.AsMemory%2A?#System_MemoryExtensions_AsMemory__1___0___>  extension method to avoid creating unnecessary data copies.
+To fix a violation of this rule, use the <xref:System.MemoryExtensions.AsSpan%2A?#System_MemoryExtensions_AsSpan__1___0___> or <xref:System.MemoryExtensions.AsMemory%2A?#System_MemoryExtensions_AsMemory__1___0___>  extension method to avoid creating unnecessary data copies.
 
 ```csharp
 class C
@@ -74,7 +76,7 @@ class C
 ```
 
 > [!TIP]
-> A code fix is available for this rule in Visual Studio. To use it, position the cursor on the violation and press <kbd>Ctrl</kbd>+<kbd>.</kbd> (period). Choose **Use AsSpan instead of the Range-based indexer on an array** from the list of options that is presented.
+> A code fix is available for this rule in Visual Studio. To use it, position the cursor on the violation and press <kbd>Ctrl</kbd>+<kbd>.</kbd> (period). Choose **Use AsSpan instead of the Range-based indexer on an array** from the list of options that's presented.
 >
 > ![Code fix for CA1832 - Use AsSpan or AsMemory instead of Range-based indexers for getting ReadOnlySpan or ReadOnlyMemory portion of an array](media/ca1832_codefix.png)
 
@@ -83,7 +85,7 @@ You can also avoid this warning by adding an explicit cast.
 ```csharp
 class C
 {
-    public void TestMethod(byte arr[])
+    public void TestMethod(byte[] arr)
     {
         // The violation occurs
         ReadOnlySpan<byte> tmp1 = arr[0..2];
@@ -96,7 +98,7 @@ class C
 ```csharp
 class C
 {
-    public void TestMethod(byte arr[])
+    public void TestMethod(byte[] arr)
     {
         // The violation fixed with explicit casting
         ReadOnlySpan<byte> tmp1 = (ReadOnlySpan<byte>)arr[0..2];

--- a/docs/fundamentals/code-analysis/quality-rules/ca1833.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1833.md
@@ -27,7 +27,7 @@ When using a range-indexer on an array and implicitly assigning the value to <xr
 
 ## Rule description
 
-Using a range-indexer on array and assigning to a memory or span type: The range indexer on a <xref:System.Span%601> is a non-copying <xref:System.Span%601.Slice%2A?#System_Span_1_Slice_System_Int32_System_Int32_> operation, but for the range indexer on array the method <xref:System.Runtime.CompilerServices.RuntimeHelpers.GetSubArray%2A> will be used instead of <xref:System.Span%601.Slice%2A?#System_Span_1_Slice_System_Int32_System_Int32_>, which produces a copy of requested portion of the array. This copy is usually unnecessary when it is implicitly used as a <xref:System.Span%601> or <xref:System.Memory%601> value. If a copy isn't intended, use the <xref:System.MemoryExtensions.AsSpan%2A?#System_MemoryExtensions_AsSpan__1___0___> or <xref:System.MemoryExtensions.AsMemory%2A?#System_MemoryExtensions_AsMemory__1___0___> method to avoid the unnecessary copy. If the copy is intended, either assign it to a local variable first or add an explicit cast. The analyzer only reports when an implicit cast is used on the result of the range indexer operation.
+The range indexer on a <xref:System.Span%601> is a non-copying <xref:System.Span%601.Slice%2A?#System_Span_1_Slice_System_Int32_System_Int32_> operation. But for the range indexer on an array, the method <xref:System.Runtime.CompilerServices.RuntimeHelpers.GetSubArray%2A> will be used instead of <xref:System.Span%601.Slice%2A?#System_Span_1_Slice_System_Int32_System_Int32_>, which produces a copy of the requested portion of the array. This copy is usually unnecessary when it's implicitly used as a <xref:System.Span%601> or <xref:System.Memory%601> value. If a copy isn't intended, use the <xref:System.MemoryExtensions.AsSpan%2A?#System_MemoryExtensions_AsSpan__1___0___> or <xref:System.MemoryExtensions.AsMemory%2A?#System_MemoryExtensions_AsMemory__1___0___> method to avoid the unnecessary copy. If the copy is intended, either assign it to a local variable first or add an explicit cast. The analyzer only reports when an implicit cast is used on the result of the range indexer operation.
 
 ### Detects
 
@@ -45,7 +45,7 @@ Explicit conversions:
 
 ## How to fix violations
 
-To fix the violation of this rule: use the <xref:System.MemoryExtensions.AsSpan%2A?#System_MemoryExtensions_AsSpan__1___0___> or <xref:System.MemoryExtensions.AsMemory%2A?#System_MemoryExtensions_AsMemory__1___0___> extension method to avoid creating unnecessary data copies.
+To fix a violation of this rule, use the <xref:System.MemoryExtensions.AsSpan%2A?#System_MemoryExtensions_AsSpan__1___0___> or <xref:System.MemoryExtensions.AsMemory%2A?#System_MemoryExtensions_AsMemory__1___0___> extension method to avoid creating unnecessary data copies.
 
 ```csharp
 class C
@@ -83,7 +83,7 @@ You can also avoid this warning by adding an explicit cast.
 ```csharp
 class C
 {
-    public void TestMethod(byte arr[])
+    public void TestMethod(byte[] arr)
     {
         // The violation occurs
         Span<byte> tmp1 = arr[0..5];
@@ -96,7 +96,7 @@ class C
 ```csharp
 class C
 {
-    public void TestMethod(byte arr[])
+    public void TestMethod(byte[] arr)
     {
         // The violation fixed with explicit casting
         Span<byte> tmp1 = (Span<byte>)arr[0..5];


### PR DESCRIPTION
Fixes #35904 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1832.md](https://github.com/dotnet/docs/blob/407313314ff0a6acfd57c3762ae53652c333d726/docs/fundamentals/code-analysis/quality-rules/ca1832.md) | [CA1832: Use AsSpan or AsMemory instead of Range-based indexers for getting ReadOnlySpan or ReadOnlyMemory portion of an array](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1832?branch=pr-en-us-36643) |
| [docs/fundamentals/code-analysis/quality-rules/ca1833.md](https://github.com/dotnet/docs/blob/407313314ff0a6acfd57c3762ae53652c333d726/docs/fundamentals/code-analysis/quality-rules/ca1833.md) | ["CA1833: Use AsSpan or AsMemory instead of Range-based indexers for getting Span or Memory portion of an array (code analysis)"](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1833?branch=pr-en-us-36643) |

<!-- PREVIEW-TABLE-END -->