### PR TITLE
Update csharp-12 interceptor

### DIFF
--- a/docs/csharp/whats-new/csharp-12.md
+++ b/docs/csharp/whats-new/csharp-12.md
@@ -135,7 +135,7 @@ Types, methods, or assemblies can be marked with the <xref:System.Diagnostics.Co
 > [!WARNING]
 > Interceptors are an experimental feature, available in preview mode with C# 12. The feature may be subject to breaking changes or removal in a future release. Therefore, it is not recommended for production or released applications.
 >
-> In order to use interceptors, the user project must specify the property <InterceptorsPreviewNamespaces>. This is a list of namespaces which are allowed to contain interceptors.
+> In order to use interceptors, the user project must specify the property `<InterceptorsPreviewNamespaces>`. This is a list of namespaces which are allowed to contain interceptors.
 >
 > For example: `<InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);Microsoft.AspNetCore.Http.Generated;MyLibrary.Generated</InterceptorsPreviewNamespaces>`
 

--- a/docs/csharp/whats-new/csharp-12.md
+++ b/docs/csharp/whats-new/csharp-12.md
@@ -136,7 +136,7 @@ Types, methods, or assemblies can be marked with the <xref:System.Diagnostics.Co
 > Interceptors are an experimental feature, available in preview mode with C# 12. The feature may be subject to breaking changes or removal in a future release. Therefore, it is not recommended for production or released applications.
 >
 > In order to use interceptors, the user project must specify the property <InterceptorsPreviewNamespaces>. This is a list of namespaces which are allowed to contain interceptors.
-> 
+>
 > For example: `<InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);Microsoft.AspNetCore.Http.Generated;MyLibrary.Generated</InterceptorsPreviewNamespaces>`
 
 An *interceptor* is a method that can declaratively substitute a call to an *interceptable* method with a call to itself at compile time. This substitution occurs by having the interceptor declare the source locations of the calls that it intercepts. Interceptors provide a limited facility to change the semantics of existing code by adding new code to a compilation, for example in a source generator.

--- a/docs/csharp/whats-new/csharp-12.md
+++ b/docs/csharp/whats-new/csharp-12.md
@@ -136,10 +136,10 @@ Types, methods, or assemblies can be marked with the <xref:System.Diagnostics.Co
 > Interceptors are an experimental feature, available in preview mode with C# 12. The feature may be subject to breaking changes or removal in a future release. Therefore, it is not recommended for production or released applications.
 >
 > In order to use interceptors, the user project must specify the property <InterceptorsPreviewNamespaces>. This is a list of namespaces which are allowed to contain interceptors.
-> for example: `<InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);Microsoft.AspNetCore.Http.Generated;MyLibrary.Generated</InterceptorsPreviewNamespaces>`
+> 
+> For example: `<InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);Microsoft.AspNetCore.Http.Generated;MyLibrary.Generated</InterceptorsPreviewNamespaces>`
 
 An *interceptor* is a method that can declaratively substitute a call to an *interceptable* method with a call to itself at compile time. This substitution occurs by having the interceptor declare the source locations of the calls that it intercepts. Interceptors provide a limited facility to change the semantics of existing code by adding new code to a compilation, for example in a source generator.
-
 
 You use an *interceptor* as part of a source generator to modify, rather than add code to an existing source compilation. The source generator substitutes calls to an interceptable method with a call to the *interceptor* method.
 

--- a/docs/csharp/whats-new/csharp-12.md
+++ b/docs/csharp/whats-new/csharp-12.md
@@ -135,9 +135,11 @@ Types, methods, or assemblies can be marked with the <xref:System.Diagnostics.Co
 > [!WARNING]
 > Interceptors are an experimental feature, available in preview mode with C# 12. The feature may be subject to breaking changes or removal in a future release. Therefore, it is not recommended for production or released applications.
 >
-> In order to use interceptors, you'll need to set the `<Features>InterceptorsPreview</Features>` element in your project file. Without this flag, interceptors are disabled, even when other C# 12 features are enabled.
+> In order to use interceptors, the user project must specify the property <InterceptorsPreviewNamespaces>. This is a list of namespaces which are allowed to contain interceptors.
+> for example: `<InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);Microsoft.AspNetCore.Http.Generated;MyLibrary.Generated</InterceptorsPreviewNamespaces>`
 
-An *interceptor* is a method that can declaratively substitute a call to an *interceptable* method with a call to itself at compile time. This substitution occurs by having the interceptor declare the source locations of the calls that it intercepts. Interceptors provides a limited facility to change the semantics of existing code by adding new code to a compilation, for example in a source generator.
+An *interceptor* is a method that can declaratively substitute a call to an *interceptable* method with a call to itself at compile time. This substitution occurs by having the interceptor declare the source locations of the calls that it intercepts. Interceptors provide a limited facility to change the semantics of existing code by adding new code to a compilation, for example in a source generator.
+
 
 You use an *interceptor* as part of a source generator to modify, rather than add code to an existing source compilation. The source generator substitutes calls to an interceptable method with a call to the *interceptor* method.
 


### PR DESCRIPTION
## Summary

Update `<Features>InterceptorsPreview</Features>` to `<InterceptorsPreviewNamespaces>` for interceptor

this behavior changed since .NET 8 RC 2

see details in the Roslyn docs: https://github.com/dotnet/roslyn/blob/main/docs/features/interceptors.md#user-opt-in


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/whats-new/csharp-12.md](https://github.com/dotnet/docs/blob/21bc3557b9bcb811f32ff48f2457d968dccec58e/docs/csharp/whats-new/csharp-12.md) | [What's new in C# 12](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-12?branch=pr-en-us-38023) |


<!-- PREVIEW-TABLE-END -->