### PR TITLE
Fix typos of Register-ArgumentCompleter parameters

### DIFF
--- a/docs/core/tools/enable-tab-autocomplete.md
+++ b/docs/core/tools/enable-tab-autocomplete.md
@@ -47,11 +47,11 @@ Add the following code to your profile:
 ```powershell
 # PowerShell parameter completion shim for the dotnet CLI
 Register-ArgumentCompleter -Native -CommandName dotnet -ScriptBlock {
-     param($commandName, $wordToComplete, $cursorPosition)
-         dotnet complete --position $cursorPosition "$wordToComplete" | ForEach-Object {
+    param($wordToComplete, $commandAst, $cursorPosition)
+        dotnet complete --position $cursorPosition "$commandAst" | ForEach-Object {
             [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
-         }
- }
+        }
+}
 ```
 
 ## bash


### PR DESCRIPTION
## Summary


[Enable tab completion - .NET CLI | Microsoft Learn](https://learn.microsoft.com/en-us/dotnet/core/tools/enable-tab-autocomplete#powershell)

>        param($commandName, $wordToComplete, $cursorPosition)

The parameter names given in the above document are incorrect.
Although it works as it is, I think it would be less confusing to follow the documentation as it is written.

[Register-ArgumentCompleter (Microsoft.PowerShell.Core) - PowerShell | Microsoft Learn](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/register-argumentcompleter?view=powershell-7.4#-scriptblock)

> When you specify the Native parameter, the script block must take the following parameters in the specified order. The names of the parameters aren't important because PowerShell passes in the values by position.
> * `$wordToComplete` (Position 0) - This parameter is set to value the user has provided before they pressed Tab. Your script block should use this value to determine tab completion values.
> * `$commandAst` (Position 1) - This parameter is set to the Abstract Syntax Tree (AST) for the current input line. For more information, see Ast Class.
> * `$cursorPosition` (Position 2) - This parameter is set to the position of the cursor when the user pressed Tab.


Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/enable-tab-autocomplete.md](https://github.com/dotnet/docs/blob/6386c8d7300871d16fb4d83d15c67bc204ce3b48/docs/core/tools/enable-tab-autocomplete.md) | [How to enable tab completion for the .NET CLI](https://review.learn.microsoft.com/en-us/dotnet/core/tools/enable-tab-autocomplete?branch=pr-en-us-38425) |

<!-- PREVIEW-TABLE-END -->