### PR TITLE
Add links to cheat sheet page to Indices and ranges operators.

### DIFF
--- a/docs/csharp/tutorials/ranges-indexes.md
+++ b/docs/csharp/tutorials/ranges-indexes.md
@@ -25,9 +25,9 @@ Indices and ranges provide a succinct syntax for accessing single elements or ra
 This language support relies on two new types and two new operators:
 
 - <xref:System.Index?displayProperty=nameWithType> represents an index into a sequence.
-- The [index from end operator `^`](../language-reference/operators/member-access-operators.md#index-from-end-operator), which specifies that an index is relative to the end of a sequence.
+- The [index from end operator `^`](../language-reference/operators/member-access-operators.md#index-from-end-operator-), which specifies that an index is relative to the end of a sequence.
 - <xref:System.Range?displayProperty=nameWithType> represents a sub range of a sequence.
-- The [range operator `..`](../language-reference/operators/member-access-operators.md#range-operator), which specifies the start and end of a range as its operands.
+- The [range operator `..`](../language-reference/operators/member-access-operators.md#range-operator-), which specifies the start and end of a range as its operands.
 
 Let's start with the rules for indices. Consider an array `sequence`. The `0` index is the same as `sequence[0]`. The `^0` index is the same as `sequence[sequence.Length]`. The expression `sequence[^0]` does throw an exception, just as `sequence[sequence.Length]` does. For any number `n`, the index `^n` is the same as `sequence.Length - n`.
 

--- a/docs/csharp/tutorials/ranges-indexes.md
+++ b/docs/csharp/tutorials/ranges-indexes.md
@@ -25,9 +25,9 @@ Indices and ranges provide a succinct syntax for accessing single elements or ra
 This language support relies on two new types and two new operators:
 
 - <xref:System.Index?displayProperty=nameWithType> represents an index into a sequence.
-- The index from end operator `^`, which specifies that an index is relative to the end of a sequence.
+- The [index from end operator `^`](../language-reference/operators/member-access-operators.md#index-from-end-operator), which specifies that an index is relative to the end of a sequence.
 - <xref:System.Range?displayProperty=nameWithType> represents a sub range of a sequence.
-- The range operator `..`, which specifies the start and end of a range as its operands.
+- The [range operator `..`](../language-reference/operators/member-access-operators.md#range-operator), which specifies the start and end of a range as its operands.
 
 Let's start with the rules for indices. Consider an array `sequence`. The `0` index is the same as `sequence[0]`. The `^0` index is the same as `sequence[sequence.Length]`. The expression `sequence[^0]` does throw an exception, just as `sequence[sequence.Length]` does. For any number `n`, the index `^n` is the same as `sequence.Length - n`.
 

--- a/docs/csharp/tutorials/ranges-indexes.md
+++ b/docs/csharp/tutorials/ranges-indexes.md
@@ -132,3 +132,7 @@ Console.WriteLine(string.Join(",", arrayOfFiveItems));
 // 11,2,3
 // 1,2,3,4,5
 ```
+
+## See also
+
+* [Member access operators and expressions](../language-reference/operators/member-access-operators.md)


### PR DESCRIPTION
This pull request fixes #36338 

It
* converts both `index from and` and `range operator` bullet points to links to their sections in `Member access operators and expressions` page
Although only the <code>range operator `..`</code> is linked to actually a *cheat sheet*, I went ahead and linked the <index from and operator `^`</code> as well, just to keep the consistency.
* Creates the "See also" section and adds there the general page of `Member access operators and expressions`.
The reasoning behind that is to make sure that if one miss the links, he/she will have another prompt to check that page in case more info (or cheat sheet) is needed.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/tutorials/ranges-indexes.md](https://github.com/dotnet/docs/blob/3f74039d68006884e4190fb80535ce35bb418a8f/docs/csharp/tutorials/ranges-indexes.md) | [Indices and ranges](https://review.learn.microsoft.com/en-us/dotnet/csharp/tutorials/ranges-indexes?branch=pr-en-us-37339) |


<!-- PREVIEW-TABLE-END -->