### PR TITLE
Added Aspose.Drawing as an alternative to System.Drawing

### DIFF
--- a/docs/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only.md
+++ b/docs/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only.md
@@ -56,6 +56,7 @@ To use these APIs for cross-platform apps, migrate to one of the following libra
 
 - [SkiaSharp](https://github.com/mono/SkiaSharp)
 - [ImageSharp](https://sixlabors.com/products/imagesharp) (tiered license)
+- [Aspose.Drawing](https://products.aspose.com/drawing/net/) (commercial license)
 - [Microsoft.Maui.Graphics](/dotnet/maui/user-interface/graphics/)
 
 Alternatively, you can enable support for non-Windows platforms in .NET 6 by setting the `System.Drawing.EnableUnixSupport` [runtime configuration switch](../../../runtime-config/index.md) to `true` in the *runtimeconfig.json* file.

--- a/docs/core/compatibility/core-libraries/7.0/system-drawing.md
+++ b/docs/core/compatibility/core-libraries/7.0/system-drawing.md
@@ -31,8 +31,9 @@ The switch to re-enable functionality on non-Windows operating systems was added
 
 To use these APIs for cross-platform apps, migrate to an alternative library, such as one of the following:
 
-- [ImageSharp](https://sixlabors.com/products/imagesharp)
 - [SkiaSharp](https://github.com/mono/SkiaSharp)
+- [ImageSharp](https://sixlabors.com/products/imagesharp) (tiered license)
+- [Aspose.Drawing](https://products.aspose.com/drawing/net/) (commercial license)
 - [Microsoft.Maui.Graphics](/dotnet/maui/user-interface/graphics/)
 
 ## Affected APIs


### PR DESCRIPTION
## Summary

Added Aspose.Drawing as an alternative to System.Drawing. (Also reordered ImageSharp link to match the main document.)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only.md](https://github.com/dotnet/docs/blob/83b6bfa1137877225ec04a4b3d3a5d7e60442acb/docs/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only.md) | [System.Drawing.Common only supported on Windows](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only?branch=pr-en-us-37651) |
| [docs/core/compatibility/core-libraries/7.0/system-drawing.md](https://github.com/dotnet/docs/blob/83b6bfa1137877225ec04a4b3d3a5d7e60442acb/docs/core/compatibility/core-libraries/7.0/system-drawing.md) | ["Breaking change: System.Drawing.Common config switch removed"](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/7.0/system-drawing?branch=pr-en-us-37651) |

<!-- PREVIEW-TABLE-END -->