### PR TITLE
Clarify L2 identifier names

### DIFF
--- a/docs/csharp/fundamentals/coding-style/identifier-names.md
+++ b/docs/csharp/fundamentals/coding-style/identifier-names.md
@@ -18,6 +18,9 @@ You can declare identifiers that match C# keywords by using the `@` prefix on th
 
 For a complete definition of valid identifiers, see the [Identifiers article in the C# Language Specification](~/_csharpstandard/standard/lexical-structure.md#643-identifiers).
 
+> [!IMPORTANT]
+> [The C# language specification](~/_csharpstandard/standard/lexical-structure.md#643-identifiers) only allows letter (Lu, Ll, Lt, Lm, Lo or Nl) , digit (Nd), connecting (Pc), combining (Mn or Mc) and formatting (Cf) categories. Anything outside that is automatically replaced using `_`. This may impact certain Unicode characters, including those within the GB18030-2022 Chinese government standard.
+
 ## Naming conventions
 
 In addition to the rules, conventions for identifier names are used throughout the .NET APIs. These conventions provide consistency for names, but the compiler doesn't enforce them. You're free to use different conventions in your projects.

--- a/docs/csharp/fundamentals/coding-style/identifier-names.md
+++ b/docs/csharp/fundamentals/coding-style/identifier-names.md
@@ -19,7 +19,7 @@ You can declare identifiers that match C# keywords by using the `@` prefix on th
 For a complete definition of valid identifiers, see the [Identifiers article in the C# Language Specification](~/_csharpstandard/standard/lexical-structure.md#643-identifiers).
 
 > [!IMPORTANT]
-> [The C# language specification](~/_csharpstandard/standard/lexical-structure.md#643-identifiers) only allows letter (Lu, Ll, Lt, Lm, Lo or Nl) , digit (Nd), connecting (Pc), combining (Mn or Mc) and formatting (Cf) categories. Anything outside that is automatically replaced using `_`. This may impact certain Unicode characters, including those within the GB18030-2022 Chinese government standard.
+> [The C# language specification](~/_csharpstandard/standard/lexical-structure.md#643-identifiers) only allows letter (Lu, Ll, Lt, Lm, Lo or Nl), digit (Nd), connecting (Pc), combining (Mn or Mc) and formatting (Cf) categories. Anything outside that is automatically replaced using `_`. This may impact certain Unicode characters, including those within the GB18030-2022 Chinese government standard.
 
 ## Naming conventions
 


### PR DESCRIPTION
Add an important note regarding L2 identifier names and the official GB18020-2022 standard.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/fundamentals/coding-style/identifier-names.md](https://github.com/dotnet/docs/blob/f29a4a1bb3997d8bf871fbe8fce6f9814f72a11d/docs/csharp/fundamentals/coding-style/identifier-names.md) | [C# identifier naming rules and conventions](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/identifier-names?branch=pr-en-us-38761) |


<!-- PREVIEW-TABLE-END -->