### PR TITLE
Regex with range breaking change

### DIFF
--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -49,6 +49,7 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 | [Legacy FileStream strategy removed](core-libraries/7.0/filestream-compat-switch.md) | ❌ | ✔️ |
 | [Library support for older frameworks](core-libraries/7.0/old-framework-support.md) | ❌ | ❌ |
 | [Maximum precision for numeric format strings](core-libraries/7.0/max-precision-numeric-format-strings.md) | ❌ | ✔️ |
+| [Regex patterns with ranges corrected](core-libraries/7.0/regex-ranges.md) | ✔️ | ✔️ |
 | [SerializationFormat.Binary is obsolete](serialization/7.0/serializationformat-binary.md) | ❌ | ❌ |
 | [System.Drawing.Common config switch removed](core-libraries/7.0/system-drawing.md) | ✔️ | ✔️ |
 | [System.Runtime.CompilerServices.Unsafe NuGet package](core-libraries/7.0/unsafe-package.md) | ✔️ | ✔️ |

--- a/docs/core/compatibility/core-libraries/7.0/regex-ranges.md
+++ b/docs/core/compatibility/core-libraries/7.0/regex-ranges.md
@@ -1,0 +1,58 @@
+---
+title: ".NET 7 breaking change: Regex patterns with ranges corrected"
+description: Learn about the .NET 7 breaking change in core .NET libraries where regular expressions that have ranges in the pattern and are used with the RegexOptions.IgnoreCase option might break.
+ms.date: 12/08/2023
+---
+# Regex patterns with ranges corrected
+
+Regex [incorrectly handles the casing of some ranges](https://github.com/dotnet/runtime/issues/36149) in .NET Framework, and in .NET 6 and earlier versions. This bug was fixed in .NET 7.
+
+The fix for this bug could cause a breaking change if your regular expression has a bug that was hidden because of this bug or if you implemented a workaround for this bug.
+
+## Previous behavior
+
+In .NET 6 and earlier versions, the following two patterns produce different results. However, they should produce the same result (`false`), since the range `\xD7-\xD8` only includes the values `\xD7` and `\xD8` themselves.
+
+```csharp
+// Evaluates to false.
+Regex.IsMatch("\xF7", @"^(?i:[\xD7\xD8])$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+// Evaluates to true.
+Regex.IsMatch("\xF7", @"^(?i:[\xD7-\xD8])$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+```
+
+## New behavior
+
+Starting in .NET 7, the example patterns both evaluate to `false`.
+
+```csharp
+// Evaluates to false.
+Regex.IsMatch("\xF7", @"^(?i:[\xD7\xD8])$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+// Evaluates to false.
+Regex.IsMatch("\xF7", @"^(?i:[\xD7-\xD8])$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+```
+
+## Version introduced
+
+.NET 7
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+The previous behavior was incorrect.
+
+## Recommended action
+
+If your regular expression has a hidden bug, fix it. If you had a workaround for this bug, you can remove the workaround.
+
+## Affected APIs
+
+- <xref:System.Text.RegularExpressions.Regex.Count%2A?displayProperty=fullName>
+- <xref:System.Text.RegularExpressions.Regex.EnumerateMatches%2A?displayProperty=fullName>
+- <xref:System.Text.RegularExpressions.Regex.IsMatch%2A?displayProperty=fullName>
+- <xref:System.Text.RegularExpressions.Regex.Match%2A?displayProperty=fullName>
+- <xref:System.Text.RegularExpressions.Regex.Matches%2A?displayProperty=fullName>
+- <xref:System.Text.RegularExpressions.Regex.Replace%2A?displayProperty=fullName>
+- <xref:System.Text.RegularExpressions.Regex.Split%2A?displayProperty=fullName>

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -258,6 +258,8 @@ items:
         href: core-libraries/7.0/max-precision-numeric-format-strings.md
       - name: Reflection invoke API exceptions
         href: core-libraries/7.0/reflection-invoke-exceptions.md
+      - name: Regex patterns with ranges corrected
+        href: core-libraries/7.0/regex-ranges.md
       - name: System.Drawing.Common config switch removed
         href: core-libraries/7.0/system-drawing.md
       - name: System.Runtime.CompilerServices.Unsafe NuGet package
@@ -1164,6 +1166,8 @@ items:
         href: core-libraries/7.0/max-precision-numeric-format-strings.md
       - name: Reflection invoke API exceptions
         href: core-libraries/7.0/reflection-invoke-exceptions.md
+      - name: Regex patterns with ranges corrected
+        href: core-libraries/7.0/regex-ranges.md
       - name: System.Drawing.Common config switch removed
         href: core-libraries/7.0/system-drawing.md
       - name: System.Runtime.CompilerServices.Unsafe NuGet package


### PR DESCRIPTION
Fixes #36733.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/7.0.md](https://github.com/dotnet/docs/blob/58df53421d660c6f4b0fbe62bf649134a3e8de69/docs/core/compatibility/7.0.md) | [Breaking changes in .NET 7](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/7.0?branch=pr-en-us-38688) |
| [docs/core/compatibility/core-libraries/7.0/regex-ranges.md](https://github.com/dotnet/docs/blob/58df53421d660c6f4b0fbe62bf649134a3e8de69/docs/core/compatibility/core-libraries/7.0/regex-ranges.md) | [Regex patterns with ranges corrected](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/7.0/regex-ranges?branch=pr-en-us-38688) |

<!-- PREVIEW-TABLE-END -->