### PR TITLE
Updated Meter Dispose guidance

### DIFF
--- a/docs/core/diagnostics/metrics-instrumentation.md
+++ b/docs/core/diagnostics/metrics-instrumentation.md
@@ -175,10 +175,10 @@ app.MapPost("/complete-sale", ([FromBody] SaleModel model, HatCoMetrics metrics)
 });
 ```
 
-### Best Practices
+### Best practices
 
-- <xref:System.Diagnostics.Metrics.Meter?displayProperty=nameWithType> implements IDisposable, but IMeterFactory automatically manages the lifetime of any Meters it
-  creates, disposing them when the DI container is disposed. Adding extra code to invoke Dispose() on the Meter is unnecessary and won't have any effect.
+- <xref:System.Diagnostics.Metrics.Meter?displayProperty=nameWithType> implements IDisposable, but IMeterFactory automatically manages the lifetime of any `Meter` objects it
+  creates, disposing them when the DI container is disposed. It's unnecessary to add extra code to invoke `Dispose()` on the `Meter`, and it won't have any effect.
 
 ## Types of instruments
 

--- a/docs/core/diagnostics/metrics-instrumentation.md
+++ b/docs/core/diagnostics/metrics-instrumentation.md
@@ -177,8 +177,8 @@ app.MapPost("/complete-sale", ([FromBody] SaleModel model, HatCoMetrics metrics)
 
 ### Best Practices
 
-- The <xref:System.Diagnostics.Metrics.Meter?displayProperty=nameWithType> does implement IDisposable, but IMeterFactory will manage the lifetime of any Meters it
-creates, automatically disposing them when the DI container is disposed. Adding extra code to invoke Dispose() on the Meter is unnecessary and won't have any effect.
+- <xref:System.Diagnostics.Metrics.Meter?displayProperty=nameWithType> implements IDisposable, but IMeterFactory automatically manages the lifetime of any Meters it
+  creates, disposing them when the DI container is disposed. Adding extra code to invoke Dispose() on the Meter is unnecessary and won't have any effect.
 
 ## Types of instruments
 

--- a/docs/core/diagnostics/metrics-instrumentation.md
+++ b/docs/core/diagnostics/metrics-instrumentation.md
@@ -175,6 +175,11 @@ app.MapPost("/complete-sale", ([FromBody] SaleModel model, HatCoMetrics metrics)
 });
 ```
 
+### Best Practices
+
+- The <xref:System.Diagnostics.Metrics.Meter?displayProperty=nameWithType> does implement IDisposable, but IMeterFactory will manage the lifetime of any Meters it
+creates, automatically disposing them when the DI container is disposed. Adding extra code to invoke Dispose() on the Meter is unnecessary and won't have any effect.
+
 ## Types of instruments
 
 So far we've only demonstrated a <xref:System.Diagnostics.Metrics.Counter`1> instrument, but there are more instrument types available. Instruments differ


### PR DESCRIPTION
IMeterFactory handles the lifetime of Meters.
Update guidance to clarify calling Dispose() isn't needed.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/metrics-instrumentation.md](https://github.com/dotnet/docs/blob/5c3f97f8a621fc4f08b01f7078b021c2cc3dbe5b/docs/core/diagnostics/metrics-instrumentation.md) | [Creating Metrics](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/metrics-instrumentation?branch=pr-en-us-37170) |


<!-- PREVIEW-TABLE-END -->