### PR TITLE
`--controllers` -> `-controllers`

### DIFF
--- a/docs/core/tools/dotnet-new-sdk-templates.md
+++ b/docs/core/tools/dotnet-new-sdk-templates.md
@@ -776,7 +776,7 @@ Creates a web API project with AOT publish enabled. For more information, see [N
 
 - **`-minimal|--use-minimal-apis`**
 
-  Create a project that uses the [ASP.NET Core minimal API](/aspnet/core/fundamentals/minimal-apis). Default is `false`, but this option is overridden by `--controllers`. Since the default for `--controllers` is `false`, entering `dotnet new webapi` without specifying either option creates a minimal API project.
+  Create a project that uses the [ASP.NET Core minimal API](/aspnet/core/fundamentals/minimal-apis). Default is `false`, but this option is overridden by `-controllers`. Since the default for `-controllers` is `false`, entering `dotnet new webapi` without specifying either option creates a minimal API project.
 
 - **`-ssp|--susi-policy-id <ID>`**
 
@@ -790,7 +790,7 @@ Creates a web API project with AOT publish enabled. For more information, see [N
 
   The Client ID for this project. Use with `IndividualB2C` or `SingleOrg` authentication. The default value is `11111111-1111-1111-11111111111111111`.
 
-- **`--controllers`**, **`--use-controllers`**
+- **`-controllers`**, **`--use-controllers`**
 
   Whether to use controllers instead of minimal APIs. If both this option and `-minimal` are specified, this option overrides the value specified by `-minimal`. Default is `false`. Available since .NET 8 SDK.
 

--- a/docs/core/tools/dotnet-new-sdk-templates.md
+++ b/docs/core/tools/dotnet-new-sdk-templates.md
@@ -790,7 +790,7 @@ Creates a web API project with AOT publish enabled. For more information, see [N
 
   The Client ID for this project. Use with `IndividualB2C` or `SingleOrg` authentication. The default value is `11111111-1111-1111-11111111111111111`.
 
-- **`-controllers`**, **`--use-controllers`**
+- **`-controllers|--use-controllers`**
 
   Whether to use controllers instead of minimal APIs. If both this option and `-minimal` are specified, this option overrides the value specified by `-minimal`. Default is `false`. Available since .NET 8 SDK.
 


### PR DESCRIPTION
## Summary

`-controllers` is shortcut for `--use-controllers`, `--controllers` is unknown one

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-new-sdk-templates.md](https://github.com/dotnet/docs/blob/c38f5bb3673a919b7e6664728df62fe4028ea8c6/docs/core/tools/dotnet-new-sdk-templates.md) | [.NET default templates for dotnet new](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-new-sdk-templates?branch=pr-en-us-38854) |


<!-- PREVIEW-TABLE-END -->