### PR TITLE
Resilience page

### DIFF
--- a/docs/core/resilience/index.md
+++ b/docs/core/resilience/index.md
@@ -109,7 +109,7 @@ To use the resilience pipeline, call any of the available `Execute*` methods on 
 
 :::code language="csharp" source="snippets/resilience/Program.cs" id="execute":::
 
-The preceding code executes the delegate within the `ExecuteAsync` method. When there are failures, the configured strategies are executed. For example, if the `RetryStrategy` is configured to retry three times, the delegate is executed four times (1 initial attempt + 3 retry attempts) before the failure is propagated.
+The preceding code executes the delegate within the `ExecuteAsync` method. When there are failures, the configured strategies are executed. For example, if the `RetryStrategy` is configured to retry three times, the delegate is executed four times (one initial attempt plus three retry attempts) before the failure is propagated.
 
 ## Next steps
 

--- a/docs/core/resilience/index.md
+++ b/docs/core/resilience/index.md
@@ -8,14 +8,14 @@ ms.date: 10/20/2023
 
 # Introduction to resilient app development
 
-Resiliency is the ability of an app to recover from failures and continue to function. In the context of .NET programming, resilience is achieved by designing apps that can handle failures gracefully and recover quickly. To help build resilient apps in .NET, the following two packages are available on NuGet:
+Resiliency is the ability of an app to recover from transient failures and continue to function. In the context of .NET programming, resilience is achieved by designing apps that can handle failures gracefully and recover quickly. To help build resilient apps in .NET, the following two packages are available on NuGet:
 
 | NuGet package | Description |
 |--|--|
 | [📦 Microsoft.Extensions.Resilience](https://www.nuget.org/packages/Microsoft.Extensions.Resilience) | This NuGet package provides mechanisms to harden apps against transient failures. |
 | [📦 Microsoft.Extensions.Http.Resilience](https://www.nuget.org/packages/Microsoft.Extensions.Http.Resilience) | This NuGet package provides resilience mechanisms specifically for the <xref:System.Net.Http.HttpClient> class. |
 
-These two NuGet packages are built on top of [Polly](https://github.com/App-vNext/Polly), which is a popular open-source project. Polly is a .NET resilience and transient fault-handling library that allows developers to express strategies such as retry, circuit breaker, timeout, bulkhead isolation, rate-limiting, fallback, and hedging in a fluent and thread-safe manner.
+These two NuGet packages are built on top of [Polly](https://github.com/App-vNext/Polly), which is a popular open-source project. Polly is a .NET resilience and transient fault-handling library that allows developers to express strategies such as retry, circuit breaker, timeout, rate-limiting, fallback, and hedging in a fluent and thread-safe manner.
 
 > [!IMPORTANT]
 > The [Microsoft.Extensions.Http.Polly](https://www.nuget.org/packages/Microsoft.Extensions.Http.Polly) NuGet package is deprecated. Use either of the aforementioned packages instead.
@@ -42,7 +42,7 @@ For more information, see [dotnet add package](../tools/dotnet-add-package.md) o
 
 ## Build a resilience pipeline
 
-To use resilience, you must first build a pipeline of resilience-based strategies. Each configured strategy executes in order of configuration. In other words, order is important. The entry point is an extension method on the <xref:Microsoft.Extensions.DependencyInjection.IServiceCollection> type, named `AddResiliencePipeline`. This method takes an identifier of the pipeline and delegate that configures the pipeline. The delegate is passed an instance of `ResiliencePipelineBuilder`, which is used to add resilience strategies to the pipeline.
+To use resilience, you must first build a pipeline of resilience-based strategies. Each configured strategy executes in order of configuration. In other words, order is important. The entry point is an extension method on the <xref:Microsoft.Extensions.DependencyInjection.IServiceCollection> type, named `AddResiliencePipeline`. This method takes an identifier of the pipeline and a delegate that configures the pipeline. The delegate is passed an instance of `ResiliencePipelineBuilder`, which is used to add resilience strategies to the pipeline.
 
 Consider the following string-based `key` example:
 
@@ -53,7 +53,7 @@ The preceding code:
 - Creates a new `ServiceCollection` instance.
 - Defines a `key` to identify the pipeline.
 - Adds a resilience pipeline to the `ServiceCollection` instance.
-- Configures the pipeline with a retry strategy, circuit breaker strategy, and timeout strategy.
+- Configures the pipeline with a retry and timeout strategies.
 
 Each pipeline is configured for a given `key`, and each `key` is used to identify its corresponding `ResiliencePipeline` when getting the pipeline from the provider. The `key` is a generic type parameter of the `AddResiliencePipeline` method.
 
@@ -64,9 +64,10 @@ To add a strategy to the pipeline, call any of the available `Add*` extension me
 - `AddRetry`: Try again if something fails, which is useful when the problem is temporary and might go away.
 - `AddCircuitBreaker`: Stop trying if something is broken or busy, which benefits you by avoiding wasted time and making things worse.
 - `AddTimeout`: Give up if something takes too long, which can improve performance by freeing up resources.
-- `AddRateLimiter`: Limit how many requests you make or accept, which enables you to control load.
+- `AddRateLimiter`: Limit how many requests you accept, which enables you to control inbound load.
+- `AddConcurrencyLimiter`: Limit how many requests you make, which enables you to control outbound load.
 - `AddFallback`: Do something else when experiencing failures, which improves user experience.
-- `AddHedging`: Do more than one thing at the same time and take the fastest one, which can improve responsiveness.
+- `AddHedging`: Issue multiple requests in case of high latency or failure, which can improve responsiveness.
 
 For more information, see [Resilience strategies](https://www.pollydocs.org/strategies).
 
@@ -98,7 +99,7 @@ To use a configured resilience pipeline, you must get the pipeline from a `Resil
 
 The preceding code:
 
-- Builds a service provider from the `ServiceCollection` instance.
+- Builds a `ServiceProvider` from the `ServiceCollection` instance.
 - Gets the `ResiliencePipelineProvider<string>` from the service provider.
 - Retrieves the `ResiliencePipeline` from the `ResiliencePipelineProvider<string>`.
 
@@ -108,7 +109,7 @@ To use the resilience pipeline, call any of the available `Execute*` methods on 
 
 :::code language="csharp" source="snippets/resilience/Program.cs" id="execute":::
 
-The preceding code executes the delegate within the `ExecuteAsync` method. When there are failures, the configured strategies are executed. For example, if the `RetryStrategy` is configured to retry three times, the delegate is executed three times before the failure is propagated.
+The preceding code executes the delegate within the `ExecuteAsync` method. When there are failures, the configured strategies are executed. For example, if the `RetryStrategy` is configured to retry three times, the delegate is executed four times (1 initial attempt + 3 retry attempts) before the failure is propagated.
 
 ## Next steps
 

--- a/docs/core/resilience/snippets/resilience/Program.cs
+++ b/docs/core/resilience/snippets/resilience/Program.cs
@@ -13,7 +13,7 @@ const string key = "Retry-Timeout";
 services.AddResiliencePipeline(key, static builder =>
 {
     // See: https://www.pollydocs.org/strategies/retry.html
-    builder.AddRetry(new RetryStrategyOptions()
+    builder.AddRetry(new RetryStrategyOptions
     {
         ShouldHandle = new PredicateBuilder().Handle<TimeoutRejectedException>()
     });

--- a/docs/core/resilience/snippets/resilience/Program.cs
+++ b/docs/core/resilience/snippets/resilience/Program.cs
@@ -4,6 +4,7 @@ using Polly;
 using Polly.CircuitBreaker;
 using Polly.Registry;
 using Polly.Retry;
+using Polly.Timeout;
 
 var services = new ServiceCollection();
 

--- a/docs/core/resilience/snippets/resilience/resilience.csproj
+++ b/docs/core/resilience/snippets/resilience/resilience.csproj
@@ -5,12 +5,11 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <OutputType>Exe</OutputType>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0-rc.2.23479.6" />
-    <PackageReference Include="Microsoft.Extensions.Resilience" Version="8.0.0-rtm.23517.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Resilience" Version="8.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- Removed the circuit breaker from the example
  - Added options to make the retry timeout-aware
  - Updated the `key` accordingly 
- Added `AddConcurrencyLimiter` next to `AddRateLimiter`
- Corrected `AddHedging` description
  -  The original description described the _parallel_ mode, but [it can work](https://www.pollydocs.org/strategies/hedging.html#concurrency-modes) in _latency_ and _fallback_ modes as well.
- Corrected the number of attempts in case of retry
- Replaced `await ValueTask.CompletedTask` to `return  ValueTask.CompletedTask` 
- Updated package references


Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/resilience/index.md](https://github.com/dotnet/docs/blob/084c8e0c767219d6f1fd9e63647aade4c85c5a32/docs/core/resilience/index.md) | [Introduction to resilient app development](https://review.learn.microsoft.com/en-us/dotnet/core/resilience/index?branch=pr-en-us-38252) |


<!-- PREVIEW-TABLE-END -->