### PR TITLE
doc - Uppercased the first letter of "Windows"

### DIFF
--- a/docs/core/compatibility/sdk/8.0/console-encoding-fix.md
+++ b/docs/core/compatibility/sdk/8.0/console-encoding-fix.md
@@ -12,7 +12,7 @@ In addition, the .NET SDK no longer changes the encoding to UTF-8 on older Windo
 ## Previous behavior
 
 - The SDK changed the encoding of a terminal after running a command such as `dotnet build`.
-- The SDK used the UTF-8 encoding to correctly render non-English characters, even on versions of windows 10 that did not officially support UTF-8. The behavior was undefined on those versions.
+- The SDK used the UTF-8 encoding to correctly render non-English characters, even on versions of Windows 10 that did not officially support UTF-8. The behavior was undefined on those versions.
 
 ## New behavior
 


### PR DESCRIPTION
## Summary

Windows is an operating system name, and is a proper noun, so we've uppercased the first letter of "Windows" in "Previous Behavior" to make it look more professional.

Changed from "windows" to "Windows."

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/sdk/8.0/console-encoding-fix.md](https://github.com/dotnet/docs/blob/282394020eb313bb36a499a9ff92b4d0d3b6f8c9/docs/core/compatibility/sdk/8.0/console-encoding-fix.md) | [Console encoding doesn't remain UTF-8 after completion](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/console-encoding-fix?branch=pr-en-us-37648) |

<!-- PREVIEW-TABLE-END -->