### PR TITLE
Add replaycheck test for customize properties article

### DIFF
--- a/.replaycheck/docs/standard/serialization/system-text-json/customize-properties.yml
+++ b/.replaycheck/docs/standard/serialization/system-text-json/customize-properties.yml
@@ -1,0 +1,11 @@
+# %version 1
+contentPath: docs\standard\serialization\system-text-json\customize-properties.md
+
+steps:
+- task: RunCodeSnippetReference@1
+  environment:
+    type: dotnet-sdk
+  outputValidationRules:
+  - operator: contains
+    value: '"WindSpeed": 10,'
+  uid: 666a9c3f

--- a/docs/standard/serialization/system-text-json/customize-properties.md
+++ b/docs/standard/serialization/system-text-json/customize-properties.md
@@ -39,6 +39,8 @@ Here's an example type to serialize and resulting JSON:
 :::code language="csharp" source="snippets/how-to/csharp/WeatherForecast.cs" id="WFWithPropertyNameAttribute":::
 :::code language="vb" source="snippets/how-to/vb/WeatherForecast.vb" id="WFWithPropertyNameAttribute":::
 
+The serialized output is as follows:
+
 ```json
 {
   "Date": "2019-08-01T00:00:00-07:00",
@@ -78,6 +80,8 @@ Here's an example class to serialize and JSON output:
 :::code language="csharp" source="snippets/how-to/csharp/WeatherForecast.cs" id="WFWithPropertyNameAttribute":::
 :::code language="vb" source="snippets/how-to/vb/WeatherForecast.vb" id="WFWithPropertyNameAttribute":::
 
+The serialized output is as follows:
+
 ```json
 {
   "date": "2019-08-01T00:00:00-07:00",
@@ -111,6 +115,8 @@ Here's an example class to serialize and JSON output:
 
 :::code language="csharp" source="snippets/how-to/csharp/WeatherForecast.cs" id="WFWithPropertyNameAttribute":::
 :::code language="vb" source="snippets/how-to/vb/WeatherForecast.vb" id="WFWithPropertyNameAttribute":::
+
+The serialized output is as follows:
 
 ```json
 {
@@ -226,6 +232,7 @@ To use the converter with source generation, see [Serialize enum fields as strin
 
 By default, properties are serialized in the order in which they're defined in their class. The [`[JsonPropertyOrder]`](xref:System.Text.Json.Serialization.JsonPropertyOrderAttribute) attribute lets you specify the order of properties in the JSON output from serialization. The default value of the `Order` property is zero. Set `Order` to a positive number to position a property after those that have the default value. A negative `Order` positions a property before those that have the default value. Properties are written in order from the lowest `Order` value to the highest. Here's an example:
 
+<!-- replaycheck-task id="666a9c3f" -->
 :::code language="csharp" source="snippets/how-to-6-0/csharp/PropertyOrder.cs":::
 
 ## See also


### PR DESCRIPTION
Most of the code snippets aren't complete programs, so I couldn't add tests for them.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/serialization/system-text-json/customize-properties.md](https://github.com/dotnet/docs/blob/198a9c65d95abb0c7578127ffe1f5c8c4ecf260e/docs/standard/serialization/system-text-json/customize-properties.md) | [How to customize property names and values with System.Text.Json](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/customize-properties?branch=pr-en-us-38762) |

<!-- PREVIEW-TABLE-END -->