### PR TITLE
Add ref readonly modifier to performance article

### DIFF
--- a/docs/csharp/advanced-topics/performance/index.md
+++ b/docs/csharp/advanced-topics/performance/index.md
@@ -34,7 +34,7 @@ You can work directly with the storage for values using `ref` variables, pass by
 
 The `ref readonly` and `in` modifiers both indicate that the argument should be passed by reference, and can't be reassigned in the method. The difference is that `ref readonly` indicates the method uses the parameter as a variable. The method might capture the parameter, or it might return the parameter by readonly reference. In those cases, you should use the `ref readonly` modifier. Otherwise, the `in` modifier offers more flexibility. You don't need to add the `in` modifier for an `in` parameter, so you can update existing APIs safely using the `in` modifier. The compiler issues a warning if you don't add either the `ref` or `in` modifier to an argument for a `ref readonly` parameter.
 
-## Ref safe to escape scope
+## Ref safe context
 
 C# includes rules for `ref` expressions to ensure that a `ref` expression can't be accessed where the storage it refers to is no longer valid. Consider the following example:
 
@@ -42,13 +42,13 @@ C# includes rules for `ref` expressions to ensure that a `ref` expression can't 
 public ref int CantEscape()
 {
     int index = 42;
-    return ref index; // Error: index's ref safe to escape scope is the body of CantEscape
+    return ref index; // Error: index's ref safe context is the body of CantEscape
 }
 ```
 
-The compiler reports an error because you can't return a reference to a local variable from a method. The caller can't access the storage being referred to. The *ref safe to escape scope* defines the scope in which a `ref` expression is safe to access or modify. The following table lists the *ref safe to escape scopes* for variable types. `ref` fields can't be declared in a `class` or a non-ref `struct`, so those rows aren't in the table:
+The compiler reports an error because you can't return a reference to a local variable from a method. The caller can't access the storage being referred to. The *ref safe context* defines the scope in which a `ref` expression is safe to access or modify. The following table lists the *ref safe contexts* for variable types. `ref` fields can't be declared in a `class` or a non-ref `struct`, so those rows aren't in the table:
 
-| Declaration                           | *ref safe to escape scope*    |
+| Declaration                           | *ref safe context*            |
 |---------------------------------------|-------------------------------|
 | non-ref local                         | block where local is declared |
 | non-ref parameter                     | current method                |
@@ -58,20 +58,20 @@ The compiler reports an error because you can't return a reference to a local va
 | non-ref `struct` field                | current method                |
 | `ref` field of `ref struct`           | calling method                |
 
-A variable can be `ref` returned if its *ref safe to escape scope* is the calling method. If its *ref safe to escape scope* is the current method or a block, `ref` return is disallowed. The following snippet shows two examples. A member field can be accessed from the scope calling a method, so a class or struct field's *ref safe to escape scope* is the calling method. The *ref safe to escape scope* for a parameter with the `ref`, or `in` modifiers is the entire method. Both can be `ref` returned from a member method:
+A variable can be `ref` returned if its *ref safe context* is the calling method. If its *ref safe context* is the current method or a block, `ref` return is disallowed. The following snippet shows two examples. A member field can be accessed from the scope calling a method, so a class or struct field's *ref safe context* is the calling method. The *ref safe context* for a parameter with the `ref`, or `in` modifiers is the entire method. Both can be `ref` returned from a member method:
 
 :::code language="csharp" source="./snippets/ref-safety/EscapeScopes.cs" id="RefSafeToEscapeScopes":::
 
 > [!NOTE]
 > When the `ref readonly` or `in` modifier is applied to a parameter, that parameter can be returned by `ref readonly`, not `ref`.
 
-The compiler ensures that a reference can't escape its *ref safe to escape scope*. You can use `ref` parameters, `ref return` and `ref` local variables safely because the compiler detects if you've accidentally written code where a `ref` expression could be accessed when its storage isn't valid.
+The compiler ensures that a reference can't escape its *ref safe context*. You can use `ref` parameters, `ref return` and `ref` local variables safely because the compiler detects if you've accidentally written code where a `ref` expression could be accessed when its storage isn't valid.
 
-## Safe to escape scope and ref structs
+## Safe context and ref structs
 
-`ref struct` types require more rules to ensure they can be used safely. A `ref struct` type can include `ref` fields. That requires the introduction of a *safe to escape scope*. For most types, the *safe to escape scope* is the calling method. In other words, a value that's not a `ref struct` can always be returned from a method.
+`ref struct` types require more rules to ensure they can be used safely. A `ref struct` type can include `ref` fields. That requires the introduction of a *safe context*. For most types, the *safe context* is the calling method. In other words, a value that's not a `ref struct` can always be returned from a method.
 
-Informally, the *safe to escape scope* for a `ref struct` is the scope where all of its `ref` fields can be accessed. In other words, it's the intersection of the *ref safe to escape scopes* of all its `ref` fields. The following method returns a `ReadOnlySpan<char>` to a member field, so its *safe to escape scope* is the method:
+Informally, the *safe context* for a `ref struct` is the scope where all of its `ref` fields can be accessed. In other words, it's the intersection of the *ref safe context* of all its `ref` fields. The following method returns a `ReadOnlySpan<char>` to a member field, so its *safe context* is the method:
 
 :::code language="csharp" source="./snippets/ref-safety/EscapeScopes.cs" id="SafeToEscapeScope":::
 
@@ -92,7 +92,7 @@ public Span<int> M()
 
 ## Unify memory types
 
-The introduction of <xref:System.Span%601?displayProperty=fullName> and <xref:System.Memory%601?displayProperty=fullName> provide a unified model for working with memory. <xref:System.ReadOnlySpan%601?displayProperty=fullName> and <xref:System.ReadOnlyMemory%601?displayProperty=fullName> provide readonly versions for accessing memory. They all provide an abstraction over a block of memory storing an array of similar elements. The difference is that `Span<T>` and `ReadOnlySpan<T>` are `ref struct` types whereas `Memory<T>` and `ReadOnlyMemory<T>` are `struct` types. Spans contain a `ref field`. Therefore instances of a span can't leave its *safe to escape scope*. The *safe to escape* scope of a `ref struct` is the *ref safe to escape scope* of its `ref field`. The implementation of `Memory<T>` and `ReadOnlyMemory<T>` remove this restriction. You use these types to directly access memory buffers.
+The introduction of <xref:System.Span%601?displayProperty=fullName> and <xref:System.Memory%601?displayProperty=fullName> provide a unified model for working with memory. <xref:System.ReadOnlySpan%601?displayProperty=fullName> and <xref:System.ReadOnlyMemory%601?displayProperty=fullName> provide readonly versions for accessing memory. They all provide an abstraction over a block of memory storing an array of similar elements. The difference is that `Span<T>` and `ReadOnlySpan<T>` are `ref struct` types whereas `Memory<T>` and `ReadOnlyMemory<T>` are `struct` types. Spans contain a `ref field`. Therefore instances of a span can't leave its *safe context*. The *safe context* of a `ref struct` is the *ref safe context* of its `ref field`. The implementation of `Memory<T>` and `ReadOnlyMemory<T>` remove this restriction. You use these types to directly access memory buffers.
 
 ## Improve performance with ref safety
 

--- a/docs/csharp/advanced-topics/performance/index.md
+++ b/docs/csharp/advanced-topics/performance/index.md
@@ -22,7 +22,7 @@ Variables in C# store *values*. In `struct` types, the value is the contents of 
 
 In C#, parameters to methods are *passed by value*, and return values are *return by value*. The *value* of the argument is passed to the method. The *value* of the return argument is the return value.
 
-The `ref`, `in`, `ref readonly` or `out` modifier indicates that parameter is *passed by reference*. The *reference* to the storage location is passed to the method. Adding `ref` to the method signature means the return value is *returned by reference*. The *reference* to the storage location is the return value.
+The `ref`, `in`, `ref readonly`, or `out` modifier indicates that the argument is *passed by reference*. A *reference* to the storage location is passed to the method. Adding `ref` to the method signature means the return value is *returned by reference*. A *reference* to the storage location is the return value.
 
 You can also use *ref assignment* to have a variable refer to another variable. A typical assignment copies the *value* of the right hand side to the variable on the left hand side of the assignment. A *ref assignment* copies the memory location of the variable on the right hand side to the variable on the left hand side. The `ref` now refers to the original variable:
 
@@ -32,7 +32,7 @@ When you *assign* a variable, you change its *value*. When you *ref assign* a va
 
 You can work directly with the storage for values using `ref` variables, pass by reference, and ref assignment. Scope rules enforced by the compiler ensure safety when working directly with storage.
 
-The `ref readonly` and `in` modifiers both indicate that the argument should be passed by reference, and can't be reassigned in the method. The difference is that `ref readonly` indicates the method uses the parameter as a variable. The method might capture the parameter, or it might return the parameter by readonly reference. In those cases, you should use the `ref readonly` modifier. Otherwise, the `in` modifier offers more flexibility. You don't need to add the `in` modifier for an `in` parameter, so you can update existing APIs safely using the `in` modifier. The compiler issues a warning if you don't add either the `ref` or `in` modifier to an argument for a `ref readonly` parameter.
+The `ref readonly` and `in` modifiers both indicate that the argument should be passed by reference and can't be reassigned in the method. The difference is that `ref readonly` indicates that the method uses the parameter as a variable. The method might capture the parameter, or it might return the parameter by readonly reference. In those cases, you should use the `ref readonly` modifier. Otherwise, the `in` modifier offers more flexibility. You don't need to add the `in` modifier to an argument for an `in` parameter, so you can update existing API signatures safely using the `in` modifier. The compiler issues a warning if you don't add either the `ref` or `in` modifier to an argument for a `ref readonly` parameter.
 
 ## Ref safe context
 
@@ -65,7 +65,7 @@ A variable can be `ref` returned if its *ref safe context* is the calling method
 > [!NOTE]
 > When the `ref readonly` or `in` modifier is applied to a parameter, that parameter can be returned by `ref readonly`, not `ref`.
 
-The compiler ensures that a reference can't escape its *ref safe context*. You can use `ref` parameters, `ref return` and `ref` local variables safely because the compiler detects if you've accidentally written code where a `ref` expression could be accessed when its storage isn't valid.
+The compiler ensures that a reference can't escape its *ref safe context*. You can use `ref` parameters, `ref return`, and `ref` local variables safely because the compiler detects if you've accidentally written code where a `ref` expression could be accessed when its storage isn't valid.
 
 ## Safe context and ref structs
 

--- a/docs/csharp/advanced-topics/performance/ref-tutorial.md
+++ b/docs/csharp/advanced-topics/performance/ref-tutorial.md
@@ -1,7 +1,7 @@
 ---
 title: "Tutorial: Reduce memory allocations using struct data types and ref language features."
 description: Learn to remove allocations from your code. Make use of `struct` types for fewer allocations. Use the `ref` and `in` modifiers to avoid copies and enable or disable modification. Use `ref struct` types like `Span<T>` to directly use memory efficiently.
-ms.date: 01/27/2023
+ms.date: 10/13/2023
 ms.technology: csharp-advanced-concepts
 ---
 # Tutorial: Reduce memory allocations with `ref` safety
@@ -163,7 +163,7 @@ Let's look again at `DebounceMeasurement.AddMeasurement`. You should add the `in
 
 :::code language="csharp" source="./snippets/ref-tutorial/IntruderAlert-finished/DebounceMeasurement.cs" id="InArgument":::
 
