### PR TITLE
Update service-discovery.md

### DIFF
--- a/docs/core/extensions/service-discovery.md
+++ b/docs/core/extensions/service-discovery.md
@@ -124,13 +124,13 @@ If service discovery was added to the host using the `AddServiceDiscoveryCore` e
 
 ## Load-balancing with endpoint selectors
 
-Each time an endpoint is resolved via the `HttpClient` pipeline, a single endpoint is selected from the set of all known endpoints for the requested service. If multiple endpoints are available, it may be desirable to balance traffic across all such endpoints. To accomplish this, a customizable _endpoint selector_ can be used. By default, endpoints are selected in round-robin order. To use a different endpoint selector, provide an `IServiceEndPointSelector` instance to the `UseServiceDiscovery` method call. For example, to select a random endpoint from the set of resolved endpoints, specify `RandomServiceEndPointSelector.Instance` as the endpoint selector:
+Each time an endpoint is resolved via the `HttpClient` pipeline, a single endpoint is selected from the set of all known endpoints for the requested service. If multiple endpoints are available, it may be desirable to balance traffic across all such endpoints. To accomplish this, a customizable _endpoint selector_ can be used. By default, endpoints are selected in round-robin order. To use a different endpoint selector, provide an `IServiceEndPointSelector` instance to the `UseServiceDiscovery` method call. For example, to select a random endpoint from the set of resolved endpoints, specify `RandomServiceEndPointSelectorProvider.Instance` as the endpoint selector:
 
 ```csharp
 builder.Services.AddHttpClient<CatalogServiceClient>(
         static client => client.BaseAddress = new("http://catalog")
     )
-    .UseServiceDiscovery(RandomServiceEndPointSelector.Instance);
+    .UseServiceDiscovery(RandomServiceEndPointSelectorProvider.Instance);
 ```
 
 The `Microsoft.Extensions.ServiceDiscovery` package includes the following endpoint selector providers:


### PR DESCRIPTION
## Summary

`RandomServiceEndPointSelector.Instance` was used instead of `RandomServiceEndPointSelectorProvider.Instance` when registering a load-balancing strategy. All occurrences have been updated accordingly.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/service-discovery.md](https://github.com/dotnet/docs/blob/8ba3db2599c2f34f136e764a803dd9c47ffd76d6/docs/core/extensions/service-discovery.md) | [Service discovery in .NET](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/service-discovery?branch=pr-en-us-38698) |

<!-- PREVIEW-TABLE-END -->