### PR TITLE
Add `dotnet package search` documentation

### DIFF
--- a/docs/core/tools/dotnet-package-search.md
+++ b/docs/core/tools/dotnet-package-search.md
@@ -1,0 +1,111 @@
+---
+title: dotnet package search command
+description: Searches a given source using the query string provided. If no sources are specified, all sources defined in the NuGet.Config file are used
+author: Nigusu-Allehu
+ms.date: 10/26/2023
+---
+# dotnet package search
+
+**This article applies to:** ✔️ .NET 8.0.2xx SDK and later versions
+
+## Name
+
+`dotnet package search` - Searches for a NuGet package.
+
+## Synopsis
+
+```dotnetcli
+dotnet package search [search terms] [options]
+    [--source <SOURCE>]
+    [--exact-match]
+    [--prerelease]
+    [--interactive]
+    [--take <TAKE>]
+    [--skip <SKIP>]
+
+dotnet package search -h|--help
+```
+
+## Description
+
+The `dotnet package search` command searches for a NuGet package.
+
+## Arguments
+
+- **`search terms`**
+
+  Specifies the search term to filter results. Use this argument to search for packages matching the provided query. Example: `dotnet package search json`.
+
+## Options
+
+- **`--source <SOURCE>`**
+
+  The package source to search. You can pass multiple --source options to search multiple package sources.
+
+- **`--exact-match`**
+
+  Return exact matches only as a search result.
+
+- **`--prerelease`**
+
+    Allow prerelease packages to be shown.
+
+- **`--interactive`**
+
+    Allows the command to stop and wait for user input or action (for example to complete authentication).
+
+- **`--take`**
+
+    The number of results to return. The default value is 20.
+
+- **`--skip`**
+
+    The number of results to skip, for pagination. The default value is 0.
+
+[!INCLUDE [help](../../../includes/cli-help.md)]
+
+## Examples
+
+```dotnetcli
+dotnet package search Newtonsoft.Json --source https://api.nuget.org/v3/index.json
+```
+
+output a list of 20 packages in the source matching the search term.
+
+```
+    Source: https://api.nuget.org/v3/index.json
+    | Package ID                                  | Latest Version | Authors | Downloads       |
+    |---------------------------------------------|----------------|---------|-----------------|
+    | Newtonsoft.Json                             | 13.0.3         |         | 3,829,822,911   |
+    | Newtonsoft.Json.Bson                        | 1.0.2          |         | 554,641,545     |
+    | Newtonsoft.Json.Schema                      | 3.0.15         |         | 39,648,430      |
+    | Microsoft.AspNetCore.Mvc.NewtonsoftJson     | 7.0.12         |         | 317,067,823     |
+    ...
+```
+
+```dotnetcli
+dotnet package search Newtonsoft.Json --source https://api.nuget.org/v3/index.json --skip 1 --take 2
+```
+
+output a list of 2 packages after skipping 1 in the source matching the search term.
+
+```
+    Source: https://api.nuget.org/v3/index.json
+    | Package ID                                  | Latest Version | Authors | Downloads       |
+    |---------------------------------------------|----------------|---------|-----------------|
+    | Newtonsoft.Json.Bson                        | 1.0.2          |         | 554,641,545     |
+    | Newtonsoft.Json.Schema                      | 3.0.15         |         | 39,648,430      |
+```
+
+```dotnetcli
+dotnet package search Newtonsoft.Json --source https://api.nuget.org/v3/index.json --exact-match
+```
+
+output only an exact match.
+
+```
+    Source: https://api.nuget.org/v3/index.json
+    | Package ID                                  | Latest Version | Authors | Downloads       |
+    |---------------------------------------------|----------------|---------|-----------------|
+    | Newtonsoft.Json                             | 13.0.3         |         | 3,829,822,911   |
+```

--- a/docs/core/tools/dotnet-package-search.md
+++ b/docs/core/tools/dotnet-package-search.md
@@ -98,7 +98,7 @@ The `dotnet package search` command searches for a NuGet package.
         ...
     ```
 
-- Search NuGet.org for packages using the search term "Newtonsoft.Json" and render the output as a json.
+- Search NuGet.org for packages that match the search term "Newtonsoft.Json," and render the output as json.
 
     ```dotnetcli
     dotnet package search Newtonsoft.Json --source https://api.nuget.org/v3/index.json --format json

