### PR TITLE
Tweak constants programming guide

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/constants.md
+++ b/docs/csharp/programming-guide/classes-and-structs/constants.md
@@ -2,14 +2,14 @@
 title: "Constants - C# Programming Guide"
 description: Constants in C# are compile-time literal values, which do not change once the program is compiled. Only C# built-in types can be constants.
 ms.date: 07/20/2015
-helpviewer_keywords: 
+helpviewer_keywords:
   - "C# language, constants"
   - "constants [C#]"
 ms.assetid: 1fb39621-1738-49b1-a1b3-8587f109123f
 ---
 # Constants (C# Programming Guide)
 
-Constants are immutable values which are known at compile time and do not change for the life of the program. Constants are declared with the [const](../../language-reference/keywords/const.md) modifier. Only the C# [built-in types](../../language-reference/builtin-types/built-in-types.md) (excluding <xref:System.Object?displayProperty=nameWithType>) may be declared as `const`. User-defined types, including classes, structs, and arrays, cannot be `const`. Use the [readonly](../../language-reference/keywords/readonly.md) modifier to create a class, struct, or array that is initialized one time at run time (for example in a constructor) and thereafter cannot be changed.  
+Constants are immutable values which are known at compile time and do not change for the life of the program. Constants are declared with the [const](../../language-reference/keywords/const.md) modifier. Only the C# [built-in types](../../language-reference/builtin-types/built-in-types.md) may be declared as `const`. Built-in reference types other than <xref:System.String> can only be initialized with a [null](../../language-reference/keywords/null.md) value. User-defined types, including classes, structs, and arrays, cannot be `const`. Use the [readonly](../../language-reference/keywords/readonly.md) modifier to create a class, struct, or array that is initialized one time at run time (for example in a constructor) and thereafter cannot be changed.  
   
  C# does not support `const` methods, properties, or events.  
   

--- a/docs/csharp/programming-guide/classes-and-structs/constants.md
+++ b/docs/csharp/programming-guide/classes-and-structs/constants.md
@@ -9,7 +9,7 @@ ms.assetid: 1fb39621-1738-49b1-a1b3-8587f109123f
 ---
 # Constants (C# Programming Guide)
 
-Constants are immutable values which are known at compile time and do not change for the life of the program. Constants are declared with the [const](../../language-reference/keywords/const.md) modifier. Only the C# [built-in types](../../language-reference/builtin-types/built-in-types.md) may be declared as `const`. Built-in reference types other than <xref:System.String> can only be initialized with a [null](../../language-reference/keywords/null.md) value. User-defined types, including classes, structs, and arrays, cannot be `const`. Use the [readonly](../../language-reference/keywords/readonly.md) modifier to create a class, struct, or array that is initialized one time at run time (for example in a constructor) and thereafter cannot be changed.  
+Constants are immutable values which are known at compile time and do not change for the life of the program. Constants are declared with the [const](../../language-reference/keywords/const.md) modifier. Only the C# [built-in types](../../language-reference/builtin-types/built-in-types.md) may be declared as `const`. Reference type constants other than <xref:System.String> can only be initialized with a [null](../../language-reference/keywords/null.md) value. User-defined types, including classes, structs, and arrays, cannot be `const`. Use the [readonly](../../language-reference/keywords/readonly.md) modifier to create a class, struct, or array that is initialized one time at run time (for example in a constructor) and thereafter cannot be changed.  
   
  C# does not support `const` methods, properties, or events.  
   


### PR DESCRIPTION
## Summary

The previous wording implied that `System.Object` cannot be marked `const`, which is not true. They are allowed but can only be initialized with a `null` value.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/classes-and-structs/constants.md](https://github.com/dotnet/docs/blob/424d2e8c463d71601144dc44f19af705f4ab89c9/docs/csharp/programming-guide/classes-and-structs/constants.md) | [Constants (C# Programming Guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/constants?branch=pr-en-us-38055) |


<!-- PREVIEW-TABLE-END -->