### PR TITLE
Fix the configuration source gen diagnostic message

### DIFF
--- a/docs/fundamentals/syslib-diagnostics/source-generator-overview.md
+++ b/docs/fundamentals/syslib-diagnostics/source-generator-overview.md
@@ -121,7 +121,7 @@ The following table provides an index to the `SYSLIB1XXX` diagnostics in .NET 6 
 | [SYSLIB1099][1099] | COM Interop APIs on `System.Runtime.InteropServices.Marshal` do not support source-generated COM and will fail at run time. |
 | [SYSLIB1100][1100] | Configuration binding generator: Type is not supported. |
 | [SYSLIB1101][1101] | Configuration binding generator: Property on type is not supported. |
-| [SYSLIB1102][1102] | Configuration binding generator: Project's language version must be at least C# 11. |
+| [SYSLIB1102][1102] | Configuration binding generator: Project's language version must be at least C# 12. |
 | [SYSLIB1103][1103] | Configuration binding generator: Value types are invalid inputs to configuration 'Bind' methods. |
 | [SYSLIB1104][1104] | Configuration binding generator: Generator cannot determine the target configuration type. |
 | [SYSLIB1105][1105] | (Reserved for Microsoft.Extensions.Configuration.Binder.SourceGeneration.) |

--- a/docs/fundamentals/syslib-diagnostics/syslib1100-1118.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib1100-1118.md
@@ -11,6 +11,6 @@ The following table shows the diagnostic IDs for configuration binder source-gen
 | - | - |
 |  `SYSLIB1100` | Type is not supported. |
 |  `SYSLIB1101` | Property on type is not supported. |
-|  `SYSLIB1102` | Project's language version must be at least C# 11. |
+|  `SYSLIB1102` | Project's language version must be at least C# 12. |
 |  `SYSLIB1103` | Value types are invalid inputs to configuration 'Bind' methods. |
 |  `SYSLIB1104` | Generator cannot determine the target configuration type. |


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/94826

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/syslib-diagnostics/source-generator-overview.md](https://github.com/dotnet/docs/blob/5055e68c265afaa43f72a230df4e0bd5e83db71f/docs/fundamentals/syslib-diagnostics/source-generator-overview.md) | [Source-generator diagnostics in .NET 6+](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/source-generator-overview?branch=pr-en-us-38287) |
| [docs/fundamentals/syslib-diagnostics/syslib1100-1118.md](https://github.com/dotnet/docs/blob/5055e68c265afaa43f72a230df4e0bd5e83db71f/docs/fundamentals/syslib-diagnostics/syslib1100-1118.md) | [SYSLIB diagnostics for configuration binder source generation](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib1100-1118?branch=pr-en-us-38287) |

<!-- PREVIEW-TABLE-END -->