### PR TITLE
Update ScopedBackgroundService

### DIFF
--- a/docs/core/extensions/scoped-service.md
+++ b/docs/core/extensions/scoped-service.md
@@ -51,7 +51,7 @@ Replace the existing `Worker` class with the following C# code, and rename the f
 
 :::code source="snippets/workers/scoped-service/ScopedBackgroundService.cs" highlight="22-28":::
 
-In the preceding code, an explicit scope is created and the `IScopedProcessingService` implementation is resolved from the dependency injection service provider. The resolved service instance is scoped, and its `DoWorkAsync` method is awaited.
+In the preceding code, an explicit scope is created and the `IScopedProcessingService` implementation is resolved from the dependency injection service scope factory. The resolved service instance is scoped, and its `DoWorkAsync` method is awaited.
 
 Replace the template *Program.cs* file contents with the following C# code:
 

--- a/docs/core/extensions/snippets/workers/scoped-service/ScopedBackgroundService.cs
+++ b/docs/core/extensions/snippets/workers/scoped-service/ScopedBackgroundService.cs
@@ -1,7 +1,7 @@
 ﻿namespace App.ScopedService;
 
 public sealed class ScopedBackgroundService(
-    IServiceProvider serviceProvider,
+    IServiceScopeFactory serviceScopeFactory,
     ILogger<ScopedBackgroundService> logger) : BackgroundService
 {
     private const string ClassName = nameof(ScopedBackgroundService);
@@ -19,7 +19,7 @@ public sealed class ScopedBackgroundService(
         logger.LogInformation(
             "{Name} is working.", ClassName);
 
-        using (IServiceScope scope = serviceProvider.CreateScope())
+        using (IServiceScope scope = serviceScopeFactory.CreateScope())
         {
             IScopedProcessingService scopedProcessingService =
                 scope.ServiceProvider.GetRequiredService<IScopedProcessingService>();


### PR DESCRIPTION
## Summary

The [IServiceScopeFactory](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.iservicescopefactory) is always registered as a singleton, but the [IServiceProvider](https://learn.microsoft.com/en-us/dotnet/api/system.iserviceprovider) can vary based on the lifetime of the containing class.

https://learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection#scope-scenarios

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/scoped-service.md](https://github.com/dotnet/docs/blob/efeb9ea5e5653bad2fb1c7a8e1524d0da2417688/docs/core/extensions/scoped-service.md) | [Use scoped services within a `BackgroundService`](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/scoped-service?branch=pr-en-us-38880) |

<!-- PREVIEW-TABLE-END -->