### PR TITLE
Update dotnet-8 KeyedSevice

### DIFF
--- a/docs/core/whats-new/dotnet-8.md
+++ b/docs/core/whats-new/dotnet-8.md
@@ -700,9 +700,9 @@ class BigCacheConsumer([FromKeyedServices("big")] IMemoryCache cache)
     public object? GetData() => cache.Get("data");
 }
 
-class SmallCacheConsumer(IKeyedServiceProvider keyedServiceProvider)
+class SmallCacheConsumer(IServiceProvider serviceProvider)
 {
-    public object? GetData() => keyedServiceProvider.GetRequiredKeyedService<IMemoryCache>("small");
+    public object? GetData() => serviceProvider.GetRequiredKeyedService<IMemoryCache>("small");
 }
 ```
 

--- a/docs/core/whats-new/dotnet-8.md
+++ b/docs/core/whats-new/dotnet-8.md
@@ -702,7 +702,7 @@ class BigCacheConsumer([FromKeyedServices("big")] IMemoryCache cache)
 
 class SmallCacheConsumer(IServiceProvider serviceProvider)
 {
-    public object? GetData() => serviceProvider.GetRequiredKeyedService<IMemoryCache>("small");
+    public object? GetData() => serviceProvider.GetRequiredKeyedService<IMemoryCache>("small").Get("data");
 }
 ```
 

--- a/docs/core/whats-new/dotnet-8.md
+++ b/docs/core/whats-new/dotnet-8.md
@@ -685,6 +685,8 @@ builder.Services.AddKeyedSingleton<ICache, SmallCache>("small");
 var app = builder.Build();
 app.MapGet("/big", (BigCacheConsumer data) => data.GetData());
 app.MapGet("/small", (SmallCacheConsumer data) => data.GetData());
+app.MapGet("/big-cache", ([FromKeyedServices("big")] ICache cache) => cache.Get("data"));
+app.MapGet("/small-cache", (HttpContext httpContext) => httpContext.RequestServices.GetRequiredKeyedService<ICache>("small").Get("data"));
 app.Run();
 
 class BigCacheConsumer([FromKeyedServices("big")] ICache cache)

--- a/docs/core/whats-new/dotnet-8.md
+++ b/docs/core/whats-new/dotnet-8.md
@@ -674,35 +674,42 @@ Keyed dependency injection (DI) services provides a means for registering and re
 - Various new extension methods for <xref:Microsoft.Extensions.DependencyInjection.IServiceCollection> to support keyed services, for example, <xref:Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddKeyedScoped%2A?displayProperty=nameWithType>.
 - The <xref:Microsoft.Extensions.DependencyInjection.ServiceProvider> implementation of <xref:Microsoft.Extensions.DependencyInjection.IKeyedServiceProvider>.
 
-The following example shows you to use keyed DI services.
+The following example shows you how to use keyed DI services.
 
 ```csharp
-using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Options;
-
 var builder = WebApplication.CreateBuilder(args);
-
 builder.Services.AddSingleton<BigCacheConsumer>();
 builder.Services.AddSingleton<SmallCacheConsumer>();
-
-builder.Services.AddKeyedSingleton<IMemoryCache, BigCache>("big");
-builder.Services.AddKeyedSingleton<IMemoryCache, SmallCache>("small");
-
+builder.Services.AddKeyedSingleton<ICache, BigCache>("big");
+builder.Services.AddKeyedSingleton<ICache, SmallCache>("small");
 var app = builder.Build();
-
 app.MapGet("/big", (BigCacheConsumer data) => data.GetData());
 app.MapGet("/small", (SmallCacheConsumer data) => data.GetData());
-
 app.Run();
 
-class BigCacheConsumer([FromKeyedServices("big")] IMemoryCache cache)
+class BigCacheConsumer([FromKeyedServices("big")] ICache cache)
 {
     public object? GetData() => cache.Get("data");
 }
 
 class SmallCacheConsumer(IServiceProvider serviceProvider)
 {
-    public object? GetData() => serviceProvider.GetRequiredKeyedService<IMemoryCache>("small").Get("data");
+    public object? GetData() => serviceProvider.GetRequiredKeyedService<ICache>("small").Get("data");
+}
+
+public interface ICache
+{
+    object Get(string key);
+}
+
+public class BigCache : ICache
+{
+    public object Get(string key) => $"Resolving {key} from big cache.";
+}
+
+public class SmallCache : ICache
+{
+    public object Get(string key) => $"Resolving {key} from small cache.";
 }
 ```
 


### PR DESCRIPTION
## Summary

- Update to `IServiceProvider` since there's no `IKeyedServiceProvider` registered
- Update the `SmallCacheConsumer` to get cache value instead of returning the `IMemoryCache`



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/whats-new/dotnet-8.md](https://github.com/dotnet/docs/blob/3dd944dafa13d9df165f049e575e3529279e24a7/docs/core/whats-new/dotnet-8.md) | [What's new in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-8?branch=pr-en-us-38333) |


<!-- PREVIEW-TABLE-END -->