### PR TITLE
Update component-design-guidelines.md

### DIFF
--- a/docs/fsharp/style-guide/component-design-guidelines.md
+++ b/docs/fsharp/style-guide/component-design-guidelines.md
@@ -50,9 +50,9 @@ You can use either the short form XML comments (`/// comment`), or standard XML 
 
 Using explicit signatures files in an F# library provides a succinct summary of public API, which helps to ensure that you know the full public surface of your library, and provides a clean separation between public documentation and internal implementation details. Signature files add friction to changing the public API, by requiring changes to be made in both the implementation and signature files. As a result, signature files should typically only be introduced when an API has become solidified and is no longer expected to change significantly.
 
-### Always follow best practices for using strings in .NET
+### Follow best practices for using strings in .NET
 
-Follow [Best Practices for Using Strings in .NET](../../standard/base-types/best-practices-strings.md) guidance. In particular, always explicitly state *cultural intent* in the conversion and comparison of strings (where applicable).
+Follow [Best Practices for Using Strings in .NET](../../standard/base-types/best-practices-strings.md) guidance when the scope of the project warrants it. In particular, explicitly stating *cultural intent* in the conversion and comparison of strings (where applicable).
 
 ## Guidelines for F#-facing libraries
 
@@ -62,7 +62,7 @@ This section presents recommendations for developing public F#-facing libraries;
 
 #### Use .NET naming and capitalization conventions
 
-The following table follows .NET naming and capitalization conventions. There are small additions to also include F# constructs.
+The following table follows .NET naming and capitalization conventions. There are small additions to also include F# constructs. Those recommendations are especially meant for APIs that cross beyond F#-to-F# boundaries, fitting with idioms from .NET BCL and majority of libraries.
 
 | Construct | Case | Part | Examples | Notes |
 |-----------|------|------|----------|-------|

--- a/docs/fsharp/style-guide/component-design-guidelines.md
+++ b/docs/fsharp/style-guide/component-design-guidelines.md
@@ -62,7 +62,7 @@ This section presents recommendations for developing public F#-facing libraries;
 
 #### Use .NET naming and capitalization conventions
 
-The following table follows .NET naming and capitalization conventions. There are small additions to also include F# constructs. Those recommendations are especially meant for APIs that cross beyond F#-to-F# boundaries, fitting with idioms from .NET BCL and majority of libraries.
+The following table follows .NET naming and capitalization conventions. There are small additions to also include F# constructs. Those recommendations are especially meant for APIs that cross beyond F#-to-F# boundaries, fitting with idioms from .NET BCL and the majority of libraries.
 
 | Construct | Case | Part | Examples | Notes |
 |-----------|------|------|----------|-------|


### PR DESCRIPTION
adjust to omit "always", and give context about naming / capitalization.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/style-guide/component-design-guidelines.md](https://github.com/dotnet/docs/blob/669859fe0b2614bc08cb8aecc7eef3681d3fed89/docs/fsharp/style-guide/component-design-guidelines.md) | [F# component design guidelines](https://review.learn.microsoft.com/en-us/dotnet/fsharp/style-guide/component-design-guidelines?branch=pr-en-us-38076) |


<!-- PREVIEW-TABLE-END -->