### PR TITLE
Corrected variable name

### DIFF
--- a/docs/machine-learning/how-to-guides/how-to-use-the-automl-api.md
+++ b/docs/machine-learning/how-to-guides/how-to-use-the-automl-api.md
@@ -720,6 +720,6 @@ To determine feature importance using AutoML:
 
     ```csharp
     var featureImportance = 
-        pfi.Select(x => Tuple.Create(x.Key, x.Value.Regression.RSquared))
+        pfiResults.Select(x => Tuple.Create(x.Key, x.Value.Regression.RSquared))
             .OrderByDescending(x => x.Item2);    
     ```


### PR DESCRIPTION
## Summary

Variable created in the earlier step `pfiResults` does not match the one being used `pfi`


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/machine-learning/how-to-guides/how-to-use-the-automl-api.md](https://github.com/dotnet/docs/blob/93839ce36f337b86225ad7d3ee7a844c2063a039/docs/machine-learning/how-to-guides/how-to-use-the-automl-api.md) | [How to use the ML.NET Automated Machine Learning (AutoML) API](https://review.learn.microsoft.com/en-us/dotnet/machine-learning/how-to-guides/how-to-use-the-automl-api?branch=pr-en-us-36666) |

<!-- PREVIEW-TABLE-END -->