### PR TITLE
Change fields to properties to match description in primary constructors tutorial

### DIFF
--- a/docs/csharp/whats-new/tutorials/snippets/primary-constructors/Distance.cs
+++ b/docs/csharp/whats-new/tutorials/snippets/primary-constructors/Distance.cs
@@ -3,8 +3,8 @@
     // <ReadonlyStruct>
     public readonly struct Distance(double dx, double dy)
     {
-        public readonly double Magnitude = Math.Sqrt(dx * dx + dy * dy);
-        public readonly double Direction = Math.Atan2(dy, dx);
+        public readonly double Magnitude { get; } = Math.Sqrt(dx * dx + dy * dy);
+        public readonly double Direction { get; } = Math.Atan2(dy, dx);
     }
     // </ReadonlyStruct>
 }


### PR DESCRIPTION
## Summary

The description above the code sample in [the primary constructors tutorial](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/tutorials/primary-constructors) says that properties are used, but the code sample used fields. All other code samples used properties as expected.