### PR TITLE
Upgrade to .NET 8 for Orleans, and sync with Training module.

### DIFF
--- a/docs/orleans/quickstarts/build-your-first-orleans-app.md
+++ b/docs/orleans/quickstarts/build-your-first-orleans-app.md
@@ -1,7 +1,7 @@
 ---
 title: 'Quickstart: Build your first Orleans app with ASP.NET Core'
 description: Learn how to use Orleans to build a scalable, distributed ASP.NET Core application
-ms.date: 10/11/2023
+ms.date: 01/09/2024
 ms.topic: quickstart
 ms.devlang: csharp
 ---
@@ -109,11 +109,11 @@ At the top of the _Program.cs_ file, refactor the code to use Orleans. The follo
 
 [Grains](../overview.md) are the most essential primitives and building blocks of Orleans applications. A grain is a class that inherits from the <xref:Orleans.Grain> base class, which manages various internal behaviors and integration points with Orleans. Grains should also implement one of the following interfaces to define their grain key identifier. Each of these interfaces defines a similar contract, but marks your class with a different data type for the identifier that Orleans uses to track the grain, such as a string or integer.
 
-- `IGrainWithGuidKey`
-- `IGrainWithIntegerKey`
-- `IGrainWithStringKey`
-- `IGrainWithGuidCompoundKey`
-- `IGrainWithIntegerCompoundKey`
+- <xref:Orleans.IGrainWithGuidKey>
+- <xref:Orleans.IGrainWithIntegerKey>
+- <xref:Orleans.IGrainWithStringKey>
+- <xref:Orleans.IGrainWithGuidCompoundKey>
+- <xref:Orleans.IGrainWithIntegerCompoundKey>
 
 For this quickstart, you use the `IGrainWithStringKey`, since strings are a logical choice for working with URL values and short codes.
 

--- a/docs/orleans/quickstarts/build-your-first-orleans-app.md
+++ b/docs/orleans/quickstarts/build-your-first-orleans-app.md
@@ -1,16 +1,14 @@
 ---
 title: 'Quickstart: Build your first Orleans app with ASP.NET Core'
 description: Learn how to use Orleans to build a scalable, distributed ASP.NET Core application
-author: alexwolfmsft
-ms.author: alexwolf
-ms.date: 06/15/2023
+ms.date: 10/11/2023
 ms.topic: quickstart
 ms.devlang: csharp
 ---
 
 # Quickstart: Build your first Orleans app with ASP.NET Core
 
-In this quickstart, you use Orleans and ASP.NET Core 7.0 Minimal APIs to build a URL shortener app. Users submit a full URL to the app's `/shorten` endpoint and get a shortened version to share with others, who are redirected to the original site. The app uses Orleans grains and silos to manage state in a distributed manner to allow for scalability and resiliency. These features are critical when developing apps for distributed cloud hosting services like Azure Container Apps and platforms like Kubernetes.
+In this quickstart, you use Orleans and ASP.NET Core 8.0 Minimal APIs to build a URL shortener app. Users submit a full URL to the app's `/shorten` endpoint and get a shortened version to share with others, who are redirected to the original site. The app uses Orleans grains and silos to manage state in a distributed manner to allow for scalability and resiliency. These features are critical when developing apps for distributed cloud hosting services like Azure Container Apps and platforms like Kubernetes.
 
 At the end of the quickstart, you have an app that creates and handles redirects using short, friendly URLs. You learn how to:
 
@@ -23,12 +21,12 @@ At the end of the quickstart, you have an app that creates and handles redirects
 
 # [Visual Studio](#tab/visual-studio)
 
