### PR TITLE
Add link to MSTest Runner protocol

### DIFF
--- a/docs/core/testing/unit-testing-mstest-runner-vs-vstest.md
+++ b/docs/core/testing/unit-testing-mstest-runner-vs-vstest.md
@@ -36,6 +36,12 @@ VSTest is extensible and common types are placed in [Microsoft.TestPlatform.Obje
 
 The MSTest runner is based on [Microsoft.Testing.Platform](https://www.nuget.org/packages/Microsoft.Testing.Platform) NuGet package and other libraries in the `Microsoft.Testing.*` namespace. Like VSTest, the `Microsoft.Testing.Platform` is open-source and has a [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Platform) GitHub repository.
 
+## Communication protocol
+
+The MSTest runner uses a JSON-RPC based protocol to communicate between Visual Studio and the test runner process. The protocol is documented in the [MSTest github repository](https://github.com/microsoft/testfx/tree/main/docs/mstest-runner-protocol).
+
+VSTest also uses a JSON based communication protocol, but it's not JSON-RPC based.
+
 ## Executables
 
 VSTest ships multiple executables, notably `vstest.console.exe`, `testhost.exe`, and `datacollector.exe`. However, MSTest is embedded directly into your test project and doesn't ship any other executables. The executable your test project compiles to is used to host all the testing tools and carry out all the tasks needed to run tests.


### PR DESCRIPTION
## Summary

Adds information comparing the RPC protocol implementation between MSTestRunner and VsTest.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-mstest-runner-vs-vstest.md](https://github.com/dotnet/docs/blob/3ad4fa9980e46f3d8b2b5aa2882e3a78fab0ae23/docs/core/testing/unit-testing-mstest-runner-vs-vstest.md) | [MSTest runner and VSTest comparison](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-runner-vs-vstest?branch=pr-en-us-39009) |

<!-- PREVIEW-TABLE-END -->