### PR TITLE
Adds NuGet audit as a potential breaking change.

### DIFF
--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -115,6 +115,7 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 | ['dotnet publish' uses Release configuration](sdk/8.0/dotnet-publish-config.md) | Behavioral change/Source incompatible            | Preview 1  |
 | [MSBuild respects DOTNET_CLI_UI_LANGUAGE](sdk/8.0/msbuild-language.md)          | Behavioral change                                | Preview 5  |
 | [Runtime-specific apps not self-contained](sdk/8.0/runtimespecific-app-default.md) | Source/binary incompatible            | Preview 5  |
+| ['dotnet restore' produces security vulnerability warnings](sdk/8.0/dotnet-restore-audit.md) | Behavioral change            | Preview 4  |
 
 ## Serialization
 

--- a/docs/core/compatibility/sdk/8.0/dotnet-restore-audit.md
+++ b/docs/core/compatibility/sdk/8.0/dotnet-restore-audit.md
@@ -29,13 +29,13 @@ In most cases when you restore a package, you want to know whether the restored 
 
 ## Recommended action
 
-- To disable the new behavior entirely, you can set the `<NuGetAudit>` project property to `false`.
-
 - To explicitly reduce the probability of this breaking your build due to warnings, you can re-consider your usage of `<TreatWarningsAsErrors>` and use `<WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>` to ensure known security vulnerabilities are still allowed in your environment.
 
 - If you'd like to set a different security audit level, you may consider `<NuGetAuditLevel>moderate</NuGetAuditLevel>` with possible values of `low`, `moderate`, `high`, and `critical`.
 
 - If you're looking to ignore these warnings, you can use `<NoWarn>` to suppress `NU1091-NU104` warnings.
+
+- To disable the new behavior entirely, you can set the `<NuGetAudit>` project property to `false`.
 
 ## See also
 

