### PR TITLE
Correct variable naming, remove highlights, and fix #38826

### DIFF
--- a/docs/core/extensions/localization.md
+++ b/docs/core/extensions/localization.md
@@ -3,7 +3,7 @@ title: Localization
 description: Learn the concepts of localization while learning how to use the IStringLocalizer and IStringLocalizerFactory implementations in your .NET workloads.
 author: IEvangelist
 ms.author: dapine
-ms.date: 12/11/2023
+ms.date: 12/19/2023
 helpviewer_keywords:
   - "culture, localization"
   - "application development [.NET], localization"
@@ -121,22 +121,22 @@ After you've [registered](#register-localization-services) (and optionally [conf
 
 To create a message service that is capable of returning localized strings, consider the following `MessageService`:
 
-:::code source="snippets/localization/example/MessageService.cs" highlight="8,10-11,16":::
+:::code source="snippets/localization/example/MessageService.cs":::
 
 In the preceding C# code:
 
-- A `IStringLocalizer<MessageService> _localizer` field is declared.
-- The constructor takes a `IStringLocalizer<MessageService>` parameter and assigns it to the `_localizer` field.
+- A `IStringLocalizer<MessageService> localizer` field is declared.
+- The primary constructor defines an `IStringLocalizer<MessageService>` parameter and captures it as a `localizer` argument.
 - The `GetGreetingMessage` method invokes the <xref:Microsoft.Extensions.Localization.IStringLocalizer.Item(System.String)?displayProperty=nameWithType> passing `"GreetingMessage"` as an argument.
 
 The `IStringLocalizer` also supports parameterized string resources, consider the following `ParameterizedMessageService`:
 
-:::code source="snippets/localization/example/ParameterizedMessageService.cs" highlight="8,10-11,16":::
+:::code source="snippets/localization/example/ParameterizedMessageService.cs":::
 
 In the preceding C# code:
 
 - A `IStringLocalizer _localizer` field is declared.
-- The constructor takes an `IStringLocalizerFactory` parameter, which is used to create an `IStringLocalizer` from the `ParameterizedMessageService` type, and assigns it to the `_localizer` field.
+- The primary constructor takes an `IStringLocalizerFactory` parameter, which is used to create an `IStringLocalizer` from the `ParameterizedMessageService` type, and assigns it to the `_localizer` field.
 - The `GetFormattedMessage` method invokes <xref:Microsoft.Extensions.Localization.IStringLocalizer.Item(System.String,System.Object[])?displayProperty=nameWithType>, passing `"DinnerPriceFormat"`, a `dateTime` object, and `dinnerPrice` as arguments.
 
 > [!IMPORTANT]

--- a/docs/core/extensions/snippets/localization/example/MessageService.cs
+++ b/docs/core/extensions/snippets/localization/example/MessageService.cs
@@ -9,6 +9,7 @@ public sealed class MessageService(IStringLocalizer<MessageService> localizer)
     public string? GetGreetingMessage()
     {
         LocalizedString localizedString = localizer["GreetingMessage"];
+
         return localizedString;
     }
 }

--- a/docs/core/extensions/snippets/localization/example/ParameterizedMessageService.cs
+++ b/docs/core/extensions/snippets/localization/example/ParameterizedMessageService.cs
@@ -12,6 +12,7 @@ public class ParameterizedMessageService(IStringLocalizerFactory factory)
     public string? GetFormattedMessage(DateTime dateTime, double dinnerPrice)
     {
         LocalizedString localizedString = _localizer["DinnerPriceFormat", dateTime, dinnerPrice];
+
         return localizedString;
     }
 }


### PR DESCRIPTION
## Summary

- Correct variable naming
- Remove highlights

Fixes #38826


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/localization.md](https://github.com/dotnet/docs/blob/a6088541781ee36681f95d2a9b7a6432f5f5925b/docs/core/extensions/localization.md) | [Localization in .NET](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/localization?branch=pr-en-us-38830) |

<!-- PREVIEW-TABLE-END -->