### PR TITLE
fix product names

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -183,11 +183,11 @@
                 "_roslyn/**.*": "https://github.com/dotnet/docs/issues/new?template=customer-feedback.yml"
             },
             "open_source_feedback_productName": {
-                "docs/**.*": ".NET feedback",
-                "_csharplang/**.*": "C# feature specification feedback",
-                "_csharpstandard/standard/*.md": "C# Standard documentation feedback",
-                "_vblang/**.*": "Visual Basic language spec feedback",
-                "_roslyn/**.*": "Roslyn breaking feedback"
+                "docs/**.*": ".NET",
+                "_csharplang/**.*": "C# feature specification",
+                "_csharpstandard/standard/*.md": "C# Standard documentation",
+                "_vblang/**.*": "Visual Basic language spec",
+                "_roslyn/**.*": "Roslyn breaking changes"
             },
             "open_source_feedback_productDescription": {
                 "docs/**.*": "The .NET documentation is open source. Provide feedback here.",


### PR DESCRIPTION
This should merge on Friday, to coincide with the platform updates.

restores the product name changes in #38448 

I didn't do the additional config changes. There will be cleanup after this change is merged, and we've verified the updated text.
