### PR TITLE
Fix typography at sample code in fsharp snippets

### DIFF
--- a/samples/snippets/fsharp/getting-started/pig-latin.fs
+++ b/samples/snippets/fsharp/getting-started/pig-latin.fs
@@ -4,7 +4,7 @@ module PigLatin =
     let toPigLatin (word: string) =
         let isVowel (c: char) =
             match c with
-            | 'a' | 'e' | 'i' |'o' |'u'
+            | 'a' | 'e' | 'i' | 'o' | 'u'
             | 'A' | 'E' | 'I' | 'O' | 'U' -> true
             |_ -> false
         

--- a/samples/snippets/fsharp/getting-started/to-pig-latin.fsx
+++ b/samples/snippets/fsharp/getting-started/to-pig-latin.fsx
@@ -1,7 +1,7 @@
 let toPigLatin (word: string) =
     let isVowel (c: char) =
         match c with
-        | 'a' | 'e' | 'i' |'o' |'u'
+        | 'a' | 'e' | 'i' | 'o' | 'u'
         | 'A' | 'E' | 'I' | 'O' | 'U' -> true
         |_ -> false
     


### PR DESCRIPTION
## Summary

`| 'a' | 'e' | 'i' |'o' |'u'` -> `| 'a' | 'e' | 'i' | 'o' | 'u'`

Fixes #Issue_Number (if available)
