### PR TITLE
Remove preview language

### DIFF
--- a/docs/core/diagnostics/snippets/exception-summary/exception-summary.csproj
+++ b/docs/core/diagnostics/snippets/exception-summary/exception-summary.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/core/diagnostics/snippets/health-checks/health-checks.csproj
+++ b/docs/core/diagnostics/snippets/health-checks/health-checks.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/core/diagnostics/snippets/lifetime-health-checks/lifetime-health-checks.csproj
+++ b/docs/core/diagnostics/snippets/lifetime-health-checks/lifetime-health-checks.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/core/diagnostics/snippets/resource-monitoring/resource-monitoring.csproj
+++ b/docs/core/diagnostics/snippets/resource-monitoring/resource-monitoring.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/core/resilience/snippets/http-resilience/http-resilience.csproj
+++ b/docs/core/resilience/snippets/http-resilience/http-resilience.csproj
@@ -5,7 +5,6 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <OutputType>Exe</OutputType>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/csharp/fundamentals/functional/snippets/deconstructing-tuples/deconstruction.csproj
+++ b/docs/csharp/fundamentals/functional/snippets/deconstructing-tuples/deconstruction.csproj
@@ -2,10 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <StartupObject>deconstruction.Program</StartupObject>
-    <LangVersion>Preview</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/docs/csharp/fundamentals/functional/snippets/discards/discards.csproj
+++ b/docs/csharp/fundamentals/functional/snippets/discards/discards.csproj
@@ -7,7 +7,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Discards</RootNamespace>
     <StartupObject>Discards.Program</StartupObject>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/docs/csharp/fundamentals/functional/snippets/patterns/patterns.csproj
+++ b/docs/csharp/fundamentals/functional/snippets/patterns/patterns.csproj
@@ -2,10 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/docs/csharp/fundamentals/types/snippets/classes/classes.csproj
+++ b/docs/csharp/fundamentals/types/snippets/classes/classes.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/docs/csharp/language-reference/attributes/snippets/attributes.csproj
+++ b/docs/csharp/language-reference/attributes/snippets/attributes.csproj
@@ -2,11 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>preview</LangVersion>
     <NoWarn>7022</NoWarn>
   </PropertyGroup>
 

--- a/docs/csharp/language-reference/builtin-types/snippets/shared/builtin-types.csproj
+++ b/docs/csharp/language-reference/builtin-types/snippets/shared/builtin-types.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
     <StartupObject>builtin_types.Program</StartupObject>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/docs/csharp/language-reference/compiler-messages/snippets/UsingDirectives/UsingDirective.csproj
+++ b/docs/csharp/language-reference/compiler-messages/snippets/UsingDirectives/UsingDirective.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>preview</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/docs/csharp/language-reference/keywords/snippets/keywords.csproj
+++ b/docs/csharp/language-reference/keywords/snippets/keywords.csproj
@@ -2,11 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <StartupObject>Keywords.Program</StartupObject>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/csharp/language-reference/operators/snippets/lambda-expressions/lambda-expressions.csproj
+++ b/docs/csharp/language-reference/operators/snippets/lambda-expressions/lambda-expressions.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>preview</LangVersion>
     <RootNamespace>lambda_expressions</RootNamespace>
     <StartupObject>lambda_expressions.Program</StartupObject>
   </PropertyGroup>

--- a/docs/csharp/language-reference/operators/snippets/patterns/patterns.csproj
+++ b/docs/csharp/language-reference/operators/snippets/patterns/patterns.csproj
@@ -3,10 +3,9 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <RootNamespace>Patterns</RootNamespace>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/docs/csharp/language-reference/operators/snippets/shared/operators.csproj
+++ b/docs/csharp/language-reference/operators/snippets/shared/operators.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
     <ImplicitUsings>true</ImplicitUsings>
     <NoWarn>7022</NoWarn>
   </PropertyGroup>

--- a/docs/csharp/language-reference/snippets/unsafe-code/UnsafeCodePointers.csproj
+++ b/docs/csharp/language-reference/snippets/unsafe-code/UnsafeCodePointers.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/docs/csharp/language-reference/statements/snippets/declarations/declarations.csproj
+++ b/docs/csharp/language-reference/statements/snippets/declarations/declarations.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/docs/csharp/language-reference/statements/snippets/fixed/fixed.csproj
+++ b/docs/csharp/language-reference/statements/snippets/fixed/fixed.csproj
@@ -6,7 +6,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/docs/csharp/language-reference/statements/snippets/iteration-statements/iteration-statements.csproj
+++ b/docs/csharp/language-reference/statements/snippets/iteration-statements/iteration-statements.csproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>IterationStatements</RootNamespace>
     <StartupObject>IterationStatements.Program</StartupObject>

--- a/docs/csharp/language-reference/statements/snippets/jump-statements/jump-statements.csproj
+++ b/docs/csharp/language-reference/statements/snippets/jump-statements/jump-statements.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/docs/csharp/language-reference/statements/snippets/lock/lock.csproj
+++ b/docs/csharp/language-reference/statements/snippets/lock/lock.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/docs/csharp/language-reference/statements/snippets/yield/yield.csproj
+++ b/docs/csharp/language-reference/statements/snippets/yield/yield.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/docs/csharp/linq/snippets/perform-left-outer-joins/perform-left-outer-joins.csproj
+++ b/docs/csharp/linq/snippets/perform-left-outer-joins/perform-left-outer-joins.csproj
@@ -4,6 +4,5 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <OutputType>Exe</OutputType>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 </Project>