--- a/docs/core/tools/dotnet-package-search.md
+++ b/docs/core/tools/dotnet-package-search.md
@@ -83,8 +83,6 @@ The `dotnet package search` command searches for a NuGet package.
     dotnet package search Newtonsoft.Json --source https://api.nuget.org/v3/index.json
     ```
 
-    output a list of 20 packages in the source matching the search term.
-
     ```output
         Source: https://api.nuget.org/v3/index.json
         | Package ID                                  | Latest Version | Owners | Downloads       |

--- a/docs/core/tools/dotnet-package-search.md
+++ b/docs/core/tools/dotnet-package-search.md
@@ -154,8 +154,6 @@ The `dotnet package search` command searches for a NuGet package.
     dotnet package search Newtonsoft.Json --source https://api.nuget.org/v3/index.json --skip 1 --take 2
     ```
 
-    output a list of 2 packages after skipping 1 in the source matching the search term.
-
     ```output
         Source: https://api.nuget.org/v3/index.json
         | Package ID                                  | Latest Version | Owners | Downloads       |

--- a/docs/core/tools/dotnet-package-search.md
+++ b/docs/core/tools/dotnet-package-search.md
@@ -168,8 +168,6 @@ The `dotnet package search` command searches for a NuGet package.
     dotnet package search Newtonsoft.Json --source https://api.nuget.org/v3/index.json --exact-match
     ```
 
-    output only an exact match.
-
     ```output
         Source: https://api.nuget.org/v3/index.json
         | Package ID                                  | Version | Owners | Downloads       |

