### PR TITLE
./dotnet-install.sh now installs .NET 8

### DIFF
--- a/docs/core/install/linux-scripted-manual.md
+++ b/docs/core/install/linux-scripted-manual.md
@@ -90,7 +90,7 @@ Before running this script, make sure you grant permission for this script to ru
 chmod +x ./dotnet-install.sh
 ```
 
-The script defaults to installing the latest [long term support (LTS)](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) SDK version, which is .NET 6. To install the latest release, which may not be an (LTS) version, use the `--version latest` parameter.
+The script defaults to installing the latest [long term support (LTS)](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) SDK version, which is .NET 8. To install the latest release, which may not be an (LTS) version, use the `--version latest` parameter.
 
 ```bash
 ./dotnet-install.sh --version latest


### PR DESCRIPTION
./dotnet-install.sh now installs .NET 8

## Summary
The -./dotnet-install.sh command now installs .NET 8, the newest LTS version, the documentation currently states it installs .NET 6.

See below my terminal output when running getting the install script and installing the latest version:

```
blakedeckard@blakedeckard:~$ wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh
--2023-11-15 22:30:02--  https://dot.net/v1/dotnet-install.sh
正在解析主机 dot.net (dot.net)... 20.70.246.20, 20.236.44.162, 20.76.201.171, ...
正在连接 dot.net (dot.net)|20.70.246.20|:443... 已连接。
已发出 HTTP 请求，正在等待回应... 301 Moved Permanently
位置：https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.sh [跟随至新的 URL]
--2023-11-15 22:30:03--  https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.sh
正在解析主机 dotnet.microsoft.com (dotnet.microsoft.com)... 2620:1ec:46::57, 2620:1ec:bdf::57, 13.107.213.57, ...
正在连接 dotnet.microsoft.com (dotnet.microsoft.com)|2620:1ec:46::57|:443... 已连接。
已发出 HTTP 请求，正在等待回应... 200 OK
来自 dotnet.microsoft.com 的 Cookie 尝试将域设置为 dotnetwebsite.azurewebsites.net
来自 dotnet.microsoft.com 的 Cookie 尝试将域设置为 dotnetwebsite.azurewebsites.net
长度： 61896 (60K) [application/x-sh]
正在保存至: ‘dotnet-install.sh’

dotnet-install.sh   100%[===================>]  60.45K  --.-KB/s    用时 0.08s 

2023-11-15 22:30:04 (727 KB/s) - 已保存 ‘dotnet-install.sh’ [61896/61896])

blakedeckard@blakedeckard:~$ chmod +x ./dotnet-install.sh
blakedeckard@blakedeckard:~$ ./dotnet-install.sh --version latest
**dotnet-install: Attempting to download using aka.ms link https://dotnetcli.azureedge.net/dotnet/Sdk/8.0.100/dotnet-sdk-8.0.100-linux-x64.tar.gz
dotnet-install: Remote file https://dotnetcli.azureedge.net/dotnet/Sdk/8.0.100/dotnet-sdk-8.0.100-linux-x64.tar.gz size is 214395068 bytes.
dotnet-install: Extracting zip from https://dotnetcli.azureedge.net/dotnet/Sdk/8.0.100/dotnet-sdk-8.0.100-linux-x64.tar.gz**
dotnet-install: Downloaded file size is 214395068 bytes.
dotnet-install: The remote and local file sizes are equal.
**dotnet-install: Installed version is 8.0.100**
dotnet-install: Adding to current process PATH: `/home/blakedeckard/.dotnet`. Note: This change will be visible only when sourcing script.
dotnet-install: Note that the script does not resolve dependencies during installation.
dotnet-install: To check the list of dependencies, go to https://learn.microsoft.com/dotnet/core/install, select your operating system and check the "Dependencies" section.
dotnet-install: Installation finished successfully.
blakedeckard@blakedeckard:~$ ./dotnet-install.sh
dotnet-install: .NET Core SDK with version '8.0.100' is already installed
```

Describe your changes here.
Change documentation to state ./dotnet-install.sh will install .NET 8

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/linux-scripted-manual.md](https://github.com/dotnet/docs/blob/803d6d98456741295316fa5db579ecd50d209c41/docs/core/install/linux-scripted-manual.md) | [Install .NET on Linux by using an install script or by extracting binaries](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-scripted-manual?branch=pr-en-us-38271) |

<!-- PREVIEW-TABLE-END -->