### PR TITLE
Update .editorconfig with newer csharp modifiers

### DIFF
--- a/docs/fundamentals/code-analysis/code-style-rule-options.md
+++ b/docs/fundamentals/code-analysis/code-style-rule-options.md
@@ -132,7 +132,7 @@ csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
 csharp_style_throw_expression = true:suggestion
 csharp_style_conditional_delegate_call = true:suggestion
 # Modifier preferences
-csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+csharp_preferred_modifier_order = public,private,protected,internal,file,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,required,volatile,async:suggestion
 # Expression-level preferences
 csharp_prefer_braces = true:silent
 csharp_style_deconstructed_variable_declaration = true:suggestion


### PR DESCRIPTION
## Summary

The example `.editorconfig` file does not include the new modifiers added with later versions of C# like `required` or `file`. 
The order of these modifiers in regards with the others is described in this [document](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0036#csharp_preferred_modifier_order).


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/code-style-rule-options.md](https://github.com/dotnet/docs/blob/cba57aaded1753a4642809e6eb5dd23748a4c278/docs/fundamentals/code-analysis/code-style-rule-options.md) | [Code-style rule options](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/code-style-rule-options?branch=pr-en-us-36839) |

<!-- PREVIEW-TABLE-END -->