### PR TITLE
Improvements to trim warnings description and fixes

### DIFF
--- a/docs/core/deploying/trimming/fixing-warnings.md
+++ b/docs/core/deploying/trimming/fixing-warnings.md
@@ -97,7 +97,7 @@ This produces a warning:
 IL2026: Using member 'MethodWithAssemblyLoad()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. This functionality is not compatible with trimming. Use 'MethodFriendlyToTrimming' instead. https://site/trimming-and-method
 ```
 
-Using `RequiresUnreferencedCode` often leads to marking more methods with it, due to the same reason. This is common when a high-level method becomes incompatible with trimming when it calls a low-level method that isn't trim-compatible. You "bubble up" the warning to a public API. Each usage of `RequiresUnreferencedCode` needs a message, and in these cases the messages are likely the same. To avoid duplicating strings and making it easier to maintain, use a constant string field to store the message:
+Using `RequiresUnreferencedCode` often leads to marking more methods with it, due to the same reason. This is common when a high-level method becomes incompatible with trimming because it calls a low-level method that isn't trim-compatible. You "bubble up" the warning to a public API. Each usage of `RequiresUnreferencedCode` needs a message, and in these cases the messages are likely the same. To avoid duplicating strings and making it easier to maintain, use a constant string field to store the message:
 
 ```csharp
 class Functionality

--- a/docs/core/deploying/trimming/fixing-warnings.md
+++ b/docs/core/deploying/trimming/fixing-warnings.md
@@ -241,12 +241,12 @@ void TestMethod()
 }
 ```
 
-> !WARNING
+> [!WARNING]
 > Be very careful when suppressing trim warnings. It's possible that the call may be trim-compatible now, but as you change your code that may change, and you may forget to review all the suppressions.
 
 `UnconditionalSuppressMessage` is like `SuppressMessage` but it can be seen by `publish` and other post-build tools.
 
-> !IMPORTANT
+> [!IMPORTANT]
 > Do not use `SuppressMessage` or `#pragma warning disable` to suppress trimmer warnings. These only work for the compiler, but are not preserved in the compiled assembly. Trimmer operates on compiled assemblies and would not see the suppression.
 
 The suppression applies to the entire method body. So in our sample above it will suppress all warnings `IL2026` from anywhere in the method. This makes it somewhat harder to understand, as it's not clear which method is the problematic one, unless you add a comment. More importantly if the code changes in the future and for example the `ReportResults` becomes trim-incompatible as well, there will ne no warning reported for this call, as it's going to be suppressed by the existing attribute.

--- a/docs/core/deploying/trimming/fixing-warnings.md
+++ b/docs/core/deploying/trimming/fixing-warnings.md
@@ -39,7 +39,7 @@ Trim warnings are meant to bring predictability to trimming. There are two large
 
 ### Functionality incompatible with trimming
 
-These are typically methods which either don't work at all, or may be broken in some cases if they're used in a trimmed application. Good example is the `Type.GetType` method from previous example. In a trimmed app it may work, but there's no guarantee. Such APIs are marked with <xref:System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute>.
+These are typically methods which either don't work at all, or may be broken in some cases if they're used in a trimmed application. A good example is the `Type.GetType` method from the previous example. In a trimmed app it may work, but there's no guarantee. Such APIs are marked with <xref:System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute>.
 
 <xref:System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute> is simple and broad: it's an attribute that means the member has been annotated incompatible with trimming. This attribute is used when code is fundamentally not trim compatible, or the trim dependency is too complex to explain to the trimmer. This would often be true for methods that dynamically load code for example via <xref:System.Reflection.Assembly.LoadFrom(System.String)>, enumerate or search through all types in an application or assembly for example via <xref:System.Type.GetType>, use the C# [`dynamic`](../../../csharp/language-reference/builtin-types/reference-types.md#the-dynamic-type) keyword, or use other runtime code generation technologies. An example would be:
 
@@ -80,7 +80,7 @@ IL2026: Using member 'MethodWithAssemblyLoad()' which has 'RequiresUnreferencedC
 
 Developers calling such APIs are generally not going to be interested in the particulars of the affected API or specifics as it relates to trimming.
 
-Good message should state what functionality is not compatible with trimming and then guide the developer what are their potential next steps. It may suggest to use a different functionality or change how the functionality is used. It may also simply state that the functionality is not yet compatible with trimming without a clear replacement.
+A good message should state what functionality is not compatible with trimming and then guide the developer what are their potential next steps. It may suggest to use a different functionality or change how the functionality is used. It may also simply state that the functionality is not yet compatible with trimming without a clear replacement.
 
 If the guidance to the developer becomes too long to be included in a warning message, you can add an optional `Url` to the <xref:System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute> to point the developer to a web page describing the problem and possible solutions in greater detail.
 
@@ -120,7 +120,7 @@ class Functionality
 
 ### Functionality with requirements on its input
 
