### PR TITLE
Fix the typo in the credit percentage of PerformMontEndTransactions

### DIFF
--- a/docs/csharp/fundamentals/tutorials/snippets/object-oriented-programming/InterestEarningAccount.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/object-oriented-programming/InterestEarningAccount.cs
@@ -13,7 +13,7 @@ public class InterestEarningAccount : BankAccount
     {
         if (Balance > 500m)
         {
-            decimal interest = Balance * 0.05m;
+            decimal interest = Balance * 0.02m;
             MakeDeposit(interest, DateTime.Now, "apply monthly interest");
         }
     }


### PR DESCRIPTION
This pull request fixes #36731 
It basically fixes the typo in the percentage of `PerformMonthEndTransactions` method presented in the Object-Oriented programming page, so that the implementation matches the requirements listed in the article.