### PR TITLE
Add SYSLIB0052

### DIFF
--- a/docs/core/compatibility/core-libraries/8.0/obsolete-apis-with-custom-diagnostics.md
+++ b/docs/core/compatibility/core-libraries/8.0/obsolete-apis-with-custom-diagnostics.md
@@ -541,8 +541,6 @@ The `SYSLIB0051` API obsoletions are organized here by namespace.
 - <xref:System.Xml.Xsl.XsltException.%23ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)?displayProperty=fullName>
 - <xref:System.Xml.Xsl.XsltException.GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)?displayProperty=fullName>
 
-
-
 ### SYSLIB0052
 
 - <xref:System.Text.RegularExpressions.Regex.InitializeReferences?displayProperty=fullName>

--- a/docs/core/compatibility/core-libraries/8.0/obsolete-apis-with-custom-diagnostics.md
+++ b/docs/core/compatibility/core-libraries/8.0/obsolete-apis-with-custom-diagnostics.md
@@ -2,7 +2,7 @@
 title: "Breaking change: .NET 8 obsoletions with custom IDs"
 titleSuffix: ""
 description: Learn about the .NET 8 breaking change in core .NET libraries where some APIs have been marked as obsolete with a custom diagnostic ID.
-ms.date: 06/08/2023
+ms.date: 09/08/2023
 ---
 # API obsoletions with non-default diagnostic IDs (.NET 8)
 
@@ -16,9 +16,11 @@ The following table lists the custom diagnostic IDs and their corresponding warn
 
 | Diagnostic ID | Description | Severity |
 | - | - |
+| [SYSLIB0011](../../../../fundamentals/syslib-diagnostics/syslib0011.md) | BinaryFormatter serialization is obsolete | Warning/error |
 | [SYSLIB0048](../../../../fundamentals/syslib-diagnostics/syslib0048.md) | <xref:System.Security.Cryptography.RSA.EncryptValue(System.Byte[])?displayProperty=nameWithType> and <xref:System.Security.Cryptography.RSA.DecryptValue(System.Byte[])?displayProperty=nameWithType> are obsolete. Use <xref:System.Security.Cryptography.RSA.Encrypt%2A?displayProperty=nameWithType> and <xref:System.Security.Cryptography.RSA.Decrypt%2A?displayProperty=nameWithType> instead. | Warning |
 | [SYSLIB0050](../../../../fundamentals/syslib-diagnostics/syslib0050.md) | Formatter-based serialization is obsolete and should not be used. | Warning |
 | [SYSLIB0051](../../../../fundamentals/syslib-diagnostics/syslib0051.md) | APIs that support obsolete formatter-based serialization are obsolete. They should not be called or extended by application code. | Warning |
+| [SYSLIB0052](../../../../fundamentals/syslib-diagnostics/syslib0052.md) | APIs that support obsolete mechanisms for Regex extensibility are obsolete. | Warning |
 | [SYSLIB0053](../../../../fundamentals/syslib-diagnostics/syslib0053.md) | <xref:System.Security.Cryptography.AesGcm> should indicate the required tag size for encryption and decryption. Use a constructor that accepts the tag size. | Warning |
 
 ## Version introduced
@@ -36,6 +38,13 @@ These obsoletions can affect [source compatibility](../../categories.md#source-c
 - Warnings or errors for these obsoletions can't be suppressed using the standard diagnostic ID for obsolete types or members; use the custom `SYSLIBxxxx` diagnostic ID value instead.
 
 ## Affected APIs
+
+### SYSLIB0011
+
+- <xref:System.Resources.Extensions.PreserializedResourceWriter.AddBinaryFormattedResource(System.String,System.Byte[],System.String)?displayProperty=fullName>
+- <xref:System.Runtime.Serialization.Formatter?displayProperty=fullName>
+- <xref:System.Runtime.Serialization.IFormatter?displayProperty=fullName>
+- <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter?displayProperty=fullName>
 
 ### SYSLIB0048
 
@@ -531,6 +540,17 @@ The `SYSLIB0051` API obsoletions are organized here by namespace.
 - <xref:System.Xml.Xsl.XsltCompileException.GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)?displayProperty=fullName>
 - <xref:System.Xml.Xsl.XsltException.%23ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)?displayProperty=fullName>
 - <xref:System.Xml.Xsl.XsltException.GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)?displayProperty=fullName>
+
+
+
+### SYSLIB0052
+
+- <xref:System.Text.RegularExpressions.Regex.InitializeReferences?displayProperty=fullName>
+- <xref:System.Text.RegularExpressions.Regex.UseOptionC?displayProperty=fullName>
+- <xref:System.Text.RegularExpressions.Regex.UseOptionR?displayProperty=fullName>
+- <xref:System.Text.RegularExpressions.RegexRunner.CharInSet(System.Char,System.String,System.String)?displayProperty=fullName>
+- <xref:System.Text.RegularExpressions.RegexRunner.Scan(System.Text.RegularExpressions.Regex,System.String,System.Int32,System.Int32,System.Int32,System.Int32,System.Boolean)?displayProperty=fullName>
+- <xref:System.Text.RegularExpressions.RegexRunner.Scan(System.Text.RegularExpressions.Regex,System.String,System.Int32,System.Int32,System.Int32,System.Int32,System.Boolean,System.TimeSpan)?displayProperty=fullName>
 
 ### SYSLIB0053
 