--- a/docs/core/tools/dotnet-package-search.md
+++ b/docs/core/tools/dotnet-package-search.md
@@ -137,36 +137,6 @@ The `dotnet package search` command searches for a NuGet package.
                 "owners": "aspnet, dotnetframework, Microsoft"
                 },
                 {
-                "id": "GraphQL.Client.Serializer.Newtonsoft",
-                "latestVersion": "6.0.2",
-                "totalDownloads": 13538118,
-                "owners": "rose-a"
-                },
-                {
-                "id": "StackExchange.Redis.Extensions.Newtonsoft",
-                "latestVersion": "10.2.0",
-                "totalDownloads": 11013705,
-                "owners": "imperugo"
-                },
-                {
-                "id": "CloudNative.CloudEvents.NewtonsoftJson",
-                "latestVersion": "2.7.1",
-                "totalDownloads": 2156165,
-                "owners": "CloudNative.CloudEvents"
-                },
-                {
-                "id": "h5.Newtonsoft.Json",
-                "latestVersion": "24.2.45748",
-                "totalDownloads": 3855727,
-                "owners": "Curiosity"
-                },
-                {
-                "id": "Newtonsoft.Json.FSharp",
-                "latestVersion": "3.2.2",
-                "totalDownloads": 245301,
-                "owners": "henrik feldt"
-                },
-                {
                 "id": "Newtonsoft.Json.Encryption",
                 "latestVersion": "2.2.0",
                 "totalDownloads": 113101,

--- a/docs/core/tools/dotnet-package-search.md
+++ b/docs/core/tools/dotnet-package-search.md
@@ -15,9 +15,9 @@ ms.date: 10/26/2023
 ## Synopsis
 
 ```dotnetcli
-dotnet package search <SEARCH TERM> [--source <SOURCE>] [--exact-match]
-    [--prerelease][--interactive][--take <NUMBER>][--skip <NUMBER>]
-    [--format <FORMAT OPTION>]
+dotnet package search <SEARCH TERM> [--configfile <FILE>] [--exact-match] [--format <FORMAT OPTION>]
+    [--interactive] [--prerelease] [--skip <NUMBER>] [--source <SOURCE>] [--take <NUMBER>]
+    [--verbosity <VERBOSITY VALUE>]
 
 dotnet package search -h|--help
 ```

--- a/docs/core/tools/dotnet-package-search.md
+++ b/docs/core/tools/dotnet-package-search.md
@@ -137,42 +137,6 @@ The `dotnet package search` command searches for a NuGet package.
                 "owners": "aspnet, dotnetframework, Microsoft"
                 },
                 {
-                "id": "RestSharp.Serializers.NewtonsoftJson",
-                "latestVersion": "110.2.0",
-                "totalDownloads": 13462500,
-                "owners": "alexey_zimarev, Ubiquitous"
-                },
-                {
-                "id": "App.Metrics.Formatters.Json",
-                "latestVersion": "4.3.0",
-                "totalDownloads": 30385383,
-                "owners": "al_hardy"
-                },
-                {
-                "id": "NServiceBus.Newtonsoft.Json",
-                "latestVersion": "3.0.0",
-                "totalDownloads": 9386309,
-                "owners": "ParticularSoftware"
-                },
-                {
-                "id": "RestSharp.Newtonsoft.Json",
-                "latestVersion": "1.5.1",
-                "totalDownloads": 4295800,
-                "owners": "adamfisher"
-                },
-                {
-                "id": "Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson",
-                "latestVersion": "8.0.3",
-                "totalDownloads": 17044287,
-                "owners": "aspnet, dotnetframework, Microsoft"
-                },
-                {
-                "id": "MassTransit.Newtonsoft",
-                "latestVersion": "8.1.3",
-                "totalDownloads": 5185238,
-                "owners": "phatboyg"
-                },
-                {
                 "id": "GraphQL.Client.Serializer.Newtonsoft",
                 "latestVersion": "6.0.2",
                 "totalDownloads": 13538118,

--- a/docs/core/tools/dotnet-package-search.md
+++ b/docs/core/tools/dotnet-package-search.md
@@ -38,7 +38,7 @@ The `dotnet package search` command searches for a NuGet package.
 
     The NuGet configuration file. If specified, only the settings from this file will be used. If not
     specified, the hierarchy of configuration files from the current directory will be used. For more
-    information, see <https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior>.
+    information, see [Common NuGet configurations](/nuget/consume-packages/configuring-nuget-behavior).
 
 - **`--exact-match`**
 

--- a/docs/core/tools/dotnet-package-search.md
+++ b/docs/core/tools/dotnet-package-search.md
@@ -137,30 +137,6 @@ The `dotnet package search` command searches for a NuGet package.
                 "owners": "aspnet, dotnetframework, Microsoft"
                 },
                 {
-                "id": "Swashbuckle.AspNetCore.Newtonsoft",
-                "latestVersion": "6.5.0",
-                "totalDownloads": 81345453,
-                "owners": "domaindrivendev"
-                },
-                {
-                "id": "GraphQL.NewtonsoftJson",
-                "latestVersion": "7.8.0",
-                "totalDownloads": 11244179,
-                "owners": "joemcbride"
-                },
-                {
-                "id": "Refit.Newtonsoft.Json",
-                "latestVersion": "7.0.0",
-                "totalDownloads": 12583471,
-                "owners": "dotnetfoundation, reactiveui"
-                },
-                {
-                "id": "Microsoft.Azure.Core.NewtonsoftJson",
-                "latestVersion": "2.0.0",
-                "totalDownloads": 6593746,
-                "owners": "azure-sdk, Microsoft"
-                },
-                {
                 "id": "RestSharp.Serializers.NewtonsoftJson",
                 "latestVersion": "110.2.0",
                 "totalDownloads": 13462500,

--- a/docs/core/tools/dotnet-package-search.md
+++ b/docs/core/tools/dotnet-package-search.md
@@ -162,7 +162,7 @@ The `dotnet package search` command searches for a NuGet package.
         | Newtonsoft.Json.Schema                      | 3.0.15         |        | 39,648,430      |
     ```
 
-- Search for packages that exactly match "Newtonsoft.Json" and list all available versions of it, ignoring any packages that contain "Newtonsoft.Json" as a part of their name or description but don't match it exactly.
+- Search for packages that exactly match "Newtonsoft.Json" and list all available versions of it, ignoring any packages that contain "Newtonsoft.Json" as a part of their name or description but don't match it exactly:
 
     ```dotnetcli
     dotnet package search Newtonsoft.Json --source https://api.nuget.org/v3/index.json --exact-match

--- a/docs/core/tools/dotnet-package-search.md
+++ b/docs/core/tools/dotnet-package-search.md
@@ -34,6 +34,12 @@ The `dotnet package search` command searches for a NuGet package.
 
 ## Options
 
+- **`--configfile`**
+
+    The NuGet configuration file. If specified, only the settings from this file will be used. If not
+    specified, the hierarchy of configuration files from the current directory will be used. For more
+    information, see <https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior>.
+
 - **`--exact-match`**
 
     This option narrows the search to only include packages whose IDs exactly match the specified search term, effectively filtering out any partial matches. It provides a concise list of all available versions for the identified package. Causes `--take` and `--skip`

--- a/docs/core/tools/dotnet-package-search.md
+++ b/docs/core/tools/dotnet-package-search.md
@@ -1,6 +1,6 @@
 ---
 title: dotnet package search command
-description: Searches a given source using the query string provided. If no sources are specified, all sources defined in the NuGet.Config file are used
+description: Searches a given source using the query string provided. If no sources are specified, all sources defined in the NuGet.Config file are used.
 author: Nigusu-Allehu
 ms.date: 10/26/2023
 ---

--- a/docs/core/tools/dotnet-package-search.md
+++ b/docs/core/tools/dotnet-package-search.md
@@ -148,7 +148,7 @@ The `dotnet package search` command searches for a NuGet package.
         }
     ```
 
-- Search NuGet.org for packages using the search term "Newtonsoft.Json", show only two results and skip the first packages in the search result
+- Search NuGet.org for packages using the search term "Newtonsoft.Json," show only two results, and skip the first packages in the search result:
 
     ```dotnetcli
     dotnet package search Newtonsoft.Json --source https://api.nuget.org/v3/index.json --skip 1 --take 2

