### PR TITLE
Three breaking changes

### DIFF
--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -80,6 +80,7 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 | [ActivatorUtilities.CreateInstance behaves consistently](extensions/8.0/activatorutilities-createinstance-behavior.md)            | Behavioral change | Preview 1  |
 | [ActivatorUtilities.CreateInstance requires non-null provider](extensions/8.0/activatorutilities-createinstance-null-provider.md) | Behavioral change | Preview 1  |
 | [ConfigurationBinder throws for mismatched value](extensions/8.0/configurationbinder-exceptions.md)                               | Behavioral change | Preview 1  |
+| [ConfigurationManager package no longer references System.Security.Permissions](extensions/8.0/configurationmanager-package.md)   | Source incompatible | Preview 3  |
 | [Empty keys added to dictionary by configuration binder](extensions/8.0/dictionary-configuration-binding.md)                      | Behavioral change | Preview 5  |
 | [HostApplicationBuilderSettings.Args respected by HostApplicationBuilder ctor](extensions/8.0/hostapplicationbuilder-ctor.md)     | Behavioral change | Preview 2  |
 

--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -53,6 +53,7 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 | [IndexOfAnyValues renamed to SearchValues](core-libraries/8.0/indexofanyvalues-renamed.md)                | Source/binary incompatible | Preview 5 |
 | [ITypeDescriptorContext nullable annotations](core-libraries/8.0/itypedescriptorcontext-props.md)         | Source incompatible | Preview 1    |
 | [Legacy Console.ReadKey removed](core-libraries/8.0/console-readkey-legacy.md)                            | Behavioral change   | Preview 1    |
+| [Method builders generate parameters with HasDefaultValue set to false](core-libraries/8.0/parameterinfo-hasdefaultvalue.md) | Behavioral change   | Preview 5    |
 | [Removed overloads of ToFrozenDictionary/ToFrozenSet](core-libraries/8.0/optimizeforreading-arg.md)       | Source/binary incompatible | Preview 7 |
 
 ## Cryptography

--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -80,7 +80,8 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 | [ActivatorUtilities.CreateInstance behaves consistently](extensions/8.0/activatorutilities-createinstance-behavior.md)            | Behavioral change | Preview 1  |
 | [ActivatorUtilities.CreateInstance requires non-null provider](extensions/8.0/activatorutilities-createinstance-null-provider.md) | Behavioral change | Preview 1  |
 | [ConfigurationBinder throws for mismatched value](extensions/8.0/configurationbinder-exceptions.md)                               | Behavioral change | Preview 1  |
-| [ConfigurationManager package no longer references System.Security.Permissions](extensions/8.0/configurationmanager-package.md)   | Source incompatible | Preview 3  |
+| [ConfigurationManager package no longer references System.Security.Permissions](extensions/8.0/configurationmanager-package.md)   | Source incompatible | Preview 3  |                              | Behavioral change | Preview 1  |
+| [DirectoryServices package no longer references System.Security.Permissions](extensions/8.0/configurationmanager-package.md)   | Source incompatible | Preview 3  |
 | [Empty keys added to dictionary by configuration binder](extensions/8.0/dictionary-configuration-binding.md)                      | Behavioral change | Preview 5  |
 | [HostApplicationBuilderSettings.Args respected by HostApplicationBuilder ctor](extensions/8.0/hostapplicationbuilder-ctor.md)     | Behavioral change | Preview 2  |
 

--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -81,7 +81,7 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 | [ActivatorUtilities.CreateInstance behaves consistently](extensions/8.0/activatorutilities-createinstance-behavior.md)            | Behavioral change | Preview 1  |
 | [ActivatorUtilities.CreateInstance requires non-null provider](extensions/8.0/activatorutilities-createinstance-null-provider.md) | Behavioral change | Preview 1  |
 | [ConfigurationBinder throws for mismatched value](extensions/8.0/configurationbinder-exceptions.md)                               | Behavioral change | Preview 1  |
-| [ConfigurationManager package no longer references System.Security.Permissions](extensions/8.0/configurationmanager-package.md)   | Source incompatible | Preview 3  |                              | Behavioral change | Preview 1  |
+| [ConfigurationManager package no longer references System.Security.Permissions](extensions/8.0/configurationmanager-package.md)   | Source incompatible | Preview 3  |
 | [DirectoryServices package no longer references System.Security.Permissions](extensions/8.0/configurationmanager-package.md)   | Source incompatible | Preview 3  |
 | [Empty keys added to dictionary by configuration binder](extensions/8.0/dictionary-configuration-binding.md)                      | Behavioral change | Preview 5  |
 | [HostApplicationBuilderSettings.Args respected by HostApplicationBuilder ctor](extensions/8.0/hostapplicationbuilder-ctor.md)     | Behavioral change | Preview 2  |

