### PR TITLE
Tweak the cryptography model document

### DIFF
--- a/docs/standard/security/cryptography-model.md
+++ b/docs/standard/security/cryptography-model.md
@@ -1,6 +1,6 @@
 ---
 title: ".NET cryptography model"
-description: Review implementations of usual cryptographic algorithms in .NET. Learn the extensible cryptography model of object inheritance, stream design, & configuration.
+description: Review implementations of usual cryptographic algorithms in .NET. Learn the cryptography model of object inheritance and one-shots.
 ms.date: 02/26/2021
 dev_langs:
   - "csharp"
@@ -12,7 +12,7 @@ ms.assetid: 12fecad4-fbab-432a-bade-2f05976a2971
 ---
 # .NET cryptography model
 
-.NET provides implementations of many standard cryptographic algorithms, and the .NET cryptography model is extensible.
+.NET provides implementations of many standard cryptographic algorithms.
 
 ## Object inheritance
 
@@ -25,6 +25,14 @@ The .NET cryptography system implements an extensible pattern of derived class i
 - Implementation of an algorithm class that inherits from an algorithm class; for example, <xref:System.Security.Cryptography.AesManaged>, <xref:System.Security.Cryptography.RC2CryptoServiceProvider>, or <xref:System.Security.Cryptography.ECDiffieHellmanCng>. This level is fully implemented.
 
 This pattern of derived classes lets you add a new algorithm or a new implementation of an existing algorithm. For example, to create a new public-key algorithm, you would inherit from the <xref:System.Security.Cryptography.AsymmetricAlgorithm> class. To create a new implementation of a specific algorithm, you would create a non-abstract derived class of that algorithm.
+
+This model of inheritance is not being used for new kinds of primitives going forward like <xref:System.Security.Cryptography.AesGcm> or <xref:System.Security.Cryptography.Shake128>. These algorithms are `sealed`. If you need an extensibility pattern or abstraction over these types, the implementation of the abstraction is the responsibility of the developer.
+
+## One-shots
+
+In .NET 5 one-shot APIs were introduced for hashing and HMAC. These one-shots are simpler to use, reduce allocations or are allocation-free, are thread safe, and use the best available implementation for the platform. The hashing and HMAC primitives expose this through a static `HashData` method on the type such as <xref:System.Security.Cryptography.SHA256.HashData%2A?displayProperty=nameWithType>. The static APIs offer no built-in extensibility mechanism. If you are implementing your own algorithms, it is recommended to also offer similar static APIs of the algorithm.
+
+The <xref:System.Security.Cryptography.RandomNumberGenerator> class also offers static methods for creating or filling buffers with cryptographic random data. These will always use the system's CSPRNG (cryptographically secure pseudorandom number generator).
 
 ## How algorithms are implemented in .NET
 
@@ -45,10 +53,6 @@ In most cases, you don't need to directly reference an algorithm implementation 
 :::code language="csharp" source="snippets/encrypting-data/csharp/aes-encrypt.cs" highlight="9":::
 :::code language="vb" source="snippets/encrypting-data/vb/aes-encrypt.vb" highlight="13":::
 
-## Cryptographic configuration
-
-Cryptographic configuration lets you resolve a specific implementation of an algorithm to an algorithm name, allowing extensibility of the .NET cryptography classes. You can add your own hardware or software implementation of an algorithm and map the implementation to the algorithm name of your choice. If an algorithm is not specified in the configuration file, the default settings are used.
-
 ## Choose an algorithm
 
 You can select an algorithm for different reasons: for example, for data integrity, for data privacy, or to generate a key. Symmetric and hash algorithms are intended for protecting data for either integrity reasons (protect from change) or privacy reasons (protect from viewing). Hash algorithms are used primarily for data integrity.
@@ -67,9 +71,10 @@ Here is a list of recommended algorithms by application:
   - <xref:System.Security.Cryptography.ECDiffieHellman>
   - <xref:System.Security.Cryptography.RSA>
 - Random number generation:
-  - <xref:System.Security.Cryptography.RandomNumberGenerator.Create%2A?displayProperty=nameWithType>
+  - <xref:System.Security.Cryptography.RandomNumberGenerator.GetBytes%2A?displayProperty=nameWithType>
+  - <xref:System.Security.Cryptography.RandomNumberGenerator.Fill%2A?displayProperty=nameWithType>
 - Generating a key from a password:
-  - <xref:System.Security.Cryptography.Rfc2898DeriveBytes>
+  - <xref:System.Security.Cryptography.Rfc2898DeriveBytes.Pbkdf2%2A?displayProperty=nameWithType>
 
 ## See also
 


### PR DESCRIPTION
## Summary

This changes the cryptography model document to reflect the current state of .NET.

1. De-emphasize extensibility. It's not the preferred mechanism any more.
2. Mention one-shots.
3. Strike the section on configuration. I don't believe we honor `cryptoNameMapping` in .NET.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/security/cryptography-model.md](https://github.com/dotnet/docs/blob/b2277c6000323022e3e564ab285e6c502a2795ed/docs/standard/security/cryptography-model.md) | [.NET cryptography model](https://review.learn.microsoft.com/en-us/dotnet/standard/security/cryptography-model?branch=pr-en-us-37419) |

<!-- PREVIEW-TABLE-END -->