### PR TITLE
Fix CodeCoverage version for MSTest runner

### DIFF
--- a/docs/core/testing/unit-testing-mstest-runner-intro.md
+++ b/docs/core/testing/unit-testing-mstest-runner-intro.md
@@ -50,7 +50,7 @@ To enable the MSTest runner in a MSTest project, you need to add the `EnableMSTe
       https://github.com/coverlet-coverage/coverlet#net-global-tool-guide-suffers-from-possible-known-issue
     --> 
     <PackageReference Include="Microsoft.Testing.Platform.Extensions.CodeCoverage" 
-                      Version="17.9.4-beta.23563.1" />
+                      Version="17.10.0-preview.23622.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Fix first available preview version of Code Coverage extension.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-mstest-runner-intro.md](https://github.com/dotnet/docs/blob/45435f08dbca29b085ea686ffdb36a8c42dbcde1/docs/core/testing/unit-testing-mstest-runner-intro.md) | [MSTest runner overview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-runner-intro?branch=pr-en-us-38983) |

<!-- PREVIEW-TABLE-END -->