### PR TITLE
Use classic syntax in interactive sample

### DIFF
--- a/docs/csharp/language-reference/operators/snippets/shared/LambdaOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/LambdaOperator.cs
@@ -27,7 +27,7 @@ public static class LambdaOperator
     private static void WithExplicitTypes()
     {
         // <SnippetExplicitTypes>
-        int[] numbers = { 4, 7, 10 ;
+        int[] numbers = { 4, 7, 10 };
         int product = numbers.Aggregate(1, (int interim, int next) => interim * next);
         Console.WriteLine(product);   // output: 280
         // </SnippetExplicitTypes>

--- a/docs/csharp/language-reference/operators/snippets/shared/LambdaOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/LambdaOperator.cs
@@ -12,13 +12,13 @@ public static class LambdaOperator
     private static void WithInferredTypes()
     {
         // <SnippetInferredTypes>
-        string[] words = ["bot", "apple", "apricot"];
+        string[] words = { "bot", "apple", "apricot" };
         int minimalLength = words
           .Where(w => w.StartsWith("a"))
           .Min(w => w.Length);
         Console.WriteLine(minimalLength);   // output: 5
 
-        int[] numbers = [4, 7, 10];
+        int[] numbers = { 4, 7, 10 };
         int product = numbers.Aggregate(1, (interim, next) => interim * next);
         Console.WriteLine(product);   // output: 280
         // </SnippetInferredTypes>
@@ -27,7 +27,7 @@ public static class LambdaOperator
     private static void WithExplicitTypes()
     {
         // <SnippetExplicitTypes>
-        int[] numbers = [4, 7, 10];
+        int[] numbers = { 4, 7, 10 ;
         int product = numbers.Aggregate(1, (int interim, int next) => interim * next);
         Console.WriteLine(product);   // output: 280
         // </SnippetExplicitTypes>


### PR DESCRIPTION
Fixes #38769

The first two samples in this article use Try.NET and arrays. The version of Try.NET currently deployed doesn't support collection expressions. So, use the classic syntax here.
