### PR TITLE
Revert collection expressions

### DIFF
--- a/docs/csharp/language-reference/operators/snippets/shared/NewOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/NewOperator.cs
@@ -59,8 +59,13 @@ public static class NewOperator
 
     private static void Array()
     {
+        // This snippet is used with try.net,
+        // which doesn't support collection expressions yet.
         // <SnippetArray>
-        int[] numbers = [10, 20, 30];
+        var numbers = new int[3];
+        numbers[0] = 10;
+        numbers[1] = 20;
+        numbers[2] = 30;
         Console.WriteLine(string.Join(", ", numbers));
         // Output:
         // 10, 20, 30
@@ -69,10 +74,12 @@ public static class NewOperator
 
     private static void ArrayInitialization()
     {
+        // This snippet is used with try.net,
+        // which doesn't support collection expressions yet.
         // <SnippetArrayInitialization>
-        int[] a = [10, 20, 30];
-        int[] b = [10, 20, 30];
-        int[] c = [10, 20, 30];
+        var a = new int[3] { 10, 20, 30 };
+        var b = new int[] { 10, 20, 30 };
+        var c = new[] { 10, 20, 30 };
         Console.WriteLine(c.GetType());  // output: System.Int32[]
         // </SnippetArrayInitialization>
     }


### PR DESCRIPTION
The Array initialization code in the `new` operator article runs in Try.NET.

The current deployed version of Try.NET doesn't support collection expressions. Until that's added, revert to the prior syntax.

Fixes #38475 