### PR TITLE
Added links to blog posts

### DIFF
--- a/docs/fsharp/index.yml
+++ b/docs/fsharp/index.yml
@@ -121,6 +121,10 @@ landingContent:
     linkLists:
       - linkListType: whats-new
         links:
+          - text: "What's new in F# 8"
+            url: whats-new/fsharp-8.md
+          - text: "What's new in F# 7"
+            url: whats-new/fsharp-7.md
           - text: "What's new in F# 6"
             url: whats-new/fsharp-6.md
           - text: "What's new in F# 5"

--- a/docs/fsharp/whats-new/fsharp-7.md
+++ b/docs/fsharp/whats-new/fsharp-7.md
@@ -1,0 +1,8 @@
+---
+title: What's new in F# 7 - F# Guide
+description: Find information on the new features available in F# 7.
+ms.date: 11/17/2023
+---
+# What's new in F# 8
+
+For information on F# 7, please see [Announcing F# 7](https://devblogs.microsoft.com/dotnet/announcing-fsharp-7).

--- a/docs/fsharp/whats-new/fsharp-7.md
+++ b/docs/fsharp/whats-new/fsharp-7.md
@@ -3,6 +3,6 @@ title: What's new in F# 7 - F# Guide
 description: Find information on the new features available in F# 7.
 ms.date: 11/17/2023
 ---
-# What's new in F# 8
+# What's new in F# 7
 
 For information on F# 7, please see [Announcing F# 7](https://devblogs.microsoft.com/dotnet/announcing-fsharp-7).

--- a/docs/fsharp/whats-new/fsharp-8.md
+++ b/docs/fsharp/whats-new/fsharp-8.md
@@ -1,0 +1,8 @@
+---
+title: What's new in F# 8 - F# Guide
+description: Find information on the new features available in F# 8.
+ms.date: 11/17/2023
+---
+# What's new in F# 8
+
+For information on F# 8, please see [Announcing F# 8](https://devblogs.microsoft.com/dotnet/announcing-fsharp-8).


### PR DESCRIPTION
## Summary

Per discussions including simple links to blog posts as at least interim fix

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/whats-new/fsharp-7.md](https://github.com/dotnet/docs/blob/ac848a19aeb66824fb9c239db308666777bbbad9/docs/fsharp/whats-new/fsharp-7.md) | [What's new in F# 7](https://review.learn.microsoft.com/en-us/dotnet/fsharp/whats-new/fsharp-7?branch=pr-en-us-38307) |
| [docs/fsharp/whats-new/fsharp-8.md](https://github.com/dotnet/docs/blob/ac848a19aeb66824fb9c239db308666777bbbad9/docs/fsharp/whats-new/fsharp-8.md) | [What's new in F# 8 - F# Guide](https://review.learn.microsoft.com/en-us/dotnet/fsharp/whats-new/fsharp-8?branch=pr-en-us-38307) |

<!-- PREVIEW-TABLE-END -->