### PR TITLE
Remove extra documentation line for `circularBuffer`.

### DIFF
--- a/docs/core/diagnostics/microsoft-diagnostics-netcore-client.md
+++ b/docs/core/diagnostics/microsoft-diagnostics-netcore-client.md
@@ -106,8 +106,6 @@ public Task<EventPipeSession> StartEventPipeSessionAsync(EventPipeProvider provi
 > [!NOTE]
 > Rundown events contain payloads that may be needed for post analysis, such as resolving method names of thread samples. Unless you know you do not want this, we recommend setting `requestRundown` to true. In large applications, this may take a while.
 
-* `circularBufferMB` : The size of the circular buffer to be used as a buffer for writing events within the runtime.
-
 ### WriteDump method
 
 ```csharp


### PR DESCRIPTION
It is already documented in the list of parameters for `StartEventPipeSession`.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/microsoft-diagnostics-netcore-client.md](https://github.com/dotnet/docs/blob/0fd5119673b40c2c7315606b53b77abfaf054671/docs/core/diagnostics/microsoft-diagnostics-netcore-client.md) | [Microsoft.Diagnostics.NETCore.Client API](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/microsoft-diagnostics-netcore-client?branch=pr-en-us-38570) |

<!-- PREVIEW-TABLE-END -->