### PR TITLE
Clarify installation location in dotnet-tool-install.md

### DIFF
--- a/docs/core/tools/dotnet-tool-install.md
+++ b/docs/core/tools/dotnet-tool-install.md
@@ -65,7 +65,7 @@ Executables are generated in these folders for each globally installed tool, alt
 
 ### `--tool-path` tools
 
-Local tools with explicit tool paths are stored wherever you specified the `--tool-path` parameter to point to. They're stored in the same way as global tools: an executable binary with the actual binaries in a sibling `.store` directory.
+Tools with explicit tool paths are stored wherever you specified the `--tool-path` parameter to point to. They're stored in the same way as global tools: an executable binary with the actual binaries in a sibling `.store` directory.
 
 ### Local tools
 


### PR DESCRIPTION
## Summary

Using `--tool-path` is incompatible with local tools. Remove the incorrect "Local" specifier in section describing the tool path option.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-tool-install.md](https://github.com/dotnet/docs/blob/80ca348f128cfefc21b74e7feeb3606a961afc8b/docs/core/tools/dotnet-tool-install.md) | [dotnet tool install](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-install?branch=pr-en-us-38361) |

<!-- PREVIEW-TABLE-END -->