### PR TITLE
fix snippet to match surrounding text

### DIFF
--- a/docs/csharp/linq/get-started/snippets/SnippetApp/WriteLinqQueries.cs
+++ b/docs/csharp/linq/get-started/snippets/SnippetApp/WriteLinqQueries.cs
@@ -126,7 +126,7 @@ public class WriteLinqQueries
     public static void WriteLinqQueries5b()
     {
         // <write_linq_queries_5b>
-        var numCount = numbers.Count(n => n is > 3 and < 7);
+        int numCount = numbers.Count(n => n is > 3 and < 7);
         // </write_linq_queries_5b>
     }
 


### PR DESCRIPTION
## Summary

Update snippet to match surrounding text "It can be written by using explicit typing, as follows:".

Fixes #38553