### PR TITLE
Remove outdated -all argument to gcroot

### DIFF
--- a/docs/core/diagnostics/debug-memory-leak.md
+++ b/docs/core/diagnostics/debug-memory-leak.md
@@ -2,7 +2,7 @@
 title: Debug a memory leak tutorial
 description: Learn how to debug a memory leak in .NET.
 ms.topic: tutorial
-ms.date: 09/11/2023
+ms.date: 11/13/2023
 ---
 
 # Debug a memory leak in .NET
@@ -190,10 +190,10 @@ Statistics:
 Total 206770 objects
 ```
 
-You can now use the `gcroot` command on a `System.String` instance to see how and why the object is rooted. Be patient because this command takes several minutes with a 30-MB heap:
+You can now use the `gcroot` command on a `System.String` instance to see how and why the object is rooted:
 
 ```console
-> gcroot -all 00007f6ad09421f8
+> gcroot 00007f6ad09421f8
 
 Thread 3f68:
     00007F6795BB58A0 00007F6C1D7D0745 System.Diagnostics.Tracing.CounterGroup.PollForValues() [/_/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/CounterGroup.cs @ 260]


### PR DESCRIPTION
## Summary

This PR updates the documentation for "Debug a memory leak in .NET" following https://github.com/dotnet/diagnostics/pull/3766 which removed the `-all` argument from the `gcroot` command.

The performance of `gcroot` was improved so the note about it taking a long time is no longer accurate. 

See also https://github.com/dotnet/docs/issues/37673 and https://github.com/dotnet/docs/issues/35077.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/debug-memory-leak.md](https://github.com/dotnet/docs/blob/fd91ac96f70df41dc62206d1dd6329428456894a/docs/core/diagnostics/debug-memory-leak.md) | [Debug a memory leak in .NET](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/debug-memory-leak?branch=pr-en-us-38035) |

<!-- PREVIEW-TABLE-END -->