### PR TITLE
- documents container image name deprecation

### DIFF
--- a/docs/core/docker/publish-as-container.md
+++ b/docs/core/docker/publish-as-container.md
@@ -98,7 +98,7 @@ dotnet add package Microsoft.NET.Build.Containers
 
 There are various configuration options available when publishing an app as a container. For more information, see [Configure container image](#configure-container-image).
 
-By default, the container image name is the `AssemblyName` of the project. If that name is invalid as a container image name, you can override it by specifying a `ContainerImageName` as shown in the following project file:
+By default, the container image name is the `AssemblyName` of the project. If that name is invalid as a container image name, you can override it by specifying a `ContainerImageName` or `ContainerRepository` as shown in the following project file:
 
 :::zone pivot="dotnet-8-0"
 
@@ -281,6 +281,9 @@ The container image name controls the name of the image itself, for example, `do
     <ContainerImageName>my-app</ContainerImageName>
 </PropertyGroup>
 ```
+
+> [!NOTE]
+> Starting with .NET 8, `ContainerImageName` is deprecated in favor of `ContainerRepository`.
 
 :::zone-end
 


### PR DESCRIPTION
## Summary

documents the fact that container image name is deprecated with dotnet 8 in favor of container repository


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/docker/publish-as-container.md](https://github.com/dotnet/docs/blob/7588a5d2dd4dfc27151dc9aa98f941eedf17ab52/docs/core/docker/publish-as-container.md) | [Containerize a .NET app with dotnet publish](https://review.learn.microsoft.com/en-us/dotnet/core/docker/publish-as-container?branch=pr-en-us-38359) |

<!-- PREVIEW-TABLE-END -->