### PR TITLE
Fix formatting consistency in coding-conventions.md

### DIFF
--- a/docs/csharp/fundamentals/coding-style/coding-conventions.md
+++ b/docs/csharp/fundamentals/coding-style/coding-conventions.md
@@ -323,7 +323,7 @@ In general, use the following format for code samples:
 - Place the comment on a separate line, not at the end of a line of code.
 - Begin comment text with an uppercase letter.
 - End comment text with a period.
-- Insert one space between the comment delimiter (//) and the comment text, as shown in the following example.
+- Insert one space between the comment delimiter (`//`) and the comment text, as shown in the following example.
 
   :::code language="csharp" source="./snippets/coding-conventions/program.cs" id="Snippet3":::
 


### PR DESCRIPTION
## Summary

Use "(`//`)", instead of "(//"), to denote the comment delimiter, as is done so above.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/fundamentals/coding-style/coding-conventions.md](https://github.com/dotnet/docs/blob/9bb33f7f91fbab717f9b9a19dc7a40079ab26b3a/docs/csharp/fundamentals/coding-style/coding-conventions.md) | [Common C# code conventions](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions?branch=pr-en-us-37261) |

<!-- PREVIEW-TABLE-END -->