### PR TITLE
Remove line from CS8160

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs8160.md
+++ b/docs/csharp/language-reference/compiler-messages/cs8160.md
@@ -18,7 +18,6 @@ A readonly field cannot be returned by writable reference
 ```csharp
 // CS8160.cs (8,20)
 
-
 class Program
 {
     readonly int i = 0;
@@ -32,7 +31,7 @@ class Program
 
 ## To correct this error
 
-To return a `readonly` field, refactoring to return by value corrects this error:
+To return a `readonly` field, refactor to return by value:
 
 ```csharp
 class Program


### PR DESCRIPTION
## Summary

Remove a superfluous empty line and made a sentence slightly more terse ("corrects this error" is already in the subheader). The error location remains unchanged at `(8,20)` since the previous one only accounted for 1 empty line.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-messages/cs8160.md](https://github.com/dotnet/docs/blob/3838e06f7b38ef4e185dd7ea09ad051ad9fb7b4c/docs/csharp/language-reference/compiler-messages/cs8160.md) | [Compiler Error CS8160](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs8160?branch=pr-en-us-37297) |

<!-- PREVIEW-TABLE-END -->