### PR TITLE
Add a fixed code sample for CS7003

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs7003.md
+++ b/docs/csharp/language-reference/compiler-messages/cs7003.md
@@ -14,27 +14,46 @@ Unexpected use of an unbound generic name
 
 This error occurs if you use a generic type needing one parameter type without passing any generic parameter type name between the angle brackets. This use may be a variable declaration, or an object instantiation.
 
-## To correct this error
-
-Provide one parameter type name in angle brackets when using a generic type.
-
 ## Example
 
 The following example generates CS7003:
 
 ```csharp
 // CS7003.cs
+using System.Collections.Generic;
+
 class Program
 {
     static void Main(string[] args)
     {
-        var myVar1 = new MyGenericClass<>();  //CS7003
+        var myDictionary = new Dictionary< , >();  //CS7003
 
-        MyGenericClass<> var2;                //CS7003
+        List<> var2;                               //CS7003
     }
 }
 
-public class MyGenericClass<T> { }
+```
+
+## To correct this error
+
+Provide the expected parameter type names in angle brackets, separated by commas, when using a generic type.
+
+The previous example could be fixed as follows :
+
+```csharp
+// CS7003-fixed.cs
+using System.Collections.Generic;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        var myDictionary = new Dictionary<int, string>();
+
+        List<string> var2;
+    }
+}
+
 ```
 
 ## See also


### PR DESCRIPTION
## Summary

Changes the code sample so it matches real-world generic types and provides a code fix sample to help users identify and fix the CS7003 error.

Fixes #37214


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-messages/cs7003.md](https://github.com/dotnet/docs/blob/d3e613a28f99028bdb2f7d6a5752347ecde52e02/docs/csharp/language-reference/compiler-messages/cs7003.md) | [Compiler Error CS7003](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs7003?branch=pr-en-us-37218) |


<!-- PREVIEW-TABLE-END -->