### PR TITLE
Update interpolated-strings.md

### DIFF
--- a/docs/fsharp/language-reference/interpolated-strings.md
+++ b/docs/fsharp/language-reference/interpolated-strings.md
@@ -124,7 +124,7 @@ Note that the type annotation must be on the interpolated string expression itse
 
 ## Extended syntax for string interpolation
 
-When you work with text containing multiple `{`, `}` or `%` characters already, you can use extended string interpolation syntax to remove the need for escaping.
+Beginning with F# 8, when you work with text containing multiple `{`, `}` or `%` characters already, you can use extended string interpolation syntax to remove the need for escaping.
 
 Triple quote string literals can start with multiple `$` characters, which changes how many braces are required to open and close interpolation.
 In these string literals, `{` and `}` characters don't need to be escaped:


### PR DESCRIPTION
Clarify that the new syntax for string interpolation is available starting from F# 8

Fixes #36662


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/interpolated-strings.md](https://github.com/dotnet/docs/blob/aad14af33b2da50b25061ad2fe1ab41eee4bddb0/docs/fsharp/language-reference/interpolated-strings.md) | [Interpolated strings](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/interpolated-strings?branch=pr-en-us-36918) |


<!-- PREVIEW-TABLE-END -->