### PR TITLE
.NET 8 can't be installed through the install script on RHEL 7.

### DIFF
--- a/docs/core/install/linux-rhel.md
+++ b/docs/core/install/linux-rhel.md
@@ -55,6 +55,10 @@ The following table is a list of currently supported .NET releases on both RHEL 
 
 [!INCLUDE [linux-dnf-install-80](includes/linux-install-80-dnf.md)]
 
+## RHEL 7 ❌ .NET 8
+
+.NET 8 isn't compatible with RHEL 7 and doesn't work.
+
 ## RHEL 7 ❌ .NET 7
 
 .NET 7 isn't officially supported on RHEL 7. To install .NET 7, see [Install .NET on Linux by using an install script or by extracting binaries](linux-scripted-manual.md).

--- a/docs/core/install/linux-rhel.md
+++ b/docs/core/install/linux-rhel.md
@@ -55,10 +55,6 @@ The following table is a list of currently supported .NET releases on both RHEL 
 
 [!INCLUDE [linux-dnf-install-80](includes/linux-install-80-dnf.md)]
 
-## RHEL 7 ❌ .NET 8
-
-.NET 8 isn't officially supported on RHEL 7. To install .NET 8, see [Install .NET on Linux by using an install script or by extracting binaries](linux-scripted-manual.md).
-
 ## RHEL 7 ❌ .NET 7
 
 .NET 7 isn't officially supported on RHEL 7. To install .NET 7, see [Install .NET on Linux by using an install script or by extracting binaries](linux-scripted-manual.md).


### PR DESCRIPTION
.NET 8 requires a newer version of the system C library than what is available on RHEL 7.

@adegeo ptal.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/linux-rhel.md](https://github.com/dotnet/docs/blob/bac2ca02ac48e3546407c87d597c8e04d52facd6/docs/core/install/linux-rhel.md) | [Install the .NET SDK or the .NET Runtime on RHEL and CentOS Stream](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-rhel?branch=pr-en-us-38365) |


<!-- PREVIEW-TABLE-END -->