### PR TITLE
Overhaul cross platform cryptography guide

### DIFF
--- a/docs/standard/security/cross-platform-cryptography.md
+++ b/docs/standard/security/cross-platform-cryptography.md
@@ -1,5 +1,5 @@
 ---
-title: "Cross-platform cryptography in .NET Core and .NET 5"
+title: "Cross-platform cryptography in .NET"
 description: Learn about cryptographic capabilities on platforms supported by .NET.
 ms.date: "06/19/2020"
 ms.technology: dotnet-standard
@@ -7,9 +7,9 @@ helpviewer_keywords:
   - "cryptography, cross-platform"
   - "encryption, cross-platform"
 ---
-# Cross-Platform Cryptography in .NET Core and .NET 5
+# Cross-Platform Cryptography in .NET
 
-Cryptographic operations in .NET Core and .NET 5+ are done by operating system (OS) libraries. This dependency has advantages:
+Cryptographic operations in .NET are done by operating system (OS) libraries. This dependency has advantages:
 
 * .NET apps benefit from OS reliability. Keeping cryptography libraries safe from vulnerabilities is a high priority for OS vendors. To do that, they provide updates that system administrators should be applying.
 * .NET apps have access to FIPS-validated algorithms if the OS libraries are FIPS-validated.
@@ -20,32 +20,56 @@ This article assumes you have a working familiarity with cryptography in .NET. F
 
 ## Hash algorithms
 
-All hash algorithm and hash-based message authentication (HMAC) classes, including the `*Managed` classes, defer to the OS libraries. While the various OS libraries differ in performance, they should be compatible.
+All hash algorithm and hash-based message authentication (HMAC) classes, including the `*Managed` classes, defer to the OS libraries with the exception of .NET on Browser WASM. In Browser WASM, SHA-1, SHA-2-256, SHA-2-384, SHA-2-512, are implemented using managed code.
+
+### SHA-3
+
+.NET 8 introduced support for the SHA-3 hash algorithms, including SHAKE-128 and SHAKE-256. SHA-3 support is currently supported on Windows 11 build 25324 or later, and Linux with OpenSSL 1.1.1 or later.
 
 ## Symmetric encryption
 
-The underlying ciphers and chaining are done by the system libraries, and all are supported by all platforms.
+The underlying ciphers and chaining are done by the system libraries.
 
-| Cipher + Mode | Windows | Linux | macOS |
-|---------------|---------|-------|-------|
-| AES-CBC       | ✔️     | ✔️    | ✔️   |
-| AES-ECB       | ✔️     | ✔️    | ✔️   |
-| 3DES-CBC      | ✔️     | ✔️    | ✔️   |
-| 3DES-ECB      | ✔️     | ✔️    | ✔️   |
-| DES-CBC       | ✔️     | ✔️    | ✔️   |
-| DES-ECB       | ✔️     | ✔️    | ✔️   |
+| Cipher + Mode | Windows  | Linux | macOS | iOS | Android |
+|---------------|----------|-------|-------|-----|---------|
+| AES-CBC       | ✔️        | ✔️     | ✔️     | ✔️   | ✔️      |
+| AES-ECB       | ✔️        | ✔️     | ✔️     | ✔️   | ✔️      |
+| AES-CFB8      | ✔️        | ✔️     | ✔️     | ✔️   | ✔️      |
+| AES-CFB128    | ✔️        | ✔️     | ✔️     | ✔️   | ✔️      |
+| 3DES-CBC      | ✔️        | ✔️     | ✔️     | ✔️   | ✔️      |
+| 3DES-ECB      | ✔️        | ✔️     | ✔️     | ✔️   | ✔️      |
+| 3DES-CFB8     | ✔️        | ✔️     | ✔️     | ✔️   | ✔️      |
+| 3DES-CFB64    | ✔️        | ✔️     | ✔️     | ✔️   | ✔️      |
+| DES-CBC       | ✔️        | ✔️     | ✔️     | ✔️   | ✔️      |
+| DES-ECB       | ✔️        | ✔️     | ✔️     | ✔️   | ✔️      |
+| DES-CFB8      | ✔️        | ✔️     | ✔️     | ✔️   | ✔️      |
+| RC2-CBC       | ✔️        | ✔️     | ✔️     | ✔️   | ❌     |
+| RC2-ECB       | ✔️        | ✔️     | ✔️     | ✔️   | ❌     |
+| RC2-CFB       | ❌       | ❌     | ❌    | ❌   | ❌     |
 
 ## Authenticated encryption
 
-Authenticated encryption (AE) support is provided for AES-CCM and AES-GCM via the <xref:System.Security.Cryptography.AesCcm?displayProperty=fullName> and <xref:System.Security.Cryptography.AesGcm?displayProperty=fullName> classes.
+Authenticated encryption (AE) support is provided for AES-CCM, AES-GCM, and ChaCha20Poly1305 via the <xref:System.Security.Cryptography.AesCcm?displayProperty=fullName>, <xref:System.Security.Cryptography.AesGcm?displayProperty=fullName>, and <xref:System.Security.Cryptography.ChaCha20Poly1305?displayProperty=fullName> classes, respectively.
 
-On Windows and Linux, the implementations of AES-CCM and AES-GCM are provided by the OS libraries.
+As authentication encryption requires newer platform APIs to support the algorithm, support may not be present on all platforms. The `IsSupported` static property on the classes for the algorithm can be used to detect at runtime if the current platform supports the algorithm or not.
 
-### AES-CCM and AES-GCM on macOS
+| Cipher + Mode     | Windows                 | Linux          | macOS   | iOS | Android       | Browser |
+|-------------------|-------------------------|----------------|---------|-----|---------------|---------|
+| AES-GCM           | ✔️                       | ✔️              | ⚠️       | ❌  | ✔️             | ❌      |
+| AES-CCM           | ✔️                       | ✔️              | ⚠️       | ❌  | ✔️             | ❌      |
+| ChaCha20Poly1305  | Windows 10 Build 20142+ | OpenSSL 1.1.0+ | ⚠️       | ❌  | API Level 28+ | ❌      |
 
-On macOS, the system libraries don't support AES-CCM or AES-GCM for third-party code, so the <xref:System.Security.Cryptography.AesCcm> and <xref:System.Security.Cryptography.AesGcm> classes use OpenSSL for support. Users on macOS need to obtain an appropriate copy of OpenSSL (libcrypto) for these types to function, and it must be in a path that the system would load a library from by default. We recommend that you install OpenSSL from a package manager such as Homebrew.
+### AES-CCM on macOS
+
+On macOS, the system libraries don't support AES-CCM for third-party code, so the <xref:System.Security.Cryptography.AesCcm> class uses OpenSSL for support. Users on macOS need to obtain an appropriate copy of OpenSSL (libcrypto) for this type to function, and it must be in a path that the system would load a library from by default. We recommend that you install OpenSSL from a package manager such as Homebrew.
 
 The `libcrypto.0.9.7.dylib` and `libcrypto.0.9.8.dylib` libraries included in macOS are from earlier versions of OpenSSL and will not be used. The `libcrypto.35.dylib`, `libcrypto.41.dylib`, and `libcrypto.42.dylib` libraries are from LibreSSL and will not be used.
+
+### AES-GCM and ChaCha20Poly1305 on macOS
+
+MacOS did not support AES-GCM or ChaCha20Poly1305 until macOS 10.15 for third-party code. Prior to .NET 8, <xref:System.Security.Cryptography.AesGcm> and <xref:System.Security.Cryptography.ChaCha20Poly1305> have the same requirement as AES-CCM and users must install OpenSSL for these types to function.
+
+Starting in .NET 8, .NET on macOS will use the Apple's CryptoKit framework for AES-GCM and ChaCha20Poly1305. Users will not need to install or configure any additional dependencies for AES-GCM or ChaCha20Poly1305 on macOS.
 
 ### AES-CCM keys, nonces, and tags
 
@@ -72,8 +96,11 @@ The `libcrypto.0.9.7.dylib` and `libcrypto.0.9.8.dylib` libraries included in ma
   The <xref:System.Security.Cryptography.AesGcm> class supports only 96-bit (12-byte) nonces.
 
 * Tag Sizes
+  On Windows and Linux, the <xref:System.Security.Cryptography.AesGcm> class supports creating or processing 96, 104, 112, 120, and 128-bit (12, 13, 14, 15, and 16-byte) tags. On macOS, the tag size is limited to 128-bit (16-byte) due to limitation of the CryptoKit framework.
 
-  The <xref:System.Security.Cryptography.AesGcm> class supports creating or processing 96, 104, 112, 120, and 128-bit (12, 13, 14, 15, and 16-byte) tags.
+### ChaCha20Poly1305 keys, nonces, and tags.
+
+ChaCha20Poly1305 has a fixed size for the key, nonce, and authentication tag. ChaCha20Poly1305 always uses a 256-bit key, a 96-bit (12-byte) nonce, and 128-bit (16-byte) tag.
 
 ## Asymmetric cryptography
 
@@ -92,18 +119,23 @@ RSA key operations are performed by the OS libraries, and the types of key that 
 
 .NET does not expose "raw" (unpadded) RSA operations.
 
-The OS libraries are used for encryption and decryption padding. Not all platforms support the same padding options:
+Padding and digest support vary by platform:
 
-| Padding Mode                          | Windows (CNG) | Linux (OpenSSL) | macOS | Windows (CAPI) |
-|---------------------------------------|---------------|-----------------|-------|----------------|
-| PKCS1 Encryption                      | ✔️           | ✔️              | ✔️   | ✔️             |
-| OAEP - SHA-1                          | ✔️           | ✔️              | ✔️   | ✔️             |
-| OAEP - SHA-2 (SHA256, SHA384, SHA512) | ✔️           | ✔️              | ✔️   | ❌             |
-| PKCS1 Signature (MD5, SHA-1)          | ✔️           | ✔️              | ✔️   | ✔️             |
-| PKCS1 Signature (SHA-2)               | ✔️           | ✔️              | ✔️   | ⚠️\*           |
-| PSS                                   | ✔️           | ✔️              | ✔️   | ❌             |
+| Padding Mode                 | Windows (CNG)            | Linux (OpenSSL) | macOS  | iOS | Android | Windows (CAPI) |
+|------------------------------|--------------------------|-----------------|--------|-----|---------|----------------|
+| PKCS1 Encryption             | ✔️                        | ✔️               | ✔️      | ✔️   | ✔️       | ✔️             |
+| OAEP - SHA-1                 | ✔️                        | ✔️               | ✔️      | ✔️   | ✔️       | ✔️             |
+| OAEP - SHA-2                 | ✔️                        | ✔️               | ✔️      | ✔️   | ✔️       | ❌             |
+| OAEP - SHA-3**               | Windows 11 Build 25324+  | OpenSSL 1.1.1+  | ❌     | ❌   | ❌      | ❌             |
+| PKCS1 Signature (MD5, SHA-1) | ✔️                        | ✔️               | ✔️      | ✔️   | ✔️       | ✔️             |
+| PKCS1 Signature (SHA-2)      | ✔️                        | ✔️               | ✔️      | ✔️   | ✔️       | ⚠️\*           |
+| PKCS1 Signature (SHA-3)**    | Windows 11 Build 25324+  | OpenSSL 1.1.1+  | ❌     |  ❌  | ❌      | ❌             |
+| PSS                          | ✔️                        | ✔️               | ✔️      | ✔️   | ✔️       | ❌             |
+
 
 \* Windows CryptoAPI (CAPI) is capable of PKCS1 signature with a SHA-2 algorithm. But the individual RSA object may be loaded in a cryptographic service provider (CSP) that doesn't support it.
