### PR TITLE
Move new node

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/toc.yml
+++ b/docs/csharp/language-reference/compiler-messages/toc.yml
@@ -1591,6 +1591,8 @@ items:
     href: cs8812.md
   - name: CS8515
     href: cs8515.md
+  - name: CS8964
+    href: CS8964.md
   - name: CS9043
     href: cs9043.md
   - name: CS9050
@@ -1901,8 +1903,6 @@ items:
     href: cs1610.md
   - name: CS1712
     href: ../../misc/cs1712.md
-  - name: CS8964
-    href: CS8964.md
 - name: Feature or version missing
   href: feature-version-errors.md
   displayName: CS0171, CS0188, CS0843, CS8904, CS1738, CS8022, CS8023, CS8024, CS8025, CS8026, CS8059, CS8107, CS8302, CS8320, CS8370, CS8400, CS8773, CS8936, CS9058, CS8303, CS8304, CS8306, CS8371, CS8401, CS8511, CS8192, CS8627, CS8630, CS8314, CS8652, CS8703, CS8704, CS8706, CS8957, CS8912, CS9014, CS9015, CS9016, CS9017, CS8967


### PR DESCRIPTION
In #37291 I'd recommended putting the new TOC node at the bottom of the file, rather than in the correct location under errors.

This fixes that mistake.
