### PR TITLE
Mention the `GraphQLRequest` class and `ToJsonText` method in async streams tutorial

### DIFF
--- a/docs/csharp/asynchronous-programming/generate-consume-asynchronous-stream.md
+++ b/docs/csharp/asynchronous-programming/generate-consume-asynchronous-stream.md
@@ -53,6 +53,12 @@ The implementation reveals why you observed the behavior discussed in the previo
 
 :::code language="csharp" source="snippets/generate-consume-asynchronous-streams/start/Program.cs" id="SnippetRunPagedQuery" :::
 
+The very first thing this method does is to create the POST object, using the `GraphQLRequest` class:
+
+:::code language="csharp" source="snippets/generate-consume-asynchronous-streams/start/Program.cs" id="SnippetStarterGraphQLRequest":::
+
+which helps to form the POST object body, and correctly convert it to JSON presented as single string with the `ToJsonText` method, which removes all newline characters from your request body marking them with the `\` (backslash) escape character.
+
 Let's concentrate on the paging algorithm and async structure of the preceding code. (You can consult the [GitHub GraphQL documentation](https://developer.github.com/v4/guides/) for details on the GitHub GraphQL API.) The `RunPagedQueryAsync` method enumerates the issues from most recent to oldest. It requests 25 issues per page and examines the `pageInfo` structure of the response to continue with the previous page. That follows GraphQL's standard paging support for multi-page responses. The response includes a `pageInfo` object that includes a `hasPreviousPages` value and a `startCursor` value used to request the previous page. The issues are in the `nodes` array. The `RunPagedQueryAsync` method appends these nodes to an array that contains all the results from all pages.
 
 After retrieving and restoring a page of results, `RunPagedQueryAsync` reports progress and checks for cancellation. If cancellation has been requested, `RunPagedQueryAsync` throws an <xref:System.OperationCanceledException>.

--- a/docs/csharp/asynchronous-programming/snippets/generate-consume-asynchronous-streams/start/Program.cs
+++ b/docs/csharp/asynchronous-programming/snippets/generate-consume-asynchronous-streams/start/Program.cs
@@ -4,6 +4,7 @@ using Octokit;
 
 namespace GitHubActivityReport;
 
+// <SnippetStarterGraphQLRequest>
 public class GraphQLRequest
 {
     [JsonProperty("query")]
@@ -15,6 +16,7 @@ public class GraphQLRequest
     public string ToJsonText() =>
         JsonConvert.SerializeObject(this);
 }
+// </SnippetStarterGraphQLRequest>
 
 class Program
 {


### PR DESCRIPTION
This pull request fixes #37399 

It adds the paragraph briefly describing the `GraphQLRequest` class, mentioning the `ToJsonText` method and it's responsibility of converting the JSON to safe text with all the special characters correctly marked in JSON format.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/asynchronous-programming/generate-consume-asynchronous-stream.md](https://github.com/dotnet/docs/blob/b02b537fc3ced91897c1f4234b07194aa3ec6812/docs/csharp/asynchronous-programming/generate-consume-asynchronous-stream.md) | [Tutorial: Generate and consume async streams using C# and .NET](https://review.learn.microsoft.com/en-us/dotnet/csharp/asynchronous-programming/generate-consume-asynchronous-stream?branch=pr-en-us-37669) |

<!-- PREVIEW-TABLE-END -->