### PR TITLE
Tidy up CS0756

### DIFF
--- a/docs/csharp/misc/cs0756.md
+++ b/docs/csharp/misc/cs0756.md
@@ -1,7 +1,7 @@
 ---
 description: "Compiler Error CS0756"
 title: "Compiler Error CS0756"
-ms.date: 07/20/2015
+ms.date: 10/02/2023
 f1_keywords:
   - "CS0756"
 helpviewer_keywords:

--- a/docs/csharp/misc/cs0756.md
+++ b/docs/csharp/misc/cs0756.md
@@ -2,39 +2,43 @@
 description: "Compiler Error CS0756"
 title: "Compiler Error CS0756"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "CS0756"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS0756"
 ms.assetid: 847b20b0-bbf0-43a2-8728-4b54cb3d9cd6
 ---
 # Compiler Error CS0756
 
-A partial method may not have multiple defining declarations.  
-  
- The defining declaration of a partial method is the part that specifies the method signature, but not the implementation (method body). A partial method must have exactly one defining declaration for each unique signature. Each overloaded version of a partial method must have its own defining declaration.  
-  
-## To correct this error  
-  
-1. Remove all except one defining declaration for the partial method.  
-  
-## Example  
-  
-```csharp  
-// cs0756.cs  
-using System;  
-  
-    public partial class C  
-    {  
-        partial void Part();  
-        partial void Part(); // CS0756  
-        public static int Main()  
-        {  
-            return 1;  
-        }  
-    }  
-```  
-  
+A partial method may not have multiple defining declarations.
+
+The defining declaration of a partial method is the part that specifies the method signature, but not the implementation (method body). A partial method must have exactly one defining declaration for each unique signature. Each overloaded version of a partial method must have its own defining declaration.
+
+## Example
+
+ The following sample generates CS0756:
+
+```csharp
+// CS0756.cs (5,18)
+
+public partial class PartialClass
+{
+    partial void PartialMethod();
+    partial void PartialMethod();
+}
+```
+
+## To correct this error
+
+Remove all except one defining declaration for the partial method:
+
+```csharp
+public partial class PartialClass
+{
+    partial void PartialMethod();
+}
+```
+
 ## See also
 
 - [Partial Classes and Methods](../programming-guide/classes-and-structs/partial-classes-and-methods.md)


### PR DESCRIPTION
## Summary

Made the example more targeted, reflowed the page and removed a huge amount of superfluous trailing space characters.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/misc/cs0756.md](https://github.com/dotnet/docs/blob/c4495af8532150ae6c3833a6463ccd960bcfeba0/docs/csharp/misc/cs0756.md) | [Compiler Error CS0756](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/cs0756?branch=pr-en-us-37313) |


<!-- PREVIEW-TABLE-END -->