### PR TITLE
Expand on source link breaking change

### DIFF
--- a/docs/core/compatibility/sdk/8.0/source-link.md
+++ b/docs/core/compatibility/sdk/8.0/source-link.md
@@ -7,6 +7,9 @@ ms.date: 11/08/2023
 
 The [Source Link](https://github.com/dotnet/sourcelink) build tooling is now included in the .NET SDK. Source Link enables packages and applications to embed information about the source control information of the built artifacts. As a side effect, commit information is included in the `InformationalVersion` value of built libraries and applications.
 
+> [!NOTE]
+> This change affects any project that's built with the .NET 8 SDK, even those that target .NET 7 or an earlier version.
+
 ## Previous behavior
 
 Prior to this change, the default `InformationalVersion` of a library or application was the `Version` property.
@@ -30,3 +33,7 @@ Source Link enables rich editor tooling, like go-to-definition support for non-l
 ## Recommended action
 
 If your build process or code doesn't expect Source Revision information in `InformationalVersion`, you can disable the new behavior by setting the `IncludeSourceRevisionInInformationalVersion` property to `false` in your project file.
+
+## See also
+
+- <xref:System.Reflection.AssemblyInformationalVersionAttribute>

--- a/docs/core/compatibility/sdk/8.0/source-link.md
+++ b/docs/core/compatibility/sdk/8.0/source-link.md
@@ -34,6 +34,12 @@ Source Link enables rich editor tooling, like go-to-definition support for non-l
 
 If your build process or code doesn't expect Source Revision information in `InformationalVersion`, you can disable the new behavior by setting the `IncludeSourceRevisionInInformationalVersion` property to `false` in your project file.
 
+```xml
+<PropertyGroup>
+  <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
+</PropertyGroup>
+```
+
 ## See also
 
 - <xref:System.Reflection.AssemblyInformationalVersionAttribute>

--- a/docs/core/whats-new/dotnet-8.md
+++ b/docs/core/whats-new/dotnet-8.md
@@ -783,13 +783,13 @@ public class SecondModelNoNamespace
 }
 
 [OptionsValidator]
-public partial class FirstValidatorNoNamespace 
+public partial class FirstValidatorNoNamespace
     : IValidateOptions<FirstModelNoNamespace>
 {
 }
 
 [OptionsValidator]
-public partial class SecondValidatorNoNamespace 
+public partial class SecondValidatorNoNamespace
     : IValidateOptions<SecondModelNoNamespace>
 {
 }
@@ -1264,6 +1264,9 @@ The [template engine](https://github.com/dotnet/templating) provides a more secu
 ### Source Link
 
 [Source Link](../../standard/library-guidance/sourcelink.md) is now included in the .NET SDK. The goal is that by bundling Source Link into the SDK, instead of requiring a separate `<PackageReference>` for the package, more packages will include this information by default. That information will improve the IDE experience for developers.
+
+> [!NOTE]
+> As a side effect of this change, commit information is included in the `InformationalVersion` value of built libraries and applications, even those that target .NET 7 or an earlier version. For more information, see [Source Link included in the .NET SDK](../compatibility/sdk/8.0/source-link.md).
 
 ### Source-build SDK
 


### PR DESCRIPTION
Fixes #38404

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/sdk/8.0/source-link.md](https://github.com/dotnet/docs/blob/dce7dadb0e840335f1663c7cc20550419ded65d6/docs/core/compatibility/sdk/8.0/source-link.md) | [Source Link included in the .NET SDK](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/source-link?branch=pr-en-us-38777) |
| [docs/core/whats-new/dotnet-8.md](https://github.com/dotnet/docs/blob/dce7dadb0e840335f1663c7cc20550419ded65d6/docs/core/whats-new/dotnet-8.md) | [Copy everything else and build app.](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-8?branch=pr-en-us-38777) |

<!-- PREVIEW-TABLE-END -->