### PR TITLE
Update ValidateSettingsOptions.cs

### DIFF
--- a/docs/core/extensions/snippets/configuration/console-json/ValidateSettingsOptions.cs
+++ b/docs/core/extensions/snippets/configuration/console-json/ValidateSettingsOptions.cs
@@ -15,25 +15,24 @@ sealed partial class ValidateSettingsOptions : IValidateOptions<SettingsOptions>
 
     public ValidateOptionsResult Validate(string? name, SettingsOptions options)
     {
-        StringBuilder failure = new();
-        Regex validationRegex = ValidationRegex();
-        Match match = validationRegex.Match(options.SiteTitle);
-        if (string.IsNullOrEmpty(match.Value))
+        StringBuilder? failure = null;
+    
+        if (!ValidationRegex().IsMatch(options.SiteTitle))
         {
-            failure.AppendLine($"{options.SiteTitle} doesn't match RegEx");
+            (failure ??= new()).AppendLine($"{options.SiteTitle} doesn't match RegEx");
         }
 
         if (options.Scale is < 0 or > 1_000)
         {
-            failure.AppendLine($"{options.Scale} isn't within Range 0 - 1000");
+            (failure ??= new()).AppendLine($"{options.Scale} isn't within Range 0 - 1000");
         }
 
         if (_settings is { Scale: 0 } && _settings.VerbosityLevel <= _settings.Scale)
         {
-            failure.AppendLine("VerbosityLevel must be > than Scale.");
+            (failure ??= new()).AppendLine("VerbosityLevel must be > than Scale.");
         }
 
-        return failure.Length > 0
+        return failure is not null ?
             ? ValidateOptionsResult.Fail(failure.ToString())
             : ValidateOptionsResult.Success;
     }


### PR DESCRIPTION
Avoid unnecessary overheads:
- There's no need to get back a Match; it should just use IsMatch.
- There's no need to create a StringBuilder on the success path.