### PR TITLE
Add doc topic for unmanaged calling conventions

### DIFF
--- a/.openpublishing.redirection.standard.json
+++ b/.openpublishing.redirection.standard.json
@@ -811,7 +811,7 @@
         },
         {
             "source_path_from_root": "/docs/standard/native-interop/cross-platform.md",
-            "redirect_url": "/dotnet/standard/native-interop/pinvoke/native-library-loading.md",
+            "redirect_url": "/dotnet/standard/native-interop/pinvoke/native-library-loading",
             "redirect_document_id": true
         }
     ]

--- a/.openpublishing.redirection.standard.json
+++ b/.openpublishing.redirection.standard.json
@@ -811,7 +811,7 @@
         },
         {
             "source_path_from_root": "/docs/standard/native-interop/cross-platform.md",
-            "redirect_url": "/dotnet/standard/native-interop/pinvoke/native-library-loading",
+            "redirect_url": "/dotnet/standard/native-interop/native-library-loading",
             "redirect_document_id": true
         }
     ]

--- a/.openpublishing.redirection.standard.json
+++ b/.openpublishing.redirection.standard.json
@@ -808,6 +808,10 @@
             "source_path_from_root": "/docs/standard/using-linq.md",
             "redirect_url": "/dotnet/standard/linq/",
             "redirect_document_id": true
+        },
+        {
+            "source_path_from_root": "/docs/standard/native-interop/cross-platform.md",
+            "redirect_url": "/dotnet/standard/native-interop/pinvoke"
         }
     ]
 }

--- a/.openpublishing.redirection.standard.json
+++ b/.openpublishing.redirection.standard.json
@@ -811,7 +811,8 @@
         },
         {
             "source_path_from_root": "/docs/standard/native-interop/cross-platform.md",
-            "redirect_url": "/dotnet/standard/native-interop/pinvoke"
+            "redirect_url": "/dotnet/standard/native-interop/pinvoke/native-library-loading.md",
+            "redirect_document_id": true
         }
     ]
 }

--- a/docs/core/dependency-loading/default-probing.md
+++ b/docs/core/dependency-loading/default-probing.md
@@ -67,11 +67,11 @@ If any matching file exists, attempt to load and return it.
 
 ## Unmanaged (native) library probing
 
-The runtime's unmanaged library probing algorithm is identical on all platforms. However, since the actual load of the unmanaged library is performed by the underlying platform, the observed behavior can be slightly different. For more information, see the guidance on how to author [cross-platform P/Invokes](../../standard/native-interop/cross-platform.md).
+The runtime's unmanaged library probing algorithm is identical on all platforms. However, since the actual load of the unmanaged library is performed by the underlying platform, the observed behavior can be slightly different.
 
 1) Check if the supplied library name represents an absolute or relative path.
 
-1) If the name represents an absolute path, use the name directly for all subsequent operations. Otherwise, use the name and create platform-defined combinations to consider. Combinations consist of platform specific prefixes (for example, `lib`) and/or suffixes (for example, `.dll`, `.dylib`, and `.so`). This is not an exhaustive list, and it doesn't represent the exact effort made on each platform. It's just an example of what is considered.
+1) If the name represents an absolute path, use the name directly for all subsequent operations. Otherwise, use the name and create platform-defined combinations to consider. Combinations consist of platform specific prefixes (for example, `lib`) and/or suffixes (for example, `.dll`, `.dylib`, and `.so`). This is not an exhaustive list, and it doesn't represent the exact effort made on each platform. It's just an example of what is considered.  For more information, see [native library loading](../../standard/native-interop/native-library-loading.md).
 
 1) The name and, if the path is relative, each combination, is then used in the following steps. The first successful load attempt immediately returns the handle to the loaded library.
 

--- a/docs/navigate/advanced-programming/toc.yml
+++ b/docs/navigate/advanced-programming/toc.yml
@@ -319,10 +319,10 @@ items:
     - name: Overview
       href: ../../standard/native-interop/pinvoke.md
       displayName: P/Invoke
