### PR TITLE
Add the Orleans meters

### DIFF
--- a/docs/core/diagnostics/compare-metric-apis.md
+++ b/docs/core/diagnostics/compare-metric-apis.md
@@ -41,7 +41,7 @@ aiming at broad compatibility, this API adds support for many things that were l
 - Multiple simultaneous listeners
 - Listener access to unaggregated measurements
 
-Although this API was designed to work well with OpenTelemetry and its growing ecosystem of pluggable vendor integration libraries, applications also have the option to use the .NET built-in listener APIs directly. With this option, you can create custom metric tooling without taking any external library dependencies. At the time of writing, the [System.Diagnostics.Metrics](xref:System.Diagnostics.Metrics) support is limited to [dotnet-counters](dotnet-counters.md) and [OpenTelemetry.NET](https://opentelemetry.io/docs/net/). However, we expect support for these APIs will grow  given the active nature of the OpenTelemetry project.
+Although this API was designed to work well with OpenTelemetry and its growing ecosystem of pluggable vendor integration libraries, applications also have the option to use the .NET built-in listener APIs directly. With this option, you can create custom metric tooling without taking any external library dependencies. At the time of writing, the [System.Diagnostics.Metrics](xref:System.Diagnostics.Metrics) support is limited to [dotnet-counters](dotnet-counters.md) and [OpenTelemetry.NET](https://opentelemetry.io/docs/net/). However, we expect support for these APIs will grow given the active nature of the OpenTelemetry project.
 
 ### PerformanceCounter
 

--- a/docs/orleans/host/monitoring/index.md
+++ b/docs/orleans/host/monitoring/index.md
@@ -128,7 +128,7 @@ A collection of gateway meters that are used to monitor the gateway layer.
 | `orleans-gateway-connected-clients` | <xref:System.Diagnostics.Metrics.UpDownCounter%601> | An up/down counter representing the number of connected clients. |
 | `orleans-gateway-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of gateway messages sent. |
 | `orleans-gateway-received` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of gateway messages received. |
-| `orleans-gateway-load-shedding` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of gateway load shedding. |
+| `orleans-gateway-load-shedding` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of gateway (load shedding) messages that have been rejected due to the gateway being overloaded. |
 
 #### Runtime
 
@@ -136,9 +136,9 @@ A collection of runtime meters that are used to monitor the runtime layer.
 
 | Meter name | Type | Description |
 |--|--|--|
-| `orleans-scheduler-long-running-turns` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-runtime-total-physical-memory` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-runtime-available-memory` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-scheduler-long-running-turns` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of long running turns within the scheduler. |
+| `orleans-runtime-total-physical-memory` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the total number of memory (in MB) of the Orleans runtime. |
+| `orleans-runtime-available-memory` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the available memory (in MB) for the Orleans runtime. |
 
 #### Catalog
 
@@ -146,15 +146,15 @@ A collection of catalog meters that are used to monitor the catalog layer.
 
 | Meter name | Type | Description |
 |--|--|--|
-| `orleans-catalog-activations` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-catalog-activation-working-set` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-catalog-activation-created` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-catalog-activation-destroyed` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-catalog-activation-failed-to-activate` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-catalog-activation-collections` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-catalog-activation-shutdown` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-catalog-activation-non-existent` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-catalog-activation-concurrent-registration-attempts` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-catalog-activations` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the number of catalog activations. |
+| `orleans-catalog-activation-working-set` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the number of activations within the working set. |
+| `orleans-catalog-activation-created` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of created activations. |
+| `orleans-catalog-activation-destroyed` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of destroyed activations. |
+| `orleans-catalog-activation-failed-to-activate` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of activations that failed to activate. |
+| `orleans-catalog-activation-collections` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of activation collections. |
+| `orleans-catalog-activation-shutdown` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of shutdown activations. |
+| `orleans-catalog-activation-non-existent` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of non-existent activations. |
+| `orleans-catalog-activation-concurrent-registration-attempts` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of concurrent activation registration attempts. |
 
 #### Directory
 

--- a/docs/orleans/host/monitoring/index.md
+++ b/docs/orleans/host/monitoring/index.md
@@ -151,7 +151,7 @@ A collection of catalog meters that are used to monitor the catalog layer.
 | `orleans-catalog-activation-created` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of created activations. |
 | `orleans-catalog-activation-destroyed` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of destroyed activations. |
 | `orleans-catalog-activation-failed-to-activate` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of activations that failed to activate. |
-| `orleans-catalog-activation-collections` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of activation collections. |
+| `orleans-catalog-activation-collections` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of idle activation collections. |
 | `orleans-catalog-activation-shutdown` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of shutdown activations. |
 | `orleans-catalog-activation-non-existent` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of non-existent activations. |
 | `orleans-catalog-activation-concurrent-registration-attempts` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of concurrent activation registration attempts. |

--- a/docs/orleans/host/monitoring/index.md
+++ b/docs/orleans/host/monitoring/index.md
@@ -183,13 +183,13 @@ A collection of directory meters that are used to monitor the directory layer.
 | `orleans-directory-registrations-single-act-local` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory single activation registrations handled by the local directory partition. |
 | `orleans-directory-registrations-single-act-remote-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory single activation registrations sent to a remote directory partition. |
 | `orleans-directory-registrations-single-act-remote-received` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory single activation registrations received from remote hosts. |
-| `orleans-directory-unregistrations-issued` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory un-registrations issued. |
-| `orleans-directory-unregistrations-local` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory un-registrations locally. |
-| `orleans-directory-unregistrations-remote-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory un-registrations sent remotely. |
-| `orleans-directory-unregistrations-remote-received` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory un-registrations received remotely. |
-| `orleans-directory-unregistrations-many-issued` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory un-registrations many issued. |
-| `orleans-directory-unregistrations-many-remote-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory un-registrations many sent remotely. |
-| `orleans-directory-unregistrations-many-remote-received` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory un-registrations many received remotely. |
+| `orleans-directory-unregistrations-issued` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory deregistrations issued. |
+| `orleans-directory-unregistrations-local` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory deregistrations handled by the local directory partition. |
+| `orleans-directory-unregistrations-remote-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory deregistrations sent to remote directory partitions. |
+| `orleans-directory-unregistrations-remote-received` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory deregistrations received from remote hosts. |
+| `orleans-directory-unregistrations-many-issued` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory multi-activation deregistrations issued. |
+| `orleans-directory-unregistrations-many-remote-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory multi-activations deregistrations sent to remote directory partitions. |
+| `orleans-directory-unregistrations-many-remote-received` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory multi-activation deregistrations received from remote hosts. |
 
 #### Consistent ring
 

--- a/docs/orleans/host/monitoring/index.md
+++ b/docs/orleans/host/monitoring/index.md
@@ -11,7 +11,7 @@ One of the most important aspects of a distributed system is observability. Obse
 
 ## Logging
 
-Orleans leverages [Microsoft.Extensions.Logging](https://www.nuget.org/packages/Microsoft.Extensions.Logging) for all silo and client logs. This means that you can use any logging provider that is compatible with `Microsoft.Extensions.Logging`. Your app code would rely on [dependency injection](../../../core/extensions/dependency-injection.md) to get an instance of <xref:Microsoft.Extensions.Logging.ILogger%601> and use it to log messages. For more information, see [Logging in .NET](../../../core/extensions/logging.md).
+Orleans uses [Microsoft.Extensions.Logging](https://www.nuget.org/packages/Microsoft.Extensions.Logging) for all silo and client logs. You can use any logging provider that is compatible with `Microsoft.Extensions.Logging`. Your app code would rely on [dependency injection](../../../core/extensions/dependency-injection.md) to get an instance of <xref:Microsoft.Extensions.Logging.ILogger%601> and use it to log messages. For more information, see [Logging in .NET](../../../core/extensions/logging.md).
 
 <!-- markdownlint-disable MD044 -->
 :::zone target="docs" pivot="orleans-7-0"
@@ -81,7 +81,7 @@ For more information, see [Investigate performance counters (dotnet-counters)](.
 
 ### Prometheus
 
-There are various third-party metrics providers that you can use with Orleans. One popular example is [Prometheus](https://prometheus.io), which can be used to collect metrics from your app in conjunction with OpenTelemetry.
+There are various third-party metrics providers that you can use with Orleans. One popular example is [Prometheus](https://prometheus.io), which can be used to collect metrics from your app with OpenTelemetry.
 
 To use OpenTelemetry and Prometheus with Orleans, call the following `IServiceCollection` extension method:
 
@@ -113,10 +113,10 @@ app.Run();
 
 Distributed tracing is a set of tools and practices to monitor and troubleshoot distributed applications. Distributed tracing is a key component of observability, and it's a critical tool for developers to understand the behavior of their apps. Orleans also supports distributed tracing with [OpenTelemetry](https://opentelemetry.io).
 
-Regardless of the distributed tracing exporter you choose, you'll call:
+Regardless of the distributed tracing exporter you choose, you call:
 
-- <xref:Orleans.Hosting.CoreHostingExtensions.AddActivityPropagation(Orleans.Hosting.ISiloBuilder)>: To enable distributed tracing for the silo.
-- <xref:Orleans.Hosting.ClientBuilderExtensions.AddActivityPropagation(Orleans.Hosting.IClientBuilder)>: To enable distributed tracing for the client.
+- <xref:Orleans.Hosting.CoreHostingExtensions.AddActivityPropagation(Orleans.Hosting.ISiloBuilder)>: which enables distributed tracing for the silo.
+- <xref:Orleans.Hosting.ClientBuilderExtensions.AddActivityPropagation(Orleans.Hosting.IClientBuilder)>: which enables distributed tracing for the client.
 
 Referring back to the [Orleans GPS Tracker sample app](/samples/dotnet/samples/orleans-gps-device-tracker-sample), you can use the [Zipkin](https://zipkin.io) distributed tracing system to monitor the app by updating the _Program.cs_. To use OpenTelemetry and Zipkin with Orleans, call the following `IServiceCollection` extension method:
 
@@ -156,11 +156,11 @@ For more information, see [Distributed tracing](../../../core/diagnostics/distri
 
 Orleans outputs its runtime statistics and metrics through the <xref:Orleans.Runtime.ITelemetryConsumer> interface. The application can register one or more telemetry consumers for their silos and clients, to receive statistics and metrics that the Orleans runtime periodically publishes. These can be consumers for popular telemetry analytics solutions or custom ones for any other destination and purpose. Three telemetry consumers are currently included in the Orleans codebase.
 
-They are released as separate NuGet packages:
+They're released as separate NuGet packages:
 
 - `Microsoft.Orleans.OrleansTelemetryConsumers.AI` for publishing to [Azure Application Insights](/azure/azure-monitor/app/app-insights-overview).
 
-- `Microsoft.Orleans.OrleansTelemetryConsumers.Counters` for publishing to Windows performance counters. The Orleans runtime continually updates a number of them. The _CounterControl.exe_ tool, included in the [`Microsoft.Orleans.CounterControl`](https://www.nuget.org/packages/Microsoft.Orleans.CounterControl/) NuGet package, helps register necessary performance counter categories. It has to run with elevated privileges. The performance counters can be monitored using any of the standard monitoring tools.
+- `Microsoft.Orleans.OrleansTelemetryConsumers.Counters` for publishing to Windows performance counters. The Orleans runtime continually updates many them. The _CounterControl.exe_ tool, included in the [`Microsoft.Orleans.CounterControl`](https://www.nuget.org/packages/Microsoft.Orleans.CounterControl/) NuGet package, helps register necessary performance counter categories. It has to run with elevated privileges. The performance counters can be monitored using any of the standard monitoring tools.
 
 - `Microsoft.Orleans.OrleansTelemetryConsumers.NewRelic`, for publishing to [New Relic](https://newrelic.com/).
 

--- a/docs/orleans/host/monitoring/index.md
+++ b/docs/orleans/host/monitoring/index.md
@@ -292,7 +292,6 @@ A collection of stream meters that are used to monitor the stream layer.
 | `orleans-streams-block-pool-claimed-memory` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the stream block pool claimed memory in bytes. |
 | `orleans-streams-block-pool-released-memory` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the stream block pool released memory in bytes. |
 | `orleans-streams-block-pool-allocated-memory` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the stream block pool allocated memory in bytes. |
-
 | `orleans-streams-queue-cache-size` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the stream queue cache size in bytes. |
 | `orleans-streams-queue-cache-length` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the stream queue length. |
 | `orleans-streams-queue-cache-messages-added` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the stream queue messages added. |

--- a/docs/orleans/host/monitoring/index.md
+++ b/docs/orleans/host/monitoring/index.md
@@ -85,7 +85,7 @@ Orleans uses the [System.Diagnostics.Metrics](../../../core/diagnostics/compare-
 
 #### Networking
 
-A collection of networking meters that are used to monitor the networking layer.
+The following table represents a collection of networking meters that are used to monitor the Orleans networking layer.
 
 | Meter name | Type | Description |
 |--|--|--|
@@ -94,7 +94,7 @@ A collection of networking meters that are used to monitor the networking layer.
 
 #### Messaging
 
-A collection of messaging meters that are used to monitor the messaging layer.
+The following table represents a collection of messaging meters that are used to monitor the Orleans messaging layer.
 
 | Meter name | Type | Description |
 |--|--|--|
@@ -121,7 +121,7 @@ A collection of messaging meters that are used to monitor the messaging layer.
 
 #### Gateway
 
-A collection of gateway meters that are used to monitor the gateway layer.
+The following table represents a collection of gateway meters that are used to monitor the Orleans gateway layer.
 
 | Meter name | Type | Description |
 |--|--|--|
@@ -132,7 +132,7 @@ A collection of gateway meters that are used to monitor the gateway layer.
 
 #### Runtime
 
-A collection of runtime meters that are used to monitor the runtime layer.
+The following table represents a collection of runtime meters that are used to monitor the Orleans runtime layer.
 
 | Meter name | Type | Description |
 |--|--|--|
@@ -142,7 +142,7 @@ A collection of runtime meters that are used to monitor the runtime layer.
 
 #### Catalog
 
-A collection of catalog meters that are used to monitor the catalog layer.
+The following table represents a collection of catalog meters that are used to monitor the Orleans catalog layer.
 
 | Meter name | Type | Description |
 |--|--|--|
@@ -158,7 +158,7 @@ A collection of catalog meters that are used to monitor the catalog layer.
 
 #### Directory
 
-A collection of directory meters that are used to monitor the directory layer.
+The following table represents a collection of directory meters that are used to monitor the Orleans directory layer.
 
 | Meter name | Type | Description |
 |--|--|--|
@@ -193,7 +193,7 @@ A collection of directory meters that are used to monitor the directory layer.
 
 #### Consistent ring
 
-A collection of consistent ring meters that are used to monitor the consistent ring layer.
+The following table represents a collection of consistent ring meters that are used to monitor the Orleans consistent ring layer.
 
 | Meter name | Type | Description |
 |--|--|--|
@@ -203,7 +203,7 @@ A collection of consistent ring meters that are used to monitor the consistent r
 
 #### Watchdog
 
-A collection of watchdog meters that are used to monitor the watchdog layer.
+The following table represents a collection of watchdog meters that are used to monitor the Orleans watchdog layer.
 
 | Meter name | Type | Description |
 |--|--|--|
@@ -212,7 +212,7 @@ A collection of watchdog meters that are used to monitor the watchdog layer.
 
 #### Client
 
-A collection of client meters that are used to monitor the client layer.
+The following table represents a collection of client meters that are used to monitor the Orleans client layer.
 
 | Meter name | Type | Description |
 |--|--|--|
@@ -220,7 +220,7 @@ A collection of client meters that are used to monitor the client layer.
 
 #### Miscellaneous
 
-A collection of miscellaneous meters that are used to monitor various layers.
+The following table represents a collection of miscellaneous meters that are used to monitor various layers.
 
 | Meter name | Type | Description |
 |--|--|--|
@@ -229,7 +229,7 @@ A collection of miscellaneous meters that are used to monitor various layers.
 
 #### App requests
 
-A collection of app request meters that are used to monitor the app request layer.
+The following table represents a collection of app request meters that are used to monitor the Orleans app request layer.
 
 | Meter name | Type | Description |
 |--|--|--|
@@ -238,7 +238,7 @@ A collection of app request meters that are used to monitor the app request laye
 
 #### Reminders
 
-A collection of reminder meters that are used to monitor the reminder layer.
+The following table represents a collection of reminder meters that are used to monitor the Orleans reminder layer.
 
 | Meter name | Type | Description |
 |--|--|--|
@@ -248,7 +248,7 @@ A collection of reminder meters that are used to monitor the reminder layer.
 
 #### Storage
 
-A collection of storage meters that are used to monitor the storage layer.
+The following table represents a collection of storage meters that are used to monitor the Orleans storage layer.
 
 | Meter name | Type | Description |
 |--|--|--|
@@ -261,7 +261,7 @@ A collection of storage meters that are used to monitor the storage layer.
 
 #### Streams
 
-A collection of stream meters that are used to monitor the stream layer.
+The following table represents a collection of stream meters that are used to monitor the Orleans stream layer.
 
 | Meter name | Type | Description |
 |--|--|--|
@@ -306,7 +306,7 @@ A collection of stream meters that are used to monitor the stream layer.
 
 #### Transactions
 
-A collection of transaction meters that are used to monitor the transaction layer.
+The following table represents a collection of transaction meters that are used to monitor the Orleans transaction layer.
 
 | Meter name | Type | Description |
 |--|--|--|

--- a/docs/orleans/host/monitoring/index.md
+++ b/docs/orleans/host/monitoring/index.md
@@ -1,7 +1,7 @@
 ---
 title: Orleans observability
 description: Explore the various runtime monitoring, logging, distributed tracing, and metrics options available in .NET Orleans.
-ms.date: 02/22/2023
+ms.date: 08/31/2023
 zone_pivot_groups: orleans-version
 ---
 

--- a/docs/orleans/host/monitoring/index.md
+++ b/docs/orleans/host/monitoring/index.md
@@ -79,6 +79,140 @@ Press p to pause, r to resume, q to quit.
 
 For more information, see [Investigate performance counters (dotnet-counters)](../../../core/diagnostics/dotnet-counters.md).
 
+### Orleans meters
+
+Orleans uses the [System.Diagnostics.Metrics](../../../core/diagnostics/compare-metric-apis.md#systemdiagnosticsmetrics) APIs to collect metrics. The following table represents the Orleans meters that are available for you to monitor:
+
+| Meter name | Discriminator | Description |
+|--|--|--|
+| `orleans-networking-sockets-closed` | Networking | ... |
+| `orleans-networking-sockets-opened` | Networking | ... |
+| `orleans-messaging-sent-messages-size` | Messaging | ... |
+| `orleans-messaging-received-messages-size` | Messaging | ... |
+| `orleans-messaging-sent-header-size` | Messaging | ... |
+| `orleans-messaging-sent-failed` | Messaging | ... |
+| `orleans-messaging-sent-dropped` | Messaging | ... |
+| `orleans-messaging-received-header-size` | Messaging | ... |
+| `orleans-messaging-processing-dispatcher-received` | Messaging | ... |
+| `orleans-messaging-processing-dispatcher-processed` | Messaging | ... |
+| `orleans-messaging-processing-dispatcher-forwarded` | Messaging | ... |
+| `orleans-messaging-processing-ima-received` | Messaging | ... |
+| `orleans-messaging-processing-ima-enqueued` | Messaging | ... |
+| `orleans-messaging-processing-activation-data` | Messaging | ... |
+| `orleans-messaging-pings-sent` | Messaging | ... |
+| `orleans-messaging-pings-received` | Messaging | ... |
+| `orleans-messaging-pings-reply-received` | Messaging | ... |
+| `orleans-messaging-pings-reply-missed` | Messaging | ... |
+| `orleans-messaging-expired"` | Messaging | ... |
+| `orleans-messaging-rejected` | Messaging | ... |
+| `orleans-messaging-rerouted` | Messaging | ... |
+| `orleans-messaging-sent-local` | Messaging | ... |
+| `orleans-gateway-connected-clients` | Gateway | ... |
+| `orleans-gateway-sent` | Gateway | ... |
+| `orleans-gateway-received` | Gateway | ... |
+| `orleans-gateway-load-shedding` | Gateway | ... |
+| `orleans-scheduler-long-running-turns` | Runtime | ... |
+| `orleans-runtime-total-physical-memory` | Runtime | ... |
+| `orleans-runtime-available-memory` | Runtime | ... |
+| `orleans-catalog-activations` | Catalog | ... |
+| `orleans-catalog-activation-working-set` | Catalog | ... |
+| `orleans-catalog-activation-created` | Catalog | ... |
+| `orleans-catalog-activation-destroyed` | Catalog | ... |
+| `orleans-catalog-activation-failed-to-activate` | Catalog | ... |
+| `orleans-catalog-activation-collections` | Catalog | ... |
+| `orleans-catalog-activation-shutdown` | Catalog | ... |
+| `orleans-catalog-activation-non-existent` | Catalog | ... |
+| `orleans-catalog-activation-concurrent-registration-attempts` | Catalog | ... |
+| `orleans-directory-lookups-local-issued` | Directory | ... |
+| `orleans-directory-lookups-local-successes` | Directory | ... |
+| `orleans-directory-lookups-full-issued` | Directory | ... |
+| `orleans-directory-lookups-remote-sent` | Directory | ... |
+| `orleans-directory-lookups-remote-received` | Directory | ... |
+| `orleans-directory-lookups-local-directory-issued` | Directory | ... |
+| `orleans-directory-lookups-local-directory-successes` | Directory | ... |
+| `orleans-directory-lookups-cache-issued` | Directory | ... |
+| `orleans-directory-lookups-cache-successes` | Directory | ... |
+| `orleans-directory-validations-cache-sent` | Directory | ... |
+| `orleans-directory-validations-cache-received` | Directory | ... |
+| `orleans-directory-partition-size` | Directory | ... |
+| `orleans-directory-cache-size` | Directory | ... |
+| `orleans-directory-ring-size` | Directory | ... |
+| `orleans-directory-ring-local-portion-distance` | Directory | ... |
+| `orleans-directory-ring-local-portion-percentage` | Directory | ... |
+| `orleans-directory-ring-local-portion-average-percentage` | Directory | ... |
+| `orleans-directory-registrations-single-act-issued` | Directory | ... |
+| `orleans-directory-registrations-single-act-local` | Directory | ... |
+| `orleans-directory-registrations-single-act-remote-sent` | Directory | ... |
+| `orleans-directory-registrations-single-act-remote-received` | Directory | ... |
+| `orleans-directory-unregistrations-issued` | Directory | ... |
+| `orleans-directory-unregistrations-local` | Directory | ... |
+| `orleans-directory-unregistrations-remote-sent` | Directory | ... |
+| `orleans-directory-unregistrations-remote-received` | Directory | ... |
+| `orleans-directory-unregistrations-many-issued` | Directory | ... |
+| `orleans-directory-unregistrations-many-remote-sent` | Directory | ... |
+| `orleans-directory-unregistrations-many-remote-received` | Directory | ... |
+| `orleans-consistent-ring-size` | Consistent ring | ... |
+| `orleans-consistent-ring-range-percentage-local` | Consistent ring | ... |
+| `orleans-consistent-ring-range-percentage-average` | Consistent ring | ... |
+| `orleans-watchdog-health-checks` | Watchdog | ... |
+| `orleans-watchdog-health-checks-failed` | Watchdog | ... |
+| `orleans-client-connected-gateways` | Client | ... |
+| `orleans-grains` | Miscellaneous | ... |
+| `orleans-system-targets` | Miscellaneous | ... |
+| `orleans-app-requests-latency` | App requests | ... |
+| `orleans-app-requests-timedout` | App requests | ... |
+| `orleans-reminders-tardiness` | Reminders | ... |
+| `orleans-reminders-active` | Reminders | ... |
+| `orleans-reminders-ticks-delivered` | Reminders | ... |
+| `orleans-storage-read-errors` | Storage | ... |
+| `orleans-storage-write-errors` | Storage | ... |
+| `orleans-storage-clear-errors` | Storage | ... |
+| `orleans-storage-read-latency` | Storage | ... |
+| `orleans-storage-write-latency` | Storage | ... |
+| `orleans-storage-clear-latency` | Storage | ... |
+| `orleans-streams-pubsub-producers-added` | Streams | ... |
+| `orleans-streams-pubsub-producers-removed` | Streams | ... |
+| `orleans-streams-pubsub-producers` | Streams | ... |
+| `orleans-streams-pubsub-consumers-added` | Streams | ... |
+| `orleans-streams-pubsub-consumers-removed` | Streams | ... |
+| `orleans-streams-pubsub-consumers` | Streams | ... |
+| `orleans-streams-persistent-stream-pulling-agents` | Streams | ... |
+| `orleans-streams-persistent-stream-messages-read` | Streams | ... |
+| `orleans-streams-persistent-stream-messages-sent` | Streams | ... |
+| `orleans-streams-persistent-stream-pubsub-cache-size` | Streams | ... |
+| `orleans-streams-queue-initialization-failures` | Streams | ... |
+| `orleans-streams-queue-initialization-duration` | Streams | ... |
+| `orleans-streams-queue-initialization-exceptions` | Streams | ... |
+| `orleans-streams-queue-read-failures` | Streams | ... |
+| `orleans-streams-queue-read-duration` | Streams | ... |
+| `orleans-streams-queue-read-exceptions` | Streams | ... |
+| `orleans-streams-queue-shutdown-failures` | Streams | ... |
+| `orleans-streams-queue-shutdown-duration` | Streams | ... |
+| `orleans-streams-queue-shutdown-exceptions` | Streams | ... |
+| `orleans-streams-queue-messages-received` | Streams | ... |
+| `orleans-streams-queue-oldest-message-enqueue-age` | Streams | ... |
+| `orleans-streams-queue-newest-message-enqueue-age` | Streams | ... |
+| `orleans-streams-block-pool-total-memory` | Streams | ... |
+| `orleans-streams-block-pool-available-memory` | Streams | ... |
+| `orleans-streams-block-pool-claimed-memory` | Streams | ... |
+| `orleans-streams-block-pool-released-memory` | Streams | ... |
+| `orleans-streams-block-pool-allocated-memory` | Streams | ... |
+| `orleans-streams-queue-cache-size` | Streams | ... |
+| `orleans-streams-queue-cache-length` | Streams | ... |
+| `orleans-streams-queue-cache-messages-added` | Streams | ... |
+| `orleans-streams-queue-cache-messages-purged` | Streams | ... |
+| `orleans-streams-queue-cache-memory-allocated` | Streams | ... |
+| `orleans-streams-queue-cache-memory-released` | Streams | ... |
+| `orleans-streams-queue-cache-oldest-to-newest-duration` | Streams | ... |
+| `orleans-streams-queue-cache-oldest-age` | Streams | ... |
+| `orleans-streams-queue-cache-pressure` | Streams | ... |
+| `orleans-streams-queue-cache-under-pressure` | Streams | ... |
+| `orleans-streams-queue-cache-pressure-contribution-count` | Streams | ... |
+| `orleans-transactions-started` | Transactions | ... |
+| `orleans-transactions-successful` | Transactions | ... |
+| `orleans-transactions-failed` | Transactions | ... |
+| `orleans-transactions-throttled` | Transactions | ... |
+
 ### Prometheus
 
 There are various third-party metrics providers that you can use with Orleans. One popular example is [Prometheus](https://prometheus.io), which can be used to collect metrics from your app with OpenTelemetry.

--- a/docs/orleans/host/monitoring/index.md
+++ b/docs/orleans/host/monitoring/index.md
@@ -275,34 +275,35 @@ A collection of stream meters that are used to monitor the stream layer.
 | `orleans-streams-persistent-stream-messages-read` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of persistent stream messages read. |
 | `orleans-streams-persistent-stream-messages-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of persistent stream messages sent. |
 | `orleans-streams-persistent-stream-pubsub-cache-size` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the persistent stream pubsub cache size. |
-| `orleans-streams-queue-initialization-failures` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-queue-initialization-duration` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-queue-initialization-exceptions` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-queue-read-failures` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-queue-read-duration` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-queue-read-exceptions` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-queue-shutdown-failures` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-queue-shutdown-duration` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-queue-shutdown-exceptions` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-queue-messages-received` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-queue-oldest-message-enqueue-age` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-queue-newest-message-enqueue-age` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-block-pool-total-memory` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-block-pool-available-memory` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-block-pool-claimed-memory` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-block-pool-released-memory` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-block-pool-allocated-memory` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-queue-cache-size` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-queue-cache-length` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-queue-cache-messages-added` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-queue-cache-messages-purged` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-queue-cache-memory-allocated` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-queue-cache-memory-released` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-queue-cache-oldest-to-newest-duration` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-queue-cache-oldest-age` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-queue-cache-pressure` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-queue-cache-under-pressure` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-queue-cache-pressure-contribution-count` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-queue-initialization-failures` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of steam queue initialization failures. |
+| `orleans-streams-queue-initialization-duration` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of steam queue initialization occurrences. |
+| `orleans-streams-queue-initialization-exceptions` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of steam queue initialization exceptions. |
+| `orleans-streams-queue-read-failures` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of steam queue read failures. |
+| `orleans-streams-queue-read-duration` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of steam queue read occurrences. |
+| `orleans-streams-queue-read-exceptions` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of steam queue read exceptions. |
+| `orleans-streams-queue-shutdown-failures` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of steam queue shutdown failures. |
+| `orleans-streams-queue-shutdown-duration` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of steam queue shutdown occurrences. |
+| `orleans-streams-queue-shutdown-exceptions` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of steam queue shutdown exceptions. |
+| `orleans-streams-queue-messages-received` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the number of stream queue messages received. |
+| `orleans-streams-queue-oldest-message-enqueue-age` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the age of the oldest enqueued message. |
+| `orleans-streams-queue-newest-message-enqueue-age` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the age of the newest enqueued message. |
+| `orleans-streams-block-pool-total-memory` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the stream block pool total memory in bytes. |
+| `orleans-streams-block-pool-available-memory` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the stream block pool available memory in bytes. |
+| `orleans-streams-block-pool-claimed-memory` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the stream block pool claimed memory in bytes. |
+| `orleans-streams-block-pool-released-memory` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the stream block pool released memory in bytes. |
+| `orleans-streams-block-pool-allocated-memory` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the stream block pool allocated memory in bytes. |
+
+| `orleans-streams-queue-cache-size` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the stream queue cache size in bytes. |
+| `orleans-streams-queue-cache-length` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the stream queue length. |
+| `orleans-streams-queue-cache-messages-added` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the stream queue messages added. |
+| `orleans-streams-queue-cache-messages-purged` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the stream queue messages purged. |
+| `orleans-streams-queue-cache-memory-allocated` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the stream queue memory allocated. |
+| `orleans-streams-queue-cache-memory-released` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the stream queue memory released. |
+| `orleans-streams-queue-cache-oldest-to-newest-duration` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the duration from the oldest to the newest stream queue cache. |
+| `orleans-streams-queue-cache-oldest-age` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the age of the oldest cached message. |
+| `orleans-streams-queue-cache-pressure` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the pressure on the stream queue cache. |
+| `orleans-streams-queue-cache-under-pressure` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing whether the stream queue cache is under pressure. |
+| `orleans-streams-queue-cache-pressure-contribution-count` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the stream queue cache pressure contributions. |
 
 #### Transactions
 
@@ -310,10 +311,10 @@ A collection of transaction meters that are used to monitor the transaction laye
 
 | Meter name | Type | Description |
 |--|--|--|
-| `orleans-transactions-started` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-transactions-successful` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-transactions-failed` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-transactions-throttled` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-transactions-started` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the number of started transactions. |
+| `orleans-transactions-successful` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the number of successful transactions. |
+| `orleans-transactions-failed` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the number of failed transactions. |
+| `orleans-transactions-throttled` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the number of throttled transactions. |
 
 ### Prometheus
 

--- a/docs/orleans/host/monitoring/index.md
+++ b/docs/orleans/host/monitoring/index.md
@@ -89,8 +89,8 @@ A collection of networking meters that are used to monitor the networking layer.
 
 | Meter name | Type | Description |
 |--|--|--|
-| `orleans-networking-sockets-closed` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of sockets that have closed. |
-| `orleans-networking-sockets-opened` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of sockets that have opened. |
+| `orleans-networking-sockets-closed` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of sockets that have closed. |
+| `orleans-networking-sockets-opened` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of sockets that have opened. |
 
 #### Messaging
 
@@ -102,21 +102,21 @@ A collection of messaging meters that are used to monitor the messaging layer.
 | `orleans-messaging-received-messages-size` | <xref:System.Diagnostics.Metrics.Histogram%601> | A histogram representing the size of messages in bytes that have been received. |
 | `orleans-messaging-sent-header-size` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the number of header bytes sent. |
 | `orleans-messaging-received-header-size` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the number of header bytes received. |
-| `orleans-messaging-sent-failed` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of failed sent messages. |
-| `orleans-messaging-sent-dropped` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of dropped sent messages. |
+| `orleans-messaging-sent-failed` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of failed sent messages. |
+| `orleans-messaging-sent-dropped` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of dropped sent messages. |
 | `orleans-messaging-processing-dispatcher-received` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the number dispatcher received messages. |
 | `orleans-messaging-processing-dispatcher-processed` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the number dispatcher processed messages. |
 | `orleans-messaging-processing-dispatcher-forwarded` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the number dispatcher forwarded messages. |
 | `orleans-messaging-processing-ima-received` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the number of incoming messages received. |
 | `orleans-messaging-processing-ima-enqueued` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the number of incoming messages enqueued. |
 | `orleans-messaging-processing-activation-data` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing all of the processing activation data. |
-| `orleans-messaging-pings-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of pings sent. |
-| `orleans-messaging-pings-received` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of pings received. |
-| `orleans-messaging-pings-reply-received` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of ping replies received. |
-| `orleans-messaging-pings-reply-missed` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of ping replies missed. |
-| `orleans-messaging-expired"` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of messages that have expired. |
-| `orleans-messaging-rejected` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of messages that have been rejected. |
-| `orleans-messaging-rerouted` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of messages that have been rerouted. |
+| `orleans-messaging-pings-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of pings sent. |
+| `orleans-messaging-pings-received` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of pings received. |
+| `orleans-messaging-pings-reply-received` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of ping replies received. |
+| `orleans-messaging-pings-reply-missed` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of ping replies missed. |
+| `orleans-messaging-expired"` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of messages that have expired. |
+| `orleans-messaging-rejected` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of messages that have been rejected. |
+| `orleans-messaging-rerouted` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of messages that have been rerouted. |
 | `orleans-messaging-sent-local` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the number of local messages sent. |
 
 #### Gateway
@@ -126,9 +126,9 @@ A collection of gateway meters that are used to monitor the gateway layer.
 | Meter name | Type | Description |
 |--|--|--|
 | `orleans-gateway-connected-clients` | <xref:System.Diagnostics.Metrics.UpDownCounter%601> | An up/down counter representing the number of connected clients. |
-| `orleans-gateway-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of gateway messages sent. |
-| `orleans-gateway-received` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of gateway messages received. |
-| `orleans-gateway-load-shedding` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of gateway (load shedding) messages that have been rejected due to the gateway being overloaded. |
+| `orleans-gateway-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of gateway messages sent. |
+| `orleans-gateway-received` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of gateway messages received. |
+| `orleans-gateway-load-shedding` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of gateway (load shedding) messages that have been rejected due to the gateway being overloaded. |
 
 #### Runtime
 
@@ -136,7 +136,7 @@ A collection of runtime meters that are used to monitor the runtime layer.
 
 | Meter name | Type | Description |
 |--|--|--|
-| `orleans-scheduler-long-running-turns` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of long running turns within the scheduler. |
+| `orleans-scheduler-long-running-turns` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of long running turns within the scheduler. |
 | `orleans-runtime-total-physical-memory` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the total number of memory (in MB) of the Orleans runtime. |
 | `orleans-runtime-available-memory` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the available memory (in MB) for the Orleans runtime. |
 
@@ -148,13 +148,13 @@ A collection of catalog meters that are used to monitor the catalog layer.
 |--|--|--|
 | `orleans-catalog-activations` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the number of catalog activations. |
 | `orleans-catalog-activation-working-set` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the number of activations within the working set. |
-| `orleans-catalog-activation-created` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of created activations. |
-| `orleans-catalog-activation-destroyed` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of destroyed activations. |
-| `orleans-catalog-activation-failed-to-activate` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of activations that failed to activate. |
-| `orleans-catalog-activation-collections` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of activation collections. |
-| `orleans-catalog-activation-shutdown` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of shutdown activations. |
-| `orleans-catalog-activation-non-existent` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of non-existent activations. |
-| `orleans-catalog-activation-concurrent-registration-attempts` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of concurrent activation registration attempts. |
+| `orleans-catalog-activation-created` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of created activations. |
+| `orleans-catalog-activation-destroyed` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of destroyed activations. |
+| `orleans-catalog-activation-failed-to-activate` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of activations that failed to activate. |
+| `orleans-catalog-activation-collections` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of activation collections. |
+| `orleans-catalog-activation-shutdown` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of shutdown activations. |
+| `orleans-catalog-activation-non-existent` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of non-existent activations. |
+| `orleans-catalog-activation-concurrent-registration-attempts` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of concurrent activation registration attempts. |
 
 #### Directory
 
@@ -162,34 +162,34 @@ A collection of directory meters that are used to monitor the directory layer.
 
 | Meter name | Type | Description |
 |--|--|--|
-| `orleans-directory-lookups-local-issued` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-directory-lookups-local-successes` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-directory-lookups-full-issued` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-directory-lookups-remote-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-directory-lookups-remote-received` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-directory-lookups-local-directory-issued` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-directory-lookups-local-directory-successes` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-directory-lookups-cache-issued` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-directory-lookups-cache-successes` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-directory-validations-cache-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-directory-validations-cache-received` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-directory-partition-size` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-directory-cache-size` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-directory-ring-size` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-directory-ring-local-portion-distance` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-directory-ring-local-portion-percentage` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-directory-ring-local-portion-average-percentage` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-directory-registrations-single-act-issued` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-directory-registrations-single-act-local` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-directory-registrations-single-act-remote-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-directory-registrations-single-act-remote-received` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-directory-unregistrations-issued` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-directory-unregistrations-local` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-directory-unregistrations-remote-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-directory-unregistrations-remote-received` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-directory-unregistrations-many-issued` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-directory-unregistrations-many-remote-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-directory-unregistrations-many-remote-received` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-directory-lookups-local-issued` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of local lookups issued. |
+| `orleans-directory-lookups-local-successes` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of local successful lookups. |
+| `orleans-directory-lookups-full-issued` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of full directory lookups issued. |
+| `orleans-directory-lookups-remote-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of remote directory lookups sent. |
+| `orleans-directory-lookups-remote-received` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of remote directory lookups received. |
+| `orleans-directory-lookups-local-directory-issued` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of local directory lookups issued. |
+| `orleans-directory-lookups-local-directory-successes` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of local directory successful lookups. |
+| `orleans-directory-lookups-cache-issued` | <xref:System.Diagnostics.Metrics.Counter%601> | A count cached lookups issued. |
+| `orleans-directory-lookups-cache-successes` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of cached successful lookups. |
+| `orleans-directory-validations-cache-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory cache validations sent.  |
+| `orleans-directory-validations-cache-received` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory cache validations received. |
+| `orleans-directory-partition-size` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the directory partition size. |
+| `orleans-directory-cache-size` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the directory cache size. |
+| `orleans-directory-ring-size` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the directory ring size. |
+| `orleans-directory-ring-local-portion-distance` |<xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the directories local portion distance. |
+| `orleans-directory-ring-local-portion-percentage` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the directories local portion percentage. |
+| `orleans-directory-ring-local-portion-average-percentage` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the directories local average percentage. |
+| `orleans-directory-registrations-single-act-issued` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory single act registrations issued. |
+| `orleans-directory-registrations-single-act-local` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory single act registrations local. |
+| `orleans-directory-registrations-single-act-remote-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory single act registrations sent remotely. |
+| `orleans-directory-registrations-single-act-remote-received` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory single act registrations received remotely. |
+| `orleans-directory-unregistrations-issued` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory un-registrations issued. |
+| `orleans-directory-unregistrations-local` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory un-registrations locally. |
+| `orleans-directory-unregistrations-remote-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory un-registrations sent remotely. |
+| `orleans-directory-unregistrations-remote-received` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory un-registrations received remotely. |
+| `orleans-directory-unregistrations-many-issued` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory un-registrations many issued. |
+| `orleans-directory-unregistrations-many-remote-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory un-registrations many sent remotely. |
+| `orleans-directory-unregistrations-many-remote-received` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory un-registrations many received remotely. |
 
 #### Consistent ring
 
@@ -197,9 +197,9 @@ A collection of consistent ring meters that are used to monitor the consistent r
 
 | Meter name | Type | Description |
 |--|--|--|
-| `orleans-consistent-ring-size` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-consistent-ring-range-percentage-local` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-consistent-ring-range-percentage-average` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-consistent-ring-size` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the consistent ring size. |
+| `orleans-consistent-ring-range-percentage-local` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the consistent ring local percentage. |
+| `orleans-consistent-ring-range-percentage-average` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the consistent ring average percentage. |
 
 #### Watchdog
 
@@ -207,8 +207,8 @@ A collection of watchdog meters that are used to monitor the watchdog layer.
 
 | Meter name | Type | Description |
 |--|--|--|
-| `orleans-watchdog-health-checks` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-watchdog-health-checks-failed` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-watchdog-health-checks` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of watchdog health checks. |
+| `orleans-watchdog-health-checks-failed` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of failed watchdog health checks. |
 
 #### Client
 
@@ -216,7 +216,7 @@ A collection of client meters that are used to monitor the client layer.
 
 | Meter name | Type | Description |
 |--|--|--|
-| `orleans-client-connected-gateways` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-client-connected-gateways` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the number of connected gateway clients. |
 
 #### Miscellaneous
 
@@ -224,8 +224,8 @@ A collection of miscellaneous meters that are used to monitor various layers.
 
 | Meter name | Type | Description |
 |--|--|--|
-| `orleans-grains` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-system-targets` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-grains` | <xref:System.Diagnostics.Metrics.Counter%601> | A count representing the number of grains. |
+| `orleans-system-targets` | <xref:System.Diagnostics.Metrics.Counter%601> | A count representing the number of system targets. |
 
 #### App requests
 
@@ -233,8 +233,8 @@ A collection of app request meters that are used to monitor the app request laye
 
 | Meter name | Type | Description |
 |--|--|--|
-| `orleans-app-requests-latency` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-app-requests-timedout` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-app-requests-latency` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing app request latency. |
+| `orleans-app-requests-timedout` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> |  An observable counter representing app requests that have timed out. |
 
 #### Reminders
 
@@ -242,9 +242,9 @@ A collection of reminder meters that are used to monitor the reminder layer.
 
 | Meter name | Type | Description |
 |--|--|--|
-| `orleans-reminders-tardiness` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-reminders-active` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-reminders-ticks-delivered` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-reminders-tardiness` | <xref:System.Diagnostics.Metrics.Histogram%601> | A histogram representing the number of seconds a reminder is tardy. |
+| `orleans-reminders-active` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the number active reminders. |
+| `orleans-reminders-ticks-delivered` | <xref:System.Diagnostics.Metrics.Counter%601> | A count representing the number of reminder ticks that have been delivered. |
 
 #### Storage
 
@@ -252,12 +252,12 @@ A collection of storage meters that are used to monitor the storage layer.
 
 | Meter name | Type | Description |
 |--|--|--|
-| `orleans-storage-read-errors` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-storage-write-errors` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-storage-clear-errors` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-storage-read-latency` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-storage-write-latency` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-storage-clear-latency` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-storage-read-errors` | <xref:System.Diagnostics.Metrics.Counter%601> |  A count representing the number of storage read errors. |
+| `orleans-storage-write-errors` | <xref:System.Diagnostics.Metrics.Counter%601> |  A count representing the number of storage write errors. |
+| `orleans-storage-clear-errors` | <xref:System.Diagnostics.Metrics.Counter%601> |  A count representing the number of storage clear errors. |
+| `orleans-storage-read-latency` | <xref:System.Diagnostics.Metrics.Histogram%601> | A histogram representing the storage read latency in milliseconds. |
+| `orleans-storage-write-latency` | <xref:System.Diagnostics.Metrics.Histogram%601> | A histogram representing the storage write latency in milliseconds. |
+| `orleans-storage-clear-latency` | <xref:System.Diagnostics.Metrics.Histogram%601> | A histogram representing the storage clear latency in milliseconds. |
 
 #### Streams
 
@@ -265,16 +265,16 @@ A collection of stream meters that are used to monitor the stream layer.
 
 | Meter name | Type | Description |
 |--|--|--|
-| `orleans-streams-pubsub-producers-added` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-pubsub-producers-removed` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-pubsub-producers` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-pubsub-consumers-added` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-pubsub-consumers-removed` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-pubsub-consumers` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-persistent-stream-pulling-agents` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-persistent-stream-messages-read` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-persistent-stream-messages-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
-| `orleans-streams-persistent-stream-pubsub-cache-size` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-pubsub-producers-added` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of streaming pubsub producers added. |
+| `orleans-streams-pubsub-producers-removed` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of streaming pubsub producers removed. |
+| `orleans-streams-pubsub-producers` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of streaming pubsub producers. |
+| `orleans-streams-pubsub-consumers-added` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of streaming pubsub consumers added. |
+| `orleans-streams-pubsub-consumers-removed` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of streaming pubsub consumers removed. |
+| `orleans-streams-pubsub-consumers` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of streaming pubsub consumers. |
+| `orleans-streams-persistent-stream-pulling-agents` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the number of persistent stream pulling agents. |
+| `orleans-streams-persistent-stream-messages-read` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of persistent stream messages read. |
+| `orleans-streams-persistent-stream-messages-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of persistent stream messages sent. |
+| `orleans-streams-persistent-stream-pubsub-cache-size` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the persistent stream pubsub cache size. |
 | `orleans-streams-queue-initialization-failures` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
 | `orleans-streams-queue-initialization-duration` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
 | `orleans-streams-queue-initialization-exceptions` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |

--- a/docs/orleans/host/monitoring/index.md
+++ b/docs/orleans/host/monitoring/index.md
@@ -179,10 +179,10 @@ A collection of directory meters that are used to monitor the directory layer.
 | `orleans-directory-ring-local-portion-distance` |<xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the ring range owned by the local directory partition. |
 | `orleans-directory-ring-local-portion-percentage` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the ring range owned by the local directory, represented as a percentage of the total range. |
 | `orleans-directory-ring-local-portion-average-percentage` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the average percentage of the directory ring range owned by each silo, giving a representation of how balanced directory ownership. |
-| `orleans-directory-registrations-single-act-issued` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory single act registrations issued. |
-| `orleans-directory-registrations-single-act-local` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory single act registrations local. |
-| `orleans-directory-registrations-single-act-remote-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory single act registrations sent remotely. |
-| `orleans-directory-registrations-single-act-remote-received` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory single act registrations received remotely. |
+| `orleans-directory-registrations-single-act-issued` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory single activation registrations issued. |
+| `orleans-directory-registrations-single-act-local` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory single activation registrations handled by the local directory partition. |
+| `orleans-directory-registrations-single-act-remote-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory single activation registrations sent to a remote directory partition. |
+| `orleans-directory-registrations-single-act-remote-received` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory single activation registrations received from remote hosts. |
 | `orleans-directory-unregistrations-issued` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory un-registrations issued. |
 | `orleans-directory-unregistrations-local` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory un-registrations locally. |
 | `orleans-directory-unregistrations-remote-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory un-registrations sent remotely. |

--- a/docs/orleans/host/monitoring/index.md
+++ b/docs/orleans/host/monitoring/index.md
@@ -176,9 +176,9 @@ A collection of directory meters that are used to monitor the directory layer.
 | `orleans-directory-partition-size` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the directory partition size. |
 | `orleans-directory-cache-size` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the directory cache size. |
 | `orleans-directory-ring-size` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the directory ring size. |
-| `orleans-directory-ring-local-portion-distance` |<xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the directories local portion distance. |
-| `orleans-directory-ring-local-portion-percentage` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the directories local portion percentage. |
-| `orleans-directory-ring-local-portion-average-percentage` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the directories local average percentage. |
+| `orleans-directory-ring-local-portion-distance` |<xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the ring range owned by the local directory partition. |
+| `orleans-directory-ring-local-portion-percentage` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the ring range owned by the local directory, represented as a percentage of the total range. |
+| `orleans-directory-ring-local-portion-average-percentage` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing the average percentage of the directory ring range owned by each silo, giving a representation of how balanced directory ownership. |
 | `orleans-directory-registrations-single-act-issued` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory single act registrations issued. |
 | `orleans-directory-registrations-single-act-local` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory single act registrations local. |
 | `orleans-directory-registrations-single-act-remote-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of directory single act registrations sent remotely. |

--- a/docs/orleans/host/monitoring/index.md
+++ b/docs/orleans/host/monitoring/index.md
@@ -81,137 +81,239 @@ For more information, see [Investigate performance counters (dotnet-counters)](.
 
 ### Orleans meters
 
-Orleans uses the [System.Diagnostics.Metrics](../../../core/diagnostics/compare-metric-apis.md#systemdiagnosticsmetrics) APIs to collect metrics. The following table represents the Orleans meters that are available for you to monitor:
+Orleans uses the [System.Diagnostics.Metrics](../../../core/diagnostics/compare-metric-apis.md#systemdiagnosticsmetrics) APIs to collect metrics. Orleans categorizes each meter into domain-centric concerns, such as networking, messaging, gateway, and so on. The following subsections describe the meters that Orleans uses.
 
-| Meter name | Discriminator | Description |
+#### Networking
+
+A collection of networking meters that are used to monitor the networking layer.
+
+| Meter name | Type | Description |
 |--|--|--|
-| `orleans-networking-sockets-closed` | Networking | ... |
-| `orleans-networking-sockets-opened` | Networking | ... |
-| `orleans-messaging-sent-messages-size` | Messaging | ... |
-| `orleans-messaging-received-messages-size` | Messaging | ... |
-| `orleans-messaging-sent-header-size` | Messaging | ... |
-| `orleans-messaging-sent-failed` | Messaging | ... |
-| `orleans-messaging-sent-dropped` | Messaging | ... |
-| `orleans-messaging-received-header-size` | Messaging | ... |
-| `orleans-messaging-processing-dispatcher-received` | Messaging | ... |
-| `orleans-messaging-processing-dispatcher-processed` | Messaging | ... |
-| `orleans-messaging-processing-dispatcher-forwarded` | Messaging | ... |
-| `orleans-messaging-processing-ima-received` | Messaging | ... |
-| `orleans-messaging-processing-ima-enqueued` | Messaging | ... |
-| `orleans-messaging-processing-activation-data` | Messaging | ... |
-| `orleans-messaging-pings-sent` | Messaging | ... |
-| `orleans-messaging-pings-received` | Messaging | ... |
-| `orleans-messaging-pings-reply-received` | Messaging | ... |
-| `orleans-messaging-pings-reply-missed` | Messaging | ... |
-| `orleans-messaging-expired"` | Messaging | ... |
-| `orleans-messaging-rejected` | Messaging | ... |
-| `orleans-messaging-rerouted` | Messaging | ... |
-| `orleans-messaging-sent-local` | Messaging | ... |
-| `orleans-gateway-connected-clients` | Gateway | ... |
-| `orleans-gateway-sent` | Gateway | ... |
-| `orleans-gateway-received` | Gateway | ... |
-| `orleans-gateway-load-shedding` | Gateway | ... |
-| `orleans-scheduler-long-running-turns` | Runtime | ... |
-| `orleans-runtime-total-physical-memory` | Runtime | ... |
-| `orleans-runtime-available-memory` | Runtime | ... |
-| `orleans-catalog-activations` | Catalog | ... |
-| `orleans-catalog-activation-working-set` | Catalog | ... |
-| `orleans-catalog-activation-created` | Catalog | ... |
-| `orleans-catalog-activation-destroyed` | Catalog | ... |
-| `orleans-catalog-activation-failed-to-activate` | Catalog | ... |
-| `orleans-catalog-activation-collections` | Catalog | ... |
-| `orleans-catalog-activation-shutdown` | Catalog | ... |
-| `orleans-catalog-activation-non-existent` | Catalog | ... |
-| `orleans-catalog-activation-concurrent-registration-attempts` | Catalog | ... |
-| `orleans-directory-lookups-local-issued` | Directory | ... |
-| `orleans-directory-lookups-local-successes` | Directory | ... |
-| `orleans-directory-lookups-full-issued` | Directory | ... |
-| `orleans-directory-lookups-remote-sent` | Directory | ... |
-| `orleans-directory-lookups-remote-received` | Directory | ... |
-| `orleans-directory-lookups-local-directory-issued` | Directory | ... |
-| `orleans-directory-lookups-local-directory-successes` | Directory | ... |
-| `orleans-directory-lookups-cache-issued` | Directory | ... |
-| `orleans-directory-lookups-cache-successes` | Directory | ... |
-| `orleans-directory-validations-cache-sent` | Directory | ... |
-| `orleans-directory-validations-cache-received` | Directory | ... |
-| `orleans-directory-partition-size` | Directory | ... |
-| `orleans-directory-cache-size` | Directory | ... |
-| `orleans-directory-ring-size` | Directory | ... |
-| `orleans-directory-ring-local-portion-distance` | Directory | ... |
-| `orleans-directory-ring-local-portion-percentage` | Directory | ... |
-| `orleans-directory-ring-local-portion-average-percentage` | Directory | ... |
-| `orleans-directory-registrations-single-act-issued` | Directory | ... |
-| `orleans-directory-registrations-single-act-local` | Directory | ... |
-| `orleans-directory-registrations-single-act-remote-sent` | Directory | ... |
-| `orleans-directory-registrations-single-act-remote-received` | Directory | ... |
-| `orleans-directory-unregistrations-issued` | Directory | ... |
-| `orleans-directory-unregistrations-local` | Directory | ... |
-| `orleans-directory-unregistrations-remote-sent` | Directory | ... |
-| `orleans-directory-unregistrations-remote-received` | Directory | ... |
-| `orleans-directory-unregistrations-many-issued` | Directory | ... |
-| `orleans-directory-unregistrations-many-remote-sent` | Directory | ... |
-| `orleans-directory-unregistrations-many-remote-received` | Directory | ... |
-| `orleans-consistent-ring-size` | Consistent ring | ... |
-| `orleans-consistent-ring-range-percentage-local` | Consistent ring | ... |
-| `orleans-consistent-ring-range-percentage-average` | Consistent ring | ... |
-| `orleans-watchdog-health-checks` | Watchdog | ... |
-| `orleans-watchdog-health-checks-failed` | Watchdog | ... |
-| `orleans-client-connected-gateways` | Client | ... |
-| `orleans-grains` | Miscellaneous | ... |
-| `orleans-system-targets` | Miscellaneous | ... |
-| `orleans-app-requests-latency` | App requests | ... |
-| `orleans-app-requests-timedout` | App requests | ... |
-| `orleans-reminders-tardiness` | Reminders | ... |
-| `orleans-reminders-active` | Reminders | ... |
-| `orleans-reminders-ticks-delivered` | Reminders | ... |
-| `orleans-storage-read-errors` | Storage | ... |
-| `orleans-storage-write-errors` | Storage | ... |
-| `orleans-storage-clear-errors` | Storage | ... |
-| `orleans-storage-read-latency` | Storage | ... |
-| `orleans-storage-write-latency` | Storage | ... |
-| `orleans-storage-clear-latency` | Storage | ... |
-| `orleans-streams-pubsub-producers-added` | Streams | ... |
-| `orleans-streams-pubsub-producers-removed` | Streams | ... |
-| `orleans-streams-pubsub-producers` | Streams | ... |
-| `orleans-streams-pubsub-consumers-added` | Streams | ... |
-| `orleans-streams-pubsub-consumers-removed` | Streams | ... |
-| `orleans-streams-pubsub-consumers` | Streams | ... |
-| `orleans-streams-persistent-stream-pulling-agents` | Streams | ... |
-| `orleans-streams-persistent-stream-messages-read` | Streams | ... |
-| `orleans-streams-persistent-stream-messages-sent` | Streams | ... |
-| `orleans-streams-persistent-stream-pubsub-cache-size` | Streams | ... |
-| `orleans-streams-queue-initialization-failures` | Streams | ... |
-| `orleans-streams-queue-initialization-duration` | Streams | ... |
-| `orleans-streams-queue-initialization-exceptions` | Streams | ... |
-| `orleans-streams-queue-read-failures` | Streams | ... |
-| `orleans-streams-queue-read-duration` | Streams | ... |
-| `orleans-streams-queue-read-exceptions` | Streams | ... |
-| `orleans-streams-queue-shutdown-failures` | Streams | ... |
-| `orleans-streams-queue-shutdown-duration` | Streams | ... |
-| `orleans-streams-queue-shutdown-exceptions` | Streams | ... |
-| `orleans-streams-queue-messages-received` | Streams | ... |
-| `orleans-streams-queue-oldest-message-enqueue-age` | Streams | ... |
-| `orleans-streams-queue-newest-message-enqueue-age` | Streams | ... |
-| `orleans-streams-block-pool-total-memory` | Streams | ... |
-| `orleans-streams-block-pool-available-memory` | Streams | ... |
-| `orleans-streams-block-pool-claimed-memory` | Streams | ... |
-| `orleans-streams-block-pool-released-memory` | Streams | ... |
-| `orleans-streams-block-pool-allocated-memory` | Streams | ... |
-| `orleans-streams-queue-cache-size` | Streams | ... |
-| `orleans-streams-queue-cache-length` | Streams | ... |
-| `orleans-streams-queue-cache-messages-added` | Streams | ... |
-| `orleans-streams-queue-cache-messages-purged` | Streams | ... |
-| `orleans-streams-queue-cache-memory-allocated` | Streams | ... |
-| `orleans-streams-queue-cache-memory-released` | Streams | ... |
-| `orleans-streams-queue-cache-oldest-to-newest-duration` | Streams | ... |
-| `orleans-streams-queue-cache-oldest-age` | Streams | ... |
-| `orleans-streams-queue-cache-pressure` | Streams | ... |
-| `orleans-streams-queue-cache-under-pressure` | Streams | ... |
-| `orleans-streams-queue-cache-pressure-contribution-count` | Streams | ... |
-| `orleans-transactions-started` | Transactions | ... |
-| `orleans-transactions-successful` | Transactions | ... |
-| `orleans-transactions-failed` | Transactions | ... |
-| `orleans-transactions-throttled` | Transactions | ... |
+| `orleans-networking-sockets-closed` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of sockets that have closed. |
+| `orleans-networking-sockets-opened` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of sockets that have opened. |
+
+#### Messaging
+
+A collection of messaging meters that are used to monitor the messaging layer.
+
+| Meter name | Type | Description |
+|--|--|--|
+| `orleans-messaging-sent-messages-size` | <xref:System.Diagnostics.Metrics.Histogram%601> | A histogram representing the size of messages in bytes that have been sent. |
+| `orleans-messaging-received-messages-size` | <xref:System.Diagnostics.Metrics.Histogram%601> | A histogram representing the size of messages in bytes that have been received. |
+| `orleans-messaging-sent-header-size` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the number of header bytes sent. |
+| `orleans-messaging-received-header-size` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the number of header bytes received. |
+| `orleans-messaging-sent-failed` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of failed sent messages. |
+| `orleans-messaging-sent-dropped` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of dropped sent messages. |
+| `orleans-messaging-processing-dispatcher-received` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the number dispatcher received messages. |
+| `orleans-messaging-processing-dispatcher-processed` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the number dispatcher processed messages. |
+| `orleans-messaging-processing-dispatcher-forwarded` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the number dispatcher forwarded messages. |
+| `orleans-messaging-processing-ima-received` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the number of incoming messages received. |
+| `orleans-messaging-processing-ima-enqueued` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the number of incoming messages enqueued. |
+| `orleans-messaging-processing-activation-data` | <xref:System.Diagnostics.Metrics.ObservableGauge%601> | An observable gauge representing all of the processing activation data. |
+| `orleans-messaging-pings-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of pings sent. |
+| `orleans-messaging-pings-received` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of pings received. |
+| `orleans-messaging-pings-reply-received` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of ping replies received. |
+| `orleans-messaging-pings-reply-missed` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of ping replies missed. |
+| `orleans-messaging-expired"` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of messages that have expired. |
+| `orleans-messaging-rejected` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of messages that have been rejected. |
+| `orleans-messaging-rerouted` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of messages that have been rerouted. |
+| `orleans-messaging-sent-local` | <xref:System.Diagnostics.Metrics.ObservableCounter%601> | An observable counter representing the number of local messages sent. |
+
+#### Gateway
+
+A collection of gateway meters that are used to monitor the gateway layer.
+
+| Meter name | Type | Description |
+|--|--|--|
+| `orleans-gateway-connected-clients` | <xref:System.Diagnostics.Metrics.UpDownCounter%601> | An up/down counter representing the number of connected clients. |
+| `orleans-gateway-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of gateway messages sent. |
+| `orleans-gateway-received` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of gateway messages received. |
+| `orleans-gateway-load-shedding` | <xref:System.Diagnostics.Metrics.Counter%601> | A count of the number of gateway load shedding. |
+
+#### Runtime
+
+A collection of runtime meters that are used to monitor the runtime layer.
+
+| Meter name | Type | Description |
+|--|--|--|
+| `orleans-scheduler-long-running-turns` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-runtime-total-physical-memory` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-runtime-available-memory` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+
+#### Catalog
+
+A collection of catalog meters that are used to monitor the catalog layer.
+
+| Meter name | Type | Description |
+|--|--|--|
+| `orleans-catalog-activations` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-catalog-activation-working-set` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-catalog-activation-created` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-catalog-activation-destroyed` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-catalog-activation-failed-to-activate` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-catalog-activation-collections` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-catalog-activation-shutdown` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-catalog-activation-non-existent` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-catalog-activation-concurrent-registration-attempts` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+
+#### Directory
+
+A collection of directory meters that are used to monitor the directory layer.
+
+| Meter name | Type | Description |
+|--|--|--|
+| `orleans-directory-lookups-local-issued` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-directory-lookups-local-successes` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-directory-lookups-full-issued` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-directory-lookups-remote-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-directory-lookups-remote-received` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-directory-lookups-local-directory-issued` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-directory-lookups-local-directory-successes` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-directory-lookups-cache-issued` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-directory-lookups-cache-successes` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-directory-validations-cache-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-directory-validations-cache-received` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-directory-partition-size` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-directory-cache-size` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-directory-ring-size` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-directory-ring-local-portion-distance` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-directory-ring-local-portion-percentage` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-directory-ring-local-portion-average-percentage` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-directory-registrations-single-act-issued` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-directory-registrations-single-act-local` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-directory-registrations-single-act-remote-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-directory-registrations-single-act-remote-received` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-directory-unregistrations-issued` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-directory-unregistrations-local` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-directory-unregistrations-remote-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-directory-unregistrations-remote-received` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-directory-unregistrations-many-issued` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-directory-unregistrations-many-remote-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-directory-unregistrations-many-remote-received` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+
+#### Consistent ring
+
+A collection of consistent ring meters that are used to monitor the consistent ring layer.
+
+| Meter name | Type | Description |
+|--|--|--|
+| `orleans-consistent-ring-size` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-consistent-ring-range-percentage-local` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-consistent-ring-range-percentage-average` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+
+#### Watchdog
+
+A collection of watchdog meters that are used to monitor the watchdog layer.
+
+| Meter name | Type | Description |
+|--|--|--|
+| `orleans-watchdog-health-checks` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-watchdog-health-checks-failed` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+
+#### Client
+
+A collection of client meters that are used to monitor the client layer.
+
+| Meter name | Type | Description |
+|--|--|--|
+| `orleans-client-connected-gateways` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+
+#### Miscellaneous
+
+A collection of miscellaneous meters that are used to monitor various layers.
+
+| Meter name | Type | Description |
+|--|--|--|
+| `orleans-grains` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-system-targets` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+
+#### App requests
+
+A collection of app request meters that are used to monitor the app request layer.
+
+| Meter name | Type | Description |
+|--|--|--|
+| `orleans-app-requests-latency` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-app-requests-timedout` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+
+#### Reminders
+
+A collection of reminder meters that are used to monitor the reminder layer.
+
+| Meter name | Type | Description |
+|--|--|--|
+| `orleans-reminders-tardiness` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-reminders-active` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-reminders-ticks-delivered` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+
+#### Storage
+
+A collection of storage meters that are used to monitor the storage layer.
+
+| Meter name | Type | Description |
+|--|--|--|
+| `orleans-storage-read-errors` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-storage-write-errors` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-storage-clear-errors` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-storage-read-latency` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-storage-write-latency` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-storage-clear-latency` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+
+#### Streams
+
+A collection of stream meters that are used to monitor the stream layer.
+
+| Meter name | Type | Description |
+|--|--|--|
+| `orleans-streams-pubsub-producers-added` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-pubsub-producers-removed` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-pubsub-producers` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-pubsub-consumers-added` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-pubsub-consumers-removed` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-pubsub-consumers` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-persistent-stream-pulling-agents` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-persistent-stream-messages-read` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-persistent-stream-messages-sent` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-persistent-stream-pubsub-cache-size` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-queue-initialization-failures` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-queue-initialization-duration` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-queue-initialization-exceptions` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-queue-read-failures` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-queue-read-duration` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-queue-read-exceptions` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-queue-shutdown-failures` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-queue-shutdown-duration` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-queue-shutdown-exceptions` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-queue-messages-received` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-queue-oldest-message-enqueue-age` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-queue-newest-message-enqueue-age` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-block-pool-total-memory` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-block-pool-available-memory` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-block-pool-claimed-memory` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-block-pool-released-memory` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-block-pool-allocated-memory` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-queue-cache-size` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-queue-cache-length` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-queue-cache-messages-added` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-queue-cache-messages-purged` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-queue-cache-memory-allocated` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-queue-cache-memory-released` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-queue-cache-oldest-to-newest-duration` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-queue-cache-oldest-age` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-queue-cache-pressure` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-queue-cache-under-pressure` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-streams-queue-cache-pressure-contribution-count` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+
+#### Transactions
+
+A collection of transaction meters that are used to monitor the transaction layer.
+
+| Meter name | Type | Description |
+|--|--|--|
+| `orleans-transactions-started` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-transactions-successful` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-transactions-failed` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
+| `orleans-transactions-throttled` | <xref:System.Diagnostics.Metrics.Counter%601> | ... |
 
 ### Prometheus
 


### PR DESCRIPTION
## Summary

Add the Orleans meters—need help from @ReubenBond for the descriptions of each.

Fixes #33984


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/compare-metric-apis.md](https://github.com/dotnet/docs/blob/56d8e8aa9dd3b9f08d1d24a67ab0b2b6305eea6a/docs/core/diagnostics/compare-metric-apis.md) | [Metric APIs comparison](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/compare-metric-apis?branch=pr-en-us-36931) |
| [docs/orleans/host/monitoring/index.md](https://github.com/dotnet/docs/blob/56d8e8aa9dd3b9f08d1d24a67ab0b2b6305eea6a/docs/orleans/host/monitoring/index.md) | [Orleans observability](https://review.learn.microsoft.com/en-us/dotnet/orleans/host/monitoring/index?branch=pr-en-us-36931) |


<!-- PREVIEW-TABLE-END -->