### PR TITLE
Move explanatory comments from code snippets to their articles

### DIFF
--- a/docs/csharp/linq/create-a-nested-group.md
+++ b/docs/csharp/linq/create-a-nested-group.md
@@ -16,6 +16,7 @@ The following example shows how to create nested groups in a LINQ query expressi
 :::code language="csharp" source="../../../samples/snippets/csharp/concepts/linq/LinqSamples/NestedGroups.cs" id="nested_groups_1":::
 
 Note that three nested `foreach` loops are required to iterate over the inner elements of a nested group.
+<br/>(Hover the mouse cursor over the iteration variables, `outerGroup`, `innerGroup` and `innerGroupElement` to see their actual type.)
 
 ## See also
 

--- a/docs/csharp/linq/group-query-results.md
+++ b/docs/csharp/linq/group-query-results.md
@@ -35,11 +35,15 @@ The following example shows how to group source elements by using something othe
 
 :::code language="csharp" source="../../../samples/snippets/csharp/concepts/linq/LinqSamples/GroupQueryResults.cs" id="group_query_results_2":::
 
+Note that nested foreach is required to access group items.
+
 ## Group by a range example
 
 The following example shows how to group source elements by using a numeric range as a group key. The query then projects the results into an anonymous type that contains only the first and last name and the percentile range to which the student belongs. An anonymous type is used because it is not necessary to use the complete `Student` object to display the results. `GetPercentile` is a helper function that calculates a percentile based on the student's average score. The method returns an integer between 0 and 10.
 
 :::code language="csharp" source="../../../samples/snippets/csharp/concepts/linq/LinqSamples/GroupQueryResults.cs" id="group_query_results_3":::
+
+Note that nested foreach required to iterate over groups and group items.
 
 ## Group by comparison example
 

