### PR TITLE
Update Azure Cosmos DB articles for Orleans

### DIFF
--- a/docs/orleans/grains/grain-persistence/azure-cosmos-db.md
+++ b/docs/orleans/grains/grain-persistence/azure-cosmos-db.md
@@ -19,16 +19,17 @@ Install the [Microsoft.Orleans.Persistence.Cosmos](https://www.nuget.org/package
 
 ## Configure clustering provider
 
-To configure the clustering provider use the `HostingExtensions.UseCosmosClustering` extension method.
+To configure the clustering provider, use the `HostingExtensions.UseCosmosClustering` extension method. You can customize the name and throughput of the database or container, enable resource creation, or configure the client's credentials in this method.
 
 ```csharp
 siloBuilder.UseCosmosClustering(
     configureOptions: static options =>
     {
-        options.DatabaseName = "Orleans";
-        options.DatabaseThroughput = 400;
-        options.ContainerName = "OrleansCluster";
-        options.ConfigureCosmosClient("AccountName=example;Key=example;");
+        options.IsResourceCreationEnabled = true;
+        options.DatabaseName = "OrleansAlternativeDatabase";
+        options.ContainerName = "OrleansClusterAlternativeContainer";
+        options.ContainerThroughputProperties = ThroughputProperties.CreateAutoscaleThroughput(1000);
+        options.ConfigureCosmosClient("<azure-cosmos-db-nosql-connection-string>");
     });
 ```
 
@@ -41,9 +42,10 @@ siloBuilder.AddCosmosGrainStorage(
     name: "profileStore",
     configureOptions: static options =>
     {
-        options.DatabaseName = "Orleans";
-        options.DatabaseThroughput = 400;
-        options.ContainerName = "OrleansStorage";
-        options.ConfigureCosmosClient("AccountName=example;Key=example;");
+        options.IsResourceCreationEnabled = true;
+        options.DatabaseName = "OrleansAlternativeDatabase";
+        options.ContainerName = "OrleansStorageAlternativeContainer";
+        options.ContainerThroughputProperties = ThroughputProperties.CreateAutoscaleThroughput(1000);
+        options.ConfigureCosmosClient("<azure-cosmos-db-nosql-connection-string>");
     });
 ```

--- a/docs/orleans/quickstarts/deploy-scale-orleans-on-azure.md
+++ b/docs/orleans/quickstarts/deploy-scale-orleans-on-azure.md
@@ -118,10 +118,17 @@ Update the `builder` configuration code in the _Program.cs_ file to match the ex
         {
             var connectionString = "<azure-cosmos-db-nosql-connection-string>";
     
-            siloBuilder
-                .UseCosmosClustering(o => o.ConfigureCosmosClient(connectionString))
-                .AddCosmosGrainStorage("urls", o => o.ConfigureCosmosClient(connectionString));
+            siloBuilder.UseCosmosClustering(options =>
+            {
+                options.IsResourceCreationEnabled = true;
+                options.ConfigureCosmosClient(connectionString);
+            });
     
+            siloBuilder.AddCosmosGrainStorage(name: "urls", options =>
+            {
+                options.IsResourceCreationEnabled = true;
+                options.ConfigureCosmosClient(connectionString);
+            });
             siloBuilder.Configure<ClusterOptions>(options =>
             {
                 options.ClusterId = "url-shortener";
@@ -130,6 +137,9 @@ Update the `builder` configuration code in the _Program.cs_ file to match the ex
         });
     }
     ```
+
+    > [!TIP]
+    > Use `IsResourceCreationEnabled` to instruct the grain to create any required Azure Cosmos DB for NoSQL resources automatically.
 
 ::: zone-end
 
@@ -188,16 +198,7 @@ Create an API for NoSQL account to hold the cluster and persistent state data yo
 
 1. Select **Go to resource** after the storage account is created.
 
-## Create the database and container resources
-
-The Orleans grain expects specific case-sensitive database and container names prior to deployment.
-
-1. On the account overview page, select **Data Explorer**.
-1. Create a database named `Orleans`.
-1. Within the `Orleans` database, create a container named `OrleansStorage` with a partition key path of `/PartitionKey`.
-1. Create another container named `OrleansCluster` within the `Orleans` database. Ensure this container has a partition key path of `/ClusterId`.
-
-## Configure the connection to Azure Storage
+## Configure the connection to Azure Cosmos DB
 
 1. On the account overview page, select **Access keys** on the navigation.
 1. On the Access keys page, next to **Primary Connection string** select **Show**, and then copy the value.

--- a/docs/orleans/quickstarts/deploy-scale-orleans-on-azure.md
+++ b/docs/orleans/quickstarts/deploy-scale-orleans-on-azure.md
@@ -215,7 +215,7 @@ Create an API for NoSQL account to hold the cluster and persistent state data yo
 
 ## Deploy to Azure Container Apps
 
-1. In the Visual Studio solution explorer, right select on the top level project node and select **Add > Dockerfile**. Visual Studio creates a Dockerfile at the root of your project. This file enables containerization for your app and allows it to run on Azure container apps.
+1. In the Visual Studio solution explorer, right select on the top level project node and select **Add > Docker Support**. Visual Studio creates a Dockerfile at the root of your project. This file enables containerization for your app and allows it to run on Azure container apps.
 1. In the Visual Studio solution explorer, right-click on the top level project node and select **Publish**.
 1. In the publishing dialog, select **Azure** as the deployment target, and then select **Next**.
 1. For the specific target, select **Azure Container Apps (Linux)**, and then select **Next**.


### PR DESCRIPTION
 - [x] Use `IsResourceCreationEnabled` to bypass manual resource creation
 - [x] Update to use autoscale throughput at the container level

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/grains/grain-persistence/azure-cosmos-db.md](https://github.com/dotnet/docs/blob/dc57986529f2f0a427b1bdab5fab8dc7ecd9e3f7/docs/orleans/grains/grain-persistence/azure-cosmos-db.md) | [Azure Cosmos DB for NoSQL grain persistence](https://review.learn.microsoft.com/en-us/dotnet/orleans/grains/grain-persistence/azure-cosmos-db?branch=pr-en-us-37745) |
| [docs/orleans/quickstarts/deploy-scale-orleans-on-azure.md](https://github.com/dotnet/docs/blob/dc57986529f2f0a427b1bdab5fab8dc7ecd9e3f7/docs/orleans/quickstarts/deploy-scale-orleans-on-azure.md) | [CustomerIntent: As a developer, I want to host my Orleans application in Azure so that I can take advantage of the scaling capabilities for the database and application services.](https://review.learn.microsoft.com/en-us/dotnet/orleans/quickstarts/deploy-scale-orleans-on-azure?branch=pr-en-us-37745) |


<!-- PREVIEW-TABLE-END -->