### PR TITLE
Use Collection expressions for all language reference samples

### DIFF
--- a/docs/csharp/language-reference/builtin-types/snippets/shared/ArrayExample.cs
+++ b/docs/csharp/language-reference/builtin-types/snippets/shared/ArrayExample.cs
@@ -16,7 +16,7 @@
     static void Main()
     {
         // Declare and initialize an array.
-        string[] weekDays = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };
+        string[] weekDays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
         // Display the array elements.
         DisplayArray(weekDays);
         Console.WriteLine();

--- a/docs/csharp/language-reference/builtin-types/snippets/shared/Arrays.cs
+++ b/docs/csharp/language-reference/builtin-types/snippets/shared/Arrays.cs
@@ -7,7 +7,7 @@
         int[] array1 = new int[5];
 
         // Declare and set array element values.
-        int[] array2 = { 1, 2, 3, 4, 5, 6 };
+        int[] array2 = [1, 2, 3, 4, 5, 6];
 
         // Declare a two dimensional array.
         int[,] multiDimensionalArray1 = new int[2, 3];
@@ -19,7 +19,7 @@
         int[][] jaggedArray = new int[6][];
 
         // Set the values of the first array in the jagged array structure.
-        jaggedArray[0] = new int[4] { 1, 2, 3, 4 };
+        jaggedArray[0] = [1, 2, 3, 4];
         // </DeclareArrays>
     }
 
@@ -27,7 +27,7 @@
     {
         // <SingleDimensionalArrayDeclaration>
         int[] array = new int[5];
-        string[] weekDays = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };
+        string[] weekDays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
         Console.WriteLine(weekDays[0]);
         Console.WriteLine(weekDays[1]);
@@ -181,16 +181,16 @@
         // <JaggedArrayDeclaration>
         int[][] jaggedArray = new int[3][];
 
-        jaggedArray[0] = new int[] { 1, 3, 5, 7, 9 };
-        jaggedArray[1] = new int[] { 0, 2, 4, 6 };
-        jaggedArray[2] = new int[] { 11, 22 };
+        jaggedArray[0] = [1, 3, 5, 7, 9];
+        jaggedArray[1] = [0, 2, 4, 6];
+        jaggedArray[2] = [11, 22];
 
         int[][] jaggedArray2 = 
-        {
-            new int[] { 1, 3, 5, 7, 9 },
-            new int[] { 0, 2, 4, 6 },
-            new int[] { 11, 22 }
-        };
+        [
+            [1, 3, 5, 7, 9],
+            [0, 2, 4, 6],
+            [11, 22]
+        ];
 
         // Assign 77 to the second element ([1]) of the first array ([0]):
         jaggedArray2[0][1] = 77;
@@ -198,12 +198,12 @@
         // Assign 88 to the second element ([1]) of the third array ([2]):
         jaggedArray2[2][1] = 88;
 
-        int[][,] jaggedArray3 = new int[3][,]
-        {
+        int[][,] jaggedArray3 =
+        [
             new int[,] { {1,3}, {5,7} },
             new int[,] { {0,2}, {4,6}, {8,10} },
             new int[,] { {11,22}, {99,88}, {0,9} }
-        };
+        ];
 
         Console.Write("{0}", jaggedArray3[0][1, 0]);
         Console.WriteLine(jaggedArray3.Length);
@@ -217,8 +217,8 @@
         int[][] arr = new int[2][];
 
         // Initialize the elements.
-        arr[0] = new int[5] { 1, 3, 5, 7, 9 };
-        arr[1] = new int[4] { 2, 4, 6, 8 };
+        arr[0] = [1, 3, 5, 7, 9];
+        arr[1] = [2, 4, 6, 8];
 
         // Display the array elements.
         for (int i = 0; i < arr.Length; i++)
