### PR TITLE
an additional fix for #38713

### DIFF
--- a/docs/core/runtime-config/garbage-collector.md
+++ b/docs/core/runtime-config/garbage-collector.md
@@ -337,7 +337,7 @@ For more information about some of these settings, see the [Middle ground betwee
 {
    "runtimeOptions": {
       "configProperties": {
-         "System.GC.HeapAffinitizeRanges": "0:1-10,0:12,1:50-52,1:70"
+         "System.GC.HeapAffinitizeRanges": "0:1-10,0:12,1:50-52,1:7"
       }
    }
 }
@@ -348,7 +348,7 @@ For more information about some of these settings, see the [Middle ground betwee
 ```json
 {
    "configProperties": {
-      "System.GC.HeapAffinitizeRanges": "0:1-10,0:12,1:50-52,1:70"
+      "System.GC.HeapAffinitizeRanges": "0:1-10,0:12,1:50-52,1:7"
    }
 }
 ```


### PR DESCRIPTION
when I made the fix in this PR: https://github.com/dotnet/docs/pull/38713 I didn't notice one additional place that needed to be changed. fixing those to be complete.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/runtime-config/garbage-collector.md](https://github.com/dotnet/docs/blob/7ee4a5692929c96bd913f561f2bfaaa9d5552c5b/docs/core/runtime-config/garbage-collector.md) | [Runtime configuration options for garbage collection](https://review.learn.microsoft.com/en-us/dotnet/core/runtime-config/garbage-collector?branch=pr-en-us-38964) |

<!-- PREVIEW-TABLE-END -->