### PR TITLE
Update missing HttpClient client parameter

### DIFF
--- a/docs/csharp/tutorials/console-webapiclient.md
+++ b/docs/csharp/tutorials/console-webapiclient.md
@@ -214,7 +214,7 @@ The `ProcessRepositoriesAsync` method can do the async work and return a collect
 1. Change the signature of `ProcessRepositoriesAsync` to return a task whose result is a list of `Repository` objects:
 
    ```csharp
-   static async Task<List<Repository>> ProcessRepositoriesAsync()
+   static async Task<List<Repository>> ProcessRepositoriesAsync(HttpClient client)
    ```
 
 1. Return the repositories after processing the JSON response:


### PR DESCRIPTION
## Summary

I was confused by the parameter error when following along with the tutorial.

Update the missing `HttpClient client` parameter in the `ProcessRepositoriesAsync` method.

Fixes: the bug part (first line) of https://github.com/dotnet/docs/issues/33590



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/tutorials/console-webapiclient.md](https://github.com/dotnet/docs/blob/bf62789a5205ab670d017250e15a36a52c874ec4/docs/csharp/tutorials/console-webapiclient.md) | [Tutorial: Make HTTP requests in a .NET console app using C\#](https://review.learn.microsoft.com/en-us/dotnet/csharp/tutorials/console-webapiclient?branch=pr-en-us-36896) |


<!-- PREVIEW-TABLE-END -->