### PR TITLE
Revert "Update summary description - issue 27060."

### DIFF
--- a/docs/csharp/language-reference/xmldoc/recommended-tags.md
+++ b/docs/csharp/language-reference/xmldoc/recommended-tags.md
@@ -164,7 +164,7 @@ If you want angle brackets to appear in the text of a documentation comment, use
 <summary>description</summary>
 ```
 
-The `<summary>` tag should be used to describe a type or a type member. Use [\<remarks>](#remarks) to add supplemental information to a type description. Use the [cref attribute](#cref-attribute) to enable documentation tools such as [DocFX](https://dotnet.github.io/docfx/) and [Sandcastle](https://github.com/EWSoftware/SHFB) to create internal hyperlinks to documentation pages for code elements. The text for the `<summary>` tag is a source of information about the type in IntelliSense, and is also displayed in the Object Browser window.
+The `<summary>` tag should be used to describe a type or a type member. Use [\<remarks>](#remarks) to add supplemental information to a type description. Use the [cref attribute](#cref-attribute) to enable documentation tools such as [DocFX](https://dotnet.github.io/docfx/) and [Sandcastle](https://github.com/EWSoftware/SHFB) to create internal hyperlinks to documentation pages for code elements. The text for the `<summary>` tag is the only source of information about the type in IntelliSense, and is also displayed in the Object Browser window.
 
 ### \<remarks>
 
@@ -174,7 +174,7 @@ description
 </remarks>
 ```
 
-The `<remarks>` tag is used to add information about a type or a type member, supplementing the information specified with [\<summary>](#summary). This information is displayed in the Object Browser window. The text for the `<remarks>` tag is a source of information about the type in IntelliSense. This tag may include more lengthy explanations. You may find that using `CDATA` sections for markdown make writing it more convenient. Tools such as [docfx](https://dotnet.github.io/docfx/) process the markdown text in `CDATA` sections.
+The `<remarks>` tag is used to add information about a type or a type member, supplementing the information specified with [\<summary>](#summary). This information is displayed in the Object Browser window. This tag may include more lengthy explanations. You may find that using `CDATA` sections for markdown make writing it more convenient. Tools such as [docfx](https://dotnet.github.io/docfx/) process the markdown text in `CDATA` sections.
 
 ## Document members
 


### PR DESCRIPTION
Reverts dotnet/docs#37853

My comment in the issue had a typo - it was meant to say "I don't" see the remarks in IntelliSense. I don't think any edits are needed to this document after this revert PR, and the issue can be closed.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/xmldoc/recommended-tags.md](https://github.com/dotnet/docs/blob/2d20b1948e6312952b5fc83d740364856e515eb8/docs/csharp/language-reference/xmldoc/recommended-tags.md) | [Recommended XML tags for C# documentation comments](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/recommended-tags?branch=pr-en-us-37870) |

<!-- PREVIEW-TABLE-END -->