### PR TITLE
Mention reloading project in Visual Studio as an optional way of solving `CS0518`

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs0518.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0518.md
@@ -29,3 +29,7 @@ Predefined type 'type' is not defined or imported
 - Make sure that the project refers to the correct mscorlib.dll.  
   
 - Reinstall the .NET Framework common language runtime (if the previous solutions do not solve the problem).
+
+Optionally
+
+- Reload the project in the Visual Studio.


### PR DESCRIPTION
This pull request fixes #38953 
It adds the optional way of solving the error by simply reloading the project in Visual Studio.

I was thinking about linking the [Open project dialog](https://learn.microsoft.com/visualstudio/ide/filtered-solutions?view=vs-2022#open-project-dialog) guide on how to reload the project, but eventually I decided not to. However, if reviewers will consider this as a good idea I'm happy to apply any suggestions!

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-messages/cs0518.md](https://github.com/dotnet/docs/blob/2c0ba960cb2535afc79afcfb47d03853235d7b48/docs/csharp/language-reference/compiler-messages/cs0518.md) | [Compiler Error CS0518](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0518?branch=pr-en-us-38982) |

<!-- PREVIEW-TABLE-END -->