### PR TITLE
Don't localize try catch finally

### DIFF
--- a/docs/visual-basic/language-reference/statements/try-catch-finally-statement.md
+++ b/docs/visual-basic/language-reference/statements/try-catch-finally-statement.md
@@ -2,13 +2,13 @@
 title: "Try...Catch...Finally statement"
 description: Learn to use exception handling with Visual Basic Try/Catch/Finally statements.
 ms.date: 12/07/2018
-f1_keywords: 
+f1_keywords:
   - "vb.Try...Catch...Finally"
   - "vb.when"
   - "vb.Finally"
   - "vb.Catch"
   - "vb.Try"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "Try...Catch...Finally statements"
   - "Try statement [Visual Basic]"
   - "try-catch exception handling, Try...Catch...Finally statements"
@@ -20,6 +20,7 @@ helpviewer_keywords:
   - "Visual Basic code, handling errors while running"
   - "structured exception handling, Try...Catch...Finally statements"
 ms.assetid: d6488026-ccb3-42b8-a810-0d97b9d6472b
+no-loc: [Try, Catch, Finally]
 ---
 # Try...Catch...Finally Statement (Visual Basic)
 
@@ -102,7 +103,7 @@ The `Catch` block `exception` argument is an instance of the <xref:System.Except
 
 The properties of the `Exception` object help to identify the cause and location of an exception. For example, the <xref:System.Exception.StackTrace%2A> property lists the called methods that led to the exception, helping you find where the error occurred in the code. <xref:System.Exception.Message%2A> returns a message that describes the exception. <xref:System.Exception.HelpLink%2A> returns a link to an associated Help file. <xref:System.Exception.InnerException%2A> returns the `Exception` object that caused the current exception, or it returns `Nothing` if there is no original `Exception`.
 
-## Considerations when using a Try…Catch statement
+## Considerations when using a `Try…Catch` statement
 
 Use a `Try…Catch` statement only to signal the occurrence of unusual or unanticipated program events. Reasons for this include the following:
 
@@ -132,7 +133,7 @@ An `Await` expression can't be inside a `Catch` block or `Finally` block.
 
 An iterator function or `Get` accessor performs a custom iteration over a collection. An iterator uses a [Yield](yield-statement.md) statement to return each element of the collection one at a time. You call an iterator function by using a [For Each...Next Statement](for-each-next-statement.md).
 
-A `Yield` statement can be inside a `Try` block. A `Try` block that contains a `Yield` statement can have `Catch` blocks, and can have a `Finally` block. See the "Try Blocks in Visual Basic" section of [Iterators](../../programming-guide/concepts/iterators.md) for an example.
+A `Yield` statement can be inside a `Try` block. A `Try` block that contains a `Yield` statement can have `Catch` blocks, and can have a `Finally` block. For an example, see [Try Blocks](../../programming-guide/concepts/iterators.md#try-blocks).
 
 A `Yield` statement cannot be inside a `Catch` block or a `Finally` block.
 
@@ -148,13 +149,13 @@ In such a partial-trust situation, you have to put the `Process.Start` statement
 
 ## Examples
 
-### The structure of Try...Catch...Finally
+### The structure of `Try...Catch...Finally`
 
 The following example illustrates the structure of the `Try...Catch...Finally` statement.
 
-[!code-vb[VbVbalrStatements#86](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrStatements/VB/Class1.vb#86)]  
+[!code-vb[VbVbalrStatements#86](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrStatements/VB/Class1.vb#86)]
 
-### Exception in a method called from a Try block
+### Exception in a method called from a `Try` block
 
 In the following example, the `CreateException` method throws a `NullReferenceException`. The code that generates the exception is not in a `Try` block. Therefore, the `CreateException` method does not handle the exception. The `RunSample` method does handle the exception because the call to the `CreateException` method is in a `Try` block.
 
@@ -168,7 +169,7 @@ The following example shows how to use a `Catch When` statement to filter on a c
 
 [!code-vb[VbVbalrStatements#92](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrStatements/VB/Class1.vb#92)]
 
-### Nested Try statements
+### Nested `Try` statements
 
 The following example has a `Try…Catch` statement that is contained in a `Try` block. The inner `Catch` block throws an exception that has its `InnerException` property set to the original exception. The outer `Catch` block reports its own exception and the inner exception.
 

--- a/docs/visual-basic/programming-guide/concepts/iterators.md
+++ b/docs/visual-basic/programming-guide/concepts/iterators.md
@@ -38,26 +38,8 @@ A Visual Basic iterator function or `get` accessor declaration includes an [Iter
 
 Iterators were introduced in Visual Basic in Visual Studio 2012.
 
-**In this topic**
-
-- [Simple Iterator](#BKMK_SimpleIterator)
-
-- [Creating a Collection Class](#BKMK_CollectionClass)
-
-- [Try Blocks](#BKMK_TryBlocks)
-
-- [Anonymous Methods](#BKMK_AnonymousMethods)
-
-- [Using Iterators with a Generic List](#BKMK_GenericList)
-
-- [Syntax Information](#BKMK_SyntaxInformation)
-
-- [Technical Implementation](#BKMK_Technical)
-
-- [Use of Iterators](#BKMK_UseOfIterators)
-
 > [!NOTE]
-> For all examples in the topic except the Simple Iterator example, include [Imports](../../language-reference/statements/imports-statement-net-namespace-and-type.md) statements for the `System.Collections` and `System.Collections.Generic` namespaces.
+> For all examples in the article except the Simple Iterator example, include [Imports](../../language-reference/statements/imports-statement-net-namespace-and-type.md) statements for the `System.Collections` and `System.Collections.Generic` namespaces.
 
 ## <a name="BKMK_SimpleIterator"></a> Simple Iterator
 
@@ -211,7 +193,7 @@ Public Class Zoo
 End Class
 ```
 
-## <a name="BKMK_TryBlocks"></a> Try Blocks
+## Try Blocks
 
 Visual Basic allows a `Yield` statement in the `Try` block of a [Try...Catch...Finally Statement](../../language-reference/statements/try-catch-finally-statement.md). A `Try` block that has a `Yield` statement can have `Catch` blocks, and can have a `Finally` block.
 


### PR DESCRIPTION
Fixes #38350

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/visual-basic/language-reference/statements/try-catch-finally-statement.md](https://github.com/dotnet/docs/blob/e2c12e8a3426ae60c3f9e2c342d5a6b3a8837738/docs/visual-basic/language-reference/statements/try-catch-finally-statement.md) | [Try...Catch...Finally Statement (Visual Basic)](https://review.learn.microsoft.com/en-us/dotnet/visual-basic/language-reference/statements/try-catch-finally-statement?branch=pr-en-us-38408) |
| [docs/visual-basic/programming-guide/concepts/iterators.md](https://github.com/dotnet/docs/blob/e2c12e8a3426ae60c3f9e2c342d5a6b3a8837738/docs/visual-basic/programming-guide/concepts/iterators.md) | ["Iterators"](https://review.learn.microsoft.com/en-us/dotnet/visual-basic/programming-guide/concepts/iterators?branch=pr-en-us-38408) |

<!-- PREVIEW-TABLE-END -->