### PR TITLE
Update the `dotnet-dump -c` description according to dotnet/diagnostics

### DIFF
--- a/docs/core/diagnostics/dotnet-dump.md
+++ b/docs/core/diagnostics/dotnet-dump.md
@@ -142,7 +142,7 @@ dotnet-dump analyze <dump_path> [-h|--help] [-c|--command]
 
 - **`-c|--command <debug_command>`**
 
-  Specifies the [command](#analyze-sos-commands) to run in the shell on start.
+  Runs the [command](#analyze-sos-commands) on start. Multiple instances of this parameter can be used in an invocation to chain commands. Commands will get run in the order that they are provided on the command line. If you want dotnet dump to exit after the commands, your last command should be 'exit'.
 
 ### Analyze SOS commands
 


### PR DESCRIPTION
This pull request fixes #36648 
It updates the description of `dotnet-dump`'s `-c` option description so that it match the description included in dotnet/diagnostics repo, in [diagnostics/scr/Tools/dotnet-dump/Program.cs line 110](https://github.com/dotnet/diagnostics/blob/3ffd6248725fdb97840f25fc346f43465af8b37e/src/Tools/dotnet-dump/Program.cs#L110C1-L110C1).

That implementation of the option's description is in another repository, so unfortunately cherry-picking was not an option. I had to copy-paste the description directly from original implementation.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/dotnet-dump.md](https://github.com/dotnet/docs/blob/ee7b85ce78ea580b75cbac0aa7b7d2f9363ef65e/docs/core/diagnostics/dotnet-dump.md) | [Dump collection and analysis utility (dotnet-dump)](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-dump?branch=pr-en-us-37231) |

<!-- PREVIEW-TABLE-END -->