### PR TITLE
Localizer type fixed.

### DIFF
--- a/docs/core/extensions/snippets/localization/example/MessageService.cs
+++ b/docs/core/extensions/snippets/localization/example/MessageService.cs
@@ -3,12 +3,12 @@ using Microsoft.Extensions.Localization;
 
 namespace Localization.Example;
 
-public sealed class MessageService(IStringLocalizer<MessageService> localizer)
+public sealed class MessageService(IStringLocalizer<MessageService> _localizer)
 {
-    [return: NotNullIfNotNull(nameof(localizer))]
+    [return: NotNullIfNotNull(nameof(_localizer))]
     public string? GetGreetingMessage()
     {
-        LocalizedString localizedString = localizer["GreetingMessage"];
+        LocalizedString localizedString = _localizer["GreetingMessage"];
         return localizedString;
     }
 }


### PR DESCRIPTION
## Summary

Fixed a typo with the localizer field in the code sample.

Fixes typo from https://github.com/dotnet/docs/issues/38826
