### PR TITLE
Clarify when rules are enabled by default

### DIFF
--- a/docs/fundamentals/code-analysis/overview.md
+++ b/docs/fundamentals/code-analysis/overview.md
@@ -2,7 +2,7 @@
 title: Code analysis in .NET
 titleSuffix: ""
 description: Learn about source code analysis in the .NET SDK.
-ms.date: 11/15/2023
+ms.date: 12/14/2023
 ms.topic: overview
 ms.custom: updateeachrelease
 helpviewer_keywords:
@@ -31,38 +31,38 @@ If rule violations are found by an analyzer, they're reported as a suggestion, w
 
 # [.NET 8](#tab/net-8)
 
-The following rules are enabled, by default, in .NET 8.
+The following rules are enabled, by default, as errors or warnings in .NET 8. Additional rules are enabled as suggestions.
 
-| Diagnostic ID | Category | Severity | Description |
-| - | - | - | - |
-| [CA1416](quality-rules/ca1416.md) | Interoperability | Warning | Validate platform compatibility |
-| [CA1417](quality-rules/ca1417.md) | Interoperability | Warning | Do not use `OutAttribute` on string parameters for P/Invokes |
-| [CA1418](quality-rules/ca1418.md) | Interoperability | Warning | Use valid platform string |
-| [CA1420](quality-rules/ca1420.md) | Interoperability | Warning | Using features that require runtime marshalling when it's disabled will result in run-time exceptions |
-| [CA1422](quality-rules/ca1422.md) | Interoperability | Warning | Validate platform compatibility |
-| [CA1831](quality-rules/ca1831.md) | Performance | Warning | Use `AsSpan` instead of range-based indexers for string when appropriate |
-| [CA1856](quality-rules/ca1856.md) | Performance | Error | Incorrect usage of `ConstantExpected` attribute |
-| [CA1857](quality-rules/ca1857.md) | Performance | Warning | A constant is expected for the parameter |
-| [CA2013](quality-rules/ca2013.md) | Reliability | Warning | Do not use `ReferenceEquals` with value types |
-| [CA2014](quality-rules/ca2014.md) | Reliability | Warning | Do not use `stackalloc` in loops |
-| [CA2015](quality-rules/ca2015.md) | Reliability | Warning | Do not define finalizers for types derived from <xref:System.Buffers.MemoryManager%601> |
-| [CA2017](quality-rules/ca2017.md) | Reliability | Warning | Parameter count mismatch |
-| [CA2018](quality-rules/ca2018.md) | Reliability | Warning | The `count` argument to `Buffer.BlockCopy` should specify the number of bytes to copy |
-| [CA2021](quality-rules/ca2021.md) | Reliability | Warning | Do not call `Enumerable.Cast<T>` or `Enumerable.OfType<T>` with incompatible types |
-| [CA2200](quality-rules/ca2200.md) | Usage | Warning | Rethrow to preserve stack details |
-| [CA2247](quality-rules/ca2247.md) | Usage | Warning | Argument passed to `TaskCompletionSource` constructor should be <xref:System.Threading.Tasks.TaskCreationOptions> enum instead of <xref:System.Threading.Tasks.TaskContinuationOptions> |
-| [CA2252](quality-rules/ca2252.md) | Usage | Error | Opt in to preview features |
-| [CA2255](quality-rules/ca2255.md) | Usage | Warning | The `ModuleInitializer` attribute should not be used in libraries |
-| [CA2256](quality-rules/ca2256.md) | Usage | Warning | All members declared in parent interfaces must have an implementation in a `DynamicInterfaceCastableImplementation`-attributed interface |
-| [CA2257](quality-rules/ca2257.md) | Usage | Warning | Members defined on an interface with the `DynamicInterfaceCastableImplementationAttribute` should be `static` |
-| [CA2258](quality-rules/ca2258.md) | Usage | Warning | Providing a `DynamicInterfaceCastableImplementation` interface in Visual Basic is unsupported |
-| [CA2259](quality-rules/ca2259.md) | Usage | Warning | `ThreadStatic` only affects static fields |
-| [CA2260](quality-rules/ca2260.md) | Usage | Warning | Use correct type parameter |
-| [CA2261](quality-rules/ca2261.md) | Usage | Warning | Do not use `ConfigureAwaitOptions.SuppressThrowing` with `Task<TResult>` |
+| Diagnostic ID | Category | Severity | Version added | Description |
+| - | - | - | - | - |
+| [CA1416](quality-rules/ca1416.md) | Interoperability | Warning | .NET 5 | Validate platform compatibility |
+| [CA1417](quality-rules/ca1417.md) | Interoperability | Warning | .NET 5 | Do not use `OutAttribute` on string parameters for P/Invokes |
+| [CA1418](quality-rules/ca1418.md) | Interoperability | Warning | .NET 6 | Use valid platform string |
+| [CA1420](quality-rules/ca1420.md) | Interoperability | Warning | .NET 7 | Using features that require runtime marshalling when it's disabled will result in run-time exceptions |
+| [CA1422](quality-rules/ca1422.md) | Interoperability | Warning | .NET 7 | Validate platform compatibility |
+| [CA1831](quality-rules/ca1831.md) | Performance | Warning | .NET 5 | Use `AsSpan` instead of range-based indexers for string when appropriate |
+| [CA1856](quality-rules/ca1856.md) | Performance | Error | .NET 8 | Incorrect usage of `ConstantExpected` attribute |
+| [CA1857](quality-rules/ca1857.md) | Performance | Warning | .NET 8 | A constant is expected for the parameter |
+| [CA2013](quality-rules/ca2013.md) | Reliability | Warning | .NET 5 | Do not use `ReferenceEquals` with value types |
+| [CA2014](quality-rules/ca2014.md) | Reliability | Warning | .NET 5 | Do not use `stackalloc` in loops |
+| [CA2015](quality-rules/ca2015.md) | Reliability | Warning | .NET 5 | Do not define finalizers for types derived from <xref:System.Buffers.MemoryManager%601> |
+| [CA2017](quality-rules/ca2017.md) | Reliability | Warning | .NET 6 | Parameter count mismatch |
+| [CA2018](quality-rules/ca2018.md) | Reliability | Warning | .NET 6 | The `count` argument to `Buffer.BlockCopy` should specify the number of bytes to copy |
+| [CA2021](quality-rules/ca2021.md) | Reliability | Warning | .NET 8 | Do not call `Enumerable.Cast<T>` or `Enumerable.OfType<T>` with incompatible types |
+| [CA2200](quality-rules/ca2200.md) | Usage | Warning | .NET 5 | Rethrow to preserve stack details |
+| [CA2247](quality-rules/ca2247.md) | Usage | Warning | .NET 5 | Argument passed to `TaskCompletionSource` constructor should be <xref:System.Threading.Tasks.TaskCreationOptions> enum instead of <xref:System.Threading.Tasks.TaskContinuationOptions> |
+| [CA2252](quality-rules/ca2252.md) | Usage | Error | .NET 6 | Opt in to preview features |
+| [CA2255](quality-rules/ca2255.md) | Usage | Warning | .NET 6 | The `ModuleInitializer` attribute should not be used in libraries |
+| [CA2256](quality-rules/ca2256.md) | Usage | Warning | .NET 6 | All members declared in parent interfaces must have an implementation in a `DynamicInterfaceCastableImplementation`-attributed interface |
+| [CA2257](quality-rules/ca2257.md) | Usage | Warning | .NET 6 | Members defined on an interface with the `DynamicInterfaceCastableImplementationAttribute` should be `static` |
+| [CA2258](quality-rules/ca2258.md) | Usage | Warning | .NET 6 | Providing a `DynamicInterfaceCastableImplementation` interface in Visual Basic is unsupported |
+| [CA2259](quality-rules/ca2259.md) | Usage | Warning | .NET 7 | `ThreadStatic` only affects static fields |
+| [CA2260](quality-rules/ca2260.md) | Usage | Warning | .NET 7 | Use correct type parameter |
+| [CA2261](quality-rules/ca2261.md) | Usage | Warning | .NET 8 | Do not use `ConfigureAwaitOptions.SuppressThrowing` with `Task<TResult>` |
 
 # [.NET 7](#tab/net-7)
 
-The following rules are enabled, by default, in .NET 7.
+The following rules are enabled, by default, as errors or warnings in .NET 7. Additional rules are enabled as suggestions.
 
 | Diagnostic ID | Category | Severity | Description |
 | - | - | - | - |
@@ -89,7 +89,7 @@ The following rules are enabled, by default, in .NET 7.
 
 # [.NET 6](#tab/net-6)
 
