### PR TITLE
Document that WebHost.CreateDefaultBuilder will use port 5000

### DIFF
--- a/docs/core/compatibility/containers/8.0/aspnet-port.md
+++ b/docs/core/compatibility/containers/8.0/aspnet-port.md
@@ -9,7 +9,7 @@ The default ASP.NET Core port configured in .NET container images has been updat
 
 We also added the new `ASPNETCORE_HTTP_PORTS` environment variable as a simpler alternative to `ASPNETCORE_URLS`. The new variable expects a semicolon delimited list of ports numbers, while the older variable expects a more complicated syntax.
 
-Apps built using the older <xref:Microsoft.AspNetCore.WebHost.CreateDefaultBuilder?displayProperty=nameWithType> API won't respect the new `ASPNETCORE_HTTP_PORTS` environment variable. And now that `ASPNETCORE_URLS` is no longer set automatically, they'll switch to use a default port of 5000.
+Apps built using the older <xref:Microsoft.AspNetCore.WebHost.CreateDefaultBuilder?displayProperty=nameWithType> API won't respect the new `ASPNETCORE_HTTP_PORTS` environment variable. And now that `ASPNETCORE_URLS` is no longer set automatically, they'll switch to use a default URL of `http://localhost:5000`, rather than `http://*:80`, as formerly.
 
 ## Previous behavior
 
@@ -87,7 +87,7 @@ There are two ways to respond to this breaking change:
 - Recommended: Explicitly set the `ASPNETCORE_HTTP_PORTS`, `ASPNETCORE_HTTPS_PORTS`, and `ASPNETCORE_URLS` environment variables to the desired port. Example: `docker run --rm -it -p 9999:80 -e ASPNETCORE_HTTP_PORTS=80 <my-app>`
 - Update existing commands and configuration that rely on the expected default port of port 80 to reference port 8080 instead. Example: `docker run --rm -it -p 9999:8080 <my-app>`
 
-If your app was built using the older <xref:Microsoft.AspNetCore.WebHost.CreateDefaultBuilder?displayProperty=nameWithType> method, either set `ASPNETCORE_URLS` (not `ASPNETCORE_HTTP_PORTS`) or update the expected default port of port 80 to reference port 5000 instead.
+If your app was built using the older <xref:Microsoft.AspNetCore.WebHost.CreateDefaultBuilder?displayProperty=nameWithType> method, set `ASPNETCORE_URLS` (not `ASPNETCORE_HTTP_PORTS`). Example: `docker run --rm -it -p 9999:80 -e ASPNETCORE_URLS=http://*:80 <my-app>`
 
 ## Affected APIs
 

--- a/docs/core/compatibility/containers/8.0/aspnet-port.md
+++ b/docs/core/compatibility/containers/8.0/aspnet-port.md
@@ -9,7 +9,7 @@ The default ASP.NET Core port configured in .NET container images has been updat
 
 We also added the new `ASPNETCORE_HTTP_PORTS` environment variable as a simpler alternative to `ASPNETCORE_URLS`. The new variable expects a semicolon delimited list of ports numbers, while the older variable expects a more complicated syntax.
 
-Apps build using the older [`WebHost.CreateDefaultBuilder`](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.webhost.createdefaultbuilder) API won't respect the new `ASPNETCORE_HTTP_PORTS` environment variable and will therefore switch to using a default port of 5000, which is not accessible outside the container, now that `ASPNETCORE_URLS` is no longer set automatically.
+Apps built using the older <xref:Microsoft.AspNetCore.WebHost.CreateDefaultBuilder?displayProperty=nameWithType> API won't respect the new `ASPNETCORE_HTTP_PORTS` environment variable. And now that `ASPNETCORE_URLS` is no longer set automatically, they'll switch to use a default port of 5000.
 
 ## Previous behavior
 

--- a/docs/core/compatibility/containers/8.0/aspnet-port.md
+++ b/docs/core/compatibility/containers/8.0/aspnet-port.md
@@ -9,6 +9,8 @@ The default ASP.NET Core port configured in .NET container images has been updat
 
 We also added the new `ASPNETCORE_HTTP_PORTS` environment variable as a simpler alternative to `ASPNETCORE_URLS`. The new variable expects a semicolon delimited list of ports numbers, while the older variable expects a more complicated syntax.
 
+Apps build using the older [`WebHost.CreateDefaultBuilder`](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.webhost.createdefaultbuilder) API won't respect the new `ASPNETCORE_HTTP_PORTS` environment variable and will therefore switch to using a default port of 5000, now that `ASPNETCORE_URLS` is no longer set automatically.
+
 ## Previous behavior
 
 Prior to .NET 8, you could run a container expecting port 80 to be the default port and be able to access the running app.
