### PR TITLE
Update dictionary-configuration-binding.md

### DIFF
--- a/docs/core/compatibility/extensions/8.0/dictionary-configuration-binding.md
+++ b/docs/core/compatibility/extensions/8.0/dictionary-configuration-binding.md
@@ -5,7 +5,7 @@ ms.date: 07/27/2023
 ---
 # Empty keys added to dictionary by configuration binder
 
-In previous versions, when configuration was bound to a dictionary type, any keys without corresponding values in the configuration were skipped and weren't added to the dictionary. The behavior has changed such that those keys are longer skipped but instead automatically created with their default values. This change ensures that all keys listed in the configuration will be present within the dictionary.
+In previous versions, when configuration was bound to a dictionary type, any keys without corresponding values in the configuration were skipped and weren't added to the dictionary. The behavior has changed such that those keys are no longer skipped but instead automatically created with their default values. This change ensures that all keys listed in the configuration will be present within the dictionary.
 
 ## Version introduced
 


### PR DESCRIPTION
Typo fixed.

Fixes #38424


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/extensions/8.0/dictionary-configuration-binding.md](https://github.com/dotnet/docs/blob/f702a92d0c359ab2a3536dc70787ab7a2a29b2aa/docs/core/compatibility/extensions/8.0/dictionary-configuration-binding.md) | [Empty keys added to dictionary by configuration binder](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/extensions/8.0/dictionary-configuration-binding?branch=pr-en-us-38429) |

<!-- PREVIEW-TABLE-END -->