### PR TITLE
Fixes (?) GitHub issue #30189 - Question about note on Creating and Throwing exceptions page

### DIFF
--- a/docs/csharp/fundamentals/exceptions/creating-and-throwing-exceptions.md
+++ b/docs/csharp/fundamentals/exceptions/creating-and-throwing-exceptions.md
@@ -1,7 +1,7 @@
 ---
 title: "Creating and Throwing Exceptions"
 description: Learn about creating and throwing exceptions. Exceptions are used to indicate that an error has occurred while running a program.
-ms.date: 09/28/2023
+ms.date: 10/31/2023
 helpviewer_keywords:
   - "catching exceptions [C#]"
   - "throwing exceptions [C#]"
@@ -26,8 +26,8 @@ Programmers should throw exceptions when one or more of the following conditions
 
   :::code language="csharp" source="snippets/exceptions/Program.cs" ID="InvalidArg":::
 
-> [!NOTE]
-> The example above is for illustrative purposes. Index validating via exceptions is in most cases bad practice. Exceptions should be reserved to guard against exceptional program conditions, not for argument checking as above.
+  > [!NOTE]
+  > The preceding example is for illustrative purposes. Ideally, you don't use exceptions to validate arguments, but to handle exceptional program conditions.
 
 Exceptions contain a property named <xref:System.Exception.StackTrace%2A>. This string contains the name of the methods on the current call stack, together with the file name and line number where the exception was thrown for each method. A <xref:System.Exception.StackTrace%2A> object is created automatically by the common language runtime (CLR) from the point of the `throw` statement, so that exceptions must be thrown from the point where the stack trace should begin.
 

--- a/docs/csharp/fundamentals/exceptions/creating-and-throwing-exceptions.md
+++ b/docs/csharp/fundamentals/exceptions/creating-and-throwing-exceptions.md
@@ -27,7 +27,7 @@ Programmers should throw exceptions when one or more of the following conditions
   :::code language="csharp" source="snippets/exceptions/Program.cs" ID="InvalidArg":::
 
   > [!NOTE]
-  > The preceding example is for illustrative purposes. Ideally, you don't use exceptions to validate arguments, but to handle exceptional program conditions.
+  > The preceding example shows how to use the `InnerException` property. It's intentionally simplified. In practice, you should check that an index is in range before using it. You could use this technique of wrapping an exception when a member of a parameter throws an exception you couldn't anticipate before calling the member.
 
 Exceptions contain a property named <xref:System.Exception.StackTrace%2A>. This string contains the name of the methods on the current call stack, together with the file name and line number where the exception was thrown for each method. A <xref:System.Exception.StackTrace%2A> object is created automatically by the common language runtime (CLR) from the point of the `throw` statement, so that exceptions must be thrown from the point where the stack trace should begin.
 


### PR DESCRIPTION
## Summary

Describe your changes here.

Fixes #30189

Edits article [Create and Throw Exceptions](https://docs.microsoft.com/en-us/dotnet/csharp/fundamentals/exceptions/creating-and-throwing-exceptions)

Note: The issue says that the code sample should be updated, but the original issue is to update the note.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/fundamentals/exceptions/creating-and-throwing-exceptions.md](https://github.com/dotnet/docs/blob/2dbc395a4f2ebfba8ddcfe6a985f2bc4a301a0fa/docs/csharp/fundamentals/exceptions/creating-and-throwing-exceptions.md) | [Create and throw exceptions](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/exceptions/creating-and-throwing-exceptions?branch=pr-en-us-37822) |


<!-- PREVIEW-TABLE-END -->