### PR TITLE
Fixes GitHub issue #32078 - Recommend not to override assembly name

### DIFF
--- a/docs/standard/library-guidance/cross-platform-targeting.md
+++ b/docs/standard/library-guidance/cross-platform-targeting.md
@@ -1,7 +1,7 @@
 ---
 title: Cross-platform targeting for .NET libraries
 description: Best practice recommendations for creating cross-platform .NET libraries.
-ms.date: 05/04/2021
+ms.date: 10/27/2023
 ---
 
 # Cross-platform targeting
@@ -120,6 +120,8 @@ public static class GpsLocation
 ```
 
 ✔️ CONSIDER using [MSBuild.Sdk.Extras](https://github.com/onovotny/MSBuildSdkExtras) when multi-targeting for UWP and Xamarin as it greatly simplifies your project file.
+
+❌ AVOID changing the assembly name or using different assembly names for each TFM your library compiles. Due to dependencies between libraries, multi-targeting with different assembly names per TFM can break package consumers. An assembly should have the same name across all TFMs.
 
 ## Older targets
 


### PR DESCRIPTION
## Summary

Fixes #32078 

Edits article [Cross-platform targeting for .NET libraries](https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/library-guidance/cross-platform-targeting.md](https://github.com/dotnet/docs/blob/b0652537b3e04c9f055a2af4d1df108944d2bf0e/docs/standard/library-guidance/cross-platform-targeting.md) | [Cross-platform targeting](https://review.learn.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting?branch=pr-en-us-37774) |

<!-- PREVIEW-TABLE-END -->