### PR TITLE
Update Run Setting Arguments link

### DIFF
--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -367,4 +367,4 @@ For more information and examples on how to use selective unit test filtering, s
 
 - [Frameworks and Targets](../../standard/frameworks.md)
 - [.NET Runtime Identifier (RID) catalog](../rid-catalog.md)
-- [Passing runsettings arguments through commandline](https://github.com/Microsoft/vstest-docs/blob/main/docs/RunSettingsArguments.md)
+- [Passing runsettings arguments through commandline](https://github.com/microsoft/vstest/blob/main/docs/RunSettingsArguments.md)


### PR DESCRIPTION
## Summary

The `vstest-docs` repo linked to previously has been archived.  Updated the `RunSettingsArguments.md` to come from the `vstest` repo.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-test.md](https://github.com/dotnet/docs/blob/a600e29f6957d76804d7968156540c3c4b50be69/docs/core/tools/dotnet-test.md) | [dotnet test](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-test?branch=pr-en-us-36943) |

<!-- PREVIEW-TABLE-END -->