### PR TITLE
Document NETSDK1202

### DIFF
--- a/docs/core/tools/sdk-errors/index.md
+++ b/docs/core/tools/sdk-errors/index.md
@@ -160,7 +160,6 @@ f1_keywords:
 - NETSDK1198
 - NETSDK1200
 - NETSDK1201
-- NETSDK1202
 - NETSDK1203
 - NETSDK1204
 - NETSDK1205
@@ -359,7 +358,7 @@ This is a complete list of the errors that you might get from the .NET SDK while
 |NETSDK1199|The ArtifactsPath and UseArtifactsOutput properties cannot be set in a project file, due to MSBuild ordering constraints. They must be set in a Directory.Build.props file or from the command line. See <https://aka.ms/netsdk1199> for more information.|
 |NETSDK1200|If UseArtifactsPath is set to true and ArtifactsPath is not set, there must be a Directory.Build.props file in order to determine where the artifacts folder should be located.|
 |NETSDK1201|For projects targeting .NET 8.0 and higher, specifying a RuntimeIdentifier will no longer produce a self contained app by default. To continue building self-contained apps, set the SelfContained property to true or use the --self-contained argument.|
-|NETSDK1202|The workload '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.|
+|[NETSDK1202](netsdk1202.md)|The workload '{0}' is out of support and will not receive security updates in the future. Please refer to {1} for more information about the support policy.|
 |NETSDK1203|Ahead-of-time compilation is not supported for the target runtime identifier '{0}'.|
 |NETSDK1204|Ahead-of-time compilation is not supported on the current platform '{0}'.|
 |NETSDK1205|The Microsoft.Net.Compilers.Toolset.Framework package should not be set directly. Set the property 'BuildWithNetFrameworkHostedCompiler' to 'true' instead if you need it.|

--- a/docs/core/tools/sdk-errors/netsdk1202.md
+++ b/docs/core/tools/sdk-errors/netsdk1202.md
@@ -1,0 +1,37 @@
+---
+title: "NETSDK1202: workload is out of support and will not receive security updates in the future"
+description: Learn about .NET SDK warning NETSDK1202, which occurs when a project depends on an optional workload that is out of support.
+ms.topic: error-reference
+ms.date: 10/10/2023
+f1_keywords:
+- NETSDK1202
+---
+# NETSDK1202: workload is out of support and will not receive security updates in the future
+
+NETSDK1202 indicates your project is using an optional workload that is out of
+support. An example of this, would be using `net6.0` target frameworks in a .NET
+MAUI application:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net6.0-android;net6.0-ios;net6.0-maccatalyst;net6.0-windows10.0.19041.0</TargetFrameworks>
+```
+
+The best solution would be to update to a newer, supported `TargetFramework`
+such as `net7.0`, `net8.0`, etc. Note that using a .NET 8 SDK and .NET 8 MAUI
+optional workload does not support building `net6.0` applications in any form,
+and so this is a hard requirement when using the latest .NET SDK.
+
+You can continue building `net6.0` .NET MAUI applications with a .NET 6 or .NET
+7 SDK in an unsupported fashion. Additionally, you can opt out of the warning in
+a project with the setting:
+
+```xml
+<PropertyGroup>
+  <CheckEolWorkloads>false</CheckEolWorkloads>
+</PropertyGroup>
+```
+
+See the [.NET MAUI support policy](https://aka.ms/maui-support-policy) for
+details about the .NET MAUI product lifecycle.

--- a/docs/core/tools/sdk-errors/netsdk1202.md
+++ b/docs/core/tools/sdk-errors/netsdk1202.md
@@ -21,7 +21,7 @@ MAUI application:
 The best solution would be to update to a newer, supported `TargetFramework`
 such as `net7.0` or `net8.0`. Note that using a .NET 8 SDK and .NET 8 MAUI
 optional workload does not support building `net6.0` applications in any form,
-and so this is a hard requirement when using the latest .NET SDK.
+so this is a hard requirement when using the latest .NET SDK.
 
 You can continue building `net6.0` .NET MAUI applications with a .NET 6 or .NET
 7 SDK in an unsupported fashion. Additionally, you can opt out of the warning in

--- a/docs/core/tools/sdk-errors/netsdk1202.md
+++ b/docs/core/tools/sdk-errors/netsdk1202.md
@@ -19,7 +19,7 @@ MAUI application:
 ```
 
 The best solution would be to update to a newer, supported `TargetFramework`
-such as `net7.0`, `net8.0`, etc. Note that using a .NET 8 SDK and .NET 8 MAUI
+such as `net7.0` or `net8.0`. Note that using a .NET 8 SDK and .NET 8 MAUI
 optional workload does not support building `net6.0` applications in any form,
 and so this is a hard requirement when using the latest .NET SDK.
 

--- a/docs/core/tools/sdk-errors/netsdk1202.md
+++ b/docs/core/tools/sdk-errors/netsdk1202.md
@@ -9,7 +9,7 @@ f1_keywords:
 # NETSDK1202: workload is out of support and will not receive security updates in the future
 
 NETSDK1202 indicates your project is using an optional workload that is out of
-support. An example of this, would be using `net6.0` target frameworks in a .NET
+support. An example of this would be using `net6.0` target frameworks in a .NET
 MAUI application:
 
 ```xml


### PR DESCRIPTION
## Summary

Related: https://github.com/dotnet/sdk/issues/35811


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/sdk-errors/index.md](https://github.com/dotnet/docs/blob/10f18896cc16125b60df21de609c46206c2f5928/docs/core/tools/sdk-errors/index.md) | [.NET SDK error list](https://review.learn.microsoft.com/en-us/dotnet/core/tools/sdk-errors/index?branch=pr-en-us-37422) |
| [docs/core/tools/sdk-errors/netsdk1202.md](https://github.com/dotnet/docs/blob/10f18896cc16125b60df21de609c46206c2f5928/docs/core/tools/sdk-errors/netsdk1202.md) | ["NETSDK1202: workload is out of support and will not receive security updates in the future"](https://review.learn.microsoft.com/en-us/dotnet/core/tools/sdk-errors/netsdk1202?branch=pr-en-us-37422) |


<!-- PREVIEW-TABLE-END -->