### PR TITLE
Fixed Typo (Markdown)

### DIFF
--- a/docs/core/tools/dotnet.md
+++ b/docs/core/tools/dotnet.md
@@ -122,7 +122,7 @@ The following options are available when `dotnet` runs an application. For examp
 
 <a name="rollforward"></a>
 
-- **`--roll-forward <SETTING>`** **
+- **`--roll-forward <SETTING>`**
 
   Controls how roll forward is applied to the app. The `SETTING` can be one of the following values. If not specified, `Minor` is the default.
 


### PR DESCRIPTION
Fixed Typo, leftover Markdown element


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet.md](https://github.com/dotnet/docs/blob/036156d15b76a43718d8ca2266df29f67e98b618/docs/core/tools/dotnet.md) | [dotnet command](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet?branch=pr-en-us-37193) |

<!-- PREVIEW-TABLE-END -->