### PR TITLE
Old term MSIL changed to CIL

### DIFF
--- a/docs/csharp/whats-new/tutorials/primary-constructors.md
+++ b/docs/csharp/whats-new/tutorials/primary-constructors.md
@@ -59,7 +59,7 @@ The preceding examples use primary constructor parameters to initialize readonly
 
 In the preceding example, the `Translate` method changes the `dx` and `dy` components. That requires the `Magnitude` and `Direction` properties be computed when accessed. The `=>` operator designates an expression-bodied `get` accessor, whereas the `=` operator designates an initializer. This version adds a parameterless constructor to the struct. The parameterless constructor must invoke the primary constructor, so that all the primary constructor parameters are initialized.
 
-In the previous example, the primary constructor properties are accessed in a method. Therefore the compiler creates hidden fields to represent each parameter. The following code shows approximately what the compiler generates. The actual field names are valid MSIL identifiers, but not valid C# identifiers.
+In the previous example, the primary constructor properties are accessed in a method. Therefore the compiler creates hidden fields to represent each parameter. The following code shows approximately what the compiler generates. The actual field names are valid CIL identifiers, but not valid C# identifiers.
 
 :::code source="./snippets/primary-constructors/Distance.cs" id="StructTwoLowered":::
 


### PR DESCRIPTION
Microsoft Intermediate Language (MSIL) is the old term for Common Intermediate Language (CIL).

https://www.wikiwand.com/en/Common_Intermediate_Language

## Summary

Describe your changes here.

Fixes #38005


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/whats-new/tutorials/primary-constructors.md](https://github.com/dotnet/docs/blob/09cf0345f305451e4eed6a1deb5ad050e79486f9/docs/csharp/whats-new/tutorials/primary-constructors.md) | [Tutorial: Explore primary constructors](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/tutorials/primary-constructors?branch=pr-en-us-38010) |

<!-- PREVIEW-TABLE-END -->