### PR TITLE
Fix a misdirected link

### DIFF
--- a/docs/csharp/fundamentals/types/index.md
+++ b/docs/csharp/fundamentals/types/index.md
@@ -130,7 +130,7 @@ All arrays are reference types, even if their elements are value types. Arrays i
 
 :::code language="csharp" source="../../programming-guide/types/snippets/index/Program.cs" ID="ArrayDeclaration":::
 
-Reference types fully support inheritance. When you create a class, you can inherit from any other interface or class that isn't defined as [sealed](../../language-reference/keywords/sealed.md). Other classes can inherit from your class and override your virtual methods. For more information about how to create your own classes, see [Classes, structs, and records](../types/index.md). For more information about inheritance and virtual methods, see [Inheritance](../object-oriented/inheritance.md).
+Reference types fully support inheritance. When you create a class, you can inherit from any other interface or class that isn't defined as [sealed](../../language-reference/keywords/sealed.md). Other classes can inherit from your class and override your virtual methods. For more information about how to create your own classes, see [Classes, structs, and records](../object-oriented/index.md). For more information about inheritance and virtual methods, see [Inheritance](../object-oriented/inheritance.md).
 
 ## Types of literal values
 


### PR DESCRIPTION
## Summary
Correct a misdirected hyperlink so it points to the proper document.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/fundamentals/types/index.md](https://github.com/dotnet/docs/blob/9cf66a2d7b69c9ca35e625a219bd8f93cd3c80ea/docs/csharp/fundamentals/types/index.md) | [The C# type system](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/types/index?branch=pr-en-us-36892) |


<!-- PREVIEW-TABLE-END -->