### PR TITLE
Adjust docs for built-in System.Net metrics

### DIFF
--- a/docs/core/diagnostics/built-in-metrics-system-net.md
+++ b/docs/core/diagnostics/built-in-metrics-system-net.md
@@ -98,7 +98,7 @@ Available starting in: .NET 8
 
 | Attribute  | Type | Description  | Examples  | Presence |
 |---|---|---|---|---|
-| `http.error.reason` | string | Request failure reason: one of [HTTP Request errors](https://github.com/dotnet/runtime/blob/c430570a01c103bc7f117be573f37d8ce8a129b8/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestError.cs), or a full exception type, or an HTTP 4xx/5xx status code. | `System.Threading.Tasks.TaskCanceledException`; `name_resolution_error`; `secure_connection_error` ; `404` | If request has failed. |
+| `error.type` | string | Request failure reason: one of [HTTP Request errors](https://github.com/dotnet/runtime/blob/c430570a01c103bc7f117be573f37d8ce8a129b8/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestError.cs), or a full exception type, or an HTTP 4xx/5xx status code. | `System.Threading.Tasks.TaskCanceledException`; `name_resolution_error`; `secure_connection_error` ; `404` | If request has failed. |
 | `http.request.method` | string | HTTP request method. | `GET`; `POST`; `HEAD` | Always |
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | If one was received. |
 | `network.protocol.version` | string | Version of the application layer protocol used. | `1.1`; `2` | Always |
@@ -109,6 +109,9 @@ Available starting in: .NET 8
 HTTP client request duration measures the time the underlying client handler takes to complete the request. Completing the request includes the time up to reading response headers from the network stream. It doesn't include the time spent reading the response body.
 
 Available starting in: .NET 8
+
+> [!TIP]
+> [Enrichment](../../fundamentals/networking/telemetry/metrics.md#enrichment) is possible for this metric.
 
 ### Instrument: `http.client.request.time_in_queue`
 
@@ -137,7 +140,6 @@ Available starting in: .NET 8
 | Attribute  | Type | Description  | Examples  | Presence |
 |---|---|---|---|---|
 | `http.request.method` | string | HTTP request method. | `GET`; `POST`; `HEAD` | Always |
-| `network.protocol.version` | string | Version of the application layer protocol used. | `1.1`; `2` | Always |
 | `server.address` | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. | `example.com` | Always |
 | `server.port` | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. | `80`; `8080`; `443` | If not default (`80` for `http` scheme, `443` for `https`) |
 | `url.scheme` | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. | `http`; `https`; `ftp` | Always |


### PR DESCRIPTION
## Summary

The HTTP metrics docs are out of sync with the implementation and the newly merged [spec](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-metrics.md). This PR adjusts them.

- Rename `http.error.reason` to `error.type`
- Remove the `network.protocol.version` attribute from the `http.client.active_requests` metric
- Add a TIP that `http.client.request.duration` is enrichable


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/built-in-metrics-system-net.md](https://github.com/dotnet/docs/blob/e191f218b783ecbc4f363fa83a718598c8a20574/docs/core/diagnostics/built-in-metrics-system-net.md) | [System.Net metrics](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/built-in-metrics-system-net?branch=pr-en-us-38790) |

<!-- PREVIEW-TABLE-END -->