### PR TITLE
Compare `init` and readonly, expand on `required` comments

### DIFF
--- a/docs/csharp/language-reference/keywords/init.md
+++ b/docs/csharp/language-reference/keywords/init.md
@@ -1,7 +1,7 @@
 ---
 description: "init keyword - C# Reference"
 title: "init keyword - C# Reference"
-ms.date: 03/03/2021
+ms.date: 12/06/2023
 f1_keywords: 
   - "init"
   - "init_CSharpKeyword"
@@ -10,15 +10,14 @@ helpviewer_keywords:
 ---
 # init (C# Reference)
 
-The `init` keyword defines an *accessor* method in a property or indexer. An init-only setter assigns a value to the property or the indexer element **only** during object construction. This enforces immutability, so  that once the object is initialized, it can't be changed again.
-
-For more information and examples, see [Properties](../../programming-guide/classes-and-structs/properties.md), [Auto-Implemented Properties](../../programming-guide/classes-and-structs/auto-implemented-properties.md), and [Indexers](../../programming-guide/indexers/index.md).
+The `init` keyword defines an *accessor* method in a property or indexer. An init-only setter assigns a value to the property or the indexer element **only** during object construction. An `init` enforces immutability, so  that once the object is initialized, it can't be changed again. An `init` accessor enables calling code to use an [object initializer](../../programming-guide/classes-and-structs/how-to-initialize-objects-by-using-an-object-initializer.md) to set the initial value. As a contrast, an
+ [Auto-Implemented Properties](../../programming-guide/classes-and-structs/auto-implemented-properties.md) with only a `get` setter must be initialized by calling a constructor. A property with a `private set` accessor can be modified after construction, but only in the class.
 
 The following example defines both a `get` and an `init` accessor for a property named `YearOfBirth`. It uses a private field named `_yearOfBirth` to back the property value.
 
