### PR TITLE
Use the draft-v8 branch of the ECMA standard.

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -55,7 +55,7 @@
     {
       "path_to_root": "_csharpstandard",
       "url": "https://github.com/dotnet/csharpstandard",
-      "branch": "standard-v7",
+      "branch": "draft-v8",
       "include_in_build": true,
       "branch_mapping": {}
     },


### PR DESCRIPTION
The ECMA committee will meet this Wednesday to start work on the V8 C# standard.

All v7 work has been merged into the V8 working branch, along with a couple small fixes.

This changes our published branch to the latest updates. We'll pickup all cleanup tasks and new V8 features as they are merged.
