### PR TITLE
Add `readonly` to CS0106 together with some ad-hoc examples

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs0106.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0106.md
@@ -26,6 +26,8 @@ The modifier 'modifier' is not valid for this item
 
  For more information, see [Interfaces](../../fundamentals/types/interfaces.md).
 
+- The [readonly](../keywords/readonly.md) keyword is not allowed on methods in a class type, with the exception of `ref readonly` returns (`readonly` keyword must appear after the `ref` keyword).
+
 ## Example
 
  The following sample generates CS0106:
@@ -41,8 +43,26 @@ namespace MyNamespace
 
    public class MyClass : I
    {
+      public readonly int Prop1 { get; set; }   // CS0106
+      public int Prop2 { get; readonly set; }   // CS0106
+
       public void I.M() {}   // CS0106
+
+      public void AccessModifierOnLocalFunction()
+      {
+         public void LocalFunction() {}   // CS0106
+      }
+
+      public readonly void ReadonlyMethod() {}   // CS0106
+      // Move the `readonly` keyword after the `ref` keyword
+      public readonly ref int ReadonlyBeforeRef(ref int reference)   // CS0106
+      {
+         return ref reference;
+      }
+
       public static void Main() {}
    }
+
+   public readonly class ReadonlyClass {}   // CS0106
 }
 ```


### PR DESCRIPTION
## Summary

Address one mistake where the programmer confuses `public readonly ref int Foo()` with `public ref readonly int Foo()` (possibly thinking they are interchangeable) within a class type. As a drive-by, I also added some new ad-hoc examples.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-messages/cs0106.md](https://github.com/dotnet/docs/blob/a498b6c89ce26b7c8c99ac89f00c7d47a4ae90bf/docs/csharp/language-reference/compiler-messages/cs0106.md) | [Compiler Error CS0106](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0106?branch=pr-en-us-37272) |

<!-- PREVIEW-TABLE-END -->