### PR TITLE
Add clarification regarding target framework symbols

### DIFF
--- a/includes/preprocessor-symbols.md
+++ b/includes/preprocessor-symbols.md
@@ -12,5 +12,5 @@ ms.custom: "updateeachrelease"
 > * Versionless symbols are defined regardless of the version you're targeting.
 > * Version-specific symbols are only defined for the version you're targeting.
 > * The `<framework>_OR_GREATER` symbols are defined for the version you're targeting and all earlier versions. For example, if you're targeting .NET Framework 2.0, the following symbols are defined: `NET20`, `NET20_OR_GREATER`, `NET11_OR_GREATER`, and `NET10_OR_GREATER`.
-> * The `NETSTANDARD<x>_<y>_OR_GREATER` symbols are only defined for .NET Standard targets, and not for .NET 5+ (and .NET Core) and .NET Framework targets, even though they may implement that version of .NET Standard.
+> * The `NETSTANDARD<x>_<y>_OR_GREATER` symbols are only defined for .NET Standard targets, and not for targets that implement .NET Standard, such as .NET Core and .NET Framework.
 > * These are different from the target framework monikers (TFMs) used by [the MSBuild `TargetFramework` property](../docs/standard/frameworks.md#supported-target-frameworks) and [NuGet](/nuget/reference/target-frameworks).

--- a/includes/preprocessor-symbols.md
+++ b/includes/preprocessor-symbols.md
@@ -12,4 +12,5 @@ ms.custom: "updateeachrelease"
 > * Versionless symbols are defined regardless of the version you're targeting.
 > * Version-specific symbols are only defined for the version you're targeting.
 > * The `<framework>_OR_GREATER` symbols are defined for the version you're targeting and all earlier versions. For example, if you're targeting .NET Framework 2.0, the following symbols are defined: `NET20`, `NET20_OR_GREATER`, `NET11_OR_GREATER`, and `NET10_OR_GREATER`.
+> * The `NETSTANDARD<x>_<y>_OR_GREATER` symbols are only defined for .NET Standard targets, and not for .NET 5+ (and .NET Core) and .NET Framework targets, even though they may implement that version of .NET Standard.
 > * These are different from the target framework monikers (TFMs) used by [the MSBuild `TargetFramework` property](../docs/standard/frameworks.md#supported-target-frameworks) and [NuGet](/nuget/reference/target-frameworks).


### PR DESCRIPTION
## Clarification regarding additional target framework symbols

The documentation regarding additional `<framework>_OR_GREATER` target framework symbols isn't clear enough about .NET Standard's symbols. Since .NET 5.0 implements .NET Standard 2.1 (according to [this interactive UI](https://dotnet.microsoft.com/en-us/platform/dotnet-standard#versions)), I expected that when targeting .NET 5.0 I would see a `NETSTANDARD2_1_OR_GREATER` symbol, but that was not the case. The same goes for targeting .NET Framework.

I spent a couple of days trying to figure out what's wrong with my MSBuild installation, examined the build logs, and looked through SDK's files, to find out that `NETSTANDARD2_1_OR_GREATER` was never intended to be defined when targeting .NET 5+/Core/Framework.

I think this should be clarified in the docs, to avoid confusion.
