### PR TITLE
nullable-references.md - improve confusing `NotNullWhen` example

### DIFF
--- a/docs/csharp/nullable-references.md
+++ b/docs/csharp/nullable-references.md
@@ -99,9 +99,11 @@ bool IsNull(string? s) => s == null;
 ```
 
 Based on inspection, any developer would consider this code safe, and one that shouldn't generate warnings. However the compiler doesn't know that `IsNull` provides a null check and will issue a warning for the `message.ToUpper()` statement, considering `message` to be a *maybe-null* variable. To fix this, we can use the [`NotNullWhen`](xref:System.Diagnostics.CodeAnalysis.NotNullWhenAttribute) attribute:
+
 ```csharp
 bool IsNull([NotNullWhen(false)] string? s) => s == null;
 ```
+
 This informs the compiler, that, if `IsNull` returns `false`, the parameter `s` is not null. This allows the compiler to change the *null-state* of `message` to *not-null* inside the `if (!IsNull(message)) {...}` block. Thanks to this, no warnings will be issued.
 
 Attributes provide detailed information about the null state of arguments, return values, and members of the object instance used to invoke a member. The details on each attribute can be found in the language reference article on [nullable reference attributes](language-reference/attributes/nullable-analysis.md). The .NET runtime APIs have all been annotated in .NET 5. You improve the static analysis by annotating your APIs to provide semantic information about the *null-state* of arguments and return values.

--- a/docs/csharp/nullable-references.md
+++ b/docs/csharp/nullable-references.md
@@ -84,23 +84,25 @@ Nullable state analysis and the warnings the compiler generates help you avoid p
 
 ## Attributes on API signatures
 
-The null state analysis needs hints from developers to understand the semantics of APIs. Some APIs provide null checks, and should change the *null-state* of a variable from *maybe-null* to *not-null*. Other APIs return expressions that are *not-null* or *maybe-null* depending on the *null-state* of the input arguments. For example, consider the following code that displays a message:
+The null state analysis needs hints from developers to understand the semantics of APIs. Some APIs provide null checks, and should change the *null-state* of a variable from *maybe-null* to *not-null*. Other APIs return expressions that are *not-null* or *maybe-null* depending on the *null-state* of the input arguments. For example, consider the following code that displays a message in upper case:
 
 ```csharp
-public void PrintMessage(string message)
+void PrintMessageUpper(string? message)
 {
-    if (!string.IsNullOrWhiteSpace(message))
+    if (!IsNull(message))
     {
-        Console.WriteLine($"{DateTime.Now}: {message}");
+        Console.WriteLine($"{DateTime.Now}: {message.ToUpper()}");
     }
 }
+
+bool IsNull(string? s) => s == null;
 ```
 
-Based on inspection, any developer would consider this code safe, and shouldn't generate warnings. The compiler doesn't know that `IsNullOrWhiteSpace` provides a null check. When `IsNullOrWhitespace` returns `false,` the *null-state* of the string is *not-null*. When `IsNullOrWhitespace` returns `true`, the *null-state* isn't changed. In the previous example, the signature includes the [`NotNullWhen`](xref:System.Diagnostics.CodeAnalysis.NotNullWhenAttribute) to indicate the null state of `message`:
-
+Based on inspection, any developer would consider this code safe, and one that shouldn't generate warnings. However the compiler doesn't know that `IsNull` provides a null check and will issue a warning for the `message.ToUpper()` statement, considering `message` to be a *maybe-null* variable. To fix this, we can use the [`NotNullWhen`](xref:System.Diagnostics.CodeAnalysis.NotNullWhenAttribute) attribute:
 ```csharp
-public static bool IsNullOrWhiteSpace([NotNullWhen(false)] string message);
+bool IsNull([NotNullWhen(false)] string? s) => s == null;
 ```
+This informs the compiler, that, if `IsNull` returns `false`, the parameter `s` is not null. This allows the compiler to change the *null-state* of `message` to *not-null* inside the `if (!IsNull(message)) {...}` block. Thanks to this, no warnings will be issued.
 
 Attributes provide detailed information about the null state of arguments, return values, and members of the object instance used to invoke a member. The details on each attribute can be found in the language reference article on [nullable reference attributes](language-reference/attributes/nullable-analysis.md). The .NET runtime APIs have all been annotated in .NET 5. You improve the static analysis by annotating your APIs to provide semantic information about the *null-state* of arguments and return values.
 


### PR DESCRIPTION
The example didn't really demonstrate correct usage of `NotNullWhen`.

Fixes #38672


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/nullable-references.md](https://github.com/dotnet/docs/blob/a4d6f025c6c655e0a691fc6e89c8162b17f1330a/docs/csharp/nullable-references.md) | [Nullable reference types](https://review.learn.microsoft.com/en-us/dotnet/csharp/nullable-references?branch=pr-en-us-38693) |


<!-- PREVIEW-TABLE-END -->