### PR TITLE
Wrap `M1` and `M2` methods in `C` class to avoid compilation errors in examples of `IDE0002`

### DIFF
--- a/docs/fundamentals/code-analysis/style-rules/ide0002.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0002.md
@@ -33,28 +33,34 @@ This rule has no associated code-style options.
 ## Example
 
 ```csharp
-static void M1() { }
-static void M2()
+class C
 {
-    // IDE0002: 'C.M1' can be simplified to 'M1'
-    C.M1();
+    static void M1() { }
 
-    // Fixed code
-    M1();
+    static void M2()
+    {
+        // IDE0002: 'C.M1' can be simplified to 'M1'
+        C.M1();
+
+        // Fixed code
+        M1();
+    }
 }
 ```
 
 ```vb
-Shared Sub M1()
-End Sub
+Public Class C
+    Shared Sub M1()
+    End Sub
 
-Shared Sub M2()
-    ' IDE0002: 'C.M1' can be simplified to 'M1'
-    C.M1()
+    Shared Sub M2()
+        ' IDE0002: 'C.M1' can be simplified to 'M1'
+        C.M1()
 
-    ' Fixed code
-    M1()
-End Sub
+        ' Fixed code
+        M1()
+    End Sub
+End Class
 ```
 
 ## Suppress a warning


### PR DESCRIPTION
This pull request fixes #38771 
It wraps both VB and C# examples of static functions with `C` class so that the code can be correctly compiled.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/style-rules/ide0002.md](https://github.com/dotnet/docs/blob/7ba36effc626b08add1f1ee9681be59a81e1bd64/docs/fundamentals/code-analysis/style-rules/ide0002.md) | [Simplify member access (IDE0002)](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0002?branch=pr-en-us-38773) |

<!-- PREVIEW-TABLE-END -->