-[!code-csharp[init#1](snippets/InitExample1.cs)]
+:::code language="csharp" source="snippets/InitExample1.cs":::
 
-Often, the `init` accessor consists of a single statement that assigns a value, as it did in the previous example. Note that, because of `init`, the following will **not** work:
+Often, the `init` accessor consists of a single statement that assigns a value, as it did in the previous example. Because of `init`, the following **doesn't** work:
 
 ```csharp
 var john = new Person_InitExample
@@ -35,11 +34,18 @@ An `init` accessor doesn't force callers to set the property. Instead, it allows
 
 The `init` accessor can be used as an expression-bodied member. Example:
 
-[!code-csharp[init#3](snippets/InitExample3.cs)]
+:::code language="csharp" source="snippets/InitExample3.cs":::
   
-The `init` accessor can also be used in auto-implemented properties as the following example code demonstrates:
+The `init` accessor can also be used in autoimplemented properties as the following example code demonstrates:
 
-[!code-csharp[init#2](snippets/InitExample2.cs)]
+:::code language="csharp" source="snippets/InitExample2.cs":::
+
+The following example shows the distinction between a `private set`, readonly and `init` properties. Both the private set version and the readonly version require callers to use the added constructor to set the name property. The `private set` version allows a person to change their name after the instance is constructed. The `init` version doesn't require a constructor. Callers can initialize the properties using an object initializer:
+
+:::code language="csharp" source="snippets/InitExample4.cs" id="SnippetClassDefinitions":::
+
+:::code language="csharp" source="snippets/InitExample4.cs" id="SnippetUsage":::
+
   
 ## C# language specification
 

--- a/docs/csharp/language-reference/keywords/init.md
+++ b/docs/csharp/language-reference/keywords/init.md
@@ -28,11 +28,11 @@ var john = new Person_InitExample
 john.YearOfBirth = 1926; //Not allowed, as its value can only be set once in the constructor
 ```
 
-An `init` accessor doesn't force callers to set the property. Instead, it allows callers to use an object initializer while prohibiting later modification. You can add the [`required`](required.md) modifier to force callers to set a property. The following example shows an `init` only property with a nullable value type as its backing field. If a caller doesn't initialize the `YearOfBirthProperty`, that property will have the default `null` value:
+An `init` accessor doesn't force callers to set the property. Instead, it allows callers to use an object initializer while prohibiting later modification. You can add the [`required`](required.md) modifier to force callers to set a property. The following example shows an `init` only property with a nullable value type as its backing field. If a caller doesn't initialize the `YearOfBirth` property, that property will have the default `null` value:
 
 :::code language="csharp" source="./snippets/InitNullablityExample.cs" id="Snippet4":::
 
-To force callers to set an initial non-null value, you add teh `required` modifier, as shown in the following example:
+To force callers to set an initial non-null value, you add the `required` modifier, as shown in the following example:
 
 :::code language="csharp" source="./snippets/InitNullablityExample.cs" id="SnippetNonNullable":::
 

--- a/docs/csharp/language-reference/keywords/init.md
+++ b/docs/csharp/language-reference/keywords/init.md
@@ -10,8 +10,8 @@ helpviewer_keywords:
 ---
 # init (C# Reference)
 
-The `init` keyword defines an *accessor* method in a property or indexer. An init-only setter assigns a value to the property or the indexer element **only** during object construction. An `init` enforces immutability, so  that once the object is initialized, it can't be changed again. An `init` accessor enables calling code to use an [object initializer](../../programming-guide/classes-and-structs/how-to-initialize-objects-by-using-an-object-initializer.md) to set the initial value. As a contrast, an
- [Auto-Implemented Properties](../../programming-guide/classes-and-structs/auto-implemented-properties.md) with only a `get` setter must be initialized by calling a constructor. A property with a `private set` accessor can be modified after construction, but only in the class.
+The `init` keyword defines an *accessor* method in a property or indexer. An init-only setter assigns a value to the property or the indexer element **only** during object construction. An `init` enforces immutability, so  that once the object is initialized, it can't be changed. An `init` accessor enables calling code to use an [object initializer](../../programming-guide/classes-and-structs/how-to-initialize-objects-by-using-an-object-initializer.md) to set the initial value. As a contrast, an
+ [auto-implemented property](../../programming-guide/classes-and-structs/auto-implemented-properties.md) with only a `get` setter must be initialized by calling a constructor. A property with a `private set` accessor can be modified after construction, but only in the class.
 
 The following example defines both a `get` and an `init` accessor for a property named `YearOfBirth`. It uses a private field named `_yearOfBirth` to back the property value.
 
@@ -36,7 +36,7 @@ The `init` accessor can be used as an expression-bodied member. Example:
 
 :::code language="csharp" source="snippets/InitExample3.cs":::
   
-The `init` accessor can also be used in autoimplemented properties as the following example code demonstrates:
+The `init` accessor can also be used in autoimplemented properties, as the following example code demonstrates:
 
 :::code language="csharp" source="snippets/InitExample2.cs":::
 

--- a/docs/csharp/language-reference/keywords/init.md
+++ b/docs/csharp/language-reference/keywords/init.md
@@ -46,7 +46,6 @@ The following example shows the distinction between a `private set`, readonly an
 
 :::code language="csharp" source="snippets/InitExample4.cs" id="SnippetUsage":::
 
-  
 ## C# language specification
 
 [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]

--- a/docs/csharp/language-reference/keywords/init.md
+++ b/docs/csharp/language-reference/keywords/init.md
@@ -28,9 +28,13 @@ var john = new Person_InitExample
 john.YearOfBirth = 1926; //Not allowed, as its value can only be set once in the constructor
 ```
 
-An `init` accessor doesn't force callers to set the property. Instead, it allows an object initializer to set the initial value while prohibiting later modification. You can add the `required` modifier to force callers to set a property. The following example shows the same behavior:
+An `init` accessor doesn't force callers to set the property. Instead, it allows callers to use an object initializer while prohibiting later modification. You can add the [`required`](required.md) modifier to force callers to set a property. The following example shows an `init` only property with a nullable value type as its backing field. If a caller doesn't initialize the `YearOfBirthProperty`, that property will have the default `null` value:
 
 :::code language="csharp" source="./snippets/InitNullablityExample.cs" id="Snippet4":::
+
+To force callers to set an initial non-null value, you add teh `required` modifier, as shown in the following example:
+
+:::code language="csharp" source="./snippets/InitNullablityExample.cs" id="SnippetNonNullable":::
 
 The `init` accessor can be used as an expression-bodied member. Example:
 
@@ -40,7 +44,7 @@ The `init` accessor can also be used in autoimplemented properties, as the follo
 
 :::code language="csharp" source="snippets/InitExample2.cs":::
 
-The following example shows the distinction between a `private set`, readonly and `init` properties. Both the private set version and the readonly version require callers to use the added constructor to set the name property. The `private set` version allows a person to change their name after the instance is constructed. The `init` version doesn't require a constructor. Callers can initialize the properties using an object initializer:
+The following example shows the distinction between a `private set`, read only, and `init` properties. Both the private set version and the read only version require callers to use the added constructor to set the name property. The `private set` version allows a person to change their name after the instance is constructed. The `init` version doesn't require a constructor. Callers can initialize the properties using an object initializer:
 
 :::code language="csharp" source="snippets/InitExample4.cs" id="SnippetClassDefinitions":::
 

--- a/docs/csharp/language-reference/keywords/snippets/InitExample4.cs
+++ b/docs/csharp/language-reference/keywords/snippets/InitExample4.cs
@@ -1,0 +1,36 @@
+
+// <SnippetClassDefinitions>
+class PersonPrivateSet
+{
+    public string FirstName { get; private set; }
+    public string LastName { get; private set; }
+    public PersonPrivateSet(string first, string last) => (FirstName, LastName) = (first, last);
+
+    public void ChangeName(string first, string last) => (FirstName, LastName) = (first, last);
+}
+
+class PersonReadOnly
+{
+    public string FirstName { get; }
+    public string LastName { get; }
+    public PersonReadOnly(string first, string last) => (FirstName, LastName) = (first, last);
+}
+
+class PersonInit
+{
+    public string FirstName { get; init; }
+    public string LastName { get; init; }
+}
+// </SnippetClassDefinitions>
+
+public class Usage
+{
+    public static void Examples()
+    {
+        // <SnippetUsage>
+        PersonPrivateSet personPrivateSet = new("Bill", "Gates");
+        PersonReadOnly personReadOnly = new("Bill", "Gates");
+        PersonInit personInit = new() { FirstName = "Bill", LastName = "Gates" };
+        // </SnippetUsage>
+    }
+}

--- a/docs/csharp/language-reference/keywords/snippets/InitNullablityExample.cs
+++ b/docs/csharp/language-reference/keywords/snippets/InitNullablityExample.cs
@@ -13,3 +13,15 @@ class Person_InitExampleNullability
 }
 // </Snippet4>
 
+// <SnippetNonNullable>
+class Person_InitExampleNonNull
+{
+    private int _yearOfBirth;
+
+    public required int YearOfBirth
+    {
+        get => _yearOfBirth;
+        init => _yearOfBirth = value;
+    }
+}
+// </SnippetNonNullable>


### PR DESCRIPTION
Fixes #27738

Add text and explanations to compare `init` accessors with a `private set` or a readonly property.

Fixes #37625

Add second example for `required` modifier.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/init.md](https://github.com/dotnet/docs/blob/fcdacef4d02f2fa2b860f1faa15e803ae2f648c0/docs/csharp/language-reference/keywords/init.md) | [init (C# Reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/init?branch=pr-en-us-38584) |


<!-- PREVIEW-TABLE-END -->