### PR TITLE
file-path-formats: fix example

### DIFF
--- a/docs/standard/io/file-path-formats.md
+++ b/docs/standard/io/file-path-formats.md
@@ -93,7 +93,7 @@ The DOS device path consists of the following components:
   `\\.\UNC\Server\Share\Test\Foo.txt`
   `\\?\UNC\Server\Share\Test\Foo.txt`
 
-    For device UNCs, the server/share portion forms the volume. For example, in `\\?\server1\e:\utilities\\filecomparer\`, the server/share portion is `server1\utilities`. This is significant when calling a method such as <xref:System.IO.Path.GetFullPath(System.String,System.String)?displayProperty=nameWithType> with relative directory segments; it is never possible to navigate past the volume.
+    For device UNCs, the server/share portion forms the volume. For example, in `\\?\server1\utilities\\filecomparer\`, the server/share portion is `server1\utilities`. This is significant when calling a method such as <xref:System.IO.Path.GetFullPath(System.String,System.String)?displayProperty=nameWithType> with relative directory segments; it is never possible to navigate past the volume.
 
 DOS device paths are fully qualified by definition and cannot begin with a relative directory segment (`.` or `..`). Current directories never enter into their usage.
 


### PR DESCRIPTION
the e: part inside the UNC path is wrong



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/io/file-path-formats.md](https://github.com/dotnet/docs/blob/814179d5fd97f58a1733adda350bf0c65f07ad06/docs/standard/io/file-path-formats.md) | [File path formats on Windows systems](https://review.learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats?branch=pr-en-us-37030) |

<!-- PREVIEW-TABLE-END -->