### PR TITLE
Update null-conditional-operators.md

### DIFF
--- a/docs/visual-basic/language-reference/operators/null-conditional-operators.md
+++ b/docs/visual-basic/language-reference/operators/null-conditional-operators.md
@@ -60,7 +60,7 @@ The null-conditional operators are short-circuiting.  If one operation in a chai
 A?.B?.C?(E)
 ```
 
-Note that when `if Not someStr?.Contains("some string")` or any other value that evaluates as `Boolean?` has the value of `nothing` or `HasValue=false`, the `else` block is run.  The evaluation follows the SQL evaluation where null/nothing doesn't equal anything, not even another null/nothing.
+Note that if `Not someStr?.Contains("some string")` or any other value that evaluates as `Boolean?` has the value of `nothing` or `HasValue=false`, the `else` block is run.  The evaluation follows the SQL evaluation where null/nothing doesn't equal anything, not even another null/nothing.
 
 Another use for null-conditional member access is to invoke delegates in a thread-safe way with much less code.  The following example defines two types, a `NewsBroadcaster` and a `NewsReceiver`. News items are sent to the receiver by the `NewsBroadcaster.SendNews` delegate.
 

--- a/docs/visual-basic/language-reference/operators/null-conditional-operators.md
+++ b/docs/visual-basic/language-reference/operators/null-conditional-operators.md
@@ -60,7 +60,7 @@ The null-conditional operators are short-circuiting.  If one operation in a chai
 A?.B?.C?(E)
 ```
 
-Note that `if Not someStr?.Contains("some string")` or any other value that evaluates as `Boolean?` and has the value of `nothing` or `HasValue=false` the `else` block is run.  The evaluation follows the SQL evaluation where null/nothing doesn't equal anything, not even another null/nothing.
+Note that when `if Not someStr?.Contains("some string")` or any other value that evaluates as `Boolean?` has the value of `nothing` or `HasValue=false`, the `else` block is run.  The evaluation follows the SQL evaluation where null/nothing doesn't equal anything, not even another null/nothing.
 
 Another use for null-conditional member access is to invoke delegates in a thread-safe way with much less code.  The following example defines two types, a `NewsBroadcaster` and a `NewsReceiver`. News items are sent to the receiver by the `NewsBroadcaster.SendNews` delegate.
 


### PR DESCRIPTION
## Summary

@BillWagner Please see the proposed change for the change to Update null-conditional-operators.md. Otherwise it seems ungrammatical. WDYT?


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/visual-basic/language-reference/operators/null-conditional-operators.md](https://github.com/dotnet/docs/blob/8d6d2b81d273d61a125cadfea61ef5ba94d7c46b/docs/visual-basic/language-reference/operators/null-conditional-operators.md) | [?. and ?() null-conditional operators (Visual Basic)](https://review.learn.microsoft.com/en-us/dotnet/visual-basic/language-reference/operators/null-conditional-operators?branch=pr-en-us-37796) |


<!-- PREVIEW-TABLE-END -->