### PR TITLE
Fix the typo in `s_accountNumberSeed` in classes fundamentals tutorial

### DIFF
--- a/docs/csharp/fundamentals/tutorials/classes.md
+++ b/docs/csharp/fundamentals/tutorials/classes.md
@@ -107,7 +107,7 @@ private static int s_accountNumberSeed = 1234567890;
 The `accountNumberSeed` is a data member. It's `private`, which means it can only be accessed by code inside the `BankAccount` class. It's a way of separating the public responsibilities (like having an account number) from the private implementation (how account numbers are generated). It's also `static`, which means it's shared by all of the `BankAccount` objects. The value of a non-static variable is unique to each instance of the `BankAccount` object. The `accountNumberSeed` is a `private static` field and thus has the `s_` prefix as per C# naming conventions. The `s` denoting `static` and `_` denoting `private` field. Add the following two lines to the constructor to assign the account number. Place them after the line that says `this.Balance = initialBalance`:
 
 ```csharp
-this.Number = s_accountNumberSeed.ToString();
+Number = s_accountNumberSeed.ToString();
 s_accountNumberSeed++;
 ```
 

--- a/docs/csharp/fundamentals/tutorials/classes.md
+++ b/docs/csharp/fundamentals/tutorials/classes.md
@@ -108,7 +108,7 @@ The `accountNumberSeed` is a data member. It's `private`, which means it can onl
 
 ```csharp
 this.Number = s_accountNumberSeed.ToString();
-accountNumberSeed++;
+s_accountNumberSeed++;
 ```
 
 Type `dotnet run` to see the results.


### PR DESCRIPTION
This pull request fixes #36714 
It corrects the typo in `s_accountNumberSeed` field which was invoked without `s_` prefix.

**NOTE:** This pull request also removes the `this.` from `this.Number = s_accountNumberSeed.ToString();` because in the full example (in the `snippets\introduction-to-classes\BankAccount.cs`) there's also no `this.` accessing, only the direct call of `Number` field.
So to keep those two example snippets matching each other the direct asses was used, as using redundant `this.` here may only lead to confusion for new to C# programmers (or new in general).


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/fundamentals/tutorials/classes.md](https://github.com/dotnet/docs/blob/a2e2405b0fdb9bf0cb90d1b1c3850a7ed2b391f4/docs/csharp/fundamentals/tutorials/classes.md) | [Explore object oriented programming with classes and objects](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/tutorials/classes?branch=pr-en-us-36728) |

<!-- PREVIEW-TABLE-END -->