### PR TITLE
Update Docker intro

### DIFF
--- a/docs/core/docker/introduction.md
+++ b/docs/core/docker/introduction.md
@@ -58,7 +58,7 @@ The `ASPNETCORE_HTTP_PORTS`, `ASPNETCORE_HTTPS_PORTS`, and `ASPNETCORE_URLS` env
 
 ## Users
 
-All .NET 8+ images include the `app` user. Chiseled images are configured to use this user. The SDK container builds feature (demonstrated above) also configures images to use this user. In all other scenarios, this user can be set manually, for example with the `USER` **Dockerfile** instruction. If an image has been configured with `app` and commands need to run as `root`, the then `USER` instruction can be used to set to the user to `root`.
+Starting with .NET 8 images, the `app` user is included. By default, chiseled images are configured with this user enabled. The publish app as .NET container feature (demonstrated in the [Building container images](#building-container-images) section) also configures images with this user enabled by default. In all other scenarios, the `app` user can be set manually, for example with the `USER` *Dockerfile* instruction. If an image has been configured with `app` and commands need to run as `root`, then the `USER` instruction can be used to set to the user to `root`.
 
 ## Staying informed
 

--- a/docs/core/docker/introduction.md
+++ b/docs/core/docker/introduction.md
@@ -7,21 +7,21 @@ ms.custom: "mvc"
 
 # Introduction to .NET and Docker
 
-Containers are one of the most popular ways for deploying and hosting cloud applications, with tools like [Docker](https://www.docker.com/), [Kubernetes](https://kubernetes.io/), and [Podman](https://podman.io/). Many developers choose containers because it is straightforward to package an app with its required dependencies and then to get that app to reliably run on any container host. There is entensive support for [using .NET with containers](https://devblogs.microsoft.com/dotnet/category/containers/).
+Containers are one of the most popular ways for deploying and hosting cloud applications, with tools like [Docker](https://www.docker.com/), [Kubernetes](https://kubernetes.io/), and [Podman](https://podman.io/). Many developers choose containers because it's straightforward to package an app with its dependencies and get that app to reliably run on any container host. There's extensive support for [using .NET with containers](https://devblogs.microsoft.com/dotnet/category/containers/).
 
 Docker provides a great [overview](https://docs.docker.com/engine/docker-overview/) of containers. [Docker Desktop: Community Edition](https://www.docker.com/products/docker-desktop) is a good tool to use for using containers on developer desktop machine.
 
 ## .NET images
 
-Official .NET Docker images are published to the [Microsoft Artifact Registry](https://mcr.microsoft.com/) and are discoverable on the [Docker Hub](https://hub.docker.com/_/microsoft-dotnet/). There are [runtime images](https://mcr.microsoft.com/product/dotnet/aspnet/) for production and [SDK images](https://mcr.microsoft.com/product/dotnet/sdk/) for building your code, for Linux (Alpine, Debian, Ubuntu) and Windows. For more information, see [.NET container images](container-images.md).
+Official .NET container images are published to the [Microsoft Artifact Registry](https://mcr.microsoft.com/) and are discoverable on the [Docker Hub](https://hub.docker.com/_/microsoft-dotnet/). There are [runtime images](https://mcr.microsoft.com/product/dotnet/aspnet/) for production and [SDK images](https://mcr.microsoft.com/product/dotnet/sdk/) for building your code, for Linux (Alpine, Debian, Ubuntu, Mariner) and Windows. For more information, see [.NET container images](container-images.md).
 
 .NET images are regularly updated, whevever a new .NET patch is published or when an operating system base image is updated.
 
-[Chiseled container images](https://devblogs.microsoft.com/dotnet/announcing-dotnet-chiseled-containers/) are Ubuntu container images with only the few components required by the .NET runtime. These images are ~100MB smaller than the regular Ubuntu images and have fewer [CVEs](https://www.cve.org/) since they have fewer components. In particular, they do not container a shell or package manager, which significantly improves their security profile. They also include a [non-root user](https://devblogs.microsoft.com/dotnet/securing-containers-with-rootless/) and are configured with that user enabled.
+[Chiseled container images](https://devblogs.microsoft.com/dotnet/announcing-dotnet-chiseled-containers/) are Ubuntu container images with a minimal set of components required by the .NET runtime. These images are ~100 MB smaller than the regular Ubuntu images and have fewer [CVEs](https://www.cve.org/) since they have fewer components. In particular, they don't contain a shell or package manager, which significantly improves their security profile. They also include a [non-root user](https://devblogs.microsoft.com/dotnet/securing-containers-with-rootless/) and are configured with that user enabled.
 
 ## Building container images
 
-You can build a container image with a **Dockerfile** or rely on the [.NET SDK to produce an image](https://devblogs.microsoft.com/dotnet/announcing-builtin-container-support-for-the-dotnet-sdk/). For samples on building images, see [dotnet/dotnet-docker](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) and [dotnet/sdk-container-builds](https://github.com/dotnet/sdk-container-builds).
+You can build a container image with a **Dockerfile** or rely on the [.NET SDK to produce an image](publish-as-container.md). For samples on building images, see [dotnet/dotnet-docker](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) and [dotnet/sdk-container-builds](https://github.com/dotnet/sdk-container-builds).
 
 The following example demonstrates building and running a container image in a few quick steps.
 

--- a/docs/core/docker/introduction.md
+++ b/docs/core/docker/introduction.md
@@ -7,41 +7,62 @@ ms.custom: "mvc"
 
 # Introduction to .NET and Docker
 
-.NET can easily run in a Docker container. Containers provide a lightweight way to isolate your application from the rest of the host system, sharing just the kernel, and using resources given to your application. If you're unfamiliar with Docker, it's highly recommended that you read through Docker's [overview documentation](https://docs.docker.com/engine/docker-overview/).
+Containers are one of the most popular ways for deploying and hosting cloud applications, with tools like [Docker](https://www.docker.com/), [Kubernetes](https://kubernetes.io/), and [Podman](https://podman.io/). Many developers choose containers because it is straightforward to package an app with its required dependencies and then to get that app to reliably run on any container host. There is entensive support for [using .NET with containers](https://devblogs.microsoft.com/dotnet/category/containers/).
 
-For more information about how to install Docker, see the download page for [Docker Desktop: Community Edition](https://www.docker.com/products/docker-desktop).
-
-## Docker basics
-
-There are a few concepts you should be familiar with. The Docker client has a CLI that you can use to manage images and containers. As previously stated, you should take the time to read through the [Docker overview](https://docs.docker.com/engine/docker-overview/) documentation.
-
-### Images
-
-An image is an ordered collection of filesystem changes that form the basis of a container. The image doesn't have a state and is read-only. An image is commonly based on another image, but with some customization. For example, when you create a new image for your application, you would base it on an existing image that already contains the .NET runtime.
-
-Because containers are created from images, images have a set of run parameters (such as a starting executable) that run when the container starts.
-
-### Containers
-
-A container is a runnable instance of an image. As you build your image, you deploy your application and dependencies. Then, multiple containers can be instantiated, each isolated from one another. Each container instance has its own filesystem, memory, and network interface.
-
-### Registries
-
-Container registries are a collection of image repositories. You can base your images on a registry image. You can create containers directly from an image in a registry. The [relationship between Docker containers, images, and registries](../../architecture/microservices/container-docker-introduction/docker-containers-images-registries.md) is an important concept when [architecting and building containerized applications or microservices](../../architecture/microservices/architect-microservice-container-applications/index.md). This approach greatly shortens the time between development and deployment.
-
-Docker has a public registry hosted at the [Docker Hub](https://hub.docker.com/) that you can use. [.NET-related images](https://hub.docker.com/_/microsoft-dotnet/) are listed at the Docker Hub.
-
-The [Microsoft Container Registry (MCR)](/azure/container-registry) is the official source of Microsoft-provided container images. The MCR is built on Azure CDN to provide globally replicated images. However, the MCR doesn't have a public-facing website, and the primary way to learn about Microsoft-provided container images is through the [Microsoft Docker Hub pages](https://hub.docker.com/_/microsoft-dotnet/).
-
-### Dockerfile
-
-A **Dockerfile** is a file that defines a set of instructions that creates an image. Each instruction in the **Dockerfile** creates a layer in the image. Usually, when you rebuild the image, only the layers that have changed are rebuilt. The **Dockerfile** can be distributed to others and allows them to recreate a new image in the same manner you created it. While this allows you to distribute the *instructions* on how to create the image, the main way to distribute your image is to publish it to a registry.
+Docker provides a great [overview](https://docs.docker.com/engine/docker-overview/) of containers. [Docker Desktop: Community Edition](https://www.docker.com/products/docker-desktop) is a good tool to use for using containers on developer desktop machine.
 
 ## .NET images
 
-Official .NET Docker images are published to the Microsoft Container Registry (MCR) and are discoverable at the [Microsoft .NET Docker Hub repository](https://hub.docker.com/_/microsoft-dotnet/). Each repository contains images for different combinations of the .NET SDK or .NET runtime and operating system that you can use.
+Official .NET Docker images are published to the [Microsoft Artifact Registry](https://mcr.microsoft.com/) and are discoverable on the [Docker Hub](https://hub.docker.com/_/microsoft-dotnet/). There are [runtime images](https://mcr.microsoft.com/product/dotnet/aspnet/) for production and [SDK images](https://mcr.microsoft.com/product/dotnet/sdk/) for building your code, for Linux (Alpine, Debian, Ubuntu) and Windows. For more information, see [.NET container images](container-images.md).
 
-Microsoft provides images that are tailored for specific scenarios. For example, the [ASP.NET Core repository](https://hub.docker.com/_/microsoft-dotnet-aspnet/) provides images that are built for running ASP.NET Core apps in production. For more information, see [.NET container images](container-images.md).
+.NET images are regularly updated, whevever a new .NET patch is published or when an operating system base image is updated.
+
+[Chiseled container images](https://devblogs.microsoft.com/dotnet/announcing-dotnet-chiseled-containers/) are Ubuntu container images with only the few components required by the .NET runtime. These images are ~100MB smaller than the regular Ubuntu images and have fewer [CVEs](https://www.cve.org/) since they have fewer components. In particular, they do not container a shell or package manager, which significantly improves their security profile. They also include a [non-root user](https://devblogs.microsoft.com/dotnet/securing-containers-with-rootless/) and are configured with that user enabled.
+
+## Building container images
+
+You can build a container image with a **Dockerfile** or rely on the [.NET SDK to produce an image](https://devblogs.microsoft.com/dotnet/announcing-builtin-container-support-for-the-dotnet-sdk/). For samples on building images, see [dotnet/dotnet-docker](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) and [dotnet/sdk-container-builds](https://github.com/dotnet/sdk-container-builds).
+
+The following example demonstrates building and running a container image in a few quick steps.
+
+```bash
+$ dotnet new webapp -o webapp
+$ cd webapp/
+$ dotnet publish -p:PublishProfile=DefaultContainer
+MSBuild version 17.8.3+195e7f5a3 for .NET
+  Determining projects to restore...
+  All projects are up-to-date for restore.
+  webapp -> /home/rich/webapp/bin/Release/net8.0/webapp.dll
+  webapp -> /home/rich/webapp/bin/Release/net8.0/publish/
+  Building image 'webapp' with tags 'latest' on top of base image 'mcr.microsoft.com/dotnet/aspnet:8.0'.
+  Pushed image 'webapp:latest' to local registry via 'docker'.
+$ docker run --rm -d -p 8000:8080 webapp
+7c7ad33409e52ddd3a9d330902acdd49845ca4575e39a6494952b642e584016e
+$ curl -s http://localhost:8000 | grep ASP.NET
+    <p>Learn about <a href="https://learn.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
+$ docker ps
+CONTAINER ID   IMAGE     COMMAND               CREATED              STATUS              PORTS                                       NAMES
+7c7ad33409e5   webapp    "dotnet webapp.dll"   About a minute ago   Up About a minute   0.0.0.0:8000->8080/tcp, :::8000->8080/tcp   jovial_shtern
+$ docker kill 7c7ad33409e5
+```
+
+[`docker init`](https://www.docker.com/blog/docker-desktop-4-23/) is a new option for developers wanting to use Dockerfiles.
+
+## Ports
+
+[Port mapping](https://docs.docker.com/network/#published-ports) is a key part of using containers. Ports must be published outside the container in order to respond to external web requests. [ASP.NET Core container images changed in .NET 8](https://learn.microsoft.com/dotnet/core/compatibility/containers/8.0/aspnet-port) to listen on port `8080`, by default. .NET 6 and 7 listen on port `80`.
+
+In the prior example with `docker run`, the host port `8000` is mapped to the container port `8080`. Kubernetes works in a similar way.
+
+The `ASPNETCORE_HTTP_PORTS`, `ASPNETCORE_HTTPS_PORTS`, and `ASPNETCORE_URLS` environment variables can be used to configure this behavior.
+
+## Users
+
+All .NET 8+ images include the `app` user. Chiseled images are configured to use this user. The SDK container builds feature (demonstrated above) also configures images to use this user. In all other scenarios, this user can be set manually, for example with the `USER` **Dockerfile** instruction. If an image has been configured with `app` and commands need to run as `root`, the then `USER` instruction can be used to set to the user to `root`.
+
+## Staying informed
+
+Container-related news is posted to [dotnet/dotnet-docker discussions](https://github.com/dotnet/dotnet-docker/discussions) and to the [.NET Blog "containers" category](https://devblogs.microsoft.com/dotnet/category/containers/).
 
 ## Azure services
 

--- a/docs/core/docker/introduction.md
+++ b/docs/core/docker/introduction.md
@@ -15,7 +15,7 @@ Docker provides a great [overview](https://docs.docker.com/engine/docker-overvie
 
 Official .NET container images are published to the [Microsoft Artifact Registry](https://mcr.microsoft.com/) and are discoverable on the [Docker Hub](https://hub.docker.com/_/microsoft-dotnet/). There are [runtime images](https://mcr.microsoft.com/product/dotnet/aspnet/) for production and [SDK images](https://mcr.microsoft.com/product/dotnet/sdk/) for building your code, for Linux (Alpine, Debian, Ubuntu, Mariner) and Windows. For more information, see [.NET container images](container-images.md).
 
-.NET images are regularly updated, whevever a new .NET patch is published or when an operating system base image is updated.
+.NET images are regularly updated whenever a new .NET patch is published or when an operating system base image is updated.
 
 [Chiseled container images](https://devblogs.microsoft.com/dotnet/announcing-dotnet-chiseled-containers/) are Ubuntu container images with a minimal set of components required by the .NET runtime. These images are ~100 MB smaller than the regular Ubuntu images and have fewer [CVEs](https://www.cve.org/) since they have fewer components. In particular, they don't contain a shell or package manager, which significantly improves their security profile. They also include a [non-root user](https://devblogs.microsoft.com/dotnet/securing-containers-with-rootless/) and are configured with that user enabled.
 

--- a/docs/core/docker/introduction.md
+++ b/docs/core/docker/introduction.md
@@ -23,12 +23,12 @@ Official .NET container images are published to the [Microsoft Artifact Registry
 
 You can build a container image with a **Dockerfile** or rely on the [.NET SDK to produce an image](publish-as-container.md). For samples on building images, see [dotnet/dotnet-docker](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md) and [dotnet/sdk-container-builds](https://github.com/dotnet/sdk-container-builds).
 
-The following example demonstrates building and running a container image in a few quick steps.
+The following example demonstrates building and running a container image in a few quick steps (supported with .NET 8 and .NET 7.0.300).
 
 ```bash
 $ dotnet new webapp -o webapp
 $ cd webapp/
-$ dotnet publish -p:PublishProfile=DefaultContainer
+$ dotnet publish -t:PublishContainer
 MSBuild version 17.8.3+195e7f5a3 for .NET
   Determining projects to restore...
   All projects are up-to-date for restore.
@@ -58,7 +58,7 @@ The `ASPNETCORE_HTTP_PORTS`, `ASPNETCORE_HTTPS_PORTS`, and `ASPNETCORE_URLS` env
 
 ## Users
 
-Starting with .NET 8 images, the `app` user is included. By default, chiseled images are configured with this user enabled. The publish app as .NET container feature (demonstrated in the [Building container images](#building-container-images) section) also configures images with this user enabled by default. In all other scenarios, the `app` user can be set manually, for example with the `USER` *Dockerfile* instruction. If an image has been configured with `app` and commands need to run as `root`, then the `USER` instruction can be used to set to the user to `root`.
+Starting with .NET 8, all images include a non-root user called `app`. By default, chiseled images are configured with this user enabled. The publish app as .NET container feature (demonstrated in the [Building container images](#building-container-images) section) also configures images with this user enabled by default. In all other scenarios, the `app` user can be set manually, for example with the `USER` *Dockerfile* instruction. If an image has been configured with `app` and commands need to run as `root`, then the `USER` instruction can be used to set to the user to `root`.
 
 ## Staying informed
 


### PR DESCRIPTION
The current intro is more about Docker-isms that we can rely on other docs for. I've updated the doc to make it more about .NET-specific topics.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/docker/introduction.md](https://github.com/dotnet/docs/blob/9c72e2787bf78a1a01bfca074334191e922f5916/docs/core/docker/introduction.md) | [Introduction to .NET and Docker](https://review.learn.microsoft.com/en-us/dotnet/core/docker/introduction?branch=pr-en-us-38947) |


<!-- PREVIEW-TABLE-END -->