### PR TITLE
Fix type of change

### DIFF
--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -23,8 +23,8 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 | [Custom converters for serialization removed](aspnet-core/8.0/problemdetails-custom-converters.md)   | Behavioral change   | Preview 2  |
 | [ISystemClock is obsolete](aspnet-core/8.0/isystemclock-obsolete.md)                                 | Source incompatible | Preview 5  |
 | [Rate-limiting middleware requires AddRateLimiter](aspnet-core/8.0/addratelimiter-requirement.md)    | Behavioral change   | Preview 5  |
-| [Security token events return a JSonWebToken](aspnet-core/8.0/securitytoken-events.md)   | Preview 7  |
-| [TrimMode defaults to full for Web SDK projects](aspnet-core/8.0/trimmode-full.md)   | Preview 7  |
+| [Security token events return a JSonWebToken](aspnet-core/8.0/securitytoken-events.md)               | Behavioral change   | Preview 7  |
+| [TrimMode defaults to full for Web SDK projects](aspnet-core/8.0/trimmode-full.md)                   | Source incompatible | Preview 7  |
 
 ## Containers
 


### PR DESCRIPTION
## Summary

Two entries were missing the `Type of Change` and therefore the `Introduced` value moved one cell to the left unintentionally.

![image](https://github.com/dotnet/docs/assets/940619/6643ab0d-e709-43ac-9478-3d9726c62237)

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/8.0.md](https://github.com/dotnet/docs/blob/71653d4663a7e9fc4b4ff95a36d721c6c16642d3/docs/core/compatibility/8.0.md) | [Breaking changes in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/8.0?branch=pr-en-us-37145) |

<!-- PREVIEW-TABLE-END -->