### PR TITLE
Fixes GitHub issue #28103: Formatting guidelines: clarify how empty class, struct and interface declarations should be formatted

### DIFF
--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -1,7 +1,7 @@
 ---
 title: F# code formatting guidelines
 description: Learn guidelines for formatting F# code.
-ms.date: 09/19/2021
+ms.date: 11/01/2023
 ---
 # F# code formatting guidelines
 
@@ -1299,6 +1299,14 @@ let comparer = {
             reversed.CompareTo(rev s2)
 }
 ```
+
+Empty type definitions may be formatted on one line:
+
+```fsharp
+type AnEmptyType = class end
+```
+
+Regardless of the chosen page width, `= class end` should always be on the same line.
 
 ### Formatting index/slice expressions
 


### PR DESCRIPTION
## Summary

Fixes #28103

Updates article [F# code formatting guidelines](https://docs.microsoft.com/en-us/dotnet/fsharp/style-guide/formatting)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/style-guide/formatting.md](https://github.com/dotnet/docs/blob/ba144efdd3ca96b872f76d28f5cda929aab05ade/docs/fsharp/style-guide/formatting.md) | [F# code formatting guidelines](https://review.learn.microsoft.com/en-us/dotnet/fsharp/style-guide/formatting?branch=pr-en-us-37860) |

<!-- PREVIEW-TABLE-END -->