### PR TITLE
[Do not merge] Document ignore exit-code functionality

### DIFF
--- a/docs/core/testing/unit-testing-mstest-runner-exit-codes.md
+++ b/docs/core/testing/unit-testing-mstest-runner-exit-codes.md
@@ -27,8 +27,8 @@ The MSTest runner uses known exit codes to communicate test failure or app error
 
 To enable verbose logging and troubleshoot issues, see [MSTest runner extensions: Troubleshoot](unit-testing-mstest-runner-extensions.md#troubleshoot).
 
-## Ignoring specific exit codes
+## Ignore specific exit codes
 
-MSTest runner is designed to be strict by default but allows for configurability. As such, it is possible for users to decide that some exit codes should be ignored (an exit code of `0` will be returned instead of the original exit code).
+MSTest runner is designed to be strict by default but allows for configurability. As such, it's possible for users to decide which exit codes should be ignored (an exit code of `0` will be returned instead of the original exit code).
 
-You can use the `--ignore-exit-code` command line option or the `TESTINGPLATFORM_EXITCODE_IGNORE` environment variable, that accept a semi-colon separated list of exit codes to ignore (e.g. `--ignore-exit-code 2;3;8`). A common scenario is to consider that test failures should not result in a non-zero exit code (which corresponds to ignoring exit-code `2`).
+To ignore specific exit codes, use the `--ignore-exit-code` command line option or the `TESTINGPLATFORM_EXITCODE_IGNORE` environment variable. The valid format accepted is a semi-colon separated list of exit codes to ignore (for example, `--ignore-exit-code 2;3;8`). A common scenario is to consider that test failures shouldn't result in a non-zero exit code (which corresponds to ignoring exit-code `2`).

--- a/docs/core/testing/unit-testing-mstest-runner-exit-codes.md
+++ b/docs/core/testing/unit-testing-mstest-runner-exit-codes.md
@@ -26,3 +26,9 @@ The MSTest runner uses known exit codes to communicate test failure or app error
 | `10` | The exit code `10` indicates that the test adapter, Testing.Platform Test Framework, MSTest, NUnit, or xUnit, failed to run tests for an infrastructure reason unrelated to the test's self. An example is failing to create a fixture needed by tests. |
 
 To enable verbose logging and troubleshoot issues, see [MSTest runner extensions: Troubleshoot](unit-testing-mstest-runner-extensions.md#troubleshoot).
+
+## Ignoring specific exit codes
+
+MSTest runner is designed to be strict by default but allows for configurability. As such, it is possible for users to decide that some exit codes should be ignored (an exit code of `0` will be returned instead of the original exit code).
+
+You can use the `--ignore-exit-code` command line option or the `TESTINGPLATFORM_EXITCODE_IGNORE` environment variable, that accept a semi-colon separated list of exit codes to ignore (e.g. `--ignore-exit-code 2;3;8`). A common scenario is to consider that test failures should not result in a non-zero exit code (which corresponds to ignoring exit-code `2`).

--- a/docs/core/testing/unit-testing-mstest-runner-intro.md
+++ b/docs/core/testing/unit-testing-mstest-runner-intro.md
@@ -189,6 +189,10 @@ Defines the verbosity level when the `--diagnostic` switch is used. The availabl
 
 Prints out a description of how to use the command.
 
+- **`-ignore-exit-code`**
+
+Allows to consider some non-zero exit codes as `0`. For more information, refer to [Ignoring specific exit codes](./unit-testing-mstest-runner-exit-codes.md#ignoring-specific-exit-codes).
+
 - **`--info`**
 
 Displays advanced information about the .NET Test Application such as:

--- a/docs/core/testing/unit-testing-mstest-runner-intro.md
+++ b/docs/core/testing/unit-testing-mstest-runner-intro.md
@@ -191,7 +191,7 @@ Prints out a description of how to use the command.
 
 - **`-ignore-exit-code`**
 
-Allows to consider some non-zero exit codes as `0`. For more information, refer to [Ignoring specific exit codes](./unit-testing-mstest-runner-exit-codes.md#ignoring-specific-exit-codes).
+Allows some non-zero exit codes to be ignored, and instead returned as `0`. For more information, see [Ignore specific exit codes](./unit-testing-mstest-runner-exit-codes.md#ignore-specific-exit-codes).
 
 - **`--info`**
 


### PR DESCRIPTION
## Summary

Do not merge yet as the feature is not yet publicly available. I'll ping here when it's available (it should be in about a week).


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-mstest-runner-exit-codes.md](https://github.com/dotnet/docs/blob/bd18adac39d9dce379fdcb28b09ada51bd80da85/docs/core/testing/unit-testing-mstest-runner-exit-codes.md) | [MSTest runner exit codes](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-runner-exit-codes?branch=pr-en-us-38984) |
| [docs/core/testing/unit-testing-mstest-runner-intro.md](https://github.com/dotnet/docs/blob/bd18adac39d9dce379fdcb28b09ada51bd80da85/docs/core/testing/unit-testing-mstest-runner-intro.md) | [MSTest runner overview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-runner-intro?branch=pr-en-us-38984) |


<!-- PREVIEW-TABLE-END -->