### PR TITLE
System.Windows.Extensions dependency breaking change

### DIFF
--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -140,16 +140,17 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 
 ## Windows Forms
 
-| Title                                                                                                    | Type of change      | Introduced |
-| -------------------------------------------------------------------------------------------------------- | ------------------- | ---------- |
-| [Anchor layout changes](windows-forms/8.0/anchor-layout.md)                                              | Behavioral change   | Preview 1  |
-| [DefaultValueAttribute removed from some properties](windows-forms/8.0/defaultvalueattribute-removal.md) | Behavioral change   | Preview 2  |
-| [ExceptionCollection ctor throws ArgumentException](windows-forms/8.0/exceptioncollection.md)            | Behavioral change   | Preview 1  |
-| [Forms scale according to AutoScaleMode](windows-forms/8.0/top-level-window-scaling.md)                  | Behavioral change   | Preview 1  |
-| [ImageList.ColorDepth default is Depth32Bit](windows-forms/8.0/imagelist-colordepth.md)                  | Behavioral change   | Preview 1  |
-| [TableLayoutStyleCollection throws ArgumentException](windows-forms/8.0/tablelayoutstylecollection.md)   | Behavioral change   | Preview 1  |
-| [Top-level forms scale minimum and maximum size to DPI](windows-forms/8.0/forms-scale-size-to-dpi.md)    | Behavioral change   | Preview 1  |
-| [WFDEV002 obsoletion is now an error](windows-forms/8.0/domainupdownaccessibleobject.md)                 | Source incompatible | Preview 1  |
+| Title                                                                                                    | Type of change      |
+| -------------------------------------------------------------------------------------------------------- | ------------------- |
+| [Anchor layout changes](windows-forms/8.0/anchor-layout.md)                                              | Behavioral change   |
+| [DefaultValueAttribute removed from some properties](windows-forms/8.0/defaultvalueattribute-removal.md) | Behavioral change   |
+| [ExceptionCollection ctor throws ArgumentException](windows-forms/8.0/exceptioncollection.md)            | Behavioral change   |
+| [Forms scale according to AutoScaleMode](windows-forms/8.0/top-level-window-scaling.md)                  | Behavioral change   |
+| [ImageList.ColorDepth default is Depth32Bit](windows-forms/8.0/imagelist-colordepth.md)                  | Behavioral change   |
+| [System.Windows.Extensions doesn't reference System.Drawing.Common](windows-forms/8.0/extensions-package-deps.md) | Source incompatible   |
+| [TableLayoutStyleCollection throws ArgumentException](windows-forms/8.0/tablelayoutstylecollection.md)   | Behavioral change   |
+| [Top-level forms scale minimum and maximum size to DPI](windows-forms/8.0/forms-scale-size-to-dpi.md)    | Behavioral change   |
+| [WFDEV002 obsoletion is now an error](windows-forms/8.0/domainupdownaccessibleobject.md)                 | Source incompatible |
 
 ## See also
 

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -172,6 +172,8 @@ items:
         href: windows-forms/8.0/top-level-window-scaling.md
       - name: ImageList.ColorDepth default is Depth32Bit
         href: windows-forms/8.0/imagelist-colordepth.md
+      - name: System.Windows.Extensions doesn't reference System.Drawing.Common
+        href: windows-forms/8.0/extensions-package-deps.md
       - name: TableLayoutStyleCollection throws ArgumentException
         href: windows-forms/8.0/tablelayoutstylecollection.md
       - name: Top-level forms scale size to DPI
@@ -1688,6 +1690,8 @@ items:
         href: windows-forms/8.0/top-level-window-scaling.md
       - name: ImageList.ColorDepth default is Depth32Bit
         href: windows-forms/8.0/imagelist-colordepth.md
+      - name: System.Windows.Extensions doesn't reference System.Drawing.Common
+        href: windows-forms/8.0/extensions-package-deps.md
       - name: TableLayoutStyleCollection throws ArgumentException
         href: windows-forms/8.0/tablelayoutstylecollection.md
       - name: Top-level forms scale size to DPI

--- a/docs/core/compatibility/windows-forms/8.0/extensions-package-deps.md
+++ b/docs/core/compatibility/windows-forms/8.0/extensions-package-deps.md
@@ -1,0 +1,40 @@
+---
+title: "Breaking change: System.Windows.Extensions doesn't reference System.Drawing.Common"
+description: Learn about the breaking change in .NET 8 where the System.Windows.Extensions package no longer references System.Drawing.Common.
+ms.date: 11/03/2023
+---
+# System.Windows.Extensions doesn't reference System.Drawing.Common
+
+The [System.Windows.Extensions package](https://www.nuget.org/packages/System.Windows.Extensions) no longer references the [System.Drawing.Common](https://www.nuget.org/packages/System.Drawing.Common) package.
+
+## Version introduced
+
+.NET 8 Preview 7
+
+## Previous behavior
+
+Previously, the System.Windows.Extensions package referenced the System.Drawing.Common package.
+
+## New behavior
+
+Starting in .NET 8, the System.Windows.Extensions package no longer references the System.Drawing.Common package. If you depended on the System.Windows.Extensions package bringing in System.Drawing.Common, you might see a compilation error similar to this (but not necessarily for <xref:System.Drawing.FontConverter>):
+
+> **error CS1069: The type name 'FontConverter' could not be found in the namespace 'System.Drawing'. This type has been forwarded to assembly 'System.Drawing.Common, Version=0.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' Consider adding a reference to that assembly.**
+
+## Change category
+
+This change can affect [*source compatibility*](../../categories.md#source-compatibility).
+
+## Reason for change
+
+This change avoids a dependency on System.Drawing.Common when System.Windows.Extensions is referenced.
+
+This change helps more components remove a dependency on System.Drawing.Common unless they actually need it. For more information, see [dotnet/msbuild issue 8962](dotnet/msbuild#8962).
+
+## Recommended action
+
+If you still need to use System.Drawing.Common, add a direct reference.
+
+## Affected APIs
+
+N/A

--- a/docs/core/compatibility/windows-forms/8.0/extensions-package-deps.md
+++ b/docs/core/compatibility/windows-forms/8.0/extensions-package-deps.md
@@ -29,7 +29,7 @@ This change can affect [*source compatibility*](../../categories.md#source-compa
 
 This change avoids a dependency on System.Drawing.Common when System.Windows.Extensions is referenced.
 
-This change helps more components remove a dependency on System.Drawing.Common unless they actually need it. For more information, see [dotnet/msbuild issue 8962](dotnet/msbuild#8962).
+This change helps more components remove a dependency on System.Drawing.Common unless they actually need it. For more information, see [dotnet/msbuild issue 8962](https://www.github.com/dotnet/msbuild/issues/8962).
 
 ## Recommended action
 


### PR DESCRIPTION
Fixes #37525

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/8.0.md](https://github.com/dotnet/docs/blob/f67c9a9e8906c1f032e1292bca2b73242bf8d994/docs/core/compatibility/8.0.md) | [Breaking changes in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/8.0?branch=pr-en-us-37889) |
| [docs/core/compatibility/windows-forms/8.0/extensions-package-deps.md](https://github.com/dotnet/docs/blob/f67c9a9e8906c1f032e1292bca2b73242bf8d994/docs/core/compatibility/windows-forms/8.0/extensions-package-deps.md) | [System.Windows.Extensions doesn't reference System.Drawing.Common](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/windows-forms/8.0/extensions-package-deps?branch=pr-en-us-37889) |


<!-- PREVIEW-TABLE-END -->