### PR TITLE
Fix typos in source-generation.md

### DIFF
--- a/docs/standard/serialization/system-text-json/source-generation.md
+++ b/docs/standard/serialization/system-text-json/source-generation.md
@@ -165,7 +165,7 @@ var serializerOptions = new JsonSerializerOptions
 
 services.AddControllers().AddJsonOptions(
     static options =>
-        options.TypeInfoResolverChain.Add(MyJsonContext.Default));
+        options.JsonSerializerOptions.TypeInfoResolverChain.Add(MyJsonContext.Default));
 ```
 
 :::zone-end
@@ -247,7 +247,7 @@ Because the property is treated as a link-time constant, the previous method doe
 
 In .NET 8 and later versions, most options that you can set using <xref:System.Text.Json.JsonSerializerOptions> can also be set using the <xref:System.Text.Json.Serialization.JsonSourceGenerationOptionsAttribute> attribute. The advantage to setting options via the attribute is that the configuration is specified at compile time, which ensures that the generated `MyContext.Default` property is preconfigured with all the relevant options set.
 
-The following code shows how to set options using the xref:System.Text.Json.Serialization.JsonSourceGenerationOptionsAttribute> attribute.
+The following code shows how to set options using the <xref:System.Text.Json.Serialization.JsonSourceGenerationOptionsAttribute> attribute.
 
 :::code language="csharp" source="snippets/source-generation/csharp/SerializeOnlyWithOptions.cs" id="JsonSourceGenerationOptions":::
 


### PR DESCRIPTION
## Summary

- Added missing "<" in class tag below **Specify Options** to fix link 
- Added JsonSerializerOptions before call to TypeInfoResolverChain for code sample in section **Source-generation support in ASP.NET Core**

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/serialization/system-text-json/source-generation.md](https://github.com/dotnet/docs/blob/839e061cd934a6b757a3b0f69415861a769729ac/docs/standard/serialization/system-text-json/source-generation.md) | [How to use source generation in System.Text.Json](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/source-generation?branch=pr-en-us-37904) |

<!-- PREVIEW-TABLE-END -->