### PR TITLE
Fix coding convention example

### DIFF
--- a/docs/csharp/fundamentals/coding-style/snippets/coding-conventions/program.cs
+++ b/docs/csharp/fundamentals/coding-style/snippets/coding-conventions/program.cs
@@ -172,9 +172,9 @@ namespace Coding_Conventions_Examples
             Console.Write("Enter a divisor: ");
             int divisor = Convert.ToInt32(Console.ReadLine());
 
-            if ((divisor != 0) && (dividend / divisor > 0))
+            if ((divisor != 0) && (dividend / divisor) is var result)
             {
-                Console.WriteLine("Quotient: {0}", dividend / divisor);
+                Console.WriteLine("Quotient: {0}", result);
             }
             else
             {


### PR DESCRIPTION
## Summary

Fixes #37292

The example is a little contrived right now as it is meant to show that `&&` short circuits unlike `&`. Hence the division expr needs to be evaluated in the second clause. This is the best I can come up with in a fixed amount of time without adding additional branches (or making the example more bloated).