### PR TITLE
Remove redundant line in extension methods guide

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/extension-methods.md
+++ b/docs/csharp/programming-guide/classes-and-structs/extension-methods.md
@@ -66,7 +66,7 @@ using System.Linq;
 
 ## Binding Extension Methods at Compile Time
 
-You can use extension methods to extend a class or interface, but not to override them. An extension method with the same name and signature as an interface or class method will never be called. At compile time, extension methods always have lower priority than instance methods defined in the type itself. In other words, if a type has a method named `Process(int i)`, and you have an extension method with the same signature, the compiler will always bind to the instance method. When the compiler encounters a method invocation, it first looks for a match in the type's instance methods. If no match is found, it will search for any extension methods that are defined for the type, and bind to the first extension method that it finds. The following example demonstrates how the compiler determines which extension method or instance method to bind to.
+You can use extension methods to extend a class or interface, but not to override them. An extension method with the same name and signature as an interface or class method will never be called. At compile time, extension methods always have lower priority than instance methods defined in the type itself. In other words, if a type has a method named `Process(int i)`, and you have an extension method with the same signature, the compiler will always bind to the instance method. When the compiler encounters a method invocation, it first looks for a match in the type's instance methods. If no match is found, it will search for any extension methods that are defined for the type, and bind to the first extension method that it finds.
 
 ## Example
 


### PR DESCRIPTION
## Summary

The sentence for "The following example..." is already present under the next subsection on "Example".


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/classes-and-structs/extension-methods.md](https://github.com/dotnet/docs/blob/11da083f8b626f56bdbd032854ab5a3c33a4a76f/docs/csharp/programming-guide/classes-and-structs/extension-methods.md) | [Extension Methods (C# Programming Guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/extension-methods?branch=pr-en-us-37331) |

<!-- PREVIEW-TABLE-END -->