+
+\** Requires .NET 8.
 
 #### RSA on Windows
 
@@ -117,13 +149,13 @@ The OS libraries are used for encryption and decryption padding. Not all platfor
 
 .NET exposes types to allow programs to interoperate with the OS libraries that the .NET cryptography code uses. The types involved do not translate between platforms, and should only be directly used when necessary.
 
-| Type                                                         | Windows | Linux         | macOS         |
-|--------------------------------------------------------------|---------|---------------|---------------|
-| <xref:System.Security.Cryptography.RSACryptoServiceProvider> | ✔️     | ⚠️<sup>1</sup>| ⚠️<sup>1</sup> |
-| <xref:System.Security.Cryptography.RSACng>                   | ✔️     | ❌            | ❌            |
-| <xref:System.Security.Cryptography.RSAOpenSsl>               | ❌     | ✔️            | ⚠️<sup>2</sup> |
+| Type                                                         | Windows | Linux         | macOS         | iOS             | Android         |
+|--------------------------------------------------------------|---------|---------------|---------------|-----------------|-----------------|
+| <xref:System.Security.Cryptography.RSACryptoServiceProvider> | ✔️     | ⚠️<sup>1</sup>   | ⚠️<sup>1</sup> | ⚠️<sup>1</sup>   | ⚠️<sup>1</sup>   |
+| <xref:System.Security.Cryptography.RSACng>                   | ✔️     | ❌              | ❌             | ❌              | ❌              |
+| <xref:System.Security.Cryptography.RSAOpenSsl>               | ❌     | ✔️              | ⚠️<sup>2</sup>  | ❌              | ❌              |
 
-<sup>1</sup> On macOS and Linux, <xref:System.Security.Cryptography.RSACryptoServiceProvider> can be used for compatibility with existing programs. In that case, any method that requires OS interop, such as opening a named key, throws a <xref:System.PlatformNotSupportedException>.
+<sup>1</sup> On non-Windows, <xref:System.Security.Cryptography.RSACryptoServiceProvider> can be used for compatibility with existing programs. In that case, any method that requires OS interop, such as opening a named key, throws a <xref:System.PlatformNotSupportedException>.
 
 <sup>2</sup> On macOS, <xref:System.Security.Cryptography.RSAOpenSsl> works if OpenSSL is installed and an appropriate libcrypto dylib can be found via dynamic library loading. If an appropriate library can't be found, exceptions will be thrown.
 
@@ -133,30 +165,32 @@ ECDSA (Elliptic Curve Digital Signature Algorithm) key generation is done by the
 
 ECDSA key curves are defined by the OS libraries and are subject to their limitations.
 
-| Elliptic Curve                     | Windows 10    | Windows 7 - 8.1 | Linux         | macOS         |
-|------------------------------------|---------------|-----------------|---------------|---------------|
-| NIST P-256 (secp256r1)             | ✔️           | ✔️              | ✔️           | ✔️            |
-| NIST P-384 (secp384r1)             | ✔️           | ✔️              | ✔️           | ✔️            |
-| NIST P-521 (secp521r1)             | ✔️           | ✔️              | ✔️           | ✔️            |
-| Brainpool curves (as named curves) | ✔️           | ❌              | ⚠️<sup>1</sup>| ❌           |
-| Other named curves                 | ⚠️<sup>2</sup>| ❌             | ⚠️<sup>1</sup>| ❌           |
-| Explicit curves                    | ✔️           | ❌              | ✔️           | ❌            |
-| Export or import as explicit       | ✔️           | ❌<sup>3</sup>  | ✔️           | ❌<sup>3</sup>|
+| Elliptic Curve                     | Windows 10    | Windows 7 - 8.1 | Linux         | macOS         | iOS           | Android        |
+|------------------------------------|---------------|-----------------|---------------|---------------|---------------|----------------|
+| NIST P-256 (secp256r1)             | ✔️           | ✔️              | ✔️                | ✔️             | ✔️             | ✔️              |
+| NIST P-384 (secp384r1)             | ✔️           | ✔️              | ✔️                | ✔️             | ✔️             | ✔️              |
+| NIST P-521 (secp521r1)             | ✔️           | ✔️              | ✔️                | ✔️             | ✔️             | ✔️              |
+| Brainpool curves (as named curves) | ✔️           | ❌              | ⚠️<sup>1</sup>   | ❌             | ❌             | ⚠️<sup>4</sup> |
+| Other named curves                 | ⚠️<sup>2</sup>| ❌             | ⚠️<sup>1</sup>   | ❌             | ❌             | ⚠️<sup>4</sup> |
+| Explicit curves                    | ✔️           | ❌              | ✔️               | ❌             | ❌             | ✔️             |
+| Export or import as explicit       | ✔️           | ❌<sup>3</sup>  | ✔️               | ❌<sup>3</sup> | ❌<sup>3</sup> | ✔️             |
 
 <sup>1</sup> Linux distributions don't all have support for the same named curves.
 
 <sup>2</sup> Support for named curves was added to Windows CNG in Windows 10. For more information, see [CNG Named Elliptic Curves](/windows/win32/seccng/cng-named-elliptic-curves). Named curves are not available in earlier versions of Windows, except for three curves in Windows 7.
 
-<sup>3</sup> Exporting with explicit curve parameters requires OS library support, which is not available on macOS or earlier versions of Windows.
+<sup>3</sup> Exporting with explicit curve parameters requires OS library support, which is not available on Apple platforms or earlier versions of Windows.
+
+<sup>4</sup> Android support for some curves depends on the Android version. Android distributors may choose to add or remove curves from their Android build as well.
 
 #### ECDSA Native Interop
 
 .NET exposes types to allow programs to interoperate with the OS libraries that the .NET cryptography code uses. The types involved don't translate between platforms and should only be directly used when necessary.
 
-| Type                                             | Windows | Linux | macOS |
-|--------------------------------------------------|---------|-------|-------|
-| <xref:System.Security.Cryptography.ECDsaCng>     | ✔️     | ❌    | ❌    |
-| <xref:System.Security.Cryptography.ECDsaOpenSsl> | ❌     | ✔️    | ⚠️\*  |
+| Type                                             | Windows | Linux | macOS | iOS | Android |
+|--------------------------------------------------|---------|-------|-------|-----|---------|
+| <xref:System.Security.Cryptography.ECDsaCng>     | ✔️       | ❌    | ❌    | ❌   | ❌      |
+| <xref:System.Security.Cryptography.ECDsaOpenSsl> | ❌      | ✔️    | ⚠️\*    | ❌   | ❌      |
 
 \* On macOS, <xref:System.Security.Cryptography.ECDsaOpenSsl> works if OpenSSL is installed in the system and an appropriate libcrypto dylib can be found via dynamic library loading. If an appropriate library can't be found, exceptions will be thrown.
 
@@ -164,7 +198,7 @@ ECDSA key curves are defined by the OS libraries and are subject to their limita
 
 ECDH (Elliptic Curve Diffie-Hellman) key generation is done by the OS libraries and is subject to their size limitations and performance characteristics.
 
-The <xref:System.Security.Cryptography.ECDiffieHellman> class doesn't return the "raw" value of the ECDH computation. All returned data is in terms of key derivation functions:
+The <xref:System.Security.Cryptography.ECDiffieHellman> class supports the "raw" value of the ECDH computation as well as through the following key derivation functions:
 
 * HASH(Z)
 * HASH(prepend || Z || append)
@@ -174,32 +208,36 @@ The <xref:System.Security.Cryptography.ECDiffieHellman> class doesn't return the
 * HMAC(Z, prepend || Z || append)
 * Tls11Prf(label, seed)
 
+"Raw" key derivation was introduced in .NET 8.
+
 ECDH key curves are defined by the OS libraries and are subject to their limitations.
 
-| Elliptic Curve                     | Windows 10    | Windows 7 - 8.1 | Linux         | macOS         |
-|------------------------------------|---------------|-----------------|---------------|---------------|
-| NIST P-256 (secp256r1)             | ✔️           | ✔️              | ✔️           | ✔️            |
-| NIST P-384 (secp384r1)             | ✔️           | ✔️              | ✔️           | ✔️            |
-| NIST P-521 (secp521r1)             | ✔️           | ✔️              | ✔️           | ✔️            |
-| brainpool curves (as named curves) | ✔️           | ❌              | ⚠️<sup>1</sup>| ❌           |
-| other named curves                 | ⚠️<sup>2</sup>| ❌             | ⚠️<sup>1</sup>| ❌           |
-| explicit curves                    | ✔️           | ❌              | ✔️           | ❌            |
-| Export or import as explicit       | ✔️           | ❌<sup>3</sup>  | ✔️           | ❌<sup>3</sup>|
+| Elliptic Curve                     | Windows 10    | Windows 7 - 8.1 | Linux         | macOS         | iOS           | Android        |
+|------------------------------------|---------------|-----------------|---------------|---------------|---------------|----------------|
+| NIST P-256 (secp256r1)             | ✔️           | ✔️              | ✔️                | ✔️             | ✔️             | ✔️              |
+| NIST P-384 (secp384r1)             | ✔️           | ✔️              | ✔️                | ✔️             | ✔️             | ✔️              |
+| NIST P-521 (secp521r1)             | ✔️           | ✔️              | ✔️                | ✔️             | ✔️             | ✔️              |
+| Brainpool curves (as named curves) | ✔️           | ❌              | ⚠️<sup>1</sup>   | ❌             | ❌             | ⚠️<sup>4</sup> |
+| Other named curves                 | ⚠️<sup>2</sup>| ❌             | ⚠️<sup>1</sup>   | ❌             | ❌             | ⚠️<sup>4</sup> |
+| Explicit curves                    | ✔️           | ❌              | ✔️               | ❌             | ❌             | ✔️             |
+| Export or import as explicit       | ✔️           | ❌<sup>3</sup>  | ✔️               | ❌<sup>3</sup> | ❌<sup>3</sup> | ✔️             |
 
 <sup>1</sup> Linux distributions don't all have support for the same named curves.
 
 <sup>2</sup> Support for named curves was added to Windows CNG in Windows 10. For more information, see [CNG Named Elliptic Curves](/windows/win32/seccng/cng-named-elliptic-curves). Named curves are not available in earlier versions of Windows, except for three curves in Windows 7.
 
