### PR TITLE
HTTP AutoClient NuGet package content

### DIFF
--- a/docs/fundamentals/networking/http/http-autoclient.md
+++ b/docs/fundamentals/networking/http/http-autoclient.md
@@ -3,10 +3,13 @@ title: Use the REST API HTTP client generator
 description: Learn how to generate HttpClient-dependent code implementations of AutoClient decorated interfaces.
 author: IEvangelist
 ms.author: dapine
-ms.date: 09/06/2023
+ms.date: 09/29/2023
 ---
 
 # Use the REST API HTTP client generator
+
+> [!NOTE]
+> This API is experimental. It might change in subsequent versions of the library, and backwards compatibility is not guaranteed.
 
 The <xref:System.Net.Http.HttpClient> is a great way to consume REST APIs, but it's not without its challenges. One of the challenges is the amount of boilerplate code you need to write to consume the API. In this article, you learn how to use the [Microsoft.Extensions.Http.AutoClient](https://www.nuget.org/packages/Microsoft.Extensions.Http.AutoClient) NuGet package to decorate an interface and generate an HTTP client dependency. The AutoClient's underlying source generator generates the implementation of your interface, along with extension methods to register it into the dependency injection container. Additionally, the AutoClient generates telemetry for each HTTP request, which is sent with <xref:Microsoft.Extensions.Http.Telemetry>.
 

--- a/docs/fundamentals/networking/http/http-autoclient.md
+++ b/docs/fundamentals/networking/http/http-autoclient.md
@@ -10,7 +10,7 @@ ms.date: 09/05/2023
 
 In this article, you'll learn how to use the [Microsoft.Extensions.Http.AutoClient](https://www.nuget.org/packages/Microsoft.Extensions.Http.AutoClient) NuGet package to decorate an interface and generate a strongly typed HTTP client dependency. This is a great way to reduce the amount of boilerplate code you need to write when using the <xref:System.Net.Http.IHttpClientFactory> to create named HTTP clients. Relying on a source generator, the .NET AutoClient package generates the implementation of your interface, along with extension methods to register it into the dependency injection container. The source-generated code is written in a highly performant way, using the <xref:System.Net.Http.HttpClient> directly, without any reflection or dynamic code.
 
-## The HTTP Auto Client interface
+## Use the AutoClient attribute
 
 The <xref:Microsoft.Extensions.Http.AutoClient.AutoClientAttribute> is a required attribute of HTTP auto clients. It receives the name of the <xref:System.Net.Http.HttpClient> to be retrieved from the <xref:System.Net.Http.IHttpClientFactory>, consider the following interface definition:
 

--- a/docs/fundamentals/networking/http/http-autoclient.md
+++ b/docs/fundamentals/networking/http/http-autoclient.md
@@ -10,9 +10,6 @@ ms.date: 09/06/2023
 
 The <xref:System.Net.Http.HttpClient> is a great way to consume REST APIs, but it's not without its challenges. One of the challenges is the amount of boilerplate code you need to write to consume the API. In this article, you learn how to use the [Microsoft.Extensions.Http.AutoClient](https://www.nuget.org/packages/Microsoft.Extensions.Http.AutoClient) NuGet package to decorate an interface and generate an HTTP client dependency. The AutoClient's underlying source generator generates the implementation of your interface, along with extension methods to register it into the dependency injection container. Additionally, the AutoClient generates telemetry for each HTTP request, which is sent with <xref:Microsoft.Extensions.Http.Telemetry>.
 
