### PR TITLE
consolidate feedback config

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -122,9 +122,16 @@
             "featureFlags": [
                 "enable_uhf_ppe"
             ],
-            "feedback_system": "GitHub",
+            "feedback_system": "OpenSource",
             "feedback_github_repo": "dotnet/docs",
             "feedback_product_url": "https://aka.ms/feedback/report?space=61",
+            "open_source_feedback_contributorGuideUrl": "https://learn.microsoft.com/contribute/content/dotnet/dotnet-contribute",
+            "open_source_feedback_issueTitle": "",
+            "open_source_feedback_productLogoLightUrl": "https://learn.microsoft.com/media/logos/logo_net.svg",
+            "open_source_feedback_productLogoDarkUrl": "https://learn.microsoft.com/media/logos/logo_net.svg",
+            "open_source_feedback_issueUrl": "https://github.com/dotnet/docs/issues/new?template=customer-feedback.yml",
+            "open_source_feedback_productName": ".NET",
+            "social_image_url": "/dotnet/media/dotnet-logo.png",
             "ms.author": "dotnetcontent",
             "ms.devlang": "dotnet",
             "ms.prod": "dotnet",
@@ -157,72 +164,27 @@
         },
         "fileMetadata": {
             "feedback_system": {
-                "_csharplang/**.*": "OpenSource",
-                "_csharpstandard/standard/*.md": "OpenSource",
-                "_vblang/**.*": "OpenSource",
-                "_roslyn/**.*": "OpenSource",
-                "docs/**.*": "OpenSource",
                 "docs/standard/design-guidelines/**/**.md": "None",
                 "docs/framework/data/adonet/**/**.md": "None",
                 "docs/framework/data/wcf/**/**.md": "None",
                 "docs/framework/ui-automation/**/**.md": "None",
                 "docs/framework/wcf/**/**.md": "None"
             },
-            "open_source_feedback_contributorGuideUrl": {
-                "docs/**/**.*": "https://learn.microsoft.com/contribute/content/dotnet/dotnet-contribute",
-                "_csharplang/**.*": "https://learn.microsoft.com/contribute/content/dotnet/dotnet-contribute",
-                "_csharpstandard/standard/*.md": "https://learn.microsoft.com/contribute/content/dotnet/dotnet-contribute",
-                "_vblang/**.*": "https://learn.microsoft.com/contribute/content/dotnet/dotnet-contribute",
-                "_roslyn/**.*": "https://learn.microsoft.com/contribute/content/dotnet/dotnet-contribute"
-            },
             "open_source_feedback_issueUrl": {
-                "docs/**.*": "https://github.com/dotnet/docs/issues/new?template=customer-feedback.yml",
                 "_csharplang/**.*": "https://github.com/dotnet/charplang/issues/new?template=docs-feedback.yml",
-                "_csharpstandard/standard/*.md": "https://github.com/dotnet/csharpstandard/issues/new?template=docs-feedback.yml",
-                "_vblang/**.*": "https://github.com/dotnet/docs/issues/new?template=customer-feedback.yml",
-                "_roslyn/**.*": "https://github.com/dotnet/docs/issues/new?template=customer-feedback.yml"
+                "_csharpstandard/standard/*.md": "https://github.com/dotnet/csharpstandard/issues/new?template=docs-feedback.yml"
             },
             "open_source_feedback_productName": {
-                "docs/**.*": ".NET",
                 "_csharplang/**.*": "C# feature specification",
                 "_csharpstandard/standard/*.md": "C# Standard documentation",
                 "_vblang/**.*": "Visual Basic language spec",
                 "_roslyn/**.*": "Roslyn breaking changes"
-            },
-            "open_source_feedback_productDescription": {
-                "docs/**.*": "The .NET documentation is open source. Provide feedback here.",
-                "_csharplang/**.*": "The C# feature specifications are open source. Provide feedback here.",
-                "_csharpstandard/standard/*.md": "The C# Standard documentation is open source. Provide feedback here.",
-                "_vblang/**.*": "The Visual Basic language documentation is open source. Provide feedback here.",
-                "_roslyn/**.*": "The Roslyn documentation is open source. Provide feedback here."
-            },
-            "open_source_feedback_issueTitle": {
-                "docs/**.*": "",
-                "_csharplang/**.*": "",
-                "_csharpstandard/standard/*.md": "",
-                "_vblang/**.*": "",
-                "_roslyn/**.*": ""
-            },
-            "open_source_feedback_productLogoLightUrl": {
-                "docs/**.*": "https://learn.microsoft.com/media/logos/logo_net.svg",
-                "_csharplang/**.*": "https://learn.microsoft.com/media/logos/logo_net.svg",
-                "_csharpstandard/standard/*.md": "https://learn.microsoft.com/media/logos/logo_net.svg",
-                "_vblang/**.*": "https://learn.microsoft.com/media/logos/logo_net.svg",
-                "_roslyn/**.*": "https://learn.microsoft.com/media/logos/logo_net.svg"
-            },
-            "open_source_feedback_productLogoDarkUrl": {
-                "docs/**.*": "https://learn.microsoft.com/media/logos/logo_net.svg",
-                "_csharplang/**.*": "https://learn.microsoft.com/media/logos/logo_net.svg",
-                "_csharpstandard/standard/*.md": "https://learn.microsoft.com/media/logos/logo_net.svg",
-                "_vblang/**.*": "https://learn.microsoft.com/media/logos/logo_net.svg",
-                "_roslyn/**.*": "https://learn.microsoft.com/media/logos/logo_net.svg"
             },
             "open_source_feedback_issueLabels": {
                 "_csharplang/**.*": "Area-Speclets,untriaged",
                 "_csharpstandard/standard/*.md": "status: needs triaging"
             },
             "social_image_url": {
-                "docs/**/*.*": "/dotnet/media/dotnet-logo.png",
                 "docs/aspire/**/*.*": "/dotnet/media/dotnet-aspire-logo.png",
                 "docs/azure/**/*.*": "/dotnet/media/dotnet-bot_cloud-apps.png",
                 "docs/orleans/**/*.*": "/dotnet/media/dotnet-orleans.png",


### PR DESCRIPTION
As part of the pilot, our repo used folder based metadata exclusively. Now that the pilot has finished, use  global metadata for the defaults (this was tested in the powershell repo) where that is applicable.
