### PR TITLE
Logical operators: make text less confusing

### DIFF
--- a/docs/csharp/language-reference/operators/boolean-logical-operators.md
+++ b/docs/csharp/language-reference/operators/boolean-logical-operators.md
@@ -58,7 +58,7 @@ The unary postfix `!` operator is the [null-forgiving operator](null-forgiving.m
 
 The `&` operator computes the logical AND of its operands. The result of `x & y` is `true` if both `x` and `y` evaluate to `true`. Otherwise, the result is `false`.
 
-The `&` operator evaluates both operands even if the left-hand operand evaluates to `false`, so that the operation result is `false` regardless of the value of the right-hand operand.
+The `&` operator always evaluates both operands. When the left-hand operand evaluates to `false`, the operation result is `false` regardless of the value of the right-hand operand. However, even then, the right-hand operand is evaluated.
 
 In the following example, the right-hand operand of the `&` operator is a method call, which is performed regardless of the value of the left-hand operand:
 
@@ -80,7 +80,7 @@ For operands of the [integral numeric types](../builtin-types/integral-numeric-t
 
 The `|` operator computes the logical OR of its operands. The result of `x | y` is `true` if either `x` or `y` evaluates to `true`. Otherwise, the result is `false`.
 
-The `|` operator evaluates both operands even if the left-hand operand evaluates to `true`, so that the operation result is `true` regardless of the value of the right-hand operand.
+The `|` operator always evaluates both operands. When the left-hand operand evaluates to `true`, the operation result is `true` regardless of the value of the right-hand operand. However, even then, the right-hand operand is evaluated.
 
 In the following example, the right-hand operand of the `|` operator is a method call, which is performed regardless of the value of the left-hand operand:
 


### PR DESCRIPTION
Fixes #38432


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/boolean-logical-operators.md](https://github.com/dotnet/docs/blob/8c814352dc7c35c8fca03fa9e498b87bdbcf4fc0/docs/csharp/language-reference/operators/boolean-logical-operators.md) | [Boolean logical operators - AND, OR, NOT, XOR](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/boolean-logical-operators?branch=pr-en-us-38444) |

<!-- PREVIEW-TABLE-END -->