### PR TITLE
Augment CS0523

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs0523.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0523.md
@@ -1,31 +1,60 @@
 ---
 description: "Compiler Error CS0523"
 title: "Compiler Error CS0523"
-ms.date: 07/20/2015
-f1_keywords: 
+ms.date: 11/09/2023
+f1_keywords:
   - "CS0523"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS0523"
 ms.assetid: f91fb0ab-e1ef-4d6d-a3ef-5adc53a7e312
 ---
 # Compiler Error CS0523
 
-Struct member 'struct2 field' of type 'struct1' causes a cycle in the struct layout  
-  
- The definitions of two structs include recursive references. Change the [struct](../builtin-types/struct.md) definitions such that each does not define itself on the other. This limitation applies only to structs, since structs are value types. If using recursive references, declare your types as classes.  
-  
- The following sample generates CS0523:  
-  
-```csharp  
-// CS0523.cs  
-// compile with: /target:library  
-struct RecursiveLayoutStruct1  
-{  
-   public RecursiveLayoutStruct2 field;  
-}  
-  
-struct RecursiveLayoutStruct2  
-{  
-   public RecursiveLayoutStruct1 field;   // CS0523  
-}  
+Struct member 'struct2 field' of type 'struct1' causes a cycle in the struct layout
+
+ The definitions of one or more [structs](../builtin-types/struct.md) include recursive references that form a cycle. This limitation applies only to structs, since structs are [value types](../builtin-types/value-types.md). To create recursive references, declare your types as classes, which are reference types.
+
+## Example 1
+
+ The following sample shows how a self referential type can cause CS0523:
+
+```csharp
+// CS0523.cs
+// compile with: /target:library
+struct SelfReferentialStruct
+{
+    public SelfReferentialStruct other;   // CS0523
+}
+
+class SelfReferentialClass
+{
+    public SelfReferentialClass other;   // OK
+}
 ```
+
+When a self referential struct type is made, it contains a copy of the same type as a member. However, that member then has another copy which continues recursively. As a result of the cycle, the size of the type cannot be determined and CS0523 is emitted.
+
+## Example 2
+
+ The following sample shows how a type reference cycle can cause CS0523:
+
+```csharp
+// CS0523b.cs
+// compile with: /target:library
+struct ReferenceCycleStruct1
+{
+    public ReferenceCycleStruct2 other;   // CS0523
+}
+
+struct ReferenceCycleStruct2
+{
+    public ReferenceCycleStruct3 other;   // CS0523
+}
+
+struct ReferenceCycleStruct3
+{
+    public ReferenceCycleStruct1 other;   // CS0523
+}
+```
+
+To resolve the errors above, you can adjust the references such that a cycle is no longer formed, or convert as least one of struct types to a class. Similar to the previous example, `ReferenceCycleStruct1` contains a `ReferenceCycleStruct2`, and that contains a `ReferenceCycleStruct3`, which eventually contains `ReferenceCycleStruct1` again.


### PR DESCRIPTION
## Summary

Add more info on self referential types and be explicit on the fact that cycles can be formed with 3 or more struct types.




<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-messages/cs0523.md](https://github.com/dotnet/docs/blob/5e5809533a37cfb860ae62c129be2dd8e98e5f6c/docs/csharp/language-reference/compiler-messages/cs0523.md) | [Compiler Error CS0523](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0523?branch=pr-en-us-37990) |

<!-- PREVIEW-TABLE-END -->