### PR TITLE
Add `readonly ref readonly` example

### DIFF
--- a/docs/csharp/language-reference/keywords/readonly.md
+++ b/docs/csharp/language-reference/keywords/readonly.md
@@ -77,7 +77,7 @@ The type returned doesn't need to be a `readonly struct`. Any type that can be r
 
 Ref readonly return can also be used in conjunction with `readonly` instance members on `struct` types:
 
-[!code-csharp[readonly ref readonly example](snippets/ReadonlyKeywordExamples.cs#ReadonlyRefReadonly)]
+:::code language="csharp" source="./snippets/ReadonlyKeywordExamples.cs" id="SnippetReadonlyRefReadonly":::
 
 The method essentially returns a `readonly` reference together with the instance member (in this case a method) being `readonly` (not able to modify any instance fields).
 

--- a/docs/csharp/language-reference/keywords/readonly.md
+++ b/docs/csharp/language-reference/keywords/readonly.md
@@ -75,7 +75,7 @@ The type returned doesn't need to be a `readonly struct`. Any type that can be r
 
 ## Readonly ref readonly return example
 
-Ref readonly return can also be used in conjunction with readonly instance members:
+Ref readonly return can also be used in conjunction with `readonly` instance members on `struct` types:
 
 [!code-csharp[readonly ref readonly example](snippets/ReadonlyKeywordExamples.cs#ReadonlyRefReadonly)]
 

--- a/docs/csharp/language-reference/keywords/readonly.md
+++ b/docs/csharp/language-reference/keywords/readonly.md
@@ -73,6 +73,14 @@ The `readonly` modifier on a `ref return` indicates that the returned reference 
 
 The type returned doesn't need to be a `readonly struct`. Any type that can be returned by `ref` can be returned by `ref readonly`.
 
+## Readonly ref readonly return example
+
+Ref readonly return can also be used in conjunction with readonly instance members:
+
+[!code-csharp[readonly ref readonly example](snippets/ReadonlyKeywordExamples.cs#ReadonlyRefReadonly)]
+
+The method essentially returns a `readonly` reference together with the instance member (in this case a method) being `readonly` (not able to modify any instance fields).
+
 ## C# language specification
 
 [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]

--- a/docs/csharp/language-reference/keywords/snippets/ReadonlyKeywordExamples.cs
+++ b/docs/csharp/language-reference/keywords/snippets/ReadonlyKeywordExamples.cs
@@ -74,4 +74,17 @@ namespace Keywords
             Console.WriteLine(Origin);
         }
     }
+
+    // <SnippetReadonlyRefReadonly>
+    public struct ReadonlyRefReadonlyExample
+    {
+        private int _data;
+
+        public readonly ref readonly int ReadonlyRefReadonly(ref int reference)
+        {
+            // _data = 1; // Compile error if uncommented.
+            return ref reference;
+        }
+    }
+    // </SnippetReadonlyRefReadonly>
 }


### PR DESCRIPTION
## Summary

The only 2 instances of `readonly ref readonly` being shown in examples are `ref` fields:
* https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-11.0/low-level-struct-improvements
* https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/ref-struct

This PR adds an example talking about `readonly ref readonly` methods, with the first `readonly` meaning readonly instance members instead of `readonly` ref fields like in the other 2 examples.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/readonly.md](https://github.com/dotnet/docs/blob/5428171f426ee6007e9c4c778f4c4c000588dd7b/docs/csharp/language-reference/keywords/readonly.md) | [readonly (C# Reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/readonly?branch=pr-en-us-37249) |


<!-- PREVIEW-TABLE-END -->