### PR TITLE
Unify Roslyn rules descriptions (RuleId and Breaking change fields)

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1003.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1003.md
@@ -19,7 +19,7 @@ dev_langs:
 
 | Item                             | Value                        |
 | -------------------------------- | ---------------------------- |
-| RuleId                           | CA1003                       |
+| Rule ID                          | CA1003                       |
 | Category                         | [Design](design-warnings.md) |
 | Fix is breaking or non-breaking  | Breaking                     |
 | Enabled by default in .NET 7     | No                           |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1010.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1010.md
@@ -18,7 +18,7 @@ ms.author: gewarren
 
 | Item                             | Value                        |
 | -------------------------------- | ---------------------------- |
-| RuleId                           | CA1010                       |
+| Rule ID                          | CA1010                       |
 | Category                         | [Design](design-warnings.md) |
 | Fix is breaking or non-breaking  | Non-breaking                 |
 | Enabled by default in .NET 7     | No                           |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1012.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1012.md
@@ -18,7 +18,7 @@ dev_langs:
 
 | Item                             | Value                        |
 | -------------------------------- | ---------------------------- |
-| RuleId                           | CA1012                       |
+| Rule ID                          | CA1012                       |
 | Category                         | [Design](design-warnings.md) |
 | Fix is breaking or non-breaking  | Non-breaking                 |
 | Enabled by default in .NET 7     | No                           |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1014.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1014.md
@@ -19,7 +19,7 @@ dev_langs:
 
 | Item                             | Value                        |
 | -------------------------------- | ---------------------------- |
-| RuleId                           | CA1014                       |
+| Rule ID                          | CA1014                       |
 | Category                         | [Design](design-warnings.md) |
 | Fix is breaking or non-breaking  | Non-breaking                 |
 | Enabled by default in .NET 7     | No                           |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1016.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1016.md
@@ -19,7 +19,7 @@ dev_langs:
 
 | Item                             | Value                        |
 | -------------------------------- | ---------------------------- |
-| RuleId                           | CA1016                       |
+| Rule ID                          | CA1016                       |
 | Category                         | [Design](design-warnings.md) |
 | Fix is breaking or non-breaking  | Non-breaking                 |
 | Enabled by default in .NET 7     | No                           |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1017.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1017.md
@@ -19,7 +19,7 @@ dev_langs:
 
 | Item                             | Value                        |
 | -------------------------------- | ---------------------------- |
-| RuleId                           | CA1017                       |
+| Rule ID                          | CA1017                       |
 | Category                         | [Design](design-warnings.md) |
 | Fix is breaking or non-breaking  | Non-breaking                 |
 | Enabled by default in .NET 7     | No                           |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1018.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1018.md
@@ -19,7 +19,7 @@ dev_langs:
 
 | Item                             | Value                        |
 | -------------------------------- | ---------------------------- |
-| RuleId                           | CA1018                       |
+| Rule ID                          | CA1018                       |
 | Category                         | [Design](design-warnings.md) |
 | Fix is breaking or non-breaking  | Breaking                     |
 | Enabled by default in .NET 7     | No                           |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1019.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1019.md
@@ -19,7 +19,7 @@ dev_langs:
 
 | Item                             | Value                        |
 | -------------------------------- | ---------------------------- |
-| RuleId                           | CA1019                       |
+| Rule ID                          | CA1019                       |
 | Category                         | [Design](design-warnings.md) |
 | Fix is breaking or non-breaking  | Non-breaking                 |
 | Enabled by default in .NET 7     | No                           |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1021.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1021.md
@@ -18,7 +18,7 @@ ms.author: gewarren
 
 | Item                             | Value                        |
 | -------------------------------- | ---------------------------- |
-| RuleId                           | CA1021                       |
+| Rule ID                          | CA1021                       |
 | Category                         | [Design](design-warnings.md) |
 | Fix is breaking or non-breaking  | Breaking                     |
 | Enabled by default in .NET 7     | No                           |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1024.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1024.md
@@ -19,7 +19,7 @@ dev_langs:
 
 | Item                             | Value                        |
 | -------------------------------- | ---------------------------- |
-| RuleId                           | CA1024                       |
+| Rule ID                          | CA1024                       |
 | Category                         | [Design](design-warnings.md) |
 | Fix is breaking or non-breaking  | Breaking                     |
 | Enabled by default in .NET 7     | No                           |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1027.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1027.md
