### PR TITLE
Non-compiling code example fixed

### DIFF
--- a/docs/core/extensions/dependency-injection.md
+++ b/docs/core/extensions/dependency-injection.md
@@ -91,7 +91,7 @@ The implementation of the `IMessageWriter` interface can be improved by using th
 The updated `AddSingleton` method registers the new `IMessageWriter` implementation:
 
 ```csharp
-builder.Services.AddSingleton<IMessageWriter, LoggingMessageWriter>());
+builder.Services.AddSingleton<IMessageWriter, LoggingMessageWriter>();
 ```
 
 The <xref:Microsoft.Extensions.Hosting.HostApplicationBuilder> (`builder`) type is part of the `Microsoft.Extensions.Hosting` NuGet package.


### PR DESCRIPTION
There was an incorrect extra parenthesis in one of the code examples. 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/dependency-injection.md](https://github.com/dotnet/docs/blob/77baba73141a0a894d25273da3475c98b015df0c/docs/core/extensions/dependency-injection.md) | [.NET dependency injection](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection?branch=pr-en-us-37232) |

<!-- PREVIEW-TABLE-END -->