### PR TITLE
Clarify setting System.Runtime.Loader.UseRidGraph via MSBuild item

### DIFF
--- a/docs/core/compatibility/deployment/8.0/rid-asset-list.md
+++ b/docs/core/compatibility/deployment/8.0/rid-asset-list.md
@@ -63,7 +63,7 @@ The RID graph was costly to maintain and understand, requiring .NET itself to be
 
 Use portable RIDs, for example, `linux`, `linux-musl`, `osx`, and `win`. For specialized use cases, you can use APIs like <xref:System.Runtime.InteropServices.NativeLibrary.SetDllImportResolver(System.Reflection.Assembly,System.Runtime.InteropServices.DllImportResolver)?displayProperty=nameWithType> or <xref:System.Runtime.Loader.AssemblyLoadContext.ResolvingUnmanagedDll?displayProperty=nameWithType> for custom loading logic.
 
-If you need to revert to the previous behavior, set the backwards compatibility switch `System.Runtime.Loader.UseRidGraph` to `true` in your *runtimeconfig.json* file or as an MSBuild property in your project file. Setting the switch to `true` instructs the host to use the previous behavior of reading the RID graph.
+If you need to revert to the previous behavior, set the backwards compatibility switch `System.Runtime.Loader.UseRidGraph` to `true` in your *runtimeconfig.json* file or as a `RuntimeHostConfigurationOption` MSBuild item in your project file. Setting the switch to `true` instructs the host to use the previous behavior of reading the RID graph.
 
 ## Affected APIs
 

--- a/docs/core/compatibility/deployment/8.0/rid-asset-list.md
+++ b/docs/core/compatibility/deployment/8.0/rid-asset-list.md
@@ -63,7 +63,12 @@ The RID graph was costly to maintain and understand, requiring .NET itself to be
 
 Use portable RIDs, for example, `linux`, `linux-musl`, `osx`, and `win`. For specialized use cases, you can use APIs like <xref:System.Runtime.InteropServices.NativeLibrary.SetDllImportResolver(System.Reflection.Assembly,System.Runtime.InteropServices.DllImportResolver)?displayProperty=nameWithType> or <xref:System.Runtime.Loader.AssemblyLoadContext.ResolvingUnmanagedDll?displayProperty=nameWithType> for custom loading logic.
 
-If you need to revert to the previous behavior, set the backwards compatibility switch `System.Runtime.Loader.UseRidGraph` to `true` in your *runtimeconfig.json* file. Setting the switch to `true` instructs the host to use the previous behavior of reading the RID graph. Alternatively, you can add a `RuntimeHostConfigurationOption` MSBuild item in your project file.
+If you need to revert to the previous behavior, set the backwards compatibility switch `System.Runtime.Loader.UseRidGraph` to `true` in your *runtimeconfig.json* file. Setting the switch to `true` instructs the host to use the previous behavior of reading the RID graph. Alternatively, you can add a `RuntimeHostConfigurationOption` MSBuild item in your project file. For example:
+
+```xml
+<ItemGroup>
+  <RuntimeHostConfigurationOption Include="System.Runtime.Loader.UseRidGraph" Value="true" />
+</ItemGroup>
 
 ## Affected APIs
 

--- a/docs/core/compatibility/deployment/8.0/rid-asset-list.md
+++ b/docs/core/compatibility/deployment/8.0/rid-asset-list.md
@@ -69,6 +69,7 @@ If you need to revert to the previous behavior, set the backwards compatibility 
 <ItemGroup>
   <RuntimeHostConfigurationOption Include="System.Runtime.Loader.UseRidGraph" Value="true" />
 </ItemGroup>
+```
 
 ## Affected APIs
 

--- a/docs/core/compatibility/deployment/8.0/rid-asset-list.md
+++ b/docs/core/compatibility/deployment/8.0/rid-asset-list.md
@@ -63,7 +63,7 @@ The RID graph was costly to maintain and understand, requiring .NET itself to be
 
 Use portable RIDs, for example, `linux`, `linux-musl`, `osx`, and `win`. For specialized use cases, you can use APIs like <xref:System.Runtime.InteropServices.NativeLibrary.SetDllImportResolver(System.Reflection.Assembly,System.Runtime.InteropServices.DllImportResolver)?displayProperty=nameWithType> or <xref:System.Runtime.Loader.AssemblyLoadContext.ResolvingUnmanagedDll?displayProperty=nameWithType> for custom loading logic.
 
-If you need to revert to the previous behavior, set the backwards compatibility switch `System.Runtime.Loader.UseRidGraph` to `true` in your *runtimeconfig.json* file or as a `RuntimeHostConfigurationOption` MSBuild item in your project file. Setting the switch to `true` instructs the host to use the previous behavior of reading the RID graph.
+If you need to revert to the previous behavior, set the backwards compatibility switch `System.Runtime.Loader.UseRidGraph` to `true` in your *runtimeconfig.json* file. Setting the switch to `true` instructs the host to use the previous behavior of reading the RID graph. Alternatively, you can add a `RuntimeHostConfigurationOption` MSBuild item in your project file.
 
 ## Affected APIs
 


### PR DESCRIPTION
## Summary

Small clarification for how to set the backwards compat switch via MSBuild


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/deployment/8.0/rid-asset-list.md](https://github.com/dotnet/docs/blob/b32cd03315104bfd7064878183cf4f8dc7387654/docs/core/compatibility/deployment/8.0/rid-asset-list.md) | [Host determines RID-specific assets](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/deployment/8.0/rid-asset-list?branch=pr-en-us-36726) |


<!-- PREVIEW-TABLE-END -->