### PR TITLE
Fix typo in dependency-injection.md

### DIFF
--- a/docs/core/extensions/dependency-injection.md
+++ b/docs/core/extensions/dependency-injection.md
@@ -412,7 +412,7 @@ From the sample source code, you can see how implementations of <xref:Microsoft.
 
 .NET also supports service registrations and lookups based on a key, meaning it's possible to register multiple services with a different key, and use this key for the lookup.
 
-For example, let's consider you have different implementation of the interface `IMessageWriter`: `MemoryMessageWriter` and `QueueMessageWriter`.
+For example, let's consider the case where you have different implementations of the interface `IMessageWriter`: `MemoryMessageWriter` and `QueueMessageWriter`.
 
 You can register these services using the overload of the service registration methods (seen earlier) that supports a key as a parameter:
 

--- a/docs/core/extensions/dependency-injection.md
+++ b/docs/core/extensions/dependency-injection.md
@@ -412,7 +412,7 @@ From the sample source code, you can see how implementations of <xref:Microsoft.
 
 .NET also supports service registrations and lookups based on a key, meaning it's possible to register multiple services with a different key, and use this key for the lookup.
 
-For example, let's consider the case where you have different implementations of the interface `IMessageWriter`: `MemoryMessageWriter` and `QueueMessageWriter`.
+For example, consider the case where you have different implementations of the interface `IMessageWriter`: `MemoryMessageWriter` and `QueueMessageWriter`.
 
 You can register these services using the overload of the service registration methods (seen earlier) that supports a key as a parameter:
 


### PR DESCRIPTION
The sentence:

> ...let's consider you have different **implementation** of the interface...

Should read:

> ...let's consider you have different **implementations** of the interface...

However, beyond the small typo, I think this version is slightly easier to read, so that's what I ended up with:

> ...let's consider **the case where** you have different **implementations** of the interface...

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/dependency-injection.md](https://github.com/dotnet/docs/blob/8c369597cf39bf4702289000250819b740b30290/docs/core/extensions/dependency-injection.md) | [.NET dependency injection](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection?branch=pr-en-us-38684) |


<!-- PREVIEW-TABLE-END -->