### PR TITLE
Mention and link XML comments in 'Comment style' section

### DIFF
--- a/docs/csharp/fundamentals/coding-style/coding-conventions.md
+++ b/docs/csharp/fundamentals/coding-style/coding-conventions.md
@@ -319,6 +319,7 @@ In general, use the following format for code samples:
 
 - Use single-line comments (`//`) for brief explanations.
 - Avoid multi-line comments (`/* */`) for longer explanations. Comments aren't localized. Instead, longer explanations are in the companion article.
+- For describing methods, classes, fields, and all public members use [XML comments](../../language-reference/xmldoc/index.md).
 - Place the comment on a separate line, not at the end of a line of code.
 - Begin comment text with an uppercase letter.
 - End comment text with a period.


### PR DESCRIPTION
This pull request fixes #36244 
It adds additional point to `Comment style` section of Coding conventions page to mention XML comments.
This new point is placed as the next right after avoiding multi-line comments rule to present another alternative and keep the context.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/fundamentals/coding-style/coding-conventions.md](https://github.com/dotnet/docs/blob/8d6287fb4bb43198ce60718d80cb93f249b1ba82/docs/csharp/fundamentals/coding-style/coding-conventions.md) | [Common C# code conventions](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions?branch=pr-en-us-36870) |

<!-- PREVIEW-TABLE-END -->