### PR TITLE
Link to the `task-type like` types in `CS1983` page

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs1983.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1983.md
@@ -9,7 +9,7 @@ helpviewer_keywords:
 ---
 # Compiler Error CS1983
 
-The return type of an async method must be void, Task, Task\<T\>, a task-like type (A task-like type is one that adheres to the pattern, [described here](https://learn.microsoft.com/dotnet/csharp/language-reference/language-specification/classes#15151-general), required by the C# specification), IAsyncEnumerable\<T\>, or IAsyncEnumerator\<T\>
+The return type of an async method must be void, Task, Task\<T\>, a task-like type (A task-like type is one that adheres to the pattern, [described here](/dotnet/csharp/language-reference/language-specification/classes#15151-general), required by the C# specification), IAsyncEnumerable\<T\>, or IAsyncEnumerator\<T\>
 
 ## Example
 

--- a/docs/csharp/language-reference/compiler-messages/cs1983.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1983.md
@@ -9,7 +9,7 @@ helpviewer_keywords:
 ---
 # Compiler Error CS1983
 
-The return type of an async method must be void, Task, Task\<T\>, a task-like type, IAsyncEnumerable\<T\>, or IAsyncEnumerator\<T\>
+The return type of an async method must be void, Task, Task\<T\>, a task-like type (A task-like type is one that adheres to the pattern, [described here](https://learn.microsoft.com/dotnet/csharp/language-reference/language-specification/classes#15151-general), required by the C# specification), IAsyncEnumerable\<T\>, or IAsyncEnumerator\<T\>
 
 ## Example
 

--- a/docs/csharp/language-reference/compiler-messages/cs1983.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1983.md
@@ -9,7 +9,7 @@ helpviewer_keywords:
 ---
 # Compiler Error CS1983
 
-The return type of an async method must be void, Task, Task\<T\>, a task-like type (A task-like type is one that adheres to the pattern, [described here](/dotnet/csharp/language-reference/language-specification/classes#15151-general), required by the C# specification), IAsyncEnumerable\<T\>, or IAsyncEnumerator\<T\>
+The return type of an async method must be void, Task, Task\<T\>, a task-like type (A task-like type is one that adheres to the pattern, [described here](~/_csharpstandard/standard/classes.md#15151-general), required by the C# specification), IAsyncEnumerable\<T\>, or IAsyncEnumerator\<T\>
 
 ## Example
 


### PR DESCRIPTION
This pull request fixes #38310 
It adds the link to the description of task-types in general async page to the `CS1983` page.

**NOTE:**
I used the `/dotnet/csharp/language-reference/language-specification` dir page, as I saw that this is the only way anything in `language-specification` is linked to.
The code base does no longer have that directory, hence no possibility to use relative linking.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-messages/cs1983.md](https://github.com/dotnet/docs/blob/1a09cad482457cc3a0e247e8d6b97b30677e4bdb/docs/csharp/language-reference/compiler-messages/cs1983.md) | [Compiler Error CS1983](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs1983?branch=pr-en-us-38339) |


<!-- PREVIEW-TABLE-END -->