### PR TITLE
Fix link

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/extension-methods.md
+++ b/docs/csharp/programming-guide/classes-and-structs/extension-methods.md
@@ -127,7 +127,7 @@ For a class library that you implemented, you shouldn't use extension methods to
 ## See also
 
 - [C# Programming Guide](../index.md)
-- [Parallel Programming Samples (these include many example extension methods)](/samples/browse/?products=dotnet-core%2Cdotnet-standard&term=parallel)
+- [Parallel Programming Samples (these include many example extension methods)](/samples/browse/?products=dotnet&term=parallel)
 - [Lambda Expressions](../../language-reference/operators/lambda-expressions.md)
 - [Standard Query Operators Overview](../concepts/linq/standard-query-operators-overview.md)
 - [Conversion rules for Instance parameters and their impact](/archive/blogs/sreekarc/conversion-rules-for-instance-parameters-and-their-impact)


### PR DESCRIPTION
The search terms for parallel samples should use ms.prod of `dotnet` instead of `dotnet-standard` and `dotnet-core`

Fixes #36766


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/classes-and-structs/extension-methods.md](https://github.com/dotnet/docs/blob/642ec637db87a5b1d701013885ea00bff5e6b09e/docs/csharp/programming-guide/classes-and-structs/extension-methods.md) | [Extension Methods (C# Programming Guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/extension-methods?branch=pr-en-us-36772) |

<!-- PREVIEW-TABLE-END -->