### PR TITLE
Fix typo publics->public

### DIFF
--- a/docs/fundamentals/package-validation/overview.md
+++ b/docs/fundamentals/package-validation/overview.md
@@ -15,7 +15,7 @@ You might think that a change is safe and compatible if source consuming that ch
 Package validation tooling allows library developers to validate that their packages are consistent and well formed. It provides the following checks:
 
 - Validates that there are no breaking changes across versions.
-- Validates that the package has the same set of publics APIs for all the different runtime-specific implementations.
+- Validates that the package has the same set of public APIs for all the different runtime-specific implementations.
 - Helps developers catch any applicability holes.
 
 ## Enable package validation


### PR DESCRIPTION
I think this is a simple enough change to skip the extended description.

## Summary

publics API is now public API


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/package-validation/overview.md](https://github.com/dotnet/docs/blob/77fef42cd87d2e15e24fd1fc81d320a421b7835a/docs/fundamentals/package-validation/overview.md) | [Package validation overview](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/overview?branch=pr-en-us-37786) |

<!-- PREVIEW-TABLE-END -->