-> [!IMPORTANT]
-> To use the [Microsoft.Extensions.Http.AutoClient](https://www.nuget.org/packages/Microsoft.Extensions.Http.AutoClient) NuGet package, you must also reference the [Microsoft.Extensions.Http.Telemetry](https://www.nuget.org/packages/Microsoft.Extensions.Http.Telemetry) NuGet package.
-
 ## Use the `AutoClientAttribute`
 
 The <xref:Microsoft.Extensions.Http.AutoClient.AutoClientAttribute> is responsible for triggering the AutoClient generator to emit the corresponding implementation of the decorated interface. It accepts the `httpClientName` of the <xref:System.Net.Http.HttpClient> to be retrieved from the <xref:System.Net.Http.IHttpClientFactory>. Consider the following interface definition:

--- a/docs/fundamentals/networking/http/http-autoclient.md
+++ b/docs/fundamentals/networking/http/http-autoclient.md
@@ -23,7 +23,7 @@ public interface IProductClient
 }
 ```
 
-The interface name must start with an `I`. It's used as the <xref:Microsoft.Extensions.Http.Telemetry.RequestMetadata.DependencyName?displayProperty=nameWithType> for the source-generated telemetry's <xref:Microsoft.Extensions.Telemetry.RequestMetadata>. If the name ends in `Api` or `Client`, those are excluded. For example, if the interface is named `IProductClient`, the dependency name is `Product`.
+The interface name must start with an `I`. It's used as the <xref:Microsoft.Extensions.Http.Telemetry.RequestMetadata.DependencyName?displayProperty=nameWithType> for the source-generated telemetry's <xref:Microsoft.Extensions.Http.Telemetry.RequestMetadata>. If the name ends in `Api` or `Client`, those are excluded. For example, if the interface is named `IProductClient`, the dependency name is `Product`.
 
 To override the calculated dependency name, use the `customDependencyName` parameter of the <xref:Microsoft.Extensions.Http.AutoClient.AutoClientAttribute>.
 

--- a/docs/fundamentals/networking/http/http-autoclient.md
+++ b/docs/fundamentals/networking/http/http-autoclient.md
@@ -1,0 +1,290 @@
+---
+title: Use AutoClient to generate HTTP client dependencies
+description: Learn how to source generate HttpClient dependent code implementations of AutoClient decorated interfaces.
+author: IEvangelist
+ms.author: dapine
+ms.date: 09/05/2023
+---
+
+# Use AutoClient to generate HTTP client dependencies
+
+In this article, you'll learn how to use the [Microsoft.Extensions.Http.AutoClient](https://www.nuget.org/packages/Microsoft.Extensions.Http.AutoClient) NuGet package to decorate an interface and generate a strongly typed HTTP client dependency. This is a great way to reduce the amount of boilerplate code you need to write when using the <xref:Microsoft.Extensions.Http.IHttpClientFactory> to create named HTTP clients. Relying on a source generator, the .NET AutoClient package generates the implementation of your interface, along with extension methods to register it into the dependency injection container. The source-generated code is written in a highly performant way, using the <xref:System.Net.Http.HttpClient> directly, without any reflection or dynamic code.
+
+## The HTTP Auto Client interface
+
+The <xref:Microsoft.Extensions.Http.AutoClient.AutoClientAttribute> is a required attribute of HTTP auto clients. It receives the name of the <xref:System.Net.Http.HttpClient> to be retrieved from the <xref:System.Net.Http.IHttpClientFactory>, consider the following interface definition:
+
+```csharp
+using Microsoft.Extensions.Http.AutoClient;
+
+[AutoClient(httpClientName: "GeneratedClient")]
+public interface IProductClient
+{
+}
+```
+
+The interface name must start with an `I`. It's used as the <xref:Microsoft.Extensions.Http.Telemetry.RequestMetadata.DependencyName?displayProperty=nameWithType> for the source-generated telemetry's <xref:Microsoft.Extensions.Telemetry.RequestMetadata>. If the name ends in `Api` or `Client`, those are excluded. For example, if the interface is named `IProductClient`, the dependency name is `Product`.
+
+To override the calculated dependency name, use the `customDependencyName` parameter of the <xref:Microsoft.Extensions.Http.AutoClient.AutoClientAttribute>.
+
+```csharp
+using Microsoft.Extensions.Http.AutoClient;
+
+[AutoClient(httpClientName: "GeneratedClient", customDependencyName: "Product Service")]
+public interface IProductClient
+{
+}
+```
+
+## Define HTTP methods with verb attributes
+
+An empty interface isn't a useful abstraction. To define HTTP methods, you must use the HTTP verb attributes. Each HTTP method must return a <xref:System.Threading.Tasks.Task%601> where `T` is any of the following types:
+
+| Return type | Description |
+|--|--|
+| `Task<string>` | The raw content of the response, as a string, will be returned. |
+| `Task<T>` | When `T` is any serializable type, the response content is deserialized from JSON and returned. |
+| `Task<HttpResponseMessage>` | If you need the <xref:System.Net.Http.HttpResponseMessage> itself, as returned from <xref:System.Net.Http.HttpClient.SendAsync%2A?displayProperty=nameWithType>, use this type. |
+
+When the content type of the response isn't `application/json` and the method's return type isn't `Task<string>`, an exception is thrown.
+
+### HTTP verb attributes
+
+The HTTP method is defined from the attribute you use. These include:
+
+* <xref:Microsoft.Extensions.Http.AutoClient.GetAttribute>
+* <xref:Microsoft.Extensions.Http.AutoClient.PostAttribute>
+* <xref:Microsoft.Extensions.Http.AutoClient.PutAttribute>
+* <xref:Microsoft.Extensions.Http.AutoClient.PatchAttribute>
+* <xref:Microsoft.Extensions.Http.AutoClient.DeleteAttribute>
+* <xref:Microsoft.Extensions.Http.AutoClient.HeadAttribute>
+* <xref:Microsoft.Extensions.Http.AutoClient.OptionsAttribute>
+
+The attribute must receive the path to call the API. This path must not contain query parameters. The path is used as the <xref:Microsoft.Extensions.Http.Telemetry.RequestMetadata.RequestRoute?displayProperty=nameWithType> for telemetry. The path must be relative, to be used along with the base address of the <xref:System.Net.Http.HttpClient>.
+
+HTTP methods decorated with any of the verb attributes must have a <xref:System.Threading.CancellationToken> parameter and it should be the last parameter defined. It can be defined as optional with `default`.
+
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Http.AutoClient;
+
+[AutoClient("GeneratedClient")]
+public interface IProductClient
+{
+    [Get("/api/users")]
+    public Task<User[]> GetUsersAsync(
+        CancellationToken cancellationToken = default);
+}
+```
+
+### Route parameters
+
+The URL may contain route parameters, for example, `/api/users/{userId}`. To define a route parameter the method must accept a parameter with the same name:
+
+```csharp
+using System.Threading.Tasks;
+using Microsoft.Extensions.Http.AutoClient;
+
+[AutoClient(nameof(IUserClient), "User Service")]
+public interface IUserClient
+{
+    [Get("/api/users/{userId}")]
+    public Task<User> GetUserAsync(
+        string userId,
+        CancellationToken cancellationToken = default);
+}
+```
+
+In the preceding code:
+
+- The `GetUserAsync` method has a route parameter named `userId`.
+- The `userId` parameter is used in the path of the request, replacing the `{userId}` placeholder.
+
+### Telemetry request name
+
+The method name is used as the <xref:Microsoft.Extensions.Http.Telemetry.RequestMetadata.RequestName?displayProperty=nameWithType>. If the method name ends in `Async`, that part is removed. For example, if a method is named `GetUsersAsync`, the request name is `GetUsers`.
+
+To override the name, use the `RequestName` property of each attribute of the [HTTP verb attributes](#http-verb-attributes).
+
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Http.AutoClient;
+
+[AutoClient(nameof(IUserClient), "User Service")]
+public interface IUserClient
+{
+    [Get("/api/users", RequestName = "CustomRequestName")]
+    public Task<List<User>> GetUsersAsync(
+        CancellationToken cancellationToken = default);
+}
+```
+
+## HTTP payloads
+
+To send a payload with your request, you must use the <xref:Microsoft.Extensions.Http.AutoClient.BodyAttribute> on a method parameter. If you don't pass any parameter to it, it treats the content type as JSON, serializing your parameter before sending. Otherwise, you define an explicit
+<xref:Microsoft.Extensions.Http.AutoClient.BodyContentType> and use it within the <xref:Microsoft.Extensions.Http.AutoClient.BodyAttribute>.
+
+```csharp
+using System.Threading.Tasks;
+using Microsoft.Extensions.Http.AutoClient;
+
+[AutoClient(nameof(IUserClient), "User Service")]
+public interface IUserClient
+{
+    [Post("/api/users")]
+    public Task<User> CreateUserAsync(
+        [Body] User user);
+
+    [Put("/api/users/{userId}/displayName")]
+    public Task<User> UpdateDisplayNameAsync(
+        string userId,
+        [Body(BodyContentType.TextPlain)] string displayName,
+        CancellationToken cancellationToken = default);
+}
+```
+
+## HTTP headers
+
+There are two ways of sending headers with your HTTP request. One of them is best suited for headers that never change value (static headers). The other way is headers that change based on the parameters of your methods.
+
+### Static headers
+
+To define a static header, you must use the <xref:Microsoft.Extensions.Http.AutoClient.StaticHeaderAttribute> on your interface. You must pass the header name and value to its constructor.
+
+You can also use more than one <xref:Microsoft.Extensions.Http.AutoClient.StaticHeaderAttribute> together and in methods as well. If used in a method, that static
+header is sent for that method only.
+
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Http.AutoClient;
+
+[AutoClient(nameof(IUserClient), "User Service")]
+[StaticHeader("X-MyHeader", "HeaderValue")]
+public interface IUserClient
+{
+    [Get("/api/users")]
+    [StaticHeader("X-MethodHeader", "HeaderValue")]
+    public Task<List<User>> GetUsersAsync(
+        CancellationToken cancellationToken = default);
+}
+```
+
+### Parameter headers
+
+Use the <xref:Microsoft.Extensions.Http.AutoClient.HeaderAttribute> to define parameter-based headers, where you can receive the value for a header from the attributes of your method. You must pass the header name to its constructor.
+
+The parameter may be of any type. When the header type is anything other than a `string`, the `.ToString()` method is called on the value of the parameter.
+
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Http.AutoClient;
+
+[AutoClient(nameof(IUserClient), "User Service")]
+public interface IUserClient
+{
+    [Get("/api/users")]
+    public Task<List<User>> GetUsersAsync(
+        [Header("X-MyHeader")] string myHeader,
+        CancellationToken cancellationToken = default);
+}
+```
+
+## Query parameters
+
+Query parameters are defined using the <xref:Microsoft.Extensions.Http.AutoClient.QueryAttribute> on a method's attribute. The parameter may be of any type. To set the query value, the `.ToString()` method is called on the value of the parameter.
+
+The query key is the name of the parameter.
+
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Http.AutoClient;
+
+[AutoClient(nameof(IUserClient))]
+public interface IUserClient
+{
+    [Get("/api/users")]
+    public Task<List<User>> GetUsersAsync(
+        [Query] string search,
+        CancellationToken cancellationToken = default);
+}
+```
+
+The `GetUsersAsync` method generates an HTTP request with a URL formatted like `/api/users?search={search}`. This format is used as the <xref:Microsoft.Extensions.Http.Telemetry.RequestMetadata.RequestRoute?displayProperty=nameWithType> for telemetry.
+
+If you need to change the query key, you may pass a string parameter to the <xref:Microsoft.Extensions.Http.AutoClient.QueryAttribute>.
+
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Http.AutoClient;
+
+[AutoClient(nameof(IUserClient))]
+public interface IUserClient
+{
+    [Get("/api/users")]
+    public Task<List<User>> GetUsersAsync(
+        [Query("customQueryKey")] string search,
+        CancellationToken cancellationToken = default);
+}
+```
+
+This time, the `GetUsersAsync` method generates an HTTP request with a URL formatted like `/api/users?customQueryKey={customQueryKey}`.
+
+## Auto client's dependency injection hooks
+
+Along with the interface's implementation, extension methods are generated to register it into the dependency injection container. The name of the generated extension method is the same as your interface name, replacing the leading `I` with `Add`.
+
+For example, consider the following interface definition:
+
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Http.AutoClient;
+
+[AutoClient(nameof(IUserClient))]
+public interface IUserClient
+{
+    [Get("/api/users")]
+    public Task<List<User>> GetUsersAsync(
+        CancellationToken cancellationToken = default);
+}
+```
+
+You'd have registration code similar to the following:
+
+```csharp
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services
+    .AddHttpClient(
+        nameof(IUserClient),
+        client => client.BaseAddress = new Uri("<The REST API base address>"))
+    .AddHttpClientMetering()
+    .AddHttpClientLogging()
+    .AddStandardResilienceHandler()
+    .AddSocketsHttpHandler();
+
+services.AddUserClient();
+```
+
+Then services would consume the client through its constructor:
+
+```csharp
+public sealed class UserService
+{
+    private readonly IUserClient _userClient;
+
+    public MyService(IUserClient userClient) => _userClient = userClient;
+
+    public async Task ProcessUsersAsync()
+    {
+        var users = await _myClient.GetUsersAsync();
+        // ...
+    }
+}
+```

--- a/docs/fundamentals/networking/http/http-autoclient.md
+++ b/docs/fundamentals/networking/http/http-autoclient.md
@@ -8,7 +8,7 @@ ms.date: 09/05/2023
 
 # Use AutoClient to generate HTTP client dependencies
 
-In this article, you'll learn how to use the [Microsoft.Extensions.Http.AutoClient](https://www.nuget.org/packages/Microsoft.Extensions.Http.AutoClient) NuGet package to decorate an interface and generate a strongly typed HTTP client dependency. This is a great way to reduce the amount of boilerplate code you need to write when using the <xref:Microsoft.Extensions.Http.IHttpClientFactory> to create named HTTP clients. Relying on a source generator, the .NET AutoClient package generates the implementation of your interface, along with extension methods to register it into the dependency injection container. The source-generated code is written in a highly performant way, using the <xref:System.Net.Http.HttpClient> directly, without any reflection or dynamic code.
+In this article, you'll learn how to use the [Microsoft.Extensions.Http.AutoClient](https://www.nuget.org/packages/Microsoft.Extensions.Http.AutoClient) NuGet package to decorate an interface and generate a strongly typed HTTP client dependency. This is a great way to reduce the amount of boilerplate code you need to write when using the <xref:System.Net.Http.IHttpClientFactory> to create named HTTP clients. Relying on a source generator, the .NET AutoClient package generates the implementation of your interface, along with extension methods to register it into the dependency injection container. The source-generated code is written in a highly performant way, using the <xref:System.Net.Http.HttpClient> directly, without any reflection or dynamic code.
 
 ## The HTTP Auto Client interface
 
@@ -50,15 +50,15 @@ When the content type of the response isn't `application/json` and the method's 
 
 ### HTTP verb attributes
 
-The HTTP method is defined from the attribute you use. These include:
+The HTTP method is defined using one of the following attributes:
 
-* <xref:Microsoft.Extensions.Http.AutoClient.GetAttribute>
-* <xref:Microsoft.Extensions.Http.AutoClient.PostAttribute>
-* <xref:Microsoft.Extensions.Http.AutoClient.PutAttribute>
-* <xref:Microsoft.Extensions.Http.AutoClient.PatchAttribute>
-* <xref:Microsoft.Extensions.Http.AutoClient.DeleteAttribute>
-* <xref:Microsoft.Extensions.Http.AutoClient.HeadAttribute>
-* <xref:Microsoft.Extensions.Http.AutoClient.OptionsAttribute>
+- <xref:Microsoft.Extensions.Http.AutoClient.GetAttribute?displayProperty=fullName>
+- <xref:Microsoft.Extensions.Http.AutoClient.PostAttribute?displayProperty=fullName>
+- <xref:Microsoft.Extensions.Http.AutoClient.PutAttribute?displayProperty=fullName>
+- <xref:Microsoft.Extensions.Http.AutoClient.PatchAttribute?displayProperty=fullName>
+- <xref:Microsoft.Extensions.Http.AutoClient.DeleteAttribute?displayProperty=fullName>
+- <xref:Microsoft.Extensions.Http.AutoClient.HeadAttribute?displayProperty=fullName>
+- <xref:Microsoft.Extensions.Http.AutoClient.OptionsAttribute?displayProperty=fullName>
 
 The attribute must receive the path to call the API. This path must not contain query parameters. The path is used as the <xref:Microsoft.Extensions.Http.Telemetry.RequestMetadata.RequestRoute?displayProperty=nameWithType> for telemetry. The path must be relative, to be used along with the base address of the <xref:System.Net.Http.HttpClient>.
 

--- a/docs/fundamentals/networking/http/http-autoclient.md
+++ b/docs/fundamentals/networking/http/http-autoclient.md
@@ -3,7 +3,7 @@ title: Use AutoClient to generate HTTP client dependencies
 description: Learn how to source generate HttpClient dependent code implementations of AutoClient decorated interfaces.
 author: IEvangelist
 ms.author: dapine
-ms.date: 09/05/2023
+ms.date: 09/06/2023
 ---
 
 # Use AutoClient to generate HTTP client dependencies

--- a/docs/fundamentals/networking/http/http-autoclient.md
+++ b/docs/fundamentals/networking/http/http-autoclient.md
@@ -86,7 +86,7 @@ The preceding code:
 - Defines an HTTP method using the <xref:Microsoft.Extensions.Http.AutoClient.GetAttribute>.
 - The `path` is `/api/users`.
 - The method returns a <xref:System.Threading.Tasks.Task%601> where `T` is `User[]`.
-- The method accepts an optional <xref:System.Threading.CancellationToken> parameter that is assigned to `default`.
+- The method accepts an optional <xref:System.Threading.CancellationToken> parameter that is assigned to `default` when an argument isn't provided.
 
 ### Route parameters
 
@@ -292,7 +292,7 @@ In the preceding example code:
   - The `AddHttpClient` extension method is called with the name of the <xref:System.Net.Http.HttpClient> to be registered, and a delegate to configure the <xref:System.Net.Http.HttpClient> instance.
 - The `AddUserClient` extension method is called to register the <xref:IUserClient> interface and its implementation.
 
-Consuming the client is as simple as injecting it into your service's constructor:
+You can consume the client by injecting it into your service's constructor:
 
 ```csharp
 public sealed class UserService(IUserClient userClient)

--- a/docs/fundamentals/networking/http/http-autoclient.md
+++ b/docs/fundamentals/networking/http/http-autoclient.md
@@ -8,36 +8,26 @@ ms.date: 09/06/2023
 
 # Use the REST API HTTP client generator
 
-The <xref:System.Net.Http.HttpClient> is a great way to consume REST APIs, but it's not without its challenges. One of the challenges is the amount of boilerplate code you need to write to consume the API. In this article, you learn how to use the [Microsoft.Extensions.Http.AutoClient](https://www.nuget.org/packages/Microsoft.Extensions.Http.AutoClient) NuGet package to decorate an interface and generate an HTTP client dependency. The AutoClient's underlying source generator generates the implementation of your interface, along with extension methods to register it into the dependency injection container. Additionally, the AutoClient generates telemetry for each HTTP request, which is sent to the <xref:Microsoft.Extensions.Http.Telemetry.IHttpTelemetrySink>.
+The <xref:System.Net.Http.HttpClient> is a great way to consume REST APIs, but it's not without its challenges. One of the challenges is the amount of boilerplate code you need to write to consume the API. In this article, you learn how to use the [Microsoft.Extensions.Http.AutoClient](https://www.nuget.org/packages/Microsoft.Extensions.Http.AutoClient) NuGet package to decorate an interface and generate an HTTP client dependency. The AutoClient's underlying source generator generates the implementation of your interface, along with extension methods to register it into the dependency injection container. Additionally, the AutoClient generates telemetry for each HTTP request, which is sent with <xref:Microsoft.Extensions.Http.Telemetry>.
+
+> [!IMPORTANT]
+> To use the [Microsoft.Extensions.Http.AutoClient](https://www.nuget.org/packages/Microsoft.Extensions.Http.AutoClient) NuGet package, you must also reference the [Microsoft.Extensions.Http.Telemetry](https://www.nuget.org/packages/Microsoft.Extensions.Http.Telemetry) NuGet package.
 
 ## Use the `AutoClientAttribute`
 
 The <xref:Microsoft.Extensions.Http.AutoClient.AutoClientAttribute> is responsible for triggering the AutoClient generator to emit the corresponding implementation of the decorated interface. It accepts the `httpClientName` of the <xref:System.Net.Http.HttpClient> to be retrieved from the <xref:System.Net.Http.IHttpClientFactory>. Consider the following interface definition:
 
-```csharp
-using Microsoft.Extensions.Http.AutoClient;
-
-[AutoClient(httpClientName: "GeneratedClient")]
-public interface IProductClient
-{
-}
-```
+:::code source="snippets/autoclient/IProductClient.cs":::
 
 > [!TIP]
 > The interface name must start with an `I`. The name is stripped of the leading `I`, and used as the <xref:Microsoft.Extensions.Http.Telemetry.RequestMetadata.DependencyName?displayProperty=nameWithType> for telemetry's <xref:Microsoft.Extensions.Http.Telemetry.RequestMetadata>. If the name ends in `Api` or `Client`, those are excluded. For example, if the interface is named `IProductClient`, the dependency name is `Product`.
 
 To override the calculated dependency name, use the `customDependencyName` parameter of the <xref:Microsoft.Extensions.Http.AutoClient.AutoClientAttribute>.
 
-```csharp
-using Microsoft.Extensions.Http.AutoClient;
+:::code source="snippets/autoclient/IWidgetClient.cs":::
 
-[AutoClient(
-    httpClientName: "GeneratedClient",
-    customDependencyName: "Product Service")]
-public interface IProductClient
-{
-}
-```
+> [!NOTE]
+> Both preceding code examples result in a compilation warning, as the interface doesn't define any HTTP methods. The warning is emitted by the AutoClient generator, and it's a reminder that the emitted implementations are be useless.
 
 ## Define HTTP methods with verb attributes
 
@@ -67,19 +57,7 @@ Each attribute requires a `path` argument that routes to the underlying REST API
 
 HTTP methods decorated with any of the verb attributes must have a <xref:System.Threading.CancellationToken> parameter and it should be the last parameter defined. The `CancellationToken` parameter is used to cancel the HTTP request.
 
-```csharp
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Http.AutoClient;
-
-[AutoClient("GeneratedClient")]
-public interface IProductClient
-{
-    [Get("/api/users")]
-    public Task<User[]> GetUsersAsync(
-        CancellationToken cancellationToken = default);
-}
-```
+:::code source="snippets/autoclient/IUserClient.cs":::
 
 The preceding code:
 
@@ -92,19 +70,7 @@ The preceding code:
 
 The URL may contain route parameters, for example, `"/api/users/{userId}"`. To define a route parameter the method must also accept a parameter with the same name, in this case, `userId`:
 
-```csharp
-using System.Threading.Tasks;
-using Microsoft.Extensions.Http.AutoClient;
-
-[AutoClient(nameof(IUserClient), "User Service")]
-public interface IUserClient
-{
-    [Get("/api/users/{userId}")]
-    public Task<User> GetUserAsync(
-        string userId,
-        CancellationToken cancellationToken = default);
-}
-```
+:::code source="snippets/autoclient/IRouteParameterUserClient.cs":::
 
 In the preceding code:
 
@@ -117,47 +83,14 @@ The method name is used as the <xref:Microsoft.Extensions.Http.Telemetry.Request
 
 To override the name, use the `RequestName` property of each attribute of the [HTTP verb attributes](#http-verb-attributes).
 
-```csharp
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Http.AutoClient;
-
-[AutoClient(nameof(IUserClient), "User Service")]
-public interface IUserClient
-{
-    [Get("/api/users", RequestName = "CustomRequestName")]
-    public Task<List<User>> GetUsersAsync(
-        CancellationToken cancellationToken = default);
-}
-```
+:::code source="snippets/autoclient/IRequestNameUserClient.cs":::
 
 ## HTTP payloads
 
 To send an HTTP payload with your request, use the <xref:Microsoft.Extensions.Http.AutoClient.BodyAttribute> on a method's parameter. If you don't pass any parameter to it, it treats the content type as JSON, serializing your parameter before sending. Otherwise, you define an explicit
 <xref:Microsoft.Extensions.Http.AutoClient.BodyContentType> and use it within the <xref:Microsoft.Extensions.Http.AutoClient.BodyAttribute>.
 
-```csharp
-using System.Threading.Tasks;
-using Microsoft.Extensions.Http.AutoClient;
-
-[AutoClient(nameof(IUserClient), "User Service")]
-public interface IUserClient
-{
-    [Post("/api/users")]
-    public Task<User> CreateUserAsync(
-        // The content type is JSON
-        // The parameter is serialized before sending
-        [Body] User user);
-
-    [Put("/api/users/{userId}/displayName")]
-    public Task<User> UpdateDisplayNameAsync(
-        string userId,
-        // The content type is text/plain
-        // The parameter is sent as is
-        [Body(BodyContentType.TextPlain)] string displayName,
-        CancellationToken cancellationToken = default);
-}
-```
+:::code source="snippets/autoclient/IPayloadUserClient.cs":::
 
 ## HTTP headers
 
@@ -169,21 +102,7 @@ To define a static header, use the <xref:Microsoft.Extensions.Http.AutoClient.St
 
 You can also use more than one <xref:Microsoft.Extensions.Http.AutoClient.StaticHeaderAttribute> together and in methods as well. When the `StaticHeader` attribute is used on a method, that HTTP header is sent for that method only, whereas the interface-level `StaticHeader` attribute is sent for all methods.
 
-```csharp
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Http.AutoClient;
-
-[AutoClient(nameof(IUserClient), "User Service")]
-[StaticHeader("X-ForAllRequests", "GlobalHeaderValue")]
-public interface IUserClient
-{
-    [Get("/api/users")]
-    [StaticHeader("X-ForJustThisRequest", "RequestHeaderValue")]
-    public Task<List<User>> GetUsersAsync(
-        CancellationToken cancellationToken = default);
-}
-```
+:::code source="snippets/autoclient/IStaticHeaderUserClient.cs":::
 
 ### Parameter headers
 
@@ -191,20 +110,7 @@ Use the <xref:Microsoft.Extensions.Http.AutoClient.HeaderAttribute> to define pa
 
 The parameter may be of any type. When the header type is anything other than a `string`, the `.ToString()` method is called on the value of the parameter.
 
-```csharp
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Http.AutoClient;
-
-[AutoClient(nameof(IUserClient), "User Service")]
-public interface IUserClient
-{
-    [Get("/api/users")]
-    public Task<List<User>> GetUsersAsync(
-        [Header("X-MyHeader")] string myHeader,
-        CancellationToken cancellationToken = default);
-}
-```
+:::code source="snippets/autoclient/IParameterHeaderUserClient.cs":::
 
 ## Query parameters
 
@@ -212,39 +118,13 @@ Query parameters are defined using the <xref:Microsoft.Extensions.Http.AutoClien
 
 The <xref:Microsoft.Extensions.Http.AutoClient.QueryAttribute.Key?displayProperty=nameWithType> is assigned from the name of the parameter.
 
-```csharp
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Http.AutoClient;
-
-[AutoClient(nameof(IUserClient))]
-public interface IUserClient
-{
-    [Get("/api/users")]
-    public Task<List<User>> GetUsersAsync(
-        [Query] string search,
-        CancellationToken cancellationToken = default);
-}
-```
+:::code source="snippets/autoclient/IQueryUserClient.cs":::
 
 The `GetUsersAsync` method generates an HTTP request with a URL formatted as `/api/users?search={search}`. This format is used as the <xref:Microsoft.Extensions.Http.Telemetry.RequestMetadata.RequestRoute?displayProperty=nameWithType> for telemetry.
 
 If you need to change the query key, you may call the `key` parameter-based constructor, <xref:Microsoft.Extensions.Http.AutoClient.QueryAttribute.%23ctor(System.String)>.
 
-```csharp
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Http.AutoClient;
-
-[AutoClient(nameof(IUserClient))]
-public interface IUserClient
-{
-    [Get("/api/users")]
-    public Task<List<User>> GetUsersAsync(
-        [Query("customQueryKey")] string search,
-        CancellationToken cancellationToken = default);
-}
-```
+:::code source="snippets/autoclient/ICustomQueryUserClient.cs":::
 
 The `GetUsersAsync` method generates an HTTP request with a URL formatted like `/api/users?customQueryKey={customQueryKey}`, as the key name was overridden to `customQueryKey`.
 
@@ -254,55 +134,25 @@ Along with the interface's implementation, extension methods are generated to re
 
 For example, consider the following interface definition:
 
-```csharp
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Http.AutoClient;
+:::code source="snippets/autoclient/ICompleteUserClient.cs":::
 
-[AutoClient(nameof(IUserClient))]
-public interface IUserClient
-{
-    [Get("/api/users")]
-    public Task<List<User>> GetUsersAsync(
-        CancellationToken cancellationToken = default);
-}
-```
+While the generator emits the implementation of the `ICompleteUserClient` interface, it also generates the `AddCompleteUserClient` extension method on the `IServiceCollection`. Consider the following example _Program.cs_ code:
 
-While the generator emits the implementation of the `IUserClient` interface, it also generates the `AddUserClient` extension method on the `IServiceCollection`. Consider the following registration code:
-
-```csharp
-var builder = Host.CreateApplicationBuilder(args);
-
-// Add the named HttpClient to the service collection
-builder.Services.AddHttpClient(
-    nameof(IUserClient),
-    client =>
-    {
-        client.BaseAddress = new Uri("<The REST API base address>");
-    });
-
-// Add the IUserClient/UserClient to the service collection
-builder.Services.AddUserClient();
-```
+:::code source="snippets/autoclient/Program.cs" id="program":::
 
 In the preceding example code:
 
-- The <xref:Microsoft.Extensions.Hosting.Host.CreateApplicationBuilder(System.String[])?displayProperty=fullName> is used to create a <xref:Microsoft.Extensions.Hosting.HostApplicationBuilder>.
-- The <xref:Microsoft.Extensions.DependencyInjection.IServiceCollection> is retrieved from the <xref:Microsoft.Extensions.Hosting.HostApplicationBuilder.Services?displayProperty=nameWithType> property, to call the `AddHttpClient` extension method.
+- The <xref:Microsoft.Extensions.Hosting.Host.CreateEmptyApplicationBuilder%2A?displayProperty=nameWithType> is used to create a <xref:Microsoft.Extensions.Hosting.HostApplicationBuilder>.
+- The <xref:Microsoft.Extensions.DependencyInjection.IServiceCollection> is retrieved from the <xref:Microsoft.Extensions.Hosting.HostApplicationBuilder.Services?displayProperty=nameWithType> property, to call the <xref:Microsoft.Extensions.DependencyInjection.HttpClientFactoryServiceCollectionExtensions.AddHttpClient(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.String,System.Action{System.Net.Http.HttpClient})> extension method.
   - The `AddHttpClient` extension method is called with the name of the <xref:System.Net.Http.HttpClient> to be registered, and a delegate to configure the <xref:System.Net.Http.HttpClient> instance.
-- The `AddUserClient` extension method is called to register the <xref:IUserClient> interface and its implementation.
+- The `AddCompleteUserClient` extension method is called to register the `ICompleteUserClient` interface and its implementation.
 
 You can consume the client by injecting it into your service's constructor:
 
-```csharp
-public sealed class UserService(IUserClient userClient)
-{
-    public async Task ProcessUsersAsync()
-    {
-        var users = await userClient.GetUsersAsync();
-        // ...
-    }
-}
-```
+:::code source="snippets/autoclient/UserService.cs":::
 
 For more information, see [.NET dependency injection](../../../core/extensions/dependency-injection.md).
+
+The application is expected to output the following:
+
+:::code source="snippets/autoclient/Program.cs" id="output":::

--- a/docs/fundamentals/networking/http/http-autoclient.md
+++ b/docs/fundamentals/networking/http/http-autoclient.md
@@ -275,15 +275,11 @@ services.AddUserClient();
 Then services would consume the client through its constructor:
 
 ```csharp
-public sealed class UserService
+public sealed class UserService(IUserClient userClient)
 {
-    private readonly IUserClient _userClient;
-
-    public MyService(IUserClient userClient) => _userClient = userClient;
-
     public async Task ProcessUsersAsync()
     {
-        var users = await _myClient.GetUsersAsync();
+        var users = await userClient.GetUsersAsync();
         // ...
     }
 }

--- a/docs/fundamentals/networking/http/http-autoclient.md
+++ b/docs/fundamentals/networking/http/http-autoclient.md
@@ -125,7 +125,7 @@ If you need to change the query key, you may call the `key` parameter-based cons
 
 The `GetUsersAsync` method generates an HTTP request with a URL formatted like `/api/users?customQueryKey={customQueryKey}`, as the key name was overridden to `customQueryKey`.
 
-## Auto client's dependency injection hooks
+## Dependency injection hooks
 
 Along with the interface's implementation, extension methods are generated to register the client in the dependency injection container. The name of the generated extension method is the same as your interface name, replacing the leading `I` with `Add`.
 

--- a/docs/fundamentals/networking/http/httpclient.md
+++ b/docs/fundamentals/networking/http/httpclient.md
@@ -377,5 +377,5 @@ For more information about configuring a proxy, see:
 - [Guidelines for using HttpClient](httpclient-guidelines.md)
 - [IHttpClientFactory with .NET](../../../core/extensions/httpclient-factory.md)
 - [Use HTTP/3 with HttpClient](../../../core/extensions/httpclient-http3.md)
-- [Use AutoClient to generate HTTP client dependencies](http-autoclient.md)
+- [REST API HTTP client generator](http-autoclient.md)
 - [Test web APIs with the HttpRepl](/aspnet/core/web-api/http-repl)

--- a/docs/fundamentals/networking/http/httpclient.md
+++ b/docs/fundamentals/networking/http/httpclient.md
@@ -377,4 +377,5 @@ For more information about configuring a proxy, see:
 - [Guidelines for using HttpClient](httpclient-guidelines.md)
 - [IHttpClientFactory with .NET](../../../core/extensions/httpclient-factory.md)
 - [Use HTTP/3 with HttpClient](../../../core/extensions/httpclient-http3.md)
+- [Use AutoClient to generate HTTP client dependencies](http-autoclient.md)
 - [Test web APIs with the HttpRepl](/aspnet/core/web-api/http-repl)

--- a/docs/fundamentals/networking/http/snippets/autoclient/Address.cs
+++ b/docs/fundamentals/networking/http/snippets/autoclient/Address.cs
@@ -1,0 +1,6 @@
+﻿public sealed record class Address(
+    string Street,
+    string? Suite,
+    string City,
+    string ZipCode,
+    Geo Geo);

--- a/docs/fundamentals/networking/http/snippets/autoclient/Company.cs
+++ b/docs/fundamentals/networking/http/snippets/autoclient/Company.cs
@@ -1,0 +1,4 @@
+﻿public sealed record class Company(
+    string Name,
+    string CatchPhrase,
+    string Bs);

--- a/docs/fundamentals/networking/http/snippets/autoclient/Geo.cs
+++ b/docs/fundamentals/networking/http/snippets/autoclient/Geo.cs
@@ -1,0 +1,1 @@
+﻿public sealed record class Geo(decimal Lat, decimal Lng);

--- a/docs/fundamentals/networking/http/snippets/autoclient/ICompleteUserClient.cs
+++ b/docs/fundamentals/networking/http/snippets/autoclient/ICompleteUserClient.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.Extensions.Http.AutoClient;
+
+[AutoClient(nameof(ICompleteUserClient))]
+[StaticHeader("User-Agent", "dotnet-auto-client sample")]
+public interface ICompleteUserClient
+{
+    [Get("users")]
+    public Task<User[]> GetAllUsersAsync(
+        CancellationToken cancellationToken = default);
+
+    [Get("users")]
+    public Task<User[]> GetUserByNameAsync(
+        [Query] string name,
+        CancellationToken cancellationToken = default);
+
+    [Get("users/{userId}")]
+    public Task<User> GetUserByIdAsync(
+        int userId,
+        CancellationToken cancellationToken = default);
+
+    [Post("users")]
+    [StaticHeader("X-CustomHeader", "custom-value")]
+    public Task<HttpResponseMessage> CreateUserAsync(
+        [Body(BodyContentType.ApplicationJson)] User user,
+        CancellationToken cancellationToken = default);
+
+    [Delete("user/{userId}")]
+    public Task<User> DeleteUserAsync(
+        int userId,
+        [Header("If-None-Match")] string eTag,
+        CancellationToken cancellationToken = default);
+}
+

--- a/docs/fundamentals/networking/http/snippets/autoclient/ICustomQueryUserClient.cs
+++ b/docs/fundamentals/networking/http/snippets/autoclient/ICustomQueryUserClient.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.Extensions.Http.AutoClient;
+
+[AutoClient(nameof(ICustomQueryUserClient))]
+public interface ICustomQueryUserClient
+{
+    [Get("/api/users")]
+    public Task<List<User>> GetUsersAsync(
+        [Query("customQueryKey")] string search,
+        CancellationToken cancellationToken = default);
+}

--- a/docs/fundamentals/networking/http/snippets/autoclient/IParameterHeaderUserClient.cs
+++ b/docs/fundamentals/networking/http/snippets/autoclient/IParameterHeaderUserClient.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.Extensions.Http.AutoClient;
+
+[AutoClient(nameof(IParameterHeaderUserClient), "User Service")]
+public interface IParameterHeaderUserClient
+{
+    [Get("/api/users")]
+    public Task<List<User>> GetUsersAsync(
+        [Header("X-MyHeader")] string myHeader,
+        CancellationToken cancellationToken = default);
+}

--- a/docs/fundamentals/networking/http/snippets/autoclient/IPayloadUserClient.cs
+++ b/docs/fundamentals/networking/http/snippets/autoclient/IPayloadUserClient.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.Extensions.Http.AutoClient;
+
+[AutoClient(nameof(IPayloadUserClient), "User Service")]
+public interface IPayloadUserClient
+{
+    [Post("/api/users")]
+    public Task<User> CreateUserAsync(
+        // The content type is JSON
+        // The parameter is serialized before sending
+        [Body] User user,
+        CancellationToken cancellationToken = default);
+
+    [Put("/api/users/{userId}/displayName")]
+    public Task<User> UpdateDisplayNameAsync(
+        string userId,
+        // The content type is text/plain
+        // The parameter is sent as is
+        [Body(BodyContentType.TextPlain)] string displayName,
+        CancellationToken cancellationToken = default);
+}

--- a/docs/fundamentals/networking/http/snippets/autoclient/IProductClient.cs
+++ b/docs/fundamentals/networking/http/snippets/autoclient/IProductClient.cs
@@ -1,0 +1,6 @@
+﻿using Microsoft.Extensions.Http.AutoClient;
+
+[AutoClient(httpClientName: "GeneratedClient")]
+public interface IProductClient
+{
+}

--- a/docs/fundamentals/networking/http/snippets/autoclient/IQueryUserClient.cs
+++ b/docs/fundamentals/networking/http/snippets/autoclient/IQueryUserClient.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.Extensions.Http.AutoClient;
+
+[AutoClient(nameof(IQueryUserClient))]
+public interface IQueryUserClient
+{
+    [Get("/api/users")]
+    public Task<List<User>> GetUsersAsync(
+        [Query] string search,
+        CancellationToken cancellationToken = default);
+}

--- a/docs/fundamentals/networking/http/snippets/autoclient/IRequestNameUserClient.cs
+++ b/docs/fundamentals/networking/http/snippets/autoclient/IRequestNameUserClient.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.Extensions.Http.AutoClient;
+
+[AutoClient(nameof(IRequestNameUserClient), "User Service")]
+public interface IRequestNameUserClient
+{
+    [Get("/api/users", RequestName = "CustomRequestName")]
+    public Task<List<User>> GetUsersAsync(
+        CancellationToken cancellationToken = default);
+}

--- a/docs/fundamentals/networking/http/snippets/autoclient/IRouteParameterUserClient.cs
+++ b/docs/fundamentals/networking/http/snippets/autoclient/IRouteParameterUserClient.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.Extensions.Http.AutoClient;
+
+[AutoClient(nameof(IRouteParameterUserClient), "User Service")]
+public interface IRouteParameterUserClient
+{
+    [Get("/api/users/{userId}")]
+    public Task<User> GetUserAsync(
+        string userId,
+        CancellationToken cancellationToken = default);
+}

--- a/docs/fundamentals/networking/http/snippets/autoclient/IStaticHeaderUserClient.cs
+++ b/docs/fundamentals/networking/http/snippets/autoclient/IStaticHeaderUserClient.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.Extensions.Http.AutoClient;
+
+[AutoClient(nameof(IStaticHeaderUserClient), "User Service")]
+[StaticHeader("X-ForAllRequests", "GlobalHeaderValue")]
+public interface IStaticHeaderUserClient
+{
+    [Get("/api/users")]
+    [StaticHeader("X-ForJustThisRequest", "RequestHeaderValue")]
+    public Task<List<User>> GetUsersAsync(
+        CancellationToken cancellationToken = default);
+}

--- a/docs/fundamentals/networking/http/snippets/autoclient/IUserClient.cs
+++ b/docs/fundamentals/networking/http/snippets/autoclient/IUserClient.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.Extensions.Http.AutoClient;
+
+[AutoClient("GeneratedClient")]
+public interface IUserClient
+{
+    [Get("/api/users")]
+    public Task<User[]> GetUsersAsync(
+        CancellationToken cancellationToken = default);
+}

--- a/docs/fundamentals/networking/http/snippets/autoclient/IWidgetClient.cs
+++ b/docs/fundamentals/networking/http/snippets/autoclient/IWidgetClient.cs
@@ -1,0 +1,8 @@
+﻿using Microsoft.Extensions.Http.AutoClient;
+
+[AutoClient(
+    httpClientName: "GeneratedClient",
+    customDependencyName: "Widget Service")]
+public interface IWidgetClient
+{
+}

--- a/docs/fundamentals/networking/http/snippets/autoclient/Program.cs
+++ b/docs/fundamentals/networking/http/snippets/autoclient/Program.cs
@@ -1,5 +1,4 @@
 ﻿// <program>
-using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/docs/fundamentals/networking/http/snippets/autoclient/Program.cs
+++ b/docs/fundamentals/networking/http/snippets/autoclient/Program.cs
@@ -1,0 +1,43 @@
+﻿// <program>
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(null);
+
+// Add a named HTTP client "ICompleteUserClient".
+builder.Services.AddHttpClient(nameof(ICompleteUserClient), options =>
+{
+    options.BaseAddress = new("https://jsonplaceholder.typicode.com");
+});
+
+builder.Services.AddCompleteUserClient(options =>
+{
+    options.JsonSerializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNameCaseInsensitive = true
+    };
+});
+
+builder.Services.AddSingleton<UserService>();
+
+using IHost host = builder.Build();
+
+UserService service = host.Services.GetRequiredService<UserService>();
+
+await service.ProcessUsersAsync();
+
+host.Run();
+// </program>
+
+// <output>
+// Sample output:
+//   CreateUserAsync: Created user
+//      'Ada Lovelace (Email: 1st-computer-programmer@example.com, Id: 11)'...
+//   
+//   GetUserAsync: Received user
+//       'Kurtis Weissnat (Email: Telly.Hoeger@billy.biz, Id: 7)'...
+//   
+//   GetUsersAsync: Received a total of 10 users...
+// </output>

