### PR TITLE
Install Script update --os option

### DIFF
--- a/docs/core/tools/dotnet-install-script.md
+++ b/docs/core/tools/dotnet-install-script.md
@@ -185,7 +185,7 @@ The install scripts do not update the registry on Windows. They just download th
 
 - **`--os <OPERATING_SYSTEM>`**
 
-  Specifies the operating system for which the tools are being installed. Possible values are: `osx`, `linux`, `linux-musl`, `freebsd`.
+  Specifies the operating system for which the tools are being installed. Possible values are: `osx`, `macos`, `linux`, `linux-musl`, `freebsd`.
 
   The parameter is optional and should only be used when it's required to override the operating system that is detected by the script.
 


### PR DESCRIPTION
## Summary

Adding an extra option for `--os` in install scripts.
https://github.com/dotnet/install-scripts/pull/408


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-install-script.md](https://github.com/dotnet/docs/blob/6b77e013f5a5b962763e043bf0f3c5e7caf40e4a/docs/core/tools/dotnet-install-script.md) | [dotnet-install scripts reference](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script?branch=pr-en-us-37901) |

<!-- PREVIEW-TABLE-END -->