### PR TITLE
Update not-operator.md

### DIFF
--- a/docs/visual-basic/language-reference/operators/not-operator.md
+++ b/docs/visual-basic/language-reference/operators/not-operator.md
@@ -53,7 +53,7 @@ result = Not expression
 > [!NOTE]
 > Since the logical and bitwise operators have a lower precedence than other arithmetic and relational operators, any bitwise operations should be enclosed in parentheses to ensure accurate execution.  
   
-Note that `if Not someStr?.Contains("some string")` or any other value that evaluates as `Boolean?` and has the value of `nothing` or `HasValue=false` the `else` block is run.  The evaluation follows the SQL evaluation where null/nothing doesn't equal anything, not even another null/nothing.
+Note that when `if Not someStr?.Contains("some string")` or any other value that evaluates as `Boolean?` has the value of `nothing` or `HasValue=false`, the `else` block is run.  The evaluation follows the SQL evaluation where null/nothing doesn't equal anything, not even another null/nothing.
 
 ## Data Types  
 

--- a/docs/visual-basic/language-reference/operators/not-operator.md
+++ b/docs/visual-basic/language-reference/operators/not-operator.md
@@ -53,7 +53,7 @@ result = Not expression
 > [!NOTE]
 > Since the logical and bitwise operators have a lower precedence than other arithmetic and relational operators, any bitwise operations should be enclosed in parentheses to ensure accurate execution.  
   
-Note that when `if Not someStr?.Contains("some string")` or any other value that evaluates as `Boolean?` has the value of `nothing` or `HasValue=false`, the `else` block is run.  The evaluation follows the SQL evaluation where null/nothing doesn't equal anything, not even another null/nothing.
+Note that if `Not someStr?.Contains("some string")` or any other value that evaluates as `Boolean?` has the value of `nothing` or `HasValue=false`, the `else` block is run.  The evaluation follows the SQL evaluation where null/nothing doesn't equal anything, not even another null/nothing.
 
 ## Data Types  
 


### PR DESCRIPTION
## Summary

@BillWagner Please see the proposed change for the change to **Update not-operator.md**. Otherwise it seems ungrammatical. WDYT?


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/visual-basic/language-reference/operators/not-operator.md](https://github.com/dotnet/docs/blob/2c8a9f199701161504fce3a2d2f04a6774a54d8a/docs/visual-basic/language-reference/operators/not-operator.md) | [Not Operator (Visual Basic)](https://review.learn.microsoft.com/en-us/dotnet/visual-basic/language-reference/operators/not-operator?branch=pr-en-us-37795) |


<!-- PREVIEW-TABLE-END -->