### PR TITLE
Fix CS1909 and CS1910

### DIFF
--- a/docs/csharp/misc/cs1909.md
+++ b/docs/csharp/misc/cs1909.md
@@ -2,31 +2,14 @@
 description: "Learn more about: Compiler Error CS1909"
 title: "Compiler Error CS1909"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "CS1909"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS1909"
 ms.assetid: d465a107-0911-4440-8b3a-1e5dea6fda3c
 ---
 # Compiler Error CS1909
 
-The DefaultValue attribute is not applicable on parameters of type 'type'  
-  
- CS1909 is generated when you use a `DefaultValue` attribute that is not applicable on the parameter type.  
-  
-## Example  
+The DefaultParameterValue attribute is not applicable on parameters of type 'type'
 
- The following sample generates CS1909.  
-  
-```csharp  
-// CS1909.cs  
-// compile with: /target:library  
-using System.Runtime.InteropServices;  
-  
-public interface ISomeInterface  
-{  
-   void Test1([DefaultParameterValue(new int[] {1, 2})] int[] arr1);   // CS1909  
-  
-   void Test2([DefaultParameterValue("Test String")] string s);   // OK  
-}  
-```
+ CS1909 is generated when you use a <xref:System.Runtime.InteropServices.DefaultParameterValueAttribute> attribute that is not applicable on the parameter type. This error message is no longer emitted, see [CS1910](cs1910.md) for more information.

--- a/docs/csharp/misc/cs1910.md
+++ b/docs/csharp/misc/cs1910.md
@@ -2,29 +2,30 @@
 description: "Learn more about: Compiler Error CS1910"
 title: "Compiler Error CS1910"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "CS1910"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS1910"
 ms.assetid: 0fef9727-e56f-451c-9255-ca4e5a26d7c6
 ---
 # Compiler Error CS1910
 
-Argument of type 'type' is not applicable for the DefaultValue attribute  
-  
- For parameters whose type is object, the argument of the <xref:System.Runtime.InteropServices.DefaultParameterValueAttribute> must be `null`, an integral type, a floating point, `bool`, `string`, `enum`, or `char`. The argument can not be of type <xref:System.Type> or any array type.  
-  
-## Example  
+Argument of type 'type' is not applicable for the DefaultParameterValue attribute
 
- The following sample generates CS1910.  
-  
-```csharp  
-// CS1910.cs  
-// compile with: /target:library  
-using System.Runtime.InteropServices;  
-  
-public interface MyI  
-{  
-   void Test([DefaultParameterValue(typeof(object))] object o);   // CS1910  
-}  
+ For parameters whose type is object, the argument of the <xref:System.Runtime.InteropServices.DefaultParameterValueAttribute> must be `null`, an integral type, a floating point, `bool`, `string`, `enum`, or `char`. The argument can not be of type <xref:System.Type> or any array type.
+
+## Example
+
+ The following sample generates CS1910:
+
+```csharp
+// CS1910.cs
+// compile with: /target:library
+using System.Runtime.InteropServices;
+
+public interface ISomeInterface
+{
+    void Bad1([DefaultParameterValue(typeof(object))] object o);   // CS1910
+    void Bad2([DefaultParameterValue(new int[] { 1, 2 })] int[] arr);   // CS1910
+}
 ```


### PR DESCRIPTION
## Summary

CS1909 is already deprecated in favor of CS1910.

https://github.com/dotnet/roslyn/blob/d1335b07d906645a57bf7c8871629404dcbce388/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs#L960-L962

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/misc/cs1909.md](https://github.com/dotnet/docs/blob/210cc4a8520ba12dec725bbc93175c1dcfad76c4/docs/csharp/misc/cs1909.md) | [Compiler Error CS1909](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/cs1909?branch=pr-en-us-37337) |
| [docs/csharp/misc/cs1910.md](https://github.com/dotnet/docs/blob/210cc4a8520ba12dec725bbc93175c1dcfad76c4/docs/csharp/misc/cs1910.md) | ["Compiler Error CS1910"](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/cs1910?branch=pr-en-us-37337) |

<!-- PREVIEW-TABLE-END -->