### PR TITLE
Add missing 'interface' keyword

### DIFF
--- a/docs/standard/native-interop/comwrappers-source-generation.md
+++ b/docs/standard/native-interop/comwrappers-source-generation.md
@@ -45,7 +45,7 @@ To use the COM interface generator, add the <xref:System.Runtime.InteropServices
 ```csharp
 [GeneratedComInterface]
 [Guid("3faca0d2-e7f1-4e9c-82a6-404fd6e0aab8")]
-internal partial IFoo
+internal partial interface IFoo
 {
     void Method(int i);
 }


### PR DESCRIPTION
## Summary

Missing the `interface` keyword in a code snippet


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/native-interop/comwrappers-source-generation.md](https://github.com/dotnet/docs/blob/22d93275e4317a0ee6bd578efba27cde8d4f251a/docs/standard/native-interop/comwrappers-source-generation.md) | [Source generation for ComWrappers](https://review.learn.microsoft.com/en-us/dotnet/standard/native-interop/comwrappers-source-generation?branch=pr-en-us-37827) |

<!-- PREVIEW-TABLE-END -->