### PR TITLE
Update comparisons-and-sorts-within-collections.md

### DIFF
--- a/docs/standard/collections/comparisons-and-sorts-within-collections.md
+++ b/docs/standard/collections/comparisons-and-sorts-within-collections.md
@@ -38,7 +38,7 @@ In addition, some constructor overloads for dictionary collections accept an <xr
 
 Methods such as `BinarySearch` and `Sort` use an ordering comparer for the collection elements. The comparisons can be between elements of the collection, or between an element and a specified value. For comparing objects, there is the concept of a `default comparer` and an `explicit comparer`.
 
-The default comparer relies on at least one of the objects being compared to implement the **IComparable** interface. It is a good practice to implement **IComparable** on all classes are used as values in a list collection or as keys in a dictionary collection. For a generic collection, equality comparison is determined according to the following:
+The default comparer relies on at least one of the objects being compared to implement the **IComparable** interface. It is a good practice to implement **IComparable** on all classes which are used as values in a list collection or as keys in a dictionary collection. For a generic collection, equality comparison is determined according to the following:
 
 - If type T implements the <xref:System.IComparable%601?displayProperty=nameWithType> generic interface, then the default comparer is the <xref:System.IComparable%601.CompareTo%28%600%29?displayProperty=nameWithType> method of that interface
 


### PR DESCRIPTION
Added a missing preposition.

## Summary

Minor edit; added a word that was probably missing.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/collections/comparisons-and-sorts-within-collections.md](https://github.com/dotnet/docs/blob/75236ca6799c9f96e012181c97c2c1de6015a36d/docs/standard/collections/comparisons-and-sorts-within-collections.md) | [Comparisons and sorts within collections](https://review.learn.microsoft.com/en-us/dotnet/standard/collections/comparisons-and-sorts-within-collections?branch=pr-en-us-38345) |

<!-- PREVIEW-TABLE-END -->