-<sup>3</sup> Exporting with explicit curve parameters requires OS library support, which is not available on macOS or earlier versions of Windows.
+<sup>3</sup> Exporting with explicit curve parameters requires OS library support, which is not available on Apple platforms or earlier versions of Windows.
+
+<sup>4</sup> Android support for some curves depends on the Android version. Android distributors may choose to add or remove curves from their Android build as well.
 
 #### ECDH native interop
 
 .NET exposes types to allow programs to interoperate with the OS libraries that .NET uses. The types involved don't translate between platforms and should only be directly used when necessary.
 
-| Type                                                       | Windows | Linux | macOS |
-|------------------------------------------------------------|---------|-------|-------|
-| <xref:System.Security.Cryptography.ECDiffieHellmanCng>     | ✔️     | ❌    | ❌   |
-| <xref:System.Security.Cryptography.ECDiffieHellmanOpenSsl> | ❌     | ✔️    | ⚠️\* |
+| Type                                                       | Windows | Linux | macOS | iOS | Android  |
+|------------------------------------------------------------|---------|-------|-------|-----|----------|
+| <xref:System.Security.Cryptography.ECDiffieHellmanCng>     | ✔️     | ❌       | ❌    | ❌  | ❌       |
+| <xref:System.Security.Cryptography.ECDiffieHellmanOpenSsl> | ❌     | ✔️       | ⚠️\*   | ❌  | ❌       |
 
 \* On macOS, <xref:System.Security.Cryptography.ECDiffieHellmanOpenSsl> works if OpenSSL is installed and an appropriate libcrypto dylib can be found via dynamic library loading. If an appropriate library can't be found, exceptions will be thrown.
 
@@ -207,14 +245,14 @@ ECDH key curves are defined by the OS libraries and are subject to their limitat
 
 DSA (Digital Signature Algorithm) key generation is performed by the system libraries and is subject to their size limitations and performance characteristics.
 
-| Function                      | Windows CNG | Linux | macOS         | Windows CAPI |
-|-------------------------------|-------------|-------|---------------|--------------|
-| Key creation (<= 1024 bits)   | ✔️         | ✔️    | ❌            | ✔️           |
-| Key creation (> 1024 bits)    | ✔️         | ✔️    | ❌            | ❌            |
-| Loading keys (<= 1024 bits)   | ✔️         | ✔️    | ✔️            | ✔️           |
-| Loading keys (> 1024 bits)    | ✔️         | ✔️    | ⚠️\*          | ❌            |
-| FIPS 186-2                    | ✔️         | ✔️    | ✔️            | ✔️           |
-| FIPS 186-3 (SHA-2 signatures) | ✔️         | ✔️    | ❌            | ❌            |
+| Function                      | Windows CNG | Linux | macOS         | Windows CAPI | iOS  | Android |
+|-------------------------------|-------------|-------|---------------|--------------|------|---------|
+| Key creation (<= 1024 bits)   | ✔️           | ✔️    | ❌             | ✔️            | ❌    | ✔️       |
+| Key creation (> 1024 bits)    | ✔️           | ✔️    | ❌             | ❌           | ❌    | ✔️       |
+| Loading keys (<= 1024 bits)   | ✔️           | ✔️    | ✔️              | ✔️            | ❌   | ✔️       |
+| Loading keys (> 1024 bits)    | ✔️           | ✔️    | ⚠️\*            | ❌           | ❌   | ✔️       |
+| FIPS 186-2                    | ✔️           | ✔️    | ✔️              | ✔️            | ❌   | ✔️       |
+| FIPS 186-3 (SHA-2 signatures) | ✔️           | ✔️    | ❌             | ❌           | ❌    | ✔️       |
 
 \* macOS loads DSA keys bigger than 1024 bits, but the behavior of those keys is undefined. They don't behave according to FIPS 186-3.
 
@@ -230,13 +268,13 @@ DSA (Digital Signature Algorithm) key generation is performed by the system libr
 
 .NET exposes types to allow programs to interoperate with the OS libraries that the .NET cryptography code uses. The types involved don't translate between platforms and should only be directly used when necessary.
 
-| Type                                                         | Windows | Linux         | macOS         |
-|--------------------------------------------------------------|---------|---------------|---------------|
-| <xref:System.Security.Cryptography.DSACryptoServiceProvider> | ✔️     | ⚠️<sup>1</sup> | ⚠️<sup>1</sup> |
-| <xref:System.Security.Cryptography.DSACng>                   | ✔️     | ❌             | ❌            |
-| <xref:System.Security.Cryptography.DSAOpenSsl>               | ❌      | ✔️            | ⚠️<sup>2</sup> |
+| Type                                                         | Windows | Linux         | macOS         | iOS    | Android       |
+|--------------------------------------------------------------|---------|---------------|---------------|--------|---------------|
+| <xref:System.Security.Cryptography.DSACryptoServiceProvider> | ✔️       | ⚠️<sup>1</sup> | ⚠️<sup>1</sup>   | ❌    | ⚠️<sup>1</sup> |
+| <xref:System.Security.Cryptography.DSACng>                   | ✔️       | ❌             | ❌              | ❌    | ❌            |
+| <xref:System.Security.Cryptography.DSAOpenSsl>               | ❌      | ✔️            | ⚠️<sup>2</sup>   | ❌     | ❌             |
 
-<sup>1</sup> On macOS and Linux, <xref:System.Security.Cryptography.DSACryptoServiceProvider> can be used for compatibility with existing programs. In that case, any method that requires system interop, such as opening a named key, throws a <xref:System.PlatformNotSupportedException>.
+<sup>1</sup> On non-Windows, <xref:System.Security.Cryptography.DSACryptoServiceProvider> can be used for compatibility with existing programs. In that case, any method that requires system interop, such as opening a named key, throws a <xref:System.PlatformNotSupportedException>.
 
 <sup>2</sup> On macOS, <xref:System.Security.Cryptography.DSAOpenSsl> works if OpenSSL is installed and an appropriate libcrypto dylib can be found via dynamic library loading. If an appropriate library can't be found, exceptions will be thrown.
 
@@ -246,30 +284,27 @@ The majority of support for X.509 certificates in .NET comes from OS libraries. 
 
 ### Read a PKCS12/PFX
 
-| Scenario                                     | Windows | Linux | macOS |
-|----------------------------------------------|---------|-------|-------|
-| Empty                                        | ✔️     | ✔️    | ✔️   |
-| One certificate, no private key              | ✔️     | ✔️    | ✔️   |
-| One certificate, with private key            | ✔️     | ✔️    | ✔️   |
-| Multiple certificates, no private keys       | ✔️     | ✔️    | ✔️   |
-| Multiple certificates, one private key       | ✔️     | ✔️    | ✔️   |
-| Multiple certificates, multiple private keys | ✔️     | ⚠️\*  | ✔️   |
-
-\* Available in .NET 5+.
+| Scenario                                     | Windows | Linux | macOS | iOS | Android |
+|----------------------------------------------|---------|-------|-------|-----|---------|
+| Empty                                        | ✔️       | ✔️     | ✔️     | ✔️   | ✔️       |
+| One certificate, no private key              | ✔️       | ✔️     | ✔️     | ✔️   | ✔️       |
+| One certificate, with private key            | ✔️       | ✔️     | ✔️     | ✔️   | ✔️       |
+| Multiple certificates, no private keys       | ✔️       | ✔️     | ✔️     | ✔️   | ✔️       |
+| Multiple certificates, one private key       | ✔️       | ✔️     | ✔️     | ✔️   | ✔️       |
+| Multiple certificates, multiple private keys | ✔️       | ✔️     | ✔️     | ✔️   | ✔️       |
 
 ### Write a PKCS12/PFX
 
-| Scenario                                     | Windows | Linux | macOS |
-|----------------------------------------------|---------|-------|-------|
-| Empty                                        | ✔️     | ✔️    | ⚠️\* |
-| One certificate, no private key              | ✔️     | ✔️    | ⚠️\* |
-| One certificate, with private key            | ✔️     | ✔️    | ✔️   |
-| Multiple certificates, no private keys       | ✔️     | ✔️    | ⚠️\* |
-| Multiple certificates, one private key       | ✔️     | ✔️    | ✔️   |
-| Multiple certificates, multiple private keys | ✔️     | ⚠️\*  | ✔️   |
-| Ephemeral loading                            | ✔️     | ✔️    | ⚠️\* |
+| Scenario                                     | Windows | Linux | macOS | iOS | Android |
+|----------------------------------------------|---------|-------|-------|-------|---------|
+| Empty                                        | ✔️       | ✔️     | ✔️     | ✔️     | ✔️       |
+| One certificate, no private key              | ✔️       | ✔️     | ✔️     | ✔️     | ✔️       |
+| One certificate, with private key            | ✔️       | ✔️     | ✔️     | ✔️     | ✔️       |
+| Multiple certificates, no private keys       | ✔️       | ✔️     | ✔️     | ✔️     | ✔️       |
+| Multiple certificates, one private key       | ✔️       | ✔️     | ✔️     | ✔️     | ✔️       |
+| Multiple certificates, multiple private keys | ✔️       | ✔️     | ✔️     | ✔️     | ✔️       |
+| Ephemeral loading                            | ✔️       | ✔️     | ❌    | ✔️     | ✔️       |
 
-\* Available in .NET 5+.
 
 macOS can't load certificate private keys without a keychain object, which requires writing to disk. Keychains are created automatically for PFX loading, and are deleted when no longer in use. Since the <xref:System.Security.Cryptography.X509Certificates.X509KeyStorageFlags.EphemeralKeySet?displayProperty=nameWithType> option means that the private key should not be written to disk, asserting that flag on macOS results in a <xref:System.PlatformNotSupportedException>.
 
@@ -281,20 +316,18 @@ Windows and Linux both emit DER-encoded PKCS7 blobs. macOS emits indefinite-leng
 
 On Windows, the <xref:System.Security.Cryptography.X509Certificates.X509Store> class is a representation of the Windows Certificate Store APIs. Those APIs work the same in .NET Core and .NET 5 as they do in .NET Framework.
 
