### PR TITLE
Acrolinx

### DIFF
--- a/docs/architecture/serverless/serverless-business-scenarios.md
+++ b/docs/architecture/serverless/serverless-business-scenarios.md
@@ -79,7 +79,7 @@ A reference architecture that walks you through the decision-making process invo
 
 ## Serverless for mobile
 
-Azure Functions are easy to implement and maintain, and accessible through HTTP. They are a great way to implement an API for a mobile application. Microsoft offers great cross-platform tools for iOS, Android, and Windows with Xamarin. As such, Xamarin and Azure Functions are working great together. This article shows how to implement an Azure Function in the Azure portal or in Visual Studio at first, and build a cross-platform client with Xamarin.Forms running on Android, iOS, and Windows.
+Azure Functions are easy to implement and maintain, and accessible through HTTP. They're a good way to implement an API for a mobile application. Microsoft offers cross-platform tools for iOS, Android, and Windows with Xamarin. As such, Xamarin and Azure Functions work well together. This article shows how to implement an Azure Function in the Azure portal or in Visual Studio, and then build a cross-platform client with Xamarin.Forms running on Android, iOS, and Windows.
 
 [Implementing a simple Azure Function with a Xamarin.Forms client](/samples/azure-samples/functions-xamarin-getting-started/implementing-a-simple-azure-function-with-a-xamarinforms-client/)
 

--- a/docs/azure/configure-visual-studio.md
+++ b/docs/azure/configure-visual-studio.md
@@ -9,7 +9,7 @@ ms.author: alexwolf
 ---
 # Configure Visual Studio for Azure development with .NET
 
-Visual Studio includes tooling to help with the development and deployment of applications on Azure. This guide will help you make sure that Visual Studio is properly configured for Azure development.
+Visual Studio includes tooling to help with the development and deployment of applications on Azure. This guide helps you make sure that Visual Studio is properly configured for Azure development.
 
 ## Download Visual Studio
 
@@ -20,13 +20,13 @@ If you already have Visual Studio installed, you can skip this step.
 
 ## Install Azure workloads
 
-Open Visual Studio Installer and validate that the workloads **Azure development** and **ASP.NET and web development** are installed.  If either of these workloads is not installed, select them to be installed.
+Open Visual Studio Installer and validate that the workloads **Azure development** and **ASP.NET and web development** are installed.  If either of these workloads isn't installed, select them to be installed.
 
 ![Screenshot of the Visual Studio Installer showing the Azure development and ASP.NET and Web Development Workloads selected](./media/visual-studio-installer-azure-development.png)
 
 ## Authenticate Visual Studio with Azure
 
-When debugging apps through Visual Studio, Visual Studio can use your Azure account to authenticate and access Azure Resources.  This account is also used when you publish apps directly from Visual Studio to Azure.
+When you debug apps through Visual Studio, Visual Studio can use your Azure account to authenticate and access Azure Resources. This account is also used when you publish apps directly from Visual Studio to Azure.
 
 To authenticate your Azure account from Visual Studio, select the **Tools** > **Options** menu to launch the **Options** dialog. Navigate to the **Azure Service Authentication** options and sign in using your Azure account.
 

--- a/docs/azure/sdk/unit-testing-mocking.md
+++ b/docs/azure/sdk/unit-testing-mocking.md
@@ -9,7 +9,7 @@ ms.date: 07/05/2023
 
 Unit testing is an important part of a sustainable development process that can improve code quality and prevent regressions or bugs in your apps. However, unit testing presents challenges when the code you're testing performs network calls, such as those made to Azure resources. Tests that run against live services can experience issues, such as latency that slows down test execution, dependencies on code outside of the isolated test, and issues with managing service state and costs every time the test is run. Instead of testing against live Azure services, replace the service clients with mocked or in-memory implementations. This avoids the above issues and lets developers focus on testing their application logic, independent from the network and service.
 
