### PR TITLE
Update F# coding conventions.md

### DIFF
--- a/docs/fsharp/style-guide/conventions.md
+++ b/docs/fsharp/style-guide/conventions.md
@@ -399,6 +399,7 @@ Don't apply this technique universally to your entire codebase, but it is a good
 F# has multiple options for [Access control](../language-reference/access-control.md), inherited from what is available in the .NET runtime. These are not just usable for types - you can use them for functions, too.
 
 Good practices in context of libraries that are widely consumed:
+
 * Prefer non-`public` types and members until you need them to be publicly consumable. This also minimizes what consumers couple to.
 * Strive to keep all helper functionality `private`.
 * Consider the use of `[<AutoOpen>]` on a private module of helper functions if they become numerous.


### PR DESCRIPTION
* some minor precisions
* adjust tone to not be as Good/Bad (we want users to not feel strong emotions about code), and explain more the reasoning of some guidelines
* provide context to some suggestions that could be overkill in regular code which do not have as many consumers as API or libraries
* minor adjustments around "functional purity"
* add example of nesting `let` bindings to show how to restrict scope of mutable binding


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/style-guide/conventions.md](https://github.com/dotnet/docs/blob/1153ded8b008057cc8bd5e317a6e76a007579201/docs/fsharp/style-guide/conventions.md) | [F# coding conventions](https://review.learn.microsoft.com/en-us/dotnet/fsharp/style-guide/conventions?branch=pr-en-us-38075) |


<!-- PREVIEW-TABLE-END -->