-On Linux, the <xref:System.Security.Cryptography.X509Certificates.X509Store> class is a projection of system trust decisions (read-only), user trust decisions (read-write), and user key storage (read-write).
-
-On macOS, the <xref:System.Security.Cryptography.X509Certificates.X509Store> class is a projection of system trust decisions (read-only), user trust decisions (read-only), and user key storage (read-write).
+On non-Windows, the <xref:System.Security.Cryptography.X509Certificates.X509Store> class is a projection of system trust decisions (read-only), user trust decisions (read-write), and user key storage (read-write).
 
 The following tables show which scenarios are supported in each platform. For unsupported scenarios (❌ in the tables), a <xref:System.Security.Cryptography.CryptographicException> is thrown.
 
 #### The My store
 
-| Scenario                                         | Windows | Linux | macOS |
-|--------------------------------------------------|---------|-------|-------|
-| Open CurrentUser\My (ReadOnly)                   | ✔️     | ✔️    | ✔️   |
-| Open CurrentUser\My (ReadWrite)                  | ✔️     | ✔️    | ✔️   |
-| Open CurrentUser\My (ExistingOnly)               | ✔️     | ⚠️    | ✔️   |
-| Open LocalMachine\My                             | ✔️     | ❌    | ✔️   |
+| Scenario                                         | Windows | Linux | macOS | iOS   | Android |
+|--------------------------------------------------|---------|-------|-------|-------|--------|
+| Open CurrentUser\My (ReadOnly)                   | ✔️     | ✔️       | ✔️     | ✔️     | ✔️     |
+| Open CurrentUser\My (ReadWrite)                  | ✔️     | ✔️       | ✔️     | ✔️     | ✔️     |
+| Open CurrentUser\My (ExistingOnly)               | ✔️     | ⚠️       | ✔️     | ✔️     | ✔️     |
+| Open LocalMachine\My                             | ✔️     | ❌       | ✔️     | ✔️     | ✔️     |
 
 On Linux, stores are created on first write, and no user stores exist by default, so opening `CurrentUser\My` with `ExistingOnly` may fail.
 
@@ -302,14 +335,14 @@ On macOS, the `CurrentUser\My` store is the user's default keychain, which is `l
 
 #### The Root store
 
-| Scenario                              | Windows | Linux | macOS           |
-|---------------------------------------|---------|-------|-----------------|
-| Open CurrentUser\Root (ReadOnly)      | ✔️     | ✔️    | ✔️             |
-| Open CurrentUser\Root (ReadWrite)     | ✔️     | ✔️    | ❌              |
-| Open CurrentUser\Root (ExistingOnly)  | ✔️     | ⚠️    | ✔️ (if ReadOnly) |
-| Open LocalMachine\Root (ReadOnly)     | ✔️     | ✔️    | ✔️             |
-| Open LocalMachine\Root (ReadWrite)    | ✔️     | ❌    | ❌              |
-| Open LocalMachine\Root (ExistingOnly) | ✔️     | ⚠️    | ✔️ (if ReadOnly) |
+| Scenario                              | Windows | Linux | macOS           | iOS | Android        |
+|---------------------------------------|---------|-------|-----------------|-----|----------------|
+| Open CurrentUser\Root (ReadOnly)      | ✔️       | ✔️     | ✔️               | ❌  | ✔️              |
+| Open CurrentUser\Root (ReadWrite)     | ✔️       | ✔️     | ❌              | ❌  | ❌              |
+| Open CurrentUser\Root (ExistingOnly)  | ✔️       | ⚠️     | ✔️ (if ReadOnly) | ❌  | ✔️ (if ReadOnly) |
+| Open LocalMachine\Root (ReadOnly)     | ✔️       | ✔️     | ✔️               | ❌  | ✔️               |
+| Open LocalMachine\Root (ReadWrite)    | ✔️       | ❌     | ❌              | ❌  | ❌              |
+| Open LocalMachine\Root (ExistingOnly) | ✔️       | ⚠️     | ✔️ (if ReadOnly) | ❌  | ✔️ (if ReadOnly) |
 
 On Linux, the `LocalMachine\Root` store is an interpretation of the CA bundle in the default path for OpenSSL.
 