--- a/docs/fundamentals/networking/http/snippets/autoclient/User.cs
+++ b/docs/fundamentals/networking/http/snippets/autoclient/User.cs
@@ -1,0 +1,12 @@
+﻿public sealed record class User(
+    int? Id,
+    string Name,
+    string Username,
+    string Email,
+    Address Address,
+    string Phone,
+    string Website,
+    Company Company)
+{
+    public sealed override string ToString() => $"{Name} (Email: {Email}, Id: {Id})";
+}

--- a/docs/fundamentals/networking/http/snippets/autoclient/UserService.cs
+++ b/docs/fundamentals/networking/http/snippets/autoclient/UserService.cs
@@ -1,0 +1,49 @@
+﻿using System.Net.Http.Json;
+
+internal sealed class UserService(ICompleteUserClient userClient)
+{
+    public async Task ProcessUsersAsync()
+    {
+        // Create a new user.
+        HttpResponseMessage response = await userClient.CreateUserAsync(new(
+            Id: null, /* Is populated upon successful HTTP POST when creating user */
+            Name: "Ada Lovelace",
+            Username: "ada.lovelace",
+            Email: "1st-computer-programmer@example.com",
+            Address: new(
+                Street: "123 Engineer Lane",
+                Suite: null,
+                City: "London",
+                ZipCode: "EC1A",
+                Geo: new(
+                    Lat: 51.509865m, Lng: -0.118092m)),
+            Phone: "+1234567890",
+            Website: "www.example.com",
+            Company: new(
+                Name: "Babbage, LLC.",
+                CatchPhrase: "works on my machine",
+                Bs: "This is the future")));
+
+        User? createdUser = await response.Content.ReadFromJsonAsync<User>();
+
+        Console.WriteLine($"""
+            CreateUserAsync: Created user
+               '{createdUser}'...
+
+            """);
+
+        // Get user by id.
+        User receivedUser = await userClient.GetUserByIdAsync(7);
+        Console.WriteLine($"""
+            GetUserAsync: Received user
+                '{receivedUser}'...
+
+            """);
+
+        // Get list of all users.
+        User[] allUsers = await userClient.GetAllUsersAsync();
+        Console.WriteLine($"""
+            GetUsersAsync: Received a total of {allUsers.Length} users...
+            """);
+    }
+}

