### PR TITLE
Mention DOTNET_SKIP_FIRST_TIME_EXPERIENCE being unsupported

### DIFF
--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -233,6 +233,9 @@ Specifies whether data about the .NET tools usage is collected and sent to Micro
 
 If `DOTNET_SKIP_FIRST_TIME_EXPERIENCE` is set to `true`, the `NuGetFallbackFolder` won't be expanded to disk and a shorter welcome message and telemetry notice will be shown.
 
+> [!NOTE]
+> This environment variable is no longer supported in .NET Core 3.0 and beyond.
+
 ### `DOTNET_MULTILEVEL_LOOKUP`
 
 Specifies whether the .NET runtime, shared framework, or SDK are resolved from the global location. If not set, it defaults to 1 (logical `true`). Set the value to 0 (logical `false`) to not resolve from the global location and have isolated .NET installations. For more information about multi-level lookup, see [Multi-level SharedFX Lookup](https://github.com/dotnet/core-setup/blob/master/Documentation/design-docs/multilevel-sharedfx-lookup.md).

--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -234,7 +234,7 @@ Specifies whether data about the .NET tools usage is collected and sent to Micro
 If `DOTNET_SKIP_FIRST_TIME_EXPERIENCE` is set to `true`, the `NuGetFallbackFolder` won't be expanded to disk and a shorter welcome message and telemetry notice will be shown.
 
 > [!NOTE]
-> This environment variable is no longer supported in .NET Core 3.0 and beyond.
+> This environment variable is no longer supported in .NET Core 3.0 and later.
 > Use [`DOTNET_NOLOGO`](#dotnet_nologo) as a replacement.
 
 ### `DOTNET_MULTILEVEL_LOOKUP`

--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -235,6 +235,7 @@ If `DOTNET_SKIP_FIRST_TIME_EXPERIENCE` is set to `true`, the `NuGetFallbackFolde
 
 > [!NOTE]
 > This environment variable is no longer supported in .NET Core 3.0 and beyond.
+> Use [`DOTNET_NOLOGO`](#dotnet_nologo) as a replacement.
 
 ### `DOTNET_MULTILEVEL_LOOKUP`
 


### PR DESCRIPTION
This pull request fixes #37830.
It adds the NOTE paragraph to `DOTNET_SKIP_FIRST_TIME_EXPERIENCE` regarding this variable to no longer be supported as of .NET Core 3.0.
There is also a link to `DOTNET_NOLOGO` from that same page, to not leave the reader/dev/user without any alternative.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-environment-variables.md](https://github.com/dotnet/docs/blob/60c16611b6d6e96ee244752a9f12a853d84d0893/docs/core/tools/dotnet-environment-variables.md) | [.NET environment variables](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables?branch=pr-en-us-38004) |


<!-- PREVIEW-TABLE-END -->