### PR TITLE
fix(orleans): remove deprecated `UseJson` in builder

### DIFF
--- a/docs/orleans/grains/grain-persistence/dynamodb-storage.md
+++ b/docs/orleans/grains/grain-persistence/dynamodb-storage.md
@@ -21,11 +21,11 @@ siloBuilder.AddDynamoDBGrainStorage(
     name: "profileStore",
     configureOptions: options =>
     {
-        options.UseJson = true;
         options.AccessKey = "<DynamoDB access key>";
         options.SecretKey = "<DynamoDB secret key>";
         options.Service = "<DynamoDB region name>"; // Such as "us-west-2"
     });
+);
 ```
 
 If your authentication method requires a token or non-default profile name, you can define those properties using the following command:


### PR DESCRIPTION
Removes `UseJson` which is no longer present in options show below:

https://github.com/dotnet/orleans/blob/main/src/AWS/Orleans.Persistence.DynamoDB/Options/DynamoDBStorageOptions.cs

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/grains/grain-persistence/dynamodb-storage.md](https://github.com/dotnet/docs/blob/9d50463a8b746dac6839f168a70400cf66ab7776/docs/orleans/grains/grain-persistence/dynamodb-storage.md) | [Amazon DynamoDB grain persistence](https://review.learn.microsoft.com/en-us/dotnet/orleans/grains/grain-persistence/dynamodb-storage?branch=pr-en-us-38433) |

<!-- PREVIEW-TABLE-END -->