### PR TITLE
Separate wrong and correct code samples in CS0230 page

### DIFF
--- a/docs/csharp/misc/cs0230.md
+++ b/docs/csharp/misc/cs0230.md
@@ -41,7 +41,7 @@ class MyClass
    {
       int[] myarray = new int[3] {1,2,3};
 
-      foreach (int x in myarray)
+      foreach (int x in myarray)  // Both type (int) and indentifier (x) are specified
       {
          Console.WriteLine(x);
       }

--- a/docs/csharp/misc/cs0230.md
+++ b/docs/csharp/misc/cs0230.md
@@ -18,8 +18,6 @@ Type and identifier are both required in a foreach statement
   
 ```csharp  
 // CS0230.cs  
-using System;  
-  
 class MyClass  
 {  
    public static void Main()  
@@ -37,8 +35,6 @@ class MyClass
 and the sample below presents the same code, but with no CS0230 error:
 
 ```csharp
-using System;
-
 class MyClass
 {
    public static void Main()

--- a/docs/csharp/misc/cs0230.md
+++ b/docs/csharp/misc/cs0230.md
@@ -27,11 +27,28 @@ class MyClass
       int[] myarray = new int[3] {1,2,3};  
   
       foreach (int in myarray)   // CS0230  
-      // try the following line instead  
-      // foreach (int x in myarray)  
       {  
          Console.WriteLine(x);  
       }  
    }  
 }  
+```
+
+and the sample below presents the same code, but with no CS0230 error:
+
+```csharp
+using System;
+
+class MyClass
+{
+   public static void Main()
+   {
+      int[] myarray = new int[3] {1,2,3};
+
+      foreach (int x in myarray)
+      {
+         Console.WriteLine(x);
+      }
+   }
+}
 ```


### PR DESCRIPTION
This pull request fixes #37226 
It makes the solution for the `CS0230` error more readable and easier to notice by introducing a separate code sample for the correct implementation.

This pull request also removes `using System` from both samples due to `ImplicitUsings`.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/misc/cs0230.md](https://github.com/dotnet/docs/blob/f553c19eaa6a336936d395cfbdce2f3264a068cb/docs/csharp/misc/cs0230.md) | [Compiler Error CS0230](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/cs0230?branch=pr-en-us-37545) |

<!-- PREVIEW-TABLE-END -->