--- a/docs/csharp/linq/group-results-by-contiguous-keys.md
+++ b/docs/csharp/linq/group-results-by-contiguous-keys.md
@@ -45,6 +45,7 @@ In the presented code, of `ChunkExtensions` class implementation, the `while(tru
 <br/>(The chunk is represented by [`Chunk`](#chunk-class) class.)
 <br/>in the source sequence. This loop corresponds to the outer foreach loop that executes the query.
 What happens in that loop is:
+
 1. Get the key for the current Chunk, by assigning it to `key` variable: `var key = keySelector(enumerator.Current);`. The source iterator will churn through the source sequence until it finds an element with a key that doesn't match.
 2. Make a new Chunk (group) object, and store it in `current` variable, that initially has one GroupItem, which is a copy of the current source element.
 3. Return that Chunk. A Chunk is an `IGrouping<TKey,TSource>`, which is the return value of the [`ChunkBy`](#chunk-class) method. At this point the Chunk only has the first element in its source sequence. The remaining elements will be returned only when the client code foreach's over this chunk. See `Chunk.GetEnumerator` for more info.

--- a/docs/csharp/linq/group-results-by-contiguous-keys.md
+++ b/docs/csharp/linq/group-results-by-contiguous-keys.md
@@ -35,7 +35,39 @@ Thread-safety is accomplished by making a copy of each group or chunk as the sou
 
 The following example shows both the extension method and the client code that uses it:
 
-:::code language="csharp" source="../../../samples/snippets/csharp/concepts/linq/LinqSamples/GroupByContiguousKeys.cs" id="group_by_contiguous_keys_1":::
+:::code language="csharp" source="../../../samples/snippets/csharp/concepts/linq/LinqSamples/GroupByContiguousKeys.cs" id="group_by_contiguous_keys_chunkextensions":::
+
+:::code language="csharp" source="../../../samples/snippets/csharp/concepts/linq/LinqSamples/GroupByContiguousKeys.cs" id="group_by_contiguous_keys_client_code":::
+
+### `ChunkExtensions` class
+
+In the presented code, of `ChunkExtensions` class implementation, the `while(true)`, loop in the `ChunkBy` method, iterates through source sequence and create a copy of each Chunk. On each pass, the iterator advances to the first element of the next "Chunk"
+<br/>(The chunk is represented by [`Chunk`](#chunk-class) class.)
+<br/>in the source sequence. This loop corresponds to the outer foreach loop that executes the query.
+What happens in that loop is:
+1. Get the key for the current Chunk, by assigning it to `key` variable: `var key = keySelector(enumerator.Current);`. The source iterator will churn through the source sequence until it finds an element with a key that doesn't match.
+2. Make a new Chunk (group) object, and store it in `current` variable, that initially has one GroupItem, which is a copy of the current source element.
+3. Return that Chunk. A Chunk is an `IGrouping<TKey,TSource>`, which is the return value of the [`ChunkBy`](#chunk-class) method. At this point the Chunk only has the first element in its source sequence. The remaining elements will be returned only when the client code foreach's over this chunk. See `Chunk.GetEnumerator` for more info.
+4. Check to see whether
+<br/>(a) the chunk has made a copy of all its source elements or
+<br/>(b) the iterator has reached the end of the source sequence.
+<br/>If the caller uses an inner foreach loop to iterate the chunk items, and that loop ran to completion, then the `Chunk.GetEnumerator` method will already have made copies of all chunk items before we get here. If the `Chunk.GetEnumerator` loop did not enumerate all elements in the chunk, we need to do it here to avoid corrupting the iterator for clients that may be calling us on a separate thread.
+
+### `Chunk` class
+
+The `Chunk` class is a contiguous group of one or more source elements that have the same key. A Chunk has a key and a list of ChunkItem objects, which are copies of the elements in the source sequence.
+<br/>A Chunk has a linked list of `ChunkItem`s, which represent the elements in the current chunk. Each `ChunkItem` (represented by `ChunkItem` class) has a reference to the next `ChunkItem` in the list.
+The list consists of it's `head` - which stores the contents of the first source element that belongs with this chunk, and it's `tail` - which is an end of the list. It is repositioned each time a new `ChunkItem` is added.
+<br/>The `Chunk` class contains the private boolean field: `DoneCopyingChunk`, which indicates that all chunk elements have been copied to the list of ChunkItems, and the source enumerator is either at the end, or else on an element with a new key.
+The tail of the linked list is set to `null` in the `CopyNextChunkElement` method if the key of the next element does not match the current chunk's key, or there are no more elements in the source.
+
+The `CopyNextChunkElement` method of the `Chunk` class adds one `ChunkItem` to the current group of items.
+<br/>By using `enumerator.MoveNext()` method, it tries to advance the iterator on the source sequence. If `MoveNext()` method returns `false` it means that iteration is at the end, and `isLastSourceElement` is set to `true`.
+Then, if iteration is at the end of the source, or at the end of the current chunk then the `enumerator` and `predicate` is null out for reuse with the next chunk.
+
+The `CopyAllChunkElements` method is called after the end of the last chunk was reached. It first checks whether there are more elements in the source sequence. If there are, it returns `true` if enumerator for this chunk was exhausted. In this method, when private `DoneCopyingChunk` field is checked for `true`, if isLastSourceElement is `false`, it signals to the outer iterator to continue iterating.
+
+The `GetEnumerator` method of the `Chunk` class is invoked by the inner foreach loop. This method stays just one step ahead of the client requests. It adds the next element of the chunk only after the clients requests the last element in the list so far.
 
 ## See also
 

--- a/docs/csharp/linq/handle-exceptions-in-query-expressions.md
+++ b/docs/csharp/linq/handle-exceptions-in-query-expressions.md
@@ -12,17 +12,23 @@ The final example shows how to handle those cases when you must throw an excepti
 
 ## Example 1
 
-The following example shows how to move exception handling code outside a query expression. This is only possible when the method does not depend on any variables local to the query.
+The following example shows how to move exception handling code outside a query expression. This is only possible when the method does not depend on any variables local to the query. It is easier to deal with exceptions outside of the query expression.
 
 :::code language="csharp" source="../../../samples/snippets/csharp/concepts/linq/LinqSamples/Exceptions.cs" id="exceptions_1":::
+
+Note that in the `catch (InvalidOperationException)` in the example above, handle (or don't handle) the exception in the way that is appropriate for your application.
 
 ## Example 2
 
 In some cases, the best response to an exception that is thrown from within a query might be to stop the query execution immediately. The following example shows how to handle exceptions that might be thrown from inside a query body. Assume that `SomeMethodThatMightThrow` can potentially cause an exception that requires the query execution to stop.
 
 Note that the `try` block encloses the `foreach` loop, and not the query itself. This is because the `foreach` loop is the point at which the query is actually executed. For more information, see [Introduction to LINQ queries](../programming-guide/concepts/linq/introduction-to-linq-queries.md).
+The runtime exception will only be thrown when the query is executed.
+Therefore they must be handled in the `foreach` loop.
 
 :::code language="csharp" source="../../../samples/snippets/csharp/concepts/linq/LinqSamples/Exceptions.cs" id="exceptions_2":::
+
+Remember to catch whatever exception you expect to raise and/or do any necessary cleanup in a finally block.
 
 ## See also
 

--- a/docs/csharp/linq/perform-custom-join-operations.md
+++ b/docs/csharp/linq/perform-custom-join-operations.md
@@ -42,6 +42,9 @@ In the following example, the query must join two sequences based on matching ke
 
 :::code language="csharp" source="../../../samples/snippets/csharp/concepts/linq/LinqSamples/CustomJoins.cs" id="merge_csv_files":::
 
+Note that `queryNamesScores`, containing the merged data sources, in the above example is using a named type. You could use `var` instead of an explicit type for the query.
+<br/>Also, the `students` variable is optional to create. This good practice of storing the newly created `Student` objects in memory allows for faster access in future queries.
+
 ## See also
 
 - [Language Integrated Query (LINQ)](index.md)

--- a/docs/csharp/linq/perform-grouped-joins.md
+++ b/docs/csharp/linq/perform-grouped-joins.md
@@ -27,6 +27,8 @@ The following example performs a group join of objects of type `Person` and `Pet
 
 :::code language="csharp" source="../../../samples/snippets/csharp/concepts/linq/LinqSamples/GroupJoins.cs" id="grouped_joins_1":::
 