--- a/docs/fundamentals/syslib-diagnostics/obsoletions-overview.md
+++ b/docs/fundamentals/syslib-diagnostics/obsoletions-overview.md
@@ -71,6 +71,7 @@ The following table provides an index to the `SYSLIB0XXX` obsoletions in .NET 5+
 | [SYSLIB0048](syslib0048.md) | Warning | <xref:System.Security.Cryptography.RSA.EncryptValue(System.Byte[])?displayProperty=nameWithType> and <xref:System.Security.Cryptography.RSA.DecryptValue(System.Byte[])?displayProperty=nameWithType> are obsolete. Use <xref:System.Security.Cryptography.RSA.Encrypt%2A?displayProperty=nameWithType> and <xref:System.Security.Cryptography.RSA.Decrypt%2A?displayProperty=nameWithType> instead. |
 | [SYSLIB0050](syslib0050.md) | Warning | Formatter-based serialization is obsolete and should not be used. |
 | [SYSLIB0051](syslib0051.md) | Warning | APIs that support obsolete formatter-based serialization are obsolete. They should not be called or extended by application code. |
+| [SYSLIB0052](syslib0052.md) | Warning | APIs that support obsolete mechanisms for Regex extensibility are obsolete. |
 | [SYSLIB0053](syslib0053.md) | Warning | <xref:System.Security.Cryptography.AesGcm> should indicate the required tag size for encryption and decryption. Use a constructor that accepts the tag size. |
 
 ## Suppress warnings

--- a/docs/fundamentals/syslib-diagnostics/syslib0011.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib0011.md
@@ -1,7 +1,7 @@
 ---
 title: SYSLIB0011 warning
 description: Learn about the obsoletions that generate compile-time warning SYSLIB0011.
-ms.date: 05/08/2023
+ms.date: 09/08/2023
 ---
 # SYSLIB0011: BinaryFormatter serialization is obsolete
 
