### PR TITLE
--sdk-version option no longer supported

### DIFF
--- a/docs/core/tools/dotnet-workload-install.md
+++ b/docs/core/tools/dotnet-workload-install.md
@@ -35,7 +35,7 @@ For macOS and Linux SDK installations that are installed to a protected director
 
 ### Results vary by SDK version
 
-The `dotnet workload` commands operate in the context of specific SDK versions. Suppose you have both .NET 6.0.100 SDK and .NET 6.0.200 SDK installed. The `dotnet workload` commands will give different results depending on which SDK version you select. This behavior applies to major and minor version and feature band differences, not to patch version differences. For example, .NET SDK 6.0.101 and 6.0.102 give the same results, whereas 6.0.100 and 6.0.200 give different results. You can specify the SDK version by using the [*global.json* file](global-json.md) or the `--sdk-version` option of the `dotnet workload` commands.
+The `dotnet workload` commands operate in the context of specific SDK versions. Suppose you have both .NET 6.0.100 SDK and .NET 6.0.200 SDK installed. The `dotnet workload` commands will give different results depending on which SDK version you select. This behavior applies to major and minor version and feature band differences, not to patch version differences. For example, .NET SDK 6.0.101 and 6.0.102 give the same results, whereas 6.0.100 and 6.0.200 give different results. You can specify the SDK version by using the [*global.json* file](global-json.md).
 
 ### Advertising manifests
 


### PR DESCRIPTION
Fixes #37498 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-workload-install.md](https://github.com/dotnet/docs/blob/75a3f8cb4f9f79b06456a660bf18c1ad7ecd1996/docs/core/tools/dotnet-workload-install.md) | [dotnet workload install](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-workload-install?branch=pr-en-us-37678) |

<!-- PREVIEW-TABLE-END -->