### PR TITLE
Fix comment on the 'init' accessor

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md
+++ b/docs/csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md
@@ -108,7 +108,7 @@ public class Person
     public string LastName { get; init; }
 }
 
-// Last name property is necessary to be initialized.
+// The `LastName` property can be set only during initialization. It CAN'T be modified afterwards.
 // The `FirstName` property can be modified after initialization.
 var pet = new Person() { FirstName = "Joe", LastName = "Doe"};
 


### PR DESCRIPTION
## Summary

Fix comment on the 'init' accessor on 'Object and Collection Initializers' page.
The `LastName` property in NOT necessary to be initialized as the accessor only gives you an option to initialize it.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md](https://github.com/dotnet/docs/blob/2c4e8b59bab50dfc5585c9b3dac987236273a5e4/docs/csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md) | [Object and Collection Initializers (C# Programming Guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/object-and-collection-initializers?branch=pr-en-us-36740) |

<!-- PREVIEW-TABLE-END -->