### PR TITLE
Core libraries breaking changes

### DIFF
--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -39,24 +39,25 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 
 ## Core .NET libraries
 
-| Title                                                                                                     | Type of change      | Introduced   |
-| --------------------------------------------------------------------------------------------------------- | ------------------- | ------------ |
-| [Activity operation name when null](core-libraries/8.0/activity-operation-name.md)                        | Behavioral change   | Preview 1    |
-| [AnonymousPipeServerStream.Dispose behavior](core-libraries/8.0/anonymouspipeserverstream-dispose.md)     | Behavioral change   | Preview 1    |
-| [API obsoletions with custom diagnostic IDs](core-libraries/8.0/obsolete-apis-with-custom-diagnostics.md) | Source incompatible | Preview 1, 4 |
-| [Backslash mapping in Unix file paths](core-libraries/8.0/file-path-backslash.md)                         | Behavioral change   | Preview 1    |
-| [Base64.DecodeFromUtf8 methods ignore whitespace](core-libraries/8.0/decodefromutf8-whitespace.md)        | Behavioral change   | Preview 5    |
-| [Boolean-backed enum type support removed](core-libraries/8.0/bool-backed-enum.md)        | Behavioral change   | Preview 1    |
-| [FileStream writes when pipe is closed](core-libraries/8.0/filestream-disposed-pipe.md)                   | Behavioral change   | Preview 1    |
-| [GC.GetGeneration might return Int32.MaxValue](core-libraries/8.0/getgeneration-return-value.md)          | Behavioral change   | Preview 4    |
-| [GetFolderPath behavior on Unix](core-libraries/8.0/getfolderpath-unix.md)                                | Behavioral change   | Preview 1    |
-| [GetSystemVersion no longer returns ImageRuntimeVersion](core-libraries/8.0/getsystemversion.md)          | Behavioral change   | RC 1            |
-| [IndexOfAnyValues renamed to SearchValues](core-libraries/8.0/indexofanyvalues-renamed.md)                | Source/binary incompatible | Preview 5 |
-| [ITypeDescriptorContext nullable annotations](core-libraries/8.0/itypedescriptorcontext-props.md)         | Source incompatible | Preview 1    |
-| [Legacy Console.ReadKey removed](core-libraries/8.0/console-readkey-legacy.md)                            | Behavioral change   | Preview 1    |
-| [Method builders generate parameters with HasDefaultValue set to false](core-libraries/8.0/parameterinfo-hasdefaultvalue.md) | Behavioral change   | Preview 5    |
-| [Removed overloads of ToFrozenDictionary/ToFrozenSet](core-libraries/8.0/optimizeforreading-arg.md)       | Source/binary incompatible | Preview 7 |
-| [RuntimeIdentifier returns platform for which runtime was built](core-libraries/8.0/runtimeidentifier.md) | Behavioral change   | RC 1            |
+| Title                                                                                                     | Type of change      |
+| --------------------------------------------------------------------------------------------------------- | ------------------- |
+| [Activity operation name when null](core-libraries/8.0/activity-operation-name.md)                        | Behavioral change   |
+| [AnonymousPipeServerStream.Dispose behavior](core-libraries/8.0/anonymouspipeserverstream-dispose.md)     | Behavioral change   |
+| [API obsoletions with custom diagnostic IDs](core-libraries/8.0/obsolete-apis-with-custom-diagnostics.md) | Source incompatible |
+| [Backslash mapping in Unix file paths](core-libraries/8.0/file-path-backslash.md)                         | Behavioral change   |
+| [Base64.DecodeFromUtf8 methods ignore whitespace](core-libraries/8.0/decodefromutf8-whitespace.md)        | Behavioral change   |
+| [Boolean-backed enum type support removed](core-libraries/8.0/bool-backed-enum.md)        | Behavioral change   |
+| [Enumerable.Sum throws new OverflowException for some inputs](core-libraries/8.0/enumerable-sum.md)       | Behavioral change   |
+| [FileStream writes when pipe is closed](core-libraries/8.0/filestream-disposed-pipe.md)                   | Behavioral change   |
+| [GC.GetGeneration might return Int32.MaxValue](core-libraries/8.0/getgeneration-return-value.md)          | Behavioral change   |
+| [GetFolderPath behavior on Unix](core-libraries/8.0/getfolderpath-unix.md)                                | Behavioral change   |
+| [GetSystemVersion no longer returns ImageRuntimeVersion](core-libraries/8.0/getsystemversion.md)          | Behavioral change   |
+| [IndexOfAnyValues renamed to SearchValues](core-libraries/8.0/indexofanyvalues-renamed.md)                | Source/binary incompatible |
+| [ITypeDescriptorContext nullable annotations](core-libraries/8.0/itypedescriptorcontext-props.md)         | Source incompatible |
+| [Legacy Console.ReadKey removed](core-libraries/8.0/console-readkey-legacy.md)                            | Behavioral change   |
+| [Method builders generate parameters with HasDefaultValue set to false](core-libraries/8.0/parameterinfo-hasdefaultvalue.md) | Behavioral change   |
+| [Removed overloads of ToFrozenDictionary/ToFrozenSet](core-libraries/8.0/optimizeforreading-arg.md)       | Source/binary incompatible |
+| [RuntimeIdentifier returns platform for which runtime was built](core-libraries/8.0/runtimeidentifier.md) | Behavioral change   |
 
 ## Cryptography
 