@@ -317,27 +350,29 @@ On macOS, the `CurrentUser\Root` store is an interpretation of the `SecTrustSett
 
 #### The Intermediate store
 
-| Scenario                                      | Windows | Linux | macOS           |
-|-----------------------------------------------|---------|-------|-----------------|
-| Open CurrentUser\Intermediate (ReadOnly)      | ✔️     | ✔️    | ✔️             |
-| Open CurrentUser\Intermediate (ReadWrite)     | ✔️     | ✔️    | ❌              |
-| Open CurrentUser\Intermediate (ExistingOnly)  | ✔️     | ⚠️    | ✔️ (if ReadOnly) |
-| Open LocalMachine\Intermediate (ReadOnly)     | ✔️     | ✔️    | ✔️             |
-| Open LocalMachine\Intermediate (ReadWrite)    | ✔️     | ❌    | ❌              |
-| Open LocalMachine\Intermediate (ExistingOnly) | ✔️     | ⚠️    | ✔️ (if ReadOnly) |
+| Scenario                                      | Windows | Linux | macOS           | iOS   | Android |
+|-----------------------------------------------|---------|-------|-----------------|-------|---------|
+| Open CurrentUser\Intermediate (ReadOnly)      | ✔️       | ✔️    | ✔️                | ❌    | ❌       |
+| Open CurrentUser\Intermediate (ReadWrite)     | ✔️       | ✔️    | ❌               | ❌    | ❌       |
+| Open CurrentUser\Intermediate (ExistingOnly)  | ✔️       | ⚠️    | ✔️ (if ReadOnly)  | ❌    | ❌       |
+| Open LocalMachine\Intermediate (ReadOnly)     | ✔️       | ✔️    | ✔️                | ❌    | ❌       |
+| Open LocalMachine\Intermediate (ReadWrite)    | ✔️       | ❌    | ❌               | ❌    | ❌       |
+| Open LocalMachine\Intermediate (ExistingOnly) | ✔️       | ⚠️    | ✔️ (if ReadOnly)  | ❌    | ❌       |
 
 On Linux, the `CurrentUser\Intermediate` store is used as a cache when downloading intermediate CAs by their Authority Information Access records on successful X509Chain builds. The `LocalMachine\Intermediate` store is an interpretation of the CA bundle in the default path for OpenSSL.
 
+On macOS, the `CurrentUser\Intermediate` store is treated as a custom store. Certificates added to this store do not affect X.509 chain building.
+
 #### The Disallowed store
 
-| Scenario                                    | Windows | Linux | macOS           |
-|---------------------------------------------|---------|-------|-----------------|
-| Open CurrentUser\Disallowed (ReadOnly)      | ✔️     | ⚠️    | ✔️             |
-| Open CurrentUser\Disallowed (ReadWrite)     | ✔️     | ⚠️    | ❌              |
-| Open CurrentUser\Disallowed (ExistingOnly)  | ✔️     | ⚠️    | ✔️ (if ReadOnly) |
-| Open LocalMachine\Disallowed (ReadOnly)     | ✔️     | ❌    | ✔️             |
-| Open LocalMachine\Disallowed (ReadWrite)    | ✔️     | ❌    | ❌              |
-| Open LocalMachine\Disallowed (ExistingOnly) | ✔️     | ❌    | ✔️ (if ReadOnly) |
+| Scenario                                    | Windows | Linux | macOS           | iOS             | Android         |
+|---------------------------------------------|---------|-------|-----------------|-----------------|-----------------|
+| Open CurrentUser\Disallowed (ReadOnly)      | ✔️     | ⚠️       | ✔️               | ✔️               | ✔️               |
+| Open CurrentUser\Disallowed (ReadWrite)     | ✔️     | ⚠️       | ❌              | ❌               | ❌               |
+| Open CurrentUser\Disallowed (ExistingOnly)  | ✔️     | ⚠️       | ✔️ (if ReadOnly) | ✔️ (if ReadOnly) | ✔️ (if ReadOnly) |
+| Open LocalMachine\Disallowed (ReadOnly)     | ✔️     | ❌       | ✔️              | ✔️               | ✔️               |
+| Open LocalMachine\Disallowed (ReadWrite)    | ✔️     | ❌       | ❌             | ❌               | ❌               |
+| Open LocalMachine\Disallowed (ExistingOnly) | ✔️     | ❌       | ✔️ (if ReadOnly)| ✔️ (if ReadOnly) | ✔️ (if ReadOnly) |
 
 On Linux, the `Disallowed` store is not used in chain building, and attempting to add contents to it results in a <xref:System.Security.Cryptography.CryptographicException>. A <xref:System.Security.Cryptography.CryptographicException> is thrown when opening the `Disallowed` store if it has already acquired contents.
 
@@ -345,11 +380,11 @@ On macOS, the CurrentUser\Disallowed and LocalMachine\Disallowed stores are inte
 
 #### Nonexistent store
 
-| Scenario                                         | Windows | Linux | macOS |
-|--------------------------------------------------|---------|-------|-------|
-| Open non-existent store (ExistingOnly)           | ❌     | ❌     | ❌    |
-| Open CurrentUser non-existent store (ReadWrite)  | ✔️     | ✔️     | ⚠️   |
-| Open LocalMachine non-existent store (ReadWrite) | ✔️     | ❌     | ❌    |
+| Scenario                                         | Windows | Linux | macOS | iOS | Android |
+|--------------------------------------------------|---------|-------|-------|-----|---------|
+| Open non-existent store (ExistingOnly)           | ❌     | ❌     | ❌    | ❌   | ❌      |
+| Open CurrentUser non-existent store (ReadWrite)  | ✔️     | ✔️     | ⚠️      | ❌   | ❌      |
+| Open LocalMachine non-existent store (ReadWrite) | ✔️     | ❌     | ❌    | ❌    | ❌      |
 
 On macOS, custom store creation with the X509Store API is supported only for `CurrentUser` location. It will create a new keychain with no password in the user's keychain directory (*~/Library/Keychains*). To create a keychain with password, a P/Invoke to `SecKeychainCreate` could be used. Similarly, `SecKeychainOpen` could be used to open keychains in different locations. The resulting `IntPtr` can be passed to [`new X509Store(IntPtr)`](xref:System.Security.Cryptography.X509Certificates.X509Store.%23ctor(System.IntPtr)) to obtain a read/write-capable store, subject to the current user's permissions.
 

--- a/docs/standard/security/cross-platform-cryptography.md
+++ b/docs/standard/security/cross-platform-cryptography.md
@@ -132,7 +132,6 @@ Padding and digest support vary by platform:
 | PKCS1 Signature (SHA-3)**    | Windows 11 Build 25324+  | OpenSSL 1.1.1+  | ❌     |  ❌ | ❌     | ❌             |
 | PSS                          | ✔️                       | ✔️              | ✔️    | ✔️  | ✔️      | ❌             |
 
-
 \* Windows CryptoAPI (CAPI) is capable of PKCS1 signature with a SHA-2 algorithm. But the individual RSA object may be loaded in a cryptographic service provider (CSP) that doesn't support it.
 
 \** Requires .NET 8.
@@ -304,7 +303,6 @@ The majority of support for X.509 certificates in .NET comes from OS libraries. 
 | Multiple certificates, one private key       | ✔️      | ✔️    | ✔️   | ✔️    | ✔️      |
 | Multiple certificates, multiple private keys | ✔️      | ✔️    | ✔️   | ✔️    | ✔️      |
 | Ephemeral loading                            | ✔️      | ✔️    | ❌   | ✔️    | ✔️      |
-
 
 macOS can't load certificate private keys without a keychain object, which requires writing to disk. Keychains are created automatically for PFX loading, and are deleted when no longer in use. Since the <xref:System.Security.Cryptography.X509Certificates.X509KeyStorageFlags.EphemeralKeySet?displayProperty=nameWithType> option means that the private key should not be written to disk, asserting that flag on macOS results in a <xref:System.PlatformNotSupportedException>.
 

--- a/docs/standard/security/cross-platform-cryptography.md
+++ b/docs/standard/security/cross-platform-cryptography.md
@@ -67,7 +67,7 @@ The `libcrypto.0.9.7.dylib` and `libcrypto.0.9.8.dylib` libraries included in ma
 
 ### AES-GCM and ChaCha20Poly1305 on macOS
 
-MacOS did not support AES-GCM or ChaCha20Poly1305 until macOS 10.15 for third-party code. Prior to .NET 8, <xref:System.Security.Cryptography.AesGcm> and <xref:System.Security.Cryptography.ChaCha20Poly1305> have the same requirement as AES-CCM and users must install OpenSSL for these types to function.
+macOS did not support AES-GCM or ChaCha20Poly1305 until macOS 10.15 for third-party code. Prior to .NET 8, <xref:System.Security.Cryptography.AesGcm> and <xref:System.Security.Cryptography.ChaCha20Poly1305> have the same requirement as AES-CCM and users must install OpenSSL for these types to function.
 
 Starting in .NET 8, .NET on macOS will use the Apple's CryptoKit framework for AES-GCM and ChaCha20Poly1305. Users will not need to install or configure any additional dependencies for AES-GCM or ChaCha20Poly1305 on macOS.
 
@@ -96,7 +96,7 @@ Starting in .NET 8, .NET on macOS will use the Apple's CryptoKit framework for A
   The <xref:System.Security.Cryptography.AesGcm> class supports only 96-bit (12-byte) nonces.
 
 * Tag Sizes
-  On Windows and Linux, the <xref:System.Security.Cryptography.AesGcm> class supports creating or processing 96, 104, 112, 120, and 128-bit (12, 13, 14, 15, and 16-byte) tags. On macOS, the tag size is limited to 128-bit (16-byte) due to limitation of the CryptoKit framework.
+  On Windows and Linux, the <xref:System.Security.Cryptography.AesGcm> class supports creating or processing 96, 104, 112, 120, and 128-bit (12, 13, 14, 15, and 16-byte) tags. On macOS, the tag size is limited to 128-bit (16-byte) due to limitations of the CryptoKit framework.
 
 ### ChaCha20Poly1305 keys, nonces, and tags.
 
@@ -121,20 +121,20 @@ RSA key operations are performed by the OS libraries, and the types of key that 
 
 Padding and digest support vary by platform:
 
-| Padding Mode                 | Windows (CNG)            | Linux (OpenSSL) | macOS  | iOS | Android | Windows (CAPI) |
-|------------------------------|--------------------------|-----------------|--------|-----|---------|----------------|
-| PKCS1 Encryption             | ✔️                       | ✔️              | ✔️    | ✔️  | ✔️      | ✔️             |
-| OAEP - SHA-1                 | ✔️                       | ✔️              | ✔️    | ✔️  | ✔️      | ✔️             |
-| OAEP - SHA-2                 | ✔️                       | ✔️              | ✔️    | ✔️  | ✔️      | ❌             |
-| OAEP - SHA-3**               | Windows 11 Build 25324+  | OpenSSL 1.1.1+  | ❌     | ❌  | ❌     | ❌             |
-| PKCS1 Signature (MD5, SHA-1) | ✔️                       | ✔️              | ✔️    | ✔️  | ✔️      | ✔️             |
-| PKCS1 Signature (SHA-2)      | ✔️                       | ✔️              | ✔️    | ✔️  | ✔️      | ⚠️\*           |
-| PKCS1 Signature (SHA-3)**    | Windows 11 Build 25324+  | OpenSSL 1.1.1+  | ❌     |  ❌ | ❌     | ❌             |
-| PSS                          | ✔️                       | ✔️              | ✔️    | ✔️  | ✔️      | ❌             |
+| Padding Mode                        | Windows (CNG)            | Linux (OpenSSL) | macOS  | iOS | Android | Windows (CAPI) |
+|-------------------------------------|--------------------------|-----------------|--------|-----|---------|----------------|
+| PKCS1 Encryption                    | ✔️                       | ✔️              | ✔️    | ✔️  | ✔️      | ✔️               |
+| OAEP - SHA-1                        | ✔️                       | ✔️              | ✔️    | ✔️  | ✔️      | ✔️               |
+| OAEP - SHA-2                        | ✔️                       | ✔️              | ✔️    | ✔️  | ✔️      | ❌               |
+| OAEP - SHA-3<sup>2</sup>            | Windows 11 Build 25324+  | OpenSSL 1.1.1+  | ❌     | ❌  | ❌     | ❌               |
+| PKCS1 Signature (MD5, SHA-1)        | ✔️                       | ✔️              | ✔️    | ✔️  | ✔️      | ✔️               |
+| PKCS1 Signature (SHA-2)             | ✔️                       | ✔️              | ✔️    | ✔️  | ✔️      | ⚠️<sup>1</sup> |
+| PKCS1 Signature (SHA-3)<sup>2</sup> | Windows 11 Build 25324+  | OpenSSL 1.1.1+  | ❌     |  ❌ | ❌     | ❌               |
+| PSS                                 | ✔️                       | ✔️              | ✔️    | ✔️  | ✔️      | ❌               |
 
-\* Windows CryptoAPI (CAPI) is capable of PKCS1 signature with a SHA-2 algorithm. But the individual RSA object may be loaded in a cryptographic service provider (CSP) that doesn't support it.
+<sup>1</sup> Windows CryptoAPI (CAPI) is capable of PKCS1 signature with a SHA-2 algorithm. But the individual RSA object may be loaded in a cryptographic service provider (CSP) that doesn't support it.
 
-\** Requires .NET 8.
+<sup>2</sup> Requires .NET 8.
 
 #### RSA on Windows
 

--- a/docs/standard/security/cross-platform-cryptography.md
+++ b/docs/standard/security/cross-platform-cryptography.md
@@ -32,20 +32,20 @@ The underlying ciphers and chaining are done by the system libraries.
 
 | Cipher + Mode | Windows  | Linux | macOS | iOS | Android |
 |---------------|----------|-------|-------|-----|---------|
-| AES-CBC       | ✔️        | ✔️     | ✔️     | ✔️   | ✔️      |
-| AES-ECB       | ✔️        | ✔️     | ✔️     | ✔️   | ✔️      |
-| AES-CFB8      | ✔️        | ✔️     | ✔️     | ✔️   | ✔️      |
-| AES-CFB128    | ✔️        | ✔️     | ✔️     | ✔️   | ✔️      |
-| 3DES-CBC      | ✔️        | ✔️     | ✔️     | ✔️   | ✔️      |
-| 3DES-ECB      | ✔️        | ✔️     | ✔️     | ✔️   | ✔️      |
-| 3DES-CFB8     | ✔️        | ✔️     | ✔️     | ✔️   | ✔️      |
-| 3DES-CFB64    | ✔️        | ✔️     | ✔️     | ✔️   | ✔️      |
-| DES-CBC       | ✔️        | ✔️     | ✔️     | ✔️   | ✔️      |
-| DES-ECB       | ✔️        | ✔️     | ✔️     | ✔️   | ✔️      |
-| DES-CFB8      | ✔️        | ✔️     | ✔️     | ✔️   | ✔️      |
-| RC2-CBC       | ✔️        | ✔️     | ✔️     | ✔️   | ❌     |
-| RC2-ECB       | ✔️        | ✔️     | ✔️     | ✔️   | ❌     |
-| RC2-CFB       | ❌       | ❌     | ❌    | ❌   | ❌     |
+| AES-CBC       | ✔️       | ✔️    | ✔️   | ✔️  | ✔️      |
+| AES-ECB       | ✔️       | ✔️    | ✔️   | ✔️  | ✔️      |
+| AES-CFB8      | ✔️       | ✔️    | ✔️   | ✔️  | ✔️      |
+| AES-CFB128    | ✔️       | ✔️    | ✔️   | ✔️  | ✔️      |
+| 3DES-CBC      | ✔️       | ✔️    | ✔️   | ✔️  | ✔️      |
+| 3DES-ECB      | ✔️       | ✔️    | ✔️   | ✔️  | ✔️      |
+| 3DES-CFB8     | ✔️       | ✔️    | ✔️   | ✔️  | ✔️      |
+| 3DES-CFB64    | ✔️       | ✔️    | ✔️   | ✔️  | ✔️      |
+| DES-CBC       | ✔️       | ✔️    | ✔️   | ✔️  | ✔️      |
+| DES-ECB       | ✔️       | ✔️    | ✔️   | ✔️  | ✔️      |
+| DES-CFB8      | ✔️       | ✔️    | ✔️   | ✔️  | ✔️      |
+| RC2-CBC       | ✔️       | ✔️    | ✔️   | ✔️  | ❌      |
+| RC2-ECB       | ✔️       | ✔️    | ✔️   | ✔️  | ❌      |
+| RC2-CFB       | ❌       | ❌    | ❌   | ❌  | ❌      |
 
 ## Authenticated encryption
 
@@ -55,9 +55,9 @@ As authentication encryption requires newer platform APIs to support the algorit
 
 | Cipher + Mode     | Windows                 | Linux          | macOS   | iOS | Android       | Browser |
 |-------------------|-------------------------|----------------|---------|-----|---------------|---------|
-| AES-GCM           | ✔️                       | ✔️              | ⚠️       | ❌  | ✔️             | ❌      |
-| AES-CCM           | ✔️                       | ✔️              | ⚠️       | ❌  | ✔️             | ❌      |
-| ChaCha20Poly1305  | Windows 10 Build 20142+ | OpenSSL 1.1.0+ | ⚠️       | ❌  | API Level 28+ | ❌      |
+| AES-GCM           | ✔️                      | ✔️            | ⚠️      | ❌  | ✔️            | ❌      |
+| AES-CCM           | ✔️                      | ✔️            | ⚠️      | ❌  | ✔️            | ❌      |
+| ChaCha20Poly1305  | Windows 10 Build 20142+ | OpenSSL 1.1.0+ | ⚠️      | ❌  | API Level 28+ | ❌      |
 
 ### AES-CCM on macOS
 
@@ -123,14 +123,14 @@ Padding and digest support vary by platform:
 
 | Padding Mode                 | Windows (CNG)            | Linux (OpenSSL) | macOS  | iOS | Android | Windows (CAPI) |
 |------------------------------|--------------------------|-----------------|--------|-----|---------|----------------|
-| PKCS1 Encryption             | ✔️                        | ✔️               | ✔️      | ✔️   | ✔️       | ✔️             |
-| OAEP - SHA-1                 | ✔️                        | ✔️               | ✔️      | ✔️   | ✔️       | ✔️             |
-| OAEP - SHA-2                 | ✔️                        | ✔️               | ✔️      | ✔️   | ✔️       | ❌             |
-| OAEP - SHA-3**               | Windows 11 Build 25324+  | OpenSSL 1.1.1+  | ❌     | ❌   | ❌      | ❌             |
-| PKCS1 Signature (MD5, SHA-1) | ✔️                        | ✔️               | ✔️      | ✔️   | ✔️       | ✔️             |
-| PKCS1 Signature (SHA-2)      | ✔️                        | ✔️               | ✔️      | ✔️   | ✔️       | ⚠️\*           |
-| PKCS1 Signature (SHA-3)**    | Windows 11 Build 25324+  | OpenSSL 1.1.1+  | ❌     |  ❌  | ❌      | ❌             |
-| PSS                          | ✔️                        | ✔️               | ✔️      | ✔️   | ✔️       | ❌             |
+| PKCS1 Encryption             | ✔️                       | ✔️              | ✔️    | ✔️  | ✔️      | ✔️             |
+| OAEP - SHA-1                 | ✔️                       | ✔️              | ✔️    | ✔️  | ✔️      | ✔️             |
+| OAEP - SHA-2                 | ✔️                       | ✔️              | ✔️    | ✔️  | ✔️      | ❌             |
+| OAEP - SHA-3**               | Windows 11 Build 25324+  | OpenSSL 1.1.1+  | ❌     | ❌  | ❌     | ❌             |
+| PKCS1 Signature (MD5, SHA-1) | ✔️                       | ✔️              | ✔️    | ✔️  | ✔️      | ✔️             |
+| PKCS1 Signature (SHA-2)      | ✔️                       | ✔️              | ✔️    | ✔️  | ✔️      | ⚠️\*           |
+| PKCS1 Signature (SHA-3)**    | Windows 11 Build 25324+  | OpenSSL 1.1.1+  | ❌     |  ❌ | ❌     | ❌             |
+| PSS                          | ✔️                       | ✔️              | ✔️    | ✔️  | ✔️      | ❌             |
 
 
 \* Windows CryptoAPI (CAPI) is capable of PKCS1 signature with a SHA-2 algorithm. But the individual RSA object may be loaded in a cryptographic service provider (CSP) that doesn't support it.
@@ -149,11 +149,11 @@ Padding and digest support vary by platform:
 
 .NET exposes types to allow programs to interoperate with the OS libraries that the .NET cryptography code uses. The types involved do not translate between platforms, and should only be directly used when necessary.
 
-| Type                                                         | Windows | Linux         | macOS         | iOS             | Android         |
-|--------------------------------------------------------------|---------|---------------|---------------|-----------------|-----------------|
-| <xref:System.Security.Cryptography.RSACryptoServiceProvider> | ✔️     | ⚠️<sup>1</sup>   | ⚠️<sup>1</sup> | ⚠️<sup>1</sup>   | ⚠️<sup>1</sup>   |
-| <xref:System.Security.Cryptography.RSACng>                   | ✔️     | ❌              | ❌             | ❌              | ❌              |
-| <xref:System.Security.Cryptography.RSAOpenSsl>               | ❌     | ✔️              | ⚠️<sup>2</sup>  | ❌              | ❌              |
+| Type                                                         | Windows | Linux         | macOS           | iOS             | Android         |
+|--------------------------------------------------------------|---------|---------------|-----------------|-----------------|-----------------|
+| <xref:System.Security.Cryptography.RSACryptoServiceProvider> | ✔️     | ⚠️<sup>1</sup> | ⚠️<sup>1</sup> | ⚠️<sup>1</sup>  | ⚠️<sup>1</sup>  |
+| <xref:System.Security.Cryptography.RSACng>                   | ✔️     | ❌             | ❌             | ❌              | ❌              |
+| <xref:System.Security.Cryptography.RSAOpenSsl>               | ❌     | ✔️             | ⚠️<sup>2</sup> | ❌              | ❌              |
 
 <sup>1</sup> On non-Windows, <xref:System.Security.Cryptography.RSACryptoServiceProvider> can be used for compatibility with existing programs. In that case, any method that requires OS interop, such as opening a named key, throws a <xref:System.PlatformNotSupportedException>.
 
@@ -165,15 +165,15 @@ ECDSA (Elliptic Curve Digital Signature Algorithm) key generation is done by the
 
 ECDSA key curves are defined by the OS libraries and are subject to their limitations.
 
-| Elliptic Curve                     | Windows 10    | Windows 7 - 8.1 | Linux         | macOS         | iOS           | Android        |
-|------------------------------------|---------------|-----------------|---------------|---------------|---------------|----------------|
-| NIST P-256 (secp256r1)             | ✔️           | ✔️              | ✔️                | ✔️             | ✔️             | ✔️              |
-| NIST P-384 (secp384r1)             | ✔️           | ✔️              | ✔️                | ✔️             | ✔️             | ✔️              |
-| NIST P-521 (secp521r1)             | ✔️           | ✔️              | ✔️                | ✔️             | ✔️             | ✔️              |
-| Brainpool curves (as named curves) | ✔️           | ❌              | ⚠️<sup>1</sup>   | ❌             | ❌             | ⚠️<sup>4</sup> |
-| Other named curves                 | ⚠️<sup>2</sup>| ❌             | ⚠️<sup>1</sup>   | ❌             | ❌             | ⚠️<sup>4</sup> |
-| Explicit curves                    | ✔️           | ❌              | ✔️               | ❌             | ❌             | ✔️             |
-| Export or import as explicit       | ✔️           | ❌<sup>3</sup>  | ✔️               | ❌<sup>3</sup> | ❌<sup>3</sup> | ✔️             |
+| Elliptic Curve                     | Windows 10     | Windows 7 - 8.1 | Linux           | macOS          | iOS            | Android        |
+|------------------------------------|----------------|-----------------|-----------------|----------------|----------------|----------------|
+| NIST P-256 (secp256r1)             | ✔️             | ✔️              | ✔️             | ✔️             | ✔️             | ✔️            |
+| NIST P-384 (secp384r1)             | ✔️             | ✔️              | ✔️             | ✔️             | ✔️             | ✔️            |
+| NIST P-521 (secp521r1)             | ✔️             | ✔️              | ✔️             | ✔️             | ✔️             | ✔️            |
+| Brainpool curves (as named curves) | ✔️             | ❌              | ⚠️<sup>1</sup> | ❌             | ❌             | ⚠️<sup>4</sup> |
+| Other named curves                 | ⚠️<sup>2</sup> | ❌              | ⚠️<sup>1</sup> | ❌             | ❌             | ⚠️<sup>4</sup> |
+| Explicit curves                    | ✔️             | ❌              | ✔️             | ❌             | ❌             | ✔️             |
+| Export or import as explicit       | ✔️             | ❌<sup>3</sup>  | ✔️             | ❌<sup>3</sup> | ❌<sup>3</sup> | ✔️             |
 
 <sup>1</sup> Linux distributions don't all have support for the same named curves.
 
@@ -189,8 +189,8 @@ ECDSA key curves are defined by the OS libraries and are subject to their limita
 
 | Type                                             | Windows | Linux | macOS | iOS | Android |
 |--------------------------------------------------|---------|-------|-------|-----|---------|
-| <xref:System.Security.Cryptography.ECDsaCng>     | ✔️       | ❌    | ❌    | ❌   | ❌      |
-| <xref:System.Security.Cryptography.ECDsaOpenSsl> | ❌      | ✔️    | ⚠️\*    | ❌   | ❌      |
+| <xref:System.Security.Cryptography.ECDsaCng>     | ✔️      | ❌   | ❌    | ❌  | ❌      |
+| <xref:System.Security.Cryptography.ECDsaOpenSsl> | ❌      | ✔️   | ⚠️\*  | ❌  | ❌      |
 
 \* On macOS, <xref:System.Security.Cryptography.ECDsaOpenSsl> works if OpenSSL is installed in the system and an appropriate libcrypto dylib can be found via dynamic library loading. If an appropriate library can't be found, exceptions will be thrown.
 
@@ -212,15 +212,15 @@ The <xref:System.Security.Cryptography.ECDiffieHellman> class supports the "raw"
 
 ECDH key curves are defined by the OS libraries and are subject to their limitations.
 
-| Elliptic Curve                     | Windows 10    | Windows 7 - 8.1 | Linux         | macOS         | iOS           | Android        |
-|------------------------------------|---------------|-----------------|---------------|---------------|---------------|----------------|
-| NIST P-256 (secp256r1)             | ✔️           | ✔️              | ✔️                | ✔️             | ✔️             | ✔️              |
-| NIST P-384 (secp384r1)             | ✔️           | ✔️              | ✔️                | ✔️             | ✔️             | ✔️              |
-| NIST P-521 (secp521r1)             | ✔️           | ✔️              | ✔️                | ✔️             | ✔️             | ✔️              |
-| Brainpool curves (as named curves) | ✔️           | ❌              | ⚠️<sup>1</sup>   | ❌             | ❌             | ⚠️<sup>4</sup> |
-| Other named curves                 | ⚠️<sup>2</sup>| ❌             | ⚠️<sup>1</sup>   | ❌             | ❌             | ⚠️<sup>4</sup> |
-| Explicit curves                    | ✔️           | ❌              | ✔️               | ❌             | ❌             | ✔️             |
-| Export or import as explicit       | ✔️           | ❌<sup>3</sup>  | ✔️               | ❌<sup>3</sup> | ❌<sup>3</sup> | ✔️             |
+| Elliptic Curve                     | Windows 10     | Windows 7 - 8.1 | Linux          | macOS           | iOS            | Android        |
+|------------------------------------|----------------|-----------------|----------------|-----------------|----------------|----------------|
+| NIST P-256 (secp256r1)             | ✔️             | ✔️              | ✔️             | ✔️             | ✔️             | ✔️             |
+| NIST P-384 (secp384r1)             | ✔️             | ✔️              | ✔️             | ✔️             | ✔️             | ✔️             |
+| NIST P-521 (secp521r1)             | ✔️             | ✔️              | ✔️             | ✔️             | ✔️             | ✔️             |
+| Brainpool curves (as named curves) | ✔️             | ❌              | ⚠️<sup>1</sup> | ❌             | ❌             | ⚠️<sup>4</sup> |
+| Other named curves                 | ⚠️<sup>2</sup> | ❌              | ⚠️<sup>1</sup> | ❌             | ❌             | ⚠️<sup>4</sup> |
+| Explicit curves                    | ✔️             | ❌              | ✔️             | ❌             | ❌             | ✔️             |
+| Export or import as explicit       | ✔️             | ❌<sup>3</sup>  | ✔️             | ❌<sup>3</sup> | ❌<sup>3</sup> | ✔️             |
 
 <sup>1</sup> Linux distributions don't all have support for the same named curves.
 
@@ -236,8 +236,8 @@ ECDH key curves are defined by the OS libraries and are subject to their limitat
 
 | Type                                                       | Windows | Linux | macOS | iOS | Android  |
 |------------------------------------------------------------|---------|-------|-------|-----|----------|
-| <xref:System.Security.Cryptography.ECDiffieHellmanCng>     | ✔️     | ❌       | ❌    | ❌  | ❌       |
-| <xref:System.Security.Cryptography.ECDiffieHellmanOpenSsl> | ❌     | ✔️       | ⚠️\*   | ❌  | ❌       |
+| <xref:System.Security.Cryptography.ECDiffieHellmanCng>     | ✔️     | ❌    | ❌    | ❌  | ❌       |
+| <xref:System.Security.Cryptography.ECDiffieHellmanOpenSsl> | ❌     | ✔️    | ⚠️\*  | ❌  | ❌       |
 
 \* On macOS, <xref:System.Security.Cryptography.ECDiffieHellmanOpenSsl> works if OpenSSL is installed and an appropriate libcrypto dylib can be found via dynamic library loading. If an appropriate library can't be found, exceptions will be thrown.
 
@@ -247,12 +247,12 @@ DSA (Digital Signature Algorithm) key generation is performed by the system libr
 
 | Function                      | Windows CNG | Linux | macOS         | Windows CAPI | iOS  | Android |
 |-------------------------------|-------------|-------|---------------|--------------|------|---------|
-| Key creation (<= 1024 bits)   | ✔️           | ✔️    | ❌             | ✔️            | ❌    | ✔️       |
-| Key creation (> 1024 bits)    | ✔️           | ✔️    | ❌             | ❌           | ❌    | ✔️       |
-| Loading keys (<= 1024 bits)   | ✔️           | ✔️    | ✔️              | ✔️            | ❌   | ✔️       |
-| Loading keys (> 1024 bits)    | ✔️           | ✔️    | ⚠️\*            | ❌           | ❌   | ✔️       |
-| FIPS 186-2                    | ✔️           | ✔️    | ✔️              | ✔️            | ❌   | ✔️       |
-| FIPS 186-3 (SHA-2 signatures) | ✔️           | ✔️    | ❌             | ❌           | ❌    | ✔️       |
+| Key creation (<= 1024 bits)   | ✔️          | ✔️    | ❌           | ✔️           | ❌   | ✔️      |
+| Key creation (> 1024 bits)    | ✔️          | ✔️    | ❌           | ❌           | ❌   | ✔️      |
+| Loading keys (<= 1024 bits)   | ✔️          | ✔️    | ✔️           | ✔️           | ❌   | ✔️      |
+| Loading keys (> 1024 bits)    | ✔️          | ✔️    | ⚠️\*         | ❌           | ❌   | ✔️      |
+| FIPS 186-2                    | ✔️          | ✔️    | ✔️           | ✔️           | ❌   | ✔️      |
+| FIPS 186-3 (SHA-2 signatures) | ✔️          | ✔️    | ❌           | ❌           | ❌   | ✔️      |
 
 \* macOS loads DSA keys bigger than 1024 bits, but the behavior of those keys is undefined. They don't behave according to FIPS 186-3.
 
@@ -268,11 +268,11 @@ DSA (Digital Signature Algorithm) key generation is performed by the system libr
 
 .NET exposes types to allow programs to interoperate with the OS libraries that the .NET cryptography code uses. The types involved don't translate between platforms and should only be directly used when necessary.
 
-| Type                                                         | Windows | Linux         | macOS         | iOS    | Android       |
-|--------------------------------------------------------------|---------|---------------|---------------|--------|---------------|
-| <xref:System.Security.Cryptography.DSACryptoServiceProvider> | ✔️       | ⚠️<sup>1</sup> | ⚠️<sup>1</sup>   | ❌    | ⚠️<sup>1</sup> |
-| <xref:System.Security.Cryptography.DSACng>                   | ✔️       | ❌             | ❌              | ❌    | ❌            |
-| <xref:System.Security.Cryptography.DSAOpenSsl>               | ❌      | ✔️            | ⚠️<sup>2</sup>   | ❌     | ❌             |
+| Type                                                         | Windows | Linux          | macOS           | iOS    | Android        |
+|--------------------------------------------------------------|---------|----------------|-----------------|--------|----------------|
+| <xref:System.Security.Cryptography.DSACryptoServiceProvider> | ✔️      | ⚠️<sup>1</sup> | ⚠️<sup>1</sup>  | ❌    | ⚠️<sup>1</sup> |
+| <xref:System.Security.Cryptography.DSACng>                   | ✔️      | ❌             | ❌              | ❌    | ❌             |
+| <xref:System.Security.Cryptography.DSAOpenSsl>               | ❌      | ✔️             | ⚠️<sup>2</sup>  | ❌    | ❌             |
 
 <sup>1</sup> On non-Windows, <xref:System.Security.Cryptography.DSACryptoServiceProvider> can be used for compatibility with existing programs. In that case, any method that requires system interop, such as opening a named key, throws a <xref:System.PlatformNotSupportedException>.
 
@@ -286,24 +286,24 @@ The majority of support for X.509 certificates in .NET comes from OS libraries. 
 
 | Scenario                                     | Windows | Linux | macOS | iOS | Android |
 |----------------------------------------------|---------|-------|-------|-----|---------|
-| Empty                                        | ✔️       | ✔️     | ✔️     | ✔️   | ✔️       |
-| One certificate, no private key              | ✔️       | ✔️     | ✔️     | ✔️   | ✔️       |
-| One certificate, with private key            | ✔️       | ✔️     | ✔️     | ✔️   | ✔️       |
-| Multiple certificates, no private keys       | ✔️       | ✔️     | ✔️     | ✔️   | ✔️       |
-| Multiple certificates, one private key       | ✔️       | ✔️     | ✔️     | ✔️   | ✔️       |
-| Multiple certificates, multiple private keys | ✔️       | ✔️     | ✔️     | ✔️   | ✔️       |
+| Empty                                        | ✔️      | ✔️    | ✔️   | ✔️  | ✔️     |
+| One certificate, no private key              | ✔️      | ✔️    | ✔️   | ✔️  | ✔️     |
+| One certificate, with private key            | ✔️      | ✔️    | ✔️   | ✔️  | ✔️     |
+| Multiple certificates, no private keys       | ✔️      | ✔️    | ✔️   | ✔️  | ✔️     |
+| Multiple certificates, one private key       | ✔️      | ✔️    | ✔️   | ✔️  | ✔️     |
+| Multiple certificates, multiple private keys | ✔️      | ✔️    | ✔️   | ✔️  | ✔️     |
 
 ### Write a PKCS12/PFX
 
 | Scenario                                     | Windows | Linux | macOS | iOS | Android |
 |----------------------------------------------|---------|-------|-------|-------|---------|
-| Empty                                        | ✔️       | ✔️     | ✔️     | ✔️     | ✔️       |
-| One certificate, no private key              | ✔️       | ✔️     | ✔️     | ✔️     | ✔️       |
-| One certificate, with private key            | ✔️       | ✔️     | ✔️     | ✔️     | ✔️       |
-| Multiple certificates, no private keys       | ✔️       | ✔️     | ✔️     | ✔️     | ✔️       |
-| Multiple certificates, one private key       | ✔️       | ✔️     | ✔️     | ✔️     | ✔️       |
-| Multiple certificates, multiple private keys | ✔️       | ✔️     | ✔️     | ✔️     | ✔️       |
-| Ephemeral loading                            | ✔️       | ✔️     | ❌    | ✔️     | ✔️       |
+| Empty                                        | ✔️      | ✔️    | ✔️   | ✔️    | ✔️      |
+| One certificate, no private key              | ✔️      | ✔️    | ✔️   | ✔️    | ✔️      |
+| One certificate, with private key            | ✔️      | ✔️    | ✔️   | ✔️    | ✔️      |
+| Multiple certificates, no private keys       | ✔️      | ✔️    | ✔️   | ✔️    | ✔️      |
+| Multiple certificates, one private key       | ✔️      | ✔️    | ✔️   | ✔️    | ✔️      |
+| Multiple certificates, multiple private keys | ✔️      | ✔️    | ✔️   | ✔️    | ✔️      |
+| Ephemeral loading                            | ✔️      | ✔️    | ❌   | ✔️    | ✔️      |
 
 
 macOS can't load certificate private keys without a keychain object, which requires writing to disk. Keychains are created automatically for PFX loading, and are deleted when no longer in use. Since the <xref:System.Security.Cryptography.X509Certificates.X509KeyStorageFlags.EphemeralKeySet?displayProperty=nameWithType> option means that the private key should not be written to disk, asserting that flag on macOS results in a <xref:System.PlatformNotSupportedException>.
@@ -324,10 +324,10 @@ The following tables show which scenarios are supported in each platform. For un
 
 | Scenario                                         | Windows | Linux | macOS | iOS   | Android |
 |--------------------------------------------------|---------|-------|-------|-------|--------|
-| Open CurrentUser\My (ReadOnly)                   | ✔️     | ✔️       | ✔️     | ✔️     | ✔️     |
-| Open CurrentUser\My (ReadWrite)                  | ✔️     | ✔️       | ✔️     | ✔️     | ✔️     |
-| Open CurrentUser\My (ExistingOnly)               | ✔️     | ⚠️       | ✔️     | ✔️     | ✔️     |
-| Open LocalMachine\My                             | ✔️     | ❌       | ✔️     | ✔️     | ✔️     |
+| Open CurrentUser\My (ReadOnly)                   | ✔️      | ✔️    | ✔️   | ✔️    | ✔️     |
+| Open CurrentUser\My (ReadWrite)                  | ✔️      | ✔️    | ✔️   | ✔️    | ✔️     |
+| Open CurrentUser\My (ExistingOnly)               | ✔️      | ⚠️    | ✔️   | ✔️    | ✔️     |
+| Open LocalMachine\My                             | ✔️      | ❌    | ✔️   | ✔️    | ✔️     |
 
 On Linux, stores are created on first write, and no user stores exist by default, so opening `CurrentUser\My` with `ExistingOnly` may fail.
 
@@ -335,14 +335,14 @@ On macOS, the `CurrentUser\My` store is the user's default keychain, which is `l
 
 #### The Root store
 