@@ -16,7 +16,7 @@ ms.author: gewarren
 
 | Item                             | Value                        |
 | -------------------------------- | ---------------------------- |
-| RuleId                           | CA1027                       |
+| Rule ID                          | CA1027                       |
 | Category                         | [Design](design-warnings.md) |
 | Fix is breaking or non-breaking  | Non-breaking                 |
 | Enabled by default in .NET 7     | No                           |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1028.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1028.md
@@ -19,7 +19,7 @@ dev_langs:
 
 | Item                             | Value                        |
 | -------------------------------- | ---------------------------- |
-| RuleId                           | CA1028                       |
+| Rule ID                          | CA1028                       |
 | Category                         | [Design](design-warnings.md) |
 | Fix is breaking or non-breaking  | Breaking                     |
 | Enabled by default in .NET 7     | No                           |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1031.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1031.md
@@ -19,7 +19,7 @@ dev_langs:
 
 | Item                             | Value                        |
 | -------------------------------- | ---------------------------- |
-| RuleId                           | CA1031                       |
+| Rule ID                          | CA1031                       |
 | Category                         | [Design](design-warnings.md) |
 | Fix is breaking or non-breaking  | Non-breaking                 |
 | Enabled by default in .NET 7     | No                           |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1032.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1032.md
@@ -16,7 +16,7 @@ ms.author: gewarren
 
 | Item                             | Value                        |
 | -------------------------------- | ---------------------------- |
-| RuleId                           | CA1032                       |
+| Rule ID                          | CA1032                       |
 | Category                         | [Design](design-warnings.md) |
 | Fix is breaking or non-breaking  | Non-breaking                 |
 | Enabled by default in .NET 7     | No                           |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1033.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1033.md
@@ -16,7 +16,7 @@ ms.author: gewarren
 
 | Item                             | Value                        |
 | -------------------------------- | ---------------------------- |
-| RuleId                           | CA1033                       |
+| Rule ID                          | CA1033                       |
 | Category                         | [Design](design-warnings.md) |
 | Fix is breaking or non-breaking  | Non-breaking                 |
 | Enabled by default in .NET 7     | No                           |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1034.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1034.md
@@ -19,7 +19,7 @@ dev_langs:
 
 | Item                             | Value                        |
 | -------------------------------- | ---------------------------- |
-| RuleId                           | CA1034                       |
+| Rule ID                          | CA1034                       |
 | Category                         | [Design](design-warnings.md) |
 | Fix is breaking or non-breaking  | Breaking                     |
 | Enabled by default in .NET 7     | No                           |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1036.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1036.md
@@ -16,7 +16,7 @@ ms.author: gewarren
 
 | Item                            | Value                        |
 | ------------------------------- | ---------------------------- |
-| RuleId                          | CA1036                       |
+| Rule ID                         | CA1036                       |
 | Category                        | [Design](design-warnings.md) |
 | Fix is breaking or non-breaking | Non-breaking                 |
 | Enabled by default in .NET 7    | No                           |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1040.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1040.md
@@ -19,7 +19,7 @@ dev_langs:
 
 | Item                            | Value                        |
 | ------------------------------- | ---------------------------- |
-| RuleId                          | CA1040                       |
+| Rule ID                         | CA1040                       |
 | Category                        | [Design](design-warnings.md) |
 | Fix is breaking or non-breaking | Breaking                     |
 | Enabled by default in .NET 7    | No                           |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1041.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1041.md
@@ -19,7 +19,7 @@ dev_langs:
 
 | Item                            | Value                        |
 | ------------------------------- | ---------------------------- |
-| RuleId                          | CA1041                       |
+| Rule ID                         | CA1041                       |
 | Category                        | [Design](design-warnings.md) |
 | Fix is breaking or non-breaking | Non-breaking                 |
 | Enabled by default in .NET 7    | No                           |

--- a/docs/fundamentals/code-analysis/quality-rules/ca2218.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2218.md
@@ -16,9 +16,9 @@ dev_langs:
 
 | Item                             | Value                      |
 | -------------------------------- | -------------------------- |
-| RuleId                           | CA2218                     |
+| Rule ID                          | CA2218                     |
 | Category                         | [Usage](usage-warnings.md) |
