### PR TITLE
Update syntax-transformation.md to change "such a ..." to "such as ..."

### DIFF
--- a/docs/csharp/roslyn-sdk/get-started/syntax-transformation.md
+++ b/docs/csharp/roslyn-sdk/get-started/syntax-transformation.md
@@ -37,7 +37,7 @@ You'll create **name syntax nodes** to build the tree that represents the `using
 * <xref:Microsoft.CodeAnalysis.CSharp.Syntax.NameSyntax?displayProperty=nameWithType>, which represents simple single identifier names like `System` and `Microsoft`.
 * <xref:Microsoft.CodeAnalysis.CSharp.Syntax.GenericNameSyntax?displayProperty=nameWithType>, which represents a generic type or method name such as `List<int>`.
 * <xref:Microsoft.CodeAnalysis.CSharp.Syntax.QualifiedNameSyntax?displayProperty=nameWithType>, which represents a qualified name of the form `<left-name>.<right-identifier-or-generic-name>` such as `System.IO`.
-* <xref:Microsoft.CodeAnalysis.CSharp.Syntax.AliasQualifiedNameSyntax?displayProperty=nameWithType>, which represents a name using an assembly extern alias such a `LibraryV2::Foo`.
+* <xref:Microsoft.CodeAnalysis.CSharp.Syntax.AliasQualifiedNameSyntax?displayProperty=nameWithType>, which represents a name using an assembly extern alias such as `LibraryV2::Foo`.
 
 You use the <xref:Microsoft.CodeAnalysis.CSharp.SyntaxFactory.IdentifierName(System.String)> method to create a <xref:Microsoft.CodeAnalysis.CSharp.Syntax.NameSyntax> node. Add the following code in your `Main` method in `Program.cs`:
 


### PR DESCRIPTION
## Summary

Update syntax-transformation.md to fix a typo and change "such a ..." to "such as ..."

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/roslyn-sdk/get-started/syntax-transformation.md](https://github.com/dotnet/docs/blob/c4a65de1f5fbdca4b0275576f2e229bbde85c086/docs/csharp/roslyn-sdk/get-started/syntax-transformation.md) | [Get started with syntax transformation](https://review.learn.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/get-started/syntax-transformation?branch=pr-en-us-37109) |

<!-- PREVIEW-TABLE-END -->