### PR TITLE
Update Interactive programming with F#

### DIFF
--- a/docs/fsharp/tools/fsharp-interactive/index.md
+++ b/docs/fsharp/tools/fsharp-interactive/index.md
@@ -12,7 +12,11 @@ F# Interactive (dotnet fsi) is used to run F# code interactively at the console,
 To run F# Interactive from the console, run `dotnet fsi`. You will find `dotnet fsi` in any .NET SDK.
 
 > [!NOTE]
-> If you intend to use F# interactive under .NET Framework runtime, you'll need the [Visual Studio Build Tools](https://visualstudio.microsoft.com/downloads/?q=build+tools) or an edition of Visual Studio installed, and invoke the `FsiAnyCPU.exe` command from a "Developer Command Prompt" or simply make `FsiAnyCPU.exe` available in the `PATH` environment variable.
+> If you intend to use F# interactive under .NET Framework runtime, you'll need the [Visual Studio Build Tools](https://visualstudio.microsoft.com/downloads/?q=build+tools) or an edition of Visual Studio installed, and invoke the `FsiAnyCPU.exe` command from a "Developer Command Prompt" or simply make `FsiAnyCPU.exe` available in the `PATH` environment variable, in place of `dotnet fsi` command line.
+> 
+> Tooling supports defining version F# Interactive runtime:
+> * In Visual Studio: In the menu bar, **Tools** / **Options** then **F# Tools** / **F# Interactive**, and adjust **Use .NET Core Scripting**.
+> * In Visual Studio Code (ionide extension): In the command palette, **Preferences: Open User Settings**, then **Extensions** / **F#** / **FSharp: Fsi Sdk File Path**.
 
 For information about available command-line options, see [F# Interactive Options](../../language-reference/fsharp-interactive-options.md).
 
@@ -88,9 +92,9 @@ F# scripting is natively supported in [Visual Studio](../../get-started/get-star
 ## Referencing packages in F# Interactive
 
 > [!NOTE]
-> Package management system is extensible.
+> Package management system is extensible, see more about the [plugins and extension mechanism](https://aka.ms/dotnetdepmanager).
 
-F# Interactive supports referencing NuGet packages with the `#r "nuget:"` syntax and an optional version:
+Since 5.0 release of the language, F# Interactive supports referencing packages through an extensibility mechanism, out of the box, it can reference NuGet packages with the `#r "nuget:"` syntax and an optional version:
 
 ```fsharp
 #r "nuget: Newtonsoft.Json"
@@ -118,6 +122,7 @@ let f (x: Tensor) = sin (sqrt x)
 printfn $"{f (dsharp.tensor 1.2)}"
 ```
 
+
 ### Specifying a package source
 
 You can also specify a package source with the `#i` command. The following example specifies a remote and a local source:
@@ -133,6 +138,9 @@ You can specify as many package references as you like in a script.
 
 > [!NOTE]
 > There's currently a limitation for scripts that use framework references (e.g.`Microsoft.NET.Sdk.Web` or  `Microsoft.NET.Sdk.WindowsDesktop`). Packages like Saturn, Giraffe, WinForms are not available. This is being tracked in issue [#9417](https://github.com/dotnet/fsharp/issues/9417).
+> WinForms, still works in the .NET Framework version of F# Interactive.
+>
+> To load additional extensions beside those shipped with the SDK and/or with your tooling, use the `--compilertool:<extensionsfolderpath>` flag as argument for F# Interactive session (or in your tooling settings).
 
 ## Referencing assemblies on disk with F# interactive
 
@@ -229,12 +237,15 @@ The `#r` and `#load` directives seen previously are only available in F# Interac
 |Directive|Description|
 |---------|-----------|
 |`#r "nuget:..."`|References a package from NuGet|
+|`#r "extname:..."`|Reference a package from `extname` extension (such as `paket`)|
 |`#r "assembly-name.dll"`|References an assembly on disk|
 |`#load "file-name.fsx"`|Reads a source file, compiles it, and runs it.|
 |`#help`|Displays information about available directives.|
 |`#I`|Specifies an assembly search path in quotation marks.|
 |`#quit`|Terminates an F# Interactive session.|
 |`#time "on"` or `#time "off"`|By itself, `#time` toggles whether to display performance information. When it is `"on"`, F# Interactive measures real time, CPU time, and garbage collection information for each section of code that is interpreted and executed.|
+
+[^1]: More about [F# Interactive extensions](https://aka.ms/dotnetdepmanager).
 
 When you specify files or paths in F# Interactive, a string literal is expected. Therefore, files and paths must be in quotation marks, and the usual escape characters apply. You can use the `@` character to cause F# Interactive to interpret a string that contains a path as a verbatim string. This causes F# Interactive to ignore any escape characters.
 

--- a/docs/fsharp/tools/fsharp-interactive/index.md
+++ b/docs/fsharp/tools/fsharp-interactive/index.md
@@ -122,7 +122,6 @@ let f (x: Tensor) = sin (sqrt x)
 printfn $"{f (dsharp.tensor 1.2)}"
 ```
 
-
 ### Specifying a package source
 
 You can also specify a package source with the `#i` command. The following example specifies a remote and a local source:

--- a/docs/fsharp/tools/fsharp-interactive/index.md
+++ b/docs/fsharp/tools/fsharp-interactive/index.md
@@ -13,7 +13,7 @@ To run F# Interactive from the console, run `dotnet fsi`. You will find `dotnet 
 
 > [!NOTE]
 > If you intend to use F# interactive under .NET Framework runtime, you'll need the [Visual Studio Build Tools](https://visualstudio.microsoft.com/downloads/?q=build+tools) or an edition of Visual Studio installed, and invoke the `FsiAnyCPU.exe` command from a "Developer Command Prompt" or simply make `FsiAnyCPU.exe` available in the `PATH` environment variable, in place of `dotnet fsi` command line.
-> 
+>
 > Tooling supports defining version F# Interactive runtime:
 > * In Visual Studio: In the menu bar, **Tools** / **Options** then **F# Tools** / **F# Interactive**, and adjust **Use .NET Core Scripting**.
 > * In Visual Studio Code (ionide extension): In the command palette, **Preferences: Open User Settings**, then **Extensions** / **F#** / **FSharp: Fsi Sdk File Path**.

--- a/docs/fsharp/tools/fsharp-interactive/index.md
+++ b/docs/fsharp/tools/fsharp-interactive/index.md
@@ -95,7 +95,7 @@ F# scripting is natively supported in [Visual Studio](../../get-started/get-star
 > [!NOTE]
 > Package management system is extensible, see more about the [plugins and extension mechanism](https://aka.ms/dotnetdepmanager).
 
-Since 5.0 release of the language, F# Interactive supports referencing packages through an extensibility mechanism, out of the box, it can reference NuGet packages with the `#r "nuget:"` syntax and an optional version:
+Since 5.0 release of the language, F# Interactive supports referencing packages through an extensibility mechanism; out of the box, it can reference NuGet packages with the `#r "nuget:"` syntax and an optional version:
 
 ```fsharp
 #r "nuget: Newtonsoft.Json"

--- a/docs/fsharp/tools/fsharp-interactive/index.md
+++ b/docs/fsharp/tools/fsharp-interactive/index.md
@@ -237,7 +237,7 @@ The `#r` and `#load` directives seen previously are only available in F# Interac
 |Directive|Description|
 |---------|-----------|
 |`#r "nuget:..."`|References a package from NuGet|
-|`#r "extname:..."`|Reference a package from `extname` extension (such as `paket`)|
+|`#r "extname:..."`|Reference a package from `extname` extension[^1] (such as `paket`)|
 |`#r "assembly-name.dll"`|References an assembly on disk|
 |`#load "file-name.fsx"`|Reads a source file, compiles it, and runs it.|
 |`#help`|Displays information about available directives.|

--- a/docs/fsharp/tools/fsharp-interactive/index.md
+++ b/docs/fsharp/tools/fsharp-interactive/index.md
@@ -15,6 +15,7 @@ To run F# Interactive from the console, run `dotnet fsi`. You will find `dotnet 
 > If you intend to use F# interactive under .NET Framework runtime, you'll need the [Visual Studio Build Tools](https://visualstudio.microsoft.com/downloads/?q=build+tools) or an edition of Visual Studio installed, and invoke the `FsiAnyCPU.exe` command from a "Developer Command Prompt" or simply make `FsiAnyCPU.exe` available in the `PATH` environment variable, in place of `dotnet fsi` command line.
 >
 > Tooling supports defining version F# Interactive runtime:
+>
 > * In Visual Studio: In the menu bar, **Tools** / **Options** then **F# Tools** / **F# Interactive**, and adjust **Use .NET Core Scripting**.
 > * In Visual Studio Code (ionide extension): In the command palette, **Preferences: Open User Settings**, then **Extensions** / **F#** / **FSharp: Fsi Sdk File Path**.
 


### PR DESCRIPTION
## Summary

* describe how to pick the interpreter in Visual Studio and Visual Studio Code, precise `FsiAnyCpu.exe` instead of `dotnet fsi`
* add precision and link to https://aka.ms/dotnetdepmanager about plugins and extension mechanism
* add precision about Winforms
* add precision about using `--compilertool:` command line argument to load out-of-band extensions

see also: #38027

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/tools/fsharp-interactive/index.md](https://github.com/dotnet/docs/blob/3ca1f4e4cb04af208f313e0ab6ad38a8344e66bf/docs/fsharp/tools/fsharp-interactive/index.md) | [Interactive programming with F\#](https://review.learn.microsoft.com/en-us/dotnet/fsharp/tools/fsharp-interactive/index?branch=pr-en-us-38026) |


<!-- PREVIEW-TABLE-END -->