### PR TITLE
Remove sealed modifier from base class

### DIFF
--- a/docs/orleans/host/configuration-guide/serialization.md
+++ b/docs/orleans/host/configuration-guide/serialization.md
@@ -178,7 +178,7 @@ Orleans supports serialization of types in type hierarchies (types which derive 
 
 ``` csharp
 // The foreign type is not sealed, allowing other types to inherit from it.
-public sealed class MyForeignLibraryType
+public class MyForeignLibraryType
 {
     public MyForeignLibraryType() { }
 


### PR DESCRIPTION
The base class from the serialization.md should not be sealed

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/host/configuration-guide/serialization.md](https://github.com/dotnet/docs/blob/af8a6e208aeb9a15866fb9de31b6b91071b5a1e4/docs/orleans/host/configuration-guide/serialization.md) | [Serialization in Orleans](https://review.learn.microsoft.com/en-us/dotnet/orleans/host/configuration-guide/serialization?branch=pr-en-us-36960) |

<!-- PREVIEW-TABLE-END -->