### PR TITLE
Fixes GitHub issue #32977 - Add linux-musl-arm64 To List of RIDs

### DIFF
--- a/docs/core/rid-catalog.md
+++ b/docs/core/rid-catalog.md
@@ -1,7 +1,7 @@
 ---
 title: .NET Runtime Identifier (RID) catalog
 description: Learn about the runtime identifier (RID) and how RIDs are used in .NET.
-ms.date: 07/11/2022
+ms.date: 10/27/2023
 ---
 # .NET RID Catalog
 
@@ -111,6 +111,7 @@ For more information, see [.NET dependencies and requirements](./install/windows
 
 - `linux-x64` (Most desktop distributions like CentOS, Debian, Fedora, Ubuntu, and derivatives)
 - `linux-musl-x64` (Lightweight distributions using [musl](https://wiki.musl-libc.org/projects-using-musl.html) like Alpine Linux)
+- `linux-musl-arm64` (Used to build Docker images for 64-bit Arm v8 and minimalistic base images)
 - `linux-arm` (Linux distributions running on Arm like Raspbian on Raspberry Pi Model 2+)
 - `linux-arm64` (Linux distributions running on 64-bit Arm like Ubuntu Server 64-bit on Raspberry Pi Model 3+)
 - `linux-bionic-arm64` (Distributions using Android's bionic libc, for example, Termux)


### PR DESCRIPTION
## Summary

Fixes #32977 

Edits article **.NET Runtime Identifier (RID) catalog**


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/rid-catalog.md](https://github.com/dotnet/docs/blob/5e66a27fbe361c44ca82e0b91f98f0ddf5ed3c52/docs/core/rid-catalog.md) | [.NET RID Catalog](https://review.learn.microsoft.com/en-us/dotnet/core/rid-catalog?branch=pr-en-us-37764) |

<!-- PREVIEW-TABLE-END -->