### PR TITLE
Added examples code for `ITimerRegistry` and `IReminderRegistry` 

### DIFF
--- a/docs/orleans/grains/snippets/timers/IPingGrain.cs
+++ b/docs/orleans/grains/snippets/timers/IPingGrain.cs
@@ -1,0 +1,6 @@
+﻿namespace Timers;
+
+public interface IPingGrain
+{
+    Task Ping();
+}

--- a/docs/orleans/grains/snippets/timers/PingGrain.cs
+++ b/docs/orleans/grains/snippets/timers/PingGrain.cs
@@ -1,0 +1,57 @@
+﻿using Orleans.Runtime;
+using Orleans.Timers;
+
+namespace Timers;
+
+public sealed class PingGrain : IGrainBase, IPingGrain, IDisposable
+{
+    private const string ReminderName = "ExampleReminder";
+
+    private readonly IReminderRegistry _reminderRegistry;
+
+    private IGrainReminder? _reminder;
+
+    public  IGrainContext GrainContext { get; }
+
+    public PingGrain(
+        ITimerRegistry timerRegistry,
+        IReminderRegistry reminderRegistry,
+        IGrainContext grainContext)
+    {
+        // Register timer
+        timerRegistry.RegisterTimer(
+            grainContext,
+            asyncCallback: static async state =>
+            {
+                // Omitted for brevity...
+                // Use state
+
+                await Task.CompletedTask;
+            },
+            state: this,
+            dueTime: TimeSpan.FromSeconds(3),
+            period: TimeSpan.FromSeconds(10));
+
+        _reminderRegistry = reminderRegistry;
+
+        GrainContext = grainContext;
+    }
+
+    public async Task Ping()
+    {
+        _reminder = await _reminderRegistry.RegisterOrUpdateReminder(
+            callingGrainId: GrainContext.GrainId,
+            reminderName: ReminderName,
+            dueTime: TimeSpan.Zero,
+            period: TimeSpan.FromHours(1));
+    }
+
+    void IDisposable.Dispose()
+    {
+        if (_reminder is not null)
+        {
+            _reminderRegistry.UnregisterReminder(
+                GrainContext.GrainId, _reminder);
+        }
+    }
+}

--- a/docs/orleans/grains/snippets/timers/Timers.csproj
+++ b/docs/orleans/grains/snippets/timers/Timers.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="7.2.1" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" Version="7.2.1" />
+    <PackageReference Include="Microsoft.Orleans.Reminders" Version="7.2.1" />
+  </ItemGroup>
+
+</Project>

--- a/docs/orleans/grains/timers-and-reminders.md
+++ b/docs/orleans/grains/timers-and-reminders.md
@@ -76,7 +76,7 @@ var silo = new HostBuilder()
     {
         builder.UseAdoNetReminderService(options =>
         {
-            options.ConnectionString = connectionString;
+            options.ConnectionString = connectionString; // Redacted
             options.Invariant = invariant;
         });
     })
@@ -109,7 +109,10 @@ Task IRemindable.ReceiveReminder(string reminderName, TickStatus status)
  To start a reminder, use the <xref:Orleans.Grain.RegisterOrUpdateReminder%2A?displayProperty=nameWithType> method, which returns an <xref:Orleans.Runtime.IGrainReminder> object:
 
 ```csharp
-protected Task<IGrainReminder> RegisterOrUpdateReminder(string reminderName, TimeSpan dueTime, TimeSpan period)
+protected Task<IGrainReminder> RegisterOrUpdateReminder(
+    string reminderName,
+    TimeSpan dueTime,
+    TimeSpan period)
 ```
 
 * `reminderName`: is a string that must uniquely identify the reminder within the scope of the contextual grain.
@@ -148,3 +151,23 @@ We recommend that you use reminders in the following circumstances:
 ## Combine timers and reminders
 
 You might consider using a combination of reminders and timers to accomplish your goal. For example, if you need a timer with a small resolution that needs to survive across activations, you can use a reminder that runs every five minutes, whose purpose is to wake up a grain that restarts a local timer that may have been lost due to deactivation.
