### PR TITLE
Provide `CS0759` page with correct implementation example

### DIFF
--- a/docs/csharp/misc/cs0759.md
+++ b/docs/csharp/misc/cs0759.md
@@ -23,20 +23,20 @@ No defining declaration found for implementing declaration of partial method 'me
  The following example generates CS0759:  
   
 ```csharp  
-// cs0759.cs  
-using System;  
-  
-    public partial class C  
-    {  
-        partial void Part() // CS0759  
-        {  
-        }  
-  
-        public static int Main()  
-        {  
-            return 1;  
-        }  
-    }  
+// cs0759.cs
+using System;
+
+public partial class C
+{
+    partial void Part() // CS0759
+    {
+    }
+
+    public static int Main()
+    {
+        return 1;
+    }
+}
 ```  
 
 To correct this error a defining declaration for `Part()` method should be provided:

--- a/docs/csharp/misc/cs0759.md
+++ b/docs/csharp/misc/cs0759.md
@@ -38,6 +38,29 @@ using System;
         }  
     }  
 ```  
+
+To correct this error a defining declaration for `Part()` method should be provided:
+
+```csharp
+using System;
+
+public partial class C
+{
+    partial void Part();    // Defining declaration
+}
+
+public partial class C
+{
+    partial void Part()     // Implementing declaration, no CS0759
+    {
+    }
+
+    public static int Main()
+    {
+        return 1;
+    }
+}
+```
   
 ## See also
 


### PR DESCRIPTION
This pull request fixes #37518 

It adds the example snippet with the correct code of two partial classes `C`: one with defining declaration for `Part()` method and the unmodified second `C` with implementing declaration for `Part()`.

I also removed the indentations from the "incorrect" example, so that it looks aligned with the "correct" snippet, and doesn't make the impression of `C` class being in some unspecified namespace.
Let me know, please, if the original indentations are intentional and the second commit should be reverted.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/misc/cs0759.md](https://github.com/dotnet/docs/blob/6909cca1892d52ec2b052a69e230598ce744a6b8/docs/csharp/misc/cs0759.md) | [Compiler Error CS0759](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/cs0759?branch=pr-en-us-37780) |

<!-- PREVIEW-TABLE-END -->