### PR TITLE
Fix typo WindowsStyle -> WindowStyle

### DIFF
--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -56,7 +56,7 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 | [ITypeDescriptorContext nullable annotations](core-libraries/8.0/itypedescriptorcontext-props.md)         | Source incompatible |
 | [Legacy Console.ReadKey removed](core-libraries/8.0/console-readkey-legacy.md)                            | Behavioral change   |
 | [Method builders generate parameters with HasDefaultValue set to false](core-libraries/8.0/parameterinfo-hasdefaultvalue.md) | Behavioral change   |
-| [ProcessStartInfo.WindowsStyle honored when UseShellExecute is false](core-libraries/8.0/processstartinfo-windowstyle.md) | Behavioral change    |
+| [ProcessStartInfo.WindowStyle honored when UseShellExecute is false](core-libraries/8.0/processstartinfo-windowstyle.md) | Behavioral change    |
 | [RuntimeIdentifier returns platform for which runtime was built](core-libraries/8.0/runtimeidentifier.md) | Behavioral change   |
 
 ## Cryptography

--- a/docs/core/compatibility/core-libraries/8.0/processstartinfo-windowstyle.md
+++ b/docs/core/compatibility/core-libraries/8.0/processstartinfo-windowstyle.md
@@ -1,6 +1,6 @@
 ---
-title: ".NET 8 breaking change: ProcessStartInfo.WindowsStyle honored when UseShellExecute is false"
-description: Learn about the .NET 8 breaking change in core .NET libraries where ProcessStartInfo.WindowsStyle is now honored even when UseShellExecute is false.
+title: ".NET 8 breaking change: ProcessStartInfo.WindowStyle honored when UseShellExecute is false"
+description: Learn about the .NET 8 breaking change in core .NET libraries where ProcessStartInfo.WindowStyle is now honored even when UseShellExecute is false.
 ms.date: 11/08/2023
 ---
 # ProcessStartInfo.WindowsStyle honored when UseShellExecute is false

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -68,7 +68,7 @@ items:
         href: core-libraries/8.0/console-readkey-legacy.md
       - name: Method builders generate parameters with HasDefaultValue=false
         href: core-libraries/8.0/parameterinfo-hasdefaultvalue.md
-      - name: ProcessStartInfo.WindowsStyle honored when UseShellExecute is false
+      - name: ProcessStartInfo.WindowStyle honored when UseShellExecute is false
         href: core-libraries/8.0/processstartinfo-windowstyle.md
       - name: RuntimeIdentifier returns platform for which runtime was built
         href: core-libraries/8.0/runtimeidentifier.md
@@ -1132,7 +1132,7 @@ items:
         href: core-libraries/8.0/console-readkey-legacy.md
       - name: Method builders generate parameters with HasDefaultValue=false
         href: core-libraries/8.0/parameterinfo-hasdefaultvalue.md
-      - name: ProcessStartInfo.WindowsStyle honored when UseShellExecute is false
+      - name: ProcessStartInfo.WindowStyle honored when UseShellExecute is false
         href: core-libraries/8.0/processstartinfo-windowstyle.md
       - name: RuntimeIdentifier returns platform for which runtime was built
         href: core-libraries/8.0/runtimeidentifier.md

--- a/docs/whats-new/dotnet-docs-mod2.md
+++ b/docs/whats-new/dotnet-docs-mod2.md
@@ -20,7 +20,7 @@ Welcome to what's new in the .NET docs for November 2023. This article lists som
 ### New articles
 
 - [Enumerable.Sum throws new OverflowException for some inputs](../core/compatibility/core-libraries/8.0/enumerable-sum.md)
-- [ProcessStartInfo.WindowsStyle honored when UseShellExecute is false](../core/compatibility/core-libraries/8.0/processstartinfo-windowstyle.md)
+- [ProcessStartInfo.WindowStyle honored when UseShellExecute is false](../core/compatibility/core-libraries/8.0/processstartinfo-windowstyle.md)
 - [PublishedTrimmed projects fail reflection-based serialization](../core/compatibility/serialization/8.0/publishtrimmed.md)
 - [Source Link included in the .NET SDK](../core/compatibility/sdk/8.0/source-link.md)
 - [Unlisted packages not installed by default for .NET tools](../core/compatibility/sdk/8.0/unlisted-versions.md)


### PR DESCRIPTION
## Summary

Fix typo WindowsStyle -> WindowStyle
https://learn.microsoft.com/en-us/dotnet/api/system.windows.window.windowstyle?view=windowsdesktop-8.0

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/8.0.md](https://github.com/dotnet/docs/blob/d9aec08d01eb85a549f6f23be573e14448665b32/docs/core/compatibility/8.0.md) | [Breaking changes in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/8.0?branch=pr-en-us-38831) |
| [docs/core/compatibility/core-libraries/8.0/processstartinfo-windowstyle.md](https://github.com/dotnet/docs/blob/d9aec08d01eb85a549f6f23be573e14448665b32/docs/core/compatibility/core-libraries/8.0/processstartinfo-windowstyle.md) | [ProcessStartInfo.WindowsStyle honored when UseShellExecute is false](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/8.0/processstartinfo-windowstyle?branch=pr-en-us-38831) |
| [docs/whats-new/dotnet-docs-mod2.md](https://github.com/dotnet/docs/blob/d9aec08d01eb85a549f6f23be573e14448665b32/docs/whats-new/dotnet-docs-mod2.md) | [".NET docs: What's new for November 2023"](https://review.learn.microsoft.com/en-us/dotnet/whats-new/dotnet-docs-mod2?branch=pr-en-us-38831) |

<!-- PREVIEW-TABLE-END -->