### PR TITLE
Update CS1101

### DIFF
--- a/docs/csharp/misc/cs1101.md
+++ b/docs/csharp/misc/cs1101.md
@@ -23,14 +23,7 @@ The parameter modifier 'ref' cannot be used with 'this'.
 // Compile with: /target:library
 public static class Extensions
 {
-    // No type parameters
     public static void Test(ref this int i) {} // CS1101
-
-    // Single type parameter
-    public static void Test<T>(ref this T t) {} // CS1101
-
-    // Multiple type parameters
-    public static void Test<T, U, V>(ref this U u) {} // CS1101
 }
 ```
 

--- a/docs/csharp/misc/cs1101.md
+++ b/docs/csharp/misc/cs1101.md
@@ -2,40 +2,39 @@
 description: "Compiler Error CS1101"
 title: "Compiler Error CS1101"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "CS1101"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS1101"
 ms.assetid: d6fc8834-eadf-4497-b442-0751895e6764
 ---
 # Compiler Error CS1101
 
-The parameter modifier 'ref' cannot be used with 'this'.  
-  
- When the `this` keyword modifies the first parameter of a static method, it signals to the compiler that the method is an extension method. No other modifiers are needed or allowed on the first parameter of an extension method.  
-  
-## Example  
+The parameter modifier 'ref' cannot be used with 'this'.
 
- The following example generates CS1101:  
-  
-```csharp  
-// cs1101.cs  
-// Compile with: /target:library  
-public static class Extensions  
-{  
-    // No type parameters.  
-        public static void Test(ref this int i) {} // CS1101  
-  
-    // Single type parameter.  
-        public static void Test<T>(ref this T t) {}// CS1101  
-  
-    // Multiple type parameters.  
-        public static void Test<T,U,V>(ref this U u) {}// CS1101  
-}  
-```  
-  
+ When the `this` keyword modifies the first parameter of a static method, it signals to the compiler that the method is an extension method. With C# version 7.1 and below, no other modifiers are needed or allowed on the first parameter of an extension method. Since C# version 7.2, `ref` extension methods are allowed, take a look at [extension methods](../programming-guide/classes-and-structs/extension-methods.md) for more details.
+
+## Example
+
+ The following example generates CS1101:
+
+```csharp
+// cs1101.cs
+// Compile with: /target:library
+public static class Extensions
+{
+    // No type parameters
+    public static void Test(ref this int i) {} // CS1101
+
+    // Single type parameter
+    public static void Test<T>(ref this T t) {} // CS1101
+
+    // Multiple type parameters
+    public static void Test<T, U, V>(ref this U u) {} // CS1101
+}
+```
+
 ## See also
 
-- [Extension Methods](../programming-guide/classes-and-structs/extension-methods.md)
 - [this](../language-reference/keywords/this.md)
 - [ref](../language-reference/keywords/ref.md)


### PR DESCRIPTION
## Summary

Update info on `ref` extension method incase anyone still reaches this error, together with some formatting. The second and third example extension methods are removed as they cause different errors today and are unnecessary in this case.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/misc/cs1101.md](https://github.com/dotnet/docs/blob/5f39b582595b767833cfe33b0ad8cab3360a877d/docs/csharp/misc/cs1101.md) | [Compiler Error CS1101](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/cs1101?branch=pr-en-us-37332) |

<!-- PREVIEW-TABLE-END -->