### PR TITLE
Fix Windowsism in standalone GC config description

### DIFF
--- a/docs/core/runtime-config/garbage-collector.md
+++ b/docs/core/runtime-config/garbage-collector.md
@@ -556,7 +556,7 @@ Example:
 
 ## Standalone GC
 
-- Specifies the name of a standalone GC DLL that the runtime loads in place of the one it has in the main runtime DLL (coreclr.dll). This DLL needs to reside in the same directory as *coreclr.dll*.
+- Specifies the name of a GC native library that the runtime loads in place of the default GC implementation. This native library needs to reside in the same directory as the .NET runtime (**coreclr.dll** on Windows, **libcoreclr.so** on Linux).
 
 | | Setting name | Values | Version introduced |
 | - | - | - | - |


### PR DESCRIPTION
Replace "DLL" with "native library".


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/runtime-config/garbage-collector.md](https://github.com/dotnet/docs/blob/eef92884a5c3c630489a452faa7a51f440630543/docs/core/runtime-config/garbage-collector.md) | [Runtime configuration options for garbage collection](https://review.learn.microsoft.com/en-us/dotnet/core/runtime-config/garbage-collector?branch=pr-en-us-37303) |

<!-- PREVIEW-TABLE-END -->