### PR TITLE
Add link to new EPA docs for Oct 2023 Windows Server release

### DIFF
--- a/docs/framework/wcf/feature-details/extended-protection-for-authentication-overview.md
+++ b/docs/framework/wcf/feature-details/extended-protection-for-authentication-overview.md
@@ -31,3 +31,4 @@ Extended Protection for Authentication helps protect against man-in-the-middle (
 ## See also
 
 - [Security Model for Windows Server App Fabric](/previous-versions/appfabric/ee677202(v=azure.10))
+- [Supporting Extended Protection for Authentication (EPA) in a service](/windows/win32/secauthn/epa-support-in-service)


### PR DESCRIPTION
## Summary

I'm creating this as a draft. The changes are all set, but please do not merge until after my topic in the win32 repo is published on Tuesday.

Adding a link to a new EPA doc to be published on Oct 17th: Supporting Extended Protection for Authentication (EPA) in a service. You can view [my PR](https://github.com/MicrosoftDocs/win32-pr/pull/1737) for the new doc to be added when the Windows Server bits are available.

Fixes #Issue_Number (if available): No GitHub issue number. This is for an internal request on the Windows team.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/wcf/feature-details/extended-protection-for-authentication-overview.md](https://github.com/dotnet/docs/blob/00a17913bfc2d271989b1cf9113a504617698311/docs/framework/wcf/feature-details/extended-protection-for-authentication-overview.md) | [Extended Protection for Authentication Overview](https://review.learn.microsoft.com/en-us/dotnet/framework/wcf/feature-details/extended-protection-for-authentication-overview?branch=pr-en-us-37471) |


<!-- PREVIEW-TABLE-END -->