### PR TITLE
Fix typo in publishing-with-visual-studio.md

### DIFF
--- a/docs/core/tutorials/publishing-with-visual-studio.md
+++ b/docs/core/tutorials/publishing-with-visual-studio.md
@@ -52,7 +52,7 @@ This tutorial shows how to publish a console app so that other users can run it.
 
 ## Inspect the files
 
-By default, the publishing process creates a framework-dependent deployment, which is a type of deployment where the published application runs on machine that has the .NET runtime installed. Users can run the published app by double-clicking the executable or issuing the `dotnet HelloWorld.dll` command from a command prompt.
+By default, the publishing process creates a framework-dependent deployment, which is a type of deployment where the published application runs on a machine that has the .NET runtime installed. Users can run the published app by double-clicking the executable or issuing the `dotnet HelloWorld.dll` command from a command prompt.
 
 In the following steps, you'll look at the files created by the publish process.
 
@@ -165,7 +165,7 @@ This tutorial shows how to publish a console app so that other users can run it.
 
 ## Inspect the files
 
-By default, the publishing process creates a framework-dependent deployment, which is a type of deployment where the published application runs on machine that has the .NET runtime installed. Users can run the published app by double-clicking the executable or issuing the `dotnet HelloWorld.dll` command from a command prompt.
+By default, the publishing process creates a framework-dependent deployment, which is a type of deployment where the published application runs on a machine that has the .NET runtime installed. Users can run the published app by double-clicking the executable or issuing the `dotnet HelloWorld.dll` command from a command prompt.
 
 In the following steps, you'll look at the files created by the publish process.
 
@@ -276,7 +276,7 @@ This tutorial shows how to publish a console app so that other users can run it.
 
 ## Inspect the files
 
-By default, the publishing process creates a framework-dependent deployment, which is a type of deployment where the published application runs on machine that has the .NET runtime installed. Users can run the published app by double-clicking the executable or issuing the `dotnet HelloWorld.dll` command from a command prompt.
+By default, the publishing process creates a framework-dependent deployment, which is a type of deployment where the published application runs on a machine that has the .NET runtime installed. Users can run the published app by double-clicking the executable or issuing the `dotnet HelloWorld.dll` command from a command prompt.
 
 In the following steps, you'll look at the files created by the publish process.
 


### PR DESCRIPTION
Add an "a" to the following sentence:
>... where the published application runs on machine that has the .NET runtime installed.

So it reads like this:
> ... where the published application runs on **a** machine that has the .NET runtime installed.

Merry Christmas and happy New Year!


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tutorials/publishing-with-visual-studio.md](https://github.com/dotnet/docs/blob/d06bcbe6c8281cdc2d951f34f6aa49a33e5f55c0/docs/core/tutorials/publishing-with-visual-studio.md) | [Tutorial: Publish a .NET console application using Visual Studio](https://review.learn.microsoft.com/en-us/dotnet/core/tutorials/publishing-with-visual-studio?branch=pr-en-us-38869) |

<!-- PREVIEW-TABLE-END -->