### PR TITLE
Revert "Update the section on resilience and static clients"

### DIFF
--- a/docs/fundamentals/networking/http/httpclient-guidelines.md
+++ b/docs/fundamentals/networking/http/httpclient-guidelines.md
@@ -52,41 +52,37 @@ To summarize recommended `HttpClient` use in terms of lifetime management, you s
 
 For more information about managing `HttpClient` lifetime with `IHttpClientFactory`, see [`IHttpClientFactory` guidelines](../../../core/extensions/httpclient-factory.md#httpclient-lifetime-management).
 
-## Resilience with static clients
+## Resilience policies with static clients
 
-It's possible to configure a `static` or *singleton* client to use any number of resilience pipelines using the following pattern:
+It's possible to configure a `static` or *singleton* client to use any number of resilience policies using the following pattern:
 
 ```csharp
 using System;
 using System.Net.Http;
 using Microsoft.Extensions.Http;
-using Microsoft.Extensions.Http.Resilience;
 using Polly;
+using Polly.Extensions.Http;
 
-var retryPipeline = new ResiliencePipelineBuilder<HttpResponseMessage>()
-    .AddRetry(new HttpRetryStrategyOptions
-    {
-        BackoffType = DelayBackoffType.Exponential,
-        MaxRetryAttempts = 3
-    })
-    .Build();
+var retryPolicy = HttpPolicyExtensions
+    .HandleTransientHttpError()
+    .WaitAndRetryAsync(3, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)));
 
 var socketHandler = new SocketsHttpHandler { PooledConnectionLifetime = TimeSpan.FromMinutes(15) };
-var resilienceHandler = new ResilienceHandler(retryPipeline)
+var pollyHandler = new PolicyHttpMessageHandler(retryPolicy)
 {
     InnerHandler = socketHandler,
 };
 
-var httpClient = new HttpClient(resilienceHandler);
+var httpClient = new HttpClient(pollyHandler);
 ```
 
 The preceding code:
 
-- Relies on [Microsoft.Extensions.Http.Resilience](https://www.nuget.org/packages/Microsoft.Extensions.Http.Resilience) NuGet package.
-- Specifies a transient HTTP error handler, configured with retry pipeline that with each attempt will exponentially backoff delay intervals.
+- Relies on [Microsoft.Extensions.Http.Polly](https://www.nuget.org/packages/Microsoft.Extensions.Http.Polly) NuGet package, transitively the [Polly.Extensions.Http](https://www.nuget.org/packages/Polly.Extensions.Http) NuGet package for the `HttpPolicyExtensions` type.
+- Specifies a transient HTTP error handler, configured with retry policy that with each attempt will exponentially backoff delay intervals.
 - Defines a pooled connection lifetime of fifteen minutes for the `socketHandler`.
-- Passes the `socketHandler` to the `resilienceHandler` with the retry logic.
-- Instantiates an `HttpClient` given the `resilienceHandler`.
+- Passes the `socketHandler` to the `policyHandler` with the retry logic.
+- Instantiates an `HttpClient` given the `policyHandler`.
 
 ## See also
 


### PR DESCRIPTION
Reverts dotnet/docs#39010, I overlooked the `DO NOT MERGE` label and merged this PR. We should instead be using draft PRs as we cannot make mistakenly merge those. 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/networking/http/httpclient-guidelines.md](https://github.com/dotnet/docs/blob/c76d79b551a250a8129af128d4d15ecf15288362/docs/fundamentals/networking/http/httpclient-guidelines.md) | [Guidelines for using HttpClient](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient-guidelines?branch=pr-en-us-39073) |


<!-- PREVIEW-TABLE-END -->