### PR TITLE
Emphasize about same anonymous types not being equal when from separate assemblies

### DIFF
--- a/docs/csharp/fundamentals/types/anonymous-types.md
+++ b/docs/csharp/fundamentals/types/anonymous-types.md
@@ -61,6 +61,10 @@ You cannot declare a field, a property, an event, or the return type of a method
 
 Because the <xref:System.Object.Equals%2A> and <xref:System.Object.GetHashCode%2A> methods on anonymous types are defined in terms of the `Equals` and `GetHashCode` methods of the properties, two instances of the same anonymous type are equal only if all their properties are equal.
 
+> [!NOTE]
+> The default accessibility level of an anonymous type is `internal`, hence two anonymous types defined in different assemblies are not of the same type.
+> Therefore instances of anonymous types can't be equal to each other when defined in different assemblies, even when having all their properties equal.
+
 Anonymous types do override the <xref:System.Object.ToString%2A> method, concatenating the name and `ToString` output of every property surrounded by curly braces.
 
 ```

--- a/docs/csharp/fundamentals/types/anonymous-types.md
+++ b/docs/csharp/fundamentals/types/anonymous-types.md
@@ -62,7 +62,7 @@ You cannot declare a field, a property, an event, or the return type of a method
 Because the <xref:System.Object.Equals%2A> and <xref:System.Object.GetHashCode%2A> methods on anonymous types are defined in terms of the `Equals` and `GetHashCode` methods of the properties, two instances of the same anonymous type are equal only if all their properties are equal.
 
 > [!NOTE]
-> The default accessibility level of an anonymous type is `internal`, hence two anonymous types defined in different assemblies are not of the same type.
+> The [default accessibility level](../../programming-guide/classes-and-structs/access-modifiers.md#default-access-summary-table) of an anonymous type is `internal`, hence two anonymous types defined in different assemblies are not of the same type.
 > Therefore instances of anonymous types can't be equal to each other when defined in different assemblies, even when having all their properties equal.
 
 Anonymous types do override the <xref:System.Object.ToString%2A> method, concatenating the name and `ToString` output of every property surrounded by curly braces.

--- a/docs/csharp/fundamentals/types/anonymous-types.md
+++ b/docs/csharp/fundamentals/types/anonymous-types.md
@@ -62,7 +62,7 @@ You cannot declare a field, a property, an event, or the return type of a method
 Because the <xref:System.Object.Equals%2A> and <xref:System.Object.GetHashCode%2A> methods on anonymous types are defined in terms of the `Equals` and `GetHashCode` methods of the properties, two instances of the same anonymous type are equal only if all their properties are equal.
 
 > [!NOTE]
-> The [default accessibility level](../../programming-guide/classes-and-structs/access-modifiers.md#default-access-summary-table) of an anonymous type is `internal`, hence two anonymous types defined in different assemblies are not of the same type.
+> The [accessibility level](../../programming-guide/classes-and-structs/access-modifiers.md#default-access-summary-table) of an anonymous type is `internal`, hence two anonymous types defined in different assemblies are not of the same type.
 > Therefore instances of anonymous types can't be equal to each other when defined in different assemblies, even when having all their properties equal.
 
 Anonymous types do override the <xref:System.Object.ToString%2A> method, concatenating the name and `ToString` output of every property surrounded by curly braces.

--- a/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
+++ b/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
@@ -78,6 +78,7 @@ Delegates behave like classes and structs. By default, they have `internal` acce
 | `record`                                          |    internal    |
 | `enum`                                            |    internal    |
 | `interface` members                               |     public     |
+| Anonymous types                                   |    internal    |
 | [class, record, and struct members](./members.md) |    private     |
 
 For more details see the [Accessibility Levels](../../language-reference/keywords/accessibility-levels.md) page.
@@ -103,3 +104,4 @@ For more details see the [Accessibility Levels](../../language-reference/keyword
 - [class](../../language-reference/keywords/class.md)
 - [struct](../../language-reference/builtin-types/struct.md)
 - [interface](../../language-reference/keywords/interface.md)
+- [Anonymous types](../../fundamentals/types/anonymous-types.md)


### PR DESCRIPTION
This pull request fixes #38353 
It adds the note regarding the fact that two same assemblies can't be equal when defined in separate assemblies, due to `internal` access set by default.

**Note** that this PR also updates the summary table of default access modifiers. That is to have that given as a reference, as I couldn't find anything about the default access of an anonymous type anywhere else.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/fundamentals/types/anonymous-types.md](https://github.com/dotnet/docs/blob/51272d9e96641ffc7303b0a9605241509dfe5670/docs/csharp/fundamentals/types/anonymous-types.md) | [Anonymous types](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/types/anonymous-types?branch=pr-en-us-38421) |
| [docs/csharp/programming-guide/classes-and-structs/access-modifiers.md](https://github.com/dotnet/docs/blob/51272d9e96641ffc7303b0a9605241509dfe5670/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md) | [Access Modifiers (C# Programming Guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/access-modifiers?branch=pr-en-us-38421) |


<!-- PREVIEW-TABLE-END -->