### PR TITLE
Fix templates package file reference to (17)

### DIFF
--- a/docs/core/distribution-packaging.md
+++ b/docs/core/distribution-packaging.md
@@ -170,7 +170,7 @@ The following lists the recommended packages:
 
 - `dotnet-templates-[major].[minor]`
   - **Version:** \<sdk version>
-  - **Contains:** (15)
+  - **Contains:** (17)
 
 The following two meta packages are optional. They bring value for end users in that they abstract the top-level package (dotnet-sdk), which simplifies the installation of the full set of .NET packages. These meta packages reference a specific .NET SDK version.
 


### PR DESCRIPTION
## Summary

The `dotnet-templates-[major].[minor]` package should contain files present in `templates/<templates version>`, which is listed as (17) in the Disk Layout section.

This fixes the file reference in the Recommended packages section from (15) to (17).


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/distribution-packaging.md](https://github.com/dotnet/docs/blob/622e90f1b87b9905e2f26e3130985d24a58cfe7b/docs/core/distribution-packaging.md) | [.NET distribution packaging](https://review.learn.microsoft.com/en-us/dotnet/core/distribution-packaging?branch=pr-en-us-39001) |

<!-- PREVIEW-TABLE-END -->