-| Breaking change                  | Non-breaking               |
+| Fix is breaking or non-breaking  | Non-breaking               |
 | Enabled by default in .NET 7     | No                         |
 
 ## Cause

--- a/docs/fundamentals/code-analysis/quality-rules/ca2224.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2224.md
@@ -15,9 +15,9 @@ helpviewer_keywords:
 
 | Item                             | Value                      |
 | -------------------------------- | -------------------------- |
-| RuleId                           | CA2224                     |
+| Rule ID                          | CA2224                     |
 | Category                         | [Usage](usage-warnings.md) |
-| Breaking change                  | Non-breaking               |
+| Fix is breaking or non-breaking  | Non-breaking               |
 | Enabled by default in .NET 7     | No                         |
 
 ## Cause


### PR DESCRIPTION
## Summary

Replace "RuleId" with "Rule ID" and "Breaking change" with "Fix is breaking or non-breaking".
All other rule descriptions use "Rule ID" and "Fix is breaking or non-breaking".


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

<details><summary><strong>Toggle expand/collapse</strong></summary><br/>

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1003.md](https://github.com/dotnet/docs/blob/78c6e8cf3a5631566f3abcfe54bc99ac79564343/docs/fundamentals/code-analysis/quality-rules/ca1003.md) | [CA1003: Use generic event handler instances](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1003?branch=pr-en-us-36738) |
| [docs/fundamentals/code-analysis/quality-rules/ca1010.md](https://github.com/dotnet/docs/blob/78c6e8cf3a5631566f3abcfe54bc99ac79564343/docs/fundamentals/code-analysis/quality-rules/ca1010.md) | ["CA1010: Collections should implement generic interface (code analysis)"](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1010?branch=pr-en-us-36738) |
| [docs/fundamentals/code-analysis/quality-rules/ca1012.md](https://github.com/dotnet/docs/blob/78c6e8cf3a5631566f3abcfe54bc99ac79564343/docs/fundamentals/code-analysis/quality-rules/ca1012.md) | [CA1012: Abstract types should not have public constructors](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1012?branch=pr-en-us-36738) |
| [docs/fundamentals/code-analysis/quality-rules/ca1014.md](https://github.com/dotnet/docs/blob/78c6e8cf3a5631566f3abcfe54bc99ac79564343/docs/fundamentals/code-analysis/quality-rules/ca1014.md) | [docs/fundamentals/code-analysis/quality-rules/ca1014](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1014?branch=pr-en-us-36738) |
| [docs/fundamentals/code-analysis/quality-rules/ca1016.md](https://github.com/dotnet/docs/blob/78c6e8cf3a5631566f3abcfe54bc99ac79564343/docs/fundamentals/code-analysis/quality-rules/ca1016.md) | [CA1016: Mark assemblies with AssemblyVersionAttribute](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1016?branch=pr-en-us-36738) |
| [docs/fundamentals/code-analysis/quality-rules/ca1017.md](https://github.com/dotnet/docs/blob/78c6e8cf3a5631566f3abcfe54bc99ac79564343/docs/fundamentals/code-analysis/quality-rules/ca1017.md) | ["CA1017: Mark assemblies with ComVisibleAttribute (code analysis)"](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1017?branch=pr-en-us-36738) |
| [docs/fundamentals/code-analysis/quality-rules/ca1018.md](https://github.com/dotnet/docs/blob/78c6e8cf3a5631566f3abcfe54bc99ac79564343/docs/fundamentals/code-analysis/quality-rules/ca1018.md) | [CA1018: Mark attributes with AttributeUsageAttribute](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1018?branch=pr-en-us-36738) |
| [docs/fundamentals/code-analysis/quality-rules/ca1019.md](https://github.com/dotnet/docs/blob/78c6e8cf3a5631566f3abcfe54bc99ac79564343/docs/fundamentals/code-analysis/quality-rules/ca1019.md) | [docs/fundamentals/code-analysis/quality-rules/ca1019](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1019?branch=pr-en-us-36738) |
| [docs/fundamentals/code-analysis/quality-rules/ca1021.md](https://github.com/dotnet/docs/blob/78c6e8cf3a5631566f3abcfe54bc99ac79564343/docs/fundamentals/code-analysis/quality-rules/ca1021.md) | [CA1021: Avoid out parameters](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1021?branch=pr-en-us-36738) |
| [docs/fundamentals/code-analysis/quality-rules/ca1024.md](https://github.com/dotnet/docs/blob/78c6e8cf3a5631566f3abcfe54bc99ac79564343/docs/fundamentals/code-analysis/quality-rules/ca1024.md) | [CA1024: Use properties where appropriate](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1024?branch=pr-en-us-36738) |
| [docs/fundamentals/code-analysis/quality-rules/ca1027.md](https://github.com/dotnet/docs/blob/78c6e8cf3a5631566f3abcfe54bc99ac79564343/docs/fundamentals/code-analysis/quality-rules/ca1027.md) | ["CA1027: Mark enums with FlagsAttribute (code analysis)"](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1027?branch=pr-en-us-36738) |
| [docs/fundamentals/code-analysis/quality-rules/ca1028.md](https://github.com/dotnet/docs/blob/78c6e8cf3a5631566f3abcfe54bc99ac79564343/docs/fundamentals/code-analysis/quality-rules/ca1028.md) | [CA1028: Enum storage should be Int32](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1028?branch=pr-en-us-36738) |
| [docs/fundamentals/code-analysis/quality-rules/ca1031.md](https://github.com/dotnet/docs/blob/78c6e8cf3a5631566f3abcfe54bc99ac79564343/docs/fundamentals/code-analysis/quality-rules/ca1031.md) | [docs/fundamentals/code-analysis/quality-rules/ca1031](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1031?branch=pr-en-us-36738) |
| [docs/fundamentals/code-analysis/quality-rules/ca1032.md](https://github.com/dotnet/docs/blob/78c6e8cf3a5631566f3abcfe54bc99ac79564343/docs/fundamentals/code-analysis/quality-rules/ca1032.md) | [CA1032: Implement standard exception constructors](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1032?branch=pr-en-us-36738) |
| [docs/fundamentals/code-analysis/quality-rules/ca1033.md](https://github.com/dotnet/docs/blob/78c6e8cf3a5631566f3abcfe54bc99ac79564343/docs/fundamentals/code-analysis/quality-rules/ca1033.md) | ["CA1033: Interface methods should be callable by child types (code analysis)"](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1033?branch=pr-en-us-36738) |
| [docs/fundamentals/code-analysis/quality-rules/ca1034.md](https://github.com/dotnet/docs/blob/78c6e8cf3a5631566f3abcfe54bc99ac79564343/docs/fundamentals/code-analysis/quality-rules/ca1034.md) | [CA1034: Nested types should not be visible](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1034?branch=pr-en-us-36738) |
| [docs/fundamentals/code-analysis/quality-rules/ca1036.md](https://github.com/dotnet/docs/blob/78c6e8cf3a5631566f3abcfe54bc99ac79564343/docs/fundamentals/code-analysis/quality-rules/ca1036.md) | [docs/fundamentals/code-analysis/quality-rules/ca1036](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1036?branch=pr-en-us-36738) |
| [docs/fundamentals/code-analysis/quality-rules/ca1040.md](https://github.com/dotnet/docs/blob/78c6e8cf3a5631566f3abcfe54bc99ac79564343/docs/fundamentals/code-analysis/quality-rules/ca1040.md) | [CA1040: Avoid empty interfaces](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1040?branch=pr-en-us-36738) |
| [docs/fundamentals/code-analysis/quality-rules/ca1041.md](https://github.com/dotnet/docs/blob/78c6e8cf3a5631566f3abcfe54bc99ac79564343/docs/fundamentals/code-analysis/quality-rules/ca1041.md) | [CA1041: Provide ObsoleteAttribute message](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1041?branch=pr-en-us-36738) |
| [docs/fundamentals/code-analysis/quality-rules/ca2218.md](https://github.com/dotnet/docs/blob/78c6e8cf3a5631566f3abcfe54bc99ac79564343/docs/fundamentals/code-analysis/quality-rules/ca2218.md) | ["CA2218: Override GetHashCode on overriding Equals"](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2218?branch=pr-en-us-36738) |
| [docs/fundamentals/code-analysis/quality-rules/ca2224.md](https://github.com/dotnet/docs/blob/78c6e8cf3a5631566f3abcfe54bc99ac79564343/docs/fundamentals/code-analysis/quality-rules/ca2224.md) | [CA2224: Override Equals on overloading operator equals](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2224?branch=pr-en-us-36738) |

</details>

<!-- PREVIEW-TABLE-END -->