+
+## POCO grain registrations
+
+To register a timer or reminder with [a POCO grain](../migration-guide.md#poco-grains-and-igrainbase), you implement the <xref:Orleans.IGrainBase> interface and inject the <xref:Orleans.Timers.ITimerRegistry> or <xref:Orleans.Timers.IReminderRegistry> into the grain's constructor.
+
+```csharp
+public sealed class PingGrain : IGrainBase, IPingGrain
+{
+    private readonly ITimerRegistry _timerRegistry;
+    private readonly IReminderRegistry _reminderRegistry;
+
+    public PingGrain(ITimerRegistry timerRegistry, IReminderRegistry reminderRegistry)
+    {
+        _timerRegistry = timerRegistry;
+        _reminderRegistry = reminderRegistry;
+    }
+
+    // Omitted for brevity...
+}
+```

--- a/docs/orleans/grains/timers-and-reminders.md
+++ b/docs/orleans/grains/timers-and-reminders.md
@@ -10,7 +10,7 @@ The Orleans runtime provides two mechanisms, called timers and reminders, that e
 
 ## Timers
 
-**Timers** are used to create periodic grain behavior that isn't required to span multiple activations (instantiations of the grain). A timer is essentially identical to the standard .NET <xref:System.Threading.Timer?displayProperty=fullName> class. In addition, timers are subject to single-threaded execution guarantees within the grain activation that it operates on and their execution will be interleaved with other requests, as though the timer callback was a grain method marked with <xref:Orleans.Concurrency.AlwaysInterleaveAttribute>.
+**Timers** are used to create periodic grain behavior that isn't required to span multiple activations (instantiations of the grain). A timer is identical to the standard .NET <xref:System.Threading.Timer?displayProperty=fullName> class. In addition, timers are subject to single-threaded execution guarantees within the grain activation that it operates on, and their executions are interleaved with other requests, as though the timer callback was a grain method marked with <xref:Orleans.Concurrency.AlwaysInterleaveAttribute>.
 
 Each activation may have zero or more timers associated with it. The runtime executes each timer routine within the runtime context of the activation that it's associated with.
 
@@ -28,29 +28,29 @@ public IDisposable RegisterTimer(
 
 To cancel the timer, you dispose of it.
 
-A timer will cease to trigger if the grain is deactivated or when a fault occurs and its silo crashes.
+A timer ceases to trigger if the grain is deactivated or when a fault occurs and its silo crashes.
 
 ***Important considerations:***
 
 * When activation collection is enabled, the execution of a timer callback doesn't change the activation's state from idle to in-use. This means that a timer can't be used to postpone the deactivation of otherwise idle activations.
 * The period passed to `Grain.RegisterTimer` is the amount of time that passes from the moment the Task returned by `asyncCallback` is resolved to the moment that the next invocation of `asyncCallback` should occur. This not only makes it impossible for successive calls to `asyncCallback` to overlap, but also makes it so that the length of time `asyncCallback` takes to complete affects the frequency at which `asyncCallback` is invoked. This is an important deviation from the semantics of <xref:System.Threading.Timer?displayProperty=fullName>.
-* Each invocation of `asyncCallback` is delivered to an activation on a separate turn, and will never run concurrently with other turns on the same activation. However, `asyncCallback` invocations aren't delivered as messages and thus aren't subject to message interleaving semantics. This means that invocations of `asyncCallback` will behave as if the grain is re-entrant and will execute concurrently with other grain requests. In order to use the grain's request scheduling semantics, you can call a grain method to perform the work you would have done within `asyncCallback`. Another alternative is to use an `AsyncLock` or a <xref:System.Threading.SemaphoreSlim>. A more detailed explanation is available in [Orleans GitHub issue #2574](https://github.com/dotnet/orleans/issues/2574).
+* Each invocation of `asyncCallback` is delivered to an activation on a separate turn, and never runs concurrently with other turns on the same activation. However, `asyncCallback` invocations aren't delivered as messages and thus aren't subject to message interleaving semantics. This means that invocations of `asyncCallback` behave as if the grain is re-entrant and executes concurrently with other grain requests. In order to use the grain's request scheduling semantics, you can call a grain method to perform the work you would have done within `asyncCallback`. Another alternative is to use an `AsyncLock` or a <xref:System.Threading.SemaphoreSlim>. A more detailed explanation is available in [Orleans GitHub issue #2574](https://github.com/dotnet/orleans/issues/2574).
 
 ## Reminders
 
 Reminders are similar to timers, with a few important differences:
 
-* Reminders are persistent and will continue to trigger in almost all situations (including partial or full cluster restarts) unless explicitly canceled.
-* Reminder "definitions" are written to storage. However, each specific occurrence, with its specific time, is not. This has the side effect that if the cluster is down at the time of a specific reminder tick, it will be missed and only the next tick of the reminder will happen.
+* Reminders are persistent and continue to trigger in almost all situations (including partial or full cluster restarts) unless explicitly canceled.
+* Reminder "definitions" are written to storage. However, each specific occurrence, with its specific time, isn't. This has the side effect that if the cluster is down at the time of a specific reminder tick, it will be missed and only the next tick of the reminder happens.
 * Reminders are associated with a grain, not any specific activation.
-* If a grain has no activation associated with it when a reminder ticks, the grain will be created. If an activation becomes idle and is deactivated, a reminder associated with the same grain will reactivate the grain when it ticks next.
-* Reminders are delivered by message and are subject to the same interleaving semantics as all other grain methods.
+* If a grain has no activation associated with it when a reminder ticks, the grain is created. If an activation becomes idle and is deactivated, a reminder associated with the same grain reactivates the grain when it ticks next.
+* Reminder delivery occurs via message and is subject to the same interleaving semantics as all other grain methods.
 * Reminders shouldn't be used for high-frequency timers- their period should be measured in minutes, hours, or days.
 
 ## Configuration
 
 Reminders, being persistent, rely upon storage to function.
-You must specify which storage backing to use before the reminder subsystem will function.
+You must specify which storage backing to use before the reminder subsystem functions.
 This is done by configuring one of the reminder providers via `Use{X}ReminderService` extension methods, where `X` is the name of the provider, for example, <xref:Orleans.Hosting.SiloHostBuilderReminderExtensions.UseAzureTableReminderService%2A>.
 
 Azure Table configuration:
@@ -61,7 +61,7 @@ const string connectionString = "YOUR_CONNECTION_STRING_HERE";
 var silo = new HostBuilder()
     .UseOrleans(builder =>
     {
-        builder.UseAzureTableReminderService(options => options.ConnectionString = connectionString)
+        builder.UseAzureTableReminderService(connectionString)
     })
     .Build();
 ```
@@ -83,7 +83,7 @@ var silo = new HostBuilder()
     .Build();
 ```
 
- If you just want a placeholder implementation of reminders to work without needing to set up an Azure account or SQL database, then this will give you a development-only implementation of the reminder system:
+ If you just want a placeholder implementation of reminders to work without needing to set up an Azure account or SQL database, then this gives you a development-only implementation of the reminder system:
 
 ```csharp
 var silo = new HostBuilder()
@@ -136,7 +136,7 @@ protected Task<IGrainReminder> GetReminder(string reminderName)
 
 We recommend that you use timers in the following circumstances:
 
-* When it doesn't matter (or is desirable) that the timer ceases to function if the activation is deactivated or failures occur.
+* If it doesn't matter (or is desirable) that the timer ceases to function when the activation is deactivated or failures occur.
 * The resolution of the timer is small (for example, reasonably expressible in seconds or minutes).
 * The timer callback can be started from <xref:Orleans.Grain.OnActivateAsync?displayProperty=nameWithType> or when a grain method is invoked.
 

--- a/docs/orleans/grains/timers-and-reminders.md
+++ b/docs/orleans/grains/timers-and-reminders.md
@@ -156,18 +156,11 @@ You might consider using a combination of reminders and timers to accomplish you
 
 To register a timer or reminder with [a POCO grain](../migration-guide.md#poco-grains-and-igrainbase), you implement the <xref:Orleans.IGrainBase> interface and inject the <xref:Orleans.Timers.ITimerRegistry> or <xref:Orleans.Timers.IReminderRegistry> into the grain's constructor.
 
-```csharp
-public sealed class PingGrain : IGrainBase, IPingGrain
-{
-    private readonly ITimerRegistry _timerRegistry;
-    private readonly IReminderRegistry _reminderRegistry;
+:::code source="./snippets/timers/PingGrain.cs":::
 
-    public PingGrain(ITimerRegistry timerRegistry, IReminderRegistry reminderRegistry)
-    {
-        _timerRegistry = timerRegistry;
-        _reminderRegistry = reminderRegistry;
-    }
+The preceding code:
 
-    // Omitted for brevity...
-}
-```
+- Defines a POCO grain that implements <xref:Orleans.IGrainBase>, `IPingGrain`, and <xref:System.IDisposable>.
+- Registers a timer that is invoked every ten seconds, and starts three seconds after registration.
+- When `Ping` is called, registers a reminder that is invoked hour, and starts immediately following registration.
+- The `Dispose` method cancels the reminder if it's registered.

--- a/docs/orleans/grains/timers-and-reminders.md
+++ b/docs/orleans/grains/timers-and-reminders.md
@@ -1,7 +1,7 @@
 ---
 title: Timers and reminders
 description: Learn how to use timers and reminders in .NET Orleans.
-ms.date: 03/16/2022
+ms.date: 08/28/2023
 ---
 
 # Timers and reminders

--- a/docs/orleans/grains/timers-and-reminders.md
+++ b/docs/orleans/grains/timers-and-reminders.md
@@ -10,7 +10,7 @@ The Orleans runtime provides two mechanisms, called timers and reminders, that e
 
 ## Timers
 
-**Timers** are used to create periodic grain behavior that isn't required to span multiple activations (instantiations of the grain). A timer is identical to the standard .NET <xref:System.Threading.Timer?displayProperty=fullName> class. In addition, timers are subject to single-threaded execution guarantees within the grain activation that it operates on, and their executions are interleaved with other requests, as though the timer callback was a grain method marked with <xref:Orleans.Concurrency.AlwaysInterleaveAttribute>.
+**Timers** are used to create periodic grain behavior that isn't required to span multiple activations (instantiations of the grain). A timer is identical to the standard .NET <xref:System.Threading.Timer?displayProperty=fullName> class. In addition, timers are subject to single-threaded execution guarantees within the grain activation that they operate on, and their executions are interleaved with other requests, as though the timer callback was a grain method marked with <xref:Orleans.Concurrency.AlwaysInterleaveAttribute>.
 
 Each activation may have zero or more timers associated with it. The runtime executes each timer routine within the runtime context of the activation that it's associated with.
 
@@ -161,6 +161,6 @@ To register a timer or reminder with [a POCO grain](../migration-guide.md#poco-g
 The preceding code:
 
 - Defines a POCO grain that implements <xref:Orleans.IGrainBase>, `IPingGrain`, and <xref:System.IDisposable>.
-- Registers a timer that is invoked every ten seconds, and starts three seconds after registration.
-- When `Ping` is called, registers a reminder that is invoked hour, and starts immediately following registration.
+- Registers a timer that is invoked every 10 seconds, and starts 3 seconds after registration.
+- When `Ping` is called, registers a reminder that is invoked every hour, and starts immediately following registration.
 - The `Dispose` method cancels the reminder if it's registered.


### PR DESCRIPTION
## Summary

Added examples code for `ITimerRegistry` and `IReminderRegistry` 

Fixes #33961


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/grains/timers-and-reminders.md](https://github.com/dotnet/docs/blob/7328cfec9f53f1642cf152af067eb092985c1708/docs/orleans/grains/timers-and-reminders.md) | [Timers and reminders](https://review.learn.microsoft.com/en-us/dotnet/orleans/grains/timers-and-reminders?branch=pr-en-us-36872) |


<!-- PREVIEW-TABLE-END -->