### PR TITLE
Update component-design-guidelines.md

### DIFF
--- a/docs/fsharp/style-guide/component-design-guidelines.md
+++ b/docs/fsharp/style-guide/component-design-guidelines.md
@@ -226,6 +226,8 @@ Adding the `[<RequireQualifiedAccess>]` attribute to a module indicates that the
 
 This is useful when functions and values in the module have names that are likely to conflict with names in other modules. Requiring qualified access can greatly increase the long-term maintainability and evolvability of a library.
 
+It is strongly suggested to have the `[<RequireQualifiedAccess>]` attribute for custom modules that extend those provided by `FSharp.Core` (such as `Seq`, `List`, `Array`), as those modules are prevalently used in F# code and have `[<RequireQualifiedAccess>]` defined on them; more generally, it is discouraged to define custom modules lacking the attribute, when such module shadows or extend other modules that have the attribute. 
+
 Adding the `[<AutoOpen>]` attribute to a module means the module will be opened when the containing namespace is opened. The `[<AutoOpen>]` attribute may also be applied to an assembly to indicate a module that is automatically opened when the assembly is referenced.
 
 For example, a statistics library **MathsHeaven.Statistics** might contain a `module MathsHeaven.Statistics.Operators` containing functions `erf` and `erfc`. It is reasonable to mark this module as `[<AutoOpen>]`. This means `open MathsHeaven.Statistics` will also open this module and bring the names `erf` and `erfc` into scope. Another good use of `[<AutoOpen>]` is for modules containing extension methods.

--- a/docs/fsharp/style-guide/component-design-guidelines.md
+++ b/docs/fsharp/style-guide/component-design-guidelines.md
@@ -226,7 +226,7 @@ Adding the `[<RequireQualifiedAccess>]` attribute to a module indicates that the
 
 This is useful when functions and values in the module have names that are likely to conflict with names in other modules. Requiring qualified access can greatly increase the long-term maintainability and evolvability of a library.
 
-It is strongly suggested to have the `[<RequireQualifiedAccess>]` attribute for custom modules that extend those provided by `FSharp.Core` (such as `Seq`, `List`, `Array`), as those modules are prevalently used in F# code and have `[<RequireQualifiedAccess>]` defined on them; more generally, it is discouraged to define custom modules lacking the attribute, when such module shadows or extend other modules that have the attribute. 
+It is strongly suggested to have the `[<RequireQualifiedAccess>]` attribute for custom modules that extend those provided by `FSharp.Core` (such as `Seq`, `List`, `Array`), as those modules are prevalently used in F# code and have `[<RequireQualifiedAccess>]` defined on them; more generally, it is discouraged to define custom modules lacking the attribute, when such module shadows or extend other modules that have the attribute.
 
 Adding the `[<AutoOpen>]` attribute to a module means the module will be opened when the containing namespace is opened. The `[<AutoOpen>]` attribute may also be applied to an assembly to indicate a module that is automatically opened when the assembly is referenced.
 


### PR DESCRIPTION
being very explicit about good practices related to `[<RequireQualifiedAccess>]` when defining modules that shadow or extend others that have the attribute.

Language design notes:
* we should consider a soft RequireQualifiedAccess mode, which gives a warning, allows API authors to do a warning wave on future change
* we should consider warnings / analyzer to implement the rules that are suggested in this edit

related:
* https://github.com/fslaborg/FSharp.Stats/issues/312
* https://github.com/dotnet/fsharp/issues/16219

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/style-guide/component-design-guidelines.md](https://github.com/dotnet/docs/blob/fb8928fa4d94c02798c65dee673ca719dddb4715/docs/fsharp/style-guide/component-design-guidelines.md) | [F# component design guidelines](https://review.learn.microsoft.com/en-us/dotnet/fsharp/style-guide/component-design-guidelines?branch=pr-en-us-38349) |


<!-- PREVIEW-TABLE-END -->