### PR TITLE
Built-in metrics refactor

### DIFF
--- a/docs/core/diagnostics/built-in-metrics-aspnetcore.md
+++ b/docs/core/diagnostics/built-in-metrics-aspnetcore.md
@@ -14,34 +14,34 @@ see [here](available-counters.md).
 > [!TIP]
 > For more information about how to collect, report, enrich, and test ASP.NET Core metrics, see [Using ASP.NET Core metrics](/aspnet/core/log-mon/metrics/metrics).
 
-- [Meter: `Microsoft.AspNetCore.Hosting`](#meter-microsoftaspnetcorehosting)
-  - [Instrument: `http.server.request.duration`](#instrument-httpserverrequestduration)
-  - [Instrument: `http.server.active_requests`](#instrument-httpserveractive_requests)
-- [Meter: `Microsoft.AspNetCore.Routing`](#meter-microsoftaspnetcorerouting)
-  - [Instrument: `aspnetcore.routing.match_attempts`](#instrument-aspnetcoreroutingmatch_attempts)
-- [Meter: `Microsoft.AspNetCore.Diagnostics`](#meter-microsoftaspnetcorediagnostics)
-  - [Instrument: `aspnetcore.diagnostics.exceptions`](#instrument-aspnetcorediagnosticsexceptions)
-- [Meter: `Microsoft.AspNetCore.RateLimiting`](#meter-microsoftaspnetcoreratelimiting)
-  - [Instrument: `aspnetcore.rate_limiting.active_request_leases`](#instrument-aspnetcorerate_limitingactive_request_leases)
-  - [Instrument: `aspnetcore.rate_limiting.request_lease.duration`](#instrument-aspnetcorerate_limitingrequest_leaseduration)
-  - [Instrument: `aspnetcore.rate_limiting.queued_requests`](#instrument-aspnetcorerate_limitingqueued_requests)
-  - [Instrument: `aspnetcore.rate_limiting.request.time_in_queue`](#instrument-aspnetcorerate_limitingrequesttime_in_queue)
-  - [Instrument: `aspnetcore.rate_limiting.requests`](#instrument-aspnetcorerate_limitingrequests)
-- [Meter: `Microsoft.AspNetCore.HeaderParsing`](#meter-microsoftaspnetcoreheaderparsing)
-  - [Instrument: `aspnetcore.header_parsing.parse_errors`](#instrument-aspnetcoreheader_parsingparse_errors)
-  - [Instrument: `aspnetcore.header_parsing.cache_accesses`](#instrument-aspnetcoreheader_parsingcache_accesses)
-- [Meter: `Microsoft.AspNetCore.Server.Kestrel`](#meter-microsoftaspnetcoreserverkestrel)
-  - [Instrument: `kestrel.active_connections`](#instrument-kestrelactive_connections)
-  - [Instrument: `kestrel.connection.duration`](#instrument-kestrelconnectionduration)
-  - [Instrument: `kestrel.rejected_connections`](#instrument-kestrelrejected_connections)
-  - [Instrument: `kestrel.queued_connections`](#instrument-kestrelqueued_connections)
-  - [Instrument: `kestrel.queued_requests`](#instrument-kestrelqueued_requests)
-  - [Instrument: `kestrel.upgraded_connections`](#instrument-kestrelupgraded_connections)
-  - [Instrument: `kestrel.tls_handshake.duration`](#instrument-kestreltls_handshakeduration)
-  - [Instrument: `kestrel.active_tls_handshakes`](#instrument-kestrelactive_tls_handshakes)
-- [Meter: `Microsoft.AspNetCore.Http.Connections`](#meter-microsoftaspnetcorehttpconnections)
-  - [Instrument: `signalr.server.connection.duration`](#instrument-signalrserverconnectionduration)
-  - [Instrument: `signalr.server.active_connections`](#instrument-signalrserveractive_connections)
+- [`Microsoft.AspNetCore.Hosting`](#meter-microsoftaspnetcorehosting)
+  - [`http.server.request.duration`](#instrument-httpserverrequestduration)
+  - [`http.server.active_requests`](#instrument-httpserveractive_requests)
+- [`Microsoft.AspNetCore.Routing`](#meter-microsoftaspnetcorerouting)
+  - [`aspnetcore.routing.match_attempts`](#instrument-aspnetcoreroutingmatch_attempts)
+- [`Microsoft.AspNetCore.Diagnostics`](#meter-microsoftaspnetcorediagnostics)
+  - [`aspnetcore.diagnostics.exceptions`](#instrument-aspnetcorediagnosticsexceptions)
+- [`Microsoft.AspNetCore.RateLimiting`](#meter-microsoftaspnetcoreratelimiting)
+  - [`aspnetcore.rate_limiting.active_request_leases`](#instrument-aspnetcorerate_limitingactive_request_leases)
+  - [`aspnetcore.rate_limiting.request_lease.duration`](#instrument-aspnetcorerate_limitingrequest_leaseduration)
+  - [`aspnetcore.rate_limiting.queued_requests`](#instrument-aspnetcorerate_limitingqueued_requests)
+  - [`aspnetcore.rate_limiting.request.time_in_queue`](#instrument-aspnetcorerate_limitingrequesttime_in_queue)
+  - [`aspnetcore.rate_limiting.requests`](#instrument-aspnetcorerate_limitingrequests)
+- [`Microsoft.AspNetCore.HeaderParsing`](#meter-microsoftaspnetcoreheaderparsing)
+  - [`aspnetcore.header_parsing.parse_errors`](#instrument-aspnetcoreheader_parsingparse_errors)
+  - [`aspnetcore.header_parsing.cache_accesses`](#instrument-aspnetcoreheader_parsingcache_accesses)
+- [`Microsoft.AspNetCore.Server.Kestrel`](#meter-microsoftaspnetcoreserverkestrel)
+  - [`kestrel.active_connections`](#instrument-kestrelactive_connections)
+  - [`kestrel.connection.duration`](#instrument-kestrelconnectionduration)
+  - [`kestrel.rejected_connections`](#instrument-kestrelrejected_connections)
+  - [`kestrel.queued_connections`](#instrument-kestrelqueued_connections)
+  - [`kestrel.queued_requests`](#instrument-kestrelqueued_requests)
+  - [`kestrel.upgraded_connections`](#instrument-kestrelupgraded_connections)
+  - [`kestrel.tls_handshake.duration`](#instrument-kestreltls_handshakeduration)
+  - [`kestrel.active_tls_handshakes`](#instrument-kestrelactive_tls_handshakes)
+- [`Microsoft.AspNetCore.Http.Connections`](#meter-microsoftaspnetcorehttpconnections)
+  - [`signalr.server.connection.duration`](#instrument-signalrserverconnectionduration)
+  - [`signalr.server.active_connections`](#instrument-signalrserveractive_connections)
 
 ## Meter: `Microsoft.AspNetCore.Hosting`
 
@@ -49,7 +49,7 @@ see [here](available-counters.md).
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `http.server.request.duration` | Histogram | `s` | Measures the duration of inbound HTTP requests. |
+| [`http.server.request.duration`](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-http-metrics/#metric-httpclientrequestduration) | Histogram | `s` | Measures the duration of inbound HTTP requests. |
 
 | Attribute  | Type | Description  | Examples  | Presence |
 |---|---|---|---|---|
@@ -72,9 +72,6 @@ The time ends when:
 - The ASP.NET Core handler pipeline is finished executing.
 - All response data has been sent.
 - The context data structures for the request are being disposed.
-
-<!-- Once we migrate this doc to https://github.com/dotnet/AspNetCore.Docs we can remove the following version info -->
-Available staring in: ASP.NET Core 8.0
 
 ### Instrument: `http.server.active_requests`
 

--- a/docs/core/diagnostics/built-in-metrics-aspnetcore.md
+++ b/docs/core/diagnostics/built-in-metrics-aspnetcore.md
@@ -11,16 +11,6 @@ This article describes the metrics built-in for ASP.NET Core produced using the
 <xref:System.Diagnostics.Metrics?displayProperty=nameWithType> API. For a listing of metrics based on the older [EventCounters](event-counters.md) API,
 see [here](available-counters.md).
 
-ASP.NET Core metrics are grouped into meters:
-
-- [`Microsoft.AspNetCore.Hosting`](#microsoftaspnetcorehosting)
-- [`Microsoft.AspNetCore.Routing`](#microsoftaspnetcorerouting)
-- [`Microsoft.AspNetCore.Diagnostics`](#microsoftaspnetcorediagnostics)
-- [`Microsoft.AspNetCore.RateLimiting`](#microsoftaspnetcoreratelimiting)
-- [`Microsoft.AspNetCore.HeaderParsing`](#microsoftaspnetcoreheaderparsing)
-- [`Microsoft.AspNetCore.Server.Kestrel`](#microsoftaspnetcoreserverkestrel)
-- [`Microsoft.AspNetCore.Http.Connections`](#microsoftaspnetcorehttpconnections)
-
 > [!TIP]
 > For more information about how to collect, report, enrich, and test ASP.NET Core metrics, see [Using ASP.NET Core metrics](/aspnet/core/log-mon/metrics/metrics).
 
@@ -43,7 +33,6 @@ The `Microsoft.AspNetCore.Hosting` metrics report high-level information about H
 | `error.type` | string | Describes a class of error the operation ended with. | `timeout`; `name_resolution_error`; `500` | If request has ended with an error. |
 | `http.request.method` | string | HTTP request method. | `GET`; `POST`; `HEAD` | Always |
 | `http.response.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | If one was sent. |
-| `network.protocol.name` | string | [OSI application layer](https://osi-model.com/application-layer/) or non-OSI equivalent. | `amqp`; `http`; `mqtt` | Always |
 | `network.protocol.version` | string | Version of the protocol specified in `network.protocol.name`. | `3.1.1` | Always |
 | `url.scheme` | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. | `http`; `https` | Always |
 | `aspnetcore.request.is_unhandled` | boolean | True when the request wasn't handled by the application pipeline. | `true` | If the request was unhandled. |
@@ -65,7 +54,7 @@ Available staring in: ASP.NET Core 8.0
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `http.server.active_requests` | UpDownCounter | `{request}` | Measures the number of concurrent HTTP requests that are currently in-flight. |
+| [`http.server.active_requests`](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-http-metrics/#metric-httpclientactive_requests) | UpDownCounter | `{request}` | Measures the number of concurrent HTTP requests that are currently in-flight. |
 
 | Attribute  | Type | Description  | Examples  | Presence |
 |---|---|---|---|---|
@@ -84,7 +73,7 @@ The `Microsoft.AspNetCore.Hosting` metrics report information about [routing HTT
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `aspnetcore.routing.match_attempts` | Counter | `{match_attempt}` | Number of requests that were attempted to be matched to an endpoint. |
+| [`aspnetcore.routing.match_attempts`](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-aspnetcore-metrics/#metric-aspnetcoreroutingmatch_attempts) | Counter | `{match_attempt}` | Number of requests that were attempted to be matched to an endpoint. |
 
 | Attribute  | Type | Description  | Examples  | Presence |
 |---|---|---|---|---|
@@ -96,11 +85,15 @@ Available staring in: ASP.NET Core 8.0
 
 ## `Microsoft.AspNetCore.Diagnostics`
 
+The `Microsoft.AspNetCore.Diagnostics` metrics report information about ASP.NET Core diagnostics:
+
+- [`aspnetcore.diagnostics.exceptions`](#metric-aspnetcorediagnosticsexceptions)
+
 ### Metric: `aspnetcore.diagnostics.exceptions`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `aspnetcore.diagnostics.exceptions` | Counter | `{exception}` | Number of exceptions caught by exception handling middleware. |
+| [`aspnetcore.diagnostics.exceptions`](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-aspnetcore-metrics/#metric-aspnetcorediagnosticsexceptions) | Counter | `{exception}` | Number of exceptions caught by exception handling middleware. |
 
 | Attribute  | Type | Description  | Examples  | Presence |
 |---|---|---|---|---|
@@ -112,11 +105,19 @@ Available staring in: ASP.NET Core 8.0
 
 ## `Microsoft.AspNetCore.RateLimiting`
 
+The `Microsoft.AspNetCore.RateLimiting` metrics report information about [ASP.NET Core rate-limiting middleware](/aspnet/core/performance/rate-limit):
+
+  - [`aspnetcore.rate_limiting.active_request_leases`](#metric-aspnetcorerate_limitingactive_request_leases)
+  - [`aspnetcore.rate_limiting.request_lease.duration`](#metric-aspnetcorerate_limitingrequest_leaseduration)
+  - [`aspnetcore.rate_limiting.queued_requests`](#metric-aspnetcorerate_limitingqueued_requests)
+  - [`aspnetcore.rate_limiting.request.time_in_queue`](#metric-aspnetcorerate_limitingrequesttime_in_queue)
+  - [`aspnetcore.rate_limiting.requests`](#metric-aspnetcorerate_limitingrequests)
+
 ### Metric: `aspnetcore.rate_limiting.active_request_leases`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `aspnetcore.rate_limiting.active_request_leases` | UpDownCounter | `{request}` | Number of requests that are currently active on the server that hold a rate limiting lease. |
+| [`aspnetcore.rate_limiting.active_request_leases`](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-aspnetcore-metrics/#metric-aspnetcorerate_limitingactive_request_leases) | UpDownCounter | `{request}` | Number of requests that are currently active on the server that hold a rate limiting lease. |
 
 | Attribute  | Type | Description  | Examples  | Presence |
 |---|---|---|---|---|
@@ -128,7 +129,7 @@ Available staring in: ASP.NET Core 8.0
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `aspnetcore.rate_limiting.request_lease.duration` | Histogram | `s` | The duration of the rate limiting lease held by requests on the server. |
+| [`aspnetcore.rate_limiting.request_lease.duration`](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-aspnetcore-metrics/#metric-aspnetcorerate_limitingrequest_leaseduration) | Histogram | `s` | The duration of the rate limiting lease held by requests on the server. |
 
 | Attribute  | Type | Description  | Examples  | Presence |
 |---|---|---|---|---|
@@ -140,7 +141,7 @@ Available staring in: ASP.NET Core 8.0
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `aspnetcore.rate_limiting.queued_requests` | UpDownCounter | `{request}` | Number of requests that are currently queued waiting to acquire a rate limiting lease. |
+| [`aspnetcore.rate_limiting.queued_requests`](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-aspnetcore-metrics/#metric-aspnetcorerate_limitingqueued_requests) | UpDownCounter | `{request}` | Number of requests that are currently queued waiting to acquire a rate limiting lease. |
 
 | Attribute  | Type | Description  | Examples  | Presence |
 |---|---|---|---|---|
@@ -152,7 +153,7 @@ Available staring in: ASP.NET Core 8.0
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `aspnetcore.rate_limiting.request.time_in_queue` | Histogram | `s` | The time a request spent in a queue waiting to acquire a rate limiting lease. |
+| [`aspnetcore.rate_limiting.request.time_in_queue`](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-aspnetcore-metrics/#metric-aspnetcorerate_limitingrequesttime_in_queue) | Histogram | `s` | The time a request spent in a queue waiting to acquire a rate limiting lease. |
 
 | Attribute  | Type | Description  | Examples  | Presence |
 |---|---|---|---|---|
@@ -165,7 +166,7 @@ Available staring in: ASP.NET Core 8.0
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `aspnetcore.rate_limiting.requests` | Counter | `{request}` | Number of requests that tried to acquire a rate limiting lease. |
+| [`aspnetcore.rate_limiting.requests`](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-aspnetcore-metrics/#metric-aspnetcorerate_limitingrequests) | Counter | `{request}` | Number of requests that tried to acquire a rate limiting lease. |
 
 | Attribute  | Type | Description  | Examples  | Presence |
 |---|---|---|---|---|
@@ -175,6 +176,11 @@ Available staring in: ASP.NET Core 8.0
 Available staring in: ASP.NET Core 8.0
 
 ## `Microsoft.AspNetCore.HeaderParsing`
+
+The `Microsoft.AspNetCore.HeaderParsing` metrics report information about [ASP.NET Core header parsing](https://www.nuget.org/packages/Microsoft.AspNetCore.HeaderParsing):
+
+  - [`aspnetcore.header_parsing.parse_errors`](#metric-aspnetcoreheader_parsingparse_errors)
+  - [`aspnetcore.header_parsing.cache_accesses`](#metric-aspnetcoreheader_parsingcache_accesses)
 
 ### Metric: `aspnetcore.header_parsing.parse_errors`
 
@@ -206,11 +212,22 @@ Available starting in: .NET 8.0.
 
 ## `Microsoft.AspNetCore.Server.Kestrel`
 
+The `Microsoft.AspNetCore.Server.Kestrel` metrics report information about [ASP.NET Core Kestrel web server](/aspnet/core/fundamentals/servers/kestrel):
+
+  - [`kestrel.active_connections`](#metric-kestrelactive_connections)
+  - [`kestrel.connection.duration`](#metric-kestrelconnectionduration)
+  - [`kestrel.rejected_connections`](#metric-kestrelrejected_connections)
+  - [`kestrel.queued_connections`](#metric-kestrelqueued_connections)
+  - [`kestrel.queued_requests`](#metric-kestrelqueued_requests)
+  - [`kestrel.upgraded_connections`](#metric-kestrelupgraded_connections)
+  - [`kestrel.tls_handshake.duration`](#metric-kestreltls_handshakeduration)
+  - [`kestrel.active_tls_handshakes`](#metric-kestrelactive_tls_handshakes)
+
 ### Metric: `kestrel.active_connections`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `kestrel.active_connections` | UpDownCounter | `{connection}` | Number of connections that are currently active on the server. |
+| [`kestrel.active_connections`](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-kestrel-metrics/#metric-kestrelactive_connections) | UpDownCounter | `{connection}` | Number of connections that are currently active on the server. |
 
 | Attribute  | Type | Description  | Examples  | Presence |
 |---|---|---|---|---|
@@ -225,7 +242,7 @@ Available staring in: ASP.NET Core 8.0
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `kestrel.connection.duration` | Histogram | `s` | The duration of connections on the server. |
+| [`kestrel.connection.duration`](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-kestrel-metrics/#metric-kestrelconnectionduration) | Histogram | `s` | The duration of connections on the server. |
 
 | Attribute  | Type | Description  | Examples  | Presence |
 |---|---|---|---|---|
@@ -244,7 +261,7 @@ Available staring in: ASP.NET Core 8.0
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `kestrel.rejected_connections` | Counter | `{connection}` | Number of connections rejected by the server. |
+| [`kestrel.rejected_connections`](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-kestrel-metrics/#metric-kestrelrejected_connections) | Counter | `{connection}` | Number of connections rejected by the server. |
 
 | Attribute  | Type | Description  | Examples  | Presence |
 |---|---|---|---|---|
@@ -261,7 +278,7 @@ Available staring in: ASP.NET Core 8.0
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `kestrel.queued_connections` | UpDownCounter | `{connection}` | Number of connections that are currently queued and are waiting to start. |
+| [`kestrel.queued_connections`](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-kestrel-metrics/#metric-kestrelqueued_connections) | UpDownCounter | `{connection}` | Number of connections that are currently queued and are waiting to start. |
 
 | Attribute  | Type | Description  | Examples  | Presence |
 |---|---|---|---|---|
@@ -276,7 +293,7 @@ Available staring in: ASP.NET Core 8.0
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `kestrel.queued_requests` | UpDownCounter | `{request}` | Number of HTTP requests on multiplexed connections (HTTP/2 and HTTP/3) that are currently queued and are waiting to start. |
+| [`kestrel.queued_requests`](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-kestrel-metrics/#metric-kestrelqueued_requests) | UpDownCounter | `{request}` | Number of HTTP requests on multiplexed connections (HTTP/2 and HTTP/3) that are currently queued and are waiting to start. |
 
 | Attribute  | Type | Description  | Examples  | Presence |
 |---|---|---|---|---|
@@ -293,7 +310,7 @@ Available staring in: ASP.NET Core 8.0
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `kestrel.upgraded_connections` | UpDownCounter | `{connection}` | Number of connections that are currently upgraded (WebSockets). |
+| [`kestrel.upgraded_connections`](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-kestrel-metrics/#metric-kestrelupgraded_connections) | UpDownCounter | `{connection}` | Number of connections that are currently upgraded (WebSockets). |
 
 | Attribute  | Type | Description  | Examples  | Presence |
 |---|---|---|---|---|
@@ -310,7 +327,7 @@ Available staring in: ASP.NET Core 8.0
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `kestrel.tls_handshake.duration` | Histogram | `s` | The duration of TLS handshakes on the server. |
+| [`kestrel.tls_handshake.duration`](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-kestrel-metrics/#metric-kestreltls_handshakeduration) | Histogram | `s` | The duration of TLS handshakes on the server. |
 
 | Attribute  | Type | Description  | Examples  | Presence |
 |---|---|---|---|---|
@@ -327,7 +344,7 @@ Available staring in: ASP.NET Core 8.0
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `kestrel.active_tls_handshakes` | UpDownCounter | `{handshake}` | Number of TLS handshakes that are currently in progress on the server. |
+| [`kestrel.active_tls_handshakes`](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-kestrel-metrics/#metric-kestrelactive_tls_handshakes) | UpDownCounter | `{handshake}` | Number of TLS handshakes that are currently in progress on the server. |
 
 | Attribute  | Type | Description  | Examples  | Presence |
 |---|---|---|---|---|
@@ -340,11 +357,16 @@ Available staring in: ASP.NET Core 8.0
 
 ## `Microsoft.AspNetCore.Http.Connections`
 
+The `Microsoft.AspNetCore.Http.Connections` metrics report information about [ASP.NET Core SignalR connections](/aspnet/core/signalr/introduction):
+
+  - [`signalr.server.connection.duration`](#instrument-signalrserverconnectionduration)
+  - [`signalr.server.active_connections`](#instrument-signalrserveractive_connections)
+
 ### Metric: `signalr.server.connection.duration`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `signalr.server.connection.duration` | Histogram | `s` | The duration of connections on the server. |
+| [`signalr.server.connection.duration`](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-signalr-metrics/#metric-signalrserverconnectionduration) | Histogram | `s` | The duration of connections on the server. |
 
 | Attribute  | Type | Description  | Examples  | Presence |
 |---|---|---|---|---|
@@ -357,7 +379,7 @@ Available staring in: ASP.NET Core 8.0
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `signalr.server.active_connections` | UpDownCounter | `{connection}` | Number of connections that are currently active on the server. |
+| [`signalr.server.active_connections`](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-signalr-metrics/#metric-signalrserveractive_connections) | UpDownCounter | `{connection}` | Number of connections that are currently active on the server. |
 
 | Attribute  | Type | Description  | Examples  | Presence |
 |---|---|---|---|---|

--- a/docs/core/diagnostics/built-in-metrics-aspnetcore.md
+++ b/docs/core/diagnostics/built-in-metrics-aspnetcore.md
@@ -359,8 +359,8 @@ Available starting in: .NET 8.0.
 
 The `Microsoft.AspNetCore.Http.Connections` metrics report information about [ASP.NET Core SignalR connections](/aspnet/core/signalr/introduction):
 
-- [`signalr.server.connection.duration`](#instrument-signalrserverconnectionduration)
-- [`signalr.server.active_connections`](#instrument-signalrserveractive_connections)
+- [`signalr.server.connection.duration`](#metric-signalrserverconnectionduration)
+- [`signalr.server.active_connections`](#metric-signalrserveractive_connections)
 
 ### Metric: `signalr.server.connection.duration`
 

--- a/docs/core/diagnostics/built-in-metrics-aspnetcore.md
+++ b/docs/core/diagnostics/built-in-metrics-aspnetcore.md
@@ -16,7 +16,7 @@ see [here](available-counters.md).
 
 ## `Microsoft.AspNetCore.Hosting`
 
-The `Microsoft.AspNetCore.Hosting` metrics report high-level information about HTTP requests:
+The `Microsoft.AspNetCore.Hosting` metrics report high-level information about HTTP requests received by ASP.NET Core:
 
 - [`http.server.request.duration`](#metric-httpserverrequestduration)
 - [`http.server.active_requests`](#metric-httpserveractive_requests)
@@ -85,7 +85,7 @@ Available starting in: .NET 8.0.
 
 ## `Microsoft.AspNetCore.Diagnostics`
 
-The `Microsoft.AspNetCore.Diagnostics` metrics report information about ASP.NET Core diagnostics:
+The `Microsoft.AspNetCore.Diagnostics` metrics report diagnostics information from [ASP.NET Core error handling middleware](/aspnet/core/fundamentals/error-handling):
 
 - [`aspnetcore.diagnostics.exceptions`](#metric-aspnetcorediagnosticsexceptions)
 
@@ -105,7 +105,7 @@ Available starting in: .NET 8.0.
 
 ## `Microsoft.AspNetCore.RateLimiting`
 
-The `Microsoft.AspNetCore.RateLimiting` metrics report information about [ASP.NET Core rate-limiting middleware](/aspnet/core/performance/rate-limit):
+The `Microsoft.AspNetCore.RateLimiting` metrics report rate limiting information from [ASP.NET Core rate-limiting middleware](/aspnet/core/performance/rate-limit):
 
 - [`aspnetcore.rate_limiting.active_request_leases`](#metric-aspnetcorerate_limitingactive_request_leases)
 - [`aspnetcore.rate_limiting.request_lease.duration`](#metric-aspnetcorerate_limitingrequest_leaseduration)
@@ -212,7 +212,7 @@ Available starting in: .NET 8.0.
 
 ## `Microsoft.AspNetCore.Server.Kestrel`
 
-The `Microsoft.AspNetCore.Server.Kestrel` metrics report information about [ASP.NET Core Kestrel web server](/aspnet/core/fundamentals/servers/kestrel):
+The `Microsoft.AspNetCore.Server.Kestrel` metrics report HTTP connection information from [ASP.NET Core Kestrel web server](/aspnet/core/fundamentals/servers/kestrel):
 
 - [`kestrel.active_connections`](#metric-kestrelactive_connections)
 - [`kestrel.connection.duration`](#metric-kestrelconnectionduration)
@@ -357,7 +357,7 @@ Available starting in: .NET 8.0.
 
 ## `Microsoft.AspNetCore.Http.Connections`
 
-The `Microsoft.AspNetCore.Http.Connections` metrics report information about [ASP.NET Core SignalR connections](/aspnet/core/signalr/introduction):
+The `Microsoft.AspNetCore.Http.Connections` metrics report connection information from [ASP.NET Core SignalR](/aspnet/core/signalr/introduction):
 
 - [`signalr.server.connection.duration`](#metric-signalrserverconnectionduration)
 - [`signalr.server.active_connections`](#metric-signalrserveractive_connections)

--- a/docs/core/diagnostics/built-in-metrics-aspnetcore.md
+++ b/docs/core/diagnostics/built-in-metrics-aspnetcore.md
@@ -11,9 +11,6 @@ This article describes the metrics built-in for ASP.NET Core produced using the
 <xref:System.Diagnostics.Metrics?displayProperty=nameWithType> API. For a listing of metrics based on the older [EventCounters](event-counters.md) API,
 see [here](available-counters.md).
 
-> [!TIP]
-> For more information about how to collect, report, enrich, and test ASP.NET Core metrics, see [Using ASP.NET Core metrics](/aspnet/core/log-mon/metrics/metrics).
-
 ASP.NET Core metrics are grouped into meters:
 
 - [`Microsoft.AspNetCore.Hosting`](#microsoftaspnetcorehosting)
@@ -24,9 +21,12 @@ ASP.NET Core metrics are grouped into meters:
 - [`Microsoft.AspNetCore.Server.Kestrel`](#microsoftaspnetcoreserverkestrel)
 - [`Microsoft.AspNetCore.Http.Connections`](#microsoftaspnetcorehttpconnections)
 
+> [!TIP]
+> For more information about how to collect, report, enrich, and test ASP.NET Core metrics, see [Using ASP.NET Core metrics](/aspnet/core/log-mon/metrics/metrics).
+
 ## `Microsoft.AspNetCore.Hosting`
 
-The `Microsoft.AspNetCore.Hosting` meter has instruments reporting high-level information about HTTP requests:
+The `Microsoft.AspNetCore.Hosting` metrics report high-level information about HTTP requests:
 
 - [`http.server.request.duration`](#metric-httpserverrequestduration)
 - [`http.server.active_requests`](#metric-httpserveractive_requests)
@@ -76,7 +76,7 @@ Available staring in: ASP.NET Core 8.0
 
 ## `Microsoft.AspNetCore.Routing`
 
-The `Microsoft.AspNetCore.Hosting` meter has instruments about [routing HTTP requests](/aspnet/core/fundamentals/routing) to ASP.NET Core endpoints:
+The `Microsoft.AspNetCore.Hosting` metrics report information about [routing HTTP requests](/aspnet/core/fundamentals/routing) to ASP.NET Core endpoints:
 
 - [`aspnetcore.routing.match_attempts`](#metric-aspnetcoreroutingmatch_attempts)
 

--- a/docs/core/diagnostics/built-in-metrics-aspnetcore.md
+++ b/docs/core/diagnostics/built-in-metrics-aspnetcore.md
@@ -107,11 +107,11 @@ Available starting in: .NET 8.0.
 
 The `Microsoft.AspNetCore.RateLimiting` metrics report information about [ASP.NET Core rate-limiting middleware](/aspnet/core/performance/rate-limit):
 
-  - [`aspnetcore.rate_limiting.active_request_leases`](#metric-aspnetcorerate_limitingactive_request_leases)
-  - [`aspnetcore.rate_limiting.request_lease.duration`](#metric-aspnetcorerate_limitingrequest_leaseduration)
-  - [`aspnetcore.rate_limiting.queued_requests`](#metric-aspnetcorerate_limitingqueued_requests)
-  - [`aspnetcore.rate_limiting.request.time_in_queue`](#metric-aspnetcorerate_limitingrequesttime_in_queue)
-  - [`aspnetcore.rate_limiting.requests`](#metric-aspnetcorerate_limitingrequests)
+- [`aspnetcore.rate_limiting.active_request_leases`](#metric-aspnetcorerate_limitingactive_request_leases)
+- [`aspnetcore.rate_limiting.request_lease.duration`](#metric-aspnetcorerate_limitingrequest_leaseduration)
+- [`aspnetcore.rate_limiting.queued_requests`](#metric-aspnetcorerate_limitingqueued_requests)
+- [`aspnetcore.rate_limiting.request.time_in_queue`](#metric-aspnetcorerate_limitingrequesttime_in_queue)
+- [`aspnetcore.rate_limiting.requests`](#metric-aspnetcorerate_limitingrequests)
 
 ### Metric: `aspnetcore.rate_limiting.active_request_leases`
 
@@ -179,8 +179,8 @@ Available starting in: .NET 8.0.
 
 The `Microsoft.AspNetCore.HeaderParsing` metrics report information about [ASP.NET Core header parsing](https://www.nuget.org/packages/Microsoft.AspNetCore.HeaderParsing):
 
-  - [`aspnetcore.header_parsing.parse_errors`](#metric-aspnetcoreheader_parsingparse_errors)
-  - [`aspnetcore.header_parsing.cache_accesses`](#metric-aspnetcoreheader_parsingcache_accesses)
+- [`aspnetcore.header_parsing.parse_errors`](#metric-aspnetcoreheader_parsingparse_errors)
+- [`aspnetcore.header_parsing.cache_accesses`](#metric-aspnetcoreheader_parsingcache_accesses)
 
 ### Metric: `aspnetcore.header_parsing.parse_errors`
 
@@ -214,14 +214,14 @@ Available starting in: .NET 8.0.
 
 The `Microsoft.AspNetCore.Server.Kestrel` metrics report information about [ASP.NET Core Kestrel web server](/aspnet/core/fundamentals/servers/kestrel):
 
-  - [`kestrel.active_connections`](#metric-kestrelactive_connections)
-  - [`kestrel.connection.duration`](#metric-kestrelconnectionduration)
-  - [`kestrel.rejected_connections`](#metric-kestrelrejected_connections)
-  - [`kestrel.queued_connections`](#metric-kestrelqueued_connections)
-  - [`kestrel.queued_requests`](#metric-kestrelqueued_requests)
-  - [`kestrel.upgraded_connections`](#metric-kestrelupgraded_connections)
-  - [`kestrel.tls_handshake.duration`](#metric-kestreltls_handshakeduration)
-  - [`kestrel.active_tls_handshakes`](#metric-kestrelactive_tls_handshakes)
+- [`kestrel.active_connections`](#metric-kestrelactive_connections)
+- [`kestrel.connection.duration`](#metric-kestrelconnectionduration)
+- [`kestrel.rejected_connections`](#metric-kestrelrejected_connections)
+- [`kestrel.queued_connections`](#metric-kestrelqueued_connections)
+- [`kestrel.queued_requests`](#metric-kestrelqueued_requests)
+- [`kestrel.upgraded_connections`](#metric-kestrelupgraded_connections)
+- [`kestrel.tls_handshake.duration`](#metric-kestreltls_handshakeduration)
+- [`kestrel.active_tls_handshakes`](#metric-kestrelactive_tls_handshakes)
 
 ### Metric: `kestrel.active_connections`
 
@@ -359,8 +359,8 @@ Available starting in: .NET 8.0.
 
 The `Microsoft.AspNetCore.Http.Connections` metrics report information about [ASP.NET Core SignalR connections](/aspnet/core/signalr/introduction):
 
-  - [`signalr.server.connection.duration`](#instrument-signalrserverconnectionduration)
-  - [`signalr.server.active_connections`](#instrument-signalrserveractive_connections)
+- [`signalr.server.connection.duration`](#instrument-signalrserverconnectionduration)
+- [`signalr.server.active_connections`](#instrument-signalrserveractive_connections)
 
 ### Metric: `signalr.server.connection.duration`
 

--- a/docs/core/diagnostics/built-in-metrics-aspnetcore.md
+++ b/docs/core/diagnostics/built-in-metrics-aspnetcore.md
@@ -14,38 +14,24 @@ see [here](available-counters.md).
 > [!TIP]
 > For more information about how to collect, report, enrich, and test ASP.NET Core metrics, see [Using ASP.NET Core metrics](/aspnet/core/log-mon/metrics/metrics).
 
+ASP.NET Core metrics are grouped into meters:
+
 - [`Microsoft.AspNetCore.Hosting`](#meter-microsoftaspnetcorehosting)
-  - [`http.server.request.duration`](#instrument-httpserverrequestduration)
-  - [`http.server.active_requests`](#instrument-httpserveractive_requests)
 - [`Microsoft.AspNetCore.Routing`](#meter-microsoftaspnetcorerouting)
-  - [`aspnetcore.routing.match_attempts`](#instrument-aspnetcoreroutingmatch_attempts)
 - [`Microsoft.AspNetCore.Diagnostics`](#meter-microsoftaspnetcorediagnostics)
-  - [`aspnetcore.diagnostics.exceptions`](#instrument-aspnetcorediagnosticsexceptions)
 - [`Microsoft.AspNetCore.RateLimiting`](#meter-microsoftaspnetcoreratelimiting)
-  - [`aspnetcore.rate_limiting.active_request_leases`](#instrument-aspnetcorerate_limitingactive_request_leases)
-  - [`aspnetcore.rate_limiting.request_lease.duration`](#instrument-aspnetcorerate_limitingrequest_leaseduration)
-  - [`aspnetcore.rate_limiting.queued_requests`](#instrument-aspnetcorerate_limitingqueued_requests)
-  - [`aspnetcore.rate_limiting.request.time_in_queue`](#instrument-aspnetcorerate_limitingrequesttime_in_queue)
-  - [`aspnetcore.rate_limiting.requests`](#instrument-aspnetcorerate_limitingrequests)
 - [`Microsoft.AspNetCore.HeaderParsing`](#meter-microsoftaspnetcoreheaderparsing)
-  - [`aspnetcore.header_parsing.parse_errors`](#instrument-aspnetcoreheader_parsingparse_errors)
-  - [`aspnetcore.header_parsing.cache_accesses`](#instrument-aspnetcoreheader_parsingcache_accesses)
 - [`Microsoft.AspNetCore.Server.Kestrel`](#meter-microsoftaspnetcoreserverkestrel)
-  - [`kestrel.active_connections`](#instrument-kestrelactive_connections)
-  - [`kestrel.connection.duration`](#instrument-kestrelconnectionduration)
-  - [`kestrel.rejected_connections`](#instrument-kestrelrejected_connections)
-  - [`kestrel.queued_connections`](#instrument-kestrelqueued_connections)
-  - [`kestrel.queued_requests`](#instrument-kestrelqueued_requests)
-  - [`kestrel.upgraded_connections`](#instrument-kestrelupgraded_connections)
-  - [`kestrel.tls_handshake.duration`](#instrument-kestreltls_handshakeduration)
-  - [`kestrel.active_tls_handshakes`](#instrument-kestrelactive_tls_handshakes)
 - [`Microsoft.AspNetCore.Http.Connections`](#meter-microsoftaspnetcorehttpconnections)
-  - [`signalr.server.connection.duration`](#instrument-signalrserverconnectionduration)
-  - [`signalr.server.active_connections`](#instrument-signalrserveractive_connections)
 
-## Meter: `Microsoft.AspNetCore.Hosting`
+## `Microsoft.AspNetCore.Hosting`
 
-### Instrument: `http.server.request.duration`
+The `Microsoft.AspNetCore.Hosting` meter has instruments reporting high-level information about HTTP requests:
+
+- [`http.server.request.duration`](#metric-httpserverrequestduration)
+- [`http.server.active_requests`](#metric-httpserveractive_requests)
+
+### Metric: `http.server.request.duration`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -73,7 +59,7 @@ The time ends when:
 - All response data has been sent.
 - The context data structures for the request are being disposed.
 
-### Instrument: `http.server.active_requests`
+### Metric: `http.server.active_requests`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -86,9 +72,13 @@ The time ends when:
 
 Available staring in: ASP.NET Core 8.0
 
-## Meter: `Microsoft.AspNetCore.Routing`
+## `Microsoft.AspNetCore.Routing`
 
-### Instrument: `aspnetcore.routing.match_attempts`
+The `Microsoft.AspNetCore.Hosting` meter has instruments about [routing HTTP requests](/aspnet/core/fundamentals/routing) to ASP.NET Core endpoints:
+
+- [`aspnetcore.routing.match_attempts`](#metric-aspnetcoreroutingmatch_attempts)
+
+### Metric: `aspnetcore.routing.match_attempts`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -102,9 +92,9 @@ Available staring in: ASP.NET Core 8.0
 
 Available staring in: ASP.NET Core 8.0
 
-## Meter: `Microsoft.AspNetCore.Diagnostics`
+## `Microsoft.AspNetCore.Diagnostics`
 
-### Instrument: `aspnetcore.diagnostics.exceptions`
+### Metric: `aspnetcore.diagnostics.exceptions`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -127,9 +117,9 @@ Available staring in: ASP.NET Core 8.0
 
 Available staring in: ASP.NET Core 8.0
 
-## Meter: `Microsoft.AspNetCore.RateLimiting`
+## `Microsoft.AspNetCore.RateLimiting`
 
-### Instrument: `aspnetcore.rate_limiting.active_request_leases`
+### Metric: `aspnetcore.rate_limiting.active_request_leases`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -141,7 +131,7 @@ Available staring in: ASP.NET Core 8.0
 
 Available staring in: ASP.NET Core 8.0
 
-### Instrument: `aspnetcore.rate_limiting.request_lease.duration`
+### Metric: `aspnetcore.rate_limiting.request_lease.duration`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -153,7 +143,7 @@ Available staring in: ASP.NET Core 8.0
 
 Available staring in: ASP.NET Core 8.0
 
-### Instrument: `aspnetcore.rate_limiting.queued_requests`
+### Metric: `aspnetcore.rate_limiting.queued_requests`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -165,7 +155,7 @@ Available staring in: ASP.NET Core 8.0
 
 Available staring in: ASP.NET Core 8.0
 
-### Instrument: `aspnetcore.rate_limiting.request.time_in_queue`
+### Metric: `aspnetcore.rate_limiting.request.time_in_queue`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -187,7 +177,7 @@ Available staring in: ASP.NET Core 8.0
 
 Available staring in: ASP.NET Core 8.0
 
-### Instrument: `aspnetcore.rate_limiting.requests`
+### Metric: `aspnetcore.rate_limiting.requests`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -209,9 +199,9 @@ Available staring in: ASP.NET Core 8.0
 
 Available staring in: ASP.NET Core 8.0
 
-## Meter: `Microsoft.AspNetCore.HeaderParsing`
+## `Microsoft.AspNetCore.HeaderParsing`
 
-### Instrument: `aspnetcore.header_parsing.parse_errors`
+### Metric: `aspnetcore.header_parsing.parse_errors`
 
 | Name | Instrument Type | Unit (UCUM) | Description |
 |--|--|--|--|
@@ -224,7 +214,7 @@ Available staring in: ASP.NET Core 8.0
 
 Available starting in: .NET 8.0.
 
-### Instrument: `aspnetcore.header_parsing.cache_accesses`
+### Metric: `aspnetcore.header_parsing.cache_accesses`
 
 The metric is emitted only for HTTP request header parsers that support caching.
 
@@ -246,9 +236,9 @@ The metric is emitted only for HTTP request header parsers that support caching.
 
 Available starting in: .NET 8.0.
 
-## Meter: `Microsoft.AspNetCore.Server.Kestrel`
+## `Microsoft.AspNetCore.Server.Kestrel`
 
-### Instrument: `kestrel.active_connections`
+### Metric: `kestrel.active_connections`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -263,7 +253,7 @@ Available starting in: .NET 8.0.
 
 Available staring in: ASP.NET Core 8.0
 
-### Instrument: `kestrel.connection.duration`
+### Metric: `kestrel.connection.duration`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -282,7 +272,7 @@ Available staring in: ASP.NET Core 8.0
 
 Available staring in: ASP.NET Core 8.0
 
-### Instrument: `kestrel.rejected_connections`
+### Metric: `kestrel.rejected_connections`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -299,7 +289,7 @@ Connections are rejected when the currently active count exceeds the value confi
 
 Available staring in: ASP.NET Core 8.0
 
-### Instrument: `kestrel.queued_connections`
+### Metric: `kestrel.queued_connections`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -314,7 +304,7 @@ Available staring in: ASP.NET Core 8.0
 
 Available staring in: ASP.NET Core 8.0
 
-### Instrument: `kestrel.queued_requests`
+### Metric: `kestrel.queued_requests`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -331,7 +321,7 @@ Available staring in: ASP.NET Core 8.0
 
 Available staring in: ASP.NET Core 8.0
 
-### Instrument: `kestrel.upgraded_connections`
+### Metric: `kestrel.upgraded_connections`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -348,7 +338,7 @@ The counter only tracks HTTP/1.1 connections.
 
 Available staring in: ASP.NET Core 8.0
 
-### Instrument: `kestrel.tls_handshake.duration`
+### Metric: `kestrel.tls_handshake.duration`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -365,7 +355,7 @@ Available staring in: ASP.NET Core 8.0
 
 Available staring in: ASP.NET Core 8.0
 
-### Instrument: `kestrel.active_tls_handshakes`
+### Metric: `kestrel.active_tls_handshakes`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -380,9 +370,9 @@ Available staring in: ASP.NET Core 8.0
 
 Available staring in: ASP.NET Core 8.0
 
-## Meter: `Microsoft.AspNetCore.Http.Connections`
+## `Microsoft.AspNetCore.Http.Connections`
 
-### Instrument: `signalr.server.connection.duration`
+### Metric: `signalr.server.connection.duration`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -411,7 +401,7 @@ Available staring in: ASP.NET Core 8.0
 
 Available staring in: ASP.NET Core 8.0
 
-### Instrument: `signalr.server.active_connections`
+### Metric: `signalr.server.active_connections`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |

--- a/docs/core/diagnostics/built-in-metrics-aspnetcore.md
+++ b/docs/core/diagnostics/built-in-metrics-aspnetcore.md
@@ -48,7 +48,7 @@ The time ends when:
 - All response data has been sent.
 - The context data structures for the request are being disposed.
 
-Available staring in: ASP.NET Core 8.0
+Available starting in: .NET 8.0.
 
 ### Metric: `http.server.active_requests`
 
@@ -61,7 +61,7 @@ Available staring in: ASP.NET Core 8.0
 | `http.request.method` | string | HTTP request method. [1] | `GET`; `POST`; `HEAD` | Always |
 | `url.scheme`| string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. | `http`; `https` | Always |
 
-Available staring in: ASP.NET Core 8.0
+Available starting in: .NET 8.0.
 
 ## `Microsoft.AspNetCore.Routing`
 
@@ -81,7 +81,7 @@ The `Microsoft.AspNetCore.Hosting` metrics report information about [routing HTT
 | `aspnetcore.routing.is_fallback_route` | boolean | A value that indicates whether the matched route is a fallback route. | `True` | If a route was successfully matched. |
 | `http.route` | string | The matched route | `{controller}/{action}/{id?}` | If a route was successfully matched. |
 
-Available staring in: ASP.NET Core 8.0
+Available starting in: .NET 8.0.
 
 ## `Microsoft.AspNetCore.Diagnostics`
 
@@ -101,7 +101,7 @@ The `Microsoft.AspNetCore.Diagnostics` metrics report information about ASP.NET 
 | `aspnetcore.diagnostics.handler.type` | string | Full type name of the [`IExceptionHandler`](/dotnet/api/microsoft.aspnetcore.diagnostics.iexceptionhandler) implementation that handled the exception. | `Contoso.MyHandler` | If the exception was handled by this handler. |
 | `exception.type` | string | The full name of exception type. | `System.OperationCanceledException`; `Contoso.MyException` | Always |
 
-Available staring in: ASP.NET Core 8.0
+Available starting in: .NET 8.0.
 
 ## `Microsoft.AspNetCore.RateLimiting`
 
@@ -123,7 +123,7 @@ The `Microsoft.AspNetCore.RateLimiting` metrics report information about [ASP.NE
 |---|---|---|---|---|
 | `aspnetcore.rate_limiting.policy` | string | Rate limiting policy name. | `fixed`; `sliding`; `token` | If the matched endpoint for the request had a rate-limiting policy. |
 
-Available staring in: ASP.NET Core 8.0
+Available starting in: .NET 8.0.
 
 ### Metric: `aspnetcore.rate_limiting.request_lease.duration`
 
@@ -135,7 +135,7 @@ Available staring in: ASP.NET Core 8.0
 |---|---|---|---|---|
 | `aspnetcore.rate_limiting.policy` | string | Rate limiting policy name. | `fixed`; `sliding`; `token` | If the matched endpoint for the request had a rate-limiting policy. |
 
-Available staring in: ASP.NET Core 8.0
+Available starting in: .NET 8.0.
 
 ### Metric: `aspnetcore.rate_limiting.queued_requests`
 
@@ -147,7 +147,7 @@ Available staring in: ASP.NET Core 8.0
 |---|---|---|---|---|
 | `aspnetcore.rate_limiting.policy` | string | Rate limiting policy name. | `fixed`; `sliding`; `token` | If the matched endpoint for the request had a rate-limiting policy. |
 
-Available staring in: ASP.NET Core 8.0
+Available starting in: .NET 8.0.
 
 ### Metric: `aspnetcore.rate_limiting.request.time_in_queue`
 
@@ -160,7 +160,7 @@ Available staring in: ASP.NET Core 8.0
 | `aspnetcore.rate_limiting.policy` | string | Rate limiting policy name. | `fixed`; `sliding`; `token` | If the matched endpoint for the request had a rate-limiting policy. |
 | `aspnetcore.rate_limiting.result` | string | The rate limiting result shows whether lease was acquired or contains a rejection reason. | `acquired`; `request_canceled` | Always |
 
-Available staring in: ASP.NET Core 8.0
+Available starting in: .NET 8.0.
 
 ### Metric: `aspnetcore.rate_limiting.requests`
 
@@ -173,7 +173,7 @@ Available staring in: ASP.NET Core 8.0
 | `aspnetcore.rate_limiting.policy` | string | Rate limiting policy name. | `fixed`; `sliding`; `token` | If the matched endpoint for the request had a rate-limiting policy. |
 | `aspnetcore.rate_limiting.result` | string | The rate limiting result shows whether lease was acquired or contains a rejection reason. | `acquired`; `request_canceled` | Always |
 
-Available staring in: ASP.NET Core 8.0
+Available starting in: .NET 8.0.
 
 ## `Microsoft.AspNetCore.HeaderParsing`
 
@@ -236,7 +236,7 @@ The `Microsoft.AspNetCore.Server.Kestrel` metrics report information about [ASP.
 | `server.address` | string | Server address domain name if available without reverse DNS lookup;  otherwise, IP address or Unix domain socket name. | `example.com` | Always |
 | `server.port`| int | Server port number | `80`; `8080`; `443` | If the transport is `tcp` or `udp`. |
 
-Available staring in: ASP.NET Core 8.0
+Available starting in: .NET 8.0.
 
 ### Metric: `kestrel.connection.duration`
 
@@ -255,7 +255,7 @@ Available staring in: ASP.NET Core 8.0
 | `server.port` | int | Server port number | `80`; `8080`; `443` | If the transport is `tcp` or `udp`. |
 | `tls.protocol.version` | string | TLS protocol version. | `1.2`; `1.3` | If the connection is secured with TLS. |
 
-Available staring in: ASP.NET Core 8.0
+Available starting in: .NET 8.0.
 
 ### Metric: `kestrel.rejected_connections`
 
@@ -272,7 +272,7 @@ Available staring in: ASP.NET Core 8.0
 
 Connections are rejected when the currently active count exceeds the value configured with `MaxConcurrentConnections`.
 
-Available staring in: ASP.NET Core 8.0
+Available starting in: .NET 8.0.
 
 ### Metric: `kestrel.queued_connections`
 
@@ -287,7 +287,7 @@ Available staring in: ASP.NET Core 8.0
 | `server.address` | string | Server address domain name if available without reverse DNS lookup;  otherwise, IP address or Unix domain socket name. | `example.com` | Always |
 | `server.port` | int | Server port number | `80`; `8080`; `443` | If the transport is `tcp` or `udp`. |
 
-Available staring in: ASP.NET Core 8.0
+Available starting in: .NET 8.0.
 
 ### Metric: `kestrel.queued_requests`
 
@@ -304,7 +304,7 @@ Available staring in: ASP.NET Core 8.0
 | `server.address` | string | Server address domain name if available without reverse DNS lookup;  otherwise, IP address or Unix domain socket name. | `example.com` | Always |
 | `server.port` | int | Server port number | `80`; `8080`; `443` | If the transport is `tcp` or `udp`. |
 
-Available staring in: ASP.NET Core 8.0
+Available starting in: .NET 8.0.
 
 ### Metric: `kestrel.upgraded_connections`
 
@@ -321,7 +321,7 @@ Available staring in: ASP.NET Core 8.0
 
 The counter only tracks HTTP/1.1 connections.
 
-Available staring in: ASP.NET Core 8.0
+Available starting in: .NET 8.0.
 
 ### Metric: `kestrel.tls_handshake.duration`
 
@@ -338,7 +338,7 @@ Available staring in: ASP.NET Core 8.0
 | `server.port` | int | Server port number | `80`; `8080`; `443` | If the transport is `tcp` or `udp`. |
 | `tls.protocol.version` | string | TLS protocol version. | `1.2`; `1.3` | If the connection is secured with TLS. |
 
-Available staring in: ASP.NET Core 8.0
+Available starting in: .NET 8.0.
 
 ### Metric: `kestrel.active_tls_handshakes`
 
@@ -353,7 +353,7 @@ Available staring in: ASP.NET Core 8.0
 | `server.address` | string | Server address domain name if available without reverse DNS lookup;  otherwise, IP address or Unix domain socket name. | `example.com` | Always |
 | `server.port` | int | Server port number | `80`; `8080`; `443` | If the transport is `tcp` or `udp`. |
 
-Available staring in: ASP.NET Core 8.0
+Available starting in: .NET 8.0.
 
 ## `Microsoft.AspNetCore.Http.Connections`
 
@@ -373,7 +373,7 @@ The `Microsoft.AspNetCore.Http.Connections` metrics report information about [AS
 | `signalr.connection.status` | string | SignalR HTTP connection closure status. | `app_shutdown`; `timeout` | Always |
 | `signalr.transport` | string | [SignalR transport type](https://github.com/dotnet/aspnetcore/blob/main/src/SignalR/docs/specs/TransportProtocols.md) | `web_sockets`; `long_polling` | Always |
 
-Available staring in: ASP.NET Core 8.0
+Available starting in: .NET 8.0.
 
 ### Metric: `signalr.server.active_connections`
 
@@ -386,4 +386,4 @@ Available staring in: ASP.NET Core 8.0
 | `signalr.connection.status` | string | SignalR HTTP connection closure status. | `app_shutdown`; `timeout` | Always |
 | `signalr.transport` | string | [SignalR transport type](https://github.com/dotnet/aspnetcore/blob/main/src/SignalR/docs/specs/TransportProtocols.md) | `web_sockets`; `long_polling` | Always |
 
-Available staring in: ASP.NET Core 8.0
+Available starting in: .NET 8.0.

--- a/docs/core/diagnostics/built-in-metrics-aspnetcore.md
+++ b/docs/core/diagnostics/built-in-metrics-aspnetcore.md
@@ -16,13 +16,13 @@ see [here](available-counters.md).
 
 ASP.NET Core metrics are grouped into meters:
 
-- [`Microsoft.AspNetCore.Hosting`](#meter-microsoftaspnetcorehosting)
-- [`Microsoft.AspNetCore.Routing`](#meter-microsoftaspnetcorerouting)
-- [`Microsoft.AspNetCore.Diagnostics`](#meter-microsoftaspnetcorediagnostics)
-- [`Microsoft.AspNetCore.RateLimiting`](#meter-microsoftaspnetcoreratelimiting)
-- [`Microsoft.AspNetCore.HeaderParsing`](#meter-microsoftaspnetcoreheaderparsing)
-- [`Microsoft.AspNetCore.Server.Kestrel`](#meter-microsoftaspnetcoreserverkestrel)
-- [`Microsoft.AspNetCore.Http.Connections`](#meter-microsoftaspnetcorehttpconnections)
+- [`Microsoft.AspNetCore.Hosting`](#microsoftaspnetcorehosting)
+- [`Microsoft.AspNetCore.Routing`](#microsoftaspnetcorerouting)
+- [`Microsoft.AspNetCore.Diagnostics`](#microsoftaspnetcorediagnostics)
+- [`Microsoft.AspNetCore.RateLimiting`](#microsoftaspnetcoreratelimiting)
+- [`Microsoft.AspNetCore.HeaderParsing`](#microsoftaspnetcoreheaderparsing)
+- [`Microsoft.AspNetCore.Server.Kestrel`](#microsoftaspnetcoreserverkestrel)
+- [`Microsoft.AspNetCore.Http.Connections`](#microsoftaspnetcorehttpconnections)
 
 ## `Microsoft.AspNetCore.Hosting`
 
@@ -58,6 +58,8 @@ The time ends when:
 - The ASP.NET Core handler pipeline is finished executing.
 - All response data has been sent.
 - The context data structures for the request are being disposed.
+
+Available staring in: ASP.NET Core 8.0
 
 ### Metric: `http.server.active_requests`
 

--- a/docs/core/diagnostics/built-in-metrics-aspnetcore.md
+++ b/docs/core/diagnostics/built-in-metrics-aspnetcore.md
@@ -108,15 +108,6 @@ Available staring in: ASP.NET Core 8.0
 | `aspnetcore.diagnostics.handler.type` | string | Full type name of the [`IExceptionHandler`](/dotnet/api/microsoft.aspnetcore.diagnostics.iexceptionhandler) implementation that handled the exception. | `Contoso.MyHandler` | If the exception was handled by this handler. |
 | `exception.type` | string | The full name of exception type. | `System.OperationCanceledException`; `Contoso.MyException` | Always |
 
-`aspnetcore.diagnostics.exception.result` is one of the following:
-
-| Value  | Description |
-|---|---|
-| `handled` | Exception was handled by the exception handling middleware. |
-| `unhandled` | Exception wasn't handled by the exception handling middleware. |
-| `skipped` | Exception handling was skipped because the response had started. |
-| `aborted` | Exception handling didn't run because the request was aborted. |
-
 Available staring in: ASP.NET Core 8.0
 
 ## `Microsoft.AspNetCore.RateLimiting`
@@ -168,15 +159,6 @@ Available staring in: ASP.NET Core 8.0
 | `aspnetcore.rate_limiting.policy` | string | Rate limiting policy name. | `fixed`; `sliding`; `token` | If the matched endpoint for the request had a rate-limiting policy. |
 | `aspnetcore.rate_limiting.result` | string | The rate limiting result shows whether lease was acquired or contains a rejection reason. | `acquired`; `request_canceled` | Always |
 
-`aspnetcore.rate_limiting.result` is one of the following:
-
-| Value  | Description |
-|---|---|
-| `acquired` | Lease was acquired |
-| `endpoint_limiter` | Lease request was rejected by the endpoint limiter |
-| `global_limiter` | Lease request was rejected by the global limiter |
-| `request_canceled` | Lease request was canceled |
-
 Available staring in: ASP.NET Core 8.0
 
 ### Metric: `aspnetcore.rate_limiting.requests`
@@ -189,15 +171,6 @@ Available staring in: ASP.NET Core 8.0
 |---|---|---|---|---|
 | `aspnetcore.rate_limiting.policy` | string | Rate limiting policy name. | `fixed`; `sliding`; `token` | If the matched endpoint for the request had a rate-limiting policy. |
 | `aspnetcore.rate_limiting.result` | string | The rate limiting result shows whether lease was acquired or contains a rejection reason. | `acquired`; `request_canceled` | Always |
-
-`aspnetcore.rate_limiting.result` is one of the following:
-
-| Value  | Description |
-|---|---|
-| `acquired` | Lease was acquired |
-| `endpoint_limiter` | Lease request was rejected by the endpoint limiter |
-| `global_limiter` | Lease request was rejected by the global limiter |
-| `request_canceled` | Lease request was canceled |
 
 Available staring in: ASP.NET Core 8.0
 
@@ -228,13 +201,6 @@ The metric is emitted only for HTTP request header parsers that support caching.
 |---|---|---|---|---|
 | `aspnetcore.header_parsing.header.name` | string | The header name. | `Content-Type` | Always |
 | `aspnetcore.header_parsing.cache_access.type` | string | A value indicating whether the header's value was found in the cache or not. | `Hit`; `Miss` | Always |
-
-`aspnetcore.header_parsing.cache_access.type` is one of the following:
-
-| Value | Description |
-|---|---|
-| `Hit` | The header's value was found in the cache. |
-| `Miss` | The header's value wasn't found in the cache. |
 
 Available starting in: .NET 8.0.
 
@@ -385,22 +351,6 @@ Available staring in: ASP.NET Core 8.0
 | `signalr.connection.status` | string | SignalR HTTP connection closure status. | `app_shutdown`; `timeout` | Always |
 | `signalr.transport` | string | [SignalR transport type](https://github.com/dotnet/aspnetcore/blob/main/src/SignalR/docs/specs/TransportProtocols.md) | `web_sockets`; `long_polling` | Always |
 
-`signalr.connection.status` is one of the following:
-
-| Value  | Description |
-|---|---|
-| `normal_closure` | The connection was closed normally. |
-| `timeout` | The connection was closed due to a timeout. |
-| `app_shutdown` | The connection was closed because the app is shutting down. |
-
-`signalr.transport` is one of the following:
-
-| Value  | Protocol |
-|---|---|
-| `server_sent_events` | [server-sent events](https://developer.mozilla.org/docs/Web/API/Server-sent_events/Using_server-sent_events)  |
-| `long_polling` | [Long Polling](/archive/msdn-magazine/2012/april/cutting-edge-long-polling-and-signalr) |
-| `web_sockets` | [WebSocket](https://datatracker.ietf.org/doc/html/rfc6455) |
-
 Available staring in: ASP.NET Core 8.0
 
 ### Metric: `signalr.server.active_connections`
@@ -413,21 +363,5 @@ Available staring in: ASP.NET Core 8.0
 |---|---|---|---|---|
 | `signalr.connection.status` | string | SignalR HTTP connection closure status. | `app_shutdown`; `timeout` | Always |
 | `signalr.transport` | string | [SignalR transport type](https://github.com/dotnet/aspnetcore/blob/main/src/SignalR/docs/specs/TransportProtocols.md) | `web_sockets`; `long_polling` | Always |
-
-`signalr.connection.status` is one of the following:
-
-| Value  | Description |
-|---|---|
-| `normal_closure` | The connection was closed normally. |
-| `timeout` | The connection was closed due to a timeout. |
-| `app_shutdown` | The connection was closed because the app is shutting down. |
-
-`signalr.transport` is one of the following:
-
-| Value  | Description |
-|---|---|
-| `server_sent_events` | ServerSentEvents protocol |
-| `long_polling` | LongPolling protocol |
-| `web_sockets` | WebSockets protocol |
 
 Available staring in: ASP.NET Core 8.0

--- a/docs/core/diagnostics/built-in-metrics-diagnostics.md
+++ b/docs/core/diagnostics/built-in-metrics-diagnostics.md
@@ -10,17 +10,14 @@ ms.date: 11/02/2023
 This article describes the built-in metrics for diagnostic .NET extensions libraries that are produced using the
 <xref:System.Diagnostics.Metrics?displayProperty=nameWithType> API. For a listing of metrics based on the older [EventCounters](event-counters.md) API, see [Available counters](available-counters.md).
 
-- [Meter: `Microsoft.Extensions.Diagnostics.HealthChecks`](#meter-microsoftextensionsdiagnosticshealthchecks)
-  - [Instrument: `dotnet.health_check.reports`](#instrument-dotnethealth_checkreports)
-  - [Instrument: `dotnet.health_check.unhealthy_checks`](#instrument-dotnethealth_checkunhealthy_checks)
-- [Meter: `Microsoft.Extensions.Diagnostics.ResourceMonitoring`](#meter-microsoftextensionsdiagnosticsresourcemonitoring)
-  - [Instrument: `process.cpu.utilization`](#instrument-processcpuutilization)
-  - [Instrument: `dotnet.process.memory.virtual.utilization`](#instrument-dotnetprocessmemoryvirtualutilization)
-  - [Instrument: `system.network.connections`](#instrument-systemnetworkconnections)
+## `Microsoft.Extensions.Diagnostics.HealthChecks`
 
-## Meter: `Microsoft.Extensions.Diagnostics.HealthChecks`
+The `Microsoft.Extensions.Diagnostics.HealthChecks` metrics report health check information by [Microsoft.Extensions.Diagnostics.HealthChecks.Common](https://www.nuget.org/packages/Microsoft.Extensions.Diagnostics.HealthChecks.Common):
 
-### Instrument: `dotnet.health_check.reports`
+- [`dotnet.health_check.reports`](#metric-dotnethealth_checkreports)
+- [`dotnet.health_check.unhealthy_checks`](#metric-dotnethealth_checkunhealthy_checks)
+
+### Metric: `dotnet.health_check.reports`
 
 | Name | Instrument Type | Unit (UCUM) | Description |
 | ---- | --------------- | ----------- | ----------- |
@@ -40,7 +37,7 @@ This article describes the built-in metrics for diagnostic .NET extensions libra
 
 Available starting in: .NET 8.0.
 
-### Instrument: `dotnet.health_check.unhealthy_checks`
+### Metric: `dotnet.health_check.unhealthy_checks`
 
 | Name | Instrument Type | Unit (UCUM) | Description |
 | ---- | --------------- | ----------- | ----------- |
@@ -61,12 +58,18 @@ Available starting in: .NET 8.0.
 
 Available starting in: .NET 8.0.
 
-## Meter: `Microsoft.Extensions.Diagnostics.ResourceMonitoring`
+## `Microsoft.Extensions.Diagnostics.ResourceMonitoring`
+
+The `Microsoft.Extensions.Diagnostics.ResourceMonitoring` metrics report information resource by [resource monitoring](/dotnet/core/diagnostics/diagnostic-resource-monitoring):
+
+- [`process.cpu.utilization`](#metric-processcpuutilization)
+- [`dotnet.process.memory.virtual.utilization`](#metric-dotnetprocessmemoryvirtualutilization)
+- [`system.network.connections`](#metric-systemnetworkconnections)
 
 > [!NOTE]
 > Metrics emitted by the `Microsoft.Extensions.Diagnostics.ResourceMonitoring` meter are in experimental stage. This means that there could be breaking changes to them.
 
-### Instrument: `process.cpu.utilization`
+### Metric: `process.cpu.utilization`
 
 The instrument is available only on Linux.
 
@@ -76,7 +79,7 @@ The instrument is available only on Linux.
 
 Available starting in: .NET 8.0.
 
-### Instrument: `dotnet.process.memory.virtual.utilization`
+### Metric: `dotnet.process.memory.virtual.utilization`
 
 The instrument is available only on Linux.
 
@@ -86,7 +89,7 @@ The instrument is available only on Linux.
 
 Available starting in: .NET 8.0.
 
-### Instrument: `system.network.connections`
+### Metric: `system.network.connections`
 
 The instrument is available only on Windows.
 
@@ -98,29 +101,5 @@ The instrument is available only on Windows.
 |---|---|---|---|---|
 | `network.type` | string | OSI network layer or non-OSI equivalent. | `ipv4`; `ipv6` | Always |
 | `system.network.state` | string | The state of a network connection. | `close`; `listen` | Always |
-
-`network.type` is one of the following:
-
-| Value  | Description |
-|---|---|
-| `ipv4` | IPv4 |
-| `ipv6` | IPv6 |
-
-`system.network.state` is one of the following:
-
-| Value  | Description |
-|---|---|
-| `close` | A connection is closed. |
-| `close_wait` | A connection is in the close wait state. |
-| `closing` | A connection is closing. |
-| `delete` | A connection is in the delete TCB state. |
-| `established` | A connection is established. |
-| `fin_wait_1` | A connection is waiting for a FIN packet 1. |
-| `fin_wait_2` | A connection is waiting for a FIN packet 2. |
-| `last_ack` | A connection is in the last ACK state. |
-| `listen` | A connection is in the listen state. |
-| `syn_recv` | A connection has received a SYN packet. |
-| `syn_sent` | A connection has sent a SYN packet. |
-| `time_wait` | A connection is in the time wait state. |
 
 Available starting in: .NET 8.0.

--- a/docs/core/diagnostics/built-in-metrics-diagnostics.md
+++ b/docs/core/diagnostics/built-in-metrics-diagnostics.md
@@ -12,7 +12,7 @@ This article describes the built-in metrics for diagnostic .NET extensions libra
 
 ## `Microsoft.Extensions.Diagnostics.HealthChecks`
 
-The `Microsoft.Extensions.Diagnostics.HealthChecks` metrics report health check information by [Microsoft.Extensions.Diagnostics.HealthChecks.Common](https://www.nuget.org/packages/Microsoft.Extensions.Diagnostics.HealthChecks.Common):
+The `Microsoft.Extensions.Diagnostics.HealthChecks` metrics report health check information from [.NET health checks](diagnostic-health-checks.md):
 
 - [`dotnet.health_check.reports`](#metric-dotnethealth_checkreports)
 - [`dotnet.health_check.unhealthy_checks`](#metric-dotnethealth_checkunhealthy_checks)
@@ -60,7 +60,7 @@ Available starting in: .NET 8.0.
 
 ## `Microsoft.Extensions.Diagnostics.ResourceMonitoring`
 
-The `Microsoft.Extensions.Diagnostics.ResourceMonitoring` metrics report information resource by [resource monitoring](/dotnet/core/diagnostics/diagnostic-resource-monitoring):
+The `Microsoft.Extensions.Diagnostics.ResourceMonitoring` metrics report resource information from [resource monitoring](diagnostic-resource-monitoring.md):
 
 - [`process.cpu.utilization`](#metric-processcpuutilization)
 - [`dotnet.process.memory.virtual.utilization`](#metric-dotnetprocessmemoryvirtualutilization)

--- a/docs/core/diagnostics/built-in-metrics-system-net.md
+++ b/docs/core/diagnostics/built-in-metrics-system-net.md
@@ -13,22 +13,17 @@ This article describes the networking metrics built-in for <xref:System.Net> pro
 > [!TIP]
 > For more information about how to collect, report, enrich, and test System.Net metrics, see [Networking metrics in .NET](../../fundamentals/networking/telemetry/metrics.md).
 
-- [Meter: `System.Net.NameResolution`](#meter-systemnetnameresolution) - Metrics for DNS lookups
-  * [Instrument: `dns.lookup.duration`](#instrument-dnslookupduration)
-- [Meter: `System.Net.Http`](#meter-systemnethttp) - Metrics for outbound networking requests using HttpClient
-  * [Instrument: `http.client.open_connections`](#instrument-httpclientopen_connections)
-  * [Instrument: `http.client.connection.duration`](#instrument-httpclientconnectionduration)
-  * [Instrument: `http.client.request.duration`](#instrument-httpclientrequestduration)
-  * [Instrument: `http.client.request.time_in_queue`](#instrument-httpclientrequesttime_in_queue)
-  * [Instrument: `http.client.active_requests`](#instrument-httpclientactive_requests)
+## `System.Net.NameResolution`
 
-## Meter: `System.Net.NameResolution`
+The `System.Net.NameResolution` metrics report information about DNS name resolution by <xref:System.Net.Dns>:
 
-### Instrument: `dns.lookup.duration`
+- [`dns.lookup.duration`](#metric-dnslookupduration)
+
+### Metric: `dns.lookup.duration`
 
 | Name     | Instrument Type | Unit | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `dns.lookup.duration` | Histogram | `s` | Measures the time taken to perform a DNS lookup. |
+| [`dns.lookup.duration`](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-dns-metrics/#metric-dnslookupduration) | Histogram | `s` | Measures the time taken to perform a DNS lookup. |
 
 | Attribute  | Type | Description  | Examples  | Presence |
 |---|---|---|---|---|
@@ -51,13 +46,21 @@ Socket exceptions with any other `SocketError` value are reported as `System.Net
 
 Available starting in: .NET 8
 
-## Meter: `System.Net.Http`
+## `System.Net.Http`
 
-### Instrument: `http.client.open_connections`
+The `System.Net.Http` metrics report information about HTTP requests by <xref:System.Net.Http>:
+
+  * [`http.client.open_connections`](#metric-httpclientopen_connections)
+  * [`http.client.connection.duration`](#metric-httpclientconnectionduration)
+  * [`http.client.request.duration`](#metric-httpclientrequestduration)
+  * [`http.client.request.time_in_queue`](#metric-httpclientrequesttime_in_queue)
+  * [`http.client.active_requests`](#metric-httpclientactive_requests)
+
+### Metric: `http.client.open_connections`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `http.client.open_connections` | UpDownCounter | `{connection}` | Number of outbound HTTP connections that are currently active or idle on the client |
+| [`http.client.open_connections`](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-http-metrics/#metric-httpclientopen_connections) | UpDownCounter | `{connection}` | Number of outbound HTTP connections that are currently active or idle on the client |
 
 | Attribute  | Type | Description  | Examples  | Presence |
 |---|---|---|---|---|
@@ -72,11 +75,11 @@ Available starting in: .NET 8
 
 Available starting in: .NET 8
 
-### Instrument: `http.client.connection.duration`
+### Metric: `http.client.connection.duration`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `http.client.connection.duration` | Histogram | `s` | The duration of successfully established outbound HTTP connections. |
+| [`http.client.connection.duration`](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-http-metrics/#metric-httpclientconnectionduration) | Histogram | `s` | The duration of successfully established outbound HTTP connections. |
 
 | Attribute  | Type | Description  | Examples  | Presence |
 |---|---|---|---|---|
@@ -90,11 +93,11 @@ This metric is only captured when <xref:System.Net.Http.HttpClient> is configure
 
 Available starting in: .NET 8
 
-### Instrument: `http.client.request.duration`
+### Metric: `http.client.request.duration`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `http.client.request.duration` | Histogram | `s` | The duration of outbound HTTP requests. |
+| [`http.client.request.duration`](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-http-metrics/#metric-httpserverrequestduration) | Histogram | `s` | The duration of outbound HTTP requests. |
 
 | Attribute  | Type | Description  | Examples  | Presence |
 |---|---|---|---|---|
@@ -113,11 +116,11 @@ Available starting in: .NET 8
 > [!TIP]
 > [Enrichment](../../fundamentals/networking/telemetry/metrics.md#enrichment) is possible for this metric.
 
-### Instrument: `http.client.request.time_in_queue`
+### Metric: `http.client.request.time_in_queue`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `http.client.request.time_in_queue` | Histogram | `s` | The amount of time requests spent on a queue waiting for an available connection. |
+| [`http.client.request.time_in_queue`](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-http-metrics/#metric-httpclientrequesttime_in_queue) | Histogram | `s` | The amount of time requests spent on a queue waiting for an available connection. |
 
 | Attribute  | Type | Description  | Examples  | Presence |
 |---|---|---|---|---|
@@ -131,11 +134,11 @@ Available starting in: .NET 8
 
 Available starting in: .NET 8
 
-### Instrument: `http.client.active_requests`
+### Metric: `http.client.active_requests`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `http.client.active_requests` | UpDownCounter | `{request}` | Number of active HTTP requests. |
+| [`http.client.active_requests`](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-http-metrics/#metric-httpserveractive_requests) | UpDownCounter | `{request}` | Number of active HTTP requests. |
 
 | Attribute  | Type | Description  | Examples  | Presence |
 |---|---|---|---|---|

--- a/docs/core/diagnostics/built-in-metrics-system-net.md
+++ b/docs/core/diagnostics/built-in-metrics-system-net.md
@@ -50,11 +50,11 @@ Available starting in: .NET 8
 
 The `System.Net.Http` metrics report information about HTTP requests by <xref:System.Net.Http>:
 
-  * [`http.client.open_connections`](#metric-httpclientopen_connections)
-  * [`http.client.connection.duration`](#metric-httpclientconnectionduration)
-  * [`http.client.request.duration`](#metric-httpclientrequestduration)
-  * [`http.client.request.time_in_queue`](#metric-httpclientrequesttime_in_queue)
-  * [`http.client.active_requests`](#metric-httpclientactive_requests)
+- [`http.client.open_connections`](#metric-httpclientopen_connections)
+- [`http.client.connection.duration`](#metric-httpclientconnectionduration)
+- [`http.client.request.duration`](#metric-httpclientrequestduration)
+- [`http.client.request.time_in_queue`](#metric-httpclientrequesttime_in_queue)
+- [`http.client.active_requests`](#metric-httpclientactive_requests)
 
 ### Metric: `http.client.open_connections`
 

--- a/docs/core/diagnostics/built-in-metrics-system-net.md
+++ b/docs/core/diagnostics/built-in-metrics-system-net.md
@@ -147,6 +147,6 @@ Available starting in: .NET 8
 | `server.port` | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. | `80`; `8080`; `443` | If not default (`80` for `http` scheme, `443` for `https`) |
 | `url.scheme` | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. | `http`; `https`; `ftp` | Always |
 
-This metric counts how many requests are considered active. Requests are active for the same time period that is measured by the [http.client.request.duration](#instrument-httpclientrequestduration) instrument.
+This metric counts how many requests are considered active. Requests are active for the same time period that is measured by the [http.client.request.duration](#metric-httpclientrequestduration) instrument.
 
 Available starting in: .NET 8

--- a/docs/core/diagnostics/built-in-metrics-system-net.md
+++ b/docs/core/diagnostics/built-in-metrics-system-net.md
@@ -15,7 +15,7 @@ This article describes the networking metrics built-in for <xref:System.Net> pro
 
 ## `System.Net.NameResolution`
 
-The `System.Net.NameResolution` metrics report information about DNS name resolution by <xref:System.Net.Dns>:
+The `System.Net.NameResolution` metrics report DNS name resolution from <xref:System.Net.Dns>:
 
 - [`dns.lookup.duration`](#metric-dnslookupduration)
 
@@ -48,7 +48,7 @@ Available starting in: .NET 8
 
 ## `System.Net.Http`
 
-The `System.Net.Http` metrics report information about HTTP requests by <xref:System.Net.Http>:
+The `System.Net.Http` metrics report HTTP request and connection information from <xref:System.Net.Http>:
 
 - [`http.client.open_connections`](#metric-httpclientopen_connections)
 - [`http.client.connection.duration`](#metric-httpclientconnectionduration)

--- a/docs/core/diagnostics/diagnostic-health-checks.md
+++ b/docs/core/diagnostics/diagnostic-health-checks.md
@@ -14,7 +14,7 @@ The following heath check status results are possible:
 - <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Degraded?displayProperty=nameWithType>
 - <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Unhealthy?displayProperty=nameWithType>
 
-In addition, health checks often report various diagnostic metrics. For more information, see [Diagnostic Metrics: `Microsoft.Extensions.Diagnostics.HealthChecks`](built-in-metrics-diagnostics.md#meter-microsoftextensionsdiagnosticshealthchecks).
+In addition, health checks often report various diagnostic metrics. For more information, see [Diagnostic Metrics: `Microsoft.Extensions.Diagnostics.HealthChecks`](built-in-metrics-diagnostics.md#microsoftextensionsdiagnosticshealthchecks).
 
 ## Resource utilization health checks
 

--- a/docs/core/diagnostics/diagnostic-resource-monitoring.md
+++ b/docs/core/diagnostics/diagnostic-resource-monitoring.md
@@ -10,7 +10,7 @@ Resource monitoring involves the continuous measurement of resource utilization 
 
 The <xref:Microsoft.Extensions.Diagnostics.ResourceMonitoring.IResourceMonitor> interface furnishes methods for retrieving real-time information concerning process resource utilization. This interface supports the retrieval of data related to CPU and memory usage and is currently compatible with both Windows and Linux platforms. All resource monitoring diagnostic information is published to OpenTelemetry by default, so there's no need to manually publish this yourself.
 
-In addition, the resource monitoring library reports various diagnostic metrics. For more information, see [Diagnostic Metrics: `Microsoft.Extensions.Diagnostics.ResourceMonitoring`](built-in-metrics-diagnostics.md#meter-microsoftextensionsdiagnosticsresourcemonitoring).
+In addition, the resource monitoring library reports various diagnostic metrics. For more information, see [Diagnostic Metrics: `Microsoft.Extensions.Diagnostics.ResourceMonitoring`](built-in-metrics-diagnostics.md#microsoftextensionsdiagnosticsresourcemonitoring).
 
 ## Example resource monitoring usage
 

--- a/docs/fundamentals/networking/telemetry/metrics.md
+++ b/docs/fundamentals/networking/telemetry/metrics.md
@@ -146,7 +146,7 @@ sum by(http_connection_state) (http_client_open_connections{network_protocol_ver
 ## Enrichment
 
 *Enrichment* is the addition of custom tags (a.k.a. attributes or labels) to a metric. This is useful if an app wants to add a custom categorization to dashboards or alerts built with metrics.
-The [`http.client.request.duration`](../../../core/diagnostics/built-in-metrics-system-net.md#instrument-httpclientrequestduration) instrument supports enrichment by registering callbacks with the <xref:System.Net.Http.Metrics.HttpMetricsEnrichmentContext>.
+The [`http.client.request.duration`](../../../core/diagnostics/built-in-metrics-system-net.md#httpclientrequestduration) instrument supports enrichment by registering callbacks with the <xref:System.Net.Http.Metrics.HttpMetricsEnrichmentContext>.
 Note that this is a low-level API and a separate callback registration is needed for each `HttpRequestMessage`.
 
 A simple way to do the callback registration at a single place is to implement a custom <xref:System.Net.Http.DelegatingHandler>.
@@ -189,7 +189,7 @@ Nevertheless, as of .NET 8, only the `System.Net.Http` and the `System.Net.NameR
 
 Moreover, there are some semantical differences between Metrics and their matching EventCounters.
 For example, when using `HttpCompletionOption.ResponseContentRead`, the [`current-requests` EventCounter](../../../core/diagnostics/available-counters.md) considers a request to be active until the moment when the last byte of the request body has been read.
-Its metrics counterpart [`http.client.active_requests`](../../../core/diagnostics/built-in-metrics-system-net.md#instrument-httpclientactive_requests) doesn't include the time spent reading the response body when counting the active requests.
+Its metrics counterpart [`http.client.active_requests`](../../../core/diagnostics/built-in-metrics-system-net.md#httpclientactive_requests) doesn't include the time spent reading the response body when counting the active requests.
 
 ## Need more metrics?
 

--- a/docs/fundamentals/networking/telemetry/metrics.md
+++ b/docs/fundamentals/networking/telemetry/metrics.md
@@ -146,7 +146,7 @@ sum by(http_connection_state) (http_client_open_connections{network_protocol_ver
 ## Enrichment
 
 *Enrichment* is the addition of custom tags (a.k.a. attributes or labels) to a metric. This is useful if an app wants to add a custom categorization to dashboards or alerts built with metrics.
-The [`http.client.request.duration`](../../../core/diagnostics/built-in-metrics-system-net.md#httpclientrequestduration) instrument supports enrichment by registering callbacks with the <xref:System.Net.Http.Metrics.HttpMetricsEnrichmentContext>.
+The [`http.client.request.duration`](../../../core/diagnostics/built-in-metrics-system-net.md#metric-httpclientrequestduration) instrument supports enrichment by registering callbacks with the <xref:System.Net.Http.Metrics.HttpMetricsEnrichmentContext>.
 Note that this is a low-level API and a separate callback registration is needed for each `HttpRequestMessage`.
 
 A simple way to do the callback registration at a single place is to implement a custom <xref:System.Net.Http.DelegatingHandler>.
@@ -189,7 +189,7 @@ Nevertheless, as of .NET 8, only the `System.Net.Http` and the `System.Net.NameR
 
 Moreover, there are some semantical differences between Metrics and their matching EventCounters.
 For example, when using `HttpCompletionOption.ResponseContentRead`, the [`current-requests` EventCounter](../../../core/diagnostics/available-counters.md) considers a request to be active until the moment when the last byte of the request body has been read.
-Its metrics counterpart [`http.client.active_requests`](../../../core/diagnostics/built-in-metrics-system-net.md#httpclientactive_requests) doesn't include the time spent reading the response body when counting the active requests.
+Its metrics counterpart [`http.client.active_requests`](../../../core/diagnostics/built-in-metrics-system-net.md#metric-httpclientactive_requests) doesn't include the time spent reading the response body when counting the active requests.
 
 ## Need more metrics?
 


### PR DESCRIPTION
## Summary

Refactor built-in metrics.

Goals:

* Make top of documentation more approachable. Large multi-level table was intimidating.
* More information at the meter level, i.e. description, metrics list.
* Improve look and feel. I didn't like `Meter: ` and `Instrument: ` repeated multiple times.
* Remove some information and link to semantic conventions for complete information about a metric.

Changes:

* Change top level list of meters and instruments to only meters.
* Add description and metrics list to meter.
* Removed `Meter: ` from meter headers. Unnecessary now that each meter has a description.
* Changed `Instrument: ` to `Metric: ` on metric/instruments. While the implementation is of instruments grouped by meters, from the developer's point of view they care about the metric with that name. I think discussing metrics rather than instruments aligns with how people care about this feature.
* Metric name links to Open Telemetry semantic conventions for that metric. e.g https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-http-metrics/#metric-httpclientrequestduration
* Remove enum tables. This information is available in the semantic conventions link.

> [!NOTE]
> These changes aren't complete. For example, lists of metrics have only been added to some meters. And this is only on the ASP.NET Core page. Once there is consensus about changes then I'll apply changes everywhere.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/built-in-metrics-aspnetcore.md](https://github.com/dotnet/docs/blob/454b3acd9a8060cf1292699bf0189e08a0b3e27c/docs/core/diagnostics/built-in-metrics-aspnetcore.md) | [ASP.NET Core metrics](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/built-in-metrics-aspnetcore?branch=pr-en-us-38914) |
| [docs/core/diagnostics/built-in-metrics-diagnostics.md](https://github.com/dotnet/docs/blob/454b3acd9a8060cf1292699bf0189e08a0b3e27c/docs/core/diagnostics/built-in-metrics-diagnostics.md) | [.NET extensions metrics](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/built-in-metrics-diagnostics?branch=pr-en-us-38914) |
| [docs/core/diagnostics/built-in-metrics-system-net.md](https://github.com/dotnet/docs/blob/454b3acd9a8060cf1292699bf0189e08a0b3e27c/docs/core/diagnostics/built-in-metrics-system-net.md) | [System.Net metrics](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/built-in-metrics-system-net?branch=pr-en-us-38914) |
| [docs/core/diagnostics/diagnostic-health-checks.md](https://github.com/dotnet/docs/blob/454b3acd9a8060cf1292699bf0189e08a0b3e27c/docs/core/diagnostics/diagnostic-health-checks.md) | [.NET app health checks in C\#](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/diagnostic-health-checks?branch=pr-en-us-38914) |
| [docs/core/diagnostics/diagnostic-resource-monitoring.md](https://github.com/dotnet/docs/blob/454b3acd9a8060cf1292699bf0189e08a0b3e27c/docs/core/diagnostics/diagnostic-resource-monitoring.md) | [docs/core/diagnostics/diagnostic-resource-monitoring](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/diagnostic-resource-monitoring?branch=pr-en-us-38914) |
| [docs/fundamentals/networking/telemetry/metrics.md](https://github.com/dotnet/docs/blob/454b3acd9a8060cf1292699bf0189e08a0b3e27c/docs/fundamentals/networking/telemetry/metrics.md) | [Networking metrics in .NET](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/networking/telemetry/metrics?branch=pr-en-us-38914) |


<!-- PREVIEW-TABLE-END -->