-| Scenario                              | Windows | Linux | macOS           | iOS | Android        |
-|---------------------------------------|---------|-------|-----------------|-----|----------------|
-| Open CurrentUser\Root (ReadOnly)      | ✔️       | ✔️     | ✔️               | ❌  | ✔️              |
-| Open CurrentUser\Root (ReadWrite)     | ✔️       | ✔️     | ❌              | ❌  | ❌              |
-| Open CurrentUser\Root (ExistingOnly)  | ✔️       | ⚠️     | ✔️ (if ReadOnly) | ❌  | ✔️ (if ReadOnly) |
-| Open LocalMachine\Root (ReadOnly)     | ✔️       | ✔️     | ✔️               | ❌  | ✔️               |
-| Open LocalMachine\Root (ReadWrite)    | ✔️       | ❌     | ❌              | ❌  | ❌              |
-| Open LocalMachine\Root (ExistingOnly) | ✔️       | ⚠️     | ✔️ (if ReadOnly) | ❌  | ✔️ (if ReadOnly) |
+| Scenario                              | Windows | Linux | macOS             | iOS | Android          |
+|---------------------------------------|---------|-------|-------------------|-----|------------------|
+| Open CurrentUser\Root (ReadOnly)      | ✔️      | ✔️    | ✔️               | ❌  | ✔️               |
+| Open CurrentUser\Root (ReadWrite)     | ✔️      | ✔️    | ❌               | ❌  | ❌               |
+| Open CurrentUser\Root (ExistingOnly)  | ✔️      | ⚠️    | ✔️ (if ReadOnly) | ❌  | ✔️ (if ReadOnly) |
+| Open LocalMachine\Root (ReadOnly)     | ✔️      | ✔️    | ✔️               | ❌  | ✔️               |
+| Open LocalMachine\Root (ReadWrite)    | ✔️      | ❌    | ❌               | ❌  | ❌               |
+| Open LocalMachine\Root (ExistingOnly) | ✔️      | ⚠️    | ✔️ (if ReadOnly) | ❌  | ✔️ (if ReadOnly) |
 
 On Linux, the `LocalMachine\Root` store is an interpretation of the CA bundle in the default path for OpenSSL.
 
