### PR TITLE
Refactor the page of `CS1929`

### DIFF
--- a/docs/csharp/misc/cs1929.md
+++ b/docs/csharp/misc/cs1929.md
@@ -12,7 +12,7 @@ ms.assetid: effdd5d4-e156-418b-9d45-4ca194ab4319
 
 'typeB' does not contain a definition for 'method' and the best extension method overload 'typeC.method' requires a receiver of type 'typeA'
 
-This error is generated when you try to invoke an extension method from a class that it does not extend. In the example shown here, the extension method is defined for the derived class `A`, but not for the base class `B`.  
+This error is generated when you try to invoke an extension method from a class that it does not extend. In the example shown here, the extension method is defined for the derived class `D`, but not for the base class `B`.  
 
 ## To correct this error
 
@@ -24,17 +24,14 @@ This error is generated when you try to invoke an extension method from a class 
 The following code generates CS1929:
 
 ```csharp
-using System.Linq;
-using System.Collections;
-
-static class Ext
+static class Extension
 {
-    public static void ExtMethod(this A a)
+    public static void ExtensionMethod(this D d)
     {
     }
 }
 
-class A : B
+class D : B
 {
 }
 
@@ -43,7 +40,7 @@ class B
     static void Main()
     {
         B b = new B();
-        b.ExtMethod(); // CS1929
+        b.ExtensionMethod(); // CS1929
     }
 }
 ```
@@ -51,17 +48,18 @@ class B
 The following code solves the CS1929 as described in 1. - by creating a new extension method for proper type 'B':
 
 ```csharp
-using System.Linq;
-using System.Collections;
-
-static class Ext
+static class Extension
 {
-    public static void ExtMethod(this B a)
+    public static void ExtensionMethod(this D d)
+    {
+    }
+
+    public static void NewExtensionMethod(this B b)
     {
     }
 }
 
-class A : B
+class D : B
 {
 }
 
@@ -70,25 +68,22 @@ class B
     static void Main()
     {
         B b = new B();
-        b.ExtMethod();
+        b.NewExtensionMethod();
     }
 }
 ```
 
-The following code solves the CS1929 as described in 2. - moving the call into an object of the proper type 'A':
+The following code solves the CS1929 as described in 2. - moving the call into an object of the proper type 'D':
 
 ```csharp
-using System.Linq;
-using System.Collections;
-
-static class Ext
+static class Extension
 {
-    public static void ExtMethod(this A a)
+    public static void ExtensionMethod(this D d)
     {
     }
 }
 
-class A : B
+class D : B
 {
 }
 
@@ -96,8 +91,8 @@ class B
 {
     static void Main()
     {
-        A a = new A();
-        a.ExtMethod();
+        D d = new D();
+        d.ExtensionMethod();
     }
 }
 ```

--- a/docs/csharp/misc/cs1929.md
+++ b/docs/csharp/misc/cs1929.md
@@ -10,44 +10,99 @@ ms.assetid: effdd5d4-e156-418b-9d45-4ca194ab4319
 ---
 # Compiler Error CS1929
 
-Instance argument: cannot convert from 'typeA' to 'typeB'.  
-  
- This error is generated when you try to invoke an extension method from a class that it does not extend. In the example shown here, the extension method is defined for the derived class `A`, but not for the base class `B`.  
-  
-## To correct this error  
-  
-1. Create a new extension method for the type where you have to invoke it, or else move the call into an object of the type that the existing method extends.  
-  
-## Example  
+'typeB' does not contain a definition for 'method' and the best extension method overload 'typeC.method' requires a receiver of type 'typeA'
 
- The following code generates CS1928 and CS1929:  
-  
-```csharp  
-// cs1929.cs  
-using System.Linq;  
-    using System.Collections;  
-  
-    static class Ext  
-    {  
-        public static void ExtMethod(this A a)  
-        {  
-        }  
-    }  
-  
-    class A : B  
-    {  
-    }  
-  
-    class B  
-    {  
-        static void Main()  
-        {  
-            B b = new B();  
-            b.ExtMethod(); // CS1929  
-        }  
-    }  
-```  
-  
+This error is generated when you try to invoke an extension method from a class that it does not extend. In the example shown here, the extension method is defined for the derived class `A`, but not for the base class `B`.  
+
+## To correct this error
+
+1. Create a new extension method for the type where you have to invoke it, or
+2. move the call into an object of the type that the existing method extends.
+
+## Example
+
+The following code generates CS1929:
+
+```csharp
+using System.Linq;
+using System.Collections;
+
+static class Ext
+{
+    public static void ExtMethod(this A a)
+    {
+    }
+}
+
+class A : B
+{
+}
+
+class B
+{
+    static void Main()
+    {
+        B b = new B();
+        b.ExtMethod(); // CS1929
+    }
+}
+```
+
+The following code solves the CS1929 as described in 1. - by creating a new extension method for proper type 'B':
+
+```csharp
+using System.Linq;
+using System.Collections;
+
+static class Ext
+{
+    public static void ExtMethod(this B a)
+    {
+    }
+}
+
+class A : B
+{
+}
+
+class B
+{
+    static void Main()
+    {
+        B b = new B();
+        b.ExtMethod();
+    }
+}
+```
+
+The following code solves the CS1929 as described in 2. - moving the call into an object of the proper type 'A':
+
+```csharp
+using System.Linq;
+using System.Collections;
+
+static class Ext
+{
+    public static void ExtMethod(this A a)
+    {
+    }
+}
+
+class A : B
+{
+}
+
+class B
+{
+    static void Main()
+    {
+        A a = new A();
+        a.ExtMethod();
+    }
+}
+```
+
+
 ## See also
 
 - [Extension Methods](../programming-guide/classes-and-structs/extension-methods.md)

--- a/docs/csharp/misc/cs1929.md
+++ b/docs/csharp/misc/cs1929.md
@@ -102,7 +102,6 @@ class B
 }
 ```
 
-
 ## See also
 
 - [Extension Methods](../programming-guide/classes-and-structs/extension-methods.md)


### PR DESCRIPTION
This pull request potentially fixes #38646 

Although the author does not specify what exactly is incorrect in the page, there are couple of things that are to be corrected and that this PR addresses:
* The summary text is incorrect, as the `CS1929` error is totally different than `Instance argument: cannot convert from 'typeA' to 'typeB'`
* Two ways of dealing with the error is written in one point, while still making it a one point list.
This was separated into two points.
* The original code does not generate `CS1928`, at least not on my end, perhaps there are some specific compiler flags required to have it? However, I removed mentioning this error, as by default, this code does not result in `CS1928`.
* Indentations were messy
* Samples of how to deal with this error were missing - added those for convenience.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/misc/cs1929.md](https://github.com/dotnet/docs/blob/a6729e7372bdeac6d3ea5ca4d1a6296f6d085f7a/docs/csharp/misc/cs1929.md) | [Compiler Error CS1929](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/cs1929?branch=pr-en-us-38686) |


<!-- PREVIEW-TABLE-END -->