### PR TITLE
Improve CS1106

### DIFF
--- a/docs/csharp/misc/cs1106.md
+++ b/docs/csharp/misc/cs1106.md
@@ -2,31 +2,42 @@
 description: "Compiler Error CS1106"
 title: "Compiler Error CS1106"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "CS1106"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS1106"
 ms.assetid: 3585600a-6b2c-47aa-a418-ef049f07c107
 ---
 # Compiler Error CS1106
 
-Extension methods must be defined in a non generic static class.  
-  
- Extension methods must be defined as static methods in a non-generic static class.  
-  
-## Example  
+Extension methods must be defined in a non generic static class.
 
- The following example generates CS1106 because the class `Extensions` is not defined as `static`:  
-  
-```csharp  
-// cs1106.cs  
-public class Extensions // CS1106  
-{  
-    public static void Test<T>(this System.String s) { }
-}  
-```  
-  
+ Extension methods must be defined as static methods in a non-generic static class.
+
+## Example
+
+ The following example generates CS1106:
+
+```csharp
+// CS1106.cs
+public class NonStaticClass // CS1106
+{
+    public static void ExtensionMethod1(this int num) {}
+}
+
+public static class StaticGenericClass<T> // CS1106
+{
+    public static void ExtensionMethod2(this int num) {}
+}
+
+public static class StaticClass // OK
+{
+    public static void ExtensionMethod3(this int num) {}
+}
+```
+
 ## See also
 
 - [Extension Methods](../programming-guide/classes-and-structs/extension-methods.md)
+- [Generic Classes](../programming-guide/generics/generic-classes.md)
 - [static](../language-reference/keywords/static.md)


### PR DESCRIPTION
## Summary

The extension method taking `System.String` and being generic is not needed. Made the example also explicit on the generic part of the error.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/misc/cs1106.md](https://github.com/dotnet/docs/blob/dd4bb67d5e63133ef23f6698d6a58942b3811b2d/docs/csharp/misc/cs1106.md) | [Compiler Error CS1106](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/cs1106?branch=pr-en-us-37361) |

<!-- PREVIEW-TABLE-END -->