### PR TITLE
Clarify the 1xx and 4xx versioning support

### DIFF
--- a/docs/core/porting/versioning-sdk-msbuild-vs.md
+++ b/docs/core/porting/versioning-sdk-msbuild-vs.md
@@ -30,14 +30,14 @@ The support timeframe for the SDK typically matches that of the Visual Studio ve
 | 5.0.2xx          | 16.9               | March '21    | May '22   |
 | 5.0.3xx          | 16.10              | May '21      | Aug '21   |
 | 5.0.4xx          | 16.11              | Aug '21      | May '22   |
-| 6.0.1xx          | 17.0<sup>2</sup>   | Nov '21      | Jul '23   |
+| 6.0.1xx          | 17.0               | Nov '21      | Nov '24<sup>1</sup>   |
 | 6.0.2xx          | 17.1               | Feb '22      | May '22   |
 | 6.0.3xx          | 17.2<sup>3</sup>   | May '22      | Oct '23   |
-| 6.0.4xx          | 17.3               | Aug '22      | Nov '24<sup>1</sup>   |
-| 7.0.1xx          | 17.4               | Nov '22      | Jul '23   |
+| 6.0.4xx          | 17.3               | Aug '22      | Nov '24<sup>2</sup>   |
+| 7.0.1xx          | 17.4               | Nov '22      | May '24<sup>1</sup>   |
 | 7.0.2xx          | 17.5<sup>3</sup>   | Feb '23      | May '23   |
-| 7.0.3xx          | 17.6               | May '23      | Jan '25   |
-| 7.0.4xx          | 17.7               | Aug '23      | Nov '23   |
+| 7.0.3xx          | 17.6               | May '23      | May '24   |
+| 7.0.4xx          | 17.7               | Aug '23      | May '24<sup>2</sup>   |
 | 8.0.1xx          | 17.8               | Nov '23      | TBD       |
 | 8.0.2xx          | 17.9<sup>3</sup>   | Feb '24      | TBD       |
 
@@ -46,11 +46,9 @@ The support timeframe for the SDK typically matches that of the Visual Studio ve
 > Targeting `net7.0` is officially supported in Visual Studio 17.4+ only.
 > Targeting `net8.0` is officially supported in Visual Studio 17.8+ only.
 >
-> .1xx SDK feature band is supported throughout the lifecycle of major .NET versions. During the extended support period, support is limited to security fixes and minimal high-priority non-security fixes for Linux only. To learn more about the reasoning for this extended support, refer to this [document](https://github.com/dotnet/source-build#support).
+> <sup>1</<sup>.1xx .NET SDK feature bands are supported throughout the lifecycle of major .NET versions. During the extended support period, support is limited to security fixes and minimal high-priority non-security fixes for Linux only. To learn more about the reasoning for this extended support, refer to this [document](https://github.com/dotnet/source-build#support).
 >
-> <sup>1</sup> Visual Studio 2022 version 17.3 went out of support in Nov 2022. 6.0.4xx will be in support for the life of .NET 6 as a standalone release.
->
-> <sup>2</sup> With .NET 6, the.NET 6.0.100 SDK can be used in version 16.11 for **downlevel** targeting. This means that you're not forced to update your SDK and Visual Studio versions simultaneously. However, you won't be able to target .NET 6 because of limitations in 6.0 features and C# 10 features in version 16.11. This compatibility is specifically for targeting 5.0 and below.
+> <sup>2</sup> .4xx .NET SDK feature bands will be supported for the life of the matching runtime as stand-alone installs.
 >
 > <sup>3</sup> 6.0.300, 7.0.200, and 8.0.200 require newer Visual Studio versions. For more information, see the [support rules](#targeting-and-support-rules).
 >

--- a/docs/core/porting/versioning-sdk-msbuild-vs.md
+++ b/docs/core/porting/versioning-sdk-msbuild-vs.md
@@ -46,9 +46,9 @@ The support timeframe for the SDK typically matches that of the Visual Studio ve
 > Targeting `net7.0` is officially supported in Visual Studio 17.4+ only.
 > Targeting `net8.0` is officially supported in Visual Studio 17.8+ only.
 >
-> <sup>1</<sup>.1xx .NET SDK feature bands are supported throughout the lifecycle of major .NET versions. During the extended support period, support is limited to security fixes and minimal high-priority non-security fixes for Linux only. To learn more about the reasoning for this extended support, refer to this [document](https://github.com/dotnet/source-build#support).
+> <sup>1</<sup>.1xx .NET SDK feature bands are supported throughout the lifecycle of major .NET versions. During the extended support period, support is limited to security fixes and minimal high-priority non-security fixes for Linux only. To learn more about the reasoning for this extended support, see [Source-build support](https://github.com/dotnet/source-build#support).
 >
-> <sup>2</sup> .4xx .NET SDK feature bands will be supported for the life of the matching runtime as stand-alone installs.
+> <sup>2</sup> .4xx .NET SDK feature bands are supported for the life of the matching runtime as stand-alone installs.
 >
 > <sup>3</sup> 6.0.300, 7.0.200, and 8.0.200 require newer Visual Studio versions. For more information, see the [support rules](#targeting-and-support-rules).
 >


### PR DESCRIPTION
## Summary

I removed one of the notes and tried to clarify the reasons that 1xx and 4xx stay in support longer (as well as updated the table to match)

Question: Should the table list when the 1xx VS support went out of support or when the linux support will end?


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/porting/versioning-sdk-msbuild-vs.md](https://github.com/dotnet/docs/blob/6b48cdaa24757a01db1d3fde66dcfcc93b542413/docs/core/porting/versioning-sdk-msbuild-vs.md) | [.NET SDK, MSBuild, and Visual Studio versioning](https://review.learn.microsoft.com/en-us/dotnet/core/porting/versioning-sdk-msbuild-vs?branch=pr-en-us-38685) |


<!-- PREVIEW-TABLE-END -->