### PR TITLE
Change reference to POSIX conventions

### DIFF
--- a/docs/standard/commandline/define-commands.md
+++ b/docs/standard/commandline/define-commands.md
@@ -37,7 +37,7 @@ myapp sub1 sub1a
 
 ## Define options
 
-A command handler method typically has parameters, and the values can come from command-line [options](syntax.md#options). The following example creates two options and adds them to the root command. The option names include double-hyphen prefixes, in accordance with [POSIX conventions](syntax.md#options). The command handler code displays the values of those options:
+A command handler method typically has parameters, and the values can come from command-line [options](syntax.md#options). The following example creates two options and adds them to the root command. The option names include double-hyphen prefixes, which is [typical for POSIX CLIs](syntax.md#options). The command handler code displays the values of those options:
 
 :::code language="csharp" source="snippets/define-commands/csharp/Program2.cs" id="defineoptions" :::
 

--- a/docs/standard/commandline/syntax.md
+++ b/docs/standard/commandline/syntax.md
@@ -62,7 +62,7 @@ Subcommands can have their own subcommands. In `dotnet tool install`, `install` 
 
 ## Options
 
-An option is a named parameter that can be passed to a command. The [POSIX](https://en.wikipedia.org/wiki/POSIX) convention is to prefix the option name with two hyphens (`--`). The following example shows two options:
+An option is a named parameter that can be passed to a command. [POSIX](https://en.wikipedia.org/wiki/POSIX) CLIs typically prefix the option name with two hyphens (`--`). The following example shows two options:
 
 ```dotnetcli
 dotnet tool update dotnet-suggest --verbosity quiet --global


### PR DESCRIPTION
Fixes #38018 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/commandline/define-commands.md](https://github.com/dotnet/docs/blob/6dcaa96b9dbe8ef0daef2d967fecc60a8bb55607/docs/standard/commandline/define-commands.md) | [How to define commands, options, and arguments in System.CommandLine](https://review.learn.microsoft.com/en-us/dotnet/standard/commandline/define-commands?branch=pr-en-us-38658) |
| [docs/standard/commandline/syntax.md](https://github.com/dotnet/docs/blob/6dcaa96b9dbe8ef0daef2d967fecc60a8bb55607/docs/standard/commandline/syntax.md) | [Command-line syntax overview for System.CommandLine](https://review.learn.microsoft.com/en-us/dotnet/standard/commandline/syntax?branch=pr-en-us-38658) |


<!-- PREVIEW-TABLE-END -->