### PR TITLE
Fix CS1908

### DIFF
--- a/docs/csharp/misc/cs1908.md
+++ b/docs/csharp/misc/cs1908.md
@@ -2,31 +2,30 @@
 description: "Learn more about: Compiler Error CS1908"
 title: "Compiler Error CS1908"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "CS1908"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS1908"
 ms.assetid: d7da31c2-48ef-4401-b885-3459b4d7f6f6
 ---
 # Compiler Error CS1908
 
-The type of the argument to the DefaultValue attribute must match the parameter type  
-  
- This error is generated when you use the wrong argument for the <xref:System.ComponentModel.DefaultValueAttribute> attribute value. Use a value that matches the parameter type.  
-  
-## Example  
+The type of the argument to the DefaultParameterValue attribute must match the parameter type
 
- The following sample generates CS1908.  
-  
-```csharp  
-// CS1908.cs  
-// compile with: /target:library  
-using System.Runtime.InteropServices;  
-  
-public interface ISomeInterface  
-{  
-   void Bad([Optional] [DefaultParameterValue("true")] bool b);   // CS1908  
-  
-   void Good([Optional] [DefaultParameterValue(true)] bool b);   // OK  
-}  
+ This error is generated when you pass a value of the wrong type to <xref:System.Runtime.InteropServices.DefaultParameterValueAttribute>. Ensure the type of the attribute argument matches that of the target parameter.
+
+## Example
+
+ The following sample generates CS1908:
+
+```csharp
+// CS1908.cs
+// compile with: /target:library
+using System.Runtime.InteropServices;
+
+public interface ISomeInterface
+{
+    void Bad([DefaultParameterValue("true")] bool b);   // CS1908
+    void Good([DefaultParameterValue(true)] bool b);   // OK
+}
 ```


### PR DESCRIPTION
## Summary

Error is talking about the wrong attribute, fix the error message, description and attribute link. Tidy up the example and remove use of `OptionalAttribute` as it is not strictly needed for the example.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/misc/cs1908.md](https://github.com/dotnet/docs/blob/2c535c056d3c12280e37119caaf543dac3ed28d7/docs/csharp/misc/cs1908.md) | [Compiler Error CS1908](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/cs1908?branch=pr-en-us-37335) |

<!-- PREVIEW-TABLE-END -->