@@ -15,7 +15,7 @@ Due to [security vulnerabilities](../../standard/serialization/binaryformatter-s
 - <xref:System.Runtime.Serialization.IFormatter.Serialize(System.IO.Stream,System.Object)?displayProperty=nameWithType>
 - <xref:System.Runtime.Serialization.IFormatter.Deserialize(System.IO.Stream)?displayProperty=nameWithType>
 
-Starting in .NET 8, <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter.Serialize%2A?displayProperty=nameWithType> and <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter.Deserialize%2A?displayProperty=nameWithType> throw a <xref:System.NotSupportedException> at run time on most project types. In addition, the following APIs are marked obsolete *as error*:
+Starting in .NET 8, <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter.Serialize%2A?displayProperty=nameWithType> and <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter.Deserialize%2A?displayProperty=nameWithType> throw a <xref:System.NotSupportedException> at run time on most project types. In addition, <xref:System.Resources.Extensions.PreserializedResourceWriter.AddBinaryFormattedResource(System.String,System.Byte[],System.String)?displayProperty=nameWithType> is obsolete *as warning*, and the following APIs are obsolete *as error*:
 
 - <xref:System.Runtime.Serialization.Formatter?displayProperty=fullName>
 - <xref:System.Runtime.Serialization.IFormatter?displayProperty=fullName>

--- a/docs/fundamentals/syslib-diagnostics/syslib0052.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib0052.md
@@ -5,7 +5,7 @@ ms.date: 09/08/2023
 ---
 # SYSLIB0052: APIs that support obsolete mechanisms for Regex extensibility are obsolete
 
-The following kinds of APIs are obsolete, starting in .NET 8. Calling them in code generates warning `SYSLIB0052` at compile time. These <xref:System.Text.RegularExpressions.Regex> and <xref:System.Text.RegularExpressions.RegexRunner> APIs supported the now obsolete <xref:System.Text.RegularExpressions.Regex.CompileToAssembly%2A>.
+The following <xref:System.Text.RegularExpressions.Regex> and <xref:System.Text.RegularExpressions.RegexRunner> APIs are obsolete, starting in .NET 8. Calling them in code generates warning `SYSLIB0052` at compile time. These APIs supported the now obsolete <xref:System.Text.RegularExpressions.Regex.CompileToAssembly%2A>.
 
 - <xref:System.Text.RegularExpressions.Regex.InitializeReferences?displayProperty=nameWithType>
 - <xref:System.Text.RegularExpressions.Regex.UseOptionC?displayProperty=nameWithType>

--- a/docs/fundamentals/syslib-diagnostics/syslib0052.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib0052.md
@@ -1,0 +1,49 @@
+---
+title: SYSLIB0052 warning - APIs that support obsolete mechanisms for Regex extensibility are obsolete
+description: Learn about the obsoletion of APIs that support obsolete mechanisms for Regex extensibility that generates compile-time warning SYSLIB0052.
+ms.date: 09/08/2023
+---
+# SYSLIB0052: APIs that support obsolete mechanisms for Regex extensibility are obsolete
+
+The following kinds of APIs are obsolete, starting in .NET 8. Calling them in code generates warning `SYSLIB0052` at compile time. These <xref:System.Text.RegularExpressions.Regex> and <xref:System.Text.RegularExpressions.RegexRunner> APIs supported the now obsolete <xref:System.Text.RegularExpressions.Regex.CompileToAssembly%2A>.
+
+- <xref:System.Text.RegularExpressions.Regex.InitializeReferences?displayProperty=nameWithType>
+- <xref:System.Text.RegularExpressions.Regex.UseOptionC?displayProperty=nameWithType>
+- <xref:System.Text.RegularExpressions.Regex.UseOptionR?displayProperty=nameWithType>
+- <xref:System.Text.RegularExpressions.RegexRunner.CharInSet(System.Char,System.String,System.String)?displayProperty=nameWithType>
+- <xref:System.Text.RegularExpressions.RegexRunner.Scan(System.Text.RegularExpressions.Regex,System.String,System.Int32,System.Int32,System.Int32,System.Int32,System.Boolean)?displayProperty=nameWithType>
+- <xref:System.Text.RegularExpressions.RegexRunner.Scan(System.Text.RegularExpressions.Regex,System.String,System.Int32,System.Int32,System.Int32,System.Int32,System.Boolean,System.TimeSpan)?displayProperty=nameWithType>
+
+## Workaround
+
+N/A
+
+## Suppress a warning
+
+If you must use the obsolete APIs, you can suppress the warning in code or in your project file.
+
+To suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the warning.
+
+```csharp
+// Disable the warning.
+#pragma warning disable SYSLIB0052
+
+// Code that uses obsolete API.
+// ...
+
+// Re-enable the warning.
+#pragma warning restore SYSLIB0052
+```
+
+To suppress all the `SYSLIB0052` warnings in your project, add a `<NoWarn>` property to your project file.
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+   ...
+   <NoWarn>$(NoWarn);SYSLIB0052</NoWarn>
+  </PropertyGroup>
+</Project>
+```
+
+For more information, see [Suppress warnings](obsoletions-overview.md#suppress-warnings).

--- a/docs/navigate/tools-diagnostics/toc.yml
+++ b/docs/navigate/tools-diagnostics/toc.yml
@@ -1479,6 +1479,8 @@ items:
             href: ../../fundamentals/syslib-diagnostics/syslib0050.md
           - name: SYSLIB0051
             href: ../../fundamentals/syslib-diagnostics/syslib0051.md
+          - name: SYSLIB0052
+            href: ../../fundamentals/syslib-diagnostics/syslib0052.md
           - name: SYSLIB0053
             href: ../../fundamentals/syslib-diagnostics/syslib0053.md
       - name: Source-generated code


### PR DESCRIPTION
Fixes #36993 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/core-libraries/8.0/obsolete-apis-with-custom-diagnostics.md](https://github.com/dotnet/docs/blob/7e025ada4c6f4c9ee16edf03bba27ac4953b1a8c/docs/core/compatibility/core-libraries/8.0/obsolete-apis-with-custom-diagnostics.md) | [API obsoletions with non-default diagnostic IDs (.NET 8)](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/8.0/obsolete-apis-with-custom-diagnostics?branch=pr-en-us-37032) |
| [docs/fundamentals/syslib-diagnostics/obsoletions-overview.md](https://github.com/dotnet/docs/blob/7e025ada4c6f4c9ee16edf03bba27ac4953b1a8c/docs/fundamentals/syslib-diagnostics/obsoletions-overview.md) | [Obsolete features in .NET 5+](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/obsoletions-overview?branch=pr-en-us-37032) |
| [docs/fundamentals/syslib-diagnostics/syslib0011.md](https://github.com/dotnet/docs/blob/7e025ada4c6f4c9ee16edf03bba27ac4953b1a8c/docs/fundamentals/syslib-diagnostics/syslib0011.md) | [SYSLIB0011: BinaryFormatter serialization is obsolete](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib0011?branch=pr-en-us-37032) |
| [docs/fundamentals/syslib-diagnostics/syslib0052.md](https://github.com/dotnet/docs/blob/7e025ada4c6f4c9ee16edf03bba27ac4953b1a8c/docs/fundamentals/syslib-diagnostics/syslib0052.md) | [SYSLIB0052: APIs that support obsolete mechanisms for Regex extensibility are obsolete](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib0052?branch=pr-en-us-37032) |

<!-- PREVIEW-TABLE-END -->