### PR TITLE
Two breaking changes for RC 2

### DIFF
--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -123,6 +123,7 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 | [MSBuild custom derived build events deprecated](sdk/8.0/custombuildeventargs.md)                  | Behavioral change                  | RC 1       |
 | [MSBuild respects DOTNET_CLI_UI_LANGUAGE](sdk/8.0/msbuild-language.md)                             | Behavioral change                                | Preview 5  |
 | [Runtime-specific apps not self-contained](sdk/8.0/runtimespecific-app-default.md)                 | Source/binary incompatible                       | Preview 5  |
+| [--arch option doesn't imply self-contained](sdk/8.0/arch-option.md)                               | Behavioral change                                | RC 2       |
 | ['dotnet restore' produces security vulnerability warnings](sdk/8.0/dotnet-restore-audit.md)       | Behavioral change                                | Preview 4  |
 | [SDK uses a smaller RID graph](sdk/8.0/rid-graph.md)                                               | Behavioral change/Source incompatible            | RC 1  |
 | [Trimming may not be used with .NET Standard or .NET Framework](sdk/8.0/trimming-unsupported-targetframework.md) | Behavioral change                                | RC 1       |

--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -2,7 +2,7 @@
 title: Breaking changes in .NET 8
 titleSuffix: ""
 description: Navigate to the breaking changes in .NET 8.
-ms.date: 09/13/2023
+ms.date: 10/05/2023
 no-loc: [Blazor, Razor, Kestrel]
 ---
 # Breaking changes in .NET 8
@@ -87,6 +87,7 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 | [DirectoryServices package no longer references System.Security.Permissions](extensions/8.0/configurationmanager-package.md)   | Source incompatible | Preview 3  |
 | [Empty keys added to dictionary by configuration binder](extensions/8.0/dictionary-configuration-binding.md)                      | Behavioral change | Preview 5  |
 | [HostApplicationBuilderSettings.Args respected by HostApplicationBuilder ctor](extensions/8.0/hostapplicationbuilder-ctor.md)     | Behavioral change | Preview 2  |
+| [ManagementDateTimeConverter.ToDateTime returns a local time](extensions/8.0/dmtf-todatetime.md)     | Behavioral change | RC 1 |
 
 ## Globalization
 

--- a/docs/core/compatibility/extensions/8.0/dmtf-todatetime.md
+++ b/docs/core/compatibility/extensions/8.0/dmtf-todatetime.md
@@ -1,0 +1,36 @@
+---
+title: "Breaking change: ManagementDateTimeConverter.ToDateTime returns a local time"
+description: Learn about the .NET 8 breaking change in .NET extensions where the DateTime returned by ManagementDateTimeConverter.ToDateTime is based on local time.
+ms.date: 10/05/2023
+---
+# ManagementDateTimeConverter.ToDateTime returns a local time
+
+The <xref:System.DateTime> value returned by <xref:System.Management.ManagementDateTimeConverter.ToDateTime(System.String)?displayProperty=nameWithType> is now based on the local time zone.
+
+## Version introduced
+
+.NET 8 RC 1
+
+## Previous behavior
+
+Previously, <xref:System.Management.ManagementDateTimeConverter.ToDateTime(System.String)?displayProperty=nameWithType> returned a value whose <xref:System.DateTime.Kind?displayProperty=nameWithType> value was <xref:System.DateTimeKind.Unspecified?displayProperty=nameWithType>.
+
+## New behavior
+
+Starting in .NET 8, <xref:System.Management.ManagementDateTimeConverter.ToDateTime(System.String)?displayProperty=nameWithType> returns a value whose <xref:System.DateTime.Kind?displayProperty=nameWithType> value was <xref:System.DateTimeKind.Local?displayProperty=nameWithType>.
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+This change was made so that the code matched what the documentation said it did.
+
+## Recommended action
+
+If your code expected the returned value to be based on an unspecified time zone, update it to expect a value that's based on the local time zone.
+
+## Affected APIs
+
+- <xref:System.Management.ManagementDateTimeConverter.ToDateTime(System.String)?displayProperty=fullName>

--- a/docs/core/compatibility/sdk/8.0/arch-option.md
+++ b/docs/core/compatibility/sdk/8.0/arch-option.md
@@ -5,7 +5,7 @@ ms.date: 10/05/2023
 ---
 # --arch option doesn't imply self-contained
 
-Up until now, the `--arch` option for `dotnet` CLI commands such as [dotnet publish](../../../tools/dotnet-publish.md) implied that the app was [self-contained](../../../deploying/index.md#publish-self-contained). The behavior of the `--arch` option has now been changed to match that of the `--runtime option`, and it no longer implies that an app is self-contained.
+Up until now, the `--arch` option for `dotnet` CLI commands such as [dotnet publish](../../../tools/dotnet-publish.md) implied that the app was [self-contained](../../../deploying/index.md#publish-self-contained). The behavior of the `--arch` option has now been changed to match that of the `--runtime` option, and it no longer implies that an app is self-contained.
 
 ## Previous behavior
 

--- a/docs/core/compatibility/sdk/8.0/arch-option.md
+++ b/docs/core/compatibility/sdk/8.0/arch-option.md
@@ -1,0 +1,36 @@
+---
+title: "Breaking change: Architecture option doesn't imply self-contained"
+description: Learn about a breaking change in the .NET 8 SDK where the `--arch` option no longer implies that an app is self-contained.
+ms.date: 10/05/2023
+---
+# --arch option doesn't imply self-contained
+
+Up until now, the `--arch` option for `dotnet` CLI commands such as [dotnet publish](../../../tools/dotnet-publish.md) implied that the app was [self-contained](../../../deploying/index.md#publish-self-contained). The behavior of the `--arch` option has now been changed to match that of the `--runtime option`, and it no longer implies that an app is self-contained.
+
+## Previous behavior
+
+`--arch` implied `--self-contained`.
+
+## New behavior
+
+`--arch` doesn't imply anything about `--self-contained`.
+
+## Version introduced
+
+.NET 8 RC 2
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+This change was made to unify the behavior of `--arch` with that of `--runtime`, which it's an alias for. The [behavior for `--runtime` was changed](runtimespecific-app-default.md) in an earlier preview version of .NET 8.
+
+## Recommended action
+
+If your application needs to be self contained, set `--self-contained` on your CLI calls, or set MSBuild properties such as `<SelfContained>true</SelfContained>` or `<PublishSelfContained>true</PublishSelfContained>`.
+
+## See also
+
+- [Runtime-specific apps no longer self-contained](runtimespecific-app-default.md)

--- a/docs/core/compatibility/sdk/8.0/runtimespecific-app-default.md
+++ b/docs/core/compatibility/sdk/8.0/runtimespecific-app-default.md
@@ -34,7 +34,7 @@ In addition:
 - The `PublishReadyToRun` property no longer implies `SelfContained` if the project targets .NET 8 or later.
 
 > [!NOTE]
->If you publish using `msbuild /t:Publish`, you must explicitly specify `SelfContained` if you want your app to be self-contained, even if your project has one of the listed publish properties.
+> If you publish using `msbuild /t:Publish` and you want your app to be self-contained, you must explicitly specify `SelfContained`, even if your project has one of the listed publish properties.
 
 ## Version introduced
 

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -142,6 +142,8 @@ items:
         href: sdk/8.0/msbuild-language.md
       - name: Runtime-specific apps not self-contained
         href: sdk/8.0/runtimespecific-app-default.md
+      - name: --arch option doesn't imply self-contained
+        href: sdk/8.0/arch-option.md
       - name: SDK uses a smaller RID graph
         href: sdk/8.0/rid-graph.md
       - name: Trimming may not be used with .NET Standard or .NET Framework
@@ -1504,6 +1506,8 @@ items:
         href: sdk/8.0/msbuild-language.md
       - name: Runtime-specific apps not self-contained
         href: sdk/8.0/runtimespecific-app-default.md
+      - name: --arch option doesn't imply self-contained
+        href: sdk/8.0/arch-option.md
       - name: SDK uses a smaller RID graph
         href: sdk/8.0/rid-graph.md
       - name: Trimming may not be usedwith .NET Standard or .NET Framework

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -100,6 +100,8 @@ items:
         href: extensions/8.0/dictionary-configuration-binding.md
       - name: HostApplicationBuilderSettings.Args respected by constructor
         href: extensions/8.0/hostapplicationbuilder-ctor.md
+      - name: ManagementDateTimeConverter.ToDateTime returns a local time
+        href: extensions/8.0/dmtf-todatetime.md
     - name: Globalization
       items:
       - name: Date and time converters honor culture argument
@@ -1348,6 +1350,8 @@ items:
         href: extensions/8.0/dictionary-configuration-binding.md
       - name: HostApplicationBuilderSettings.Args respected by constructor
         href: extensions/8.0/hostapplicationbuilder-ctor.md
+      - name: ManagementDateTimeConverter.ToDateTime returns a local time
+        href: extensions/8.0/dmtf-todatetime.md
     - name: .NET 7
       items:
       - name: Binding config to dictionary extends values


### PR DESCRIPTION
Fixes #37058 
Fixes #36651 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/8.0.md](https://github.com/dotnet/docs/blob/1933d59adc3ef1514408a922a3b2251a5cf7cda6/docs/core/compatibility/8.0.md) | [Breaking changes in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/8.0?branch=pr-en-us-37385) |
| [docs/core/compatibility/extensions/8.0/dmtf-todatetime.md](https://github.com/dotnet/docs/blob/1933d59adc3ef1514408a922a3b2251a5cf7cda6/docs/core/compatibility/extensions/8.0/dmtf-todatetime.md) | [ManagementDateTimeConverter.ToDateTime returns a local time](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/extensions/8.0/dmtf-todatetime?branch=pr-en-us-37385) |
| [docs/core/compatibility/sdk/8.0/arch-option.md](https://github.com/dotnet/docs/blob/1933d59adc3ef1514408a922a3b2251a5cf7cda6/docs/core/compatibility/sdk/8.0/arch-option.md) | ["Breaking change: Architecture option doesn't imply self-contained"](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/arch-option?branch=pr-en-us-37385) |
| [docs/core/compatibility/sdk/8.0/runtimespecific-app-default.md](https://github.com/dotnet/docs/blob/1933d59adc3ef1514408a922a3b2251a5cf7cda6/docs/core/compatibility/sdk/8.0/runtimespecific-app-default.md) | [Runtime-specific apps no longer self-contained](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/runtimespecific-app-default?branch=pr-en-us-37385) |


<!-- PREVIEW-TABLE-END -->