### PR TITLE
Remove "introduced version" column

### DIFF
--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -13,83 +13,83 @@ If you're migrating an app to .NET 6, the breaking changes listed here might aff
 
 ## ASP.NET Core
 
-| Title | Binary compatible | Source compatible | Introduced |
-| - | :-: | :-: | - |
-| [ActionResult\<T> sets StatusCode to 200](aspnet-core/6.0/actionresult-statuscode.md) | ✔️ | ❌ |  |
-| [AddDataAnnotationsValidation method made obsolete](aspnet-core/6.0/adddataannotationsvalidation-obsolete.md) | ✔️ | ❌ |  |
-| [Assemblies removed from Microsoft.AspNetCore.App shared framework](aspnet-core/6.0/assemblies-removed-from-shared-framework.md) | ❌ | ✔️ |  |
-| [Blazor: Parameter name changed in RequestImageFileAsync method](aspnet-core/6.0/blazor-parameter-name-changed-in-method.md) | ✔️ | ❌ | Preview 1 |
-| [Blazor: WebEventDescriptor.EventArgsType property replaced](aspnet-core/6.0/blazor-eventargstype-property-replaced.md) | ❌ | ❌ |  |
-| [Blazor: Byte array interop](aspnet-core/6.0/byte-array-interop.md) | ✔️ | ❌ | Preview 6 |
-| [Changed MessagePack library in @microsoft/signalr-protocol-msgpack](aspnet-core/6.0/messagepack-library-change.md) | ❌ | ✔️ |  |
-| [ClientCertificate property doesn't trigger renegotiation for HttpSys](aspnet-core/6.0/clientcertificate-doesnt-trigger-renegotiation.md) | ✔️ | ❌ |  |
-| [EndpointName metadata not set automatically](aspnet-core/6.0/endpointname-metadata.md) | ✔️ | ❌ | RC 2 |
-| [Identity: Default Bootstrap version of UI changed](aspnet-core/6.0/identity-bootstrap4-to-5.md) | ❌ | ❌  |  |
-| [Kestrel: Log message attributes changed](aspnet-core/6.0/kestrel-log-message-attributes-changed.md) | ✔️ | ❌ |  |
-| [Microsoft.AspNetCore.Http.Features split](aspnet-core/6.0/microsoft-aspnetcore-http-features-package-split.md) | ❌ | ✔️ |  |
-| [Middleware: HTTPS Redirection Middleware throws exception on ambiguous HTTPS ports](aspnet-core/6.0/middleware-ambiguous-https-ports-exception.md) | ✔️ | ❌ |  |
-| [Middleware: New Use overload](aspnet-core/6.0/middleware-new-use-overload.md) | ✔️ | ❌ | Preview 4 |
-| [Minimal API renames in RC 1](aspnet-core/6.0/rc1-minimal-api-renames.md) | ❌ | ❌ | RC 1 |
-| [Minimal API renames in RC 2](aspnet-core/6.0/rc2-minimal-api-renames.md) | ❌ | ❌ | RC 2 |
-| [MVC doesn't buffer IAsyncEnumerable types when using System.Text.Json](aspnet-core/6.0/iasyncenumerable-not-buffered-by-mvc.md) | ✔️ | ❌ | Preview 4 |
-| [Nullable reference type annotations changed](aspnet-core/6.0/nullable-reference-type-annotations-changed.md) | ✔️ | ❌ |  |
-| [Obsoleted and removed APIs](aspnet-core/6.0/obsolete-removed-apis.md) | ✔️ | ❌ | Preview 1 |
-| [PreserveCompilationContext not configured by default](aspnet-core/6.0/preservecompilationcontext-not-set-by-default.md) | ❌ | ✔️ |  |
-| [Razor: Compiler no longer produces a Views assembly](aspnet-core/6.0/razor-compiler-doesnt-produce-views-assembly.md) | ✔️ | ❌ | Preview 3 |
-| [Razor: Logging ID changes](aspnet-core/6.0/razor-pages-logging-ids.md) | ❌ | ✔️ | RC1 |
-| [Razor: RazorEngine APIs marked obsolete](aspnet-core/6.0/razor-engine-apis-obsolete.md) | ✔️ | ❌ | Preview 1 |
-| [SignalR: Java Client updated to RxJava3](aspnet-core/6.0/signalr-java-client-updated.md) | ❌ | ✔️ | Preview 4 |
-| [TryParse and BindAsync methods are validated](aspnet-core/6.0/tryparse-bindasync-validation.md) | ❌ | ❌ | RC 2 |
+| Title | Binary compatible | Source compatible |
+| - | :-: | :-: |
+| [ActionResult\<T> sets StatusCode to 200](aspnet-core/6.0/actionresult-statuscode.md) | ✔️ | ❌ |
+| [AddDataAnnotationsValidation method made obsolete](aspnet-core/6.0/adddataannotationsvalidation-obsolete.md) | ✔️ | ❌ |
+| [Assemblies removed from Microsoft.AspNetCore.App shared framework](aspnet-core/6.0/assemblies-removed-from-shared-framework.md) | ❌ | ✔️ |
+| [Blazor: Parameter name changed in RequestImageFileAsync method](aspnet-core/6.0/blazor-parameter-name-changed-in-method.md) | ✔️ | ❌ |
+| [Blazor: WebEventDescriptor.EventArgsType property replaced](aspnet-core/6.0/blazor-eventargstype-property-replaced.md) | ❌ | ❌ |
+| [Blazor: Byte array interop](aspnet-core/6.0/byte-array-interop.md) | ✔️ | ❌ |
+| [Changed MessagePack library in @microsoft/signalr-protocol-msgpack](aspnet-core/6.0/messagepack-library-change.md) | ❌ | ✔️ |
+| [ClientCertificate property doesn't trigger renegotiation for HttpSys](aspnet-core/6.0/clientcertificate-doesnt-trigger-renegotiation.md) | ✔️ | ❌ |
+| [EndpointName metadata not set automatically](aspnet-core/6.0/endpointname-metadata.md) | ✔️ | ❌ |
+| [Identity: Default Bootstrap version of UI changed](aspnet-core/6.0/identity-bootstrap4-to-5.md) | ❌ | ❌  |
+| [Kestrel: Log message attributes changed](aspnet-core/6.0/kestrel-log-message-attributes-changed.md) | ✔️ | ❌ |
+| [Microsoft.AspNetCore.Http.Features split](aspnet-core/6.0/microsoft-aspnetcore-http-features-package-split.md) | ❌ | ✔️ |
+| [Middleware: HTTPS Redirection Middleware throws exception on ambiguous HTTPS ports](aspnet-core/6.0/middleware-ambiguous-https-ports-exception.md) | ✔️ | ❌ |
+| [Middleware: New Use overload](aspnet-core/6.0/middleware-new-use-overload.md) | ✔️ | ❌ |
+| [Minimal API renames in RC 1](aspnet-core/6.0/rc1-minimal-api-renames.md) | ❌ | ❌ |
+| [Minimal API renames in RC 2](aspnet-core/6.0/rc2-minimal-api-renames.md) | ❌ | ❌ |
+| [MVC doesn't buffer IAsyncEnumerable types when using System.Text.Json](aspnet-core/6.0/iasyncenumerable-not-buffered-by-mvc.md) | ✔️ | ❌ |
+| [Nullable reference type annotations changed](aspnet-core/6.0/nullable-reference-type-annotations-changed.md) | ✔️ | ❌ |
+| [Obsoleted and removed APIs](aspnet-core/6.0/obsolete-removed-apis.md) | ✔️ | ❌ |
+| [PreserveCompilationContext not configured by default](aspnet-core/6.0/preservecompilationcontext-not-set-by-default.md) | ❌ | ✔️ |
+| [Razor: Compiler no longer produces a Views assembly](aspnet-core/6.0/razor-compiler-doesnt-produce-views-assembly.md) | ✔️ | ❌ |
+| [Razor: Logging ID changes](aspnet-core/6.0/razor-pages-logging-ids.md) | ❌ | ✔️ |
+| [Razor: RazorEngine APIs marked obsolete](aspnet-core/6.0/razor-engine-apis-obsolete.md) | ✔️ | ❌ |
+| [SignalR: Java Client updated to RxJava3](aspnet-core/6.0/signalr-java-client-updated.md) | ❌ | ✔️ |
+| [TryParse and BindAsync methods are validated](aspnet-core/6.0/tryparse-bindasync-validation.md) | ❌ | ❌ |
 
 ## Containers
 
-| Title | Binary compatible | Source compatible | Introduced |
-| - | :-: | :-: | - |
-| [Default console logger formatting in container images](containers/6.0/console-formatter-default.md) | ✔️ | ❌ | Servicing 6.0.6 |
+| Title | Binary compatible | Source compatible |
+| - | :-: | :-: |
+| [Default console logger formatting in container images](containers/6.0/console-formatter-default.md) | ✔️ | ❌ |
 
 For information on other breaking changes for containers in .NET 6, see [.NET 6 Container Release Notes](https://github.com/dotnet/dotnet-docker/discussions/3699).
 
 ## Core .NET libraries
 
-| Title | Binary compatible | Source compatible | Introduced |
-| - | :-: | :-: | - |
-| [API obsoletions with non-default diagnostic IDs](core-libraries/6.0/obsolete-apis-with-custom-diagnostics.md) | ✔️ | ❌ | Preview 1 |
-| [Changes to nullable reference type annotations](core-libraries/6.0/nullable-ref-type-annotation-changes.md) | ✔️ | ❌ | Preview 1-2 |
-| [Conditional string evaluation in Debug methods](core-libraries/6.0/debug-assert-conditional-evaluation.md) | ✔️ | ❌ | RC 1 |
-| [Environment.ProcessorCount behavior on Windows](core-libraries/6.0/environment-processorcount-on-windows.md) | ✔️ | ❌ | Preview 2 |
-| [EventSource callback behavior](core-libraries/6.0/eventsource-callback.md) | ✔️ | ✔️ | Servicing |
-| [File.Replace on Unix throws exceptions to match Windows](core-libraries/6.0/file-replace-exceptions-on-unix.md) | ✔️ | ❌ | Preview 7 |
-| [FileStream locks files with shared lock on Unix](core-libraries/6.0/filestream-file-locks-unix.md) | ❌ | ✔️ | Preview 1 |
-| [FileStream no longer synchronizes file offset with OS](core-libraries/6.0/filestream-doesnt-sync-offset-with-os.md) | ❌ | ❌ | Preview 4 |
-| [FileStream.Position updates after ReadAsync or WriteAsync completes](core-libraries/6.0/filestream-position-updates-after-readasync-writeasync-completion.md) | ❌ | ❌ | Preview 4 |
-| [New diagnostic IDs for obsoleted APIs](core-libraries/6.0/diagnostic-id-change-for-obsoletions.md) | ✔️ | ❌ | Preview 5 |
-| [New nullable annotation in AssociatedMetadataTypeTypeDescriptionProvider](core-libraries/6.0/nullable-ref-type-annotations-added.md) | ✔️ | ❌ | RC 2 |
-| [New System.Linq.Queryable method overloads](core-libraries/6.0/additional-linq-queryable-method-overloads.md) | ✔️ | ❌ | Preview 3-4 |
-| [Older framework versions dropped from package](core-libraries/6.0/older-framework-versions-dropped.md) | ❌ | ✔️ | Preview 5 |
-| [Parameter names changed](core-libraries/6.0/parameter-name-changes.md) | ✔️ | ❌ | Preview 1 |
-| [Parameter names in Stream-derived types](core-libraries/6.0/parameters-renamed-on-stream-derived-types.md) | ✔️ | ❌ | Preview 1 |
-| [Partial and zero-byte reads in DeflateStream, GZipStream, and CryptoStream](core-libraries/6.0/partial-byte-reads-in-streams.md) | ✔️ | ❌ | Preview 6 |
-| [Set timestamp on read-only file on Windows](core-libraries/6.0/set-timestamp-readonly-file.md) | ❌ | ✔️ | Servicing 6.0.2 |
-| [Standard numeric format parsing precision](core-libraries/6.0/numeric-format-parsing-handles-higher-precision.md) | ✔️ | ❌ | Preview 2 |
-| [Static abstract members in interfaces](core-libraries/6.0/static-abstract-interface-methods.md) | ❌ | ✔️ | Preview 7 |
-| [StringBuilder.Append overloads and evaluation order](core-libraries/6.0/stringbuilder-append-evaluation-order.md) | ❌ | ✔️ | RC 1 |
-| [Strong-name APIs throw PlatformNotSupportedException](core-libraries/6.0/strong-name-signing-exceptions.md) | ❌ | ✔️ |  Preview 4 |
-| [System.Drawing.Common only supported on Windows](core-libraries/6.0/system-drawing-common-windows-only.md) | ❌ | ❌ | Preview 7 |
-| [System.Security.SecurityContext is marked obsolete](core-libraries/6.0/securitycontext-obsolete.md) | ✔️ | ❌ | RC 1 |
-| [Task.FromResult may return singleton](core-libraries/6.0/task-fromresult-returns-singleton.md) | ❌ | ✔️ | Preview 1 |
-| [Unhandled exceptions from a BackgroundService](core-libraries/6.0/hosting-exception-handling.md) | ✔️ | ❌ | Preview 4 |
+| Title | Binary compatible | Source compatible |
+| - | :-: | :-: |
+| [API obsoletions with non-default diagnostic IDs](core-libraries/6.0/obsolete-apis-with-custom-diagnostics.md) | ✔️ | ❌ |
+| [Changes to nullable reference type annotations](core-libraries/6.0/nullable-ref-type-annotation-changes.md) | ✔️ | ❌ |
+| [Conditional string evaluation in Debug methods](core-libraries/6.0/debug-assert-conditional-evaluation.md) | ✔️ | ❌ |
+| [Environment.ProcessorCount behavior on Windows](core-libraries/6.0/environment-processorcount-on-windows.md) | ✔️ | ❌ |
+| [EventSource callback behavior](core-libraries/6.0/eventsource-callback.md) | ✔️ | ✔️ |
+| [File.Replace on Unix throws exceptions to match Windows](core-libraries/6.0/file-replace-exceptions-on-unix.md) | ✔️ | ❌ |
+| [FileStream locks files with shared lock on Unix](core-libraries/6.0/filestream-file-locks-unix.md) | ❌ | ✔️ |
+| [FileStream no longer synchronizes file offset with OS](core-libraries/6.0/filestream-doesnt-sync-offset-with-os.md) | ❌ | ❌ |
+| [FileStream.Position updates after ReadAsync or WriteAsync completes](core-libraries/6.0/filestream-position-updates-after-readasync-writeasync-completion.md) | ❌ | ❌ |
+| [New diagnostic IDs for obsoleted APIs](core-libraries/6.0/diagnostic-id-change-for-obsoletions.md) | ✔️ | ❌ |
+| [New nullable annotation in AssociatedMetadataTypeTypeDescriptionProvider](core-libraries/6.0/nullable-ref-type-annotations-added.md) | ✔️ | ❌ |
+| [New System.Linq.Queryable method overloads](core-libraries/6.0/additional-linq-queryable-method-overloads.md) | ✔️ | ❌ |
+| [Older framework versions dropped from package](core-libraries/6.0/older-framework-versions-dropped.md) | ❌ | ✔️ |
+| [Parameter names changed](core-libraries/6.0/parameter-name-changes.md) | ✔️ | ❌ |
+| [Parameter names in Stream-derived types](core-libraries/6.0/parameters-renamed-on-stream-derived-types.md) | ✔️ | ❌ |
+| [Partial and zero-byte reads in DeflateStream, GZipStream, and CryptoStream](core-libraries/6.0/partial-byte-reads-in-streams.md) | ✔️ | ❌ |
+| [Set timestamp on read-only file on Windows](core-libraries/6.0/set-timestamp-readonly-file.md) | ❌ | ✔️ |
+| [Standard numeric format parsing precision](core-libraries/6.0/numeric-format-parsing-handles-higher-precision.md) | ✔️ | ❌ |
+| [Static abstract members in interfaces](core-libraries/6.0/static-abstract-interface-methods.md) | ❌ | ✔️ |
+| [StringBuilder.Append overloads and evaluation order](core-libraries/6.0/stringbuilder-append-evaluation-order.md) | ❌ | ✔️
+| [Strong-name APIs throw PlatformNotSupportedException](core-libraries/6.0/strong-name-signing-exceptions.md) | ❌ | ✔️ |
+| [System.Drawing.Common only supported on Windows](core-libraries/6.0/system-drawing-common-windows-only.md) | ❌ | ❌ |
+| [System.Security.SecurityContext is marked obsolete](core-libraries/6.0/securitycontext-obsolete.md) | ✔️ | ❌
+| [Task.FromResult may return singleton](core-libraries/6.0/task-fromresult-returns-singleton.md) | ❌ | ✔️ |
+| [Unhandled exceptions from a BackgroundService](core-libraries/6.0/hosting-exception-handling.md) | ✔️ | ❌ |
 
 ## Cryptography
 
-| Title | Binary compatible | Source compatible | Introduced |
-| - | :-: | :-: | - |
-| [CreateEncryptor methods throw exception for incorrect feedback size](cryptography/6.0/cfb-mode-feedback-size-exception.md) | ❌ | ✔️ | Preview 7 |
+| Title | Binary compatible | Source compatible |
+| - | :-: | :-: |
+| [CreateEncryptor methods throw exception for incorrect feedback size](cryptography/6.0/cfb-mode-feedback-size-exception.md) | ❌ | ✔️ |
 
 ## Deployment
 
-| Title | Binary compatible | Source compatible | Introduced |
-| - | :-: | :-: | - |
-| [x86 host path on 64-bit Windows](deployment/7.0/x86-host-path.md) | ✔️ | ✔️ | Servicing release |
+| Title | Binary compatible | Source compatible |
+| - | :-: | :-: |
+| [x86 host path on 64-bit Windows](deployment/7.0/x86-host-path.md) | ✔️ | ✔️ |
 
 ## Entity Framework Core
 
@@ -97,90 +97,90 @@ For information on other breaking changes for containers in .NET 6, see [.NET 6 
 
 ## Extensions
 
-| Title | Binary compatible | Source compatible | Introduced |
-| - | :-: | :-: | - |
-| [AddProvider checks for non-null provider](extensions/6.0/addprovider-null-check.md) | ✔️ | ❌ | RC 1 |
-| [FileConfigurationProvider.Load throws InvalidDataException](extensions/6.0/filename-in-load-exception.md) | ✔️ | ❌ | RC 1 |
-| [Repeated XML elements include index](extensions/6.0/repeated-xml-elements.md) | ❌ | ✔️ | |
-| [Resolving disposed ServiceProvider throws exception](extensions/6.0/service-provider-disposed.md) | ✔️ | ❌ | RC 1 |
+| Title | Binary compatible | Source compatible |
+| - | :-: | :-: |
+| [AddProvider checks for non-null provider](extensions/6.0/addprovider-null-check.md) | ✔️ | ❌ |
+| [FileConfigurationProvider.Load throws InvalidDataException](extensions/6.0/filename-in-load-exception.md) | ✔️ | ❌ |
+| [Repeated XML elements include index](extensions/6.0/repeated-xml-elements.md) | ❌ | ✔️ |
+| [Resolving disposed ServiceProvider throws exception](extensions/6.0/service-provider-disposed.md) | ✔️ | ❌ |
 
 ## Globalization
 
-| Title | Binary compatible | Source compatible | Introduced |
-| - | :-: | :-: | - |
-| [Culture creation and case mapping in globalization-invariant mode](globalization/6.0/culture-creation-invariant-mode.md) |  |  | Preview 7 |
+| Title | Binary compatible | Source compatible |
+| - | :-: | :-: |
+| [Culture creation and case mapping in globalization-invariant mode](globalization/6.0/culture-creation-invariant-mode.md) |  |  |
 
 ## Interop
 
-| Title | Binary compatible | Source compatible | Introduced |
-| - | :-: | :-: | - |
-| [Static abstract members in interfaces](core-libraries/6.0/static-abstract-interface-methods.md) | ❌ | ✔️ | Preview 7 |
+| Title | Binary compatible | Source compatible |
+| - | :-: | :-: |
+| [Static abstract members in interfaces](core-libraries/6.0/static-abstract-interface-methods.md) | ❌ | ✔️ |
 
 ## JIT compiler
 
-| Title | Binary compatible | Source compatible | Introduced |
-| - | :-: | :-: | - |
-| [Coerce call arguments according to ECMA-335](jit/6.0/coerce-call-arguments-ecma-335.md) | ✔️ | ✔️ | Preview 1 |
+| Title | Binary compatible | Source compatible |
+| - | :-: | :-: |
+| [Coerce call arguments according to ECMA-335](jit/6.0/coerce-call-arguments-ecma-335.md) | ✔️ | ✔️ |
 
 ## Networking
 
-| Title | Binary compatible | Source compatible | Introduced |
-| - | :-: | :-: | - |
-| [Port removed from SPN for Kerberos and Negotiate](networking/6.0/httpclient-port-lookup.md) | ❌ | ✔️ | RC 1 |
-| [WebRequest, WebClient, and ServicePoint are obsolete](networking/6.0/webrequest-deprecated.md) | ✔️ | ❌ | Preview 1 |
+| Title | Binary compatible | Source compatible |
+| - | :-: | :-: |
+| [Port removed from SPN for Kerberos and Negotiate](networking/6.0/httpclient-port-lookup.md) | ❌ | ✔️ |
+| [WebRequest, WebClient, and ServicePoint are obsolete](networking/6.0/webrequest-deprecated.md) | ✔️ | ❌ |
 
 ## SDK
 
-| Title | Binary compatible | Source compatible | Introduced |
-| - | :-: | :-: | - |
-| [`-p` option for `dotnet run` is deprecated](sdk/6.0/deprecate-p-option-dotnet-run.md) | ✔️ | ❌ | Preview 6 |
-| [C# code in templates not supported by earlier versions](sdk/6.0/csharp-template-code.md) | ✔️ | ✔️ | Preview 7 |
-| [EditorConfig files implicitly included](sdk/6.0/editorconfig-additional-files.md) | ✔️ | ❌ | |
-| [Generate apphost for macOS](sdk/6.0/apphost-generated-for-macos.md) | ✔️ | ❌ | Preview 6 |
-| [Generate error for duplicate files in publish output](sdk/6.0/duplicate-files-in-output.md) | ❌ | ✔️ | Preview 1 |
-| [GetTargetFrameworkProperties and GetNearestTargetFramework removed from ProjectReference protocol](sdk/6.0/gettargetframeworkproperties-and-getnearesttargetframework-removed.md) | ❌ | ✔️ | Preview 1 |
-| [Install location for x64 emulated on Arm64](sdk/6.0/path-x64-emulated.md) | ✔️ | ❌ | RC 2 |
-| [MSBuild no longer supports calling GetType()](sdk/6.0/calling-gettype-property-functions.md) | | | RC 1 |
-| [.NET can't be installed to custom location](sdk/6.0/install-location.md) | ✔️ | ✔️ | |
-| [OutputType not automatically set to WinExe](sdk/6.0/outputtype-not-set-automatically.md) | ✔️ | ❌ | RC 1 |
-| [Publish ReadyToRun with --no-restore requires changes](sdk/6.0/publish-readytorun-requires-restore-change.md) | ✔️ | ❌ | 6.0.100 |
-| [runtimeconfig.dev.json file not generated](sdk/6.0/runtimeconfigdev-file.md) | ❌ | ✔️ | 6.0.100 |
-| [RuntimeIdentifier warning if self-contained is unspecified](sdk/6.0/runtimeidentifier-self-contained.md) | ✔️ | ❌ | RC 1 |
-| [Tool manifests in root folder](sdk/7.0/manifest-search.md) | ✔️ | ✔️ | 6.0.4xx, 6.0.3xx, 6.0.1xx |
-| [Version requirements for .NET 6 SDK](sdk/6.0/vs-msbuild-version.md) | ✔️ | ✔️ | 6.0.300 |
-| [.version file includes build version](sdk/6.0/version-file-entries.md) | ✔️ | ✔️ | 6.0.401 |
-| [Write reference assemblies to IntermediateOutputPath](sdk/6.0/write-reference-assemblies-to-obj.md) | ❌ | ✔️ | 6.0.200 |
+| Title | Binary compatible | Source compatible |
+| - | :-: | :-: |
+| [`-p` option for `dotnet run` is deprecated](sdk/6.0/deprecate-p-option-dotnet-run.md) | ✔️ | ❌ |
+| [C# code in templates not supported by earlier versions](sdk/6.0/csharp-template-code.md) | ✔️ | ✔️ |
+| [EditorConfig files implicitly included](sdk/6.0/editorconfig-additional-files.md) | ✔️ | ❌ |
+| [Generate apphost for macOS](sdk/6.0/apphost-generated-for-macos.md) | ✔️ | ❌ |
+| [Generate error for duplicate files in publish output](sdk/6.0/duplicate-files-in-output.md) | ❌ | ✔️ |
+| [GetTargetFrameworkProperties and GetNearestTargetFramework removed from ProjectReference protocol](sdk/6.0/gettargetframeworkproperties-and-getnearesttargetframework-removed.md) | ❌ | ✔️ |
+| [Install location for x64 emulated on Arm64](sdk/6.0/path-x64-emulated.md) | ✔️ | ❌ |
+| [MSBuild no longer supports calling GetType()](sdk/6.0/calling-gettype-property-functions.md) | | |
+| [.NET can't be installed to custom location](sdk/6.0/install-location.md) | ✔️ | ✔️ |
+| [OutputType not automatically set to WinExe](sdk/6.0/outputtype-not-set-automatically.md) | ✔️ | ❌ |
+| [Publish ReadyToRun with --no-restore requires changes](sdk/6.0/publish-readytorun-requires-restore-change.md) | ✔️ | ❌ |
+| [runtimeconfig.dev.json file not generated](sdk/6.0/runtimeconfigdev-file.md) | ❌ | ✔️ |
+| [RuntimeIdentifier warning if self-contained is unspecified](sdk/6.0/runtimeidentifier-self-contained.md) | ✔️ | ❌ |
+| [Tool manifests in root folder](sdk/7.0/manifest-search.md) | ✔️ | ✔️ |
+| [Version requirements for .NET 6 SDK](sdk/6.0/vs-msbuild-version.md) | ✔️ | ✔️ |
+| [.version file includes build version](sdk/6.0/version-file-entries.md) | ✔️ | ✔️ |
+| [Write reference assemblies to IntermediateOutputPath](sdk/6.0/write-reference-assemblies-to-obj.md) | ❌ | ✔️ |
 
 ## Serialization
 
-| Title | Binary compatible | Source compatible | Introduced |
-| - | :-: | :-: | - |
-| [DataContractSerializer retains sign when deserializing -0](serialization/7.0/datacontractserializer-negative-sign.md) | ❌ | ✔️ | Servicing 6.0.11 |
-| [Default serialization format for TimeSpan](serialization/6.0/timespan-serialization-format.md) | ❌ | ✔️ | Servicing 6.0.2 |
-| [IAsyncEnumerable serialization](serialization/6.0/iasyncenumerable-serialization.md) | ✔️ | ❌ | Preview 4 |
-| [JSON source-generation API refactoring](serialization/6.0/json-source-gen-api-refactor.md) | ❌ | ✔️ | RC 2 |
-| [JsonNumberHandlingAttribute on collection properties](serialization/6.0/jsonnumberhandlingattribute-behavior.md) | ❌ | ✔️ | RC 1 |
-| [New JsonSerializer source generator overloads](serialization/6.0/jsonserializer-source-generator-overloads.md) | ❌ | ✔️ | Preview 6 |
+| Title | Binary compatible | Source compatible |
+| - | :-: | :-: |
+| [DataContractSerializer retains sign when deserializing -0](serialization/7.0/datacontractserializer-negative-sign.md) | ❌ | ✔️ |
+| [Default serialization format for TimeSpan](serialization/6.0/timespan-serialization-format.md) | ❌ | ✔️ |
+| [IAsyncEnumerable serialization](serialization/6.0/iasyncenumerable-serialization.md) | ✔️ | ❌ |
+| [JSON source-generation API refactoring](serialization/6.0/json-source-gen-api-refactor.md) | ❌ | ✔️ |
+| [JsonNumberHandlingAttribute on collection properties](serialization/6.0/jsonnumberhandlingattribute-behavior.md) | ❌ | ✔️ |
+| [New JsonSerializer source generator overloads](serialization/6.0/jsonserializer-source-generator-overloads.md) | ❌ | ✔️ |
 
 ## Windows Forms
 
-| Title | Binary compatible | Source compatible | Introduced |
-| - | :-: | :-: | - |
-| [C# templates use application bootstrap](windows-forms/6.0/application-bootstrap.md) | ✔️ | ❌ | RC 1 |
-| [Selected TableLayoutSettings properties throw InvalidEnumArgumentException](windows-forms/6.0/tablelayoutsettings-apis-throw-invalidenumargumentexception.md) | ❌ | ✔️ | Preview 1 |
-| [DataGridView-related APIs now throw InvalidOperationException](windows-forms/6.0/null-owner-causes-invalidoperationexception.md) | ❌ | ✔️ | Preview 4 |
-| [ListViewGroupCollection methods throw new InvalidOperationException](windows-forms/6.0/listview-invalidoperationexception.md) | ❌ | ✔️ | RC 2 |
-| [NotifyIcon.Text maximum text length increased](windows-forms/6.0/notifyicon-text-max-text-length-increased.md) | ❌ | ✔️ | Preview 1 |
-| [ScaleControl called only when needed](windows-forms/6.0/optimize-scalecontrol-calls.md) | ✔️ | ❌ | Servicing 6.0.101 |
-| [Some APIs throw ArgumentNullException](windows-forms/6.0/apis-throw-argumentnullexception.md) | ❌ | ✔️ | Preview 1-4 |
-| [TreeNodeCollection.Item throws exception if node is assigned elsewhere](windows-forms/6.0/treenodecollection-item-throws-argumentexception.md) | ❌ | ✔️ | Preview 1 |
+| Title | Binary compatible | Source compatible |
+| - | :-: | :-: |
+| [C# templates use application bootstrap](windows-forms/6.0/application-bootstrap.md) | ✔️ | ❌ |
+| [Selected TableLayoutSettings properties throw InvalidEnumArgumentException](windows-forms/6.0/tablelayoutsettings-apis-throw-invalidenumargumentexception.md) | ❌ | ✔️ |
+| [DataGridView-related APIs now throw InvalidOperationException](windows-forms/6.0/null-owner-causes-invalidoperationexception.md) | ❌ | ✔️ |
+| [ListViewGroupCollection methods throw new InvalidOperationException](windows-forms/6.0/listview-invalidoperationexception.md) | ❌ | ✔️ |
+| [NotifyIcon.Text maximum text length increased](windows-forms/6.0/notifyicon-text-max-text-length-increased.md) | ❌ | ✔️ |
+| [ScaleControl called only when needed](windows-forms/6.0/optimize-scalecontrol-calls.md) | ✔️ | ❌ |
+| [Some APIs throw ArgumentNullException](windows-forms/6.0/apis-throw-argumentnullexception.md) | ❌ | ✔️ |
+| [TreeNodeCollection.Item throws exception if node is assigned elsewhere](windows-forms/6.0/treenodecollection-item-throws-argumentexception.md) | ❌ | ✔️ |
 
 ## XML and XSLT
 
-| Title | Binary compatible | Source compatible | Introduced |
-| - | :-: | :-: | - |
-| [XmlDocument.XmlResolver nullability change](core-libraries/6.0/xmlresolver-nullable.md) | ❌ | ✔️ | RC 1 |
-| [XNodeReader.GetAttribute behavior for invalid index](core-libraries/6.0/xnodereader-getattribute.md) | ✔️ | ❌ | Preview 2 |
+| Title | Binary compatible | Source compatible |
+| - | :-: | :-: |
+| [XmlDocument.XmlResolver nullability change](core-libraries/6.0/xmlresolver-nullable.md) | ❌ | ✔️ |
+| [XNodeReader.GetAttribute behavior for invalid index](core-libraries/6.0/xnodereader-getattribute.md) | ✔️ | ❌ |
 
 ## See also
 

--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -17,25 +17,25 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 
 ## ASP.NET Core
 
-| Title                                                                                                | Type of change      | Introduced |
-| ---------------------------------------------------------------------------------------------------- | ------------------- | ---------- |
-| [ConcurrencyLimiterMiddleware is obsolete](aspnet-core/8.0/concurrencylimitermiddleware-obsolete.md) | Source incompatible | Preview 4  |
-| [Custom converters for serialization removed](aspnet-core/8.0/problemdetails-custom-converters.md)   | Behavioral change   | Preview 2  |
-| [ISystemClock is obsolete](aspnet-core/8.0/isystemclock-obsolete.md)                                 | Source incompatible | Preview 5  |
-| [Rate-limiting middleware requires AddRateLimiter](aspnet-core/8.0/addratelimiter-requirement.md)    | Behavioral change   | Preview 5  |
-| [Security token events return a JSonWebToken](aspnet-core/8.0/securitytoken-events.md)               | Behavioral change   | Preview 7  |
-| [TrimMode defaults to full for Web SDK projects](aspnet-core/8.0/trimmode-full.md)                   | Source incompatible | Preview 7  |
+| Title                                                                                                | Type of change      |
+| ---------------------------------------------------------------------------------------------------- | ------------------- |
+| [ConcurrencyLimiterMiddleware is obsolete](aspnet-core/8.0/concurrencylimitermiddleware-obsolete.md) | Source incompatible |
+| [Custom converters for serialization removed](aspnet-core/8.0/problemdetails-custom-converters.md)   | Behavioral change   |
+| [ISystemClock is obsolete](aspnet-core/8.0/isystemclock-obsolete.md)                                 | Source incompatible |
+| [Rate-limiting middleware requires AddRateLimiter](aspnet-core/8.0/addratelimiter-requirement.md)    | Behavioral change   |
+| [Security token events return a JSonWebToken](aspnet-core/8.0/securitytoken-events.md)               | Behavioral change   |
+| [TrimMode defaults to full for Web SDK projects](aspnet-core/8.0/trimmode-full.md)                   | Source incompatible |
 
 ## Containers
 
-| Title                                                                   | Type of change    | Introduced |
-| ----------------------------------------------------------------------- | ----------------- | ---------- |
-| ['ca-certificates' and 'krb5-libs' packages removed from Alpine images](containers/8.0/krb5-libs-package.md) | Binary incompatible | Preview 7 |
-| [Debian container images upgraded to Debian 12](containers/8.0/debian-version.md) | Binary incompatible/behavioral change | Preview 1 |
-| [Default ASP.NET Core port changed to 8080](containers/8.0/aspnet-port.md) | Behavioral change | Preview 1 |
-| ['libintl' package removed from Alpine images](containers/8.0/libintl-package.md) | Behavioral change | Preview 5 |
-| [Multi-platform container tags are Linux-only](containers/8.0/multi-platform-tags.md) | Behavioral change | Preview 3 |
-| [New 'app' user in Linux images](containers/8.0/app-user.md) | Behavioral change | Preview 1 |
+| Title                                                                   | Type of change    |
+| ----------------------------------------------------------------------- | ----------------- |
+| ['ca-certificates' and 'krb5-libs' packages removed from Alpine images](containers/8.0/krb5-libs-package.md) | Binary incompatible |
+| [Debian container images upgraded to Debian 12](containers/8.0/debian-version.md) | Binary incompatible/behavioral change |
+| [Default ASP.NET Core port changed to 8080](containers/8.0/aspnet-port.md) | Behavioral change |
+| ['libintl' package removed from Alpine images](containers/8.0/libintl-package.md) | Behavioral change |
+| [Multi-platform container tags are Linux-only](containers/8.0/multi-platform-tags.md) | Behavioral change |
+| [New 'app' user in Linux images](containers/8.0/app-user.md) | Behavioral change |
 
 ## Core .NET libraries
 
@@ -67,10 +67,10 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 
 ## Deployment
 
-| Title                                                                   | Type of change    | Introduced |
-| ----------------------------------------------------------------------- | ----------------- | ---------- |
-| [Host determines RID-specific assets](deployment/8.0/rid-asset-list.md) | Binary incompatible/behavioral change | Preview 5 |
-| [StripSymbols defaults to true](deployment/8.0/stripsymbols-default.md) | Behavioral change | Preview 4  |
+| Title                                                                   | Type of change    |
+| ----------------------------------------------------------------------- | ----------------- |
+| [Host determines RID-specific assets](deployment/8.0/rid-asset-list.md) | Binary incompatible/behavioral change |
+| [StripSymbols defaults to true](deployment/8.0/stripsymbols-default.md) | Behavioral change |
 
 ## Entity Framework Core
 
@@ -92,10 +92,10 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 
 ## Globalization
 
-| Title                                                                                             | Type of change    | Introduced |
-| ------------------------------------------------------------------------------------------------- | ----------------- | ---------- |
-| [Date and time converters honor culture argument](globalization/8.0/typeconverter-cultureinfo.md) | Behavioral change | Preview 4  |
-| [TwoDigitYearMax default is 2049](globalization/8.0/twodigityearmax-default.md)                   | Behavioral change | Preview 1  |
+| Title                                                                                             | Type of change    |
+| ------------------------------------------------------------------------------------------------- | ----------------- |
+| [Date and time converters honor culture argument](globalization/8.0/typeconverter-cultureinfo.md) | Behavioral change |
+| [TwoDigitYearMax default is 2049](globalization/8.0/twodigityearmax-default.md)                   | Behavioral change |
 
 ## Interop
 
@@ -115,9 +115,9 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 
 ## Reflection
 
-| Title                                                                                             | Type of change    | Introduced |
-| ------------------------------------------------------------------------------------------------- | ----------------- | ---------- |
-| [IntPtr no longer used for function pointer types](reflection/8.0/function-pointer-reflection.md) | Behavioral change | Preview 2  |
+| Title                                                                                             | Type of change    |
+| ------------------------------------------------------------------------------------------------- | ----------------- |
+| [IntPtr no longer used for function pointer types](reflection/8.0/function-pointer-reflection.md) | Behavioral change |
 
 ## SDK
 
@@ -142,10 +142,10 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 
 ## Serialization
 
-| Title                                                                                       | Type of change    | Introduced |
-| ------------------------------------------------------------------------------------------- | ----------------- | ---------- |
-| [BinaryFormatter disabled for most projects](serialization/8.0/binaryformatter-disabled.md) | Behavioral change | Preview 4  |
-| [Reflection-based deserializer resolves metadata eagerly](serialization/8.0/metadata-resolving.md) | Behavioral change | Preview 4 |
+| Title                                                                                       | Type of change    |
+| ------------------------------------------------------------------------------------------- | ----------------- |
+| [BinaryFormatter disabled for most projects](serialization/8.0/binaryformatter-disabled.md) | Behavioral change |
+| [Reflection-based deserializer resolves metadata eagerly](serialization/8.0/metadata-resolving.md) | Behavioral change |
 
 ## Windows Forms
 


### PR DESCRIPTION
The introduced version isn't really relevant after a product GAs.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/6.0.md](https://github.com/dotnet/docs/blob/a3d726691e99020bd6a60658f36a731443621eaa/docs/core/compatibility/6.0.md) | [Breaking changes in .NET 6](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/6.0?branch=pr-en-us-38306) |
| [docs/core/compatibility/8.0.md](https://github.com/dotnet/docs/blob/a3d726691e99020bd6a60658f36a731443621eaa/docs/core/compatibility/8.0.md) | [Breaking changes in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/8.0?branch=pr-en-us-38306) |

<!-- PREVIEW-TABLE-END -->