### PR TITLE
doc - Fixed grammatical mistake in "Cross-built Windows apps"

### DIFF
--- a/docs/core/whats-new/dotnet-8.md
+++ b/docs/core/whats-new/dotnet-8.md
@@ -1391,7 +1391,7 @@ Building in a container is the easiest approach for most people, since the `dotn
 
 ## Cross-built Windows apps
 
-When you build apps that Windows on non-Windows platforms, the resulting executable is now updated with any specified Win32 resources&mdash;for example, application icon, manifest, version information.
+When you build apps for Windows on non-Windows platforms, the resulting executable is now updated with any specified Win32 resources&mdash;for example, application icon, manifest, version information.
 
 Previously, applications had to be built on Windows in order to have such resources. Fixing this gap in cross-building support has been a popular request, as it was a significant pain point affecting both infrastructure complexity and resource usage.
 


### PR DESCRIPTION
## Summary

In "Cross-built Windows apps," the introduction paragraph states "When you build apps that Windows on non-Windows," which contains a grammatical error.

"When you build apps for Windows on non-Windows..." is the correction.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/whats-new/dotnet-8.md](https://github.com/dotnet/docs/blob/c9c2f61e5feb2aa1d25097c60e1df1b523d1e252/docs/core/whats-new/dotnet-8.md) | [What's new in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-8?branch=pr-en-us-37290) |

<!-- PREVIEW-TABLE-END -->