### PR TITLE
Update DOTNET_EnableDiagnostics setting documentation

### DIFF
--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -175,7 +175,7 @@ Starting with .NET 8, when set to `0`, disables the [Diagnostic Port](../diagnos
 
 ### `DOTNET_EnableDiagnostics_Debugger`
 
-Starting with .NET 8, when set to `0`, disables debugging and cannot be overriden by other diagnostics settings. Defaults to 1.
+Starting with .NET 8, when set to `0`, disables debugging and can't be overridden by other diagnostics settings. Defaults to `1`.
 
 ### `DOTNET_EnableDiagnostics_Profiler`
 

--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -179,7 +179,7 @@ Starting with .NET 8, when set to `0`, disables debugging and can't be overridde
 
 ### `DOTNET_EnableDiagnostics_Profiler`
 
-Starting with .NET 8, when set to `0`, disables profiling and cannot be overriden by other diagnostics settings. Defaults to 1.
+Starting with .NET 8, when set to `0`, disables profiling and can't be overridden by other diagnostics settings. Defaults to `1`.
 
 ### EventPipe variables
 

--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -167,7 +167,7 @@ Configures the runtime to pause during startup and wait for the _Diagnostics IPC
 
 ### `DOTNET_EnableDiagnostics`
 
-When set to `0`, disables debugging, profiling, and other diagnostics via the [Diagnostic Port](../diagnostics/diagnostic-port.md) and cannot be overriden by other diagnostics settings. Defaults to 1.
+When set to `0`, disables debugging, profiling, and other diagnostics via the [Diagnostic Port](../diagnostics/diagnostic-port.md) and can't be overridden by other diagnostics settings. Defaults to `1`.
 
 ### `DOTNET_EnableDiagnostics_IPC`
 

--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -171,7 +171,7 @@ When set to `0`, disables debugging, profiling, and other diagnostics via the [D
 
 ### `DOTNET_EnableDiagnostics_IPC`
 
-Starting with .NET 8, when set to `0`, disables the [Diagnostic Port](../diagnostics/diagnostic-port.md) and cannot be overriden by other diagnostics settings. Defaults to 1.
+Starting with .NET 8, when set to `0`, disables the [Diagnostic Port](../diagnostics/diagnostic-port.md) and can't be overridden by other diagnostics settings. Defaults to `1`.
 
 ### `DOTNET_EnableDiagnostics_Debugger`
 

--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -167,19 +167,19 @@ Configures the runtime to pause during startup and wait for the _Diagnostics IPC
 
 ### `DOTNET_EnableDiagnostics`
 
-When set to `1`, enables debugging, profiling, and other diagnostics via the [Diagnostic Port](../diagnostics/diagnostic-port.md). Defaults to 1.
+When set to `0`, disables debugging, profiling, and other diagnostics via the [Diagnostic Port](../diagnostics/diagnostic-port.md) and cannot be overriden by other diagnostics settings. Defaults to 1.
 
 ### `DOTNET_EnableDiagnostics_IPC`
 
-Starting with .NET 8, when set to `1`, enables the [Diagnostic Port](../diagnostics/diagnostic-port.md). Defaults to 1.
+Starting with .NET 8, when set to `0`, disables the [Diagnostic Port](../diagnostics/diagnostic-port.md) and cannot be overriden by other diagnostics settings. Defaults to 1.
 
 ### `DOTNET_EnableDiagnostics_Debugger`
 
-Starting with .NET 8, when set to `1`, enables debugging. Defaults to 1.
+Starting with .NET 8, when set to `0`, disables debugging and cannot be overriden by other diagnostics settings. Defaults to 1.
 
 ### `DOTNET_EnableDiagnostics_Profiler`
 
-Starting with .NET 8, when set to `1`, enables profiling. Defaults to 1.
+Starting with .NET 8, when set to `0`, disables profiling and cannot be overriden by other diagnostics settings. Defaults to 1.
 
 ### EventPipe variables
 


### PR DESCRIPTION
## Summary

Clarifies documentation as mentioned in https://github.com/dotnet/runtime/issues/96227#issuecomment-1865326080. 

Fixes dotnet/runtime#96227

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-environment-variables.md](https://github.com/dotnet/docs/blob/5230c25d88c38ce6a00867ea2aa93f557adf31f0/docs/core/tools/dotnet-environment-variables.md) | [.NET environment variables](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables?branch=pr-en-us-38931) |


<!-- PREVIEW-TABLE-END -->