### PR TITLE
Add IDE0300 - IDE0305

### DIFF
--- a/docs/fundamentals/code-analysis/style-rules/csharp-formatting-options.md
+++ b/docs/fundamentals/code-analysis/style-rules/csharp-formatting-options.md
@@ -593,6 +593,7 @@ for(int i;i<x;i++) { ... }
 | **Option values**        | `control_flow_statements`        | Place space between parentheses of control flow statements |
 |                          | `expressions`                    | Place space between parentheses of expressions             |
 |                          | `type_casts`                     | Place space between parentheses in type casts              |
+|                          | `false` (or any other value)     | Never add spaces between parentheses                       |
 
 If you omit this rule or use a value other than `control_flow_statements`, `expressions`, or `type_casts`, the setting is not applied.
 
@@ -607,6 +608,9 @@ var z = ( x * y ) - ( ( y - x ) * 3 );
 
 // csharp_space_between_parentheses = type_casts
 int y = ( int )x;
+
+// csharp_space_between_parentheses = false
+int y = (int)x;
 ```
 
 ### csharp_space_before_colon_in_inheritance_clause

--- a/docs/fundamentals/code-analysis/style-rules/ide0028.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0028.md
@@ -42,21 +42,31 @@ For more information about configuring options, see [Option format](language-rul
 
 | Property                 | Value  | Description                                                                       |
 | ------------------------ | ------ | --------------------------------------------------------------------------------- |
-| **Option name**          | dotnet_style_collection_initializer |                                                                                   |
+| **Option name**          | dotnet_style_collection_initializer |                                                      |
 | **Option values**        | `true`  | Prefer collections to be initialized using collection initializers when possible |
 |                          | `false` | Prefer collections to *not* be initialized using collection initializers         |
 | **Default option value** | `true`  |                                                                                  |
 
+## Examples
+
 ```csharp
-// dotnet_style_collection_initializer = true
+// IDE0028 violation.
+var c = new List<int>();
+c.Add(1);
+
+// Fixed code.
 var c = new List<int>
 {
     1
 };
+```
 
-// dotnet_style_collection_initializer = false
-var c = new List<int>();
-c.Add(1);
+```csharp
+// IDE0028 violation (C# 12 and later only)
+List<int> d = new List<int> { 1, 2, 3 };
+
+// Fixed code.
+List<int> d = [1, 2, 3];
 ```
 
 ```vb

--- a/docs/fundamentals/code-analysis/style-rules/ide0028.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0028.md
@@ -1,7 +1,7 @@
 ---
-title: "IDE0028: Use collection initializers"
-description: "Learn about code analysis rule IDE0028: Use collection initializers"
-ms.date: 12/11/2023
+title: "IDE0028: Use collection initializers or expressions"
+description: "Learn about code analysis rule IDE0028: Use collection initializers or expressions"
+ms.date: 12/12/2023
 f1_keywords:
 - IDE0028
 - dotnet_style_collection_initializer
@@ -10,11 +10,12 @@ helpviewer_keywords:
 - dotnet_style_collection_initializer
 author: gewarren
 ms.author: gewarren
+zone_pivot_groups: dotnet-version
 dev_langs:
 - CSharp
 - VB
 ---
-# Use collection initializers (IDE0028)
+# Use collection initializers or expressions (IDE0028)
 
 | Property                 | Value                                         |
 | ------------------------ | --------------------------------------------- |
@@ -24,61 +25,109 @@ dev_langs:
 | **Subcategory**          | Language rules (expression-level preferences) |
 | **Applicable languages** | C# and Visual Basic                           |
 | **Options**              | `dotnet_style_collection_initializer`         |
+| **Options**              | `dotnet_style_prefer_collection_expression`   |
 
 ## Overview
 
