### PR TITLE
Fix the link to DirectoryServices-package in 8.0 compatibility page

### DIFF
--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -84,7 +84,7 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 | [ActivatorUtilities.CreateInstance requires non-null provider](extensions/8.0/activatorutilities-createinstance-null-provider.md) | Behavioral change | Preview 1  |
 | [ConfigurationBinder throws for mismatched value](extensions/8.0/configurationbinder-exceptions.md)                               | Behavioral change | Preview 1  |
 | [ConfigurationManager package no longer references System.Security.Permissions](extensions/8.0/configurationmanager-package.md)   | Source incompatible | Preview 3  |
-| [DirectoryServices package no longer references System.Security.Permissions](extensions/8.0/configurationmanager-package.md)   | Source incompatible | Preview 3  |
+| [DirectoryServices package no longer references System.Security.Permissions](extensions/8.0/directoryservices-package.md)         | Source incompatible | Preview 3  |
 | [Empty keys added to dictionary by configuration binder](extensions/8.0/dictionary-configuration-binding.md)                      | Behavioral change | Preview 5  |
 | [HostApplicationBuilderSettings.Args respected by HostApplicationBuilder ctor](extensions/8.0/hostapplicationbuilder-ctor.md)     | Behavioral change | Preview 2  |
 | [ManagementDateTimeConverter.ToDateTime returns a local time](extensions/8.0/dmtf-todatetime.md)     | Behavioral change | RC 1 |


### PR DESCRIPTION
This pull request fixes #37464
It corrects the link in the `Breaking changes in .NET 8` page to DirectoryServices package error.
The incorrect link simply looked like a copy-paste error.

The rest of the information (`Type of change` and `Introduced` columns) is correct according to the proper `DirectoryServices package`.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/8.0.md](https://github.com/dotnet/docs/blob/97769573b51d8ce738936dbd315c60901f5e52ee/docs/core/compatibility/8.0.md) | [Breaking changes in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/8.0?branch=pr-en-us-37684) |

<!-- PREVIEW-TABLE-END -->