### PR TITLE
Fix the transformation of DecimalValue to decimal

### DIFF
--- a/docs/architecture/grpc-for-wcf-developers/protobuf-data-types.md
+++ b/docs/architecture/grpc-for-wcf-developers/protobuf-data-types.md
@@ -169,7 +169,7 @@ public partial class DecimalValue
 
     public static implicit operator decimal(CustomTypes.DecimalValue grpcDecimal)
     {
-        return grpcDecimal.Units + grpcDecimal.Nanos / NanoFactor;
+        return (grpcDecimal.Units + grpcDecimal.Nanos) / NanoFactor;
     }
 
     public static implicit operator CustomTypes.DecimalValue(decimal value)


### PR DESCRIPTION
## Summary

Describe your changes here.

- Fix the transformation of DecimalValue to decimal

Before

 ```
  public static implicit operator decimal(CustomTypes.DecimalValue grpcDecimal)
  {
       return grpcDecimal.Units + grpcDecimal.Nanos / NanoFactor;
  }
```

After
```

   public static implicit operator decimal(CustomTypes.DecimalValue grpcDecimal)
   {
       return (grpcDecimal.Units + grpcDecimal.Nanos) / NanoFactor;
   }
```


Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/architecture/grpc-for-wcf-developers/protobuf-data-types.md](https://github.com/dotnet/docs/blob/7925db57cf6f0e2009ced915e12f6b6a021bae82/docs/architecture/grpc-for-wcf-developers/protobuf-data-types.md) | [Protobuf scalar data types](https://review.learn.microsoft.com/en-us/dotnet/architecture/grpc-for-wcf-developers/protobuf-data-types?branch=pr-en-us-38343) |

<!-- PREVIEW-TABLE-END -->