### PR TITLE
Fix the OpenTelemetry metrics tutorial

### DIFF
--- a/docs/core/diagnostics/metrics-collection.md
+++ b/docs/core/diagnostics/metrics-collection.md
@@ -132,7 +132,7 @@ This tutorial shows one of the integrations available for OpenTelemetry metrics 
 Add a reference to the OpenTelemetry Prometheus exporter to the example app:
 
 ```dotnetcli
-dotnet add package OpenTelemetry.Exporter.Prometheus.AspNetCore --prerelease
+dotnet add package OpenTelemetry.Exporter.Prometheus.HttpListener --prerelease
 ```
 
 > [!NOTE]
@@ -145,7 +145,7 @@ Update `Program.cs` with OpenTelemetry configuration:
 In the preceding code:
 
 - `AddMeter("HatCo.HatStore")` configures OpenTelemetry to transmit all the metrics collected by the Meter defined in the app.
-- `AddPrometheusExporter` configures OpenTelemetry to:
+- `AddPrometheusHttpListener` configures OpenTelemetry to:
   - Expose Prometheus' metrics endpoint on port `9184`
   - Use the HttpListener.
 

--- a/docs/core/diagnostics/snippets/Metrics/Program.cs
+++ b/docs/core/diagnostics/snippets/Metrics/Program.cs
@@ -40,11 +40,7 @@ class Program
     {
         using MeterProvider meterProvider = Sdk.CreateMeterProviderBuilder()
                 .AddMeter("HatCo.HatStore")
-                .AddPrometheusExporter(opt =>
-                {
-                    opt.StartHttpListener = true;
-                    opt.HttpListenerPrefixes = new string[] { $"http://localhost:9184/" };
-                })
+                .AddPrometheusHttpListener(options => options.UriPrefixes = new string[] { "http://localhost:9464/" })
                 .Build();
 
         var rand = Random.Shared;

--- a/docs/core/diagnostics/snippets/Metrics/metric-instr.csproj
+++ b/docs/core/diagnostics/snippets/Metrics/metric-instr.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus" Version="1.3.0-rc.2" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.HttpListener" Version="1.6.0-rc.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.2" />
   </ItemGroup>
 


### PR DESCRIPTION
The original doc was written based on 1.3.0-rc1 version of OpenTelemetry Prometheus Exporter, breaking changes were introduced between 1.3.0-rc1 and 1.6.0-rc1. This PR should make the doc working again.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/metrics-collection.md](https://github.com/dotnet/docs/blob/5255473daea8a7579bc28fbc9c1bf6c9eff87449/docs/core/diagnostics/metrics-collection.md) | [Collect metrics](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/metrics-collection?branch=pr-en-us-37162) |

<!-- PREVIEW-TABLE-END -->