### PR TITLE
Policheck update – Sept. 7 | [bulk update] "dialect" to "regional language"

### DIFF
--- a/docs/core/extensions/localization.md
+++ b/docs/core/extensions/localization.md
@@ -40,13 +40,13 @@ Where:
 
 ### Specifying locales
 
-The locale should define the language, at a bare minimum, but it can also define the culture (dialect), and even the country or region. These segments are commonly delimited by the `-` character. With the added specificity of a culture, the "culture fallback" rules are applied where best matches are prioritized. The locale should map to a well-known language tag. For more information, see <xref:System.Globalization.CultureInfo.Name?displayProperty=nameWithType>.
+The locale should define the language, at a bare minimum, but it can also define the culture (regional language), and even the country or region. These segments are commonly delimited by the `-` character. With the added specificity of a culture, the "culture fallback" rules are applied where best matches are prioritized. The locale should map to a well-known language tag. For more information, see <xref:System.Globalization.CultureInfo.Name?displayProperty=nameWithType>.
 
 ### Culture fallback scenarios
 
 Imagine that your localized app supports various Serbian locales, and has the following resource files for its `MessageService`:
 
-| File                             | Dialect                       | Country Code |
+| File                             | Regional language             | Country Code |
 |----------------------------------|-------------------------------|--------------|
 | *MessageService.sr-Cyrl-RS.resx* | (Cyrillic, Serbia)            | RS           |
 | *MessageService.sr-Cyrl.resx*    | Cyrillic                      |              |
@@ -57,7 +57,7 @@ Imagine that your localized app supports various Serbian locales, and has the fo
 | *MessageService.sr.resx*         | <sup>†</sup> Latin            |              |
 | *MessageService.resx*            |                               |              |
 
-_<sup>†</sup>  The default dialect for the language._
+_<sup>†</sup>  The default regional language for the language._
 
 When your app is running with the <xref:System.Globalization.CultureInfo.CurrentCulture?displayProperty=nameWithType> set to a culture of `"sr-Cyrl-RS"` localization attempts to resolve files in the following order:
 


### PR DESCRIPTION
## Summary

Change sensitive term "dialect" to "regional language"

Fixes bugs 

- https://dev.azure.com/msft-skilling/learn-platform-policheck/_workitems/edit/118811
- https://dev.azure.com/msft-skilling/learn-platform-policheck/_workitems/edit/97468

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/localization.md](https://github.com/dotnet/docs/blob/6e665cf2a304507175fbf1d28d33460501e97933/docs/core/extensions/localization.md) | [Localization in .NET](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/localization?branch=pr-en-us-37010) |

<!-- PREVIEW-TABLE-END -->