### PR TITLE
document warning wave eight

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/snippets/WarningWaves/WarningWaves.csproj
+++ b/docs/csharp/language-reference/compiler-messages/snippets/WarningWaves/WarningWaves.csproj
@@ -3,10 +3,11 @@
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <WarningLevel>7</WarningLevel>
+    <WarningLevel>8</WarningLevel>
     <AnalysisLevel>preview</AnalysisLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/csharp/language-reference/compiler-messages/snippets/WarningWaves/WaveEight.cs
+++ b/docs/csharp/language-reference/compiler-messages/snippets/WarningWaves/WaveEight.cs
@@ -1,0 +1,16 @@
+﻿namespace WarningWaves;
+
+public class ProgramEight
+{
+    // <NoAmpersand>
+    public static async Task LogValue()
+    {
+        int x = 1;
+        unsafe {
+            int* y = &x;
+            Console.WriteLine(*y);
+        }
+        await Task.Delay(1000);
+    }
+    // </NoAmpersand>
+}

--- a/docs/csharp/language-reference/compiler-messages/warning-waves.md
+++ b/docs/csharp/language-reference/compiler-messages/warning-waves.md
@@ -39,7 +39,16 @@ helpviewer_keywords:
 ---
 # C# Warning waves
 
-New warnings and errors may be introduced in each release of the C# compiler. When new warnings could be reported on existing code, those warnings are introduced under an opt-in system referred to as a *warning wave*. The opt-in system means that you shouldn't see new warnings on existing code without taking action to enable them. Warning waves are enabled using the [**AnalysisLevel**](../compiler-options/errors-warnings.md#analysis-level) element in your project file. When `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` is specified, enabled warning wave warnings generate errors. Warning wave 5 diagnostics were added in C# 9. Warning wave 6 diagnostics were added in C# 10. Warning wave 7 diagnostics were added in C# 11. Warning wave 8 diagnostics were added in C# 11.
+New warnings and errors may be introduced in each release of the C# compiler. When new warnings could be reported on existing code, those warnings are introduced under an opt-in system referred to as a *warning wave*. The opt-in system means that you shouldn't see new warnings on existing code without taking action to enable them. Warning waves are enabled using the [**AnalysisLevel**](../compiler-options/errors-warnings.md#analysis-level) element in your project file. When `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` is specified, enabled warning wave warnings generate errors. Warning wave 5 diagnostics were added in C# 9. Warning wave 6 diagnostics were added in C# 10. Warning wave 7 diagnostics were added in C# 11. Warning wave 8 diagnostics were added in C# 12.
+
+## CS9123 - Taking address of local or parameter in async method can create a GC hole.
+
+*Warning wave 8*
+
+The `&` operator should not be used on parameters or local variables in async methods.
+The following code produces CS9123:
+
+:::code language="csharp" source="./snippets/WarningWaves/WaveEight.cs" id="NoAmpersand":::
 
 ## CS8981 - The type name only contains lower-cased ascii characters.
 


### PR DESCRIPTION
## Summary

Describe your changes here.

Fixes #38568

The example produces the warning.
![image](https://github.com/dotnet/docs/assets/28659384/e3d099c8-f873-46fc-b7d1-de9c17097c48)

Side note: for some reason I cannot serve the documentation with the code examples included locally.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-messages/warning-waves.md](https://github.com/dotnet/docs/blob/0c80a757441ff5f38d629c59e776fe64d4bed1b3/docs/csharp/language-reference/compiler-messages/warning-waves.md) | [C# Warning waves](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/warning-waves?branch=pr-en-us-38976) |

<!-- PREVIEW-TABLE-END -->