### PR TITLE
Minor clarification to "." custom format

### DIFF
--- a/docs/standard/base-types/custom-numeric-format-strings.md
+++ b/docs/standard/base-types/custom-numeric-format-strings.md
@@ -91,7 +91,7 @@ To return a result string in which absent digits or leading zeroes are replaced 
 
 ## The "." custom specifier
 
-The "." custom format specifier inserts a localized decimal separator into the result string. The first period in the format string determines the location of the decimal separator in the formatted value; any additional periods are ignored.
+The "." custom format specifier inserts a localized decimal separator into the result string. The first period in the format string determines the location of the decimal separator in the formatted value; any additional periods are ignored. If the format specifier ends with a "." only the significant digits are formatted into the result string.
 
 The character that is used as the decimal separator in the result string is not always a period; it is determined by the <xref:System.Globalization.NumberFormatInfo.NumberDecimalSeparator%2A> property of the <xref:System.Globalization.NumberFormatInfo> object that controls formatting.
 


### PR DESCRIPTION
## Summary

Add note about formatting with a trailing `.`

Fixes #35243


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/base-types/custom-numeric-format-strings.md](https://github.com/dotnet/docs/blob/802ca8fbda34dcd919578208dc6720209066397f/docs/standard/base-types/custom-numeric-format-strings.md) | [Custom numeric format strings](https://review.learn.microsoft.com/en-us/dotnet/standard/base-types/custom-numeric-format-strings?branch=pr-en-us-37387) |

<!-- PREVIEW-TABLE-END -->