### PR TITLE
add note for IDE0052 rule

### DIFF
--- a/docs/fundamentals/code-analysis/categories.md
+++ b/docs/fundamentals/code-analysis/categories.md
@@ -113,7 +113,7 @@ The following table shows the different code analysis rule categories and provid
 | **EditorConfig value** | `dotnet_analyzer_diagnostic.category-Style.severity` |
 | [**MSBuild property value**](../../core/project-sdk/msbuild-props.md#analysismodecategory) | `<AnalysisModeStyle>` |
 
-\* Use the EditorConfig value `dotnet_analyzer_diagnostic.category-CodeQuality.severity` to enable the following rules: [IDE0051](style-rules/ide0051.md), [IDE0064](style-rules/ide0064.md), and [IDE0076](style-rules/ide0076.md). While these rules start with "IDE", they aren't technically part of the `Style` category.
+\* Use the EditorConfig value `dotnet_analyzer_diagnostic.category-CodeQuality.severity` to enable the following rules: [IDE0051](style-rules/ide0051.md), [IDE0052](style-rules/ide0052.md), [IDE0064](style-rules/ide0064.md), and [IDE0076](style-rules/ide0076.md). While these rules start with "IDE", they aren't technically part of the `Style` category.
 
 ## Usage rules
 


### PR DESCRIPTION
## Summary

Include `IDE0052` in note about `Style` category.

Fixes #38635

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/categories.md](https://github.com/dotnet/docs/blob/e5ee3560e86fb36092da954d05ae196488312f72/docs/fundamentals/code-analysis/categories.md) | [Rule categories](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/categories?branch=pr-en-us-38844) |

<!-- PREVIEW-TABLE-END -->