--- a/docs/csharp/programming-guide/classes-and-structs/snippets/instance-constructors/widgets/widgets.csproj
+++ b/docs/csharp/programming-guide/classes-and-structs/snippets/instance-constructors/widgets/widgets.csproj
@@ -2,10 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/docs/csharp/programming-guide/classes-and-structs/snippets/properties/properties.csproj
+++ b/docs/csharp/programming-guide/classes-and-structs/snippets/properties/properties.csproj
@@ -2,10 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/docs/csharp/programming-guide/concepts/linq/snippets/extensions/linq.csproj
+++ b/docs/csharp/programming-guide/concepts/linq/snippets/extensions/linq.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/docs/csharp/programming-guide/concepts/linq/snippets/partition/partition.csproj
+++ b/docs/csharp/programming-guide/concepts/linq/snippets/partition/partition.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/docs/csharp/programming-guide/concepts/linq/snippets/projection/projection.csproj
+++ b/docs/csharp/programming-guide/concepts/linq/snippets/projection/projection.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/docs/csharp/programming-guide/concepts/linq/snippets/set-operators/set-operators.csproj
+++ b/docs/csharp/programming-guide/concepts/linq/snippets/set-operators/set-operators.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/docs/csharp/programming-guide/generics/snippets/generics.csproj
+++ b/docs/csharp/programming-guide/generics/snippets/generics.csproj
@@ -6,6 +6,5 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 </Project>

--- a/docs/csharp/programming-guide/indexers/snippets/DayOfWeekIndexers/DayOfWeekIndexers.csproj
+++ b/docs/csharp/programming-guide/indexers/snippets/DayOfWeekIndexers/DayOfWeekIndexers.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/docs/csharp/programming-guide/indexers/snippets/StringIndexers/StringIndexers.csproj
+++ b/docs/csharp/programming-guide/indexers/snippets/StringIndexers/StringIndexers.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/docs/csharp/programming-guide/indexers/snippets/Temperatures/Temperatures.csproj
+++ b/docs/csharp/programming-guide/indexers/snippets/Temperatures/Temperatures.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/docs/csharp/programming-guide/strings/snippets/StringExamples.csproj
+++ b/docs/csharp/programming-guide/strings/snippets/StringExamples.csproj
@@ -2,10 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/docs/csharp/programming-guide/types/snippets/index/index.csproj
+++ b/docs/csharp/programming-guide/types/snippets/index/index.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/docs/csharp/snippets/properties/properties.csproj
+++ b/docs/csharp/snippets/properties/properties.csproj
@@ -2,9 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 </Project>

--- a/docs/csharp/tour-of-csharp/snippets/shared/TourOfCsharp.csproj
+++ b/docs/csharp/tour-of-csharp/snippets/shared/TourOfCsharp.csproj
@@ -6,7 +6,6 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <StartupObject>TourOfCsharp.Program</StartupObject>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/docs/csharp/tutorials/snippets/RangesIndexes/RangesIndexes.csproj
+++ b/docs/csharp/tutorials/snippets/RangesIndexes/RangesIndexes.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/docs/csharp/whats-new/tutorials/snippets/primary-constructors/primary-constructors.csproj
+++ b/docs/csharp/whats-new/tutorials/snippets/primary-constructors/primary-constructors.csproj
@@ -6,7 +6,6 @@
     <RootNamespace>PrimaryConstructors</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/csharp/whats-new/tutorials/snippets/staticinterfaces/staticinterfaces.csproj
+++ b/docs/csharp/whats-new/tutorials/snippets/staticinterfaces/staticinterfaces.csproj
@@ -2,10 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/CsCsrefQueryKeywords/CS/csquerykeywords.csproj
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/CsCsrefQueryKeywords/CS/csquerykeywords.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <StartupObject>Group.GroupSample2</StartupObject>

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/CsLINQQuantifier/CS/Project.csproj
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/CsLINQQuantifier/CS/Project.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>   
 </Project>

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/CsLINQSetOperation/CS/Project.csproj
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/CsLINQSetOperation/CS/Project.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>   
 </Project>

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/csLINQJoinOperation/CS/Sandbox.csproj
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/csLINQJoinOperation/CS/Sandbox.csproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideExtensionMethods/cs/extensionmethods.csproj
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideExtensionMethods/cs/extensionmethods.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>preview</LangVersion>
     <AssemblyName>ExtensionMethods</AssemblyName>
     <StartupObject>Extension_Methods_Simple.Program</StartupObject>
   </PropertyGroup>

--- a/samples/snippets/csharp/concepts/linq/LinqSamples.Test/LinqSamples.Test.csproj
+++ b/samples/snippets/csharp/concepts/linq/LinqSamples.Test/LinqSamples.Test.csproj
@@ -3,9 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/samples/snippets/csharp/programming-guide/classes-and-structs/ExpressionBodiedMembers/ExpressionBodiedMembers.csproj
+++ b/samples/snippets/csharp/programming-guide/classes-and-structs/ExpressionBodiedMembers/ExpressionBodiedMembers.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/samples/snippets/csharp/programming-guide/dynamic-linq-expression-trees/dynamic-linq-expression-trees.csproj
+++ b/samples/snippets/csharp/programming-guide/dynamic-linq-expression-trees/dynamic-linq-expression-trees.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>dynamic_linq_expression_trees</RootNamespace>
     <Nullable>enable</Nullable>
-    <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes #38544

Now that .NET 8 / C# 12 has shipped, remove all the nodes indicating preview version of the language. We don't want customers to use it by accident.

While making the edits, I saw some project files that use .NET 7. Those were updated to .NET 8.