-Trimming provides tools to specify additional requirements on input to methods and other members which lead to trim compatible code. These requirements are usually about reflection and ability to access certain members or operations on a type. Such requirements are specified using the <xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute>.
+Trimming provides tools to specify additional requirements on input to methods and other members which lead to trim compatible code. These requirements are usually about reflection and the ability to access certain members or operations on a type. Such requirements are specified using the <xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute>.
 
 Unlike `RequiresUnreferencedCode`, reflection can sometimes be understood by the trimmer as long as it's annotated correctly. Let's take another look at the original example:
 
@@ -217,7 +217,7 @@ void Method3(
 
 Now there are no warnings because the trimmer knows which members may be accessed via runtime reflection (public methods) and on which types (`System.DateTime`), and it will preserve them. In general, this is the best way to deal with reflection related warnings: if possible, add annotations so the trimmer knows what to preserve.
 
-Warnings produces by these additional requirements are automatically suppressed if the affected code is in a method with `RequiresUnreferencedCode`.
+Warnings produced by these additional requirements are automatically suppressed if the affected code is in a method with `RequiresUnreferencedCode`.
 
 Unlike `RequiresUnreferencedCode` which simply reports the incompatibility, adding `DynamicallyAccessedMembers` makes the code compatible with trimming.
 
@@ -251,7 +251,7 @@ void TestMethod()
 
 The suppression applies to the entire method body. So in our sample above it will suppress all warnings `IL2026` from anywhere in the method. This makes it somewhat harder to understand, as it's not clear which method is the problematic one, unless you add a comment. More importantly if the code changes in the future and for example the `ReportResults` becomes trim-incompatible as well, there will ne no warning reported for this call, as it's going to be suppressed by the existing attribute.
 
-You can be resolve this by refactoring the problematic call into a separate method or local function and then apply the suppression to just that method:
+You can resolve this by refactoring the problematic call into a separate method or local function and then applying the suppression to just that method:
 
 ```csharp
 void TestMethod()

--- a/docs/core/deploying/trimming/fixing-warnings.md
+++ b/docs/core/deploying/trimming/fixing-warnings.md
@@ -1,15 +1,15 @@
 ---
 title: Introduction to trim warnings
-description: Learn about why warnings may be produced when publishing a trimmed application, how to address them, and how to make the application "trim compatible."
+description: Learn about why warnings might be produced when publishing a trimmed application, how to address them, and how to make the application "trim compatible."
 author: agocke
 ms.author: angocke
-ms.date: 09/08/2021
+ms.date: 10/30/2023
 ---
 # Introduction to trim warnings
 
-Conceptually, [trimming](trim-self-contained.md) is simple: when publishing the application, the .NET SDK analyzes the entire application and removes all unused code. However, it can be difficult to determine what is unused, or more precisely, what is used.
+Conceptually, [trimming](trim-self-contained.md) is simple: when you publish an application, the .NET SDK analyzes the entire application and removes all unused code. However, it can be difficult to determine what is unused, or more precisely, what is used.
 
-To prevent changes in behavior when trimming applications, the .NET SDK provides static analysis of trim compatibility through "trim warnings". Trim warnings are produced by the trimmer when it finds code that may not be compatible with trimming. Code that's not trim-compatible may produce behavioral changes, or even crashes, in an application after it has been trimmed. Ideally, all applications that use trimming should have no trim warnings. If there are any trim warnings, the app should be thoroughly tested after trimming to ensure that there are no behavior changes.
+To prevent changes in behavior when trimming applications, the .NET SDK provides static analysis of trim compatibility through **trim warnings**. The trimmer produces trim warnings when it finds code that might not be compatible with trimming. Code that's not trim-compatible can produce behavioral changes, or even crashes, in an application after it has been trimmed.  Ideally, all applications that use trimming shouldn't produce any trim warnings. If there are any trim warnings, the app should be thoroughly tested after trimming to ensure that there are no behavior changes.
 
 This article helps you understand why some patterns produce trim warnings, and how these warnings can be addressed.
 
@@ -26,20 +26,20 @@ foreach (var m in type.GetMethods())
 }
 ```
 
-In this example, <xref:System.Type.GetType> dynamically requests a type with an unknown name, and then prints the names of all of its methods. Because there's no way to know at publish time what type name is going to be used, there's no way for the trimmer to know which type to preserve in the output. It's likely that this code could have worked before trimming (as long as the input is something known to exist in the target framework), but would probably produce a null reference exception after trimming (due to `Type.GetType` returning null).
+In this example, <xref:System.Type.GetType> dynamically requests a type with an unknown name, and then prints the names of all of its methods. Because there's no way to know at publish-time what type name is going to be used, there's no way for the trimmer to know which type to preserve in the output. It's likely that this code could have worked before trimming (as long as the input is something known to exist in the target framework), but would probably produce a null reference exception after trimming, as `Type.GetType` returns null when the type isn't found.
 
-In this case, the trimmer issues a warning on the call to `Type.GetType`, indicating that it cannot determine which type is going to be used by the application.
+In this case, the trimmer issues a warning on the call to `Type.GetType`, indicating that it can't determine which type is going to be used by the application.
 
 ## Reacting to trim warnings
 
-Trim warnings are meant to bring predictability to trimming. There are two large categories of warnings that you will likely see:
+Trim warnings are meant to bring predictability to trimming. There are two large categories of warnings that you'll likely see:
 
-1. Functionality is not compatible with trimming
+1. Functionality isn't compatible with trimming
 2. Functionality has certain requirements on the input to be trim compatible
 
 ### Functionality incompatible with trimming
 
-These are typically methods which either don't work at all, or may be broken in some cases if they're used in a trimmed application. A good example is the `Type.GetType` method from the previous example. In a trimmed app it may work, but there's no guarantee. Such APIs are marked with <xref:System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute>.
+These are typically methods that either don't work at all, or might be broken in some cases if they're used in a trimmed application. A good example is the `Type.GetType` method from the previous example. In a trimmed app it might work, but there's no guarantee. Such APIs are marked with <xref:System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute>.
 
 <xref:System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute> is simple and broad: it's an attribute that means the member has been annotated incompatible with trimming. This attribute is used when code is fundamentally not trim compatible, or the trim dependency is too complex to explain to the trimmer. This would often be true for methods that dynamically load code for example via <xref:System.Reflection.Assembly.LoadFrom(System.String)>, enumerate or search through all types in an application or assembly for example via <xref:System.Type.GetType>, use the C# [`dynamic`](../../../csharp/language-reference/builtin-types/reference-types.md#the-dynamic-type) keyword, or use other runtime code generation technologies. An example would be:
 
@@ -64,7 +64,7 @@ There aren't many workarounds for `RequiresUnreferencedCode`. The best fix is to
 
 #### Mark functionality as incompatible with trimming
 
-If you're writing a library and it's not in your control whether or not to use incompatible functionality, you can mark it with `RequiresUnreferencedCode`. This will annotate your method as not trim compatible. Adding `RequiresUnreferencedCode` will silence all trim warnings in the given method, but will produce a warning whenever someone else calls it.
+If you're writing a library and it's not in your control whether or not to use incompatible functionality, you can mark it with `RequiresUnreferencedCode`. This annotates your method as incompatible with trimming. Using `RequiresUnreferencedCode` silences all trim warnings in the given method, but produces a warning whenever someone else calls it.
 
 The <xref:System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute> requires you to specify a `Message`. The message is shown as part of a warning reported to the developer who calls the marked method. For example:
 
@@ -72,7 +72,7 @@ The <xref:System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute> req
 IL2026: Using member <incompatible method> which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. <The message value>
 ```
 
-Using the example above a warning for a specific method may look like this:
+With the example above, a warning for a specific method might look like this:
 
 ```console
 IL2026: Using member 'MethodWithAssemblyLoad()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. This functionality is not compatible with trimming. Use 'MethodFriendlyToTrimming' instead.
@@ -80,7 +80,7 @@ IL2026: Using member 'MethodWithAssemblyLoad()' which has 'RequiresUnreferencedC
 
 Developers calling such APIs are generally not going to be interested in the particulars of the affected API or specifics as it relates to trimming.
 
-A good message should state what functionality is not compatible with trimming and then guide the developer what are their potential next steps. It may suggest to use a different functionality or change how the functionality is used. It may also simply state that the functionality is not yet compatible with trimming without a clear replacement.
+A good message should state what functionality isn't compatible with trimming and then guide the developer what are their potential next steps. It might suggest to use a different functionality or change how the functionality is used. It might also simply state that the functionality isn't yet compatible with trimming without a clear replacement.
 
 If the guidance to the developer becomes too long to be included in a warning message, you can add an optional `Url` to the <xref:System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute> to point the developer to a web page describing the problem and possible solutions in greater detail.
 
@@ -97,7 +97,7 @@ This produces a warning:
 IL2026: Using member 'MethodWithAssemblyLoad()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. This functionality is not compatible with trimming. Use 'MethodFriendlyToTrimming' instead. https://site/trimming-and-method
 ```
 
-Using `RequiresUnreferencedCode` often leads to marking more methods with it due to the same reason. This is common when a low-level method is not trim-compatible, then the higher level method which calls it is also incompatible. You "bubble up" the warning to a public API. Each usage of `RequiresUnreferencedCode` needs a message, and in these cases the messages are likely the same. To avoid duplicating strings and making it easier to maintain, use a constant string field to store the message:
+Using `RequiresUnreferencedCode` often leads to marking more methods with it, due to the same reason. This is common when a high-level method becomes incompatible with trimming when it calls a low-level method that isn't trim-compatible. You "bubble up" the warning to a public API. Each usage of `RequiresUnreferencedCode` needs a message, and in these cases the messages are likely the same. To avoid duplicating strings and making it easier to maintain, use a constant string field to store the message:
 
 ```csharp
 class Functionality
@@ -120,7 +120,7 @@ class Functionality
 
 ### Functionality with requirements on its input
 
-Trimming provides tools to specify additional requirements on input to methods and other members which lead to trim compatible code. These requirements are usually about reflection and the ability to access certain members or operations on a type. Such requirements are specified using the <xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute>.
+Trimming provides APIs to specify more requirements on input to methods and other members that lead to trim-compatible code. These requirements are usually about reflection and the ability to access certain members or operations on a type. Such requirements are specified using the <xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute>.
 
 Unlike `RequiresUnreferencedCode`, reflection can sometimes be understood by the trimmer as long as it's annotated correctly. Let's take another look at the original example:
 
@@ -133,7 +133,7 @@ foreach (var m in type.GetMethods())
 }
 ```
 
-In the example above, the real problem is `Console.ReadLine()`. Because *any* type could be read, the trimmer has no way to know if you need methods on `System.DateTime` or `System.Guid` or any other type. On the other hand, the following code would be fine:
+In the previous example, the real problem is `Console.ReadLine()`. Because *any* type could be read, the trimmer has no way to know if you need methods on `System.DateTime` or `System.Guid` or any other type. On the other hand, the following code would be fine:
 
 ```csharp
 Type type = typeof(System.DateTime);
