### PR TITLE
Add C# hot reload support for generics to the "What's new in .NET 8" doc

### DIFF
--- a/docs/core/whats-new/dotnet-8.md
+++ b/docs/core/whats-new/dotnet-8.md
@@ -1539,6 +1539,12 @@ Most users shouldn't notice the verification. However, if you have an existing r
 
 You can opt out of verification by setting the environment variable `DOTNET_NUGET_SIGNATURE_VERIFICATION` to `false`.
 
+## Diagnostics
+
+### C# Hot Reload supports modifying generics
+
+Starting in .NET 8, C# Hot Reload [supports modifying generic types and generic methods](https://devblogs.microsoft.com/dotnet/hot-reload-generics/).  When debugging console, desktop, mobile or WebAssembly applications with Visual Studio, applying changes to C# code or Razor pages is now supported in generic classes and generic methods.  See the [full list of edits supported by Roslyn](https://github.com/dotnet/roslyn/blob/main/docs/wiki/EnC-Supported-Edits.md)
+
 ## See also
 
 - [Breaking changes in .NET 8](../compatibility/8.0.md)

--- a/docs/core/whats-new/dotnet-8.md
+++ b/docs/core/whats-new/dotnet-8.md
@@ -1543,7 +1543,7 @@ You can opt out of verification by setting the environment variable `DOTNET_NUGE
 
 ### C# Hot Reload supports modifying generics
 
-Starting in .NET 8, C# Hot Reload [supports modifying generic types and generic methods](https://devblogs.microsoft.com/dotnet/hot-reload-generics/).  When debugging console, desktop, mobile or WebAssembly applications with Visual Studio, applying changes to C# code or Razor pages is now supported in generic classes and generic methods.  See the [full list of edits supported by Roslyn](https://github.com/dotnet/roslyn/blob/main/docs/wiki/EnC-Supported-Edits.md)
+Starting in .NET 8, C# Hot Reload [supports modifying generic types and generic methods](https://devblogs.microsoft.com/dotnet/hot-reload-generics/). When you debug console, desktop, mobile, or WebAssembly applications with Visual Studio, you can apply changes to generic classes and generic methods in C# code or Razor pages. For more information, see the [full list of edits supported by Roslyn](https://github.com/dotnet/roslyn/blob/main/docs/wiki/EnC-Supported-Edits.md)
 
 ## See also
 


### PR DESCRIPTION
## Summary

Add a section to "What's new in .NET 8" that mentions support for hot reload of generic types and methods.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/whats-new/dotnet-8.md](https://github.com/dotnet/docs/blob/15ca7508a805bd14a96f42408b80382b9f9d043f/docs/core/whats-new/dotnet-8.md) | [What's new in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-8?branch=pr-en-us-37761) |


<!-- PREVIEW-TABLE-END -->