### PR TITLE
Compare IDE0025 and IDE0027

### DIFF
--- a/docs/fundamentals/code-analysis/style-rules/ide0025.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0025.md
@@ -53,6 +53,64 @@ public int Age => _age;
 public int Age { get { return _age; }}
 ```
 
+## This rule versus IDE0027
+
+This rule, `IDE0025`, and [IDE0027 (Use expression body for accessors)](ide0027.md) are very similar. `IDE0025` concerns the property as a whole, whereas `IDE0027` specifically concerns the accessor parts of the property.
+
+For a read-only property that simply returns a value without doing any computation, if `IDE0025` is set to `csharp_style_expression_bodied_properties = false` but `IDE0027` is set to `csharp_style_expression_bodied_accessors = true`, you end up with a property that looks like this:
+
+```csharp
+public int TemperatureF
+{
+    get => _temp;
+}
+```
+
+But if you set `IDE0025` to `csharp_style_expression_bodied_properties = true`, the property is simplified even further (even if you set `IDE0027` to `csharp_style_expression_bodied_accessors = false`):
+
+```csharp
+public int TemperatureF => _temp;
+```
+
+For a read-write property, the difference becomes a little more apparent, because the property can't be written in an expression-bodied manner (because it consists of more than one line). So even if `IDE0025` is set to `csharp_style_expression_bodied_properties = true`, you still end up with curly braces, that is, a block body.
+
+The following examples show how a property looks with various combinations of the two options.
+
+```csharp
+// csharp_style_expression_bodied_properties = false
+// csharp_style_expression_bodied_accessors = true
+public int TemperatureB
+{
+    get => _temp;
+}
+
+// csharp_style_expression_bodied_properties = true
+// csharp_style_expression_bodied_accessors = true (or false)
+public int TemperatureC => _temp;
+
+// csharp_style_expression_bodied_properties = true (or false)
+// csharp_style_expression_bodied_accessors = true
+public int TemperatureD
+{
+    get => _temp;
+    set => _temp = value;
+}
+
+// csharp_style_expression_bodied_properties = true
+// csharp_style_expression_bodied_accessors = false
+public int TemperatureE
+{
+    get
+    {
+        return _temp;
+    }
+    set
+    {
+        _temp = value;
+    }
+}
+```
+
 ## Suppress a warning
 
 If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.

--- a/docs/fundamentals/code-analysis/style-rules/ide0027.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0027.md
@@ -53,6 +53,10 @@ public int Age { get => _age; set => _age = value; }
 public int Age { get { return _age; } set { _age = value; } }
 ```
 
+## This rule versus IDE0025
+
+This rule, `IDE0027`, and [IDE0025 (Use expression body for properties)](ide0025.md) are very similar. `IDE0025` concerns the property as a whole, whereas `IDE0027` specifically concerns the accessor parts of the property. For more information about the differences between these rules, see [IDE0025 versus IDE0027](ide0025.md#this-rule-versus-ide0027).
+
 ## Suppress a warning
 
 If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.


### PR DESCRIPTION
Fixes #35306 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/style-rules/ide0025.md](https://github.com/dotnet/docs/blob/f3fc5370407fc3b40d2922d2a73c37acbd65b697/docs/fundamentals/code-analysis/style-rules/ide0025.md) | [Use expression body for properties (IDE0025)](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0025?branch=pr-en-us-37118) |
| [docs/fundamentals/code-analysis/style-rules/ide0027.md](https://github.com/dotnet/docs/blob/f3fc5370407fc3b40d2922d2a73c37acbd65b697/docs/fundamentals/code-analysis/style-rules/ide0027.md) | ["IDE0027: Use expression body for accessors"](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0027?branch=pr-en-us-37118) |

<!-- PREVIEW-TABLE-END -->