--- a/docs/core/compatibility/core-libraries/8.0/parameterinfo-hasdefaultvalue.md
+++ b/docs/core/compatibility/core-libraries/8.0/parameterinfo-hasdefaultvalue.md
@@ -1,0 +1,36 @@
+---
+title: ".NET 8 breaking change: Method builders generate parameters with HasDefaultValue set to false"
+description: Learn about the .NET 8 breaking change in core .NET libraries where ConstructorBuilder and MethodBuilder now generate method parameters with HasDefaultValue set to false.
+ms.date: 08/22/2023
+---
+# Method builders generate parameters with HasDefaultValue set to false
+
+<xref:System.Reflection.Emit.ConstructorBuilder?displayProperty=fullName> and <xref:System.Reflection.Emit.MethodBuilder?displayProperty=fullName> now generate method parameters that, when reflected on, have <xref:System.Reflection.ParameterInfo.HasDefaultValue?displayProperty=nameWithType> set to `false`.
+
+## Previous behavior
+
+Previously, <xref:System.Reflection.Emit.ConstructorBuilder> and <xref:System.Reflection.Emit.MethodBuilder> generated IL for method parameters where the <xref:System.Reflection.ParameterInfo.HasDefaultValue> of the parameters was set to `true`.
+
+## New behavior
+
+Starting in .NET 8, <xref:System.Reflection.Emit.ConstructorBuilder> and <xref:System.Reflection.Emit.MethodBuilder> generate IL for method parameters where the <xref:System.Reflection.ParameterInfo.HasDefaultValue> of the parameters is set to `false`, which is the expected value.
+
+## Version introduced
+
+.NET 8 Preview 5
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+The previous behavior was incorrect, as no default parameter values were specified when the method or constructor was defined.
+
+## Recommended action
+
+If you use <xref:System.Reflection.Emit.TypeBuilder.DefineConstructor%2A?displayProperty=nameWithType> or <xref:System.Reflection.Emit.TypeBuilder.DefineMethod%2A?displayProperty=nameWithType>, make sure consumers of the generated types' methods don't rely on the <xref:System.Reflection.ParameterInfo.HasDefaultValue?displayProperty=nameWithType> property being `true`.
+
+## Affected APIs
+
+- <xref:System.Reflection.ParameterInfo.HasDefaultValue?displayProperty=fullName>

--- a/docs/core/compatibility/extensions/8.0/configurationmanager-package.md
+++ b/docs/core/compatibility/extensions/8.0/configurationmanager-package.md
@@ -17,7 +17,7 @@ The `System.Configuration.ConfigurationManager` package referenced the `System.S
 
 ## New behavior
 
-Starting in .NET 8, the `System.Configuration.ConfigurationManager` package *does not reference* the `System.Security.Permissions` package.
+Starting in .NET 8, the `System.Configuration.ConfigurationManager` package *does not* reference the `System.Security.Permissions` package.
 
 ## Type of breaking change
 
@@ -30,10 +30,10 @@ This change avoids a dependency on `System.Drawing.Common` when `System.Configur
 The dependency on `System.Drawing.Common` was caused by the following package dependencies:
 
 ```txt
-System.Configuration.ConfigurationManager ->
-System.Security.Permissions ->
-System.Windows.Extensions ->
-System.Drawing.Common
+System.Configuration.ConfigurationManager
+└──System.Security.Permissions
+    └──System.Windows.Extensions
+        └──System.Drawing.Common
 ```
 
 ## Recommended action

