### PR TITLE
Flow the `GITHUB_TOKEN` as a `token` input.

### DIFF
--- a/.github/workflows/version-sweep.yml
+++ b/.github/workflows/version-sweep.yml
@@ -35,3 +35,4 @@ jobs:
               uses: dotnet/docs-tools/actions/dotnet-version-updater@main
               with:
                   support: ${{ github.event.inputs.support }}
+                  token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Flow the `GITHUB_TOKEN` as a `token` input.

Requires dotnet/docs-tools#265 to be merged first.
