### PR TITLE
--use-controllers is available since .NET 8 SDK

### DIFF
--- a/docs/core/tools/dotnet-new-sdk-templates.md
+++ b/docs/core/tools/dotnet-new-sdk-templates.md
@@ -725,7 +725,7 @@ Creates a web API project with AOT publish enabled. For more information, see [N
 
 - **`--controllers`**, **`--use-controllers`**
 
-  Whether to use controllers instead of minimal APIs. If both this option and `-minimal` are specified, this option overrides the value specified by `-minimal`. Default is `false`.
+  Whether to use controllers instead of minimal APIs. If both this option and `-minimal` are specified, this option overrides the value specified by `-minimal`. Default is `false`. Available since .NET 8 SDK.
 
 - **`--domain <DOMAIN>`**
 


### PR DESCRIPTION
Fixes #37782 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-new-sdk-templates.md](https://github.com/dotnet/docs/blob/c5573fc7a413e9e8aeffa09fdf563262afbf8fbd/docs/core/tools/dotnet-new-sdk-templates.md) | [.NET default templates for dotnet new](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-new-sdk-templates?branch=pr-en-us-38288) |

<!-- PREVIEW-TABLE-END -->