### PR TITLE
Update SLES 12 to SP5 min

### DIFF
--- a/docs/core/install/linux-sles.md
+++ b/docs/core/install/linux-sles.md
@@ -19,7 +19,7 @@ The following table is a list of currently supported .NET releases on both SLES 
 | SLES   | .NET |
 |--------|------|
 | 15     | 7, 6 |
-| 12 SP2 | 7, 6 |
+| 12 SP5 | 7, 6 |
 
 [!INCLUDE [versions-not-supported](includes/versions-not-supported.md)]
 


### PR DESCRIPTION
## Summary

SP2 went out of support a while back.

Following https://github.com/dotnet/core/pull/8711

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/linux-sles.md](https://github.com/dotnet/docs/blob/207a11eed790e2619e84d5ca0748f2232e450dff/docs/core/install/linux-sles.md) | [Install the .NET SDK or the .NET Runtime on SLES](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-sles?branch=pr-en-us-36878) |

<!-- PREVIEW-TABLE-END -->