### PR TITLE
Missing dash

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs0120.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0120.md
@@ -10,7 +10,7 @@ ms.assetid: 3ff67f11-bdf9-436b-bc0c-4fa3cd1925a6
 ---
 # Compiler Error CS0120
 
-An object reference is required for the nonstatic field, method, or property 'member'
+An object reference is required for the non-static field, method, or property 'member'
 
  In order to use a non-static field, method, or property, you must first create an object instance. For more information about static methods, see [Static Classes and Static Class Members](../../programming-guide/classes-and-structs/static-classes-and-static-class-members.md). For more information about creating instances of classes, see [Instance Constructors](../../programming-guide/classes-and-structs/instance-constructors.md).
 


### PR DESCRIPTION
## Summary

Fixes a missing dash in the compiler error description. 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-messages/cs0120.md](https://github.com/dotnet/docs/blob/205ea58c8f3583ae5c8696ec29d435aa56ffccd6/docs/csharp/language-reference/compiler-messages/cs0120.md) | [Compiler Error CS0120](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0120?branch=pr-en-us-36944) |

<!-- PREVIEW-TABLE-END -->