### PR TITLE
Update dotnet-restore-audit.md

### DIFF
--- a/docs/core/compatibility/sdk/8.0/dotnet-restore-audit.md
+++ b/docs/core/compatibility/sdk/8.0/dotnet-restore-audit.md
@@ -33,7 +33,7 @@ In most cases when you restore a package, you want to know whether the restored 
 
 - If you want to set a different security audit level, add the `<NuGetAuditLevel>` property to your project file with possible values of `low`, `moderate`, `high`, and `critical`.
 
-- If you want to ignore these warnings, you can use `<NoWarn>` to suppress `NU1091-NU104` warnings.
+- If you want to ignore these warnings, you can use `<NoWarn>` to suppress `NU1901-NU1904` warnings.
 
 - To disable the new behavior entirely, you can set the `<NuGetAudit>` project property to `false`.
 


### PR DESCRIPTION
Fixing warning numbers to match https://learn.microsoft.com/en-us/nuget/concepts/auditing-packages

## Summary

It looks like these warning numbers are wrong.  Fixing per the referenced page.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/sdk/8.0/dotnet-restore-audit.md](https://github.com/dotnet/docs/blob/76d76e025c305f8b7e5ae886247da53c9d778038/docs/core/compatibility/sdk/8.0/dotnet-restore-audit.md) | ['dotnet restore' produces security vulnerability warnings](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/dotnet-restore-audit?branch=pr-en-us-38800) |

<!-- PREVIEW-TABLE-END -->