@@ -241,7 +241,7 @@
     public static void ArraysWithLINQ()
     {
         //<LINQAndArrays>
-        var a = new[] { 1, 10, 100, 1000 }; // int[]
+        int[] a = new[] { 1, 10, 100, 1000 }; // int[]
 
         // Accessing array
         Console.WriteLine("First element: " + a[0]);
@@ -264,11 +264,11 @@
         */
 
         // single-dimension jagged array
-        var c = new[]
-        {
-                                            new[]{1,2,3,4},
-                                            new[]{5,6,7,8}
-                    };
+        int[][] c =
+        [
+            [1,2,3,4],
+            [5,6,7,8]
+        ];
         // Looping through the outer array
         for (int k = 0; k < c.Length; k++)
         {
@@ -291,11 +291,11 @@
         */
 
         // jagged array of strings
-        var d = new[]
-        {
-                        new[]{"Luca", "Mads", "Luke", "Dinesh"},
-                        new[]{"Karen", "Suma", "Frances"}
-                    };
+        string[][] d =
+        [
+            ["Luca", "Mads", "Luke", "Dinesh"],
+            ["Karen", "Suma", "Frances"]
+        ];
 
         // Looping through the outer array
         int i = 0;

--- a/docs/csharp/language-reference/builtin-types/snippets/shared/Collections.cs
+++ b/docs/csharp/language-reference/builtin-types/snippets/shared/Collections.cs
@@ -7,7 +7,7 @@ public class Collections
         // <SnippetCreateList>
         // Create a list of strings by using a
         // collection initializer.
-        var salmons = new List<string> { "chinook", "coho", "pink", "sockeye" };
+        List<string> salmons = ["chinook", "coho", "pink", "sockeye"];
 
         // Iterate through the list.
         foreach (var salmon in salmons)
@@ -43,7 +43,7 @@ public class Collections
     {
 
         // <SnippetRemoveItemByIndex>
-        var numbers = new List<int> { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+        List<int> numbers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 
         // Remove odd numbers.
         for (var index = numbers.Count - 1; index >= 0; index--)

--- a/docs/csharp/language-reference/builtin-types/snippets/shared/RecordType.cs
+++ b/docs/csharp/language-reference/builtin-types/snippets/shared/RecordType.cs
@@ -83,7 +83,7 @@ namespace builtin_types
         // <MixedSyntax>
         public record Person(string FirstName, string LastName)
         {
-            public string[] PhoneNumbers { get; init; } = Array.Empty<string>();
+            public string[] PhoneNumbers { get; init; } = [];
         };
         // </MixedSyntax>
     }

--- a/docs/csharp/language-reference/builtin-types/snippets/shared/RetrievingArrayElements.cs
+++ b/docs/csharp/language-reference/builtin-types/snippets/shared/RetrievingArrayElements.cs
@@ -10,7 +10,7 @@ public class RetrievingArrayElements
     private static void Retrieving()
     {
         //<RetrievingDataArray>
-        string[] weekDays2 = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };
+        string[] weekDays2 = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
         Console.WriteLine(weekDays2[0]);
         Console.WriteLine(weekDays2[1]);

--- a/docs/csharp/language-reference/builtin-types/snippets/shared/ValueTuples.cs
+++ b/docs/csharp/language-reference/builtin-types/snippets/shared/ValueTuples.cs
@@ -98,13 +98,13 @@ public static class ValueTuples
     private static void MultipleReturns()
     {
         // <SnippetMultipleReturns>
-        var xs = new[] { 4, 7, 9 };
+        int[] xs = [4, 7, 9];
         var limits = FindMinMax(xs);
         Console.WriteLine($"Limits of [{string.Join(" ", xs)}] are {limits.min} and {limits.max}");
         // Output:
         // Limits of [4 7 9] are 4 and 9
 
-        var ys = new[] { -9, 0, 67, 100 };
+        int[] ys = [-9, 0, 67, 100];
         var (minimum, maximum) = FindMinMax(ys);
         Console.WriteLine($"Limits of [{string.Join(" ", ys)}] are {minimum} and {maximum}");
         // Output:

--- a/docs/csharp/language-reference/builtin-types/snippets/shared/VoidType.cs
+++ b/docs/csharp/language-reference/builtin-types/snippets/shared/VoidType.cs
@@ -4,7 +4,7 @@ public static class VoidType
 {
     public static void Examples()
     {
-        Display(new[] { 1, 2, 9 });
+        Display([ 1, 2, 9 ]);
     }
 
     // <SnippetVoidExample>

--- a/docs/csharp/language-reference/builtin-types/snippets/shared/VoidType.cs
+++ b/docs/csharp/language-reference/builtin-types/snippets/shared/VoidType.cs
@@ -4,7 +4,7 @@ public static class VoidType
 {
     public static void Examples()
     {
-        Display([ 1, 2, 9 ]);
+        Display([1, 2, 9]);
     }
 
     // <SnippetVoidExample>

--- a/docs/csharp/language-reference/builtin-types/snippets/shared/builtin-types.csproj
+++ b/docs/csharp/language-reference/builtin-types/snippets/shared/builtin-types.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
     <StartupObject>builtin_types.Program</StartupObject>

--- a/docs/csharp/language-reference/operators/snippets/shared/AssignmentOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/AssignmentOperator.cs
@@ -11,7 +11,7 @@ public static class AssignmentOperator
     private static void Simple()
     {
         // <SnippetSimple>
-        var numbers = new List<double>() { 1.0, 2.0, 3.0 };
+        List<double> numbers = [1.0, 2.0, 3.0];
 
         Console.WriteLine(numbers.Capacity);
         numbers.Capacity = 100;

--- a/docs/csharp/language-reference/operators/snippets/shared/AwaitOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/AwaitOperator.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Net.Http;
-using System.Threading.Tasks;
-
-public class AwaitOperator
+﻿public class AwaitOperator
 {
     public static async Task Main()
     {

--- a/docs/csharp/language-reference/operators/snippets/shared/BitwiseAndShiftOperators.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/BitwiseAndShiftOperators.cs
@@ -1,238 +1,237 @@
-﻿namespace operators
+﻿namespace operators;
+
+public static class BitwiseAndShiftOperators
 {
-    public static class BitwiseAndShiftOperators
+    public static void Examples()
     {
-        public static void Examples()
-        {
-            Console.WriteLine("==== ~, &, ^, and | operators");
-            BitwiseComplement();
-            BitwiseAnd();
-            BitwiseXor();
-            BitwiseOr();
+        Console.WriteLine("==== ~, &, ^, and | operators");
+        BitwiseComplement();
+        BitwiseAnd();
+        BitwiseXor();
+        BitwiseOr();
 
-            Console.WriteLine("==== <<, >>, and >>> operators");
-            LeftShift();
-            RightShift();
-            ShiftCount();
-            UnsignedRightShift();
+        Console.WriteLine("==== <<, >>, and >>> operators");
+        LeftShift();
+        RightShift();
+        ShiftCount();
+        UnsignedRightShift();
 
-            Console.WriteLine("==== Additional examples");
-            CompoundAssignment();
-            CompoundAssignmentWithCast();
-            Precedence();
-        }
+        Console.WriteLine("==== Additional examples");
+        CompoundAssignment();
+        CompoundAssignmentWithCast();
+        Precedence();
+    }
 
-        private static void BitwiseComplement()
-        {
-            // <SnippetBitwiseComplement>
-            uint a = 0b_0000_1111_0000_1111_0000_1111_0000_1100;
-            uint b = ~a;
-            Console.WriteLine(Convert.ToString(b, toBase: 2));
-            // Output:
-            // 11110000111100001111000011110011
-            // </SnippetBitwiseComplement>
-        }
+    private static void BitwiseComplement()
+    {
+        // <SnippetBitwiseComplement>
+        uint a = 0b_0000_1111_0000_1111_0000_1111_0000_1100;
+        uint b = ~a;
+        Console.WriteLine(Convert.ToString(b, toBase: 2));
+        // Output:
+        // 11110000111100001111000011110011
+        // </SnippetBitwiseComplement>
+    }
 
-        private static void BitwiseAnd()
-        {
-            // <SnippetBitwiseAnd>
-            uint a = 0b_1111_1000;
-            uint b = 0b_1001_1101;
-            uint c = a & b;
-            Console.WriteLine(Convert.ToString(c, toBase: 2));
-            // Output:
-            // 10011000
-            // </SnippetBitwiseAnd>
-        }
+    private static void BitwiseAnd()
+    {
+        // <SnippetBitwiseAnd>
+        uint a = 0b_1111_1000;
+        uint b = 0b_1001_1101;
+        uint c = a & b;
+        Console.WriteLine(Convert.ToString(c, toBase: 2));
+        // Output:
+        // 10011000
+        // </SnippetBitwiseAnd>
+    }
 
-        private static void BitwiseXor()
-        {
-            // <SnippetBitwiseXor>
-            uint a = 0b_1111_1000;
-            uint b = 0b_0001_1100;
-            uint c = a ^ b;
-            Console.WriteLine(Convert.ToString(c, toBase: 2));
-            // Output:
-            // 11100100
-            // </SnippetBitwiseXor>
-        }
+    private static void BitwiseXor()
+    {
+        // <SnippetBitwiseXor>
+        uint a = 0b_1111_1000;
+        uint b = 0b_0001_1100;
+        uint c = a ^ b;
+        Console.WriteLine(Convert.ToString(c, toBase: 2));
+        // Output:
+        // 11100100
+        // </SnippetBitwiseXor>
+    }
 
-        private static void BitwiseOr()
-        {
-            // <SnippetBitwiseOr>
-            uint a = 0b_1010_0000;
-            uint b = 0b_1001_0001;
-            uint c = a | b;
-            Console.WriteLine(Convert.ToString(c, toBase: 2));
-            // Output:
-            // 10110001
-            // </SnippetBitwiseOr>
-        }
+    private static void BitwiseOr()
+    {
+        // <SnippetBitwiseOr>
+        uint a = 0b_1010_0000;
+        uint b = 0b_1001_0001;
+        uint c = a | b;
+        Console.WriteLine(Convert.ToString(c, toBase: 2));
+        // Output:
+        // 10110001
+        // </SnippetBitwiseOr>
+    }
 
-        private static void LeftShift()
-        {
-            // <SnippetLeftShift>
-            uint x = 0b_1100_1001_0000_0000_0000_0000_0001_0001;
-            Console.WriteLine($"Before: {Convert.ToString(x, toBase: 2)}");
+    private static void LeftShift()
+    {
+        // <SnippetLeftShift>
+        uint x = 0b_1100_1001_0000_0000_0000_0000_0001_0001;
+        Console.WriteLine($"Before: {Convert.ToString(x, toBase: 2)}");
 
-            uint y = x << 4;
-            Console.WriteLine($"After:  {Convert.ToString(y, toBase: 2)}");
-            // Output:
-            // Before: 11001001000000000000000000010001
-            // After:  10010000000000000000000100010000
-            // </SnippetLeftShift>
+        uint y = x << 4;
+        Console.WriteLine($"After:  {Convert.ToString(y, toBase: 2)}");
+        // Output:
+        // Before: 11001001000000000000000000010001
+        // After:  10010000000000000000000100010000
+        // </SnippetLeftShift>
 
-            // <SnippetLeftShiftPromoted>
-            byte a = 0b_1111_0001;
+        // <SnippetLeftShiftPromoted>
+        byte a = 0b_1111_0001;
 
-            var b = a << 8;
-            Console.WriteLine(b.GetType());
-            Console.WriteLine($"Shifted byte: {Convert.ToString(b, toBase: 2)}");
-            // Output:
-            // System.Int32
-            // Shifted byte: 1111000100000000
-            // </SnippetLeftShiftPromoted>
-        }
+        var b = a << 8;
+        Console.WriteLine(b.GetType());
+        Console.WriteLine($"Shifted byte: {Convert.ToString(b, toBase: 2)}");
+        // Output:
+        // System.Int32
+        // Shifted byte: 1111000100000000
+        // </SnippetLeftShiftPromoted>
+    }
 
-        private static void RightShift()
-        {
-            // <SnippetRightShift>
-            uint x = 0b_1001;
-            Console.WriteLine($"Before: {Convert.ToString(x, toBase: 2), 4}");
+    private static void RightShift()
+    {
+        // <SnippetRightShift>
+        uint x = 0b_1001;
+        Console.WriteLine($"Before: {Convert.ToString(x, toBase: 2), 4}");
 
-            uint y = x >> 2;
-            Console.WriteLine($"After:  {Convert.ToString(y, toBase: 2).PadLeft(4, '0'), 4}");
-            // Output:
-            // Before: 1001
-            // After:  0010
-            // </SnippetRightShift>
+        uint y = x >> 2;
+        Console.WriteLine($"After:  {Convert.ToString(y, toBase: 2).PadLeft(4, '0'), 4}");
+        // Output:
+        // Before: 1001
+        // After:  0010
+        // </SnippetRightShift>
 
-            // <SnippetArithmeticRightShift>
-            int a = int.MinValue;
-            Console.WriteLine($"Before: {Convert.ToString(a, toBase: 2)}");
+        // <SnippetArithmeticRightShift>
+        int a = int.MinValue;
+        Console.WriteLine($"Before: {Convert.ToString(a, toBase: 2)}");
 
-            int b = a >> 3;
-            Console.WriteLine($"After:  {Convert.ToString(b, toBase: 2)}");
-            // Output:
-            // Before: 10000000000000000000000000000000
-            // After:  11110000000000000000000000000000
-            // </SnippetArithmeticRightShift>
+        int b = a >> 3;
+        Console.WriteLine($"After:  {Convert.ToString(b, toBase: 2)}");
+        // Output:
+        // Before: 10000000000000000000000000000000
+        // After:  11110000000000000000000000000000
+        // </SnippetArithmeticRightShift>
 
-            // <SnippetLogicalRightShift>
-            uint c = 0b_1000_0000_0000_0000_0000_0000_0000_0000;
-            Console.WriteLine($"Before: {Convert.ToString(c, toBase: 2), 32}");
+        // <SnippetLogicalRightShift>
+        uint c = 0b_1000_0000_0000_0000_0000_0000_0000_0000;
+        Console.WriteLine($"Before: {Convert.ToString(c, toBase: 2), 32}");
 
-            uint d = c >> 3;
-            Console.WriteLine($"After:  {Convert.ToString(d, toBase: 2).PadLeft(32, '0'), 32}");
-            // Output:
-            // Before: 10000000000000000000000000000000
-            // After:  00010000000000000000000000000000
-            // </SnippetLogicalRightShift>
-        }
+        uint d = c >> 3;
+        Console.WriteLine($"After:  {Convert.ToString(d, toBase: 2).PadLeft(32, '0'), 32}");
+        // Output:
+        // Before: 10000000000000000000000000000000
+        // After:  00010000000000000000000000000000
+        // </SnippetLogicalRightShift>
+    }
 
-        private static void UnsignedRightShift()
-        {
-            // <SnippetUnsignedRightShift>
-            int x = -8;
-            Console.WriteLine($"Before:    {x,11}, hex: {x,8:x}, binary: {Convert.ToString(x, toBase: 2), 32}");
+    private static void UnsignedRightShift()
+    {
+        // <SnippetUnsignedRightShift>
+        int x = -8;
+        Console.WriteLine($"Before:    {x,11}, hex: {x,8:x}, binary: {Convert.ToString(x, toBase: 2), 32}");
 
-            int y = x >> 2;
-            Console.WriteLine($"After  >>: {y,11}, hex: {y,8:x}, binary: {Convert.ToString(y, toBase: 2), 32}");
+        int y = x >> 2;
+        Console.WriteLine($"After  >>: {y,11}, hex: {y,8:x}, binary: {Convert.ToString(y, toBase: 2), 32}");
 
-            int z = x >>> 2;
-            Console.WriteLine($"After >>>: {z,11}, hex: {z,8:x}, binary: {Convert.ToString(z, toBase: 2).PadLeft(32, '0'), 32}");
-            // Output:
-            // Before:             -8, hex: fffffff8, binary: 11111111111111111111111111111000
-            // After  >>:          -2, hex: fffffffe, binary: 11111111111111111111111111111110
-            // After >>>:  1073741822, hex: 3ffffffe, binary: 00111111111111111111111111111110
-            // </SnippetUnsignedRightShift>
-        }
+        int z = x >>> 2;
+        Console.WriteLine($"After >>>: {z,11}, hex: {z,8:x}, binary: {Convert.ToString(z, toBase: 2).PadLeft(32, '0'), 32}");
+        // Output:
+        // Before:             -8, hex: fffffff8, binary: 11111111111111111111111111111000
+        // After  >>:          -2, hex: fffffffe, binary: 11111111111111111111111111111110
+        // After >>>:  1073741822, hex: 3ffffffe, binary: 00111111111111111111111111111110
+        // </SnippetUnsignedRightShift>
+    }
 
-        private static void ShiftCount()
-        {
-            // <SnippetShiftCount>
-            int count1 = 0b_0000_0001;
-            int count2 = 0b_1110_0001;
+    private static void ShiftCount()
+    {
+        // <SnippetShiftCount>
+        int count1 = 0b_0000_0001;
+        int count2 = 0b_1110_0001;
 
-            int a = 0b_0001;
-            Console.WriteLine($"{a} << {count1} is {a << count1}; {a} << {count2} is {a << count2}");
-            // Output:
-            // 1 << 1 is 2; 1 << 225 is 2
+        int a = 0b_0001;
+        Console.WriteLine($"{a} << {count1} is {a << count1}; {a} << {count2} is {a << count2}");
+        // Output:
+        // 1 << 1 is 2; 1 << 225 is 2
 
-            int b = 0b_0100;
-            Console.WriteLine($"{b} >> {count1} is {b >> count1}; {b} >> {count2} is {b >> count2}");
-            // Output:
-            // 4 >> 1 is 2; 4 >> 225 is 2
+        int b = 0b_0100;
+        Console.WriteLine($"{b} >> {count1} is {b >> count1}; {b} >> {count2} is {b >> count2}");
+        // Output:
+        // 4 >> 1 is 2; 4 >> 225 is 2
 
-            int count = -31;
-            int c = 0b_0001;
-            Console.WriteLine($"{c} << {count} is {c << count}");
-            // Output:
-            // 1 << -31 is 2
-            // </SnippetShiftCount>
-        }
+        int count = -31;
+        int c = 0b_0001;
+        Console.WriteLine($"{c} << {count} is {c << count}");
+        // Output:
+        // 1 << -31 is 2
+        // </SnippetShiftCount>
+    }
 
-        private static void CompoundAssignment()
-        {
-            // <SnippetCompoundAssignment>
-            uint INITIAL_VALUE = 0b_1111_1000;
-            
-            uint a = INITIAL_VALUE;
-            a &= 0b_1001_1101; 
-            Display(a);  // output: 10011000
+    private static void CompoundAssignment()
+    {
+        // <SnippetCompoundAssignment>
+        uint INITIAL_VALUE = 0b_1111_1000;
+        
+        uint a = INITIAL_VALUE;
+        a &= 0b_1001_1101; 
+        Display(a);  // output: 10011000
 
-            a = INITIAL_VALUE;
-            a |= 0b_0011_0001; 
-            Display(a);  // output: 11111001
+        a = INITIAL_VALUE;
+        a |= 0b_0011_0001; 
+        Display(a);  // output: 11111001
 
-            a = INITIAL_VALUE;
-            a ^= 0b_1000_0000;
-            Display(a);  // output: 01111000
+        a = INITIAL_VALUE;
+        a ^= 0b_1000_0000;
+        Display(a);  // output: 01111000
 
-            a = INITIAL_VALUE;
-            a <<= 2;
-            Display(a);  // output: 1111100000
+        a = INITIAL_VALUE;
+        a <<= 2;
+        Display(a);  // output: 1111100000
 
-            a = INITIAL_VALUE;
-            a >>= 4;
-            Display(a);  // output: 00001111
+        a = INITIAL_VALUE;
+        a >>= 4;
+        Display(a);  // output: 00001111
 
-            a = INITIAL_VALUE;
-            a >>>= 4;
-            Display(a);  // output: 00001111
+        a = INITIAL_VALUE;
+        a >>>= 4;
+        Display(a);  // output: 00001111
 
-            void Display(uint x) => Console.WriteLine($"{Convert.ToString(x, toBase: 2).PadLeft(8, '0'), 8}");
-            // </SnippetCompoundAssignment>
-        }
+        void Display(uint x) => Console.WriteLine($"{Convert.ToString(x, toBase: 2).PadLeft(8, '0'), 8}");
+        // </SnippetCompoundAssignment>
+    }
 
-        private static void CompoundAssignmentWithCast()
-        {
-            // <SnippetCompoundAssignmentWithCast>
-            byte x = 0b_1111_0001;
+    private static void CompoundAssignmentWithCast()
+    {
+        // <SnippetCompoundAssignmentWithCast>
+        byte x = 0b_1111_0001;
 
-            int b = x << 8;
-            Console.WriteLine($"{Convert.ToString(b, toBase: 2)}");  // output: 1111000100000000
+        int b = x << 8;
+        Console.WriteLine($"{Convert.ToString(b, toBase: 2)}");  // output: 1111000100000000
 
-            x <<= 8;
-            Console.WriteLine(x);  // output: 0
-            // </SnippetCompoundAssignmentWithCast>
-        }
+        x <<= 8;
+        Console.WriteLine(x);  // output: 0
+        // </SnippetCompoundAssignmentWithCast>
+    }
 
-        private static void Precedence()
-        {
-            // <SnippetPrecedence>
-            uint a = 0b_1101;
-            uint b = 0b_1001;
-            uint c = 0b_1010;
+    private static void Precedence()
+    {
+        // <SnippetPrecedence>
+        uint a = 0b_1101;
+        uint b = 0b_1001;
+        uint c = 0b_1010;
 
-            uint d1 = a | b & c;
-            Display(d1);  // output: 1101
+        uint d1 = a | b & c;
+        Display(d1);  // output: 1101
 
-            uint d2 = (a | b) & c;
-            Display(d2);  // output: 1000
+        uint d2 = (a | b) & c;
+        Display(d2);  // output: 1000
 
-            void Display(uint x) => Console.WriteLine($"{Convert.ToString(x, toBase: 2), 4}");
-            // </SnippetPrecedence>
-        }
+        void Display(uint x) => Console.WriteLine($"{Convert.ToString(x, toBase: 2), 4}");
+        // </SnippetPrecedence>
     }
 }

--- a/docs/csharp/language-reference/operators/snippets/shared/ConditionalOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/ConditionalOperator.cs
@@ -24,8 +24,8 @@ public class ConditionalOperator
     private static void ConditionalRefExpressions()
     {
         // <SnippetConditionalRef>
-        var smallArray = new int[] { 1, 2, 3, 4, 5 };
-        var largeArray = new int[] { 10, 20, 30, 40, 50 };
+        int[] smallArray = [1, 2, 3, 4, 5];
+        int[] largeArray = [10, 20, 30, 40, 50];
 
         int index = 7;
         ref int refValue = ref ((index < 5) ? ref smallArray[index] : ref largeArray[index - 5]);

--- a/docs/csharp/language-reference/operators/snippets/shared/IsOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/IsOperator.cs
@@ -52,11 +52,11 @@ public static class IsOperator
     private static void ListPattern()
     {
         // <ListPatterns>
-        int[] empty = { };
-        int[] one = { 1 };
-        int[] odd = { 1, 3, 5 };
-        int[] even = { 2, 4, 6 };
-        int[] fib = { 1, 1, 2, 3, 5 };
+        int[] empty = [];
+        int[] one = [1];
+        int[] odd = [1, 3, 5];
+        int[] even = [2, 4, 6];
+        int[] fib = [1, 1, 2, 3, 5];
 
         Console.WriteLine(odd is [1, _, 2, ..]);   // false
         Console.WriteLine(fib is [1, _, 2, ..]);   // true

--- a/docs/csharp/language-reference/operators/snippets/shared/LambdaOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/LambdaOperator.cs
@@ -12,13 +12,13 @@ public static class LambdaOperator
     private static void WithInferredTypes()
     {
         // <SnippetInferredTypes>
-        string[] words = { "bot", "apple", "apricot" };
+        string[] words = ["bot", "apple", "apricot"];
         int minimalLength = words
           .Where(w => w.StartsWith("a"))
           .Min(w => w.Length);
         Console.WriteLine(minimalLength);   // output: 5
 
-        int[] numbers = { 4, 7, 10 };
+        int[] numbers = [4, 7, 10];
         int product = numbers.Aggregate(1, (interim, next) => interim * next);
         Console.WriteLine(product);   // output: 280
         // </SnippetInferredTypes>
@@ -27,7 +27,7 @@ public static class LambdaOperator
     private static void WithExplicitTypes()
     {
         // <SnippetExplicitTypes>
-        int[] numbers = { 4, 7, 10 };
+        int[] numbers = [4, 7, 10];
         int product = numbers.Aggregate(1, (int interim, int next) => interim * next);
         Console.WriteLine(product);   // output: 280
         // </SnippetExplicitTypes>

--- a/docs/csharp/language-reference/operators/snippets/shared/MemberAccessOperators.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/MemberAccessOperators.cs
@@ -23,16 +23,18 @@ public static class MemberAccessOperators
     private static void QualifiedName()
     {
         // <SnippetQualifiedName>
-        System.Collections.Generic.IEnumerable<int> numbers = new int[] { 1, 2, 3 };
+        System.Collections.Generic.IEnumerable<int> numbers = [1, 2, 3];
         // </SnippetQualifiedName>
     }
 
     private static void TypeMemberAccess()
     {
         // <SnippetTypeMemberAccess>
-        var constants = new List<double>();
-        constants.Add(Math.PI);
-        constants.Add(Math.E);
+        List<double> constants =
+        [
+            Math.PI,
+            Math.E
+        ];
         Console.WriteLine($"{constants.Count} values to show:");
         Console.WriteLine(string.Join(", ", constants));
         // Output:
@@ -82,11 +84,11 @@ public static class MemberAccessOperators
         var sum1 = SumNumbers(null, 0);
         Console.WriteLine(sum1);  // output: NaN
 
-        var numberSets = new List<double[]>
-        {
-            new[] { 1.0, 2.0, 3.0 },
+        List<double[]?> numberSets =
+        [
+            [1.0, 2.0, 3.0],
             null
-        };
+        ];
 
         var sum2 = SumNumbers(numberSets, 0);
         Console.WriteLine(sum2);  // output: 6
@@ -99,7 +101,7 @@ public static class MemberAccessOperators
     private static void NullConditionalWithNullCoalescing()
     {
         // <SnippetNullConditionalWithNullCoalescing>
-        int GetSumOfFirstTwoOrDefault(int[] numbers)
+        int GetSumOfFirstTwoOrDefault(int[]? numbers)
         {
             if ((numbers?.Length ?? 0) < 2)
             {
@@ -109,8 +111,8 @@ public static class MemberAccessOperators
         }
 
         Console.WriteLine(GetSumOfFirstTwoOrDefault(null));  // output: 0
-        Console.WriteLine(GetSumOfFirstTwoOrDefault(new int[0]));  // output: 0
-        Console.WriteLine(GetSumOfFirstTwoOrDefault(new[] { 3, 4, 5 }));  // output: 7
+        Console.WriteLine(GetSumOfFirstTwoOrDefault([]));  // output: 0
+        Console.WriteLine(GetSumOfFirstTwoOrDefault([3, 4, 5]));  // output: 7
         // </SnippetNullConditionalWithNullCoalescing>
     }
 
@@ -119,9 +121,11 @@ public static class MemberAccessOperators
         // <SnippetInvocation>
         Action<int> display = s => Console.WriteLine(s);
 
-        var numbers = new List<int>();
-        numbers.Add(10);
-        numbers.Add(17);
+        List<int> numbers =
+        [
+            10,
+            17
+        ];
         display(numbers.Count);   // output: 2
 
         numbers.Clear();
@@ -132,11 +136,11 @@ public static class MemberAccessOperators
     private static void IndexFromEnd()
     {
         // <SnippetIndexFromEnd>
-        int[] xs = new[] { 0, 10, 20, 30, 40 };
+        int[] xs = [0, 10, 20, 30, 40];
         int last = xs[^1];
         Console.WriteLine(last);  // output: 40
 
-        var lines = new List<string> { "one", "two", "three", "four" };
+        List<string> lines = ["one", "two", "three", "four"];
         string prelast = lines[^2];
         Console.WriteLine(prelast);  // output: three
 
@@ -150,7 +154,7 @@ public static class MemberAccessOperators
     private static void Ranges()
     {
         // <SnippetRanges>
-        int[] numbers = new[] { 0, 10, 20, 30, 40, 50 };
+        int[] numbers = [0, 10, 20, 30, 40, 50];
         int start = 1;
         int amountToTake = 3;
         int[] subset = numbers[start..(start + amountToTake)];
@@ -173,7 +177,7 @@ public static class MemberAccessOperators
     private static void RangesOptional()
     {
         // <SnippetRangesOptional>
-        int[] numbers = new[] { 0, 10, 20, 30, 40, 50 };
+        int[] numbers = [0, 10, 20, 30, 40, 50];
         int amountToDrop = numbers.Length / 2;
 
         int[] rightHalf = numbers[amountToDrop..];
@@ -193,9 +197,9 @@ public static class MemberAccessOperators
     {
         // <RangesAllPossible>
         int[] oneThroughTen =
-        {
+        [
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10
-        };
+        ];
 
         Write(oneThroughTen, ..);
         Write(oneThroughTen, ..3);

--- a/docs/csharp/language-reference/operators/snippets/shared/MemberAccessOperators2.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/MemberAccessOperators2.cs
@@ -4,7 +4,7 @@ public static class NullConditionalShortCircuiting
 {
     public static void Main()
     {
-        Person person = null;
+        Person? person = null;
         person?.Name.Write(); // no output: Write() is not called due to short-circuit.
         try
         {
@@ -19,15 +19,12 @@ public static class NullConditionalShortCircuiting
 
 public class Person
 {
-    public FullName Name { get; set; }
+    public required FullName Name { get; set; }
 }
 
 public class FullName
 {
-    public string FirstName { get; set; }
-    public string LastName { get; set; }
-    public void Write()
-    {
-        Console.WriteLine($"{FirstName} {LastName}");
-    }
+    public required string FirstName { get; set; }
+    public required string LastName { get; set; }
+    public void Write() => Console.WriteLine($"{FirstName} {LastName}");
 }

--- a/docs/csharp/language-reference/operators/snippets/shared/NameOfOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/NameOfOperator.cs
@@ -10,7 +10,7 @@ public static class NameOfOperator
         Console.WriteLine(nameof(List<int>.Count));  // output: Count
         Console.WriteLine(nameof(List<int>.Add));  // output: Add
 
-        var numbers = new List<int> { 1, 2, 3 };
+        List<int> numbers = [1, 2, 3];
         Console.WriteLine(nameof(numbers));  // output: numbers
         Console.WriteLine(nameof(numbers.Count));  // output: Count
         Console.WriteLine(nameof(numbers.Add));  // output: Add
@@ -40,7 +40,7 @@ public static class NameOfOperator
 
     private class Person
     {
-        string name;
+        string name = string.Empty;
 
         // <SnippetExceptionMessage>
         public string Name

--- a/docs/csharp/language-reference/operators/snippets/shared/NewOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/NewOperator.cs
@@ -60,11 +60,7 @@ public static class NewOperator
     private static void Array()
     {
         // <SnippetArray>
-        var numbers = new int[3];
-        numbers[0] = 10;
-        numbers[1] = 20;
-        numbers[2] = 30;
-
+        int[] numbers = [10, 20, 30];
         Console.WriteLine(string.Join(", ", numbers));
         // Output:
         // 10, 20, 30
@@ -74,9 +70,9 @@ public static class NewOperator
     private static void ArrayInitialization()
     {
         // <SnippetArrayInitialization>
-        var a = new int[3] { 10, 20, 30 };
-        var b = new int[] { 10, 20, 30 };
-        var c = new[] { 10, 20, 30 };
+        int[] a = [10, 20, 30];
+        int[] b = [10, 20, 30];
+        int[] c = [10, 20, 30];
         Console.WriteLine(c.GetType());  // output: System.Int32[]
         // </SnippetArrayInitialization>
     }

--- a/docs/csharp/language-reference/operators/snippets/shared/NullCoalescingOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/NullCoalescingOperator.cs
@@ -54,7 +54,7 @@ public static class NullCoalescingOperator
     private static void NullCoalescingAssignment()
     {
         // <SnippetAssignment>
-        List<int> numbers = null;
+        List<int>? numbers = null;
         int? a = null;
 
         Console.WriteLine((numbers is null)); // expected: true

--- a/docs/csharp/language-reference/operators/snippets/shared/Overview.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/Overview.cs
@@ -10,6 +10,8 @@ public static class Overview
         Query();
     }
 
+    private static readonly int[] collection = [1, 2, 3];
+
     private static void GeneralExamples()
     {
         // <SnippetExpressions>
@@ -23,8 +25,8 @@ public static class Overview
         
         string s = "String literal";
         char l = s[s.Length - 1];
-        
-        var numbers = new List<int>(new[] { 1, 2, 3 });
+
+        List<int> numbers = [..collection];
         b = numbers.FindLast(n => n > 1);
         // </SnippetExpressions>
     }
@@ -43,7 +45,7 @@ public static class Overview
     private static void Lambda()
     {
         // <SnippetLambda>
-        int[] numbers = { 2, 3, 4, 5 };
+        int[] numbers = [2, 3, 4, 5];
         var maximumSquare = numbers.Max(x => x * x);
         Console.WriteLine(maximumSquare);
         // Output:
@@ -54,7 +56,7 @@ public static class Overview
     private static void Query()
     {
         // <SnippetQuery>
-        var scores = new[] { 90, 97, 78, 68, 85 };
+        int[] scores = [90, 97, 78, 68, 85];
         IEnumerable<int> highScoresQuery =
             from score in scores
             where score > 80

--- a/docs/csharp/language-reference/operators/snippets/shared/StackallocOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/StackallocOperator.cs
@@ -48,6 +48,10 @@ public static class StackallocOperator
         Span<int> first = stackalloc int[3] { 1, 2, 3 };
         Span<int> second = stackalloc int[] { 1, 2, 3 };
         ReadOnlySpan<int> third = stackalloc[] { 1, 2, 3 };
+
+        // Using collection expressions:
+        Span<int> fourth= [1, 2, 3];
+        ReadOnlySpan<int> fifth= [1, 2, 3];
         // </SnippetStackallocInit>
     }
 
@@ -57,6 +61,10 @@ public static class StackallocOperator
         Span<int> numbers = stackalloc[] { 1, 2, 3, 4, 5, 6 };
         var ind = numbers.IndexOfAny(stackalloc[] { 2, 4, 6, 8 });
         Console.WriteLine(ind);  // output: 1
+
+        Span<int> numbers2 = [1, 2, 3, 4, 5, 6];
+        var ind2 = numbers2.IndexOfAny([2, 4, 6, 8]);
+        Console.WriteLine(ind2);  // output: 1
         // </SnippetNested>
     }
 

--- a/docs/csharp/language-reference/operators/snippets/shared/TypeTestingAndConversionOperators.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/TypeTestingAndConversionOperators.cs
@@ -21,7 +21,8 @@ public static class TypeTestingAndConversionOperators
         int a = (int)x;
         Console.WriteLine(a);   // output: 1234
 
-        IEnumerable<int> numbers = new int[] { 10, 20, 30 };
+        int[] ints = [10, 20, 30];
+        IEnumerable<int> numbers = ints;
         IList<int> list = (IList<int>)numbers;
         Console.WriteLine(list.Count);  // output: 3
         Console.WriteLine(list[1]);  // output: 20
@@ -76,7 +77,7 @@ public static class TypeTestingAndConversionOperators
     private static void AsOperator()
     {
         // <SnippetAsOperator>
-        IEnumerable<int> numbers = new[] { 10, 20, 30 };
+        IEnumerable<int> numbers = [ 10, 20, 30 ];
         IList<int> indexable = numbers as IList<int>;
         if (indexable != null)
         {

--- a/docs/csharp/language-reference/operators/snippets/shared/TypeTestingAndConversionOperators.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/TypeTestingAndConversionOperators.cs
@@ -77,7 +77,7 @@ public static class TypeTestingAndConversionOperators
     private static void AsOperator()
     {
         // <SnippetAsOperator>
-        IEnumerable<int> numbers = [ 10, 20, 30 ];
+        IEnumerable<int> numbers = [10, 20, 30];
         IList<int> indexable = numbers as IList<int>;
         if (indexable != null)
         {

--- a/docs/csharp/language-reference/operators/stackalloc.md
+++ b/docs/csharp/language-reference/operators/stackalloc.md
@@ -23,7 +23,7 @@ You can assign the result of a `stackalloc` expression to a variable of one of t
 
   [!code-csharp[stackalloc expression](snippets/shared/StackallocOperator.cs#AsExpression)]
 
-  You can use a `stackalloc` expression inside other expressions whenever a <xref:System.Span%601> or <xref:System.ReadOnlySpan%601> variable is allowed, as the following example shows:
+  You can use a `stackalloc` expression or a collection expression inside other expressions whenever a <xref:System.Span%601> or <xref:System.ReadOnlySpan%601> variable is allowed, as the following example shows:
 
   [!code-csharp[stackalloc in nested expressions](snippets/shared/StackallocOperator.cs#Nested)]
 
@@ -55,7 +55,7 @@ You can use array initializer syntax to define the content of the newly allocate
 
 [!code-csharp[stackalloc initialization](snippets/shared/StackallocOperator.cs#StackallocInit)]
 
-In expression `stackalloc T[E]`, `T` must be an [unmanaged type](../builtin-types/unmanaged-types.md) and `E` must evaluate to a non-negative [int](../builtin-types/integral-numeric-types.md) value.
+In expression `stackalloc T[E]`, `T` must be an [unmanaged type](../builtin-types/unmanaged-types.md) and `E` must evaluate to a non-negative [int](../builtin-types/integral-numeric-types.md) value. When you use the [collection expression](./collection-expressions.md) syntax to initialize the span, the compiler may use stack allocated storage for a span if it won't violate ref safety.
 
 ## Security
 

--- a/docs/csharp/language-reference/snippets/unsafe-code/FixedKeywordExamples.cs
+++ b/docs/csharp/language-reference/snippets/unsafe-code/FixedKeywordExamples.cs
@@ -1,201 +1,196 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿namespace UnsafeCodePointers;
 
-namespace UnsafeCodePointers
+public static class FixedKeywordExamples
 {
-    public static class FixedKeywordExamples
+    public static void Examples()
     {
-        public static void Examples()
-        {
-            PointerTypes();
-            AccessEmbeddedArray();
-            UnsafeCopyArrays();
-        }
-
-        private static void PointerTypes()
-        {
-            // <Snippet5>
-            // Normal pointer to an object.
-            int[] a = new int[5] { 10, 20, 30, 40, 50 };
-            // Must be in unsafe code to use interior pointers.
-            unsafe
-            {
-                // Must pin object on heap so that it doesn't move while using interior pointers.
-                fixed (int* p = &a[0])
-                {
-                    // p is pinned as well as object, so create another pointer to show incrementing it.
-                    int* p2 = p;
-                    Console.WriteLine(*p2);
-                    // Incrementing p2 bumps the pointer by four bytes due to its type ...
-                    p2 += 1;
-                    Console.WriteLine(*p2);
-                    p2 += 1;
-                    Console.WriteLine(*p2);
-                    Console.WriteLine("--------");
-                    Console.WriteLine(*p);
-                    // Dereferencing p and incrementing changes the value of a[0] ...
-                    *p += 1;
-                    Console.WriteLine(*p);
-                    *p += 1;
-                    Console.WriteLine(*p);
-                }
-            }
-
-            Console.WriteLine("--------");
-            Console.WriteLine(a[0]);
-
-            /*
-            Output:
-            10
-            20
-            30
-            --------
-            10
-            11
-            12
-            --------
-            12
-            */
-            // </Snippet5>
-        }
-
-        // <Snippet6>
-        public struct PathArray
-        {
-            public char[] pathName;
-            private int reserved;
-        }
-        // </Snippet6>
-
-        // <Snippet7>
-        internal unsafe struct Buffer
-        {
-            public fixed char fixedBuffer[128];
-        }
-
-        internal unsafe class Example
-        {
-            public Buffer buffer = default;
-        }
-
-        private static void AccessEmbeddedArray()
-        {
-            var example = new Example();
-
-            unsafe
-            {
-                // Pin the buffer to a fixed location in memory.
-                fixed (char* charPtr = example.buffer.fixedBuffer)
-                {
-                    *charPtr = 'A';
-                }
-                // Access safely through the index:
-                char c = example.buffer.fixedBuffer[0];
-                Console.WriteLine(c);
-
-                // Modify through the index:
-                example.buffer.fixedBuffer[0] = 'B';
-                Console.WriteLine(example.buffer.fixedBuffer[0]);
-            }
-        }
-        // </Snippet7>
-
-        // <Snippet8>
-        static unsafe void Copy(byte[] source, int sourceOffset, byte[] target,
-            int targetOffset, int count)
-        {
-            // If either array is not instantiated, you cannot complete the copy.
-            if ((source == null) || (target == null))
-            {
-                throw new System.ArgumentException("source or target is null");
-            }
-
-            // If either offset, or the number of bytes to copy, is negative, you
-            // cannot complete the copy.
-            if ((sourceOffset < 0) || (targetOffset < 0) || (count < 0))
-            {
-                throw new System.ArgumentException("offset or bytes to copy is negative");
-            }
-
-            // If the number of bytes from the offset to the end of the array is
-            // less than the number of bytes you want to copy, you cannot complete
-            // the copy.
-            if ((source.Length - sourceOffset < count) ||
-                (target.Length - targetOffset < count))
-            {
-                throw new System.ArgumentException("offset to end of array is less than bytes to be copied");
-            }
-
-            // The following fixed statement pins the location of the source and
-            // target objects in memory so that they will not be moved by garbage
-            // collection.
-            fixed (byte* pSource = source, pTarget = target)
-            {
-                // Copy the specified number of bytes from source to target.
-                for (int i = 0; i < count; i++)
-                {
-                    pTarget[targetOffset + i] = pSource[sourceOffset + i];
-                }
-            }
-        }
-
-        static void UnsafeCopyArrays()
-        {
-            // Create two arrays of the same length.
-            int length = 100;
-            byte[] byteArray1 = new byte[length];
-            byte[] byteArray2 = new byte[length];
-
-            // Fill byteArray1 with 0 - 99.
-            for (int i = 0; i < length; ++i)
-            {
-                byteArray1[i] = (byte)i;
-            }
-
-            // Display the first 10 elements in byteArray1.
-            System.Console.WriteLine("The first 10 elements of the original are:");
-            for (int i = 0; i < 10; ++i)
-            {
-                System.Console.Write(byteArray1[i] + " ");
-            }
-            System.Console.WriteLine("\n");
-
-            // Copy the contents of byteArray1 to byteArray2.
-            Copy(byteArray1, 0, byteArray2, 0, length);
-
-            // Display the first 10 elements in the copy, byteArray2.
-            System.Console.WriteLine("The first 10 elements of the copy are:");
-            for (int i = 0; i < 10; ++i)
-            {
-                System.Console.Write(byteArray2[i] + " ");
-            }
-            System.Console.WriteLine("\n");
-
-            // Copy the contents of the last 10 elements of byteArray1 to the
-            // beginning of byteArray2.
-            // The offset specifies where the copying begins in the source array.
-            int offset = length - 10;
-            Copy(byteArray1, offset, byteArray2, 0, length - offset);
-
-            // Display the first 10 elements in the copy, byteArray2.
-            System.Console.WriteLine("The first 10 elements of the copy are:");
-            for (int i = 0; i < 10; ++i)
-            {
-                System.Console.Write(byteArray2[i] + " ");
-            }
-            System.Console.WriteLine("\n");
-            /* Output:
-                The first 10 elements of the original are:
-                0 1 2 3 4 5 6 7 8 9
-
-                The first 10 elements of the copy are:
-                0 1 2 3 4 5 6 7 8 9
-
-                The first 10 elements of the copy are:
-                90 91 92 93 94 95 96 97 98 99
-            */
-        }
-        // </Snippet8>
+        PointerTypes();
+        AccessEmbeddedArray();
+        UnsafeCopyArrays();
     }
+
+    private static void PointerTypes()
+    {
+        // <Snippet5>
+        // Normal pointer to an object.
+        int[] a = [10, 20, 30, 40, 50];
+        // Must be in unsafe code to use interior pointers.
+        unsafe
+        {
+            // Must pin object on heap so that it doesn't move while using interior pointers.
+            fixed (int* p = &a[0])
+            {
+                // p is pinned as well as object, so create another pointer to show incrementing it.
+                int* p2 = p;
+                Console.WriteLine(*p2);
+                // Incrementing p2 bumps the pointer by four bytes due to its type ...
+                p2 += 1;
+                Console.WriteLine(*p2);
+                p2 += 1;
+                Console.WriteLine(*p2);
+                Console.WriteLine("--------");
+                Console.WriteLine(*p);
+                // Dereferencing p and incrementing changes the value of a[0] ...
+                *p += 1;
+                Console.WriteLine(*p);
+                *p += 1;
+                Console.WriteLine(*p);
+            }
+        }
+
+        Console.WriteLine("--------");
+        Console.WriteLine(a[0]);
+
+        /*
+        Output:
+        10
+        20
+        30
+        --------
+        10
+        11
+        12
+        --------
+        12
+        */
+        // </Snippet5>
+    }
+
+    // <Snippet6>
+    public struct PathArray
+    {
+        public char[] pathName;
+        private int reserved;
+    }
+    // </Snippet6>
+
+    // <Snippet7>
+    internal unsafe struct Buffer
+    {
+        public fixed char fixedBuffer[128];
+    }
+
+    internal unsafe class Example
+    {
+        public Buffer buffer = default;
+    }
+
+    private static void AccessEmbeddedArray()
+    {
+        var example = new Example();
+
+        unsafe
+        {
+            // Pin the buffer to a fixed location in memory.
+            fixed (char* charPtr = example.buffer.fixedBuffer)
+            {
+                *charPtr = 'A';
+            }
+            // Access safely through the index:
+            char c = example.buffer.fixedBuffer[0];
+            Console.WriteLine(c);
+
+            // Modify through the index:
+            example.buffer.fixedBuffer[0] = 'B';
+            Console.WriteLine(example.buffer.fixedBuffer[0]);
+        }
+    }
+    // </Snippet7>
+
+    // <Snippet8>
+    static unsafe void Copy(byte[] source, int sourceOffset, byte[] target,
+        int targetOffset, int count)
+    {
+        // If either array is not instantiated, you cannot complete the copy.
+        if ((source == null) || (target == null))
+        {
+            throw new System.ArgumentException("source or target is null");
+        }
+
+        // If either offset, or the number of bytes to copy, is negative, you
+        // cannot complete the copy.
+        if ((sourceOffset < 0) || (targetOffset < 0) || (count < 0))
+        {
+            throw new System.ArgumentException("offset or bytes to copy is negative");
+        }
+
+        // If the number of bytes from the offset to the end of the array is
+        // less than the number of bytes you want to copy, you cannot complete
+        // the copy.
+        if ((source.Length - sourceOffset < count) ||
+            (target.Length - targetOffset < count))
+        {
+            throw new System.ArgumentException("offset to end of array is less than bytes to be copied");
+        }
+
+        // The following fixed statement pins the location of the source and
+        // target objects in memory so that they will not be moved by garbage
+        // collection.
+        fixed (byte* pSource = source, pTarget = target)
+        {
+            // Copy the specified number of bytes from source to target.
+            for (int i = 0; i < count; i++)
+            {
+                pTarget[targetOffset + i] = pSource[sourceOffset + i];
+            }
+        }
+    }
+
+    static void UnsafeCopyArrays()
+    {
+        // Create two arrays of the same length.
+        int length = 100;
+        byte[] byteArray1 = new byte[length];
+        byte[] byteArray2 = new byte[length];
+
+        // Fill byteArray1 with 0 - 99.
+        for (int i = 0; i < length; ++i)
+        {
+            byteArray1[i] = (byte)i;
+        }
+
+        // Display the first 10 elements in byteArray1.
+        System.Console.WriteLine("The first 10 elements of the original are:");
+        for (int i = 0; i < 10; ++i)
+        {
+            System.Console.Write(byteArray1[i] + " ");
+        }
+        System.Console.WriteLine("\n");
+
+        // Copy the contents of byteArray1 to byteArray2.
+        Copy(byteArray1, 0, byteArray2, 0, length);
+
+        // Display the first 10 elements in the copy, byteArray2.
+        System.Console.WriteLine("The first 10 elements of the copy are:");
+        for (int i = 0; i < 10; ++i)
+        {
+            System.Console.Write(byteArray2[i] + " ");
+        }
+        System.Console.WriteLine("\n");
+
+        // Copy the contents of the last 10 elements of byteArray1 to the
+        // beginning of byteArray2.
+        // The offset specifies where the copying begins in the source array.
+        int offset = length - 10;
+        Copy(byteArray1, offset, byteArray2, 0, length - offset);
+
+        // Display the first 10 elements in the copy, byteArray2.
+        System.Console.WriteLine("The first 10 elements of the copy are:");
+        for (int i = 0; i < 10; ++i)
+        {
+            System.Console.Write(byteArray2[i] + " ");
+        }
+        System.Console.WriteLine("\n");
+        /* Output:
+            The first 10 elements of the original are:
+            0 1 2 3 4 5 6 7 8 9
+
+            The first 10 elements of the copy are:
+            0 1 2 3 4 5 6 7 8 9
+
+            The first 10 elements of the copy are:
+            90 91 92 93 94 95 96 97 98 99
+        */
+    }
+    // </Snippet8>
 }

--- a/docs/csharp/language-reference/snippets/unsafe-code/FunctionPointers.cs
+++ b/docs/csharp/language-reference/snippets/unsafe-code/FunctionPointers.cs
@@ -1,50 +1,44 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Runtime.InteropServices;
+﻿namespace UnsafeCodePointers;
 
-namespace UnsafeCodePointers
+public unsafe class FunctionPointers
 {
-    public unsafe class FunctionPointers
+    public static void PointerExamples()
     {
-        public static void PointerExamples()
-        {
-            int sum = Combine((x, y) => x + y, 3, 4);
-            Console.WriteLine(sum);
+        int sum = Combine((x, y) => x + y, 3, 4);
+        Console.WriteLine(sum);
 
-            Console.WriteLine();
+        Console.WriteLine();
 
-            // <InvokeViaFunctionPointer>
-            static int localMultiply(int x, int y) => x * y;
-            int product = UnsafeCombine(&localMultiply, 3, 4);
-            // </InvokeViaFunctionPointer>
-            Console.WriteLine(product);
+        // <InvokeViaFunctionPointer>
+        static int localMultiply(int x, int y) => x * y;
+        int product = UnsafeCombine(&localMultiply, 3, 4);
+        // </InvokeViaFunctionPointer>
+        Console.WriteLine(product);
 
-
-        }
-
-        // <UseDelegateOrPointer>
-        public static T Combine<T>(Func<T, T, T> combinator, T left, T right) => 
-            combinator(left, right);
-
-        public static T UnsafeCombine<T>(delegate*<T, T, T> combinator, T left, T right) => 
-            combinator(left, right);
-        // </UseDelegateOrPointer>
-
-        // <UnmanagedFunctionPointers>
-        public static T ManagedCombine<T>(delegate* managed<T, T, T> combinator, T left, T right) =>
-            combinator(left, right);
-        public static T CDeclCombine<T>(delegate* unmanaged[Cdecl]<T, T, T> combinator, T left, T right) =>
-            combinator(left, right);
-        public static T StdcallCombine<T>(delegate* unmanaged[Stdcall]<T, T, T> combinator, T left, T right) =>
-            combinator(left, right);
-        public static T FastcallCombine<T>(delegate* unmanaged[Fastcall]<T, T, T> combinator, T left, T right) =>
-            combinator(left, right);
-        public static T ThiscallCombine<T>(delegate* unmanaged[Thiscall]<T, T, T> combinator, T left, T right) =>
-            combinator(left, right);
-        public static T UnmanagedCombine<T>(delegate* unmanaged<T, T, T> combinator, T left, T right) =>
-            combinator(left, right);
-        // </UnmanagedFunctionPointers>
 
     }
+
+    // <UseDelegateOrPointer>
+    public static T Combine<T>(Func<T, T, T> combinator, T left, T right) => 
+        combinator(left, right);
+
+    public static T UnsafeCombine<T>(delegate*<T, T, T> combinator, T left, T right) => 
+        combinator(left, right);
+    // </UseDelegateOrPointer>
+
+    // <UnmanagedFunctionPointers>
+    public static T ManagedCombine<T>(delegate* managed<T, T, T> combinator, T left, T right) =>
+        combinator(left, right);
+    public static T CDeclCombine<T>(delegate* unmanaged[Cdecl]<T, T, T> combinator, T left, T right) =>
+        combinator(left, right);
+    public static T StdcallCombine<T>(delegate* unmanaged[Stdcall]<T, T, T> combinator, T left, T right) =>
+        combinator(left, right);
+    public static T FastcallCombine<T>(delegate* unmanaged[Fastcall]<T, T, T> combinator, T left, T right) =>
+        combinator(left, right);
+    public static T ThiscallCombine<T>(delegate* unmanaged[Thiscall]<T, T, T> combinator, T left, T right) =>
+        combinator(left, right);
+    public static T UnmanagedCombine<T>(delegate* unmanaged<T, T, T> combinator, T left, T right) =>
+        combinator(left, right);
+    // </UnmanagedFunctionPointers>
+
 }

--- a/docs/csharp/language-reference/snippets/unsafe-code/Program.cs
+++ b/docs/csharp/language-reference/snippets/unsafe-code/Program.cs
@@ -1,20 +1,11 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿
+using UnsafeCodePointers;
 
-namespace UnsafeCodePointers
-{
-    class Program
-    {
-        static async Task Main(string[] args)
-        {
-            Console.WriteLine("=================    Fixed Memory Examples ======================");
-            FixedKeywordExamples.Examples();
+Console.WriteLine("=================    Fixed Memory Examples ======================");
+FixedKeywordExamples.Examples();
 
-            Console.WriteLine("=================    Conversion Examples   ======================");
-            ClassConvert.Conversions();
+Console.WriteLine("=================    Conversion Examples   ======================");
+ClassConvert.Conversions();
 
-            Console.WriteLine("===================   Function pointers   =======================");
-            FunctionPointers.PointerExamples();
-        }
-    }
-}
+Console.WriteLine("===================   Function pointers   =======================");
+FunctionPointers.PointerExamples();

--- a/docs/csharp/language-reference/snippets/unsafe-code/UnsafeCodePointers.csproj
+++ b/docs/csharp/language-reference/snippets/unsafe-code/UnsafeCodePointers.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/docs/csharp/language-reference/snippets/unsafe-code/UnsafeCodePointers.csproj
+++ b/docs/csharp/language-reference/snippets/unsafe-code/UnsafeCodePointers.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/docs/csharp/language-reference/snippets/unsafe-code/UnsafeCodePointers.csproj
+++ b/docs/csharp/language-reference/snippets/unsafe-code/UnsafeCodePointers.csproj
@@ -7,6 +7,5 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <StartupObject>UnsafeCodePointers.Program</StartupObject>
   </PropertyGroup>
 </Project>

--- a/docs/csharp/language-reference/statements/snippets/declarations/NumberStore.cs
+++ b/docs/csharp/language-reference/statements/snippets/declarations/NumberStore.cs
@@ -5,7 +5,7 @@
 
     public class NumberStore
     {
-        private readonly int[] numbers = { 1, 30, 7, 1557, 381, 63, 1027, 2550, 511, 1023 };
+        private readonly int[] numbers = [1, 30, 7, 1557, 381, 63, 1027, 2550, 511, 1023];
 
         public ref int GetReferenceToMax()
         {

--- a/docs/csharp/language-reference/statements/snippets/declarations/ReferenceVariables.cs
+++ b/docs/csharp/language-reference/statements/snippets/declarations/ReferenceVariables.cs
@@ -1,4 +1,4 @@
-public static class ReferenceVariables
+﻿public static class ReferenceVariables
 {
     public static void Examples()
     {
@@ -27,7 +27,7 @@ public static class ReferenceVariables
         // <RefReassign>
         void Display(int[] s) => Console.WriteLine(string.Join(" ", s));
 
-        int[] xs = { 0, 0, 0 };
+        int[] xs = [0, 0, 0];
         Display(xs);
 
         ref int element = ref xs[0];
@@ -47,7 +47,7 @@ public static class ReferenceVariables
     private static void RefReadonly()
     {
         // <RefReadonly>
-        int[] xs = { 1, 2, 3 };
+        int[] xs = [1, 2, 3];
 
         ref readonly int element = ref xs[0];
         // element = 100;  error CS0131: The left-hand side of an assignment must be a variable, property or indexer

--- a/docs/csharp/language-reference/statements/snippets/declarations/declarations.csproj
+++ b/docs/csharp/language-reference/statements/snippets/declarations/declarations.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/docs/csharp/language-reference/statements/snippets/declarations/declarations.csproj
+++ b/docs/csharp/language-reference/statements/snippets/declarations/declarations.csproj
@@ -2,9 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
     <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
 </Project>

--- a/docs/csharp/language-reference/statements/snippets/fixed/Program.cs
+++ b/docs/csharp/language-reference/statements/snippets/fixed/Program.cs
@@ -8,7 +8,7 @@ static void PinnedArray()
     // <PinnedArray>
     unsafe
     {
-        byte[] bytes = { 1, 2, 3 };
+        byte[] bytes = [1, 2, 3];
         fixed (byte* pointerToFirst = bytes)
         {
             Console.WriteLine($"The address of the first array element: {(long)pointerToFirst:X}.");
@@ -26,7 +26,7 @@ static void PinnedVariable()
     // <PinnedVariable>
     unsafe
     {
-        int[] numbers = { 10, 20, 30 };
+        int[] numbers = [10, 20, 30];
         fixed (int* toFirst = &numbers[0], toLast = &numbers[^1])
         {
             Console.WriteLine(toLast - toFirst);  // output: 2
@@ -40,7 +40,7 @@ static void PinnedSpan()
     // <PinnedSpan>
     unsafe
     {
-        int[] numbers = { 10, 20, 30, 40, 50 };
+        int[] numbers = [10, 20, 30, 40, 50];
         Span<int> interior = numbers.AsSpan()[1..^1];
         fixed (int* p = interior)
         {

--- a/docs/csharp/language-reference/statements/snippets/fixed/fixed.csproj
+++ b/docs/csharp/language-reference/statements/snippets/fixed/fixed.csproj
@@ -2,10 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/docs/csharp/language-reference/statements/snippets/iteration-statements/ForeachStatement.cs
+++ b/docs/csharp/language-reference/statements/snippets/iteration-statements/ForeachStatement.cs
@@ -12,7 +12,7 @@ public static class ForeachStatement
     private static void ForeachWithIEnumerable()
     {
         // <WithIEnumerable>
-        var fibNumbers = new List<int> { 0, 1, 1, 2, 3, 5, 8, 13 };
+        List<int> fibNumbers = [0, 1, 1, 2, 3, 5, 8, 13];
         foreach (int element in fibNumbers)
         {
             Console.Write($"{element} ");
@@ -26,7 +26,7 @@ public static class ForeachStatement
     private static void ForeachWithSpan()
     {
         // <WithSpan>
-        Span<int> numbers = new int[] { 3, 14, 15, 92, 6 };
+        Span<int> numbers = [3, 14, 15, 92, 6];
         foreach (int number in numbers)
         {
             Console.Write($"{number} ");

--- a/docs/csharp/language-reference/statements/snippets/iteration-statements/iteration-statements.csproj
+++ b/docs/csharp/language-reference/statements/snippets/iteration-statements/iteration-statements.csproj
@@ -2,8 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
     <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>IterationStatements</RootNamespace>
     <StartupObject>IterationStatements.Program</StartupObject>

--- a/docs/csharp/language-reference/statements/snippets/iteration-statements/iteration-statements.csproj
+++ b/docs/csharp/language-reference/statements/snippets/iteration-statements/iteration-statements.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/docs/csharp/language-reference/statements/snippets/jump-statements/BreakStatement.cs
+++ b/docs/csharp/language-reference/statements/snippets/jump-statements/BreakStatement.cs
@@ -12,7 +12,7 @@ public static class BreakStatement
     private static void BasicExample()
     {
         // <BasicExample>
-        int[] numbers = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+        int[] numbers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
         foreach (int number in numbers)
         {
             if (number == 3)
@@ -58,7 +58,7 @@ public static class BreakStatement
     private static void SwitchInsideLoop()
     {
         // <SwitchInsideLoop>
-        double[] measurements = { -4, 5, 30, double.NaN };
+        double[] measurements = [-4, 5, 30, double.NaN];
         foreach (double measurement in measurements)
         {
             switch (measurement)

--- a/docs/csharp/language-reference/statements/snippets/jump-statements/GotoStatement.cs
+++ b/docs/csharp/language-reference/statements/snippets/jump-statements/GotoStatement.cs
@@ -13,16 +13,16 @@ public static class GotoStatement
         // <NestedLoops>
         var matrices = new Dictionary<string, int[][]>
         {
-            ["A"] = new[]
-            {
-                new[] { 1, 2, 3, 4 },
-                new[] { 4, 3, 2, 1 }
-            },
-            ["B"] = new[]
-            {
-                new[] { 5, 6, 7, 8 },
-                new[] { 8, 7, 6, 5 }
-            },
+            ["A"] =
+            [
+                [1, 2, 3, 4],
+                [4, 3, 2, 1]
+            ],
+            ["B"] =
+            [
+                [5, 6, 7, 8],
+                [8, 7, 6, 5]
+            ],
         };
 
         CheckMatrices(matrices, 4);

--- a/docs/csharp/language-reference/statements/snippets/jump-statements/ReturnStatement.cs
+++ b/docs/csharp/language-reference/statements/snippets/jump-statements/ReturnStatement.cs
@@ -52,7 +52,7 @@ public static class ReturnStatement
     private static void RefReturn()
     {
         // <RefReturn>
-        var xs = new int[] { 10, 20, 30, 40 };
+        int[] xs = [10, 20, 30, 40];
         ref int found = ref FindFirst(xs, s => s == 30);
         found = 0;
         Console.WriteLine(string.Join(" ", xs));  // output: 10 20 0 40

--- a/docs/csharp/language-reference/statements/snippets/jump-statements/jump-statements.csproj
+++ b/docs/csharp/language-reference/statements/snippets/jump-statements/jump-statements.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/docs/csharp/language-reference/statements/snippets/jump-statements/jump-statements.csproj
+++ b/docs/csharp/language-reference/statements/snippets/jump-statements/jump-statements.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
+    <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/docs/csharp/language-reference/statements/snippets/lock/Program.cs
+++ b/docs/csharp/language-reference/statements/snippets/lock/Program.cs
@@ -67,7 +67,7 @@ class AccountTest
 
     static void Update(Account account)
     {
-        decimal[] amounts = { 0, 2, -3, 6, -2, -1, 8, -5, 11, -6 };
+        decimal[] amounts = [0, 2, -3, 6, -2, -1, 8, -5, 11, -6];
         foreach (var amount in amounts)
         {
             if (amount >= 0)

--- a/docs/csharp/language-reference/statements/snippets/lock/lock.csproj
+++ b/docs/csharp/language-reference/statements/snippets/lock/lock.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/docs/csharp/language-reference/statements/snippets/lock/lock.csproj
+++ b/docs/csharp/language-reference/statements/snippets/lock/lock.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
+    <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/docs/csharp/language-reference/statements/snippets/yield/GetEnumeratorExample.cs
+++ b/docs/csharp/language-reference/statements/snippets/yield/GetEnumeratorExample.cs
@@ -1,4 +1,4 @@
-public class GetEnumeratorExample
+﻿public class GetEnumeratorExample
 {
     // <GetEnumeratorExample>
     public static void Example()

--- a/docs/csharp/language-reference/statements/snippets/yield/Program.cs
+++ b/docs/csharp/language-reference/statements/snippets/yield/Program.cs
@@ -29,10 +29,10 @@ static void YieldReturn()
 static void YieldBreak()
 {
     // <YieldBreak>
-    Console.WriteLine(string.Join(" ", TakeWhilePositive(new[] { 2, 3, 4, 5, -1, 3, 4})));
+    Console.WriteLine(string.Join(" ", TakeWhilePositive([2, 3, 4, 5, -1, 3, 4])));
     // Output: 2 3 4 5
 
-    Console.WriteLine(string.Join(" ", TakeWhilePositive(new[] { 9, 8, 7 })));
+    Console.WriteLine(string.Join(" ", TakeWhilePositive([9, 8, 7])));
     // Output: 9 8 7
 
     IEnumerable<int> TakeWhilePositive(IEnumerable<int> numbers)

--- a/docs/csharp/language-reference/statements/snippets/yield/yield.csproj
+++ b/docs/csharp/language-reference/statements/snippets/yield/yield.csproj
@@ -2,9 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/docs/csharp/language-reference/statements/snippets/yield/yield.csproj
+++ b/docs/csharp/language-reference/statements/snippets/yield/yield.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/CsCsrefQueryKeywords/CS/Common.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/CsCsrefQueryKeywords/CS/Common.cs
@@ -1,36 +1,30 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿namespace CommonTypes;
 
-namespace CommonTypes
+
+public class Common
 {
-
-    public class Common
+    // The element type of the data source
+    public class Student
     {
-        // The element type of the data source
-        public class Student
-        {
-            public string First { get; set; }
-            public string Last { get; set; }
-            public int ID { get; set; }
-            public List<int> Scores;
-        }
+        public required string First { get; init; }
+        public required string Last { get; init; }
+        public required int ID { get; init; }
+        public required List<int> Scores;
+    }
 
-        public static List<Student> GetStudents()
-        {
-            // Use a collection initializer to create the data source. Note that each element
-            //  in the list contains an inner sequence of scores.
-            List<Student> students = new List<Student>
-            {
-               new Student {First="Svetlana", Last="Omelchenko", ID=111, Scores= new List<int> {97, 72, 81, 60}},
-               new Student {First="Claire", Last="O'Donnell", ID=112, Scores= new List<int> {75, 84, 91, 39}},
-               new Student {First="Sven", Last="Mortensen", ID=113, Scores= new List<int> {88, 94, 65, 85}},
-               new Student {First="Cesar", Last="Garcia", ID=114, Scores= new List<int> {97, 89, 85, 82}},
-               new Student {First="Debra", Last="Garcia", ID=115, Scores= new List<int> {35, 72, 91, 70}}
-            };
+    public static List<Student> GetStudents()
+    {
+        // Use a collection initializer to create the data source. Note that each element
+        //  in the list contains an inner sequence of scores.
+        List<Student> students =
+        [
+           new Student {First="Svetlana", Last="Omelchenko", ID=111, Scores= [97, 72, 81, 60]},
+           new Student {First="Claire", Last="O'Donnell", ID=112, Scores= [75, 84, 91, 39]},
+           new Student {First="Sven", Last="Mortensen", ID=113, Scores= [88, 94, 65, 85]},
+           new Student {First="Cesar", Last="Garcia", ID=114, Scores= [97, 89, 85, 82]},
+           new Student {First="Debra", Last="Garcia", ID=115, Scores= [35, 72, 91, 70]}
+        ];
 
-            return students;
-        }
+        return students;
     }
 }

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/CsCsrefQueryKeywords/CS/From.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/CsCsrefQueryKeywords/CS/From.cs
@@ -1,182 +1,168 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Linq;
-using System.Xml.Linq;
-//using System.Data.Linq;
-using System.IO;
+﻿namespace FromClause;
 
-namespace FromClause
+//<snippet1>
+class LowNums
 {
-    using CommonTypes;
-    //<snippet1>
-    class LowNums
+    static void Main()
     {
-        static void Main()
+        // A simple data source.
+        int[] numbers = [5, 4, 1, 3, 9, 8, 6, 7, 2, 0];
+
+        // Create the query.
+        // lowNums is an IEnumerable<int>
+        var lowNums = from num in numbers
+            where num < 5
+            select num;
+
+        // Execute the query.
+        foreach (int i in lowNums)
         {
-            // A simple data source.
-            int[] numbers = { 5, 4, 1, 3, 9, 8, 6, 7, 2, 0 };
-
-            // Create the query.
-            // lowNums is an IEnumerable<int>
-            var lowNums = from num in numbers
-                where num < 5
-                select num;
-
-            // Execute the query.
-            foreach (int i in lowNums)
-            {
-                Console.Write(i + " ");
-            }
+            Console.Write(i + " ");
         }
     }
-    // Output: 4 1 3 2 0
-    //</snippet1>
-
-    //<Snippet2>
-    class CompoundFrom
-    {
-        // The element type of the data source.
-        public class Student
-        {
-            public string LastName { get; set; }
-            public List<int> Scores {get; set;}
-        }
-
-        static void Main()
-        {
-
-            // Use a collection initializer to create the data source. Note that
-            // each element in the list contains an inner sequence of scores.
-            List<Student> students = new List<Student>
-            {
-               new Student {LastName="Omelchenko", Scores= new List<int> {97, 72, 81, 60}},
-               new Student {LastName="O'Donnell", Scores= new List<int> {75, 84, 91, 39}},
-               new Student {LastName="Mortensen", Scores= new List<int> {88, 94, 65, 85}},
-               new Student {LastName="Garcia", Scores= new List<int> {97, 89, 85, 82}},
-               new Student {LastName="Beebe", Scores= new List<int> {35, 72, 91, 70}}
-            };
-
-            // Use a compound from to access the inner sequence within each element.
-            // Note the similarity to a nested foreach statement.
-            var scoreQuery = from student in students
-                             from score in student.Scores
-                                where score > 90
-                                select new { Last = student.LastName, score };
-
-            // Execute the queries.
-            Console.WriteLine("scoreQuery:");
-            // Rest the mouse pointer on scoreQuery in the following line to
-            // see its type. The type is IEnumerable<'a>, where 'a is an
-            // anonymous type defined as new {string Last, int score}. That is,
-            // each instance of this anonymous type has two members, a string
-            // (Last) and an int (score).
-            foreach (var student in scoreQuery)
-            {
-                Console.WriteLine("{0} Score: {1}", student.Last, student.score);
-            }
-
-            // Keep the console window open in debug mode.
-            Console.WriteLine("Press any key to exit.");
-            Console.ReadKey();
-        }
-    }
-    /*
-    scoreQuery:
-    Omelchenko Score: 97
-    O'Donnell Score: 91
-    Mortensen Score: 94
-    Garcia Score: 97
-    Beebe Score: 91
-    */
-    //</snippet2>
-
-    // <snippet3>
-    class CompoundFrom2
-    {
-        static void Main()
-        {
-            char[] upperCase = { 'A', 'B', 'C' };
-            char[] lowerCase = { 'x', 'y', 'z' };
-
-            // The type of joinQuery1 is IEnumerable<'a>, where 'a
-            // indicates an anonymous type. This anonymous type has two
-            // members, upper and lower, both of type char.
-            var joinQuery1 =
-                from upper in upperCase
-                from lower in lowerCase
-                select new { upper, lower };
-
-            // The type of joinQuery2 is IEnumerable<'a>, where 'a
-            // indicates an anonymous type. This anonymous type has two
-            // members, upper and lower, both of type char.
-            var joinQuery2 =
-                from lower in lowerCase
-                where lower != 'x'
-                from upper in upperCase
-                select new { lower, upper };
-
-            // Execute the queries.
-            Console.WriteLine("Cross join:");
-            // Rest the mouse pointer on joinQuery1 to verify its type.
-            foreach (var pair in joinQuery1)
-            {
-                Console.WriteLine("{0} is matched to {1}", pair.upper, pair.lower);
-            }
-
-            Console.WriteLine("Filtered non-equijoin:");
-            // Rest the mouse pointer over joinQuery2 to verify its type.
-            foreach (var pair in joinQuery2)
-            {
-                Console.WriteLine("{0} is matched to {1}", pair.lower, pair.upper);
-            }
-
-            // Keep the console window open in debug mode.
-            Console.WriteLine("Press any key to exit.");
-            Console.ReadKey();
-        }
-    }
-    /* Output:
-            Cross join:
-            A is matched to x
-            A is matched to y
-            A is matched to z
-            B is matched to x
-            B is matched to y
-            B is matched to z
-            C is matched to x
-            C is matched to y
-            C is matched to z
-            Filtered non-equijoin:
-            y is matched to A
-            y is matched to B
-            y is matched to C
-            z is matched to A
-            z is matched to B
-            z is matched to C
-            */
-    //</Snippet3>
-
-    // NOT USED. DELETED FROM TOPIC
-    //<Snippet4>
-    //class CompoundFrom3
-    //{
-    //    static void Main()
-    //    {
-    //        int[] numbersA = { 0, 2, 4, 5, 6, 8, 9 };
-    //        int[] numbersB = { 1, 3, 5, 7, 8 };
-
-    //        var pairQuery2 =
-    //            from a in numbersA
-    //            join b in numbersB on a equals b
-    //            select a;
-
-    //        foreach (var prod in pairQuery2)
-    //        {
-    //            Console.Write(prod + " ");
-    //        }
-    //    }
-    //}
-    //Output: 5 8
-    //</snippet4>
 }
+// Output: 4 1 3 2 0
+//</snippet1>
+
+//<Snippet2>
+class CompoundFrom
+{
+    // The element type of the data source.
+    public class Student
+    {
+        public required string LastName { get; init; }
+        public required List<int> Scores {get; init;}
+    }
+
+    static void Main()
+    {
+
+        // Use a collection initializer to create the data source. Note that
+        // each element in the list contains an inner sequence of scores.
+        List<Student> students =
+        [
+           new Student {LastName="Omelchenko", Scores= [97, 72, 81, 60]},
+           new Student {LastName="O'Donnell", Scores= [75, 84, 91, 39]},
+           new Student {LastName="Mortensen", Scores= [88, 94, 65, 85]},
+           new Student {LastName="Garcia", Scores= [97, 89, 85, 82]},
+           new Student {LastName="Beebe", Scores= [35, 72, 91, 70]}
+        ];
+
+        // Use a compound from to access the inner sequence within each element.
+        // Note the similarity to a nested foreach statement.
+        var scoreQuery = from student in students
+                         from score in student.Scores
+                            where score > 90
+                            select new { Last = student.LastName, score };
+
+        // Execute the queries.
+        Console.WriteLine("scoreQuery:");
+        // Rest the mouse pointer on scoreQuery in the following line to
+        // see its type. The type is IEnumerable<'a>, where 'a is an
+        // anonymous type defined as new {string Last, int score}. That is,
+        // each instance of this anonymous type has two members, a string
+        // (Last) and an int (score).
+        foreach (var student in scoreQuery)
+        {
+            Console.WriteLine("{0} Score: {1}", student.Last, student.score);
+        }
+    }
+}
+/*
+scoreQuery:
+Omelchenko Score: 97
+O'Donnell Score: 91
+Mortensen Score: 94
+Garcia Score: 97
+Beebe Score: 91
+*/
+//</snippet2>
+
+// <snippet3>
+class CompoundFrom2
+{
+    static void Main()
+    {
+        char[] upperCase = ['A', 'B', 'C'];
+        char[] lowerCase = ['x', 'y', 'z'];
+
+        // The type of joinQuery1 is IEnumerable<'a>, where 'a
+        // indicates an anonymous type. This anonymous type has two
+        // members, upper and lower, both of type char.
+        var joinQuery1 =
+            from upper in upperCase
+            from lower in lowerCase
+            select new { upper, lower };
+
+        // The type of joinQuery2 is IEnumerable<'a>, where 'a
+        // indicates an anonymous type. This anonymous type has two
+        // members, upper and lower, both of type char.
+        var joinQuery2 =
+            from lower in lowerCase
+            where lower != 'x'
+            from upper in upperCase
+            select new { lower, upper };
+
+        // Execute the queries.
+        Console.WriteLine("Cross join:");
+        // Rest the mouse pointer on joinQuery1 to verify its type.
+        foreach (var pair in joinQuery1)
+        {
+            Console.WriteLine("{0} is matched to {1}", pair.upper, pair.lower);
+        }
+
+        Console.WriteLine("Filtered non-equijoin:");
+        // Rest the mouse pointer over joinQuery2 to verify its type.
+        foreach (var pair in joinQuery2)
+        {
+            Console.WriteLine("{0} is matched to {1}", pair.lower, pair.upper);
+        }
+
+        // Keep the console window open in debug mode.
+        Console.WriteLine("Press any key to exit.");
+        Console.ReadKey();
+    }
+}
+/* Output:
+        Cross join:
+        A is matched to x
+        A is matched to y
+        A is matched to z
+        B is matched to x
+        B is matched to y
+        B is matched to z
+        C is matched to x
+        C is matched to y
+        C is matched to z
+        Filtered non-equijoin:
+        y is matched to A
+        y is matched to B
+        y is matched to C
+        z is matched to A
+        z is matched to B
+        z is matched to C
+        */
+//</Snippet3>
+
+// NOT USED. DELETED FROM TOPIC
+//<Snippet4>
+//class CompoundFrom3
+//{
+//    static void Main()
+//    {
+//        int[] numbersA = { 0, 2, 4, 5, 6, 8, 9 };
+//        int[] numbersB = { 1, 3, 5, 7, 8 };
+
+//        var pairQuery2 =
+//            from a in numbersA
+//            join b in numbersB on a equals b
+//            select a;
+
+//        foreach (var prod in pairQuery2)
+//        {
+//            Console.Write(prod + " ");
+//        }
+//    }
+//}
+//Output: 5 8
+//</snippet4>

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/CsCsrefQueryKeywords/CS/Group.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/CsCsrefQueryKeywords/CS/Group.cs
@@ -1,287 +1,265 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿namespace Group;
 
-namespace Group
+using CommonTypes;
+// For the group clause topic, we only use bits and pieces of this class. The same
+// class is also used for  How To: Group Results in Various Ways HowTo and
+// How To: Enumerate Groups and Group Items
+
+// Code snippets not compilable samples
+class GroupCodeExcerpts : CommonTypes.Common
 {
-    using CommonTypes;
-    // For the group clause topic, we only use bits and pieces of this class. The same
-    // class is also used for  How To: Group Results in Various Ways HowTo and
-    // How To: Enumerate Groups and Group Items
-
-    // Code snippets not compilable samples
-    class GroupCodeExcerpts : CommonTypes.Common
+    List<Common.Student> students = CommonTypes.Common.GetStudents();
+    // Use a compound from to access the inner sequence within each element.
+    // Note the similarity to a nested foreach statement.
+    void SimpleGroups()
     {
-        List<Common.Student> students = CommonTypes.Common.GetStudents();
-        // Use a compound from to access the inner sequence within each element.
-        // Note the similarity to a nested foreach statement.
-        void SimpleGroups()
-        {
 
-            //<Snippet10>
-            // Query variable is an IEnumerable<IGrouping<char, Student>>
-            var studentQuery1 =
-                from student in students
-                group student by student.Last[0];
-            //</snippet10>
+        //<Snippet10>
+        // Query variable is an IEnumerable<IGrouping<char, Student>>
+        var studentQuery1 =
+            from student in students
+            group student by student.Last[0];
+        //</snippet10>
 
-            // This query could be easily modified to group by the entire last name.
-            //<Snippet11>
-            // Group students by the first letter of their last name
-            // Query variable is an IEnumerable<IGrouping<char, Student>>
-            var studentQuery2 =
-                from student in students
-                group student by student.Last[0] into g
-                orderby g.Key
-                select g;
-            //</snippet11>
-            Console.WriteLine("The SimpleGroup method produces this output:\r\n");
+        // This query could be easily modified to group by the entire last name.
+        //<Snippet11>
+        // Group students by the first letter of their last name
+        // Query variable is an IEnumerable<IGrouping<char, Student>>
+        var studentQuery2 =
+            from student in students
+            group student by student.Last[0] into g
+            orderby g.Key
+            select g;
+        //</snippet11>
+        Console.WriteLine("The SimpleGroup method produces this output:\r\n");
 
-           //<snippet12>
-           // Iterate group items with a nested foreach. This IGrouping encapsulates
-           // a sequence of Student objects, and a Key of type char.
-           // For convenience, var can also be used in the foreach statement.
-           foreach (IGrouping<char, Student> studentGroup in studentQuery2)
-           {
-                Console.WriteLine(studentGroup.Key);
-                // Explicit type for student could also be used here.
-                foreach (var student in studentGroup)
-                {
-                    Console.WriteLine("   {0}, {1}", student.Last, student.First);
-                }
+       //<snippet12>
+       // Iterate group items with a nested foreach. This IGrouping encapsulates
+       // a sequence of Student objects, and a Key of type char.
+       // For convenience, var can also be used in the foreach statement.
+       foreach (IGrouping<char, Student> studentGroup in studentQuery2)
+       {
+            Console.WriteLine(studentGroup.Key);
+            // Explicit type for student could also be used here.
+            foreach (var student in studentGroup)
+            {
+                Console.WriteLine("   {0}, {1}", student.Last, student.First);
             }
-            //</snippet12>
-
-            //<Snippet13>
-            // Same as previous example except we use the entire last name as a key.
-            // Query variable is an IEnumerable<IGrouping<string, Student>>
-            var studentQuery3 =
-                from student in students
-                group student by student.Last;
-            //</snippet13>
         }
+        //</snippet12>
+
+        //<Snippet13>
+        // Same as previous example except we use the entire last name as a key.
+        // Query variable is an IEnumerable<IGrouping<string, Student>>
+        var studentQuery3 =
+            from student in students
+            group student by student.Last;
+        //</snippet13>
+    }
+}
+
+// The rest of the samples must run and produce output
+//<snippet14>
+class GroupSample1
+{
+    // The element type of the data source.
+    public class Student
+    {
+        public required string First { get; init; }
+        public required string Last { get; init; }
+        public required int ID { get; init; }
+        public required List<int> Scores;
     }
 
-    // The rest of the samples must run and produce output
-    //<snippet14>
-    class GroupSample1
+    public static List<Student> GetStudents()
     {
-        // The element type of the data source.
-        public class Student
-        {
-            public string First { get; set; }
-            public string Last { get; set; }
-            public int ID { get; set; }
-            public List<int> Scores;
-        }
+        // Use a collection initializer to create the data source. Note that each element
+        //  in the list contains an inner sequence of scores.
+        List<Student> students =
+        [
+           new Student {First="Svetlana", Last="Omelchenko", ID=111, Scores= [97, 72, 81, 60]},
+           new Student {First="Claire", Last="O'Donnell", ID=112, Scores= [75, 84, 91, 39]},
+           new Student {First="Sven", Last="Mortensen", ID=113, Scores= [99, 89, 91, 95]},
+           new Student {First="Cesar", Last="Garcia", ID=114, Scores= [72, 81, 65, 84]},
+           new Student {First="Debra", Last="Garcia", ID=115, Scores= [97, 89, 85, 82]}
+        ];
 
-        public static List<Student> GetStudents()
+        return students;
+    }
+
+    static void Main()
+    {
+        // Obtain the data source.
+        List<Student> students = GetStudents();
+
+        // Group by true or false.
+        // Query variable is an IEnumerable<IGrouping<bool, Student>>
+        var booleanGroupQuery =
+            from student in students
+            group student by student.Scores.Average() >= 80; //pass or fail!
+
+        // Execute the query and access items in each group
+        foreach (var studentGroup in booleanGroupQuery)
         {
-            // Use a collection initializer to create the data source. Note that each element
-            //  in the list contains an inner sequence of scores.
-            List<Student> students = new List<Student>
+            Console.WriteLine(studentGroup.Key == true ? "High averages" : "Low averages");
+            foreach (var student in studentGroup)
             {
-               new Student {First="Svetlana", Last="Omelchenko", ID=111, Scores= new List<int> {97, 72, 81, 60}},
-               new Student {First="Claire", Last="O'Donnell", ID=112, Scores= new List<int> {75, 84, 91, 39}},
-               new Student {First="Sven", Last="Mortensen", ID=113, Scores= new List<int> {99, 89, 91, 95}},
-               new Student {First="Cesar", Last="Garcia", ID=114, Scores= new List<int> {72, 81, 65, 84}},
-               new Student {First="Debra", Last="Garcia", ID=115, Scores= new List<int> {97, 89, 85, 82}}
-            };
-
-            return students;
-        }
-
-        static void Main()
-        {
-            // Obtain the data source.
-            List<Student> students = GetStudents();
-
-            // Group by true or false.
-            // Query variable is an IEnumerable<IGrouping<bool, Student>>
-            var booleanGroupQuery =
-                from student in students
-                group student by student.Scores.Average() >= 80; //pass or fail!
-
-            // Execute the query and access items in each group
-            foreach (var studentGroup in booleanGroupQuery)
-            {
-                Console.WriteLine(studentGroup.Key == true ? "High averages" : "Low averages");
-                foreach (var student in studentGroup)
-                {
-                    Console.WriteLine("   {0}, {1}:{2}", student.Last, student.First, student.Scores.Average());
-                }
+                Console.WriteLine("   {0}, {1}:{2}", student.Last, student.First, student.Scores.Average());
             }
-
-            // Keep the console window open in debug mode.
-            Console.WriteLine("Press any key to exit.");
-            Console.ReadKey();
         }
     }
-    /* Output:
-      Low averages
+}
+/* Output:
+  Low averages
+   Omelchenko, Svetlana:77.5
+   O'Donnell, Claire:72.25
+   Garcia, Cesar:75.5
+  High averages
+   Mortensen, Sven:93.5
+   Garcia, Debra:88.25
+*/
+//</snippet14>
+
+//<snippet15>
+class GroupSample2
+{
+    // The element type of the data source.
+    public class Student
+    {
+        public required string First { get; init; }
+        public required string Last { get; init; }
+        public required int ID { get; init; }
+        public required List<int> Scores;
+    }
+
+    public static List<Student> GetStudents()
+    {
+        // Use a collection initializer to create the data source. Note that each element
+        //  in the list contains an inner sequence of scores.
+        List<Student> students =
+        [
+           new Student {First="Svetlana", Last="Omelchenko", ID=111, Scores= [97, 72, 81, 60]},
+           new Student {First="Claire", Last="O'Donnell", ID=112, Scores= [75, 84, 91, 39]},
+           new Student {First="Sven", Last="Mortensen", ID=113, Scores= [99, 89, 91, 95]},
+           new Student {First="Cesar", Last="Garcia", ID=114, Scores= [72, 81, 65, 84]},
+           new Student {First="Debra", Last="Garcia", ID=115, Scores= [97, 89, 85, 82]}
+        ];
+
+        return students;
+    }
+
+    // This method groups students into percentile ranges based on their
+    // grade average. The Average method returns a double, so to produce a whole
+    // number it is necessary to cast to int before dividing by 10.
+    static void Main()
+    {
+        // Obtain the data source.
+        List<Student> students = GetStudents();
+
+        // Write the query.
+        var studentQuery =
+            from student in students
+            let avg = (int)student.Scores.Average()
+            group student by (avg / 10) into g
+            orderby g.Key
+            select g;
+
+        // Execute the query.
+        foreach (var studentGroup in studentQuery)
+        {
+            int temp = studentGroup.Key * 10;
+            Console.WriteLine("Students with an average between {0} and {1}", temp, temp + 10);
+            foreach (var student in studentGroup)
+            {
+                Console.WriteLine("   {0}, {1}:{2}", student.Last, student.First, student.Scores.Average());
+            }
+        }
+    }
+}
+/* Output:
+     Students with an average between 70 and 80
        Omelchenko, Svetlana:77.5
        O'Donnell, Claire:72.25
        Garcia, Cesar:75.5
-      High averages
-       Mortensen, Sven:93.5
+     Students with an average between 80 and 90
        Garcia, Debra:88.25
-    */
-    //</snippet14>
+     Students with an average between 90 and 100
+       Mortensen, Sven:93.5
+ */
+//</snippet15>
 
-    //<snippet15>
-    class GroupSample2
+//<snippet16>
+class GroupExample1
+{
+    static void Main()
     {
-        // The element type of the data source.
-        public class Student
-        {
-            public string First { get; set; }
-            public string Last { get; set; }
-            public int ID { get; set; }
-            public List<int> Scores;
-        }
+        // Create a data source.
+        string[] words = ["blueberry", "chimpanzee", "abacus", "banana", "apple", "cheese"];
 
-        public static List<Student> GetStudents()
+        // Create the query.
+        var wordGroups =
+            from w in words
+            group w by w[0];
+
+        // Execute the query.
+        foreach (var wordGroup in wordGroups)
         {
-            // Use a collection initializer to create the data source. Note that each element
-            //  in the list contains an inner sequence of scores.
-            List<Student> students = new List<Student>
+            Console.WriteLine("Words that start with the letter '{0}':", wordGroup.Key);
+            foreach (var word in wordGroup)
             {
-               new Student {First="Svetlana", Last="Omelchenko", ID=111, Scores= new List<int> {97, 72, 81, 60}},
-               new Student {First="Claire", Last="O'Donnell", ID=112, Scores= new List<int> {75, 84, 91, 39}},
-               new Student {First="Sven", Last="Mortensen", ID=113, Scores= new List<int> {99, 89, 91, 95}},
-               new Student {First="Cesar", Last="Garcia", ID=114, Scores= new List<int> {72, 81, 65, 84}},
-               new Student {First="Debra", Last="Garcia", ID=115, Scores= new List<int> {97, 89, 85, 82}}
-            };
-
-            return students;
-        }
-
-        // This method groups students into percentile ranges based on their
-        // grade average. The Average method returns a double, so to produce a whole
-        // number it is necessary to cast to int before dividing by 10.
-        static void Main()
-        {
-            // Obtain the data source.
-            List<Student> students = GetStudents();
-
-            // Write the query.
-            var studentQuery =
-                from student in students
-                let avg = (int)student.Scores.Average()
-                group student by (avg / 10) into g
-                orderby g.Key
-                select g;
-
-            // Execute the query.
-            foreach (var studentGroup in studentQuery)
-            {
-                int temp = studentGroup.Key * 10;
-                Console.WriteLine("Students with an average between {0} and {1}", temp, temp + 10);
-                foreach (var student in studentGroup)
-                {
-                    Console.WriteLine("   {0}, {1}:{2}", student.Last, student.First, student.Scores.Average());
-                }
+                Console.WriteLine(word);
             }
-
-            // Keep the console window open in debug mode.
-            Console.WriteLine("Press any key to exit.");
-            Console.ReadKey();
         }
     }
-    /* Output:
-         Students with an average between 70 and 80
-           Omelchenko, Svetlana:77.5
-           O'Donnell, Claire:72.25
-           Garcia, Cesar:75.5
-         Students with an average between 80 and 90
-           Garcia, Debra:88.25
-         Students with an average between 90 and 100
-           Mortensen, Sven:93.5
-     */
-    //</snippet15>
-
-    //<snippet16>
-    class GroupExample1
-    {
-        static void Main()
-        {
-            // Create a data source.
-            string[] words = { "blueberry", "chimpanzee", "abacus", "banana", "apple", "cheese" };
-
-            // Create the query.
-            var wordGroups =
-                from w in words
-                group w by w[0];
-
-            // Execute the query.
-            foreach (var wordGroup in wordGroups)
-            {
-                Console.WriteLine("Words that start with the letter '{0}':", wordGroup.Key);
-                foreach (var word in wordGroup)
-                {
-                    Console.WriteLine(word);
-                }
-            }
-
-            // Keep the console window open in debug mode
-            Console.WriteLine("Press any key to exit.");
-            Console.ReadKey();
-        }
-    }
-    /* Output:
-          Words that start with the letter 'b':
-            blueberry
-            banana
-          Words that start with the letter 'c':
-            chimpanzee
-            cheese
-          Words that start with the letter 'a':
-            abacus
-            apple
-         */
-    //</snippet16>
-
-    //<snippet17>
-    class GroupClauseExample2
-    {
-        static void Main()
-        {
-            // Create the data source.
-            string[] words2 = { "blueberry", "chimpanzee", "abacus", "banana", "apple", "cheese", "elephant", "umbrella", "anteater" };
-
-            // Create the query.
-            var wordGroups2 =
-                from w in words2
-                group w by w[0] into grps
-                where (grps.Key == 'a' || grps.Key == 'e' || grps.Key == 'i'
-                       || grps.Key == 'o' || grps.Key == 'u')
-                select grps;
-
-            // Execute the query.
-            foreach (var wordGroup in wordGroups2)
-            {
-                Console.WriteLine("Groups that start with a vowel: {0}", wordGroup.Key);
-                foreach (var word in wordGroup)
-                {
-                    Console.WriteLine("   {0}", word);
-                }
-            }
-
-            // Keep the console window open in debug mode
-            Console.WriteLine("Press any key to exit.");
-            Console.ReadKey();
-        }
-    }
-    /* Output:
-        Groups that start with a vowel: a
-            abacus
-            apple
-            anteater
-        Groups that start with a vowel: e
-            elephant
-        Groups that start with a vowel: u
-            umbrella
-    */
-    //</snippet17>
 }
+/* Output:
+      Words that start with the letter 'b':
+        blueberry
+        banana
+      Words that start with the letter 'c':
+        chimpanzee
+        cheese
+      Words that start with the letter 'a':
+        abacus
+        apple
+     */
+//</snippet16>
+
+//<snippet17>
+class GroupClauseExample2
+{
+    static void Main()
+    {
+        // Create the data source.
+        string[] words2 = ["blueberry", "chimpanzee", "abacus", "banana", "apple", "cheese", "elephant", "umbrella", "anteater"];
+
+        // Create the query.
+        var wordGroups2 =
+            from w in words2
+            group w by w[0] into grps
+            where (grps.Key == 'a' || grps.Key == 'e' || grps.Key == 'i'
+                   || grps.Key == 'o' || grps.Key == 'u')
+            select grps;
+
+        // Execute the query.
+        foreach (var wordGroup in wordGroups2)
+        {
+            Console.WriteLine("Groups that start with a vowel: {0}", wordGroup.Key);
+            foreach (var word in wordGroup)
+            {
+                Console.WriteLine("   {0}", word);
+            }
+        }
+    }
+}
+/* Output:
+    Groups that start with a vowel: a
+        abacus
+        apple
+        anteater
+    Groups that start with a vowel: e
+        elephant
+    Groups that start with a vowel: u
+        umbrella
+*/
+//</snippet17>

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/CsCsrefQueryKeywords/CS/Into.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/CsCsrefQueryKeywords/CS/Into.cs
@@ -1,81 +1,67 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿namespace IntoClause;
 
-namespace IntoClause
+//<snippet18>
+class IntoSample1
 {
-    //<snippet18>
-    class IntoSample1
+    static void Main()
     {
-        static void Main()
+
+        // Create a data source.
+        string[] words = ["apples", "blueberries", "oranges", "bananas", "apricots"];
+
+        // Create the query.
+        var wordGroups1 =
+            from w in words
+            group w by w[0] into fruitGroup
+            where fruitGroup.Count() >= 2
+            select new { FirstLetter = fruitGroup.Key, Words = fruitGroup.Count() };
+
+        // Execute the query. Note that we only iterate over the groups,
+        // not the items in each group
+        foreach (var item in wordGroups1)
         {
-
-            // Create a data source.
-            string[] words = { "apples", "blueberries", "oranges", "bananas", "apricots"};
-
-            // Create the query.
-            var wordGroups1 =
-                from w in words
-                group w by w[0] into fruitGroup
-                where fruitGroup.Count() >= 2
-                select new { FirstLetter = fruitGroup.Key, Words = fruitGroup.Count() };
-
-            // Execute the query. Note that we only iterate over the groups,
-            // not the items in each group
-            foreach (var item in wordGroups1)
-            {
-                Console.WriteLine(" {0} has {1} elements.", item.FirstLetter, item.Words);
-            }
-
-            // Keep the console window open in debug mode
-            Console.WriteLine("Press any key to exit.");
-            Console.ReadKey();
+            Console.WriteLine(" {0} has {1} elements.", item.FirstLetter, item.Words);
         }
     }
-    /* Output:
-       a has 2 elements.
-       b has 2 elements.
-    */
-    //</snippet18>
-
-    //<snippet19>
-    class IntoSample2
-    {
-        static void Main()
-        {
-            //Create a data source
-            string[] words2 = { "apples", "blueberries", "oranges", "bananas" };
-
-            //Create a query
-            var wordGroups2 =
-                from w in words2
-                group w by w[0];
-
-            // Nested foreach loop to iterate over groups
-            // and the items in each group.
-            foreach (var item in wordGroups2)
-            {
-                Console.WriteLine("Words that start with the letter '{0}':", item.Key);
-                foreach (var w in item)
-                {
-                    Console.WriteLine(w);
-                }
-            }
-
-            // Keep the console window open in debug mode
-            Console.WriteLine("Press any key to exit.");
-            Console.ReadKey();
-        }
-    }
-    /* Output:
-        Words that start with the letter 'a':
-        apples
-        Words that start with the letter 'b':
-        blueberries
-        bananas
-        Words that start with the letter 'o':
-        oranges
-     */
-    //</snippet19>
 }
+/* Output:
+   a has 2 elements.
+   b has 2 elements.
+*/
+//</snippet18>
+
+//<snippet19>
+class IntoSample2
+{
+    static void Main()
+    {
+        //Create a data source
+        string[] words2 = ["apples", "blueberries", "oranges", "bananas"];
+
+        //Create a query
+        var wordGroups2 =
+            from w in words2
+            group w by w[0];
+
+        // Nested foreach loop to iterate over groups
+        // and the items in each group.
+        foreach (var item in wordGroups2)
+        {
+            Console.WriteLine("Words that start with the letter '{0}':", item.Key);
+            foreach (var w in item)
+            {
+                Console.WriteLine(w);
+            }
+        }
+    }
+}
+/* Output:
+    Words that start with the letter 'a':
+    apples
+    Words that start with the letter 'b':
+    blueberries
+    bananas
+    Words that start with the letter 'o':
+    oranges
+ */
+//</snippet19>

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/CsCsrefQueryKeywords/CS/Join.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/CsCsrefQueryKeywords/CS/Join.cs
@@ -1,390 +1,381 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿namespace Joins;
 
-namespace Joins
+
+//<snippet23>
+class JoinDemonstration
 {
+    #region Data
 
-    //<snippet23>
-    class JoinDemonstration
+    class Product
     {
-        #region Data
-
-        class Product
-        {
-            public string Name { get; set; }
-            public int CategoryID { get; set; }
-        }
-
-        class Category
-        {
-            public string Name { get; set; }
-            public int ID { get; set; }
-        }
-
-        // Specify the first data source.
-        List<Category> categories = new List<Category>()
-        {
-            new Category {Name="Beverages", ID=001},
-            new Category {Name="Condiments", ID=002},
-            new Category {Name="Vegetables", ID=003},
-            new Category {Name="Grains", ID=004},
-            new Category {Name="Fruit", ID=005}
-        };
-
-        // Specify the second data source.
-        List<Product> products = new List<Product>()
-       {
-          new Product {Name="Cola",  CategoryID=001},
-          new Product {Name="Tea",  CategoryID=001},
-          new Product {Name="Mustard", CategoryID=002},
-          new Product {Name="Pickles", CategoryID=002},
-          new Product {Name="Carrots", CategoryID=003},
-          new Product {Name="Bok Choy", CategoryID=003},
-          new Product {Name="Peaches", CategoryID=005},
-          new Product {Name="Melons", CategoryID=005},
-        };
-        #endregion
-
-        static void Main(string[] args)
-        {
-            JoinDemonstration app = new JoinDemonstration();
-
-            app.InnerJoin();
-            app.GroupJoin();
-            app.GroupInnerJoin();
-            app.GroupJoin3();
-            app.LeftOuterJoin();
-            app.LeftOuterJoin2();
-
-            // Keep the console window open in debug mode.
-            Console.WriteLine("Press any key to exit.");
-            Console.ReadKey();
-        }
-
-        void InnerJoin()
-        {
-            // Create the query that selects
-            // a property from each element.
-            var innerJoinQuery =
-               from category in categories
-               join prod in products on category.ID equals prod.CategoryID
-               select new { Category = category.ID, Product = prod.Name };
-
-            Console.WriteLine("InnerJoin:");
-            // Execute the query. Access results
-            // with a simple foreach statement.
-            foreach (var item in innerJoinQuery)
-            {
-                Console.WriteLine("{0,-10}{1}", item.Product, item.Category);
-            }
-            Console.WriteLine("InnerJoin: {0} items in 1 group.", innerJoinQuery.Count());
-            Console.WriteLine(System.Environment.NewLine);
-        }
-
-        void GroupJoin()
-        {
-            // This is a demonstration query to show the output
-            // of a "raw" group join. A more typical group join
-            // is shown in the GroupInnerJoin method.
-            var groupJoinQuery =
-               from category in categories
-               join prod in products on category.ID equals prod.CategoryID into prodGroup
-               select prodGroup;
-
-            // Store the count of total items (for demonstration only).
-            int totalItems = 0;
-
-            Console.WriteLine("Simple GroupJoin:");
-
-            // A nested foreach statement is required to access group items.
-            foreach (var prodGrouping in groupJoinQuery)
-            {
-                Console.WriteLine("Group:");
-                foreach (var item in prodGrouping)
-                {
-                    totalItems++;
-                    Console.WriteLine("   {0,-10}{1}", item.Name, item.CategoryID);
-                }
-            }
-            Console.WriteLine("Unshaped GroupJoin: {0} items in {1} unnamed groups", totalItems, groupJoinQuery.Count());
-            Console.WriteLine(System.Environment.NewLine);
-        }
-
-        void GroupInnerJoin()
-        {
-            var groupJoinQuery2 =
-                from category in categories
-                orderby category.ID
-                join prod in products on category.ID equals prod.CategoryID into prodGroup
-                select new
-                {
-                    Category = category.Name,
-                    Products = from prod2 in prodGroup
-                               orderby prod2.Name
-                               select prod2
-                };
-
-            //Console.WriteLine("GroupInnerJoin:");
-            int totalItems = 0;
-
-            Console.WriteLine("GroupInnerJoin:");
-            foreach (var productGroup in groupJoinQuery2)
-            {
-                Console.WriteLine(productGroup.Category);
-                foreach (var prodItem in productGroup.Products)
-                {
-                    totalItems++;
-                    Console.WriteLine("  {0,-10} {1}", prodItem.Name, prodItem.CategoryID);
-                }
-            }
-            Console.WriteLine("GroupInnerJoin: {0} items in {1} named groups", totalItems, groupJoinQuery2.Count());
-            Console.WriteLine(System.Environment.NewLine);
-        }
-
-        void GroupJoin3()
-        {
-
-            var groupJoinQuery3 =
-                from category in categories
-                join product in products on category.ID equals product.CategoryID into prodGroup
-                from prod in prodGroup
-                orderby prod.CategoryID
-                select new { Category = prod.CategoryID, ProductName = prod.Name };
-
-            //Console.WriteLine("GroupInnerJoin:");
-            int totalItems = 0;
-
-            Console.WriteLine("GroupJoin3:");
-            foreach (var item in groupJoinQuery3)
-            {
-                totalItems++;
-                Console.WriteLine("   {0}:{1}", item.ProductName, item.Category);
-            }
-
-            Console.WriteLine("GroupJoin3: {0} items in 1 group", totalItems);
-            Console.WriteLine(System.Environment.NewLine);
-        }
-
-        void LeftOuterJoin()
-        {
-            // Create the query.
-            var leftOuterQuery =
-               from category in categories
-               join prod in products on category.ID equals prod.CategoryID into prodGroup
-               select prodGroup.DefaultIfEmpty(new Product() { Name = "Nothing!", CategoryID = category.ID });
-
-            // Store the count of total items (for demonstration only).
-            int totalItems = 0;
-
-            Console.WriteLine("Left Outer Join:");
-
-            // A nested foreach statement  is required to access group items
-            foreach (var prodGrouping in leftOuterQuery)
-            {
-                Console.WriteLine("Group:");
-                foreach (var item in prodGrouping)
-                {
-                    totalItems++;
-                    Console.WriteLine("  {0,-10}{1}", item.Name, item.CategoryID);
-                }
-            }
-            Console.WriteLine("LeftOuterJoin: {0} items in {1} groups", totalItems, leftOuterQuery.Count());
-            Console.WriteLine(System.Environment.NewLine);
-        }
-
-        void LeftOuterJoin2()
-        {
-            // Create the query.
-            var leftOuterQuery2 =
-               from category in categories
-               join prod in products on category.ID equals prod.CategoryID into prodGroup
-               from item in prodGroup.DefaultIfEmpty()
-               select new { Name = item == null ? "Nothing!" : item.Name, CategoryID = category.ID };
-
-            Console.WriteLine("LeftOuterJoin2: {0} items in 1 group", leftOuterQuery2.Count());
-            // Store the count of total items
-            int totalItems = 0;
-
-            Console.WriteLine("Left Outer Join 2:");
-
-            // Groups have been flattened.
-            foreach (var item in leftOuterQuery2)
-            {
-                totalItems++;
-                Console.WriteLine("{0,-10}{1}", item.Name, item.CategoryID);
-            }
-            Console.WriteLine("LeftOuterJoin2: {0} items in 1 group", totalItems);
-        }
+        public required string Name { get; init; }
+        public required int CategoryID { get; init; }
     }
-    /*Output:
 
-    InnerJoin:
+    class Category
+    {
+        public required string Name { get; init; }
+        public required int ID { get; init; }
+    }
+
+    // Specify the first data source.
+    List<Category> categories =
+    [
+        new Category {Name="Beverages", ID=001},
+        new Category {Name="Condiments", ID=002},
+        new Category {Name="Vegetables", ID=003},
+        new Category {Name="Grains", ID=004},
+        new Category {Name="Fruit", ID=005}
+    ];
+
+    // Specify the second data source.
+    List<Product> products =
+    [
+      new Product {Name="Cola",  CategoryID=001},
+      new Product {Name="Tea",  CategoryID=001},
+      new Product {Name="Mustard", CategoryID=002},
+      new Product {Name="Pickles", CategoryID=002},
+      new Product {Name="Carrots", CategoryID=003},
+      new Product {Name="Bok Choy", CategoryID=003},
+      new Product {Name="Peaches", CategoryID=005},
+      new Product {Name="Melons", CategoryID=005},
+    ];
+    #endregion
+
+    static void Main(string[] args)
+    {
+        JoinDemonstration app = new JoinDemonstration();
+
+        app.InnerJoin();
+        app.GroupJoin();
+        app.GroupInnerJoin();
+        app.GroupJoin3();
+        app.LeftOuterJoin();
+        app.LeftOuterJoin2();
+    }
+
+    void InnerJoin()
+    {
+        // Create the query that selects
+        // a property from each element.
+        var innerJoinQuery =
+           from category in categories
+           join prod in products on category.ID equals prod.CategoryID
+           select new { Category = category.ID, Product = prod.Name };
+
+        Console.WriteLine("InnerJoin:");
+        // Execute the query. Access results
+        // with a simple foreach statement.
+        foreach (var item in innerJoinQuery)
+        {
+            Console.WriteLine("{0,-10}{1}", item.Product, item.Category);
+        }
+        Console.WriteLine("InnerJoin: {0} items in 1 group.", innerJoinQuery.Count());
+        Console.WriteLine(System.Environment.NewLine);
+    }
+
+    void GroupJoin()
+    {
+        // This is a demonstration query to show the output
+        // of a "raw" group join. A more typical group join
+        // is shown in the GroupInnerJoin method.
+        var groupJoinQuery =
+           from category in categories
+           join prod in products on category.ID equals prod.CategoryID into prodGroup
+           select prodGroup;
+
+        // Store the count of total items (for demonstration only).
+        int totalItems = 0;
+
+        Console.WriteLine("Simple GroupJoin:");
+
+        // A nested foreach statement is required to access group items.
+        foreach (var prodGrouping in groupJoinQuery)
+        {
+            Console.WriteLine("Group:");
+            foreach (var item in prodGrouping)
+            {
+                totalItems++;
+                Console.WriteLine("   {0,-10}{1}", item.Name, item.CategoryID);
+            }
+        }
+        Console.WriteLine("Unshaped GroupJoin: {0} items in {1} unnamed groups", totalItems, groupJoinQuery.Count());
+        Console.WriteLine(System.Environment.NewLine);
+    }
+
+    void GroupInnerJoin()
+    {
+        var groupJoinQuery2 =
+            from category in categories
+            orderby category.ID
+            join prod in products on category.ID equals prod.CategoryID into prodGroup
+            select new
+            {
+                Category = category.Name,
+                Products = from prod2 in prodGroup
+                           orderby prod2.Name
+                           select prod2
+            };
+
+        //Console.WriteLine("GroupInnerJoin:");
+        int totalItems = 0;
+
+        Console.WriteLine("GroupInnerJoin:");
+        foreach (var productGroup in groupJoinQuery2)
+        {
+            Console.WriteLine(productGroup.Category);
+            foreach (var prodItem in productGroup.Products)
+            {
+                totalItems++;
+                Console.WriteLine("  {0,-10} {1}", prodItem.Name, prodItem.CategoryID);
+            }
+        }
+        Console.WriteLine("GroupInnerJoin: {0} items in {1} named groups", totalItems, groupJoinQuery2.Count());
+        Console.WriteLine(System.Environment.NewLine);
+    }
+
+    void GroupJoin3()
+    {
+
+        var groupJoinQuery3 =
+            from category in categories
+            join product in products on category.ID equals product.CategoryID into prodGroup
+            from prod in prodGroup
+            orderby prod.CategoryID
+            select new { Category = prod.CategoryID, ProductName = prod.Name };
+
+        //Console.WriteLine("GroupInnerJoin:");
+        int totalItems = 0;
+
+        Console.WriteLine("GroupJoin3:");
+        foreach (var item in groupJoinQuery3)
+        {
+            totalItems++;
+            Console.WriteLine("   {0}:{1}", item.ProductName, item.Category);
+        }
+
+        Console.WriteLine("GroupJoin3: {0} items in 1 group", totalItems);
+        Console.WriteLine(System.Environment.NewLine);
+    }
+
+    void LeftOuterJoin()
+    {
+        // Create the query.
+        var leftOuterQuery =
+           from category in categories
+           join prod in products on category.ID equals prod.CategoryID into prodGroup
+           select prodGroup.DefaultIfEmpty(new Product() { Name = "Nothing!", CategoryID = category.ID });
+
+        // Store the count of total items (for demonstration only).
+        int totalItems = 0;
+
+        Console.WriteLine("Left Outer Join:");
+
+        // A nested foreach statement  is required to access group items
+        foreach (var prodGrouping in leftOuterQuery)
+        {
+            Console.WriteLine("Group:");
+            foreach (var item in prodGrouping)
+            {
+                totalItems++;
+                Console.WriteLine("  {0,-10}{1}", item.Name, item.CategoryID);
+            }
+        }
+        Console.WriteLine("LeftOuterJoin: {0} items in {1} groups", totalItems, leftOuterQuery.Count());
+        Console.WriteLine(System.Environment.NewLine);
+    }
+
+    void LeftOuterJoin2()
+    {
+        // Create the query.
+        var leftOuterQuery2 =
+           from category in categories
+           join prod in products on category.ID equals prod.CategoryID into prodGroup
+           from item in prodGroup.DefaultIfEmpty()
+           select new { Name = item == null ? "Nothing!" : item.Name, CategoryID = category.ID };
+
+        Console.WriteLine("LeftOuterJoin2: {0} items in 1 group", leftOuterQuery2.Count());
+        // Store the count of total items
+        int totalItems = 0;
+
+        Console.WriteLine("Left Outer Join 2:");
+
+        // Groups have been flattened.
+        foreach (var item in leftOuterQuery2)
+        {
+            totalItems++;
+            Console.WriteLine("{0,-10}{1}", item.Name, item.CategoryID);
+        }
+        Console.WriteLine("LeftOuterJoin2: {0} items in 1 group", totalItems);
+    }
+}
+/*Output:
+
+InnerJoin:
+Cola      1
+Tea       1
+Mustard   2
+Pickles   2
+Carrots   3
+Bok Choy  3
+Peaches   5
+Melons    5
+InnerJoin: 8 items in 1 group.
+
+
+Unshaped GroupJoin:
+Group:
     Cola      1
     Tea       1
+Group:
     Mustard   2
     Pickles   2
+Group:
     Carrots   3
     Bok Choy  3
+Group:
+Group:
     Peaches   5
     Melons    5
-    InnerJoin: 8 items in 1 group.
+Unshaped GroupJoin: 8 items in 5 unnamed groups
 
 
-    Unshaped GroupJoin:
-    Group:
-        Cola      1
-        Tea       1
-    Group:
-        Mustard   2
-        Pickles   2
-    Group:
-        Carrots   3
-        Bok Choy  3
-    Group:
-    Group:
-        Peaches   5
-        Melons    5
-    Unshaped GroupJoin: 8 items in 5 unnamed groups
+GroupInnerJoin:
+Beverages
+    Cola       1
+    Tea        1
+Condiments
+    Mustard    2
+    Pickles    2
+Vegetables
+    Bok Choy   3
+    Carrots    3
+Grains
+Fruit
+    Melons     5
+    Peaches    5
+GroupInnerJoin: 8 items in 5 named groups
 
 
-    GroupInnerJoin:
-    Beverages
-        Cola       1
-        Tea        1
-    Condiments
-        Mustard    2
-        Pickles    2
-    Vegetables
-        Bok Choy   3
-        Carrots    3
-    Grains
-    Fruit
-        Melons     5
-        Peaches    5
-    GroupInnerJoin: 8 items in 5 named groups
+GroupJoin3:
+    Cola:1
+    Tea:1
+    Mustard:2
+    Pickles:2
+    Carrots:3
+    Bok Choy:3
+    Peaches:5
+    Melons:5
+GroupJoin3: 8 items in 1 group
 
 
-    GroupJoin3:
-        Cola:1
-        Tea:1
-        Mustard:2
-        Pickles:2
-        Carrots:3
-        Bok Choy:3
-        Peaches:5
-        Melons:5
-    GroupJoin3: 8 items in 1 group
-
-
-    Left Outer Join:
-    Group:
-        Cola      1
-        Tea       1
-    Group:
-        Mustard   2
-        Pickles   2
-    Group:
-        Carrots   3
-        Bok Choy  3
-    Group:
-        Nothing!  4
-    Group:
-        Peaches   5
-        Melons    5
-    LeftOuterJoin: 9 items in 5 groups
-
-
-    LeftOuterJoin2: 9 items in 1 group
-    Left Outer Join 2:
+Left Outer Join:
+Group:
     Cola      1
     Tea       1
+Group:
     Mustard   2
     Pickles   2
+Group:
     Carrots   3
     Bok Choy  3
+Group:
     Nothing!  4
+Group:
     Peaches   5
     Melons    5
-    LeftOuterJoin2: 9 items in 1 group
-    Press any key to exit.
-    */
-    //</snippet23>
+LeftOuterJoin: 9 items in 5 groups
 
-    class JoinDemo2
+
+LeftOuterJoin2: 9 items in 1 group
+Left Outer Join 2:
+Cola      1
+Tea       1
+Mustard   2
+Pickles   2
+Carrots   3
+Bok Choy  3
+Nothing!  4
+Peaches   5
+Melons    5
+LeftOuterJoin2: 9 items in 1 group
+Press any key to exit.
+*/
+//</snippet23>
+
+class JoinDemo2
+{
+    #region Data
+
+    class Product
     {
-        #region Data
-
-        class Product
-        {
-            public string Name { get; set; }
-            public int CategoryID { get; set; }
-            public decimal UnitPrice { get; set; }
-        }
-
-        class Category
-        {
-            public string Name { get; set; }
-            public int ID { get; set; }
-        }
-
-        // Specify the first data source.
-        List<Category> categories = new List<Category>()
-        {
-            new Category(){Name="Beverages", ID=001},
-            new Category(){ Name="Condiments", ID=002},
-            new Category(){ Name="Vegetables", ID=003},
-            new Category() {  Name="Grains", ID=004},
-            new Category() {  Name="Fruit", ID=005}
-        };
-
-        // Specify the second data source.
-        List<Product> products = new List<Product>()
-       {
-          new Product{Name="Cola",  CategoryID=001},
-          new Product{Name="Tea",  CategoryID=001},
-          new Product{Name="Mustard", CategoryID=002},
-          new Product{Name="Pickles", CategoryID=002},
-          new Product{Name="Carrots", CategoryID=003},
-          new Product{Name="Bok Choy", CategoryID=003},
-          new Product{Name="Peaches", CategoryID=005},
-          new Product{Name="Melons", CategoryID=005},
-        };
-        #endregion
-
-        void SnippetMethod()
-        {
-            // <snippet24>
-            var innerJoinQuery =
-                from category in categories
-                join prod in products on category.ID equals prod.CategoryID
-                select new { ProductName = prod.Name, Category = category.Name }; //produces flat sequence
-            //</snippet24>
-
-            //<snippet25>
-            var innerGroupJoinQuery =
-                from category in categories
-                join prod in products on category.ID equals prod.CategoryID into prodGroup
-                select new { CategoryName = category.Name, Products = prodGroup };
-            //</snippet25>
-
-            //<snippet26>
-            var innerGroupJoinQuery2 =
-                from category in categories
-                join prod in products on category.ID equals prod.CategoryID into prodGroup
-                from prod2 in prodGroup
-                where prod2.UnitPrice > 2.50M
-                select prod2;
-            //</snippet26>
-
-            //<snippet27>
-            var leftOuterJoinQuery =
-                from category in categories
-                join prod in products on category.ID equals prod.CategoryID into prodGroup
-                from item in prodGroup.DefaultIfEmpty(new Product { Name = String.Empty, CategoryID = 0 })
-                select new { CatName = category.Name, ProdName = item.Name };
-            //</snippet27>
-        }
+        public required string Name { get; init; }
+        public required int CategoryID { get; init; }
+        public decimal UnitPrice { get; init; }
     }
-} // end namespace
+
+    class Category
+    {
+        public required string Name { get; init; }
+        public required int ID { get; init; }
+    }
+
+    // Specify the first data source.
+    List<Category> categories =
+    [
+        new Category(){Name="Beverages", ID=001},
+        new Category(){ Name="Condiments", ID=002},
+        new Category(){ Name="Vegetables", ID=003},
+        new Category() {  Name="Grains", ID=004},
+        new Category() {  Name="Fruit", ID=005}
+    ];
+
+    // Specify the second data source.
+    List<Product> products =
+    [
+      new Product{Name="Cola",  CategoryID=001},
+      new Product{Name="Tea",  CategoryID=001},
+      new Product{Name="Mustard", CategoryID=002},
+      new Product{Name="Pickles", CategoryID=002},
+      new Product{Name="Carrots", CategoryID=003},
+      new Product{Name="Bok Choy", CategoryID=003},
+      new Product{Name="Peaches", CategoryID=005},
+      new Product{Name="Melons", CategoryID=005},
+    ];
+    #endregion
+
+    void SnippetMethod()
+    {
+        // <snippet24>
+        var innerJoinQuery =
+            from category in categories
+            join prod in products on category.ID equals prod.CategoryID
+            select new { ProductName = prod.Name, Category = category.Name }; //produces flat sequence
+        //</snippet24>
+
+        //<snippet25>
+        var innerGroupJoinQuery =
+            from category in categories
+            join prod in products on category.ID equals prod.CategoryID into prodGroup
+            select new { CategoryName = category.Name, Products = prodGroup };
+        //</snippet25>
+
+        //<snippet26>
+        var innerGroupJoinQuery2 =
+            from category in categories
+            join prod in products on category.ID equals prod.CategoryID into prodGroup
+            from prod2 in prodGroup
+            where prod2.UnitPrice > 2.50M
+            select prod2;
+        //</snippet26>
+
+        //<snippet27>
+        var leftOuterJoinQuery =
+            from category in categories
+            join prod in products on category.ID equals prod.CategoryID into prodGroup
+            from item in prodGroup.DefaultIfEmpty(new Product { Name = String.Empty, CategoryID = 0 })
+            select new { CatName = category.Name, ProdName = item.Name };
+        //</snippet27>
+    }
+}
+// end namespace

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/CsCsrefQueryKeywords/CS/Let.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/CsCsrefQueryKeywords/CS/Let.cs
@@ -1,52 +1,42 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿namespace LetClause;
 
-namespace LetClause
+//<snippet28>
+class LetSample1
 {
-    //<snippet28>
-    class LetSample1
+    static void Main()
     {
-        static void Main()
+        string[] strings =
+        [
+            "A penny saved is a penny earned.",
+            "The early bird catches the worm.",
+            "The pen is mightier than the sword."
+        ];
+
+        // Split the sentence into an array of words
+        // and select those whose first letter is a vowel.
+        var earlyBirdQuery =
+            from sentence in strings
+            let words = sentence.Split(' ')
+            from word in words
+            let w = word.ToLower()
+            where w[0] == 'a' || w[0] == 'e'
+                || w[0] == 'i' || w[0] == 'o'
+                || w[0] == 'u'
+            select word;
+
+        // Execute the query.
+        foreach (var v in earlyBirdQuery)
         {
-            string[] strings =
-            {
-                "A penny saved is a penny earned.",
-                "The early bird catches the worm.",
-                "The pen is mightier than the sword."
-            };
-
-            // Split the sentence into an array of words
-            // and select those whose first letter is a vowel.
-            var earlyBirdQuery =
-                from sentence in strings
-                let words = sentence.Split(' ')
-                from word in words
-                let w = word.ToLower()
-                where w[0] == 'a' || w[0] == 'e'
-                    || w[0] == 'i' || w[0] == 'o'
-                    || w[0] == 'u'
-                select word;
-
-            // Execute the query.
-            foreach (var v in earlyBirdQuery)
-            {
-                Console.WriteLine("\"{0}\" starts with a vowel", v);
-            }
-
-            // Keep the console window open in debug mode.
-            Console.WriteLine("Press any key to exit.");
-            Console.ReadKey();
+            Console.WriteLine("\"{0}\" starts with a vowel", v);
         }
     }
-    /* Output:
-        "A" starts with a vowel
-        "is" starts with a vowel
-        "a" starts with a vowel
-        "earned." starts with a vowel
-        "early" starts with a vowel
-        "is" starts with a vowel
-    */
-    //</snippet28>
 }
+/* Output:
+    "A" starts with a vowel
+    "is" starts with a vowel
+    "a" starts with a vowel
+    "earned." starts with a vowel
+    "early" starts with a vowel
+    "is" starts with a vowel
+*/
+//</snippet28>

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/CsCsrefQueryKeywords/CS/Orderby.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/CsCsrefQueryKeywords/CS/Orderby.cs
@@ -1,149 +1,133 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿namespace OrderbyClause;
 
-namespace OrderbyClause
+//<snippet20>
+class OrderbySample1
 {
-    using CommonTypes;
-
-    //<snippet20>
-    class OrderbySample1
+    static void Main()
     {
-        static void Main()
+        // Create a delicious data source.
+        string[] fruits = ["cherry", "apple", "blueberry"];
+
+        // Query for ascending sort.
+        IEnumerable<string> sortAscendingQuery =
+            from fruit in fruits
+            orderby fruit //"ascending" is default
+            select fruit;
+
+        // Query for descending sort.
+        IEnumerable<string> sortDescendingQuery =
+            from w in fruits
+            orderby w descending
+            select w;
+
+        // Execute the query.
+        Console.WriteLine("Ascending:");
+        foreach (string s in sortAscendingQuery)
         {
-            // Create a delicious data source.
-            string[] fruits = { "cherry", "apple", "blueberry" };
+            Console.WriteLine(s);
+        }
 
-            // Query for ascending sort.
-            IEnumerable<string> sortAscendingQuery =
-                from fruit in fruits
-                orderby fruit //"ascending" is default
-                select fruit;
-
-            // Query for descending sort.
-            IEnumerable<string> sortDescendingQuery =
-                from w in fruits
-                orderby w descending
-                select w;
-
-            // Execute the query.
-            Console.WriteLine("Ascending:");
-            foreach (string s in sortAscendingQuery)
-            {
-                Console.WriteLine(s);
-            }
-
-            // Execute the query.
-            Console.WriteLine(Environment.NewLine + "Descending:");
-            foreach (string s in sortDescendingQuery)
-            {
-                Console.WriteLine(s);
-            }
-
-            // Keep the console window open in debug mode.
-            Console.WriteLine("Press any key to exit.");
-            Console.ReadKey();
+        // Execute the query.
+        Console.WriteLine(Environment.NewLine + "Descending:");
+        foreach (string s in sortDescendingQuery)
+        {
+            Console.WriteLine(s);
         }
     }
-    /* Output:
-    Ascending:
-    apple
-    blueberry
-    cherry
-
-    Descending:
-    cherry
-    blueberry
-    apple
-    */
-    //</snippet20>
-
-    //<snippet22>
-    class OrderbySample2
-    {
-        // The element type of the data source.
-        public class Student
-        {
-            public string First { get; set; }
-            public string Last { get; set; }
-            public int ID { get; set; }
-        }
-
-        public static List<Student> GetStudents()
-        {
-            // Use a collection initializer to create the data source. Note that each element
-            //  in the list contains an inner sequence of scores.
-            List<Student> students = new List<Student>
-            {
-               new Student {First="Svetlana", Last="Omelchenko", ID=111},
-               new Student {First="Claire", Last="O'Donnell", ID=112},
-               new Student {First="Sven", Last="Mortensen", ID=113},
-               new Student {First="Cesar", Last="Garcia", ID=114},
-               new Student {First="Debra", Last="Garcia", ID=115}
-            };
-
-            return students;
-        }
-        static void Main(string[] args)
-        {
-            // Create the data source.
-            List<Student> students = GetStudents();
-
-            // Create the query.
-            IEnumerable<Student> sortedStudents =
-                from student in students
-                orderby student.Last ascending, student.First ascending
-                select student;
-
-            // Execute the query.
-            Console.WriteLine("sortedStudents:");
-            foreach (Student student in sortedStudents)
-                Console.WriteLine(student.Last + " " + student.First);
-
-            // Now create groups and sort the groups. The query first sorts the names
-            // of all students so that they will be in alphabetical order after they are
-            // grouped. The second orderby sorts the group keys in alpha order.
-            var sortedGroups =
-                from student in students
-                orderby student.Last, student.First
-                group student by student.Last[0] into newGroup
-                orderby newGroup.Key
-                select newGroup;
-
-            // Execute the query.
-            Console.WriteLine(Environment.NewLine + "sortedGroups:");
-            foreach (var studentGroup in sortedGroups)
-            {
-                Console.WriteLine(studentGroup.Key);
-                foreach (var student in studentGroup)
-                {
-                    Console.WriteLine("   {0}, {1}", student.Last, student.First);
-                }
-            }
-
-            // Keep the console window open in debug mode
-            Console.WriteLine("Press any key to exit.");
-            Console.ReadKey();
-        }
-    }
-    /* Output:
-    sortedStudents:
-    Garcia Cesar
-    Garcia Debra
-    Mortensen Sven
-    O'Donnell Claire
-    Omelchenko Svetlana
-
-    sortedGroups:
-    G
-       Garcia, Cesar
-       Garcia, Debra
-    M
-       Mortensen, Sven
-    O
-       O'Donnell, Claire
-       Omelchenko, Svetlana
-    */
-    //</snippet22>
 }
+/* Output:
+Ascending:
+apple
+blueberry
+cherry
+
+Descending:
+cherry
+blueberry
+apple
+*/
+//</snippet20>
+
+//<snippet22>
+class OrderbySample2
+{
+    // The element type of the data source.
+    public class Student
+    {
+        public required string First { get; init; }
+        public required string Last { get; init; }
+        public int ID { get; set; }
+    }
+
+    public static List<Student> GetStudents()
+    {
+        // Use a collection initializer to create the data source. Note that each element
+        //  in the list contains an inner sequence of scores.
+        List<Student> students = new List<Student>
+        {
+           new Student {First="Svetlana", Last="Omelchenko", ID=111},
+           new Student {First="Claire", Last="O'Donnell", ID=112},
+           new Student {First="Sven", Last="Mortensen", ID=113},
+           new Student {First="Cesar", Last="Garcia", ID=114},
+           new Student {First="Debra", Last="Garcia", ID=115}
+        };
+
+        return students;
+    }
+    static void Main(string[] args)
+    {
+        // Create the data source.
+        List<Student> students = GetStudents();
+
+        // Create the query.
+        IEnumerable<Student> sortedStudents =
+            from student in students
+            orderby student.Last ascending, student.First ascending
+            select student;
+
+        // Execute the query.
+        Console.WriteLine("sortedStudents:");
+        foreach (Student student in sortedStudents)
+            Console.WriteLine(student.Last + " " + student.First);
+
+        // Now create groups and sort the groups. The query first sorts the names
+        // of all students so that they will be in alphabetical order after they are
+        // grouped. The second orderby sorts the group keys in alpha order.
+        var sortedGroups =
+            from student in students
+            orderby student.Last, student.First
+            group student by student.Last[0] into newGroup
+            orderby newGroup.Key
+            select newGroup;
+
+        // Execute the query.
+        Console.WriteLine(Environment.NewLine + "sortedGroups:");
+        foreach (var studentGroup in sortedGroups)
+        {
+            Console.WriteLine(studentGroup.Key);
+            foreach (var student in studentGroup)
+            {
+                Console.WriteLine("   {0}, {1}", student.Last, student.First);
+            }
+        }
+    }
+}
+/* Output:
+sortedStudents:
+Garcia Cesar
+Garcia Debra
+Mortensen Sven
+O'Donnell Claire
+Omelchenko Svetlana
+
+sortedGroups:
+G
+   Garcia, Cesar
+   Garcia, Debra
+M
+   Mortensen, Sven
+O
+   O'Donnell, Claire
+   Omelchenko, Svetlana
+*/
+//</snippet22>

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/CsCsrefQueryKeywords/CS/Select.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/CsCsrefQueryKeywords/CS/Select.cs
@@ -1,268 +1,256 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿namespace SelectClause;
 
-namespace SelectClause
+//<Snippet8>
+class SelectSample1
 {
-    //<Snippet8>
-    class SelectSample1
+    static void Main()
     {
-        static void Main()
+        //Create the data source
+        List<int> Scores = [97, 92, 81, 60];
+
+        // Create the query.
+        IEnumerable<int> queryHighScores =
+            from score in Scores
+            where score > 80
+            select score;
+
+        // Execute the query.
+        foreach (int i in queryHighScores)
         {
-            //Create the data source
-            List<int> Scores = new List<int>() { 97, 92, 81, 60 };
-
-            // Create the query.
-            IEnumerable<int> queryHighScores =
-                from score in Scores
-                where score > 80
-                select score;
-
-            // Execute the query.
-            foreach (int i in queryHighScores)
-            {
-                Console.Write(i + " ");
-            }
+            Console.Write(i + " ");
         }
     }
-    //Output: 97 92 81
-    //</Snippet8>
+}
+//Output: 97 92 81
+//</Snippet8>
 
-    //<Snippet9>
-    class SelectSample2
+//<Snippet9>
+class SelectSample2
+{
+    // Define some classes
+    public class Student
     {
-        // Define some classes
-        public class Student
+        public required string First { get; init; }
+        public required string Last { get; init; }
+        public required int ID { get; init; }
+        public required List<int> Scores;
+        public ContactInfo? GetContactInfo(SelectSample2 app, int id)
         {
-            public string First { get; set; }
-            public string Last { get; set; }
-            public int ID { get; set; }
-            public List<int> Scores;
-            public ContactInfo GetContactInfo(SelectSample2 app, int id)
-            {
-                ContactInfo cInfo =
-                    (from ci in app.contactList
-                    where ci.ID == id
-                    select ci)
-                    .FirstOrDefault();
+            ContactInfo? cInfo =
+                (from ci in app.contactList
+                where ci.ID == id
+                select ci)
+                .FirstOrDefault();
 
-                return cInfo;
-            }
-
-            public override string ToString()
-            {
-                return First + " " + Last + ":" + ID;
-            }
+            return cInfo;
         }
 
-        public class ContactInfo
+        public override string ToString() => $"{First} {Last}:{ID}";
+    }
+
+    public class ContactInfo
+    {
+        public required int ID { get; init; }
+        public required string Email { get; init; }
+        public required string Phone { get; init; }
+        public override string ToString() => $"{Email},{Phone}";
+    }
+
+    public class ScoreInfo
+    {
+        public double Average { get; init; }
+        public int ID { get; init; }
+    }
+
+    // The primary data source
+    List<Student> students =
+    [
+         new Student {First="Svetlana", Last="Omelchenko", ID=111, Scores= new List<int>() {97, 92, 81, 60}},
+         new Student {First="Claire", Last="O'Donnell", ID=112, Scores= new List<int>() {75, 84, 91, 39}},
+         new Student {First="Sven", Last="Mortensen", ID=113, Scores= new List<int>() {88, 94, 65, 91}},
+         new Student {First="Cesar", Last="Garcia", ID=114, Scores= new List<int>() {97, 89, 85, 82}},
+    ];
+
+    // Separate data source for contact info.
+    List<ContactInfo> contactList =
+    [
+        new ContactInfo {ID=111, Email="SvetlanO@Contoso.com", Phone="206-555-0108"},
+        new ContactInfo {ID=112, Email="ClaireO@Contoso.com", Phone="206-555-0298"},
+        new ContactInfo {ID=113, Email="SvenMort@Contoso.com", Phone="206-555-1130"},
+        new ContactInfo {ID=114, Email="CesarGar@Contoso.com", Phone="206-555-0521"}
+    ];
+
+    static void Main(string[] args)
+    {
+        SelectSample2 app = new SelectSample2();
+
+        // Produce a filtered sequence of unmodified Students.
+        IEnumerable<Student> studentQuery1 =
+            from student in app.students
+            where student.ID > 111
+            select student;
+
+        Console.WriteLine("Query1: select range_variable");
+        foreach (Student s in studentQuery1)
         {
-            public int ID { get; set; }
-            public string Email { get; set; }
-            public string Phone { get; set; }
-            public override string ToString() { return Email + "," + Phone; }
+            Console.WriteLine(s.ToString());
         }
 
-        public class ScoreInfo
+        // Produce a filtered sequence of elements that contain
+        // only one property of each Student.
+        IEnumerable<String> studentQuery2 =
+            from student in app.students
+            where student.ID > 111
+            select student.Last;
+
+        Console.WriteLine("\r\n studentQuery2: select range_variable.Property");
+        foreach (string s in studentQuery2)
         {
-            public double Average { get; set; }
-            public int ID { get; set; }
+            Console.WriteLine(s);
         }
 
-        // The primary data source
-        List<Student> students = new List<Student>()
+        // Produce a filtered sequence of objects created by
+        // a method call on each Student.
+        IEnumerable<ContactInfo> studentQuery3 =
+            from student in app.students
+            where student.ID > 111
+            select student.GetContactInfo(app, student.ID);
+
+        Console.WriteLine("\r\n studentQuery3: select range_variable.Method");
+        foreach (ContactInfo ci in studentQuery3)
         {
-             new Student {First="Svetlana", Last="Omelchenko", ID=111, Scores= new List<int>() {97, 92, 81, 60}},
-             new Student {First="Claire", Last="O'Donnell", ID=112, Scores= new List<int>() {75, 84, 91, 39}},
-             new Student {First="Sven", Last="Mortensen", ID=113, Scores= new List<int>() {88, 94, 65, 91}},
-             new Student {First="Cesar", Last="Garcia", ID=114, Scores= new List<int>() {97, 89, 85, 82}},
-        };
-
-        // Separate data source for contact info.
-        List<ContactInfo> contactList = new List<ContactInfo>()
-        {
-            new ContactInfo {ID=111, Email="SvetlanO@Contoso.com", Phone="206-555-0108"},
-            new ContactInfo {ID=112, Email="ClaireO@Contoso.com", Phone="206-555-0298"},
-            new ContactInfo {ID=113, Email="SvenMort@Contoso.com", Phone="206-555-1130"},
-            new ContactInfo {ID=114, Email="CesarGar@Contoso.com", Phone="206-555-0521"}
-        };
-
-        static void Main(string[] args)
-        {
-            SelectSample2 app = new SelectSample2();
-
-            // Produce a filtered sequence of unmodified Students.
-            IEnumerable<Student> studentQuery1 =
-                from student in app.students
-                where student.ID > 111
-                select student;
-
-            Console.WriteLine("Query1: select range_variable");
-            foreach (Student s in studentQuery1)
-            {
-                Console.WriteLine(s.ToString());
-            }
-
-            // Produce a filtered sequence of elements that contain
-            // only one property of each Student.
-            IEnumerable<String> studentQuery2 =
-                from student in app.students
-                where student.ID > 111
-                select student.Last;
-
-            Console.WriteLine("\r\n studentQuery2: select range_variable.Property");
-            foreach (string s in studentQuery2)
-            {
-                Console.WriteLine(s);
-            }
-
-            // Produce a filtered sequence of objects created by
-            // a method call on each Student.
-            IEnumerable<ContactInfo> studentQuery3 =
-                from student in app.students
-                where student.ID > 111
-                select student.GetContactInfo(app, student.ID);
-
-            Console.WriteLine("\r\n studentQuery3: select range_variable.Method");
-            foreach (ContactInfo ci in studentQuery3)
-            {
-                Console.WriteLine(ci.ToString());
-            }
-
-            // Produce a filtered sequence of ints from
-            // the internal array inside each Student.
-            IEnumerable<int> studentQuery4 =
-                from student in app.students
-                where student.ID > 111
-                select student.Scores[0];
-
-            Console.WriteLine("\r\n studentQuery4: select range_variable[index]");
-            foreach (int i in studentQuery4)
-            {
-                Console.WriteLine("First score = {0}", i);
-            }
-
-            // Produce a filtered sequence of doubles
-            // that are the result of an expression.
-            IEnumerable<double> studentQuery5 =
-                from student in app.students
-                where student.ID > 111
-                select student.Scores[0] * 1.1;
-
-            Console.WriteLine("\r\n studentQuery5: select expression");
-            foreach (double d in studentQuery5)
-            {
-                Console.WriteLine("Adjusted first score = {0}", d);
-            }
-
-            // Produce a filtered sequence of doubles that are
-            // the result of a method call.
-            IEnumerable<double> studentQuery6 =
-                from student in app.students
-                where student.ID > 111
-                select student.Scores.Average();
-
-            Console.WriteLine("\r\n studentQuery6: select expression2");
-            foreach (double d in studentQuery6)
-            {
-                Console.WriteLine("Average = {0}", d);
-            }
-
-            // Produce a filtered sequence of anonymous types
-            // that contain only two properties from each Student.
-            var studentQuery7 =
-                from student in app.students
-                where student.ID > 111
-                select new { student.First, student.Last };
-
-            Console.WriteLine("\r\n studentQuery7: select new anonymous type");
-            foreach (var item in studentQuery7)
-            {
-                Console.WriteLine("{0}, {1}", item.Last, item.First);
-            }
-
-            // Produce a filtered sequence of named objects that contain
-            // a method return value and a property from each Student.
-            // Use named types if you need to pass the query variable
-            // across a method boundary.
-            IEnumerable<ScoreInfo> studentQuery8 =
-                from student in app.students
-                where student.ID > 111
-                select new ScoreInfo
-                {
-                    Average = student.Scores.Average(),
-                    ID = student.ID
-                };
-
-            Console.WriteLine("\r\n studentQuery8: select new named type");
-            foreach (ScoreInfo si in studentQuery8)
-            {
-                Console.WriteLine("ID = {0}, Average = {1}", si.ID, si.Average);
-            }
-
-            // Produce a filtered sequence of students who appear on a contact list
-            // and whose average is greater than 85.
-            IEnumerable<ContactInfo> studentQuery9 =
-                from student in app.students
-                where student.Scores.Average() > 85
-                join ci in app.contactList on student.ID equals ci.ID
-                select ci;
-
-            Console.WriteLine("\r\n studentQuery9: select result of join clause");
-            foreach (ContactInfo ci in studentQuery9)
-            {
-                Console.WriteLine("ID = {0}, Email = {1}", ci.ID, ci.Email);
-            }
-
-            // Keep the console window open in debug mode
-            Console.WriteLine("Press any key to exit.");
-            Console.ReadKey();
-            }
+            Console.WriteLine(ci.ToString());
         }
-    /* Output
-        Query1: select range_variable
-        Claire O'Donnell:112
-        Sven Mortensen:113
-        Cesar Garcia:114
 
-        studentQuery2: select range_variable.Property
-        O'Donnell
-        Mortensen
-        Garcia
+        // Produce a filtered sequence of ints from
+        // the internal array inside each Student.
+        IEnumerable<int> studentQuery4 =
+            from student in app.students
+            where student.ID > 111
+            select student.Scores[0];
 
-        studentQuery3: select range_variable.Method
-        ClaireO@Contoso.com,206-555-0298
-        SvenMort@Contoso.com,206-555-1130
-        CesarGar@Contoso.com,206-555-0521
+        Console.WriteLine("\r\n studentQuery4: select range_variable[index]");
+        foreach (int i in studentQuery4)
+        {
+            Console.WriteLine("First score = {0}", i);
+        }
 
-        studentQuery4: select range_variable[index]
-        First score = 75
-        First score = 88
-        First score = 97
+        // Produce a filtered sequence of doubles
+        // that are the result of an expression.
+        IEnumerable<double> studentQuery5 =
+            from student in app.students
+            where student.ID > 111
+            select student.Scores[0] * 1.1;
 
-        studentQuery5: select expression
-        Adjusted first score = 82.5
-        Adjusted first score = 96.8
-        Adjusted first score = 106.7
+        Console.WriteLine("\r\n studentQuery5: select expression");
+        foreach (double d in studentQuery5)
+        {
+            Console.WriteLine("Adjusted first score = {0}", d);
+        }
 
-        studentQuery6: select expression2
-        Average = 72.25
-        Average = 84.5
-        Average = 88.25
+        // Produce a filtered sequence of doubles that are
+        // the result of a method call.
+        IEnumerable<double> studentQuery6 =
+            from student in app.students
+            where student.ID > 111
+            select student.Scores.Average();
 
-        studentQuery7: select new anonymous type
-        O'Donnell, Claire
-        Mortensen, Sven
-        Garcia, Cesar
+        Console.WriteLine("\r\n studentQuery6: select expression2");
+        foreach (double d in studentQuery6)
+        {
+            Console.WriteLine("Average = {0}", d);
+        }
 
-        studentQuery8: select new named type
-        ID = 112, Average = 72.25
-        ID = 113, Average = 84.5
-        ID = 114, Average = 88.25
+        // Produce a filtered sequence of anonymous types
+        // that contain only two properties from each Student.
+        var studentQuery7 =
+            from student in app.students
+            where student.ID > 111
+            select new { student.First, student.Last };
 
-        studentQuery9: select result of join clause
-        ID = 114, Email = CesarGar@Contoso.com
+        Console.WriteLine("\r\n studentQuery7: select new anonymous type");
+        foreach (var item in studentQuery7)
+        {
+            Console.WriteLine("{0}, {1}", item.Last, item.First);
+        }
+
+        // Produce a filtered sequence of named objects that contain
+        // a method return value and a property from each Student.
+        // Use named types if you need to pass the query variable
+        // across a method boundary.
+        IEnumerable<ScoreInfo> studentQuery8 =
+            from student in app.students
+            where student.ID > 111
+            select new ScoreInfo
+            {
+                Average = student.Scores.Average(),
+                ID = student.ID
+            };
+
+        Console.WriteLine("\r\n studentQuery8: select new named type");
+        foreach (ScoreInfo si in studentQuery8)
+        {
+            Console.WriteLine("ID = {0}, Average = {1}", si.ID, si.Average);
+        }
+
+        // Produce a filtered sequence of students who appear on a contact list
+        // and whose average is greater than 85.
+        IEnumerable<ContactInfo> studentQuery9 =
+            from student in app.students
+            where student.Scores.Average() > 85
+            join ci in app.contactList on student.ID equals ci.ID
+            select ci;
+
+        Console.WriteLine("\r\n studentQuery9: select result of join clause");
+        foreach (ContactInfo ci in studentQuery9)
+        {
+            Console.WriteLine("ID = {0}, Email = {1}", ci.ID, ci.Email);
+        }
+    }
+}
+/* Output
+    Query1: select range_variable
+    Claire O'Donnell:112
+    Sven Mortensen:113
+    Cesar Garcia:114
+
+    studentQuery2: select range_variable.Property
+    O'Donnell
+    Mortensen
+    Garcia
+
+    studentQuery3: select range_variable.Method
+    ClaireO@Contoso.com,206-555-0298
+    SvenMort@Contoso.com,206-555-1130
+    CesarGar@Contoso.com,206-555-0521
+
+    studentQuery4: select range_variable[index]
+    First score = 75
+    First score = 88
+    First score = 97
+
+    studentQuery5: select expression
+    Adjusted first score = 82.5
+    Adjusted first score = 96.8
+    Adjusted first score = 106.7
+
+    studentQuery6: select expression2
+    Average = 72.25
+    Average = 84.5
+    Average = 88.25
+
+    studentQuery7: select new anonymous type
+    O'Donnell, Claire
+    Mortensen, Sven
+    Garcia, Cesar
+
+    studentQuery8: select new named type
+    ID = 112, Average = 72.25
+    ID = 113, Average = 84.5
+    ID = 114, Average = 88.25
+
+    studentQuery9: select result of join clause
+    ID = 114, Email = CesarGar@Contoso.com
 */
-    //</Snippet9>
-} //class SelectClause
+//</Snippet9>
+//class SelectClause

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/CsCsrefQueryKeywords/CS/Where.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/CsCsrefQueryKeywords/CS/Where.cs
@@ -1,103 +1,94 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿namespace Where;
 
-namespace Where
-{
-    //<snippet5>
-    class WhereSample
-    {
-        static void Main()
-        {
-            // Simple data source. Arrays support IEnumerable<T>.
-            int[] numbers = { 5, 4, 1, 3, 9, 8, 6, 7, 2, 0 };
-
-            // Simple query with one predicate in where clause.
-            var queryLowNums =
-                from num in numbers
-                where num < 5
-                select num;
-
-            // Execute the query.
-            foreach (var s in queryLowNums)
-            {
-                Console.Write(s.ToString() + " ");
-            }
-        }
-    }
-    //Output: 4 1 3 2 0
-    //</snippet5>
-
-    //<snippet6>
-class WhereSample2
+//<snippet5>
+class WhereSample
 {
     static void Main()
     {
-        // Data source.
-        int[] numbers = { 5, 4, 1, 3, 9, 8, 6, 7, 2, 0 };
+        // Simple data source. Arrays support IEnumerable<T>.
+        int[] numbers = [5, 4, 1, 3, 9, 8, 6, 7, 2, 0];
 
-        // Create the query with two predicates in where clause.
-        var queryLowNums2 =
-            from num in numbers
-            where num < 5 && num % 2 == 0
-            select num;
-
-        // Execute the query
-        foreach (var s in queryLowNums2)
-        {
-            Console.Write(s.ToString() + " ");
-        }
-        Console.WriteLine();
-
-        // Create the query with two where clause.
-        var queryLowNums3 =
+        // Simple query with one predicate in where clause.
+        var queryLowNums =
             from num in numbers
             where num < 5
-            where num % 2 == 0
             select num;
 
-        // Execute the query
-        foreach (var s in queryLowNums3)
+        // Execute the query.
+        foreach (var s in queryLowNums)
         {
             Console.Write(s.ToString() + " ");
         }
     }
+}
+//Output: 4 1 3 2 0
+//</snippet5>
+
+//<snippet6>
+class WhereSample2
+{
+static void Main()
+{
+    // Data source.
+    int[] numbers = [5, 4, 1, 3, 9, 8, 6, 7, 2, 0];
+
+    // Create the query with two predicates in where clause.
+    var queryLowNums2 =
+        from num in numbers
+        where num < 5 && num % 2 == 0
+        select num;
+
+    // Execute the query
+    foreach (var s in queryLowNums2)
+    {
+        Console.Write(s.ToString() + " ");
+    }
+    Console.WriteLine();
+
+    // Create the query with two where clause.
+    var queryLowNums3 =
+        from num in numbers
+        where num < 5
+        where num % 2 == 0
+        select num;
+
+    // Execute the query
+    foreach (var s in queryLowNums3)
+    {
+        Console.Write(s.ToString() + " ");
+    }
+}
 }
 // Output:
 // 4 2 0
 // 4 2 0
-    //</snippet6>
+//</snippet6>
 
-    //<snippet7>
-    class WhereSample3
+//<snippet7>
+class WhereSample3
+{
+    static void Main()
     {
-        static void Main()
+        // Data source
+        int[] numbers = [5, 4, 1, 3, 9, 8, 6, 7, 2, 0];
+
+        // Create the query with a method call in the where clause.
+        // Note: This won't work in LINQ to SQL unless you have a
+        // stored procedure that is mapped to a method by this name.
+        var queryEvenNums =
+            from num in numbers
+            where IsEven(num)
+            select num;
+
+         // Execute the query.
+        foreach (var s in queryEvenNums)
         {
-            // Data source
-            int[] numbers = { 5, 4, 1, 3, 9, 8, 6, 7, 2, 0 };
-
-            // Create the query with a method call in the where clause.
-            // Note: This won't work in LINQ to SQL unless you have a
-            // stored procedure that is mapped to a method by this name.
-            var queryEvenNums =
-                from num in numbers
-                where IsEven(num)
-                select num;
-
-             // Execute the query.
-            foreach (var s in queryEvenNums)
-            {
-                Console.Write(s.ToString() + " ");
-            }
-        }
-
-        // Method may be instance method or static method.
-        static bool IsEven(int i)
-        {
-            return i % 2 == 0;
+            Console.Write(s.ToString() + " ");
         }
     }
-    //Output: 4 8 6 2 0
-    //</snippet7>
+
+    // Method may be instance method or static method.
+    static bool IsEven(int i) => i % 2 == 0;
 }
+//Output: 4 8 6 2 0
+//</snippet7>

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/CsCsrefQueryKeywords/CS/csquerykeywords.csproj
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/CsCsrefQueryKeywords/CS/csquerykeywords.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/CsCsrefQueryKeywords/CS/csquerykeywords.csproj
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/CsCsrefQueryKeywords/CS/csquerykeywords.csproj
@@ -2,8 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net48</TargetFramework>
-
+    <TargetFramework>net8</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
     <StartupObject>Group.GroupSample2</StartupObject>
   </PropertyGroup>
 

--- a/samples/snippets/csharp/concepts/methods/byref108.cs
+++ b/samples/snippets/csharp/concepts/methods/byref108.cs
@@ -5,7 +5,7 @@ class RefArrayExample
 {
     static void Main()
     {
-        int[] arr = {1, 4, 5};
+        int[] arr = [1, 4, 5];
         Console.WriteLine("In Main, array has {0} elements and starts with {1}",
                           arr.Length, arr[0]);
 
@@ -17,7 +17,7 @@ class RefArrayExample
     static void Change(ref int[] arr)
     {
         // Both of the following changes will affect the original variables:
-        arr = new int[5] {-9, -7, -5, -3, -1};
+        arr = [-9, -7, -5, -3, -1];
         Console.WriteLine("In Change, array has {0} elements and starts with {1}",
                           arr.Length, arr[0]);
     }

--- a/samples/snippets/csharp/concepts/methods/methods.csproj
+++ b/samples/snippets/csharp/concepts/methods/methods.csproj
@@ -2,10 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <StartupObject>methods.Program</StartupObject>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/samples/snippets/csharp/concepts/methods/params75.cs
+++ b/samples/snippets/csharp/concepts/methods/params75.cs
@@ -6,7 +6,7 @@ class ParamsExample
 {
     static void Main()
     {
-        string fromArray = GetVowels(new[] { "apple", "banana", "pear" });
+        string fromArray = GetVowels(["apple", "banana", "pear"]);
         Console.WriteLine($"Vowels from array: '{fromArray}'");
 
         string fromMultipleArguments = GetVowels("apple", "banana", "pear");
@@ -26,7 +26,7 @@ class ParamsExample
             return string.Empty;
         }
 
-        var vowels = new char[] { 'A', 'E', 'I', 'O', 'U' };
+        char[] vowels = ['A', 'E', 'I', 'O', 'U'];
         return string.Concat(
             input.SelectMany(
                 word => word.Where(letter => vowels.Contains(char.ToUpper(letter)))));

--- a/samples/snippets/csharp/concepts/methods/return44.cs
+++ b/samples/snippets/csharp/concepts/methods/return44.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-//<Snippet44>
+﻿//<Snippet44>
 class SimpleMath
 {
     public int AddTwoNumbers(int number1, int number2)

--- a/samples/snippets/csharp/concepts/methods/returnarray1.cs
+++ b/samples/snippets/csharp/concepts/methods/returnarray1.cs
@@ -6,7 +6,7 @@ public class ArrayValueExample
 {
    static void Main(string[] args)
    {
-      int[] values = { 2, 4, 6, 8 };
+      int[] values = [2, 4, 6, 8];
       DoubleValues(values);
       foreach (var value in values)
          Console.Write("{0}  ", value);

--- a/samples/snippets/csharp/concepts/methods/swap107.cs
+++ b/samples/snippets/csharp/concepts/methods/swap107.cs
@@ -1,6 +1,7 @@
 ﻿// <Snippet107>
 
 using System;
+
 public class RefSwapExample
 {
    static void Main()

--- a/samples/snippets/csharp/concepts/methods/swap107.cs
+++ b/samples/snippets/csharp/concepts/methods/swap107.cs
@@ -1,6 +1,6 @@
 ﻿// <Snippet107>
-using System;
 
+using System;
 public class RefSwapExample
 {
    static void Main()


### PR DESCRIPTION
Contributes to #37000 

Update all the samples in the C# Language reference to use collection expressions where applicable.

I converted a number of the source files to use file scoped namespaces. Hide whitespace to better see actual diffs.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/stackalloc.md](https://github.com/dotnet/docs/blob/7a9861a616d29ddd2cf4ef9dd9881074890c0e74/docs/csharp/language-reference/operators/stackalloc.md) | [stackalloc expression (C# reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/stackalloc?branch=pr-en-us-37993) |


<!-- PREVIEW-TABLE-END -->