### PR TITLE
Fix GitHub issue #32585: GUID interop guidance is confusing

### DIFF
--- a/docs/standard/native-interop/best-practices.md
+++ b/docs/standard/native-interop/best-practices.md
@@ -1,7 +1,7 @@
 ---
 title: Native interoperability best practices - .NET
 description: Learn the best practices for interfacing with native components in .NET.
-ms.date: 01/18/2019
+ms.date: 10/27/2023
 ---
 # Native interoperability best practices
 
@@ -34,7 +34,7 @@ The guidance in this section applies to all interop scenarios.
 
 When the CharSet is Unicode or the argument is explicitly marked as `[MarshalAs(UnmanagedType.LPWSTR)]` _and_ the string is passed by value (not `ref` or `out`), the string will be pinned and used directly by native code (rather than copied).
 
-❌ DO NOT use `[Out] string` parameters. String parameters passed by value with the `[Out]` attribute can destabilize the runtime if the string is an interned string. See more information about string interning in the documentation for <xref:System.String.Intern%2A?displayProperty=nameWithType>.
+❌ DON'T use `[Out] string` parameters. String parameters passed by value with the `[Out]` attribute can destabilize the runtime if the string is an interned string. See more information about string interning in the documentation for <xref:System.String.Intern%2A?displayProperty=nameWithType>.
 
 ✔️ CONSIDER setting the `CharSet` property in `[DllImport]` so the runtime knows the expected string encoding.
 
@@ -74,13 +74,13 @@ Booleans are easy to mess up. By default, a .NET `bool` is marshalled to a Windo
 
 ## GUIDs
 
-GUIDs are usable directly in signatures. Many Windows APIs take `GUID&` type aliases like `REFIID`. When passed by ref, they can either be passed by `ref` or with the `[MarshalAs(UnmanagedType.LPStruct)]` attribute.
+GUIDs are usable directly in signatures. Many Windows APIs take `GUID&` type aliases like `REFIID`. When the method signature contains a reference parameter, place either a `ref` keyword or a `[MarshalAs(UnmanagedType.LPStruct)]` attribute on the GUID parameter declaration.
 
 | GUID | By-ref GUID |
 |------|-------------|
 | `KNOWNFOLDERID` | `REFKNOWNFOLDERID` |
 
-❌ DO NOT Use `[MarshalAs(UnmanagedType.LPStruct)]` for anything other than `ref` GUID parameters.
+❌ DON'T Use `[MarshalAs(UnmanagedType.LPStruct)]` for anything other than `ref` GUID parameters.
 
 ## Blittable types
 


### PR DESCRIPTION
## Summary

Fixes #32585

Edits article [Native interoperability best practices - .NET](https://learn.microsoft.com/en-us/dotnet/standard/native-interop/best-practices#guids)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/native-interop/best-practices.md](https://github.com/dotnet/docs/blob/408627da8ac59be2ebb8a1e7fa16269b8b6bef81/docs/standard/native-interop/best-practices.md) | [Native interoperability best practices](https://review.learn.microsoft.com/en-us/dotnet/standard/native-interop/best-practices?branch=pr-en-us-37772) |

<!-- PREVIEW-TABLE-END -->