### PR TITLE
Fix broken link in What's new in C# 12

### DIFF
--- a/docs/csharp/whats-new/csharp-12.md
+++ b/docs/csharp/whats-new/csharp-12.md
@@ -13,7 +13,7 @@ Some C# 12 features have been introduced in previews. You can try these features
 - [Optional parameters in lambda expressions](#default-lambda-parameters) - Introduced in Visual Studio version 17.5 Preview 2.
 - [`ref readonly` parameters](#ref-readonly-parameters) - Introduced in Visual Studio version 17.8 Preview 2.
 - [Alias any type](#alias-any-type) - Introduced in Visual Studio version 17.6 Preview 3.
-- [Experimental attribute](#experimental attribute) - Introduced in Visual Studio version 17.7 Preview 3.
+- [Experimental attribute](#experimental-attribute) - Introduced in Visual Studio version 17.7 Preview 3.
 
 - [Interceptors](#interceptors) - *Preview feature* Introduced in Visual Studio version 17.7 Preview 3.
 


### PR DESCRIPTION
## Summary

Fixes broken link for "Experimental attribute" in list of new features

Fixes #37808


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/whats-new/csharp-12.md](https://github.com/dotnet/docs/blob/d77939405e191936d720fc0b9a0a22090961d7be/docs/csharp/whats-new/csharp-12.md) | [What's new in C# 12](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-12?branch=pr-en-us-37809) |

<!-- PREVIEW-TABLE-END -->