### PR TITLE
Fix: HttpClientFactory sample highlighted lines

### DIFF
--- a/docs/core/extensions/httpclient-factory.md
+++ b/docs/core/extensions/httpclient-factory.md
@@ -50,7 +50,7 @@ To register the `IHttpClientFactory`, call `AddHttpClient`:
 
 Consuming services can require the `IHttpClientFactory` as a constructor parameter with [DI][di]. The following code uses `IHttpClientFactory` to create an `HttpClient` instance:
 
-:::code source="snippets/http/basic/TodoService.cs" highlight="11,15,17,22":::
+:::code source="snippets/http/basic/TodoService.cs" highlight="10,14,16,21":::
 
 Using `IHttpClientFactory` like in the preceding example is a good way to refactor an existing app. It has no impact on how `HttpClient` is used. In places where `HttpClient` instances are created in an existing app, replace those occurrences with calls to <xref:System.Net.Http.IHttpClientFactory.CreateClient%2A>.
 


### PR DESCRIPTION
## Summary

This change fixes the text highlighting for a code sample in the HttpClientFactory documentation. One of the examples had highlights which were off by one consistently. The highlighted lines have been updated to match those which include reference to HttpClientFactory.

Screenshot of https://learn.microsoft.com/en-us/dotnet/core/extensions/httpclient-factory from 9/12/2023:

![screenshot showing the highlights which are off by one](https://github.com/dotnet/docs/assets/16418643/a04b0620-e65c-4509-8f35-dae70a22d3e7)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/httpclient-factory.md](https://github.com/dotnet/docs/blob/b8dcb19b57e30eadc36910c15e1cb849542779d9/docs/core/extensions/httpclient-factory.md) | [IHttpClientFactory with .NET](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/httpclient-factory?branch=pr-en-us-37061) |

<!-- PREVIEW-TABLE-END -->