### PR TITLE
document ArrayPoolEventSource.BufferDropped event

### DIFF
--- a/docs/core/diagnostics/well-known-event-providers.md
+++ b/docs/core/diagnostics/well-known-event-providers.md
@@ -47,6 +47,7 @@ This provider logs information from the ArrayPool. The following table shows the
 |`BufferReturned`|Verbose (5)|A buffer is returned to the pool.|
 |`BufferTrimmed`|Informational (4)|A buffer is attempted to be freed due to memory pressure or inactivity.|
 |`BufferTrimPoll`|Informational (4)|A check is being made to trim buffers.|
+|`BufferDropped`|Informational (4)|A buffer is dropped when returned to the pool.|
 
 ### "System.Net.Http" provider
 


### PR DESCRIPTION
## Summary

document ArrayPoolEventSource.BufferDropped event

Fixes dotnet/runtime#96199


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/well-known-event-providers.md](https://github.com/dotnet/docs/blob/7a6ec22b44d3b8de9627ac87f728ba9e5a24547e/docs/core/diagnostics/well-known-event-providers.md) | [Well-known event providers in .NET](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/well-known-event-providers?branch=pr-en-us-38873) |

<!-- PREVIEW-TABLE-END -->