### PR TITLE
Update BankAccount.cs class name to match the documentation - CheckAccount => CheckingAccount

### DIFF
--- a/docs/csharp/whats-new/tutorials/snippets/primary-constructors/BankAccount.cs
+++ b/docs/csharp/whats-new/tutorials/snippets/primary-constructors/BankAccount.cs
@@ -11,7 +11,7 @@ public class BankAccount(string accountID, string owner)
 // </BaseClass>
 
 // <DerivedClass>
-public class CheckAccount(string accountID, string owner, decimal overdraftLimit = 0) : BankAccount(accountID, owner)
+public class CheckingAccount(string accountID, string owner, decimal overdraftLimit = 0) : BankAccount(accountID, owner)
 {
     public decimal CurrentBalance { get; private set; } = 0;
 


### PR DESCRIPTION
Change class name to match the documentation.

## Summary

The code snippet class name is CheckAccount but the associated documentation calls it CheckingAccount.

![image](https://github.com/dotnet/docs/assets/490221/df06ac48-9127-4304-8064-d92a4d17c2f1)


Fixes #Issue_Number (if available)
