### PR TITLE
Update overview.md to be more clear about packing

### DIFF
--- a/docs/fundamentals/package-validation/overview.md
+++ b/docs/fundamentals/package-validation/overview.md
@@ -46,7 +46,7 @@ There are three different validators that verify your package as part of the `Pa
 ## Suppress compatibility errors
 
 To suppress compatibility errors for intentional changes, add a *CompatibilitySuppressions.xml* file to your project.
-You can generate this file automatically by passing `/p:GenerateCompatibilitySuppressionFile=true` if you're building the project from the command line, or by adding the following property to your project: `<GenerateCompatibilitySuppressionFile>true</GenerateCompatibilitySuppressionFile>`
+You can generate this file automatically by passing `/p:GenerateCompatibilitySuppressionFile=true` if you're packing the project from the command line, or by adding the following property to your project: `<GenerateCompatibilitySuppressionFile>true</GenerateCompatibilitySuppressionFile>`
 
 The suppression file looks like this.
 


### PR DESCRIPTION
## Summary

As far as I can tell, *CompatibilitySuppressions.xml* is never generated when "building" the project but only when packing it (running `dotnet pack`). This might save others from scratching their head (like me) wondering why the file is not generated.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/package-validation/overview.md](https://github.com/dotnet/docs/blob/06e36dd4f40b768b2c819c90f1ee44fb1112195d/docs/fundamentals/package-validation/overview.md) | [Package validation overview](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/overview?branch=pr-en-us-36861) |

<!-- PREVIEW-TABLE-END -->