### PR TITLE
Update aspnet-port.md

### DIFF
--- a/docs/core/compatibility/containers/8.0/aspnet-port.md
+++ b/docs/core/compatibility/containers/8.0/aspnet-port.md
@@ -19,9 +19,9 @@ For example, running the following command allowed you to access the app locally
 
 ## New behavior
 
-Starting with .NET 8, if you map to port 80 in the container without explicitly setting the ASP.NET Core port used in the container, any attempt to connect to that mapped port will fail.
+Starting with .NET 8, if you map to port 80 in the container without explicitly setting the ASP.NET Core port used in the container to 80, any attempt to connect to that mapped port will fail.
 
-For example, if you run the following command, you'd be unable to connect to the application locally using port 8000.
+For example, if you run the following command, you'd be _unable_ to connect to the application locally using port 8000.
 
 `docker run --rm -it -p 8000:80 <my-app>`
 

--- a/docs/core/compatibility/containers/8.0/aspnet-port.md
+++ b/docs/core/compatibility/containers/8.0/aspnet-port.md
@@ -64,6 +64,8 @@ $ docker kill 3cc86b4b3ea1a7303d83171c132b0645d4adf61d80131152936b01661ae82a09
 3cc86b4b3ea1a7303d83171c132b0645d4adf61d80131152936b01661ae82a09
 ```
 
+If you are using [Kubernetes](https://kubernetes.io/docs/tutorials/services/connect-applications-service/) or [Docker Compose](https://docs.docker.com/compose/compose-file/05-services/#ports), you will need to change the port per those schemas. See [Using .NET with Kubernetes](https://github.com/dotnet/dotnet-docker/blob/main/samples/kubernetes/README.md) for examples.
+
 ## Version introduced
 
 .NET 8 Preview 1

--- a/docs/core/compatibility/containers/8.0/aspnet-port.md
+++ b/docs/core/compatibility/containers/8.0/aspnet-port.md
@@ -1,9 +1,9 @@
 ---
-title: "Breaking change: Default ASP.NET Core port changed to 8080"
-description: Learn about the breaking change in containers where the default ASP.NET Core port changed to 8080.
+title: "Breaking change: Default ASP.NET Core port changed from 80 to 8080"
+description: Learn about the breaking change in containers where the default ASP.NET Core port changed from 80 to 8080.
 ms.date: 07/12/2023
 ---
-# Default ASP.NET Core port changed to 8080
+# Default ASP.NET Core port changed from 80 to 8080
 
 The default ASP.NET Core port configured in .NET container images has been updated from port 80 to 8080.
 

--- a/docs/core/compatibility/containers/8.0/aspnet-port.md
+++ b/docs/core/compatibility/containers/8.0/aspnet-port.md
@@ -7,7 +7,7 @@ ms.date: 07/12/2023
 
 The default ASP.NET Core port configured in .NET container images has been updated from port 80 to 8080.
 
-We also added the new `ASPNETCORE_HTTP_PORTS` environment variable as a simpler alternative to `ASPNETCORE_URLS`.
+We also added the new `ASPNETCORE_HTTP_PORTS` environment variable as a simpler alternative to `ASPNETCORE_URLS`. The new variable expects a semicolon delimited list of ports numbers, while the older variable expects a more complicated syntax.
 
 ## Previous behavior
 

--- a/docs/core/compatibility/containers/8.0/aspnet-port.md
+++ b/docs/core/compatibility/containers/8.0/aspnet-port.md
@@ -7,27 +7,62 @@ ms.date: 07/12/2023
 
 The default ASP.NET Core port configured in .NET container images has been updated from port 80 to 8080.
 
-We also added the new `ASPNETCORE_HTTP_PORTS` environment variable instead of `ASPNETCORE_URLS`.
+We also added the new `ASPNETCORE_HTTP_PORTS` environment variable as a simpler alternative to `ASPNETCORE_URLS`.
 
 ## Previous behavior
 
 Prior to .NET 8, you could run a container expecting port 80 to be the default port and be able to access the running app.
 
-For example, running the following command allowed you to access the app locally at port 9999, which is mapped to port 80 in the container:
+For example, running the following command allowed you to access the app locally at port 8000, which is mapped to port 80 in the container:
 
-`docker run --rm -it -p 9999:80 <my-app>`
+`docker run --rm -it -p 8000:80 <my-app>`
 
 ## New behavior
 
 Starting with .NET 8, if you map to port 80 in the container without explicitly setting the ASP.NET Core port used in the container, any attempt to connect to that mapped port will fail.
 
-For example, if you run the following command, you'd be unable to connect to the application locally using port 9999.
+For example, if you run the following command, you'd be unable to connect to the application locally using port 8000.
 
-`docker run --rm -it -p 9999:80 <my-app>`
+`docker run --rm -it -p 8000:80 <my-app>`
 
 Instead, change the command to use port 8080 within the container:
 
-`docker run --rm -it -p 9999:8080 <my-app>`
+`docker run --rm -it -p 8000:8080 <my-app>`
+
+You can see the difference in behavior in the following examples.
+
+Mapping port `80` (failure case):
+
+```bash
+$ docker run --rm -d -p 8000:80 mcr.microsoft.com/dotnet/samples:aspnetapp
+ba88b746bd7097e503f8ab6e5320c595640e242f6de4f734412944a0e2836acc
+$ curl http://localhost:8000/Environment
+curl: (56) Recv failure: Connection reset by peer
+$ docker kill ba88b746bd7097e503f8ab6e5320c595640e242f6de4f734412944a0e2836acc
+ba88b746bd7097e503f8ab6e5320c595640e242f6de4f734412944a0e2836acc
+```
+
+Mapping port `8080`:
+
+```bash
+$ docker run --rm -d -p 8000:8080 mcr.microsoft.com/dotnet/samples:aspnetapp
+74d866bdaa8a5a09e4a347bba17ced321d77a2524a0853294a123640bcc7f21d
+$ curl http://localhost:8000/Environment
+{"runtimeVersion":".NET 8.0.0-rc.1.23419.4","osVersion":"Alpine Linux v3.18","osArchitecture":"Arm64","user":"root","processorCount":4,"totalAvailableMemoryBytes":4123820032,"memoryLimit":0,"memoryUsage":30081024,"hostName":"74d866bdaa8a"}
+$ docker kill 74d866bdaa8a5a09e4a347bba17ced321d77a2524a0853294a123640bcc7f21d
+74d866bdaa8a5a09e4a347bba17ced321d77a2524a0853294a123640bcc7f21d
+```
+
+Mapping port `80` with `ASPNETCORE_HTTP_PORTS` set to port `80`:
+
+```bash
+$ docker run --rm -d -p 8000:80 -e ASPNETCORE_HTTP_PORTS=80 mcr.microsoft.com/dotnet/samples:aspnetapp 
+3cc86b4b3ea1a7303d83171c132b0645d4adf61d80131152936b01661ae82a09
+$ curl http://localhost:8000/Environment
+{"runtimeVersion":".NET 8.0.0-rc.1.23419.4","osVersion":"Alpine Linux v3.18","osArchitecture":"Arm64","user":"root","processorCount":4,"totalAvailableMemoryBytes":4123820032,"memoryLimit":0,"memoryUsage":95383552,"hostName":"3cc86b4b3ea1"}
+$ docker kill 3cc86b4b3ea1a7303d83171c132b0645d4adf61d80131152936b01661ae82a09
+3cc86b4b3ea1a7303d83171c132b0645d4adf61d80131152936b01661ae82a09
+```
 
 ## Version introduced
 


### PR DESCRIPTION
Add examples and switch to more common local port.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/containers/8.0/aspnet-port.md](https://github.com/dotnet/docs/blob/9f7bfb3ebbe82206b07c8ee5fd18ee5427d35347/docs/core/compatibility/containers/8.0/aspnet-port.md) | [Default ASP.NET Core port changed from 80 to 8080](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/containers/8.0/aspnet-port?branch=pr-en-us-37241) |


<!-- PREVIEW-TABLE-END -->