### PR TITLE
Add note about limitation of fast-path serialization

### DIFF
--- a/docs/standard/serialization/system-text-json/source-generation.md
+++ b/docs/standard/serialization/system-text-json/source-generation.md
@@ -207,9 +207,7 @@ services.AddControllers().AddJsonOptions(options =>
 > [!NOTE]
 > <xref:System.Text.Json.Serialization.JsonSourceGenerationMode.Serialization?displayProperty=nameWithType>, or fast-path serialization, isn't supported for asynchronous serialization.
 >
-> In .NET 7 and earlier versions, this limitation also applies to synchronous overloads of <xref:System.Text.Json.JsonSerializer.Serialize%2A?displayProperty=nameWithType> that accept a <xref:System.IO.Stream>. Starting with .NET 8, even though streaming serialization requires metadata-based models, it will fall back to fast-path if the payloads are known to be small enough to fit in the predetermined buffer size.
-
-See https://devblogs.microsoft.com/dotnet/performance-improvements-in-net-8/#json for more details.
+> In .NET 7 and earlier versions, this limitation also applies to synchronous overloads of <xref:System.Text.Json.JsonSerializer.Serialize%2A?displayProperty=nameWithType> that accept a <xref:System.IO.Stream>. Starting with .NET 8, even though streaming serialization requires metadata-based models, it will fall back to fast-path if the payloads are known to be small enough to fit in the predetermined buffer size. For more information, see <https://devblogs.microsoft.com/dotnet/performance-improvements-in-net-8/#json>.
 
 :::zone pivot="dotnet-8-0"
 

--- a/docs/standard/serialization/system-text-json/source-generation.md
+++ b/docs/standard/serialization/system-text-json/source-generation.md
@@ -205,7 +205,11 @@ services.AddControllers().AddJsonOptions(options =>
 :::zone-end
 
 > [!NOTE]
-> <xref:System.Text.Json.Serialization.JsonSourceGenerationMode.Serialization?displayProperty=nameWithType>, or fast-path serialization, isn't supported for asynchronous serialization. This limitation also applies to synchronous overloads of <xref:System.Text.Json.JsonSerializer.Serialize%2A?displayProperty=nameWithType> that accept a <xref:System.IO.Stream>.
+> <xref:System.Text.Json.Serialization.JsonSourceGenerationMode.Serialization?displayProperty=nameWithType>, or fast-path serialization, isn't supported for asynchronous serialization.
+>
+> In .NET 7 and earlier versions, this limitation also applies to synchronous overloads of <xref:System.Text.Json.JsonSerializer.Serialize%2A?displayProperty=nameWithType> that accept a <xref:System.IO.Stream>. Starting with .NET 8, even though streaming serialization requires metadata-based models, it will fall back to fast-path if the payloads are known to be small enough to fit in the predetermined buffer size.
+
+See https://devblogs.microsoft.com/dotnet/performance-improvements-in-net-8/#json for more details.
 
 :::zone pivot="dotnet-8-0"
 

--- a/docs/standard/serialization/system-text-json/source-generation.md
+++ b/docs/standard/serialization/system-text-json/source-generation.md
@@ -146,10 +146,6 @@ In Blazor apps, use overloads of <xref:System.Net.Http.Json.HttpClientJsonExtens
 
 Starting with .NET 8, you can also use overloads of <xref:System.Net.Http.Json.HttpClientJsonExtensions.GetFromJsonAsAsyncEnumerable%2A?displayProperty=nameWithType> extension methods that accept a source generation context or `TypeInfo<TValue>`.
 
-:::zone-end
-
-:::zone pivot="dotnet-8-0"
-
 In Razor Pages, MVC, SignalR, and Web API apps, use the <xref:System.Text.Json.JsonSerializerOptions.TypeInfoResolver?displayProperty=nameWithType> property to specify the context.
 
 ```csharp
@@ -207,6 +203,9 @@ services.AddControllers().AddJsonOptions(options =>
 ```
 
 :::zone-end
+
+> [!NOTE]
+> <xref:System.Text.Json.Serialization.JsonSourceGenerationMode.Serialization?displayProperty=nameWithType>, or fast-path serialization, isn't supported for asynchronous serialization. This includes synchronous overloads of <xref:System.Text.Json.JsonSerializer.Serialize%2A?displayProperty=nameWithType> that accept a <xref:System.IO.Stream>.
 
 :::zone pivot="dotnet-8-0"
 

--- a/docs/standard/serialization/system-text-json/source-generation.md
+++ b/docs/standard/serialization/system-text-json/source-generation.md
@@ -205,7 +205,7 @@ services.AddControllers().AddJsonOptions(options =>
 :::zone-end
 
 > [!NOTE]
-> <xref:System.Text.Json.Serialization.JsonSourceGenerationMode.Serialization?displayProperty=nameWithType>, or fast-path serialization, isn't supported for asynchronous serialization. This includes synchronous overloads of <xref:System.Text.Json.JsonSerializer.Serialize%2A?displayProperty=nameWithType> that accept a <xref:System.IO.Stream>.
+> <xref:System.Text.Json.Serialization.JsonSourceGenerationMode.Serialization?displayProperty=nameWithType>, or fast-path serialization, isn't supported for asynchronous serialization. This limitation also applies to synchronous overloads of <xref:System.Text.Json.JsonSerializer.Serialize%2A?displayProperty=nameWithType> that accept a <xref:System.IO.Stream>.
 
 :::zone pivot="dotnet-8-0"
 


### PR DESCRIPTION
Fixes #32897.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/serialization/system-text-json/source-generation.md](https://github.com/dotnet/docs/blob/bcd7e107cf579e38d71b324e4ee12c640d547bf0/docs/standard/serialization/system-text-json/source-generation.md) | [How to use source generation in System.Text.Json](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/source-generation?branch=pr-en-us-38757) |


<!-- PREVIEW-TABLE-END -->