### PR TITLE
Fixes GitHub issue #30937 - It is not clear what is the functional programming way of doing things

### DIFF
--- a/docs/fsharp/language-reference/async-expressions.md
+++ b/docs/fsharp/language-reference/async-expressions.md
@@ -1,11 +1,11 @@
 ---
-title: Async Expressions
+title: Async expressions
 description: Learn about support in the F# programming language for writing async expressions, which execute without blocking execution of other work.
-ms.date: 10/29/2021
+ms.date: 10/31/2023
 ---
 # Async expressions
 
-This article describes support in F# for async expressions. Async expressions provide one way of performing computations asynchronously, that is, without blocking execution of other work. For example, asynchronous computations can be used to write apps that have UIs that remain responsive to users as the application performs other work.
+This article describes support in F# for async expressions. Async expressions provide one way of performing computations asynchronously, that is, without blocking execution of other work. For example, asynchronous computations can be used to write apps that have UIs that remain responsive to users as the application performs other work. The [F# Asynchronous Workflows programming model](https://www.microsoft.com/research/publication/the-f-asynchronous-programming-model) allows you to write functional programs while hiding the details of thread transition within a library.
 
 Asynchronous code can also be authored using [task expressions](task-expressions.md), which create .NET tasks directly. Using task expressions is preferred when interoperating extensively with .NET libraries that create or consume .NET tasks. When writing most asynchronous code in F#, F# async expressions are preferred because they are more succinct, more compositional, and avoid certain caveats associated with .NET tasks.
 
@@ -76,7 +76,8 @@ The `runAll` function launches three async expressions in parallel and waits unt
 
 ## See also
 
+- [Async programming in F#](../tutorials/async.md)
 - [F# Language Reference](index.md)
 - [Computation Expressions](computation-expressions.md)
-- [Task Expressions](task-expressions.md)
+- [Tasks expressions](task-expressions.md)
 - [Control.Async Class](https://fsharp.github.io/fsharp-core-docs/reference/fsharp-control-fsharpasync.html)

--- a/docs/fsharp/language-reference/async-expressions.md
+++ b/docs/fsharp/language-reference/async-expressions.md
@@ -79,5 +79,5 @@ The `runAll` function launches three async expressions in parallel and waits unt
 - [Async programming in F#](../tutorials/async.md)
 - [F# Language Reference](index.md)
 - [Computation Expressions](computation-expressions.md)
-- [Tasks expressions](task-expressions.md)
+- [Task expressions](task-expressions.md)
 - [Control.Async Class](https://fsharp.github.io/fsharp-core-docs/reference/fsharp-control-fsharpasync.html)


### PR DESCRIPTION
## Summary

Fixes #30937

Edits article [Async Expressions - F#](https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/async-expressions)



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/async-expressions.md](https://github.com/dotnet/docs/blob/be60478f5108f8152a244cde99e0018eee38b01f/docs/fsharp/language-reference/async-expressions.md) | [Async expressions](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/async-expressions?branch=pr-en-us-37823) |

<!-- PREVIEW-TABLE-END -->