### PR TITLE
Fixed typo in types.md

### DIFF
--- a/docs/csharp/tour-of-csharp/types.md
+++ b/docs/csharp/tour-of-csharp/types.md
@@ -37,7 +37,7 @@ The memory occupied by an object is automatically reclaimed when the object is n
 
 :::code language="csharp" source="./snippets/shared/Types.cs" ID="CreatePoints":::
 
-Applications or tests for algorithms might need to create multiple `Point` objects. The following class generates a sequence of random points. The number of points is set by the *primary constructor* parameter. The primary constructor parameter `numPoints` is in scope for all members of the class:
+Applications or tests for algorithms might need to create multiple `Point` objects. The following class generates a sequence of random points. The number of points is set by the *primary constructor* parameter. The primary constructor parameter `numberOfPoints` is in scope for all members of the class:
 
 :::code language="csharp" source="./snippets/shared/Types.cs" ID="PointFactoryClass":::
 


### PR DESCRIPTION
fixes #37059

## Summary

changed numPoints to numberOfPoints in types.md file 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/tour-of-csharp/types.md](https://github.com/dotnet/docs/blob/2d2cbba75007278a150da7c791a13f463268f0a1/docs/csharp/tour-of-csharp/types.md) | [C# types and members](https://review.learn.microsoft.com/en-us/dotnet/csharp/tour-of-csharp/types?branch=pr-en-us-37063) |

<!-- PREVIEW-TABLE-END -->