### PR TITLE
Clarify correct examples

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/nullable-warnings.md
+++ b/docs/csharp/language-reference/compiler-messages/nullable-warnings.md
@@ -199,7 +199,7 @@ In many instances, you can fix these warnings by checking that a variable isn't 
 
 The following example initializes the backing storage for the `States` and removes the `set` accessor. Consumers of the class can modify the contents of the collection, and the storage for the collection is never `null`:
 
-:::code language="csharp" source="snippets/null-warnings/Program.cs" id="SnippetUpdatedDefinition":::
+:::code language="csharp" source="snippets/null-warnings/NullWarnings.cs" id="SnippetUpdatedDefinition":::
 
 Other instances when you get these warnings may be false positive. You may have a private utility method that tests for null. The compiler doesn't know that the method provides a null check. Consider the following example that uses a private utility method, `IsNotNull`:
 

--- a/docs/csharp/language-reference/compiler-messages/nullable-warnings.md
+++ b/docs/csharp/language-reference/compiler-messages/nullable-warnings.md
@@ -193,7 +193,7 @@ In the example above, the warning is because the `Container`, `c`, may have a nu
 
 To remove these warnings, you need to add code to change that variable's *null-state* to *not-null* before dereferencing it. The collection initializer warning may be harder to spot. The compiler detects that the collection *maybe-null* when the initializer adds elements to it.
 
-In many instances, you can fix these warnings by checking that a variable isn't null before dereferencing it. For example, the following example adds a null check before dereferencing the `message` parameter:
+In many instances, you can fix these warnings by checking that a variable isn't null before dereferencing it. Consider the following that adds a null check before dereferencing the `message` parameter:
 
 :::code language="csharp" source="snippets/null-warnings/Program.cs" id="ProvideNullCheck":::
 

--- a/docs/csharp/language-reference/compiler-messages/nullable-warnings.md
+++ b/docs/csharp/language-reference/compiler-messages/nullable-warnings.md
@@ -193,9 +193,13 @@ In the example above, the warning is because the `Container`, `c`, may have a nu
 
 To remove these warnings, you need to add code to change that variable's *null-state* to *not-null* before dereferencing it. The collection initializer warning may be harder to spot. The compiler detects that the collection *maybe-null* when the initializer adds elements to it.
 
-In many instances, you can fix these warnings by checking that a variable isn't null before dereferencing it. For example, the above example could be rewritten as:
+In many instances, you can fix these warnings by checking that a variable isn't null before dereferencing it. For example, the following example adds a null check before dereferencing the `message` parameter:
 
 :::code language="csharp" source="snippets/null-warnings/Program.cs" id="ProvideNullCheck":::
+
+The following example initializes the backing storage for the `States` and removes the `set` accessor. Consumers of the class can modify the contents of the collection, and the storage for the collection is never `null`:
+
+:::code language="csharp" source="snippets/null-warnings/Program.cs" id="SnippetUpdatedDefinition":::
 
 Other instances when you get these warnings may be false positive. You may have a private utility method that tests for null. The compiler doesn't know that the method provides a null check. Consider the following example that uses a private utility method, `IsNotNull`:
 

--- a/docs/csharp/language-reference/compiler-messages/snippets/null-warnings/NullWarnings.cs
+++ b/docs/csharp/language-reference/compiler-messages/snippets/null-warnings/NullWarnings.cs
@@ -35,4 +35,15 @@ internal class NullWarnings
 
 }
 
+internal class UpdatedDefinition
+{
+    // <SnippetUpdatedDefinition>
+    class Container
+    {
+        public List<string> States { get; } = new();
+    }
+    // </SnippetUpdatedDefinition>
+
+}
+
 

--- a/docs/csharp/language-reference/compiler-messages/snippets/null-warnings/Program.cs
+++ b/docs/csharp/language-reference/compiler-messages/snippets/null-warnings/Program.cs
@@ -5,6 +5,7 @@ void WriteMessageLength(string? message)
     {
         Console.WriteLine(message.Length);
     }
+    
 }
 // </ProvideNullCheck>
 


### PR DESCRIPTION
Add a clarifying example for the first set of issues.

Fixes #38523

The first sample demonstrated two different warnings. The corrected sample only fixed one, and didn't clarify why it was fixed.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-messages/nullable-warnings.md](https://github.com/dotnet/docs/blob/811ad7c479e4e7bdde123a473d479daaee95ce9c/docs/csharp/language-reference/compiler-messages/nullable-warnings.md) | [Resolve nullable warnings](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/nullable-warnings?branch=pr-en-us-38589) |


<!-- PREVIEW-TABLE-END -->