### PR TITLE
Scripting APIs in Understand the .NET Compiler Platform SDK model

### DIFF
--- a/docs/csharp/roslyn-sdk/compiler-api-model.md
+++ b/docs/csharp/roslyn-sdk/compiler-api-model.md
@@ -77,11 +77,11 @@ and suggesting code fixes.
 
 ### Scripting APIs
 
-Hosting and scripting APIs are part of the compiler layer. You can use them
-for executing code snippets and accumulating a runtime execution context.
-The C# interactive REPL (Read-Evaluate-Print Loop) uses these APIs. The REPL
-enables you to use C# as a scripting language, executing the code interactively
-as you write it.
+Hosting and scripting APIs are built on top of the compiler layer. You
+can use the scripting APIs to run code snippets and accumulate a runtime
+execution context. The C# interactive REPL (Read-Evaluate-Print Loop)
+uses these APIs. The REPL enables you to use C# as a scripting language,
+running the code interactively as you write it.
 
 ### Workspaces APIs
 


### PR DESCRIPTION
## Summary

Modify text based on comments to linked issue.

Fixes #23402

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/roslyn-sdk/compiler-api-model.md](https://github.com/dotnet/docs/blob/113ccf913e7c22281ae15dba406c5fb78ac1fefa/docs/csharp/roslyn-sdk/compiler-api-model.md) | [Understand the .NET Compiler Platform SDK model](https://review.learn.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/compiler-api-model?branch=pr-en-us-37769) |

<!-- PREVIEW-TABLE-END -->