### PR TITLE
Fix sample code for CA1859

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1859.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1859.md
@@ -7,9 +7,6 @@ f1_keywords:
 - UseConcreteTypes
 helpviewer_keywords:
 - CA1859
-dev_langs:
-- CSharp
-- VB
 ---
 
 # CA1859: Use concrete types when possible for improved performance
@@ -60,7 +57,8 @@ internal class C
 
     public void Trigger()
     {
-        // this performs a virtual call because _a is defined as an abstract class
+        // This performs a virtual call because
+        // _a is defined as an abstract class.
         _a.M();
     }
 }

--- a/docs/fundamentals/code-analysis/quality-rules/ca1859.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1859.md
@@ -51,7 +51,7 @@ abstract class A
     public virtual void M() { }
 }
 
-sealed class B
+sealed class B : A
 { }
 
 internal class C
@@ -74,7 +74,7 @@ abstract class A
     public virtual void M() { }
 }
 
-sealed class B
+sealed class B : A
 { }
 
 internal class C


### PR DESCRIPTION
The sample code doesn't compile, because `B` doesn't inherit `A`.

👋 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1859.md](https://github.com/dotnet/docs/blob/4e3d770702353a8913e8778e523a2bccc164ac14/docs/fundamentals/code-analysis/quality-rules/ca1859.md) | [CA1859: Use concrete types when possible for improved performance](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1859?branch=pr-en-us-38300) |


<!-- PREVIEW-TABLE-END -->