### PR TITLE
Augment CS0106

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs0106.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0106.md
@@ -22,11 +22,11 @@ The modifier 'modifier' is not valid for this item
 
 - Access modifiers are not allowed on a [local function](../../programming-guide/classes-and-structs/local-functions.md). Local functions are always private.
 
+- The [readonly](../keywords/readonly.md) keyword is not allowed on methods in a class type, with the exception of `ref readonly` returns (`readonly` keyword must appear after the `ref` keyword).
+
  In prior releases of Visual Studio, the `static` modifier was not permitted on a class, but `static` classes are allowed starting with Visual Studio 2005.
 
  For more information, see [Interfaces](../../fundamentals/types/interfaces.md).
-
-- The [readonly](../keywords/readonly.md) keyword is not allowed on methods in a class type, with the exception of `ref readonly` returns (`readonly` keyword must appear after the `ref` keyword).
 
 ## Example
 
@@ -38,7 +38,8 @@ namespace MyNamespace
 {
    interface I
    {
-      void M();
+      void M1();
+      void M2();
    }
 
    public class MyClass : I
@@ -46,7 +47,8 @@ namespace MyNamespace
       public readonly int Prop1 { get; set; }   // CS0106
       public int Prop2 { get; readonly set; }   // CS0106
 
-      public void I.M() {}   // CS0106
+      public void I.M1() {}   // CS0106
+      abstract void I.M2() {}   // CS0106
 
       public void AccessModifierOnLocalFunction()
       {


### PR DESCRIPTION
## Summary

Did not realize the content added in #37272 was not in the optimal location, hence I moved it.

Also added a quick example for:
> - The `abstract` keyword is not allowed on an explicit interface declaration because an explicit interface implementation can never be overridden.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-messages/cs0106.md](https://github.com/dotnet/docs/blob/9807ebf06b72e8c9b3e72429ee08a172fa565841/docs/csharp/language-reference/compiler-messages/cs0106.md) | [Compiler Error CS0106](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0106?branch=pr-en-us-37315) |

<!-- PREVIEW-TABLE-END -->