### PR TITLE
Fix typo

### DIFF
--- a/docs/core/compatibility/core-libraries/8.0/getgeneration-return-value.md
+++ b/docs/core/compatibility/core-libraries/8.0/getgeneration-return-value.md
@@ -8,7 +8,7 @@ ms.date: 05/02/2023
 Starting in .NET 8, <xref:System.GC.GetGeneration%2A?displayProperty=nameWithType> might return <xref:System.Int32.MaxValue?displayProperty=nameWithType> for objects allocated on non-GC heaps (also referred as "frozen" heaps), where previously it returned 2. When and how the runtime allocates objects on non-GC heaps is an internal implementation detail. String literals, for example, are allocated on a non-GC heap, and the following method call might return <xref:System.Int32.MaxValue?displayProperty=nameWithType>.
 
 ```csharp
-int gen = int GetGeneration("string");
+int gen = GC.GetGeneration("string");
 ```
 
 ## Previous behavior


### PR DESCRIPTION
## Summary

Fix typo in exmaple on page 
https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/8.0/getgeneration-return-value

Fixes #38416


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/core-libraries/8.0/getgeneration-return-value.md](https://github.com/dotnet/docs/blob/dc7e4a9a05ee42f34feb99ca6b3bf4071a5c7c03/docs/core/compatibility/core-libraries/8.0/getgeneration-return-value.md) | [GC.GetGeneration might return Int32.MaxValue](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/8.0/getgeneration-return-value?branch=pr-en-us-38417) |

<!-- PREVIEW-TABLE-END -->