--- a/docs/core/compatibility/sdk/8.0/dotnet-restore-audit.md
+++ b/docs/core/compatibility/sdk/8.0/dotnet-restore-audit.md
@@ -1,0 +1,42 @@
+---
+title: "Breaking change: 'dotnet restore' produces security vulnerability warnings"
+description: Learn about a breaking change in the .NET 8 SDK where 'dotnet restore' produces security vulnerability warnings by default.
+ms.date: 08/15/2023
+---
+# 'dotnet restore' produces security vulnerability warnings
+
+The [`dotnet restore` command](../../../tools/dotnet-restore.md), which restores the dependencies and tools of a project, now produces security vulnerability warnings by default.
+
+## Previous behavior
+
+Previously, `dotnet restore` did not emit any security vulnerability warnings by default.
+
+## New behavior
+
+If you're developing with the .NET 8 SDK or a later version, `dotnet restore` produces security vulnerability warnings by default for *all* restored projects. When you load a solution, project, or run a CI/CD script, this change may break your workflow if you have `<TreatWarningsAsErrors>` enabled. 
+
+## Version introduced
+
+.NET 8 Preview 4
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+In most cases when you restore a package, you want to know whether the restored package version contains any known security vulnerabilities. This functionality was added in order
+
+## Recommended action
+
+- To disable the new behavior entirely, you can set the `<NuGetAudit>` project property to `false`.
+
+- To explicitly reduce the probability of this breaking your build due to warnings, you can re-consider your usage of `<TreatWarningsAsErrors>` and use `<WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>` to ensure known security vulnerabilities are still allowed in your environment.
+
+- If you'd like to set a different security audit level, you may consider `<NuGetAuditLevel>moderate</NuGetAuditLevel>` with possible values of `low`, `moderate`, `high`, and `critical`.
+
+- If you're looking to ignore these warnings, you can use `<NoWarn>` to suppress `NU1091-NU104` warnings.
+
+## See also
+
+- [Auditing package dependencies for security vulnerabilities](https://learn.microsoft.com/nuget/concepts/auditing-packages)

--- a/docs/core/compatibility/sdk/8.0/dotnet-restore-audit.md
+++ b/docs/core/compatibility/sdk/8.0/dotnet-restore-audit.md
@@ -13,7 +13,7 @@ Previously, `dotnet restore` did not emit any security vulnerability warnings by
 
 ## New behavior
 
-If you're developing with the .NET 8 SDK or a later version, `dotnet restore` produces security vulnerability warnings by default for *all* restored projects. When you load a solution, project, or run a CI/CD script, this change may break your workflow if you have `<TreatWarningsAsErrors>` enabled.
+If you're developing with the .NET 8 SDK or a later version, `dotnet restore` produces security vulnerability warnings by default for *all* restored projects. When you load a solution or project, or run a CI/CD script, this change may break your workflow if you have `<TreatWarningsAsErrors>` enabled.
 
 ## Version introduced
 

--- a/docs/core/compatibility/sdk/8.0/dotnet-restore-audit.md
+++ b/docs/core/compatibility/sdk/8.0/dotnet-restore-audit.md
@@ -13,7 +13,7 @@ Previously, `dotnet restore` did not emit any security vulnerability warnings by
 
 ## New behavior
 
-If you're developing with the .NET 8 SDK or a later version, `dotnet restore` produces security vulnerability warnings by default for *all* restored projects. When you load a solution, project, or run a CI/CD script, this change may break your workflow if you have `<TreatWarningsAsErrors>` enabled. 
+If you're developing with the .NET 8 SDK or a later version, `dotnet restore` produces security vulnerability warnings by default for *all* restored projects. When you load a solution, project, or run a CI/CD script, this change may break your workflow if you have `<TreatWarningsAsErrors>` enabled.
 
 ## Version introduced
 

--- a/docs/core/compatibility/sdk/8.0/dotnet-restore-audit.md
+++ b/docs/core/compatibility/sdk/8.0/dotnet-restore-audit.md
@@ -31,7 +31,7 @@ In most cases when you restore a package, you want to know whether the restored 
 
 - To explicitly reduce the probability of this breaking your build due to warnings, you can re-consider your usage of `<TreatWarningsAsErrors>` and use `<WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>` to ensure known security vulnerabilities are still allowed in your environment.
 
-- If you'd like to set a different security audit level, you may consider `<NuGetAuditLevel>moderate</NuGetAuditLevel>` with possible values of `low`, `moderate`, `high`, and `critical`.
+- If you want to set a different security audit level, add the `<NuGetAuditLevel>` property to your project file with possible values of `low`, `moderate`, `high`, and `critical`.
 
 - If you're looking to ignore these warnings, you can use `<NoWarn>` to suppress `NU1091-NU104` warnings.
 

--- a/docs/core/compatibility/sdk/8.0/dotnet-restore-audit.md
+++ b/docs/core/compatibility/sdk/8.0/dotnet-restore-audit.md
@@ -29,7 +29,7 @@ In most cases when you restore a package, you want to know whether the restored 
 
 ## Recommended action
 
-- To explicitly reduce the probability of this breaking your build due to warnings, you can re-consider your usage of `<TreatWarningsAsErrors>` and use `<WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>` to ensure known security vulnerabilities are still allowed in your environment.
+- To explicitly reduce the probability of this breaking your build due to warnings, you can consider your usage of `<TreatWarningsAsErrors>` and use `<WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>` to ensure known security vulnerabilities are still allowed in your environment.
 
 - If you want to set a different security audit level, add the `<NuGetAuditLevel>` property to your project file with possible values of `low`, `moderate`, `high`, and `critical`.
 

--- a/docs/core/compatibility/sdk/8.0/dotnet-restore-audit.md
+++ b/docs/core/compatibility/sdk/8.0/dotnet-restore-audit.md
@@ -25,7 +25,7 @@ This change is a [behavioral change](../../categories.md#behavioral-change).
 
 ## Reason for change
 
-In most cases when you restore a package, you want to know whether the restored package version contains any known security vulnerabilities. This functionality was added in order
+In most cases when you restore a package, you want to know whether the restored package version contains any known security vulnerabilities. This functionality was added as it is a highly requested feature and security concerns continue to increase each year where known security issues can not be visible enough to taking immediate action.
 
 ## Recommended action
 

--- a/docs/core/compatibility/sdk/8.0/dotnet-restore-audit.md
+++ b/docs/core/compatibility/sdk/8.0/dotnet-restore-audit.md
@@ -39,4 +39,4 @@ In most cases when you restore a package, you want to know whether the restored 
 
 ## See also
 
-- [Auditing package dependencies for security vulnerabilities](https://learn.microsoft.com/nuget/concepts/auditing-packages)
+- [Auditing package dependencies for security vulnerabilities](/nuget/concepts/auditing-packages)

--- a/docs/core/compatibility/sdk/8.0/dotnet-restore-audit.md
+++ b/docs/core/compatibility/sdk/8.0/dotnet-restore-audit.md
@@ -33,7 +33,7 @@ In most cases when you restore a package, you want to know whether the restored 
 
 - If you want to set a different security audit level, add the `<NuGetAuditLevel>` property to your project file with possible values of `low`, `moderate`, `high`, and `critical`.
 
-- If you're looking to ignore these warnings, you can use `<NoWarn>` to suppress `NU1091-NU104` warnings.
+- If you want to ignore these warnings, you can use `<NoWarn>` to suppress `NU1091-NU104` warnings.
 
 - To disable the new behavior entirely, you can set the `<NuGetAudit>` project property to `false`.
 

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -124,6 +124,8 @@ items:
         href: sdk/8.0/msbuild-language.md
       - name: Runtime-specific apps not self-contained
         href: sdk/8.0/runtimespecific-app-default.md
+      - name: "'dotnet restore'" produces security vulnerability warnings
+        href: sdk/8.0/dotnet-restore-audit.md
     - name: Serialization
       items:
       - name: BinaryFormatter disabled for most projects

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -120,12 +120,12 @@ items:
         href: sdk/8.0/dotnet-pack-config.md
       - name: "'dotnet publish' uses Release configuration"
         href: sdk/8.0/dotnet-publish-config.md
+      - name: "'dotnet restore' produces security vulnerability warnings"
+        href: sdk/8.0/dotnet-restore-audit.md
       - name: MSBuild respects DOTNET_CLI_UI_LANGUAGE
         href: sdk/8.0/msbuild-language.md
       - name: Runtime-specific apps not self-contained
         href: sdk/8.0/runtimespecific-app-default.md
-      - name: "'dotnet restore'" produces security vulnerability warnings
-        href: sdk/8.0/dotnet-restore-audit.md
     - name: Serialization
       items:
       - name: BinaryFormatter disabled for most projects
@@ -1458,6 +1458,8 @@ items:
         href: sdk/8.0/dotnet-pack-config.md
       - name: "'dotnet publish' uses Release configuration"
         href: sdk/8.0/dotnet-publish-config.md
+      - name: "'dotnet restore' produces security vulnerability warnings"
+        href: sdk/8.0/dotnet-restore-audit.md
       - name: MSBuild respects DOTNET_CLI_UI_LANGUAGE
         href: sdk/8.0/msbuild-language.md
       - name: Runtime-specific apps not self-contained


### PR DESCRIPTION
## Summary

Adds `dotnet restore` as a potential breaking change with new audit functionality.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/8.0.md](https://github.com/dotnet/docs/blob/8741e7d7565cc86ac8062ba723a8a1bcd50b11b1/docs/core/compatibility/8.0.md) | [Breaking changes in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/8.0?branch=pr-en-us-36701) |
| [docs/core/compatibility/sdk/8.0/dotnet-restore-audit.md](https://github.com/dotnet/docs/blob/8741e7d7565cc86ac8062ba723a8a1bcd50b11b1/docs/core/compatibility/sdk/8.0/dotnet-restore-audit.md) | [docs/core/compatibility/sdk/8.0/dotnet-restore-audit](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/dotnet-restore-audit?branch=pr-en-us-36701) |


<!-- PREVIEW-TABLE-END -->