### PR TITLE
IDispatchImplAttribute removed

### DIFF
--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -95,6 +95,7 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 | Title                                                                                             | Type of change      | Introduced |
 | ------------------------------------------------------------------------------------------------- | ------------------- | ---------- |
 | [CreateObjectFlags.Unwrap only unwraps on target instance](interop/8.0/comwrappers-unwrap.md)     | Behavioral change   | Preview 5  |
+| [IDispatchImplAttribute API is removed](interop/8.0/idispatchimplattribute-removed.md)            | Binary incompatible   | Preview 6  |
 | [SafeHandle types must have public constructor](interop/8.0/safehandle-constructor.md)            | Source incompatible | Preview 5  |
 
 ## Reflection

--- a/docs/core/compatibility/fx-core.md
+++ b/docs/core/compatibility/fx-core.md
@@ -2,7 +2,7 @@
 title: Breaking changes - .NET Framework to .NET Core
 titleSuffix: ""
 description: Lists the breaking changes from .NET Framework to .NET Core 1.0 - 3.1.
-ms.date: 05/05/2020
+ms.date: 08/22/2023
 ---
 # Breaking changes for migration from .NET Framework to .NET Core
 
@@ -14,10 +14,15 @@ If you're migrating an app from .NET Framework to .NET Core versions 1.0 through
 ## Core .NET libraries
 
 - [Change in default value of UseShellExecute](#change-in-default-value-of-useshellexecute)
+- [IDispatchImplAttribute API is removed](#net-8)
 - [UnauthorizedAccessException thrown by FileSystemInfo.Attributes](#unauthorizedaccessexception-thrown-by-filesysteminfoattributes)
 - [Handling corrupted-process-state exceptions is not supported](#handling-corrupted-state-exceptions-is-not-supported)
 - [UriBuilder properties no longer prepend leading characters](#uribuilder-properties-no-longer-prepend-leading-characters)
 - [Process.StartInfo throws InvalidOperationException for processes you didn't start](#processstartinfo-throws-invalidoperationexception-for-processes-you-didnt-start)
+
+### .NET 8
+
+[IDispatchImplAttribute API is removed](interop/8.0/idispatchimplattribute-removed.md)
 
 ### .NET Core 2.1
 

--- a/docs/core/compatibility/interop/8.0/idispatchimplattribute-removed.md
+++ b/docs/core/compatibility/interop/8.0/idispatchimplattribute-removed.md
@@ -1,0 +1,36 @@
+---
+title: "Breaking change: IDispatchImplAttribute API is removed"
+description: Learn about the breaking change in interop in .NET 8 where the IDispatchImplAttribute API has been removed.
+ms.date: 08/22/2023
+---
+# IDispatchImplAttribute API is removed
+
+The <xref:System.Runtime.InteropServices.IDispatchImplAttribute> implementation has officially been removed from .NET. This type was only discoverable at run time and its removal has no impact on visible API surface area. However, if an assembly targeting .NET Framework uses this type and is loaded in .NET 8 or a later version, the runtime will throw a <xref:System.TypeLoadException>.
+
+## Previous behavior
+
+The <xref:System.Runtime.InteropServices.IDispatchImplAttribute> type could be found at run time, but none of the documented semantics of the deprecated attribute applied.
+
+## New behavior
+
+Starting in .NET 8, attempting to load an assembly that contains this attribute throws a <xref:System.TypeLoadException>.
+
+## Version introduced
+
+.NET 8 Preview 6
+
+## Type of breaking change
+
+This change can affect [binary compatibility](../../categories.md#binary-compatibility).
+
+## Reason for change
+
+This attribute was removed as it was not longer respected and served no functional purpose.
+
+## Recommended action
+
+Remove use of this API in assemblies that are loaded in .NET 8 and later versions.
+
+## Affected APIs
+
+- <xref:System.Runtime.InteropServices.IDispatchImplAttribute?displayProperty=fullName>

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -100,6 +100,8 @@ items:
       items:
       - name: CreateObjectFlags.Unwrap only unwraps on target instance
         href: interop/8.0/comwrappers-unwrap.md
+      - name: IDispatchImplAttribute API is removed
+        href: interop/8.0/idispatchimplattribute-removed.md
       - name: SafeHandle types must have public constructor
         href: interop/8.0/safehandle-constructor.md
     - name: Reflection
@@ -1368,6 +1370,8 @@ items:
       items:
       - name: CreateObjectFlags.Unwrap only unwraps on target instance
         href: interop/8.0/comwrappers-unwrap.md
+      - name: IDispatchImplAttribute API is removed
+        href: interop/8.0/idispatchimplattribute-removed.md
       - name: SafeHandle types must have public constructor
         href: interop/8.0/safehandle-constructor.md
     - name: .NET 7

--- a/docs/core/compatibility/unsupported-apis.md
+++ b/docs/core/compatibility/unsupported-apis.md
@@ -2,7 +2,7 @@
 title: Unsupported APIs on .NET Core and .NET 5+
 titleSuffix: ""
 description: Learn which .NET APIs always throw an exception on .NET Core and .NET 5 and later versions.
-ms.date: 05/02/2023
+ms.date: 08/22/2023
 ---
 # APIs that always throw exceptions on .NET Core and .NET 5+
 
@@ -184,6 +184,7 @@ This article organizes the affected APIs by namespace.
 
 | Member | Platforms that throw |
 | - | - |
+| <xref:System.Runtime.InteropServices.IDispatchImplAttribute> | All |
 | <xref:System.Runtime.InteropServices.Marshal.GetIDispatchForObject(System.Object)?displayProperty=nameWithType> | All |
 | <xref:System.Runtime.InteropServices.RuntimeEnvironment.SystemConfigurationFile?displayProperty=nameWithType> | All |
 | <xref:System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeInterfaceAsIntPtr(System.Guid,System.Guid)?displayProperty=nameWithType> | All |


### PR DESCRIPTION
Fixes #36729 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/8.0.md](https://github.com/dotnet/docs/blob/1a9b042c7994e99f129957f2ca4d201c5c6a8dbb/docs/core/compatibility/8.0.md) | [Breaking changes in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/8.0?branch=pr-en-us-36788) |
| [docs/core/compatibility/fx-core.md](https://github.com/dotnet/docs/blob/1a9b042c7994e99f129957f2ca4d201c5c6a8dbb/docs/core/compatibility/fx-core.md) | [Breaking changes - .NET Framework to .NET Core](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/fx-core?branch=pr-en-us-36788) |
| [docs/core/compatibility/interop/8.0/idispatchimplattribute-removed.md](https://github.com/dotnet/docs/blob/1a9b042c7994e99f129957f2ca4d201c5c6a8dbb/docs/core/compatibility/interop/8.0/idispatchimplattribute-removed.md) | [docs/core/compatibility/interop/8.0/idispatchimplattribute-removed](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/interop/8.0/idispatchimplattribute-removed?branch=pr-en-us-36788) |
| [docs/core/compatibility/unsupported-apis.md](https://github.com/dotnet/docs/blob/1a9b042c7994e99f129957f2ca4d201c5c6a8dbb/docs/core/compatibility/unsupported-apis.md) | [APIs that always throw exceptions on .NET Core and .NET 5+](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/unsupported-apis?branch=pr-en-us-36788) |

<!-- PREVIEW-TABLE-END -->