### PR TITLE
ReplayCheck tests for dictionary initalization

### DIFF
--- a/.replaycheck/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-a-dictionary-with-a-collection-initializer.yml
+++ b/.replaycheck/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-a-dictionary-with-a-collection-initializer.yml
@@ -1,0 +1,15 @@
+# %version 1
+contentPath: docs\csharp\programming-guide\classes-and-structs\how-to-initialize-a-dictionary-with-a-collection-initializer.md
+
+steps:
+- task: RunCodeSnippetReference@1
+  environment:
+    type: dotnet-sdk
+  outputValidationRules:
+  - operator: contains
+    value: Student 111 is Sachin Karnik
+  - operator: contains
+    value: Student 112 is Dina Salimzianova
+  - operator: contains
+    value: Student 113 is Andy Ruth
+  uid: a8f61ff8

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-a-dictionary-with-a-collection-initializer.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-a-dictionary-with-a-collection-initializer.md
@@ -27,6 +27,7 @@ A <xref:System.Collections.Generic.Dictionary%602> contains a collection of key/
 
 In the following code example, a <xref:System.Collections.Generic.Dictionary%602> is initialized with instances of type `StudentName`.  The first initialization uses the `Add` method with two arguments. The compiler generates a call to `Add` for each of the pairs of `int` keys and `StudentName` values. The second uses a public read / write indexer method of the `Dictionary` class:
 
+<!-- replaycheck-task id="a8f61ff8" -->
 [!code-csharp[InitializerExample](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/object-collection-initializers/HowToDictionaryInitializer.cs#HowToDictionaryInitializer)]  
 
 Note the two pairs of braces in each element of the collection in the first declaration. The innermost braces enclose the object initializer for the `StudentName`, and the outermost braces enclose the initializer for the key/value pair that will be added to the `students` <xref:System.Collections.Generic.Dictionary%602>. Finally, the whole collection initializer for the dictionary is enclosed in braces. In the second initialization, the left side of the assignment is the key and the right side is the value, using an object initializer for `StudentName`.


### PR DESCRIPTION
Add ReplayCheck based tests for the collection initializer article.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/classes-and-structs/how-to-initialize-a-dictionary-with-a-collection-initializer.md](https://github.com/dotnet/docs/blob/10a125106cdc4602635b5bae55ad62fb136a479c/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-a-dictionary-with-a-collection-initializer.md) | [How to initialize a dictionary with a collection initializer (C# Programming Guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/how-to-initialize-a-dictionary-with-a-collection-initializer?branch=pr-en-us-38709) |

<!-- PREVIEW-TABLE-END -->