### PR TITLE
Fix dupe word typos

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/source-generator-errors.md
+++ b/docs/csharp/language-reference/compiler-messages/source-generator-errors.md
@@ -110,7 +110,7 @@ The following errors indicate a mismatch between the interceptor method and the 
 - **CS9155**: *Cannot intercept call with `M` because it is not accessible within `V`.*
 - **CS9156**: *Cannot intercept call to `M` with `V` because of a difference in 'scoped' modifiers or `[UnscopedRef]` attributes.*
 
-In addition, the following warnings indicate a mismatch in the signatures of the interceptor and and the interceptable method:
+In addition, the following warnings indicate a mismatch in the signatures of the interceptor and the interceptable method:
 
 - **CS9154**: *Intercepting a call to `M` with interceptor `V`, but the signatures do not match.*
 - **CS9158**: *Nullability of reference types in return type doesn't match interceptable method.*

--- a/docs/csharp/language-reference/tokens/interpolated.md
+++ b/docs/csharp/language-reference/tokens/interpolated.md
@@ -54,7 +54,7 @@ Beginning with C# 11, you can use an interpolated [raw string literal](../builti
 
 :::code language="csharp" source="./snippets/string-interpolation.cs" id="InterpolatedRawStringLiteral":::
 
-To embed `{` and `}` characters in the result string, start an interpolated raw string literal with multiple `$` characters. When you do that, any sequence of `{` or `}` characters shorter than the number of `$` characters is embedded in the result string. To enclose any interpolation expression within that string, you need to use the same number of braces as the number of `$` characters, as the the following example shows:
+To embed `{` and `}` characters in the result string, start an interpolated raw string literal with multiple `$` characters. When you do that, any sequence of `{` or `}` characters shorter than the number of `$` characters is embedded in the result string. To enclose any interpolation expression within that string, you need to use the same number of braces as the number of `$` characters, as the following example shows:
 
 :::code language="csharp" source="./snippets/string-interpolation.cs" id="InterpolatedRawStringLiteralWithBraces":::
 


### PR DESCRIPTION
## Summary

Fix a small amount of dupe word typos.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-messages/source-generator-errors.md](https://github.com/dotnet/docs/blob/703e5e8cb23844712103e591caad4ce86cb46e9c/docs/csharp/language-reference/compiler-messages/source-generator-errors.md) | [Errors and warnings associated with source generators and interceptors](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/source-generator-errors?branch=pr-en-us-37273) |
| [docs/csharp/language-reference/tokens/interpolated.md](https://github.com/dotnet/docs/blob/703e5e8cb23844712103e591caad4ce86cb46e9c/docs/csharp/language-reference/tokens/interpolated.md) | ["$ - string interpolation - format string output"](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/interpolated?branch=pr-en-us-37273) |

<!-- PREVIEW-TABLE-END -->