@@ -56,7 +58,7 @@ $ docker kill 74d866bdaa8a5a09e4a347bba17ced321d77a2524a0853294a123640bcc7f21d
 Mapping port `80` with `ASPNETCORE_HTTP_PORTS` set to port `80`:
 
 ```bash
-$ docker run --rm -d -p 8000:80 -e ASPNETCORE_HTTP_PORTS=80 mcr.microsoft.com/dotnet/samples:aspnetapp 
+$ docker run --rm -d -p 8000:80 -e ASPNETCORE_HTTP_PORTS=80 mcr.microsoft.com/dotnet/samples:aspnetapp
 3cc86b4b3ea1a7303d83171c132b0645d4adf61d80131152936b01661ae82a09
 $ curl http://localhost:8000/Environment
 {"runtimeVersion":".NET 8.0.0-rc.1.23419.4","osVersion":"Alpine Linux v3.18","osArchitecture":"Arm64","user":"root","processorCount":4,"totalAvailableMemoryBytes":4123820032,"memoryLimit":0,"memoryUsage":95383552,"hostName":"3cc86b4b3ea1"}
@@ -84,6 +86,8 @@ There are two ways to respond to this breaking change:
 
 - Recommended: Explicitly set the `ASPNETCORE_HTTP_PORTS`, `ASPNETCORE_HTTPS_PORTS`, and `ASPNETCORE_URLS` environment variables to the desired port. Example: `docker run --rm -it -p 9999:80 -e ASPNETCORE_HTTP_PORTS=80 <my-app>`
 - Update existing commands and configuration that rely on the expected default port of port 80 to reference port 8080 instead. Example: `docker run --rm -it -p 9999:8080 <my-app>`
+
+Apps build using the older [`WebHost.CreateDefaultBuilder`](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.webhost.createdefaultbuilder) will need to either set `ASPNETCORE_URLS` (not `ASPNETCORE_HTTP_PORTS`) or update the expected default port of port 80 to reference port 5000 instead.
 
 ## Affected APIs
 

--- a/docs/core/compatibility/containers/8.0/aspnet-port.md
+++ b/docs/core/compatibility/containers/8.0/aspnet-port.md
@@ -9,7 +9,7 @@ The default ASP.NET Core port configured in .NET container images has been updat
 
 We also added the new `ASPNETCORE_HTTP_PORTS` environment variable as a simpler alternative to `ASPNETCORE_URLS`. The new variable expects a semicolon delimited list of ports numbers, while the older variable expects a more complicated syntax.
 
-Apps build using the older [`WebHost.CreateDefaultBuilder`](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.webhost.createdefaultbuilder) API won't respect the new `ASPNETCORE_HTTP_PORTS` environment variable and will therefore switch to using a default port of 5000, now that `ASPNETCORE_URLS` is no longer set automatically.
+Apps build using the older [`WebHost.CreateDefaultBuilder`](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.webhost.createdefaultbuilder) API won't respect the new `ASPNETCORE_HTTP_PORTS` environment variable and will therefore switch to using a default port of 5000, which is not accessible outside the container, now that `ASPNETCORE_URLS` is no longer set automatically.
 
 ## Previous behavior
 
@@ -87,7 +87,7 @@ There are two ways to respond to this breaking change:
 - Recommended: Explicitly set the `ASPNETCORE_HTTP_PORTS`, `ASPNETCORE_HTTPS_PORTS`, and `ASPNETCORE_URLS` environment variables to the desired port. Example: `docker run --rm -it -p 9999:80 -e ASPNETCORE_HTTP_PORTS=80 <my-app>`
 - Update existing commands and configuration that rely on the expected default port of port 80 to reference port 8080 instead. Example: `docker run --rm -it -p 9999:8080 <my-app>`
 
-Apps build using the older [`WebHost.CreateDefaultBuilder`](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.webhost.createdefaultbuilder) will need to either set `ASPNETCORE_URLS` (not `ASPNETCORE_HTTP_PORTS`) or update the expected default port of port 80 to reference port 5000 instead.
+If your app was built using the older <xref:Microsoft.AspNetCore.WebHost.CreateDefaultBuilder?displayProperty=nameWithType> method, either set `ASPNETCORE_URLS` (not `ASPNETCORE_HTTP_PORTS`) or update the expected default port of port 80 to reference port 5000 instead.
 
 ## Affected APIs
 


### PR DESCRIPTION
...rather than port 8080, like newer hosts.

Fixes https://github.com/dotnet/aspnetcore/issues/51125

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/containers/8.0/aspnet-port.md](https://github.com/dotnet/docs/blob/7ab47bf08baf737cea1e6e0a29a9995f1b30d2a2/docs/core/compatibility/containers/8.0/aspnet-port.md) | [Default ASP.NET Core port changed from 80 to 8080](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/containers/8.0/aspnet-port?branch=pr-en-us-37661) |


<!-- PREVIEW-TABLE-END -->