### PR TITLE
Update troubleshoot-usage-issues.md

### DIFF
--- a/docs/core/tools/troubleshoot-usage-issues.md
+++ b/docs/core/tools/troubleshoot-usage-issues.md
@@ -55,7 +55,7 @@ The .NET CLI tries to add the default location to the PATH environment variable 
 * If you've installed the .NET Core 3.0 SDK and you've set the `DOTNET_ADD_GLOBAL_TOOLS_TO_PATH` environment variable to `false`.
 * If you've installed .NET Core 2.2 SDK or earlier versions, and you've set the `DOTNET_SKIP_FIRST_TIME_EXPERIENCE` environment variable to `true`.
 
-In these scenarios or if you specified the `--tool-path` option [while installing a dotnet tool](https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools#install-a-global-tool-in-a-custom-location), the `PATH` environment variable on your machine doesn't automatically contain the path where you installed the global tool. In that case, append the tool location (for example, `$HOME/.dotnet/tools`) to the `PATH` environment variable by using whatever method your shell provides for updating environment variables. For more information, see [.NET tools](global-tools.md).
+In these scenarios or if you specified the `--tool-path` option [while installing a dotnet tool](/dotnet/core/tools/global-tools#install-a-global-tool-in-a-custom-location), the `PATH` environment variable on your machine doesn't automatically contain the path where you installed the global tool. In that case, append the tool location (for example, `$HOME/.dotnet/tools`) to the `PATH` environment variable by using whatever method your shell provides for updating environment variables. For more information, see [.NET tools](global-tools.md).
 
 #### Local tools
 

--- a/docs/core/tools/troubleshoot-usage-issues.md
+++ b/docs/core/tools/troubleshoot-usage-issues.md
@@ -55,7 +55,7 @@ The .NET CLI tries to add the default location to the PATH environment variable 
 * If you've installed the .NET Core 3.0 SDK and you've set the `DOTNET_ADD_GLOBAL_TOOLS_TO_PATH` environment variable to `false`.
 * If you've installed .NET Core 2.2 SDK or earlier versions, and you've set the `DOTNET_SKIP_FIRST_TIME_EXPERIENCE` environment variable to `true`.
 
-In these scenarios or if you specified the `--tool-path` option, the `PATH` environment variable on your machine doesn't automatically contain the path where you installed the global tool. In that case, append the tool location (for example, `$HOME/.dotnet/tools`) to the `PATH` environment variable by using whatever method your shell provides for updating environment variables. For more information, see [.NET tools](global-tools.md).
+In these scenarios or if you specified the `--tool-path` option [while installing a dotnet tool](https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools#install-a-global-tool-in-a-custom-location), the `PATH` environment variable on your machine doesn't automatically contain the path where you installed the global tool. In that case, append the tool location (for example, `$HOME/.dotnet/tools`) to the `PATH` environment variable by using whatever method your shell provides for updating environment variables. For more information, see [.NET tools](global-tools.md).
 
 #### Local tools
 


### PR DESCRIPTION
Added hyper link to Install a dotnet global tool in a custom location

## Summary

I made the sentence more descriptive and added an hyperlink to the page that explains how to add `--tool-path` option while installing a dotnet tool


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/troubleshoot-usage-issues.md](https://github.com/dotnet/docs/blob/9d406248662d9fd71e9344438d30c2545139b11c/docs/core/tools/troubleshoot-usage-issues.md) | [Troubleshoot .NET tool usage issues](https://review.learn.microsoft.com/en-us/dotnet/core/tools/troubleshoot-usage-issues?branch=pr-en-us-38924) |


<!-- PREVIEW-TABLE-END -->