### PR TITLE
Update the section on resilience and static clients

### DIFF
--- a/docs/fundamentals/networking/http/httpclient-guidelines.md
+++ b/docs/fundamentals/networking/http/httpclient-guidelines.md
@@ -72,7 +72,7 @@ var retryPipeline = new ResiliencePipelineBuilder<HttpResponseMessage>()
     .Build();
 
 var socketHandler = new SocketsHttpHandler { PooledConnectionLifetime = TimeSpan.FromMinutes(15) };
-var resilienceHandler = new ResilienceHandler(retryPolicy)
+var resilienceHandler = new ResilienceHandler(retryPipeline)
 {
     InnerHandler = socketHandler,
 };

--- a/docs/fundamentals/networking/http/httpclient-guidelines.md
+++ b/docs/fundamentals/networking/http/httpclient-guidelines.md
@@ -52,37 +52,41 @@ To summarize recommended `HttpClient` use in terms of lifetime management, you s
 
 For more information about managing `HttpClient` lifetime with `IHttpClientFactory`, see [`IHttpClientFactory` guidelines](../../../core/extensions/httpclient-factory.md#httpclient-lifetime-management).
 
-## Resilience policies with static clients
+## Resilience pipelines with static clients
 
-It's possible to configure a `static` or *singleton* client to use any number of resilience policies using the following pattern:
+It's possible to configure a `static` or *singleton* client to use any number of resilience pipelines using the following pattern:
 
 ```csharp
 using System;
 using System.Net.Http;
 using Microsoft.Extensions.Http;
+using Microsoft.Extensions.Http.Resilience;
 using Polly;
-using Polly.Extensions.Http;
 
-var retryPolicy = HttpPolicyExtensions
-    .HandleTransientHttpError()
-    .WaitAndRetryAsync(3, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)));
+var retryPipeline = new ResiliencePipelineBuilder<HttpResponseMessage>()
+    .AddRetry(new HttpRetryStrategyOptions
+    {
+        BackoffType = DelayBackoffType.Exponential,
+        MaxRetryAttempts = 3
+    })
+    .Build();
 
 var socketHandler = new SocketsHttpHandler { PooledConnectionLifetime = TimeSpan.FromMinutes(15) };
-var pollyHandler = new PolicyHttpMessageHandler(retryPolicy)
+var resilienceHandler = new ResilienceHandler(retryPolicy)
 {
     InnerHandler = socketHandler,
 };
 
-var httpClient = new HttpClient(pollyHandler);
+var httpClient = new HttpClient(resilienceHandler);
 ```
 
 The preceding code:
 
-- Relies on [Microsoft.Extensions.Http.Polly](https://www.nuget.org/packages/Microsoft.Extensions.Http.Polly) NuGet package, transitively the [Polly.Extensions.Http](https://www.nuget.org/packages/Polly.Extensions.Http) NuGet package for the `HttpPolicyExtensions` type.
-- Specifies a transient HTTP error handler, configured with retry policy that with each attempt will exponentially backoff delay intervals.
+- Relies on [Microsoft.Extensions.Http.Resilience](https://www.nuget.org/packages/Microsoft.Extensions.Http.Resilience) NuGet package.
+- Specifies a transient HTTP error handler, configured with retry pipeline that with each attempt will exponentially backoff delay intervals.
 - Defines a pooled connection lifetime of fifteen minutes for the `socketHandler`.
-- Passes the `socketHandler` to the `policyHandler` with the retry logic.
-- Instantiates an `HttpClient` given the `policyHandler`.
+- Passes the `socketHandler` to the `resilienceHandler` with the retry logic.
+- Instantiates an `HttpClient` given the `resilienceHandler`.
 
 ## See also
 

--- a/docs/fundamentals/networking/http/httpclient-guidelines.md
+++ b/docs/fundamentals/networking/http/httpclient-guidelines.md
@@ -52,7 +52,7 @@ To summarize recommended `HttpClient` use in terms of lifetime management, you s
 
 For more information about managing `HttpClient` lifetime with `IHttpClientFactory`, see [`IHttpClientFactory` guidelines](../../../core/extensions/httpclient-factory.md#httpclient-lifetime-management).
 
-## Resilience pipelines with static clients
+## Resilience with static clients
 
 It's possible to configure a `static` or *singleton* client to use any number of resilience pipelines using the following pattern:
 


### PR DESCRIPTION
## Summary

This section should use the latest Polly v8 and `Microsoft.Extensions.Http.Resilience` package as Polly v7 is not developed anymore. 

We should wait a while before merging this, after new version of `Microsoft.Extensions.Http.Resilience` is available that contains the `ResilienceHandler` type. (https://github.com/dotnet/extensions/pull/4858)




<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/networking/http/httpclient-guidelines.md](https://github.com/dotnet/docs/blob/bbaa3590205aa0411729d2b9785dc7aac360809f/docs/fundamentals/networking/http/httpclient-guidelines.md) | [Guidelines for using HttpClient](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient-guidelines?branch=pr-en-us-39010) |


<!-- PREVIEW-TABLE-END -->