### PR TITLE
[QUIC] Shuffles QUIC dependencies

### DIFF
--- a/docs/core/extensions/httpclient-http3.md
+++ b/docs/core/extensions/httpclient-http3.md
@@ -29,7 +29,7 @@ The HTTP version can be configured by setting `HttpRequestMessage.Version` to 3.
 
 ## Platform dependencies
 
-HTTP/3 uses QUIC as its transport protocol. The .NET implementation of HTTP/3 uses [MsQuic](https://github.com/microsoft/msquic) to provide QUIC functionality. As a result, .NET support of HTTP/3 depends on MsQuic platform requirements which are documented in [QUIC Platform dependencies](../../fundamentals/networking/quic/quic-overview.md#platform-dependencies). If the platform that HttpClient is running on doesn't have all the requirements for HTTP/3, then it's disabled.
+HTTP/3 uses QUIC as its transport protocol. The .NET implementation of HTTP/3 uses [MsQuic](https://github.com/microsoft/msquic) to provide QUIC functionality. As a result, .NET support of HTTP/3 depends on MsQuic platform requirements, which are documented in [QUIC Platform dependencies](../../fundamentals/networking/quic/quic-overview.md#platform-dependencies). If the platform that HttpClient is running on doesn't have all the requirements for HTTP/3, then it's disabled.
 
 ## Using HttpClient
 

--- a/docs/core/extensions/httpclient-http3.md
+++ b/docs/core/extensions/httpclient-http3.md
@@ -29,30 +29,7 @@ The HTTP version can be configured by setting `HttpRequestMessage.Version` to 3.
 
 ## Platform dependencies
 
-HTTP/3 uses QUIC as its transport protocol. The .NET implementation of HTTP/3 uses [MsQuic](https://github.com/microsoft/msquic) to provide QUIC functionality. If the platform that HttpClient is running on doesn't have all the requirements for HTTP/3, then it's disabled.
-
-### Windows
-
-- Windows 11, Windows Server 2022, or later. (Earlier Windows versions are missing the cryptographic APIs required to support QUIC.)
-
-On Windows, msquic.dll is distributed as part of the .NET runtime, and no other steps are required to install it.
-
-### Linux
-
-- OpenSSL 1.1
-
-On Linux, libmsquic is published via Microsoft's official Linux package repository packages.microsoft.com. To consume it, it must be added manually. For more information, see [Linux Software Repository for Microsoft Products](/windows-server/administration/linux-package-repository-for-microsoft-software). After configuring the package feed, it's installed via the package manager of your distro, for example, for Ubuntu:
-
-```bash
-sudo apt install libmsquic
-```
-
-> [!NOTE]
-> .NET 7 is only compatible with 2.1+ versions of libmsquic.
-
-### macOS
-
-HTTP/3 isn't currently supported on macOS but may be available in a future release.
+HTTP/3 uses QUIC as its transport protocol. The .NET implementation of HTTP/3 uses [MsQuic](https://github.com/microsoft/msquic) to provide QUIC functionality. As a result, .NET support of HTTP/3 depends on MsQuic platform requirements which are documented in [QUIC Platform dependencies](../../fundamentals/networking/quic/quic-overview.md#platform-dependencies). If the platform that HttpClient is running on doesn't have all the requirements for HTTP/3, then it's disabled.
 
 ## Using HttpClient
 

--- a/docs/fundamentals/networking/quic/quic-overview.md
+++ b/docs/fundamentals/networking/quic/quic-overview.md
@@ -42,7 +42,7 @@ On Windows, msquic.dll is distributed as part of the .NET runtime, and no other 
 
 ### Linux
 
-All the following dependencies are stated in `libmsquic` package manifest and will be automatically installed by the package manager:
+All the following dependencies are stated in the `libmsquic` package manifest and are automatically installed by the package manager:
 
 - OpenSSL 3+ or 1.1 - depends on the default OpenSSL version for the distribution version, e.g. OpenSSL 3 for Debian 12 and OpenSSL 1.1 for Debian 11
 

--- a/docs/fundamentals/networking/quic/quic-overview.md
+++ b/docs/fundamentals/networking/quic/quic-overview.md
@@ -30,7 +30,7 @@ The QUIC implementation was introduced in .NET 5 as the `System.Net.Quic` librar
 > [!NOTE]
 > In .NET 7.0, the APIs are published as [preview features](https://github.com/dotnet/designs/blob/main/accepted/2021/preview-features/preview-features.md).
 
-From the implementation perspective, `System.Net.Quic` depends on [MsQuic](https://github.com/microsoft/msquic), the native implementation of QUIC protocol. As a result, `System.Net.Quic` platform support and dependencies are inherited from MsQuic and documented bellow in [Platform dependencies](#platform-dependencies). In short, the MsQuic library is shipped as part of .NET for Windows. But for Linux, `libmsquic` must be manually installed via an appropriate package manager. For the other platforms, it's still possible to build MsQuic manually, whether against SChannel or OpenSSL, and use it with `System.Net.Quic`. However, these scenarios are not part of our testing matrix and unforeseen problems might occur.
+From the implementation perspective, `System.Net.Quic` depends on [MsQuic](https://github.com/microsoft/msquic), the native implementation of QUIC protocol. As a result, `System.Net.Quic` platform support and dependencies are inherited from MsQuic and documented in the [Platform dependencies](#platform-dependencies) section. In short, the MsQuic library is shipped as part of .NET for Windows. But for Linux, you must manually install `libmsquic` via an appropriate package manager. For the other platforms, it's still possible to build MsQuic manually, whether against SChannel or OpenSSL, and use it with `System.Net.Quic`. However, these scenarios are not part of our testing matrix and unforeseen problems might occur.
 
 ## Platform dependencies
 

--- a/docs/fundamentals/networking/quic/quic-overview.md
+++ b/docs/fundamentals/networking/quic/quic-overview.md
@@ -44,7 +44,7 @@ On Windows, msquic.dll is distributed as part of the .NET runtime, and no other 
 
 All the following dependencies are stated in the `libmsquic` package manifest and are automatically installed by the package manager:
 
-- OpenSSL 3+ or 1.1 - depends on the default OpenSSL version for the distribution version, for example, OpenSSL 3 for Debian 12 and OpenSSL 1.1 for Debian 11.
+- OpenSSL 3+ or 1.1 - depends on the default OpenSSL version for the distribution version, for example, OpenSSL 3 for [Ubuntu 22](https://packages.ubuntu.com/jammy/openssl) and OpenSSL 1.1 for [Ubuntu 20](https://packages.ubuntu.com/focal/utils/openssl).
 
 - libnuma 1
 

--- a/docs/fundamentals/networking/quic/quic-overview.md
+++ b/docs/fundamentals/networking/quic/quic-overview.md
@@ -48,7 +48,7 @@ All the following dependencies are stated in the `libmsquic` package manifest an
 
 - libnuma 1
 
-On Linux, libmsquic is published via Microsoft's official Linux package repository, <https:packages.microsoft.com>. To consume libmsquic, you must add it manually. For more information, see [Linux Software Repository for Microsoft Products](/windows-server/administration/linux-package-repository-for-microsoft-software). After configuring the package feed, it's installed via the package manager of your distro, for example, for Ubuntu:
+On Linux, libmsquic is published via Microsoft's official Linux package repository, <https://packages.microsoft.com>. To consume libmsquic, you must add it manually. For more information, see [Linux Software Repository for Microsoft Products](/windows-server/administration/linux-package-repository-for-microsoft-software). After configuring the package feed, it's installed via the package manager of your distro, for example, for Ubuntu:
 
 ```bash
 sudo apt install libmsquic

--- a/docs/fundamentals/networking/quic/quic-overview.md
+++ b/docs/fundamentals/networking/quic/quic-overview.md
@@ -48,9 +48,7 @@ All the following dependencies are stated in `libmsquic` package manifest and wi
 
 - libnuma 1
 
-
 On Linux, libmsquic is published via Microsoft's official Linux package repository packages.microsoft.com. To consume it, it must be added manually. For more information, see [Linux Software Repository for Microsoft Products](/windows-server/administration/linux-package-repository-for-microsoft-software). After configuring the package feed, it's installed via the package manager of your distro, for example, for Ubuntu:
-
 
 ```bash
 sudo apt install libmsquic

--- a/docs/fundamentals/networking/quic/quic-overview.md
+++ b/docs/fundamentals/networking/quic/quic-overview.md
@@ -48,7 +48,7 @@ All the following dependencies are stated in the `libmsquic` package manifest an
 
 - libnuma 1
 
-On Linux, libmsquic is published via Microsoft's official Linux package repository packages.microsoft.com. To consume it, it must be added manually. For more information, see [Linux Software Repository for Microsoft Products](/windows-server/administration/linux-package-repository-for-microsoft-software). After configuring the package feed, it's installed via the package manager of your distro, for example, for Ubuntu:
+On Linux, libmsquic is published via Microsoft's official Linux package repository, <https:packages.microsoft.com>. To consume libmsquic, you must add it manually. For more information, see [Linux Software Repository for Microsoft Products](/windows-server/administration/linux-package-repository-for-microsoft-software). After configuring the package feed, it's installed via the package manager of your distro, for example, for Ubuntu:
 
 ```bash
 sudo apt install libmsquic

--- a/docs/fundamentals/networking/quic/quic-overview.md
+++ b/docs/fundamentals/networking/quic/quic-overview.md
@@ -44,7 +44,7 @@ On Windows, msquic.dll is distributed as part of the .NET runtime, and no other 
 
 All the following dependencies are stated in the `libmsquic` package manifest and are automatically installed by the package manager:
 
-- OpenSSL 3+ or 1.1 - depends on the default OpenSSL version for the distribution version, e.g. OpenSSL 3 for Debian 12 and OpenSSL 1.1 for Debian 11
+- OpenSSL 3+ or 1.1 - depends on the default OpenSSL version for the distribution version, for example, OpenSSL 3 for Debian 12 and OpenSSL 1.1 for Debian 11.
 
 - libnuma 1
 

--- a/docs/fundamentals/networking/quic/quic-overview.md
+++ b/docs/fundamentals/networking/quic/quic-overview.md
@@ -30,7 +30,38 @@ The QUIC implementation was introduced in .NET 5 as the `System.Net.Quic` librar
 > [!NOTE]
 > In .NET 7.0, the APIs are published as [preview features](https://github.com/dotnet/designs/blob/main/accepted/2021/preview-features/preview-features.md).
 
-From the implementation perspective, `System.Net.Quic` depends on [MsQuic](https://github.com/microsoft/msquic), the native implementation of QUIC protocol. As a result, `System.Net.Quic` platform support and dependencies are inherited from `MsQuic` and documented in [HTTP/3 Platform dependencies](../../../core/extensions/httpclient-http3.md#platform-dependencies). In short, the `MsQuic` library is shipped as part of .NET for Windows. But for Linux, `libmsquic` must be manually installed via an appropriate package manager. For the other platforms, it's still possible to build `MsQuic` manually, whether against SChannel or OpenSSL, and use it with `System.Net.Quic`. However, these scenarios are not part of our testing matrix and unforeseen problems might occur.
+From the implementation perspective, `System.Net.Quic` depends on [MsQuic](https://github.com/microsoft/msquic), the native implementation of QUIC protocol. As a result, `System.Net.Quic` platform support and dependencies are inherited from MsQuic and documented bellow in [Platform dependencies](#platform-dependencies). In short, the MsQuic library is shipped as part of .NET for Windows. But for Linux, `libmsquic` must be manually installed via an appropriate package manager. For the other platforms, it's still possible to build MsQuic manually, whether against SChannel or OpenSSL, and use it with `System.Net.Quic`. However, these scenarios are not part of our testing matrix and unforeseen problems might occur.
+
+## Platform dependencies
+
+### Windows
+
+- Windows 11, Windows Server 2022, or later. (Earlier Windows versions are missing the cryptographic APIs required to support QUIC.)
+
+On Windows, msquic.dll is distributed as part of the .NET runtime, and no other steps are required to install it.
+
+### Linux
+
+All the following dependencies are stated in `libmsquic` package manifest and will be automatically installed by the package manager:
+
+- OpenSSL 3+ or 1.1 - depends on the default OpenSSL version for the distribution version, e.g. OpenSSL 3 for Debian 12 and OpenSSL 1.1 for Debian 11
+
+- libnuma 1
+
+
+On Linux, libmsquic is published via Microsoft's official Linux package repository packages.microsoft.com. To consume it, it must be added manually. For more information, see [Linux Software Repository for Microsoft Products](/windows-server/administration/linux-package-repository-for-microsoft-software). After configuring the package feed, it's installed via the package manager of your distro, for example, for Ubuntu:
+
+
+```bash
+sudo apt install libmsquic
+```
+
+> [!NOTE]
+> .NET 7 is only compatible with 2.2+ versions of libmsquic.
+
+### macOS
+
+QUIC isn't currently supported on macOS but may be available in a future release.
 
 ## API overview
 


### PR DESCRIPTION
## Summary

Moves QUIC requirements into QUIC docs and references them from H/3 docs.
Also updates the versions and some details.

See https://github.com/dotnet/dotnet-api-docs/pull/8750#issuecomment-1368934721

cc @CarnaViire @wfurt @rzikm 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/httpclient-http3.md](https://github.com/dotnet/docs/blob/7c2355be4b9a17e1cd78535771433d777a4c76dd/docs/core/extensions/httpclient-http3.md) | [Use HTTP/3 with HttpClient](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/httpclient-http3?branch=pr-en-us-38054) |
| [docs/fundamentals/networking/quic/quic-overview.md](https://github.com/dotnet/docs/blob/7c2355be4b9a17e1cd78535771433d777a4c76dd/docs/fundamentals/networking/quic/quic-overview.md) | [QUIC protocol](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview?branch=pr-en-us-38054) |


<!-- PREVIEW-TABLE-END -->