### PR TITLE
Fix code regarding to console output log

### DIFF
--- a/docs/csharp/language-reference/keywords/snippets/RefParameterModifier.cs
+++ b/docs/csharp/language-reference/keywords/snippets/RefParameterModifier.cs
@@ -54,7 +54,7 @@ namespace InRefOutModifier
         private static void ChangeByReference(ref Product itemRef)
         {
             // Change the address that is stored in the itemRef parameter.
-            itemRef = new Product("Stapler", 99999);
+            itemRef = new Product("Stapler", 12345);
         }
 
         private static void ModifyProductsByReference()


### PR DESCRIPTION
I could change the console output but based on the other part of the code it seems the code should be changed. So the snippet is talking about ``ref parameter `` and first creates an object with ID ``54321`` and then seems to want to change ID to ``12345`` to show the case.

Docs link: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/method-parameters

![image](https://github.com/dotnet/docs/assets/12181394/04d420d5-c86b-4244-9ed7-9fddfe63fae5)

