### PR TITLE
Update spelling of JsonSerializer in publishtrimmed.md

### DIFF
--- a/docs/core/compatibility/serialization/8.0/publishtrimmed.md
+++ b/docs/core/compatibility/serialization/8.0/publishtrimmed.md
@@ -12,7 +12,7 @@ Projects that enable the [PublishTrimmed](../../../deploying/trimming/trimming-o
 Prior to this change, projects that have the `PublishTrimmed` property enabled, that is, `<PublishTrimmed>true</PublishTrimmed>`, published a trimmed application. However, the reflection-based default serialization behavior wasn't necessarily disabled. Depending on what code got trimmed, the follow code might or might not succeed serialization, or might or might not output the correct serialization data.
 
 ```csharp
-JSonSerializer.Serialize(new { Value = 42 });
+JsonSerializer.Serialize(new { Value = 42 });
 ```
 
 ## New behavior


### PR DESCRIPTION
## Summary

The spelling of the static class is incorrect, making the small change so that you can copy-paste the code example


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/serialization/8.0/publishtrimmed.md](https://github.com/dotnet/docs/blob/5ca80c6a3eb7b3272ffea900594712da9e40c281/docs/core/compatibility/serialization/8.0/publishtrimmed.md) | [PublishedTrimmed projects fail reflection-based serialization](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/serialization/8.0/publishtrimmed?branch=pr-en-us-38956) |

<!-- PREVIEW-TABLE-END -->