### PR TITLE
Fix incorrect file extension

### DIFF
--- a/docs/framework/app-domains/build-multifile-assembly.md
+++ b/docs/framework/app-domains/build-multifile-assembly.md
@@ -95,7 +95,7 @@ This article explains how to create a multifile assembly and provides code that 
 
 3. Compile all other modules, using the necessary compiler options to indicate the other modules that are referenced in the code. This step uses the **/addmodule** compiler option.
 
-   In the following example, a code module called *Client* has an entry point `Main` method that references a method in the *Stringer.dll* module created in step 1.
+   In the following example, a code module called *Client* has an entry point `Main` method that references a method in the *Stringer.netmodule* module created in step 1.
 
    ```cpp
    #using "Stringer.netmodule"


### PR DESCRIPTION
## Summary
`Stringer.netmodule` is incorrectly being referred to as `Stringer.dll`.

Describe your changes here.
`Stringer.dll` -> `Stringer.netmodule`

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/app-domains/build-multifile-assembly.md](https://github.com/dotnet/docs/blob/1209a5caf85b9ff99ad39a598a91316eb81c0bb4/docs/framework/app-domains/build-multifile-assembly.md) | [How to: Build a multifile assembly](https://review.learn.microsoft.com/en-us/dotnet/framework/app-domains/build-multifile-assembly?branch=pr-en-us-37328) |

<!-- PREVIEW-TABLE-END -->