### PR TITLE
Fixes GitHub issue #33488 - Suggest using streamreader instead of iterating over the stream

### DIFF
--- a/docs/core/compatibility/core-libraries/6.0/partial-byte-reads-in-streams.md
+++ b/docs/core/compatibility/core-libraries/6.0/partial-byte-reads-in-streams.md
@@ -1,7 +1,7 @@
 ---
 title: "Breaking change: Partial and zero-byte reads in DeflateStream, GZipStream, and CryptoStream"
 description: Learn about the .NET 6 breaking change in core .NET libraries where DeflateStream, GZipStream, and CryptoStream handle partial and zero-byte reads differently.
-ms.date: 06/23/2021
+ms.date: 10/26/2023
 ---
 # Partial and zero-byte reads in DeflateStream, GZipStream, and CryptoStream
 
@@ -64,6 +64,12 @@ In general, code should:
   {
       bytesRead = stream.Read(buffer);
   }
+  ```
+
+- Alternatively, use a `StreamReader` instead of manually iterating over the stream.
+
+  ```csharp
+  return new StreamReader(cryptoStream).ReadToEnd();
   ```
 
 ## Affected APIs


### PR DESCRIPTION
## Summary

Fixes #33488 

Edits article **Partial and zero-byte reads in DeflateStream, GZipStream, and CryptoStream**

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/core-libraries/6.0/partial-byte-reads-in-streams.md](https://github.com/dotnet/docs/blob/55c80114f4d43038b8e3190fa2128f81e106079b/docs/core/compatibility/core-libraries/6.0/partial-byte-reads-in-streams.md) | [Partial and zero-byte reads in DeflateStream, GZipStream, and CryptoStream](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/partial-byte-reads-in-streams?branch=pr-en-us-37752) |

<!-- PREVIEW-TABLE-END -->