--- a/docs/core/tools/dotnet-package-search.md
+++ b/docs/core/tools/dotnet-package-search.md
@@ -77,7 +77,7 @@ The `dotnet package search` command searches for a NuGet package.
 
 ## Examples
 
-- Search NuGet.org for packages using the search term "Newtonsoft.Json"
+- Search NuGet.org for packages that match the search term "Newtonsoft.Json," and render the output as a table with up to 20 packages:
 
     ```dotnetcli
     dotnet package search Newtonsoft.Json --source https://api.nuget.org/v3/index.json

--- a/docs/core/tools/dotnet-package-search.md
+++ b/docs/core/tools/dotnet-package-search.md
@@ -15,13 +15,9 @@ ms.date: 10/26/2023
 ## Synopsis
 
 ```dotnetcli
-dotnet package search [search terms] [options]
-    [--source <SOURCE>]
-    [--exact-match]
-    [--prerelease]
-    [--interactive]
-    [--take <TAKE>]
-    [--skip <SKIP>]
+dotnet package search <SEARCH TERM> [--source <SOURCE>] [--exact-match]
+    [--prerelease][--interactive][--take <NUMBER>][--skip <NUMBER>]
+    [--format <FORMAT OPTION>]
 
 dotnet package search -h|--help
 ```
@@ -38,74 +34,233 @@ The `dotnet package search` command searches for a NuGet package.
 
 ## Options
 
-- **`--source <SOURCE>`**
-
-  The package source to search. You can pass multiple --source options to search multiple package sources.
-
 - **`--exact-match`**
 
-  Return exact matches only as a search result.
+    This option narrows the search to only include packages whose IDs exactly match the specified search term, effectively filtering out any partial matches. It provides a concise list of all available versions for the identified package. Causes `--take` and `--skip`
+    options to be ignored. Utilize this option to display all available versions of a specified package.
 
-- **`--prerelease`**
+- **`--format`**
 
-    Allow prerelease packages to be shown.
+    Format the output accordingly. The format options are either `table` or `json`. The default is `table`.
 
 - **`--interactive`**
 
     Allows the command to stop and wait for user input or action (for example to complete authentication).
 
-- **`--take`**
+- **`--prerelease`**
 
-    The number of results to return. The default value is 20.
+    Allow prerelease packages to be shown.
 
 - **`--skip`**
 
     The number of results to skip, for pagination. The default value is 0.
 
+- **`--source <SOURCE>`**
+
+    The package source to search. You can pass multiple --source options to search multiple package sources.
+
+- **`--take`**
+
+    The number of results to return. The default value is 20.
+
+- **`--verbosity`**
+
+    Display this amount of details in the output: `normal`, `minimal`,`detailed`. The default is`normal`.
+
 [!INCLUDE [help](../../../includes/cli-help.md)]
 
 ## Examples
 
-```dotnetcli
-dotnet package search Newtonsoft.Json --source https://api.nuget.org/v3/index.json
-```
+- Search NuGet.org for packages using the search term "Newtonsoft.Json"
 
-output a list of 20 packages in the source matching the search term.
+    ```dotnetcli
+    dotnet package search Newtonsoft.Json --source https://api.nuget.org/v3/index.json
+    ```
 
-```
-    Source: https://api.nuget.org/v3/index.json
-    | Package ID                                  | Latest Version | Authors | Downloads       |
-    |---------------------------------------------|----------------|---------|-----------------|
-    | Newtonsoft.Json                             | 13.0.3         |         | 3,829,822,911   |
-    | Newtonsoft.Json.Bson                        | 1.0.2          |         | 554,641,545     |
-    | Newtonsoft.Json.Schema                      | 3.0.15         |         | 39,648,430      |
-    | Microsoft.AspNetCore.Mvc.NewtonsoftJson     | 7.0.12         |         | 317,067,823     |
-    ...
-```
+    output a list of 20 packages in the source matching the search term.
 
-```dotnetcli
-dotnet package search Newtonsoft.Json --source https://api.nuget.org/v3/index.json --skip 1 --take 2
-```
+    ```output
+        Source: https://api.nuget.org/v3/index.json
+        | Package ID                                  | Latest Version | Owners | Downloads       |
+        |---------------------------------------------|----------------|--------|-----------------|
+        | Newtonsoft.Json                             | 13.0.3         |        | 3,829,822,911   |
+        |---------------------------------------------|----------------|--------|-----------------|
+        | Newtonsoft.Json.Bson                        | 1.0.2          |        | 554,641,545     |
+        |---------------------------------------------|----------------|--------|-----------------|
+        | Newtonsoft.Json.Schema                      | 3.0.15         |        | 39,648,430      |
+        |---------------------------------------------|----------------|--------|-----------------|
+        | Microsoft.AspNetCore.Mvc.NewtonsoftJson     | 7.0.12         |        | 317,067,823     |
+        |---------------------------------------------|----------------|--------|-----------------|
+        ...
+    ```
 
-output a list of 2 packages after skipping 1 in the source matching the search term.
+- Search NuGet.org for packages using the search term "Newtonsoft.Json" and render the output as a json.
 
-```
-    Source: https://api.nuget.org/v3/index.json
-    | Package ID                                  | Latest Version | Authors | Downloads       |
-    |---------------------------------------------|----------------|---------|-----------------|
-    | Newtonsoft.Json.Bson                        | 1.0.2          |         | 554,641,545     |
-    | Newtonsoft.Json.Schema                      | 3.0.15         |         | 39,648,430      |
-```
+    ```dotnetcli
+    dotnet package search Newtonsoft.Json --source https://api.nuget.org/v3/index.json --format json
+    ```
 
-```dotnetcli
-dotnet package search Newtonsoft.Json --source https://api.nuget.org/v3/index.json --exact-match
-```
+    ```output
+        {
+        "version": 2,
+        "problems": [],
+        "searchResult": [
+            {
+            "sourceName": "https://api.nuget.org/v3/index.json",
+            "packages": [
+                {
+                "id": "Newtonsoft.Json",
+                "latestVersion": "13.0.3",
+                "totalDownloads": 4456137550,
+                "owners": "dotnetfoundation, jamesnk, newtonsoft"
+                },
+                {
+                "id": "Newtonsoft.Json.Bson",
+                "latestVersion": "1.0.2",
+                "totalDownloads": 655362732,
+                "owners": "dotnetfoundation, jamesnk, newtonsoft"
+                },
+                {
+                "id": "Newtonsoft.Json.Schema",
+                "latestVersion": "3.0.15",
+                "totalDownloads": 46062119,
+                "owners": "jamesnk, newtonsoft"
+                },
+                {
+                "id": "Microsoft.AspNetCore.Mvc.NewtonsoftJson",
+                "latestVersion": "8.0.3",
+                "totalDownloads": 372202749,
+                "owners": "aspnet, dotnetframework, Microsoft"
+                },
+                {
+                "id": "Swashbuckle.AspNetCore.Newtonsoft",
+                "latestVersion": "6.5.0",
+                "totalDownloads": 81345453,
+                "owners": "domaindrivendev"
+                },
+                {
+                "id": "GraphQL.NewtonsoftJson",
+                "latestVersion": "7.8.0",
+                "totalDownloads": 11244179,
+                "owners": "joemcbride"
+                },
+                {
+                "id": "Refit.Newtonsoft.Json",
+                "latestVersion": "7.0.0",
+                "totalDownloads": 12583471,
+                "owners": "dotnetfoundation, reactiveui"
+                },
+                {
+                "id": "Microsoft.Azure.Core.NewtonsoftJson",
+                "latestVersion": "2.0.0",
+                "totalDownloads": 6593746,
+                "owners": "azure-sdk, Microsoft"
+                },
+                {
+                "id": "RestSharp.Serializers.NewtonsoftJson",
+                "latestVersion": "110.2.0",
+                "totalDownloads": 13462500,
+                "owners": "alexey_zimarev, Ubiquitous"
+                },
+                {
+                "id": "App.Metrics.Formatters.Json",
+                "latestVersion": "4.3.0",
+                "totalDownloads": 30385383,
+                "owners": "al_hardy"
+                },
+                {
+                "id": "NServiceBus.Newtonsoft.Json",
+                "latestVersion": "3.0.0",
+                "totalDownloads": 9386309,
+                "owners": "ParticularSoftware"
+                },
+                {
+                "id": "RestSharp.Newtonsoft.Json",
+                "latestVersion": "1.5.1",
+                "totalDownloads": 4295800,
+                "owners": "adamfisher"
+                },
+                {
+                "id": "Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson",
+                "latestVersion": "8.0.3",
+                "totalDownloads": 17044287,
+                "owners": "aspnet, dotnetframework, Microsoft"
+                },
+                {
+                "id": "MassTransit.Newtonsoft",
+                "latestVersion": "8.1.3",
+                "totalDownloads": 5185238,
+                "owners": "phatboyg"
+                },
+                {
+                "id": "GraphQL.Client.Serializer.Newtonsoft",
+                "latestVersion": "6.0.2",
+                "totalDownloads": 13538118,
+                "owners": "rose-a"
+                },
+                {
+                "id": "StackExchange.Redis.Extensions.Newtonsoft",
+                "latestVersion": "10.2.0",
+                "totalDownloads": 11013705,
+                "owners": "imperugo"
+                },
+                {
+                "id": "CloudNative.CloudEvents.NewtonsoftJson",
+                "latestVersion": "2.7.1",
+                "totalDownloads": 2156165,
+                "owners": "CloudNative.CloudEvents"
+                },
+                {
+                "id": "h5.Newtonsoft.Json",
+                "latestVersion": "24.2.45748",
+                "totalDownloads": 3855727,
+                "owners": "Curiosity"
+                },
+                {
+                "id": "Newtonsoft.Json.FSharp",
+                "latestVersion": "3.2.2",
+                "totalDownloads": 245301,
+                "owners": "henrik feldt"
+                },
+                {
+                "id": "Newtonsoft.Json.Encryption",
+                "latestVersion": "2.2.0",
+                "totalDownloads": 113101,
+                "owners": "simoncropp"
+                }
+            ]
+            }
+        ]
+        }
+    ```
 
-output only an exact match.
+- Search NuGet.org for packages using the search term "Newtonsoft.Json", show only two results and skip the first packages in the search result
 
-```
-    Source: https://api.nuget.org/v3/index.json
-    | Package ID                                  | Latest Version | Authors | Downloads       |
-    |---------------------------------------------|----------------|---------|-----------------|
-    | Newtonsoft.Json                             | 13.0.3         |         | 3,829,822,911   |
-```
+    ```dotnetcli
+    dotnet package search Newtonsoft.Json --source https://api.nuget.org/v3/index.json --skip 1 --take 2
+    ```
+
+    output a list of 2 packages after skipping 1 in the source matching the search term.
+
+    ```output
+        Source: https://api.nuget.org/v3/index.json
+        | Package ID                                  | Latest Version | Owners | Downloads       |
+        |---------------------------------------------|----------------|--------|-----------------|
+        | Newtonsoft.Json.Bson                        | 1.0.2          |        | 554,641,545     |
+        | Newtonsoft.Json.Schema                      | 3.0.15         |        | 39,648,430      |
+    ```
+
+- Search for packages that exactly match "Newtonsoft.Json" and list all available versions of it, ignoring any packages that contain "Newtonsoft.Json" as a part of their name or description but don't match it exactly.
+
+    ```dotnetcli
+    dotnet package search Newtonsoft.Json --source https://api.nuget.org/v3/index.json --exact-match
+    ```
+
+    output only an exact match.
+
+    ```output
+        Source: https://api.nuget.org/v3/index.json
+        | Package ID                                  | Version | Owners | Downloads       |
+        |---------------------------------------------|---------|--------|-----------------|
+        | Newtonsoft.Json                             | 13.0.3  |        | 3,829,822,911   |
+    ```

--- a/docs/core/tools/dotnet-package-search.md
+++ b/docs/core/tools/dotnet-package-search.md
@@ -47,7 +47,7 @@ The `dotnet package search` command searches for a NuGet package.
 
 - **`--format`**
 
-    Format the output accordingly. The format options are either `table` or `json`. The default is `table`.
+    The format options are `table` and `json`. The default is `table`.
 
 - **`--interactive`**
 

--- a/docs/core/tools/dotnet-package-search.md
+++ b/docs/core/tools/dotnet-package-search.md
@@ -71,7 +71,7 @@ The `dotnet package search` command searches for a NuGet package.
 
 - **`--verbosity`**
 
-    Display this amount of details in the output: `normal`, `minimal`,`detailed`. The default is`normal`.
+    Display this amount of details in the output: `normal`, `minimal`, or `detailed`. The default is `normal`.
 
 [!INCLUDE [help](../../../includes/cli-help.md)]
 

--- a/docs/core/tools/index.md
+++ b/docs/core/tools/index.md
@@ -59,6 +59,7 @@ The following commands are installed by default:
 - [`nuget verify`](dotnet-nuget-verify.md) (Available since .NET 5 SDK)
 - [`nuget trust`](dotnet-nuget-trust.md) (Available since .NET 5 SDK)
 - [`nuget sign`](dotnet-nuget-sign.md) (Available since .NET 6 SDK)
+- [`package search`](dotnet-package-search.md)
 
 ### Workload management commands
 

--- a/docs/core/tools/index.md
+++ b/docs/core/tools/index.md
@@ -59,7 +59,7 @@ The following commands are installed by default:
 - [`nuget verify`](dotnet-nuget-verify.md) (Available since .NET 5 SDK)
 - [`nuget trust`](dotnet-nuget-trust.md) (Available since .NET 5 SDK)
 - [`nuget sign`](dotnet-nuget-sign.md) (Available since .NET 6 SDK)
-- [`package search`](dotnet-package-search.md)
+- [`package search`](dotnet-package-search.md) (Available since .NET 8.02 SDK)
 
 ### Workload management commands
 

--- a/docs/core/tools/index.md
+++ b/docs/core/tools/index.md
@@ -59,7 +59,7 @@ The following commands are installed by default:
 - [`nuget verify`](dotnet-nuget-verify.md) (Available since .NET 5 SDK)
 - [`nuget trust`](dotnet-nuget-trust.md) (Available since .NET 5 SDK)
 - [`nuget sign`](dotnet-nuget-sign.md) (Available since .NET 6 SDK)
-- [`package search`](dotnet-package-search.md) (Available since .NET 8.02xx SDK)
+- [`package search`](dotnet-package-search.md) (Available since .NET 8.0.2xx SDK)
 
 ### Workload management commands
 

--- a/docs/core/tools/index.md
+++ b/docs/core/tools/index.md
@@ -59,7 +59,7 @@ The following commands are installed by default:
 - [`nuget verify`](dotnet-nuget-verify.md) (Available since .NET 5 SDK)
 - [`nuget trust`](dotnet-nuget-trust.md) (Available since .NET 5 SDK)
 - [`nuget sign`](dotnet-nuget-sign.md) (Available since .NET 6 SDK)
-- [`package search`](dotnet-package-search.md) (Available since .NET 8.02 SDK)
+- [`package search`](dotnet-package-search.md) (Available since .NET 8.02xx SDK)
 
 ### Workload management commands
 


### PR DESCRIPTION
## Summary

Add `dotnet package search` documentation.
Implementation: https://github.com/NuGet/NuGet.Client/pull/5466


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-package-search.md](https://github.com/dotnet/docs/blob/e56d055db72724d30dc2d12712bb23a6753aae9b/docs/core/tools/dotnet-package-search.md) | [dotnet package search](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-package-search?branch=pr-en-us-37747) |
| [docs/core/tools/index.md](https://github.com/dotnet/docs/blob/e56d055db72724d30dc2d12712bb23a6753aae9b/docs/core/tools/index.md) | [.NET CLI](https://review.learn.microsoft.com/en-us/dotnet/core/tools/index?branch=pr-en-us-37747) |


<!-- PREVIEW-TABLE-END -->