### PR TITLE
Fix string formatting

### DIFF
--- a/docs/framework/data/adonet/connection-string-syntax.md
+++ b/docs/framework/data/adonet/connection-string-syntax.md
@@ -81,7 +81,7 @@ When you connect to Azure SQL Database or to Azure SQL Data Warehouse and provid
 To connect to a named instance of SQL Server, use the *server name\instance name* syntax.  
   
 ```csharp  
-"Data Source=MySqlServer\MSSQL1;"  
+"Data Source=MySqlServer\\MSSQL1;"  
 ```  
 
 You can also set the <xref:System.Data.SqlClient.SqlConnectionStringBuilder.DataSource%2A> property of the `SqlConnectionStringBuilder` to the instance name when building a connection string. The <xref:System.Data.SqlClient.SqlConnection.DataSource%2A> property of a <xref:System.Data.SqlClient.SqlConnection> object is read-only.  


### PR DESCRIPTION
## Summary

It showed error `unrecognized escape sequence` because of `\M` instead of `\\`


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/data/adonet/connection-string-syntax.md](https://github.com/dotnet/docs/blob/94e9cf592330c5949b4b24f438418b532adb563a/docs/framework/data/adonet/connection-string-syntax.md) | [Connection String Syntax](https://review.learn.microsoft.com/en-us/dotnet/framework/data/adonet/connection-string-syntax?branch=pr-en-us-37196) |

<!-- PREVIEW-TABLE-END -->