### PR TITLE
Implicit global using breaking change

### DIFF
--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -121,21 +121,22 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 
 ## SDK
 
-| Title                                                                                              | Type of change                                   | Introduced |
-| -------------------------------------------------------------------------------------------------- | ------------------------------------------------ | ---------- |
-| [CLI console output uses UTF-8](sdk/8.0/console-encoding.md)                                       | Behavioral change/Source and binary incompatible | Preview 1  |
-| [Console encoding not UTF-8 after completion](sdk/8.0/console-encoding-fix.md)                     | Behavioral change/Binary incompatible            | Preview 3  |
-| [Containers default to use the 'latest' tag](sdk/8.0/default-image-tag.md)                         | Behavioral change                                | Preview 6  |
-| ['dotnet pack' uses Release configuration](sdk/8.0/dotnet-pack-config.md)                          | Behavioral change/Source incompatible            | Preview 1  |
-| ['dotnet publish' uses Release configuration](sdk/8.0/dotnet-publish-config.md)                    | Behavioral change/Source incompatible            | Preview 1  |
-| [MSBuild custom derived build events deprecated](sdk/8.0/custombuildeventargs.md)                  | Behavioral change                  | RC 1       |
-| [MSBuild respects DOTNET_CLI_UI_LANGUAGE](sdk/8.0/msbuild-language.md)                             | Behavioral change                                | Preview 5  |
-| [Runtime-specific apps not self-contained](sdk/8.0/runtimespecific-app-default.md)                 | Source/binary incompatible                       | Preview 5  |
-| [--arch option doesn't imply self-contained](sdk/8.0/arch-option.md)                               | Behavioral change                                | RC 2       |
-| ['dotnet restore' produces security vulnerability warnings](sdk/8.0/dotnet-restore-audit.md)       | Behavioral change                                | Preview 4  |
-| [SDK uses a smaller RID graph](sdk/8.0/rid-graph.md)                                               | Behavioral change/Source incompatible            | RC 1  |
-| [Trimming may not be used with .NET Standard or .NET Framework](sdk/8.0/trimming-unsupported-targetframework.md) | Behavioral change                                | RC 1       |
-| [Version requirements for .NET 8 SDK](sdk/8.0/version-requirements.md)                             |                | RC 1       |
+| Title                                                                                              | Type of change                                   |
+| -------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| [CLI console output uses UTF-8](sdk/8.0/console-encoding.md)                                       | Behavioral change/Source and binary incompatible |
+| [Console encoding not UTF-8 after completion](sdk/8.0/console-encoding-fix.md)                     | Behavioral change/Binary incompatible            |
+| [Containers default to use the 'latest' tag](sdk/8.0/default-image-tag.md)                         | Behavioral change                                |
+| ['dotnet pack' uses Release configuration](sdk/8.0/dotnet-pack-config.md)                          | Behavioral change/Source incompatible            |
+| ['dotnet publish' uses Release configuration](sdk/8.0/dotnet-publish-config.md)                    | Behavioral change/Source incompatible            |
+| [Implicit `using` for System.Net.Http no longer added](sdk/8.0/implicit-global-using-netfx.md)                  | Behavioral change/Source incompatible     |
+| [MSBuild custom derived build events deprecated](sdk/8.0/custombuildeventargs.md)                  | Behavioral change                  |
+| [MSBuild respects DOTNET_CLI_UI_LANGUAGE](sdk/8.0/msbuild-language.md)                             | Behavioral change                                |
+| [Runtime-specific apps not self-contained](sdk/8.0/runtimespecific-app-default.md)                 | Source/binary incompatible                       |
+| [--arch option doesn't imply self-contained](sdk/8.0/arch-option.md)                               | Behavioral change                                |
+| ['dotnet restore' produces security vulnerability warnings](sdk/8.0/dotnet-restore-audit.md)       | Behavioral change                                |
+| [SDK uses a smaller RID graph](sdk/8.0/rid-graph.md)                                               | Behavioral change/Source incompatible            |
+| [Trimming may not be used with .NET Standard or .NET Framework](sdk/8.0/trimming-unsupported-targetframework.md) | Behavioral change                                |
+| [Version requirements for .NET 8 SDK](sdk/8.0/version-requirements.md)                             |                |
 
 ## Serialization
 

--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -128,15 +128,15 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 | [Containers default to use the 'latest' tag](sdk/8.0/default-image-tag.md)                         | Behavioral change                                |
 | ['dotnet pack' uses Release configuration](sdk/8.0/dotnet-pack-config.md)                          | Behavioral change/Source incompatible            |
 | ['dotnet publish' uses Release configuration](sdk/8.0/dotnet-publish-config.md)                    | Behavioral change/Source incompatible            |
-| [Implicit `using` for System.Net.Http no longer added](sdk/8.0/implicit-global-using-netfx.md)                  | Behavioral change/Source incompatible     |
-| [MSBuild custom derived build events deprecated](sdk/8.0/custombuildeventargs.md)                  | Behavioral change                  |
+| [Implicit `using` for System.Net.Http no longer added](sdk/8.0/implicit-global-using-netfx.md)     | Behavioral change/Source incompatible            |
+| [MSBuild custom derived build events deprecated](sdk/8.0/custombuildeventargs.md)                  | Behavioral change                                |
 | [MSBuild respects DOTNET_CLI_UI_LANGUAGE](sdk/8.0/msbuild-language.md)                             | Behavioral change                                |
 | [Runtime-specific apps not self-contained](sdk/8.0/runtimespecific-app-default.md)                 | Source/binary incompatible                       |
 | [--arch option doesn't imply self-contained](sdk/8.0/arch-option.md)                               | Behavioral change                                |
 | ['dotnet restore' produces security vulnerability warnings](sdk/8.0/dotnet-restore-audit.md)       | Behavioral change                                |
 | [SDK uses a smaller RID graph](sdk/8.0/rid-graph.md)                                               | Behavioral change/Source incompatible            |
 | [Trimming may not be used with .NET Standard or .NET Framework](sdk/8.0/trimming-unsupported-targetframework.md) | Behavioral change                                |
-| [Version requirements for .NET 8 SDK](sdk/8.0/version-requirements.md)                             |                |
+| [Version requirements for .NET 8 SDK](sdk/8.0/version-requirements.md) | Source incompatible               |
 
 ## Serialization
 

--- a/docs/core/compatibility/sdk/8.0/implicit-global-using-netfx.md
+++ b/docs/core/compatibility/sdk/8.0/implicit-global-using-netfx.md
@@ -1,0 +1,39 @@
+---
+title: "Breaking change: Implicit `using` for System.Net.Http no longer added"
+description: Learn about a breaking change in the .NET 8 SDK where an implicit global using directive for System.Net.Http is no longer added to .NET Framework projects.
+ms.date: 11/07/2023
+---
+# Implicit `using` for System.Net.Http no longer added
+
+The implicit global `using` directive for the <xref:System.Net.Http> namespace was removed for .NET Framework TFMs in an SDK-style project. This change was made because it's not guaranteed that the `System.Net.Http` namespace will be accessible in a .NET Framework-targeted project, because the library typically requires an additional reference. With this change, .NET Framework projects are more likely to compile when they are first created.
+
+## Previous behavior
+
+For SDK-style projects with .NET Framework TFMs, a global `using` directive for <xref:System.Net.Http> was injected into the project's build process.
+
+## New behavior
+
+The global `using` directive for <xref:System.Net.Http> is no longer added automatically.
+
+## Version introduced
+
+.NET 8 Preview 6
+
+## Type of breaking change
+
+This change can affect [source compatibility](../../categories.md#source-compatibility) and is also a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+Default projects should compile.
+
+## Recommended action
+
+If you relied on the implicit global using directive, you can:
+
+- Add a [global using directive](../../../../csharp/language-reference/keywords/using-directive.md#global-modifier) to one of your source files.
+- Add a using directive to each source code file that uses APIs from System.Net.Http.
+
+## Affected APIs
+
+N/A

--- a/docs/core/compatibility/sdk/8.0/version-requirements.md
+++ b/docs/core/compatibility/sdk/8.0/version-requirements.md
@@ -5,7 +5,7 @@ ms.date: 09/05/2023
 ---
 # Version requirements for .NET 8 SDK
 
-Per the [published support rules](../../../porting/versioning-sdk-msbuild-vs.md#targeting-and-support-rules), we update the minimum Visual Studio and MSBuild version for each new major release with a one quarter delay. For the .NET 8 release, 8.0.100 requires version 17.7 to be loaded but only supports targeting .NET 7 in that version. To target `net8.0`, you must use version 17.8 or later.
+Per the [published support rules](../../../porting/versioning-sdk-msbuild-vs.md#targeting-and-support-rules), the minimum Visual Studio and MSBuild version for each new major release is updated with a one quarter delay. For the .NET 8 release, 8.0.100 requires version 17.7 to be loaded but only supports targeting .NET 7 in that version. To target `net8.0`, you must use version 17.8 or later.
 
 ## Version introduced
 
@@ -18,6 +18,10 @@ Per the [published support rules](../../../porting/versioning-sdk-msbuild-vs.md#
 ## New behavior
 
 Versions 8.0.1xx of the .NET SDK require Visual Studio version 17.7 and MSBuild version 17.7.
+
+## Type of breaking change
+
+This change can affect [source compatibility](../../categories.md#source-compatibility).
 
 ## Reason for change
 

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -144,6 +144,8 @@ items:
         href: sdk/8.0/dotnet-publish-config.md
       - name: "'dotnet restore' produces security vulnerability warnings"
         href: sdk/8.0/dotnet-restore-audit.md
+      - name: Implicit `using` for System.Net.Http no longer added
+        href: sdk/8.0/implicit-global-using-netfx.md
       - name: MSBuild custom derived build events deprecated
         href: sdk/8.0/custombuildeventargs.md
       - name: MSBuild respects DOTNET_CLI_UI_LANGUAGE
@@ -1518,6 +1520,8 @@ items:
         href: sdk/8.0/dotnet-publish-config.md
       - name: "'dotnet restore' produces security vulnerability warnings"
         href: sdk/8.0/dotnet-restore-audit.md
+      - name: Implicit `using` for System.Net.Http no longer added
+        href: sdk/8.0/implicit-global-using-netfx.md
       - name: MSBuild custom derived build events deprecated
         href: sdk/8.0/custombuildeventargs.md
       - name: MSBuild respects DOTNET_CLI_UI_LANGUAGE


### PR DESCRIPTION
Fixes #37643

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/8.0.md](https://github.com/dotnet/docs/blob/130c10046f8c4a7f491b16a7896fbc28d27f6417/docs/core/compatibility/8.0.md) | [Breaking changes in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/8.0?branch=pr-en-us-37927) |
| [docs/core/compatibility/sdk/8.0/implicit-global-using-netfx.md](https://github.com/dotnet/docs/blob/130c10046f8c4a7f491b16a7896fbc28d27f6417/docs/core/compatibility/sdk/8.0/implicit-global-using-netfx.md) | [Implicit `using` for System.Net.Http no longer added](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/implicit-global-using-netfx?branch=pr-en-us-37927) |
| [docs/core/compatibility/sdk/8.0/version-requirements.md](https://github.com/dotnet/docs/blob/130c10046f8c4a7f491b16a7896fbc28d27f6417/docs/core/compatibility/sdk/8.0/version-requirements.md) | ["Breaking change: Version requirements for .NET 8 SDK"](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/version-requirements?branch=pr-en-us-37927) |

<!-- PREVIEW-TABLE-END -->