### PR TITLE
Fixes GitHub issue #31976 - Add advise when to use NoWarn and when to refrain from it

### DIFF
--- a/docs/csharp/language-reference/compiler-options/errors-warnings.md
+++ b/docs/csharp/language-reference/compiler-options/errors-warnings.md
@@ -1,7 +1,7 @@
 ---
 description: "C# Compiler Options for errors and warnings. These options suppress or enable warnings, and control warnings as errors."
 title: "C# Compiler Options - errors and warnings"
-ms.date: 05/11/2022
+ms.date: 10/30/2023
 f1_keywords: 
   - "cs.build.options"
 helpviewer_keywords: 
@@ -105,19 +105,33 @@ You use **WarningsAsErrors** to configure a set of warnings as errors. Use **War
 
 ## NoWarn
 
-The **NoWarn** option lets you suppress the compiler from displaying one or more warnings. Separate multiple warning numbers with a comma.
+The **NoWarn** option lets you suppress the compiler from displaying one or more warnings, where `warningnumber1`, `warningnumber2` are warning numbers that you want the compiler to suppress. Separate multiple warning numbers with a comma.
 
 ```xml
-<NoWarn>number1, number2</NoWarn>
+<NoWarn>warningnumber1,warningnumber2</NoWarn>
 ```
 
-`number1`, `number2` Warning number(s) that you want the compiler to suppress. You specify the numeric part of the warning identifier. For example, if you want to suppress *CS0028*, you could specify `<NoWarn>28</NoWarn>`. The compiler silently ignores warning numbers passed to **NoWarn** that were valid in previous releases, but that have been removed. For example, *CS0679* was valid in the compiler in Visual Studio .NET 2002 but was removed later.
+You need to specify only the numeric part of the warning identifier. For example, if you want to suppress *CS0028*, you could specify `<NoWarn>28</NoWarn>`. The compiler silently ignores warning numbers passed to **NoWarn** that were valid in previous releases, but that have been removed. For example, *CS0679* was valid in the compiler in Visual Studio .NET 2002 but was removed later.
 
- The following warnings cannot be suppressed by the **NoWarn** option:
+The following warnings can't be suppressed by the **NoWarn** option:
 
 - Compiler Warning (level 1) CS2002  
 - Compiler Warning (level 1) CS2023
 - Compiler Warning (level 1) CS2029
+
+Note that warnings are intended to be an indication of a potential problem with your code, so you should understand the risks of disabling any particular warning. Use **NoWarn** only when you're certain that a warning is a false positive and can't possibly be a runtime bug.
+
+You might want to use a more targeted approach to disabling warnings:
+
+- Most compilers provide ways to disable warnings just for certain lines of code, so that you can still review the warnings if they occur elsewhere in the same project. To suppress a warning only in a specific part of the code in C#, use [#pragma warning](../preprocessor-directives.md#pragma-warning).
+
+- If your goal is to see more concise and focused output in your build log, you might want to change the build log verbosity. For more information, see [How to: View, save, and configure build log files](/visualstudio/ide/how-to-view-save-and-configure-build-log-files).
+
+To add warning numbers to any previously set value for **NoWarn** without overwriting it, reference `$(NoWarn)` as shown in the following example:
+
+```xml
+   <NoWarn>$(NoWarn);newwarningnumber3;newwarningnumber4</NoWarn>
+```
 
 ## CodeAnalysisRuleSet
 


### PR DESCRIPTION
## Summary

Fixes #31976

Edits article **C# Compiler Options to report errors and warnings**

Note that the basic nowarn configuration instructions say to separate values by commas (I removed the space), but the example of using a reference in the project file (from https://learn.microsoft.com/en-us/visualstudio/ide/how-to-suppress-compiler-warnings) separates new values with semicolons.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-options/errors-warnings.md](https://github.com/dotnet/docs/blob/1d631fa864e17bef8ee8dcbc6b24ac3496f46343/docs/csharp/language-reference/compiler-options/errors-warnings.md) | [C# Compiler Options to report errors and warnings](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/errors-warnings?branch=pr-en-us-37798) |

<!-- PREVIEW-TABLE-END -->