### PR TITLE
Add info table to IDE0055 page

### DIFF
--- a/docs/fundamentals/code-analysis/style-rules/ide0055.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0055.md
@@ -24,7 +24,7 @@ helpviewer_keywords:
 | **Rule ID**              | IDE0055                                       |
 | **Title**                | Formatting rule                               |
 | **Category**             | Style                                         |
-| **Subcategory**          |                                               |
+| **Subcategory**          | N/A                                           |
 | **Applicable languages** | C# and Visual Basic                           |
 
 All formatting options have rule ID IDE0055 and title `Fix formatting`. These formatting options affect how indentation, spaces, and new lines are aligned around .NET programming language constructs. The options fall into the following categories and are documented on separate pages:

--- a/docs/fundamentals/code-analysis/style-rules/ide0055.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0055.md
@@ -19,6 +19,14 @@ helpviewer_keywords:
 ---
 # Formatting rule (IDE0055)
 
+| Property                 | Value                                         |
+| ------------------------ | --------------------------------------------- |
+| **Rule ID**              | IDE0055                                       |
+| **Title**                | Formatting rule                               |
+| **Category**             | Style                                         |
+| **Subcategory**          |                                               |
+| **Applicable languages** | C# and Visual Basic                           |
+
 All formatting options have rule ID IDE0055 and title `Fix formatting`. These formatting options affect how indentation, spaces, and new lines are aligned around .NET programming language constructs. The options fall into the following categories and are documented on separate pages:
 
 - [.NET formatting options](dotnet-formatting-options.md)


### PR DESCRIPTION
## Summary

Page for IDE0055 does not contains table with information about rule like all(?) other rules.

Questions: 

- Not sure about `Subcategory`. Any ideas?
- Other rules also contain a list of options. But IDE0055's options described in dotnet-formatting-options.md and csharp-formatting-options.md. Is it a good idea to add all of them?



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/style-rules/ide0055.md](https://github.com/dotnet/docs/blob/162104333216874837db947b10058f18933b7f19/docs/fundamentals/code-analysis/style-rules/ide0055.md) | [Formatting rule (IDE0055)](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0055?branch=pr-en-us-36922) |


<!-- PREVIEW-TABLE-END -->