+In the above example, `query` variable contains the query that creates a list where each element is an anonymous type that contains the person's first name and a collection of pets that are owned by them.
+
 ## Example - Group join to create XML
 
 Group joins are ideal for creating XML by using LINQ to XML. The following example is similar to the previous example except that instead of creating anonymous types, the result selector function creates XML elements that represent the joined objects.

--- a/docs/csharp/linq/query-expression-basics.md
+++ b/docs/csharp/linq/query-expression-basics.md
@@ -76,6 +76,8 @@ This documentation usually provides the explicit type of the query variable in o
 
 :::code language="csharp" source="../../../samples/snippets/csharp/concepts/linq/LinqSamples/Basics.cs" id="basics8":::
 
+In the above, the use of var is optional here and in all queries. `queryCities` is an `IEnumerable<City>` just as when it is explicitly typed.
+
 For more information, see [Implicitly typed local variables](../programming-guide/classes-and-structs/implicitly-typed-local-variables.md) and [Type relationships in LINQ query operations](../programming-guide/concepts/linq/type-relationships-in-linq-query-operations.md).
 
 ### Starting a query expression
@@ -113,6 +115,8 @@ Use the `select` clause to produce all other types of sequences. A simple `selec
 The `select` clause can be used to transform source data into sequences of new types. This transformation is also named a *projection*. In the following example, the `select` clause *projects* a sequence of anonymous types which contains only a subset of the fields in the original element. Note that the new objects are initialized by using an object initializer.
 
 :::code language="csharp" source="../../../samples/snippets/csharp/concepts/linq/LinqSamples/Basics.cs" id="basics13":::
+
+So in this example, the `var` is required because the query produces an anonymous type.
 
 For more information about all the ways that a `select` clause can be used to transform source data, see [select clause](../language-reference/keywords/select-clause.md).
 

--- a/docs/csharp/linq/return-a-query-from-a-method.md
+++ b/docs/csharp/linq/return-a-query-from-a-method.md
@@ -10,11 +10,30 @@ This example shows how to return a query from a method as the return value and a
   
  Query objects are composable, meaning that you can return a query from a method. Objects that represent queries do not store the resulting collection, but rather the steps to produce the results when needed. The advantage of returning query objects from methods is that they can be further composed or modified. Therefore any return value or `out` parameter of a method that returns a query must also have that type. If a method materializes a query into a concrete <xref:System.Collections.Generic.List%601> or <xref:System.Array> type, it is considered to be returning the query results instead of the query itself. A query variable that is returned from a method can still be composed or modified.  
   
-## Example  
+## Example
 
- In the following example, the first method returns a query as a return value, and the second method returns a query as an `out` parameter. Note that in both cases it is a query that is returned, not query results.  
-  
- :::code language="csharp" source="../../../samples/snippets/csharp/concepts/linq/LinqSamples/ReturnQueryFromMethod.cs" id="return_query_from_method_1":::
+In the following example, the first method `QueryMethod1` returns a query as a return value, and the second method `QueryMethod2` returns a query as an `out` parameter (`returnQ` in the example). Note that in both cases it is a query that is returned, not query results.
+
+:::code language="csharp" source="../../../samples/snippets/csharp/concepts/linq/LinqSamples/ReturnQueryFromMethod.cs" id="return_query_from_method_1":::
+
+Query `myQuery1` is executed in the following foreach loop.
+
+:::code language="csharp" source="../../../samples/snippets/csharp/concepts/linq/LinqSamples/ReturnQueryFromMethod.cs" id="return_query_from_method_2":::
+
+Rest the mouse pointer over `myQuery1` to see its type.
+
+You also can execute the query returned from `QueryMethod1` directly, without using `myQuery1`.
+
+:::code language="csharp" source="../../../samples/snippets/csharp/concepts/linq/LinqSamples/ReturnQueryFromMethod.cs" id="return_query_from_method_3":::
+
+Rest the mouse pointer over the call to `QueryMethod1` to see its return type.
+
+`QueryMethod2` returns a query as the value of its out parameter:
+:::code language="csharp" source="../../../samples/snippets/csharp/concepts/linq/LinqSamples/ReturnQueryFromMethod.cs" id="return_query_from_method_4":::
+
+You can modify a query by using query composition. In this case, the previous query object is used to create a new query object. This new object will return different results than the original query object.
+
+:::code language="csharp" source="../../../samples/snippets/csharp/concepts/linq/LinqSamples/ReturnQueryFromMethod.cs" id="return_query_from_method_5":::
 
 ## See also
 

--- a/samples/snippets/csharp/concepts/linq/LinqSamples/Basics.cs
+++ b/samples/snippets/csharp/concepts/linq/LinqSamples/Basics.cs
@@ -134,9 +134,6 @@ public static class Basics
     public static void Basics8()
     {
         // <basics8>
-        // Use of var is optional here and in all queries.
-        // queryCities is an IEnumerable<City> just as
-        // when it is explicitly typed.
         var queryCities =
             from city in cities
             where city.Population > 100000
@@ -187,8 +184,6 @@ public static class Basics
     public static void Basics13()
     {
         // <basics13>
-        // Here var is required because the query
-        // produces an anonymous type.
         var queryNameAndPop =
             from country in countries
             select new

--- a/samples/snippets/csharp/concepts/linq/LinqSamples/CustomJoins.cs
+++ b/samples/snippets/csharp/concepts/linq/LinqSamples/CustomJoins.cs
@@ -109,8 +109,6 @@ public static class CustomJoins
         string[] names = File.ReadAllLines(@"csv/names.csv");
         string[] scores = File.ReadAllLines(@"csv/scores.csv");
 
-        // Merge the data sources using a named type.
-        // You could use var instead of an explicit type for the query.
         IEnumerable<Student> queryNamesScores =
             // Split each line in the data files into an array of strings.
             from name in names
@@ -130,8 +128,6 @@ public static class CustomJoins
                 ).ToList()
             );
 
-        // Optional. Store the newly created student objects in memory
-        // for faster access in future queries
         List<Student> students = queryNamesScores.ToList();
 
         foreach (var student in students)

--- a/samples/snippets/csharp/concepts/linq/LinqSamples/Exceptions.cs
+++ b/samples/snippets/csharp/concepts/linq/LinqSamples/Exceptions.cs
@@ -9,8 +9,7 @@ public static class Exceptions
         IEnumerable<int> GetData() => throw new InvalidOperationException();
 
         // DO THIS with a datasource that might
-        // throw an exception. It is easier to deal with
-        // outside of the query expression.
+        // throw an exception.
         IEnumerable<int>? dataSource = null;
         try
         {
@@ -18,8 +17,6 @@ public static class Exceptions
         }
         catch (InvalidOperationException)
         {
-            // Handle (or don't handle) the exception
-            // in the way that is appropriate for your application.
             Console.WriteLine("Invalid operation");
         }
 
@@ -56,8 +53,6 @@ public static class Exceptions
             let n = SomeMethodThatMightThrow(file)
             select n;
 
-        // The runtime exception will only be thrown when the query is executed.
-        // Therefore they must be handled in the foreach loop.
         try
         {
             foreach (var item in exceptionDemoQuery)
@@ -66,8 +61,6 @@ public static class Exceptions
             }
         }
 
-        // Catch whatever exception you expect to raise
-        // and/or do any necessary cleanup in a finally block
         catch (InvalidOperationException e)
         {
             Console.WriteLine(e.Message);

--- a/samples/snippets/csharp/concepts/linq/LinqSamples/GroupByContiguousKeys.cs
+++ b/samples/snippets/csharp/concepts/linq/LinqSamples/GroupByContiguousKeys.cs
@@ -1,6 +1,6 @@
 ﻿namespace LinqSamples;
 
-// <group_by_contiguous_keys_1>
+// <group_by_contiguous_keys_chunkextensions>
 public static class ChunkExtensions
 {
     public static IEnumerable<IGrouping<TKey, TSource>> ChunkBy<TSource, TKey>(
@@ -27,32 +27,15 @@ public static class ChunkExtensions
             yield break;
         }
 
-        // Iterate through source sequence and create a copy of each Chunk.
-        // On each pass, the iterator advances to the first element of the next "Chunk"
-        // in the source sequence. This loop corresponds to the outer foreach loop that
-        // executes the query.
         Chunk<TKey, TSource> current = null;
         while (true)
         {
-            // Get the key for the current Chunk. The source iterator will churn through
-            // the source sequence until it finds an element with a key that doesn't match.
             var key = keySelector(enumerator.Current);
 
-            // Make a new Chunk (group) object that initially has one GroupItem, which is a copy of the current source element.
             current = new Chunk<TKey, TSource>(key, enumerator, value => comparer.Equals(key, keySelector(value)));
 
-            // Return the Chunk. A Chunk is an IGrouping<TKey,TSource>, which is the return value of the ChunkBy method.
-            // At this point the Chunk only has the first element in its source sequence. The remaining elements will be
-            // returned only when the client code foreach's over this chunk. See Chunk.GetEnumerator for more info.
             yield return current;
 
-            // Check to see whether (a) the chunk has made a copy of all its source elements or
-            // (b) the iterator has reached the end of the source sequence. If the caller uses an inner
-            // foreach loop to iterate the chunk items, and that loop ran to completion,
-            // then the Chunk.GetEnumerator method will already have made
-            // copies of all chunk items before we get here. If the Chunk.GetEnumerator loop did not
-            // enumerate all elements in the chunk, we need to do it here to avoid corrupting the iterator
-            // for clients that may be calling us on a separate thread.
             if (current.CopyAllChunkElements() == noMoreSourceElements)
             {
                 yield break;
@@ -61,9 +44,9 @@ public static class ChunkExtensions
 
     }
 }
+// </group_by_contiguous_keys_chunkextensions>
 
-// A Chunk is a contiguous group of one or more source elements that have the same key. A Chunk
-// has a key and a list of ChunkItem objects, which are copies of the elements in the source sequence.
+// <group_by_contiguous_keys_chunk_class>
 class Chunk<TKey, TSource> : IGrouping<TKey, TSource>
 {
     // INVARIANT: DoneCopyingChunk == true ||
@@ -117,10 +100,7 @@ class Chunk<TKey, TSource> : IGrouping<TKey, TSource>
         m_Lock = new object();
     }
 
-    // Indicates that all chunk elements have been copied to the list of ChunkItems,
-    // and the source enumerator is either at the end, or else on an element with a new key.
-    // the tail of the linked list is set to null in the CopyNextChunkElement method if the
-    // key of the next element does not match the current chunk's key, or there are no more elements in the source.
+    // Indicates that all chunk elements have been copied to the list of ChunkItems.
     private bool DoneCopyingChunk => tail == null;
 
     // Adds one ChunkItem to the current group
@@ -128,7 +108,6 @@ class Chunk<TKey, TSource> : IGrouping<TKey, TSource>
     private void CopyNextChunkElement()
     {
         // Try to advance the iterator on the source sequence.
-        // If MoveNext returns false we are at the end, and isLastSourceElement is set to true
         isLastSourceElement = !enumerator.MoveNext();
 
         // If we are (a) at the end of the source, or (b) at the end of the current chunk
@@ -148,9 +127,7 @@ class Chunk<TKey, TSource> : IGrouping<TKey, TSource>
         tail = tail.Next!;
     }
 
-    // Called after the end of the last chunk was reached. It first checks whether
-    // there are more elements in the source sequence. If there are, it
-    // Returns true if enumerator for this chunk was exhausted.
+    // Called after the end of the last chunk was reached.
     internal bool CopyAllChunkElements()
     {
         while (true)
@@ -159,9 +136,6 @@ class Chunk<TKey, TSource> : IGrouping<TKey, TSource>
             {
                 if (DoneCopyingChunk)
                 {
-                    // If isLastSourceElement is false,
-                    // it signals to the outer iterator
-                    // to continue iterating.
                     return isLastSourceElement;
                 }
                 else
@@ -174,12 +148,10 @@ class Chunk<TKey, TSource> : IGrouping<TKey, TSource>
 
     public TKey Key { get; }
 
-    // Invoked by the inner foreach loop. This method stays just one step ahead
-    // of the client requests. It adds the next element of the chunk only after
-    // the clients requests the last element in the list so far.
+    // Stays just one step ahead of the client requests.
     public IEnumerator<TSource> GetEnumerator()
     {
-        //Specify the initial element to enumerate.
+        // Specify the initial element to enumerate.
         ChunkItem current = head;
 
         // There should always be at least one ChunkItem in a Chunk.
@@ -205,7 +177,9 @@ class Chunk<TKey, TSource> : IGrouping<TKey, TSource>
 
     System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
 }
+// </group_by_contiguous_keys_chunk_class>
 
+// <group_by_contiguous_keys_client_code>
 public static class GroupByContiguousKeys
 {
     // The source sequence.
@@ -239,4 +213,4 @@ public static class GroupByContiguousKeys
         }
     }
 }
-// </group_by_contiguous_keys_1>
+// </group_by_contiguous_keys_client_code>

--- a/samples/snippets/csharp/concepts/linq/LinqSamples/GroupJoins.cs
+++ b/samples/snippets/csharp/concepts/linq/LinqSamples/GroupJoins.cs
@@ -23,9 +23,6 @@ public static class GroupJoins
             new("Daisy", magnus),
         };
 
-        // Create a list where each element is an anonymous type
-        // that contains the person's first name and a collection of
-        // pets that are owned by them.
         var query =
             from person in people
             join pet in pets on person equals pet.Owner into gj

--- a/samples/snippets/csharp/concepts/linq/LinqSamples/GroupQueryResults.cs
+++ b/samples/snippets/csharp/concepts/linq/LinqSamples/GroupQueryResults.cs
@@ -62,7 +62,6 @@ public static class GroupQueryResults
         foreach (var studentGroup in groupByFirstLetterQuery)
         {
             Console.WriteLine($"Key: {studentGroup.Key}");
-            // Nested foreach is required to access group items.
             foreach (var student in studentGroup)
             {
                 Console.WriteLine($"\t{student.LastName}, {student.FirstName}");
@@ -114,7 +113,6 @@ public static class GroupQueryResults
             orderby percentGroup.Key
             select percentGroup;
 
-        // Nested foreach required to iterate over groups and group items.
         foreach (var studentGroup in groupByPercentileQuery)
         {
             Console.WriteLine($"Key: {studentGroup.Key * 10}");

--- a/samples/snippets/csharp/concepts/linq/LinqSamples/NestedGroups.cs
+++ b/samples/snippets/csharp/concepts/linq/LinqSamples/NestedGroups.cs
@@ -16,9 +16,6 @@ public class NestedGroups
             )
             group newGroup2 by newGroup1.Key;
 
-        // Three nested foreach loops are required to iterate
-        // over all elements of a grouped group. Hover the mouse
-        // cursor over the iteration variables to see their actual type.
         foreach (var outerGroup in nestedGroupsQuery)
         {
             Console.WriteLine($"DataClass.Student Level = {outerGroup.Key}");

--- a/samples/snippets/csharp/concepts/linq/LinqSamples/ReturnQueryFromMethod.cs
+++ b/samples/snippets/csharp/concepts/linq/LinqSamples/ReturnQueryFromMethod.cs
@@ -5,13 +5,11 @@ public class ReturnQueryFromMethod
     public static void ReturnQueryFromMethod1()
     {
         // <return_query_from_method_1>
-        // QueryMethod1 returns a query as its value.
         IEnumerable<string> QueryMethod1(int[] ints) =>
             from i in ints
             where i > 4
             select i.ToString();
 
-        // QueryMethod2 returns a query as the value of the out parameter returnQ
         void QueryMethod2(int[] ints, out IEnumerable<string> returnQ) =>
             returnQ =
                 from i in ints
@@ -20,40 +18,37 @@ public class ReturnQueryFromMethod
 
         int[] nums = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 
-        // QueryMethod1 returns a query as the value of the method.
         var myQuery1 = QueryMethod1(nums);
+        // </return_query_from_method_1>
 
-        // Query myQuery1 is executed in the following foreach loop.
         Console.WriteLine("Results of executing myQuery1:");
-        // Rest the mouse pointer over myQuery1 to see its type.
+        // <return_query_from_method_2>
         foreach (var s in myQuery1)
         {
             Console.WriteLine(s);
         }
+        // </return_query_from_method_2>
 
-        // You also can execute the query returned from QueryMethod1
-        // directly, without using myQuery1.
         Console.WriteLine("\nResults of executing myQuery1 directly:");
-        // Rest the mouse pointer over the call to QueryMethod1 to see its
-        // return type.
+        // <return_query_from_method_3>
         foreach (var s in QueryMethod1(nums))
         {
             Console.WriteLine(s);
         }
+        // </return_query_from_method_3>
 
-        // QueryMethod2 returns a query as the value of its out parameter.
+        Console.WriteLine("\nResults of executing myQuery2:");
+        // <return_query_from_method_4>
         QueryMethod2(nums, out IEnumerable<string> myQuery2);
 
         // Execute the returned query.
-        Console.WriteLine("\nResults of executing myQuery2:");
         foreach (var s in myQuery2)
         {
             Console.WriteLine(s);
         }
+        // </return_query_from_method_4>
 
-        // You can modify a query by using query composition. In this case, the
-        // previous query object is used to create a new query object; this new object
-        // will return different results than the original query object.
+        // <return_query_from_method_5>
         myQuery1 =
             from item in myQuery1
             orderby item descending
@@ -65,6 +60,6 @@ public class ReturnQueryFromMethod
         {
             Console.WriteLine(s);
         }
-        // </return_query_from_method_1>
+        // </return_query_from_method_5>
     }
 }


### PR DESCRIPTION
This pull request closes #28273 

It moves crucial or more advanced, explanatory comments from the code snippets, to the articles linking these snippets for translations.

The strategy I took for this PR is to go file by file through all `csharp/linq` dir pages and check for their associated code files to look for the comments that meet the following criteria:
Are more explanatory then the description in the article,
Describe something that is not mentioned in the article,
Feels crucial due to their length, complexity, etc,
After finding such comment, I either:
moved it directly to the article, by direct copying it,
or refactored it a bit to embed the explanation in the article.

Most of the times I deleted the comment that was directly copied into article, to avoid duplicating of translated and non-translated text describing the same part of code example.

In two articles: `return-a-query-from-a-method.md` and `group-results-by-contiguous-keys.md` I had to refactor how the examples are linked into the articles.
This was done to have a better control of how the moved comments apply to their appropriate part of code. This way I could almost directly copy the comments and not worry whether they will still relate to the code.

The only exception is the `perform-inner-joins.md` article, where the description and explanations in the article was already decent, so I decided to avoid moving the comments from the code, as I didn't want to introduce duplications, or confusions explaining something twice. Hence I left that one intact in this PR.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/linq/create-a-nested-group.md](https://github.com/dotnet/docs/blob/aafcce060842cef82c43786ffd58f47c95d12a1a/docs/csharp/linq/create-a-nested-group.md) | [Create a nested group](https://review.learn.microsoft.com/en-us/dotnet/csharp/linq/create-a-nested-group?branch=pr-en-us-38029) |
| [docs/csharp/linq/group-query-results.md](https://github.com/dotnet/docs/blob/aafcce060842cef82c43786ffd58f47c95d12a1a/docs/csharp/linq/group-query-results.md) | [Group query results (LINQ in C#)](https://review.learn.microsoft.com/en-us/dotnet/csharp/linq/group-query-results?branch=pr-en-us-38029) |
| [docs/csharp/linq/group-results-by-contiguous-keys.md](https://github.com/dotnet/docs/blob/aafcce060842cef82c43786ffd58f47c95d12a1a/docs/csharp/linq/group-results-by-contiguous-keys.md) | [Group results by contiguous keys](https://review.learn.microsoft.com/en-us/dotnet/csharp/linq/group-results-by-contiguous-keys?branch=pr-en-us-38029) |
| [docs/csharp/linq/handle-exceptions-in-query-expressions.md](https://github.com/dotnet/docs/blob/aafcce060842cef82c43786ffd58f47c95d12a1a/docs/csharp/linq/handle-exceptions-in-query-expressions.md) | [docs/csharp/linq/handle-exceptions-in-query-expressions](https://review.learn.microsoft.com/en-us/dotnet/csharp/linq/handle-exceptions-in-query-expressions?branch=pr-en-us-38029) |
| [docs/csharp/linq/perform-custom-join-operations.md](https://github.com/dotnet/docs/blob/aafcce060842cef82c43786ffd58f47c95d12a1a/docs/csharp/linq/perform-custom-join-operations.md) | [Perform custom join operations](https://review.learn.microsoft.com/en-us/dotnet/csharp/linq/perform-custom-join-operations?branch=pr-en-us-38029) |
| [docs/csharp/linq/perform-grouped-joins.md](https://github.com/dotnet/docs/blob/aafcce060842cef82c43786ffd58f47c95d12a1a/docs/csharp/linq/perform-grouped-joins.md) | [Perform grouped joins (LINQ in C#)](https://review.learn.microsoft.com/en-us/dotnet/csharp/linq/perform-grouped-joins?branch=pr-en-us-38029) |
| [docs/csharp/linq/query-expression-basics.md](https://github.com/dotnet/docs/blob/aafcce060842cef82c43786ffd58f47c95d12a1a/docs/csharp/linq/query-expression-basics.md) | [Query expression basics](https://review.learn.microsoft.com/en-us/dotnet/csharp/linq/query-expression-basics?branch=pr-en-us-38029) |
| [docs/csharp/linq/return-a-query-from-a-method.md](https://github.com/dotnet/docs/blob/aafcce060842cef82c43786ffd58f47c95d12a1a/docs/csharp/linq/return-a-query-from-a-method.md) | [docs/csharp/linq/return-a-query-from-a-method](https://review.learn.microsoft.com/en-us/dotnet/csharp/linq/return-a-query-from-a-method?branch=pr-en-us-38029) |


<!-- PREVIEW-TABLE-END -->