### PR TITLE
Fix link to .NET Aspire Service Discovery

### DIFF
--- a/docs/core/extensions/service-discovery.md
+++ b/docs/core/extensions/service-discovery.md
@@ -148,4 +148,4 @@ When service endpoints are being resolved, each registered resolver is called in
 
 ## See also
 
-- [Service discovery in .NET Aspire](/dotnet/aspire/service-discovery/overview.md)
+- [Service discovery in .NET Aspire](/dotnet/aspire/service-discovery/overview)


### PR DESCRIPTION
Fix link to .NET Aspire Service Discovery


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/service-discovery.md](https://github.com/dotnet/docs/blob/00d4e89aff66a570888054ab136fb35c8c8c7313/docs/core/extensions/service-discovery.md) | [Service discovery in .NET](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/service-discovery?branch=pr-en-us-38064) |

<!-- PREVIEW-TABLE-END -->