### PR TITLE
Update units-of-measure.md

### DIFF
--- a/docs/fsharp/language-reference/units-of-measure.md
+++ b/docs/fsharp/language-reference/units-of-measure.md
@@ -7,7 +7,8 @@ ms.date: 08/15/2020
 
 Floating point and signed integer values in F# can have associated units of measure, which are typically used to indicate length, volume, mass, and so on. By using quantities with units, you enable the compiler to verify that arithmetic relationships have the correct units, which helps prevent programming errors.
 
-> [!NOTE] despite the units of measure main raison d'être is correctness in arithmetic computations, the feature can also be leveraged for adding type safe annotation with zero representation costs to other types, with approach such as [FSharp.UMX](https://github.com/fsprojects/FSharp.UMX) project.
+> [!NOTE]
+> These examples demonstrates correctness in arithmetic computations involving units of measure, the feature can also be leveraged for adding type safe annotation with zero representation costs to other types, with approach such as [FSharp.UMX](https://github.com/fsprojects/FSharp.UMX) project.
 
 ## Syntax
 

--- a/docs/fsharp/language-reference/units-of-measure.md
+++ b/docs/fsharp/language-reference/units-of-measure.md
@@ -7,6 +7,8 @@ ms.date: 08/15/2020
 
 Floating point and signed integer values in F# can have associated units of measure, which are typically used to indicate length, volume, mass, and so on. By using quantities with units, you enable the compiler to verify that arithmetic relationships have the correct units, which helps prevent programming errors.
 
+> [!NOTE] despite the units of measure main raison d'être is correctness in arithmetic computations, the feature can also be leveraged for adding type safe annotation with zero representation costs to other types, with approach such as [FSharp.UMX](https://github.com/fsprojects/FSharp.UMX) project.
+
 ## Syntax
 
 ```fsharp


### PR DESCRIPTION
Add a mention that F# can support the feature for other types, for type safety purpose (not only arithmetic), and the fact it is zero cost abstraction.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/units-of-measure.md](https://github.com/dotnet/docs/blob/283d7ea2dd72f1d82e9ecc3bbdaf5310d4aa4585/docs/fsharp/language-reference/units-of-measure.md) | [Units of Measure](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/units-of-measure?branch=pr-en-us-37468) |


<!-- PREVIEW-TABLE-END -->