### PR TITLE
Fix broken redirection

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -137,7 +137,7 @@
     },
     {
       "source_path": "docs/spark/index.yml",
-      "redirect_url": "/previous-versions/dotnet/spark",
+      "redirect_url": "/previous-versions/dotnet/spark/what-is-spark",
       "redirect_document_id": false
     },
     {


### PR DESCRIPTION
## Summary

Customers are reporting on the .NET marketing site that the spark docs link is broken. Given the current redirection is broken, I'm proposing we change the redirection to the next top-level article.