### PR TITLE
Add note about nullable type of `var` to "Iteration statements" page

### DIFF
--- a/docs/csharp/language-reference/statements/iteration-statements.md
+++ b/docs/csharp/language-reference/statements/iteration-statements.md
@@ -117,6 +117,10 @@ You can use the [`var` keyword](declarations.md#implicitly-typed-local-variables
 foreach (var item in collection) { }
 ```
 
+> [!NOTE]
+> Type of `var` can be inferred by the compiler as a nullable reference type, depending on whether the [nullable aware context](../../language-reference/builtin-types/nullable-reference-types.md) is enabled and whether the type of an initialization expression is a reference type.
+> For more information see [Implicitly-typed local variables](./declarations.md#implicitly-typed-local-variables).
+
 You can also explicitly specify the type of an iteration variable, as the following code shows:
 
 ```csharp
@@ -159,4 +163,5 @@ For more information about features added in C# 8.0 and later, see the following
 ## See also
 
 - [C# reference](../index.md)
+- [Declarations](./declarations.md)
 - [Iterators](../../iterators.md)


### PR DESCRIPTION
This pull request fixes #38020 
It adds the cross-note about `var` being nullable depending on the nullable context enabled.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/statements/iteration-statements.md](https://github.com/dotnet/docs/blob/686dfca34ecb4ce31ebb2ee33e1cf4577fbc6da2/docs/csharp/language-reference/statements/iteration-statements.md) | [Iteration statements - `for`, `foreach`, `do`, and `while`](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/statements/iteration-statements?branch=pr-en-us-38042) |

<!-- PREVIEW-TABLE-END -->