### PR TITLE
WPF trimming incompatibility is not .NET 6 specific

### DIFF
--- a/docs/core/deploying/trimming/incompatibilities.md
+++ b/docs/core/deploying/trimming/incompatibilities.md
@@ -17,7 +17,7 @@ Automatic [COM marshalling](../../../standard/native-interop/cominterop.md) has 
 
 ## WPF
 
-The Windows Presentation Foundation (WPF) framework makes substantial use of reflection and some features are heavily reliant on run-time code inspection. In .NET 6, it's not possible for trimming analysis to preserve all necessary code for WPF applications. Unfortunately, almost no WPF apps are runnable after trimming, so trimming support for WPF is currently disabled in the .NET SDK. See [WPF is not trim-compatible](https://github.com/dotnet/wpf/issues/3811) issue for progress on enabling trimming for WPF.
+The Windows Presentation Foundation (WPF) framework makes substantial use of reflection and some features are heavily reliant on run-time code inspection. It's not possible for trimming analysis to preserve all necessary code for WPF applications. Unfortunately, almost no WPF apps are runnable after trimming, so trimming support for WPF is currently disabled in the .NET SDK. See [WPF is not trim-compatible](https://github.com/dotnet/wpf/issues/3811) issue for progress on enabling trimming for WPF.
 
 ## Windows Forms
 


### PR DESCRIPTION
Fix omission from https://github.com/dotnet/docs/pull/36769

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/deploying/trimming/incompatibilities.md](https://github.com/dotnet/docs/blob/f92253a9357937d9a4bb1e0e090a0ac3036206c1/docs/core/deploying/trimming/incompatibilities.md) | [Known trimming incompatibilities](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/incompatibilities?branch=pr-en-us-37110) |

<!-- PREVIEW-TABLE-END -->