### PR TITLE
Address issues in readonly reference

### DIFF
--- a/docs/csharp/language-reference/keywords/readonly.md
+++ b/docs/csharp/language-reference/keywords/readonly.md
@@ -87,7 +87,7 @@ The type returned doesn't need to be a `readonly struct`. Any type that can be r
 
 ## Readonly ref readonly return example
 
-Ref readonly return can also be used with `readonly` instance members on `struct` types:
+A `ref readonly return` can also be used with `readonly` instance members on `struct` types:
 
 :::code language="csharp" source="./snippets/ReadonlyKeywordExamples.cs" id="SnippetReadonlyRefReadonly":::
 

--- a/docs/csharp/language-reference/keywords/readonly.md
+++ b/docs/csharp/language-reference/keywords/readonly.md
@@ -18,7 +18,7 @@ The `readonly` keyword is a modifier that can be used in five contexts:
   A `readonly` field can't be assigned after the constructor exits. This rule has different implications for value types and reference types:
 
   - Because value types directly contain their data, a field that is a  `readonly` value type is immutable.
-  - Because reference types contain a reference to their data, a field that is a `readonly` reference type must always refer to the same object. That object isn't immutable. The `readonly` modifier prevents the field from being replaced by a different instance of the reference type. However, the modifier doesn't prevent the instance data of the field from being modified through the read-only field.
+  - Because reference types contain a reference to their data, a field that is a `readonly` reference type must always refer to the same object. That object might not be immutable. The `readonly` modifier prevents replacing the field value with a different instance of the reference type. However, the modifier doesn't prevent the instance data of the field from being modified through the read-only field.
 
   > [!WARNING]
   > An externally visible type that contains an externally visible read-only field that is a mutable reference type may be a security vulnerability and may trigger warning [CA2104](/visualstudio/code-quality/ca2104) : "Do not declare read only mutable reference types."
@@ -30,7 +30,7 @@ The `readonly` keyword is a modifier that can be used in five contexts:
 
 ## Readonly field example
 
-In this example, the value of the field `year` can't be changed in the method `ChangeYear`, even though it's assigned a value in the class constructor:
+In this example, the value of the field `year` can't be changed in the method `ChangeYear`, even though it was assigned a value in the class constructor:
 
 :::code language="csharp" source="snippets/ReadonlyKeywordExamples.cs" id="ReadonlyField":::
 
@@ -62,7 +62,7 @@ In the preceding example, if you use a statement like the following example:
 p2.y = 66;        // Error
 ```
 
-you'll get the compiler error message:
+you get the compiler error message:
 
 **A readonly field cannot be assigned to (except in a constructor or a variable initializer)**
 
@@ -75,6 +75,8 @@ You can also use the `readonly` modifier to declare that an instance member does
 > [!NOTE]
 > In the case of a read/write property, you can add the `readonly` modifier to the `get` accessor. Some `get` accessors may perform a calculation and cache the result, rather than simply returning the value of a private field. Adding the `readonly` modifier to the `get` accessor guarantees that the `get` accessor doesn't modify the internal state of the object by caching any result.
 
+You can find more examples in the [`readonly` instance members](../builtin-types/struct.md#readonly-instance-members) section of the [Structure types](../builtin-types/struct.md) article.
+
 ## Ref readonly return example
 
 The `readonly` modifier on a `ref return` indicates that the returned reference can't be modified. The following example returns a reference to the origin. It uses the `readonly` modifier to indicate that callers can't modify the origin:
@@ -85,7 +87,7 @@ The type returned doesn't need to be a `readonly struct`. Any type that can be r
 
 ## Readonly ref readonly return example
 
-Ref readonly return can also be used in conjunction with `readonly` instance members on `struct` types:
+Ref readonly return can also be used with `readonly` instance members on `struct` types:
 
 :::code language="csharp" source="./snippets/ReadonlyKeywordExamples.cs" id="SnippetReadonlyRefReadonly":::
 

--- a/docs/csharp/language-reference/keywords/readonly.md
+++ b/docs/csharp/language-reference/keywords/readonly.md
@@ -1,7 +1,7 @@
 ---
 description: "readonly keyword - C# Reference"
 title: "readonly keyword - C# Reference"
-ms.date: 09/25/2023
+ms.date: 01/09/2024
 f1_keywords:
   - "readonly_CSharpKeyword"
   - "readonly"
@@ -32,7 +32,7 @@ The `readonly` keyword is a modifier that can be used in five contexts:
 
 In this example, the value of the field `year` can't be changed in the method `ChangeYear`, even though it's assigned a value in the class constructor:
 
-[!code-csharp[Readonly Field example](snippets/ReadonlyKeywordExamples.cs#ReadonlyField)]
+:::code language="csharp" source="snippets/ReadonlyKeywordExamples.cs" id="ReadonlyField":::
 
 You can assign a value to a `readonly` field only in the following contexts:
 
@@ -54,7 +54,7 @@ These constructor contexts are also the only contexts in which it's valid to pas
 > public static readonly uint timeStamp = (uint)DateTime.Now.Ticks;
 > ```
 
-[!code-csharp[Initialize readonly Field example](snippets/ReadonlyKeywordExamples.cs#InitReadonlyField)]
+:::code language="csharp" source="snippets/ReadonlyKeywordExamples.cs" id="InitReadonlyField":::
 
 In the preceding example, if you use a statement like the following example:
 
@@ -72,11 +72,14 @@ You can also use the `readonly` modifier to declare that an instance member does
 
 :::code language="csharp" source="../builtin-types/snippets/shared/StructType.cs" id="SnippetReadonlyMethod":::
 
+> [!NOTE]
+> In the case of a read/write property, you can add the `readonly` modifier to the `get` accessor. Some `get` accessors may perform a calculation and cache the result, rather than simply returning the value of a private field. Adding the `readonly` modifier to the `get` accessor guarantees that the `get` accessor doesn't modify the internal state of the object by caching any result.
+
 ## Ref readonly return example
 
 The `readonly` modifier on a `ref return` indicates that the returned reference can't be modified. The following example returns a reference to the origin. It uses the `readonly` modifier to indicate that callers can't modify the origin:
 
-[!code-csharp[readonly return example](snippets/ReadonlyKeywordExamples.cs#ReadonlyReturn)]
+:::code language="csharp" source="snippets/ReadonlyKeywordExamples.cs" id="ReadonlyReturn":::
 
 The type returned doesn't need to be a `readonly struct`. Any type that can be returned by `ref` can be returned by `ref readonly`.
 


### PR DESCRIPTION
First commit:

Fixes #38550 - Add a note that `readonly` can be applied to a `get` accessor of a property.

Fixes #27148 - One example had already been added in #37250. I added a link to the pertinent section of the `struct` types.

Finally, do a grammar check.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/readonly.md](https://github.com/dotnet/docs/blob/618aaec324cba4ffe82f9c18a3f88e1ac6c71577/docs/csharp/language-reference/keywords/readonly.md) | [readonly (C# Reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/readonly?branch=pr-en-us-39016) |


<!-- PREVIEW-TABLE-END -->