### PR TITLE
Add `readonly` instance member example

### DIFF
--- a/docs/csharp/language-reference/keywords/readonly.md
+++ b/docs/csharp/language-reference/keywords/readonly.md
@@ -69,7 +69,7 @@ you'll get the compiler error message:
 
 You can also use the `readonly` modifier to declare that an instance member doesn't modify the state of a struct.
 
-[!code-csharp[readonly method](../builtin-types/snippets/shared/StructType.cs#ReadonlyMethod)]
+:::code language="csharp" source="../builtin-types/snippets/shared/StructType.cs" id="SnippetReadonlyMethod":::
 
 ## Ref readonly return example
 

--- a/docs/csharp/language-reference/keywords/readonly.md
+++ b/docs/csharp/language-reference/keywords/readonly.md
@@ -65,6 +65,12 @@ you'll get the compiler error message:
 
 **A readonly field cannot be assigned to (except in a constructor or a variable initializer)**
 
+## Readonly instance members
+
+You can also use the `readonly` modifier to declare that an instance member doesn't modify the state of a struct.
+
+[!code-csharp[readonly method](../builtin-types/snippets/shared/StructType.cs#ReadonlyMethod)]
+
 ## Ref readonly return example
 
 The `readonly` modifier on a `ref return` indicates that the returned reference can't be modified. The following example returns a reference to the origin. It uses the `readonly` modifier to indicate that callers can't modify the origin:


### PR DESCRIPTION
## Summary

Add a short section with example on `readonly` instance members to make #37249 make a bit more sense (since that is a combination of `readonly` instance member and `ref readonly` returns.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/readonly.md](https://github.com/dotnet/docs/blob/6aedc3b0eb4ec61dcc78a9dc8c5d32eea1a9770a/docs/csharp/language-reference/keywords/readonly.md) | [readonly (C# Reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/readonly?branch=pr-en-us-37250) |


<!-- PREVIEW-TABLE-END -->