-That saves one copy operation. The `in` parameter is a reference to the copy already created by the caller. You can also save a copy with the `TakeMeasurement` method in the `Room` type. This method illustrates how the compiler provides safety when you pass arguments by `ref`. The initial `TakeMeasurement` method in the `Room` type takes an argument of `Func<SensorMeasurement, bool>`. If you try to add the `in` or `ref` modifier to that declaration, the compiler reports an error. You can't pass a `ref` argument to a lambda expression. The compiler can't guarantee that the called expression doesn't copy the reference. If the lambda expression *captures* the reference, the reference could have a lifetime longer than the value it refers to. Accessing it outside its *ref safe to escape scope* would result in memory corruption. The `ref` safety rules don't allow it. You can learn more in the overview of [ref safety features](index.md#ref-safe-to-escape-scope).
+That saves one copy operation. The `in` parameter is a reference to the copy already created by the caller. You can also save a copy with the `TakeMeasurement` method in the `Room` type. This method illustrates how the compiler provides safety when you pass arguments by `ref`. The initial `TakeMeasurement` method in the `Room` type takes an argument of `Func<SensorMeasurement, bool>`. If you try to add the `in` or `ref` modifier to that declaration, the compiler reports an error. You can't pass a `ref` argument to a lambda expression. The compiler can't guarantee that the called expression doesn't copy the reference. If the lambda expression *captures* the reference, the reference could have a lifetime longer than the value it refers to. Accessing it outside its *ref safe context* would result in memory corruption. The `ref` safety rules don't allow it. You can learn more in the overview of [ref safety features](index.md#ref-safe-context).
 
 ## Preserve semantics
 


### PR DESCRIPTION
Add a discussion of the ref readonly modifier in this article.

I also updated the terms for "safe context" and "ref safe context" as decided in the ECMA committee. There weren't other uses of the terms, so it was easiest to just add them to this PR.

Contributes to #36682


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/advanced-topics/performance/index.md](https://github.com/dotnet/docs/blob/7d7a16971d39eccefd5c383628874d29451e30cb/docs/csharp/advanced-topics/performance/index.md) | [Reduce memory allocations using new C# features](https://review.learn.microsoft.com/en-us/dotnet/csharp/advanced-topics/performance/index?branch=pr-en-us-37492) |
| [docs/csharp/advanced-topics/performance/ref-tutorial.md](https://github.com/dotnet/docs/blob/7d7a16971d39eccefd5c383628874d29451e30cb/docs/csharp/advanced-topics/performance/ref-tutorial.md) | [Tutorial: Reduce memory allocations with `ref` safety](https://review.learn.microsoft.com/en-us/dotnet/csharp/advanced-topics/performance/ref-tutorial?branch=pr-en-us-37492) |


<!-- PREVIEW-TABLE-END -->