### PR TITLE
Update standard links

### DIFF
--- a/docs/csharp/language-reference/compiler-options/language.md
+++ b/docs/csharp/language-reference/compiler-options/language.md
@@ -97,7 +97,8 @@ For information about how to set this compiler option programmatically, see <xre
 
 | Version          | Link                       | Description                                                  |
 |------------------|----------------------------|--------------------------------------------------------------|
-| C# 7.0 and later | [link][csharp-7]           | C# Language Specification Version 7: .NET Foundation         |
+| C# 8.0 and later | [download PDF][csharp-8]   | C# Language Specification Version 7: .NET Foundation         |
+| C# 7.3           | [download PDF][csharp-7]   | Standard ECMA-334 7th Edition                                |
 | C# 6.0           | [download PDF][csharp-6]   | Standard ECMA-334 6th Edition                                |
 | C# 5.0           | [Download PDF][csharp-5]   | Standard ECMA-334 5th Edition                                |
 | C# 3.0           | [Download DOC][csharp-3]   | C# Language Specification Version 3.0: Microsoft Corporation |
@@ -105,7 +106,8 @@ For information about how to set this compiler option programmatically, see <xre
 | C# 1.2           | [Download DOC][csharp-1.2] | Standard ECMA-334 2nd Edition                                |
 | C# 1.0           | [Download DOC][csharp-1]   | Standard ECMA-334 1st Edition                                |
 
-[csharp-7]: /dotnet/csharp/language-reference/language-specification/introduction
+[csharp-8]: /dotnet/csharp/language-reference/language-specification/introduction
+[csharp-7]: https://ecma-international.org/wp-content/uploads/ECMA-334_7th_edition_december_2023.pdfn
 [csharp-6]: https://www.ecma-international.org/wp-content/uploads/ECMA-334_6th_edition_june_2022.pdf
 [csharp-5]: https://www.ecma-international.org/wp-content/uploads/ECMA-334_5th_edition_december_2017.pdf
 [csharp-3]: https://download.microsoft.com/download/3/8/8/388e7205-bc10-4226-b2a8-75351c669b09/CSharp%20Language%20Specification.doc

--- a/docs/csharp/language-reference/specifications.md
+++ b/docs/csharp/language-reference/specifications.md
@@ -5,7 +5,7 @@ ms.date: 06/19/2023
 ---
 # C# standard specification
 
-The [C# language specification](~/_csharpstandard/standard/README.md) is the definitive source for the C# language. The [C# standard committee (TC49-TG2)](https://www.ecma-international.org/task-groups/tc49-tg2/) produces the specification. The committee is currently finishing the work for version 7.3. The committee uses [feature speclets](https://github.com/dotnet/csharplang/tree/main/proposals) and [language design meeting (LDM) notes](https://github.com/dotnet/csharplang/tree/main/meetings) to produce the specification.
+The [C# language specification](~/_csharpstandard/standard/README.md) is the definitive source for the C# language. The [C# standard committee (TC49-TG2)](https://www.ecma-international.org/task-groups/tc49-tg2/) produces the specification. The committee is currently working on version 8 of the standard. The committee uses [feature speclets](https://github.com/dotnet/csharplang/tree/main/proposals) and [language design meeting (LDM) notes](https://github.com/dotnet/csharplang/tree/main/meetings) to produce the specification.
 
 This section contains the latest draft of the [C# language specification](~/_csharpstandard/standard/README.md). The latest working draft is published here before being submitted to ECMA for approval. The committee works in the [dotnet/csharpstandard](https://github.com/dotnet/csharpstandard) repository. You can track the committee's progress and participate in the standard work there.
 

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1188,7 +1188,7 @@ items:
   items:
   - name: Overview
     href: language-reference/specifications.md
-  - name: C# 7 draft specification
+  - name: C# 8 draft specification
     items:
     - name: Detailed table of contents
       href: ../../_csharpstandard/standard/README.md

--- a/docs/fundamentals/standards.md
+++ b/docs/fundamentals/standards.md
@@ -13,7 +13,7 @@ Subsequent revisions to the standards have been developed by the TC49-TG2 (C#) a
 
 The following official Ecma documents are available for [C#](https://www.ecma-international.org/publications-and-standards/standards/ecma-334/) and the [CLI](https://www.ecma-international.org/publications-and-standards/standards/ecma-335/) ([TR-84](https://www.ecma-international.org/publications-and-standards/technical-reports/ecma-tr-84/)):
 
-- **The C# Language Standard (version 6.0)**: [ECMA-334.pdf](https://www.ecma-international.org/wp-content/uploads/ECMA-334_6th_edition_june_2022.pdf)
+- **The C# Language Standard (version 7)**: [ECMA-334.pdf](https://ecma-international.org/wp-content/uploads/ECMA-334_7th_edition_december_2023.pdf)
 - **The Common Language Infrastructure**: [ECMA-335.pdf](https://www.ecma-international.org/wp-content/uploads/ECMA-335_6th_edition_june_2012.pdf).
 - **Information Derived from the Partition IV XML File**: [ECMA TR/84](https://www.ecma-international.org/publications-and-standards/technical-reports/ecma-tr-84/) format.
 


### PR DESCRIPTION
Fixes #38660

The ECMA general assembly approved C# version 7 at their December meeting. Update all links to the current standard, and note that the committee is working on C# 8.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-options/language.md](https://github.com/dotnet/docs/blob/66c45675b3a719552c4f19ee1fb5aeecbce695f9/docs/csharp/language-reference/compiler-options/language.md) | [C# Compiler Options for language feature rules](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/language?branch=pr-en-us-38673) |
| [docs/csharp/language-reference/specifications.md](https://github.com/dotnet/docs/blob/66c45675b3a719552c4f19ee1fb5aeecbce695f9/docs/csharp/language-reference/specifications.md) | ["C# standard and feature specifications"](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/specifications?branch=pr-en-us-38673) |
| [docs/fundamentals/standards.md](https://github.com/dotnet/docs/blob/66c45675b3a719552c4f19ee1fb5aeecbce695f9/docs/fundamentals/standards.md) | [Ecma standards](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/standards?branch=pr-en-us-38673) |

<!-- PREVIEW-TABLE-END -->