-The following rules are enabled, by default, in .NET 6.
+The following rules are enabled, by default, as errors or warnings in .NET 6. Additional rules are enabled as suggestions.
 
 | Diagnostic ID | Category | Severity | Description |
 | - | - | - | - |

--- a/docs/fundamentals/code-analysis/quality-rules/ca1016.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1016.md
@@ -22,7 +22,7 @@ dev_langs:
 | **Title**                           | Mark assemblies with AssemblyVersionAttribute |
 | **Category**                        | [Design](design-warnings.md)                  |
 | **Fix is breaking or non-breaking** | Non-breaking                                  |
-| **Enabled by default in .NET 8**    | No                                            |
+| **Enabled by default in .NET 8**    | As suggestion                                 |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1018.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1018.md
@@ -22,7 +22,7 @@ dev_langs:
 | **Title**                           | Mark attributes with AttributeUsageAttribute |
 | **Category**                        | [Design](design-warnings.md)                 |
 | **Fix is breaking or non-breaking** | Breaking                                     |
-| **Enabled by default in .NET 8**    | No                                           |
+| **Enabled by default in .NET 8**    | As suggestion                                |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1041.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1041.md
@@ -22,7 +22,7 @@ dev_langs:
 | **Title**                           | Provide ObsoleteAttribute message |
 | **Category**                        | [Design](design-warnings.md)      |
 | **Fix is breaking or non-breaking** | Non-breaking                      |
-| **Enabled by default in .NET 8**    | No                                |
+| **Enabled by default in .NET 8**    | As suggestion                     |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1047.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1047.md
@@ -22,7 +22,7 @@ dev_langs:
 | **Title**                           | Do not declare protected members in sealed types |
 | **Category**                        | [Design](design-warnings.md)                     |
 | **Fix is breaking or non-breaking** | Non-breaking                                     |
-| **Enabled by default in .NET 8**    | No                                               |
+| **Enabled by default in .NET 8**    | As suggestion                                    |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1050.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1050.md
@@ -22,7 +22,7 @@ dev_langs:
 | **Title**                           | Declare types in namespaces  |
 | **Category**                        | [Design](design-warnings.md) |
 | **Fix is breaking or non-breaking** | Breaking                     |
-| **Enabled by default in .NET 8**    | No                           |
+| **Enabled by default in .NET 8**    | As suggestion                |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1061.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1061.md
@@ -19,7 +19,7 @@ ms.author: gewarren
 | **Title**                           | Do not hide base class methods |
 | **Category**                        | [Design](design-warnings.md)   |
 | **Fix is breaking or non-breaking** | Breaking                       |
-| **Enabled by default in .NET 8**    | No                             |
+| **Enabled by default in .NET 8**    | As suggestion                  |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1067.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1067.md
@@ -17,7 +17,7 @@ ms.author: mavasani
 | **Title**                           | Override Equals when implementing IEquatable |
 | **Category**                        | [Design](design-warnings.md)                 |
 | **Fix is breaking or non-breaking** | Non-breaking                                 |
-| **Enabled by default in .NET 8**    | No                                           |
+| **Enabled by default in .NET 8**    | As suggestion                                |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1068.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1068.md
@@ -19,7 +19,7 @@ ms.author: mavasani
 | **Title**                           | CancellationToken parameters must come last |
 | **Category**                        | [Design](design-warnings.md)                |
 | **Fix is breaking or non-breaking** | Breaking                                    |
-| **Enabled by default in .NET 8**    | No                                          |
+| **Enabled by default in .NET 8**    | As suggestion                               |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1069.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1069.md
@@ -17,7 +17,7 @@ ms.author: mavasani
 | **Title**                           | Enums should not have duplicate values |
 | **Category**                        | [Design](design-warnings.md)           |
 | **Fix is breaking or non-breaking** | Breaking                               |
-| **Enabled by default in .NET 8**    | No                                     |
+| **Enabled by default in .NET 8**    | As suggestion                          |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1070.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1070.md
@@ -17,7 +17,7 @@ ms.author: mavasani
 | **Title**                           | Do not declare event fields as virtual |
 | **Category**                        | [Design](design-warnings.md)           |
 | **Fix is breaking or non-breaking** | Breaking                               |
-| **Enabled by default in .NET 8**    | No                                     |
+| **Enabled by default in .NET 8**    | As suggestion                          |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1401.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1401.md
@@ -22,7 +22,7 @@ dev_langs:
 | **Title**                           | P/Invokes should not be visible                  |
 | **Category**                        | [Interoperability](interoperability-warnings.md) |
 | **Fix is breaking or non-breaking** | Breaking                                         |
