### PR TITLE
remove redundant lang version note

### DIFF
--- a/docs/csharp/whats-new/tutorials/static-virtual-interface-members.md
+++ b/docs/csharp/whats-new/tutorials/static-virtual-interface-members.md
@@ -70,14 +70,7 @@ This small example demonstrates the motivation for this feature. You can use nat
 
 The motivating scenario for allowing static methods, including operators, in interfaces is to support [generic math](../../../standard/generics/math.md) algorithms. The .NET 7 base class library contains interface definitions for many arithmetic operators, and derived interfaces that combine many arithmetic operators in an `INumber<T>` interface. Let's apply those types to build a `Point<T>` record that can use any numeric type for `T`. The point can be moved by some `XOffset` and `YOffset` using the `+` operator.
 
-Start by creating a new Console application, either by using `dotnet new` or Visual Studio. Set the C# language version to "preview", which enables C# 11 preview features. Add the following element to your *csproj* file inside a `<PropertyGroup>` element:
-
-```xml
-<LangVersion>preview</LangVersion>
-```
-
-> [!NOTE]
-> This element cannot be set using the Visual Studio UI. You need to edit the project file directly.
+Start by creating a new Console application, either by using `dotnet new` or Visual Studio.
 
 The public interface for the `Translation<T>` and `Point<T>` should look like the following code:
 


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/whats-new/tutorials/static-virtual-interface-members.md](https://github.com/dotnet/docs/blob/61f260c2738526cf583ed8a5e31a27be77f14ac1/docs/csharp/whats-new/tutorials/static-virtual-interface-members.md) | [Tutorial: Explore C# 11 feature - static virtual members in interfaces](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/tutorials/static-virtual-interface-members?branch=pr-en-us-37930) |

<!-- PREVIEW-TABLE-END -->