### PR TITLE
Update linux-alpine.md

### DIFF
--- a/docs/core/install/linux-alpine.md
+++ b/docs/core/install/linux-alpine.md
@@ -78,7 +78,8 @@ When you install with a package manager, these libraries are installed for you. 
 - libgcc
 - libgdiplus (if the .NET app requires the *System.Drawing.Common* assembly)
 - libintl
-- libssl1.1
+- libssl1.1 (for 3.14.x and older)
+- libssl3 (for 3.15.x and newer)
 - libstdc++
 - zlib
 


### PR DESCRIPTION
Changed the version of the "libssl" library based on the Alpine version used.

## Summary

Version "3.14.x" references the library "libssl1.1".
Version >= "3.15.x" and <= "3.18.x" references both libraries "libssl1.1" and "libssl3".
Version "3.19.x" references the library "libssl3".

I wanted to update the documentation because version "libssl1.1" is out of support and Linux Alpine has no longer used it since December 7, 2023.

#sign-off

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/linux-alpine.md](https://github.com/dotnet/docs/blob/582881a62234820346cbced800e05684edbb1b5a/docs/core/install/linux-alpine.md) | [Install the .NET SDK or the .NET Runtime on Alpine](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-alpine?branch=pr-en-us-38707) |

<!-- PREVIEW-TABLE-END -->