### PR TITLE
Correct mistake in CS0523

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs0523.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0523.md
@@ -12,7 +12,7 @@ ms.assetid: f91fb0ab-e1ef-4d6d-a3ef-5adc53a7e312
 
 Struct member 'struct2 field' of type 'struct1' causes a cycle in the struct layout
 
- The definitions of one or more [structs](../builtin-types/struct.md) include recursive references that form a cycle. This limitation applies only to structs, since structs are [value types](../builtin-types/value-types.md). To create recursive references, declare your types as classes, which are reference types.
+ The definitions of one or more [structs](../builtin-types/struct.md) include recursive references that form a cycle. This limitation only applies to structs, since structs are [value types](../builtin-types/value-types.md). To create recursive references, declare your types as classes, which are reference types.
 
 ## Example 1
 
@@ -32,7 +32,7 @@ class SelfReferentialClass
 }
 ```
 
-When a self referential struct type is made, it contains a copy of the same type as a member. However, that member then has another copy which continues recursively. As a result of the cycle, the size of the type cannot be determined and CS0523 is emitted.
+When a self referential struct type is made, it contains a copy of the same type as a member. However, that member then has another copy, which continues recursively. As a result of the cycle, the size of the type cannot be determined and CS0523 is emitted.
 
 ## Example 2
 
@@ -57,4 +57,4 @@ struct ReferenceCycleStruct3
 }
 ```
 
-To resolve the errors above, you can adjust the references such that a cycle is no longer formed, or convert as least one of struct types to a class. Similar to the previous example, `ReferenceCycleStruct1` contains a `ReferenceCycleStruct2`, and that contains a `ReferenceCycleStruct3`, which eventually contains `ReferenceCycleStruct1` again.
+To resolve the errors above, you can adjust the references such that a cycle is no longer formed, or convert at least one of the struct types to a class. Similar to the previous example, `ReferenceCycleStruct1` contains a `ReferenceCycleStruct2`, and that contains a `ReferenceCycleStruct3`, which eventually contains `ReferenceCycleStruct1` again.


### PR DESCRIPTION
## Summary

Fix some errors introduced in #37990.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-messages/cs0523.md](https://github.com/dotnet/docs/blob/21aeefd252c7f64aa0b1f8cb294f731413217be0/docs/csharp/language-reference/compiler-messages/cs0523.md) | [Compiler Error CS0523](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0523?branch=pr-en-us-38840) |

<!-- PREVIEW-TABLE-END -->