### PR TITLE
NuGet:  update signed-package verification documentation

### DIFF
--- a/docs/core/tools/dotnet-nuget-sign.md
+++ b/docs/core/tools/dotnet-nuget-sign.md
@@ -37,7 +37,7 @@ dotnet nuget sign -h|--help
 The `dotnet nuget sign` command signs all the packages matching the first argument with a certificate. The certificate with the private key can be obtained from a file or from a certificate installed in a certificate store by providing a subject name or a SHA-1 fingerprint.
 
   > [!NOTE]
-  > This command requires a certificate root store that's valid for both code signing and timestamping. For more information, see [NuGet signed package verification](nuget-signed-package-verification.md).
+  > This command requires a certificate root store that is valid for both code signing and timestamping. Also, this command may not be supported on some combinations of operating system and .NET SDK. For more information, see [NuGet signed package verification](nuget-signed-package-verification.md).
 
 ## Arguments
 

--- a/docs/core/tools/dotnet-nuget-trust.md
+++ b/docs/core/tools/dotnet-nuget-trust.md
@@ -25,7 +25,7 @@ dotnet nuget trust -h|--help
 The `dotnet nuget trust` command manages the trusted signers. By default, NuGet accepts all authors and repositories. These commands allow you to specify only a specific subset of signers whose signatures will be accepted, while rejecting all others. For more information, see [Common NuGet configurations](/nuget/consume-packages/configuring-nuget-behavior). For details on what the nuget.config schema looks like, refer to the [NuGet config file reference](/nuget/reference/nuget-config-file).
 
   > [!NOTE]
-  > This command requires a certificate root store that is valid for both code signing and timestamping.  See [NuGet signed package verification](nuget-signed-package-verification.md) for details.
+  > This command requires a certificate root store that is valid for both code signing and timestamping. Also, this command may not be supported on some combinations of operating system and .NET SDK. For more information, see [NuGet signed package verification](nuget-signed-package-verification.md).
 
 ## Options
 

--- a/docs/core/tools/dotnet-nuget-verify.md
+++ b/docs/core/tools/dotnet-nuget-verify.md
@@ -29,7 +29,7 @@ dotnet nuget verify -h|--help
 The `dotnet nuget verify` command verifies a signed NuGet package.
 
   > [!NOTE]
-  > This command requires a certificate root store that is valid for both code signing and timestamping.  See [NuGet signed package verification](nuget-signed-package-verification.md) for details.
+  > This command requires a certificate root store that is valid for both code signing and timestamping. Also, this command may not be supported on some combinations of operating system and .NET SDK. For more information, see [NuGet signed package verification](nuget-signed-package-verification.md).
 
 ## Arguments
 

--- a/docs/core/tools/nuget-signed-package-verification.md
+++ b/docs/core/tools/nuget-signed-package-verification.md
@@ -22,7 +22,7 @@ The following sections for each operating system describe:
 
 ## Windows
 
-Verification is enabled by default during package restore operations.
+Verification is always enabled during package restore operations.
 
 NuGet uses the default root store on Windows, which already supports general-purpose code signing and timestamping. .NET SDK certificate bundles aren't used.  All signed-package verification functionality is supported on Windows in the .NET SDK version in which it was introduced.
 

--- a/docs/core/tools/nuget-signed-package-verification.md
+++ b/docs/core/tools/nuget-signed-package-verification.md
@@ -1,6 +1,6 @@
 ---
-title: NuGet signed package verification
-description: Learn about how NuGet performs signed package verification using root stores that are valid for code signing and timestamping.
+title: NuGet signed-package verification
+description: Learn about how NuGet performs signed-package verification using root stores that are valid for code signing and timestamping.
 author: DTivel
 ms.date: 11/07/2022
 ---
@@ -10,9 +10,9 @@ You can [sign a NuGet package](/nuget/create-packages/sign-a-package) to enable 
 
 NuGet package signatures are based on X.509 certificates, and a prerequisite for signed-package verification is a certificate root store that is valid for both code signing and timestamping.
 