-    - name: Cross-platform P/Invoke
-      href: ../../standard/native-interop/cross-platform.md
     - name: Source generation
       href: ../../standard/native-interop/pinvoke-source-generation.md
+    - name: Native library loading
+      href: ../../standard/native-interop/native-library-loading.md
   - name: Type marshalling
     items:
     - name: Overview

--- a/docs/navigate/advanced-programming/toc.yml
+++ b/docs/navigate/advanced-programming/toc.yml
@@ -323,6 +323,8 @@ items:
       href: ../../standard/native-interop/pinvoke-source-generation.md
     - name: Native library loading
       href: ../../standard/native-interop/native-library-loading.md
+    - name: Calling conventions
+      href: ../../standard/native-interop/calling-conventions.md
   - name: Type marshalling
     items:
     - name: Overview

--- a/docs/standard/native-interop/calling-conventions.md
+++ b/docs/standard/native-interop/calling-conventions.md
@@ -20,7 +20,7 @@ Most platforms use one canonical calling convention and an explicitly specified 
 
 For the x86 architecture, the default calling convention is platform-specific. Stdcall ("standard call") is the default calling convention on Windows x86
 and it is used by most Win32 APIs. Cdecl is the default calling convention on Linux x86. Windows ports of open source libraries that
-originated on Unix often use Cdecl calling convention even on Windows x86 and it is necessary to explicitly specifify the Cdecl calling
+originated on Unix often use the Cdecl calling convention even on Windows x86 and it is necessary to explicitly specify the Cdecl calling
 convention in P/Invoke declarations for interop with these libraries.
 
 For non-x86 architectures, both Stdcall and Cdecl calling conventions are treated as the canonical platform default calling convention.

--- a/docs/standard/native-interop/calling-conventions.md
+++ b/docs/standard/native-interop/calling-conventions.md
@@ -7,7 +7,7 @@ ms.date: 08/19/2023
 
 # Unmanaged calling conventions
 