--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -56,6 +56,7 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 | [ITypeDescriptorContext nullable annotations](core-libraries/8.0/itypedescriptorcontext-props.md)         | Source incompatible |
 | [Legacy Console.ReadKey removed](core-libraries/8.0/console-readkey-legacy.md)                            | Behavioral change   |
 | [Method builders generate parameters with HasDefaultValue set to false](core-libraries/8.0/parameterinfo-hasdefaultvalue.md) | Behavioral change   |
+| [ProcessStartInfo.WindowsStyle honored when UseShellExecute is false](core-libraries/8.0/processstartinfo-windowstyle.md) | Behavioral change    |
 | [Removed overloads of ToFrozenDictionary/ToFrozenSet](core-libraries/8.0/optimizeforreading-arg.md)       | Source/binary incompatible |
 | [RuntimeIdentifier returns platform for which runtime was built](core-libraries/8.0/runtimeidentifier.md) | Behavioral change   |
 

--- a/docs/core/compatibility/core-libraries/8.0/enumerable-sum.md
+++ b/docs/core/compatibility/core-libraries/8.0/enumerable-sum.md
@@ -1,0 +1,107 @@
+---
+title: ".NET 8 breaking change: Enumerable.Sum throws new OverflowException for some inputs"
+description: Learn about the .NET 8 breaking change in core .NET libraries where Enumerable.Sum can throw new OverflowException exceptions for certain inputs.
+ms.date: 11/08/2023
+---
+# Enumerable.Sum throws new OverflowException for some inputs
+
+.NET 8 adds support for vectorization in the <xref:System.Linq.Enumerable.Sum%2A?displayProperty=nameWithType> methods where applicable. As a side-effect of that change, the vectorized implementation can change the order in which the different elements are added. While this shouldn't change the final result in successful runs, it can result in unexpected <xref:System.OverflowException> exceptions for certain sets of pathological inputs.
+
+## Previous behavior
+
+Consider the following code:
+
+```csharp
+Test(GetEnumerable1());           // Non-vectorizable
+Test(GetEnumerable1().ToArray()); // Vectorizable
+Test(GetEnumerable2());           // Non-vectorizable
+Test(GetEnumerable2().ToArray()); // Vectorizable
+
+static IEnumerable<int> GetEnumerable1()
+{
+    for (int i = 0; i < 32; ++i)
+    {
+        yield return 1_000_000_000;
+        yield return -1_000_000_000;
+    }
+}
+
+static IEnumerable<int> GetEnumerable2()
+{
+    for (int i = 0; i < 32; ++i)
+    {
+        yield return 100_000_000;
+    }
+    for (int i = 0; i < 32; ++i)
+    {
+        yield return -100_000_000;
+    }
+}
+
+static void Test(IEnumerable<int> input)
+{
+    try
+    {
+        Console.WriteLine(input.Sum());
+    }
+    catch (Exception ex)
+    {
+        Console.WriteLine(ex.GetType().Name);
+    }
+}
+```
+
+Prior to this change, the preceding code printed the following output:
+
+```txt
+0
+0
+OverflowException
+OverflowException
+```
+
+## New behavior
+
+Starting in .NET 8, the code snippet from the [Previous behavior](#previous-behavior) section prints the following output:
+
+```txt
+0
+OverflowException
+OverflowException
+0
+```
+
+## Version introduced
+
+.NET 8 Preview 7
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+This change was made to take advantage of vectorization in LINQ APIs.
+
+## Recommended action
+
+If your code is impacted by the change, you can either:
+
+- Disable vectorization altogether in your application by setting the `DOTNET_EnableHWIntrinsic` environment variable to 0.
+- Write a custom `Sum` method that doesn't use vectorization:
+
+  ```csharp
+  static int Sum(IEnumerable<int> values)
+  {
+      int acc = 0;
+      foreach (int value in values)
+      {
+          checked { acc += value; }
+      }
+      return acc;
+  }
+  ```
+
+## Affected APIs
+
+- <xref:System.Linq.Enumerable.Sum%2A?displayProperty=fullName>

--- a/docs/core/compatibility/core-libraries/8.0/processstartinfo-windowstyle.md
+++ b/docs/core/compatibility/core-libraries/8.0/processstartinfo-windowstyle.md
@@ -1,0 +1,52 @@
+---
+title: ".NET 8 breaking change: ProcessStartInfo.WindowsStyle honored when UseShellExecute is false"
+description: Learn about the .NET 8 breaking change in core .NET libraries where ProcessStartInfo.WindowsStyle is now honored even when UseShellExecute is false.
+ms.date: 11/08/2023
+---
+# ProcessStartInfo.WindowsStyle honored when UseShellExecute is false
+
+Previously, <xref:System.Diagnostics.ProcessStartInfo.WindowStyle?displayName=nameWithType> was only honored when <xref:System.Diagnostics.ProcessStartInfo.UseShellExecute?displayName=nameWithType> was `true`. This change honors <xref:System.Diagnostics.ProcessStartInfo.WindowStyle> even when <xref:System.Diagnostics.ProcessStartInfo.UseShellExecute> is `false`.
+
+## Previous behavior
+
+Prior to this change, the following code started the process as though <xref:System.Diagnostics.ProcessStartInfo.WindowStyle> hadn't been specified, because `UseShellExecute = false`. That is, the window was visible, not hidden.
+
+```csharp
+using System.Diagnostics;
+
+ProcessStartInfo startInfo = new()
+{
+    FileName = @"C:\Windows\System32\notepad.exe",
+    UseShellExecute = false,
+    WindowStyle = ProcessWindowStyle.Hidden
+};
+
+var process = Process.Start(startInfo);
+process!.WaitForExit();
+```
+
+## New behavior
+
+Starting in .NET 8, <xref:System.Diagnostics.ProcessStartInfo.WindowStyle> is honored even for processes started with `UseShellExecute = false`.
+
+The code from the [Previous behavior](#previous-behavior) section starts the process with the window hidden.
+
+## Version introduced
+
+.NET 8 Preview 6
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+Some scenarios require changing the style of the spawned process's window (especially to hide it).
+
+## Recommended action
+
+This change affects code that specified <xref:System.Diagnostics.ProcessStartInfo.WindowStyle> even when it wasn't properly supported. For example, WPF's order of event firing is now altered. To mitigate the breaking change, don't specify `WindowStyle` in <xref:System.Diagnostics.ProcessStartInfo>.
+
+## Affected APIs
+
+- <xref:System.Diagnostics.Process.Start%2A?displayName=fullName>

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -68,6 +68,8 @@ items:
         href: core-libraries/8.0/console-readkey-legacy.md
       - name: Method builders generate parameters with HasDefaultValue=false
         href: core-libraries/8.0/parameterinfo-hasdefaultvalue.md
+      - name: ProcessStartInfo.WindowsStyle honored when UseShellExecute is false
+        href: core-libraries/8.0/processstartinfo-windowstyle.md
       - name: Removed overloads of ToFrozenDictionary/ToFrozenSet
         href: core-libraries/8.0/optimizeforreading-arg.md
       - name: RuntimeIdentifier returns platform for which runtime was built
@@ -1130,6 +1132,8 @@ items:
         href: core-libraries/8.0/console-readkey-legacy.md
       - name: Method builders generate parameters with HasDefaultValue=false
         href: core-libraries/8.0/parameterinfo-hasdefaultvalue.md
+      - name: ProcessStartInfo.WindowsStyle honored when UseShellExecute is false
+        href: core-libraries/8.0/processstartinfo-windowstyle.md
       - name: Removed overloads of ToFrozenDictionary/ToFrozenSet
         href: core-libraries/8.0/optimizeforreading-arg.md
       - name: RuntimeIdentifier returns platform for which runtime was built

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -50,6 +50,8 @@ items:
         href: core-libraries/8.0/decodefromutf8-whitespace.md
       - name: Boolean-backed enum type support removed
         href: core-libraries/8.0/bool-backed-enum.md
+      - name: Enumerable.Sum throws new OverflowException for some inputs
+        href: core-libraries/8.0/enumerable-sum.md
       - name: FileStream writes when pipe is closed
         href: core-libraries/8.0/filestream-disposed-pipe.md
       - name: GC.GetGeneration might return Int32.MaxValue
@@ -1110,6 +1112,8 @@ items:
         href: core-libraries/8.0/decodefromutf8-whitespace.md
       - name: Boolean-backed enum type support removed
         href: core-libraries/8.0/bool-backed-enum.md
+      - name: Enumerable.Sum throws new OverflowException for some inputs
+        href: core-libraries/8.0/enumerable-sum.md
       - name: FileStream writes when pipe is closed
         href: core-libraries/8.0/filestream-disposed-pipe.md
       - name: GC.GetGeneration might return Int32.MaxValue


### PR DESCRIPTION
Fixes #37739 
Fixes #37734

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/8.0.md](https://github.com/dotnet/docs/blob/bf0937717840ecf866f4c09ca3faac719b7f9919/docs/core/compatibility/8.0.md) | [Breaking changes in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/8.0?branch=pr-en-us-37988) |
| [docs/core/compatibility/core-libraries/8.0/enumerable-sum.md](https://github.com/dotnet/docs/blob/bf0937717840ecf866f4c09ca3faac719b7f9919/docs/core/compatibility/core-libraries/8.0/enumerable-sum.md) | [Enumerable.Sum throws new OverflowException for some inputs](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/8.0/enumerable-sum?branch=pr-en-us-37988) |
| [docs/core/compatibility/core-libraries/8.0/processstartinfo-windowstyle.md](https://github.com/dotnet/docs/blob/bf0937717840ecf866f4c09ca3faac719b7f9919/docs/core/compatibility/core-libraries/8.0/processstartinfo-windowstyle.md) | [".NET 8 breaking change: ProcessStartInfo.WindowsStyle honored when UseShellExecute is false"](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/8.0/processstartinfo-windowstyle?branch=pr-en-us-37988) |

<!-- PREVIEW-TABLE-END -->