@@ -350,14 +350,14 @@ On macOS, the `CurrentUser\Root` store is an interpretation of the `SecTrustSett
 
 #### The Intermediate store
 
-| Scenario                                      | Windows | Linux | macOS           | iOS   | Android |
-|-----------------------------------------------|---------|-------|-----------------|-------|---------|
-| Open CurrentUser\Intermediate (ReadOnly)      | ✔️       | ✔️    | ✔️                | ❌    | ❌       |
-| Open CurrentUser\Intermediate (ReadWrite)     | ✔️       | ✔️    | ❌               | ❌    | ❌       |
-| Open CurrentUser\Intermediate (ExistingOnly)  | ✔️       | ⚠️    | ✔️ (if ReadOnly)  | ❌    | ❌       |
-| Open LocalMachine\Intermediate (ReadOnly)     | ✔️       | ✔️    | ✔️                | ❌    | ❌       |
-| Open LocalMachine\Intermediate (ReadWrite)    | ✔️       | ❌    | ❌               | ❌    | ❌       |
-| Open LocalMachine\Intermediate (ExistingOnly) | ✔️       | ⚠️    | ✔️ (if ReadOnly)  | ❌    | ❌       |
+| Scenario                                      | Windows | Linux | macOS             | iOS   | Android |
+|-----------------------------------------------|---------|-------|-------------------|-------|---------|
+| Open CurrentUser\Intermediate (ReadOnly)      | ✔️      | ✔️    | ✔️               | ❌    | ❌     |
+| Open CurrentUser\Intermediate (ReadWrite)     | ✔️      | ✔️    | ❌               | ❌    | ❌     |
+| Open CurrentUser\Intermediate (ExistingOnly)  | ✔️      | ⚠️    | ✔️ (if ReadOnly) | ❌    | ❌     |
+| Open LocalMachine\Intermediate (ReadOnly)     | ✔️      | ✔️    | ✔️               | ❌    | ❌     |
+| Open LocalMachine\Intermediate (ReadWrite)    | ✔️      | ❌    | ❌               | ❌    | ❌     |
+| Open LocalMachine\Intermediate (ExistingOnly) | ✔️      | ⚠️    | ✔️ (if ReadOnly) | ❌    | ❌     |
 
 On Linux, the `CurrentUser\Intermediate` store is used as a cache when downloading intermediate CAs by their Authority Information Access records on successful X509Chain builds. The `LocalMachine\Intermediate` store is an interpretation of the CA bundle in the default path for OpenSSL.
 
@@ -365,14 +365,14 @@ On macOS, the `CurrentUser\Intermediate` store is treated as a custom store. Cer
 
 #### The Disallowed store
 
-| Scenario                                    | Windows | Linux | macOS           | iOS             | Android         |
-|---------------------------------------------|---------|-------|-----------------|-----------------|-----------------|
-| Open CurrentUser\Disallowed (ReadOnly)      | ✔️     | ⚠️       | ✔️               | ✔️               | ✔️               |
-| Open CurrentUser\Disallowed (ReadWrite)     | ✔️     | ⚠️       | ❌              | ❌               | ❌               |
-| Open CurrentUser\Disallowed (ExistingOnly)  | ✔️     | ⚠️       | ✔️ (if ReadOnly) | ✔️ (if ReadOnly) | ✔️ (if ReadOnly) |
-| Open LocalMachine\Disallowed (ReadOnly)     | ✔️     | ❌       | ✔️              | ✔️               | ✔️               |
-| Open LocalMachine\Disallowed (ReadWrite)    | ✔️     | ❌       | ❌             | ❌               | ❌               |
-| Open LocalMachine\Disallowed (ExistingOnly) | ✔️     | ❌       | ✔️ (if ReadOnly)| ✔️ (if ReadOnly) | ✔️ (if ReadOnly) |
+| Scenario                                    | Windows | Linux | macOS            | iOS              | Android          |
+|---------------------------------------------|---------|-------|------------------|------------------|------------------|
+| Open CurrentUser\Disallowed (ReadOnly)      | ✔️     | ⚠️    | ✔️               | ✔️               | ✔️               |
+| Open CurrentUser\Disallowed (ReadWrite)     | ✔️     | ⚠️    | ❌               | ❌               | ❌               |
+| Open CurrentUser\Disallowed (ExistingOnly)  | ✔️     | ⚠️    | ✔️ (if ReadOnly) | ✔️ (if ReadOnly) | ✔️ (if ReadOnly) |
+| Open LocalMachine\Disallowed (ReadOnly)     | ✔️     | ❌    | ✔️               | ✔️               | ✔️               |
+| Open LocalMachine\Disallowed (ReadWrite)    | ✔️     | ❌    | ❌               | ❌               | ❌               |
+| Open LocalMachine\Disallowed (ExistingOnly) | ✔️     | ❌    | ✔️ (if ReadOnly) | ✔️ (if ReadOnly) | ✔️ (if ReadOnly) |
 
 On Linux, the `Disallowed` store is not used in chain building, and attempting to add contents to it results in a <xref:System.Security.Cryptography.CryptographicException>. A <xref:System.Security.Cryptography.CryptographicException> is thrown when opening the `Disallowed` store if it has already acquired contents.
 
@@ -382,9 +382,9 @@ On macOS, the CurrentUser\Disallowed and LocalMachine\Disallowed stores are inte
 
 | Scenario                                         | Windows | Linux | macOS | iOS | Android |
 |--------------------------------------------------|---------|-------|-------|-----|---------|
-| Open non-existent store (ExistingOnly)           | ❌     | ❌     | ❌    | ❌   | ❌      |
-| Open CurrentUser non-existent store (ReadWrite)  | ✔️     | ✔️     | ⚠️      | ❌   | ❌      |
-| Open LocalMachine non-existent store (ReadWrite) | ✔️     | ❌     | ❌    | ❌    | ❌      |
+| Open non-existent store (ExistingOnly)           | ❌     | ❌     | ❌    | ❌   | ❌    |
+| Open CurrentUser non-existent store (ReadWrite)  | ✔️     | ✔️     | ⚠️    | ❌   | ❌    |
+| Open LocalMachine non-existent store (ReadWrite) | ✔️     | ❌     | ❌    | ❌   | ❌    |
 
 On macOS, custom store creation with the X509Store API is supported only for `CurrentUser` location. It will create a new keychain with no password in the user's keychain directory (*~/Library/Keychains*). To create a keychain with password, a P/Invoke to `SecKeychainCreate` could be used. Similarly, `SecKeychainOpen` could be used to open keychains in different locations. The resulting `IntPtr` can be passed to [`new X509Store(IntPtr)`](xref:System.Security.Cryptography.X509Certificates.X509Store.%23ctor(System.IntPtr)) to obtain a read/write-capable store, subject to the current user's permissions.
 


### PR DESCRIPTION
## Summary

This overhauls the Cross Platform Cryptography guide to bring it up-to-date with changes in cryptography since .NET 5.

This PR heavily edits tables. I recommend reviewing the tables in a rendered view of the markdown.

Fixes #32708

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/security/cross-platform-cryptography.md](https://github.com/dotnet/docs/blob/cd2da5c4a01b37f4bd049482ce6e69c4c99e9721/docs/standard/security/cross-platform-cryptography.md) | [Cross-Platform Cryptography in .NET](https://review.learn.microsoft.com/en-us/dotnet/standard/security/cross-platform-cryptography?branch=pr-en-us-37409) |


<!-- PREVIEW-TABLE-END -->