@@ -143,7 +143,7 @@ foreach (var m in type.GetMethods())
 }
 ```
 
-Here the trimmer can see the exact type being referenced: `System.DateTime`. Now it can use flow analysis to determine that it needs to keep all public methods on `System.DateTime`. So where does `DynamicallyAccessMembers` come in? When reflection is split across multiple methods. In the below code, we can see that the type `System.DateTime` flows to `Method3` where reflection is used to access `System.DateTime`'s methods,
+Here the trimmer can see the exact type being referenced: `System.DateTime`. Now it can use flow analysis to determine that it needs to keep all public methods on `System.DateTime`. So where does `DynamicallyAccessMembers` come in? When reflection is split across multiple methods. In the following code, we can see that the type `System.DateTime` flows to `Method3` where reflection is used to access `System.DateTime`'s methods,
 
 ```csharp
 void Method1()
@@ -162,7 +162,7 @@ void Method3(Type type)
 }
 ```
 
-If you compile the previous code, now you see a warning:
+If you compile the previous code, the following warning is produced:
 
 > IL2070: Program.Method3(Type): 'this' argument does not satisfy
 > 'DynamicallyAccessedMemberTypes.PublicMethods' in call to 'System.Type.GetMethods()'. The
@@ -170,7 +170,7 @@ If you compile the previous code, now you see a warning:
 > source value must declare at least the same requirements as those declared on the target
 > location it is assigned to.
 
-For performance and stability, flow analysis isn't performed between methods, so an annotation is needed to pass information between methods, from the reflection call (`GetMethods`) to the source of the `Type`. In the previous example, the trimmer warning is saying that `GetMethods` requires the `Type` object instance it is called on to have the `PublicMethods` annotation, but the `type` variable doesn't have the same requirement. In other words, we need to pass the requirements from `GetMethods` up to the caller:
+For performance and stability, flow analysis isn't performed between methods, so an annotation is needed to pass information between methods, from the reflection call (`GetMethods`) to the source of the `Type`. In the previous example, the trimmer warning is saying that `GetMethods` requires the `Type` object instance it's called on to have the `PublicMethods` annotation, but the `type` variable doesn't have the same requirement. In other words, we need to pass the requirements from `GetMethods` up to the caller:
 
 ```csharp
 void Method1()
