### PR TITLE
Document perfmap settings

### DIFF
--- a/docs/core/diagnostics/debug-highcpu.md
+++ b/docs/core/diagnostics/debug-highcpu.md
@@ -131,7 +131,7 @@ When analyzing an app with high CPU usage, you need a diagnostics tool that can 
 
 The `perf` tool can be used to generate .NET Core app profiles. We will demonstrate this tool, although dotnet-trace could be used as well. Exit the previous instance of the [sample debug target](/samples/dotnet/samples/diagnostic-scenarios).
 
-Set the `DOTNET_PerfMapEnabled` environment variable to cause the .NET app to create a `map` file in the `/tmp` directory. This `map` file is used by `perf` to map CPU addresses to JIT-generated functions by name. For more information, see [Export perf maps](../runtime-config/debugging-profiling.md#export-perf-maps).
+Set the `DOTNET_PerfMapEnabled` environment variable to cause the .NET app to create a `map` file in the `/tmp` directory. This `map` file is used by `perf` to map CPU addresses to JIT-generated functions by name. For more information, see [Export perf maps and jit dumps](../runtime-config/debugging-profiling.md#export-perf-maps-and-jit-dumps).
 
 [!INCLUDE [complus-prefix](../../../includes/complus-prefix.md)]
 

--- a/docs/core/runtime-config/debugging-profiling.md
+++ b/docs/core/runtime-config/debugging-profiling.md
@@ -66,7 +66,7 @@ This article details the settings you can use to configure .NET debugging and pr
 | | Setting name | Values |
 | - | - | - |
 | **runtimeconfig.json** | N/A | N/A |
-| **Environment variable** | `COMPlus_PerfMapEnabled` or `DOTNET_PerfMapEnabled` | `0` - disabled<br/>`1` - perfmaps and jitdumps both enabled<br/>`2` - jitdumps enabled<br/>`3` - perfmaps enabled |
+| **Environment variable** | `COMPlus_PerfMapEnabled` or `DOTNET_PerfMapEnabled` | `0` - disabled<br/>`1` - perf maps and jit dumps both enabled<br/>`2` - jit dumps enabled<br/>`3` - perf maps enabled |
 
 ## Perf log markers
 

--- a/docs/core/runtime-config/debugging-profiling.md
+++ b/docs/core/runtime-config/debugging-profiling.md
@@ -63,7 +63,7 @@ The following table compares perf maps and jit maps.
 | Format | Description | Supported on |
 | - | - | - |
 | *Perf maps* | Emits `/tmp/perf-<pid>.map`, which contains symbolic information for dynamically generated code.<br/>Emits `/tmp/perfinfo-<pid>.map`, which includes ReadyToRun (R2R) module symbol information and is used by [PerfCollect](../diagnostics/trace-perfcollect-lttng.md). | Perf maps are supported on all Linux kernel versions. |
-| *Jit dumps* | The jit dump format supercedes perf maps and contains more detailed symbolic information. When enabled, jit dumps will be output to `/tmp/jit-<pid>.dump` files.|Linux kernel versions 5.4 or higher|
+| *Jit dumps* | The jit dump format supersedes perf maps and contains more detailed symbolic information. When enabled, jit dumps are output to `/tmp/jit-<pid>.dump` files. | Linux kernel versions 5.4 or higher. |
 
 | | Setting name | Values |
 | - | - | - |

--- a/docs/core/runtime-config/debugging-profiling.md
+++ b/docs/core/runtime-config/debugging-profiling.md
@@ -56,7 +56,7 @@ This article details the settings you can use to configure .NET debugging and pr
 - If you omit this setting, writing perf map and jit dump files are both disabled. This is equivalent to setting the value to `0`.
 - When perf maps are disabled, not all managed callsites will be properly resolved.
 - Depending on the Linux kernel version, both formats are supported by the `perf` tool.
-- Enabling perf maps or jit dumps causes a 10-20% overhead. It is recommended to selectively enable either perf maps or jit dumps, but not both to minimize performance impact.
+- Enabling perf maps or jit dumps causes a 10-20% overhead. To minimize performance impact, it's recommended to selectively enable either perf maps or jit dumps, but not both.
 
 | Format | Description | Supported on |
 | - | - | - |

--- a/docs/core/runtime-config/debugging-profiling.md
+++ b/docs/core/runtime-config/debugging-profiling.md
@@ -79,4 +79,4 @@ This article details the settings you can use to configure .NET debugging and pr
 | **Environment variable** | `COMPlus_PerfMapIgnoreSignal` or `DOTNET_PerfMapIgnoreSignal` | `0` - disabled<br/>`1` - enabled |
 
 > [!NOTE]
-> This setting is ignored if [DOTNET_PerfMapEnabled](#export-perf-maps) is omitted or set to `0` (that is, disabled).
+> This setting is ignored if [DOTNET_PerfMapEnabled](#export-perf-maps-and-jit-dumps) is omitted or set to `0` (that is, disabled).

--- a/docs/core/runtime-config/debugging-profiling.md
+++ b/docs/core/runtime-config/debugging-profiling.md
@@ -50,15 +50,18 @@ This article details the settings you can use to configure .NET debugging and pr
 | **Environment variable** | `CORECLR_PROFILER_PATH_32` | *string-path* |
 | **Environment variable** | `CORECLR_PROFILER_PATH_64` | *string-path* |
 
-## Export perf maps
+## Export perf maps and jit dumps
 
-- Enables or disables emitting perf maps to */tmp/perf-$pid.map*. Allows for selective enablement of Perf maps or Jit dumps, which both allow third party tools, such as perf, to identify call sites from precompiled ReadyToRun (R2R) modules.
-- If you omit this setting, writing the perf map is disabled. This is equivalent to setting the value to `0`.
+- Enables or disables selective enablement of perf maps or jit dumps. These files allow third party tools, such as the Linux `perf` tool, to identify call sites for dynamically generated code and precompiled ReadyToRun (R2R) modules.
+- If you omit this setting, writing perf map and jit dump files are both disabled. This is equivalent to setting the value to `0`.
 - When perf maps are disabled, not all managed callsites will be properly resolved.
-- Enabling perf maps causes a 10-20% overhead.
-- The JitDump format which includes highly detailed information for .NET method methods.
-- The PerfMap format is less verbose compared to the JitDump format.  
-- PerfMaps are supported on all known Linux kernel versions, and JitDumps requires Linux kernel 5.4 or later.
+- Depending on the Linux kernel version, both formats are supported by the `perf` tool.
+- Enabling perf maps or jit dumps causes a 10-20% overhead. It is recommended to selectively enable either perf maps or jit dumps, but not both to minimize performance impact.
+
+| Format | Description | Supported on |
+| - | - | - |
+| *Perf maps* | Emits `/tmp/perf-<pid>.map` which contains symbolic information for dynamically generated code.<br/>Emits `/tmp/perfinfo-<pid>.map` which includes ReadyToRun (R2R) module symbol information and is used by [PerfCollect](../diagnostics/trace-perfcollect-lttng.md). | Perf maps are supported on all Linux kernel versions.|
+| *Jit dumps* | The jit dump format supercedes perf maps and contains more detailed symbolic information. When enabled, jit dumps will be output to `/tmp/jit-<pid>.dump` files.|Linux kernel versions 5.4 or higher|
 
 | | Setting name | Values |
 | - | - | - |

--- a/docs/core/runtime-config/debugging-profiling.md
+++ b/docs/core/runtime-config/debugging-profiling.md
@@ -58,6 +58,8 @@ This article details the settings you can use to configure .NET debugging and pr
 - Depending on the Linux kernel version, both formats are supported by the `perf` tool.
 - Enabling perf maps or jit dumps causes a 10-20% overhead. To minimize performance impact, it's recommended to selectively enable either perf maps or jit dumps, but not both.
 
+The following table compares perf maps and jit maps.
+
 | Format | Description | Supported on |
 | - | - | - |
 | *Perf maps* | Emits `/tmp/perf-<pid>.map` which contains symbolic information for dynamically generated code.<br/>Emits `/tmp/perfinfo-<pid>.map` which includes ReadyToRun (R2R) module symbol information and is used by [PerfCollect](../diagnostics/trace-perfcollect-lttng.md). | Perf maps are supported on all Linux kernel versions.|

--- a/docs/core/runtime-config/debugging-profiling.md
+++ b/docs/core/runtime-config/debugging-profiling.md
@@ -52,15 +52,18 @@ This article details the settings you can use to configure .NET debugging and pr
 
 ## Export perf maps
 
-- Enables or disables emitting perf maps to */tmp/perf-$pid.map*. Perf maps allow third party tools, such as perf, to identify call sites from precompiled ReadyToRun (R2R) modules.
+- Enables or disables emitting perf maps to */tmp/perf-$pid.map*. Allows for selective enablement of Perf maps or Jit dumps, which both allow third party tools, such as perf, to identify call sites from precompiled ReadyToRun (R2R) modules.
 - If you omit this setting, writing the perf map is disabled. This is equivalent to setting the value to `0`.
 - When perf maps are disabled, not all managed callsites will be properly resolved.
 - Enabling perf maps causes a 10-20% overhead.
+- The JitDump format which includes highly detailed information for .NET method methods.
+- The PerfMap format is less verbose compared to the JitDump format.  
+- PerfMaps are supported on all known Linux kernel versions, and JitDumps requires Linux kernel 5.4 or later.
 
 | | Setting name | Values |
 | - | - | - |
 | **runtimeconfig.json** | N/A | N/A |
-| **Environment variable** | `COMPlus_PerfMapEnabled` or `DOTNET_PerfMapEnabled` | `0` - disabled<br/>`1` - enabled |
+| **Environment variable** | `COMPlus_PerfMapEnabled` or `DOTNET_PerfMapEnabled` | `0` - disabled<br/>`1` - perfmaps and jitdumps both enabled<br/>`2` - jitdumps enabled<br/>`3` - perfmaps enabled |
 
 ## Perf log markers
 

--- a/docs/core/runtime-config/debugging-profiling.md
+++ b/docs/core/runtime-config/debugging-profiling.md
@@ -62,7 +62,7 @@ The following table compares perf maps and jit maps.
 
 | Format | Description | Supported on |
 | - | - | - |
-| *Perf maps* | Emits `/tmp/perf-<pid>.map` which contains symbolic information for dynamically generated code.<br/>Emits `/tmp/perfinfo-<pid>.map` which includes ReadyToRun (R2R) module symbol information and is used by [PerfCollect](../diagnostics/trace-perfcollect-lttng.md). | Perf maps are supported on all Linux kernel versions.|
+| *Perf maps* | Emits `/tmp/perf-<pid>.map`, which contains symbolic information for dynamically generated code.<br/>Emits `/tmp/perfinfo-<pid>.map`, which includes ReadyToRun (R2R) module symbol information and is used by [PerfCollect](../diagnostics/trace-perfcollect-lttng.md). | Perf maps are supported on all Linux kernel versions. |
 | *Jit dumps* | The jit dump format supercedes perf maps and contains more detailed symbolic information. When enabled, jit dumps will be output to `/tmp/jit-<pid>.dump` files.|Linux kernel versions 5.4 or higher|
 
 | | Setting name | Values |


### PR DESCRIPTION
Document  DOTNET_PerfMapEnabled  behavior:

DOTNET_PerfMapEnabled | Behavior
-- | --
0 | Disabled
1 | Generate both
2 | Generate only JitDump
3 | Generate only PerfMaps



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/debug-highcpu.md](https://github.com/dotnet/docs/blob/75e0d992dc7c18e556853c5f4235fa9d0a5b9ae1/docs/core/diagnostics/debug-highcpu.md) | [Debug high CPU usage in .NET Core](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/debug-highcpu?branch=pr-en-us-38538) |
| [docs/core/runtime-config/debugging-profiling.md](https://github.com/dotnet/docs/blob/75e0d992dc7c18e556853c5f4235fa9d0a5b9ae1/docs/core/runtime-config/debugging-profiling.md) | [Debugging profiling config settings](https://review.learn.microsoft.com/en-us/dotnet/core/runtime-config/debugging-profiling?branch=pr-en-us-38538) |


<!-- PREVIEW-TABLE-END -->