### PR TITLE
Refresh CS1525

### DIFF
--- a/docs/csharp/misc/cs1525.md
+++ b/docs/csharp/misc/cs1525.md
@@ -1,51 +1,39 @@
 ---
 description: "Compiler Error CS1525"
 title: "Compiler Error CS1525"
-ms.date: 07/20/2015
-f1_keywords: 
+ms.date: 12/28/2023
+f1_keywords:
   - "CS1525"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS1525"
 ms.assetid: 7913f589-2f2e-40bc-a27e-0b6930336484
 ---
 # Compiler Error CS1525
 
-Invalid expression term 'character'  
-  
- The compiler detected an invalid character in an expression.  
-  
- The following sample generates CS1525:  
-  
-```csharp  
-// CS1525.cs  
-class x  
-{  
-   public static void Main()  
-   {  
-      int i = 0;  
-      i = i +   // OK - identifier  
-      'c' +     // OK - character  
-      (5) +     // OK - parenthesis  
-      [ +       // CS1525, operator not a valid expression element  
-      throw +   // CS1525, keyword not allowed in expression  
-      void;     // CS1525, void not allowed in expression  
-   }  
-}  
-```  
-  
- An empty label can also generate CS1525, as in the following sample:  
-  
-```csharp  
-// CS1525b.cs  
-using System;  
-public class MyClass  
-{  
-   public static void Main()  
-   {  
-      goto FoundIt;  
-      FoundIt:      // CS1525  
-      // Uncomment the following line to resolve:  
-      // System.Console.Write("Hello");  
-   }  
-}  
+Invalid expression term 'term'
+
+ The compiler detected an invalid term in an expression. This error can be caused by a missing expression where one is expected, leading to subsequent tokens being wrongly parsed as an expression, or an invalid construct is used within an expression. Common root causes include unmatched tokens, missing semicolon or excess delimiters.
+
+ The following sample generates CS1525:
+
+```csharp
+// CS1525.cs
+class MyClass
+{
+    public static void Method(int number) {}
+
+    public static void Main()
+    {
+        int i = 0;
+        i = i + 'c' + 1 + (2);   // OK
+        i = i + void + throw;    // CS1525, these keywords are not valid in this expression
+
+        Method(123,);            // CS1525, excess trailing comma
+
+        goto EmptyLabel;
+        EmptyLabel:              // CS1525, empty label
+        // Add something here to resolve the error, for example:
+        // System.Console.WriteLine("Hello!");
+    }
+}
 ```


### PR DESCRIPTION
## Summary

Reduced the verbosity of the examples and added the excess trailing delimiter case, together with a brief description and some miscellaneous cleanups.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/misc/cs1525.md](https://github.com/dotnet/docs/blob/519702d759a07c03dc25fbce34ee3e2cd7a51e64/docs/csharp/misc/cs1525.md) | [Compiler Error CS1525](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/cs1525?branch=pr-en-us-38910) |

<!-- PREVIEW-TABLE-END -->