@@ -191,6 +191,7 @@ void Method3(
 ```
 
 After annotating the parameter `type`, the original warning disappears, but another appears:
+
 > IL2087: 'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods'
 > in call to 'Program.Method3(Type)'. The generic parameter 'T' of 'Program.Method2\<T\>()' does not
 > have matching annotations.
@@ -215,11 +216,11 @@ void Method3(
 }
 ```
 
-Now there are no warnings because the trimmer knows which members may be accessed via runtime reflection (public methods) and on which types (`System.DateTime`), and it will preserve them. In general, this is the best way to deal with reflection related warnings: if possible, add annotations so the trimmer knows what to preserve.
+Now there are no warnings because the trimmer knows which members might be accessed via runtime reflection (public methods) and on which types (`System.DateTime`), and it preserves them. It's best practice to add annotations so the trimmer knows what to preserve.
 
-Warnings produced by these additional requirements are automatically suppressed if the affected code is in a method with `RequiresUnreferencedCode`.
+Warnings produced by these extra requirements are automatically suppressed if the affected code is in a method with `RequiresUnreferencedCode`.
 
-Unlike `RequiresUnreferencedCode` which simply reports the incompatibility, adding `DynamicallyAccessedMembers` makes the code compatible with trimming.
+Unlike `RequiresUnreferencedCode`, which simply reports the incompatibility, adding `DynamicallyAccessedMembers` makes the code compatible with trimming.
 
 ### Suppressing trimmer warnings
 
@@ -249,9 +250,9 @@ void TestMethod()
 > [!IMPORTANT]
 > Do not use `SuppressMessage` or `#pragma warning disable` to suppress trimmer warnings. These only work for the compiler, but are not preserved in the compiled assembly. Trimmer operates on compiled assemblies and would not see the suppression.
 
-The suppression applies to the entire method body. So in our sample above it will suppress all warnings `IL2026` from anywhere in the method. This makes it somewhat harder to understand, as it's not clear which method is the problematic one, unless you add a comment. More importantly if the code changes in the future and for example the `ReportResults` becomes trim-incompatible as well, there will ne no warning reported for this call, as it's going to be suppressed by the existing attribute.
+The suppression applies to the entire method body. So in our sample above it suppresses all `IL2026` warnings from the method. This makes it harder to understand, as it's not clear which method is the problematic one, unless you add a comment. More importantly, if the code changes in the future, such as if `ReportResults` becomes trim-incompatible as well, no warning is reported for this method call.
 
-You can resolve this by refactoring the problematic call into a separate method or local function and then applying the suppression to just that method:
+You can resolve this by refactoring the problematic method call into a separate method or local function and then applying the suppression to just that method:
 
 ```csharp
 void TestMethod()

--- a/docs/core/deploying/trimming/trim-warnings/il2067.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2067.md
@@ -29,4 +29,4 @@ void TestMethod(Type type)
 
 ## Fixing
 
-See [Fixing Warnings](../fixing-warnings.md#dynamicallyaccessedmembers) for guidance.
+See [Fixing Warnings](../fixing-warnings.md#functionality-with-requirements-on-its-input) for guidance.

--- a/docs/core/deploying/trimming/trim-warnings/il2068.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2068.md
@@ -25,4 +25,4 @@ Type TestMethod(Type type)
 
 ## Fixing
 
-See [Fixing Warnings](../fixing-warnings.md#dynamicallyaccessedmembers) for guidance.
+See [Fixing Warnings](../fixing-warnings.md#functionality-with-requirements-on-its-input) for guidance.

--- a/docs/core/deploying/trimming/trim-warnings/il2069.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2069.md
@@ -27,4 +27,4 @@ void TestMethod(Type type)
 
 ## Fixing
 
-See [Fixing Warnings](../fixing-warnings.md#dynamicallyaccessedmembers) for guidance.
+See [Fixing Warnings](../fixing-warnings.md#functionality-with-requirements-on-its-input) for guidance.

--- a/docs/core/deploying/trimming/trim-warnings/il2070.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2070.md
@@ -28,4 +28,4 @@ void TestMethod(Type type)
 
 ## Fixing
 
-See [Fixing Warnings](../fixing-warnings.md#dynamicallyaccessedmembers) for guidance.
+See [Fixing Warnings](../fixing-warnings.md#functionality-with-requirements-on-its-input) for guidance.

--- a/docs/core/deploying/trimming/trim-warnings/il2072.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2072.md
@@ -31,4 +31,4 @@ void TestMethod()
 
 ## Fixing
 
-See [Fixing Warnings](../fixing-warnings.md#dynamicallyaccessedmembers) for guidance.
+See [Fixing Warnings](../fixing-warnings.md#functionality-with-requirements-on-its-input) for guidance.

--- a/docs/core/deploying/trimming/trim-warnings/il2073.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2073.md
@@ -27,4 +27,4 @@ Type TestMethod()
 
 ## Fixing
 
-See [Fixing Warnings](../fixing-warnings.md#dynamicallyaccessedmembers) for guidance.
+See [Fixing Warnings](../fixing-warnings.md#functionality-with-requirements-on-its-input) for guidance.

--- a/docs/core/deploying/trimming/trim-warnings/il2074.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2074.md
@@ -29,4 +29,4 @@ void TestMethod()
 
 ## Fixing
 
-See [Fixing Warnings](../fixing-warnings.md#dynamicallyaccessedmembers) for guidance.
+See [Fixing Warnings](../fixing-warnings.md#functionality-with-requirements-on-its-input) for guidance.

--- a/docs/core/deploying/trimming/trim-warnings/il2075.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2075.md
@@ -26,4 +26,4 @@ void TestMethod()
 
 ## Fixing
 
-See [Fixing Warnings](../fixing-warnings.md#dynamicallyaccessedmembers) for guidance.
+See [Fixing Warnings](../fixing-warnings.md#functionality-with-requirements-on-its-input) for guidance.

--- a/docs/core/deploying/trimming/trim-warnings/il2077.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2077.md
@@ -31,4 +31,4 @@ void TestMethod()
 
 ## Fixing
 
-See [Fixing Warnings](../fixing-warnings.md#dynamicallyaccessedmembers) for guidance.
+See [Fixing Warnings](../fixing-warnings.md#functionality-with-requirements-on-its-input) for guidance.

--- a/docs/core/deploying/trimming/trim-warnings/il2078.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2078.md
@@ -27,4 +27,4 @@ Type TestMethod()
 
 ## Fixing
 
-See [Fixing Warnings](../fixing-warnings.md#dynamicallyaccessedmembers) for guidance.
+See [Fixing Warnings](../fixing-warnings.md#functionality-with-requirements-on-its-input) for guidance.

--- a/docs/core/deploying/trimming/trim-warnings/il2079.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2079.md
@@ -29,4 +29,4 @@ void TestMethod()
 
 ## Fixing
 
-See [Fixing Warnings](../fixing-warnings.md#dynamicallyaccessedmembers) for guidance.
+See [Fixing Warnings](../fixing-warnings.md#functionality-with-requirements-on-its-input) for guidance.

--- a/docs/core/deploying/trimming/trim-warnings/il2080.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2080.md
@@ -27,4 +27,4 @@ void TestMethod()
 
 ## Fixing
 
-See [Fixing Warnings](../fixing-warnings.md#dynamicallyaccessedmembers) for guidance.
+See [Fixing Warnings](../fixing-warnings.md#functionality-with-requirements-on-its-input) for guidance.

--- a/docs/core/deploying/trimming/trim-warnings/il2082.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2082.md
@@ -30,4 +30,4 @@ void TestMethod()
 
 ## Fixing
 
-See [Fixing Warnings](../fixing-warnings.md#dynamicallyaccessedmembers) for guidance.
+See [Fixing Warnings](../fixing-warnings.md#functionality-with-requirements-on-its-input) for guidance.

--- a/docs/core/deploying/trimming/trim-warnings/il2083.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2083.md
@@ -27,4 +27,4 @@ Type TestMethod()
 
 ## Fixing
 
-See [Fixing Warnings](../fixing-warnings.md#dynamicallyaccessedmembers) for guidance.
+See [Fixing Warnings](../fixing-warnings.md#functionality-with-requirements-on-its-input) for guidance.

--- a/docs/core/deploying/trimming/trim-warnings/il2084.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2084.md
@@ -28,4 +28,4 @@ void TestMethod()
 
 ## Fixing
 
-See [Fixing Warnings](../fixing-warnings.md#dynamicallyaccessedmembers) for guidance.
+See [Fixing Warnings](../fixing-warnings.md#functionality-with-requirements-on-its-input) for guidance.

--- a/docs/core/deploying/trimming/trim-warnings/il2085.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2085.md
@@ -25,4 +25,4 @@ void TestMethod()
 
 ## Fixing
 
-See [Fixing Warnings](../fixing-warnings.md#dynamicallyaccessedmembers) for guidance.
+See [Fixing Warnings](../fixing-warnings.md#functionality-with-requirements-on-its-input) for guidance.

--- a/docs/core/deploying/trimming/trim-warnings/il2087.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2087.md
@@ -29,4 +29,4 @@ void TestMethod<TSource>()
 
 ## Fixing
 
-See [Fixing Warnings](../fixing-warnings.md#dynamicallyaccessedmembers) for guidance.
+See [Fixing Warnings](../fixing-warnings.md#functionality-with-requirements-on-its-input) for guidance.

--- a/docs/core/deploying/trimming/trim-warnings/il2088.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2088.md
@@ -26,4 +26,4 @@ Type TestMethod<TSource>()
 
 ## Fixing
 
-See [Fixing Warnings](../fixing-warnings.md#dynamicallyaccessedmembers) for guidance.
+See [Fixing Warnings](../fixing-warnings.md#functionality-with-requirements-on-its-input) for guidance.

--- a/docs/core/deploying/trimming/trim-warnings/il2089.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2089.md
@@ -27,4 +27,4 @@ void TestMethod<TSource>()
 
 ## Fixing
 
-See [Fixing Warnings](../fixing-warnings.md#dynamicallyaccessedmembers) for guidance.
+See [Fixing Warnings](../fixing-warnings.md#functionality-with-requirements-on-its-input) for guidance.

--- a/docs/core/deploying/trimming/trim-warnings/il2090.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2090.md
@@ -24,4 +24,4 @@ void TestMethod<TSource>()
 
 ## Fixing
 
-See [Fixing Warnings](../fixing-warnings.md#dynamicallyaccessedmembers) for guidance.
+See [Fixing Warnings](../fixing-warnings.md#functionality-with-requirements-on-its-input) for guidance.

--- a/docs/core/deploying/trimming/trim-warnings/il2091.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2091.md
@@ -29,4 +29,4 @@ void TestMethod<TSource>()
 
 ## Fixing
 
-See [Fixing Warnings](../fixing-warnings.md#dynamicallyaccessedmembers) for guidance.
+See [Fixing Warnings](../fixing-warnings.md#functionality-with-requirements-on-its-input) for guidance.

--- a/docs/core/deploying/trimming/trim-warnings/il2117.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2117.md
@@ -16,7 +16,7 @@ Trimmer currently can't correctly handle if the same compiler generated lambda o
 
 Only a meta-sample:
 
-```C#
+```csharp
 [RequiresUnreferencedCode ("")] // This should suppress all warnings from the method
 void UserDefinedMethod()
 {


### PR DESCRIPTION
## Summary

Improves the description of trim warnings and adds several new recommendations.
* Frame it around types of warnings, not the specific code used to handle such warnings
* Add a subsection on how to mark functionality as incompatible
  * Recommendations on how to produce a good warning message
  * Recommendation to use const string fields to avoid message duplication
* Suppressions
  * Move them to the end - should be the last resort
  * Format the text as a warning to make it very clear that suppressions are potentially dangerous
  * Make it stand out that `UnconditionalSuppressMessage` must be used over the other methods of suppressing warnings
  * Add a recommendation on refactoring suppressions to only a small piece of code


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

<details><summary><strong>Toggle expand/collapse</strong></summary><br/>

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/deploying/trimming/fixing-warnings.md](https://github.com/dotnet/docs/blob/c9238a440a97362b40b521a3b6ec0cb2c4d615b7/docs/core/deploying/trimming/fixing-warnings.md) | [Introduction to trim warnings](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/fixing-warnings?branch=pr-en-us-37514) |
| [docs/core/deploying/trimming/trim-warnings/il2067.md](https://github.com/dotnet/docs/blob/c9238a440a97362b40b521a3b6ec0cb2c4d615b7/docs/core/deploying/trimming/trim-warnings/il2067.md) | [IL2067: 'target parameter' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to 'target method'. The parameter 'source parameter' of method 'source method' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il2067?branch=pr-en-us-37514) |
| [docs/core/deploying/trimming/trim-warnings/il2068.md](https://github.com/dotnet/docs/blob/c9238a440a97362b40b521a3b6ec0cb2c4d615b7/docs/core/deploying/trimming/trim-warnings/il2068.md) | ["IL2068: 'target method' method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter 'source parameter' of method 'source method' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to."](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il2068?branch=pr-en-us-37514) |
| [docs/core/deploying/trimming/trim-warnings/il2069.md](https://github.com/dotnet/docs/blob/c9238a440a97362b40b521a3b6ec0cb2c4d615b7/docs/core/deploying/trimming/trim-warnings/il2069.md) | [IL2069: Value stored in field 'target field' does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The parameter 'source parameter' of method 'source method' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il2069?branch=pr-en-us-37514) |
| [docs/core/deploying/trimming/trim-warnings/il2070.md](https://github.com/dotnet/docs/blob/c9238a440a97362b40b521a3b6ec0cb2c4d615b7/docs/core/deploying/trimming/trim-warnings/il2070.md) | [docs/core/deploying/trimming/trim-warnings/il2070](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il2070?branch=pr-en-us-37514) |
| [docs/core/deploying/trimming/trim-warnings/il2072.md](https://github.com/dotnet/docs/blob/c9238a440a97362b40b521a3b6ec0cb2c4d615b7/docs/core/deploying/trimming/trim-warnings/il2072.md) | [IL2072: 'target parameter' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to 'target method'. The return value of method 'source method' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il2072?branch=pr-en-us-37514) |
| [docs/core/deploying/trimming/trim-warnings/il2073.md](https://github.com/dotnet/docs/blob/c9238a440a97362b40b521a3b6ec0cb2c4d615b7/docs/core/deploying/trimming/trim-warnings/il2073.md) | ["IL2073: 'target method' method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of method 'source method' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to."](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il2073?branch=pr-en-us-37514) |
| [docs/core/deploying/trimming/trim-warnings/il2074.md](https://github.com/dotnet/docs/blob/c9238a440a97362b40b521a3b6ec0cb2c4d615b7/docs/core/deploying/trimming/trim-warnings/il2074.md) | [IL2074: Value stored in field 'target field' does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The return value of method 'source method' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il2074?branch=pr-en-us-37514) |
| [docs/core/deploying/trimming/trim-warnings/il2075.md](https://github.com/dotnet/docs/blob/c9238a440a97362b40b521a3b6ec0cb2c4d615b7/docs/core/deploying/trimming/trim-warnings/il2075.md) | [docs/core/deploying/trimming/trim-warnings/il2075](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il2075?branch=pr-en-us-37514) |
| [docs/core/deploying/trimming/trim-warnings/il2077.md](https://github.com/dotnet/docs/blob/c9238a440a97362b40b521a3b6ec0cb2c4d615b7/docs/core/deploying/trimming/trim-warnings/il2077.md) | [IL2077: 'target parameter' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to 'target method'. The field 'source field' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il2077?branch=pr-en-us-37514) |
| [docs/core/deploying/trimming/trim-warnings/il2078.md](https://github.com/dotnet/docs/blob/c9238a440a97362b40b521a3b6ec0cb2c4d615b7/docs/core/deploying/trimming/trim-warnings/il2078.md) | ["IL2078: 'target method' method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The field 'source field' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to."](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il2078?branch=pr-en-us-37514) |
| [docs/core/deploying/trimming/trim-warnings/il2079.md](https://github.com/dotnet/docs/blob/c9238a440a97362b40b521a3b6ec0cb2c4d615b7/docs/core/deploying/trimming/trim-warnings/il2079.md) | [IL2079: Value stored in field 'target field' does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The field 'source field' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il2079?branch=pr-en-us-37514) |
| [docs/core/deploying/trimming/trim-warnings/il2080.md](https://github.com/dotnet/docs/blob/c9238a440a97362b40b521a3b6ec0cb2c4d615b7/docs/core/deploying/trimming/trim-warnings/il2080.md) | [docs/core/deploying/trimming/trim-warnings/il2080](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il2080?branch=pr-en-us-37514) |
| [docs/core/deploying/trimming/trim-warnings/il2082.md](https://github.com/dotnet/docs/blob/c9238a440a97362b40b521a3b6ec0cb2c4d615b7/docs/core/deploying/trimming/trim-warnings/il2082.md) | [IL2082: 'target parameter' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to 'target method'. The implicit 'this' argument of method 'source method' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il2082?branch=pr-en-us-37514) |
| [docs/core/deploying/trimming/trim-warnings/il2083.md](https://github.com/dotnet/docs/blob/c9238a440a97362b40b521a3b6ec0cb2c4d615b7/docs/core/deploying/trimming/trim-warnings/il2083.md) | ["IL2083: 'target method' method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of method 'source method' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to."](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il2083?branch=pr-en-us-37514) |
| [docs/core/deploying/trimming/trim-warnings/il2084.md](https://github.com/dotnet/docs/blob/c9238a440a97362b40b521a3b6ec0cb2c4d615b7/docs/core/deploying/trimming/trim-warnings/il2084.md) | [IL2084: Value stored in field 'target field' does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The implicit 'this' argument of method 'source method' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il2084?branch=pr-en-us-37514) |
| [docs/core/deploying/trimming/trim-warnings/il2085.md](https://github.com/dotnet/docs/blob/c9238a440a97362b40b521a3b6ec0cb2c4d615b7/docs/core/deploying/trimming/trim-warnings/il2085.md) | [docs/core/deploying/trimming/trim-warnings/il2085](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il2085?branch=pr-en-us-37514) |
| [docs/core/deploying/trimming/trim-warnings/il2087.md](https://github.com/dotnet/docs/blob/c9238a440a97362b40b521a3b6ec0cb2c4d615b7/docs/core/deploying/trimming/trim-warnings/il2087.md) | [IL2087: 'target parameter' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to 'target method'. The generic parameter 'source generic parameter' of 'source method or type' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il2087?branch=pr-en-us-37514) |
| [docs/core/deploying/trimming/trim-warnings/il2088.md](https://github.com/dotnet/docs/blob/c9238a440a97362b40b521a3b6ec0cb2c4d615b7/docs/core/deploying/trimming/trim-warnings/il2088.md) | ["IL2088: 'target method' method return value does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter 'source generic parameter' of 'source method or type' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to."](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il2088?branch=pr-en-us-37514) |
| [docs/core/deploying/trimming/trim-warnings/il2089.md](https://github.com/dotnet/docs/blob/c9238a440a97362b40b521a3b6ec0cb2c4d615b7/docs/core/deploying/trimming/trim-warnings/il2089.md) | [IL2089: Value stored in field 'target field' does not satisfy 'DynamicallyAccessedMembersAttribute' requirements. The generic parameter 'source generic parameter' of 'source method or type' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il2089?branch=pr-en-us-37514) |
| [docs/core/deploying/trimming/trim-warnings/il2090.md](https://github.com/dotnet/docs/blob/c9238a440a97362b40b521a3b6ec0cb2c4d615b7/docs/core/deploying/trimming/trim-warnings/il2090.md) | [docs/core/deploying/trimming/trim-warnings/il2090](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il2090?branch=pr-en-us-37514) |
| [docs/core/deploying/trimming/trim-warnings/il2091.md](https://github.com/dotnet/docs/blob/c9238a440a97362b40b521a3b6ec0cb2c4d615b7/docs/core/deploying/trimming/trim-warnings/il2091.md) | [IL2091: 'target generic parameter' generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in 'target method or type'. The generic parameter 'source target parameter' of 'source method or type' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il2091?branch=pr-en-us-37514) |
| [docs/core/deploying/trimming/trim-warnings/il2117.md](https://github.com/dotnet/docs/blob/c9238a440a97362b40b521a3b6ec0cb2c4d615b7/docs/core/deploying/trimming/trim-warnings/il2117.md) | ["IL2116: Methods 'method1' and 'method2' are both associated with lambda or local function 'method'. This is currently unsupported and may lead to incorrectly reported warnings."](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il2117?branch=pr-en-us-37514) |

</details>


<!-- PREVIEW-TABLE-END -->