### PR TITLE
Add note that .NET 8 may not yet be available

### DIFF
--- a/docs/core/install/linux-fedora.md
+++ b/docs/core/install/linux-fedora.md
@@ -31,6 +31,8 @@ The following table is a list of currently supported .NET releases and the versi
 
 ## Install .NET 8
 
+[!INCLUDE [linux-release-wait](includes/linux-release-wait.md)]
+
 [!INCLUDE [linux-dnf-install-80](includes/linux-install-80-dnf.md)]
 
 ## Install .NET 7

--- a/docs/core/install/linux-rhel.md
+++ b/docs/core/install/linux-rhel.md
@@ -47,11 +47,15 @@ The following table is a list of currently supported .NET releases on both RHEL 
 
 .NET is included in the AppStream repositories for RHEL 9.
 
+[!INCLUDE [linux-release-wait](includes/linux-release-wait.md)]
+
 [!INCLUDE [linux-dnf-install-80](includes/linux-install-80-dnf.md)]
 
 ## RHEL 8
 
 .NET is included in the AppStream repositories for RHEL 8.
+
+[!INCLUDE [linux-release-wait](includes/linux-release-wait.md)]
 
 [!INCLUDE [linux-dnf-install-80](includes/linux-install-80-dnf.md)]
 


### PR DESCRIPTION
## Summary

Note to self, keep this note around for until the new year for distros with their own package feeds that source .NET, such as Ubuntu, RHEL, and Fedora 😁 

Fixes #38366
Fixes #38419


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/linux-fedora.md](https://github.com/dotnet/docs/blob/74b58bcb5fde4baa69826d85a46555093b430dc0/docs/core/install/linux-fedora.md) | [Install the .NET SDK or the .NET Runtime on Fedora](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-fedora?branch=pr-en-us-38512) |
| [docs/core/install/linux-rhel.md](https://github.com/dotnet/docs/blob/74b58bcb5fde4baa69826d85a46555093b430dc0/docs/core/install/linux-rhel.md) | [Install .NET on RHEL and CentOS Stream](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-rhel?branch=pr-en-us-38512) |

<!-- PREVIEW-TABLE-END -->