### PR TITLE
Add a missing parenthesis

### DIFF
--- a/docs/fundamentals/code-analysis/style-rules/language-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/language-rules.md
@@ -99,7 +99,7 @@ C# style rules:
 
 - [Use expression body for constructors (IDE0021)](ide0021.md)
 - [Use expression body for methods (IDE0022)](ide0022.md)
-- [Use expression body for operators (IDE0023](ide0023-ide0024.md)
+- [Use expression body for operators (IDE0023)](ide0023-ide0024.md)
 - [Use expression body for operators (IDE0024)](ide0023-ide0024.md)
 - [Use expression body for properties (IDE0025)](ide0025.md)
 - [Use expression body for indexers (IDE0026)](ide0026.md)


### PR DESCRIPTION
## Summary

Fix a minor syntax error in [`language-rules.md`](https://github.com/dotnet/docs/blob/cc154cadc987b5ee27dc299b51b634c7b7ef9502/docs/fundamentals/code-analysis/style-rules/language-rules.md?plain=1#L102) file, with the addition of a missing closing parenthesis at the end of `IDE0023` link.

Fixes #38258
