### PR TITLE
Update ca1863.md

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1863.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1863.md
@@ -37,7 +37,7 @@ The following example shows two violations of the rule:
 ```csharp
 class C
 {
-    private static readonly string StaticField;
+    private static readonly string StaticField = "Format one value: {0}";
 
     static void Main()
     {
@@ -54,15 +54,14 @@ The following example shows code that fixes both violations:
 ```csharp
 class C
 {
-    private static readonly string StaticField;
+    private static readonly CompositeFormat StaticField = CompositeFormat.Parse("Format one value: {0}");
 
     static void Main()
     {
-        CompositeFormat cf = CompositeFormat.Parse(StaticField);
-        _ = string.Format(null, cf, 42);
+        _ = string.Format(null, StaticField, 42);
 
         StringBuilder sb = new();
-        sb.AppendFormat(null, cf, 42);
+        sb.AppendFormat(null, StaticField, 42);
     }
 }
 ```


### PR DESCRIPTION
1. Make snippets runnable
2. I would argue changing the static field type is more real life fix because you can an actually do something like:

```
class C1
{
    private static readonly string StaticField = "Format one value: {0}";

    static void Main()
    {
        _ = string.Format(null, CompositeFormat.Parse(StaticField), 42);

        StringBuilder sb = new();
        sb.AppendFormat(null, CompositeFormat.Parse(StaticField), 42);
    }
}
```

Which obviously makes the warning to go away but does not actually cover the underlying issue. 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1863.md](https://github.com/dotnet/docs/blob/c111447f9b3b55fc3cb2f153442d2f31041b96c4/docs/fundamentals/code-analysis/quality-rules/ca1863.md) | [CA1863: Use 'CompositeFormat'](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1863?branch=pr-en-us-38488) |

<!-- PREVIEW-TABLE-END -->