### PR TITLE
Use precise version of MSTest.Adapter

### DIFF
--- a/docs/core/testing/unit-testing-mstest-runner-intro.md
+++ b/docs/core/testing/unit-testing-mstest-runner-intro.md
@@ -10,11 +10,11 @@ ms.date: 12/15/2023
 
 The MSTest runner is a lightweight and portable alternative to [VSTest](https://github.com/microsoft/vstest) for running tests in all contexts (continuous integration (CI) pipelines, CLI, Visual Studio Test Explorer, VS Code Text Explorer...). The MSTest runner is embedded directly in your MSTest test projects, and there's no other app dependencies, such as `vstest.console` or `dotnet test` needed to run your tests.
 
-The MSTest runner is open source, and builds on a `Microsoft.Testing.Platform` library. You can find `Microsoft.Testing.Platform` code in [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Platform) GitHub repository. The MSTest runner comes bundled with `MSTest in 3.2.0-preview`.
+The MSTest runner is open source, and builds on a `Microsoft.Testing.Platform` library. You can find `Microsoft.Testing.Platform` code in [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Platform) GitHub repository. The MSTest runner comes bundled with `MSTest in 3.2.0-preview.23622.1` or newer.
 
 ## Enable MSTest runner in a MSTest project
 
-To enable the MSTest runner in a MSTest project, you need to add the `EnableMSTestRunner` property and set `OutputType` to `Exe` in your project file, and ensure that you're using `MSTest 3.2.0-preview` or newer, consider the following example _*.csproj_ file:
+To enable the MSTest runner in a MSTest project, you need to add the `EnableMSTestRunner` property and set `OutputType` to `Exe` in your project file, and ensure that you're using `MSTest 3.2.0-preview.23622.1` or newer, consider the following example _*.csproj_ file:
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
@@ -41,7 +41,7 @@ To enable the MSTest runner in a MSTest project, you need to add the `EnableMSTe
           MSTest.TestFramework
           MSTest.Analyzers
     -->    
-    <PackageReference Include="MSTest" Version="3.2.0-preview.23570.1" />
+    <PackageReference Include="MSTest" Version="3.2.0-preview.23623.1" />
 
     <!-- 
       Coverlet collector isn't compatible with MSTest runner, you can 

--- a/docs/core/testing/unit-testing-mstest-runner-intro.md
+++ b/docs/core/testing/unit-testing-mstest-runner-intro.md
@@ -10,11 +10,11 @@ ms.date: 12/15/2023
 
 The MSTest runner is a lightweight and portable alternative to [VSTest](https://github.com/microsoft/vstest) for running tests in all contexts (continuous integration (CI) pipelines, CLI, Visual Studio Test Explorer, VS Code Text Explorer...). The MSTest runner is embedded directly in your MSTest test projects, and there's no other app dependencies, such as `vstest.console` or `dotnet test` needed to run your tests.
 
-The MSTest runner is open source, and builds on a `Microsoft.Testing.Platform` library. You can find `Microsoft.Testing.Platform` code in [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Platform) GitHub repository. The MSTest runner comes bundled with `MSTest in 3.2.0-preview.23622.1` or newer.
+The MSTest runner is open source, and builds on a `Microsoft.Testing.Platform` library. You can find `Microsoft.Testing.Platform` code in [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Platform) GitHub repository. The MSTest runner comes bundled with `MSTest in 3.2.0-preview.23623.1` or newer.
 
 ## Enable MSTest runner in a MSTest project
 
-To enable the MSTest runner in a MSTest project, you need to add the `EnableMSTestRunner` property and set `OutputType` to `Exe` in your project file, and ensure that you're using `MSTest 3.2.0-preview.23622.1` or newer, consider the following example _*.csproj_ file:
+To enable the MSTest runner in a MSTest project, you need to add the `EnableMSTestRunner` property and set `OutputType` to `Exe` in your project file, and ensure that you're using `MSTest 3.2.0-preview.23623.1` or newer, consider the following example _*.csproj_ file:
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">


### PR DESCRIPTION
## Summary

Use precise version of MSTest.TestAdapter package that ships MSTest Runner.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-mstest-runner-intro.md](https://github.com/dotnet/docs/blob/a201723620e3c8418c3fbb9bbf4f79715ce9a0b1/docs/core/testing/unit-testing-mstest-runner-intro.md) | [MSTest runner overview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-runner-intro?branch=pr-en-us-38952) |


<!-- PREVIEW-TABLE-END -->