### PR TITLE
Fix grammatical error

### DIFF
--- a/docs/core/resilience/http-resilience.md
+++ b/docs/core/resilience/http-resilience.md
@@ -8,7 +8,7 @@ ms.date: 10/20/2023
 
 # Build resilient HTTP apps: Key development patterns
 
-Building robust HTTP apps that can recover from transient fault errors is a common requirement. This article assumes that you've already read [Introduction to resilient app development](index.md), as this article extends the core concepts conveyed. To help build resilient HTTP apps, the [Microsoft.Extensions.Http.Resilience](https://www.nuget.org/packages/Microsoft.Extensions.Http.Resilience) NuGet package provides resilience mechanisms specifically for the <xref:System.Net.Http.HttpClient>. This NuGet package is relies on the `Microsoft.Extensions.Resilience` library and _Polly_, which is a popular open-source project. For more information, see [Polly](https://github.com/App-vNext/Polly).
+Building robust HTTP apps that can recover from transient fault errors is a common requirement. This article assumes that you've already read [Introduction to resilient app development](index.md), as this article extends the core concepts conveyed. To help build resilient HTTP apps, the [Microsoft.Extensions.Http.Resilience](https://www.nuget.org/packages/Microsoft.Extensions.Http.Resilience) NuGet package provides resilience mechanisms specifically for the <xref:System.Net.Http.HttpClient>. This NuGet package relies on the `Microsoft.Extensions.Resilience` library and _Polly_, which is a popular open-source project. For more information, see [Polly](https://github.com/App-vNext/Polly).
 
 ## Get started
 


### PR DESCRIPTION
## Summary

Fixes a grammatical error by removing `is`, which does not belong in the sentence.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/resilience/http-resilience.md](https://github.com/dotnet/docs/blob/75955e151c5d5112e1f21bda8f814078bc5344bd/docs/core/resilience/http-resilience.md) | [Build resilient HTTP apps: Key development patterns](https://review.learn.microsoft.com/en-us/dotnet/core/resilience/http-resilience?branch=pr-en-us-38268) |

<!-- PREVIEW-TABLE-END -->