### PR TITLE
"first exam" is at offset ZERO !

### DIFF
--- a/samples/snippets/csharp/concepts/linq/LinqSamples/GroupByContiguousKeys.cs
+++ b/samples/snippets/csharp/concepts/linq/LinqSamples/GroupByContiguousKeys.cs
@@ -121,7 +121,7 @@ class Chunk<TKey, TSource> : IGrouping<TKey, TSource>
 
         // tail will be null if we are at the end of the chunk elements
         // This check is made in DoneCopyingChunk.
-        tail = tail!.Next!;
+        tail = tail!.Next;
     }
 
     // Called after the end of the last chunk was reached.

--- a/samples/snippets/csharp/concepts/linq/LinqSamples/QueryCollectionOfObjects.cs
+++ b/samples/snippets/csharp/concepts/linq/LinqSamples/QueryCollectionOfObjects.cs
@@ -24,7 +24,7 @@ public static class QueryCollectionOfObjects
             }
         }
 
-        QueryHighScores(1, 90);
+        QueryHighScores(0, 90);
         // </query_a_collection_of_objects_2>
     }
 }


### PR DESCRIPTION
1. QueryCollectionOfObjects.cs : in .NET subscripts start from 0
2. GroupByContiguousKeys.cs : left-over from PR38457/PR38516