### PR TITLE
fix incorrect JsonWebToken class name

### DIFF
--- a/docs/core/compatibility/aspnet-core/8.0/securitytoken-events.md
+++ b/docs/core/compatibility/aspnet-core/8.0/securitytoken-events.md
@@ -43,7 +43,7 @@ However, if you were down-casting one of the affected `SecurityToken` properties
   service.Configure<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme, options => {
       options.Events.TokenValidated = (context) => {
           // Replace your cast to JwtSecurityToken.
-          JSonWebToken token = context.SecurityToken as JSonWebToken;
+          JsonWebToken token = context.SecurityToken as JsonWebToken;
           // Do something ...
       };
   });


### PR DESCRIPTION
## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/aspnet-core/8.0/securitytoken-events.md](https://github.com/dotnet/docs/blob/4dae661db545f221dd0c5a08ec81daf7c7f42d52/docs/core/compatibility/aspnet-core/8.0/securitytoken-events.md) | [Security token events return a JSonWebToken](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/aspnet-core/8.0/securitytoken-events?branch=pr-en-us-38309) |

<!-- PREVIEW-TABLE-END -->