### PR TITLE
SendFile breaking change

### DIFF
--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -107,6 +107,12 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 | [JSFunctionBinding implicit public default constructor removed](interop/8.0/jsfunctionbinding-constructor.md) | Binary incompatible   |
 | [SafeHandle types must have public constructor](interop/8.0/safehandle-constructor.md)            | Source incompatible |
 
+## Networking
+
+| Title                                                                                             | Type of change    |
+| ------------------------------------------------------------------------------------------------- | ----------------- |
+| [SendFile throws NotSupportedException for connectionless sockets](networking/8.0/sendfile-connectionless.md) | Behavioral change |
+
 ## Reflection
 
 | Title                                                                                             | Type of change    | Introduced |

--- a/docs/core/compatibility/networking/8.0/sendfile-connectionless.md
+++ b/docs/core/compatibility/networking/8.0/sendfile-connectionless.md
@@ -1,0 +1,46 @@
+---
+title: "Breaking change: SendFile throws NotSupportedException for connectionless sockets"
+description: Learn about the .NET 8 breaking change in networking where the SendFile, SendFileAsync, and EndSendFile methods now throw a NotSupportedException for connectionless sockets on all platforms.
+ms.date: 11/03/2023
+---
+# SendFile throws NotSupportedException for connectionless sockets
+
+The behavior of the <xref:System.Net.Sockets.SendFile%2A> method family for connectionless (for example, UDP) sockets is now consistent across all platforms. The [affected methods](#affected-apis) now throw a <xref:System.NotSupportedException> on all platforms.
+
+## Previous behavior
+
+Previously, for a connectionless <xref:System.Net.Sockets.Socket> (for example, UDP), the following behaviors were observed:
+
+- <xref:System.Net.Sockets.SendFile%2A> threw a <xref:System.NotSupportedException> on Windows, but not on Unix-like platforms.
+- The <xref:System.Threading.Tasks.ValueTask> returned from <xref:System.Net.Sockets.SendFileAsync%2A> stored a <xref:System.Net.Sockets.SocketException> on all platforms.
+- Calling <xref:System.Net.Sockets.EndSendFile%2A> on an <xref:System.IAsyncResult> returned from <xref:System.Net.Sockets.BeginSendFile%2A> threw a <xref:System.Net.Sockets.SocketException> on all platforms.
+
+## New behavior
+
+Starting in .NET 8, for a connectionless <xref:System.Net.Sockets.Socket> (for example, UDP), the following behaviors are observed:
+
+- <xref:System.Net.Sockets.SendFile%2A> throws a <xref:System.NotSupportedException> on all platforms.
+- The <xref:System.Threading.Tasks.ValueTask> returned from <xref:System.Net.Sockets.SendFileAsync%2A> stores a <xref:System.NotSupportedException> on all platforms.
+- Calling <xref:System.Net.Sockets.EndSendFile%2A> on an <xref:System.IAsyncResult> returned from <xref:System.Net.Sockets.BeginSendFile%2A> throws a <xref:System.NotSupportedException> on all platforms.
+
+## Version introduced
+
+.NET 8 RC 1
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+Given that `SendFile` is typically used with large amounts of data, it doesn't make sense to use it with connectionless sockets. In addition, the previous behavior was inconsistent, throwing `SocketException` on some platforms, while succeeding on others with an unpredictable outcome.
+
+## Recommended action
+
+Do not use `SendFile` methods for connectionless sockets.
+
+## Affected APIs
+
+- <xref:System.Net.Sockets.SendFile%2A?displayProperty=fullName>
+- <xref:System.Net.Sockets.SendFileAsync%2A?displayProperty=fullName>
+- <xref:System.Net.Sockets.EndSendFile%2A?displayProperty=fullName>

--- a/docs/core/compatibility/networking/8.0/sendfile-connectionless.md
+++ b/docs/core/compatibility/networking/8.0/sendfile-connectionless.md
@@ -5,23 +5,23 @@ ms.date: 11/03/2023
 ---
 # SendFile throws NotSupportedException for connectionless sockets
 
-The behavior of the <xref:System.Net.Sockets.SendFile%2A> method family for connectionless (for example, UDP) sockets is now consistent across all platforms. The [affected methods](#affected-apis) now throw a <xref:System.NotSupportedException> on all platforms.
+The behavior of the <xref:System.Net.Sockets.Socket.SendFile%2A> method family for connectionless (for example, UDP) sockets is now consistent across all platforms. The [affected methods](#affected-apis) now throw a <xref:System.NotSupportedException> on all platforms.
 
 ## Previous behavior
 
 Previously, for a connectionless <xref:System.Net.Sockets.Socket> (for example, UDP), the following behaviors were observed:
 
-- <xref:System.Net.Sockets.SendFile%2A> threw a <xref:System.NotSupportedException> on Windows, but not on Unix-like platforms.
-- The <xref:System.Threading.Tasks.ValueTask> returned from <xref:System.Net.Sockets.SendFileAsync%2A> stored a <xref:System.Net.Sockets.SocketException> on all platforms.
-- Calling <xref:System.Net.Sockets.EndSendFile%2A> on an <xref:System.IAsyncResult> returned from <xref:System.Net.Sockets.BeginSendFile%2A> threw a <xref:System.Net.Sockets.SocketException> on all platforms.
+- <xref:System.Net.Sockets.Socket.SendFile%2A> threw a <xref:System.NotSupportedException> on Windows, but not on Unix-like platforms.
+- The <xref:System.Threading.Tasks.ValueTask> returned from <xref:System.Net.Sockets.Socket.SendFileAsync%2A> stored a <xref:System.Net.Sockets.SocketException> on all platforms.
+- Calling <xref:System.Net.Sockets.Socket.EndSendFile%2A> on an <xref:System.IAsyncResult> returned from <xref:System.Net.Sockets.Socket.BeginSendFile%2A> threw a <xref:System.Net.Sockets.SocketException> on all platforms.
 
 ## New behavior
 
 Starting in .NET 8, for a connectionless <xref:System.Net.Sockets.Socket> (for example, UDP), the following behaviors are observed:
 
-- <xref:System.Net.Sockets.SendFile%2A> throws a <xref:System.NotSupportedException> on all platforms.
-- The <xref:System.Threading.Tasks.ValueTask> returned from <xref:System.Net.Sockets.SendFileAsync%2A> stores a <xref:System.NotSupportedException> on all platforms.
-- Calling <xref:System.Net.Sockets.EndSendFile%2A> on an <xref:System.IAsyncResult> returned from <xref:System.Net.Sockets.BeginSendFile%2A> throws a <xref:System.NotSupportedException> on all platforms.
+- <xref:System.Net.Sockets.Socket.SendFile%2A> throws a <xref:System.NotSupportedException> on all platforms.
+- The <xref:System.Threading.Tasks.ValueTask> returned from <xref:System.Net.Sockets.Socket.SendFileAsync%2A> stores a <xref:System.NotSupportedException> on all platforms.
+- Calling <xref:System.Net.Sockets.Socket.EndSendFile%2A> on an <xref:System.IAsyncResult> returned from <xref:System.Net.Sockets.Socket.BeginSendFile%2A> throws a <xref:System.NotSupportedException> on all platforms.
 
 ## Version introduced
 
@@ -41,6 +41,6 @@ Do not use `SendFile` methods for connectionless sockets.
 
 ## Affected APIs
 
-- <xref:System.Net.Sockets.SendFile%2A?displayProperty=fullName>
-- <xref:System.Net.Sockets.SendFileAsync%2A?displayProperty=fullName>
-- <xref:System.Net.Sockets.EndSendFile%2A?displayProperty=fullName>
+- <xref:System.Net.Sockets.Socket.SendFile%2A?displayProperty=fullName>
+- <xref:System.Net.Sockets.Socket.SendFileAsync%2A?displayProperty=fullName>
+- <xref:System.Net.Sockets.Socket.EndSendFile%2A?displayProperty=fullName>

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -122,6 +122,10 @@ items:
         href: interop/8.0/jsfunctionbinding-constructor.md
       - name: SafeHandle types must have public constructor
         href: interop/8.0/safehandle-constructor.md
+    - name: Networking
+      items:
+      - name: SendFile throws NotSupportedException for connectionless sockets
+        href: networking/8.0/sendfile-connectionless.md
     - name: Reflection
       items:
       - name: IntPtr no longer used for function pointer types
@@ -1458,6 +1462,10 @@ items:
         href: maui/7.0/iwindowstatemanager-apis-removed.md
   - name: Networking
     items:
+    - name: .NET 8
+      items:
+      - name: SendFile throws NotSupportedException for connectionless sockets
+        href: networking/8.0/sendfile-connectionless.md
     - name: .NET 7
       items:
       - name: AllowRenegotiation default is false


### PR DESCRIPTION
Fixes #37544 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/8.0.md](https://github.com/dotnet/docs/blob/5089e4c87a0441ce53b21f11a8f72f70977046f2/docs/core/compatibility/8.0.md) | [Breaking changes in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/8.0?branch=pr-en-us-37890) |
| [docs/core/compatibility/networking/8.0/sendfile-connectionless.md](https://github.com/dotnet/docs/blob/5089e4c87a0441ce53b21f11a8f72f70977046f2/docs/core/compatibility/networking/8.0/sendfile-connectionless.md) | [SendFile throws NotSupportedException for connectionless sockets](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/networking/8.0/sendfile-connectionless?branch=pr-en-us-37890) |


<!-- PREVIEW-TABLE-END -->