### PR TITLE
Add note to `CS0577` for finalizer as term for destructor

### DIFF
--- a/docs/csharp/misc/cs0577.md
+++ b/docs/csharp/misc/cs0577.md
@@ -11,7 +11,10 @@ ms.assetid: 34f8f453-f016-4f2c-981a-0d61449cd74b
 # Compiler Error CS0577
 
 The Conditional attribute is not valid on 'function' because it is a constructor, destructor, operator, or explicit interface implementation  
-  
+
+> [!NOTE]
+> Destructor is a deprecated term for [finalizer](../programming-guide/classes-and-structs/finalizers.md)
+
  `Conditional` cannot be applied to the specified methods.  
   
  For example, you cannot use some attributes on an explicit interface definition. The following sample generates CS0577:  

--- a/docs/csharp/misc/cs0577.md
+++ b/docs/csharp/misc/cs0577.md
@@ -13,7 +13,7 @@ ms.assetid: 34f8f453-f016-4f2c-981a-0d61449cd74b
 The Conditional attribute is not valid on 'function' because it is a constructor, destructor, operator, or explicit interface implementation  
 
 > [!NOTE]
-> Destructor is a deprecated term for [finalizer](../programming-guide/classes-and-structs/finalizers.md)
+> Destructor is a deprecated term for [finalizer](../programming-guide/classes-and-structs/finalizers.md).
 
  `Conditional` cannot be applied to the specified methods.  
   


### PR DESCRIPTION
This pull request closes #38720 

It adds the NOTE mentioning that the `destructor` term is depracted form of `finalizer`.
Also, finalizers are linked.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/misc/cs0577.md](https://github.com/dotnet/docs/blob/aaef714b75a4bcfa9a7935bd3a9611774fcdb406/docs/csharp/misc/cs0577.md) | [Compiler Error CS0577](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/cs0577?branch=pr-en-us-38834) |

<!-- PREVIEW-TABLE-END -->