### PR TITLE
Repoman guard against empty issue

### DIFF
--- a/.repoman.yml
+++ b/.repoman.yml
@@ -69,6 +69,14 @@ issues:
       pass:
         - prod_tech_labels: true
 
+    # Try to detect an empty issue
+    - check:
+        - type: comment-body
+          value: "### Description\n\n\n\n\[Enter feedback here\]\n\n\n###"
+      pass:
+        - labels-add: ["needs-more-info"]
+        - close
+
   reopened:
 
     # Remove won't fix label


### PR DESCRIPTION
## Summary

I think this check will close an issue as it's created if no information was provided.