### PR TITLE
Add mstest runner docs

### DIFF
--- a/docs/core/testing/unit-testing-mstest-runner-exit-codes.md
+++ b/docs/core/testing/unit-testing-mstest-runner-exit-codes.md
@@ -28,9 +28,7 @@ The MSTest runner uses known exit codes to communicate test failure or app error
 To enable verbose logging in order to troubleshoot issues, see [troubleshooting](./unit-testing-mstest-runner-intro.md#troubleshooting).
 <!-- Setting special name so we can simply link to the number from here, and from error message that is built into Microsoft.Testing.Platform source code. -->
 
-## <a name="0"></a>
-
-Success — 0
+## <a name="0"></a> Success — 0
 
 The `0` exit code indicates success. All tests that were chosen to run have run to completion and there were no errors.
 

--- a/docs/core/testing/unit-testing-mstest-runner-exit-codes.md
+++ b/docs/core/testing/unit-testing-mstest-runner-exit-codes.md
@@ -1,3 +1,12 @@
+---
+title: MSTest Test Runner Exit Codes
+description: Learn about MSTest Test Runner exit codes.
+author: nohwnd
+ms.author: jajares
+ms.date: 11/28/2023
+ms.custom: 
+---
+
 # Exit codes
 
 MSTest Runner uses known exit codes to communicate test failure or application error. Exit codes start at 0 and are non-negative:

--- a/docs/core/testing/unit-testing-mstest-runner-exit-codes.md
+++ b/docs/core/testing/unit-testing-mstest-runner-exit-codes.md
@@ -34,62 +34,42 @@ Success — 0
 
 The `0` exit code indicates success. All tests that were chosen to run have run to completion and there were no errors.
 
-## <a name="1"></a>
-
-Generic failure — `1`
+## <a name="1"></a> Generic failure — `1`
 
 The `1` exit code indicates unknown errors and acts as a _catch all_. To find additional error information and details look in the output.
 
-## <a name="2"></a>
-
-At least one test failed — `2`
+## <a name="2"></a> At least one test failed — `2`
 
 An exit code of `2` is used to indicate that there was at least one test failure.
 
-## <a name="3"></a>
-
-Test session aborted — `3`
+## <a name="3"></a> Test session aborted — `3`
 
 The exit code `3` indicates that the test session was aborted. A session can be aborted using <kbd>Ctrl</kbd>+<kbd>C</kbd>, as an example.
 
-## <a name="4"></a>
-
-Invalid platform setup — `4`
+## <a name="4"></a> Invalid platform setup — `4`
 
 The exit code `4` indicates that the setup of used extensions is invalid and the tests session cannot run.
 
-## <a name="5"></a>
-
-Invalid command line — `5`
+## <a name="5"></a> Invalid command line — `5`
 
 The exit code `5` indicates that the command line arguments passed to the test app are invalid.
 
-## <a name="6"></a>
-
-Feature not implemented — `6`
+## <a name="6"></a> Feature not implemented — `6`
 
 The exit code `6` indicates that the test session is using a non-implemented feature.
 
-## <a name="7"></a>
-
-Test host process didn't exit gracefully — `7`
+## <a name="7"></a> Test host process didn't exit gracefully — `7`
 
 The exit code `7` indicates that a test session was unable to complete successfully, and likely crashed. It's possible that this was caused by a test session that was ran via a test controller's extension point.
 
-## <a name="8"></a>
-
-Zero tests ran — `8`
+## <a name="8"></a> Zero tests ran — `8`
 
 The exit code `8` indicates that the test session ran zero tests.
 
-## <a name="9"></a>
-
-Minimum expected tests policy violation — `9`
+## <a name="9"></a> Minimum expected tests policy violation — `9`
 
 The exit code `9` indicates that the minimum execution policy for the executed tests was violated.
 
-## <a name="10"></a>
-
-Test adapter test session failure — `10`
+## <a name="10"></a> Test adapter test session failure — `10`
 
 The exit code `10` indicates that the test adapter, Testing.Platform Test Framework, MSTest, NUnit, or xUnit, failed to run tests for an infrastructure reason unrelated to the test's self. An example is failing to create a fixture needed by tests.

--- a/docs/core/testing/unit-testing-mstest-runner-exit-codes.md
+++ b/docs/core/testing/unit-testing-mstest-runner-exit-codes.md
@@ -29,56 +29,67 @@ To enable verbose logging in order to troubleshoot issues, see [troubleshooting]
 <!-- Setting special name so we can simply link to the number from here, and from error message that is built into Microsoft.Testing.Platform source code. -->
 
 ## <a name="0"></a>
+
 Success — 0
 
 The `0` exit code indicates success. All tests that were chosen to run have run to completion and there were no errors.
 
 ## <a name="1"></a>
+
 Generic failure — `1`
 
 The `1` exit code indicates unknown errors and acts as a _catch all_. To find additional error information and details look in the output.
 
 ## <a name="2"></a>
+
 At least one test failed — `2`
 
 An exit code of `2` is used to indicate that there was at least one test failure.
 
 ## <a name="3"></a>
+
 Test session aborted — `3`
 
 The exit code `3` indicates that the test session was aborted. A session can be aborted using <kbd>Ctrl</kbd>+<kbd>C</kbd>, as an example.
 
 ## <a name="4"></a>
+
 Invalid platform setup — `4`
 
 The exit code `4` indicates that the setup of used extensions is invalid and the tests session cannot run.
 
 ## <a name="5"></a>
+
 Invalid command line — `5`
 
 The exit code `5` indicates that the command line arguments passed to the test app are invalid.
 
 ## <a name="6"></a>
+
 Feature not implemented — `6`
 
 The exit code `6` indicates that the test session is using a non-implemented feature.
 
 ## <a name="7"></a>
+
 Test host process didn't exit gracefully — `7`
 
 The exit code `7` indicates that a test session was unable to complete successfully, and likely crashed. It's possible that this was caused by a test session that was ran via a test controller's extension point.
 
 ## <a name="8"></a>
+
 Zero tests ran — `8`
 
 The exit code `8` indicates that the test session ran zero tests.
 
 ## <a name="9"></a>
+
 Minimum expected tests policy violation — `9`
 
 The exit code `9` indicates that the minimum execution policy for the executed tests was violated.
 
 ## <a name="10"></a>
+
 Test adapter test session failure — `10`
 
 The exit code `10` indicates that the test adapter, Testing.Platform Test Framework, MSTest, NUnit, or xUnit, failed to run tests for an infrastructure reason unrelated to the test's self. An example is failing to create a fixture needed by tests.

--- a/docs/core/testing/unit-testing-mstest-runner-exit-codes.md
+++ b/docs/core/testing/unit-testing-mstest-runner-exit-codes.md
@@ -26,7 +26,7 @@ The MSTest runner uses known exit codes to communicate test failure or app error
 | [10](#10) | Test adapter test session failure. |
 
 To enable verbose logging in order to troubleshoot issues, see [troubleshooting](./unit-testing-mstest-runner-intro.md#troubleshooting).
-<!-- Setting special name so we can simply link to the number from here, and from error message that is built into TA source code. -->
+<!-- Setting special name so we can simply link to the number from here, and from error message that is built into Microsoft.Testing.Platform source code. -->
 
 ## <a name="0"></a>
 Success — 0

--- a/docs/core/testing/unit-testing-mstest-runner-exit-codes.md
+++ b/docs/core/testing/unit-testing-mstest-runner-exit-codes.md
@@ -1,0 +1,64 @@
+# Exit codes
+
+MSTest Runner uses known exit codes to communicate test failure or application error. Exit codes start at 0 and are non-negative:
+
+| Exit&nbsp;Code | Reason |
+|:-----|----------|
+| [0](#0) | Success |
+| [1](#1) | Generic failure. |
+| [2](#2) | At least 1 test failed. |
+| [3](#3) | Test session aborted. |
+| [4](#4) | Invalid platform setup. |
+| [5](#5) | Invalid command line. |
+| [6](#6) | Feature not implemented. |
+| [7](#7) | Test host process did not exit gracefully. |
+| [8](#8) | Zero tests ran. |
+| [9](#9) | Minimum expected tests policy violation. |
+| [10](#10) | Test adapter test session failure. |
+
+To enable verbose logging in order to troubleshoot issue(s), see [troubleshooting](guides/troubleshooting.md).
+<!-- Setting special name so we can simply link to the number from here, and from error message that is built into TA source code. -->
+
+## <a name="0"></a>0 - Success
+
+This exit code means success. All tests that were chosen for run has run, and there were no additional errors.
+
+## <a name="1"></a>1 - Generic failure
+
+This is a catch all for all unknown errors. Look for error in the output or log to get more information.
+
+## <a name="2"></a>2 - At least 1 test failed
+
+There was at least 1 failed test.
+
+## <a name="3"></a>3 - Test session aborted
+
+When the test session is aborted, for instance through CTRL+C.
+
+## <a name="4"></a>4 - Invalid platform setup
+
+The setup of used extensions are invalid and the tests session cannot run.
+
+## <a name="5"></a>5 - Invalid command line
+
+Command line arguments passed to the test application are invalid.
+
+## <a name="6"></a>6 - Feature not implemented
+
+Test session is using a not implemented feature.
+
+## <a name="7"></a>7 - Test host process did not exit gracefully
+
+When test session run under test controllers extension point it's possible that the test host won't close gracefully for instance due to a crash.
+
+## <a name="8"></a>8 - Zero tests ran
+
+Test session ran zero tests.
+
+## <a name="9"></a>9 - Minimum expected tests policy violation
+
+Policy for the minimum expected executed tests violated.
+
+## <a name="10"></a>10 - Test adapter test session failure
+
+The test adapter (i.e. Testing.Platform Test Framework, MSTest, NUnit, xUnit) failed to run tests for an infrastructure reason unrelated to the tests self (for instance failing to create a fixture needed by tests).

--- a/docs/core/testing/unit-testing-mstest-runner-exit-codes.md
+++ b/docs/core/testing/unit-testing-mstest-runner-exit-codes.md
@@ -25,7 +25,7 @@ MSTest Runner uses known exit codes to communicate test failure or application e
 | [9](#9) | Minimum expected tests policy violation. |
 | [10](#10) | Test adapter test session failure. |
 
-To enable verbose logging in order to troubleshoot issue(s), see [troubleshooting](guides/troubleshooting.md).
+To enable verbose logging in order to troubleshoot issue(s), see [troubleshooting](./unit-testing-mstest-runner-intro.md#troubleshooting).
 <!-- Setting special name so we can simply link to the number from here, and from error message that is built into TA source code. -->
 
 ## <a name="0"></a>0 - Success

--- a/docs/core/testing/unit-testing-mstest-runner-exit-codes.md
+++ b/docs/core/testing/unit-testing-mstest-runner-exit-codes.md
@@ -1,21 +1,21 @@
 ---
-title: MSTest Runner Exit Codes
-description: Learn about MSTest Runner exit codes.
+title: MSTest runner exit codes
+description: Learn about the various MSTest runner exit codes and their meaning.
 author: nohwnd
 ms.author: jajares
 ms.date: 11/28/2023
-ms.custom: 
+ms.topic: reference
 ---
 
-# Exit codes
+# MSTest runner exit codes
 
-MSTest Runner uses known exit codes to communicate test failure or application error. Exit codes start at 0 and are non-negative:
+The MSTest runner uses known exit codes to communicate test failure or app errors. Exit codes start at `0` and are non-negative. Consider the following table that details the various exit codes and their corresponding reasons:
 
-| Exit&nbsp;Code | Reason |
+| Exit code | Reason |
 |:-----|----------|
 | [0](#0) | Success |
 | [1](#1) | Generic failure. |
-| [2](#2) | At least 1 test failed. |
+| [2](#2) | At least one test failed. |
 | [3](#3) | Test session aborted. |
 | [4](#4) | Invalid platform setup. |
 | [5](#5) | Invalid command line. |
@@ -25,49 +25,60 @@ MSTest Runner uses known exit codes to communicate test failure or application e
 | [9](#9) | Minimum expected tests policy violation. |
 | [10](#10) | Test adapter test session failure. |
 
-To enable verbose logging in order to troubleshoot issue(s), see [troubleshooting](./unit-testing-mstest-runner-intro.md#troubleshooting).
+To enable verbose logging in order to troubleshoot issues, see [troubleshooting](./unit-testing-mstest-runner-intro.md#troubleshooting).
 <!-- Setting special name so we can simply link to the number from here, and from error message that is built into TA source code. -->
 
-## <a name="0"></a>0 - Success
+## <a name="0"></a>
+Success — 0
 
-This exit code means success. All tests that were chosen for run has run, and there were no additional errors.
+The `0` exit code indicates success. All tests that were chosen to run have run to completion and there were no errors.
 
-## <a name="1"></a>1 - Generic failure
+## <a name="1"></a>
+Generic failure — `1`
 
-This is a catch all for all unknown errors. Look for error in the output or log to get more information.
+The `1` exit code indicates unknown errors and acts as a _catch all_. To find additional error information and details look in the output.
 
-## <a name="2"></a>2 - At least 1 test failed
+## <a name="2"></a>
+At least one test failed — `2`
 
-There was at least 1 failed test.
+An exit code of `2` is used to indicate that there was at least one test failure.
 
-## <a name="3"></a>3 - Test session aborted
+## <a name="3"></a>
+Test session aborted — `3`
 
-When the test session is aborted, for instance through CTRL+C.
+The exit code `3` indicates that the test session was aborted. A session can be aborted using <kbd>Ctrl</kbd>+<kbd>C</kbd>, as an example.
 
-## <a name="4"></a>4 - Invalid platform setup
+## <a name="4"></a>
+Invalid platform setup — `4`
 
-The setup of used extensions are invalid and the tests session cannot run.
+The exit code `4` indicates that the setup of used extensions is invalid and the tests session cannot run.
 
-## <a name="5"></a>5 - Invalid command line
+## <a name="5"></a>
+Invalid command line — `5`
 
-Command line arguments passed to the test application are invalid.
+The exit code `5` indicates that the command line arguments passed to the test app are invalid.
 
-## <a name="6"></a>6 - Feature not implemented
+## <a name="6"></a>
+Feature not implemented — `6`
 
-Test session is using a not implemented feature.
+The exit code `6` indicates that the test session is using a non-implemented feature.
 
-## <a name="7"></a>7 - Test host process did not exit gracefully
+## <a name="7"></a>
+Test host process didn't exit gracefully — `7`
 
-When test session run under test controllers extension point it's possible that the test host won't close gracefully for instance due to a crash.
+The exit code `7` indicates that a test session was unable to complete successfully, and likely crashed. It's possible that this was caused by a test session that was ran via a test controller's extension point.
 
-## <a name="8"></a>8 - Zero tests ran
+## <a name="8"></a>
+Zero tests ran — `8`
 
-Test session ran zero tests.
+The exit code `8` indicates that the test session ran zero tests.
 
-## <a name="9"></a>9 - Minimum expected tests policy violation
+## <a name="9"></a>
+Minimum expected tests policy violation — `9`
 
-Policy for the minimum expected executed tests violated.
+The exit code `9` indicates that the minimum execution policy for the executed tests was violated.
 
-## <a name="10"></a>10 - Test adapter test session failure
+## <a name="10"></a>
+Test adapter test session failure — `10`
 
-The test adapter (i.e. Testing.Platform Test Framework, MSTest, NUnit, xUnit) failed to run tests for an infrastructure reason unrelated to the tests self (for instance failing to create a fixture needed by tests).
+The exit code `10` indicates that the test adapter, Testing.Platform Test Framework, MSTest, NUnit, or xUnit, failed to run tests for an infrastructure reason unrelated to the test's self. An example is failing to create a fixture needed by tests.

--- a/docs/core/testing/unit-testing-mstest-runner-exit-codes.md
+++ b/docs/core/testing/unit-testing-mstest-runner-exit-codes.md
@@ -1,6 +1,6 @@
 ---
-title: MSTest Test Runner Exit Codes
-description: Learn about MSTest Test Runner exit codes.
+title: MSTest Runner Exit Codes
+description: Learn about MSTest Runner exit codes.
 author: nohwnd
 ms.author: jajares
 ms.date: 11/28/2023

--- a/docs/core/testing/unit-testing-mstest-runner-intro.md
+++ b/docs/core/testing/unit-testing-mstest-runner-intro.md
@@ -12,7 +12,7 @@ The MSTest runner is a lightweight and portable alternative to [VSTest](https://
 
 The MSTest runner is embedded directly in your MSTest test projects, and there's no additional app dependencies, such as `vstest.console` or `dotnet test` needed to run your tests.
 
-The MSTest runner open source and you can view its code in the [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Platform) GitHub repository. The MSTest runner comes bundled with MSTest in 3.2.0-preview. This preview is available in the [test-tools NuGet feed](https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json).
+The MSTest runner is open source, and builds on a Microsoft.Testing.Platform library. You can find Microsoft.Testing.Platform code in [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Platform) GitHub repository. The MSTest runner comes bundled with MSTest in 3.2.0-preview. This preview is available in the [test-tools NuGet feed](https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json).
 
 ## Enable MSTest runner in a MSTest project
 
@@ -94,7 +94,7 @@ The `dotnet run` command can be used to build and run your test project. This is
 > > [!IMPORTANT]
 > The `dotnet test` command only works with MSTest, NUnit and xUnit tests.
 
-For tests authored with MSTest, NUnit or xUnit test framework, it's possible to run tests with `dotnet test`.
+For tests authored with MSTest, NUnit or xUnit test framework, it's possible to run tests with [dotnet test](https://learn.microsoft.com/dotnet/core/tools/dotnet-test).
 
 Provide a path to the tested dll, or to the project and your tests will run.
 

--- a/docs/core/testing/unit-testing-mstest-runner-intro.md
+++ b/docs/core/testing/unit-testing-mstest-runner-intro.md
@@ -107,7 +107,7 @@ Testing.Platform test project are built as executables, and can be run directly.
 
 1. Navigate the test project you want to run in Solution Explorer, right click it and select `Set as Startup Project`.
 
-1. Go to Debug > Start without Debugging, (or press `Ctrl + F5`) to run the selected test project.
+1. Go to `Debug > Start without Debugging`, (or press `Ctrl + F5`) to run the selected test project.
 
 Console window will pop up with the execution and summary of your test run.
 
@@ -218,16 +218,6 @@ It can be configured using the following options:
 | `--hangdump-timeout` | Specify the timeout after which the dump will be generated. The timeout value is specified in one of the following formats:<br/>1.5h, 1.5hour, 1.5hours<br/>90m, 90min, 90minute, 90minutes<br/>5400s, 5400sec, 5400second, 5400seconds. Default is 30m. |
 | `--hangdump-type` | Specify the type of the dump. Valid values are `Mini`, `Heap`, `Triage` (only .NET 6+), `Full`. Default type is `Full`. For more information visit [MS Learn Crash Dump Types](https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps) |
 
-To be able to use this feature you will need to
-
-1. Add a dependency to `Microsoft.Testing.Platform.Extensions.HangDump`
-
-2. Update your `Program.cs` to add
-
-    ```csharp
-    using Microsoft.Testing.Platform.Extensions;
-    builder.AddHangDumpGenerator();
-    ```
 
 ### Crash Dump
 
@@ -241,13 +231,3 @@ It can be configured using the following options:
 | `⁠-⁠-⁠crashdump-⁠filename` | Specify the file name of the dump. |
 | `--crashdump-type` | Specify the type of the dump. Valid values are `Mini`, `Heap`, `Triage`, `Full`. Default type is `Full`. For more information visit [MS Learn Crash Dump Types](https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps) |
 
-To be able to use this feature you will need to
-
-1. Add a dependency to `Microsoft.Testing.Platform.Extensions`
-
-1. Update your `Program.cs` to add
-
-    ```csharp
-    using Microsoft.Testing.Platform.Extensions;
-    builder.AddCrashDumpGenerator();
-    ```

--- a/docs/core/testing/unit-testing-mstest-runner-intro.md
+++ b/docs/core/testing/unit-testing-mstest-runner-intro.md
@@ -22,8 +22,8 @@ To enable the MSTest Runner in an MSTest project, you need to add `UseMSTestRunn
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- Enable the MSTest runner. -->
-    <UseMSTestRunner>true</UseMSTestRunner>
+    <!-- Enable the MSTest runner, this is an opt-in feature -->
+    <EnableMSTestRunner>true</EnableMSTestRunner>
 
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -34,16 +34,15 @@ To enable the MSTest Runner in an MSTest project, you need to add `UseMSTestRunn
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Replace these 3 packages by reference to just MSTest 
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-      <PackageReference Include="MSTest.TestAdapter" Version="3.2.0-preview.23570.1" />
-      <PackageReference Include="MSTest.TestFramework" Version="3.2.0-preview.23570.1" />
-    -->
-
+    <!-- 
+      MSTest meta package is the recommended way to reference MSTest. 
+      It's equivalent to referencing: Microsoft.NET.Test.Sdk, MSTest.TestAdapter, MSTest.TestFramework and MSTest.Analyzers
+    -->    
     <PackageReference Include="MSTest" Version="3.2.0-preview.23570.1" />
 
-    <!-- Replace coverlet collector 
-      <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <!-- 
+      Coverlet collector is not compatible with MSTest runner, you can either switch to Microsoft CodeCoverage (as shown below),
+      or switch to be using coverlet global tool https://github.com/coverlet-coverage/coverlet#net-global-tool-guide-suffers-from-possible-known-issue
     --> 
     <PackageReference Include="Microsoft.Testing.Platform.Extensions.CodeCoverage" 
                       Version="17.9.4-beta.23563.1" />
@@ -57,7 +56,7 @@ Building the application will generate an executable application for your test p
 ## Run and debug tests
 
 > [!IMPORTANT]
-> By default, the MStest runner collects telemetry. For more information and options on opting out, see [MSTest runner telemetery](unit-testing-mstest-runner-telemetry.md).
+> By default, the MStest runner collects telemetry. For more information and options on opting out, see [MSTest runner telemetry](unit-testing-mstest-runner-telemetry.md).
 
 MSTest runner test projects are built as executables that can be run (or debugged) directly. There's no additional test running console or command that's needed.
 
@@ -233,4 +232,3 @@ It can be configured using the following options:
 | `--crashdump` | Generated a dump file in case of test host process crash. Supported by .NET 6.0+ |
 | `⁠-⁠-⁠crashdump-⁠filename` | Specify the file name of the dump. |
 | `--crashdump-type` | Specify the type of the dump. Valid values are `Mini`, `Heap`, `Triage`, `Full`. Default type is `Full`. For more information visit [MS Learn Crash Dump Types](https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps) |
-

--- a/docs/core/testing/unit-testing-mstest-runner-intro.md
+++ b/docs/core/testing/unit-testing-mstest-runner-intro.md
@@ -51,8 +51,6 @@ To enable the MSTest Runner in an MSTest project, you need to add `UseMSTestRunn
 </Project>
 ```
 
-Building the application will generate an executable application for your test project. For example `Contoso.MyTests.exe` on Windows.
-
 ## Run and debug tests
 
 > [!IMPORTANT]

--- a/docs/core/testing/unit-testing-mstest-runner-intro.md
+++ b/docs/core/testing/unit-testing-mstest-runner-intro.md
@@ -1,0 +1,266 @@
+---
+title: MSTest Test Runner
+description: Learn about MSTest Test Runner, a lightweight way to run tests without depending on dotnet SDK.
+author: nohwnd
+ms.author: jajares
+ms.date: 11/28/2023
+ms.custom: 
+---
+
+# Overview
+
+MSTestRunner is a light-weight and portable alternative to [microsoft/vstest](https://github.com/microsoft/vstest) for running tests in continuous integration pipelines, and in VisualStudio TestExplorer (Coming soon!).
+
+This runner is embedded directly in your MSTest test project, and there is no additional application (e.g. vstest.console / dotnet test) or any additional infrastructure (e.g. dotnet SDK) needed to run your tests.
+
+MSTestRunner lives in [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Platform) repository, and comes bundled with MSTest in 3.2.0-preview. This preview is available on [test-tools NuGet feed](https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json).
+
+## Enabling MSTest Runner in an MSTest project
+
+To enable MSTest Runnerin an MSTest project, you need to add `<UseMSTestRunner>true</UseMSTestRunner>` into your project file, and make sure you are using MSTest 3.2.0-preview or newer: 
+
+```csproj
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- The secret sauce to enabling MSTestRunner. -->
+    <UseMSTestRunner>true</UseMSTestRunner>
+
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- All these 3 packages can be replaced by reference to:
+        <PackageReference Include="MSTest" Version="3.2.0-preview.23570.1" />
+    -->
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.2.0-preview.23570.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.2.0-preview.23570.1" />
+
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+
+</Project>
+```
+
+Building the application will generate an executable application for your test project. For example `Contoso.MyTests.exe`.
+
+## Running & Debugging tests
+
+::: info
+
+Telemetry is by default collected by the runner, see [Telemetry](./unit-testing-mstest-runner-telemetry.md) to learn more.
+
+:::
+
+MSTest Runner test projects are built as executables that can be run (or debugged) directly. There is no additional test running console or command that is needed.
+
+The application will exit with non-zero exit code in case of an error. For a list of known exit codes see [exit codes](unite-testing-mstest-runner-exit-codes.md).
+
+This is how you run tests in common scenarios:
+
+### In console
+
+#### Running the application directly in Console
+
+Publishing the test project using `dotnet publish` and running the application directly is another way to run your tests. For example `./Contoso.MyTests.exe`. In some scenarios it is also viable to use `dotnet build`, to produce the executable, but there can be edge cases to that for example when using Native AOT.
+
+#### Using `dotnet run`
+
+`dotnet run` can be used to build and run your test project. This is the easiest, although sometimes slow, way to run your tests. Using `dotnet run` is practical when you are editing and running tests locally because it ensures that the test project is re-built when needed. `dotnet run` will also automatically find the project in the current folder.
+
+#### Using `dotnet exec`
+
+`dotnet exec` can be used to run an already built test project, this is an alternative to running the application directly. `dotnet exec` requires path to the built test project dll.
+
+:::caution
+
+Providing path to the test project executable (.exe) will result in an error:
+
+```plaintext
+Error:
+  An assembly specified in the application dependencies manifest
+  (Contoso.MyTests.deps.json) has already been found but with a different
+  file extension:
+    package: 'Contoso.MyTests', version: '1.0.0'
+    path: 'Contoso.MyTests.dll'
+    previously found assembly: 'S:\t\Contoso.MyTests\bin\Debug\net8.0\Contoso.MyTests.exe'
+```
+
+:::
+
+#### Using `dotnet test`
+
+:::caution
+
+ `dotnet test` is currently working only with MSTest, NUnit and xUnit tests. TPTF tests will not run using `dotnet test` and no error will be reported.
+
+:::
+
+For tests authored with MSTest, NUnit or xUnit test framework, it is possible to run tests with `dotnet test`.
+
+Provide a path to the tested dll, or to the project and your tests will run.
+
+### In Visual Studio
+
+Testing.Platform tests can be run (and debugged) in VisualStudio, they integrate with Test Explorer, and can also be run directly as Startup Project.
+
+#### Running the application directly in VS
+
+Testing.Platform test project are built as executables, and can be run directly. This will run all the tests in the given executable, unless a filter is provided.
+
+1. Navigate the test project you want to run in Solution Explorer, right click it and select `Set as Startup Project`.
+
+1. Go to Debug > Start without Debugging, (or press `Ctrl + F5`) to run the selected test project.
+
+Console window will pop up with the execution and summary of your test run.
+
+#### Debugging the application directly in VS
+
+Testing.Platform test project are built as executables, and can be debugged directly. This will debug all the tests in the given executable, unless a filter is provided.
+
+1. Navigate the test project you want to run in Solution Explorer, right click it and select `Set as Startup Project`.
+
+1. Set breakpoint into the test that you'd like to debug.
+
+1. Go to Debug > Start Debugging, (or press `F5`) to debug the selected test project.
+
+All tests will be executed until your test with a breakpoint is reached. Step through your test to debug it. Once you are done debugging the application will resume running all remaining tests, unless you stop it.
+
+### Using Test Explorer
+
+Testing.Platform tests partially integrate with Test Explorer. Tests can be Run and Debugged from Test Explorer.
+
+:::caution
+
+Automatic update of tests without building the project is not yet available.
+
+:::
+
+To run a test, navigate to Test Explorer, select the test (or tests) to run. Right click it, and choose `Run`.
+
+Similarly to debug a test, select the test (or tests) in Test Explorer, right click and choose `Debug`.
+
+## In Continuous Integration (CI)
+
+There is no special pipeline task, or any additional tooling to run Testing.Platform tests. There is also no additional tooling to run multiple tests projects through a single command.
+
+To run a test project in CI add one step for each test executable that you wish to run, such as this on AzureDevOps:
+
+```yml
+- task: CmdLine@2
+  displayName: "Run Contonso.MyTests.exe"
+  inputs:
+    script: '.\Contoso.MyTests\bin\Debug\net8.0\Contoso.MyTests.exe'
+```
+
+## Test Reports
+
+A test report is a file that contains information about the execution and outcome of the tests
+
+### TRX Test Report
+
+Visual Studio Test Result file (TRX) is the default format for publishing test results.
+
+Available options:
+
+| Option | Description |
+| ------ | ----------- |
+| `--report-trx` | Generate the TRX report. |
+| `--report-trx-filename` | Name of the generated TRX report. The default name matches the following format `<UserName>_<MachineName>_<yyyy-MM-dd HH:mm:ss>.trx`. |
+
+The report will be saved inside the default `TestResults` folder that can be specified through the `--results-directory` command line argument.
+
+
+## Troubleshooting
+
+Microsoft Testing Platform offers some built-in functionalities and some extensions to ease troubleshooting of your test application.
+
+### `--info` option
+
+When running your Testing.Platform test application with the `--info` options, the platform will display advanced information about:
+
+- the platform
+- the environment
+- for each registered command line providers: name, version, description and options
+- for each registered tool: command, name, version, description and then all command line providers (with the same specification as above)
+
+This feature can be used to understand extensions that would be registering the same command line option or the changes in available options between multiple versions of an extension (or the platform).
+
+### Diagnostics logs
+
+The platform can produce diagnostic logs that are helpful to understand what is happening during the execution of your test application.
+
+The following options are available to configure the produced diagnostic logs:
+
+| Option | Description |
+| ------ | ----------- |
+| `--diagnostic` | Enable the diagnostic logging. The default log level is `Information`. The file will be written in the output directory with the name `log_[MMddHHssfff].diag` |
+| `⁠-⁠-⁠diagnostic-⁠filelogger-⁠synchronouswrite` | Force the built-in file logger to write the log synchronously. Useful for scenario where you don't want to lose any log (i.e. in case of crash). The effect is to slow down the test execution. |
+| `--diagnostic-verbosity` | Define the level of the verbosity for the `--diagnostic`. The available values are `Trace`, `Debug`, `Information`, `Warning`, `Error`, `Critical` |
+| `--diagnostic-output-fileprefix` | Prefix for the log file name that will replace [log]_. |
+| `--diagnostic-output-directory` |  Output directory of the diagnostic logging, if not specified the file will be generated inside the default `TestResults` directory. |
+
+You can enable the diagnostics logs also using the environment variables.
+
+| Environment variable name | Description |
+| ------ | ----------- |
+| `TESTINGPLATFORM_DIAGNOSTIC` | If set to `1` enable the diagnostic logging.  |
+| `TESTINGPLATFORM_DIAGNOSTIC_VERBOSITY` | Define the level of the verbosity. The available values are `Trace`, `Debug`, `Information`, `Warning`, `Error`, `Critical`  |
+| `TESTINGPLATFORM_DIAGNOSTIC_OUTPUT_DIRECTORY` | Output directory of the diagnostic logging, if not specified the file will be generated inside the default `TestResults` directory. |
+| `TESTINGPLATFORM_DIAGNOSTIC_OUTPUT_FILEPREFIX` | Prefix for the log file name that will replace [log]_. |
+| `TESTINGPLATFORM_DIAGNOSTIC_FILELOGGER_SYNCHRONOUSWRITE` | Force the built-in file logger to write the log synchronously. Useful for scenario where you don't want to lose any log (i.e. in case of crash). The effect is to slow down the test execution. |
+
+**Environment variables take precedence on the command line arguments.**
+
+### Hang Dump
+
+This extension allows to create a dump file after a given timeout.
+
+It can be configured using the following options:
+
+| Option | Description |
+| ------ | ----------- |
+| `--hangdump` | Generated a dump file in case of test host process hang. |
+| `-⁠-⁠hangdump-⁠filename` | Specify the file name of the dump. |
+| `--hangdump-timeout` | Specify the timeout after which the dump will be generated. The timeout value is specified in one of the following formats:<br/>1.5h, 1.5hour, 1.5hours<br/>90m, 90min, 90minute, 90minutes<br/>5400s, 5400sec, 5400second, 5400seconds. Default is 30m. |
+| `--hangdump-type` | Specify the type of the dump. Valid values are `Mini`, `Heap`, `Triage` (only .NET 6+), `Full`. Default type is `Full`. For more information visit [MS Learn Crash Dump Types](https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps) |
+
+To be able to use this feature you will need to
+
+1. Add a dependency to `Microsoft.Testing.Platform.Extensions.HangDump`
+
+2. Update your `Program.cs` to add
+
+    ```csharp
+    using Microsoft.Testing.Platform.Extensions;
+    builder.AddHangDumpGenerator();
+    ```
+
+### Crash Dump
+
+This extension allows to create a crash dump file in case of process crash.
+
+It can be configured using the following options:
+
+| Option | Description |
+| ------ | ----------- |
+| `--crashdump` | Generated a dump file in case of test host process crash. Supported by .NET 6.0+ |
+| `⁠-⁠-⁠crashdump-⁠filename` | Specify the file name of the dump. |
+| `--crashdump-type` | Specify the type of the dump. Valid values are `Mini`, `Heap`, `Triage`, `Full`. Default type is `Full`. For more information visit [MS Learn Crash Dump Types](https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps) |
+
+To be able to use this feature you will need to
+
+1. Add a dependency to `Microsoft.Testing.Platform.Extensions`
+
+1. Update your `Program.cs` to add
+
+    ```csharp
+    using Microsoft.Testing.Platform.Extensions;
+    builder.AddCrashDumpGenerator();
+    ```

--- a/docs/core/testing/unit-testing-mstest-runner-intro.md
+++ b/docs/core/testing/unit-testing-mstest-runner-intro.md
@@ -60,7 +60,7 @@ Telemetry is by default collected by the runner, see [Telemetry](./unit-testing-
 
 MSTest Runner test projects are built as executables that can be run (or debugged) directly. There is no additional test running console or command that is needed.
 
-The application will exit with non-zero exit code in case of an error. For a list of known exit codes see [exit codes](unite-testing-mstest-runner-exit-codes.md).
+The application will exit with non-zero exit code in case of an error. For a list of known exit codes see [exit codes](unit-testing-mstest-runner-exit-codes.md).
 
 This is how you run tests in common scenarios:
 

--- a/docs/core/testing/unit-testing-mstest-runner-intro.md
+++ b/docs/core/testing/unit-testing-mstest-runner-intro.md
@@ -52,11 +52,8 @@ Building the application will generate an executable application for your test p
 
 ## Running & Debugging tests
 
-::: info
-
-Telemetry is by default collected by the runner, see [Telemetry](./unit-testing-mstest-runner-telemetry.md) to learn more.
-
-:::
+> [!IMPORTANT]
+> Telemetry is by default collected by the runner, see [Telemetry](./unit-testing-mstest-runner-telemetry.md) to learn more.
 
 MSTest Runner test projects are built as executables that can be run (or debugged) directly. There is no additional test running console or command that is needed.
 
@@ -78,29 +75,23 @@ Publishing the test project using `dotnet publish` and running the application d
 
 `dotnet exec` can be used to run an already built test project, this is an alternative to running the application directly. `dotnet exec` requires path to the built test project dll.
 
-:::caution
+> [!IMPORTANT]
+> Providing path to the test project executable (.exe) will result in an error:
 
-Providing path to the test project executable (.exe) will result in an error:
-
-```plaintext
-Error:
-  An assembly specified in the application dependencies manifest
-  (Contoso.MyTests.deps.json) has already been found but with a different
-  file extension:
-    package: 'Contoso.MyTests', version: '1.0.0'
-    path: 'Contoso.MyTests.dll'
-    previously found assembly: 'S:\t\Contoso.MyTests\bin\Debug\net8.0\Contoso.MyTests.exe'
-```
-
-:::
+> ```plaintext
+> Error:
+>   An assembly specified in the application dependencies manifest
+>   (Contoso.MyTests.deps.json) has already been found but with a different
+>   file extension:
+>     package: 'Contoso.MyTests', version: '1.0.0'
+>     path: 'Contoso.MyTests.dll'
+>     previously found assembly: 'S:\t\Contoso.MyTests\bin\Debug\net8.0\Contoso.MyTests.exe'
+> ```
 
 #### Using `dotnet test`
 
-:::caution
-
- `dotnet test` is currently working only with MSTest, NUnit and xUnit tests. TPTF tests will not run using `dotnet test` and no error will be reported.
-
-:::
+> > [!IMPORTANT]
+> `dotnet test` is currently working only with MSTest, NUnit and xUnit tests. TPTF tests will not run using `dotnet test` and no error will be reported.
 
 For tests authored with MSTest, NUnit or xUnit test framework, it is possible to run tests with `dotnet test`.
 
@@ -136,11 +127,8 @@ All tests will be executed until your test with a breakpoint is reached. Step th
 
 Testing.Platform tests partially integrate with Test Explorer. Tests can be Run and Debugged from Test Explorer.
 
-:::caution
-
-Automatic update of tests without building the project is not yet available.
-
-:::
+> [!IMPORTANT]
+> Automatic update of tests without building the project is not yet available.
 
 To run a test, navigate to Test Explorer, select the test (or tests) to run. Right click it, and choose `Run`.
 

--- a/docs/core/testing/unit-testing-mstest-runner-intro.md
+++ b/docs/core/testing/unit-testing-mstest-runner-intro.md
@@ -9,7 +9,7 @@ ms.custom:
 
 # Overview
 
-MSTestRunner is a light-weight and portable alternative to [microsoft/vstest](https://github.com/microsoft/vstest) for running tests in continuous integration pipelines, and in VisualStudio TestExplorer (Coming soon!).
+MSTest Runner is a light-weight and portable alternative to [microsoft/vstest](https://github.com/microsoft/vstest) for running tests in continuous integration pipelines, and in VisualStudio TestExplorer (Coming soon!).
 
 This runner is embedded directly in your MSTest test project, and there is no additional application (e.g. vstest.console / dotnet test) or any additional infrastructure (e.g. dotnet SDK) needed to run your tests.
 

--- a/docs/core/testing/unit-testing-mstest-runner-intro.md
+++ b/docs/core/testing/unit-testing-mstest-runner-intro.md
@@ -17,7 +17,7 @@ MSTestRunner lives in [microsoft/testfx](https://github.com/microsoft/testfx/tre
 
 ## Enabling MSTest Runner in an MSTest project
 
-To enable MSTest Runnerin an MSTest project, you need to add `<UseMSTestRunner>true</UseMSTestRunner>` into your project file, and make sure you are using MSTest 3.2.0-preview or newer: 
+To enable MSTest Runnerin an MSTest project, you need to add `<UseMSTestRunner>true</UseMSTestRunner>` into your project file, and make sure you are using MSTest 3.2.0-preview or newer:
 
 ```csproj
 <Project Sdk="Microsoft.NET.Sdk">
@@ -175,7 +175,6 @@ Available options:
 | `--report-trx-filename` | Name of the generated TRX report. The default name matches the following format `<UserName>_<MachineName>_<yyyy-MM-dd HH:mm:ss>.trx`. |
 
 The report will be saved inside the default `TestResults` folder that can be specified through the `--results-directory` command line argument.
-
 
 ## Troubleshooting
 

--- a/docs/core/testing/unit-testing-mstest-runner-intro.md
+++ b/docs/core/testing/unit-testing-mstest-runner-intro.md
@@ -17,7 +17,7 @@ MSTestRunner lives in [microsoft/testfx](https://github.com/microsoft/testfx/tre
 
 ## Enabling MSTest Runner in a MSTest project
 
-To enable MSTest Runnerin an MSTest project, you need to add `<UseMSTestRunner>true</UseMSTestRunner>` into your project file, and make sure you are using MSTest 3.2.0-preview or newer:
+To enable MSTest Runner in an MSTest project, you need to add `<UseMSTestRunner>true</UseMSTestRunner>` into your project file, and make sure you are using MSTest 3.2.0-preview or newer:
 
 ```csproj
 <Project Sdk="Microsoft.NET.Sdk">

--- a/docs/core/testing/unit-testing-mstest-runner-intro.md
+++ b/docs/core/testing/unit-testing-mstest-runner-intro.md
@@ -15,7 +15,7 @@ This runner is embedded directly in your MSTest test project, and there is no ad
 
 MSTestRunner lives in [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Platform) repository, and comes bundled with MSTest in 3.2.0-preview. This preview is available on [test-tools NuGet feed](https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json).
 
-## Enabling MSTest Runner in an MSTest project
+## Enabling MSTest Runner in a MSTest project
 
 To enable MSTest Runnerin an MSTest project, you need to add `<UseMSTestRunner>true</UseMSTestRunner>` into your project file, and make sure you are using MSTest 3.2.0-preview or newer:
 

--- a/docs/core/testing/unit-testing-mstest-runner-intro.md
+++ b/docs/core/testing/unit-testing-mstest-runner-intro.md
@@ -48,7 +48,7 @@ To enable MSTest Runner in an MSTest project, you need to add `<UseMSTestRunner>
 </Project>
 ```
 
-Building the application will generate an executable application for your test project. For example `Contoso.MyTests.exe`.
+Building the application will generate an executable application for your test project. For example `Contoso.MyTests.exe` on Windows.
 
 ## Running & Debugging tests
 

--- a/docs/core/testing/unit-testing-mstest-runner-intro.md
+++ b/docs/core/testing/unit-testing-mstest-runner-intro.md
@@ -1,29 +1,28 @@
 ---
-title: MSTest Runner
-description: Learn about MSTest Runner, a lightweight way to run tests without depending on dotnet SDK.
+title: MSTest runner overview
+description: Learn about the MSTest runner, a lightweight way to run tests without depending on the .NET SDK.
 author: nohwnd
 ms.author: jajares
 ms.date: 11/28/2023
-ms.custom: 
 ---
 
-# Overview
+# MSTest runner overview
 
-MSTest Runner is a light-weight and portable alternative to [microsoft/vstest](https://github.com/microsoft/vstest) for running tests in continuous integration pipelines, and in VisualStudio TestExplorer (as a Preview Feature).
+The MSTest runner is a lightweight and portable alternative to [VSTest](https://github.com/microsoft/vstest) for running tests in continuous integration (CI) pipelines, and in Visual Studio Test Explorer.
 
-This runner is embedded directly in your MSTest test project, and there is no additional application (e.g. vstest.console / dotnet test) or any additional infrastructure (e.g. dotnet SDK) needed to run your tests.
+The MSTest runner is embedded directly in your MSTest test projects, and there's no additional app dependencies, such as `vstest.console` or `dotnet test` needed to run your tests.
 
-MSTestRunner lives in [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Platform) repository, and comes bundled with MSTest in 3.2.0-preview. This preview is available on [test-tools NuGet feed](https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json).
+The MSTest runner open source and you can view its code in the [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Platform) GitHub repository. The MSTest runner comes bundled with MSTest in 3.2.0-preview. This preview is available in the [test-tools NuGet feed](https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json).
 
-## Enabling MSTest Runner in a MSTest project
+## Enable MSTest runner in a MSTest project
 
-To enable MSTest Runner in an MSTest project, you need to add `<UseMSTestRunner>true</UseMSTestRunner>` into your project file, and make sure you are using MSTest 3.2.0-preview or newer:
+To enable the MSTest Runner in an MSTest project, you need to add `UseMSTestRunner` into your project file, and make sure you are using MSTest 3.2.0-preview or newer, consider the following example _*.csproj_ file:
 
-```csproj
+```xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- The secret sauce to enabling MSTestRunner. -->
+    <!-- Enable the MSTest runner. -->
     <UseMSTestRunner>true</UseMSTestRunner>
 
     <TargetFramework>net8.0</TargetFramework>
@@ -46,7 +45,8 @@ To enable MSTest Runner in an MSTest project, you need to add `<UseMSTestRunner>
     <!-- Replace coverlet collector 
       <PackageReference Include="coverlet.collector" Version="6.0.0" />
     --> 
-    <PackageReference Include="Microsoft.Testing.Platform.Extensions.CodeCoverage" Version="17.9.4-beta.23563.1" />
+    <PackageReference Include="Microsoft.Testing.Platform.Extensions.CodeCoverage" 
+                      Version="17.9.4-beta.23563.1" />
   </ItemGroup>
 
 </Project>
@@ -54,35 +54,33 @@ To enable MSTest Runner in an MSTest project, you need to add `<UseMSTestRunner>
 
 Building the application will generate an executable application for your test project. For example `Contoso.MyTests.exe` on Windows.
 
-## Running & Debugging tests
+## Run and debug tests
 
 > [!IMPORTANT]
-> Telemetry is by default collected by the runner, see [Telemetry](./unit-testing-mstest-runner-telemetry.md) to learn more.
+> By default, the MStest runner collects telemetry. For more information and options on opting out, see [MSTest runner telemetery](unit-testing-mstest-runner-telemetry.md).
 
-MSTest Runner test projects are built as executables that can be run (or debugged) directly. There is no additional test running console or command that is needed.
+MSTest runner test projects are built as executables that can be run (or debugged) directly. There's no additional test running console or command that's needed.
 
-The application will exit with non-zero exit code in case of an error. For a list of known exit codes see [exit codes](unit-testing-mstest-runner-exit-codes.md).
+The app exits with a non-zero exit code in case of an error, as typical with most executables. For more information on the known exit codes, see [MStest runner exit codes](unit-testing-mstest-runner-exit-codes.md).
 
-This is how you run tests in common scenarios:
+### [.NET CLI](#tab/dotnetcli)
 
-### In console
+## Run the app with .NET CLI
 
-#### Running the application directly in Console
+Publishing the test project using `dotnet publish` and running the app directly is another way to run your tests. For example, executing the `./Contoso.MyTests.exe`. In some scenarios it's also viable to use `dotnet build` to produce the executable, but there can be edge cases to consider, such as when using Native AOT.
 
-Publishing the test project using `dotnet publish` and running the application directly is another way to run your tests. For example `./Contoso.MyTests.exe`. In some scenarios it is also viable to use `dotnet build`, to produce the executable, but there can be edge cases to that for example when using Native AOT.
+### Use `dotnet run`
 
-#### Using `dotnet run`
+The `dotnet run` command can be used to build and run your test project. This is the easiest, although sometimes slowest, way to run your tests. Using `dotnet run` is practical when you are editing and running tests locally, because it ensures that the test project is re-built when needed. `dotnet run` will also automatically find the project in the current folder.
 
-`dotnet run` can be used to build and run your test project. This is the easiest, although sometimes slow, way to run your tests. Using `dotnet run` is practical when you are editing and running tests locally because it ensures that the test project is re-built when needed. `dotnet run` will also automatically find the project in the current folder.
-
-#### Using `dotnet exec`
+### Use `dotnet exec`
 
 `dotnet exec` can be used to run an already built test project, this is an alternative to running the application directly. `dotnet exec` requires path to the built test project dll.
 
 > [!IMPORTANT]
-> Providing path to the test project executable (.exe) will result in an error:
-
-> ```plaintext
+> Providing the path to the test project executable (_*.exe_) results in an error:
+>
+> ```Output
 > Error:
 >   An assembly specified in the application dependencies manifest
 >   (Contoso.MyTests.deps.json) has already been found but with a different
@@ -92,26 +90,26 @@ Publishing the test project using `dotnet publish` and running the application d
 >     previously found assembly: 'S:\t\Contoso.MyTests\bin\Debug\net8.0\Contoso.MyTests.exe'
 > ```
 
-#### Using `dotnet test`
+#### Use `dotnet test`
 
 > > [!IMPORTANT]
-> `dotnet test` is currently working only with MSTest, NUnit and xUnit tests.
+> The `dotnet test` command only works with MSTest, NUnit and xUnit tests.
 
-For tests authored with MSTest, NUnit or xUnit test framework, it is possible to run tests with `dotnet test`.
+For tests authored with MSTest, NUnit or xUnit test framework, it's possible to run tests with `dotnet test`.
 
 Provide a path to the tested dll, or to the project and your tests will run.
 
-### In Visual Studio
+### [Visual Studio](#tab/visual-studio)
 
 Testing.Platform tests can be run (and debugged) in VisualStudio, they integrate with Test Explorer, and can also be run directly as Startup Project.
 
-#### Running the application directly in VS
+#### Run the app with Visual Studio
 
 Testing.Platform test project are built as executables, and can be run directly. This will run all the tests in the given executable, unless a filter is provided.
 
 1. Navigate the test project you want to run in Solution Explorer, right click it and select `Set as Startup Project`.
 
-1. Go to `Debug > Start without Debugging`, (or press `Ctrl + F5`) to run the selected test project.
+1. Select **Debug** > **Start without Debugging** (or use <kbd>Ctrl</kbd>+<kbd>F5</kbd>) to run the selected test project.
 
 Console window will pop up with the execution and summary of your test run.
 

--- a/docs/core/testing/unit-testing-mstest-runner-intro.md
+++ b/docs/core/testing/unit-testing-mstest-runner-intro.md
@@ -119,7 +119,7 @@ Testing.Platform test project are built as executables, and can be debugged dire
 
 1. Set breakpoint into the test that you'd like to debug.
 
-1. Go to Debug > Start Debugging, (or press `F5`) to debug the selected test project.
+1. Go to `Debug > Start Debugging`, (or press `F5`) to debug the selected test project.
 
 All tests will be executed until your test with a breakpoint is reached. Step through your test to debug it. Once you are done debugging the application will resume running all remaining tests, unless you stop it.
 

--- a/docs/core/testing/unit-testing-mstest-runner-intro.md
+++ b/docs/core/testing/unit-testing-mstest-runner-intro.md
@@ -9,7 +9,7 @@ ms.custom:
 
 # Overview
 
-MSTest Runner is a light-weight and portable alternative to [microsoft/vstest](https://github.com/microsoft/vstest) for running tests in continuous integration pipelines, and in VisualStudio TestExplorer (Coming soon!).
+MSTest Runner is a light-weight and portable alternative to [microsoft/vstest](https://github.com/microsoft/vstest) for running tests in continuous integration pipelines, and in VisualStudio TestExplorer (as a Preview Feature).
 
 This runner is embedded directly in your MSTest test project, and there is no additional application (e.g. vstest.console / dotnet test) or any additional infrastructure (e.g. dotnet SDK) needed to run your tests.
 

--- a/docs/core/testing/unit-testing-mstest-runner-intro.md
+++ b/docs/core/testing/unit-testing-mstest-runner-intro.md
@@ -35,14 +35,18 @@ To enable MSTest Runner in an MSTest project, you need to add `<UseMSTestRunner>
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- All these 3 packages can be replaced by reference to:
-        <PackageReference Include="MSTest" Version="3.2.0-preview.23570.1" />
+    <!-- Replace these 3 packages by reference to just MSTest 
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+      <PackageReference Include="MSTest.TestAdapter" Version="3.2.0-preview.23570.1" />
+      <PackageReference Include="MSTest.TestFramework" Version="3.2.0-preview.23570.1" />
     -->
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.0-preview.23570.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.0-preview.23570.1" />
 
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="MSTest" Version="3.2.0-preview.23570.1" />
+
+    <!-- Replace coverlet collector 
+      <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    --> 
+    <PackageReference Include="Microsoft.Testing.Platform.Extensions.CodeCoverage" Version="17.9.4-beta.23563.1" />
   </ItemGroup>
 
 </Project>
@@ -147,11 +151,13 @@ To run a test project in CI add one step for each test executable that you wish 
     script: '.\Contoso.MyTests\bin\Debug\net8.0\Contoso.MyTests.exe'
 ```
 
-## Test Reports
+## Extensions
+
+### Test Reports
 
 A test report is a file that contains information about the execution and outcome of the tests
 
-### TRX Test Report
+#### TRX Test Report
 
 Visual Studio Test Result file (TRX) is the default format for publishing test results.
 
@@ -217,7 +223,6 @@ It can be configured using the following options:
 | `-⁠-⁠hangdump-⁠filename` | Specify the file name of the dump. |
 | `--hangdump-timeout` | Specify the timeout after which the dump will be generated. The timeout value is specified in one of the following formats:<br/>1.5h, 1.5hour, 1.5hours<br/>90m, 90min, 90minute, 90minutes<br/>5400s, 5400sec, 5400second, 5400seconds. Default is 30m. |
 | `--hangdump-type` | Specify the type of the dump. Valid values are `Mini`, `Heap`, `Triage` (only .NET 6+), `Full`. Default type is `Full`. For more information visit [MS Learn Crash Dump Types](https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps) |
-
 
 ### Crash Dump
 

--- a/docs/core/testing/unit-testing-mstest-runner-intro.md
+++ b/docs/core/testing/unit-testing-mstest-runner-intro.md
@@ -91,7 +91,7 @@ Publishing the test project using `dotnet publish` and running the application d
 #### Using `dotnet test`
 
 > > [!IMPORTANT]
-> `dotnet test` is currently working only with MSTest, NUnit and xUnit tests. TPTF tests will not run using `dotnet test` and no error will be reported.
+> `dotnet test` is currently working only with MSTest, NUnit and xUnit tests.
 
 For tests authored with MSTest, NUnit or xUnit test framework, it is possible to run tests with `dotnet test`.
 

--- a/docs/core/testing/unit-testing-mstest-runner-intro.md
+++ b/docs/core/testing/unit-testing-mstest-runner-intro.md
@@ -1,6 +1,6 @@
 ---
-title: MSTest Test Runner
-description: Learn about MSTest Test Runner, a lightweight way to run tests without depending on dotnet SDK.
+title: MSTest Runner
+description: Learn about MSTest Runner, a lightweight way to run tests without depending on dotnet SDK.
 author: nohwnd
 ms.author: jajares
 ms.date: 11/28/2023

--- a/docs/core/testing/unit-testing-mstest-runner-telemetry.md
+++ b/docs/core/testing/unit-testing-mstest-runner-telemetry.md
@@ -1,0 +1,88 @@
+# Telemetry
+
+MSTest Runner collects telemetry data, which is used to help understand how to improve the product. For example, this usage data helps to debug issues, such as slow start-up times, and to prioritize new features. While we appreciate the insights this data provides, we also know that not everyone wants to send usage data and you can [disable telemetry](#disable-telemetry-reporting) as described in disable telemetry reporting. You can also read our [privacy statement](https://go.microsoft.com/fwlink/?LinkID=528096&clcid=0x409) to learn more.
+
+## Types of telemetry data
+
+MSTest Runner collects only telemetry of type **Usage Data**. These data are used to understand how features are used and where time is spent when executing the test application. This is helping us to prioritize product improvements.
+
+## Disable telemetry reporting
+
+You can fully disable telemetry by setting `TESTINGPLATFORM_TELEMETRY_OPTOUT` or `DOTNET_CLI_TELEMETRY_OPTOUT` environment variable to `1`.
+
+## Disclosure
+
+Test Anywhere displays text similar to the following when you first run your executable. Text may vary slightly depending on the version MSTest Runner you are running. This "first run" experience is how Microsoft notifies you about data collection.
+
+```console
+Telemetry
+---------
+MSTest Runner collects usage data in order to help us improve your experience.
+The data is collected by Microsoft and are not shared.
+You can opt-out of telemetry by setting the TESTINGPLATFORM_TELEMETRY_OPTOUT
+or DOTNET_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
+
+Read more about MSTest Runner telemetry: https://aka.ms/testingplatform-telemetry
+```
+
+## Data points
+
+The telemetry feature doesn't collect personal data, such as usernames or email addresses. It doesn't scan your code and doesn't extract project-level data, such as repository, or author, **it extracts the name of your executable and sends it in hashed form.**
+
+It doesn't extract the contents of any data files accessed or created by your apps, dumps of any memory occupied by your apps' objects, or the contents of the clipboard.
+
+The data is sent securely to Microsoft servers using Azure Monitor technology, held under restricted access, and published under strict security controls from secure Azure Storage systems.
+
+Protecting your privacy is important to us. If you suspect the telemetry is collecting sensitive data or the data is being insecurely or inappropriately handled, file an issue in the [microsoft/testfx](https://github.com/microsoft/testfx) or send an email to [dotnet@microsoft.com](mailto:dotnet@microsoft.com) for investigation.
+
+The telemetry feature collects the following data:
+
+---
+| Version | Data|
+|-|-|
+| All | Timestamp of invocation, timestamp of start and end of various steps in the execution. |
+| All | Three octet IP address used to determine the geographical location. |
+| All | Operating system, version and architecture. |
+| All | Process architecture. |
+| All | Runtime ID (RID). |
+| All | .NET Runtime version. |
+| All | Name of your executable (which is usually the same as the name of the project), **hashed**. |
+| All | DisplayName of the extensions you are using, **hashed**. |
+| All | Version of your extensions. |
+| All | Name of the test framework you are using, **hashed**. |
+| All | Version of your test adapter. |
+| All | Version of the platform. |
+| All | Application mode, such as 'server'. |
+| All | If the application is running as NativeAOT. |
+| All | If Hot reload is enabled.  |
+| All | If the repository is our own repository. Based on telemetry:isDevelopmentRepository setting in testingplatformconfig.json. |
+| All | The exit code of the application. |
+| All | If the application crashed. |
+| All | If debug build of platform is used. |
+| All | If debugger was attached to the process. |
+| All | If filter of tests was used. |
+| All | Count of tests that ran. |
+| All | Count of tests that passed. |
+| All | Count of tests that failed. |
+| All | Count of test retries that passed. |
+| All | Count of test retries that failed. |
+
+## Continuous Integration Detection
+
+In order to detect if the .NET CLI is running in a Continuous Integration environment, the .NET CLI probes for the presence and values of several well-known environment variables that common CI providers set.
+
+The full list of environment variables, and what is done with their values, is shown below.  Note that in every case, the value of the environment variable is never collected, only used to set a boolean flag.
+
+| Variable(s) | Provider | Action |
+| ----------- | -------- | ------ |
+| TF_BUILD    | Azure Pipelines | Parse boolean value |
+| GITHUB_ACTIONS | GitHub Actions | Parse boolean value |
+| APPVEYOR | Appveyor | Parse boolean value |
+| CI | Many/Most | Parse boolean value |
+| TRAVIS | Travis CI | Parse boolean value |
+| CIRCLECI | Circle CI | Parse boolean value |
+| CODEBUILD_BUILD_ID, AWS_REGION | Amazon Web Services CodeBuild | Check if all are present and non-null |
+| BUILD_ID, BUILD_URL | Jenkins | Check if all are present and non-null |
+| BUILD_ID, PROJECT_ID | Google Cloud Build | Check if all are present and non-null |
+| TEAMCITY_VERSION | TeamCity | Check if present and non-null |
+| JB_SPACE_API_URL | JetBrains Space | Check if present and non-null |

--- a/docs/core/testing/unit-testing-mstest-runner-telemetry.md
+++ b/docs/core/testing/unit-testing-mstest-runner-telemetry.md
@@ -1,6 +1,6 @@
 ---
-title: MSTest Test Runner Telemetry
-description: Learn about MSTest Test Runner Telemetry.
+title: MSTest Runner Telemetry
+description: Learn about MSTest Runner Telemetry.
 author: nohwnd
 ms.author: jajares
 ms.date: 11/28/2023

--- a/docs/core/testing/unit-testing-mstest-runner-telemetry.md
+++ b/docs/core/testing/unit-testing-mstest-runner-telemetry.md
@@ -1,3 +1,12 @@
+---
+title: MSTest Test Runner Telemetry
+description: Learn about MSTest Test Runner Telemetry.
+author: nohwnd
+ms.author: jajares
+ms.date: 11/28/2023
+ms.custom: 
+---
+
 # Telemetry
 
 MSTest Runner collects telemetry data, which is used to help understand how to improve the product. For example, this usage data helps to debug issues, such as slow start-up times, and to prioritize new features. While we appreciate the insights this data provides, we also know that not everyone wants to send usage data and you can [disable telemetry](#disable-telemetry-reporting) as described in disable telemetry reporting. You can also read our [privacy statement](https://go.microsoft.com/fwlink/?LinkID=528096&clcid=0x409) to learn more.

--- a/docs/core/testing/unit-testing-mstest-runner-vs-vstest.md
+++ b/docs/core/testing/unit-testing-mstest-runner-vs-vstest.md
@@ -1,0 +1,48 @@
+---
+title: MSTest runner and VSTest comparison
+description: Learn the difference between MSTest runner and VSTest.
+author: nohwnd
+ms.author: jajares
+ms.date: 12/13/2023
+---
+
+# MSTest runner and VSTest comparison
+
+The MSTest runner is a lightweight and portable alternative to [VSTest](https://github.com/microsoft/vstest) for running tests in continuous integration (CI) pipelines, and in Visual Studio Test Explorer.
+
+The article below describes the main differences between VSTest and MSTest.
+
+## Executing tests
+
+### Executing VSTest tests
+
+VSTest ships with Visual Studio, dotnet SDK and also standalone in `Microsoft.TestingPlatform` NuGet package. VSTest uses a runner executable to run tests, this runner is called `vstest.console.exe`, and can be used directly or through `dotnet test`.
+
+### Executing MSTest runner tests
+
+MSTest is embedded directly into your test project, and does not ship any additional executables. Running your project executable directly will run yours tests.
+
+## Namespaces
+
+### VSTest namespaces
+
+VSTest is a collection of testing tools, that are also known as Test Platform. VSTest source code is placed in [microsoft/vstest](https://github.com/microsoft/vstest) repository. The code uses `Microsoft.TestPlatform.*` namespace. 
+
+VSTest is extensible and common types are placed in `Microsoft.TestPlatform.ObjectModel` library.
+
+### MSTest runner namespaces
+
+The MSTest runner is based on Microsoft.Testing.Platform library and additional libraries in `Microsoft.Testing.*` namespace. Microsoft.Testing.Platform code is placed in [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Platform) GitHub repository.
+
+MSTest runner uses VSTest extensibility model `Microsoft.TestPlatform.ObjectModel` to extend MSTest testing framework.
+
+## Executables
+
+### VSTest executables
+
+VSTest ships multiple executables, the most known `vstest.console.exe`, `testhost.exe`, `datacollector.exe`.
+
+### MSTest runner executables
+
+MSTest is embedded directly into your test project, and does not ship any additional executables. The executable of your test project is used to host all the testing tools, and carry out all the tasks that are needed for running tests.
+

--- a/docs/core/testing/unit-testing-mstest-runner-vs-vstest.md
+++ b/docs/core/testing/unit-testing-mstest-runner-vs-vstest.md
@@ -8,7 +8,7 @@ ms.date: 12/13/2023
 
 # MSTest runner and VSTest comparison
 
-The MSTest runner is a lightweight and portable alternative to [VSTest](https://github.com/microsoft/vstest) for running tests in continuous integration (CI) pipelines, and in Visual Studio Test Explorer.
+The MSTest runner is a lightweight and portable alternative to [VSTest](https://github.com/microsoft/vstest) for running tests in command line, in continuous integration (CI) pipelines, in Visual Studio Test Explorer, and in Visual Studio Code.
 
 The article below describes the main differences between VSTest and MSTest runner.
 
@@ -34,7 +34,6 @@ VSTest is extensible and common types are placed in `Microsoft.TestPlatform.Obje
 
 The MSTest runner is based on `Microsoft.Testing.Platform` library and additional libraries in `Microsoft.Testing.*` namespace. `Microsoft.Testing.Platform` code is placed in [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Platform) GitHub repository.
 
-MSTest runner uses VSTest extensibility model `Microsoft.TestPlatform.ObjectModel` to extend MSTest testing framework.
 
 ## Executables
 

--- a/docs/core/testing/unit-testing-mstest-runner-vs-vstest.md
+++ b/docs/core/testing/unit-testing-mstest-runner-vs-vstest.md
@@ -43,4 +43,3 @@ VSTest ships multiple executables, the most known `vstest.console.exe`, `testhos
 ### MSTest runner executables
 
 MSTest is embedded directly into your test project, and does not ship any additional executables. The executable of your test project is used to host all the testing tools, and carry out all the tasks that are needed for running tests.
-

--- a/docs/core/testing/unit-testing-mstest-runner-vs-vstest.md
+++ b/docs/core/testing/unit-testing-mstest-runner-vs-vstest.md
@@ -10,13 +10,13 @@ ms.date: 12/13/2023
 
 The MSTest runner is a lightweight and portable alternative to [VSTest](https://github.com/microsoft/vstest) for running tests in continuous integration (CI) pipelines, and in Visual Studio Test Explorer.
 
-The article below describes the main differences between VSTest and MSTest.
+The article below describes the main differences between VSTest and MSTest runner.
 
 ## Executing tests
 
 ### Executing VSTest tests
 
-VSTest ships with Visual Studio, dotnet SDK and also standalone in `Microsoft.TestingPlatform` NuGet package. VSTest uses a runner executable to run tests, this runner is called `vstest.console.exe`, and can be used directly or through `dotnet test`.
+VSTest ships with Visual Studio, .NET SDK and also as a standalone tool in `Microsoft.TestingPlatform` NuGet package. VSTest uses a runner executable to run tests, this runner is called `vstest.console.exe`, and can be used directly or through `dotnet test`.
 
 ### Executing MSTest runner tests
 
@@ -26,13 +26,13 @@ MSTest is embedded directly into your test project, and does not ship any additi
 
 ### VSTest namespaces
 
-VSTest is a collection of testing tools, that are also known as Test Platform. VSTest source code is placed in [microsoft/vstest](https://github.com/microsoft/vstest) repository. The code uses `Microsoft.TestPlatform.*` namespace. 
+VSTest is a collection of testing tools, that are also known as Test Platform. VSTest source code is placed in [microsoft/vstest](https://github.com/microsoft/vstest) repository. The code uses `Microsoft.TestPlatform.*` namespace.
 
 VSTest is extensible and common types are placed in `Microsoft.TestPlatform.ObjectModel` library.
 
 ### MSTest runner namespaces
 
-The MSTest runner is based on Microsoft.Testing.Platform library and additional libraries in `Microsoft.Testing.*` namespace. Microsoft.Testing.Platform code is placed in [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Platform) GitHub repository.
+The MSTest runner is based on `Microsoft.Testing.Platform` library and additional libraries in `Microsoft.Testing.*` namespace. `Microsoft.Testing.Platform` code is placed in [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Platform) GitHub repository.
 
 MSTest runner uses VSTest extensibility model `Microsoft.TestPlatform.ObjectModel` to extend MSTest testing framework.
 

--- a/docs/core/testing/unit-testing-mstest-runner-vs-vstest.md
+++ b/docs/core/testing/unit-testing-mstest-runner-vs-vstest.md
@@ -34,7 +34,6 @@ VSTest is extensible and common types are placed in `Microsoft.TestPlatform.Obje
 
 The MSTest runner is based on `Microsoft.Testing.Platform` library and additional libraries in `Microsoft.Testing.*` namespace. `Microsoft.Testing.Platform` code is placed in [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Platform) GitHub repository.
 
-
 ## Executables
 
 ### VSTest executables


### PR DESCRIPTION
## Summary

Add documentation for MSTest Runner.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-mstest-runner-exit-codes.md](https://github.com/dotnet/docs/blob/112c8874e67461c995a65872ab938556aaa2d73b/docs/core/testing/unit-testing-mstest-runner-exit-codes.md) | [MSTest runner exit codes](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-runner-exit-codes?branch=pr-en-us-38459) |
| [docs/core/testing/unit-testing-mstest-runner-intro.md](https://github.com/dotnet/docs/blob/112c8874e67461c995a65872ab938556aaa2d73b/docs/core/testing/unit-testing-mstest-runner-intro.md) | [MSTest runner overview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-runner-intro?branch=pr-en-us-38459) |
| [docs/core/testing/unit-testing-mstest-runner-telemetry.md](https://github.com/dotnet/docs/blob/112c8874e67461c995a65872ab938556aaa2d73b/docs/core/testing/unit-testing-mstest-runner-telemetry.md) | [Telemetry](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-runner-telemetry?branch=pr-en-us-38459) |
| [docs/core/testing/unit-testing-mstest-runner-vs-vstest.md](https://github.com/dotnet/docs/blob/112c8874e67461c995a65872ab938556aaa2d73b/docs/core/testing/unit-testing-mstest-runner-vs-vstest.md) | [MSTest runner and VSTest comparison](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-runner-vs-vstest?branch=pr-en-us-38459) |


<!-- PREVIEW-TABLE-END -->