### PR TITLE
Remaining STJ work for .NET 8

### DIFF
--- a/docs/core/whats-new/dotnet-8.md
+++ b/docs/core/whats-new/dotnet-8.md
@@ -79,7 +79,7 @@ The serializer has built-in support for the following additional types.
 
 #### Source generator
 
-.NET 8 includes enhancements of the System.Text.Json [source generator](../../standard/serialization/system-text-json/source-generation.md) that are aimed at making the [Native AOT](../../standard/glossary.md#native-aot) experience on par with the [reflection-based serializer](../../standard/serialization/system-text-json/source-generation-modes.md#overview). For example:
+.NET 8 includes enhancements of the System.Text.Json [source generator](../../standard/serialization/system-text-json/source-generation.md) that are aimed at making the [Native AOT](../../standard/glossary.md#native-aot) experience on par with the [reflection-based serializer](../../standard/serialization/system-text-json/reflection-vs-source-generation.md#reflection). For example:
 
 - The source generator now supports serializing types with [`required`](../../standard/serialization/system-text-json/required-properties.md) and [`init`](../../csharp/language-reference/keywords/init.md) properties. These were both already supported in reflection-based serialization.
 - Improved formatting of source-generated code.
@@ -98,7 +98,7 @@ The serializer has built-in support for the following additional types.
   public partial class MyContext : JsonSerializerContext { }
   ```
 
-  For more information, see [Serialize enum fields as strings](../../standard/serialization/system-text-json/source-generation-modes.md#serialize-enum-fields-as-strings).
+  For more information, see [Serialize enum fields as strings](../../standard/serialization/system-text-json/source-generation.md#serialize-enum-fields-as-strings).
 
 - New `JsonConverter.Type` property lets you look up the type of a non-generic `JsonConverter` instance:
 

--- a/docs/core/whats-new/dotnet-8.md
+++ b/docs/core/whats-new/dotnet-8.md
@@ -83,8 +83,8 @@ The serializer has built-in support for the following additional types.
 
 - The source generator now supports serializing types with [`required`](../../standard/serialization/system-text-json/required-properties.md) and [`init`](../../csharp/language-reference/keywords/init.md) properties. These were both already supported in reflection-based serialization.
 - Improved formatting of source-generated code.
-- <xref:System.Text.Json.Serialization.JsonSourceGenerationOptionsAttribute> feature parity with <xref:System.Text.Json.JsonSerializerOptions>. This parity lets you specify serialization configuration at compile time, which ensures that the generated `MyContext.Default` property is preconfigured with all the relevant options set.
-- Additional diagnostics (such as `SYSLIB1034` and `SYSLIB1039`).
+- <xref:System.Text.Json.Serialization.JsonSourceGenerationOptionsAttribute> feature parity with <xref:System.Text.Json.JsonSerializerOptions>. For more information, see [Specify options (source generation)](../../standard/serialization/system-text-json/source-generation.md#specify-options).
+- Additional diagnostics (such as [SYSLIB1034](../../fundamentals/syslib-diagnostics/syslib1034.md) and [SYSLIB1039](../../fundamentals/syslib-diagnostics/syslib1039.md)).
 - Don't include types of ignored or inaccessible properties.
 - Support for nesting `JsonSerializerContext` declarations within arbitrary type kinds.
 - Support for compiler-generated or *unspeakable* types in weakly typed source generation scenarios. Since compiler-generated types can't be explicitly specified by the source generator, <xref:System.Text.Json?displayProperty=fullName> now performs nearest-ancestor resolution at run time. This resolution determines the most appropriate supertype with which to serialize the value.
@@ -111,21 +111,7 @@ The serializer has built-in support for the following additional types.
 
 ##### Chain source generators
 
-The <xref:System.Text.Json.JsonSerializerOptions> class includes a new <xref:System.Text.Json.JsonSerializerOptions.TypeInfoResolverChain> property that complements the existing <xref:System.Text.Json.JsonSerializerOptions.TypeInfoResolver> property. These properties are used in contract customization for chaining source generators. The addition of the new property means that you don't have to specify all chained components at one call site&mdash;they can be added after the fact.
-
-<xref:System.Text.Json.JsonSerializerOptions.TypeInfoResolverChain> also lets you introspect the chain or remove components from it. The following code snippet shows an example.
-
-```csharp
-var options = new JsonSerializerOptions
-{
-    TypeInfoResolver = JsonTypeInfoResolver.Combine(
-        ContextA.Default, ContextB.Default, ContextC.Default);
-};
-
-options.TypeInfoResolverChain.Count; // 3
-options.TypeInfoResolverChain.RemoveAt(0);
-options.TypeInfoResolverChain.Count; // 2
-```
+The <xref:System.Text.Json.JsonSerializerOptions> class includes a new <xref:System.Text.Json.JsonSerializerOptions.TypeInfoResolverChain> property that complements the existing <xref:System.Text.Json.JsonSerializerOptions.TypeInfoResolver> property. These properties are used in contract customization for chaining source generators. The addition of the new property means that you don't have to specify all chained components at one call site&mdash;they can be added after the fact. <xref:System.Text.Json.JsonSerializerOptions.TypeInfoResolverChain> also lets you introspect the chain or remove components from it. For more information, see [Combine source generators](../../standard/serialization/system-text-json/source-generation.md#combine-source-generators).
 
 In addition, <xref:System.Text.Json.JsonSerializerOptions.AddContext%60%601?displayProperty=nameWithType> is now obsolete. It's been superseded by the <xref:System.Text.Json.JsonSerializerOptions.TypeInfoResolver> and <xref:System.Text.Json.JsonSerializerOptions.TypeInfoResolverChain> properties. For more information, see [SYSLIB0049](../../fundamentals/syslib-diagnostics/syslib0049.md).
 
@@ -164,6 +150,8 @@ public class DerivedImplement : IDerived
 var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
 JsonSerializer.Serialize(new { PropertyName = "value" }, options); // { "property_name" : "value" }
 ```
+
+For more information, see [Use a built-in naming policy](../../standard/serialization/system-text-json/customize-properties.md#use-a-built-in-naming-policy).
 
 #### Read-only properties
 
@@ -214,31 +202,9 @@ For more information about the *populate* deserialization behavior, see [Populat
 
 You can now disable using the reflection-based serializer by default. This disablement is useful to avoid accidental rooting of reflection components that aren't even in use, especially in trimmed and Native AOT apps. To disable default reflection-based serialization by requiring that a <xref:System.Text.Json.JsonSerializerOptions> argument be passed to the <xref:System.Text.Json.JsonSerializer> serialization and deserialization methods, set the `JsonSerializerIsReflectionEnabledByDefault` MSBuild property to `false` in your project file.
 
-```xml
-<JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
-```
-
-(If the property is set to `false` and you don't pass a configured <xref:System.Text.Json.JsonSerializerOptions> argument, the `Serialize` and `Deserialize` methods throw a <xref:System.NotSupportedException> at run time.)
-
 Use the new <xref:System.Text.Json.JsonSerializer.IsReflectionEnabledByDefault> API to check the value of the feature switch. If you're a library author building on top of <xref:System.Text.Json?displayProperty=fullName>, you can rely on the property to configure your defaults without accidentally rooting reflection components.
 
-```csharp
-static JsonSerializerOptions GetDefaultOptions()
-{
-    if (JsonSerializer.IsReflectionEnabledByDefault)
-    {
-        // This branch has a dependency on DefaultJsonTypeInfo,
-        // but it will get trimmed away if the feature switch is disabled.
-        return new()
-        {
-            TypeInfoResolver = new DefaultJsonTypeInfoResolver(),
-            PropertyNamingPolicy = JsonNamingPolicy.KebabCaseLower,
-        }
-    }
-
-    return new() { PropertyNamingPolicy = JsonNamingPolicy.KebabCaseLower };
-}
-```
+For more information, see [Disable reflection defaults](../../standard/serialization/system-text-json/source-generation.md#disable-reflection-defaults).
 
 #### New JsonNode API methods
 

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -592,6 +592,8 @@ items:
         - name: Source generation
           items:
           - name: Reflection vs. source generation
+            href: ../standard/serialization/system-text-json/reflection-vs-source-generation.md
+          - name: Source-generation modes
             href: ../standard/serialization/system-text-json/source-generation-modes.md
           - name: Use source generation
             href: ../standard/serialization/system-text-json/source-generation.md

--- a/docs/standard/serialization/system-text-json/customize-properties.md
+++ b/docs/standard/serialization/system-text-json/customize-properties.md
@@ -218,7 +218,7 @@ The resulting JSON looks like the following example:
 }
 ```
 
-To use the converter with source generation, see [Serialize enum fields as strings](source-generation-modes.md#serialize-enum-fields-as-strings).
+To use the converter with source generation, see [Serialize enum fields as strings](source-generation.md#serialize-enum-fields-as-strings).
 
 :::zone-end
 

--- a/docs/standard/serialization/system-text-json/overview.md
+++ b/docs/standard/serialization/system-text-json/overview.md
@@ -25,7 +25,7 @@ For Visual Basic, there are some limitations on what parts of the library you ca
 
 ## How to get the library
 
-The library is built-in as part of the shared framework for .NET Core 3.0 and later versions. The [source generation feature](source-generation-modes.md#source-generation---metadata-collection-mode) is built-in as part of the shared framework for .NET 6 and later versions. Use of source generation requires .NET 5 SDK or later.
+The library is built-in as part of the shared framework for .NET Core 3.0 and later versions. The [source generation feature](source-generation-modes.md#metadata-collection-mode) is built-in as part of the shared framework for .NET 6 and later versions. Use of source generation requires .NET 5 SDK or later.
 
 For framework versions earlier than .NET Core 3.0, install the [System.Text.Json](https://www.nuget.org/packages/System.Text.Json) NuGet package. The package supports:
 

--- a/docs/standard/serialization/system-text-json/overview.md
+++ b/docs/standard/serialization/system-text-json/overview.md
@@ -3,6 +3,9 @@ title: "Serialize and deserialize JSON using C# - .NET"
 description: This overview describes the System.Text.Json namespace functionality for serializing to and deserializing from JSON in .NET.
 ms.date: 10/18/2021
 no-loc: [System.Text.Json, Newtonsoft.Json]
+dev_langs:
+  - CSharp
+  - VB
 helpviewer_keywords:
   - "JSON serialization"
   - "serializing objects"
@@ -58,7 +61,9 @@ There are also extension methods for System.Text.Json on [HttpContent](xref:Syst
 
 ## Reflection vs. source generation
 
-By default, `System.Text.Json` uses [reflection](/dotnet/csharp/advanced-topics/reflection-and-attributes/) to gather the metadata it needs to access properties of objects for serialization and deserialization *at run time*. As an alternative, `System.Text.Json` can use the C# [source generation](../../../csharp/roslyn-sdk/source-generators-overview.md) feature to improve performance, reduce private memory usage, and facilitate [assembly trimming](../../../core/deploying/trimming/trim-self-contained.md), which reduces app size. For more information, see [How to choose reflection or source generation in System.Text.Json](source-generation-modes.md).
+By default, `System.Text.Json` gathers the metadata it needs to access properties of objects for serialization and deserialization *at run time* using [reflection](/dotnet/csharp/advanced-topics/reflection-and-attributes/). As an alternative, `System.Text.Json` can use the C# [source generation](../../../csharp/roslyn-sdk/source-generators-overview.md) feature to improve performance, reduce private memory usage, and facilitate [assembly trimming](../../../core/deploying/trimming/trim-self-contained.md), which reduces app size.
+
+For more information, see [Reflection versus source generation](reflection-vs-source-generation.md).
 
 ## Security information
 

--- a/docs/standard/serialization/system-text-json/overview.md
+++ b/docs/standard/serialization/system-text-json/overview.md
@@ -25,7 +25,7 @@ For Visual Basic, there are some limitations on what parts of the library you ca
 
 ## How to get the library
 
-The library is built-in as part of the shared framework for .NET Core 3.0 and later versions. The [source generation feature](source-generation-modes.md#metadata-collection-mode) is built-in as part of the shared framework for .NET 6 and later versions. Use of source generation requires .NET 5 SDK or later.
+The library is built-in as part of the shared framework for .NET Core 3.0 and later versions. The [source generation feature](source-generation-modes.md#metadata-based-mode) is built-in as part of the shared framework for .NET 6 and later versions.
 
 For framework versions earlier than .NET Core 3.0, install the [System.Text.Json](https://www.nuget.org/packages/System.Text.Json) NuGet package. The package supports:
 

--- a/docs/standard/serialization/system-text-json/populate-properties.md
+++ b/docs/standard/serialization/system-text-json/populate-properties.md
@@ -42,6 +42,9 @@ Starting in .NET 8, you can change the deserialization behavior to modify (*popu
 
   A struct property must have a setter; otherwise, an <xref:System.InvalidOperationException> is thrown at run time.
 
+> [!NOTE]
+> The populate behavior currently doesn't work for types that have a parameterized constructor. For more information, see [dotnet/runtime issue 92877](https://github.com/dotnet/runtime/issues/92877).
+
 ### Read-only properties
 
 For populating reference properties that are mutable, since the instance that the property references isn't *replaced*, the property doesn't need to have a setter. This behavior means that deserialization can also populate *read-only* properties.

--- a/docs/standard/serialization/system-text-json/reflection-vs-source-generation.md
+++ b/docs/standard/serialization/system-text-json/reflection-vs-source-generation.md
@@ -23,7 +23,7 @@ This information is referred to as *metadata*.
 
 ## Reflection
 
-By default, `JsonSerializer` collects metadata at run time by using [reflection](/dotnet/csharp/advanced-topics/reflection-and-attributes/). Whenever `JsonSerializer` has to serialize or deserialize a type for the first time, it collects and caches this metadata. The metadata collection process takes time and uses memory.
+By default, <xref:System.Text.Json.JsonSerializer> collects metadata at run time by using [reflection](/dotnet/csharp/advanced-topics/reflection-and-attributes/). Whenever `JsonSerializer` has to serialize or deserialize a type for the first time, it collects and caches this metadata. The metadata collection process takes time and uses memory.
 
 ## Source generation
 
@@ -33,7 +33,7 @@ Source generation can be used in two modes:
 
 * **Metadata collection mode**
 
-  During compilation, System.Text.Json collects the metadata needed for serialization and generates source code files. The generated source code files are automatically compiled as an integral part of the application.
+  During compilation, `System.Text.Json` collects the metadata needed for serialization and generates source code files. The generated source code files are automatically compiled as an integral part of the app.
 
 * **Serialization optimization (fast track) mode**
 

--- a/docs/standard/serialization/system-text-json/reflection-vs-source-generation.md
+++ b/docs/standard/serialization/system-text-json/reflection-vs-source-generation.md
@@ -31,13 +31,15 @@ As an alternative, `System.Text.Json` can use the C# [source generation](../../.
 
 Source generation can be used in two modes:
 
-* **Metadata collection mode**
+* **Metadata-based mode**
 
   During compilation, `System.Text.Json` collects the metadata needed for serialization and generates source code files. The generated source code files are automatically compiled as an integral part of the app.
 
-* **Serialization optimization (fast track) mode**
+* **Serialization-optimization (fast path) mode**
 
-  <xref:System.Text.Json.JsonSerializer> features that customize the output of serialization, such as naming policies and reference preservation, carry a performance overhead. In serialization optimization mode, System.Text.Json generates optimized code that uses [`Utf8JsonWriter`](use-utf8jsonwriter.md) directly. This optimized or *fast path* code increases serialization throughput.
+  <xref:System.Text.Json.JsonSerializer> features that customize the output of serialization, such as naming policies and reference preservation, carry a performance overhead. In serialization-optimization mode, System.Text.Json generates optimized serialization code that uses [`Utf8JsonWriter`](use-utf8jsonwriter.md) directly. This optimized or *fast path* code increases serialization throughput.
+
+  Fast-path *deserialization* isn't currently available. For more information, see [dotnet/runtime issue 55043](https://github.com/dotnet/runtime/issues/55043).
 
 Source generation for `System.Text.Json` requires C# 9.0 or a later version.
 
@@ -47,25 +49,29 @@ Choose reflection or source-generation modes based on the following benefits tha
 
 :::zone pivot="dotnet-8-0"
 
-| Benefit                                              | Reflection | Source generation<br/>(Metadata collection mode) | Source generation<br/>(Serialization optimization mode) |
+| Benefit                                              | Reflection | Source generation<br/>(Metadata-based mode) | Source generation<br/>(Serialization-optimization mode) |
 |------------------------------------------------------|------------|---------------------|----------------------------|
-| Simpler to code and debug.                           | ✔️        | ❌                  | ❌                        |
-| Supports non-public accessors.                       | ✔️        | ❌                  | ❌                        |
-| Supports all available serialization customizations. | ✔️        | ❌                  | ❌                        |
+| Simpler to code.                                     | ✔️        | ❌                  | ❌                        |
+| Simpler to debug.                                    | ❌        | ✔️                  | ✔️                        |
+| Supports non-public members.                         | ✔️        | ✔️<sup>*</sup>      | ✔️<sup>*</sup>            |
+| Supports all available serialization customizations. | ✔️        | ❌<sup>†</sup>      | ❌<sup>†</sup>            |
 | Reduces start-up time.                               | ❌        | ✔️                  | ❌                        |
 | Reduces private memory usage.                        | ❌        | ✔️                  | ✔️                        |
 | Eliminates run-time reflection.                      | ❌        | ✔️                  | ✔️                        |
 | Facilitates trim-safe app size reduction.            | ❌        | ✔️                  | ✔️                        |
 | Increases serialization throughput.                  | ❌        | ❌                  | ✔️                        |
 
+\* The source generator supports *some* non-public members, for example, internal types in the same assembly.
+† Source-generated contracts can be modified using the contract customization API.
+
 :::zone-end
 
 :::zone pivot="dotnet-7-0,dotnet-6-0"
 
-| Benefit                                              | Reflection | Source generation:<br/>Metadata collection | Source generation:<br/>Serialization optimization |
+| Benefit                                              | Reflection | Source generation<br/>(Metadata-based mode) | Source generation<br/>(Serialization-optimization mode) |
 |------------------------------------------------------|------------|---------------------|----------------------------|
-| Simpler to code and debug.                           | ✔️        | ❌                  | ❌                        |
-| Supports non-public accessors.                       | ✔️        | ❌                  | ❌                        |
+| Simpler to code.                                     | ✔️        | ❌                  | ❌                        |
+| Simpler to debug.                                    | ❌        | ❌                  | ✔️                        |
 | Supports required properties.                        | ✔️        | ❌                  | ❌                        |
 | Supports init-only properties.                       | ✔️        | ❌                  | ❌                        |
 | Supports all available serialization customizations. | ✔️        | ❌                  | ❌                        |

--- a/docs/standard/serialization/system-text-json/reflection-vs-source-generation.md
+++ b/docs/standard/serialization/system-text-json/reflection-vs-source-generation.md
@@ -1,0 +1,78 @@
+---
+title: How to choose reflection or source generation in System.Text.Json
+description: "Learn how to choose reflection or source generation in System.Text.Json."
+ms.date: 10/30/2023
+no-loc: [System.Text.Json]
+zone_pivot_groups: dotnet-preview-version
+---
+
+# Reflection versus source generation in System.Text.Json
+
+This article explains the differences between reflection and source generation as it relates to `System.Text.Json` serialization. It also provides guidance on how to choose the best approach for your scenario.
+
+## Metadata collection
+
+To serialize or deserialize a type, <xref:System.Text.Json.JsonSerializer> needs information about how to access the members of the type. `JsonSerializer` needs the following information:
+
+* How to access property getters and fields for serialization.
+* How to access a constructor, property setters, and fields for deserialization.
+* Information about which attributes have been used to customize serialization or deserialization.
+* Run-time configuration from <xref:System.Text.Json.JsonSerializerOptions>.
+
+This information is referred to as *metadata*.
+
+## Reflection
+
+By default, `JsonSerializer` collects metadata at run time by using [reflection](/dotnet/csharp/advanced-topics/reflection-and-attributes/). Whenever `JsonSerializer` has to serialize or deserialize a type for the first time, it collects and caches this metadata. The metadata collection process takes time and uses memory.
+
+## Source generation
+
+As an alternative, `System.Text.Json` can use the C# [source generation](../../../csharp/roslyn-sdk/source-generators-overview.md) feature to improve performance, reduce private memory usage, and facilitate [assembly trimming](../../../core/deploying/trimming/trim-self-contained.md), which reduces app size. In addition, reflection can't be used in [Native AOT applications](../../../core/deploying/native-aot/index.md), so you must use source generation for those apps.
+
+Source generation can be used in two modes:
+
+* **Metadata collection mode**
+
+  During compilation, System.Text.Json collects the metadata needed for serialization and generates source code files. The generated source code files are automatically compiled as an integral part of the application.
+
+* **Serialization optimization (fast track) mode**
+
+  <xref:System.Text.Json.JsonSerializer> features that customize the output of serialization, such as naming policies and reference preservation, carry a performance overhead. In serialization optimization mode, System.Text.Json generates optimized code that uses [`Utf8JsonWriter`](use-utf8jsonwriter.md) directly. This optimized or *fast path* code increases serialization throughput.
+
+Source generation for `System.Text.Json` requires C# 9.0 or a later version.
+
+## Feature comparison
+
+Choose reflection or source-generation modes based on the following benefits that each one offers:
+
+:::zone pivot="dotnet-8-0"
+
+| Benefit                                              | Reflection | Source generation<br/>(Metadata collection mode) | Source generation<br/>(Serialization optimization mode) |
+|------------------------------------------------------|------------|---------------------|----------------------------|
+| Simpler to code and debug.                           | ✔️        | ❌                  | ❌                        |
+| Supports non-public accessors.                       | ✔️        | ❌                  | ❌                        |
+| Supports all available serialization customizations. | ✔️        | ❌                  | ❌                        |
+| Reduces start-up time.                               | ❌        | ✔️                  | ❌                        |
+| Reduces private memory usage.                        | ❌        | ✔️                  | ✔️                        |
+| Eliminates run-time reflection.                      | ❌        | ✔️                  | ✔️                        |
+| Facilitates trim-safe app size reduction.            | ❌        | ✔️                  | ✔️                        |
+| Increases serialization throughput.                  | ❌        | ❌                  | ✔️                        |
+
+:::zone-end
+
+:::zone pivot="dotnet-7-0,dotnet-6-0"
+
+| Benefit                                              | Reflection | Source generation:<br/>Metadata collection | Source generation:<br/>Serialization optimization |
+|------------------------------------------------------|------------|---------------------|----------------------------|
+| Simpler to code and debug.                           | ✔️        | ❌                  | ❌                        |
+| Supports non-public accessors.                       | ✔️        | ❌                  | ❌                        |
+| Supports required properties.                        | ✔️        | ❌                  | ❌                        |
+| Supports init-only properties.                       | ✔️        | ❌                  | ❌                        |
+| Supports all available serialization customizations. | ✔️        | ❌                  | ❌                        |
+| Reduces start-up time.                               | ❌        | ✔️                  | ❌                        |
+| Reduces private memory usage.                        | ❌        | ✔️                  | ✔️                        |
+| Eliminates run-time reflection.                      | ❌        | ✔️                  | ✔️                        |
+| Facilitates trim-safe app size reduction.            | ❌        | ✔️                  | ✔️                        |
+| Increases serialization throughput.                  | ❌        | ❌                  | ✔️                        |
+
+:::zone-end

--- a/docs/standard/serialization/system-text-json/reflection-vs-source-generation.md
+++ b/docs/standard/serialization/system-text-json/reflection-vs-source-generation.md
@@ -27,15 +27,15 @@ By default, <xref:System.Text.Json.JsonSerializer> collects metadata at run time
 
 ## Source generation
 
-As an alternative, `System.Text.Json` can use the C# [source generation](../../../csharp/roslyn-sdk/source-generators-overview.md) feature to improve performance, reduce private memory usage, and facilitate [assembly trimming](../../../core/deploying/trimming/trim-self-contained.md), which reduces app size. In addition, reflection can't be used in [Native AOT applications](../../../core/deploying/native-aot/index.md), so you must use source generation for those apps.
+As an alternative, `System.Text.Json` can use the C# [source generation](../../../csharp/roslyn-sdk/source-generators-overview.md) feature to improve performance, reduce private memory usage, and facilitate [assembly trimming](../../../core/deploying/trimming/trim-self-contained.md), which reduces app size. In addition, certain reflection APIs can't be used in [Native AOT applications](../../../core/deploying/native-aot/index.md), so you must use source generation for those apps.
 
 Source generation can be used in two modes:
 
 * **Metadata collection mode**
 
-  During compilation, `System.Text.Json` collects the metadata needed for serialization and generates source code files. The generated source code files are automatically compiled as an integral part of the app.
+  During compilation, `System.Text.Json` collects the information needed for serialization and generates source code files that populate JSON contract metadata for the requested types.
 
-* **Serialization optimization (fast track) mode**
+* **Serialization optimization (fast path) mode**
 
   <xref:System.Text.Json.JsonSerializer> features that customize the output of serialization, such as naming policies and reference preservation, carry a performance overhead. In serialization optimization mode, System.Text.Json generates optimized code that uses [`Utf8JsonWriter`](use-utf8jsonwriter.md) directly. This optimized or *fast path* code increases serialization throughput.
 
@@ -52,7 +52,7 @@ Choose reflection or source-generation modes based on the following benefits tha
 | Simpler to code and debug.                           | ✔️        | ❌                  | ❌                        |
 | Supports non-public accessors.                       | ✔️        | ❌                  | ❌                        |
 | Supports all available serialization customizations. | ✔️        | ❌                  | ❌                        |
-| Reduces start-up time.                               | ❌        | ✔️                  | ❌                        |
+| Reduces start-up time.                               | ❌        | ✔️                  | ✔️                        |
 | Reduces private memory usage.                        | ❌        | ✔️                  | ✔️                        |
 | Eliminates run-time reflection.                      | ❌        | ✔️                  | ✔️                        |
 | Facilitates trim-safe app size reduction.            | ❌        | ✔️                  | ✔️                        |
@@ -65,11 +65,10 @@ Choose reflection or source-generation modes based on the following benefits tha
 | Benefit                                              | Reflection | Source generation:<br/>Metadata collection | Source generation:<br/>Serialization optimization |
 |------------------------------------------------------|------------|---------------------|----------------------------|
 | Simpler to code and debug.                           | ✔️        | ❌                  | ❌                        |
-| Supports non-public accessors.                       | ✔️        | ❌                  | ❌                        |
+| Supports non-public members.                       | ✔️        | ❌                  | ❌                        |
 | Supports required properties.                        | ✔️        | ❌                  | ❌                        |
 | Supports init-only properties.                       | ✔️        | ❌                  | ❌                        |
-| Supports all available serialization customizations. | ✔️        | ❌                  | ❌                        |
-| Reduces start-up time.                               | ❌        | ✔️                  | ❌                        |
+| Reduces start-up time.                               | ❌        | ✔️                  | ✔️                        |
 | Reduces private memory usage.                        | ❌        | ✔️                  | ✔️                        |
 | Eliminates run-time reflection.                      | ❌        | ✔️                  | ✔️                        |
 | Facilitates trim-safe app size reduction.            | ❌        | ✔️                  | ✔️                        |

--- a/docs/standard/serialization/system-text-json/required-properties.md
+++ b/docs/standard/serialization/system-text-json/required-properties.md
@@ -18,7 +18,7 @@ From the serializer's perspective, these two demarcations are equivalent and bot
 
 - If you're using a programming language other than C# or a down-level version of C#.
 - If you only want the requirement to apply to JSON deserialization.
-- If you're using `System.Text.Json` serialization in [source generation](source-generation-modes.md#metadata-collection-mode) mode. In this case, your code won't compile if you use the `required` modifier, as source generation occurs at compile time.
+- If you're using `System.Text.Json` serialization in [source generation](source-generation-modes.md#metadata-based-mode) mode. In this case, your code won't compile if you use the `required` modifier, as source generation occurs at compile time.
 
 The following code snippet shows an example of a property modified with the `required` keyword. This property must be present in the JSON payload for deserialization to succeed.
 

--- a/docs/standard/serialization/system-text-json/required-properties.md
+++ b/docs/standard/serialization/system-text-json/required-properties.md
@@ -18,7 +18,7 @@ From the serializer's perspective, these two demarcations are equivalent and bot
 
 - If you're using a programming language other than C# or a down-level version of C#.
 - If you only want the requirement to apply to JSON deserialization.
-- If you're using `System.Text.Json` serialization in [source generation](source-generation-modes.md#source-generation---metadata-collection-mode) mode. In this case, your code won't compile if you use the `required` modifier, as source generation occurs at compile time.
+- If you're using `System.Text.Json` serialization in [source generation](source-generation-modes.md#metadata-collection-mode) mode. In this case, your code won't compile if you use the `required` modifier, as source generation occurs at compile time.
 
 The following code snippet shows an example of a property modified with the `required` keyword. This property must be present in the JSON payload for deserialization to succeed.
 

--- a/docs/standard/serialization/system-text-json/source-generation-modes.md
+++ b/docs/standard/serialization/system-text-json/source-generation-modes.md
@@ -13,11 +13,11 @@ helpviewer_keywords:
 
 # Source-generation modes in System.Text.Json
 
-Source generation can be used in two modes: metadata collection and serialization optimization. This article describes the different modes.
+Source generation can be used in two modes: metadata-based and serialization optimization. This article describes the different modes.
 
 For information about how to use source generation modes, see [How to use source generation in System.Text.Json](source-generation.md).
 
-## Metadata collection mode
+## Metadata-based mode
 
 You can use source generation to move the metadata collection process from run time to compile time. During compilation, the metadata is collected and source code files are generated. The generated source code files are automatically compiled as an integral part of the application. This technique eliminates run-time metadata collection, which improves performance of both serialization and deserialization.
 
@@ -39,53 +39,52 @@ Only `public` properties and fields are supported by default in either serializa
 
 For information about other known issues with source generation, see the [GitHub issues that are labeled "source-generator"](https://github.com/dotnet/runtime/issues?q=is%3Aopen+is%3Aissue+label%3Aarea-System.Text.Json+label%3Asource-generator) in the *dotnet/runtime* repository.
 
-## Serialization optimization mode
+## Serialization-optimization (fast path) mode
 
 `JsonSerializer` has many features that customize the output of serialization, such as [naming policies](customize-properties.md#use-a-built-in-naming-policy) and [preserving references](preserve-references.md#preserve-references-and-handle-circular-references). Support for all those features causes some performance overhead. Source generation can improve serialization performance by generating optimized code that uses [`Utf8JsonWriter`](use-utf8jsonwriter.md) directly.
 
 The optimized code doesn't support all of the serialization features that `JsonSerializer` supports. The serializer detects whether the optimized code can be used and falls back to default serialization code if unsupported options are specified. For example, <xref:System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString?displayProperty=nameWithType> isn't applicable to writing, so specifying this option doesn't cause a fallback to default code.
 
-The following table shows which options in `JsonSerializerOptions` are supported by the optimized serialization code:
+The following table shows which options in `JsonSerializerOptions` are supported by fast-path serialization:
 
-| Serialization option                                                   | Supported by optimized code |
-|------------------------------------------------------------------------|-----------------------------|
-| <xref:System.Text.Json.JsonSerializerOptions.AllowTrailingCommas>      | ❌                          |
-| <xref:System.Text.Json.JsonSerializerOptions.Converters>               | ❌                          |
-| <xref:System.Text.Json.JsonSerializerOptions.DefaultBufferSize>        | ❌                          |
-| <xref:System.Text.Json.JsonSerializerOptions.DefaultIgnoreCondition>   | ✔️                         |
-| <xref:System.Text.Json.JsonSerializerOptions.DictionaryKeyPolicy>      | ❌                          |
-| <xref:System.Text.Json.JsonSerializerOptions.Encoder>                  | ❌                          |
-| <xref:System.Text.Json.JsonSerializerOptions.IgnoreNullValues>         | ❌                          |
-| <xref:System.Text.Json.JsonSerializerOptions.IgnoreReadOnlyFields>     | ✔️                         |
-| <xref:System.Text.Json.JsonSerializerOptions.IgnoreReadOnlyProperties> | ✔️                         |
-| <xref:System.Text.Json.JsonSerializerOptions.IncludeFields>            | ✔️                         |
-| <xref:System.Text.Json.JsonSerializerOptions.MaxDepth>                 | ❌                          |
-| <xref:System.Text.Json.JsonSerializerOptions.NumberHandling>           | ❌                          |
-| <xref:System.Text.Json.JsonSerializerOptions.PropertyNameCaseInsensitive> | ❌                       |
-| <xref:System.Text.Json.JsonSerializerOptions.PropertyNamingPolicy>     | ✔️                         |
-| <xref:System.Text.Json.JsonSerializerOptions.ReadCommentHandling>      | ❌                          |
-| <xref:System.Text.Json.JsonSerializerOptions.ReferenceHandler>         | ❌                          |
-| <xref:System.Text.Json.JsonSerializerOptions.TypeInfoResolver>         | ✔️                         |
-| <xref:System.Text.Json.JsonSerializerOptions.UnknownTypeHandling>      | ❌                          |
-| <xref:System.Text.Json.JsonSerializerOptions.WriteIndented>            | ✔️                         |
+| Serialization option                                                   | Supported for fast-path |
+|------------------------------------------------------------------------|-------------------------|
+| <xref:System.Text.Json.JsonSerializerOptions.AllowTrailingCommas>      | ❌                      |
+| <xref:System.Text.Json.JsonSerializerOptions.Converters>               | ❌                      |
+| <xref:System.Text.Json.JsonSerializerOptions.DefaultBufferSize>        | ❌                      |
+| <xref:System.Text.Json.JsonSerializerOptions.DefaultIgnoreCondition>   | ✔️                      |
+| <xref:System.Text.Json.JsonSerializerOptions.DictionaryKeyPolicy>      | ❌                      |
+| <xref:System.Text.Json.JsonSerializerOptions.Encoder>                  | ❌                      |
+| <xref:System.Text.Json.JsonSerializerOptions.IgnoreNullValues>         | ❌                      |
+| <xref:System.Text.Json.JsonSerializerOptions.IgnoreReadOnlyFields>     | ✔️                      |
+| <xref:System.Text.Json.JsonSerializerOptions.IgnoreReadOnlyProperties> | ✔️                      |
+| <xref:System.Text.Json.JsonSerializerOptions.IncludeFields>            | ✔️                      |
+| <xref:System.Text.Json.JsonSerializerOptions.MaxDepth>                 | ❌                      |
+| <xref:System.Text.Json.JsonSerializerOptions.NumberHandling>           | ❌                      |
+| <xref:System.Text.Json.JsonSerializerOptions.PropertyNamingPolicy>     | ✔️                      |
+| <xref:System.Text.Json.JsonSerializerOptions.ReferenceHandler>         | ❌                      |
+| <xref:System.Text.Json.JsonSerializerOptions.TypeInfoResolver>         | ✔️                      |
+| <xref:System.Text.Json.JsonSerializerOptions.WriteIndented>            | ✔️                      |
 
-The following table shows which attributes are supported by the optimized serialization code:
+(The following options aren't supported because they apply only to *de*serialization: <xref:System.Text.Json.JsonSerializerOptions.PropertyNameCaseInsensitive>, <xref:System.Text.Json.JsonSerializerOptions.ReadCommentHandling>, and <xref:System.Text.Json.JsonSerializerOptions.UnknownTypeHandling>.)
 
-| Attribute                                                         | Supported by optimized code |
-|-------------------------------------------------------------------|-----------------------------|
-| <xref:System.Text.Json.Serialization.JsonConstructorAttribute>    | ❌                         |
-| <xref:System.Text.Json.Serialization.JsonConverterAttribute>      | ❌                         |
-| <xref:System.Text.Json.Serialization.JsonDerivedTypeAttribute>    | ✔️                         |
-| <xref:System.Text.Json.Serialization.JsonExtensionDataAttribute>  | ❌                         |
-| <xref:System.Text.Json.Serialization.JsonIgnoreAttribute>         | ✔️                         |
-| <xref:System.Text.Json.Serialization.JsonIncludeAttribute>        | ✔️                         |
-| <xref:System.Text.Json.Serialization.JsonNumberHandlingAttribute> | ❌                         |
-| <xref:System.Text.Json.Serialization.JsonPolymorphicAttribute>    | ✔️                         |
-| <xref:System.Text.Json.Serialization.JsonPropertyNameAttribute>   | ✔️                         |
-| <xref:System.Text.Json.Serialization.JsonPropertyOrderAttribute>  | ❌                         |
-| <xref:System.Text.Json.Serialization.JsonRequiredAttribute>       | ✔️                         |
+The following table shows which attributes are supported by fast-path serialization:
 
-If a non-supported option or attribute is specified for a type, the serializer falls back to the default `JsonSerializer` code. In that case, the optimized code isn't used when serializing that type but may be used for other types. Therefore it's important to do performance testing with your options and workloads to determine how much benefit you can actually get from serialization-optimization mode. Also, the ability to fall back to `JsonSerializer` code requires metadata-collection mode. If you select only serialization-optimization mode, serialization might fail for types or options that need to fall back to `JsonSerializer` code.
+| Attribute                                                         | Supported for fast-path |
+|-------------------------------------------------------------------|-------------------------|
+| <xref:System.Text.Json.Serialization.JsonConstructorAttribute>    | ❌                      |
+| <xref:System.Text.Json.Serialization.JsonConverterAttribute>      | ❌                      |
+| <xref:System.Text.Json.Serialization.JsonDerivedTypeAttribute>    | ✔️                      |
+| <xref:System.Text.Json.Serialization.JsonExtensionDataAttribute>  | ❌                      |
+| <xref:System.Text.Json.Serialization.JsonIgnoreAttribute>         | ✔️                      |
+| <xref:System.Text.Json.Serialization.JsonIncludeAttribute>        | ✔️                      |
+| <xref:System.Text.Json.Serialization.JsonNumberHandlingAttribute> | ❌                      |
+| <xref:System.Text.Json.Serialization.JsonPolymorphicAttribute>    | ✔️                      |
+| <xref:System.Text.Json.Serialization.JsonPropertyNameAttribute>   | ✔️                      |
+| <xref:System.Text.Json.Serialization.JsonPropertyOrderAttribute>  | ❌                      |
+| <xref:System.Text.Json.Serialization.JsonRequiredAttribute>       | ✔️                      |
+
+If a non-supported option or attribute is specified for a type, the serializer falls back to the default `JsonSerializer` code. In that case, the optimized code isn't used when serializing that type but may be used for other types. Therefore it's important to do performance testing with your options and workloads to determine how much benefit you can actually get from serialization-optimization mode. Also, the ability to fall back to `JsonSerializer` code requires metadata-based mode. If you select only serialization-optimization mode, serialization might fail for types or options that need to fall back to `JsonSerializer` code.
 
 ## See also
 

--- a/docs/standard/serialization/system-text-json/source-generation-modes.md
+++ b/docs/standard/serialization/system-text-json/source-generation-modes.md
@@ -1,7 +1,7 @@
 ---
-title: How to choose reflection or source generation in System.Text.Json
-description: "Learn how to choose reflection or source generation in System.Text.Json."
-ms.date: 09/25/2023
+title: Source-generation modes in System.Text.Json
+description: Learn about the two different source-generation modes in System.Text.Json.
+ms.date: 10/30/2023
 no-loc: [System.Text.Json]
 zone_pivot_groups: dotnet-preview-version
 helpviewer_keywords:
@@ -9,69 +9,13 @@ helpviewer_keywords:
   - "serializing objects"
   - "serialization"
   - "objects, serializing"
-ms.topic: how-to
 ---
 
-# How to choose reflection or source generation in System.Text.Json
+# Source-generation modes in System.Text.Json
 
-By default, `System.Text.Json` uses run-time reflection to gather the metadata it needs to access properties of objects for serialization and deserialization. As an alternative, `System.Text.Json` 6.0 and later can use the C# [source generation](../../../csharp/roslyn-sdk/source-generators-overview.md) feature to improve performance, reduce private memory usage, and facilitate [assembly trimming](../../../core/deploying/trimming/trim-self-contained.md), which reduces app size.
+Source generation can be used in two modes: metadata collection and serialization optimization. This article describes the different modes.
 
-You can use version 6.0+ of `System.Text.Json` in projects that target earlier frameworks. For more information, see [How to get the library](overview.md#how-to-get-the-library).
-
-This article explains the options and provides guidance on how to choose the best approach for your scenario.
-
-## Overview
-
-Choose reflection or source generation modes based on the following benefits that each one offers:
-
-:::zone pivot="dotnet-8-0"
-
-| Benefit                                              | Reflection | Source generation:<br/>Metadata collection | Source generation:<br/>Serialization optimization |
-|------------------------------------------------------|------------|---------------------|----------------------------|
-| Simpler to code and debug.                           | ✔️        | ❌                  | ❌                        |
-| Supports non-public accessors.                       | ✔️        | ❌                  | ❌                        |
-| Supports required properties.                        | ✔️        | ✔️                  | ✔️                        |
-| Supports init-only properties.                       | ✔️        | ✔️                  | ✔️                        |
-| Supports all available serialization customizations. | ✔️        | ❌                  | ❌                        |
-| Reduces start-up time.                               | ❌        | ✔️                  | ❌                        |
-| Reduces private memory usage.                        | ❌        | ✔️                  | ✔️                        |
-| Eliminates run-time reflection.                      | ❌        | ✔️                  | ✔️                        |
-| Facilitates trim-safe app size reduction.            | ❌        | ✔️                  | ✔️                        |
-| Increases serialization throughput.                  | ❌        | ❌                  | ✔️                        |
-
-:::zone-end
-
-:::zone pivot="dotnet-7-0,dotnet-6-0"
-
-| Benefit                                              | Reflection | Source generation:<br/>Metadata collection | Source generation:<br/>Serialization optimization |
-|------------------------------------------------------|------------|---------------------|----------------------------|
-| Simpler to code and debug.                           | ✔️        | ❌                  | ❌                        |
-| Supports non-public accessors.                       | ✔️        | ❌                  | ❌                        |
-| Supports required properties.                        | ✔️        | ❌                  | ❌                        |
-| Supports init-only properties.                       | ✔️        | ❌                  | ❌                        |
-| Supports all available serialization customizations. | ✔️        | ❌                  | ❌                        |
-| Reduces start-up time.                               | ❌        | ✔️                  | ❌                        |
-| Reduces private memory usage.                        | ❌        | ✔️                  | ✔️                        |
-| Eliminates run-time reflection.                      | ❌        | ✔️                  | ✔️                        |
-| Facilitates trim-safe app size reduction.            | ❌        | ✔️                  | ✔️                        |
-| Increases serialization throughput.                  | ❌        | ❌                  | ✔️                        |
-
-:::zone-end
-
-The following sections explain these options and their relative benefits.
-
-## System.Text.Json metadata
-
-To serialize or deserialize a type, <xref:System.Text.Json.JsonSerializer> needs information about how to access the members of the type. `JsonSerializer` needs the following information:
-
-* How to access property getters and fields for serialization.
-* How to access a constructor, property setters, and fields for deserialization.
-* Information about which attributes have been used to customize serialization or deserialization.
-* Run-time configuration from <xref:System.Text.Json.JsonSerializerOptions>.
-
-This information is referred to as *metadata*.
-
-By default, `JsonSerializer` collects metadata at run time by using [reflection](/dotnet/csharp/advanced-topics/reflection-and-attributes/). Whenever `JsonSerializer` has to serialize or deserialize a type for the first time, it collects and caches this metadata. The metadata collection process takes time and uses memory.
+For information about how to use source generation modes, see [How to use source generation in System.Text.Json](source-generation.md).
 
 ## Source generation - metadata collection mode
 
@@ -99,13 +43,15 @@ For information about other known issues with source generation, see the [GitHub
 
 `JsonSerializer` has many features that customize the output of serialization, such as [naming policies](customize-properties.md#use-a-built-in-naming-policy) and [preserving references](preserve-references.md#preserve-references-and-handle-circular-references). Support for all those features causes some performance overhead. Source generation can improve serialization performance by generating optimized code that uses [`Utf8JsonWriter`](use-utf8jsonwriter.md) directly.
 
-The optimized code doesn't support all of the serialization features that `JsonSerializer` supports. The serializer detects whether the optimized code can be used and falls back to default serialization code if unsupported options are specified. For example, <xref:System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString?displayProperty=nameWithType> is not applicable to writing, so specifying this option doesn't cause a fall-back to default code.
+The optimized code doesn't support all of the serialization features that `JsonSerializer` supports. The serializer detects whether the optimized code can be used and falls back to default serialization code if unsupported options are specified. For example, <xref:System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString?displayProperty=nameWithType> isn't applicable to writing, so specifying this option doesn't cause a fallback to default code.
 
 The following table shows which options in `JsonSerializerOptions` are supported by the optimized serialization code:
 
 | Serialization option                                                   | Supported by optimized code |
 |------------------------------------------------------------------------|-----------------------------|
+| <xref:System.Text.Json.JsonSerializerOptions.AllowTrailingCommas>      | ❌                          |
 | <xref:System.Text.Json.JsonSerializerOptions.Converters>               | ❌                          |
+| <xref:System.Text.Json.JsonSerializerOptions.DefaultBufferSize>        | ❌                          |
 | <xref:System.Text.Json.JsonSerializerOptions.DefaultIgnoreCondition>   | ✔️                         |
 | <xref:System.Text.Json.JsonSerializerOptions.DictionaryKeyPolicy>      | ❌                          |
 | <xref:System.Text.Json.JsonSerializerOptions.Encoder>                  | ❌                          |
@@ -113,16 +59,21 @@ The following table shows which options in `JsonSerializerOptions` are supported
 | <xref:System.Text.Json.JsonSerializerOptions.IgnoreReadOnlyFields>     | ✔️                         |
 | <xref:System.Text.Json.JsonSerializerOptions.IgnoreReadOnlyProperties> | ✔️                         |
 | <xref:System.Text.Json.JsonSerializerOptions.IncludeFields>            | ✔️                         |
+| <xref:System.Text.Json.JsonSerializerOptions.MaxDepth>                 | ❌                          |
 | <xref:System.Text.Json.JsonSerializerOptions.NumberHandling>           | ❌                          |
+| <xref:System.Text.Json.JsonSerializerOptions.PropertyNameCaseInsensitive> | ❌                       |
 | <xref:System.Text.Json.JsonSerializerOptions.PropertyNamingPolicy>     | ✔️                         |
+| <xref:System.Text.Json.JsonSerializerOptions.ReadCommentHandling>      | ❌                          |
 | <xref:System.Text.Json.JsonSerializerOptions.ReferenceHandler>         | ❌                          |
 | <xref:System.Text.Json.JsonSerializerOptions.TypeInfoResolver>         | ✔️                         |
+| <xref:System.Text.Json.JsonSerializerOptions.UnknownTypeHandling>      | ❌                          |
 | <xref:System.Text.Json.JsonSerializerOptions.WriteIndented>            | ✔️                         |
 
 The following table shows which attributes are supported by the optimized serialization code:
 
 | Attribute                                                         | Supported by optimized code |
 |-------------------------------------------------------------------|-----------------------------|
+| <xref:System.Text.Json.Serialization.JsonConstructorAttribute>    | ❌                         |
 | <xref:System.Text.Json.Serialization.JsonConverterAttribute>      | ❌                         |
 | <xref:System.Text.Json.Serialization.JsonDerivedTypeAttribute>    | ✔️                         |
 | <xref:System.Text.Json.Serialization.JsonExtensionDataAttribute>  | ❌                         |
@@ -131,58 +82,12 @@ The following table shows which attributes are supported by the optimized serial
 | <xref:System.Text.Json.Serialization.JsonNumberHandlingAttribute> | ❌                         |
 | <xref:System.Text.Json.Serialization.JsonPolymorphicAttribute>    | ✔️                         |
 | <xref:System.Text.Json.Serialization.JsonPropertyNameAttribute>   | ✔️                         |
+| <xref:System.Text.Json.Serialization.JsonPropertyOrderAttribute>  | ❌                         |
 | <xref:System.Text.Json.Serialization.JsonRequiredAttribute>       | ✔️                         |
 
-If a non-supported option or attribute is specified for a type, the serializer falls back to the default `JsonSerializer` code. In that case, the optimized code isn't used when serializing that type but may be used for other types. Therefore it's important to do performance testing with your options and workloads to determine how much benefit you can actually get from serialization optimization mode. Also, the ability to fall back to `JsonSerializer` code requires metadata collection mode. If you select only serialization optimization mode, serialization might fail for types or options that need to fall back to `JsonSerializer` code.
-
-## How to use source generation modes
-
-Most of the System.Text.Json documentation shows how to write code that uses reflection mode. For information about how to use source generation modes, see [How to use source generation in System.Text.Json](source-generation.md).
-
-:::zone pivot="dotnet-8-0"
-
-## Serialize enum fields as strings
-
-### `JsonStringEnumConverter<T>` converter
-
-By default, enums are serialized as numbers. To serialize enum names as strings using source generation, use the <xref:System.Text.Json.Serialization.JsonStringEnumConverter%601> converter. (The non-generic <xref:System.Text.Json.Serialization.JsonStringEnumConverter> type is not supported by the Native AOT runtime.)
-
-Suppose you need to serialize the following class that has an enum property:
-
-:::code language="csharp" source="snippets/how-to/csharp/WeatherForecast.cs" id="WFWithConverterEnum":::
-
-Create a <xref:System.Text.Json.Serialization.JsonSerializerContext> class and annotate it with the <xref:System.Text.Json.Serialization.JsonSerializableAttribute> attribute:
-
-:::code language="csharp" source="snippets/how-to/csharp/RoundtripEnumSourceGeneration.cs" id="Context1":::
-
-The following code serializes the enum names instead of the numeric values:
-
-:::code language="csharp" source="snippets/how-to/csharp/RoundtripEnumSourceGeneration.cs" id="Serialize":::
-
-The resulting JSON looks like the following example:
-
-```json
-{
-  "Date": "2019-08-01T00:00:00-07:00",
-  "TemperatureCelsius": 25,
-  "Precipitation": "Sleet"
-}
-```
-
-### Blanket policy
-
-Instead of using the <xref:System.Text.Json.Serialization.JsonStringEnumConverter%601> type, you can apply a blanket policy to serialize enums as strings by using the <xref:System.Text.Json.Serialization.JsonSourceGenerationOptionsAttribute>. Create a <xref:System.Text.Json.Serialization.JsonSerializerContext> class and annotate it with the <xref:System.Text.Json.Serialization.JsonSerializableAttribute> *and <xref:System.Text.Json.Serialization.JsonSourceGenerationOptionsAttribute>* attributes:
-
-:::code language="csharp" source="snippets/how-to/csharp/RoundtripEnumSourceGeneration.cs" id="Context2":::
-
-Notice that the enum doesn't have the <xref:System.Text.Json.Serialization.JsonConverterAttribute>:
-
-:::code language="csharp" source="snippets/how-to/csharp/WeatherForecast.cs" id="WFWithPrecipEnumNoConverter":::
-
-:::zone-end
+If a non-supported option or attribute is specified for a type, the serializer falls back to the default `JsonSerializer` code. In that case, the optimized code isn't used when serializing that type but may be used for other types. Therefore it's important to do performance testing with your options and workloads to determine how much benefit you can actually get from serialization-optimization mode. Also, the ability to fall back to `JsonSerializer` code requires metadata-collection mode. If you select only serialization-optimization mode, serialization might fail for types or options that need to fall back to `JsonSerializer` code.
 
 ## See also
 
-* [Try the new System.Text.Json source generator](https://devblogs.microsoft.com/dotnet/try-the-new-system-text-json-source-generator/)
 * [JSON serialization and deserialization in .NET - overview](overview.md)
 * [How to use the library](how-to.md)

--- a/docs/standard/serialization/system-text-json/source-generation-modes.md
+++ b/docs/standard/serialization/system-text-json/source-generation-modes.md
@@ -49,9 +49,9 @@ The following table shows which options in `JsonSerializerOptions` are supported
 
 | Serialization option                                                   | Supported by optimized code |
 |------------------------------------------------------------------------|-----------------------------|
-| <xref:System.Text.Json.JsonSerializerOptions.AllowTrailingCommas>      | ❌                          |
+| <xref:System.Text.Json.JsonSerializerOptions.AllowTrailingCommas>      | ✔️                          |
 | <xref:System.Text.Json.JsonSerializerOptions.Converters>               | ❌                          |
-| <xref:System.Text.Json.JsonSerializerOptions.DefaultBufferSize>        | ❌                          |
+| <xref:System.Text.Json.JsonSerializerOptions.DefaultBufferSize>        | ✔️                          |
 | <xref:System.Text.Json.JsonSerializerOptions.DefaultIgnoreCondition>   | ✔️                         |
 | <xref:System.Text.Json.JsonSerializerOptions.DictionaryKeyPolicy>      | ❌                          |
 | <xref:System.Text.Json.JsonSerializerOptions.Encoder>                  | ❌                          |
@@ -59,7 +59,7 @@ The following table shows which options in `JsonSerializerOptions` are supported
 | <xref:System.Text.Json.JsonSerializerOptions.IgnoreReadOnlyFields>     | ✔️                         |
 | <xref:System.Text.Json.JsonSerializerOptions.IgnoreReadOnlyProperties> | ✔️                         |
 | <xref:System.Text.Json.JsonSerializerOptions.IncludeFields>            | ✔️                         |
-| <xref:System.Text.Json.JsonSerializerOptions.MaxDepth>                 | ❌                          |
+| <xref:System.Text.Json.JsonSerializerOptions.MaxDepth>                 | ✔️                          |
 | <xref:System.Text.Json.JsonSerializerOptions.NumberHandling>           | ❌                          |
 | <xref:System.Text.Json.JsonSerializerOptions.PropertyNameCaseInsensitive> | ❌                       |
 | <xref:System.Text.Json.JsonSerializerOptions.PropertyNamingPolicy>     | ✔️                         |
@@ -85,7 +85,7 @@ The following table shows which attributes are supported by the optimized serial
 | <xref:System.Text.Json.Serialization.JsonPropertyOrderAttribute>  | ❌                         |
 | <xref:System.Text.Json.Serialization.JsonRequiredAttribute>       | ✔️                         |
 
-If a non-supported option or attribute is specified for a type, the serializer falls back to the default `JsonSerializer` code. In that case, the optimized code isn't used when serializing that type but may be used for other types. Therefore it's important to do performance testing with your options and workloads to determine how much benefit you can actually get from serialization-optimization mode. Also, the ability to fall back to `JsonSerializer` code requires metadata-collection mode. If you select only serialization-optimization mode, serialization might fail for types or options that need to fall back to `JsonSerializer` code.
+If a non-supported option or attribute is specified for a type, the serializer falls back to metadata mode, assuming that the source generator has been configured to generate metadata. In that case, the optimized code isn't used when serializing that type but may be used for other types. Therefore it's important to do performance testing with your options and workloads to determine how much benefit you can actually get from serialization-optimization mode. Also, the ability to fall back to `JsonSerializer` code requires metadata-collection mode. If you select only serialization-optimization mode, serialization might fail for types or options that need to fall back to `JsonSerializer` code.
 
 ## See also
 

--- a/docs/standard/serialization/system-text-json/source-generation-modes.md
+++ b/docs/standard/serialization/system-text-json/source-generation-modes.md
@@ -17,7 +17,7 @@ Source generation can be used in two modes: metadata collection and serializatio
 
 For information about how to use source generation modes, see [How to use source generation in System.Text.Json](source-generation.md).
 
-## Source generation - metadata collection mode
+## Metadata collection mode
 
 You can use source generation to move the metadata collection process from run time to compile time. During compilation, the metadata is collected and source code files are generated. The generated source code files are automatically compiled as an integral part of the application. This technique eliminates run-time metadata collection, which improves performance of both serialization and deserialization.
 
@@ -27,13 +27,13 @@ The performance improvements provided by source generation can be substantial. F
 
 :::zone pivot="dotnet-7-0,dotnet-6-0"
 
-Only `public` properties and fields are supported by default<sup>\*</sup> in either serialization mode. However, reflection mode supports the use of `private` *accessors*, while source-generation mode doesn't. For example, you can apply the [JsonInclude attribute](xref:System.Text.Json.Serialization.JsonIncludeAttribute) to a property that has a `private` setter or getter and it will be serialized in reflection mode. Source-generation mode supports only `public` or `internal` accessors of `public` properties. If you set `[JsonInclude]` on non-public accessors and choose source-generation mode, a `NotSupportedException` will be thrown at run time.
+Only `public` properties and fields are supported by default in either serialization mode. However, reflection mode supports the use of `private` *accessors*, while source-generation mode doesn't. For example, you can apply the [JsonInclude attribute](xref:System.Text.Json.Serialization.JsonIncludeAttribute) to a property that has a `private` setter or getter and it will be serialized in reflection mode. Source-generation mode supports only `public` or `internal` accessors of `public` properties. If you set `[JsonInclude]` on non-public accessors and choose source-generation mode, a `NotSupportedException` will be thrown at run time.
 
 :::zone-end
 
 :::zone pivot="dotnet-8-0"
 
-Only `public` properties and fields are supported by default<sup>\*</sup> in either serialization mode. However, reflection mode supports the use of `private` members and `private` *accessors*, while source-generation mode doesn't. For example, if you apply the [JsonInclude attribute](xref:System.Text.Json.Serialization.JsonIncludeAttribute) to a `private` property or a property that has a `private` setter or getter, it will be serialized in reflection mode. Source-generation mode supports only `public` or `internal` members and `public` or `internal` accessors of `public` properties. If you set `[JsonInclude]` on `private` members or accessors and choose source-generation mode, a `NotSupportedException` will be thrown at run time.
+Only `public` properties and fields are supported by default in either serialization mode. However, reflection mode supports the use of `private` members and `private` *accessors*, while source-generation mode doesn't. For example, if you apply the [JsonInclude attribute](xref:System.Text.Json.Serialization.JsonIncludeAttribute) to a `private` property or a property that has a `private` setter or getter, it will be serialized in reflection mode. Source-generation mode supports only `public` or `internal` members and `public` or `internal` accessors of `public` properties. If you set `[JsonInclude]` on `private` members or accessors and choose source-generation mode, a `NotSupportedException` will be thrown at run time.
 
 :::zone-end
 

--- a/docs/standard/serialization/system-text-json/source-generation.md
+++ b/docs/standard/serialization/system-text-json/source-generation.md
@@ -286,6 +286,8 @@ options.TypeInfoResolverChain.Insert(0, ContextE.Default); // Insert at the begi
 
 Any change made to the <xref:System.Text.Json.JsonSerializerOptions.TypeInfoResolverChain> property is reflected by <xref:System.Text.Json.JsonSerializerOptions.TypeInfoResolver> and vice versa.
 
+:::zone-end
+
 :::zone pivot="dotnet-8-0"
 
 ## Serialize enum fields as strings

--- a/docs/standard/serialization/system-text-json/source-generation.md
+++ b/docs/standard/serialization/system-text-json/source-generation.md
@@ -141,7 +141,8 @@ You can specify metadata-collection mode or serialization-optimization mode for 
 ## Source-generation support in ASP.NET Core
 
 In Blazor apps, use overloads of <xref:System.Net.Http.Json.HttpClientJsonExtensions.GetFromJsonAsync%2A?displayProperty=nameWithType> and <xref:System.Net.Http.Json.HttpClientJsonExtensions.PostAsJsonAsync%2A?displayProperty=nameWithType> extension methods that take a source generation context or `TypeInfo<TValue>`.
-:::zone pivot="dotnet-8"
+
+:::zone pivot="dotnet-8-0"
 
 Starting with .NET 8, you can also use overloads of <xref:System.Net.Http.Json.HttpClientJsonExtensions.GetFromJsonAsAsyncEnumerable%2A?displayProperty=nameWithType> extension methods that accept a source generation context or `TypeInfo<TValue>`.
 

--- a/docs/standard/serialization/system-text-json/source-generation.md
+++ b/docs/standard/serialization/system-text-json/source-generation.md
@@ -141,6 +141,11 @@ You can specify metadata-collection mode or serialization-optimization mode for 
 ## Source-generation support in ASP.NET Core
 
 In Blazor apps, use overloads of <xref:System.Net.Http.Json.HttpClientJsonExtensions.GetFromJsonAsync%2A?displayProperty=nameWithType> and <xref:System.Net.Http.Json.HttpClientJsonExtensions.PostAsJsonAsync%2A?displayProperty=nameWithType> extension methods that take a source generation context or `TypeInfo<TValue>`.
+:::zone pivot="dotnet-8"
+
+Starting with .NET 8, you can also use overloads of <xref:System.Net.Http.Json.HttpClientJsonExtensions.GetFromJsonAsAsyncEnumerable%2A?displayProperty=nameWithType> extension methods that accept a source generation context or `TypeInfo<TValue>`.
+
+:::zone-end
 
 :::zone pivot="dotnet-8-0,dotnet-7-0"
 
@@ -157,8 +162,9 @@ var serializerOptions = new JsonSerializerOptions
     TypeInfoResolver = MyJsonContext.Default;
 };
 
-services.AddControllers().AddJsonOptions(options =>
-    options.JsonSerializerOptions = serializerOptions);
+services.AddControllers().AddJsonOptions(
+    static options =>
+        options.JsonSerializerOptions = serializerOptions);
 ```
 
 :::zone-end

--- a/docs/standard/serialization/system-text-json/source-generation.md
+++ b/docs/standard/serialization/system-text-json/source-generation.md
@@ -97,12 +97,12 @@ Here are the preceding examples in a complete program:
 
 ## Specify source-generation mode
 
-You can specify metadata-collection mode or serialization-optimization mode for an entire context, which may include multiple types. Or you can specify the mode for an individual type. If you do both, the mode specification for a type wins.
+You can specify metadata-based mode or serialization-optimization mode for an entire context, which may include multiple types. Or you can specify the mode for an individual type. If you do both, the mode specification for a type wins.
 
 - For an entire context, use the <xref:System.Text.Json.Serialization.JsonSourceGenerationOptionsAttribute.GenerationMode?displayProperty=nameWithType> property.
 - For an individual type, use the <xref:System.Text.Json.Serialization.JsonSerializableAttribute.GenerationMode?displayProperty=nameWithType> property.
 
-### Serialization-optimization mode example
+### Serialization-optimization (fast path) mode example
 
 - For an entire context:
 
@@ -116,7 +116,7 @@ You can specify metadata-collection mode or serialization-optimization mode for 
 
   :::code language="csharp" source="snippets/source-generation/csharp/SerializeOnlyNoOptions.cs" id="All":::
 
-### Metadata-collection mode example
+### Metadata-based mode example
 
 - For an entire context:
 
@@ -148,7 +148,29 @@ Starting with .NET 8, you can also use overloads of <xref:System.Net.Http.Json.H
 
 :::zone-end
 
-:::zone pivot="dotnet-8-0,dotnet-7-0"
+:::zone pivot="dotnet-8-0"
+
+In Razor Pages, MVC, SignalR, and Web API apps, use the <xref:System.Text.Json.JsonSerializerOptions.TypeInfoResolver?displayProperty=nameWithType> property to specify the context.
+
+```csharp
+[JsonSerializable(typeof(WeatherForecast[]))]
+internal partial class MyJsonContext : JsonSerializerContext { }
+```
+
+```csharp
+var serializerOptions = new JsonSerializerOptions
+{
+    TypeInfoResolver = MyJsonContext.Default;
+};
+
+services.AddControllers().AddJsonOptions(
+    static options =>
+        options.TypeInfoResolverChain.Add(MyJsonContext.Default));
+```
+
+:::zone-end
+
+:::zone pivot="dotnet-7-0"
 
 In Razor Pages, MVC, SignalR, and Web API apps, use the <xref:System.Text.Json.JsonSerializerOptions.TypeInfoResolver?displayProperty=nameWithType> property to specify the context.
 

--- a/docs/standard/serialization/system-text-json/source-generation.md
+++ b/docs/standard/serialization/system-text-json/source-generation.md
@@ -17,9 +17,11 @@ ms.topic: how-to
 
 # How to use source generation in System.Text.Json
 
-Source generation in System.Text.Json is available in .NET 6 and later versions. Source generation consists of two modes: *metadata collection* and *serialization optimization*.
+Source generation in System.Text.Json is available in .NET 6 and later versions. When used in an app, the app's language version must be C# 9.0 or later. This article shows you how to use source-generation-backed serialization in your apps.
 
-## Use source generation defaults
+For information about the different source-generation modes, see [Source-generation modes](source-generation-modes.md).
+
+## Use source-generation defaults
 
 To use source generation with all defaults (both modes, default options):
 
@@ -93,14 +95,14 @@ Here are the preceding examples in a complete program:
 
 :::code language="csharp" source="snippets/source-generation/csharp/BothModesNoOptions.cs" id="All":::
 
-## Specify source generation mode
+## Specify source-generation mode
 
-You can specify metadata collection mode or serialization optimization mode for an entire context, which may include multiple types. Or you can specify the mode for an individual type. If you do both, the mode specification for a type wins.
+You can specify metadata-collection mode or serialization-optimization mode for an entire context, which may include multiple types. Or you can specify the mode for an individual type. If you do both, the mode specification for a type wins.
 
 - For an entire context, use the <xref:System.Text.Json.Serialization.JsonSourceGenerationOptionsAttribute.GenerationMode?displayProperty=nameWithType> property.
 - For an individual type, use the <xref:System.Text.Json.Serialization.JsonSerializableAttribute.GenerationMode?displayProperty=nameWithType> property.
 
-### Serialization optimization mode example
+### Serialization-optimization mode example
 
 - For an entire context:
 
@@ -114,7 +116,7 @@ You can specify metadata collection mode or serialization optimization mode for 
 
   :::code language="csharp" source="snippets/source-generation/csharp/SerializeOnlyNoOptions.cs" id="All":::
 
-### Metadata collection mode example
+### Metadata-collection mode example
 
 - For an entire context:
 
@@ -136,77 +138,7 @@ You can specify metadata collection mode or serialization optimization mode for 
 
   :::code language="csharp" source="snippets/source-generation/csharp/MetadataOnlyNoOptions.cs" id="All":::
 
-## Specify options for serialization optimization mode
-
-Use <xref:System.Text.Json.Serialization.JsonSourceGenerationOptionsAttribute> to specify options that are supported by serialization optimization mode. You can use these options without causing a fallback to `JsonSerializer` code. For example, `WriteIndented` and `CamelCase` are supported:
-
-:::code language="csharp" source="snippets/source-generation/csharp/SerializeOnlyWithOptions.cs" id="JsonSourceGenerationOptions":::
-
-When using `JsonSourceGenerationOptionsAttribute` to specify serialization options, call one of the following serialization methods:
-
-- A `JsonSerializer.Serialize` method that takes a `TypeInfo<TValue>`. Pass it the `Default.<TypeName>` property of your context class:
-
-  :::code language="csharp" source="snippets/source-generation/csharp/SerializeOnlyWithOptions.cs" id="SerializeWithTypeInfo":::
-
-- A `JsonSerializer.Serialize` method that takes a context. Pass it the `Default` static property of your context class.
-
-  :::code language="csharp" source="snippets/source-generation/csharp/SerializeOnlyWithOptions.cs" id="SerializeWithContext":::
-
-If you call a method that lets you pass in your own instance of `Utf8JsonWriter`, the writer's <xref:System.Text.Json.JsonWriterOptions.Indented> setting is honored instead of the `JsonSourceGenerationOptionsAttribute.WriteIndented` option.
-
-If you create and use a context instance by calling the constructor that takes a `JsonSerializerOptions` instance, the supplied instance will be used instead of the options specified by `JsonSourceGenerationOptionsAttribute`.
-
-Here are the preceding examples in a complete program:
-
-:::code language="csharp" source="snippets/source-generation/csharp/SerializeOnlyWithOptions.cs" id="All":::
-
-## Specify options by using `JsonSerializerOptions`
-
-Some options of <xref:System.Text.Json.JsonSerializerOptions> aren't supported by serialization optimization mode. Such options cause a fallback to the non-source-generated `JsonSerializer` code. For more information, see [Serialization optimization](source-generation-modes.md#serialization-optimization-mode).
-
-To specify options by using <xref:System.Text.Json.JsonSerializerOptions>:
-
-- Create an instance of `JsonSerializerOptions`.
-- Create an instance of your class that derives from <xref:System.Text.Json.Serialization.JsonSerializerContext>, and pass the `JsonSerializerOptions` instance to the constructor.
-- Call serialization or deserialization methods of `JsonSerializer` that take a context instance or `TypeInfo<TValue>`.
-
-Here's an example context class followed by serialization and deserialization example code:
-
-:::code language="csharp" source="snippets/source-generation/csharp/JsonSerializerOptionsExample.cs" id="DefineContext":::
-
-:::code language="csharp" source="snippets/source-generation/csharp/JsonSerializerOptionsExample.cs" id="Serialize":::
-
-:::code language="csharp" source="snippets/source-generation/csharp/JsonSerializerOptionsExample.cs" id="Deserialize":::
-
-Here are the preceding examples in a complete program:
-
-:::code language="csharp" source="snippets/source-generation/csharp/JsonSerializerOptionsExample.cs" id="All":::
-
-:::zone pivot="dotnet-8-0,dotnet-7-0"
-
-## Combine source generators
-
-You can combine contracts from multiple source-generated contexts inside a single <xref:System.Text.Json.JsonSerializerOptions> instance. Use the <xref:System.Text.Json.JsonSerializerOptions.TypeInfoResolver?displayProperty=nameWithType> property to chain multiple contexts that have been combined by using the <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfoResolver.Combine(System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver[])?displayProperty=nameWithType> method.
-
-```csharp
-var options = new JsonSerializerOptions
-{
-    TypeInfoResolver = JsonTypeInfoResolver.Combine(ContextA.Default, ContextB.Default, ContextC.Default);
-};
-```
-
-Starting in .NET 8, if you later want to prepend or append another context, you can do so using the <xref:System.Text.Json.JsonSerializerOptions.TypeInfoResolverChain?displayProperty=nameWithType> property. The ordering of the chain is significant: <xref:System.Text.Json.JsonSerializerOptions> queries each of the resolvers in their specified order and returns the first result that's non-null.
-
-```csharp
-options.TypeInfoResolverChain.Add(ContextD.Default); // Append to the end of the list.
-options.TypeInfoResolverChain.Insert(0, ContextE.Default); // Insert at the beginning of the list.
-```
-
-Any change made to the <xref:System.Text.Json.JsonSerializerOptions.TypeInfoResolverChain> property is reflected by <xref:System.Text.Json.JsonSerializerOptions.TypeInfoResolver> and vice versa.
-
-:::zone-end
-
-## Source generation support in ASP.NET Core
+## Source-generation support in ASP.NET Core
 
 In Blazor apps, use overloads of <xref:System.Net.Http.Json.HttpClientJsonExtensions.GetFromJsonAsync%2A?displayProperty=nameWithType> and <xref:System.Net.Http.Json.HttpClientJsonExtensions.PostAsJsonAsync%2A?displayProperty=nameWithType> extension methods that take a source generation context or `TypeInfo<TValue>`.
 
@@ -247,8 +179,158 @@ services.AddControllers().AddJsonOptions(options =>
 
 :::zone-end
 
+:::zone pivot="dotnet-8-0"
+
+## Disable reflection defaults
+
+Because System.Text.Json uses reflection by default, calling a basic serialization method can break Native AOT apps, which can't reflect at run time. These breaks can be challenging to diagnose since apps are often debugged using the CoreCLR runtime, where the code works. Instead, if you explicitly disable reflection-based serialization, breaks are easier to diagnose. Code that uses reflection-based serialization will cause an <xref:System.InvalidOperationException> with a descriptive message to be thrown at run time.
+
+To disable default reflection in your app, set the `JsonSerializerIsReflectionEnabledByDefault` MSBuild property to `false` in your project file:
+
+```xml
+<PropertyGroup>
+  <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
+</PropertyGroup>
+```
+
+- The behavior of this property is consistent regardless of runtime, either CoreCLR or Native AOT.
+- If you don't specify this property and [PublishTrimmed](../../../core/project-sdk/msbuild-props.md#trim-related-properties) is enabled, reflection-based serialization is automatically disabled.
+
+You can programmatically check whether reflection is disabled by using the <xref:System.Text.Json.JsonSerializer.IsReflectionEnabledByDefault?displayProperty=nameWithType> property. The following code snippet shows how you might configure your serializer depending on whether reflection is enabled:
+
+```csharp
+static JsonSerializerOptions CreateDefaultOptions()
+{
+    return new()
+    {
+        TypeInfoResolver = JsonSerializer.IsReflectionEnabledByDefault
+            ? new DefaultJsonTypeInfoResolver()
+            : MyContext.Default
+    };
+}
+```
+
+Because the property is treated as a link-time constant, the previous method doesn't root the reflection-based resolver in applications that run in Native AOT.
+
+:::zone-end
+
+## Specify options
+
+In .NET 8 and later versions, most options that you can set using <xref:System.Text.Json.JsonSerializerOptions> can also be set using the <xref:System.Text.Json.Serialization.JsonSourceGenerationOptionsAttribute> attribute. The advantage to setting options via the attribute is that the configuration is specified at compile time, which ensures that the generated `MyContext.Default` property is preconfigured with all the relevant options set.
+
+The following code shows how to set options using the xref:System.Text.Json.Serialization.JsonSourceGenerationOptionsAttribute> attribute.
+
+:::code language="csharp" source="snippets/source-generation/csharp/SerializeOnlyWithOptions.cs" id="JsonSourceGenerationOptions":::
+
+When using `JsonSourceGenerationOptionsAttribute` to specify serialization options, call one of the following serialization methods:
+
+- A `JsonSerializer.Serialize` method that takes a `TypeInfo<TValue>`. Pass it the `Default.<TypeName>` property of your context class:
+
+  :::code language="csharp" source="snippets/source-generation/csharp/SerializeOnlyWithOptions.cs" id="SerializeWithTypeInfo":::
+
+- A `JsonSerializer.Serialize` method that takes a context. Pass it the `Default` static property of your context class.
+
+  :::code language="csharp" source="snippets/source-generation/csharp/SerializeOnlyWithOptions.cs" id="SerializeWithContext":::
+
+If you call a method that lets you pass in your own instance of `Utf8JsonWriter`, the writer's <xref:System.Text.Json.JsonWriterOptions.Indented> setting is honored instead of the `JsonSourceGenerationOptionsAttribute.WriteIndented` option.
+
+If you create and use a context instance by calling the constructor that takes a `JsonSerializerOptions` instance, the supplied instance will be used instead of the options specified by `JsonSourceGenerationOptionsAttribute`.
+
+Here are the preceding examples in a complete program:
+
+:::code language="csharp" source="snippets/source-generation/csharp/SerializeOnlyWithOptions.cs" id="All":::
+
+:::zone pivot="dotnet-7-0,dotnet-6-0"
+
+### Specify options by using `JsonSerializerOptions`
+
+Some options of <xref:System.Text.Json.JsonSerializerOptions> can't be set using <xref:System.Text.Json.Serialization.JsonSourceGenerationOptionsAttribute>. To specify options by using <xref:System.Text.Json.JsonSerializerOptions>:
+
+- Create an instance of `JsonSerializerOptions`.
+- Create an instance of your class that derives from <xref:System.Text.Json.Serialization.JsonSerializerContext>, and pass the `JsonSerializerOptions` instance to the constructor.
+- Call serialization or deserialization methods of `JsonSerializer` that take a context instance or `TypeInfo<TValue>`.
+
+Here's an example context class followed by serialization and deserialization example code:
+
+:::code language="csharp" source="snippets/source-generation/csharp/JsonSerializerOptionsExample.cs" id="DefineContext":::
+
+:::code language="csharp" source="snippets/source-generation/csharp/JsonSerializerOptionsExample.cs" id="Serialize":::
+
+:::code language="csharp" source="snippets/source-generation/csharp/JsonSerializerOptionsExample.cs" id="Deserialize":::
+
+Here are the preceding examples in a complete program:
+
+:::code language="csharp" source="snippets/source-generation/csharp/JsonSerializerOptionsExample.cs" id="All":::
+
+:::zone-end
+
+:::zone pivot="dotnet-8-0,dotnet-7-0"
+
+## Combine source generators
+
+You can combine contracts from multiple source-generated contexts inside a single <xref:System.Text.Json.JsonSerializerOptions> instance. Use the <xref:System.Text.Json.JsonSerializerOptions.TypeInfoResolver?displayProperty=nameWithType> property to chain multiple contexts that have been combined by using the <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfoResolver.Combine(System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver[])?displayProperty=nameWithType> method.
+
+```csharp
+var options = new JsonSerializerOptions
+{
+    TypeInfoResolver = JsonTypeInfoResolver.Combine(ContextA.Default, ContextB.Default, ContextC.Default);
+};
+```
+
+Starting in .NET 8, if you later want to prepend or append another context, you can do so using the <xref:System.Text.Json.JsonSerializerOptions.TypeInfoResolverChain?displayProperty=nameWithType> property. The ordering of the chain is significant: <xref:System.Text.Json.JsonSerializerOptions> queries each of the resolvers in their specified order and returns the first result that's non-null.
+
+```csharp
+options.TypeInfoResolverChain.Add(ContextD.Default); // Append to the end of the list.
+options.TypeInfoResolverChain.Insert(0, ContextE.Default); // Insert at the beginning of the list.
+```
+
+Any change made to the <xref:System.Text.Json.JsonSerializerOptions.TypeInfoResolverChain> property is reflected by <xref:System.Text.Json.JsonSerializerOptions.TypeInfoResolver> and vice versa.
+
+:::zone pivot="dotnet-8-0"
+
+## Serialize enum fields as strings
+
+By default, enums are serialized as numbers. To [serialize a specific enum's fields as strings](#jsonstringenumconvertert-converter) when using source generation, annotate it with the <xref:System.Text.Json.Serialization.JsonStringEnumConverter%601> converter. Or to set a [blanket policy](#blanket-policy) for all enumerations, use the <xref:System.Text.Json.Serialization.JsonSourceGenerationOptionsAttribute> attribute.
+
+### `JsonStringEnumConverter<T>` converter
+
+To serialize enum names as strings using source generation, use the <xref:System.Text.Json.Serialization.JsonStringEnumConverter%601> converter. (The non-generic <xref:System.Text.Json.Serialization.JsonStringEnumConverter> type is not supported by the Native AOT runtime.)
+
+Annotate the enumeration type with the <xref:System.Text.Json.Serialization.JsonStringEnumConverter%601> converter using the <xref:System.Text.Json.Serialization.JsonConverterAttribute> attribute:
+
+:::code language="csharp" source="snippets/how-to/csharp/WeatherForecast.cs" id="WFWithConverterEnum":::
+
+Create a <xref:System.Text.Json.Serialization.JsonSerializerContext> class and annotate it with the <xref:System.Text.Json.Serialization.JsonSerializableAttribute> attribute:
+
+:::code language="csharp" source="snippets/how-to/csharp/RoundtripEnumSourceGeneration.cs" id="Context1":::
+
+The following code serializes the enum names instead of the numeric values:
+
+:::code language="csharp" source="snippets/how-to/csharp/RoundtripEnumSourceGeneration.cs" id="Serialize":::
+
+The resulting JSON looks like the following example:
+
+```json
+{
+  "Date": "2019-08-01T00:00:00-07:00",
+  "TemperatureCelsius": 25,
+  "Precipitation": "Sleet"
+}
+```
+
+### Blanket policy
+
+Instead of using the <xref:System.Text.Json.Serialization.JsonStringEnumConverter%601> type, you can apply a blanket policy to serialize enums as strings by using the <xref:System.Text.Json.Serialization.JsonSourceGenerationOptionsAttribute>. Create a <xref:System.Text.Json.Serialization.JsonSerializerContext> class and annotate it with the <xref:System.Text.Json.Serialization.JsonSerializableAttribute> *and <xref:System.Text.Json.Serialization.JsonSourceGenerationOptionsAttribute>* attributes:
+
+:::code language="csharp" source="snippets/how-to/csharp/RoundtripEnumSourceGeneration.cs" id="Context2":::
+
+Notice that the enum doesn't have the <xref:System.Text.Json.Serialization.JsonConverterAttribute>:
+
+:::code language="csharp" source="snippets/how-to/csharp/WeatherForecast.cs" id="WFWithPrecipEnumNoConverter":::
+
+:::zone-end
+
 ## See also
 
-- [Try the new System.Text.Json source generator](https://devblogs.microsoft.com/dotnet/try-the-new-system-text-json-source-generator/)
 - [JSON serialization and deserialization in .NET - overview](overview.md)
 - [How to use the library](how-to.md)

--- a/docs/standard/serialization/system-text-json/source-generation.md
+++ b/docs/standard/serialization/system-text-json/source-generation.md
@@ -190,7 +190,7 @@ services.AddControllers().AddJsonOptions(options =>
 
 ## Disable reflection defaults
 
-Because System.Text.Json uses reflection by default, calling a basic serialization method can break Native AOT apps, which can't reflect at run time. These breaks can be challenging to diagnose since apps are often debugged using the CoreCLR runtime, where the code works. Instead, if you explicitly disable reflection-based serialization, breaks are easier to diagnose. Code that uses reflection-based serialization will cause an <xref:System.InvalidOperationException> with a descriptive message to be thrown at run time.
+Because System.Text.Json uses reflection by default, calling a basic serialization method can break Native AOT apps, which doesn't support all required reflection APIs. These breaks can be challenging to diagnose since they can be unpredictable, and apps are often debugged using the CoreCLR runtime, where reflection works. Instead, if you explicitly disable reflection-based serialization, breaks are easier to diagnose. Code that uses reflection-based serialization will cause an <xref:System.InvalidOperationException> with a descriptive message to be thrown at run time.
 
 To disable default reflection in your app, set the `JsonSerializerIsReflectionEnabledByDefault` MSBuild property to `false` in your project file:
 


### PR DESCRIPTION
Fixes #37101.

Adds section on disabling reflection defaults.

Splits the source generation modes article into two separate articles:

1) Choose reflection vs. source generation.
2) Source generation modes.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/whats-new/dotnet-8.md](https://github.com/dotnet/docs/blob/289d55283e35d35c215ab44be9cdc1e6251e26c9/docs/core/whats-new/dotnet-8.md) | [What's new in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-8?branch=pr-en-us-37806) |
| [docs/standard/serialization/system-text-json/customize-properties.md](https://github.com/dotnet/docs/blob/289d55283e35d35c215ab44be9cdc1e6251e26c9/docs/standard/serialization/system-text-json/customize-properties.md) | [How to customize property names and values with System.Text.Json](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/customize-properties?branch=pr-en-us-37806) |
| [docs/standard/serialization/system-text-json/overview.md](https://github.com/dotnet/docs/blob/289d55283e35d35c215ab44be9cdc1e6251e26c9/docs/standard/serialization/system-text-json/overview.md) | ["Serialize and deserialize JSON using C# - .NET"](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/overview?branch=pr-en-us-37806) |
| [docs/standard/serialization/system-text-json/populate-properties.md](https://github.com/dotnet/docs/blob/289d55283e35d35c215ab44be9cdc1e6251e26c9/docs/standard/serialization/system-text-json/populate-properties.md) | [Populate initialized properties](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/populate-properties?branch=pr-en-us-37806) |
| [docs/standard/serialization/system-text-json/reflection-vs-source-generation.md](https://github.com/dotnet/docs/blob/289d55283e35d35c215ab44be9cdc1e6251e26c9/docs/standard/serialization/system-text-json/reflection-vs-source-generation.md) | [docs/standard/serialization/system-text-json/reflection-vs-source-generation](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/reflection-vs-source-generation?branch=pr-en-us-37806) |
| [docs/standard/serialization/system-text-json/required-properties.md](https://github.com/dotnet/docs/blob/289d55283e35d35c215ab44be9cdc1e6251e26c9/docs/standard/serialization/system-text-json/required-properties.md) | [Required properties](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/required-properties?branch=pr-en-us-37806) |
| [docs/standard/serialization/system-text-json/source-generation-modes.md](https://github.com/dotnet/docs/blob/289d55283e35d35c215ab44be9cdc1e6251e26c9/docs/standard/serialization/system-text-json/source-generation-modes.md) | [Source-generation modes in System.Text.Json](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/source-generation-modes?branch=pr-en-us-37806) |
| [docs/standard/serialization/system-text-json/source-generation.md](https://github.com/dotnet/docs/blob/289d55283e35d35c215ab44be9cdc1e6251e26c9/docs/standard/serialization/system-text-json/source-generation.md) | [How to use source generation in System.Text.Json](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/source-generation?branch=pr-en-us-37806) |


<!-- PREVIEW-TABLE-END -->