### PR TITLE
Add link to ASP.NET Core what's new

### DIFF
--- a/docs/core/whats-new/dotnet-8.md
+++ b/docs/core/whats-new/dotnet-8.md
@@ -18,6 +18,10 @@ This article has been updated for .NET 8 release candidate (RC) 2.
 > - This information relates to a pre-release product that may be substantially modified before it's commercially released. Microsoft makes no warranties, express or implied, with respect to the information provided here.
 > - Much of the other .NET documentation on [https://learn.microsoft.com/dotnet](/dotnet) has not yet been updated for .NET 8.
 
+## ASP.NET Core
+
+For information about what's new in ASP.NET Core, see [What's new in ASP.NET Core 8.0](/aspnet/core/release-notes/aspnetcore-8.0).
+
 ## Core .NET libraries
 
 This section contains the following subtopics:


### PR DESCRIPTION
Add higher link to ASP.NET Core what's new.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/whats-new/dotnet-8.md](https://github.com/dotnet/docs/blob/2a5582bb055227e56c35f89188f4419ff603403c/docs/core/whats-new/dotnet-8.md) | [What's new in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-8?branch=pr-en-us-37741) |

<!-- PREVIEW-TABLE-END -->