### PR TITLE
Fix GitHub issues #32882-3: Surprising flow with Not Boolean?

### DIFF
--- a/docs/visual-basic/language-reference/operators/not-operator.md
+++ b/docs/visual-basic/language-reference/operators/not-operator.md
@@ -1,7 +1,7 @@
 ---
 description: "Learn more about: Not Operator (Visual Basic)"
 title: "Not Operator"
-ms.date: 07/20/2015
+ms.date: 10/27/2023
 f1_keywords: 
   - "vb.Not"
 helpviewer_keywords: 
@@ -53,6 +53,8 @@ result = Not expression
 > [!NOTE]
 > Since the logical and bitwise operators have a lower precedence than other arithmetic and relational operators, any bitwise operations should be enclosed in parentheses to ensure accurate execution.  
   
+Note that `if Not someStr?.Contains("some string")` or any other value that evaluates as `Boolean`? and has the value of `nothing` or `HasValue=false` should actually run an `else` block in `if` to prevent any confusion. The evaluation follows the SQL evaluation where null/nothing doesn't equal anything, not even another null/nothing.
+
 ## Data Types  
 
  For a Boolean negation, the data type of the result is `Boolean`. For a bitwise negation, the result data type is the same as that of `expression`. However, if expression is `Decimal`, the result is `Long`.  

--- a/docs/visual-basic/language-reference/operators/not-operator.md
+++ b/docs/visual-basic/language-reference/operators/not-operator.md
@@ -53,7 +53,7 @@ result = Not expression
 > [!NOTE]
 > Since the logical and bitwise operators have a lower precedence than other arithmetic and relational operators, any bitwise operations should be enclosed in parentheses to ensure accurate execution.  
   
-Note that `if Not someStr?.Contains("some string")` or any other value that evaluates as `Boolean`? and has the value of `nothing` or `HasValue=false` should actually run an `else` block in `if` to prevent any confusion. The evaluation follows the SQL evaluation where null/nothing doesn't equal anything, not even another null/nothing.
+Note that `if Not someStr?.Contains("some string")` or any other value that evaluates as `Boolean?` and has the value of `nothing` or `HasValue=false` the `else` block is run.  The evaluation follows the SQL evaluation where null/nothing doesn't equal anything, not even another null/nothing.
 
 ## Data Types  
 

--- a/docs/visual-basic/language-reference/operators/null-conditional-operators.md
+++ b/docs/visual-basic/language-reference/operators/null-conditional-operators.md
@@ -1,7 +1,7 @@
 ---
 description: "Learn more about: ?. and ?() null-conditional operators (Visual Basic)"
 title: "Null-conditional Operators"
-ms.date: 10/19/2018
+ms.date: 10/27/2023
 helpviewer_keywords:
   - "null-conditional operators [Visual Basic]"
   - "?. operator [Visual Basic]"
@@ -59,6 +59,8 @@ The null-conditional operators are short-circuiting.  If one operation in a chai
 ```vb
 A?.B?.C?(E)
 ```
+
+Note that `if Not someStr?.Contains("some string")` or any other value that evaluates as `Boolean`? and has the value of `nothing` or `HasValue=false` should actually run an `else` block in `if` to prevent any confusion. The evaluation follows the SQL evaluation where null/nothing doesn't equal anything, not even another null/nothing.
 
 Another use for null-conditional member access is to invoke delegates in a thread-safe way with much less code.  The following example defines two types, a `NewsBroadcaster` and a `NewsReceiver`. News items are sent to the receiver by the `NewsBroadcaster.SendNews` delegate.
 

--- a/docs/visual-basic/language-reference/operators/null-conditional-operators.md
+++ b/docs/visual-basic/language-reference/operators/null-conditional-operators.md
@@ -60,7 +60,7 @@ The null-conditional operators are short-circuiting.  If one operation in a chai
 A?.B?.C?(E)
 ```
 
-Note that `if Not someStr?.Contains("some string")` or any other value that evaluates as `Boolean`? and has the value of `nothing` or `HasValue=false` should actually run an `else` block in `if` to prevent any confusion. The evaluation follows the SQL evaluation where null/nothing doesn't equal anything, not even another null/nothing.
+Note that `if Not someStr?.Contains("some string")` or any other value that evaluates as `Boolean?` and has the value of `nothing` or `HasValue=false` the `else` block is run.  The evaluation follows the SQL evaluation where null/nothing doesn't equal anything, not even another null/nothing.
 
 Another use for null-conditional member access is to invoke delegates in a thread-safe way with much less code.  The following example defines two types, a `NewsBroadcaster` and a `NewsReceiver`. News items are sent to the receiver by the `NewsBroadcaster.SendNews` delegate.
 


### PR DESCRIPTION
## Summary

Fixes #32882

Fixes #32883 

Edits articles
- [Not Operator - Visual Basic](https://learn.microsoft.com/en-us/dotnet/visual-basic/language-reference/operators/not-operator)
- [Null-conditional Operators - Visual Basic](https://learn.microsoft.com/en-us/dotnet/visual-basic/language-reference/operators/null-conditional-operators)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/visual-basic/language-reference/operators/not-operator.md](https://github.com/dotnet/docs/blob/2ee4eb61c6f3fe410a450c83ba7dda0e35203976/docs/visual-basic/language-reference/operators/not-operator.md) | [Not Operator (Visual Basic)](https://review.learn.microsoft.com/en-us/dotnet/visual-basic/language-reference/operators/not-operator?branch=pr-en-us-37773) |
| [docs/visual-basic/language-reference/operators/null-conditional-operators.md](https://github.com/dotnet/docs/blob/2ee4eb61c6f3fe410a450c83ba7dda0e35203976/docs/visual-basic/language-reference/operators/null-conditional-operators.md) | ["Null-conditional Operators"](https://review.learn.microsoft.com/en-us/dotnet/visual-basic/language-reference/operators/null-conditional-operators?branch=pr-en-us-37773) |


<!-- PREVIEW-TABLE-END -->