### PR TITLE
Fix comments in collection expression array samples

### DIFF
--- a/docs/csharp/whats-new/csharp-12.md
+++ b/docs/csharp/whats-new/csharp-12.md
@@ -44,10 +44,10 @@ int[] a = [1, 2, 3, 4, 5, 6, 7, 8];
 // Create a span
 Span<int> b  = ['a', 'b', 'c', 'd', 'e', 'f', 'h', 'i'];
 
-// Create a 2 D array:
+// Create a jagged 2D array:
 int[][] twoD = [[1, 2, 3], [4, 5, 6], [7, 8, 9]];
 
-// create a 2 D array from variables:
+// Create a jagged 2D array from variables:
 int[] row0 = [1, 2, 3];
 int[] row1 = [4, 5, 6];
 int[] row2 = [7, 8, 9];


### PR DESCRIPTION
## Summary

This PR fixes the naming of 2D arrays in the sample code for collection expressions. The code was saying "2D" array while showing a jagged array instead, which was not correct. This change uses "jagged 2D array" instead, which is more accurate.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/whats-new/csharp-12.md](https://github.com/dotnet/docs/blob/b8024061b951bd6f140a4b04a5ec88bda0bf36de/docs/csharp/whats-new/csharp-12.md) | [What's new in C# 12](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-12?branch=pr-en-us-37792) |

<!-- PREVIEW-TABLE-END -->