### PR TITLE
Fix formatting for Roslyn CA1000 - CA2260 rules

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1000.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1000.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA1000: Do not declare static members on generic types
 
-|                                     | Value                        |
-|-------------------------------------|------------------------------|
-| **Rule ID**                         | CA1000                       |
-| **Category**                        | [Design](design-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                     |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                          |
+|-------------------------------------|------------------------------------------------|
+| **Rule ID**                         | CA1000                                         |
+| **Title**                           | Do not declare static members on generic types |
+| **Category**                        | [Design](design-warnings.md)                   |
+| **Fix is breaking or non-breaking** | Breaking                                       |
+| **Enabled by default in .NET 7**    | No                                             |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1001.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1001.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA1001: Types that own disposable fields should be disposable
 
-| | Value |
-|-|-|
-| **Rule ID** | CA1001 |
-| **Category** | [Design](design-warnings.md) |
+| Property                            | Value                                                                                                                            |
+|-------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
+| **Rule ID**                         | CA1001                                                                                                                           |
+| **Title**                           | Types that own disposable fields should be disposable                                                                            |
+| **Category**                        | [Design](design-warnings.md)                                                                                                     |
 | **Fix is breaking or non-breaking** | Non-breaking - If the type is not visible outside the assembly.<br/><br/>Breaking - If the type is visible outside the assembly. |
-| **Enabled by default in .NET 7**    | No |
+| **Enabled by default in .NET 7**    | No                                                                                                                               |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1002.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1002.md
@@ -14,9 +14,10 @@ ms.author: gewarren
 ---
 # CA1002: Do not expose generic lists
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
+| Property                            | Value                        |
+|-------------------------------------|------------------------------|
 | **Rule ID**                         | CA1002                       |
+| **Title**                           | Do not expose generic lists  |
 | **Category**                        | [Design](design-warnings.md) |
 | **Fix is breaking or non-breaking** | Breaking                     |
 | **Enabled by default in .NET 7**    | No                           |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1003.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1003.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA1003: Use generic event handler instances
 
-| Item                             | Value                        |
-| -------------------------------- | ---------------------------- |
-| Rule ID                          | CA1003                       |
-| Category                         | [Design](design-warnings.md) |
-| Fix is breaking or non-breaking  | Breaking                     |
-| Enabled by default in .NET 7     | No                           |
+| Property                            | Value                               |
+|-------------------------------------|-------------------------------------|
+| **Rule ID**                         | CA1003                              |
+| **Title**                           | Use generic event handler instances |
+| **Category**                        | [Design](design-warnings.md)        |
+| **Fix is breaking or non-breaking** | Breaking                            |
+| **Enabled by default in .NET 7**    | No                                  |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1005.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1005.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA1005: Avoid excessive parameters on generic types
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1005                       |
-| **Category**                        | [Design](design-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                     |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                       |
+|-------------------------------------|---------------------------------------------|
+| **Rule ID**                         | CA1005                                      |
+| **Title**                           | Avoid excessive parameters on generic types |
+| **Category**                        | [Design](design-warnings.md)                |
+| **Fix is breaking or non-breaking** | Breaking                                    |
+| **Enabled by default in .NET 7**    | No                                          |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1008.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1008.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA1008: Enums should have zero value
 
-| | Value |
-|-|-|
-| **Rule ID** | CA1008 |
-| **Category** | [Design](design-warnings.md) |
+| Property                            | Value                                                                                                                                                            |
+|-------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Rule ID**                         | CA1008                                                                                                                                                           |
+| **Title**                           | Enums should have zero value                                                                                                                                     |
+| **Category**                        | [Design](design-warnings.md)                                                                                                                                     |
 | **Fix is breaking or non-breaking** | Non-breaking - When you're prompted to add a `None` value to a non-flag enumeration. Breaking - When you're prompted to rename or remove any enumeration values. |
-| **Enabled by default in .NET 7**    | No |
+| **Enabled by default in .NET 7**    | No                                                                                                                                                               |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1010.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1010.md
@@ -16,12 +16,13 @@ ms.author: gewarren
 ---
 # CA1010: Collections should implement generic interface
 
-| Item                             | Value                        |
-| -------------------------------- | ---------------------------- |
-| Rule ID                          | CA1010                       |
-| Category                         | [Design](design-warnings.md) |
-| Fix is breaking or non-breaking  | Non-breaking                 |
-| Enabled by default in .NET 7     | No                           |
+| Property                            | Value                                          |
+|-------------------------------------|------------------------------------------------|
+| **Rule ID**                         | CA1010                                         |
+| **Title**                           | Collections should implement generic interface |
+| **Category**                        | [Design](design-warnings.md)                   |
+| **Fix is breaking or non-breaking** | Non-breaking                                   |
+| **Enabled by default in .NET 7**    | No                                             |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1012.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1012.md
@@ -16,12 +16,13 @@ dev_langs:
 ---
 # CA1012: Abstract types should not have public constructors
 
-| Item                             | Value                        |
-| -------------------------------- | ---------------------------- |
-| Rule ID                          | CA1012                       |
-| Category                         | [Design](design-warnings.md) |
-| Fix is breaking or non-breaking  | Non-breaking                 |
-| Enabled by default in .NET 7     | No                           |
+| Property                            | Value                                              |
+|-------------------------------------|----------------------------------------------------|
+| **Rule ID**                         | CA1012                                             |
+| **Title**                           | Abstract types should not have public constructors |
+| **Category**                        | [Design](design-warnings.md)                       |
+| **Fix is breaking or non-breaking** | Non-breaking                                       |
+| **Enabled by default in .NET 7**    | No                                                 |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1014.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1014.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA1014: Mark assemblies with CLSCompliantAttribute
 
-| Item                             | Value                        |
-| -------------------------------- | ---------------------------- |
-| Rule ID                          | CA1014                       |
-| Category                         | [Design](design-warnings.md) |
-| Fix is breaking or non-breaking  | Non-breaking                 |
-| Enabled by default in .NET 7     | No                           |
+| Property                            | Value                                      |
+|-------------------------------------|--------------------------------------------|
+| **Rule ID**                         | CA1014                                     |
+| **Title**                           | Mark assemblies with CLSCompliantAttribute |
+| **Category**                        | [Design](design-warnings.md)               |
+| **Fix is breaking or non-breaking** | Non-breaking                               |
+| **Enabled by default in .NET 7**    | No                                         |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1016.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1016.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA1016: Mark assemblies with AssemblyVersionAttribute
 
-| Item                             | Value                        |
-| -------------------------------- | ---------------------------- |
-| Rule ID                          | CA1016                       |
-| Category                         | [Design](design-warnings.md) |
-| Fix is breaking or non-breaking  | Non-breaking                 |
-| Enabled by default in .NET 7     | No                           |
+| Property                            | Value                                         |
+|-------------------------------------|-----------------------------------------------|
+| **Rule ID**                         | CA1016                                        |
+| **Title**                           | Mark assemblies with AssemblyVersionAttribute |
+| **Category**                        | [Design](design-warnings.md)                  |
+| **Fix is breaking or non-breaking** | Non-breaking                                  |
+| **Enabled by default in .NET 7**    | No                                            |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1017.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1017.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA1017: Mark assemblies with ComVisibleAttribute
 
-| Item                             | Value                        |
-| -------------------------------- | ---------------------------- |
-| Rule ID                          | CA1017                       |
-| Category                         | [Design](design-warnings.md) |
-| Fix is breaking or non-breaking  | Non-breaking                 |
-| Enabled by default in .NET 7     | No                           |
+| Property                            | Value                                                         |
+|-------------------------------------|---------------------------------------------------------------|
+| **Rule ID**                         | CA1017                                                        |
+| **Title**                           | Mark assemblies with Mark assemblies with ComVisibleAttribute |
+| **Category**                        | [Design](design-warnings.md)                                  |
+| **Fix is breaking or non-breaking** | Non-breaking                                                  |
+| **Enabled by default in .NET 7**    | No                                                            |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1018.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1018.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA1018: Mark attributes with AttributeUsageAttribute
 
-| Item                             | Value                        |
-| -------------------------------- | ---------------------------- |
-| Rule ID                          | CA1018                       |
-| Category                         | [Design](design-warnings.md) |
-| Fix is breaking or non-breaking  | Breaking                     |
-| Enabled by default in .NET 7     | No                           |
+| Property                            | Value                                        |
+|-------------------------------------|----------------------------------------------|
+| **Rule ID**                         | CA1018                                       |
+| **Title**                           | Mark attributes with AttributeUsageAttribute |
+| **Category**                        | [Design](design-warnings.md)                 |
+| **Fix is breaking or non-breaking** | Breaking                                     |
+| **Enabled by default in .NET 7**    | No                                           |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1019.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1019.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA1019: Define accessors for attribute arguments
 
-| Item                             | Value                        |
-| -------------------------------- | ---------------------------- |
-| Rule ID                          | CA1019                       |
-| Category                         | [Design](design-warnings.md) |
-| Fix is breaking or non-breaking  | Non-breaking                 |
-| Enabled by default in .NET 7     | No                           |
+| Property                            | Value                                    |
+|-------------------------------------|------------------------------------------|
+| **Rule ID**                         | CA1019                                   |
+| **Title**                           | Define accessors for attribute arguments |
+| **Category**                        | [Design](design-warnings.md)             |
+| **Fix is breaking or non-breaking** | Non-breaking                             |
+| **Enabled by default in .NET 7**    | No                                       |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1021.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1021.md
@@ -16,12 +16,13 @@ ms.author: gewarren
 ---
 # CA1021: Avoid out parameters
 
-| Item                             | Value                        |
-| -------------------------------- | ---------------------------- |
-| Rule ID                          | CA1021                       |
-| Category                         | [Design](design-warnings.md) |
-| Fix is breaking or non-breaking  | Breaking                     |
-| Enabled by default in .NET 7     | No                           |
+| Property                            | Value                        |
+|-------------------------------------|------------------------------|
+| **Rule ID**                         | CA1021                       |
+| **Title**                           | Avoid out parameters         |
+| **Category**                        | [Design](design-warnings.md) |
+| **Fix is breaking or non-breaking** | Breaking                     |
+| **Enabled by default in .NET 7**    | No                           |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1024.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1024.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA1024: Use properties where appropriate
 
-| Item                             | Value                        |
-| -------------------------------- | ---------------------------- |
-| Rule ID                          | CA1024                       |
-| Category                         | [Design](design-warnings.md) |
-| Fix is breaking or non-breaking  | Breaking                     |
-| Enabled by default in .NET 7     | No                           |
+| Property                            | Value                            |
+|-------------------------------------|----------------------------------|
+| **Rule ID**                         | CA1024                           |
+| **Title**                           | Use properties where appropriate |
+| **Category**                        | [Design](design-warnings.md)     |
+| **Fix is breaking or non-breaking** | Breaking                         |
+| **Enabled by default in .NET 7**    | No                               |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1027.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1027.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA1027: Mark enums with FlagsAttribute
 
-| Item                             | Value                        |
-| -------------------------------- | ---------------------------- |
-| Rule ID                          | CA1027                       |
-| Category                         | [Design](design-warnings.md) |
-| Fix is breaking or non-breaking  | Non-breaking                 |
-| Enabled by default in .NET 7     | No                           |
+| Property                            | Value                          |
+|-------------------------------------|--------------------------------|
+| **Rule ID**                         | CA1027                         |
+| **Title**                           | Mark enums with FlagsAttribute |
+| **Category**                        | [Design](design-warnings.md)   |
+| **Fix is breaking or non-breaking** | Non-breaking                   |
+| **Enabled by default in .NET 7**    | No                             |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1028.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1028.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA1028: Enum storage should be Int32
 
-| Item                             | Value                        |
-| -------------------------------- | ---------------------------- |
-| Rule ID                          | CA1028                       |
-| Category                         | [Design](design-warnings.md) |
-| Fix is breaking or non-breaking  | Breaking                     |
-| Enabled by default in .NET 7     | No                           |
+| Property                            | Value                        |
+|-------------------------------------|------------------------------|
+| **Rule ID**                         | CA1028                       |
+| **Title**                           | Enum storage should be Int32 |
+| **Category**                        | [Design](design-warnings.md) |
+| **Fix is breaking or non-breaking** | Breaking                     |
+| **Enabled by default in .NET 7**    | No                           |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1030.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1030.md
@@ -14,9 +14,10 @@ ms.author: gewarren
 ---
 # CA1030: Use events where appropriate
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
+| Property                            | Value                        |
+|-------------------------------------|------------------------------|
 | **Rule ID**                         | CA1030                       |
+| **Title**                           | Use events where appropriate |
 | **Category**                        | [Design](design-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                 |
 | **Enabled by default in .NET 7**    | No                           |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1031.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1031.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA1031: Do not catch general exception types
 
-| Item                             | Value                        |
-| -------------------------------- | ---------------------------- |
-| Rule ID                          | CA1031                       |
-| Category                         | [Design](design-warnings.md) |
-| Fix is breaking or non-breaking  | Non-breaking                 |
-| Enabled by default in .NET 7     | No                           |
+| Property                            | Value                                |
+|-------------------------------------|--------------------------------------|
+| **Rule ID**                         | CA1031                               |
+| **Title**                           | Do not catch general exception types |
+| **Category**                        | [Design](design-warnings.md)         |
+| **Fix is breaking or non-breaking** | Non-breaking                         |
+| **Enabled by default in .NET 7**    | No                                   |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1032.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1032.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA1032: Implement standard exception constructors
 
-| Item                             | Value                        |
-| -------------------------------- | ---------------------------- |
-| Rule ID                          | CA1032                       |
-| Category                         | [Design](design-warnings.md) |
-| Fix is breaking or non-breaking  | Non-breaking                 |
-| Enabled by default in .NET 7     | No                           |
+| Property                            | Value                                     |
+|-------------------------------------|-------------------------------------------|
+| **Rule ID**                         | CA1032                                    |
+| **Title**                           | Implement standard exception constructors |
+| **Category**                        | [Design](design-warnings.md)              |
+| **Fix is breaking or non-breaking** | Non-breaking                              |
+| **Enabled by default in .NET 7**    | No                                        |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1033.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1033.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA1033: Interface methods should be callable by child types
 
-| Item                             | Value                        |
-| -------------------------------- | ---------------------------- |
-| Rule ID                          | CA1033                       |
-| Category                         | [Design](design-warnings.md) |
-| Fix is breaking or non-breaking  | Non-breaking                 |
-| Enabled by default in .NET 7     | No                           |
+| Property                            | Value                                               |
+|-------------------------------------|-----------------------------------------------------|
+| **Rule ID**                         | CA1033                                              |
+| **Title**                           | Interface methods should be callable by child types |
+| **Category**                        | [Design](design-warnings.md)                        |
+| **Fix is breaking or non-breaking** | Non-breaking                                        |
+| **Enabled by default in .NET 7**    | No                                                  |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1034.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1034.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA1034: Nested types should not be visible
 
-| Item                             | Value                        |
-| -------------------------------- | ---------------------------- |
-| Rule ID                          | CA1034                       |
-| Category                         | [Design](design-warnings.md) |
-| Fix is breaking or non-breaking  | Breaking                     |
-| Enabled by default in .NET 7     | No                           |
+| Property                            | Value                              |
+|-------------------------------------|------------------------------------|
+| **Rule ID**                         | CA1034                             |
+| **Title**                           | Nested types should not be visible |
+| **Category**                        | [Design](design-warnings.md)       |
+| **Fix is breaking or non-breaking** | Breaking                           |
+| **Enabled by default in .NET 7**    | No                                 |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1036.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1036.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA1036: Override methods on comparable types
 
-| Item                            | Value                        |
-| ------------------------------- | ---------------------------- |
-| Rule ID                         | CA1036                       |
-| Category                        | [Design](design-warnings.md) |
-| Fix is breaking or non-breaking | Non-breaking                 |
-| Enabled by default in .NET 7    | No                           |
+| Property                            | Value                                |
+|-------------------------------------|--------------------------------------|
+| **Rule ID**                         | CA1036                               |
+| **Title**                           | Override methods on comparable types |
+| **Category**                        | [Design](design-warnings.md)         |
+| **Fix is breaking or non-breaking** | Non-breaking                         |
+| **Enabled by default in .NET 7**    | No                                   |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1040.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1040.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA1040: Avoid empty interfaces
 
-| Item                            | Value                        |
-| ------------------------------- | ---------------------------- |
-| Rule ID                         | CA1040                       |
-| Category                        | [Design](design-warnings.md) |
-| Fix is breaking or non-breaking | Breaking                     |
-| Enabled by default in .NET 7    | No                           |
+| Property                            | Value                        |
+|-------------------------------------|------------------------------|
+| **Rule ID**                         | CA1040                       |
+| **Title**                           | Avoid empty interfaces       |
+| **Category**                        | [Design](design-warnings.md) |
+| **Fix is breaking or non-breaking** | Breaking                     |
+| **Enabled by default in .NET 7**    | No                           |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1041.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1041.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA1041: Provide ObsoleteAttribute message
 
-| Item                            | Value                        |
-| ------------------------------- | ---------------------------- |
-| Rule ID                         | CA1041                       |
-| Category                        | [Design](design-warnings.md) |
-| Fix is breaking or non-breaking | Non-breaking                 |
-| Enabled by default in .NET 7    | No                           |
+| Property                            | Value                             |
+|-------------------------------------|-----------------------------------|
+| **Rule ID**                         | CA1041                            |
+| **Title**                           | Provide ObsoleteAttribute message |
+| **Category**                        | [Design](design-warnings.md)      |
+| **Fix is breaking or non-breaking** | Non-breaking                      |
+| **Enabled by default in .NET 7**    | No                                |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1043.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1043.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA1043: Use integral or string argument for indexers
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1043                       |
-| **Category**                        | [Design](design-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                     |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                        |
+|-------------------------------------|----------------------------------------------|
+| **Rule ID**                         | CA1043                                       |
+| **Title**                           | Use integral or string argument for indexers |
+| **Category**                        | [Design](design-warnings.md)                 |
+| **Fix is breaking or non-breaking** | Breaking                                     |
+| **Enabled by default in .NET 7**    | No                                           |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1044.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1044.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA1044: Properties should not be write only
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1044                       |
-| **Category**                        | [Design](design-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                     |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                               |
+|-------------------------------------|-------------------------------------|
+| **Rule ID**                         | CA1044                              |
+| **Title**                           | Properties should not be write only |
+| **Category**                        | [Design](design-warnings.md)        |
+| **Fix is breaking or non-breaking** | Breaking                            |
+| **Enabled by default in .NET 7**    | No                                  |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1045.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1045.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA1045: Do not pass types by reference
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1045                       |
-| **Category**                        | [Design](design-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                     |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                          |
+|-------------------------------------|--------------------------------|
+| **Rule ID**                         | CA1045                         |
+| **Title**                           | Do not pass types by reference |
+| **Category**                        | [Design](design-warnings.md)   |
+| **Fix is breaking or non-breaking** | Breaking                       |
+| **Enabled by default in .NET 7**    | No                             |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1046.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1046.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA1046: Do not overload operator equals on reference types
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1046                       |
-| **Category**                        | [Design](design-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                     |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                              |
+|-------------------------------------|----------------------------------------------------|
+| **Rule ID**                         | CA1046                                             |
+| **Title**                           | Do not overload operator equals on reference types |
+| **Category**                        | [Design](design-warnings.md)                       |
+| **Fix is breaking or non-breaking** | Breaking                                           |
+| **Enabled by default in .NET 7**    | No                                                 |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1047.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1047.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA1047: Do not declare protected members in sealed types
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1047                       |
-| **Category**                        | [Design](design-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                 |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                            |
+|-------------------------------------|--------------------------------------------------|
+| **Rule ID**                         | CA1047                                           |
+| **Title**                           | Do not declare protected members in sealed types |
+| **Category**                        | [Design](design-warnings.md)                     |
+| **Fix is breaking or non-breaking** | Non-breaking                                     |
+| **Enabled by default in .NET 7**    | No                                               |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1050.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1050.md
@@ -17,9 +17,10 @@ dev_langs:
 ---
 # CA1050: Declare types in namespaces
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
+| Property                            | Value                        |
+|-------------------------------------|------------------------------|
 | **Rule ID**                         | CA1050                       |
+| **Title**                           | Declare types in namespaces  |
 | **Category**                        | [Design](design-warnings.md) |
 | **Fix is breaking or non-breaking** | Breaking                     |
 | **Enabled by default in .NET 7**    | No                           |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1051.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1051.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA1051: Do not declare visible instance fields
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1051                       |
-| **Category**                        | [Design](design-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                     |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                  |
+|-------------------------------------|----------------------------------------|
+| **Rule ID**                         | CA1051                                 |
+| **Title**                           | Do not declare visible instance fields |
+| **Category**                        | [Design](design-warnings.md)           |
+| **Fix is breaking or non-breaking** | Breaking                               |
+| **Enabled by default in .NET 7**    | No                                     |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1052.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1052.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA1052: Static holder types should be Static or NotInheritable
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1052                       |
-| **Category**                        | [Design](design-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                     |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                                  |
+|-------------------------------------|--------------------------------------------------------|
+| **Rule ID**                         | CA1052                                                 |
+| **Title**                           | Static holder types should be Static or NotInheritable |
+| **Category**                        | [Design](design-warnings.md)                           |
+| **Fix is breaking or non-breaking** | Breaking                                               |
+| **Enabled by default in .NET 7**    | No                                                     |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1053.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1053.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA1053: Static holder types should not have default constructors
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1053                       |
-| **Category**                        | [Design](design-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                     |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                                    |
+|-------------------------------------|----------------------------------------------------------|
+| **Rule ID**                         | CA1053                                                   |
+| **Title**                           | Static holder types should not have default constructors |
+| **Category**                        | [Design](design-warnings.md)                             |
+| **Fix is breaking or non-breaking** | Breaking                                                 |
+| **Enabled by default in .NET 7**    | No                                                       |
 
 > [!NOTE]
 > Rule CA1053 only applies to legacy Visual Studio code analysis. In the .NET code-quality analyzers, it's combined into rule [CA1052: Static holder types should be Static or NotInheritable](ca1052.md).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1054.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1054.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA1054: URI parameters should not be strings
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1054                       |
-| **Category**                        | [Design](design-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                     |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                |
+|-------------------------------------|--------------------------------------|
+| **Rule ID**                         | CA1054                               |
+| **Title**                           | URI parameters should not be strings |
+| **Category**                        | [Design](design-warnings.md)         |
+| **Fix is breaking or non-breaking** | Breaking                             |
+| **Enabled by default in .NET 7**    | No                                   |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1055.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1055.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA1055: URI return values should not be strings
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1055                       |
-| **Category**                        | [Design](design-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                     |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                   |
+|-------------------------------------|-----------------------------------------|
+| **Rule ID**                         | CA1055                                  |
+| **Title**                           | URI return values should not be strings |
+| **Category**                        | [Design](design-warnings.md)            |
+| **Fix is breaking or non-breaking** | Breaking                                |
+| **Enabled by default in .NET 7**    | No                                      |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1056.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1056.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA1056: URI properties should not be strings
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1056                       |
-| **Category**                        | [Design](design-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                     |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                |
+|-------------------------------------|--------------------------------------|
+| **Rule ID**                         | CA1056                               |
+| **Title**                           | URI properties should not be strings |
+| **Category**                        | [Design](design-warnings.md)         |
+| **Fix is breaking or non-breaking** | Breaking                             |
+| **Enabled by default in .NET 7**    | No                                   |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1058.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1058.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA1058: Types should not extend certain base types
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1058                       |
-| **Category**                        | [Design](design-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                     |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                      |
+|-------------------------------------|--------------------------------------------|
+| **Rule ID**                         | CA1058                                     |
+| **Title**                           | Types should not extend certain base types |
+| **Category**                        | [Design](design-warnings.md)               |
+| **Fix is breaking or non-breaking** | Breaking                                   |
+| **Enabled by default in .NET 7**    | No                                         |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1060.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1060.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA1060: Move P/Invokes to NativeMethods class
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1060                       |
-| **Category**                        | [Design](design-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                     |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                 |
+|-------------------------------------|---------------------------------------|
+| **Rule ID**                         | CA1060                                |
+| **Title**                           | Move P/Invokes to NativeMethods class |
+| **Category**                        | [Design](design-warnings.md)          |
+| **Fix is breaking or non-breaking** | Breaking                              |
+| **Enabled by default in .NET 7**    | No                                    |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1061.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1061.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA1061: Do not hide base class methods
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1061                       |
-| **Category**                        | [Design](design-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                     |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                          |
+|-------------------------------------|--------------------------------|
+| **Rule ID**                         | CA1061                         |
+| **Title**                           | Do not hide base class methods |
+| **Category**                        | [Design](design-warnings.md)   |
+| **Fix is breaking or non-breaking** | Breaking                       |
+| **Enabled by default in .NET 7**    | No                             |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1062.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1062.md
@@ -18,12 +18,13 @@ dev_langs:
 ---
 # CA1062: Validate arguments of public methods
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1062                       |
-| **Category**                        | [Design](design-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                 |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                |
+|-------------------------------------|--------------------------------------|
+| **Rule ID**                         | CA1062                               |
+| **Title**                           | Validate arguments of public methods |
+| **Category**                        | [Design](design-warnings.md)         |
+| **Fix is breaking or non-breaking** | Non-breaking                         |
+| **Enabled by default in .NET 7**    | No                                   |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1063.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1063.md
@@ -16,12 +16,13 @@ dev_langs:
 ---
 # CA1063: Implement IDisposable correctly
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1063                       |
-| **Category**                        | [Design](design-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                 |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                           |
+|-------------------------------------|---------------------------------|
+| **Rule ID**                         | CA1063                          |
+| **Title**                           | Implement IDisposable correctly |
+| **Category**                        | [Design](design-warnings.md)    |
+| **Fix is breaking or non-breaking** | Non-breaking                    |
+| **Enabled by default in .NET 7**    | No                              |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1064.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1064.md
@@ -14,9 +14,10 @@ ms.author: gewarren
 ---
 # CA1064: Exceptions should be public
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
+| Property                            | Value                        |
+|-------------------------------------|------------------------------|
 | **Rule ID**                         | CA1064                       |
+| **Title**                           | Exceptions should be public  |
 | **Category**                        | [Design](design-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                 |
 | **Enabled by default in .NET 7**    | No                           |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1065.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1065.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA1065: Do not raise exceptions in unexpected locations
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1065                       |
-| **Category**                        | [Design](design-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                 |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                           |
+|-------------------------------------|-------------------------------------------------|
+| **Rule ID**                         | CA1065                                          |
+| **Title**                           | Do not raise exceptions in unexpected locations |
+| **Category**                        | [Design](design-warnings.md)                    |
+| **Fix is breaking or non-breaking** | Non-breaking                                    |
+| **Enabled by default in .NET 7**    | No                                              |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1066.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1066.md
@@ -12,12 +12,13 @@ ms.author: mavasani
 ---
 # CA1066: Implement IEquatable when overriding Equals
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1066                       |
-| **Category**                        | [Design](design-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                 |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                       |
+|-------------------------------------|---------------------------------------------|
+| **Rule ID**                         | CA1066                                      |
+| **Title**                           | Implement IEquatable when overriding Equals |
+| **Category**                        | [Design](design-warnings.md)                |
+| **Fix is breaking or non-breaking** | Non-breaking                                |
+| **Enabled by default in .NET 7**    | No                                          |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1067.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1067.md
@@ -12,12 +12,13 @@ ms.author: mavasani
 ---
 # CA1067: Override Equals when implementing IEquatable
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1067                       |
-| **Category**                        | [Design](design-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                 |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                        |
+|-------------------------------------|----------------------------------------------|
+| **Rule ID**                         | CA1067                                       |
+| **Title**                           | Override Equals when implementing IEquatable |
+| **Category**                        | [Design](design-warnings.md)                 |
+| **Fix is breaking or non-breaking** | Non-breaking                                 |
+| **Enabled by default in .NET 7**    | No                                           |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1068.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1068.md
@@ -14,12 +14,13 @@ ms.author: mavasani
 ---
 # CA1068: CancellationToken parameters must come last
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1068                       |
-| **Category**                        | [Design](design-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                     |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                       |
+|-------------------------------------|---------------------------------------------|
+| **Rule ID**                         | CA1068                                      |
+| **Title**                           | CancellationToken parameters must come last |
+| **Category**                        | [Design](design-warnings.md)                |
+| **Fix is breaking or non-breaking** | Breaking                                    |
+| **Enabled by default in .NET 7**    | No                                          |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1069.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1069.md
@@ -12,12 +12,13 @@ ms.author: mavasani
 ---
 # CA1069: Enums should not have duplicate values
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1069                       |
-| **Category**                        | [Design](design-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                     |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                  |
+|-------------------------------------|----------------------------------------|
+| **Rule ID**                         | CA1069                                 |
+| **Title**                           | Enums should not have duplicate values |
+| **Category**                        | [Design](design-warnings.md)           |
+| **Fix is breaking or non-breaking** | Breaking                               |
+| **Enabled by default in .NET 7**    | No                                     |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1070.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1070.md
@@ -12,12 +12,13 @@ ms.author: mavasani
 ---
 # CA1070: Do not declare event fields as virtual
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1070                       |
-| **Category**                        | [Design](design-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                     |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                  |
+|-------------------------------------|----------------------------------------|
+| **Rule ID**                         | CA1070                                 |
+| **Title**                           | Do not declare event fields as virtual |
+| **Category**                        | [Design](design-warnings.md)           |
+| **Fix is breaking or non-breaking** | Breaking                               |
+| **Enabled by default in .NET 7**    | No                                     |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1200.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1200.md
@@ -16,9 +16,10 @@ dev_langs:
 ---
 # CA1200: Avoid using cref tags with a prefix
 
-|                                     | Value                                      |
-| ----------------------------------- | ------------------------------------------ |
+| Property                            | Value                                      |
+|-------------------------------------|--------------------------------------------|
 | **Rule ID**                         | CA1200                                     |
+| **Title**                           | Avoid using cref tags with a prefix        |
 | **Category**                        | [Documentation](documentation-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                               |
 | **Enabled by default in .NET 7**    | No                                         |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1303.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1303.md
@@ -18,12 +18,13 @@ dev_langs:
 ---
 # CA1303: Do not pass literals as localized parameters
 
-|                                     | Value                                      |
-| ----------------------------------- | ------------------------------------------ |
-| **Rule ID**                         | CA1303                                     |
-| **Category**                        | [Globalization](globalization-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                               |
-| **Enabled by default in .NET 7**    | No                                         |
+| Property                            | Value                                        |
+|-------------------------------------|----------------------------------------------|
+| **Rule ID**                         | CA1303                                       |
+| **Title**                           | Do not pass literals as localized parameters |
+| **Category**                        | [Globalization](globalization-warnings.md)   |
+| **Fix is breaking or non-breaking** | Non-breaking                                 |
+| **Enabled by default in .NET 7**    | No                                           |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1304.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1304.md
@@ -14,9 +14,10 @@ ms.author: gewarren
 ---
 # CA1304: Specify CultureInfo
 
-|                                     | Value                                      |
-| ----------------------------------- | ------------------------------------------ |
+| Property                            | Value                                      |
+|-------------------------------------|--------------------------------------------|
 | **Rule ID**                         | CA1304                                     |
+| **Title**                           | Specify CultureInfo                        |
 | **Category**                        | [Globalization](globalization-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                               |
 | **Enabled by default in .NET 7**    | No                                         |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1305.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1305.md
@@ -16,9 +16,10 @@ dev_langs:
 ---
 # CA1305: Specify IFormatProvider
 
-|                                     | Value                                      |
-| ----------------------------------- | ------------------------------------------ |
+| Property                            | Value                                      |
+|-------------------------------------|--------------------------------------------|
 | **Rule ID**                         | CA1305                                     |
+| **Title**                           | Specify IFormatProvider                    |
 | **Category**                        | [Globalization](globalization-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                               |
 | **Enabled by default in .NET 7**    | No                                         |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1307.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1307.md
@@ -16,9 +16,10 @@ ms.author: gewarren
 ---
 # CA1307: Specify StringComparison for clarity
 
-|                                     | Value                                      |
-| ----------------------------------- | ------------------------------------------ |
+| Property                            | Value                                      |
+|-------------------------------------|--------------------------------------------|
 | **Rule ID**                         | CA1307                                     |
+| **Title**                           | Specify StringComparison for clarity       |
 | **Category**                        | [Globalization](globalization-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                               |
 | **Enabled by default in .NET 7**    | No                                         |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1308.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1308.md
@@ -14,9 +14,10 @@ ms.author: gewarren
 ---
 # CA1308: Normalize strings to uppercase
 
-|                                     | Value                                      |
-| ----------------------------------- | ------------------------------------------ |
+| Property                            | Value                                      |
+|-------------------------------------|--------------------------------------------|
 | **Rule ID**                         | CA1308                                     |
+| **Title**                           | Normalize strings to uppercase             |
 | **Category**                        | [Globalization](globalization-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                               |
 | **Enabled by default in .NET 7**    | No                                         |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1309.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1309.md
@@ -14,9 +14,10 @@ ms.author: gewarren
 ---
 # CA1309: Use ordinal StringComparison
 
-|                                     | Value                                      |
-| ----------------------------------- | ------------------------------------------ |
+| Property                            | Value                                      |
+|-------------------------------------|--------------------------------------------|
 | **Rule ID**                         | CA1309                                     |
+| **Title**                           | Use ordinal StringComparison               |
 | **Category**                        | [Globalization](globalization-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                               |
 | **Enabled by default in .NET 7**    | No                                         |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1310.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1310.md
@@ -16,9 +16,10 @@ ms.author: gewarren
 ---
 # CA1310: Specify StringComparison for correctness
 
-|                                     | Value                                      |
-| ----------------------------------- | ------------------------------------------ |
+| Property                            | Value                                      |
+|-------------------------------------|--------------------------------------------|
 | **Rule ID**                         | CA1310                                     |
+| **Title**                           | Specify StringComparison for correctness   |
 | **Category**                        | [Globalization](globalization-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                               |
 | **Enabled by default in .NET 7**    | No                                         |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1311.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1311.md
@@ -14,12 +14,13 @@ dev_langs:
 ---
 # CA1311: Specify a culture or use an invariant version
 
-|                                     | Value                                      |
-| ----------------------------------- | ------------------------------------------ |
-| **Rule ID**                         | CA1311                                     |
-| **Category**                        | [Globalization](globalization-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                               |
-| **Enabled by default in .NET 7**    | No                                         |
+| Property                            | Value                                         |
+|-------------------------------------|-----------------------------------------------|
+| **Rule ID**                         | CA1311                                        |
+| **Title**                           | Specify a culture or use an invariant version |
+| **Category**                        | [Globalization](globalization-warnings.md)    |
+| **Fix is breaking or non-breaking** | Non-breaking                                  |
+| **Enabled by default in .NET 7**    | No                                            |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1401.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1401.md
@@ -17,9 +17,10 @@ dev_langs:
 ---
 # CA1401: P/Invokes should not be visible
 
-|                                     | Value                                            |
-| ----------------------------------- | ------------------------------------------------ |
+| Property                            | Value                                            |
+|-------------------------------------|--------------------------------------------------|
 | **Rule ID**                         | CA1401                                           |
+| **Title**                           | P/Invokes should not be visible                  |
 | **Category**                        | [Interoperability](interoperability-warnings.md) |
 | **Fix is breaking or non-breaking** | Breaking                                         |
 | **Enabled by default in .NET 7**    | No                                               |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1416.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1416.md
@@ -14,9 +14,10 @@ ms.author: bunamnan
 ---
 # CA1416: Validate platform compatibility
 
-|                                     | Value                                            |
-| ----------------------------------- | ------------------------------------------------ |
+| Property                            | Value                                            |
+|-------------------------------------|--------------------------------------------------|
 | **Rule ID**                         | CA1416                                           |
+| **Title**                           | Validate platform compatibility                  |
 | **Category**                        | [Interoperability](interoperability-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                                     |
 | **Enabled by default in .NET 7**    | Yes                                              |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1417.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1417.md
@@ -14,12 +14,13 @@ ms.author: elfung
 ---
 # CA1417: Do not use `OutAttribute` on string parameters for P/Invokes
 
-|                                     | Value                                            |
-| ----------------------------------- | ------------------------------------------------ |
-| **Rule ID**                         | CA1417                                           |
-| **Category**                        | [Interoperability](interoperability-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                                     |
-| **Enabled by default in .NET 7**    | Yes                                              |
+| Property                            | Value                                                        |
+|-------------------------------------|--------------------------------------------------------------|
+| **Rule ID**                         | CA1417                                                       |
+| **Title**                           | Do not use `OutAttribute` on string parameters for P/Invokes |
+| **Category**                        | [Interoperability](interoperability-warnings.md)             |
+| **Fix is breaking or non-breaking** | Non-breaking                                                 |
+| **Enabled by default in .NET 7**    | Yes                                                          |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1418.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1418.md
@@ -14,9 +14,10 @@ ms.author: bunamnan
 ---
 # CA1418: Validate platform compatibility
 
-|                                     | Value                                            |
-| ----------------------------------- | ------------------------------------------------ |
+| Property                            | Value                                            |
+|-------------------------------------|--------------------------------------------------|
 | **Rule ID**                         | CA1418                                           |
+| **Title**                           | Validate platform compatibility                  |
 | **Category**                        | [Interoperability](interoperability-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                                     |
 | **Enabled by default in .NET 7**    | Yes                                              |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1419.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1419.md
@@ -13,12 +13,13 @@ author: Youssef1313
 ---
 # CA1419: Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
 
-|                                     | Value                                            |
-| ----------------------------------- | ------------------------------------------------ |
-| **Rule ID**                         | CA1419                                           |
-| **Category**                        | [Interoperability](interoperability-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                                     |
-| **Enabled by default in .NET 7**    | No                                               |
+| Property                            | Value                                                                                                                                                     |
+|-------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Rule ID**                         | CA1419                                                                                                                                                    |
+| **Title**                           | Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle' |
+| **Category**                        | [Interoperability](interoperability-warnings.md)                                                                                                          |
+| **Fix is breaking or non-breaking** | Non-breaking                                                                                                                                              |
+| **Enabled by default in .NET 7**    | No                                                                                                                                                        |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1420.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1420.md
@@ -13,12 +13,13 @@ dev_langs:
 ---
 # CA1420: Property, type, or attribute requires runtime marshalling
 
-|                                     | Value                                            |
-| ----------------------------------- | ------------------------------------------------ |
-| **Rule ID**                         | CA1420                                           |
-| **Category**                        | [Interoperability](interoperability-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                                         |
-| **Enabled by default in .NET 7**    | Yes                                              |
+| Property                            | Value                                                     |
+|-------------------------------------|-----------------------------------------------------------|
+| **Rule ID**                         | CA1420                                                    |
+| **Title**                           | Property, type, or attribute requires runtime marshalling |
+| **Category**                        | [Interoperability](interoperability-warnings.md)          |
+| **Fix is breaking or non-breaking** | Breaking                                                  |
+| **Enabled by default in .NET 7**    | Yes                                                       |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1421.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1421.md
@@ -14,12 +14,13 @@ dev_langs:
 ---
 # CA1421: Method uses runtime marshalling when DisableRuntimeMarshallingAttribute is applied
 
-|                                     | Value                                            |
-| ----------------------------------- | ------------------------------------------------ |
-| **Rule ID**                         | CA1421                                           |
-| **Category**                        | [Interoperability](interoperability-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                                     |
-| **Enabled by default in .NET 7**    | No                                               |
+| Property                            | Value                                                                              |
+|-------------------------------------|------------------------------------------------------------------------------------|
+| **Rule ID**                         | CA1421                                                                             |
+| **Title**                           | Method uses runtime marshalling when DisableRuntimeMarshallingAttribute is applied |
+| **Category**                        | [Interoperability](interoperability-warnings.md)                                   |
+| **Fix is breaking or non-breaking** | Non-breaking                                                                       |
+| **Enabled by default in .NET 7**    | No                                                                                 |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1422.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1422.md
@@ -13,9 +13,10 @@ dev_langs:
 ---
 # CA1422: Validate platform compatibility - obsoleted APIs
 
-|                                     | Value                                            |
-| ----------------------------------- | ------------------------------------------------ |
+| Property                            | Value                                            |
+|-------------------------------------|--------------------------------------------------|
 | **Rule ID**                         | CA1422                                           |
+| **Title**                           | Validate platform compatibility - obsoleted APIs |
 | **Category**                        | [Interoperability](interoperability-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                                     |
 | **Enabled by default in .NET 7**    | Yes                                              |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1501.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1501.md
@@ -17,9 +17,10 @@ dev_langs:
 ---
 # CA1501: Avoid excessive inheritance
 
-|                                     | Value                                          |
-| ----------------------------------- | ---------------------------------------------- |
+| Property                            | Value                                          |
+|-------------------------------------|------------------------------------------------|
 | **Rule ID**                         | CA1501                                         |
+| **Title**                           | Avoid excessive inheritance                    |
 | **Category**                        | [Maintainability](maintainability-warnings.md) |
 | **Fix is breaking or non-breaking** | Breaking                                       |
 | **Default threshold**               | 5                                              |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1502.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1502.md
@@ -17,9 +17,10 @@ dev_langs:
 ---
 # CA1502: Avoid excessive complexity
 
-|                                     | Value                                          |
-| ----------------------------------- | ---------------------------------------------- |
+| Property                            | Value                                          |
+|-------------------------------------|------------------------------------------------|
 | **Rule ID**                         | CA1502                                         |
+| **Title**                           | Avoid excessive complexity                     |
 | **Category**                        | [Maintainability](maintainability-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                                   |
 | **Default threshold**               | 25                                             |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1505.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1505.md
@@ -14,9 +14,10 @@ ms.author: gewarren
 ---
 # CA1505: Avoid unmaintainable code
 
-|                                     | Value                                          |
-| ----------------------------------- | ---------------------------------------------- |
+| Property                            | Value                                          |
+|-------------------------------------|------------------------------------------------|
 | **Rule ID**                         | CA1505                                         |
+| **Title**                           | Avoid unmaintainable code                      |
 | **Category**                        | [Maintainability](maintainability-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                                   |
 | **Default threshold**               | 10                                             |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1506.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1506.md
@@ -11,9 +11,10 @@ helpviewer_keywords:
 ---
 # CA1506: Avoid excessive class coupling
 
-|                                     | Value                                          |
-| ----------------------------------- | ---------------------------------------------- |
+| Property                            | Value                                          |
+|-------------------------------------|------------------------------------------------|
 | **Rule ID**                         | CA1506                                         |
+| **Title**                           | Avoid excessive class coupling                 |
 | **Category**                        | [Maintainability](maintainability-warnings.md) |
 | **Fix is breaking or non-breaking** | Breaking                                       |
 | **Default threshold**               | Types: 95&nbsp;&nbsp;Other symbols: 40         |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1507.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1507.md
@@ -14,9 +14,10 @@ ms.author: gewarren
 ---
 # CA1507: Use `nameof` in place of string
 
-|                                     | Value                                          |
-| ----------------------------------- | ---------------------------------------------- |
+| Property                            | Value                                          |
+|-------------------------------------|------------------------------------------------|
 | **Rule ID**                         | CA1507                                         |
+| **Title**                           | Use `nameof` in place of string                |
 | **Category**                        | [Maintainability](maintainability-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                                   |
 | **Enabled by default in .NET 7**    | No                                             |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1508.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1508.md
@@ -14,9 +14,10 @@ ms.author: mavasani
 ---
 # CA1508: Avoid dead conditional code
 
-|                                     | Value                                          |
-| ----------------------------------- | ---------------------------------------------- |
+| Property                            | Value                                          |
+|-------------------------------------|------------------------------------------------|
 | **Rule ID**                         | CA1508                                         |
+| **Title**                           | Avoid dead conditional code                    |
 | **Category**                        | [Maintainability](maintainability-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-Breaking                                   |
 | **Enabled by default in .NET 7**    | No                                             |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1509.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1509.md
@@ -14,12 +14,13 @@ ms.author: mavasani
 ---
 # CA1509: Invalid entry in code metrics configuration file
 
-|                                     | Value                                          |
-| ----------------------------------- | ---------------------------------------------- |
-| **Rule ID**                         | CA1509                                         |
-| **Category**                        | [Maintainability](maintainability-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-Breaking                                   |
-| **Enabled by default in .NET 7**    | No                                             |
+| Property                            | Value                                            |
+|-------------------------------------|--------------------------------------------------|
+| **Rule ID**                         | CA1509                                           |
+| **Title**                           | Invalid entry in code metrics configuration file |
+| **Category**                        | [Maintainability](maintainability-warnings.md)   |
+| **Fix is breaking or non-breaking** | Non-Breaking                                     |
+| **Enabled by default in .NET 7**    | No                                               |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1700.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1700.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA1700: Do not name enum values &#39;Reserved&#39;
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1700                       |
-| **Category**                        | [Naming](naming-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                     |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                      |
+|-------------------------------------|--------------------------------------------|
+| **Rule ID**                         | CA1700                                     |
+| **Title**                           | Do not name enum values &#39;Reserved&#39; |
+| **Category**                        | [Naming](naming-warnings.md)               |
+| **Fix is breaking or non-breaking** | Breaking                                   |
+| **Enabled by default in .NET 7**    | No                                         |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1707.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1707.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA1707: Identifiers should not contain underscores
 
-| | Value |
-|-|-|
-| **Rule ID** |CA1707|
-| **Category** |[Naming](naming-warnings.md)|
-| **Fix is breaking or non-breaking** |Breaking - when raised on assemblies<br/><br/>Non-breaking - when raised on type parameters|
-| **Enabled by default in .NET 7**    | No |
+| Property                            | Value                                                                                       |
+|-------------------------------------|---------------------------------------------------------------------------------------------|
+| **Rule ID**                         | CA1707                                                                                      |
+| **Title**                           | Identifiers should not contain underscores                                                  |
+| **Category**                        | [Naming](naming-warnings.md)                                                                |
+| **Fix is breaking or non-breaking** | Breaking - when raised on assemblies<br/><br/>Non-breaking - when raised on type parameters |
+| **Enabled by default in .NET 7**    | No                                                                                          |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1708.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1708.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA1708: Identifiers should differ by more than case
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1708                       |
-| **Category**                        | [Naming](naming-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                     |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                       |
+|-------------------------------------|---------------------------------------------|
+| **Rule ID**                         | CA1708                                      |
+| **Title**                           | Identifiers should differ by more than case |
+| **Category**                        | [Naming](naming-warnings.md)                |
+| **Fix is breaking or non-breaking** | Breaking                                    |
+| **Enabled by default in .NET 7**    | No                                          |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1710.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1710.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA1710: Identifiers should have correct suffix
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1710                       |
-| **Category**                        | [Naming](naming-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                     |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                  |
+|-------------------------------------|----------------------------------------|
+| **Rule ID**                         | CA1710                                 |
+| **Title**                           | Identifiers should have correct suffix |
+| **Category**                        | [Naming](naming-warnings.md)           |
+| **Fix is breaking or non-breaking** | Breaking                               |
+| **Enabled by default in .NET 7**    | No                                     |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1711.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1711.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA1711: Identifiers should not have incorrect suffix
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1711                       |
-| **Category**                        | [Naming](naming-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                     |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                        |
+|-------------------------------------|----------------------------------------------|
+| **Rule ID**                         | CA1711                                       |
+| **Title**                           | Identifiers should not have incorrect suffix |
+| **Category**                        | [Naming](naming-warnings.md)                 |
+| **Fix is breaking or non-breaking** | Breaking                                     |
+| **Enabled by default in .NET 7**    | No                                           |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1712.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1712.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA1712: Do not prefix enum values with type name
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1712                       |
-| **Category**                        | [Naming](naming-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                     |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                    |
+|-------------------------------------|------------------------------------------|
+| **Rule ID**                         | CA1712                                   |
+| **Title**                           | Do not prefix enum values with type name |
+| **Category**                        | [Naming](naming-warnings.md)             |
+| **Fix is breaking or non-breaking** | Breaking                                 |
+| **Enabled by default in .NET 7**    | No                                       |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1713.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1713.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA1713: Events should not have before or after prefix
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1713                       |
-| **Category**                        | [Naming](naming-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                     |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                         |
+|-------------------------------------|-----------------------------------------------|
+| **Rule ID**                         | CA1713                                        |
+| **Title**                           | Events should not have before or after prefix |
+| **Category**                        | [Naming](naming-warnings.md)                  |
+| **Fix is breaking or non-breaking** | Breaking                                      |
+| **Enabled by default in .NET 7**    | No                                            |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1714.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1714.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA1714: Flags enums should have plural names
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1714                       |
-| **Category**                        | [Naming](naming-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                     |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                |
+|-------------------------------------|--------------------------------------|
+| **Rule ID**                         | CA1714                               |
+| **Title**                           | Flags enums should have plural names |
+| **Category**                        | [Naming](naming-warnings.md)         |
+| **Fix is breaking or non-breaking** | Breaking                             |
+| **Enabled by default in .NET 7**    | No                                   |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1715.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1715.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA1715: Identifiers should have correct prefix
 
-| | Value |
-|-|-|
-| **Rule ID** |CA1715|
-| **Category** |[Naming](naming-warnings.md)|
-| **Fix is breaking or non-breaking** |Breaking - when fired on interfaces.<br/><br/>Non-breaking - when raised on generic type parameters.|
-| **Enabled by default in .NET 7**    | No |
+| Property                            | Value                                                                                                |
+|-------------------------------------|------------------------------------------------------------------------------------------------------|
+| **Rule ID**                         | CA1715                                                                                               |
+| **Title**                           | Identifiers should have correct prefix                                                               |
+| **Category**                        | [Naming](naming-warnings.md)                                                                         |
+| **Fix is breaking or non-breaking** | Breaking - when fired on interfaces.<br/><br/>Non-breaking - when raised on generic type parameters. |
+| **Enabled by default in .NET 7**    | No                                                                                                   |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1716.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1716.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA1716: Identifiers should not match keywords
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1716                       |
-| **Category**                        | [Naming](naming-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                     |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                 |
+|-------------------------------------|---------------------------------------|
+| **Rule ID**                         | CA1716                                |
+| **Title**                           | Identifiers should not match keywords |
+| **Category**                        | [Naming](naming-warnings.md)          |
+| **Fix is breaking or non-breaking** | Breaking                              |
+| **Enabled by default in .NET 7**    | No                                    |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1717.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1717.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA1717: Only FlagsAttribute enums should have plural names
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1717                       |
-| **Category**                        | [Naming](naming-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                     |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                              |
+|-------------------------------------|----------------------------------------------------|
+| **Rule ID**                         | CA1717                                             |
+| **Title**                           | Only FlagsAttribute enums should have plural names |
+| **Category**                        | [Naming](naming-warnings.md)                       |
+| **Fix is breaking or non-breaking** | Breaking                                           |
+| **Enabled by default in .NET 7**    | No                                                 |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1720.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1720.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA1720: Identifiers should not contain type names
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1720                       |
-| **Category**                        | [Naming](naming-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                     |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                     |
+|-------------------------------------|-------------------------------------------|
+| **Rule ID**                         | CA1720                                    |
+| **Title**                           | Identifiers should not contain type names |
+| **Category**                        | [Naming](naming-warnings.md)              |
+| **Fix is breaking or non-breaking** | Breaking                                  |
+| **Enabled by default in .NET 7**    | No                                        |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1721.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1721.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA1721: Property names should not match get methods
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1721                       |
-| **Category**                        | [Naming](naming-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                     |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                       |
+|-------------------------------------|---------------------------------------------|
+| **Rule ID**                         | CA1721                                      |
+| **Title**                           | Property names should not match get methods |
+| **Category**                        | [Naming](naming-warnings.md)                |
+| **Fix is breaking or non-breaking** | Breaking                                    |
+| **Enabled by default in .NET 7**    | No                                          |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1724.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1724.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA1724: Type names should not match namespaces
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1724                       |
-| **Category**                        | [Naming](naming-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                     |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                  |
+|-------------------------------------|----------------------------------------|
+| **Rule ID**                         | CA1724                                 |
+| **Title**                           | Type names should not match namespaces |
+| **Category**                        | [Naming](naming-warnings.md)           |
+| **Fix is breaking or non-breaking** | Breaking                               |
+| **Enabled by default in .NET 7**    | No                                     |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1725.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1725.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA1725: Parameter names should match base declaration
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1725                       |
-| **Category**                        | [Naming](naming-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                     |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                         |
+|-------------------------------------|-----------------------------------------------|
+| **Rule ID**                         | CA1725                                        |
+| **Title**                           | Parameter names should match base declaration |
+| **Category**                        | [Naming](naming-warnings.md)                  |
+| **Fix is breaking or non-breaking** | Breaking                                      |
+| **Enabled by default in .NET 7**    | No                                            |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1727.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1727.md
@@ -13,12 +13,13 @@ author: Youssef1313
 ---
 # CA1727: Use PascalCase for named placeholders
 
-|                                     | Value                        |
-| ----------------------------------- | ---------------------------- |
-| **Rule ID**                         | CA1727                       |
-| **Category**                        | [Naming](naming-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                 |
-| **Enabled by default in .NET 7**    | No                           |
+| Property                            | Value                                 |
+|-------------------------------------|---------------------------------------|
+| **Rule ID**                         | CA1727                                |
+| **Title**                           | Use PascalCase for named placeholders |
+| **Category**                        | [Naming](naming-warnings.md)          |
+| **Fix is breaking or non-breaking** | Non-breaking                          |
+| **Enabled by default in .NET 7**    | No                                    |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1801.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1801.md
@@ -15,12 +15,13 @@ ms.author: gewarren
 ---
 # CA1801: Review unused parameters
 
-| | Value |
-|-|-|
-| **Rule ID** |CA1801|
-| **Category** |[Usage](usage-warnings.md)|
-| **Fix is breaking or non-breaking** |Non-breaking - If the member is not visible outside the assembly, regardless of the change you make.<br/><br/>Non-breaking - If you change the member to use the parameter within its body.<br/><br/>Breaking - If you remove the parameter and it is visible outside the assembly.|
-| **Enabled by default in .NET 7** | No |
+| Property                            | Value                                                                                                |
+|-------------------------------------|------------------------------------------------------------------------------------------------------|
+| **Rule ID**                         | CA1801                                                                                               |
+| **Title**                           | Review unused parameters                                                                             |
+| **Category**                        | [Usage](usage-warnings.md)                                                                           |
+| **Fix is breaking or non-breaking** | Non-breaking - If the member is not visible outside the assembly, regardless of the change you make. <br/><br/>Non-breaking - If you change the member to use the parameter within its body.<br/><br/>Breaking - If you remove the parameter and it is visible outside the assembly. |
+| **Enabled by default in .NET 7**    | No                                                                                                   |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1802.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1802.md
@@ -17,9 +17,10 @@ dev_langs:
 ---
 # CA1802: Use Literals Where Appropriate
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
+| Property                            | Value                                  |
+|-------------------------------------|----------------------------------------|
 | **Rule ID**                         | CA1802                                 |
+| **Title**                           | Use Literals Where Appropriate         |
 | **Category**                        | [Performance](performance-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                           |
 | **Enabled by default in .NET 7**    | No                                     |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1805.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1805.md
@@ -14,9 +14,10 @@ ms.author: stoub
 ---
 # CA1805: Do not initialize unnecessarily
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
+| Property                            | Value                                  |
+|-------------------------------------|----------------------------------------|
 | **Rule ID**                         | CA1805                                 |
+| **Title**                           | Do not initialize unnecessarily        |
 | **Category**                        | [Performance](performance-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                           |
 | **Enabled by default in .NET 7**    | No                                     |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1806.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1806.md
@@ -17,9 +17,10 @@ dev_langs:
 ---
 # CA1806: Do not ignore method results
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
+| Property                            | Value                                  |
+|-------------------------------------|----------------------------------------|
 | **Rule ID**                         | CA1806                                 |
+| **Title**                           | Do not ignore method results           |
 | **Category**                        | [Performance](performance-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                           |
 | **Enabled by default in .NET 7**    | No                                     |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1810.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1810.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA1810: Initialize reference type static fields inline
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA1810                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                          |
+|-------------------------------------|------------------------------------------------|
+| **Rule ID**                         | CA1810                                         |
+| **Title**                           | Initialize reference type static fields inline |
+| **Category**                        | [Performance](performance-warnings.md)         |
+| **Fix is breaking or non-breaking** | Non-breaking                                   |
+| **Enabled by default in .NET 7**    | No                                             |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1812.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1812.md
@@ -14,9 +14,10 @@ ms.author: gewarren
 ---
 # CA1812: Avoid uninstantiated internal classes
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
+| Property                            | Value                                  |
+|-------------------------------------|----------------------------------------|
 | **Rule ID**                         | CA1812                                 |
+| **Title**                           | Avoid uninstantiated internal classes  |
 | **Category**                        | [Performance](performance-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                           |
 | **Enabled by default in .NET 7**    | No                                     |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1813.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1813.md
@@ -17,9 +17,10 @@ dev_langs:
 ---
 # CA1813: Avoid unsealed attributes
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
+| Property                            | Value                                  |
+|-------------------------------------|----------------------------------------|
 | **Rule ID**                         | CA1813                                 |
+| **Title**                           | Avoid unsealed attributes              |
 | **Category**                        | [Performance](performance-warnings.md) |
 | **Fix is breaking or non-breaking** | Breaking                               |
 | **Enabled by default in .NET 7**    | No                                     |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1814.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1814.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA1814: Prefer jagged arrays over multidimensional
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA1814                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                               |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                      |
+|-------------------------------------|--------------------------------------------|
+| **Rule ID**                         | CA1814                                     |
+| **Title**                           | Prefer jagged arrays over multidimensional |
+| **Category**                        | [Performance](performance-warnings.md)     |
+| **Fix is breaking or non-breaking** | Breaking                                   |
+| **Enabled by default in .NET 7**    | No                                         |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1815.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1815.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA1815: Override equals and operator equals on value types
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA1815                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                              |
+|-------------------------------------|----------------------------------------------------|
+| **Rule ID**                         | CA1815                                             |
+| **Title**                           | Override equals and operator equals on value types |
+| **Category**                        | [Performance](performance-warnings.md)             |
+| **Fix is breaking or non-breaking** | Non-breaking                                       |
+| **Enabled by default in .NET 7**    | No                                                 |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1816.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1816.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA1816: Call GC.SuppressFinalize correctly
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA1816                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | No                         |
+| Property                            | Value                              |
+|-------------------------------------|------------------------------------|
+| **Rule ID**                         | CA1816                             |
+| **Title**                           | Call GC.SuppressFinalize correctly |
+| **Category**                        | [Usage](usage-warnings.md)         |
+| **Fix is breaking or non-breaking** | Non-breaking                       |
+| **Enabled by default in .NET 7**    | No                                 |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1819.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1819.md
@@ -17,9 +17,10 @@ dev_langs:
 ---
 # CA1819: Properties should not return arrays
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
+| Property                            | Value                                  |
+|-------------------------------------|----------------------------------------|
 | **Rule ID**                         | CA1819                                 |
+| **Title**                           | Properties should not return arrays    |
 | **Category**                        | [Performance](performance-warnings.md) |
 | **Fix is breaking or non-breaking** | Breaking                               |
 | **Enabled by default in .NET 7**    | No                                     |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1820.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1820.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA1820: Test for empty strings using string length
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA1820                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                      |
+|-------------------------------------|--------------------------------------------|
+| **Rule ID**                         | CA1820                                     |
+| **Title**                           | Test for empty strings using string length |
+| **Category**                        | [Performance](performance-warnings.md)     |
+| **Fix is breaking or non-breaking** | Non-breaking                               |
+| **Enabled by default in .NET 7**    | No                                         |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1821.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1821.md
@@ -13,9 +13,10 @@ ms.author: gewarren
 ---
 # CA1821: Remove empty finalizers
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
+| Property                            | Value                                  |
+|-------------------------------------|----------------------------------------|
 | **Rule ID**                         | CA1821                                 |
+| **Title**                           | Remove empty finalizers                |
 | **Category**                        | [Performance](performance-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                           |
 | **Enabled by default in .NET 7**    | No                                     |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1822.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1822.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA1822: Mark members as static
 
-| | Value |
-|-|-|
-| **Rule ID** |CA1822|
-| **Category** |[Performance](performance-warnings.md)|
-| **Fix is breaking or non-breaking** |Non-breaking - If the member is not visible outside the assembly, regardless of the change you make.<br /><br />Non-breaking - If you just change the member to an instance member with the `this` keyword.<br/><br/>Breaking - If you change the member from an instance member to a static member and it is visible outside the assembly.|
-| **Enabled by default in .NET 7** | No |
+| Property                            | Value                                                                                                |
+|-------------------------------------|------------------------------------------------------------------------------------------------------|
+| **Rule ID**                         | CA1822                                                                                               |
+| **Title**                           | Mark members as static                                                                               |
+| **Category**                        | [Performance](performance-warnings.md)                                                               |
+| **Fix is breaking or non-breaking** | Non-breaking - If the member is not visible outside the assembly, regardless of the change you make. <br /><br />Non-breaking - If you just change the member to an instance member with the `this` keyword.<br/><br/>Breaking - If you change the member from an instance member to a static member and it is visible outside the assembly. |
+| **Enabled by default in .NET 7**    | No                                                                                                   |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1823.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1823.md
@@ -14,9 +14,10 @@ ms.author: gewarren
 ---
 # CA1823: Avoid unused private fields
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
+| Property                            | Value                                  |
+|-------------------------------------|----------------------------------------|
 | **Rule ID**                         | CA1823                                 |
+| **Title**                           | Avoid unused private fields            |
 | **Category**                        | [Performance](performance-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                           |
 | **Enabled by default in .NET 7**    | No                                     |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1824.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1824.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA1824: Mark assemblies with NeutralResourcesLanguageAttribute
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA1824                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                                  |
+|-------------------------------------|--------------------------------------------------------|
+| **Rule ID**                         | CA1824                                                 |
+| **Title**                           | Mark assemblies with NeutralResourcesLanguageAttribute |
+| **Category**                        | [Performance](performance-warnings.md)                 |
+| **Fix is breaking or non-breaking** | Non-breaking                                           |
+| **Enabled by default in .NET 7**    | No                                                     |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1825.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1825.md
@@ -16,9 +16,10 @@ dev_langs:
 ---
 # CA1825: Avoid zero-length array allocations
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
+| Property                            | Value                                  |
+|-------------------------------------|----------------------------------------|
 | **Rule ID**                         | CA1825                                 |
+| **Title**                           | Avoid zero-length array allocations    |
 | **Category**                        | [Performance](performance-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                           |
 | **Enabled by default in .NET 7**    | No                                     |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1826.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1826.md
@@ -14,12 +14,13 @@ ms.author: mavasani
 ---
 # CA1826: Use property instead of Linq Enumerable method
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA1826                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                          |
+|-------------------------------------|------------------------------------------------|
+| **Rule ID**                         | CA1826                                         |
+| **Title**                           | Use property instead of Linq Enumerable method |
+| **Category**                        | [Performance](performance-warnings.md)         |
+| **Fix is breaking or non-breaking** | Non-breaking                                   |
+| **Enabled by default in .NET 7**    | No                                             |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1827.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1827.md
@@ -14,12 +14,13 @@ ms.author: mavasani
 ---
 # CA1827: Do not use Count()/LongCount() when Any() can be used
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA1827                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                                 |
+|-------------------------------------|-------------------------------------------------------|
+| **Rule ID**                         | CA1827                                                |
+| **Title**                           | Do not use Count()/LongCount() when Any() can be used |
+| **Category**                        | [Performance](performance-warnings.md)                |
+| **Fix is breaking or non-breaking** | Non-breaking                                          |
+| **Enabled by default in .NET 7**    | No                                                    |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1828.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1828.md
@@ -14,12 +14,13 @@ ms.author: mavasani
 ---
 # CA1828: Do not use CountAsync/LongCountAsync when AnyAsync can be used
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA1828                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                                          |
+|-------------------------------------|----------------------------------------------------------------|
+| **Rule ID**                         | CA1828                                                         |
+| **Title**                           | Do not use CountAsync/LongCountAsync when AnyAsync can be used |
+| **Category**                        | [Performance](performance-warnings.md)                         |
+| **Fix is breaking or non-breaking** | Non-breaking                                                   |
+| **Enabled by default in .NET 7**    | No                                                             |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1829.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1829.md
@@ -14,12 +14,13 @@ ms.author: mavasani
 ---
 # CA1829: Use Length/Count property instead of Enumerable.Count method
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA1829                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                                        |
+|-------------------------------------|--------------------------------------------------------------|
+| **Rule ID**                         | CA1829                                                       |
+| **Title**                           | Use Length/Count property instead of Enumerable.Count method |
+| **Category**                        | [Performance](performance-warnings.md)                       |
+| **Fix is breaking or non-breaking** | Non-breaking                                                 |
+| **Enabled by default in .NET 7**    | No                                                           |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1830.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1830.md
@@ -14,12 +14,13 @@ ms.author: stoub
 ---
 # CA1830: Prefer strongly-typed Append and Insert method overloads on StringBuilder
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA1830                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                                                     |
+|-------------------------------------|---------------------------------------------------------------------------|
+| **Rule ID**                         | CA1830                                                                    |
+| **Title**                           | Prefer strongly-typed Append and Insert method overloads on StringBuilder |
+| **Category**                        | [Performance](performance-warnings.md)                                    |
+| **Fix is breaking or non-breaking** | Non-breaking                                                              |
+| **Enabled by default in .NET 7**    | No                                                                        |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1831.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1831.md
@@ -14,12 +14,13 @@ ms.author: bunamnan
 ---
 # CA1831: Use AsSpan instead of Range-based indexers for string when appropriate
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA1831                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | Yes                                    |
+| Property                            | Value                                                                  |
+|-------------------------------------|------------------------------------------------------------------------|
+| **Rule ID**                         | CA1831                                                                 |
+| **Title**                           | Use AsSpan instead of Range-based indexers for string when appropriate |
+| **Category**                        | [Performance](performance-warnings.md)                                 |
+| **Fix is breaking or non-breaking** | Non-breaking                                                           |
+| **Enabled by default in .NET 7**    | Yes                                                                    |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1832.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1832.md
@@ -14,12 +14,13 @@ ms.author: bunamnan
 ---
 # CA1832: Use AsSpan or AsMemory instead of Range-based indexers for getting ReadOnlySpan or ReadOnlyMemory portion of an array
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA1832                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                                                                                                 |
+|-------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
+| **Rule ID**                         | CA1832                                                                                                                |
+| **Title**                           | Use AsSpan or AsMemory instead of Range-based indexers for getting ReadOnlySpan or ReadOnlyMemory portion of an array |
+| **Category**                        | [Performance](performance-warnings.md)                                                                                |
+| **Fix is breaking or non-breaking** | Non-breaking                                                                                                          |
+| **Enabled by default in .NET 7**    | No                                                                                                                    |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1833.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1833.md
@@ -14,12 +14,13 @@ ms.author: bunamnan
 ---
 # CA1833: Use AsSpan or AsMemory instead of Range-based indexers for getting Span or Memory portion of an array
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA1833                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                                                                                 |
+|-------------------------------------|-------------------------------------------------------------------------------------------------------|
+| **Rule ID**                         | CA1833                                                                                                |
+| **Title**                           | Use AsSpan or AsMemory instead of Range-based indexers for getting Span or Memory portion of an array |
+| **Category**                        | [Performance](performance-warnings.md)                                                                |
+| **Fix is breaking or non-breaking** | Non-breaking                                                                                          |
+| **Enabled by default in .NET 7**    | No                                                                                                    |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1834.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1834.md
@@ -13,12 +13,13 @@ author: pgovind
 ---
 # CA1834: Use StringBuilder.Append(char) for single character strings
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA1834                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                                       |
+|-------------------------------------|-------------------------------------------------------------|
+| **Rule ID**                         | CA1834                                                      |
+| **Title**                           | Use StringBuilder.Append(char) for single character strings |
+| **Category**                        | [Performance](performance-warnings.md)                      |
+| **Fix is breaking or non-breaking** | Non-breaking                                                |
+| **Enabled by default in .NET 7**    | No                                                          |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1835.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1835.md
@@ -17,13 +17,14 @@ dev_langs:
 ---
 # CA1835: Prefer the memory-based overloads of ReadAsync/WriteAsync methods in stream-based classes
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Type name**                       | PreferStreamAsyncMemoryOverloads       |
-| **Rule ID**                         | CA1835                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                                                                     |
+|-------------------------------------|-------------------------------------------------------------------------------------------|
+| **Type name**                       | PreferStreamAsyncMemoryOverloads                                                          |
+| **Rule ID**                         | CA1835                                                                                    |
+| **Title**                           | Prefer the memory-based overloads of ReadAsync/WriteAsync methods in stream-based classes |
+| **Category**                        | [Performance](performance-warnings.md)                                                    |
+| **Fix is breaking or non-breaking** | Non-breaking                                                                              |
+| **Enabled by default in .NET 7**    | No                                                                                        |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1836.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1836.md
@@ -14,12 +14,13 @@ ms.author: dacantu
 ---
 # CA1836: Prefer IsEmpty over Count when available
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA1836                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                    |
+|-------------------------------------|------------------------------------------|
+| **Rule ID**                         | CA1836                                   |
+| **Title**                           | Prefer IsEmpty over Count when available |
+| **Category**                        | [Performance](performance-warnings.md)   |
+| **Fix is breaking or non-breaking** | Non-breaking                             |
+| **Enabled by default in .NET 7**    | No                                       |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1837.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1837.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA1837: Use Environment.ProcessId instead of Process.GetCurrentProcess().Id
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA1837                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                                               |
+|-------------------------------------|---------------------------------------------------------------------|
+| **Rule ID**                         | CA1837                                                              |
+| **Title**                           | Use Environment.ProcessId instead of Process.GetCurrentProcess().Id |
+| **Category**                        | [Performance](performance-warnings.md)                              |
+| **Fix is breaking or non-breaking** | Non-breaking                                                        |
+| **Enabled by default in .NET 7**    | No                                                                  |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1838.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1838.md
@@ -15,12 +15,13 @@ ms.author: elfung
 
 # CA1838: Avoid `StringBuilder` parameters for P/Invokes
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA1838                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                          |
+|-------------------------------------|------------------------------------------------|
+| **Rule ID**                         | CA1838                                         |
+| **Title**                           | Avoid `StringBuilder` parameters for P/Invokes |
+| **Category**                        | [Performance](performance-warnings.md)         |
+| **Fix is breaking or non-breaking** | Non-breaking                                   |
+| **Enabled by default in .NET 7**    | No                                             |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1839.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1839.md
@@ -15,12 +15,13 @@ dev_langs:
 
 # CA1839: Use Environment.ProcessPath instead of Process.GetCurrentProcess().MainModule.FileName
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA1839                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                                                                  |
+|-------------------------------------|----------------------------------------------------------------------------------------|
+| **Rule ID**                         | CA1839                                                                                 |
+| **Title**                           | Use Environment.ProcessPath instead of Process.GetCurrentProcess().MainModule.FileName |
+| **Category**                        | [Performance](performance-warnings.md)                                                 |
+| **Fix is breaking or non-breaking** | Non-breaking                                                                           |
+| **Enabled by default in .NET 7**    | No                                                                                     |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1840.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1840.md
@@ -15,12 +15,13 @@ dev_langs:
 
 # CA1840: Use Environment.CurrentManagedThreadId instead of Thread.CurrentThread.ManagedThreadId
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA1840                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                                                                  |
+|-------------------------------------|----------------------------------------------------------------------------------------|
+| **Rule ID**                         | CA1840                                                                                 |
+| **Title**                           | Use Environment.CurrentManagedThreadId instead of Thread.CurrentThread.ManagedThreadId |
+| **Category**                        | [Performance](performance-warnings.md)                                                 |
+| **Fix is breaking or non-breaking** | Non-breaking                                                                           |
+| **Enabled by default in .NET 7**    | No                                                                                     |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1841.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1841.md
@@ -16,9 +16,10 @@ dev_langs:
 ---
 # CA1841: Prefer Dictionary Contains methods
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
+| Property                            | Value                                  |
+|-------------------------------------|----------------------------------------|
 | **Rule ID**                         | CA1841                                 |
+| **Title**                           | Prefer Dictionary Contains methods     |
 | **Category**                        | [Performance](performance-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                           |
 | **Enabled by default in .NET 7**    | No                                     |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1842.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1842.md
@@ -13,12 +13,13 @@ author: Youssef1313
 ---
 # CA1842: Do not use 'WhenAll' with a single task
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA1842                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                   |
+|-------------------------------------|-----------------------------------------|
+| **Rule ID**                         | CA1842                                  |
+| **Title**                           | Do not use 'WhenAll' with a single task |
+| **Category**                        | [Performance](performance-warnings.md)  |
+| **Fix is breaking or non-breaking** | Non-breaking                            |
+| **Enabled by default in .NET 7**    | No                                      |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1843.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1843.md
@@ -13,12 +13,13 @@ author: Youssef1313
 ---
 # CA1843: Do not use 'WaitAll' with a single task
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA1843                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                   |
+|-------------------------------------|-----------------------------------------|
+| **Rule ID**                         | CA1843                                  |
+| **Title**                           | Do not use 'WaitAll' with a single task |
+| **Category**                        | [Performance](performance-warnings.md)  |
+| **Fix is breaking or non-breaking** | Non-breaking                            |
+| **Enabled by default in .NET 7**    | No                                      |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1844.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1844.md
@@ -16,12 +16,13 @@ dev_langs:
 ---
 # CA1844: Provide memory-based overrides of async methods when subclassing 'Stream'
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA1844                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                                                     |
+|-------------------------------------|---------------------------------------------------------------------------|
+| **Rule ID**                         | CA1844                                                                    |
+| **Title**                           | Provide memory-based overrides of async methods when subclassing 'Stream' |
+| **Category**                        | [Performance](performance-warnings.md)                                    |
+| **Fix is breaking or non-breaking** | Non-breaking                                                              |
+| **Enabled by default in .NET 7**    | No                                                                        |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1845.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1845.md
@@ -15,9 +15,10 @@ dev_langs:
 ---
 # CA1845: Use span-based 'string.Concat'
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
+| Property                            | Value                                  |
+|-------------------------------------|----------------------------------------|
 | **Rule ID**                         | CA1845                                 |
+| **Title**                           | Use span-based 'string.Concat'         |
 | **Category**                        | [Performance](performance-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                           |
 | **Enabled by default in .NET 7**    | No                                     |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1846.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1846.md
@@ -16,9 +16,10 @@ dev_langs:
 ---
 # CA1846: Prefer `AsSpan` over `Substring`
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
+| Property                            | Value                                  |
+|-------------------------------------|----------------------------------------|
 | **Rule ID**                         | CA1846                                 |
+| **Title**                           | Prefer `AsSpan` over `Substring`       |
 | **Category**                        | [Performance](performance-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                           |
 | **Enabled by default in .NET 7**    | No                                     |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1847.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1847.md
@@ -15,12 +15,13 @@ dev_langs:
 
 # CA1847: Use string.Contains(char) instead of string.Contains(string) with single characters
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA1847                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                                                               |
+|-------------------------------------|-------------------------------------------------------------------------------------|
+| **Rule ID**                         | CA1847                                                                              |
+| **Title**                           | Use string.Contains(char) instead of string.Contains(string) with single characters |
+| **Category**                        | [Performance](performance-warnings.md)                                              |
+| **Fix is breaking or non-breaking** | Non-breaking                                                                        |
+| **Enabled by default in .NET 7**    | No                                                                                  |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1848.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1848.md
@@ -13,9 +13,10 @@ author: Youssef1313
 ---
 # CA1848: Use the LoggerMessage delegates
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
+| Property                            | Value                                  |
+|-------------------------------------|----------------------------------------|
 | **Rule ID**                         | CA1848                                 |
+| **Title**                           | Use the LoggerMessage delegates        |
 | **Category**                        | [Performance](performance-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                           |
 | **Enabled by default in .NET 7**    | No                                     |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1849.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1849.md
@@ -13,12 +13,13 @@ author: mahdiva
 ---
 # CA1849: Call async methods when in an async method
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA1849                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                      |
+|-------------------------------------|--------------------------------------------|
+| **Rule ID**                         | CA1849                                     |
+| **Title**                           | Call async methods when in an async method |
+| **Category**                        | [Performance](performance-warnings.md)     |
+| **Fix is breaking or non-breaking** | Non-breaking                               |
+| **Enabled by default in .NET 7**    | No                                         |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1850.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1850.md
@@ -15,12 +15,13 @@ dev_langs:
 
 # CA1850: Prefer static `HashData` method over `ComputeHash`
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA1850                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                              |
+|-------------------------------------|----------------------------------------------------|
+| **Rule ID**                         | CA1850                                             |
+| **Title**                           | Prefer static `HashData` method over `ComputeHash` |
+| **Category**                        | [Performance](performance-warnings.md)             |
+| **Fix is breaking or non-breaking** | Non-breaking                                       |
+| **Enabled by default in .NET 7**    | No                                                 |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1851.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1851.md
@@ -14,13 +14,14 @@ dev_langs:
 
 # CA1851: Possible multiple enumerations of `IEnumerable` collection
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA1851                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Introduced version**              | .NET 7                                 |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                                      |
+|-------------------------------------|------------------------------------------------------------|
+| **Rule ID**                         | CA1851                                                     |
+| **Title**                           | Possible multiple enumerations of `IEnumerable` collection |
+| **Category**                        | [Performance](performance-warnings.md)                     |
+| **Fix is breaking or non-breaking** | Non-breaking                                               |
+| **Introduced version**              | .NET 7                                                     |
+| **Enabled by default in .NET 7**    | No                                                         |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1852.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1852.md
@@ -15,9 +15,10 @@ dev_langs:
 
 # CA1852: Seal internal types
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
+| Property                            | Value                                  |
+|-------------------------------------|----------------------------------------|
 | **Rule ID**                         | CA1852                                 |
+| **Title**                           | Seal internal types                    |
 | **Category**                        | [Performance](performance-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                           |
 | **Introduced version**              | .NET 7                                 |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1853.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1853.md
@@ -15,13 +15,14 @@ dev_langs:
 
 # CA1853: Unnecessary call to 'Dictionary.ContainsKey(key)'
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA1853                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Introduced version**              | .NET 7                                 |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                             |
+|-------------------------------------|---------------------------------------------------|
+| **Rule ID**                         | CA1853                                            |
+| **Title**                           | Unnecessary call to 'Dictionary.ContainsKey(key)' |
+| **Category**                        | [Performance](performance-warnings.md)            |
+| **Fix is breaking or non-breaking** | Non-breaking                                      |
+| **Introduced version**              | .NET 7                                            |
+| **Enabled by default in .NET 7**    | No                                                |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1854.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1854.md
@@ -16,12 +16,13 @@ dev_langs:
 
 # CA1854: Prefer the `IDictionary.TryGetValue(TKey, out TValue)` method
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA1854                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                                         |
+|-------------------------------------|---------------------------------------------------------------|
+| **Rule ID**                         | CA1854                                                        |
+| **Title**                           | Prefer the `IDictionary.TryGetValue(TKey, out TValue)` method |
+| **Category**                        | [Performance](performance-warnings.md)                        |
+| **Fix is breaking or non-breaking** | Non-breaking                                                  |
+| **Enabled by default in .NET 7**    | No                                                            |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1855.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1855.md
@@ -14,12 +14,13 @@ dev_langs:
 
 # CA1855: Use Span\<T>.Clear() instead of Span\<T>.Fill()
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA1855                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                           |
+|-------------------------------------|-------------------------------------------------|
+| **Rule ID**                         | CA1855                                          |
+| **Title**                           | Use Span\<T>.Clear() instead of Span\<T>.Fill() |
+| **Category**                        | [Performance](performance-warnings.md)          |
+| **Fix is breaking or non-breaking** | Non-breaking                                    |
+| **Enabled by default in .NET 7**    | No                                              |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1858.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1858.md
@@ -15,9 +15,10 @@ dev_langs:
 
 # CA1858: Use StartsWith instead of IndexOf
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
+| Property                            | Value                                  |
+|-------------------------------------|----------------------------------------|
 | **Rule ID**                         | CA1858                                 |
+| **Title**                           | Use StartsWith instead of IndexOf      |
 | **Category**                        | [Performance](performance-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                           |
 | **Enabled by default in .NET 7**    | No                                     |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1859.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1859.md
@@ -15,13 +15,14 @@ dev_langs:
 
 # CA1859: Use concrete types when possible for improved performance
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA1859                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Introduced version**              | .NET 8                                 |
-| **Enabled by default in .NET 8**    | No                                     |
+| Property                            | Value                                                     |
+|-------------------------------------|-----------------------------------------------------------|
+| **Rule ID**                         | CA1859                                                    |
+| **Title**                           | Use concrete types when possible for improved performance |
+| **Category**                        | [Performance](performance-warnings.md)                    |
+| **Fix is breaking or non-breaking** | Non-breaking                                              |
+| **Introduced version**              | .NET 8                                                    |
+| **Enabled by default in .NET 8**    | No                                                        |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1860.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1860.md
@@ -15,12 +15,13 @@ dev_langs:
 
 # CA1860: Avoid using 'Enumerable.Any()' extension method
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA1860                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                           |
+|-------------------------------------|-------------------------------------------------|
+| **Rule ID**                         | CA1860                                          |
+| **Title**                           | Avoid using 'Enumerable.Any()' extension method |
+| **Category**                        | [Performance](performance-warnings.md)          |
+| **Fix is breaking or non-breaking** | Non-breaking                                    |
+| **Enabled by default in .NET 7**    | No                                              |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1861.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1861.md
@@ -17,9 +17,10 @@ dev_langs:
 
 # CA1861: Avoid constant arrays as arguments
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
+| Property                            | Value                                  |
+|-------------------------------------|----------------------------------------|
 | **Rule ID**                         | CA1861                                 |
+| **Title**                           | Avoid constant arrays as arguments     |
 | **Category**                        | [Performance](performance-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                           |
 | **Enabled by default in .NET 7**    | No                                     |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1864.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1864.md
@@ -15,12 +15,13 @@ dev_langs:
 
 # CA1864: Prefer the 'IDictionary.TryAdd(TKey, TValue)' method
 
-|                                     | Value                                  |
-| ----------------------------------- |----------------------------------------|
-| **Rule ID**                         | CA1864                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                                |
+|-------------------------------------|------------------------------------------------------|
+| **Rule ID**                         | CA1864                                               |
+| **Title**                           | Prefer the 'IDictionary.TryAdd(TKey, TValue)' method |
+| **Category**                        | [Performance](performance-warnings.md)               |
+| **Fix is breaking or non-breaking** | Non-breaking                                         |
+| **Enabled by default in .NET 7**    | No                                                   |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1865-ca1867.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1865-ca1867.md
@@ -19,12 +19,13 @@ author: mrahhal
 
 # CA1865-CA1867: Use 'string.Method(char)' instead of 'string.Method(string)' for string with single char
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA1865-CA1867                          |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                                                                    |
+|-------------------------------------|------------------------------------------------------------------------------------------|
+| **Rule ID**                         | CA1865-CA1867                                                                            |
+| **Title**                           | Use 'string.Method(char)' instead of 'string.Method(string)' for string with single char |
+| **Category**                        | [Performance](performance-warnings.md)                                                   |
+| **Fix is breaking or non-breaking** | Non-breaking                                                                             |
+| **Enabled by default in .NET 7**    | No                                                                                       |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1868.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1868.md
@@ -16,12 +16,13 @@ dev_langs:
 
 # CA1868: Unnecessary call to 'Contains' for sets
 
-|                                     | Value                                  |
-| ----------------------------------- |----------------------------------------|
-| **Rule ID**                         | CA1868                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                   |
+|-------------------------------------|-----------------------------------------|
+| **Rule ID**                         | CA1868                                  |
+| **Title**                           | Unnecessary call to 'Contains' for sets |
+| **Category**                        | [Performance](performance-warnings.md)  |
+| **Fix is breaking or non-breaking** | Non-breaking                            |
+| **Enabled by default in .NET 7**    | No                                      |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1869.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1869.md
@@ -14,12 +14,13 @@ ms.author: dacantu
 
 # CA1869: Cache and reuse 'JsonSerializerOptions' instances
 
-|                                     | Value                                  |
-| ----------------------------------- |----------------------------------------|
-| **Rule ID**                         | CA1869                                 |
-| **Category**                        | [Performance](performance-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                             |
+|-------------------------------------|---------------------------------------------------|
+| **Rule ID**                         | CA1869                                            |
+| **Title**                           | Cache and reuse 'JsonSerializerOptions' instances |
+| **Category**                        | [Performance](performance-warnings.md)            |
+| **Fix is breaking or non-breaking** | Non-breaking                                      |
+| **Enabled by default in .NET 7**    | No                                                |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2000.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2000.md
@@ -18,9 +18,10 @@ dev_langs:
 ---
 # CA2000: Dispose objects before losing scope
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
+| Property                            | Value                                  |
+|-------------------------------------|----------------------------------------|
 | **Rule ID**                         | CA2000                                 |
+| **Title**                           | Dispose objects before losing scope    |
 | **Category**                        | [Reliability](reliability-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                           |
 | **Enabled by default in .NET 7**    | No                                     |

--- a/docs/fundamentals/code-analysis/quality-rules/ca2002.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2002.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA2002: Do not lock on objects with weak identity
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA2002                                 |
-| **Category**                        | [Reliability](reliability-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                     |
+|-------------------------------------|-------------------------------------------|
+| **Rule ID**                         | CA2002                                    |
+| **Title**                           | Do not lock on objects with weak identity |
+| **Category**                        | [Reliability](reliability-warnings.md)    |
+| **Fix is breaking or non-breaking** | Non-breaking                              |
+| **Enabled by default in .NET 7**    | No                                        |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2007.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2007.md
@@ -15,9 +15,10 @@ dev_langs:
 ---
 # CA2007: Do not directly await a Task
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
+| Property                            | Value                                  |
+|-------------------------------------|----------------------------------------|
 | **Rule ID**                         | CA2007                                 |
+| **Title**                           | Do not directly await a Task           |
 | **Category**                        | [Reliability](reliability-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                           |
 | **Enabled by default in .NET 7**    | No                                     |

--- a/docs/fundamentals/code-analysis/quality-rules/ca2008.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2008.md
@@ -13,12 +13,13 @@ ms.author: gewarren
 ---
 # CA2008: Do not create tasks without passing a TaskScheduler
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA2008                                 |
-| **Category**                        | [Reliability](reliability-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                               |
+|-------------------------------------|-----------------------------------------------------|
+| **Rule ID**                         | CA2008                                              |
+| **Title**                           | Do not create tasks without passing a TaskScheduler |
+| **Category**                        | [Reliability](reliability-warnings.md)              |
+| **Fix is breaking or non-breaking** | Non-breaking                                        |
+| **Enabled by default in .NET 7**    | No                                                  |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2009.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2009.md
@@ -13,12 +13,13 @@ ms.author: mavasani
 ---
 # CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA2009                                 |
-| **Category**                        | [Reliability](reliability-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                                             |
+|-------------------------------------|-------------------------------------------------------------------|
+| **Rule ID**                         | CA2009                                                            |
+| **Title**                           | Do not call ToImmutableCollection on an ImmutableCollection value |
+| **Category**                        | [Reliability](reliability-warnings.md)                            |
+| **Fix is breaking or non-breaking** | Non-breaking                                                      |
+| **Enabled by default in .NET 7**    | No                                                                |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2011.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2011.md
@@ -12,12 +12,13 @@ ms.author: mavasani
 ---
 # CA2011: Do not assign property within its setter
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA2011                                 |
-| **Category**                        | [Reliability](reliability-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                    |
+|-------------------------------------|------------------------------------------|
+| **Rule ID**                         | CA2011                                   |
+| **Title**                           | Do not assign property within its setter |
+| **Category**                        | [Reliability](reliability-warnings.md)   |
+| **Fix is breaking or non-breaking** | Non-breaking                             |
+| **Enabled by default in .NET 7**    | No                                       |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2012.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2012.md
@@ -14,9 +14,10 @@ ms.author: stoub
 ---
 # CA2012: Use ValueTasks correctly
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
+| Property                            | Value                                  |
+|-------------------------------------|----------------------------------------|
 | **Rule ID**                         | CA2012                                 |
+| **Title**                           | Use ValueTasks correctly               |
 | **Category**                        | [Reliability](reliability-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                           |
 | **Enabled by default in .NET 7**    | No                                     |

--- a/docs/fundamentals/code-analysis/quality-rules/ca2013.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2013.md
@@ -14,12 +14,13 @@ ms.author: bunamnan
 ---
 # CA2013: Do not use ReferenceEquals with value types
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA2013                                 |
-| **Category**                        | [Reliability](reliability-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | Yes                                    |
+| Property                            | Value                                       |
+|-------------------------------------|---------------------------------------------|
+| **Rule ID**                         | CA2013                                      |
+| **Title**                           | Do not use ReferenceEquals with value types |
+| **Category**                        | [Reliability](reliability-warnings.md)      |
+| **Fix is breaking or non-breaking** | Non-breaking                                |
+| **Enabled by default in .NET 7**    | Yes                                         |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2014.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2014.md
@@ -14,9 +14,10 @@ ms.author: stoub
 ---
 # CA2014: Do not use stackalloc in loops
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
+| Property                            | Value                                  |
+|-------------------------------------|----------------------------------------|
 | **Rule ID**                         | CA2014                                 |
+| **Title**                           | Do not use stackalloc in loops         |
 | **Category**                        | [Reliability](reliability-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                           |
 | **Enabled by default in .NET 7**    | Yes                                    |

--- a/docs/fundamentals/code-analysis/quality-rules/ca2015.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2015.md
@@ -14,12 +14,13 @@ ms.author: bunamnan
 ---
 # CA2015: Do not define finalizers for types derived from MemoryManager&lt;T&gt;
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA2015                                 |
-| **Category**                        | [Reliability](reliability-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | Yes                                    |
+| Property                            | Value                                                                  |
+|-------------------------------------|------------------------------------------------------------------------|
+| **Rule ID**                         | CA2015                                                                 |
+| **Title**                           | Do not define finalizers for types derived from MemoryManager&lt;T&gt; |
+| **Category**                        | [Reliability](reliability-warnings.md)                                 |
+| **Fix is breaking or non-breaking** | Non-breaking                                                           |
+| **Enabled by default in .NET 7**    | Yes                                                                    |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2016.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2016.md
@@ -17,13 +17,14 @@ dev_langs:
 ---
 # CA2016: Forward the CancellationToken parameter to methods that take one
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Type name**                       | ForwardCancellationTokenToInvocations  |
-| **Rule ID**                         | CA2016                                 |
-| **Category**                        | [Reliability](reliability-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                                            |
+|-------------------------------------|------------------------------------------------------------------|
+| **Type name**                       | ForwardCancellationTokenToInvocations                            |
+| **Rule ID**                         | CA2016                                                           |
+| **Title**                           | Forward the CancellationToken parameter to methods that take one |
+| **Category**                        | [Reliability](reliability-warnings.md)                           |
+| **Fix is breaking or non-breaking** | Non-breaking                                                     |
+| **Enabled by default in .NET 7**    | No                                                               |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2017.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2017.md
@@ -13,9 +13,10 @@ author: Youssef1313
 ---
 # CA2017: Parameter count mismatch
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
+| Property                            | Value                                  |
+|-------------------------------------|----------------------------------------|
 | **Rule ID**                         | CA2017                                 |
+| **Title**                           | Parameter count mismatch               |
 | **Category**                        | [Reliability](reliability-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                           |
 | **Enabled by default in .NET 7**    | Yes                                    |

--- a/docs/fundamentals/code-analysis/quality-rules/ca2018.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2018.md
@@ -13,12 +13,13 @@ author: mahdiva
 ---
 # CA2018: The `count` argument to `Buffer.BlockCopy` should specify the number of bytes to copy
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA2018                                 |
-| **Category**                        | [Reliability](reliability-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | Yes                                    |
+| Property                            | Value                                                                                 |
+|-------------------------------------|---------------------------------------------------------------------------------------|
+| **Rule ID**                         | CA2018                                                                                |
+| **Title**                           | The `count` argument to `Buffer.BlockCopy` should specify the number of bytes to copy |
+| **Category**                        | [Reliability](reliability-warnings.md)                                                |
+| **Fix is breaking or non-breaking** | Non-breaking                                                                          |
+| **Enabled by default in .NET 7**    | Yes                                                                                   |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2019.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2019.md
@@ -13,12 +13,13 @@ dev_langs:
 ---
 # CA2019: `ThreadStatic` fields should not use inline initialization
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA2019                                 |
-| **Category**                        | [Reliability](reliability-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                                      |
+|-------------------------------------|------------------------------------------------------------|
+| **Rule ID**                         | CA2019                                                     |
+| **Title**                           | `ThreadStatic` fields should not use inline initialization |
+| **Category**                        | [Reliability](reliability-warnings.md)                     |
+| **Fix is breaking or non-breaking** | Non-breaking                                               |
+| **Enabled by default in .NET 7**    | No                                                         |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2020.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2020.md
@@ -13,12 +13,13 @@ author: buyaa-n
 ---
 # CA2020: Prevent behavioral change caused by built-in operators of IntPtr/UIntPtr
 
-|                                     | Value                                  |
-| ----------------------------------- | -------------------------------------- |
-| **Rule ID**                         | CA2020                                 |
-| **Category**                        | [Reliability](reliability-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 7**    | No                                     |
+| Property                            | Value                                                                    |
+|-------------------------------------|--------------------------------------------------------------------------|
+| **Rule ID**                         | CA2020                                                                   |
+| **Title**                           | Prevent behavioral change caused by built-in operators of IntPtr/UIntPtr |
+| **Category**                        | [Reliability](reliability-warnings.md)                                   |
+| **Fix is breaking or non-breaking** | Non-breaking                                                             |
+| **Enabled by default in .NET 7**    | No                                                                       |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2100.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2100.md
@@ -18,12 +18,13 @@ dev_langs:
 ---
 # CA2100: Review SQL queries for security vulnerabilities
 
-|                                     | Value                            |
-| ----------------------------------- | -------------------------------- |
-| **Rule ID**                         | CA2100                           |
-| **Category**                        | [Security](security-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                     |
-| **Enabled by default in .NET 7**    | No                               |
+| Property                            | Value                                           |
+|-------------------------------------|-------------------------------------------------|
+| **Rule ID**                         | CA2100                                          |
+| **Title**                           | Review SQL queries for security vulnerabilities |
+| **Category**                        | [Security](security-warnings.md)                |
+| **Fix is breaking or non-breaking** | Non-breaking                                    |
+| **Enabled by default in .NET 7**    | No                                              |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2101.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2101.md
@@ -15,12 +15,13 @@ dev_langs:
 ---
 # CA2101: Specify marshalling for P/Invoke string arguments
 
-|                                     | Value                                      |
-| ----------------------------------- | ------------------------------------------ |
-| **Rule ID**                         | CA2101                                     |
-| **Category**                        | [Globalization](globalization-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                               |
-| **Enabled by default in .NET 7**    | No                                         |
+| Property                            | Value                                             |
+|-------------------------------------|---------------------------------------------------|
+| **Rule ID**                         | CA2101                                            |
+| **Title**                           | Specify marshalling for P/Invoke string arguments |
+| **Category**                        | [Globalization](globalization-warnings.md)        |
+| **Fix is breaking or non-breaking** | Non-breaking                                      |
+| **Enabled by default in .NET 7**    | No                                                |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2109.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2109.md
@@ -14,9 +14,10 @@ ms.author: gewarren
 ---
 # CA2109: Review visible event handlers
 
-|                                     | Value                            |
-| ----------------------------------- | -------------------------------- |
+| Property                            | Value                            |
+|-------------------------------------|----------------------------------|
 | **Rule ID**                         | CA2109                           |
+| **Title**                           | Review visible event handlers    |
 | **Category**                        | [Security](security-warnings.md) |
 | **Fix is breaking or non-breaking** | Breaking                         |
 | **Enabled by default in .NET 7**    | No                               |

--- a/docs/fundamentals/code-analysis/quality-rules/ca2119.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2119.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA2119: Seal methods that satisfy private interfaces
 
-|                                     | Value                            |
-| ----------------------------------- | -------------------------------- |
-| **Rule ID**                         | CA2119                           |
-| **Category**                        | [Security](security-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                         |
-| **Enabled by default in .NET 7**    | No                               |
+| Property                            | Value                                        |
+|-------------------------------------|----------------------------------------------|
+| **Rule ID**                         | CA2119                                       |
+| **Title**                           | Seal methods that satisfy private interfaces |
+| **Category**                        | [Security](security-warnings.md)             |
+| **Fix is breaking or non-breaking** | Breaking                                     |
+| **Enabled by default in .NET 7**    | No                                           |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2153.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2153.md
@@ -8,12 +8,13 @@ ms.author: gewarren
 ---
 # CA2153: Avoid handling Corrupted State Exceptions
 
-|                                     | Value                            |
-| ----------------------------------- | -------------------------------- |
-| **Rule ID**                         | CA2153                           |
-| **Category**                        | [Security](security-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                     |
-| **Enabled by default in .NET 7**    | No                               |
+| Property                            | Value                                     |
+|-------------------------------------|-------------------------------------------|
+| **Rule ID**                         | CA2153                                    |
+| **Title**                           | Avoid handling Corrupted State Exceptions |
+| **Category**                        | [Security](security-warnings.md)          |
+| **Fix is breaking or non-breaking** | Non-breaking                              |
+| **Enabled by default in .NET 7**    | No                                        |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2200.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2200.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA2200: Rethrow to preserve stack details
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2200                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | Yes                        |
+| Property                            | Value                             |
+|-------------------------------------|-----------------------------------|
+| **Rule ID**                         | CA2200                            |
+| **Title**                           | Rethrow to preserve stack details |
+| **Category**                        | [Usage](usage-warnings.md)        |
+| **Fix is breaking or non-breaking** | Non-breaking                      |
+| **Enabled by default in .NET 7**    | Yes                               |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2201.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2201.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA2201: Do not raise reserved exception types
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2201                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                   |
-| **Enabled by default in .NET 7**    | No                         |
+| Property                            | Value                                 |
+|-------------------------------------|---------------------------------------|
+| **Rule ID**                         | CA2201                                |
+| **Title**                           | Do not raise reserved exception types |
+| **Category**                        | [Usage](usage-warnings.md)            |
+| **Fix is breaking or non-breaking** | Breaking                              |
+| **Enabled by default in .NET 7**    | No                                    |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2207.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2207.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA2207: Initialize value type static fields inline
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2207                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | No                         |
+| Property                            | Value                                      |
+|-------------------------------------|--------------------------------------------|
+| **Rule ID**                         | CA2207                                     |
+| **Title**                           | Initialize value type static fields inline |
+| **Category**                        | [Usage](usage-warnings.md)                 |
+| **Fix is breaking or non-breaking** | Non-breaking                               |
+| **Enabled by default in .NET 7**    | No                                         |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2208.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2208.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA2208: Instantiate argument exceptions correctly
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2208                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | No                         |
+| Property                            | Value                                     |
+|-------------------------------------|-------------------------------------------|
+| **Rule ID**                         | CA2208                                    |
+| **Title**                           | Instantiate argument exceptions correctly |
+| **Category**                        | [Usage](usage-warnings.md)                |
+| **Fix is breaking or non-breaking** | Non-breaking                              |
+| **Enabled by default in .NET 7**    | No                                        |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2211.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2211.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA2211: Non-constant fields should not be visible
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2211                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                   |
-| **Enabled by default in .NET 7**    | No                         |
+| Property                            | Value                                     |
+|-------------------------------------|-------------------------------------------|
+| **Rule ID**                         | CA2211                                    |
+| **Title**                           | Non-constant fields should not be visible |
+| **Category**                        | [Usage](usage-warnings.md)                |
+| **Fix is breaking or non-breaking** | Breaking                                  |
+| **Enabled by default in .NET 7**    | No                                        |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2213.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2213.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA2213: Disposable fields should be disposed
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2213                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | No                         |
+| Property                            | Value                                |
+|-------------------------------------|--------------------------------------|
+| **Rule ID**                         | CA2213                               |
+| **Title**                           | Disposable fields should be disposed |
+| **Category**                        | [Usage](usage-warnings.md)           |
+| **Fix is breaking or non-breaking** | Non-breaking                         |
+| **Enabled by default in .NET 7**    | No                                   |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2214.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2214.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA2214: Do not call overridable methods in constructors
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2214                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | No                         |
+| Property                            | Value                                           |
+|-------------------------------------|-------------------------------------------------|
+| **Rule ID**                         | CA2214                                          |
+| **Title**                           | Do not call overridable methods in constructors |
+| **Category**                        | [Usage](usage-warnings.md)                      |
+| **Fix is breaking or non-breaking** | Non-breaking                                    |
+| **Enabled by default in .NET 7**    | No                                              |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2215.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2215.md
@@ -18,12 +18,13 @@ dev_langs:
 ---
 # CA2215: Dispose methods should call base class dispose
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2215                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | No                         |
+| Property                            | Value                                          |
+|-------------------------------------|------------------------------------------------|
+| **Rule ID**                         | CA2215                                         |
+| **Title**                           | Dispose methods should call base class dispose |
+| **Category**                        | [Usage](usage-warnings.md)                     |
+| **Fix is breaking or non-breaking** | Non-breaking                                   |
+| **Enabled by default in .NET 7**    | No                                             |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2216.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2216.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA2216: Disposable types should declare finalizer
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2216                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | No                         |
+| Property                            | Value                                     |
+|-------------------------------------|-------------------------------------------|
+| **Rule ID**                         | CA2216                                    |
+| **Title**                           | Disposable types should declare finalizer |
+| **Category**                        | [Usage](usage-warnings.md)                |
+| **Fix is breaking or non-breaking** | Non-breaking                              |
+| **Enabled by default in .NET 7**    | No                                        |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2217.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2217.md
@@ -17,12 +17,13 @@ ms.author: gewarren
 ---
 # CA2217: Do not mark enums with FlagsAttribute
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2217                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | No                         |
+| Property                            | Value                                 |
+|-------------------------------------|---------------------------------------|
+| **Rule ID**                         | CA2217                                |
+| **Title**                           | Do not mark enums with FlagsAttribute |
+| **Category**                        | [Usage](usage-warnings.md)            |
+| **Fix is breaking or non-breaking** | Non-breaking                          |
+| **Enabled by default in .NET 7**    | No                                    |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2218.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2218.md
@@ -14,12 +14,13 @@ dev_langs:
 ---
 # CA2218: Override GetHashCode on overriding Equals
 
-| Item                             | Value                      |
-| -------------------------------- | -------------------------- |
-| Rule ID                          | CA2218                     |
-| Category                         | [Usage](usage-warnings.md) |
-| Fix is breaking or non-breaking  | Non-breaking               |
-| Enabled by default in .NET 7     | No                         |
+| Property                            | Value                                     |
+|-------------------------------------|-------------------------------------------|
+| **Rule ID**                         | CA2218                                    |
+| **Title**                           | Override GetHashCode on overriding Equals |
+| **Category**                        | [Usage](usage-warnings.md)                |
+| **Fix is breaking or non-breaking** | Non-breaking                              |
+| **Enabled by default in .NET 7**    | No                                        |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2219.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2219.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA2219: Do not raise exceptions in exception clauses
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2219                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking, Breaking     |
-| **Enabled by default in .NET 7**    | No                         |
+| Property                            | Value                                        |
+|-------------------------------------|----------------------------------------------|
+| **Rule ID**                         | CA2219                                       |
+| **Title**                           | Do not raise exceptions in exception clauses |
+| **Category**                        | [Usage](usage-warnings.md)                   |
+| **Fix is breaking or non-breaking** | Non-breaking, Breaking                       |
+| **Enabled by default in .NET 7**    | No                                           |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2224.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2224.md
@@ -13,12 +13,13 @@ helpviewer_keywords:
 ---
 # CA2224: Override Equals on overloading operator equals
 
-| Item                             | Value                      |
-| -------------------------------- | -------------------------- |
-| Rule ID                          | CA2224                     |
-| Category                         | [Usage](usage-warnings.md) |
-| Fix is breaking or non-breaking  | Non-breaking               |
-| Enabled by default in .NET 7     | No                         |
+| Property                            | Value                                          |
+|-------------------------------------|------------------------------------------------|
+| **Rule ID**                         | CA2224                                         |
+| **Title**                           | Override Equals on overloading operator equals |
+| **Category**                        | [Usage](usage-warnings.md)                     |
+| **Fix is breaking or non-breaking** | Non-breaking                                   |
+| **Enabled by default in .NET 7**    | No                                             |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2225.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2225.md
@@ -16,12 +16,13 @@ dev_langs:
 ---
 # CA2225: Operator overloads have named alternates
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2225                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | No                         |
+| Property                            | Value                                    |
+|-------------------------------------|------------------------------------------|
+| **Rule ID**                         | CA2225                                   |
+| **Title**                           | Operator overloads have named alternates |
+| **Category**                        | [Usage](usage-warnings.md)               |
+| **Fix is breaking or non-breaking** | Non-breaking                             |
+| **Enabled by default in .NET 7**    | No                                       |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2226.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2226.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA2226: Operators should have symmetrical overloads
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2226                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | No                         |
+| Property                            | Value                                       |
+|-------------------------------------|---------------------------------------------|
+| **Rule ID**                         | CA2226                                      |
+| **Title**                           | Operators should have symmetrical overloads |
+| **Category**                        | [Usage](usage-warnings.md)                  |
+| **Fix is breaking or non-breaking** | Non-breaking                                |
+| **Enabled by default in .NET 7**    | No                                          |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2227.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2227.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA2227: Collection properties should be read only
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2227                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Breaking                   |
-| **Enabled by default in .NET 7**    | No                         |
+| Property                            | Value                                     |
+|-------------------------------------|-------------------------------------------|
+| **Rule ID**                         | CA2227                                    |
+| **Title**                           | Collection properties should be read only |
+| **Category**                        | [Usage](usage-warnings.md)                |
+| **Fix is breaking or non-breaking** | Breaking                                  |
+| **Enabled by default in .NET 7**    | No                                        |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2229.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2229.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA2229: Implement serialization constructors
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2229                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | No                         |
+| Property                            | Value                                |
+|-------------------------------------|--------------------------------------|
+| **Rule ID**                         | CA2229                               |
+| **Title**                           | Implement serialization constructors |
+| **Category**                        | [Usage](usage-warnings.md)           |
+| **Fix is breaking or non-breaking** | Non-breaking                         |
+| **Enabled by default in .NET 7**    | No                                   |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2231.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2231.md
@@ -18,12 +18,13 @@ dev_langs:
 ---
 # CA2231: Overload operator equals on overriding ValueType.Equals
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2231                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | No                         |
+| Property                            | Value                                                   |
+|-------------------------------------|---------------------------------------------------------|
+| **Rule ID**                         | CA2231                                                  |
+| **Title**                           | Overload operator equals on overriding ValueType.Equals |
+| **Category**                        | [Usage](usage-warnings.md)                              |
+| **Fix is breaking or non-breaking** | Non-breaking                                            |
+| **Enabled by default in .NET 7**    | No                                                      |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2234.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2234.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA2234: Pass System.Uri objects instead of strings
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2234                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | No                         |
+| Property                            | Value                                      |
+|-------------------------------------|--------------------------------------------|
+| **Rule ID**                         | CA2234                                     |
+| **Title**                           | Pass System.Uri objects instead of strings |
+| **Category**                        | [Usage](usage-warnings.md)                 |
+| **Fix is breaking or non-breaking** | Non-breaking                               |
+| **Enabled by default in .NET 7**    | No                                         |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2235.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2235.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA2235: Mark all non-serializable fields
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2235                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | No                         |
+| Property                            | Value                            |
+|-------------------------------------|----------------------------------|
+| **Rule ID**                         | CA2235                           |
+| **Title**                           | Mark all non-serializable fields |
+| **Category**                        | [Usage](usage-warnings.md)       |
+| **Fix is breaking or non-breaking** | Non-breaking                     |
+| **Enabled by default in .NET 7**    | No                               |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2237.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2237.md
@@ -17,12 +17,13 @@ dev_langs:
 ---
 # CA2237: Mark ISerializable types with SerializableAttribute
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2237                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | No                         |
+| Property                            | Value                                               |
+|-------------------------------------|-----------------------------------------------------|
+| **Rule ID**                         | CA2237                                              |
+| **Title**                           | Mark ISerializable types with SerializableAttribute |
+| **Category**                        | [Usage](usage-warnings.md)                          |
+| **Fix is breaking or non-breaking** | Non-breaking                                        |
+| **Enabled by default in .NET 7**    | No                                                  |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2241.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2241.md
@@ -18,12 +18,13 @@ dev_langs:
 ---
 # CA2241: Provide correct arguments to formatting methods
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2241                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | No                         |
+| Property                            | Value                                           |
+|-------------------------------------|-------------------------------------------------|
+| **Rule ID**                         | CA2241                                          |
+| **Title**                           | Provide correct arguments to formatting methods |
+| **Category**                        | [Usage](usage-warnings.md)                      |
+| **Fix is breaking or non-breaking** | Non-breaking                                    |
+| **Enabled by default in .NET 7**    | No                                              |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2242.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2242.md
@@ -16,9 +16,10 @@ dev_langs:
 ---
 # CA2242: Test for NaN correctly
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
+| Property                            | Value                      |
+|-------------------------------------|----------------------------|
 | **Rule ID**                         | CA2242                     |
+| **Title**                           | Test for NaN correctly     |
 | **Category**                        | [Usage](usage-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking               |
 | **Enabled by default in .NET 7**    | No                         |

--- a/docs/fundamentals/code-analysis/quality-rules/ca2243.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2243.md
@@ -14,12 +14,13 @@ ms.author: gewarren
 ---
 # CA2243: Attribute string literals should parse correctly
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2243                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | No                         |
+| Property                            | Value                                            |
+|-------------------------------------|--------------------------------------------------|
+| **Rule ID**                         | CA2243                                           |
+| **Title**                           | Attribute string literals should parse correctly |
+| **Category**                        | [Usage](usage-warnings.md)                       |
+| **Fix is breaking or non-breaking** | Non-breaking                                     |
+| **Enabled by default in .NET 7**    | No                                               |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2244.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2244.md
@@ -12,12 +12,13 @@ ms.author: mavasani
 ---
 # CA2244: Do not duplicate indexed element initializations
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2244                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | No                         |
+| Property                            | Value                                            |
+|-------------------------------------|--------------------------------------------------|
+| **Rule ID**                         | CA2244                                           |
+| **Title**                           | Do not duplicate indexed element initializations |
+| **Category**                        | [Usage](usage-warnings.md)                       |
+| **Fix is breaking or non-breaking** | Non-breaking                                     |
+| **Enabled by default in .NET 7**    | No                                               |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2245.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2245.md
@@ -12,12 +12,13 @@ ms.author: mavasani
 ---
 # CA2245: Do not assign a property to itself
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2245                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | No                         |
+| Property                            | Value                              |
+|-------------------------------------|------------------------------------|
+| **Rule ID**                         | CA2245                             |
+| **Title**                           | Do not assign a property to itself |
+| **Category**                        | [Usage](usage-warnings.md)         |
+| **Fix is breaking or non-breaking** | Non-breaking                       |
+| **Enabled by default in .NET 7**    | No                                 |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2246.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2246.md
@@ -12,12 +12,13 @@ ms.author: mavasani
 ---
 # CA2246: Do not assign a symbol and its member in the same statement
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2246                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | No                         |
+| Property                            | Value                                                       |
+|-------------------------------------|-------------------------------------------------------------|
+| **Rule ID**                         | CA2246                                                      |
+| **Title**                           | Do not assign a symbol and its member in the same statement |
+| **Category**                        | [Usage](usage-warnings.md)                                  |
+| **Fix is breaking or non-breaking** | Non-breaking                                                |
+| **Enabled by default in .NET 7**    | No                                                          |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2247.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2247.md
@@ -14,12 +14,13 @@ ms.author: stoub
 ---
 # CA2247: Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2247                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | Yes                        |
+| Property                            | Value                                                                                                                          |
+|-------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| **Rule ID**                         | CA2247                                                                                                                         |
+| **Title**                           | Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum |
+| **Category**                        | [Usage](usage-warnings.md)                                                                                                     |
+| **Fix is breaking or non-breaking** | Non-breaking                                                                                                                   |
+| **Enabled by default in .NET 7**    | Yes                                                                                                                            |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2248.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2248.md
@@ -12,12 +12,13 @@ ms.author: mavasani
 ---
 # CA2248: Provide correct enum argument to Enum.HasFlag
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2248                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | No                         |
+| Property                            | Value                                         |
+|-------------------------------------|-----------------------------------------------|
+| **Rule ID**                         | CA2248                                        |
+| **Title**                           | Provide correct enum argument to Enum.HasFlag |
+| **Category**                        | [Usage](usage-warnings.md)                    |
+| **Fix is breaking or non-breaking** | Non-breaking                                  |
+| **Enabled by default in .NET 7**    | No                                            |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2249.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2249.md
@@ -11,12 +11,13 @@ author: pgovind
 ---
 # CA2249: Consider using String.Contains instead of String.IndexOf
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2249                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | No                         |
+| Property                            | Value                                                    |
+|-------------------------------------|----------------------------------------------------------|
+| **Rule ID**                         | CA2249                                                   |
+| **Title**                           | Consider using String.Contains instead of String.IndexOf |
+| **Category**                        | [Usage](usage-warnings.md)                               |
+| **Fix is breaking or non-breaking** | Non-breaking                                             |
+| **Enabled by default in .NET 7**    | No                                                       |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2250.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2250.md
@@ -16,12 +16,13 @@ dev_langs:
 ---
 # CA2250: Use `ThrowIfCancellationRequested`
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2250                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | No                         |
+| Property                            | Value                              |
+|-------------------------------------|------------------------------------|
+| **Rule ID**                         | CA2250                             |
+| **Title**                           | Use `ThrowIfCancellationRequested` |
+| **Category**                        | [Usage](usage-warnings.md)         |
+| **Fix is breaking or non-breaking** | Non-breaking                       |
+| **Enabled by default in .NET 7**    | No                                 |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2251.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2251.md
@@ -13,12 +13,13 @@ author: NewellClark
 ---
 # CA2251: Use `String.Equals` over `String.Compare`
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2251                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | No                         |
+| Property                            | Value                                     |
+|-------------------------------------|-------------------------------------------|
+| **Rule ID**                         | CA2251                                    |
+| **Title**                           | Use `String.Equals` over `String.Compare` |
+| **Category**                        | [Usage](usage-warnings.md)                |
+| **Fix is breaking or non-breaking** | Non-breaking                              |
+| **Enabled by default in .NET 7**    | No                                        |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2252.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2252.md
@@ -15,12 +15,13 @@ dev_langs:
 ---
 # CA2252: Opt in to preview features before using them
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2252                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | Yes                        |
+| Property                            | Value                                        |
+|-------------------------------------|----------------------------------------------|
+| **Rule ID**                         | CA2252                                       |
+| **Title**                           | Opt in to preview features before using them |
+| **Category**                        | [Usage](usage-warnings.md)                   |
+| **Fix is breaking or non-breaking** | Non-breaking                                 |
+| **Enabled by default in .NET 7**    | Yes                                          |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2253.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2253.md
@@ -13,12 +13,13 @@ author: Youssef1313
 ---
 # CA2253: Named placeholders should not be numeric values
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2253                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | No                         |
+| Property                            | Value                                           |
+|-------------------------------------|-------------------------------------------------|
+| **Rule ID**                         | CA2253                                          |
+| **Title**                           | Named placeholders should not be numeric values |
+| **Category**                        | [Usage](usage-warnings.md)                      |
+| **Fix is breaking or non-breaking** | Non-breaking                                    |
+| **Enabled by default in .NET 7**    | No                                              |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2254.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2254.md
@@ -13,12 +13,13 @@ author: Youssef1313
 ---
 # CA2254: Template should be a static expression
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2254                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | No                         |
+| Property                            | Value                                  |
+|-------------------------------------|----------------------------------------|
+| **Rule ID**                         | CA2254                                 |
+| **Title**                           | Template should be a static expression |
+| **Category**                        | [Usage](usage-warnings.md)             |
+| **Fix is breaking or non-breaking** | Non-breaking                           |
+| **Enabled by default in .NET 7**    | No                                     |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2255.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2255.md
@@ -13,12 +13,13 @@ author: jeffhandley
 ---
 # CA2255: The `ModuleInitializer` attribute should not be used in libraries
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2255                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | Yes                        |
+| Property                            | Value                                                             |
+|-------------------------------------|-------------------------------------------------------------------|
+| **Rule ID**                         | CA2255                                                            |
+| **Title**                           | The `ModuleInitializer` attribute should not be used in libraries |
+| **Category**                        | [Usage](usage-warnings.md)                                        |
+| **Fix is breaking or non-breaking** | Non-breaking                                                      |
+| **Enabled by default in .NET 7**    | Yes                                                               |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2256.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2256.md
@@ -13,12 +13,13 @@ author: Youssef1313
 ---
 # CA2256: All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2256                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | Yes                        |
+| Property                            | Value                                                                                                                                  |
+|-------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
+| **Rule ID**                         | CA2256                                                                                                                                 |
+| **Title**                           | All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface |
+| **Category**                        | [Usage](usage-warnings.md)                                                                                                             |
+| **Fix is breaking or non-breaking** | Non-breaking                                                                                                                           |
+| **Enabled by default in .NET 7**    | Yes                                                                                                                                    |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2257.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2257.md
@@ -13,12 +13,13 @@ author: Youssef1313
 ---
 # CA2257: Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2257                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | Yes                        |
+| Property                            | Value                                                                                                         |
+|-------------------------------------|---------------------------------------------------------------------------------------------------------------|
+| **Rule ID**                         | CA2257                                                                                                        |
+| **Title**                           | Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static' |
+| **Category**                        | [Usage](usage-warnings.md)                                                                                    |
+| **Fix is breaking or non-breaking** | Non-breaking                                                                                                  |
+| **Enabled by default in .NET 7**    | Yes                                                                                                           |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2258.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2258.md
@@ -13,12 +13,13 @@ author: Youssef1313
 ---
 # CA2258: Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2258                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | Yes                        |
+| Property                            | Value                                                                                         |
+|-------------------------------------|-----------------------------------------------------------------------------------------------|
+| **Rule ID**                         | CA2258                                                                                        |
+| **Title**                           | Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported |
+| **Category**                        | [Usage](usage-warnings.md)                                                                    |
+| **Fix is breaking or non-breaking** | Non-breaking                                                                                  |
+| **Enabled by default in .NET 7**    | Yes                                                                                           |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2259.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2259.md
@@ -13,12 +13,13 @@ dev_langs:
 ---
 # CA2259: Ensure `ThreadStatic` is only used with static fields
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2259                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | Yes                        |
+| Property                            | Value                                                 |
+|-------------------------------------|-------------------------------------------------------|
+| **Rule ID**                         | CA2259                                                |
+| **Title**                           | Ensure `ThreadStatic` is only used with static fields |
+| **Category**                        | [Usage](usage-warnings.md)                            |
+| **Fix is breaking or non-breaking** | Non-breaking                                          |
+| **Enabled by default in .NET 7**    | Yes                                                   |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2260.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2260.md
@@ -13,12 +13,13 @@ author: buyaa-n
 ---
 # CA2260: Implement generic math interfaces correctly
 
-|                                     | Value                      |
-| ----------------------------------- | -------------------------- |
-| **Rule ID**                         | CA2260                     |
-| **Category**                        | [Usage](usage-warnings.md) |
-| **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 7**    | Yes                        |
+| Property                            | Value                                       |
+|-------------------------------------|---------------------------------------------|
+| **Rule ID**                         | CA2260                                      |
+| **Title**                           | Implement generic math interfaces correctly |
+| **Category**                        | [Usage](usage-warnings.md)                  |
+| **Fix is breaking or non-breaking** | Non-breaking                                |
+| **Enabled by default in .NET 7**    | Yes                                         |
 
 ## Cause
 


### PR DESCRIPTION
## Summary

- Correct tabs
- Add title "Property" (same as all other IDE* rules)
- Add title property
- Add missed bold formatting for some rules


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

<details><summary><strong>Toggle expand/collapse</strong></summary><br/>

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1000.md](https://github.com/dotnet/docs/blob/d04dc51937b4a3d25b1d79ddc075e2b71d495ee1/docs/fundamentals/code-analysis/quality-rules/ca1000.md) | [CA1000: Do not declare static members on generic types](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1000?branch=pr-en-us-36953) |
| [docs/fundamentals/code-analysis/quality-rules/ca1003.md](https://github.com/dotnet/docs/blob/d04dc51937b4a3d25b1d79ddc075e2b71d495ee1/docs/fundamentals/code-analysis/quality-rules/ca1003.md) | ["CA1003: Use generic event handler instances (code analysis)"](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1003?branch=pr-en-us-36953) |
| [docs/fundamentals/code-analysis/quality-rules/ca1005.md](https://github.com/dotnet/docs/blob/d04dc51937b4a3d25b1d79ddc075e2b71d495ee1/docs/fundamentals/code-analysis/quality-rules/ca1005.md) | [CA1005: Avoid excessive parameters on generic types](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1005?branch=pr-en-us-36953) |
| [docs/fundamentals/code-analysis/quality-rules/ca1010.md](https://github.com/dotnet/docs/blob/d04dc51937b4a3d25b1d79ddc075e2b71d495ee1/docs/fundamentals/code-analysis/quality-rules/ca1010.md) | [docs/fundamentals/code-analysis/quality-rules/ca1010](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1010?branch=pr-en-us-36953) |
| [docs/fundamentals/code-analysis/quality-rules/ca1012.md](https://github.com/dotnet/docs/blob/d04dc51937b4a3d25b1d79ddc075e2b71d495ee1/docs/fundamentals/code-analysis/quality-rules/ca1012.md) | [CA1012: Abstract types should not have public constructors](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1012?branch=pr-en-us-36953) |
| [docs/fundamentals/code-analysis/quality-rules/ca1014.md](https://github.com/dotnet/docs/blob/d04dc51937b4a3d25b1d79ddc075e2b71d495ee1/docs/fundamentals/code-analysis/quality-rules/ca1014.md) | ["CA1014: Mark assemblies with CLSCompliantAttribute (code analysis)"](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1014?branch=pr-en-us-36953) |
| [docs/fundamentals/code-analysis/quality-rules/ca1016.md](https://github.com/dotnet/docs/blob/d04dc51937b4a3d25b1d79ddc075e2b71d495ee1/docs/fundamentals/code-analysis/quality-rules/ca1016.md) | [CA1016: Mark assemblies with AssemblyVersionAttribute](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1016?branch=pr-en-us-36953) |
| [docs/fundamentals/code-analysis/quality-rules/ca1017.md](https://github.com/dotnet/docs/blob/d04dc51937b4a3d25b1d79ddc075e2b71d495ee1/docs/fundamentals/code-analysis/quality-rules/ca1017.md) | [docs/fundamentals/code-analysis/quality-rules/ca1017](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1017?branch=pr-en-us-36953) |
| [docs/fundamentals/code-analysis/quality-rules/ca1018.md](https://github.com/dotnet/docs/blob/d04dc51937b4a3d25b1d79ddc075e2b71d495ee1/docs/fundamentals/code-analysis/quality-rules/ca1018.md) | [CA1018: Mark attributes with AttributeUsageAttribute](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1018?branch=pr-en-us-36953) |
| [docs/fundamentals/code-analysis/quality-rules/ca1019.md](https://github.com/dotnet/docs/blob/d04dc51937b4a3d25b1d79ddc075e2b71d495ee1/docs/fundamentals/code-analysis/quality-rules/ca1019.md) | ["CA1019: Define accessors for attribute arguments (code analysis)"](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1019?branch=pr-en-us-36953) |
| [docs/fundamentals/code-analysis/quality-rules/ca1021.md](https://github.com/dotnet/docs/blob/d04dc51937b4a3d25b1d79ddc075e2b71d495ee1/docs/fundamentals/code-analysis/quality-rules/ca1021.md) | [CA1021: Avoid out parameters](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1021?branch=pr-en-us-36953) |
| [docs/fundamentals/code-analysis/quality-rules/ca1024.md](https://github.com/dotnet/docs/blob/d04dc51937b4a3d25b1d79ddc075e2b71d495ee1/docs/fundamentals/code-analysis/quality-rules/ca1024.md) | [CA1024: Use properties where appropriate](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1024?branch=pr-en-us-36953) |
| [docs/fundamentals/code-analysis/quality-rules/ca1027.md](https://github.com/dotnet/docs/blob/d04dc51937b4a3d25b1d79ddc075e2b71d495ee1/docs/fundamentals/code-analysis/quality-rules/ca1027.md) | [docs/fundamentals/code-analysis/quality-rules/ca1027](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1027?branch=pr-en-us-36953) |
| [docs/fundamentals/code-analysis/quality-rules/ca1028.md](https://github.com/dotnet/docs/blob/d04dc51937b4a3d25b1d79ddc075e2b71d495ee1/docs/fundamentals/code-analysis/quality-rules/ca1028.md) | [CA1028: Enum storage should be Int32](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1028?branch=pr-en-us-36953) |
| [docs/fundamentals/code-analysis/quality-rules/ca1031.md](https://github.com/dotnet/docs/blob/d04dc51937b4a3d25b1d79ddc075e2b71d495ee1/docs/fundamentals/code-analysis/quality-rules/ca1031.md) | ["CA1031: Do not catch general exception types (code analysis)"](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1031?branch=pr-en-us-36953) |
| [docs/fundamentals/code-analysis/quality-rules/ca1032.md](https://github.com/dotnet/docs/blob/d04dc51937b4a3d25b1d79ddc075e2b71d495ee1/docs/fundamentals/code-analysis/quality-rules/ca1032.md) | [CA1032: Implement standard exception constructors](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1032?branch=pr-en-us-36953) |
| [docs/fundamentals/code-analysis/quality-rules/ca1033.md](https://github.com/dotnet/docs/blob/d04dc51937b4a3d25b1d79ddc075e2b71d495ee1/docs/fundamentals/code-analysis/quality-rules/ca1033.md) | [docs/fundamentals/code-analysis/quality-rules/ca1033](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1033?branch=pr-en-us-36953) |
| [docs/fundamentals/code-analysis/quality-rules/ca1034.md](https://github.com/dotnet/docs/blob/d04dc51937b4a3d25b1d79ddc075e2b71d495ee1/docs/fundamentals/code-analysis/quality-rules/ca1034.md) | [CA1034: Nested types should not be visible](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1034?branch=pr-en-us-36953) |
| [docs/fundamentals/code-analysis/quality-rules/ca1036.md](https://github.com/dotnet/docs/blob/d04dc51937b4a3d25b1d79ddc075e2b71d495ee1/docs/fundamentals/code-analysis/quality-rules/ca1036.md) | ["CA1036: Override methods on comparable types (code analysis)"](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1036?branch=pr-en-us-36953) |
| [docs/fundamentals/code-analysis/quality-rules/ca1040.md](https://github.com/dotnet/docs/blob/d04dc51937b4a3d25b1d79ddc075e2b71d495ee1/docs/fundamentals/code-analysis/quality-rules/ca1040.md) | [CA1040: Avoid empty interfaces](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1040?branch=pr-en-us-36953) |
| [docs/fundamentals/code-analysis/quality-rules/ca1041.md](https://github.com/dotnet/docs/blob/d04dc51937b4a3d25b1d79ddc075e2b71d495ee1/docs/fundamentals/code-analysis/quality-rules/ca1041.md) | [CA1041: Provide ObsoleteAttribute message](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1041?branch=pr-en-us-36953) |
| [docs/fundamentals/code-analysis/quality-rules/ca1043.md](https://github.com/dotnet/docs/blob/d04dc51937b4a3d25b1d79ddc075e2b71d495ee1/docs/fundamentals/code-analysis/quality-rules/ca1043.md) | [docs/fundamentals/code-analysis/quality-rules/ca1043](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1043?branch=pr-en-us-36953) |
| [docs/fundamentals/code-analysis/quality-rules/ca1044.md](https://github.com/dotnet/docs/blob/d04dc51937b4a3d25b1d79ddc075e2b71d495ee1/docs/fundamentals/code-analysis/quality-rules/ca1044.md) | [CA1044: Properties should not be write only](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1044?branch=pr-en-us-36953) |
| [docs/fundamentals/code-analysis/quality-rules/ca1045.md](https://github.com/dotnet/docs/blob/d04dc51937b4a3d25b1d79ddc075e2b71d495ee1/docs/fundamentals/code-analysis/quality-rules/ca1045.md) | ["CA1045: Do not pass types by reference (code analysis)"](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1045?branch=pr-en-us-36953) |
| [docs/fundamentals/code-analysis/quality-rules/ca1046.md](https://github.com/dotnet/docs/blob/d04dc51937b4a3d25b1d79ddc075e2b71d495ee1/docs/fundamentals/code-analysis/quality-rules/ca1046.md) | [CA1046: Do not overload operator equals on reference types](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1046?branch=pr-en-us-36953) |
| [docs/fundamentals/code-analysis/quality-rules/ca1835.md](https://github.com/dotnet/docs/blob/d04dc51937b4a3d25b1d79ddc075e2b71d495ee1/docs/fundamentals/code-analysis/quality-rules/ca1835.md) | [CA1835: Prefer the memory-based overloads of ReadAsync/WriteAsync methods in stream-based classes](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1835?branch=pr-en-us-36953) |
| [docs/fundamentals/code-analysis/quality-rules/ca1851.md](https://github.com/dotnet/docs/blob/d04dc51937b4a3d25b1d79ddc075e2b71d495ee1/docs/fundamentals/code-analysis/quality-rules/ca1851.md) | [docs/fundamentals/code-analysis/quality-rules/ca1851](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1851?branch=pr-en-us-36953) |
| [docs/fundamentals/code-analysis/quality-rules/ca1853.md](https://github.com/dotnet/docs/blob/d04dc51937b4a3d25b1d79ddc075e2b71d495ee1/docs/fundamentals/code-analysis/quality-rules/ca1853.md) | [CA1853: Unnecessary call to 'Dictionary.ContainsKey(key)'](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1853?branch=pr-en-us-36953) |
| [docs/fundamentals/code-analysis/quality-rules/ca1859.md](https://github.com/dotnet/docs/blob/d04dc51937b4a3d25b1d79ddc075e2b71d495ee1/docs/fundamentals/code-analysis/quality-rules/ca1859.md) | ["CA1859: Use concrete types when possible for improved performance"](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1859?branch=pr-en-us-36953) |
| [docs/fundamentals/code-analysis/quality-rules/ca2016.md](https://github.com/dotnet/docs/blob/d04dc51937b4a3d25b1d79ddc075e2b71d495ee1/docs/fundamentals/code-analysis/quality-rules/ca2016.md) | [CA2016: Forward the CancellationToken parameter to methods that take one](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2016?branch=pr-en-us-36953) |

</details>

> **Note**
> This table shows preview links for the 30 files with the most changes. For preview links for other files in this PR, select <strong>OpenPublishing.Build Details</strong> within [checks](https://github.com/dotnet/docs/pull/36953/checks).

<!-- PREVIEW-TABLE-END -->