### PR TITLE
Update httpclient-guidelines.md

### DIFF
--- a/docs/fundamentals/networking/http/httpclient-guidelines.md
+++ b/docs/fundamentals/networking/http/httpclient-guidelines.md
@@ -54,7 +54,7 @@ For more information about managing `HttpClient` lifetime with `IHttpClientFacto
 
 ## Resilience policies with static clients
 
-It is possible to configure a `static` or *singleton* client to use any number of resilience policies using the following pattern:
+It's possible to configure a `static` or *singleton* client to use any number of resilience policies using the following pattern:
 
 ```csharp
 var retryPolicy = HttpPolicyExtensions

--- a/docs/fundamentals/networking/http/httpclient-guidelines.md
+++ b/docs/fundamentals/networking/http/httpclient-guidelines.md
@@ -57,6 +57,12 @@ For more information about managing `HttpClient` lifetime with `IHttpClientFacto
 It's possible to configure a `static` or *singleton* client to use any number of resilience policies using the following pattern:
 
 ```csharp
+using System;
+using System.Net.Http;
+using Microsoft.Extensions.Http;
+using Polly;
+using Polly.Extensions.Http;
+
 var retryPolicy = HttpPolicyExtensions
     .HandleTransientHttpError()
     .WaitAndRetryAsync(3, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)));
@@ -69,6 +75,14 @@ var pollyHandler = new PolicyHttpMessageHandler(retryPolicy)
 
 var httpClient = new HttpClient(pollyHandler);
 ```
+
+The preceding code:
+
+- Relies on [Microsoft.Extensions.Http.Polly](https://www.nuget.org/packages/Microsoft.Extensions.Http.Polly) NuGet package, transitively the [Polly.Extensions.Http](https://www.nuget.org/packages/Polly.Extensions.Http) NuGet package for the `HttpPolicyExtensions` type.
+- Specifies a transient HTTP error handler, configured with retry policy that with each attempt will exponentially backoff delay intervals.
+- Defines a pooled connection lifetime of fifteen minutes for the `socketHandler`.
+- Passes the `socketHandler` to the `policyHandler` with the retry logic.
+- Instantiates an `HttpClient` given the `policyHandler`.
 
 ## See also
 

--- a/docs/fundamentals/networking/http/httpclient-guidelines.md
+++ b/docs/fundamentals/networking/http/httpclient-guidelines.md
@@ -62,8 +62,10 @@ var retryPolicy = HttpPolicyExtensions
     .WaitAndRetryAsync(3, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)));
 
 var socketHandler = new SocketsHttpHandler { PooledConnectionLifetime = TimeSpan.FromMinutes(15) };
-var pollyHandler = new PolicyHttpMessageHandler(retryPolicy);
-pollyHandler.InnerHandler = socketHandler;
+var pollyHandler = new PolicyHttpMessageHandler(retryPolicy)
+{
+    InnerHandler = socketHandler;
+};
 
 var httpClient = new HttpClient(pollyHandler);
 ```

--- a/docs/fundamentals/networking/http/httpclient-guidelines.md
+++ b/docs/fundamentals/networking/http/httpclient-guidelines.md
@@ -52,6 +52,22 @@ To summarize recommended `HttpClient` use in terms of lifetime management, you s
 
 For more information about managing `HttpClient` lifetime with `IHttpClientFactory`, see [`IHttpClientFactory` guidelines](../../../core/extensions/httpclient-factory.md#httpclient-lifetime-management).
 
+## Resilience policies with static clients
+
+It is possible to configure a `static` or *singleton* client to use any number of resilience policies using the following pattern:
+
+```csharp
+var retryPolicy = HttpPolicyExtensions
+    .HandleTransientHttpError()
+    .WaitAndRetryAsync(3, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)));
+
+var socketHandler = new SocketsHttpHandler { PooledConnectionLifetime = TimeSpan.FromMinutes(15) };
+var pollyHandler = new PolicyHttpMessageHandler(retryPolicy);
+pollyHandler.InnerHandler = socketHandler;
+
+var httpClient = new HttpClient(pollyHandler);
+```
+
 ## See also
 
 - [HTTP support in .NET](http-overview.md)


### PR DESCRIPTION
Added example of using a Polly policy with a static HttpClient instance.

Fixes #35495 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/networking/http/httpclient-guidelines.md](https://github.com/dotnet/docs/blob/7fc3d9cd500861aacb000bb6dc9b8bf94662a039/docs/fundamentals/networking/http/httpclient-guidelines.md) | [Guidelines for using HttpClient](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient-guidelines?branch=pr-en-us-36866) |


<!-- PREVIEW-TABLE-END -->