### PR TITLE
Explain how to solve "It was not possible to find any compatible fram…

### DIFF
--- a/docs/core/diagnostics/faq-dumps.yml
+++ b/docs/core/diagnostics/faq-dumps.yml
@@ -33,3 +33,7 @@ sections:
           * [Debug Linux dumps](debug-linux-dumps.md) 
           * [Debug a deadlock in a .NET app](debug-deadlock.md) 
        
+      - question: |
+           How can I solve "It was not possible to find any compatible framework version"
+        answer: |
+            On Linux, the DOTNET_ROOT environment variable must point to the correct folder when set. When it points to another .net version, dotnet-dump will always show this error. When the DOTNET_ROOT environment variable is not set, another error occurs: "You must install .NET to run this application."

--- a/docs/core/diagnostics/faq-dumps.yml
+++ b/docs/core/diagnostics/faq-dumps.yml
@@ -36,4 +36,4 @@ sections:
       - question: |
            How can I solve "It was not possible to find any compatible framework version"
         answer: |
-            On Linux, the DOTNET_ROOT environment variable must point to the correct folder when set. When it points to another .net version, dotnet-dump will always show this error. When the DOTNET_ROOT environment variable is not set, another error occurs: "You must install .NET to run this application."
+            On Linux, the `DOTNET_ROOT` environment variable must point to the correct folder when set. When it points to another .NET version, `dotnet-dump` always produces this error. When the `DOTNET_ROOT` environment variable isn't set, a different error is produced ("You must install .NET to run this application").


### PR DESCRIPTION
…ework version."

Occurs when DOTNET_ROOT is pointing to another install such as 5.0.23, but the dotnet-dump expects a more recent release such as 6 or 7.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
