### PR TITLE
Update check-for-build-warnings.yml

### DIFF
--- a/.github/workflows/check-for-build-warnings.yml
+++ b/.github/workflows/check-for-build-warnings.yml
@@ -13,7 +13,10 @@ jobs:
         issues: write
         pull-requests: write
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
     - uses: dotnet/docs-tools/actions/status-checker@main
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

I believe I've finally discovered why some preview titles couldn't be found, it's because we were checking out `main`, not the PR code. As such, new files don't exist:

![image](https://github.com/dotnet/docs/assets/7679720/a47b8190-e723-4795-b77b-3be21c4c7b30)

Fixes #36973