-- [.NET 7.0 SDK](https://dotnet.microsoft.com/download)
+- [.NET 8.0 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
 - [Visual Studio 2022](https://visualstudio.microsoft.com/) with the ASP.NET and web development workload
 
 # [Visual Studio Code](#tab/visual-studio-code)
 
-- [.NET 7.0 SDK](https://dotnet.microsoft.com/download)
+- [.NET 8.0 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
 - [Visual Studio Code](https://code.visualstudio.com/)
 
 ---
@@ -43,7 +41,7 @@ At the end of the quickstart, you have an app that creates and handles redirects
 
 1. On the **Configure your new project** dialog, enter `OrleansURLShortener` for **Project name**, and then select **Next**.
 
-1. On the **Additional information** dialog, select **.NET 7.0 (Standard support)** and uncheck **Use controllers**, and then select **Create**.
+1. On the **Additional information** dialog, select **.NET 8.0 (Long Term Support)** and uncheck **Use controllers**, and then select **Create**.
 
 # [Visual Studio Code](#tab/visual-studio-code)
 

--- a/docs/orleans/quickstarts/snippets/url-shortener/orleansurlshortener/Program.cs
+++ b/docs/orleans/quickstarts/snippets/url-shortener/orleansurlshortener/Program.cs
@@ -3,7 +3,7 @@ using Orleans.Runtime;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Host.UseOrleans(siloBuilder =>
+builder.Host.UseOrleans(static siloBuilder =>
 {
     siloBuilder.UseLocalhostClustering();
     siloBuilder.AddMemoryGrainStorage("urls");
@@ -22,7 +22,7 @@ app.MapGet("/shorten",
 
         // Validate the URL query string.
         if (string.IsNullOrWhiteSpace(url) &&
-            Uri.IsWellFormedUriString(url, UriKind.Absolute) is false )
+            Uri.IsWellFormedUriString(url, UriKind.Absolute) is false)
         {
             return Results.BadRequest($"""
                 The URL query string is required and needs to be well formed.
@@ -98,7 +98,7 @@ public sealed class UrlShortenerGrain(
         Task.FromResult(state.State.FullUrl);
 }
 
-[GenerateSerializer]
+[GenerateSerializer, Alias(nameof(UrlDetails))]
 public sealed record class UrlDetails
 {
     [Id(0)]

--- a/docs/orleans/quickstarts/snippets/url-shortener/orleansurlshortener/Program.cs
+++ b/docs/orleans/quickstarts/snippets/url-shortener/orleansurlshortener/Program.cs
@@ -1,7 +1,7 @@
 ﻿// <configuration>
 using Orleans.Runtime;
 
-WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+var builder = WebApplication.CreateBuilder(args);
 
 builder.Host.UseOrleans(siloBuilder =>
 {
@@ -9,20 +9,20 @@ builder.Host.UseOrleans(siloBuilder =>
     siloBuilder.AddMemoryGrainStorage("urls");
 });
 
-using WebApplication app = builder.Build();
+using var app = builder.Build();
 // </configuration>
 
 // <endpoints>
-app.MapGet("/", () => "Hello World!");
+app.MapGet("/", static () => "Welcome to the URL shortener, powered by Orleans!");
 
 app.MapGet("/shorten",
-    async (IGrainFactory grains, HttpRequest request, string url) =>
+    static async (IGrainFactory grains, HttpRequest request, string url) =>
     {
         var host = $"{request.Scheme}://{request.Host.Value}";
 
         // Validate the URL query string.
         if (string.IsNullOrWhiteSpace(url) &&
-            Uri.IsWellFormedUriString(url, UriKind.Absolute) is false)
+            Uri.IsWellFormedUriString(url, UriKind.Absolute) is false )
         {
             return Results.BadRequest($"""
                 The URL query string is required and needs to be well formed.
@@ -34,7 +34,9 @@ app.MapGet("/shorten",
         var shortenedRouteSegment = Guid.NewGuid().GetHashCode().ToString("X");
 
         // Create and persist a grain with the shortened ID and full URL
-        var shortenerGrain = grains.GetGrain<IUrlShortenerGrain>(shortenedRouteSegment);
+        var shortenerGrain =
+            grains.GetGrain<IUrlShortenerGrain>(shortenedRouteSegment);
+
         await shortenerGrain.SetUrl(url);
 
         // Return the shortened URL for later use
@@ -47,13 +49,18 @@ app.MapGet("/shorten",
     });
 
 app.MapGet("/go/{shortenedRouteSegment:required}",
-    async (IGrainFactory grains, string shortenedRouteSegment) =>
+    static async (IGrainFactory grains, string shortenedRouteSegment) =>
     {
-        // Retrieve the grain using the shortened ID and url to the original URL        
-        var shortenerGrain = grains.GetGrain<IUrlShortenerGrain>(shortenedRouteSegment);
+        // Retrieve the grain using the shortened ID and url to the original URL
+        var shortenerGrain =
+            grains.GetGrain<IUrlShortenerGrain>(shortenedRouteSegment);
+
         var url = await shortenerGrain.GetUrl();
 
-        return Results.Redirect(url);
+        // Handles missing schemes, defaults to "http://".
+        var redirectBuilder = new UriBuilder(url);
+
+        return Results.Redirect(redirectBuilder.Uri.ToString());
     });
 
 app.Run();
@@ -69,38 +76,35 @@ public interface IUrlShortenerGrain : IGrainWithStringKey
 // </graininterface>
 
 // <grain>
-public sealed class UrlShortenerGrain : Grain, IUrlShortenerGrain
+public sealed class UrlShortenerGrain(
+    [PersistentState(
+        stateName: "url",
+        storageName: "urls")]
+        IPersistentState<UrlDetails> state)
+    : Grain, IUrlShortenerGrain
 {
-    private readonly IPersistentState<UrlDetails> _state;
-
-    public UrlShortenerGrain(
-        [PersistentState(
-            stateName: "url",
-            storageName: "urls")]
-            IPersistentState<UrlDetails> state) => _state = state;
-
     public async Task SetUrl(string fullUrl)
     {
-        _state.State = new()
+        state.State = new()
         {
             ShortenedRouteSegment = this.GetPrimaryKeyString(),
             FullUrl = fullUrl
         };
 
-        await _state.WriteStateAsync();
+        await state.WriteStateAsync();
     }
 
     public Task<string> GetUrl() =>
-        Task.FromResult(_state.State.FullUrl);
+        Task.FromResult(state.State.FullUrl);
 }
 
 [GenerateSerializer]
-public record class UrlDetails
+public sealed record class UrlDetails
 {
     [Id(0)]
-    public string FullUrl { get; set; }
+    public string FullUrl { get; set; } = "";
 
     [Id(1)]
-    public string ShortenedRouteSegment { get; set; }
+    public string ShortenedRouteSegment { get; set; } = "";
 }
 // </grain>

--- a/docs/orleans/quickstarts/snippets/url-shortener/orleansurlshortener/orleansurlshortener.csproj
+++ b/docs/orleans/quickstarts/snippets/url-shortener/orleansurlshortener/orleansurlshortener.csproj
@@ -1,15 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>disable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.14" />
-    <PackageReference Include="Microsoft.Orleans.Server" Version="7.2.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.Orleans.Server" Version="8.0.*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Upgrading this Orleans tutorial to synchronize with changes in the corresponding Learn Training content, the Azure-Samples repo, and all of this is for .NET 8.

Fixes #37449

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/quickstarts/build-your-first-orleans-app.md](https://github.com/dotnet/docs/blob/9a26cfb84683fe3a5796a9caba76f2dfb9994215/docs/orleans/quickstarts/build-your-first-orleans-app.md) | [Quickstart: Build your first Orleans app with ASP.NET Core](https://review.learn.microsoft.com/en-us/dotnet/orleans/quickstarts/build-your-first-orleans-app?branch=pr-en-us-37451) |


<!-- PREVIEW-TABLE-END -->