### PR TITLE
Fix macos supported releases table

### DIFF
--- a/docs/core/install/macos.md
+++ b/docs/core/install/macos.md
@@ -29,10 +29,11 @@ The following table is a list of currently supported .NET releases and the versi
 
 | Operating System       | .NET 8 (LTS) | .NET 7 (STS) | .NET 6 (LTS) |
 |------------------------|--------------|--------------|--------------|
-| macOS 13.0 "Ventura"   | ❌           | ✔️ 7.0        | ✔️ 6.0        |
-| macOS 12.0 "Monterey"  | ❌           | ✔️ 7.0        | ✔️ 6.0        |
+| macOS 14.0 "Sonoma"    | ✔️ 8.0        | ✔️ 7.0        | ✔️ 6.0        |
+| macOS 13.0 "Ventura"   | ✔️ 8.0        | ✔️ 7.0        | ✔️ 6.0        |
+| macOS 12.0 "Monterey"  | ✔️ 8.0        | ✔️ 7.0        | ✔️ 6.0        |
 | macOS 11.0 "Big Sur"   | ❌           | ✔️ 7.0        | ✔️ 6.0        |
-| macOS 10.15 "Catalina" | ✔️ 8.0       | ✔️ 7.0        | ✔️ 6.0        |
+| macOS 10.15 "Catalina" | ❌           | ✔️ 7.0        | ✔️ 6.0        |
 
 For a full list of .NET versions and their support life cycle, see [.NET Support Policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-core).
 

--- a/docs/core/install/remove-runtime-sdk-versions.md
+++ b/docs/core/install/remove-runtime-sdk-versions.md
@@ -3,7 +3,7 @@ title: Remove the .NET runtime and SDK
 description: This article describes how to uninstall .NET. You'll need to determine which versions of the .NET Runtime and SDK are currently installed, and then, how to remove them on Windows, Mac, and Linux.
 author: adegeo
 ms.author: adegeo
-ms.date: 02/22/2023
+ms.date: 11/21/2023
 zone_pivot_groups: operating-systems-set-one
 ---
 
