### PR TITLE
Add missed dashes to script argument

### DIFF
--- a/docs/core/tools/dotnet-install-script.md
+++ b/docs/core/tools/dotnet-install-script.md
@@ -19,7 +19,7 @@ dotnet-install.ps1 [-Architecture <ARCHITECTURE>] [-AzureFeed]
     [-InstallDir <DIRECTORY>] [-JSonFile <JSONFILE>]
     [-NoCdn] [-NoPath] [-ProxyAddress] [-ProxyBypassList <LIST_OF_URLS>]
     [-ProxyUseDefaultCredentials] [-Quality <QUALITY>] [-Runtime <RUNTIME>]
-    [-SkipNonVersionedFiles] [-UncachedFeed] [KeepZip] [ZipPath <PATH>] [-Verbose]
+    [-SkipNonVersionedFiles] [-UncachedFeed] [-KeepZip] [-ZipPath <PATH>] [-Verbose]
     [-Version <VERSION>]
 
 Get-Help ./dotnet-install.ps1


### PR DESCRIPTION
## Summary

The missed part of https://github.com/dotnet/docs/pull/37146

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-install-script.md](https://github.com/dotnet/docs/blob/ef03414eae6f5c0a3a377c120880a47df0eba60d/docs/core/tools/dotnet-install-script.md) | [dotnet-install scripts reference](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script?branch=pr-en-us-37161) |

<!-- PREVIEW-TABLE-END -->