--- a/docs/core/compatibility/extensions/8.0/configurationmanager-package.md
+++ b/docs/core/compatibility/extensions/8.0/configurationmanager-package.md
@@ -1,0 +1,45 @@
+---
+title: "Breaking change: ConfigurationManager package no longer references System.Security.Permissions"
+description: Learn about the .NET 8 breaking change in .NET extensions where the System.Configuration.ConfigurationManager package no longer references the System.Security.Permissions package.
+ms.date: 08/22/2023
+---
+# ConfigurationManager package no longer references System.Security.Permissions
+
+The `System.Configuration.ConfigurationManager` package no longer references the `System.Security.Permissions` package.
+
+## Version introduced
+
+.NET 8 Preview 3
+
+## Previous behavior
+
+The `System.Configuration.ConfigurationManager` package referenced the `System.Security.Permissions` package.
+
+## New behavior
+
+Starting in .NET 8, the `System.Configuration.ConfigurationManager` package *does not reference* the `System.Security.Permissions` package.
+
+## Type of breaking change
+
+This change can affect [source compatibility](../../categories.md#source-compatibility).
+
+## Reason for change
+
+This change avoids a dependency on `System.Drawing.Common` when `System.Configuration.ConfigurationManager` is referenced, which is primarily an issue for non-Windows operating systems.
+
+The dependency on `System.Drawing.Common` was caused by the following package dependencies:
+
+```txt
+System.Configuration.ConfigurationManager ->
+System.Security.Permissions ->
+System.Windows.Extensions ->
+System.Drawing.Common
+```
+
+## Recommended action
+
+If your app references the `System.Configuration.ConfigurationManager` package and you also have a dependency on `System.Security.Permissions` or any of its dependencies, which might include `System.Windows.Extensions`, `System.Security.AccessControl`, or `System.Drawing.Common`, you'll need to reference those packages either directly or indirectly.
+
+## Affected APIs
+
+N/A

--- a/docs/core/compatibility/extensions/8.0/directoryservices-package.md
+++ b/docs/core/compatibility/extensions/8.0/directoryservices-package.md
@@ -1,0 +1,45 @@
+---
+title: "Breaking change: DirectoryServices package no longer references System.Security.Permissions"
+description: Learn about the .NET 8 breaking change in .NET extensions where the System.DirectoryServices package no longer references the System.Security.Permissions package.
+ms.date: 08/22/2023
+---
+# DirectoryServices package no longer references System.Security.Permissions
+
+The `System.DirectoryServices` package no longer references the `System.Security.Permissions` package.
+
+## Version introduced
+
+.NET 8 Preview 3
+
+## Previous behavior
+
+The `System.DirectoryServices` package referenced the `System.Security.Permissions` package.
+
+## New behavior
+
+Starting in .NET 8, the `System.DirectoryServices` package *does not reference* the `System.Security.Permissions` package.
+
+## Type of breaking change
+
+This change can affect [source compatibility](../../categories.md#source-compatibility).
+
+## Reason for change
+
+This change avoids a dependency on `System.Drawing.Common` when `System.DirectoryServices` is referenced, which is primarily an issue for non-Windows operating systems.
+
+The dependency on `System.Drawing.Common` was caused by the following package dependencies:
+
+```txt
+System.DirectoryServices ->
+System.Security.Permissions ->
+System.Windows.Extensions ->
+System.Drawing.Common
+```
+
+## Recommended action
+
+If your app references the `System.DirectoryServices` package and you also have a dependency on `System.Security.Permissions` or any of its dependencies, which might include `System.Windows.Extensions` or `System.Drawing.Common`, you'll need to reference those packages either directly or indirectly.
+
+## Affected APIs
+
+N/A

--- a/docs/core/compatibility/extensions/8.0/directoryservices-package.md
+++ b/docs/core/compatibility/extensions/8.0/directoryservices-package.md
@@ -17,7 +17,7 @@ The `System.DirectoryServices` package referenced the `System.Security.Permissio
 
 ## New behavior
 
-Starting in .NET 8, the `System.DirectoryServices` package *does not reference* the `System.Security.Permissions` package.
+Starting in .NET 8, the `System.DirectoryServices` package *does not* reference the `System.Security.Permissions` package.
 
 ## Type of breaking change
 
@@ -30,10 +30,10 @@ This change avoids a dependency on `System.Drawing.Common` when `System.Director
 The dependency on `System.Drawing.Common` was caused by the following package dependencies:
 
 ```txt
-System.DirectoryServices ->
-System.Security.Permissions ->
-System.Windows.Extensions ->
-System.Drawing.Common
+System.DirectoryServices
+ └──System.Security.Permissions
+      └──System.Windows.Extensions
+           └──System.Drawing.Common
 ```
 
 ## Recommended action

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -88,6 +88,8 @@ items:
         href: extensions/8.0/configurationbinder-exceptions.md
       - name: ConfigurationManager package no longer references System.Security.Permissions
         href: extensions/8.0/configurationmanager-package.md
+      - name: DirectoryServices package no longer references System.Security.Permissions
+        href: extensions/8.0/configurationmanager-package.md
       - name: Empty keys added to dictionary by configuration binder
         href: extensions/8.0/dictionary-configuration-binding.md
       - name: HostApplicationBuilderSettings.Args respected by constructor
@@ -1315,6 +1317,8 @@ items:
       - name: ConfigurationBinder throws for mismatched value
         href: extensions/8.0/configurationbinder-exceptions.md
       - name: ConfigurationManager package no longer references System.Security.Permissions
+        href: extensions/8.0/configurationmanager-package.md
+      - name: DirectoryServices package no longer references System.Security.Permissions
         href: extensions/8.0/configurationmanager-package.md
       - name: Empty keys added to dictionary by configuration binder
         href: extensions/8.0/dictionary-configuration-binding.md

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -62,6 +62,8 @@ items:
         href: core-libraries/8.0/itypedescriptorcontext-props.md
       - name: Legacy Console.ReadKey removed
         href: core-libraries/8.0/console-readkey-legacy.md
+      - name: Method builders generate parameters with HasDefaultValue=false
+        href: core-libraries/8.0/parameterinfo-hasdefaultvalue.md
       - name: Removed overloads of ToFrozenDictionary/ToFrozenSet
         href: core-libraries/8.0/optimizeforreading-arg.md
     - name: Cryptography
@@ -1084,6 +1086,8 @@ items:
         href: core-libraries/8.0/itypedescriptorcontext-props.md
       - name: Legacy Console.ReadKey removed
         href: core-libraries/8.0/console-readkey-legacy.md
+      - name: Method builders generate parameters with HasDefaultValue=false
+        href: core-libraries/8.0/parameterinfo-hasdefaultvalue.md
       - name: Removed overloads of ToFrozenDictionary/ToFrozenSet
         href: core-libraries/8.0/optimizeforreading-arg.md
     - name: .NET 7

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -86,6 +86,8 @@ items:
         href: extensions/8.0/activatorutilities-createinstance-null-provider.md
       - name: ConfigurationBinder throws for mismatched value
         href: extensions/8.0/configurationbinder-exceptions.md
+      - name: ConfigurationManager package no longer references System.Security.Permissions
+        href: extensions/8.0/configurationmanager-package.md
       - name: Empty keys added to dictionary by configuration binder
         href: extensions/8.0/dictionary-configuration-binding.md
       - name: HostApplicationBuilderSettings.Args respected by constructor
@@ -1312,6 +1314,8 @@ items:
         href: extensions/8.0/activatorutilities-createinstance-null-provider.md
       - name: ConfigurationBinder throws for mismatched value
         href: extensions/8.0/configurationbinder-exceptions.md
+      - name: ConfigurationManager package no longer references System.Security.Permissions
+        href: extensions/8.0/configurationmanager-package.md
       - name: Empty keys added to dictionary by configuration binder
         href: extensions/8.0/dictionary-configuration-binding.md
       - name: HostApplicationBuilderSettings.Args respected by constructor


### PR DESCRIPTION
Fixes #36720 
Fixes #36724 
Fixes #36725 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/8.0.md](https://github.com/dotnet/docs/blob/20a2266c04a6e96533b263cd1bd446379854f3d3/docs/core/compatibility/8.0.md) | [Breaking changes in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/8.0?branch=pr-en-us-36787) |
| [docs/core/compatibility/core-libraries/8.0/parameterinfo-hasdefaultvalue.md](https://github.com/dotnet/docs/blob/20a2266c04a6e96533b263cd1bd446379854f3d3/docs/core/compatibility/core-libraries/8.0/parameterinfo-hasdefaultvalue.md) | [docs/core/compatibility/core-libraries/8.0/parameterinfo-hasdefaultvalue](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/8.0/parameterinfo-hasdefaultvalue?branch=pr-en-us-36787) |
| [docs/core/compatibility/extensions/8.0/configurationmanager-package.md](https://github.com/dotnet/docs/blob/20a2266c04a6e96533b263cd1bd446379854f3d3/docs/core/compatibility/extensions/8.0/configurationmanager-package.md) | [docs/core/compatibility/extensions/8.0/configurationmanager-package](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/extensions/8.0/configurationmanager-package?branch=pr-en-us-36787) |
| [docs/core/compatibility/extensions/8.0/directoryservices-package.md](https://github.com/dotnet/docs/blob/20a2266c04a6e96533b263cd1bd446379854f3d3/docs/core/compatibility/extensions/8.0/directoryservices-package.md) | [docs/core/compatibility/extensions/8.0/directoryservices-package](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/extensions/8.0/directoryservices-package?branch=pr-en-us-36787) |


<!-- PREVIEW-TABLE-END -->