### PR TITLE
Fix the LTS mention

### DIFF
--- a/docs/core/install/linux-scripted-manual.md
+++ b/docs/core/install/linux-scripted-manual.md
@@ -90,7 +90,7 @@ Before running this script, make sure you grant permission for this script to ru
 chmod +x ./dotnet-install.sh
 ```
 
-The script defaults to installing the latest [long term support (LTS)](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) SDK version, which is .NET 6. To install the latest release, which may not be an (LTS) version, use the `--version latest` parameter.
+The script defaults to installing the latest [long term support (LTS)](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) SDK version, which is .NET 8. To install the latest release, which may not be an (LTS) version, use the `--version latest` parameter.
 
 ```bash
 ./dotnet-install.sh --version latest

--- a/docs/core/install/linux-scripted-manual.md
+++ b/docs/core/install/linux-scripted-manual.md
@@ -90,7 +90,7 @@ Before running this script, make sure you grant permission for this script to ru
 chmod +x ./dotnet-install.sh
 ```
 
-The script defaults to installing the latest [long term support (LTS)](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) SDK version, which is .NET 8. To install the latest release, which may not be an (LTS) version, use the `--version latest` parameter.
+The script defaults to installing the latest [long term support (LTS)](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) SDK version, which is .NET 8. To install the latest release, which might not be an (LTS) version, use the `--version latest` parameter.
 
 ```bash
 ./dotnet-install.sh --version latest


### PR DESCRIPTION
## Summary

Fix the LTS mention (.NET 6 -> .NET 8)

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/linux-scripted-manual.md](https://github.com/dotnet/docs/blob/ea4b4e61583484afe991389b9da4d6c160d3b7d2/docs/core/install/linux-scripted-manual.md) | [Install .NET on Linux by using an install script or by extracting binaries](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-scripted-manual?branch=pr-en-us-38302) |


<!-- PREVIEW-TABLE-END -->