### PR TITLE
JSFunctionBinding constructor

### DIFF
--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -98,12 +98,13 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 
 ## Interop
 
-| Title                                                                                             | Type of change      | Introduced |
-| ------------------------------------------------------------------------------------------------- | ------------------- | ---------- |
-| [CreateObjectFlags.Unwrap only unwraps on target instance](interop/8.0/comwrappers-unwrap.md)     | Behavioral change   | Preview 5  |
-| [Custom marshallers require additional members](interop/8.0/marshal-modes.md)                     | Source incompatible | RC 1       |
-| [IDispatchImplAttribute API is removed](interop/8.0/idispatchimplattribute-removed.md)            | Binary incompatible   | Preview 6  |
-| [SafeHandle types must have public constructor](interop/8.0/safehandle-constructor.md)            | Source incompatible | Preview 5  |
+| Title                                                                                             | Type of change      |
+| ------------------------------------------------------------------------------------------------- | ------------------- |
+| [CreateObjectFlags.Unwrap only unwraps on target instance](interop/8.0/comwrappers-unwrap.md)     | Behavioral change   |
+| [Custom marshallers require additional members](interop/8.0/marshal-modes.md)                     | Source incompatible |
+| [IDispatchImplAttribute API is removed](interop/8.0/idispatchimplattribute-removed.md)            | Binary incompatible   |
+| [JSFunctionBinding implicit public default constructor removed](interop/8.0/jsfunctionbinding-constructor.md)            | Binary incompatible   |
+| [SafeHandle types must have public constructor](interop/8.0/safehandle-constructor.md)            | Source incompatible |
 
 ## Reflection
 

--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -103,7 +103,7 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 | [CreateObjectFlags.Unwrap only unwraps on target instance](interop/8.0/comwrappers-unwrap.md)     | Behavioral change   |
 | [Custom marshallers require additional members](interop/8.0/marshal-modes.md)                     | Source incompatible |
 | [IDispatchImplAttribute API is removed](interop/8.0/idispatchimplattribute-removed.md)            | Binary incompatible   |
-| [JSFunctionBinding implicit public default constructor removed](interop/8.0/jsfunctionbinding-constructor.md)            | Binary incompatible   |
+| [JSFunctionBinding implicit public default constructor removed](interop/8.0/jsfunctionbinding-constructor.md) | Binary incompatible   |
 | [SafeHandle types must have public constructor](interop/8.0/safehandle-constructor.md)            | Source incompatible |
 
 ## Reflection

--- a/docs/core/compatibility/interop/8.0/jsfunctionbinding-constructor.md
+++ b/docs/core/compatibility/interop/8.0/jsfunctionbinding-constructor.md
@@ -1,0 +1,36 @@
+---
+title: "Breaking change: JSFunctionBinding implicit public default constructor removed"
+description: Learn about the breaking change in interop in .NET 8 where the implicit public default constructor for System.Runtime.InteropServices.JavaScript.JSFunctionBinding was removed.
+ms.date: 11/02/2023
+---
+# JSFunctionBinding implicit public default constructor removed
+
+The implicit public default constructor for `System.Runtime.InteropServices.JavaScript.JSFunctionBinding` has been removed.
+
+## Previous behavior
+
+Previously, you could create empty instances of <xref:System.Runtime.InteropServices.JavaScript.JSFunctionBinding>.
+
+## New behavior
+
+Starting in .NET 8, you can't instantiate a <xref:System.Runtime.InteropServices.JavaScript.JSFunctionBinding> object.
+
+## Version introduced
+
+.NET 8
+
+## Type of breaking change
+
+This change can affect [binary compatibility](../../categories.md#binary-compatibility).
+
+## Reason for change
+
+The constructor was not intended to be public and this is just fixing the mistake.
+
+## Recommended action
+
+N/A
+
+## Affected APIs
+
+- `System.Runtime.InteropServices.JavaScript.JSFunctionBinding.#ctor`

--- a/docs/core/compatibility/interop/8.0/jsfunctionbinding-constructor.md
+++ b/docs/core/compatibility/interop/8.0/jsfunctionbinding-constructor.md
@@ -25,7 +25,7 @@ This change can affect [binary compatibility](../../categories.md#binary-compati
 
 ## Reason for change
 
-The constructor was not intended to be public and this is just fixing the mistake.
+The constructor was not intended to be public; this change fixes the mistake.
 
 ## Recommended action
 

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -116,6 +116,8 @@ items:
         href: interop/8.0/marshal-modes.md
       - name: IDispatchImplAttribute API is removed
         href: interop/8.0/idispatchimplattribute-removed.md
+      - name: JSFunctionBinding implicit public default constructor removed
+        href: interop/8.0/jsfunctionbinding-constructor.md
       - name: SafeHandle types must have public constructor
         href: interop/8.0/safehandle-constructor.md
     - name: Reflection
@@ -1410,6 +1412,8 @@ items:
         href: interop/8.0/marshal-modes.md
       - name: IDispatchImplAttribute API is removed
         href: interop/8.0/idispatchimplattribute-removed.md
+      - name: JSFunctionBinding implicit public default constructor removed
+        href: interop/8.0/jsfunctionbinding-constructor.md
       - name: SafeHandle types must have public constructor
         href: interop/8.0/safehandle-constructor.md
     - name: .NET 7


### PR DESCRIPTION
Fixes #37520 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/8.0.md](https://github.com/dotnet/docs/blob/e3ac9aacda04df05bb095e4bfb8c531e0d80ff91/docs/core/compatibility/8.0.md) | [Breaking changes in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/8.0?branch=pr-en-us-37882) |
| [docs/core/compatibility/interop/8.0/jsfunctionbinding-constructor.md](https://github.com/dotnet/docs/blob/e3ac9aacda04df05bb095e4bfb8c531e0d80ff91/docs/core/compatibility/interop/8.0/jsfunctionbinding-constructor.md) | [JSFunctionBinding implicit public default constructor removed](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/interop/8.0/jsfunctionbinding-constructor?branch=pr-en-us-37882) |

<!-- PREVIEW-TABLE-END -->