### PR TITLE
Update dotnet-tool-uninstall.md to include optional --tool-manifest argument

### DIFF
--- a/docs/core/tools/dotnet-tool-uninstall.md
+++ b/docs/core/tools/dotnet-tool-uninstall.md
@@ -51,7 +51,7 @@ The `dotnet tool uninstall` command provides a way for you to uninstall .NET too
 
 - **`--tool-manifest <PATH>`**
 
-  Specifies that the tool to be removed from the manifest file. PATH can be absolute or relative. Can't be combined with the `--global` option.
+  Specifies the manifest file that the tool is to be removed from. PATH can be absolute or relative. Can't be combined with the `--global` option.
 
 ## Examples
 

--- a/docs/core/tools/dotnet-tool-uninstall.md
+++ b/docs/core/tools/dotnet-tool-uninstall.md
@@ -16,7 +16,7 @@ ms.date: 02/14/2020
 ```dotnetcli
 dotnet tool uninstall <PACKAGE_NAME> -g|--global
 
-dotnet tool uninstall <PACKAGE_NAME> --tool-path <PATH>
+dotnet tool uninstall <PACKAGE_NAME> --tool-path <PATH> [--tool-manifest <PATH>]
 
 dotnet tool uninstall <PACKAGE_NAME>
 
@@ -48,6 +48,10 @@ The `dotnet tool uninstall` command provides a way for you to uninstall .NET too
 - **`--tool-path <PATH>`**
 
   Specifies the location where to uninstall the tool. PATH can be absolute or relative. Can't be combined with the `--global` option. Omitting both `--global` and `--tool-path` specifies that the tool to be removed is a local tool.
+
+- **`--tool-manifest <PATH>`**
+
+  Specifies that the tool to be removed from the manifest file. PATH can be absolute or relative. Can't be combined with the `--global` option.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

Updated documentation to add optional argument passed to "dotnet tool uninstall" command



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-tool-uninstall.md](https://github.com/dotnet/docs/blob/7f212878f8d90cadecf30611f80cac08a291aab1/docs/core/tools/dotnet-tool-uninstall.md) | [dotnet tool uninstall](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-uninstall?branch=pr-en-us-37298) |


<!-- PREVIEW-TABLE-END -->