-Starting with .NET 6.0.4xx SDK, NuGet uses certificate bundles included in the .NET SDK to verify signed packages where a suitable system root store is not available. These bundles are sourced from the [Microsoft Trusted Root Program](/security/trusted-root/program-requirements) and contain the same code signing and timestamping certificates as the root store on Windows.  These certificate bundles should contain all of the root certificates necessary to verify packages from [NuGet.org](https://nuget.org).
+Starting with .NET 6.0.400 SDK, NuGet uses certificate bundles included in the .NET SDK to verify signed packages where a suitable system root store is not available. These bundles are sourced from the [Microsoft Trusted Root Program](/security/trusted-root/program-requirements) and contain the same code signing and timestamping certificates as the root store on Windows. These certificate bundles should contain all of the root certificates necessary to verify packages from [NuGet.org](https://nuget.org).
 
-Some NuGet commands, such as `sign` and `verify`, always perform signed package verification.
+Some NuGet commands, such as `sign` and `verify`, always perform signed-package verification.
 
 The following sections for each operating system describe:
 
@@ -24,9 +24,12 @@ The following sections for each operating system describe:
 
 Verification is enabled by default during package restore operations.
 
-NuGet uses the default root store on Windows, which already supports general-purpose code signing and timestamping. .NET SDK certificate bundles aren't used.
+NuGet uses the default root store on Windows, which already supports general-purpose code signing and timestamping. .NET SDK certificate bundles aren't used.  All signed-package verification functionality is supported on Windows in the .NET SDK version in which it was introduced.
 
 ## Linux
+
+> [!IMPORTANT]
+> Although signed-package verification functionality was added in .NET 5 SDK's, the functionality isn't supported on Linux until .NET 6.0.400 SDK. We strongly recommend that signed-package verification not be used with .NET SDK's below 6.0.400.
 
 Prior to .NET 8 Preview 4 SDK, verification is disabled by default during package restore operations. To opt in, set the environment variable `DOTNET_NUGET_SIGNATURE_VERIFICATION` to `true`.
 
@@ -38,7 +41,7 @@ For code signing certificate verification, NuGet will first probe for a certific
 /etc/pki/ca-trust/extracted/pem/objsign-ca-bundle.pem
 ```
 
-If a valid certificate bundle is found, NuGet will prefer it over the .NET SDK's certificate bundle for code signing.  If it contains at least the same set of root certificates as the .NET SDK's certificate bundle, then NuGet signed package verification should succeed.  If it lacks root certificates, like those used in signed packages on [NuGet.org](https://nuget.org), NuGet signed package verification will fail with an untrusted status (via [NU3018](/nuget/reference/errors-and-warnings/nu3018) or [NU3028](/nuget/reference/errors-and-warnings/nu3028)).  Adding root certificates to this certificate bundle can enable successful verification; however, keep in mind that this certificate bundle is a system-wide trust store, whereas .NET SDK certificate bundles are used as an application-wide trust store.
+If a valid certificate bundle is found, NuGet will prefer it over the .NET SDK's certificate bundle for code signing. If it contains at least the same set of root certificates as the .NET SDK's certificate bundle, then NuGet signed-package verification should succeed. If it lacks root certificates, like those used in signed packages on [NuGet.org](https://nuget.org), NuGet signed-package verification will fail with an untrusted status (via [NU3018](/nuget/reference/errors-and-warnings/nu3018) or [NU3028](/nuget/reference/errors-and-warnings/nu3028)). Adding root certificates to this certificate bundle can enable successful verification; however, keep in mind that this certificate bundle is a system-wide trust store, whereas .NET SDK certificate bundles are used as an application-wide trust store.
 
 If a valid certificate bundle is not found at the above location, NuGet will fall back to using the .NET SDK's certificate bundle for code signing.
 
@@ -49,6 +52,9 @@ For timestamping certificate verification, NuGet always uses the .NET SDK's cert
 Verification is disabled by default during package restore operations. To opt in, set the environment variable `DOTNET_NUGET_SIGNATURE_VERIFICATION` to `true`. However, we recommend that you don't enable verification. For more information, see [NuGet/Home#11985](https://github.com/NuGet/Home/issues/11985) and [NuGet/Home#11986](https://github.com/NuGet/Home/issues/11986).
 
 NuGet uses only the .NET SDK's certificate bundles.
+
+> [!IMPORTANT]
+> Although signed-package verification functionality was added in .NET 5 SDK's, the functionality isn't currently supported on macOS. We strongly recommend that signed-package verification not be used with .NET SDK's below 6.0.400 and that it remains disabled by default.
 
 ## See also
 


### PR DESCRIPTION
## Summary

This change updates NuGet's dotnet CLI documentation to indicate that some signed-package verification functionality is not supported below .NET 6.0.400 SDK.

Fixes #36721.

CC @JonDouglas, @aortiz-msft


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-nuget-sign.md](https://github.com/dotnet/docs/blob/a1710cab1737cbde848b75d48711ee567dbe241e/docs/core/tools/dotnet-nuget-sign.md) | [dotnet nuget sign](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-sign?branch=pr-en-us-36723) |
| [docs/core/tools/dotnet-nuget-trust.md](https://github.com/dotnet/docs/blob/a1710cab1737cbde848b75d48711ee567dbe241e/docs/core/tools/dotnet-nuget-trust.md) | [dotnet nuget trust command](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-trust?branch=pr-en-us-36723) |
| [docs/core/tools/dotnet-nuget-verify.md](https://github.com/dotnet/docs/blob/a1710cab1737cbde848b75d48711ee567dbe241e/docs/core/tools/dotnet-nuget-verify.md) | [dotnet nuget verify](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-verify?branch=pr-en-us-36723) |
| [docs/core/tools/nuget-signed-package-verification.md](https://github.com/dotnet/docs/blob/a1710cab1737cbde848b75d48711ee567dbe241e/docs/core/tools/nuget-signed-package-verification.md) | [NuGet signed-package verification](https://review.learn.microsoft.com/en-us/dotnet/core/tools/nuget-signed-package-verification?branch=pr-en-us-36723) |


<!-- PREVIEW-TABLE-END -->