### PR TITLE
doc DOTNET_JITMinOpts=1

### DIFF
--- a/docs/core/runtime-config/compilation.md
+++ b/docs/core/runtime-config/compilation.md
@@ -141,10 +141,10 @@ Project file:
 
 ## Debuggability
 
-- Configures whether the .NET Core runtime generates optimized code for images that were built in release configuration.
+- Configures whether the .NET runtime generates optimized code for images that were built in release configuration.
 - If you omit this setting, .NET generates optimized code. This is equivalent to setting the value to `0`.
-- Use this setting to make it easier to debug code generated from images built in release configuration.
-- See also [JIT Optimization and Debugging](/visualstudio/debugger/jit-optimization-and-debugging) which describes the equivalent setting in Visual Studio.
+- Set the value to 1 to make it easier to debug code generated from images built in release configuration.
+- [JIT Optimization and Debugging](/visualstudio/debugger/jit-optimization-and-debugging) describes the equivalent setting in Visual Studio.
 
 | | Setting name | Values |
 | - | - | - |

--- a/docs/core/runtime-config/compilation.md
+++ b/docs/core/runtime-config/compilation.md
@@ -139,6 +139,17 @@ Project file:
 | - | - | - |
 | **Environment variable** | `COMPlus_ReadyToRun` or `DOTNET_ReadyToRun` | `1` - enabled<br/>`0` - disabled |
 
+## Debuggability
+
+- Configures whether the .NET Core runtime generates optimized code for images that were built in release configuration.
+- If you omit this setting, .NET generates optimized code. This is equivalent to setting the value to `0`.
+- Use this setting to make it easier to debug code generated from images built in release configuration.
+- See also [JIT Optimization and Debugging](/visualstudio/debugger/jit-optimization-and-debugging) which describes the equivalent setting in Visual Studio.
+
+| | Setting name | Values |
+| - | - | - |
+| **Environment variable** | `COMPlus_JITMinOpts` or `DOTNET_JITMinOpts` | `1` - enabled<br/>`0` - disabled |
+
 ## Profile-guided optimization
 
 This setting enables dynamic or tiered profile-guided optimization (PGO) in .NET 6 and later versions.


### PR DESCRIPTION
Document how to get the equivalent of `Suppress JIT optimization on module load` setting in VS.

@AndyAyersMS @BruceForstall is this right?

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/runtime-config/compilation.md](https://github.com/dotnet/docs/blob/885d443d355271da52d6eac55504a0164604ec46/docs/core/runtime-config/compilation.md) | [Runtime configuration options for compilation](https://review.learn.microsoft.com/en-us/dotnet/core/runtime-config/compilation?branch=pr-en-us-37856) |


<!-- PREVIEW-TABLE-END -->