### PR TITLE
Add customer feedback GitHub template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/customer-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/customer-feedback.yml
@@ -1,0 +1,34 @@
+name: Feedback from live site
+title: "[Documentation feedback] - "
+description: |
+  This template is hooked into the feedback control on the bottom of every page on the live site. It automatically fills in several fields for you. You should not use this template for other purposes.
+labels:
+  - ":watch: Not Triaged"
+body:
+  - type: textarea
+    id: details
+    validations:
+      required: false
+    attributes:
+      label: Details
+      description: >-
+        Write a clear and concise description of your feedback for the documentation. 
+        Provide details that will add context and help the team address your feedback.
+  - type: input
+    id: pageUrl
+    validations:
+      required: true
+    attributes:
+      label: Page URL
+  - type: input
+    id: contentSourceUrl
+    validations:
+      required: true
+    attributes:
+      label: Content source URL
+  - type: input
+    id: documentId
+    validations:
+      required: true
+    attributes:
+      label: Document Id

--- a/.github/ISSUE_TEMPLATE/customer-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/customer-feedback.yml
@@ -8,7 +8,7 @@ body:
   - type: textarea
     id: details
     validations:
-      required: false
+      required: true
     attributes:
       label: Details
       description: >-

--- a/.github/ISSUE_TEMPLATE/new-feature-csharp.yml
+++ b/.github/ISSUE_TEMPLATE/new-feature-csharp.yml
@@ -19,9 +19,7 @@ body:
         - "17.8p1"
         - "17.8p2"
         - "17.8p3"
-        - Other (please put exact version in description textbox)
-    validations:
-      required: true
+        - "Other (please put exact version in description textbox)"
   - type: input
     id: Speclet
     attributes:


### PR DESCRIPTION
This is the first pass at the new issue template for feedback from the live site control.

Contributes to #37025

In this first PR, I've tried to replicate the information in the current template as best as I can. I've got a question to the team to see if ms.author and author metadata is supported yet.
