### PR TITLE
Link to Using ASP.NET Core metrics from metrics list

### DIFF
--- a/docs/core/diagnostics/built-in-metrics-aspnetcore.md
+++ b/docs/core/diagnostics/built-in-metrics-aspnetcore.md
@@ -12,7 +12,7 @@ This article describes the metrics built-in for ASP.NET Core produced using the
 see [here](available-counters.md).
 
 > [!TIP]
-> See [Using ASP.NET Core metrics](/aspnet/core/log-mon/metrics/metrics) for more information about how to collect, report, enrich, and test ASP.NET Core metrics.
+> For more information about how to collect, report, enrich, and test ASP.NET Core metrics, see [Using ASP.NET Core metrics](/aspnet/core/log-mon/metrics/metrics).
 
 - [Meter: `Microsoft.AspNetCore.Hosting`](#meter-microsoftaspnetcorehosting)
   - [Instrument: `http.server.request.duration`](#instrument-httpserverrequestduration)

--- a/docs/core/diagnostics/built-in-metrics-aspnetcore.md
+++ b/docs/core/diagnostics/built-in-metrics-aspnetcore.md
@@ -11,7 +11,8 @@ This article describes the metrics built-in for ASP.NET Core produced using the
 <xref:System.Diagnostics.Metrics?displayProperty=nameWithType> API. For a listing of metrics based on the older [EventCounters](event-counters.md) API,
 see [here](available-counters.md).
 
-See [Using ASP.NET Core metrics](/aspnet/core/log-mon/metrics/metrics) for more information about how to collect, report, enrich, and test ASP.NET Core metrics.
+> [!TIP]
+> See [Using ASP.NET Core metrics](/aspnet/core/log-mon/metrics/metrics) for more information about how to collect, report, enrich, and test ASP.NET Core metrics.
 
 - [Meter: `Microsoft.AspNetCore.Hosting`](#meter-microsoftaspnetcorehosting)
   - [Instrument: `http.server.request.duration`](#instrument-httpserverrequestduration)

--- a/docs/core/diagnostics/built-in-metrics-aspnetcore.md
+++ b/docs/core/diagnostics/built-in-metrics-aspnetcore.md
@@ -11,6 +11,8 @@ This article describes the metrics built-in for ASP.NET Core produced using the
 <xref:System.Diagnostics.Metrics?displayProperty=nameWithType> API. For a listing of metrics based on the older [EventCounters](event-counters.md) API,
 see [here](available-counters.md).
 
+See [Using ASP.NET Core metrics](/aspnet/core/log-mon/metrics/metrics) for more information about how to collect, report, enrich, and test ASP.NET Core metrics.
+
 - [Meter: `Microsoft.AspNetCore.Hosting`](#meter-microsoftaspnetcorehosting)
   - [Instrument: `http.server.request.duration`](#instrument-httpserverrequestduration)
   - [Instrument: `http.server.active_requests`](#instrument-httpserveractive_requests)


### PR DESCRIPTION
Add link for using ASP.NET Core metrics to metrics definition page.

Should do the same for other metrics definition pages, e.g. System.Net metrics definition links to using network telemetry page.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/built-in-metrics-aspnetcore.md](https://github.com/dotnet/docs/blob/df300318933feb0f7570efec6558c1fe535d1cf2/docs/core/diagnostics/built-in-metrics-aspnetcore.md) | [ASP.NET Core metrics](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/built-in-metrics-aspnetcore?branch=pr-en-us-38453) |


<!-- PREVIEW-TABLE-END -->