### PR TITLE
V7 is now standard

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -55,7 +55,7 @@
     {
       "path_to_root": "_csharpstandard",
       "url": "https://github.com/dotnet/csharpstandard",
-      "branch": "draft-v7",
+      "branch": "standard-v7",
       "include_in_build": true,
       "branch_mapping": {}
     },


### PR DESCRIPTION
The ECMA committee approved the final draft of the v7 standard. We've renamed the branch, so our build should pick that up.
