### PR TITLE
Add example to CS0076

### DIFF
--- a/docs/csharp/misc/cs0076.md
+++ b/docs/csharp/misc/cs0076.md
@@ -12,7 +12,7 @@ ms.assetid: 8b3e8674-8bfb-4be5-a466-cdf6134e3935
 
 The enumerator name 'value__' is reserved and cannot be used
 
- An item in an [enumeration](../language-reference/builtin-types/enum.md) cannot have an identifier called **value__** since it is reserved for use as the enumeration's backing field.
+An item in an [enumeration](../language-reference/builtin-types/enum.md) cannot have an identifier called **value__** since it's reserved for use as the enumeration's backing field.
 
 The following sample generates CS0076:
 

--- a/docs/csharp/misc/cs0076.md
+++ b/docs/csharp/misc/cs0076.md
@@ -12,7 +12,7 @@ ms.assetid: 8b3e8674-8bfb-4be5-a466-cdf6134e3935
 
 The enumerator name 'value__' is reserved and cannot be used
 
-An item in an [enumeration](../language-reference/builtin-types/enum.md) cannot have an identifier called **value__** since it's reserved for use as the enumeration's backing field.
+ An item in an [enumeration](../language-reference/builtin-types/enum.md) cannot have an identifier called **value__** since it's reserved for use as the enumeration's backing field.
 
 The following sample generates CS0076:
 

--- a/docs/csharp/misc/cs0076.md
+++ b/docs/csharp/misc/cs0076.md
@@ -2,14 +2,24 @@
 description: "Compiler Error CS0076"
 title: "Compiler Error CS0076"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "CS0076"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS0076"
 ms.assetid: 8b3e8674-8bfb-4be5-a466-cdf6134e3935
 ---
 # Compiler Error CS0076
 
-The enumerator name 'value__' is reserved and cannot be used  
-  
- An item in an [enumeration](../language-reference/builtin-types/enum.md) cannot have an identifier called **value__**.
+The enumerator name 'value__' is reserved and cannot be used
+
+ An item in an [enumeration](../language-reference/builtin-types/enum.md) cannot have an identifier called **value__** since it is reserved for use as the enumeration's backing field.
+
+The following sample generates CS0076:
+
+```csharp
+// CS0076.cs
+public enum E
+{
+    value__   // CS0076
+}
+```


### PR DESCRIPTION
## Summary

Add a simple example and elaborate a little on why `value__` is reserved.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/misc/cs0076.md](https://github.com/dotnet/docs/blob/69de5aff879fc00cf774964e73fb168d2cc1c230/docs/csharp/misc/cs0076.md) | [Compiler Error CS0076](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/cs0076?branch=pr-en-us-37382) |


<!-- PREVIEW-TABLE-END -->