### PR TITLE
Fix casing in named placeholder in code sample Worker.cs

### DIFF
--- a/docs/core/extensions/snippets/configuration/worker-service/Worker.cs
+++ b/docs/core/extensions/snippets/configuration/worker-service/Worker.cs
@@ -11,7 +11,7 @@ public sealed class Worker : BackgroundService
     {
         while (!stoppingToken.IsCancellationRequested)
         {
-            _logger.LogInformation("Worker running at: {time}", DateTimeOffset.UtcNow);
+            _logger.LogInformation("Worker running at: {Time}", DateTimeOffset.UtcNow);
             await Task.Delay(1_000, stoppingToken);
         }
     }


### PR DESCRIPTION
## Summary

This fixes invalid camelCase in the logging code sample `Worker.cs` in favour of PascalCase which should be used.

.NET uses the structural logging. The structural logging should use PascalCase for named placeholders. Details are explained in [the CS1727 analyzer](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1727).

[The updated page](https://learn.microsoft.com/en-us/dotnet/core/extensions/logging?tabs=command-line) is inconsistent. The proper casing is used at other samples on the page, but not in `Worker.cs` which is very first example on the page.. This change removes the page inconsistency.

The current state is confusing for less experienced .NET developers.