--- a/docs/fundamentals/networking/http/snippets/autoclient/autoclient.csproj
+++ b/docs/fundamentals/networking/http/snippets/autoclient/autoclient.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http.AutoClient" Version="8.0.0-preview.7.23407.5" />
+  </ItemGroup>
+
+
+
+</Project>

--- a/docs/fundamentals/networking/http/snippets/autoclient/autoclient.csproj
+++ b/docs/fundamentals/networking/http/snippets/autoclient/autoclient.csproj
@@ -12,6 +12,4 @@
     <PackageReference Include="Microsoft.Extensions.Http.AutoClient" Version="8.0.0-preview.7.23407.5" />
   </ItemGroup>
 
-
-
 </Project>

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -830,6 +830,9 @@ items:
       - name: HTTP/3 with .NET
         href: ../core/extensions/httpclient-http3.md
         displayName: networking,http,http3,http/3,http3 with .net,http/3 with .net
+      - name: Source generated HTTP clients
+        href: networking/http/http-autoclient.md
+        displayName: networking,http,httpclient,auto,autoclient,auto-client,source generation,source generator,httpclient source generation,httpclient source generator
       - name: Rate limit an HTTP handler
         href: ../core/extensions/http-ratelimiter.md
         displayName: networking,http,rate limit,rate limiting,rate limit http,rate limiting http,rate limit http handler,rate limiting http handler

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -830,7 +830,7 @@ items:
       - name: HTTP/3 with .NET
         href: ../core/extensions/httpclient-http3.md
         displayName: networking,http,http3,http/3,http3 with .net,http/3 with .net
-      - name: Source generated HTTP clients
+      - name: REST API HTTP client generator
         href: networking/http/http-autoclient.md
         displayName: networking,http,httpclient,auto,autoclient,auto-client,source generation,source generator,httpclient source generation,httpclient source generator
       - name: Rate limit an HTTP handler


### PR DESCRIPTION
## Summary

Content for the `Microsoft.Extensions.Http.AutoClient` NuGet package.

Fixes #36947


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/networking/http/http-autoclient.md](https://github.com/dotnet/docs/blob/95652fb8e21d162c824c73fc39e05b4376de8b12/docs/fundamentals/networking/http/http-autoclient.md) | [Use the REST API HTTP client generator](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/http-autoclient?branch=pr-en-us-36970) |
| [docs/fundamentals/networking/http/httpclient.md](https://github.com/dotnet/docs/blob/95652fb8e21d162c824c73fc39e05b4376de8b12/docs/fundamentals/networking/http/httpclient.md) | [Make HTTP requests with the HttpClient](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient?branch=pr-en-us-36970) |


<!-- PREVIEW-TABLE-END -->