### PR TITLE
Fix CA1513 example

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1513.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1513.md
@@ -49,7 +49,7 @@ class C
     private bool _disposed = false;
     void M()
     {
-        ObjectDisposedException.ThrowIf(_disposed, GetType().Name);
+        ObjectDisposedException.ThrowIf(_disposed, this);
     }
 }
 ```


### PR DESCRIPTION
## Summary

Fixes #38717

The existing proposed fix will result in an exception thrown with object name `System.String` when `_disposed` is true. That is incorrect as the object name should be `C`.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1513.md](https://github.com/dotnet/docs/blob/5e358bab6c59c2a72275423a702ee7130905e4f0/docs/fundamentals/code-analysis/quality-rules/ca1513.md) | [CA1513: Use ObjectDisposedException throw helper](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1513?branch=pr-en-us-38839) |

<!-- PREVIEW-TABLE-END -->