### PR TITLE
Add default param val attr to guide

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/named-and-optional-arguments.md
+++ b/docs/csharp/programming-guide/classes-and-structs/named-and-optional-arguments.md
@@ -99,7 +99,7 @@ IntelliSense uses brackets to indicate optional parameters, as shown in the foll
 ![Screenshot showing IntelliSense quick info for the ExampleMethod method.](./media/named-and-optional-arguments/optional-examplemethod-parameters.png)
 
 > [!NOTE]
-> You can also declare optional parameters by using the .NET <xref:System.Runtime.InteropServices.OptionalAttribute> class. `OptionalAttribute` parameters do not require a default value.
+> You can also declare optional parameters by using the .NET <xref:System.Runtime.InteropServices.OptionalAttribute> class. `OptionalAttribute` parameters do not require a default value. However, if a default value is desired, take a look at <xref:System.Runtime.InteropServices.DefaultParameterValueAttribute> class.
 
 ### Example
 


### PR DESCRIPTION
## Summary

Simple link to `DefaultParameterValueAttribute` as its commonly used in conjunction with `OptionalAttribute`.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/classes-and-structs/named-and-optional-arguments.md](https://github.com/dotnet/docs/blob/60b0f2da0c14d28a01bd4c26c23d062e89c3a7a9/docs/csharp/programming-guide/classes-and-structs/named-and-optional-arguments.md) | [Named and Optional Arguments (C# Programming Guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/named-and-optional-arguments?branch=pr-en-us-37338) |

<!-- PREVIEW-TABLE-END -->