-| **Enabled by default in .NET 8**    | No                                               |
+| **Enabled by default in .NET 8**    | As suggestion                                    |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1416.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1416.md
@@ -19,7 +19,7 @@ ms.author: bunamnan
 | **Title**                           | Validate platform compatibility                  |
 | **Category**                        | [Interoperability](interoperability-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                                     |
-| **Enabled by default in .NET 8**    | Yes                                              |
+| **Enabled by default in .NET 8**    | As warning                                       |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1417.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1417.md
@@ -19,7 +19,7 @@ ms.author: elfung
 | **Title**                           | Do not use `OutAttribute` on string parameters for P/Invokes |
 | **Category**                        | [Interoperability](interoperability-warnings.md)             |
 | **Fix is breaking or non-breaking** | Non-breaking                                                 |
-| **Enabled by default in .NET 8**    | Yes                                                          |
+| **Enabled by default in .NET 8**    | As warning                                                   |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1418.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1418.md
@@ -19,7 +19,7 @@ ms.author: bunamnan
 | **Title**                           | Validate platform compatibility                  |
 | **Category**                        | [Interoperability](interoperability-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                                     |
-| **Enabled by default in .NET 8**    | Yes                                              |
+| **Enabled by default in .NET 8**    | As warning                                       |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1419.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1419.md
@@ -12,13 +12,13 @@ author: Youssef1313
 ---
 # CA1419: Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
 
-| Property                            | Value                                                                                                                                                     |
-|-------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Rule ID**                         | CA1419                                                                                                                                                    |
-| **Title**                           | Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle' |
-| **Category**                        | [Interoperability](interoperability-warnings.md)                                                                                                          |
-| **Fix is breaking or non-breaking** | Non-breaking                                                                                                                                              |
-| **Enabled by default in .NET 8**    | No                                                                                                                                                        |
+| Property | Value |
+|--|--|
+| **Rule ID** | CA1419 |
+| **Title** | Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle' |
+| **Category** | [Interoperability](interoperability-warnings.md) |
+| **Fix is breaking or non-breaking** | Non-breaking |
+| **Enabled by default in .NET 8** | As suggestion |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1420.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1420.md
@@ -18,7 +18,7 @@ dev_langs:
 | **Title**                           | Property, type, or attribute requires runtime marshalling |
 | **Category**                        | [Interoperability](interoperability-warnings.md)          |
 | **Fix is breaking or non-breaking** | Breaking                                                  |
-| **Enabled by default in .NET 8**    | Yes                                                       |
+| **Enabled by default in .NET 8**    | As warning                                                |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1421.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1421.md
@@ -19,7 +19,7 @@ dev_langs:
 | **Title**                           | Method uses runtime marshalling when DisableRuntimeMarshallingAttribute is applied |
 | **Category**                        | [Interoperability](interoperability-warnings.md)                                   |
 | **Fix is breaking or non-breaking** | Non-breaking                                                                       |
-| **Enabled by default in .NET 8**    | No                                                                                 |
+| **Enabled by default in .NET 8**    | As suggestion                                                                      |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1422.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1422.md
@@ -18,7 +18,7 @@ dev_langs:
 | **Title**                           | Validate platform compatibility - obsoleted APIs |
 | **Category**                        | [Interoperability](interoperability-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                                     |
-| **Enabled by default in .NET 8**    | Yes                                              |
+| **Enabled by default in .NET 8**    | As warning                                       |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1507.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1507.md
@@ -1,7 +1,7 @@
 ---
 title: "CA1507: Use nameof instead of string (code analysis)"
 description: "Learn about code analysis rule CA1507: Use nameof instead of string"
-ms.date: 06/13/2020
+ms.date: 12/14/2023
 f1_keywords:
 - UseNameofInPlaceOfString
 - CA1507
@@ -19,7 +19,7 @@ ms.author: gewarren
 | **Title**                           | Use `nameof` in place of string                |
 | **Category**                        | [Maintainability](maintainability-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                                   |
-| **Enabled by default in .NET 8**    | No                                             |
+| **Enabled by default in .NET 8**    | As suggestion                                  |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1510.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1510.md
@@ -15,7 +15,7 @@ helpviewer_keywords:
 | **Title**                           | Use ArgumentNullException throw helper         |
 | **Category**                        | [Maintainability](maintainability-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-Breaking                                   |
-| **Enabled by default in .NET 8**    | No                                             |
+| **Enabled by default in .NET 8**    | As suggestion                                  |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1511.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1511.md
@@ -15,7 +15,7 @@ helpviewer_keywords:
 | **Title**                           | Use ArgumentException throw helper             |
 | **Category**                        | [Maintainability](maintainability-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-Breaking                                   |
-| **Enabled by default in .NET 8**    | No                                             |
+| **Enabled by default in .NET 8**    | As suggestion                                  |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1512.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1512.md
@@ -15,7 +15,7 @@ helpviewer_keywords:
 | **Title**                           | Use ArgumentOutOfRangeException throw helper   |
 | **Category**                        | [Maintainability](maintainability-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-Breaking                                   |
-| **Enabled by default in .NET 8**    | No                                             |
+| **Enabled by default in .NET 8**    | As suggestion                                  |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1513.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1513.md
@@ -15,7 +15,7 @@ helpviewer_keywords:
 | **Title**                           | Use ObjectDisposedException throw helper       |
 | **Category**                        | [Maintainability](maintainability-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-Breaking                                   |
-| **Enabled by default in .NET 8**    | No                                             |
+| **Enabled by default in .NET 8**    | As suggestion                                  |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1514.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1514.md
@@ -22,7 +22,7 @@ dev_langs:
 | **Title**                           | Avoid redundant length argument                |
 | **Category**                        | [Maintainability](maintainability-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                                   |
-| **Enabled by default in .NET 8**    | No                                             |
+| **Enabled by default in .NET 8**    | As suggestion                                  |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1806.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1806.md
@@ -22,7 +22,7 @@ dev_langs:
 | **Title**                           | Do not ignore method results           |
 | **Category**                        | [Performance](performance-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 8**    | No                                     |
+| **Enabled by default in .NET 8**    | As suggestion                          |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1816.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1816.md
@@ -22,7 +22,7 @@ dev_langs:
 | **Title**                           | Call GC.SuppressFinalize correctly |
 | **Category**                        | [Usage](usage-warnings.md)         |
 | **Fix is breaking or non-breaking** | Non-breaking                       |
-| **Enabled by default in .NET 8**    | No                                 |
+| **Enabled by default in .NET 8**    | As suggestion                      |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1821.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1821.md
@@ -18,7 +18,7 @@ ms.author: gewarren
 | **Title**                           | Remove empty finalizers                |
 | **Category**                        | [Performance](performance-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 8**    | No                                     |
+| **Enabled by default in .NET 8**    | As suggestion                          |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1822.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1822.md
@@ -13,13 +13,13 @@ ms.author: gewarren
 ---
 # CA1822: Mark members as static
 
-| Property                            | Value                                                                                                |
-|-------------------------------------|------------------------------------------------------------------------------------------------------|
-| **Rule ID**                         | CA1822                                                                                               |
-| **Title**                           | Mark members as static                                                                               |
-| **Category**                        | [Performance](performance-warnings.md)                                                               |
-| **Fix is breaking or non-breaking** | Non-breaking - If the member is not visible outside the assembly, regardless of the change you make. <br /><br />Non-breaking - If you just change the member to an instance member with the `this` keyword.<br/><br/>Breaking - If you change the member from an instance member to a static member and it is visible outside the assembly. |
-| **Enabled by default in .NET 8**    | No                                                                                                   |
+| Property     | Value                                  |
+|--------------|----------------------------------------|
+| **Rule ID**  | CA1822                                 |
+| **Title**    | Mark members as static                 |
+| **Category** | [Performance](performance-warnings.md) |
+| **Fix is breaking or non-breaking** | Non-breaking - If the member is not visible outside the assembly, regardless of the change you make.<br/><br/>Non-breaking - If you just change the member to an instance member with the `this` keyword.<br/><br/>Breaking - If you change the member from an instance member to a static member and it is visible outside the assembly. |
+| **Enabled by default in .NET 8** | As suggestion |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1824.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1824.md
@@ -1,7 +1,7 @@
 ---
 title: "CA1824: Mark assemblies with NeutralResourcesLanguageAttribute (code analysis)"
 description: "Learn about code analysis rule CA1824: Mark assemblies with NeutralResourcesLanguageAttribute"
-ms.date: 03/29/2018
+ms.date: 12/14/2023
 f1_keywords:
 - CA1824
 - MarkAssembliesWithNeutralResourcesLanguage
@@ -19,7 +19,7 @@ ms.author: gewarren
 | **Title**                           | Mark assemblies with NeutralResourcesLanguageAttribute |
 | **Category**                        | [Performance](performance-warnings.md)                 |
 | **Fix is breaking or non-breaking** | Non-breaking                                           |
-| **Enabled by default in .NET 8**    | No                                                     |
+| **Enabled by default in .NET 8**    | As suggestion                                          |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1825.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1825.md
@@ -21,7 +21,7 @@ dev_langs:
 | **Title**                           | Avoid zero-length array allocations    |
 | **Category**                        | [Performance](performance-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 8**    | No                                     |
+| **Enabled by default in .NET 8**    | As suggestion                          |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1826.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1826.md
@@ -19,7 +19,7 @@ ms.author: mavasani
 | **Title**                           | Use property instead of Linq Enumerable method |
 | **Category**                        | [Performance](performance-warnings.md)         |
 | **Fix is breaking or non-breaking** | Non-breaking                                   |
-| **Enabled by default in .NET 8**    | No                                             |
+| **Enabled by default in .NET 8**    | As suggestion                                  |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1827.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1827.md
@@ -19,7 +19,7 @@ ms.author: mavasani
 | **Title**                           | Do not use Count()/LongCount() when Any() can be used |
 | **Category**                        | [Performance](performance-warnings.md)                |
 | **Fix is breaking or non-breaking** | Non-breaking                                          |
-| **Enabled by default in .NET 8**    | No                                                    |
+| **Enabled by default in .NET 8**    | As suggestion                                         |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1828.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1828.md
@@ -19,7 +19,7 @@ ms.author: mavasani
 | **Title**                           | Do not use CountAsync/LongCountAsync when AnyAsync can be used |
 | **Category**                        | [Performance](performance-warnings.md)                         |
 | **Fix is breaking or non-breaking** | Non-breaking                                                   |
-| **Enabled by default in .NET 8**    | No                                                             |
+| **Enabled by default in .NET 8**    | As suggestion                                                  |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1829.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1829.md
@@ -19,7 +19,7 @@ ms.author: mavasani
 | **Title**                           | Use Length/Count property instead of Enumerable.Count method |
 | **Category**                        | [Performance](performance-warnings.md)                       |
 | **Fix is breaking or non-breaking** | Non-breaking                                                 |
-| **Enabled by default in .NET 8**    | No                                                           |
+| **Enabled by default in .NET 8**    | As suggestion                                                |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1830.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1830.md
@@ -19,7 +19,7 @@ ms.author: stoub
 | **Title**                           | Prefer strongly-typed Append and Insert method overloads on StringBuilder |
 | **Category**                        | [Performance](performance-warnings.md)                                    |
 | **Fix is breaking or non-breaking** | Non-breaking                                                              |
-| **Enabled by default in .NET 8**    | No                                                                        |
+| **Enabled by default in .NET 8**    | As suggestion                                                             |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1831.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1831.md
@@ -19,7 +19,7 @@ ms.author: bunamnan
 | **Title**                           | Use AsSpan instead of Range-based indexers for string when appropriate |
 | **Category**                        | [Performance](performance-warnings.md)                                 |
 | **Fix is breaking or non-breaking** | Non-breaking                                                           |
-| **Enabled by default in .NET 8**    | Yes                                                                    |
+| **Enabled by default in .NET 8**    | As warning                                                             |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1832.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1832.md
@@ -13,13 +13,13 @@ ms.author: bunamnan
 ---
 # CA1832: Use AsSpan or AsMemory instead of Range-based indexers for getting ReadOnlySpan or ReadOnlyMemory portion of an array
 
-| Property                            | Value                                                                                                                 |
-|-------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
-| **Rule ID**                         | CA1832                                                                                                                |
-| **Title**                           | Use AsSpan or AsMemory instead of Range-based indexers for getting ReadOnlySpan or ReadOnlyMemory portion of an array |
-| **Category**                        | [Performance](performance-warnings.md)                                                                                |
-| **Fix is breaking or non-breaking** | Non-breaking                                                                                                          |
-| **Enabled by default in .NET 8**    | No                                                                                                                    |
+| Property | Value |
+|--|--|
+| **Rule ID** | CA1832 |
+| **Title** | Use AsSpan or AsMemory instead of Range-based indexers for getting ReadOnlySpan or ReadOnlyMemory portion of an array |
+| **Category** | [Performance](performance-warnings.md) |
+| **Fix is breaking or non-breaking** | Non-breaking |
+| **Enabled by default in .NET 8** | As suggestion |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1833.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1833.md
@@ -13,13 +13,13 @@ ms.author: bunamnan
 ---
 # CA1833: Use AsSpan or AsMemory instead of Range-based indexers for getting Span or Memory portion of an array
 
-| Property                            | Value                                                                                                 |
-|-------------------------------------|-------------------------------------------------------------------------------------------------------|
-| **Rule ID**                         | CA1833                                                                                                |
-| **Title**                           | Use AsSpan or AsMemory instead of Range-based indexers for getting Span or Memory portion of an array |
-| **Category**                        | [Performance](performance-warnings.md)                                                                |
-| **Fix is breaking or non-breaking** | Non-breaking                                                                                          |
-| **Enabled by default in .NET 8**    | No                                                                                                    |
+| Property | Value |
+|--|--|
+| **Rule ID** | CA1833 |
+| **Title** | Use AsSpan or AsMemory instead of Range-based indexers for getting Span or Memory portion of an array |
+| **Category** | [Performance](performance-warnings.md) |
+| **Fix is breaking or non-breaking** | Non-breaking |
+| **Enabled by default in .NET 8** | As suggestion |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1834.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1834.md
@@ -18,7 +18,7 @@ author: pgovind
 | **Title**                           | Use StringBuilder.Append(char) for single character strings |
 | **Category**                        | [Performance](performance-warnings.md)                      |
 | **Fix is breaking or non-breaking** | Non-breaking                                                |
-| **Enabled by default in .NET 8**    | No                                                          |
+| **Enabled by default in .NET 8**    | As suggestion                                               |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1835.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1835.md
@@ -23,7 +23,7 @@ dev_langs:
 | **Title**                           | Prefer the memory-based overloads of ReadAsync/WriteAsync methods in stream-based classes |
 | **Category**                        | [Performance](performance-warnings.md)                                                    |
 | **Fix is breaking or non-breaking** | Non-breaking                                                                              |
-| **Enabled by default in .NET 8**    | No                                                                                        |
+| **Enabled by default in .NET 8**    | As suggestion                                                                             |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1836.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1836.md
@@ -19,7 +19,7 @@ ms.author: dacantu
 | **Title**                           | Prefer IsEmpty over Count when available |
 | **Category**                        | [Performance](performance-warnings.md)   |
 | **Fix is breaking or non-breaking** | Non-breaking                             |
-| **Enabled by default in .NET 8**    | No                                       |
+| **Enabled by default in .NET 8**    | As suggestion                            |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1837.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1837.md
@@ -22,7 +22,7 @@ dev_langs:
 | **Title**                           | Use Environment.ProcessId instead of Process.GetCurrentProcess().Id |
 | **Category**                        | [Performance](performance-warnings.md)                              |
 | **Fix is breaking or non-breaking** | Non-breaking                                                        |
-| **Enabled by default in .NET 8**    | No                                                                  |
+| **Enabled by default in .NET 8**    | As suggestion                                                       |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1839.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1839.md
@@ -20,7 +20,7 @@ dev_langs:
 | **Title**                           | Use Environment.ProcessPath instead of Process.GetCurrentProcess().MainModule.FileName |
 | **Category**                        | [Performance](performance-warnings.md)                                                 |
 | **Fix is breaking or non-breaking** | Non-breaking                                                                           |
-| **Enabled by default in .NET 8**    | No                                                                                     |
+| **Enabled by default in .NET 8**    | As suggestion                                                                          |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1840.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1840.md
@@ -20,7 +20,7 @@ dev_langs:
 | **Title**                           | Use Environment.CurrentManagedThreadId instead of Thread.CurrentThread.ManagedThreadId |
 | **Category**                        | [Performance](performance-warnings.md)                                                 |
 | **Fix is breaking or non-breaking** | Non-breaking                                                                           |
-| **Enabled by default in .NET 8**    | No                                                                                     |
+| **Enabled by default in .NET 8**    | As suggestion                                                                          |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1841.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1841.md
@@ -21,7 +21,7 @@ dev_langs:
 | **Title**                           | Prefer Dictionary Contains methods     |
 | **Category**                        | [Performance](performance-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 8**    | No                                     |
+| **Enabled by default in .NET 8**    | As suggestion                          |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1842.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1842.md
@@ -18,7 +18,7 @@ author: Youssef1313
 | **Title**                           | Do not use 'WhenAll' with a single task |
 | **Category**                        | [Performance](performance-warnings.md)  |
 | **Fix is breaking or non-breaking** | Non-breaking                            |
-| **Enabled by default in .NET 8**    | No                                      |
+| **Enabled by default in .NET 8**    | As suggestion                           |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1843.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1843.md
@@ -18,7 +18,7 @@ author: Youssef1313
 | **Title**                           | Do not use 'WaitAll' with a single task |
 | **Category**                        | [Performance](performance-warnings.md)  |
 | **Fix is breaking or non-breaking** | Non-breaking                            |
-| **Enabled by default in .NET 8**    | No                                      |
+| **Enabled by default in .NET 8**    | As suggestion                           |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1844.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1844.md
@@ -21,7 +21,7 @@ dev_langs:
 | **Title**                           | Provide memory-based overrides of async methods when subclassing 'Stream' |
 | **Category**                        | [Performance](performance-warnings.md)                                    |
 | **Fix is breaking or non-breaking** | Non-breaking                                                              |
-| **Enabled by default in .NET 8**    | No                                                                        |
+| **Enabled by default in .NET 8**    | As suggestion                                                             |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1845.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1845.md
@@ -20,7 +20,7 @@ dev_langs:
 | **Title**                           | Use span-based 'string.Concat'         |
 | **Category**                        | [Performance](performance-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 8**    | No                                     |
+| **Enabled by default in .NET 8**    | As suggestion                          |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1846.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1846.md
@@ -21,7 +21,7 @@ dev_langs:
 | **Title**                           | Prefer `AsSpan` over `Substring`       |
 | **Category**                        | [Performance](performance-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 8**    | No                                     |
+| **Enabled by default in .NET 8**    | As suggestion                          |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1847.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1847.md
@@ -20,7 +20,7 @@ dev_langs:
 | **Title**                           | Use string.Contains(char) instead of string.Contains(string) with single characters |
 | **Category**                        | [Performance](performance-warnings.md)                                              |
 | **Fix is breaking or non-breaking** | Non-breaking                                                                        |
-| **Enabled by default in .NET 8**    | No                                                                                  |
+| **Enabled by default in .NET 8**    | As suggestion                                                                       |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1850.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1850.md
@@ -20,7 +20,7 @@ dev_langs:
 | **Title**                           | Prefer static `HashData` method over `ComputeHash` |
 | **Category**                        | [Performance](performance-warnings.md)             |
 | **Fix is breaking or non-breaking** | Non-breaking                                       |
-| **Enabled by default in .NET 8**    | No                                                 |
+| **Enabled by default in .NET 8**    | As suggestion                                      |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1853.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1853.md
@@ -21,7 +21,7 @@ dev_langs:
 | **Category**                        | [Performance](performance-warnings.md)            |
 | **Fix is breaking or non-breaking** | Non-breaking                                      |
 | **Introduced version**              | .NET 7                                            |
-| **Enabled by default in .NET 8**    | No                                                |
+| **Enabled by default in .NET 8**    | As suggestion                                     |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1854.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1854.md
@@ -21,7 +21,7 @@ dev_langs:
 | **Title**                           | Prefer the `IDictionary.TryGetValue(TKey, out TValue)` method |
 | **Category**                        | [Performance](performance-warnings.md)                        |
 | **Fix is breaking or non-breaking** | Non-breaking                                                  |
-| **Enabled by default in .NET 8**    | No                                                            |
+| **Enabled by default in .NET 8**    | As suggestion                                                 |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1855.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1855.md
@@ -19,7 +19,7 @@ dev_langs:
 | **Title**                           | Use Span\<T>.Clear() instead of Span\<T>.Fill() |
 | **Category**                        | [Performance](performance-warnings.md)          |
 | **Fix is breaking or non-breaking** | Non-breaking                                    |
-| **Enabled by default in .NET 8**    | No                                              |
+| **Enabled by default in .NET 8**    | As suggestion                                   |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1856.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1856.md
@@ -18,7 +18,7 @@ dev_langs:
 | **Title**                           | Incorrect usage of ConstantExpected attribute |
 | **Category**                        | [Performance](performance-warnings.md)        |
 | **Fix is breaking or non-breaking** | Non-breaking                                  |
-| **Enabled by default in .NET 8**    | Yes                                           |
+| **Enabled by default in .NET 8**    | As error                                      |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1857.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1857.md
@@ -18,7 +18,7 @@ dev_langs:
 | **Title**                           | The parameter expects a constant for optimal performance |
 | **Category**                        | [Performance](performance-warnings.md)                   |
 | **Fix is breaking or non-breaking** | Non-breaking                                             |
-| **Enabled by default in .NET 8**    | Yes                                                      |
+| **Enabled by default in .NET 8**    | As warning                                               |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1858.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1858.md
@@ -20,7 +20,7 @@ dev_langs:
 | **Title**                           | Use StartsWith instead of IndexOf      |
 | **Category**                        | [Performance](performance-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 8**    | No                                     |
+| **Enabled by default in .NET 8**    | As suggestion                          |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1859.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1859.md
@@ -18,7 +18,7 @@ helpviewer_keywords:
 | **Category**                        | [Performance](performance-warnings.md)                    |
 | **Fix is breaking or non-breaking** | Non-breaking                                              |
 | **Introduced version**              | .NET 8                                                    |
-| **Enabled by default in .NET 8**    | No                                                        |
+| **Enabled by default in .NET 8**    | As suggestion                                             |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1860.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1860.md
@@ -20,7 +20,7 @@ dev_langs:
 | **Title**                           | Avoid using 'Enumerable.Any()' extension method |
 | **Category**                        | [Performance](performance-warnings.md)          |
 | **Fix is breaking or non-breaking** | Non-breaking                                    |
-| **Enabled by default in .NET 8**    | No                                              |
+| **Enabled by default in .NET 8**    | As suggestion                                   |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1861.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1861.md
@@ -22,7 +22,7 @@ dev_langs:
 | **Title**                           | Avoid constant arrays as arguments     |
 | **Category**                        | [Performance](performance-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 8**    | No                                     |
+| **Enabled by default in .NET 8**    | As suggestion                          |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1862.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1862.md
@@ -19,7 +19,7 @@ dev_langs:
 | **Title**                           | Use the 'StringComparison' method overloads to perform case-insensitive string comparisons |
 | **Category**                        | [Performance](performance-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 8**    | No                                     |
+| **Enabled by default in .NET 8**    | As suggestion                          |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1864.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1864.md
@@ -20,7 +20,7 @@ dev_langs:
 | **Title**                           | Prefer the 'IDictionary.TryAdd(TKey, TValue)' method |
 | **Category**                        | [Performance](performance-warnings.md)               |
 | **Fix is breaking or non-breaking** | Non-breaking                                         |
-| **Enabled by default in .NET 8**    | No                                                   |
+| **Enabled by default in .NET 8**    | As suggestion                                        |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1865-ca1867.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1865-ca1867.md
@@ -24,7 +24,9 @@ author: mrahhal
 | **Title**                           | Use 'string.Method(char)' instead of 'string.Method(string)' for string with single char |
 | **Category**                        | [Performance](performance-warnings.md)                                                   |
 | **Fix is breaking or non-breaking** | Non-breaking                                                                             |
-| **Enabled by default in .NET 8**    | No                                                                                       |
+| **Enabled by default in .NET 8**    | CA1865&mdash;As suggestion                                                               |
+|                                     | CA1866&mdash;As suggestion                                                               |
+|                                     | CA1867&mdash;No                                                                          |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1865-ca1867.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1865-ca1867.md
@@ -24,9 +24,7 @@ author: mrahhal
 | **Title**                           | Use 'string.Method(char)' instead of 'string.Method(string)' for string with single char |
 | **Category**                        | [Performance](performance-warnings.md)                                                   |
 | **Fix is breaking or non-breaking** | Non-breaking                                                                             |
-| **Enabled by default in .NET 8**    | CA1865&mdash;As suggestion                                                               |
-|                                     | CA1866&mdash;As suggestion                                                               |
-|                                     | CA1867&mdash;No                                                                          |
+| **Enabled by default in .NET 8**    | CA1865&mdash;As suggestion<br/>CA1866&mdash;As suggestion<br/>CA1867&mdash;No            |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1868.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1868.md
@@ -21,7 +21,7 @@ dev_langs:
 | **Title**                           | Unnecessary call to 'Contains' for sets |
 | **Category**                        | [Performance](performance-warnings.md)  |
 | **Fix is breaking or non-breaking** | Non-breaking                            |
-| **Enabled by default in .NET 8**    | No                                      |
+| **Enabled by default in .NET 8**    | As suggestion                           |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1869.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1869.md
@@ -19,7 +19,7 @@ ms.author: dacantu
 | **Title**                           | Cache and reuse 'JsonSerializerOptions' instances |
 | **Category**                        | [Performance](performance-warnings.md)            |
 | **Fix is breaking or non-breaking** | Non-breaking                                      |
-| **Enabled by default in .NET 8**    | No                                                |
+| **Enabled by default in .NET 8**    | As suggestion                                     |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1870.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1870.md
@@ -21,7 +21,7 @@ ms.author: mizupan
 | **Title**                           | Use a cached 'SearchValues' instance   |
 | **Category**                        | [Performance](performance-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 8**    | Yes                                    |
+| **Enabled by default in .NET 8**    | As suggestion                          |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2009.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2009.md
@@ -18,7 +18,7 @@ ms.author: mavasani
 | **Title**                           | Do not call ToImmutableCollection on an ImmutableCollection value |
 | **Category**                        | [Reliability](reliability-warnings.md)                            |
 | **Fix is breaking or non-breaking** | Non-breaking                                                      |
-| **Enabled by default in .NET 8**    | No                                                                |
+| **Enabled by default in .NET 8**    | As suggestion                                                     |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2011.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2011.md
@@ -17,7 +17,7 @@ ms.author: mavasani
 | **Title**                           | Do not assign property within its setter |
 | **Category**                        | [Reliability](reliability-warnings.md)   |
 | **Fix is breaking or non-breaking** | Non-breaking                             |
-| **Enabled by default in .NET 8**    | No                                       |
+| **Enabled by default in .NET 8**    | As suggestion                            |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2012.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2012.md
@@ -19,7 +19,7 @@ ms.author: stoub
 | **Title**                           | Use ValueTasks correctly               |
 | **Category**                        | [Reliability](reliability-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 8**    | No                                     |
+| **Enabled by default in .NET 8**    | As suggestion                          |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2013.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2013.md
@@ -19,7 +19,7 @@ ms.author: bunamnan
 | **Title**                           | Do not use ReferenceEquals with value types |
 | **Category**                        | [Reliability](reliability-warnings.md)      |
 | **Fix is breaking or non-breaking** | Non-breaking                                |
-| **Enabled by default in .NET 8**    | Yes                                         |
+| **Enabled by default in .NET 8**    | As warning                                  |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2014.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2014.md
@@ -19,7 +19,7 @@ ms.author: stoub
 | **Title**                           | Do not use stackalloc in loops         |
 | **Category**                        | [Reliability](reliability-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 8**    | Yes                                    |
+| **Enabled by default in .NET 8**    | As warning                             |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2015.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2015.md
@@ -19,7 +19,7 @@ ms.author: bunamnan
 | **Title**                           | Do not define finalizers for types derived from MemoryManager&lt;T&gt; |
 | **Category**                        | [Reliability](reliability-warnings.md)                                 |
 | **Fix is breaking or non-breaking** | Non-breaking                                                           |
-| **Enabled by default in .NET 8**    | Yes                                                                    |
+| **Enabled by default in .NET 8**    | As warning                                                             |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2016.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2016.md
@@ -23,7 +23,7 @@ dev_langs:
 | **Title**                           | Forward the CancellationToken parameter to methods that take one |
 | **Category**                        | [Reliability](reliability-warnings.md)                           |
 | **Fix is breaking or non-breaking** | Non-breaking                                                     |
-| **Enabled by default in .NET 8**    | No                                                               |
+| **Enabled by default in .NET 8**    | As suggestion                                                    |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2017.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2017.md
@@ -18,7 +18,7 @@ author: Youssef1313
 | **Title**                           | Parameter count mismatch               |
 | **Category**                        | [Reliability](reliability-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 8**    | Yes                                    |
+| **Enabled by default in .NET 8**    | As warning                             |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2018.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2018.md
@@ -18,7 +18,7 @@ author: mahdiva
 | **Title**                           | The `count` argument to `Buffer.BlockCopy` should specify the number of bytes to copy |
 | **Category**                        | [Reliability](reliability-warnings.md)                                                |
 | **Fix is breaking or non-breaking** | Non-breaking                                                                          |
-| **Enabled by default in .NET 8**    | Yes                                                                                   |
+| **Enabled by default in .NET 8**    | As warning                                                                            |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2019.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2019.md
@@ -18,7 +18,7 @@ dev_langs:
 | **Title**                           | `ThreadStatic` fields should not use inline initialization |
 | **Category**                        | [Reliability](reliability-warnings.md)                     |
 | **Fix is breaking or non-breaking** | Non-breaking                                               |
-| **Enabled by default in .NET 8**    | No                                                         |
+| **Enabled by default in .NET 8**    | As suggestion                                              |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2020.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2020.md
@@ -18,7 +18,7 @@ author: buyaa-n
 | **Title**                           | Prevent behavioral change caused by built-in operators of IntPtr/UIntPtr |
 | **Category**                        | [Reliability](reliability-warnings.md)                                   |
 | **Fix is breaking or non-breaking** | Non-breaking                                                             |
-| **Enabled by default in .NET 8**    | No                                                                       |
+| **Enabled by default in .NET 8**    | As suggestion                                                            |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2021.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2021.md
@@ -18,7 +18,7 @@ dev_langs:
 | **Title**                           | Don't call `Enumerable.Cast<T>` or `Enumerable.OfType<T>` with incompatible types |
 | **Category**                        | [Reliability](reliability-warnings.md)                                   |
 | **Fix is breaking or non-breaking** | Breaking                                                                 |
-| **Enabled by default in .NET 8**    | Yes                                                                      |
+| **Enabled by default in .NET 8**    | As warning                                                               |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2101.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2101.md
@@ -20,7 +20,7 @@ dev_langs:
 | **Title**                           | Specify marshalling for P/Invoke string arguments |
 | **Category**                        | [Globalization](globalization-warnings.md)        |
 | **Fix is breaking or non-breaking** | Non-breaking                                      |
-| **Enabled by default in .NET 8**    | No                                                |
+| **Enabled by default in .NET 8**    | As suggestion                                     |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2200.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2200.md
@@ -22,7 +22,7 @@ dev_langs:
 | **Title**                           | Rethrow to preserve stack details |
 | **Category**                        | [Usage](usage-warnings.md)        |
 | **Fix is breaking or non-breaking** | Non-breaking                      |
-| **Enabled by default in .NET 8**    | Yes                               |
+| **Enabled by default in .NET 8**    | As warning                        |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2208.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2208.md
@@ -22,7 +22,7 @@ dev_langs:
 | **Title**                           | Instantiate argument exceptions correctly |
 | **Category**                        | [Usage](usage-warnings.md)                |
 | **Fix is breaking or non-breaking** | Non-breaking                              |
-| **Enabled by default in .NET 8**    | No                                        |
+| **Enabled by default in .NET 8**    | As suggestion                             |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2211.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2211.md
@@ -22,7 +22,7 @@ dev_langs:
 | **Title**                           | Non-constant fields should not be visible |
 | **Category**                        | [Usage](usage-warnings.md)                |
 | **Fix is breaking or non-breaking** | Breaking                                  |
-| **Enabled by default in .NET 8**    | No                                        |
+| **Enabled by default in .NET 8**    | As suggestion                             |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2218.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2218.md
@@ -19,7 +19,7 @@ dev_langs:
 | **Title**                           | Override GetHashCode on overriding Equals |
 | **Category**                        | [Usage](usage-warnings.md)                |
 | **Fix is breaking or non-breaking** | Non-breaking                              |
-| **Enabled by default in .NET 8**    | No                                        |
+| **Enabled by default in .NET 8**    | As suggestion                             |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2219.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2219.md
@@ -19,7 +19,7 @@ ms.author: gewarren
 | **Title**                           | Do not raise exceptions in exception clauses |
 | **Category**                        | [Usage](usage-warnings.md)                   |
 | **Fix is breaking or non-breaking** | Non-breaking, Breaking                       |
-| **Enabled by default in .NET 8**    | No                                           |
+| **Enabled by default in .NET 8**    | As suggestion                                |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2224.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2224.md
@@ -18,7 +18,7 @@ helpviewer_keywords:
 | **Title**                           | Override Equals on overloading operator equals |
 | **Category**                        | [Usage](usage-warnings.md)                     |
 | **Fix is breaking or non-breaking** | Non-breaking                                   |
-| **Enabled by default in .NET 8**    | No                                             |
+| **Enabled by default in .NET 8**    | As suggestion                                  |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2231.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2231.md
@@ -23,7 +23,7 @@ dev_langs:
 | **Title**                           | Overload operator equals on overriding ValueType.Equals |
 | **Category**                        | [Usage](usage-warnings.md)                              |
 | **Fix is breaking or non-breaking** | Non-breaking                                            |
-| **Enabled by default in .NET 8**    | No                                                      |
+| **Enabled by default in .NET 8**    | As suggestion                                           |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2241.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2241.md
@@ -23,7 +23,7 @@ dev_langs:
 | **Title**                           | Provide correct arguments to formatting methods |
 | **Category**                        | [Usage](usage-warnings.md)                      |
 | **Fix is breaking or non-breaking** | Non-breaking                                    |
-| **Enabled by default in .NET 8**    | No                                              |
+| **Enabled by default in .NET 8**    | As suggestion                                   |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2242.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2242.md
@@ -21,7 +21,7 @@ dev_langs:
 | **Title**                           | Test for NaN correctly     |
 | **Category**                        | [Usage](usage-warnings.md) |
 | **Fix is breaking or non-breaking** | Non-breaking               |
-| **Enabled by default in .NET 8**    | No                         |
+| **Enabled by default in .NET 8**    | As suggestion              |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2244.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2244.md
@@ -17,7 +17,7 @@ ms.author: mavasani
 | **Title**                           | Do not duplicate indexed element initializations |
 | **Category**                        | [Usage](usage-warnings.md)                       |
 | **Fix is breaking or non-breaking** | Non-breaking                                     |
-| **Enabled by default in .NET 8**    | No                                               |
+| **Enabled by default in .NET 8**    | As suggestion                                    |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2245.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2245.md
@@ -17,7 +17,7 @@ ms.author: mavasani
 | **Title**                           | Do not assign a property to itself |
 | **Category**                        | [Usage](usage-warnings.md)         |
 | **Fix is breaking or non-breaking** | Non-breaking                       |
-| **Enabled by default in .NET 8**    | No                                 |
+| **Enabled by default in .NET 8**    | As suggestion                      |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2246.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2246.md
@@ -17,7 +17,7 @@ ms.author: mavasani
 | **Title**                           | Do not assign a symbol and its member in the same statement |
 | **Category**                        | [Usage](usage-warnings.md)                                  |
 | **Fix is breaking or non-breaking** | Non-breaking                                                |
-| **Enabled by default in .NET 8**    | No                                                          |
+| **Enabled by default in .NET 8**    | As suggestion                                               |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2247.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2247.md
@@ -13,13 +13,13 @@ ms.author: stoub
 ---
 # CA2247: Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
 
-| Property                            | Value                                                                                                                          |
-|-------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| **Rule ID**                         | CA2247                                                                                                                         |
-| **Title**                           | Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum |
-| **Category**                        | [Usage](usage-warnings.md)                                                                                                     |
-| **Fix is breaking or non-breaking** | Non-breaking                                                                                                                   |
-| **Enabled by default in .NET 8**    | Yes                                                                                                                            |
+| Property    | Value  |
+|-------------|--------|
+| **Rule ID** | CA2247 |
+| **Title** | Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum |
+| **Category** | [Usage](usage-warnings.md) |
+| **Fix is breaking or non-breaking** | Non-breaking |
+| **Enabled by default in .NET 8** | As warning |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2248.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2248.md
@@ -17,7 +17,7 @@ ms.author: mavasani
 | **Title**                           | Provide correct enum argument to Enum.HasFlag |
 | **Category**                        | [Usage](usage-warnings.md)                    |
 | **Fix is breaking or non-breaking** | Non-breaking                                  |
-| **Enabled by default in .NET 8**    | No                                            |
+| **Enabled by default in .NET 8**    | As suggestion                                 |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2249.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2249.md
@@ -16,7 +16,7 @@ author: pgovind
 | **Title**                           | Consider using String.Contains instead of String.IndexOf |
 | **Category**                        | [Usage](usage-warnings.md)                               |
 | **Fix is breaking or non-breaking** | Non-breaking                                             |
-| **Enabled by default in .NET 8**    | No                                                       |
+| **Enabled by default in .NET 8**    | As suggestion                                            |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2250.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2250.md
@@ -21,7 +21,7 @@ dev_langs:
 | **Title**                           | Use `ThrowIfCancellationRequested` |
 | **Category**                        | [Usage](usage-warnings.md)         |
 | **Fix is breaking or non-breaking** | Non-breaking                       |
-| **Enabled by default in .NET 8**    | No                                 |
+| **Enabled by default in .NET 8**    | As suggestion                      |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2252.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2252.md
@@ -20,7 +20,7 @@ dev_langs:
 | **Title**                           | Opt in to preview features before using them |
 | **Category**                        | [Usage](usage-warnings.md)                   |
 | **Fix is breaking or non-breaking** | Non-breaking                                 |
-| **Enabled by default in .NET 8**    | Yes                                          |
+| **Enabled by default in .NET 8**    | As error                                     |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2253.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2253.md
@@ -18,7 +18,7 @@ author: Youssef1313
 | **Title**                           | Named placeholders should not be numeric values |
 | **Category**                        | [Usage](usage-warnings.md)                      |
 | **Fix is breaking or non-breaking** | Non-breaking                                    |
-| **Enabled by default in .NET 8**    | No                                              |
+| **Enabled by default in .NET 8**    | As suggestion                                   |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2254.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2254.md
@@ -18,7 +18,7 @@ author: Youssef1313
 | **Title**                           | Template should be a static expression |
 | **Category**                        | [Usage](usage-warnings.md)             |
 | **Fix is breaking or non-breaking** | Non-breaking                           |
-| **Enabled by default in .NET 8**    | No                                     |
+| **Enabled by default in .NET 8**    | As suggestion                          |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2255.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2255.md
@@ -18,7 +18,7 @@ author: jeffhandley
 | **Title**                           | The `ModuleInitializer` attribute should not be used in libraries |
 | **Category**                        | [Usage](usage-warnings.md)                                        |
 | **Fix is breaking or non-breaking** | Non-breaking                                                      |
-| **Enabled by default in .NET 8**    | Yes                                                               |
+| **Enabled by default in .NET 8**    | As warning                                                        |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2256.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2256.md
@@ -12,13 +12,13 @@ author: Youssef1313
 ---
 # CA2256: All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
 
-| Property                            | Value                                                                                                                                  |
-|-------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
-| **Rule ID**                         | CA2256                                                                                                                                 |
-| **Title**                           | All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface |
-| **Category**                        | [Usage](usage-warnings.md)                                                                                                             |
-| **Fix is breaking or non-breaking** | Non-breaking                                                                                                                           |
-| **Enabled by default in .NET 8**    | Yes                                                                                                                                    |
+| Property    | Value  |
+|-------------|--------|
+| **Rule ID** | CA2256 |
+| **Title** | All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface |
+| **Category** | [Usage](usage-warnings.md) |
+| **Fix is breaking or non-breaking** | Non-breaking |
+| **Enabled by default in .NET 8** | As warning |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2257.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2257.md
@@ -12,13 +12,13 @@ author: Youssef1313
 ---
 # CA2257: Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
 
-| Property                            | Value                                                                                                         |
-|-------------------------------------|---------------------------------------------------------------------------------------------------------------|
-| **Rule ID**                         | CA2257                                                                                                        |
-| **Title**                           | Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static' |
-| **Category**                        | [Usage](usage-warnings.md)                                                                                    |
-| **Fix is breaking or non-breaking** | Non-breaking                                                                                                  |
-| **Enabled by default in .NET 8**    | Yes                                                                                                           |
+| Property | Value |
+|--|--|
+| **Rule ID** | CA2257 |
+| **Title** | Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static' |
+| **Category** | [Usage](usage-warnings.md) |
+| **Fix is breaking or non-breaking** | Non-breaking |
+| **Enabled by default in .NET 8** | As warning |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2258.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2258.md
@@ -18,7 +18,7 @@ author: Youssef1313
 | **Title**                           | Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported |
 | **Category**                        | [Usage](usage-warnings.md)                                                                    |
 | **Fix is breaking or non-breaking** | Non-breaking                                                                                  |
-| **Enabled by default in .NET 8**    | Yes                                                                                           |
+| **Enabled by default in .NET 8**    | As warning                                                                                    |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2259.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2259.md
@@ -18,7 +18,7 @@ dev_langs:
 | **Title**                           | Ensure `ThreadStatic` is only used with static fields |
 | **Category**                        | [Usage](usage-warnings.md)                            |
 | **Fix is breaking or non-breaking** | Non-breaking                                          |
-| **Enabled by default in .NET 8**    | Yes                                                   |
+| **Enabled by default in .NET 8**    | As warning                                            |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2260.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2260.md
@@ -18,7 +18,7 @@ author: buyaa-n
 | **Title**                           | Implement generic math interfaces correctly |
 | **Category**                        | [Usage](usage-warnings.md)                  |
 | **Fix is breaking or non-breaking** | Non-breaking                                |
-| **Enabled by default in .NET 8**    | Yes                                         |
+| **Enabled by default in .NET 8**    | As warning                                  |
 
 ## Cause
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2261.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2261.md
@@ -15,7 +15,7 @@ helpviewer_keywords:
 | **Title**                           | Do not use `ConfigureAwaitOptions.SuppressThrowing` with `Task<TResult>` |
 | **Category**                        | [Usage](usage-warnings.md)                  |
 | **Fix is breaking or non-breaking** | Non-breaking                                |
-| **Enabled by default in .NET 8**    | Yes                                         |
+| **Enabled by default in .NET 8**    | As warning                                  |
 
 ## Cause
 


### PR DESCRIPTION
Fixes #38305

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

<details><summary><strong>Toggle expand/collapse</strong></summary><br/>

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/overview.md](https://github.com/dotnet/docs/blob/d7c0789681400fa545bbf545b703a480bb3772eb/docs/fundamentals/code-analysis/overview.md) | [Overview of .NET source code analysis](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/overview?branch=pr-en-us-38782) |
| [docs/fundamentals/code-analysis/quality-rules/ca1016.md](https://github.com/dotnet/docs/blob/d7c0789681400fa545bbf545b703a480bb3772eb/docs/fundamentals/code-analysis/quality-rules/ca1016.md) | [CA1016: Mark assemblies with AssemblyVersionAttribute](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1016?branch=pr-en-us-38782) |
| [docs/fundamentals/code-analysis/quality-rules/ca1018.md](https://github.com/dotnet/docs/blob/d7c0789681400fa545bbf545b703a480bb3772eb/docs/fundamentals/code-analysis/quality-rules/ca1018.md) | ["CA1018: Mark attributes with AttributeUsageAttribute (code analysis)"](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1018?branch=pr-en-us-38782) |
| [docs/fundamentals/code-analysis/quality-rules/ca1041.md](https://github.com/dotnet/docs/blob/d7c0789681400fa545bbf545b703a480bb3772eb/docs/fundamentals/code-analysis/quality-rules/ca1041.md) | [CA1041: Provide ObsoleteAttribute message](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1041?branch=pr-en-us-38782) |
| [docs/fundamentals/code-analysis/quality-rules/ca1047.md](https://github.com/dotnet/docs/blob/d7c0789681400fa545bbf545b703a480bb3772eb/docs/fundamentals/code-analysis/quality-rules/ca1047.md) | [CA1047: Do not declare protected members in sealed types](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1047?branch=pr-en-us-38782) |
| [docs/fundamentals/code-analysis/quality-rules/ca1050.md](https://github.com/dotnet/docs/blob/d7c0789681400fa545bbf545b703a480bb3772eb/docs/fundamentals/code-analysis/quality-rules/ca1050.md) | [docs/fundamentals/code-analysis/quality-rules/ca1050](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1050?branch=pr-en-us-38782) |
| [docs/fundamentals/code-analysis/quality-rules/ca1061.md](https://github.com/dotnet/docs/blob/d7c0789681400fa545bbf545b703a480bb3772eb/docs/fundamentals/code-analysis/quality-rules/ca1061.md) | [CA1061: Do not hide base class methods](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1061?branch=pr-en-us-38782) |
| [docs/fundamentals/code-analysis/quality-rules/ca1067.md](https://github.com/dotnet/docs/blob/d7c0789681400fa545bbf545b703a480bb3772eb/docs/fundamentals/code-analysis/quality-rules/ca1067.md) | ["CA1067: Override Equals when implementing IEquatable (code analysis)"](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1067?branch=pr-en-us-38782) |
| [docs/fundamentals/code-analysis/quality-rules/ca1068.md](https://github.com/dotnet/docs/blob/d7c0789681400fa545bbf545b703a480bb3772eb/docs/fundamentals/code-analysis/quality-rules/ca1068.md) | [CA1068: CancellationToken parameters must come last](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1068?branch=pr-en-us-38782) |
| [docs/fundamentals/code-analysis/quality-rules/ca1069.md](https://github.com/dotnet/docs/blob/d7c0789681400fa545bbf545b703a480bb3772eb/docs/fundamentals/code-analysis/quality-rules/ca1069.md) | [docs/fundamentals/code-analysis/quality-rules/ca1069](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1069?branch=pr-en-us-38782) |
| [docs/fundamentals/code-analysis/quality-rules/ca1070.md](https://github.com/dotnet/docs/blob/d7c0789681400fa545bbf545b703a480bb3772eb/docs/fundamentals/code-analysis/quality-rules/ca1070.md) | [CA1070: Do not declare event fields as virtual](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1070?branch=pr-en-us-38782) |
| [docs/fundamentals/code-analysis/quality-rules/ca1401.md](https://github.com/dotnet/docs/blob/d7c0789681400fa545bbf545b703a480bb3772eb/docs/fundamentals/code-analysis/quality-rules/ca1401.md) | [CA1401: P/Invokes should not be visible](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1401?branch=pr-en-us-38782) |
| [docs/fundamentals/code-analysis/quality-rules/ca1416.md](https://github.com/dotnet/docs/blob/d7c0789681400fa545bbf545b703a480bb3772eb/docs/fundamentals/code-analysis/quality-rules/ca1416.md) | ["CA1416: Validate platform compatibility (code analysis)"](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1416?branch=pr-en-us-38782) |
| [docs/fundamentals/code-analysis/quality-rules/ca1417.md](https://github.com/dotnet/docs/blob/d7c0789681400fa545bbf545b703a480bb3772eb/docs/fundamentals/code-analysis/quality-rules/ca1417.md) | [CA1417: Do not use `OutAttribute` on string parameters for P/Invokes](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1417?branch=pr-en-us-38782) |
| [docs/fundamentals/code-analysis/quality-rules/ca1418.md](https://github.com/dotnet/docs/blob/d7c0789681400fa545bbf545b703a480bb3772eb/docs/fundamentals/code-analysis/quality-rules/ca1418.md) | [docs/fundamentals/code-analysis/quality-rules/ca1418](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1418?branch=pr-en-us-38782) |
| [docs/fundamentals/code-analysis/quality-rules/ca1419.md](https://github.com/dotnet/docs/blob/d7c0789681400fa545bbf545b703a480bb3772eb/docs/fundamentals/code-analysis/quality-rules/ca1419.md) | [CA1419: Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1419?branch=pr-en-us-38782) |
| [docs/fundamentals/code-analysis/quality-rules/ca1420.md](https://github.com/dotnet/docs/blob/d7c0789681400fa545bbf545b703a480bb3772eb/docs/fundamentals/code-analysis/quality-rules/ca1420.md) | ["CA1420: Property, type, or attribute requires runtime marshalling"](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1420?branch=pr-en-us-38782) |
| [docs/fundamentals/code-analysis/quality-rules/ca1421.md](https://github.com/dotnet/docs/blob/d7c0789681400fa545bbf545b703a480bb3772eb/docs/fundamentals/code-analysis/quality-rules/ca1421.md) | [CA1421: Method uses runtime marshalling when DisableRuntimeMarshallingAttribute is applied](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1421?branch=pr-en-us-38782) |
| [docs/fundamentals/code-analysis/quality-rules/ca1422.md](https://github.com/dotnet/docs/blob/d7c0789681400fa545bbf545b703a480bb3772eb/docs/fundamentals/code-analysis/quality-rules/ca1422.md) | [docs/fundamentals/code-analysis/quality-rules/ca1422](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1422?branch=pr-en-us-38782) |
| [docs/fundamentals/code-analysis/quality-rules/ca1507.md](https://github.com/dotnet/docs/blob/d7c0789681400fa545bbf545b703a480bb3772eb/docs/fundamentals/code-analysis/quality-rules/ca1507.md) | [CA1507: Use `nameof` in place of string](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1507?branch=pr-en-us-38782) |
| [docs/fundamentals/code-analysis/quality-rules/ca1510.md](https://github.com/dotnet/docs/blob/d7c0789681400fa545bbf545b703a480bb3772eb/docs/fundamentals/code-analysis/quality-rules/ca1510.md) | ["CA1510: Use ArgumentNullException throw helper"](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1510?branch=pr-en-us-38782) |
| [docs/fundamentals/code-analysis/quality-rules/ca1511.md](https://github.com/dotnet/docs/blob/d7c0789681400fa545bbf545b703a480bb3772eb/docs/fundamentals/code-analysis/quality-rules/ca1511.md) | [CA1511: Use ArgumentException throw helper](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1511?branch=pr-en-us-38782) |
| [docs/fundamentals/code-analysis/quality-rules/ca1512.md](https://github.com/dotnet/docs/blob/d7c0789681400fa545bbf545b703a480bb3772eb/docs/fundamentals/code-analysis/quality-rules/ca1512.md) | [docs/fundamentals/code-analysis/quality-rules/ca1512](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1512?branch=pr-en-us-38782) |
| [docs/fundamentals/code-analysis/quality-rules/ca1822.md](https://github.com/dotnet/docs/blob/d7c0789681400fa545bbf545b703a480bb3772eb/docs/fundamentals/code-analysis/quality-rules/ca1822.md) | [CA1822: Mark members as static](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1822?branch=pr-en-us-38782) |
| [docs/fundamentals/code-analysis/quality-rules/ca1824.md](https://github.com/dotnet/docs/blob/d7c0789681400fa545bbf545b703a480bb3772eb/docs/fundamentals/code-analysis/quality-rules/ca1824.md) | [CA1824: Mark assemblies with NeutralResourcesLanguageAttribute](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1824?branch=pr-en-us-38782) |
| [docs/fundamentals/code-analysis/quality-rules/ca1832.md](https://github.com/dotnet/docs/blob/d7c0789681400fa545bbf545b703a480bb3772eb/docs/fundamentals/code-analysis/quality-rules/ca1832.md) | [CA1832: Use AsSpan or AsMemory instead of Range-based indexers for getting ReadOnlySpan or ReadOnlyMemory portion of an array](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1832?branch=pr-en-us-38782) |
| [docs/fundamentals/code-analysis/quality-rules/ca1833.md](https://github.com/dotnet/docs/blob/d7c0789681400fa545bbf545b703a480bb3772eb/docs/fundamentals/code-analysis/quality-rules/ca1833.md) | ["CA1833: Use AsSpan or AsMemory instead of Range-based indexers for getting Span or Memory portion of an array (code analysis)"](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1833?branch=pr-en-us-38782) |
| [docs/fundamentals/code-analysis/quality-rules/ca2247.md](https://github.com/dotnet/docs/blob/d7c0789681400fa545bbf545b703a480bb3772eb/docs/fundamentals/code-analysis/quality-rules/ca2247.md) | [CA2247: Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2247?branch=pr-en-us-38782) |
| [docs/fundamentals/code-analysis/quality-rules/ca2256.md](https://github.com/dotnet/docs/blob/d7c0789681400fa545bbf545b703a480bb3772eb/docs/fundamentals/code-analysis/quality-rules/ca2256.md) | [docs/fundamentals/code-analysis/quality-rules/ca2256](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2256?branch=pr-en-us-38782) |
| [docs/fundamentals/code-analysis/quality-rules/ca2257.md](https://github.com/dotnet/docs/blob/d7c0789681400fa545bbf545b703a480bb3772eb/docs/fundamentals/code-analysis/quality-rules/ca2257.md) | [CA2257: Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2257?branch=pr-en-us-38782) |

</details>

> **Note**
> This table shows preview links for the 30 files with the most changes. For preview links for other files in this PR, select <strong>OpenPublishing.Build Details</strong> within [checks](https://github.com/dotnet/docs/pull/38782/checks).


<!-- PREVIEW-TABLE-END -->