### PR TITLE
Typo fix in console-log-formatter.md

### DIFF
--- a/docs/core/extensions/console-log-formatter.md
+++ b/docs/core/extensions/console-log-formatter.md
@@ -136,7 +136,7 @@ The `AddConsoleFormatter` API:
 
 :::code language="csharp" source="snippets/logging/console-formatter-custom/Program.cs" highlight="6-7":::
 
-Define a `CustomerFormatter` subclass of `ConsoleFormatter`:
+Define a `CustomFormatter` subclass of `ConsoleFormatter`:
 
 :::code language="csharp" source="snippets/logging/console-formatter-custom/CustomFormatter.cs" highlight="22-38":::
 


### PR DESCRIPTION
## Summary

Fixes a typo in docs (Incorrect class name)
| File | Line Number |
|:------:|:------:|
| [docs/core/extensions/console-log-formatter.md](https://github.com/dotnet/docs/blob/main/docs/core/extensions/console-log-formatter.md) | [139](https://github.com/dotnet/docs/blob/d76373eedb7ef34f2cec28c1ce341b7bb131af84/docs/core/extensions/console-log-formatter.md?plain=1#L139) |

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/console-log-formatter.md](https://github.com/dotnet/docs/blob/0c231cd879f136afcf5850c431df58ff8232086e/docs/core/extensions/console-log-formatter.md) | [Console log formatting](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/console-log-formatter?branch=pr-en-us-37230) |

<!-- PREVIEW-TABLE-END -->