-This style rule concerns the use of [collection initializers](../../../csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md) for collection initialization.
+This style rule concerns the use of [collection initializers](../../../csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md) and, if you're using C# 12 or later, [collection expressions](../../../csharp/language-reference/operators/collection-expressions.md) for collection initialization.
+
+In .NET 8 (C# 12) and later versions, if you have the `dotnet_style_prefer_collection_expression` option set to `true`, the code fixer in Visual Studio converts your collection initialization code to use a collection expression (`List<int> list = [1, 2, 3];`). In Visual Basic and in .NET 7 (C# 11) and earlier versions, the code fixer converts your code to use a collection initializer (`List<int> list = new List<int> { 1, 2, 3 };`).
 
 > [!NOTE]
-> C# 12 introduced an even more succinct way to initialize collections using [collection expressions](../../../csharp/language-reference/operators/collection-expressions.md). Accordingly, in .NET 8 and later versions, this rule is superseded by [IDE0300](ide0300.md) for array initialization.
+> If you use the code fixer in Visual Studio, the change it offers might have different semantics in some cases. For example, `int[] x = new int[] { }` is replaced with `int[] x = [];`, which has slightly different semantics&mdash;the compiler uses a singleton for `x` instead of creating a new instance.
 
 ## Options
 
-Set the value of the associated option for this rule to specify whether or not collection initializers are preferred when initializing collections.
+Set the values of the associated options for this rule to specify whether or not collection initializers and collection expressions are preferred when initializing collections.
 
 For more information about configuring options, see [Option format](language-rules.md#option-format).
 
 ### dotnet_style_collection_initializer
 
-| Property                 | Value  | Description                                                                       |
-| ------------------------ | ------ | --------------------------------------------------------------------------------- |
-| **Option name**          | dotnet_style_collection_initializer |                                                      |
-| **Option values**        | `true`  | Prefer collections to be initialized using collection initializers when possible |
-|                          | `false` | Prefer collections to *not* be initialized using collection initializers         |
-| **Default option value** | `true`  |                                                                                  |
+| Property                 | Value                               | Description                            |
+|--------------------------|-------------------------------------|----------------------------------------|
+| **Option name**          | dotnet_style_collection_initializer |                                        |
+| **Option values**        | `true`                              | Prefer to use collection initializers. |
+|                          | `false`                             | Don't prefer collection initializers.  |
+| **Default option value** | `true`                              |                                        |
+
+### dotnet_style_prefer_collection_expression (C# only)
+
+| Property                 | Value                                     | Description                           |
+|--------------------------|-------------------------------------------|---------------------------------------|
+| **Option name**          | dotnet_style_prefer_collection_expression |                                       |
+| **Option values**        | `true`                                    | Prefer to use collection expressions. |
+|                          | `false`                                   | Don't prefer collection expressions.  |
+| **Default option value** | `true`                                    |                                       |
 
 ## Examples
 
+:::zone pivot="dotnet-8-0"
+
 ```csharp
 // IDE0028 violation.
-var c = new List<int>();
-c.Add(1);
+List<int> list = new List<int>();
+list.Add(1);
+list.Add(2);
+list.Add(3);
 
-// Fixed code.
-var c = new List<int>
-{
-    1
-};
-```
-
-```csharp
-// IDE0028 violation (C# 12 and later only)
-List<int> d = new List<int> { 1, 2, 3 };
-
-// Fixed code.
-List<int> d = [1, 2, 3];
+// Fixed code (with dotnet_style_prefer_collection_expression = true)
+List<int> list = [1, 2, 3];
 ```
 
 ```vb
-' dotnet_style_collection_initializer = true
-Dim list = New List(Of Integer) From {1, 2, 3}
-
-' dotnet_style_collection_initializer = false
+' IDE0028 violation.
 Dim list = New List(Of Integer)
 list.Add(1)
 list.Add(2)
 list.Add(3)
+
+' Fixed code.
+Dim list = New List(Of Integer) From {1, 2, 3}
 ```
+
+:::zone-end
+
+:::zone pivot="dotnet-7-0,dotnet-6-0"
+
+```csharp
+// IDE0028 violation.
+List<int> list = new List<int>();
+list.Add(1);
+list.Add(2);
+list.Add(3);
+
+// Fixed code.
+List<int> list = new List<int>
+{
+    1,
+    2,
+    3
+};
+```
+
+```csharp
+// IDE0028 violation.
+List<int> list = new List<int>();
+list.Add(1);
+list.AddRange(new[] { 5, 6, 7 });
+
+// Fixed code.
+List<int> list = [1, .. new[] { 5, 6, 7 }];
+```
+
+```vb
+' IDE0028 violation.
+Dim list = New List(Of Integer)
+list.Add(1)
+list.Add(2)
+list.Add(3)
+
+' Fixed code.
+Dim list = New List(Of Integer) From {1, 2, 3}
+```
+
+:::zone-end
 
 ## Suppress a warning
 
@@ -108,7 +157,5 @@ For more information, see [How to suppress code analysis warnings](../suppress-w
 
 ## See also
 
-- [Use object initializers](ide0017.md)
-- [Code style language rules](language-rules.md)
-- [Code style rules reference](index.md)
-- [Use collection expression (IDE0300)](ide0300.md)
+- [Use object initializers (IDE0017)](ide0017.md)
+- [Use collection expression for array (IDE0300)](ide0300.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0028.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0028.md
@@ -25,7 +25,7 @@ dev_langs:
 | **Subcategory**          | Language rules (expression-level preferences) |
 | **Applicable languages** | C# and Visual Basic                           |
 | **Options**              | `dotnet_style_collection_initializer`         |
-| **Options**              | `dotnet_style_prefer_collection_expression`   |
+|                          | `dotnet_style_prefer_collection_expression`   |
 
 ## Overview
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0028.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0028.md
@@ -1,7 +1,7 @@
 ---
 title: "IDE0028: Use collection initializers"
 description: "Learn about code analysis rule IDE0028: Use collection initializers"
-ms.date: 09/30/2020
+ms.date: 12/11/2023
 f1_keywords:
 - IDE0028
 - dotnet_style_collection_initializer
@@ -24,11 +24,13 @@ dev_langs:
 | **Subcategory**          | Language rules (expression-level preferences) |
 | **Applicable languages** | C# and Visual Basic                           |
 | **Options**              | `dotnet_style_collection_initializer`         |
-|                          | `dotnet_style_prefer_collection_expression`   |
 
 ## Overview
 
 This style rule concerns the use of [collection initializers](../../../csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md) for collection initialization.
+
+> [!NOTE]
+> C# 12 introduced an even more succinct way to initialize collections using [collection expressions](../../../csharp/language-reference/operators/collection-expressions.md). Accordingly, in .NET 8 and later versions, this rule is superseded by [IDE0300](ide0300.md) for array initialization.
 
 ## Options
 
@@ -43,26 +45,18 @@ For more information about configuring options, see [Option format](language-rul
 | **Option name**          | dotnet_style_collection_initializer |                                                                                   |
 | **Option values**        | `true`  | Prefer collections to be initialized using collection initializers when possible |
 |                          | `false` | Prefer collections to *not* be initialized using collection initializers         |
-| **Default option value** | `true`  |
-
-### dotnet_style_prefer_collection_expression
-
-| Property                 | Value                                     | Description                           |
-|--------------------------|-------------------------------------------|---------------------------------------|
-| **Option name**          | dotnet_style_prefer_collection_expression |                                       |
-| **Option values**        | `true`                                    | Prefer to use collection expressions. |
-|                          | `false`                                   | Disables the rule.                    |
-| **Default option value** | `true`                                    |                                       |                                                                         |
+| **Default option value** | `true`  |                                                                                  |
 
 ```csharp
 // dotnet_style_collection_initializer = true
-var list = new List<int> { 1, 2, 3 };
+var c = new List<int>
+{
+    1
+};
 
 // dotnet_style_collection_initializer = false
-var list = new List<int>();
-list.Add(1);
-list.Add(2);
-list.Add(3);
+var c = new List<int>();
+c.Add(1);
 ```
 
 ```vb

--- a/docs/fundamentals/code-analysis/style-rules/ide0028.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0028.md
@@ -24,6 +24,7 @@ dev_langs:
 | **Subcategory**          | Language rules (expression-level preferences) |
 | **Applicable languages** | C# and Visual Basic                           |
 | **Options**              | `dotnet_style_collection_initializer`         |
+|                          | `dotnet_style_prefer_collection_expression`   |
 
 ## Overview
 
@@ -37,12 +38,21 @@ For more information about configuring options, see [Option format](language-rul
 
 ### dotnet_style_collection_initializer
 
-| Property                 | Value                               | Description                                                                      |
-| ------------------------ | ----------------------------------- | -------------------------------------------------------------------------------- |
-| **Option name**          | dotnet_style_collection_initializer |                                                                                  |
-| **Option values**        | `true`                              | Prefer collections to be initialized using collection initializers when possible |
-|                          | `false`                             | Prefer collections to *not* be initialized using collection initializers         |
-| **Default option value** | `true`                              |                                                                                  |
+| Property                 | Value  | Description                                                                       |
+| ------------------------ | ------ | --------------------------------------------------------------------------------- |
+| **Option name**          | dotnet_style_collection_initializer |                                                                                   |
+| **Option values**        | `true`  | Prefer collections to be initialized using collection initializers when possible |
+|                          | `false` | Prefer collections to *not* be initialized using collection initializers         |
+| **Default option value** | `true`  |
+
+### dotnet_style_prefer_collection_expression
+
+| Property                 | Value                                     | Description                           |
+|--------------------------|-------------------------------------------|---------------------------------------|
+| **Option name**          | dotnet_style_prefer_collection_expression |                                       |
+| **Option values**        | `true`                                    | Prefer to use collection expressions. |
+|                          | `false`                                   | Disables the rule.                    |
+| **Default option value** | `true`                                    |                                       |                                                                         |
 
 ```csharp
 // dotnet_style_collection_initializer = true
@@ -97,3 +107,4 @@ For more information, see [How to suppress code analysis warnings](../suppress-w
 - [Use object initializers](ide0017.md)
 - [Code style language rules](language-rules.md)
 - [Code style rules reference](index.md)
+- [Use collection expression (IDE0300)](ide0300.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0300.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0300.md
@@ -1,5 +1,5 @@
 ---
-title: "IDE0300: Use collection expression"
+title: "IDE0300: Use collection expression for array"
 description: "Learn about code analysis rule IDE0300: Use collection expression"
 ms.date: 12/12/2023
 f1_keywords:
@@ -14,7 +14,7 @@ dev_langs:
 | Property                 | Value                                         |
 |--------------------------|-----------------------------------------------|
 | **Rule ID**              | IDE0300                                       |
-| **Title**                | Use collection expression                     |
+| **Title**                | Use collection expression for array           |
 | **Category**             | Style                                         |
 | **Subcategory**          | Language rules (expression-level preferences) |
 | **Applicable languages** | C# 12+                                        |

--- a/docs/fundamentals/code-analysis/style-rules/ide0300.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0300.md
@@ -1,0 +1,76 @@
+---
+title: "IDE0300: Use collection expression"
+description: "Learn about code analysis rule IDE0300: Use collection expression"
+ms.date: 12/08/2023
+f1_keywords:
+- IDE0300
+helpviewer_keywords:
+- IDE0300
+dev_langs:
+- CSharp
+---
+# Use collection expression (IDE0300)
+
+| Property                 | Value                                         |
+|--------------------------|-----------------------------------------------|
+| **Rule ID**              | IDE0300                                       |
+| **Title**                | Use collection expression                     |
+| **Category**             | Style                                         |
+| **Subcategory**          | Language rules (expression-level preferences) |
+| **Applicable languages** | C#                                            |
+| **Options**              | `dotnet_style_prefer_collection_expression`   |
+
+## Overview
+
+This rule flags places where a [collection expression](../../../csharp/language-reference/operators/collection-expressions.md) could be used to initialize an array.
+
+## Options
+
+Options specify the behavior that you want the rule to enforce. For information about configuring options, see [Option format](language-rules.md#option-format).
+
+### dotnet_style_prefer_collection_expression
+
+| Property                 | Value                                     | Description                           |
+|--------------------------|-------------------------------------------|---------------------------------------|
+| **Option name**          | dotnet_style_prefer_collection_expression |                                       |
+| **Option values**        | `true`                                    | Prefer to use collection expressions. |
+|                          | `false`                                   | Disables the rule.                    |
+| **Default option value** | `true`                                    |                                       |
+
+## Example
+
+```csharp
+// Code with violations.
+
+// Fixed code.
+```
+
+## Suppress a warning
+
+If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable IDE0300
+// The code that's violating the rule is on this line.
+#pragma warning restore IDE0300
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.IDE0300.severity = none
+```
+
+To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
+## See also
+
+- [Use collection initializers (IDE0028)](ide0028.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0300.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0300.md
@@ -1,7 +1,7 @@
 ---
 title: "IDE0300: Use collection expression"
 description: "Learn about code analysis rule IDE0300: Use collection expression"
-ms.date: 12/08/2023
+ms.date: 12/12/2023
 f1_keywords:
 - IDE0300
 helpviewer_keywords:
@@ -17,12 +17,12 @@ dev_langs:
 | **Title**                | Use collection expression                     |
 | **Category**             | Style                                         |
 | **Subcategory**          | Language rules (expression-level preferences) |
-| **Applicable languages** | C#                                            |
+| **Applicable languages** | C# 12+                                        |
 | **Options**              | `dotnet_style_prefer_collection_expression`   |
 
 ## Overview
 
-This rule flags places where a [collection expression](../../../csharp/language-reference/operators/collection-expressions.md) could be used to initialize an array.
+This rule flags places where a [collection expression](../../../csharp/language-reference/operators/collection-expressions.md) could be used to initialize an array. For example, this rule offers to simplify code like `new C[] { ... }`, `new[] { ... }`, and `C[] c = { ... }` into the collection expression form (`[...]`).
 
 ## Options
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0301.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0301.md
@@ -1,19 +1,19 @@
 ---
-title: "IDE0300: Use collection expression"
-description: "Learn about code analysis rule IDE0300: Use collection expression"
+title: "IDE0301: Use collection expression"
+description: "Learn about code analysis rule IDE0301: Use collection expression"
 ms.date: 12/08/2023
 f1_keywords:
-- IDE0300
+- IDE0301
 helpviewer_keywords:
-- IDE0300
+- IDE0301
 dev_langs:
 - CSharp
 ---
-# Use collection expression for array (IDE0300)
+# Use collection expression for empty (IDE0301)
 
 | Property                 | Value                                         |
 |--------------------------|-----------------------------------------------|
-| **Rule ID**              | IDE0300                                       |
+| **Rule ID**              | IDE0301                                       |
 | **Title**                | Use collection expression                     |
 | **Category**             | Style                                         |
 | **Subcategory**          | Language rules (expression-level preferences) |
@@ -22,7 +22,7 @@ dev_langs:
 
 ## Overview
 
-This rule flags places where a [collection expression](../../../csharp/language-reference/operators/collection-expressions.md) could be used to initialize an array.
+This rule flags places where a [collection expression](../../../csharp/language-reference/operators/collection-expressions.md) could be used to initialize an empty collection instead of calling an `Empty` method or property.
 
 ## Options
 
@@ -41,10 +41,36 @@ Options specify the behavior that you want the rule to enforce. For information 
 
 ```csharp
 // Code with violations.
-int[] i = new int[] { 1, 2, 3 };
+int[] i = Array.Empty<int>();
+ReadOnlySpan<int> span = ReadOnlySpan<int>.Empty;
 
 // Fixed code.
-int[] i = [1, 2, 3];
+int[] i = [];
+ReadOnlySpan<int> span = [];
+```
+
+The following code snippet shows an example with a custom type.
+
+```csharp
+public class Program
+{
+    public static void Main()
+    {
+        // IDE0301 violation.
+        MyList<int> x = MyList<int>.Empty;
+
+        // IDE0301 fixed code.
+        MyList<int> x = [];
+    }
+}
+
+class MyList<T> : IEnumerable<T>
+{
+    public static MyList<T> Empty { get; }
+
+    public IEnumerator<T> GetEnumerator() => default;
+    IEnumerator IEnumerable.GetEnumerator() => default;
+}
 ```
 
 ## Suppress a warning
@@ -52,16 +78,16 @@ int[] i = [1, 2, 3];
 If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
-#pragma warning disable IDE0300
+#pragma warning disable IDE0301
 // The code that's violating the rule is on this line.
-#pragma warning restore IDE0300
+#pragma warning restore IDE0301
 ```
 
 To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
-dotnet_diagnostic.IDE0300.severity = none
+dotnet_diagnostic.IDE0301.severity = none
 ```
 
 To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
@@ -75,4 +101,4 @@ For more information, see [How to suppress code analysis warnings](../suppress-w
 
 ## See also
 
-- [Use collection initializers (IDE0028)](ide0028.md)
+- [Use collection expression for array (IDE0300)](ide0300.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0301.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0301.md
@@ -1,6 +1,6 @@
 ---
-title: "IDE0301: Use collection expression"
-description: "Learn about code analysis rule IDE0301: Use collection expression"
+title: "IDE0301: Use collection expression for empty"
+description: "Learn about code analysis rule IDE0301: Use collection expression for empty"
 ms.date: 12/12/2023
 f1_keywords:
 - IDE0301
@@ -14,7 +14,7 @@ dev_langs:
 | Property                 | Value                                         |
 |--------------------------|-----------------------------------------------|
 | **Rule ID**              | IDE0301                                       |
-| **Title**                | Use collection expression                     |
+| **Title**                | Use collection expression for empty           |
 | **Category**             | Style                                         |
 | **Subcategory**          | Language rules (expression-level preferences) |
 | **Applicable languages** | C# 12+                                        |

--- a/docs/fundamentals/code-analysis/style-rules/ide0301.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0301.md
@@ -1,7 +1,7 @@
 ---
 title: "IDE0301: Use collection expression"
 description: "Learn about code analysis rule IDE0301: Use collection expression"
-ms.date: 12/08/2023
+ms.date: 12/12/2023
 f1_keywords:
 - IDE0301
 helpviewer_keywords:
@@ -17,12 +17,12 @@ dev_langs:
 | **Title**                | Use collection expression                     |
 | **Category**             | Style                                         |
 | **Subcategory**          | Language rules (expression-level preferences) |
-| **Applicable languages** | C#                                            |
+| **Applicable languages** | C# 12+                                        |
 | **Options**              | `dotnet_style_prefer_collection_expression`   |
 
 ## Overview
 
-This rule flags places where a [collection expression](../../../csharp/language-reference/operators/collection-expressions.md) could be used to initialize an empty collection instead of calling an `Empty` method or property.
+This rule looks for code similar to `Array.Empty<T>()` (a method call that returns an empty collection) or `ImmutableArray<T>.Empty` (a property that returns an empty collection) and offers to replace it with a [collection expression](../../../csharp/language-reference/operators/collection-expressions.md) (`[]`).
 
 ## Options
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0302.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0302.md
@@ -1,19 +1,19 @@
 ---
-title: "IDE0300: Use collection expression"
-description: "Learn about code analysis rule IDE0300: Use collection expression"
+title: "IDE0302: Use collection expression"
+description: "Learn about code analysis rule IDE0302: Use collection expression"
 ms.date: 12/08/2023
 f1_keywords:
-- IDE0300
+- IDE0302
 helpviewer_keywords:
-- IDE0300
+- IDE0302
 dev_langs:
 - CSharp
 ---
-# Use collection expression for array (IDE0300)
+# Use collection expression for stackalloc (IDE0302)
 
 | Property                 | Value                                         |
 |--------------------------|-----------------------------------------------|
-| **Rule ID**              | IDE0300                                       |
+| **Rule ID**              | IDE0302                                       |
 | **Title**                | Use collection expression                     |
 | **Category**             | Style                                         |
 | **Subcategory**          | Language rules (expression-level preferences) |
@@ -22,7 +22,7 @@ dev_langs:
 
 ## Overview
 
-This rule flags places where a [collection expression](../../../csharp/language-reference/operators/collection-expressions.md) could be used to initialize an array.
+This rule flags places where an array is initialized using [`stackalloc`](../../../csharp/language-reference/operators/stackalloc.md).  Instead, a [collection expression](../../../csharp/language-reference/operators/collection-expressions.md) could be used to initialize the array.
 
 ## Options
 
@@ -41,10 +41,10 @@ Options specify the behavior that you want the rule to enforce. For information 
 
 ```csharp
 // Code with violations.
-int[] i = new int[] { 1, 2, 3 };
+ReadOnlySpan<int> x = stackalloc int[] { 1, 2, 3 };
 
 // Fixed code.
-int[] i = [1, 2, 3];
+ReadOnlySpan<int> x = [1, 2, 3];
 ```
 
 ## Suppress a warning
@@ -52,16 +52,16 @@ int[] i = [1, 2, 3];
 If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
-#pragma warning disable IDE0300
+#pragma warning disable IDE0302
 // The code that's violating the rule is on this line.
-#pragma warning restore IDE0300
+#pragma warning restore IDE0302
 ```
 
 To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
-dotnet_diagnostic.IDE0300.severity = none
+dotnet_diagnostic.IDE0302.severity = none
 ```
 
 To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
@@ -75,4 +75,5 @@ For more information, see [How to suppress code analysis warnings](../suppress-w
 
 ## See also
 
-- [Use collection initializers (IDE0028)](ide0028.md)
+- [Use collection expression for array (IDE0300)](ide0300.md)
+- [Use collection expression for empty (IDE0301)](ide0301.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0302.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0302.md
@@ -1,6 +1,6 @@
 ---
-title: "IDE0302: Use collection expression"
-description: "Learn about code analysis rule IDE0302: Use collection expression"
+title: "IDE0302: Use collection expression for stackalloc"
+description: "Learn about code analysis rule IDE0302: Use collection expression for stackalloc"
 ms.date: 12/12/2023
 f1_keywords:
 - IDE0302
@@ -14,7 +14,7 @@ dev_langs:
 | Property                 | Value                                         |
 |--------------------------|-----------------------------------------------|
 | **Rule ID**              | IDE0302                                       |
-| **Title**                | Use collection expression                     |
+| **Title**                | Use collection expression for stackalloc      |
 | **Category**             | Style                                         |
 | **Subcategory**          | Language rules (expression-level preferences) |
 | **Applicable languages** | C# 12+                                        |

--- a/docs/fundamentals/code-analysis/style-rules/ide0302.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0302.md
@@ -1,7 +1,7 @@
 ---
 title: "IDE0302: Use collection expression"
 description: "Learn about code analysis rule IDE0302: Use collection expression"
-ms.date: 12/08/2023
+ms.date: 12/12/2023
 f1_keywords:
 - IDE0302
 helpviewer_keywords:
@@ -17,12 +17,15 @@ dev_langs:
 | **Title**                | Use collection expression                     |
 | **Category**             | Style                                         |
 | **Subcategory**          | Language rules (expression-level preferences) |
-| **Applicable languages** | C#                                            |
+| **Applicable languages** | C# 12+                                        |
 | **Options**              | `dotnet_style_prefer_collection_expression`   |
 
 ## Overview
 
-This rule flags places where an array is initialized using [`stackalloc`](../../../csharp/language-reference/operators/stackalloc.md).  Instead, a [collection expression](../../../csharp/language-reference/operators/collection-expressions.md) could be used to initialize the array.
+This rule is similar to [Use collection expression for array (IDE0300)](ide0300.md) except it looks for [`stackalloc`](../../../csharp/language-reference/operators/stackalloc.md) instead of arrays. Like IDE0300, it offers to convert the code to use a [collection expression](../../../csharp/language-reference/operators/collection-expressions.md). For example, `stackalloc int[] { ... }` and `stackalloc [] { ... }` are simplified to `[...]`.
+
+> [!NOTE]
+> This rule is only available in .NET 8 and later versions where the values can be preserved on the stack.
 
 ## Options
 
@@ -76,4 +79,3 @@ For more information, see [How to suppress code analysis warnings](../suppress-w
 ## See also
 
 - [Use collection expression for array (IDE0300)](ide0300.md)
-- [Use collection expression for empty (IDE0301)](ide0301.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0303.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0303.md
@@ -1,6 +1,6 @@
 ---
-title: "IDE0303: Use collection expression"
-description: "Learn about code analysis rule IDE0303: Use collection expression"
+title: "IDE0303: Use collection expression for Create"
+description: "Learn about code analysis rule IDE0303: Use collection expression for Create"
 ms.date: 12/12/2023
 f1_keywords:
 - IDE0303
@@ -14,7 +14,7 @@ dev_langs:
 | Property                 | Value                                         |
 |--------------------------|-----------------------------------------------|
 | **Rule ID**              | IDE0303                                       |
-| **Title**                | Use collection expression                     |
+| **Title**                | Use collection expression for Create          |
 | **Category**             | Style                                         |
 | **Subcategory**          | Language rules (expression-level preferences) |
 | **Applicable languages** | C# 12+                                        |

--- a/docs/fundamentals/code-analysis/style-rules/ide0303.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0303.md
@@ -1,7 +1,7 @@
 ---
 title: "IDE0303: Use collection expression"
 description: "Learn about code analysis rule IDE0303: Use collection expression"
-ms.date: 12/08/2023
+ms.date: 12/12/2023
 f1_keywords:
 - IDE0303
 helpviewer_keywords:
@@ -17,12 +17,17 @@ dev_langs:
 | **Title**                | Use collection expression                     |
 | **Category**             | Style                                         |
 | **Subcategory**          | Language rules (expression-level preferences) |
-| **Applicable languages** | C#                                            |
+| **Applicable languages** | C# 12+                                        |
 | **Options**              | `dotnet_style_prefer_collection_expression`   |
 
 ## Overview
 
-This rule flags places where a `Create()` method or a similar method that's designated as the collection construction method (using the <xref:System.Runtime.CompilerServices.CollectionBuilderAttribute> attribute) is used to initialize a collection. Instead, a [collection expression](../../../csharp/language-reference/operators/collection-expressions.md) could be used to initialize the collection.
+This rule flags places where a `Create()` method or a similar method that's designated as the collection construction method (using the <xref:System.Runtime.CompilerServices.CollectionBuilderAttribute> attribute) is used to initialize a collection and offers to replace it with a [collection expression](../../../csharp/language-reference/operators/collection-expressions.md) (`[...]`).
+
+`Create()` methods are common for the immutable collections, for example, `ImmutableArray.Create(1, 2, 3)`.
+
+> [!NOTE]
+> This rule requires more recent versions of the immutable APIs (for example, <xref:System.Collections.Immutable>), which opt into the collection-expression pattern.
 
 ## Options
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0303.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0303.md
@@ -1,19 +1,19 @@
 ---
-title: "IDE0300: Use collection expression"
-description: "Learn about code analysis rule IDE0300: Use collection expression"
+title: "IDE0303: Use collection expression"
+description: "Learn about code analysis rule IDE0303: Use collection expression"
 ms.date: 12/08/2023
 f1_keywords:
-- IDE0300
+- IDE0303
 helpviewer_keywords:
-- IDE0300
+- IDE0303
 dev_langs:
 - CSharp
 ---
-# Use collection expression for array (IDE0300)
+# Use collection expression for `Create()` (IDE0303)
 
 | Property                 | Value                                         |
 |--------------------------|-----------------------------------------------|
-| **Rule ID**              | IDE0300                                       |
+| **Rule ID**              | IDE0303                                       |
 | **Title**                | Use collection expression                     |
 | **Category**             | Style                                         |
 | **Subcategory**          | Language rules (expression-level preferences) |
@@ -22,7 +22,7 @@ dev_langs:
 
 ## Overview
 
-This rule flags places where a [collection expression](../../../csharp/language-reference/operators/collection-expressions.md) could be used to initialize an array.
+This rule flags places where a `Create()` method or a similar method that's designated as the collection construction method (using the <xref:System.Runtime.CompilerServices.CollectionBuilderAttribute> attribute) is used to initialize a collection. Instead, a [collection expression](../../../csharp/language-reference/operators/collection-expressions.md) could be used to initialize the collection.
 
 ## Options
 
@@ -41,10 +41,39 @@ Options specify the behavior that you want the rule to enforce. For information 
 
 ```csharp
 // Code with violations.
-int[] i = new int[] { 1, 2, 3 };
+ImmutableArray<int> i = ImmutableArray.Create(1, 2, 3);
 
 // Fixed code.
-int[] i = [1, 2, 3];
+ImmutableArray<int> i = [1, 2, 3];
+```
+
+The following code snippet shows an example with a custom type that's annotated with <xref:System.Runtime.CompilerServices.CollectionBuilderAttribute>.
+
+```csharp
+public class Program
+{
+    public static void Main()
+    {
+        // IDE0303 violation.
+        MyCollection<int> c = MyCollection.Create(1, 2, 3);
+
+        // IDE0303 fixed code.
+        MyCollection<int> c = [1, 2, 3];
+    }
+}
+
+static partial class MyCollection
+{
+    public static MyCollection<T> Create<T>(System.ReadOnlySpan<T> values) => default;
+    public static MyCollection<T> Create<T>(T t1, T t2, T t3) => default;
+}
+
+[CollectionBuilder(typeof(MyCollection), "Create")]
+class MyCollection<T> : IEnumerable<T>
+{
+    public IEnumerator<T> GetEnumerator() => default;
+    IEnumerator IEnumerable.GetEnumerator() => default;
+}
 ```
 
 ## Suppress a warning
@@ -52,16 +81,16 @@ int[] i = [1, 2, 3];
 If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
-#pragma warning disable IDE0300
+#pragma warning disable IDE0303
 // The code that's violating the rule is on this line.
-#pragma warning restore IDE0300
+#pragma warning restore IDE0303
 ```
 
 To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
-dotnet_diagnostic.IDE0300.severity = none
+dotnet_diagnostic.IDE0303.severity = none
 ```
 
 To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
@@ -75,4 +104,6 @@ For more information, see [How to suppress code analysis warnings](../suppress-w
 
 ## See also
 
-- [Use collection initializers (IDE0028)](ide0028.md)
+- [Use collection expression for array (IDE0300)](ide0300.md)
+- [Use collection expression for empty (IDE0301)](ide0301.md)
+- [Use collection expression for stackalloc (IDE0302)](ide0302.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0304.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0304.md
@@ -1,7 +1,7 @@
 ---
 title: "IDE0304: Use collection expression"
 description: "Learn about code analysis rule IDE0304: Use collection expression"
-ms.date: 12/08/2023
+ms.date: 12/12/2023
 f1_keywords:
 - IDE0304
 helpviewer_keywords:
@@ -17,12 +17,15 @@ dev_langs:
 | **Title**                | Use collection expression                     |
 | **Category**             | Style                                         |
 | **Subcategory**          | Language rules (expression-level preferences) |
-| **Applicable languages** | C#                                            |
+| **Applicable languages** | C# 12+                                        |
 | **Options**              | `dotnet_style_prefer_collection_expression`   |
 
 ## Overview
 
-This rule flags places where a `CreateBuilder()` or similar method is called to create a builder type that adds elements and finally constructs a type that has the <xref:System.Runtime.CompilerServices.CollectionBuilderAttribute> attribute. Instead, a [collection expression](../../../csharp/language-reference/operators/collection-expressions.md) could be used to initialize the collection.
+This rule flags places where a `CreateBuilder()` or similar method is called to create a builder type that adds elements and finally constructs a collection type that has the <xref:System.Runtime.CompilerServices.CollectionBuilderAttribute> attribute (for example, by calling <xref:System.Collections.Immutable.ImmutableArray%601.Builder.ToImmutable?displayProperty=nameWithType>). Instead, a [collection expression](../../../csharp/language-reference/operators/collection-expressions.md) (`[...]`) could be used to initialize the collection.
+
+> [!NOTE]
+> This rule requires more recent versions of the immutable APIs (for example, <xref:System.Collections.Immutable>), which opt into the collection-expression pattern.
 
 ## Options
 
@@ -42,13 +45,12 @@ Options specify the behavior that you want the rule to enforce. For information 
 ```csharp
 // Code with violation.
 var builder = ImmutableArray.CreateBuilder<int>();
-builder.Add(0);
-builder.Add(8);
-
+builder.Add(1);
+builder.AddRange(new int[] { 5, 6, 7 });
 ImmutableArray<int> i = builder.ToImmutable();
 
 // Fixed code.
-ImmutableArray<int> i = [0, 8];
+ImmutableArray<int> i = [1, .. new int[] { 5, 6, 7 }];
 ```
 
 ## Suppress a warning

--- a/docs/fundamentals/code-analysis/style-rules/ide0304.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0304.md
@@ -1,6 +1,6 @@
 ---
-title: "IDE0304: Use collection expression"
-description: "Learn about code analysis rule IDE0304: Use collection expression"
+title: "IDE0304: Use collection expression for builder"
+description: "Learn about code analysis rule IDE0304: Use collection expression for builder"
 ms.date: 12/12/2023
 f1_keywords:
 - IDE0304
@@ -14,7 +14,7 @@ dev_langs:
 | Property                 | Value                                         |
 |--------------------------|-----------------------------------------------|
 | **Rule ID**              | IDE0304                                       |
-| **Title**                | Use collection expression                     |
+| **Title**                | Use collection expression for builder         |
 | **Category**             | Style                                         |
 | **Subcategory**          | Language rules (expression-level preferences) |
 | **Applicable languages** | C# 12+                                        |

--- a/docs/fundamentals/code-analysis/style-rules/ide0304.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0304.md
@@ -1,19 +1,19 @@
 ---
-title: "IDE0300: Use collection expression"
-description: "Learn about code analysis rule IDE0300: Use collection expression"
+title: "IDE0304: Use collection expression"
+description: "Learn about code analysis rule IDE0304: Use collection expression"
 ms.date: 12/08/2023
 f1_keywords:
-- IDE0300
+- IDE0304
 helpviewer_keywords:
-- IDE0300
+- IDE0304
 dev_langs:
 - CSharp
 ---
-# Use collection expression for array (IDE0300)
+# Use collection expression for builder (IDE0304)
 
 | Property                 | Value                                         |
 |--------------------------|-----------------------------------------------|
-| **Rule ID**              | IDE0300                                       |
+| **Rule ID**              | IDE0304                                       |
 | **Title**                | Use collection expression                     |
 | **Category**             | Style                                         |
 | **Subcategory**          | Language rules (expression-level preferences) |
@@ -22,7 +22,7 @@ dev_langs:
 
 ## Overview
 
-This rule flags places where a [collection expression](../../../csharp/language-reference/operators/collection-expressions.md) could be used to initialize an array.
+This rule flags places where a `CreateBuilder()` or similar method is called to create a builder type that adds elements and finally constructs a type that has the <xref:System.Runtime.CompilerServices.CollectionBuilderAttribute> attribute. Instead, a [collection expression](../../../csharp/language-reference/operators/collection-expressions.md) could be used to initialize the collection.
 
 ## Options
 
@@ -40,11 +40,15 @@ Options specify the behavior that you want the rule to enforce. For information 
 ## Example
 
 ```csharp
-// Code with violations.
-int[] i = new int[] { 1, 2, 3 };
+// Code with violation.
+var builder = ImmutableArray.CreateBuilder<int>();
+builder.Add(0);
+builder.Add(8);
+
+ImmutableArray<int> i = builder.ToImmutable();
 
 // Fixed code.
-int[] i = [1, 2, 3];
+ImmutableArray<int> i = [0, 8];
 ```
 
 ## Suppress a warning
@@ -52,16 +56,16 @@ int[] i = [1, 2, 3];
 If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
-#pragma warning disable IDE0300
+#pragma warning disable IDE0304
 // The code that's violating the rule is on this line.
-#pragma warning restore IDE0300
+#pragma warning restore IDE0304
 ```
 
 To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
-dotnet_diagnostic.IDE0300.severity = none
+dotnet_diagnostic.IDE0304.severity = none
 ```
 
 To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
@@ -75,4 +79,7 @@ For more information, see [How to suppress code analysis warnings](../suppress-w
 
 ## See also
 
-- [Use collection initializers (IDE0028)](ide0028.md)
+- [Use collection expression for array (IDE0300)](ide0300.md)
+- [Use collection expression for empty (IDE0301)](ide0301.md)
+- [Use collection expression for stackalloc (IDE0302)](ide0302.md)
+- [Use collection expression for `Create()` (IDE0303)](ide0303.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0305.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0305.md
@@ -1,19 +1,19 @@
 ---
-title: "IDE0300: Use collection expression"
-description: "Learn about code analysis rule IDE0300: Use collection expression"
+title: "IDE0305: Use collection expression"
+description: "Learn about code analysis rule IDE0305: Use collection expression"
 ms.date: 12/08/2023
 f1_keywords:
-- IDE0300
+- IDE0305
 helpviewer_keywords:
-- IDE0300
+- IDE0305
 dev_langs:
 - CSharp
 ---
-# Use collection expression for array (IDE0300)
+# Use collection expression for fluent (IDE0305)
 
 | Property                 | Value                                         |
 |--------------------------|-----------------------------------------------|
-| **Rule ID**              | IDE0300                                       |
+| **Rule ID**              | IDE0305                                       |
 | **Title**                | Use collection expression                     |
 | **Category**             | Style                                         |
 | **Subcategory**          | Language rules (expression-level preferences) |
@@ -22,7 +22,7 @@ dev_langs:
 
 ## Overview
 
-This rule flags places where a [collection expression](../../../csharp/language-reference/operators/collection-expressions.md) could be used to initialize an array.
+This rule flags places where a collection is built in a *fluent* manner, that is, where methods are chained. Instead, a [collection expression](../../../csharp/language-reference/operators/collection-expressions.md) could be used to initialize the collection.
 
 ## Options
 
@@ -40,11 +40,11 @@ Options specify the behavior that you want the rule to enforce. For information 
 ## Example
 
 ```csharp
-// Code with violations.
-int[] i = new int[] { 1, 2, 3 };
+// Code with violation.
+List<int> list = new[] { 1, 2, 3 }.ToList();
 
 // Fixed code.
-int[] i = [1, 2, 3];
+List<int> list = [1, 2, 3];
 ```
 
 ## Suppress a warning
@@ -52,16 +52,16 @@ int[] i = [1, 2, 3];
 If you want to suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
 
 ```csharp
-#pragma warning disable IDE0300
+#pragma warning disable IDE0305
 // The code that's violating the rule is on this line.
-#pragma warning restore IDE0300
+#pragma warning restore IDE0305
 ```
 
 To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
 
 ```ini
 [*.{cs,vb}]
-dotnet_diagnostic.IDE0300.severity = none
+dotnet_diagnostic.IDE0305.severity = none
 ```
 
 To disable all of the code-style rules, set the severity for the category `Style` to `none` in the [configuration file](../configuration-files.md).
@@ -75,4 +75,8 @@ For more information, see [How to suppress code analysis warnings](../suppress-w
 
 ## See also
 
-- [Use collection initializers (IDE0028)](ide0028.md)
+- [Use collection expression for array (IDE0300)](ide0300.md)
+- [Use collection expression for empty (IDE0301)](ide0301.md)
+- [Use collection expression for stackalloc (IDE0302)](ide0302.md)
+- [Use collection expression for `Create()` (IDE0303)](ide0303.md)
+- [Use collection expression for builder (IDE0304)](ide0304.md)

--- a/docs/fundamentals/code-analysis/style-rules/ide0305.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0305.md
@@ -1,7 +1,7 @@
 ---
 title: "IDE0305: Use collection expression"
 description: "Learn about code analysis rule IDE0305: Use collection expression"
-ms.date: 12/08/2023
+ms.date: 12/12/2023
 f1_keywords:
 - IDE0305
 helpviewer_keywords:
@@ -17,12 +17,12 @@ dev_langs:
 | **Title**                | Use collection expression                     |
 | **Category**             | Style                                         |
 | **Subcategory**          | Language rules (expression-level preferences) |
-| **Applicable languages** | C#                                            |
+| **Applicable languages** | C# 12+                                        |
 | **Options**              | `dotnet_style_prefer_collection_expression`   |
 
 ## Overview
 
-This rule flags places where a collection is built in a *fluent* manner, that is, where methods are chained. Instead, a [collection expression](../../../csharp/language-reference/operators/collection-expressions.md) could be used to initialize the collection.
+This rule flags places where a collection is built in a *fluent* manner, that is, where methods like `Add()`, `AddRange()`, `AsSpan()`, `ToList()`, and `ToArray()` are chained. Instead, a [collection expression](../../../csharp/language-reference/operators/collection-expressions.md) could be used to initialize the collection. For example, `x.AddRange(y).Add(z).AsSpan()` is converted to `[x, ..y, z]`.
 
 ## Options
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0305.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0305.md
@@ -1,6 +1,6 @@
 ---
-title: "IDE0305: Use collection expression"
-description: "Learn about code analysis rule IDE0305: Use collection expression"
+title: "IDE0305: Use collection expression for fluent"
+description: "Learn about code analysis rule IDE0305: Use collection expression for fluent"
 ms.date: 12/12/2023
 f1_keywords:
 - IDE0305
@@ -14,7 +14,7 @@ dev_langs:
 | Property                 | Value                                         |
 |--------------------------|-----------------------------------------------|
 | **Rule ID**              | IDE0305                                       |
-| **Title**                | Use collection expression                     |
+| **Title**                | Use collection expression for fluent          |
 | **Category**             | Style                                         |
 | **Subcategory**          | Language rules (expression-level preferences) |
 | **Applicable languages** | C# 12+                                        |

--- a/docs/fundamentals/code-analysis/style-rules/index.md
+++ b/docs/fundamentals/code-analysis/style-rules/index.md
@@ -1,7 +1,7 @@
 ---
 title: Code-style rules overview
 description: Learn about the different .NET code-style rules and categories.
-ms.date: 11/10/2023
+ms.date: 12/11/2023
 author: gewarren
 ms.author: gewarren
 ---
@@ -56,7 +56,7 @@ The following table list all the code-style rules by ID and [options](../code-st
 > | [IDE0025](ide0025.md) | Use expression body for properties | [csharp_style_expression_bodied_properties](ide0025.md#csharp_style_expression_bodied_properties) |
 > | [IDE0026](ide0026.md) | Use expression body for indexers | [csharp_style_expression_bodied_indexers](ide0026.md#csharp_style_expression_bodied_indexers) |
 > | [IDE0027](ide0027.md) | Use expression body for accessors | [csharp_style_expression_bodied_accessors](ide0027.md#csharp_style_expression_bodied_accessors) |
-> | [IDE0028](ide0028.md) | Use collection initializers | [dotnet_style_collection_initializer](ide0028.md#dotnet_style_collection_initializer)<br/>[dotnet_style_prefer_collection_expression](ide0028.md#dotnet_style_prefer_collection_expression) |
+> | [IDE0028](ide0028.md) | Use collection initializers | [dotnet_style_collection_initializer](ide0028.md#dotnet_style_collection_initializer) |
 > | [IDE0029](ide0029-ide0030-ide0270.md) | Null check can be simplified | [dotnet_style_coalesce_expression](ide0029-ide0030-ide0270.md#dotnet_style_coalesce_expression) |
 > | [IDE0030](ide0029-ide0030-ide0270.md) | Null check can be simplified | [dotnet_style_coalesce_expression](ide0029-ide0030-ide0270.md#dotnet_style_coalesce_expression) |
 > | [IDE0031](ide0031.md) | Use null propagation | [dotnet_style_null_propagation](ide0031.md#dotnet_style_null_propagation) |
@@ -135,7 +135,7 @@ The following table list all the code-style rules by ID and [options](../code-st
 > | [IDE0290](ide0290.md) | Use primary constructor | [csharp_style_prefer_primary_constructors](ide0290.md#csharp_style_prefer_primary_constructors) |
 > | [IDE0300](ide0300.md) | Use collection expression for array | [dotnet_style_prefer_collection_expression](ide0300.md#dotnet_style_prefer_collection_expression) |
 > | [IDE0301](ide0301.md) | Use collection expression for empty | [dotnet_style_prefer_collection_expression](ide0301.md#dotnet_style_prefer_collection_expression) |
-> | [IDE0302](ide0302.md) | Use collection expression for stack alloc | [dotnet_style_prefer_collection_expression](ide0302.md#dotnet_style_prefer_collection_expression) |
+> | [IDE0302](ide0302.md) | Use collection expression for stackalloc | [dotnet_style_prefer_collection_expression](ide0302.md#dotnet_style_prefer_collection_expression) |
 > | [IDE0303](ide0303.md) | Use collection expression for `Create()` | [dotnet_style_prefer_collection_expression](ide0303.md#dotnet_style_prefer_collection_expression) |
 > | [IDE0304](ide0304.md) | Use collection expression for builder | [dotnet_style_prefer_collection_expression](ide0304.md#dotnet_style_prefer_collection_expression) |
 > | [IDE0305](ide0305.md) | Use collection expression for fluent | [dotnet_style_prefer_collection_expression](ide0305.md#dotnet_style_prefer_collection_expression) |

--- a/docs/fundamentals/code-analysis/style-rules/index.md
+++ b/docs/fundamentals/code-analysis/style-rules/index.md
@@ -56,7 +56,7 @@ The following table list all the code-style rules by ID and [options](../code-st
 > | [IDE0025](ide0025.md) | Use expression body for properties | [csharp_style_expression_bodied_properties](ide0025.md#csharp_style_expression_bodied_properties) |
 > | [IDE0026](ide0026.md) | Use expression body for indexers | [csharp_style_expression_bodied_indexers](ide0026.md#csharp_style_expression_bodied_indexers) |
 > | [IDE0027](ide0027.md) | Use expression body for accessors | [csharp_style_expression_bodied_accessors](ide0027.md#csharp_style_expression_bodied_accessors) |
-> | [IDE0028](ide0028.md) | Use collection initializers | [dotnet_style_collection_initializer](ide0028.md#dotnet_style_collection_initializer) |
+> | [IDE0028](ide0028.md) | Use collection initializers | [dotnet_style_collection_initializer](ide0028.md#dotnet_style_collection_initializer)<br/>[dotnet_style_prefer_collection_expression](ide0028.md#dotnet_style_prefer_collection_expression) |
 > | [IDE0029](ide0029-ide0030-ide0270.md) | Null check can be simplified | [dotnet_style_coalesce_expression](ide0029-ide0030-ide0270.md#dotnet_style_coalesce_expression) |
 > | [IDE0030](ide0029-ide0030-ide0270.md) | Null check can be simplified | [dotnet_style_coalesce_expression](ide0029-ide0030-ide0270.md#dotnet_style_coalesce_expression) |
 > | [IDE0031](ide0031.md) | Use null propagation | [dotnet_style_null_propagation](ide0031.md#dotnet_style_null_propagation) |
@@ -133,6 +133,12 @@ The following table list all the code-style rules by ID and [options](../code-st
 > | [IDE0270](ide0029-ide0030-ide0270.md) | Null check can be simplified | [dotnet_style_coalesce_expression](ide0029-ide0030-ide0270.md#dotnet_style_coalesce_expression) |
 > | [IDE0280](ide0280.md) | Use `nameof` | |
 > | [IDE0290](ide0290.md) | Use primary constructor | [csharp_style_prefer_primary_constructors](ide0290.md#csharp_style_prefer_primary_constructors) |
+> | [IDE0300](ide0300.md) | Use collection expression for array | [dotnet_style_prefer_collection_expression](ide0300.md#dotnet_style_prefer_collection_expression) |
+> | [IDE0301](ide0301.md) | Use collection expression for empty | [dotnet_style_prefer_collection_expression](ide0301.md#dotnet_style_prefer_collection_expression) |
+> | [IDE0302](ide0302.md) | Use collection expression for stack alloc | [dotnet_style_prefer_collection_expression](ide0302.md#dotnet_style_prefer_collection_expression) |
+> | [IDE0303](ide0303.md) | Use collection expression for `Create()` | [dotnet_style_prefer_collection_expression](ide0303.md#dotnet_style_prefer_collection_expression) |
+> | [IDE0304](ide0304.md) | Use collection expression for builder | [dotnet_style_prefer_collection_expression](ide0304.md#dotnet_style_prefer_collection_expression) |
+> | [IDE0305](ide0305.md) | Use collection expression for fluent | [dotnet_style_prefer_collection_expression](ide0305.md#dotnet_style_prefer_collection_expression) |
 > | [IDE1005](ide1005.md) | Use conditional delegate call | [csharp_style_conditional_delegate_call](ide1005.md#csharp_style_conditional_delegate_call) |
 > | [IDE1006](naming-rules.md) | Naming styles | |
 

--- a/docs/fundamentals/code-analysis/style-rules/index.md
+++ b/docs/fundamentals/code-analysis/style-rules/index.md
@@ -56,7 +56,7 @@ The following table list all the code-style rules by ID and [options](../code-st
 > | [IDE0025](ide0025.md) | Use expression body for properties | [csharp_style_expression_bodied_properties](ide0025.md#csharp_style_expression_bodied_properties) |
 > | [IDE0026](ide0026.md) | Use expression body for indexers | [csharp_style_expression_bodied_indexers](ide0026.md#csharp_style_expression_bodied_indexers) |
 > | [IDE0027](ide0027.md) | Use expression body for accessors | [csharp_style_expression_bodied_accessors](ide0027.md#csharp_style_expression_bodied_accessors) |
-> | [IDE0028](ide0028.md) | Use collection initializers | [dotnet_style_collection_initializer](ide0028.md#dotnet_style_collection_initializer) |
+> | [IDE0028](ide0028.md) | Use collection initializers | [dotnet_style_collection_initializer](ide0028.md#dotnet_style_collection_initializer)<br/>[dotnet_style_prefer_collection_expression (C# only)](ide0028.md#dotnet_style_prefer_collection_expression-c-only) |
 > | [IDE0029](ide0029-ide0030-ide0270.md) | Null check can be simplified | [dotnet_style_coalesce_expression](ide0029-ide0030-ide0270.md#dotnet_style_coalesce_expression) |
 > | [IDE0030](ide0029-ide0030-ide0270.md) | Null check can be simplified | [dotnet_style_coalesce_expression](ide0029-ide0030-ide0270.md#dotnet_style_coalesce_expression) |
 > | [IDE0031](ide0031.md) | Use null propagation | [dotnet_style_null_propagation](ide0031.md#dotnet_style_null_propagation) |

--- a/docs/fundamentals/code-analysis/style-rules/language-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/language-rules.md
@@ -159,6 +159,12 @@ C# style rules:
 - [Use UTF-8 string literal (IDE0230)](ide0230.md)
 - [Nullable directive is redundant (IDE0240)](ide0240.md)
 - [Nullable directive is unnecessary (IDE0241)](ide0241.md)
+- [Use collection expression for array (IDE0300)](ide0300.md)
+- [Use collection expression for empty (IDE0301)](ide0301.md)
+- [Use collection expression for stack alloc (IDE0302)](ide0302.md)
+- [Use collection expression for `Create()` (IDE0303)](ide0303.md)
+- [Use collection expression for builder (IDE0304](ide0304.md)
+- [Use collection expression for fluent (IDE0305)](ide0305.md)
 
 Visual Basic style rules:
 

--- a/docs/navigate/tools-diagnostics/toc.yml
+++ b/docs/navigate/tools-diagnostics/toc.yml
@@ -1568,6 +1568,18 @@ items:
                     href: ../../fundamentals/code-analysis/style-rules/ide0280.md
                   - name: IDE0290
                     href: ../../fundamentals/code-analysis/style-rules/ide0290.md
+                  - name: IDE0300
+                    href: ../../fundamentals/code-analysis/style-rules/ide0300.md
+                  - name: IDE0301
+                    href: ../../fundamentals/code-analysis/style-rules/ide0301.md
+                  - name: IDE0302
+                    href: ../../fundamentals/code-analysis/style-rules/ide0302.md
+                  - name: IDE0303
+                    href: ../../fundamentals/code-analysis/style-rules/ide0303.md
+                  - name: IDE0304
+                    href: ../../fundamentals/code-analysis/style-rules/ide0304.md
+                  - name: IDE0305
+                    href: ../../fundamentals/code-analysis/style-rules/ide0305.md
                   - name: IDE1005
                     href: ../../fundamentals/code-analysis/style-rules/ide1005.md
               - name: Miscellaneous rules


### PR DESCRIPTION
Fixes https://github.com/dotnet/docs/issues/37130.
Fixes #38347.
Contributes to https://github.com/dotnet/docs/issues/28791.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/style-rules/csharp-formatting-options.md](https://github.com/dotnet/docs/blob/42caa68f438552bead46bf7a8c786eadaa664582/docs/fundamentals/code-analysis/style-rules/csharp-formatting-options.md) | [C# formatting options](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/csharp-formatting-options?branch=pr-en-us-38715) |
| [docs/fundamentals/code-analysis/style-rules/ide0028.md](https://github.com/dotnet/docs/blob/42caa68f438552bead46bf7a8c786eadaa664582/docs/fundamentals/code-analysis/style-rules/ide0028.md) | [Use collection initializers or expressions (IDE0028)](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0028?branch=pr-en-us-38715) |
| [docs/fundamentals/code-analysis/style-rules/ide0300.md](https://github.com/dotnet/docs/blob/42caa68f438552bead46bf7a8c786eadaa664582/docs/fundamentals/code-analysis/style-rules/ide0300.md) | ["IDE0300: Use collection expression for array"](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0300?branch=pr-en-us-38715) |
| [docs/fundamentals/code-analysis/style-rules/ide0301.md](https://github.com/dotnet/docs/blob/42caa68f438552bead46bf7a8c786eadaa664582/docs/fundamentals/code-analysis/style-rules/ide0301.md) | [Use collection expression for empty (IDE0301)](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0301?branch=pr-en-us-38715) |
| [docs/fundamentals/code-analysis/style-rules/ide0302.md](https://github.com/dotnet/docs/blob/42caa68f438552bead46bf7a8c786eadaa664582/docs/fundamentals/code-analysis/style-rules/ide0302.md) | [docs/fundamentals/code-analysis/style-rules/ide0302](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0302?branch=pr-en-us-38715) |
| [docs/fundamentals/code-analysis/style-rules/ide0303.md](https://github.com/dotnet/docs/blob/42caa68f438552bead46bf7a8c786eadaa664582/docs/fundamentals/code-analysis/style-rules/ide0303.md) | [Use collection expression for `Create()` (IDE0303)](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0303?branch=pr-en-us-38715) |
| [docs/fundamentals/code-analysis/style-rules/ide0304.md](https://github.com/dotnet/docs/blob/42caa68f438552bead46bf7a8c786eadaa664582/docs/fundamentals/code-analysis/style-rules/ide0304.md) | ["IDE0304: Use collection expression for builder"](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0304?branch=pr-en-us-38715) |
| [docs/fundamentals/code-analysis/style-rules/ide0305.md](https://github.com/dotnet/docs/blob/42caa68f438552bead46bf7a8c786eadaa664582/docs/fundamentals/code-analysis/style-rules/ide0305.md) | [Use collection expression for fluent (IDE0305)](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0305?branch=pr-en-us-38715) |
| [docs/fundamentals/code-analysis/style-rules/index.md](https://github.com/dotnet/docs/blob/42caa68f438552bead46bf7a8c786eadaa664582/docs/fundamentals/code-analysis/style-rules/index.md) | [docs/fundamentals/code-analysis/style-rules/index](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/index?branch=pr-en-us-38715) |
| [docs/fundamentals/code-analysis/style-rules/language-rules.md](https://github.com/dotnet/docs/blob/42caa68f438552bead46bf7a8c786eadaa664582/docs/fundamentals/code-analysis/style-rules/language-rules.md) | [Language and unnecessary rules](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/language-rules?branch=pr-en-us-38715) |


<!-- PREVIEW-TABLE-END -->