### PR TITLE
Reflect in the documentation that the LOHThreshold has to be less than region_size

### DIFF
--- a/docs/core/runtime-config/garbage-collector.md
+++ b/docs/core/runtime-config/garbage-collector.md
@@ -669,6 +669,7 @@ Project file:
 - Specifies the threshold size, in bytes, that causes objects to go on the large object heap (LOH).
 - The default threshold is 85,000 bytes.
 - The value you specify must be larger than the default threshold.
+- The value can be capped by the runtime to the maximum possible size for the current configuration.
 
 | | Setting name | Values | Version introduced |
 | - | - | - | - |

--- a/docs/core/runtime-config/garbage-collector.md
+++ b/docs/core/runtime-config/garbage-collector.md
@@ -669,7 +669,7 @@ Project file:
 - Specifies the threshold size, in bytes, that causes objects to go on the large object heap (LOH).
 - The default threshold is 85,000 bytes.
 - The value you specify must be larger than the default threshold.
-- The value can be capped by the runtime to the maximum possible size for the current configuration. The value actually being used at runtime can be inspected through the [GC.GetConfigurationVariables](https://learn.microsoft.com/en-us/dotnet/api/system.gc.getconfigurationvariables) API.
+- The value might be capped by the runtime to the maximum possible size for the current configuration. You can inspect the value in use at run time through the <xref:System.GC.GetConfigurationVariables?displayProperty=nameWithType> API.
 
 | | Setting name | Values | Version introduced |
 | - | - | - | - |

--- a/docs/core/runtime-config/garbage-collector.md
+++ b/docs/core/runtime-config/garbage-collector.md
@@ -669,7 +669,7 @@ Project file:
 - Specifies the threshold size, in bytes, that causes objects to go on the large object heap (LOH).
 - The default threshold is 85,000 bytes.
 - The value you specify must be larger than the default threshold.
-- The value can be capped by the runtime to the maximum possible size for the current configuration.
+- The value can be capped by the runtime to the maximum possible size for the current configuration. The value actually being used at runtime can be inspected through the [GC.GetConfigurationVariables](https://learn.microsoft.com/en-us/dotnet/api/system.gc.getconfigurationvariables) API.
 
 | | Setting name | Values | Version introduced |
 | - | - | - | - |


### PR DESCRIPTION
## Summary

We recently discovered that we cannot let the user to allocate arbitrarily large objects in the small object heap, therefore we implement a change (https://github.com/dotnet/runtime/pull/95485) in the runtime and this change in the doc reflects that.

The actual cap is the `gc_region_size`. It is an implementation detail and it changes according to different user/machine configurations. Therefore, instead of specifying the maximum, we just said it could be capped. I am open to suggestion on how to make it sounds more clear.

The product code change fixes https://github.com/dotnet/runtime/issues/95219, and we don't have a docs issue for this.

@Maoni0, @dotnet/gc 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/runtime-config/garbage-collector.md](https://github.com/dotnet/docs/blob/a90b3470f6baf64a5278d1b68ce45628ed7d365a/docs/core/runtime-config/garbage-collector.md) | [Runtime configuration options for garbage collection](https://review.learn.microsoft.com/en-us/dotnet/core/runtime-config/garbage-collector?branch=pr-en-us-38763) |


<!-- PREVIEW-TABLE-END -->