### PR TITLE
revert collection expression

### DIFF
--- a/docs/csharp/language-reference/operators/snippets/shared/Overview.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/Overview.cs
@@ -45,7 +45,7 @@ public static class Overview
     private static void Lambda()
     {
         // <SnippetLambda>
-        int[] numbers = [2, 3, 4, 5];
+        int[] numbers = { 2, 3, 4, 5 };
         var maximumSquare = numbers.Max(x => x * x);
         Console.WriteLine(maximumSquare);
         // Output:
@@ -56,7 +56,7 @@ public static class Overview
     private static void Query()
     {
         // <SnippetQuery>
-        int[] scores = [90, 97, 78, 68, 85];
+        int[] scores = { 90, 97, 78, 68, 85 };
         IEnumerable<int> highScoresQuery =
             from score in scores
             where score > 80


### PR DESCRIPTION
Fixes #38995

These two samples are run interactively, so the array initializer syntax must be used instead of the collection expression syntax.
