### PR TITLE
Add summary table for the default accesses to the Access modifiers page

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
+++ b/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
@@ -80,6 +80,8 @@ Delegates behave like classes and structs. By default, they have `internal` acce
 | `interface` members                               |     public     |
 | [class, record, and struct members](./members.md) |    private     |
 
+Reach out to [Accessibility Levels](../../language-reference/keywords/accessibility-levels.md) page for more details.
+
 ## C# language specification
 
 [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]
@@ -90,6 +92,7 @@ Delegates behave like classes and structs. By default, they have `internal` acce
 - [C# Programming Guide](../index.md)
 - [The C# type system](../../fundamentals/types/index.md)
 - [Interfaces](../../fundamentals/types/interfaces.md)
+- [Accessibility Levels](../../language-reference/keywords/accessibility-levels.md)
 - [private](../../language-reference/keywords/private.md)
 - [public](../../language-reference/keywords/public.md)
 - [internal](../../language-reference/keywords/internal.md)

--- a/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
+++ b/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
@@ -68,6 +68,18 @@ Enumeration members are always `public`, and no access modifiers can be applied.
 
 Delegates behave like classes and structs. By default, they have `internal` access when declared directly within a namespace, and `private` access when nested.
 
+## Default access summary table
+
+|  Type                                             | Default access |
+| ------------------------------------------------- | :------------: |
+| `class`                                           |    internal    |
+| `struct`                                          |    internal    |
+| `interface`                                       |    internal    |
+| `record`                                          |    internal    |
+| `enum`                                            |    internal    |
+| `interface` members                               |     public     |
+| [class, record, and struct members](./members.md) |    private     |
+
 ## C# language specification
 
 [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]


### PR DESCRIPTION
This pull request fixes #36650 

It adds a table listing all the default accesses of types as well as their members.

Also, link to the Accessibility Levels page has been added, as that page describes pretty well the defaults in more details.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/classes-and-structs/access-modifiers.md](https://github.com/dotnet/docs/blob/8e0190c99c95222026429bf4b6840f2c655c2f1f/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md) | [Access Modifiers (C# Programming Guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/access-modifiers?branch=pr-en-us-37324) |

<!-- PREVIEW-TABLE-END -->