### PR TITLE
Update the metrics port in the snippet_1 of dotnet/core/diagnostics/metrics-collection

### DIFF
--- a/docs/core/diagnostics/snippets/Metrics/Program.cs
+++ b/docs/core/diagnostics/snippets/Metrics/Program.cs
@@ -40,7 +40,7 @@ class Program
     {
         using MeterProvider meterProvider = Sdk.CreateMeterProviderBuilder()
                 .AddMeter("HatCo.HatStore")
-                .AddPrometheusHttpListener(options => options.UriPrefixes = new string[] { "http://localhost:9464/" })
+                .AddPrometheusHttpListener(options => options.UriPrefixes = new string[] { "http://localhost:9184/" })
                 .Build();
 
         var rand = Random.Shared;


### PR DESCRIPTION
## Summary

The current PR is indirectly fixing this doc page: [Collect metrics](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/metrics-collection#configure-the-example-app-to-use-opentelemetrys-prometheus-exporter).

The rest of the documentation (text, and the prometheus.yml)  used port **9184** while the code snippet was exposing the metrics at port **9464**.
This PR fixes the mismatch between the code snippet and the rest of the documentation.

Fixes #Issue_Number (if available)
