### PR TITLE
Add Int128 and UInt128 to numerics.md

### DIFF
--- a/docs/standard/numerics.md
+++ b/docs/standard/numerics.md
@@ -25,7 +25,7 @@ ms.assetid: dfebc18e-acde-4510-9fa7-9a0f4aa3bd11
 
 ## Integer types
 
-.NET supports both signed and unsigned 8-bit, 16-bit, 32-bit, and 64-bit integer types, which are listed in the following tables.
+.NET supports both signed and unsigned 8-bit, 16-bit, 32-bit, 64-bit, and 128-bit integer types, which are listed in the following tables.
 
 **Signed integer types**
 
@@ -34,6 +34,7 @@ ms.assetid: dfebc18e-acde-4510-9fa7-9a0f4aa3bd11
 |<xref:System.Int16?displayProperty=nameWithType>|2|-32,768|32,767|
 |<xref:System.Int32?displayProperty=nameWithType>|4|-2,147,483,648|2,147,483,647|
 |<xref:System.Int64?displayProperty=nameWithType>|8|-9,223,372,036,854,775,808|9,223,372,036,854,775,807|
+|<xref:System.Int128?displayProperty=nameWithType>|16|−170,141,183,460,469,231,731,687,303,715,884,105,728|170,141,183,460,469,231,731,687,303,715,884,105,727|
 |<xref:System.SByte?displayProperty=nameWithType>|1|-128|127|
 |<xref:System.IntPtr?displayProperty=nameWithType> (in 32-bit process)|4|-2,147,483,648|2,147,483,647|
 |<xref:System.IntPtr?displayProperty=nameWithType> (in 64-bit process)|8|-9,223,372,036,854,775,808|9,223,372,036,854,775,807|
@@ -46,6 +47,7 @@ ms.assetid: dfebc18e-acde-4510-9fa7-9a0f4aa3bd11
 |<xref:System.UInt16?displayProperty=nameWithType>|2|0|65,535|
 |<xref:System.UInt32?displayProperty=nameWithType>|4|0|4,294,967,295|
 |<xref:System.UInt64?displayProperty=nameWithType>|8|0|18,446,744,073,709,551,615|
+|<xref:System.UInt128?displayProperty=nameWithType>|16|0|340,282,366,920,938,463,463,374,607,431,768,211,455|
 |<xref:System.UIntPtr?displayProperty=nameWithType> (in 32-bit process)|4|0|4,294,967,295|
 |<xref:System.UIntPtr?displayProperty=nameWithType> (in 64-bit process)|8|0|18,446,744,073,709,551,615|
 


### PR DESCRIPTION
## Summary

Support for Int128 and UInt128 was shipped with .NET 7 (https://github.com/dotnet/runtime/pull/69204) but the types have yet to be added to the docs.

This pull request will add the types to [numerics.md](https://learn.microsoft.com/en-us/dotnet/standard/numerics).

The rendered result looks like this:
![image](https://github.com/dotnet/docs/assets/3706841/8dd2d378-2e2d-4ed7-9570-8e6cecfc24f4)



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/numerics.md](https://github.com/dotnet/docs/blob/eb865f1cc004722a3380b694067ad0091f8f4848/docs/standard/numerics.md) | [Numerics in .NET](https://review.learn.microsoft.com/en-us/dotnet/standard/numerics?branch=pr-en-us-36883) |


<!-- PREVIEW-TABLE-END -->