### PR TITLE
Update dictionary-configuration-binding.md

### DIFF
--- a/docs/core/compatibility/extensions/8.0/dictionary-configuration-binding.md
+++ b/docs/core/compatibility/extensions/8.0/dictionary-configuration-binding.md
@@ -5,7 +5,7 @@ ms.date: 07/27/2023
 ---
 # Empty keys added to dictionary by configuration binder
 
-In previous versions, when configuration was bound to a dictionary type, any keys without corresponding values in the configuration were skipped and weren't added to the dictionary. The behavior has changed such that those keys are longer skipped but instead automatically created with their default values. This change ensures that all keys listed in the configuration will be present within the dictionary.
+In previous versions, when configuration was bound to a dictionary type, any keys without corresponding values in the configuration were skipped and weren't added to the dictionary. The behavior has changed such that those keys are no longer skipped but instead automatically created with their default values. This change ensures that all keys listed in the configuration will be present within the dictionary.
 
 ## Version introduced
 


### PR DESCRIPTION
## Summary

Changed 'longer' to 'no longer'

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/extensions/8.0/dictionary-configuration-binding.md](https://github.com/dotnet/docs/blob/73f045e00975afc76bbbcd9fa853ec1680204147/docs/core/compatibility/extensions/8.0/dictionary-configuration-binding.md) | [Empty keys added to dictionary by configuration binder](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/extensions/8.0/dictionary-configuration-binding?branch=pr-en-us-38413) |

<!-- PREVIEW-TABLE-END -->