@@ -46,7 +46,6 @@ You can remove the following types if .NET installations:
 
 - [Package manager](#package-manager)
 - [Manually or scripted installs](#scripted-or-manual)
-- [Snap installs](#snap)
 
 ### Package manager
 
@@ -65,20 +64,9 @@ The package name for the .NET SDK installation for most package managers is `dot
 
 For machines that have installed only the runtime, and not the SDK, the package name is `dotnet-runtime-<version>` for the .NET runtime, and `aspnetcore-runtime-<version>` for the entire runtime stack.
 
-### Snap
-
-To remove a Snap package, use the `snap remove <package>` command. For example, to remove .NET Runtime 3.1, use `snap remove dotnet-runtime-31`.
-
-::: zone-end
-
-::: zone pivot="os-linux, os-macos"
-
 ### Scripted or manual
 
 If you installed .NET using the [dotnet-install script](linux-scripted-manual.md#scripted-install), or by [extracting a tarball](linux-scripted-manual.md#manual-install), you must remove .NET using the manual method.
-
-> [!IMPORTANT]
-> This information is written for Linux, but also applies to macOS. On macOS, the root directory is most likely `/usr/local/share/dotnet/`. Substitute the directories accordingly.
 
 When you manually install .NET, it's generally installed to the `/usr/share/dotnet/`, `/usr/lib/dotnet/`, or the `$HOME/.dotnet` directory. The SDK, runtime, and .NET host, are installed into separate sub directories. These "component" directories contain a directory for each version of .NET. By removing the versioned directories, you remove that version of .NET from your system. These directories may vary depending on your Linux distribution.
 
@@ -94,8 +82,8 @@ There are three commands you can use to discover where .NET is installed: `dotne
 
   ```
   /usr/share/dotnet/shared/Microsoft.NETCore.App/$version/
-  /usr/share/dotnet/shared/Microsoft.AspNetCore.All/$version/
   /usr/share/dotnet/shared/Microsoft.AspNetCore.App/$version/
+  /usr/share/dotnet/shared/Microsoft.AspNetCore.All/$version/
   ```
 
 - **.NET host**
@@ -109,24 +97,45 @@ sudo rm -rf /usr/share/dotnet/sdk/6.0.406
 ```
 
 > [!IMPORTANT]
-> The version directories may not match the "version" you're uninstalling. The individual runtimes and SDKs that are installed with a single .NET release may have different versions. For example, you may have installed ASP.NET Core 5 Runtime, which installed the 5.0.2 ASP.NET Core runtime and the 5.0.8 .NET runtime. Each has a different versioned directory. For more information, see [Overview of how .NET is versioned](../versions/index.md).
-
-> [!IMPORTANT]
-> If you're using an Arm-based Mac, such as one with an M1 chip, review the directory paths described in [Install .NET on Arm-based Macs](macos.md#arm-based-macs).
+> The version directories may not match the "version" you're uninstalling. The individual runtimes and SDKs that are installed with a single .NET release may have different versions. For example, you may have installed ASP.NET Core 8 Runtime, which installed the 8.0.2 ASP.NET Core runtime and the 8.0.8 .NET runtime. Each has a different versioned directory. For more information, see [Overview of how .NET is versioned](../versions/index.md).
 
 ::: zone-end
 
-::: zone pivot="os-linux"
+::: zone pivot="os-macos"
 
-### Prior to .NET Core 2.0
+When you manually install .NET, it's generally installed to the `/usr/local/share/dotnet/` or the `$HOME/.dotnet` directory. The SDK, runtime, and .NET host, are installed into separate sub directories. These "component" directories contain a directory for each version of .NET. By removing the versioned directories, you remove that version of .NET from your system. These directories may vary depending on your Linux distribution.
 
-.NET Core installations earlier than 2.0 didn't uninstall the .NET host application when the SDK was uninstalled using the package manager. Using `apt-get`, the command is:
+There are three commands you can use to discover where .NET is installed: `dotnet --list-sdks` for SDKs, `dotnet --list-runtimes` for runtimes, and `dotnet --info` for everything. These commands don't list the .NET host. To determine which hosts are installed, check the `/usr/local/share/dotnet/host/fxr/` directory. The following list represents the directories of a specific version of .NET, where the `$version` variable represents the version of the .NET:
+
+- **SDK**:
+
+  `/usr/local/share/dotnet/sdk/$version/`
+
+- **Runtime**:
+
+  The runtime is based on specific .NET product runtimes, such as `Microsoft.AspNetCore.All` or `Microsoft.NETCore.App` (the .NET runtime specifically). These are installed to the `/usr/local/share/dotnet/shared/$product/$version` directory, where `$product` is the product runtime. For example, you may see the following directories:
+
+  ```
+  /usr/local/share/dotnet/shared/Microsoft.NETCore.App/$version/dotnet --info
+  /usr/local/share/dotnet/shared/Microsoft.AspNetCore.App/$version/
+  /usr/local/share/dotnet/shared/Microsoft.AspNetCore.All/$version/
+  ```
+
+- **.NET host**
+
+  `/usr/local/share/dotnet/host/fxr/$version/`
+
+Use the `rm -rf` command to remove a version of .NET. For example, to remove the 6.0.406 SDK, run the following command:
 
 ```bash
-apt-get remove dotnet-host
+sudo rm -rf /usr/local/share/dotnet/sdk/6.0.406
 ```
 
-There's no version attached to `dotnet-host`.
+> [!IMPORTANT]
+> The version directories may not match the "version" you're uninstalling. The individual runtimes and SDKs that are installed with a single .NET release may have different versions. For example, you may have installed ASP.NET Core 8 Runtime, which installed the 8.0.2 ASP.NET Core runtime and the 8.0.8 .NET runtime. Each has a different versioned directory. For more information, see [Overview of how .NET is versioned](../versions/index.md).
+
+> [!IMPORTANT]
+> If you're using an Arm-based Mac, such as one with an M1 chip, review the directory paths described in [Install .NET on Arm-based Macs](macos.md#arm-based-macs).
 
 ::: zone-end
 

--- a/docs/core/install/remove-runtime-sdk-versions.md
+++ b/docs/core/install/remove-runtime-sdk-versions.md
@@ -97,13 +97,13 @@ sudo rm -rf /usr/share/dotnet/sdk/6.0.406
 ```
 
 > [!IMPORTANT]
-> The version directories may not match the "version" you're uninstalling. The individual runtimes and SDKs that are installed with a single .NET release may have different versions. For example, you may have installed ASP.NET Core 8 Runtime, which installed the 8.0.2 ASP.NET Core runtime and the 8.0.8 .NET runtime. Each has a different versioned directory. For more information, see [Overview of how .NET is versioned](../versions/index.md).
+> The version directories might not match the "version" you're uninstalling. The individual runtimes and SDKs that are installed with a single .NET release might have different versions. For example, you might have installed ASP.NET Core 8 Runtime, which installed the 8.0.2 ASP.NET Core runtime and the 8.0.8 .NET runtime. Each has a different versioned directory. For more information, see [Overview of how .NET is versioned](../versions/index.md).
 
 ::: zone-end
 
 ::: zone pivot="os-macos"
 
-When you manually install .NET, it's generally installed to the `/usr/local/share/dotnet/` or the `$HOME/.dotnet` directory. The SDK, runtime, and .NET host, are installed into separate sub directories. These "component" directories contain a directory for each version of .NET. By removing the versioned directories, you remove that version of .NET from your system. These directories may vary depending on your Linux distribution.
+When you manually install .NET, it's generally installed to the `/usr/local/share/dotnet/` or the `$HOME/.dotnet` directory. The SDK, runtime, and .NET host are installed into separate sub directories. These "component" directories contain a directory for each version of .NET. By removing the versioned directories, you remove that version of .NET from your system. These directories may vary depending on your Linux distribution.
 
 There are three commands you can use to discover where .NET is installed: `dotnet --list-sdks` for SDKs, `dotnet --list-runtimes` for runtimes, and `dotnet --info` for everything. These commands don't list the .NET host. To determine which hosts are installed, check the `/usr/local/share/dotnet/host/fxr/` directory. The following list represents the directories of a specific version of .NET, where the `$version` variable represents the version of the .NET:
 
@@ -113,7 +113,7 @@ There are three commands you can use to discover where .NET is installed: `dotne
 
 - **Runtime**:
 
-  The runtime is based on specific .NET product runtimes, such as `Microsoft.AspNetCore.All` or `Microsoft.NETCore.App` (the .NET runtime specifically). These are installed to the `/usr/local/share/dotnet/shared/$product/$version` directory, where `$product` is the product runtime. For example, you may see the following directories:
+  The runtime is based on specific .NET product runtimes, such as `Microsoft.AspNetCore.All` or `Microsoft.NETCore.App` (the .NET runtime specifically). These are installed to the `/usr/local/share/dotnet/shared/$product/$version` directory, where `$product` is the product runtime. For example, you might see the following directories:
 
   ```
   /usr/local/share/dotnet/shared/Microsoft.NETCore.App/$version/dotnet --info
@@ -132,7 +132,7 @@ sudo rm -rf /usr/local/share/dotnet/sdk/6.0.406
 ```
 
 > [!IMPORTANT]
-> The version directories may not match the "version" you're uninstalling. The individual runtimes and SDKs that are installed with a single .NET release may have different versions. For example, you may have installed ASP.NET Core 8 Runtime, which installed the 8.0.2 ASP.NET Core runtime and the 8.0.8 .NET runtime. Each has a different versioned directory. For more information, see [Overview of how .NET is versioned](../versions/index.md).
+> The version directories might not match the "version" you're uninstalling. The individual runtimes and SDKs that are installed with a single .NET release might have different versions. For example, you might have installed ASP.NET Core 8 Runtime, which installed the 8.0.2 ASP.NET Core runtime and the 8.0.8 .NET runtime. Each has a different versioned directory. For more information, see [Overview of how .NET is versioned](../versions/index.md).
 
 > [!IMPORTANT]
 > If you're using an Arm-based Mac, such as one with an M1 chip, review the directory paths described in [Install .NET on Arm-based Macs](macos.md#arm-based-macs).


### PR DESCRIPTION
## Summary

Fix the table of supported OS versions.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/macos.md](https://github.com/dotnet/docs/blob/e79788a0db639555956d6a2c7e957339e3069d0b/docs/core/install/macos.md) | [Install .NET on macOS](https://review.learn.microsoft.com/en-us/dotnet/core/install/macos?branch=pr-en-us-38355) |
| [docs/core/install/remove-runtime-sdk-versions.md](https://github.com/dotnet/docs/blob/e79788a0db639555956d6a2c7e957339e3069d0b/docs/core/install/remove-runtime-sdk-versions.md) | [How to remove the .NET Runtime and SDK](https://review.learn.microsoft.com/en-us/dotnet/core/install/remove-runtime-sdk-versions?branch=pr-en-us-38355) |


<!-- PREVIEW-TABLE-END -->