-[Calling conventions](https://en.wikipedia.org/wiki/Calling_convention) desribe low-level details for how method arguments and return values
+[Calling conventions](https://en.wikipedia.org/wiki/Calling_convention) describe low-level details for how method arguments and return values
 are passed between the caller and the called method.
 
 It is important that the unmanaged calling convention declared in P/Invoke declaration matches the unmanaged calling convention
@@ -16,18 +16,18 @@ low-level debugging skills to diagnose.
 
 ## Platform default calling convention
 
-Most platforms use one canonical calling conventions and explicitly specified calling convention is unnecessary in most cases.
+Most platforms use one canonical calling convention and an explicitly specified calling convention is unnecessary in most cases.
 
-For x86 architecture, the default calling convention is platform-specific. StdCall is the default calling convention on Windows x86
+For the x86 architecture, the default calling convention is platform-specific. Stdcall ("standard call") is the default calling convention on Windows x86
 and it is used by most Win32 APIs. Cdecl is the default calling convention on Linux x86. Windows ports of open source libraries that
 originated on Unix often use Cdecl calling convention even on Windows x86 and it is necessary to explicitly specifify the Cdecl calling
 convention in P/Invoke declarations for interop with these libraries.
 
-For non-x86 architectures, both StdCall and Cdecl calling conventions are treated as the canonical platform default calling convention.
+For non-x86 architectures, both Stdcall and Cdecl calling conventions are treated as the canonical platform default calling convention.
 
 ## Specifying calling conventions in managed P/Invoke declarations
 
-The calling conventions are specific by types in System.Runtime.CompilerServices namespace or their combinations:
+The calling conventions are specific by types in the System.Runtime.CompilerServices namespace or their combinations:
 
 - [CallConvCdecl](xref:System.Runtime.CompilerServices.CallConvCdecl)
 - [CallConvFastcall](xref:System.Runtime.CompilerServices.CallConvFastcall)
@@ -58,12 +58,12 @@ static unsafe delegate* unmanaged[Cdecl, MemberFunction]<int> GetHandler();
 ## Specifying calling conventions in unmanaged C/C++ code
 
 The default calling convention in unmanaged code is typically specified project-wide via C/C++ compiler options. For individual methods,
-the calling conventions can be specified using the `__stdcall` and `__Cdecl` compiler intrinsics under Microsoft Visual C++, and by using
-the `__attribute__((stdcall))` and `__attribute__((Cdecl))` compiler intrinsics under GCC and Clang.
+the calling conventions can be specified using the `__stdcall` and `__cdecl` compiler intrinsics under Microsoft Visual C++, and by using
+the `__attribute__((stdcall))` and `__attribute__((cdecl))` compiler intrinsics under GCC and Clang.
 
 ## Specifying calling conventions in earlier .NET versions
 
-.NET Framework and .NET versions prior to .NET 5 are limited to subset of calling conventions that can described by [CallingConvention](xref:System.Runtime.InteropServices.CallingConvention) enumeration.
+.NET Framework and .NET versions prior to .NET 5 are limited to a subset of calling conventions that can described by [CallingConvention](xref:System.Runtime.InteropServices.CallingConvention) enumeration.
 
 Examples of explicitly specified calling conventions:
 

--- a/docs/standard/native-interop/calling-conventions.md
+++ b/docs/standard/native-interop/calling-conventions.md
@@ -1,0 +1,84 @@
+---
+title: Unmanaged calling conventions
+description: Learn how to specify unmanaged calling conventions in .NET
+author: jkotas
+ms.date: 08/19/2023
+---
+
+# Unmanaged calling conventions
+
+[Calling conventions](https://en.wikipedia.org/wiki/Calling_convention) desribe low-level details for how method arguments and return values
+are passed between the caller and the called method.
+
+It is important that the unmanaged calling convention declared in P/Invoke declaration matches the unmanaged calling convention
+used by the native implementation. Unmanaged calling convention mismatches lead to data corruptions and fatal crashes that require
+low-level debugging skills to diagnose.
+
+## Platform default calling convention
+
+Most platforms use one canonical calling conventions and explicitly specified calling convention is unnecessary in most cases.
+
+For x86 architecture, the default calling convention is platform-specific. StdCall is the default calling convention on Windows x86
+and it is used by most Win32 APIs. Cdecl is the default calling convention on Linux x86. Windows ports of open source libraries that
+originated on Unix often use Cdecl calling convention even on Windows x86 and it is necessary to explicitly specifify the Cdecl calling
+convention in P/Invoke declarations for interop with these libraries.
+
+For non-x86 architectures, both StdCall and Cdecl calling conventions are treated as the canonical platform default calling convention.
+
+## Specifying calling conventions in managed P/Invoke declarations
+
+The calling conventions are specific by types in System.Runtime.CompilerServices namespace or their combinations:
+
+- [CallConvCdecl](xref:System.Runtime.CompilerServices.CallConvCdecl)
+- [CallConvFastcall](xref:System.Runtime.CompilerServices.CallConvFastcall)
+- [CallConvMemberFunction](xref:System.Runtime.CompilerServices.CallConvMemberFunction)
+- [CallConvStdcall](xref:System.Runtime.CompilerServices.CallConvStdcall)
+- [CallConvSuppressGCTransition](xref:System.Runtime.CompilerServices.CallConvSuppressGCTransition)
+- [CallConvThiscall](xref:System.Runtime.CompilerServices.CallConvThiscall)
+
+Examples of explicitly specified calling conventions:
+
+```csharp
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+
+// P/Invoke declaration using SuppressGCTransition calling convention
+[LibraryImport("kernel32.dll")]
+[UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvSuppressGCTransition) })]
+extern static ulong GetTickCount64();
+
+// Unmanaged callback with Cdecl calling convention.
+[UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+static unsafe int NativeCallback(void* context);
+
+// Method returning function pointer with combination of Cdecl and MemberFunction calling conventions.
+static unsafe delegate* unmanaged[Cdecl, MemberFunction]<int> GetHandler();
+```
+
+## Specifying calling conventions in unmanaged C/C++ code
+
+The default calling convention in unmanaged code is typically specified project-wide via C/C++ compiler options. For individual methods,
+the calling conventions can be specified using the `__stdcall` and `__Cdecl` compiler intrinsics under Microsoft Visual C++, and by using
+the `__attribute__((stdcall))` and `__attribute__((Cdecl))` compiler intrinsics under GCC and Clang.
+
+## Specifying calling conventions in earlier .NET versions
+
+.NET Framework and .NET versions prior to .NET 5 are limited to subset of calling conventions that can described by [CallingConvention](xref:System.Runtime.InteropServices.CallingConvention) enumeration.
+
+Examples of explicitly specified calling conventions:
+
+```csharp
+using System.Runtime.InteropServices;
+
+// P/Invoke declaration using Cdecl calling convention
+[DllImport("ucrtbase.dll", CallingConvention=CallingConvention.Cdecl)]
+static void* malloc(UIntPtr size);
+
+// Delegate marshalled as callback with Cdecl calling convention
+[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+delegate void Callback(IntPtr context);
+```
+
+## See also
+
+- [Platform Invoke (P/Invoke)](pinvoke.md)

--- a/docs/standard/native-interop/calling-conventions.md
+++ b/docs/standard/native-interop/calling-conventions.md
@@ -27,7 +27,7 @@ For non-x86 architectures, both Stdcall and Cdecl calling conventions are treate
 
 ## Specifying calling conventions in managed P/Invoke declarations
 
-The calling conventions are specific by types in the System.Runtime.CompilerServices namespace or their combinations:
+The calling conventions are specific by types in the `System.Runtime.CompilerServices` namespace or their combinations:
 
 - [CallConvCdecl](xref:System.Runtime.CompilerServices.CallConvCdecl)
 - [CallConvFastcall](xref:System.Runtime.CompilerServices.CallConvFastcall)
@@ -54,12 +54,6 @@ static unsafe int NativeCallback(void* context);
 // Method returning function pointer with combination of Cdecl and MemberFunction calling conventions.
 static unsafe delegate* unmanaged[Cdecl, MemberFunction]<int> GetHandler();
 ```
-
-## Specifying calling conventions in unmanaged C/C++ code
-
-The default calling convention in unmanaged code is typically specified project-wide via C/C++ compiler options. For individual methods,
-the calling conventions can be specified using the `__stdcall` and `__cdecl` compiler intrinsics under Microsoft Visual C++, and by using
-the `__attribute__((stdcall))` and `__attribute__((cdecl))` compiler intrinsics under GCC and Clang.
 
 ## Specifying calling conventions in earlier .NET versions
 

--- a/docs/standard/native-interop/calling-conventions.md
+++ b/docs/standard/native-interop/calling-conventions.md
@@ -10,24 +10,24 @@ ms.date: 08/19/2023
 [Calling conventions](https://en.wikipedia.org/wiki/Calling_convention) describe low-level details for how method arguments and return values
 are passed between the caller and the called method.
 
-It is important that the unmanaged calling convention declared in P/Invoke declaration matches the unmanaged calling convention
-used by the native implementation. Unmanaged calling convention mismatches lead to data corruptions and fatal crashes that require
+It's important that the unmanaged calling convention declared in a P/Invoke declaration matches the unmanaged calling convention
+used by the native implementation. Mismatches in unmanaged calling conventions lead to data corruptions and fatal crashes that require
 low-level debugging skills to diagnose.
 
 ## Platform default calling convention
 
 Most platforms use one canonical calling convention and an explicitly specified calling convention is unnecessary in most cases.
 
-For the x86 architecture, the default calling convention is platform-specific. Stdcall ("standard call") is the default calling convention on Windows x86
-and it is used by most Win32 APIs. Cdecl is the default calling convention on Linux x86. Windows ports of open source libraries that
-originated on Unix often use the Cdecl calling convention even on Windows x86 and it is necessary to explicitly specify the Cdecl calling
+For the x86 architecture, the default calling convention is platform specific. `Stdcall` ("standard call") is the default calling convention on Windows x86
+and it is used by most Win32 APIs. `Cdecl` is the default calling convention on Linux x86. Windows ports of open-source libraries that
+originated on Unix often use the `Cdecl` calling convention even on Windows x86. It's necessary to explicitly specify the `Cdecl` calling
 convention in P/Invoke declarations for interop with these libraries.
 
-For non-x86 architectures, both Stdcall and Cdecl calling conventions are treated as the canonical platform default calling convention.
+For non-x86 architectures, both `Stdcall` and `Cdecl` calling conventions are treated as the canonical platform default calling convention.
 
 ## Specifying calling conventions in managed P/Invoke declarations
 
-The calling conventions are specific by types in the `System.Runtime.CompilerServices` namespace or their combinations:
+The calling conventions are specified by types in the `System.Runtime.CompilerServices` namespace or their combinations:
 
 - [CallConvCdecl](xref:System.Runtime.CompilerServices.CallConvCdecl)
 - [CallConvFastcall](xref:System.Runtime.CompilerServices.CallConvFastcall)
@@ -42,7 +42,7 @@ Examples of explicitly specified calling conventions:
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 
-// P/Invoke declaration using SuppressGCTransition calling convention
+// P/Invoke declaration using SuppressGCTransition calling convention.
 [LibraryImport("kernel32.dll")]
 [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvSuppressGCTransition) })]
 extern static ulong GetTickCount64();
@@ -57,7 +57,7 @@ static unsafe delegate* unmanaged[Cdecl, MemberFunction]<int> GetHandler();
 
 ## Specifying calling conventions in earlier .NET versions
 
-.NET Framework and .NET versions prior to .NET 5 are limited to a subset of calling conventions that can described by [CallingConvention](xref:System.Runtime.InteropServices.CallingConvention) enumeration.
+.NET Framework and .NET versions prior to .NET 5 are limited to a subset of calling conventions that can described by the [CallingConvention](xref:System.Runtime.InteropServices.CallingConvention) enumeration.
 
 Examples of explicitly specified calling conventions:
 

--- a/docs/standard/native-interop/native-library-loading.md
+++ b/docs/standard/native-interop/native-library-loading.md
@@ -1,21 +1,21 @@
 ---
-title: Cross Platform P/Invoke
+title: Native library loading
 description: Learn which paths the runtime will search when loading native libraries via P/Invoke. Also learn how to use SetDllImportResolver.
 author: saul
 ms.date: 03/14/2022
 ---
 
-# Writing cross platform P/Invoke code
+# Native library loading
 
 This article explains which paths the runtime searches when loading native libraries via P/Invoke. It also shows how to use
 <xref:System.Runtime.InteropServices.NativeLibrary.SetDllImportResolver%2A>.
 
 ## Library name variations
 
-To facilitate simpler cross platform P/Invoke code, the runtime adds the canonical shared library extension (`.dll`, `.so` or `.dylib`) to native library names. On Linux and macOS, the runtime will also try prepending `lib`. These library names variations are automatically searched when you use APIs that load unmanaged libraries, such as <xref:System.Runtime.InteropServices.DllImportAttribute>.
+To facilitate simpler cross platform P/Invoke code, the runtime adds the canonical shared library extension (`.dll`, `.so` or `.dylib`) to native library names. On Unix-based platforms, the runtime will also try prepending `lib`. These library names variations are automatically searched when you use APIs that load native libraries, such as <xref:System.Runtime.InteropServices.DllImportAttribute>.
 
 > [!NOTE]
-> Absolute paths in library names (e.g., `/usr/lib/libc`) are treated as-is and no variations will be searched.
+> Absolute paths in library names (e.g., `/usr/lib/libc.so`) are treated as-is and no variations will be searched.
 
 Consider the following example of using P/Invoke:
 
@@ -57,7 +57,7 @@ In this case, the library name variations are tried in the following order:
 In more complex scenarios, you can use <xref:System.Runtime.InteropServices.NativeLibrary.SetDllImportResolver%2A> to resolve DLL imports at run time. In the following example, `nativedep` is resolved to `nativedep_avx2` if the CPU supports it.
 
 > [!TIP]
-> This functionality is only available in .NET 5 and .NET Core 3.1 or later.
+> This functionality is only available in .NET Core 3.1 and .NET 5+.
 
 [!code-csharp[import resolver](~/samples/snippets/standard/interop/pinvoke/import-resolver/Program.cs)]
 

--- a/docs/standard/native-interop/pinvoke.md
+++ b/docs/standard/native-interop/pinvoke.md
@@ -60,6 +60,6 @@ Both of the previous examples depend on parameters, and in both cases, the param
 
 ## More resources
 
-- [C#/Win32 P/Invoke Source Generator](https://github.com/microsoft/CsWin32/) automatically generates definitions for Windows APIs.
+- [C#/Win32 P/Invoke source generator](https://github.com/microsoft/CsWin32/) automatically generates definitions for Windows APIs.
 - [P/Invoke in C++/CLI](/cpp/dotnet/native-and-dotnet-interoperability)
 - [Mono documentation on P/Invoke](https://www.mono-project.com/docs/advanced/pinvoke/)

--- a/docs/standard/native-interop/pinvoke.md
+++ b/docs/standard/native-interop/pinvoke.md
@@ -16,7 +16,7 @@ Let's start from the most common example, and that is calling unmanaged function
 The previous example is simple, but it does show off what's needed to invoke unmanaged functions from managed code. Let's step through the example:
 
 - Line #2 shows the using statement for the `System.Runtime.InteropServices` namespace that holds all the items needed.
-- Line #8 introduces the `DllImport` attribute. This attribute is crucial, as it tells the runtime that it should load the unmanaged DLL. The string passed in is the DLL our target function is in. Additionally, it specifies which [character set](./charset.md) to use for marshalling the strings. Finally, it specifies that this function calls [SetLastError](/windows/desktop/api/errhandlingapi/nf-errhandlingapi-setlasterror) and that the runtime should capture that error code so the user can retrieve it via <xref:System.Runtime.InteropServices.Marshal.GetLastWin32Error?displayProperty=nameWithType>.
+- Line #8 introduces the `DllImport` attribute. This attribute tells the runtime that it should load the unmanaged DLL. The string passed in is the DLL our target function is in. Additionally, it specifies which [character set](./charset.md) to use for marshalling the strings. Finally, it specifies that this function calls [SetLastError](/windows/desktop/api/errhandlingapi/nf-errhandlingapi-setlasterror) and that the runtime should capture that error code so the user can retrieve it via <xref:System.Runtime.InteropServices.Marshal.GetLastWin32Error?displayProperty=nameWithType>.
 - Line #9 is the crux of the P/Invoke work. It defines a managed method that has the **exact same signature** as the unmanaged one. The declaration has a new keyword that you can notice, `extern`, which tells the runtime this is an external method, and that when you invoke it, the runtime should find it in the DLL specified in `DllImport` attribute.
 
 The rest of the example is just invoking the method as you would any other managed method.
@@ -60,6 +60,6 @@ Both of the previous examples depend on parameters, and in both cases, the param
 
 ## More resources
 
-- [PInvoke.net wiki](https://www.pinvoke.net/) an excellent Wiki with information on common Windows APIs and how to call them.
+- [C#/Win32 P/Invoke Source Generator](https://github.com/microsoft/CsWin32/) automatically generates definitions for Windows APIs.
 - [P/Invoke in C++/CLI](/cpp/dotnet/native-and-dotnet-interoperability)
 - [Mono documentation on P/Invoke](https://www.mono-project.com/docs/advanced/pinvoke/)

--- a/samples/snippets/standard/interop/pinvoke/ftw-linux.cs
+++ b/samples/snippets/standard/interop/pinvoke/ftw-linux.cs
@@ -6,7 +6,7 @@ namespace PInvokeSamples
     public static class Program
     {
         // Define a delegate that has the same signature as the native function.
-        private delegate int DirClbk(string fName, StatClass stat, int typeFlag);
+        private delegate int DirClbk(string fName, ref Stat stat, int typeFlag);
 
         // Import the libc and define the method to represent the native function.
         [DllImport("libc.so.6")]
@@ -14,7 +14,7 @@ namespace PInvokeSamples
 
         // Implement the above DirClbk delegate;
         // this one just prints out the filename that is passed to it.
-        private static int DisplayEntry(string fName, StatClass stat, int typeFlag)
+        private static int DisplayEntry(string fName, ref Stat stat, int typeFlag)
         {
             Console.WriteLine(fName);
             return 0;
@@ -28,11 +28,10 @@ namespace PInvokeSamples
         }
     }
 
-    // The native callback takes a pointer to a struct. The below class
-    // represents that struct in managed code. You can find more information
-    // about this in the section on marshalling below.
+    // The native callback takes a pointer to a struct. This type
+    // represents that struct in managed code.
     [StructLayout(LayoutKind.Sequential)]
-    public class StatClass
+    public struct Stat
     {
         public uint DeviceID;
         public uint InodeNumber;

--- a/samples/snippets/standard/interop/pinvoke/ftw-macos.cs
+++ b/samples/snippets/standard/interop/pinvoke/ftw-macos.cs
@@ -6,7 +6,7 @@ namespace PInvokeSamples
     public static class Program
     {
         // Define a delegate that has the same signature as the native function.
-        private delegate int DirClbk(string fName, StatClass stat, int typeFlag);
+        private delegate int DirClbk(string fName, ref Stat stat, int typeFlag);
 
         // Import the libc and define the method to represent the native function.
         [DllImport("libSystem.dylib")]
@@ -14,7 +14,7 @@ namespace PInvokeSamples
 
         // Implement the above DirClbk delegate;
         // this one just prints out the filename that is passed to it.
-        private static int DisplayEntry(string fName, StatClass stat, int typeFlag)
+        private static int DisplayEntry(string fName, ref Stat stat, int typeFlag)
         {
             Console.WriteLine(fName);
             return 0;
@@ -28,10 +28,10 @@ namespace PInvokeSamples
         }
     }
 
-    // The native callback takes a pointer to a struct. The below class
+    // The native callback takes a pointer to a struct. This type
     // represents that struct in managed code.
     [StructLayout(LayoutKind.Sequential)]
-    public class StatClass
+    public struct Stat
     {
         public uint DeviceID;
         public uint InodeNumber;


### PR DESCRIPTION
## Summary

Add doc topic for unmanaged calling conventions. Addresses feedback from https://github.com/dotnet/runtime/issues/90462#issuecomment-1676049957

Other miscellaneous interop doc improvements:
- Rename article title to match the content
- Replace link to PInvoke.net wiki with a link to CsWin32. CsWin32 is more modern and precise.
- Update Linux and macOS samples to follow best practices



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/dependency-loading/default-probing.md](https://github.com/dotnet/docs/blob/33e9434e20155b56b476f2194a383e18847b168f/docs/core/dependency-loading/default-probing.md) | [Default probing](https://review.learn.microsoft.com/en-us/dotnet/core/dependency-loading/default-probing?branch=pr-en-us-36768) |
| [docs/standard/native-interop/calling-conventions.md](https://github.com/dotnet/docs/blob/33e9434e20155b56b476f2194a383e18847b168f/docs/standard/native-interop/calling-conventions.md) | [docs/standard/native-interop/calling-conventions](https://review.learn.microsoft.com/en-us/dotnet/standard/native-interop/calling-conventions?branch=pr-en-us-36768) |
| [docs/standard/native-interop/native-library-loading.md](https://github.com/dotnet/docs/blob/33e9434e20155b56b476f2194a383e18847b168f/docs/standard/native-interop/native-library-loading.md) | [docs/standard/native-interop/native-library-loading](https://review.learn.microsoft.com/en-us/dotnet/standard/native-interop/native-library-loading?branch=pr-en-us-36768) |
| [docs/standard/native-interop/pinvoke.md](https://github.com/dotnet/docs/blob/33e9434e20155b56b476f2194a383e18847b168f/docs/standard/native-interop/pinvoke.md) | [Platform Invoke (P/Invoke)](https://review.learn.microsoft.com/en-us/dotnet/standard/native-interop/pinvoke?branch=pr-en-us-36768) |


<!-- PREVIEW-TABLE-END -->