-In this article, you'll learn how to write unit tests for the Azure SDK for .NET that isolate your dependencies to make your tests more reliable. You'll also learn how to replace key components with in-memory test implementations to create fast and reliable unit tests, and see how to design your own classes to better support unit testing. This article includes examples that use [Moq](https://www.nuget.org/packages/moq/) and [NSubstitute](https://www.nuget.org/packages/nsubstitute/), which are popular mocking libraries for .NET.
+In this article, you learn how to write unit tests for the Azure SDK for .NET that isolate your dependencies to make your tests more reliable. You also learn how to replace key components with in-memory test implementations to create fast and reliable unit tests, and see how to design your own classes to better support unit testing. This article includes examples that use [Moq](https://www.nuget.org/packages/moq/) and [NSubstitute](https://www.nuget.org/packages/nsubstitute/), which are popular mocking libraries for .NET.
 
 ## Understand service clients
 
@@ -181,7 +181,7 @@ When unit testing you only want the unit tests to verify the application logic a
 
 ## Refactor your types for testability
 
-Classes that need to be tested should be designed for [dependency injection](dependency-injection.md), which allows the class to receive its dependencies instead of creating them internally. It was a seamless process to replace the `SecretClient` implementation in the example from the previous section because it was one of the constructor parameters. However, there may be classes in your code that create their own dependencies and aren't easily testable, such as the following:
+Classes that need to be tested should be designed for [dependency injection](dependency-injection.md), which allows the class to receive its dependencies instead of creating them internally. It was a seamless process to replace the `SecretClient` implementation in the example from the previous section because it was one of the constructor parameters. However, there might be classes in your code that create their own dependencies and aren't easily testable, such as the following class:
 
 ```csharp
 public class AboutToExpireSecretFinder

--- a/docs/core/compatibility/sdk/8.0/custombuildeventargs.md
+++ b/docs/core/compatibility/sdk/8.0/custombuildeventargs.md
@@ -17,7 +17,7 @@ Starting in .NET 8, a build error is issued if your code uses any type derived f
 
 > Usage of unsecure BinaryFormatter during serialization of custom event type 'MyCustomBuildEventArgs'. This will be deprecated soon. Please use Extended*EventArgs instead. More info: <https://aka.ms/msbuild/eventargs>
 
-If you build from Visual Studio, there is no change in behavior unless you opt in by setting the `MSBUILDCUSTOMBUILDEVENTWARNING` environment variable to 1 (available in Visual Studio version 17.8 and later).
+If you build from Visual Studio, there's no change in behavior unless you opt in by setting the `MSBUILDCUSTOMBUILDEVENTWARNING` environment variable to 1 (available in Visual Studio version 17.8 and later).
 
 ## Version introduced
 
@@ -40,7 +40,7 @@ Use one of the following newly introduced, built-in events for extensibility ins
 - `Microsoft.Build.Framework.ExtendedBuildMessageEventArgs`
 - `Microsoft.Build.Framework.ExtendedBuildWarningEventArgs`
 
-Alternatively, you can temporarily disable the check by explicitly setting the environment variable `MSBUILDCUSTOMBUILDEVENTWARNING` to something other than 1.
+Alternatively, you can temporarily disable the check by explicitly setting the environment variable `MSBUILDCUSTOMBUILDEVENTWARNING` to something other than `1`.
 
 ## Affected APIs
 

--- a/docs/core/deploying/native-aot/diagnostics.md
+++ b/docs/core/deploying/native-aot/diagnostics.md
@@ -59,7 +59,7 @@ Collecting a [dump](../../diagnostics/dumps.md) file for a Native AOT applicatio
 
 ### Visual Studio-specific notes
 
-You can launch a Native AOT-compiled executable under the Visual Studio debugger by opening it in the Visual Studio IDE. You'll need to [open the executable itself in Visual Studio](/visualstudio/debugger/how-to-debug-an-executable-not-part-of-a-visual-studio-solution).
+You can launch a Native AOT-compiled executable under the Visual Studio debugger by opening it in the Visual Studio IDE. You need to [open the executable itself in Visual Studio](/visualstudio/debugger/how-to-debug-an-executable-not-part-of-a-visual-studio-solution).
 
 To set a breakpoint that breaks whenever an exception is thrown, choose the **Breakpoints** option from the **Debug > Windows** menu. In the new window, select **New > Function** breakpoint. Specify `RhThrowEx` as the Function Name and leave the Language option at **All Languages** (don't select C#).
 

--- a/docs/core/deploying/native-aot/diagnostics.md
+++ b/docs/core/deploying/native-aot/diagnostics.md
@@ -8,7 +8,7 @@ ms.date: 08/07/2023
 
 # Diagnostics and instrumentation
 
-Native AOT shares some, but not all, diagnostics and instrumentation capabilities with CoreCLR. Because of CoreCLR's rich selection of diagnostic utilities, it's sometimes appropriate to diagnose and debug problems in CoreCLR. Apps that are [trim-compatible](../trimming/prepare-libraries-for-trimming.md) should not have behavioral differences, so investigations often apply to both runtimes. Nonetheless, some information can only be gathered after publishing, so Native AOT also provides post-publish diagnostic tooling.
+Native AOT shares some, but not all, diagnostics and instrumentation capabilities with CoreCLR. Because of CoreCLR's rich selection of diagnostic utilities, it's sometimes appropriate to diagnose and debug problems in CoreCLR. Apps that are [trim-compatible](../trimming/prepare-libraries-for-trimming.md) shouldn't have behavioral differences, so investigations often apply to both runtimes. Nonetheless, some information can only be gathered after publishing, so Native AOT also provides post-publish diagnostic tooling.
 
 ## .NET 8 Native AOT diagnostic support
 
@@ -39,17 +39,16 @@ Native AOT provides partial support for some [well-known event providers](../../
 The .NET CLI tooling (`dotnet` SDK) and Visual Studio offer separate commands for `build` and
 `publish`. `build` (or `Start` in Visual Studio) uses CoreCLR. Only `publish` creates a
 Native AOT application.  Publishing your app as Native AOT produces an app that has been
-ahead-of-time (AOT) compiled to native code. As mentioned previously, this means that not all diagnostic
-tools will work seamlessly with published Native AOT applications in .NET 8. However, all .NET
+ahead-of-time (AOT) compiled to native code. As mentioned previously, not all diagnostic
+tools work seamlessly with published Native AOT applications in .NET 8. However, all .NET
 diagnostic tools are available for developers during the application building stage. We recommend
-developing, debugging, and testing the applications as usual and publishing the working app with Native
-AOT as one of the last steps.
+developing, debugging, and testing the applications as usual and publishing the working app with Native AOT as one of the last steps.
 
 ## Native debugging
 
-When you run your app during development, like inside Visual Studio, or with `dotnet run`, `dotnet build`, or `dotnet test`, it runs on CoreCLR by default. However, if `PublishAot` is present in the project file, the behavior should be the same between CoreCLR and Native AOT. This allows you to use the standard Visual Studio managed debugging engine for development and testing.
+When you run your app during development, like inside Visual Studio, or with `dotnet run`, `dotnet build`, or `dotnet test`, it runs on CoreCLR by default. However, if `PublishAot` is present in the project file, the behavior should be the same between CoreCLR and Native AOT. This characteristic allows you to use the standard Visual Studio managed debugging engine for development and testing.
 
-After publishing, Native AOT applications are true native binaries. The managed debugger will not work on them. However, the Native AOT compiler generates fully native executable files that can be debugged by native debuggers on your platform of choice (for example, WinDbg or Visual Studio on Windows and gdb or lldb on Unix-like systems).
+After publishing, Native AOT applications are true native binaries. The managed debugger won't work on them. However, the Native AOT compiler generates fully native executable files that native debuggers can debug on your platform of choice (for example, WinDbg or Visual Studio on Windows and gdb or lldb on Unix-like systems).
 
 The Native AOT compiler generates information about line numbers, types, locals, and parameters. The native debugger lets you inspect stack trace and variables, step into or over source lines, or set line breakpoints.
 
@@ -60,7 +59,7 @@ Collecting a [dump](../../diagnostics/dumps.md) file for a Native AOT applicatio
 
 ### Visual Studio-specific notes
 
-You can launch a Native AOT-compiled executable under the Visual Studio debugger by opening it in the Visual Studio IDE. You will need to [open the executable itself in Visual Studio](/visualstudio/debugger/how-to-debug-an-executable-not-part-of-a-visual-studio-solution).
+You can launch a Native AOT-compiled executable under the Visual Studio debugger by opening it in the Visual Studio IDE. You'll need to [open the executable itself in Visual Studio](/visualstudio/debugger/how-to-debug-an-executable-not-part-of-a-visual-studio-solution).
 
 To set a breakpoint that breaks whenever an exception is thrown, choose the **Breakpoints** option from the **Debug > Windows** menu. In the new window, select **New > Function** breakpoint. Specify `RhThrowEx` as the Function Name and leave the Language option at **All Languages** (don't select C#).
 
@@ -68,7 +67,7 @@ To see what exception was thrown, start debugging (**Debug > Start Debugging** o
 
 ### Importance of the symbol file
 
-When publishing, the Native AOT compiler produces both an executable and a symbol file. Native debugging, and related activities like profiling, require access to the native symbol file. If this file is not present, you may have degraded or broken results.
+When publishing, the Native AOT compiler produces both an executable and a symbol file. Native debugging, and related activities like profiling, require access to the native symbol file. If this file isn't present, you might have degraded or broken results.
 
 For information about the name and location of the symbol file, see [Native debug information](index.md#native-aot-deployment).
 
@@ -78,4 +77,4 @@ Platform-specific tools like [PerfView](https://github.com/microsoft/perfview) a
 
 ## Heap analysis
 
-Managed heap analysis is not currently supported in Native AOT. Heap analysis tools like [dotnet-gcdump](../../diagnostics/dotnet-gcdump.md), [PerfView](https://github.com/microsoft/perfview), and Visual Studio heap analysis tools don't work in Native AOT in .NET 8.
+Managed heap analysis isn't currently supported in Native AOT. Heap analysis tools like [dotnet-gcdump](../../diagnostics/dotnet-gcdump.md), [PerfView](https://github.com/microsoft/perfview), and Visual Studio heap analysis tools don't work in Native AOT in .NET 8.

--- a/docs/core/deploying/native-aot/warnings/il3050.md
+++ b/docs/core/deploying/native-aot/warnings/il3050.md
@@ -11,11 +11,11 @@ f1_keywords:
 
 ## Cause
 
-When publishing an app as Native AOT (by setting the `PublishAot` property in a project to `true`), calling members annotated with the `RequiresDynamicCodeAttribute` attribute may result in exceptions at run time. Members annotated with this attribute may require ability to dynamically create new code at run time, and Native AOT publishing model doesn't provide a way to generate native code at run time.
+When you publish an app as Native AOT (by setting the `PublishAot` property to `true` in a project), calling members annotated with the `RequiresDynamicCodeAttribute` attribute might result in exceptions at run time. Members annotated with this attribute might require ability to dynamically create new code at run time, and Native AOT publishing model doesn't provide a way to generate native code at run time.
 
 ## Rule description
 
-<xref:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute> indicates that the member references code that may require code generation at runtime.
+<xref:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute> indicates that the member references code that might require code generation at run time.
 
 ## Example
 

--- a/docs/core/deploying/native-aot/warnings/il3055.md
+++ b/docs/core/deploying/native-aot/warnings/il3055.md
@@ -19,7 +19,7 @@ Marshalling code is generated for delegate types that either:
 - Appear as fields of types passed to native code via P/Invoke.
 - Are decorated with <xref:System.Runtime.InteropServices.UnmanagedFunctionPointerAttribute>.
 
-If a concrete type cannot be inferred from the P/Invoke signature, marshalling code might not be available at run time and the P/Invoke will throw an exception.
+If a concrete type can't be inferred from the P/Invoke signature, marshalling code might not be available at run time and the P/Invoke will throw an exception.
 
 Replace <xref:System.Delegate> or <xref:System.MulticastDelegate> in the P/Invoke signature with a concrete delegate type.
 

--- a/docs/core/deploying/single-file/warnings/il3000.md
+++ b/docs/core/deploying/single-file/warnings/il3000.md
@@ -13,12 +13,12 @@ f1_keywords:
 |                                     | Value                                |
 |-------------------------------------|--------------------------------------|
 | **Rule ID**                         | IL3000                               |
-| **Category**                        | [SingleFile](overview.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                         |
+| **Category**                        | [SingleFile](overview.md)            |
+| **Fix is breaking or nonbreaking**  | Nonbreaking                          |
 
 ## Cause
 
-When publishing as a single-file (for example, by setting the PublishSingleFile property in a project to true), calling the `Assembly.Location` property for
+When you publish an app as a single file (for example, by setting the `PublishSingleFile` property to `true` in a project), calling the `Assembly.Location` property for
 assemblies embedded inside the single-file bundle always returns an empty string.
 
 ## How to fix violations
@@ -28,4 +28,4 @@ removing the call entirely.
 
 ## When to suppress warnings
 
-It's appropriate to silence this warning if the assembly being accessed is definitely not in the single-file bundle. This may be the case if the assembly is being loaded dynamically from a file path.
+It's appropriate to silence this warning if the assembly being accessed is definitely not in the single-file bundle. The assembly might not be in the bundle if the assembly is loaded dynamically from a file path.

--- a/docs/core/deploying/single-file/warnings/il3001.md
+++ b/docs/core/deploying/single-file/warnings/il3001.md
@@ -13,13 +13,13 @@ f1_keywords:
 |                                     | Value                                |
 |-------------------------------------|--------------------------------------|
 | **Rule ID**                         | IL3001                               |
-| **Category**                        | [SingleFile](overview.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                         |
+| **Category**                        | [SingleFile](overview.md)            |
+| **Fix is breaking or nonbreaking**  | Nonbreaking                          |
 
 ## Cause
 
-When publishing as a single file (for example, by setting the PublishSingleFile property in a project to true), calling the `Assembly.GetFile(s)` methods for
-assemblies embedded inside the single-file bundle always throws an exception, as these methods are not single-file compatible.
+When you publish an app as a single file (for example, by setting the `PublishSingleFile` property to `true` in a project), calling the `Assembly.GetFile(s)` methods for
+assemblies embedded inside the single-file bundle always throws an exception, as these methods aren't single-file compatible.
 
 ## How to fix violations
 
@@ -27,4 +27,4 @@ To embed files in assemblies in single-file bundles, consider using embedded res
 
 ## When to suppress warnings
 
-It's appropriate to silence this warning if the assembly being accessed is definitely not in the single-file bundle. This may be the case if the assembly is being loaded dynamically from a file path.
+It's appropriate to silence this warning if the assembly being accessed is definitely not in the single-file bundle. The assembly might not be in the bundle if the assembly is loaded dynamically from a file path.

--- a/docs/core/deploying/single-file/warnings/il3002.md
+++ b/docs/core/deploying/single-file/warnings/il3002.md
@@ -12,12 +12,12 @@ f1_keywords:
 |                                     | Value                                |
 |-------------------------------------|--------------------------------------|
 | **Rule ID**                         | IL3002                               |
-| **Category**                        | [SingleFile](overview.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                         |
+| **Category**                        | [SingleFile](overview.md)            |
+| **Fix is breaking or nonbreaking**  | Nonbreaking                          |
 
 ## Cause
 
-When publishing an app as a single file (for example, by setting the `PublishSingleFile` property in a project to `true`), calling members annotated with the `RequiresAssemblyFilesAttribute` attribute is not single-file compatible. These calls are not compatible because members annotated with this attribute require assembly files to be on disk, and the assemblies embedded in a single-file app are memory loaded.
+When you publish an app as a single file (for example, by setting the `PublishSingleFile` property to `true` in a project), calling members annotated with the `RequiresAssemblyFilesAttribute` attribute is not single-file compatible. These calls aren't compatible because members annotated with this attribute require assembly files to be on disk, and the assemblies embedded in a single-file app are memory loaded.
 
 Example:
 

--- a/docs/core/deploying/single-file/warnings/il3003.md
+++ b/docs/core/deploying/single-file/warnings/il3003.md
@@ -7,77 +7,77 @@ f1_keywords:
   - "IL3003"
   - "RequiresAssemblyFiles"
 ---
-# IL3003: 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides.
+# IL3003: 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides
 
 |                                     | Value                                |
 |-------------------------------------|--------------------------------------|
 | **Rule ID**                         | IL3003                               |
-| **Category**                        | [SingleFile](overview.md) |
-| **Fix is breaking or non-breaking** | Non-breaking                         |
+| **Category**                        | [SingleFile](overview.md)            |
+| **Fix is breaking or nonbreaking**  | Nonbreaking                          |
 
 ## Cause
 
-When publishing as a single file (for example, by setting the `PublishSingleFile` property in a project to `true`), interface implementations or derived classes with members that don't have matching annotations of `[RequiresAssemblyFiles]` can lead to calling a member with the attribute, which is not single-file compatible. There are four possible scenarios where the warning can be generated:
+When you publish an app as a single file (for example, by setting the `PublishSingleFile` property to `true` in a project), interface implementations or derived classes with members that don't have matching annotations of `[RequiresAssemblyFiles]` can lead to calling a member with the attribute, which is not single-file compatible. There are four possible scenarios where the warning can be generated:
 
-A member of a base class has the attribute but the overriding member of the derived class does not have the attribute:
+- A member of a base class has the attribute but the overriding member of the derived class doesn't have the attribute:
 
-```csharp
-public class Base
-{
-    [RequiresAssemblyFiles]
-    public virtual void TestMethod() {}
-}
-public class Derived : Base
-{
-    // IL3003: Base member 'Base.TestMethod' with 'RequiresAssemblyFilesAttribute' has a derived member 'Derived.TestMethod()' without 'RequiresAssemblyFilesAttribute'. For all interfaces and overrides the implementation attribute must match the definition attribute.
-    public override void TestMethod() {}
-}
-```
+  ```csharp
+  public class Base
+  {
+      [RequiresAssemblyFiles]
+      public virtual void TestMethod() {}
+  }
+  public class Derived : Base
+  {
+      // IL3003: Base member 'Base.TestMethod' with 'RequiresAssemblyFilesAttribute' has a derived member 'Derived.TestMethod()' without 'RequiresAssemblyFilesAttribute'. For all interfaces and overrides the implementation attribute must match the definition attribute.
+      public override void TestMethod() {}
+  }
+  ```
 
-A member of a base class does not have the attribute but the overriding member of the derived class does have the attribute:
+- A member of a base class doesn't have the attribute but the overriding member of the derived class does have the attribute:
 
-```csharp
-public class Base
-{
-    public virtual void TestMethod() {}
-}
-public class Derived : Base
-{
-    // IL3003: Member 'Derived.TestMethod()' with 'RequiresAssemblyFilesAttribute' overrides base member 'Base.TestMethod()' without 'RequiresAssemblyFilesAttribute'. For all interfaces and overrides the implementation attribute must match the definition attribute.
-    [RequiresAssemblyFiles]
-    public override void TestMethod() {}
-}
-```
+  ```csharp
+  public class Base
+  {
+      public virtual void TestMethod() {}
+  }
+  public class Derived : Base
+  {
+      // IL3003: Member 'Derived.TestMethod()' with 'RequiresAssemblyFilesAttribute' overrides base member 'Base.TestMethod()' without 'RequiresAssemblyFilesAttribute'. For all interfaces and overrides the implementation attribute must match the definition attribute.
+      [RequiresAssemblyFiles]
+      public override void TestMethod() {}
+  }
+  ```
 
-An interface member has the attribute but its implementation does not have the attribute:
+- An interface member has the attribute but its implementation doesn't have the attribute:
 
-```csharp
-interface IRAF
-{
-    [RequiresAssemblyFiles]
-    void TestMethod();
-}
-class Implementation : IRAF
-{
-    // IL3003: Interface member 'IRAF.TestMethod()' with 'RequiresAssemblyFilesAttribute' has an implementation member 'Implementation.TestMethod()' without 'RequiresAssemblyFilesAttribute'. For all interfaces and overrides the implementation attribute must match the definition attribute.
-    public void TestMethod () { }
-}
-```
+  ```csharp
+  interface IRAF
+  {
+      [RequiresAssemblyFiles]
+      void TestMethod();
+  }
+  class Implementation : IRAF
+  {
+      // IL3003: Interface member 'IRAF.TestMethod()' with 'RequiresAssemblyFilesAttribute' has an implementation member 'Implementation.TestMethod()' without 'RequiresAssemblyFilesAttribute'. For all interfaces and overrides the implementation attribute must match the definition attribute.
+      public void TestMethod () { }
+  }
+  ```
 
-An interface member does not have the attribute but its implementation does have the attribute:
+- An interface member doesn't have the attribute but its implementation does have the attribute:
 
-```csharp
-interface INoRAF
-{
-    void TestMethod();
-}
-class Implementation : INoRAF
-{
-    [RequiresAssemblyFiles]
-    // IL3003: Member 'Implementation.TestMethod()' with 'RequiresAssemblyFilesAttribute' implements interface member 'INoRAF.TestMethod()' without 'RequiresAssemblyFilesAttribute'. For all interfaces and overrides the implementation attribute must match the definition attribute.
-    public void TestMethod () { }
-}
-```
+  ```csharp
+  interface INoRAF
+  {
+      void TestMethod();
+  }
+  class Implementation : INoRAF
+  {
+      [RequiresAssemblyFiles]
+      // IL3003: Member 'Implementation.TestMethod()' with 'RequiresAssemblyFilesAttribute' implements interface member 'INoRAF.TestMethod()' without 'RequiresAssemblyFilesAttribute'. For all interfaces and overrides the implementation attribute must match the definition attribute.
+      public void TestMethod () { }
+  }
+  ```
 
 ## How to fix violations
 
@@ -85,4 +85,4 @@ For all interfaces and overrides, the implementation must match the definition i
 
 ## When to suppress warnings
 
-This warning should not be suppressed.
+You should not suppress this warning.

--- a/docs/core/deploying/trimming/incompatibilities.md
+++ b/docs/core/deploying/trimming/incompatibilities.md
@@ -7,13 +7,13 @@ ms.date: 10/08/2021
 ---
 # Known trimming incompatibilities
 
-There are some patterns that are known to be incompatible with trimming. Some of these patterns may become compatible as tooling improves or as libraries make modifications to become trimming compatible.
+There are some patterns that are known to be incompatible with trimming. Some of these patterns might become compatible as tooling improves or as libraries make modifications to become trimming compatible.
 
 ## Built-in COM marshalling
 
 Alternative: [COM Wrappers](../../../standard/native-interop/com-wrappers.md)
 
-Automatic [COM marshalling](../../../standard/native-interop/cominterop.md) has been built in to .NET since .NET Framework 1.0. It uses run-time code analysis to automatically convert between native COM objects and managed .NET objects. Unfortunately, trimming analysis cannot always predict what .NET code will need to be preserved for automatic COM marshalling. However, if [COM Wrappers](../../../standard/native-interop/com-wrappers.md) are used instead, trimming analysis can guarantee that all used code will be correctly preserved.
+Automatic [COM marshalling](../../../standard/native-interop/cominterop.md) has been built in to .NET since .NET Framework 1.0. It uses run-time code analysis to automatically convert between native COM objects and managed .NET objects. Unfortunately, trimming analysis can't always predict what .NET code needs to be preserved for automatic COM marshalling. However, if [COM Wrappers](../../../standard/native-interop/com-wrappers.md) are used instead, trimming analysis can guarantee that all used code will be correctly preserved.
 
 ## WPF
 
@@ -27,7 +27,7 @@ The Windows Forms framework makes minimal use of reflection, but is heavily reli
 
 Alternative: Reflection-free serializers.
 
-Many uses of reflection can be made trimming-compatible, as described in [Introduction to trim warnings](fixing-warnings.md). However, serializers tend to have very complex uses of reflection. Many of these uses cannot be made analyzable at build time. Unfortunately, the best option is often to rewrite the system to use source generation instead.
+Many uses of reflection can be made trimming-compatible, as described in [Introduction to trim warnings](fixing-warnings.md). However, serializers tend to have complex uses of reflection. Many of these uses can't be made analyzable at build time. Unfortunately, the best option is often to rewrite the system to use source generation instead.
 
 Popular reflection-based serializers and their recommended alternatives:
 
@@ -37,4 +37,4 @@ Popular reflection-based serializers and their recommended alternatives:
 
 ## Dynamic assembly loading and execution
 
-Trimming and dynamic assembly loading is a common problem for systems that support plugins or extensions, usually through APIs like <xref:System.Reflection.Assembly.LoadFrom(System.String)>. Trimming relies on seeing all assemblies at build time, so it knows which code is used and cannot be trimmed away. Most plugin systems load third-party code dynamically, so it's not possible for the trimmer to identify what code is needed.
+Trimming and dynamic assembly loading is a common problem for systems that support plugins or extensions, usually through APIs like <xref:System.Reflection.Assembly.LoadFrom(System.String)>. Trimming relies on seeing all assemblies at build time, so it knows which code is used and can't be trimmed away. Most plugin systems load third-party code dynamically, so it's not possible for the trimmer to identify what code is needed.

--- a/docs/core/diagnostics/observability-with-otel.md
+++ b/docs/core/diagnostics/observability-with-otel.md
@@ -7,7 +7,7 @@ ms.topic: conceptual
 
 # .NET observability with OpenTelemetry
 
-When you run an application, you want to know how well the app is performing and to detect potential problems before they become larger. Commonly developers accomplish this by making the app emit telemetry data such as logs or metrics, then monitor and analyze that data.
+When you run an application, you want to know how well the app is performing and to detect potential problems before they become larger. You can do this by emitting telemetry data such as logs or metrics from your app, then monitoring and analyzing that data.
 
 ## What is observability
 
@@ -19,7 +19,7 @@ Observability is commonly done using a combination of:
 - Metrics, which are measuring counters and gauges such as number of completed requests, active requests, widgets that have been sold; or a histogram of the request latency.
 - Distributed tracing, which tracks requests and activities across components in a distributed system so that you can see where time is spent and track down specific failures.
 
-Together, logs, metrics, and distributed tracing are known as the *3 pillars of observability*.
+Together, logs, metrics, and distributed tracing are known as the *three pillars of observability*.
 
 Each pillar might include telemetry data from:
 

--- a/docs/core/extensions/httpclient-sni.md
+++ b/docs/core/extensions/httpclient-sni.md
@@ -8,7 +8,7 @@ ms.date: 9/5/2023
 
 # Customize SNI in HTTP requests
 
-When it negotiates an HTTPS connection, a TLS connection needs to be established first. As part of the TLS handshake, the client sends the domain name of the server it's connecting to in one of the TLS extensions. When multiple (virtual) servers are hosted on the same machine, this feature of the TLS protocol allows clients to distinguish which of these servers they're connecting to and to configure TLS settings, such as the server certificate, accordingly.
+When a client and server negotiate an HTTPS connection, a TLS connection needs to be established first. As part of the TLS handshake, the client sends the domain name of the server it's connecting to in one of the TLS extensions. When multiple (virtual) servers are hosted on the same machine, this feature of the TLS protocol allows clients to distinguish which of these servers they're connecting to and to configure TLS settings, such as the server certificate, accordingly.
 
 When an HTTP request using `HttpClient` is made, the implementation automatically selects a value for the server name indication (SNI) extension based on the URL the client is connecting to. For scenarios that require more manual control of the extension, you can use one of the following approaches.
 

--- a/docs/core/extensions/httpclient-sni.md
+++ b/docs/core/extensions/httpclient-sni.md
@@ -8,9 +8,9 @@ ms.date: 9/5/2023
 
 # Customize SNI in HTTP requests
 
-When negotiating an HTTPS connection, a TLS connection needs to be established first. As part of the TLS handshake, the client sends the domain name of the server it's connecting to in one of the TLS extensions. When hosting multiple (virtual) servers on the same machine, this feature of the TLS protocol allows clients to distinguish which of these servers they're connecting to and to configure TLS settings, such as the server certificate, accordingly.
+When it negotiates an HTTPS connection, a TLS connection needs to be established first. As part of the TLS handshake, the client sends the domain name of the server it's connecting to in one of the TLS extensions. When multiple (virtual) servers are hosted on the same machine, this feature of the TLS protocol allows clients to distinguish which of these servers they're connecting to and to configure TLS settings, such as the server certificate, accordingly.
 
-When making an HTTP request using `HttpClient`, the implementation automatically selects a value for the server name indication (SNI) extension based on the URL the client is connecting to. For scenarios that require more manual control of the extension, you can use one of the following approaches.
+When an HTTP request using `HttpClient` is made, the implementation automatically selects a value for the server name indication (SNI) extension based on the URL the client is connecting to. For scenarios that require more manual control of the extension, you can use one of the following approaches.
 
 ## Host header
 
@@ -34,7 +34,7 @@ System.Console.WriteLine(response);
 
 ## Manual SslStream authentication via ConnectCallback
 
-A more complicated, but also more powerful, option is to use the `SocketsHttpHandler.ConnectCallback`. Since .NET 7, it is possible to return an authenticated `SslStream` and thus customize how the TLS connection is established. Inside the callback, arbitrary `SslClientAuthenticationOptions` options can be used to perform client-side authentication.
+A more complicated, but also more powerful, option is to use the `SocketsHttpHandler.ConnectCallback`. Since .NET 7, it's possible to return an authenticated `SslStream` and thus customize how the TLS connection is established. Inside the callback, arbitrary `SslClientAuthenticationOptions` options can be used to perform client-side authentication.
 
 ```csharp
 var handler = new SocketsHttpHandler

--- a/docs/core/install/macos.md
+++ b/docs/core/install/macos.md
@@ -14,7 +14,7 @@ ms.date: 12/21/2022
 > - [Install on macOS](macos.md)
 > - [Install on Linux](linux.md)
 
-In this article, you'll learn how to install .NET on macOS. .NET is made up of the runtime and the SDK. The runtime is used to run a .NET app and may or may not be included with the app. The SDK is used to create .NET apps and libraries. The .NET runtime is always installed with the SDK.
+In this article, you learn how to install .NET on macOS. .NET is made up of the runtime and the SDK. The runtime is used to run a .NET app and might or might not be included with the app. The SDK is used to create .NET apps and libraries. The .NET runtime is always installed with the SDK.
 
 The latest version of .NET is 7.
 
@@ -23,7 +23,7 @@ The latest version of .NET is 7.
 
 ## Supported releases
 
-There are two types of supported releases, Long Term Support (LTS) releases or Standard Term Support (STS). The quality of all releases is the same. The only difference is the length of support. LTS releases get free support and patches for 3 years. STS releases get free support and patches for 18 months. For more information, see [.NET Support Policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-core).
+There are two types of supported releases, Long Term Support (LTS) releases or Standard Term Support (STS). The quality of all releases is the same. The only difference is the length of support. LTS releases get free support and patches for three years. STS releases get free support and patches for 18 months. For more information, see [.NET Support Policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-core).
 
 The following table is a list of currently supported .NET releases and the versions of macOS they're supported on:
 
@@ -92,7 +92,7 @@ macOS has standalone installers that can be used to install .NET 7:
 
 As an alternative to the macOS installers for .NET, you can download and manually install the SDK and runtime. Manual installation is usually performed as part of continuous integration testing. For a developer or user, it's generally better to use an [installer](https://dotnet.microsoft.com/download/dotnet).
 
-First, download a **binary** release for either the SDK or the runtime from one of the following sites. If you install the .NET SDK, you will not need to install the corresponding runtime:
+First, download a **binary** release for either the SDK or the runtime from one of the following sites. If you install the .NET SDK, you won't need to install the corresponding runtime:
 
 - ✔️ [.NET 7 downloads](https://dotnet.microsoft.com/download/dotnet/7.0)
 - ✔️ [.NET 6 downloads](https://dotnet.microsoft.com/download/dotnet/6.0)
@@ -101,7 +101,7 @@ First, download a **binary** release for either the SDK or the runtime from one 
 
 Next, extract the downloaded file and use the `export` command to set `DOTNET_ROOT` to the extracted folder's location and then ensure .NET is in PATH. This should make the .NET CLI commands available at the terminal. For more information about .NET environment variables, see [.NET SDK and CLI environment variables](../tools/dotnet-environment-variables.md#net-sdk-and-cli-environment-variables).
 
-Alternatively, after downloading the .NET binary, the following commands may be run from the directory where the file is saved to extract the runtime. This will also make the .NET CLI commands available at the terminal and set the required environment variables. **Remember to change the `DOTNET_FILE` value to the name of the downloaded binary**:
+Alternatively, after downloading the .NET binary, the following commands can be run from the directory where the file is saved to extract the runtime. These commands also make the .NET CLI commands available at the terminal and set the required environment variables. **Remember to change the `DOTNET_FILE` value to the name of the downloaded binary**:
 
 ```bash
 DOTNET_FILE=dotnet-sdk-7.0.100-osx-x64.tar.gz
@@ -158,11 +158,11 @@ On an Arm-based Mac, all Arm64 versions of .NET are installed to the normal _/us
 
 ### Path conflicts
 
-Starting with .NET 6, the **x64** .NET SDK installs to its own directory, as described in the previous section. This allows the Arm64 and x64 versions of the .NET SDK to exist on the same machine. However, any **x64** SDK prior to .NET 6 isn't supported and installs to the same location as the Arm64 version, the _/usr/local/share/dotnet/_ folder. If you want to install an unsupported x64 SDK, you'll need to first uninstall the Arm64 version. The opposite is also true, you'll need to uninstall the unsupported x64 SDK to install the Arm64 version.
+Starting with .NET 6, the **x64** .NET SDK installs to its own directory, as described in the previous section. This allows the Arm64 and x64 versions of the .NET SDK to exist on the same machine. However, any **x64** SDK prior to .NET 6 isn't supported and installs to the same location as the Arm64 version, the _/usr/local/share/dotnet/_ folder. If you want to install an unsupported x64 SDK, you need to first uninstall the Arm64 version. The opposite is also true, you need to uninstall the unsupported x64 SDK to install the Arm64 version.
 
 ### Path variables
 
-Environment variables that add .NET to system path, such as the `PATH` variable, may need to be changed if you have both the x64 and Arm64 versions of the .NET 6 SDK installed. Additionally, some tools rely on the `DOTNET_ROOT` environment variable, which would also need to be updated to point to the appropriate .NET 6 SDK installation folder.
+Environment variables that add .NET to system path, such as the `PATH` variable, might need to be changed if you have both the x64 and Arm64 versions of the .NET 6 SDK installed. Additionally, some tools rely on the `DOTNET_ROOT` environment variable, which would also need to be updated to point to the appropriate .NET 6 SDK installation folder.
 
 ## Install with Visual Studio for Mac
 

--- a/docs/core/tools/sdk-errors/index.md
+++ b/docs/core/tools/sdk-errors/index.md
@@ -169,7 +169,7 @@ f1_keywords:
 
 **This article applies to:** ✔️ .NET 6 SDK and later versions
 
-This is a complete list of the errors that you might get from the .NET SDK while developing .NET apps. If more info is available for a particular error, the error number is a link.
+This list is a complete list of the errors that you might get from the .NET SDK while developing .NET apps. If more info is available for a particular error, the error number is a link.
 
 | SDK Message Number | Message            |
 |--------------------|--------------------|

--- a/docs/fsharp/language-reference/functions/external-functions.md
+++ b/docs/fsharp/language-reference/functions/external-functions.md
@@ -5,7 +5,7 @@ ms.date: 05/16/2016
 ---
 # External Functions
 
-This topic describes F# language support for calling functions in native code.
+This article describes F# language support for calling functions in native code.
 
 ## Syntax
 
@@ -16,7 +16,7 @@ extern declaration
 
 ## Remarks
 
-In the previous syntax, *arguments* represents arguments that are supplied to the `System.Runtime.InteropServices.DllImportAttribute` attribute. The first argument is a string that represents the name of the DLL that contains this function, without the .dll extension. Additional arguments can be supplied for any of the public properties of the `System.Runtime.InteropServices.DllImportAttribute` class, such as the calling convention.
+In the previous syntax, `arguments` represents arguments that are supplied to the `System.Runtime.InteropServices.DllImportAttribute` attribute. The first argument is a string that represents the name of the DLL that contains this function, without the .dll extension. Additional arguments can be supplied for any of the public properties of the `System.Runtime.InteropServices.DllImportAttribute` class, such as the calling convention.
 
 Assume you have a native C++ DLL that contains the following exported function.
 
@@ -44,20 +44,20 @@ Interoperability with native code is referred to as *platform invoke* and is a f
 
 ### Defining Parameters in External Functions
 
-When declaring external functions with return values or parameters you use a syntax similar to C. You have the option to use the managed (where the CLR will perform some automatic conversions between native and .NET types) and unmanaged declarations which may offer better performance in some circumstances. Take the example of the Windows function [GetBinaryTypeW](/windows/win32/api/winbase/nf-winbase-getbinarytypew). It can be declared in two different ways:
+When you declare external functions with return values or parameters, you use a syntax similar to C. You have the option to use the managed declarations (where the CLR will perform some automatic conversions between native and .NET types) and unmanaged declarations, which might offer better performance in some circumstances. For example, the Windows function [GetBinaryTypeW](/windows/win32/api/winbase/nf-winbase-getbinarytypew) can be declared in two different ways:
 
 ```fs
 // Using automatic marshaling of managed types
-[<DllImport("kernel32.dll", 
-    CallingConvention = CallingConvention.StdCall, 
-    CharSet = CharSet.Unicode, 
+[<DllImport("kernel32.dll",
+    CallingConvention = CallingConvention.StdCall,
+    CharSet = CharSet.Unicode,
     ExactSpelling = true)>]
 extern bool GetBinaryTypeW([<MarshalAs(UnmanagedType.LPWStr)>] string lpApplicationName, uint& lpBinaryType);
 ```
 
-`MarshalAs(UnmanagedType.LPWStr)` instructs the CLR to perform an automatic conversion between a .NET `string` and Windows native string representation when the function is called. `uint&` declares a `uint` that will be passed `byref` i.e. as a managed pointer. To obtain a managed pointer you use the address of `&` operator.
+`MarshalAs(UnmanagedType.LPWStr)` instructs the CLR to perform an automatic conversion between a .NET `string` and Windows native string representation when the function is called. `uint&` declares a `uint` that will be passed `byref`, that is, as a managed pointer. To obtain a managed pointer, you use the address of `&` operator.
 
-Alternately, you may wish to manage the marshalling of data types manually and declare the external functions using only [unmanaged types](../../../csharp/language-reference/builtin-types/unmanaged-types.md).
+Alternately, you might want to manage the marshalling of data types manually and declare the external functions using only [unmanaged types](../../../csharp/language-reference/builtin-types/unmanaged-types.md).
 
 ```fs
 // Using unmanaged types
@@ -67,7 +67,7 @@ extern int GetBinaryTypeW(nativeint lpApplicationName, uint* lpBinaryType);
 
 You could use<xref:System.Runtime.InteropServices.Marshal.StringToHGlobalUni%2A?displayProperty=nameWithType> to convert a .NET string to native format and receive a pointer (`nativeint`) to it that could be supplied to `lpApplicationName`.
 
-To obtain a pointer to an integer you would use the pointer of `&&` operator or the [`fixed`](../fixed.md) keyword.
+To obtain a pointer to an integer, use the pointer of `&&` operator or the [`fixed`](../fixed.md) keyword.
 
 ## See also
 

--- a/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md
+++ b/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md
@@ -2,7 +2,7 @@
 
 #### Details
 
-When using TLS 1.x, the .NET Framework relies on the underlying Windows SCHANNEL API. Starting with .NET Framework 4.6, the [SCH_SEND_AUX_RECORD](/windows/win32/api/schannel/ns-schannel-schannel_cred) flag is passed by default to SCHANNEL. This causes SCHANNEL to split data to be encrypted into two separate records, the first as a single byte and the second as *n*-1 bytes.In rare cases, this breaks communication between clients and existing servers that make the assumption that the data resides in a single record.
+When using TLS 1.x, the .NET Framework relies on the underlying Windows SCHANNEL API. Starting with .NET Framework 4.6, the [SCH_SEND_AUX_RECORD](/windows/win32/api/schannel/ns-schannel-schannel_cred) flag is passed by default to SCHANNEL. This causes SCHANNEL to split data to be encrypted into two separate records, the first as a single byte and the second as *n*-1 bytes. In rare cases, this breaks communication between clients and existing servers that make the assumption that the data resides in a single record.
 
 #### Suggestion
 


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

<details><summary><strong>Toggle expand/collapse</strong></summary><br/>

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/architecture/serverless/serverless-business-scenarios.md](https://github.com/dotnet/docs/blob/81d34b57cbf65bb7accbc080efca43aafec6d4dc/docs/architecture/serverless/serverless-business-scenarios.md) | [Serverless business scenarios and use cases](https://review.learn.microsoft.com/en-us/dotnet/architecture/serverless/serverless-business-scenarios?branch=pr-en-us-37497) |
| [docs/azure/configure-visual-studio.md](https://github.com/dotnet/docs/blob/81d34b57cbf65bb7accbc080efca43aafec6d4dc/docs/azure/configure-visual-studio.md) | [Configure Visual Studio for Azure Development with .NET](https://review.learn.microsoft.com/en-us/dotnet/azure/configure-visual-studio?branch=pr-en-us-37497) |
| [docs/azure/sdk/unit-testing-mocking.md](https://github.com/dotnet/docs/blob/81d34b57cbf65bb7accbc080efca43aafec6d4dc/docs/azure/sdk/unit-testing-mocking.md) | [Unit testing and mocking with the Azure SDK for .NET](https://review.learn.microsoft.com/en-us/dotnet/azure/sdk/unit-testing-mocking?branch=pr-en-us-37497) |
| [docs/core/compatibility/sdk/8.0/custombuildeventargs.md](https://github.com/dotnet/docs/blob/81d34b57cbf65bb7accbc080efca43aafec6d4dc/docs/core/compatibility/sdk/8.0/custombuildeventargs.md) | [docs/core/compatibility/sdk/8.0/custombuildeventargs](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/custombuildeventargs?branch=pr-en-us-37497) |
| [docs/core/deploying/native-aot/diagnostics.md](https://github.com/dotnet/docs/blob/81d34b57cbf65bb7accbc080efca43aafec6d4dc/docs/core/deploying/native-aot/diagnostics.md) | [Diagnostics and instrumentation](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/diagnostics?branch=pr-en-us-37497) |
| [docs/core/deploying/native-aot/warnings/il3050.md](https://github.com/dotnet/docs/blob/81d34b57cbf65bb7accbc080efca43aafec6d4dc/docs/core/deploying/native-aot/warnings/il3050.md) | [IL3050: Avoid calling members annotated with 'RequiresDynamicCodeAttribute' when publishing as Native AOT](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/warnings/il3050?branch=pr-en-us-37497) |
| [docs/core/deploying/native-aot/warnings/il3055.md](https://github.com/dotnet/docs/blob/81d34b57cbf65bb7accbc080efca43aafec6d4dc/docs/core/deploying/native-aot/warnings/il3055.md) | ["IL3055: P/Invoke method declares a parameter with an abstract delegate"](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/warnings/il3055?branch=pr-en-us-37497) |
| [docs/core/deploying/single-file/warnings/il3000.md](https://github.com/dotnet/docs/blob/81d34b57cbf65bb7accbc080efca43aafec6d4dc/docs/core/deploying/single-file/warnings/il3000.md) | [IL3000: Avoid accessing Assembly file path when publishing as a single file](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/single-file/warnings/il3000?branch=pr-en-us-37497) |
| [docs/core/deploying/single-file/warnings/il3001.md](https://github.com/dotnet/docs/blob/81d34b57cbf65bb7accbc080efca43aafec6d4dc/docs/core/deploying/single-file/warnings/il3001.md) | [docs/core/deploying/single-file/warnings/il3001](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/single-file/warnings/il3001?branch=pr-en-us-37497) |
| [docs/core/deploying/single-file/warnings/il3002.md](https://github.com/dotnet/docs/blob/81d34b57cbf65bb7accbc080efca43aafec6d4dc/docs/core/deploying/single-file/warnings/il3002.md) | [IL3002: Avoid calling members annotated with 'RequiresAssemblyFilesAttribute' when publishing as a single file.](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/single-file/warnings/il3002?branch=pr-en-us-37497) |
| [docs/core/deploying/single-file/warnings/il3003.md](https://github.com/dotnet/docs/blob/81d34b57cbf65bb7accbc080efca43aafec6d4dc/docs/core/deploying/single-file/warnings/il3003.md) | ["IL3003: 'RequiresAssemblyFilesAttribute' annotations must match across all interface implementations or overrides."](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/single-file/warnings/il3003?branch=pr-en-us-37497) |
| [docs/core/deploying/trimming/incompatibilities.md](https://github.com/dotnet/docs/blob/81d34b57cbf65bb7accbc080efca43aafec6d4dc/docs/core/deploying/trimming/incompatibilities.md) | [Known trimming incompatibilities](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/incompatibilities?branch=pr-en-us-37497) |
| [docs/core/diagnostics/observability-with-otel.md](https://github.com/dotnet/docs/blob/81d34b57cbf65bb7accbc080efca43aafec6d4dc/docs/core/diagnostics/observability-with-otel.md) | [TYPE greetings_count counter](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/observability-with-otel?branch=pr-en-us-37497) |
| [docs/core/extensions/httpclient-sni.md](https://github.com/dotnet/docs/blob/81d34b57cbf65bb7accbc080efca43aafec6d4dc/docs/core/extensions/httpclient-sni.md) | [docs/core/extensions/httpclient-sni](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/httpclient-sni?branch=pr-en-us-37497) |
| [docs/core/install/macos.md](https://github.com/dotnet/docs/blob/81d34b57cbf65bb7accbc080efca43aafec6d4dc/docs/core/install/macos.md) | [Install .NET on macOS](https://review.learn.microsoft.com/en-us/dotnet/core/install/macos?branch=pr-en-us-37497) |
| [docs/core/tools/sdk-errors/index.md](https://github.com/dotnet/docs/blob/81d34b57cbf65bb7accbc080efca43aafec6d4dc/docs/core/tools/sdk-errors/index.md) | [.NET SDK error list](https://review.learn.microsoft.com/en-us/dotnet/core/tools/sdk-errors/index?branch=pr-en-us-37497) |
| [docs/fsharp/language-reference/functions/external-functions.md](https://github.com/dotnet/docs/blob/81d34b57cbf65bb7accbc080efca43aafec6d4dc/docs/fsharp/language-reference/functions/external-functions.md) | [External Functions](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/functions/external-functions?branch=pr-en-us-37497) |

</details>


<!-- PREVIEW-TABLE-END -->