### PR TITLE
Add a GitHub Action workflow that fails when PRs are labeled with 'DO…

### DIFF
--- a/.github/workflows/do-not-merge-label-check.yml
+++ b/.github/workflows/do-not-merge-label-check.yml
@@ -1,7 +1,7 @@
 # This GitHub Action workflow is triggered on label changes for pull requests.
-# When a pull request is labeled with "DO NOT MERGE", the workflow will fails, 
-# preventing the pull request from being merged.
-# Otherwise, the workflow will succeed, allowing the pull request to be merged.
+# When a pull request is labeled with "DO NOT MERGE", the workflow fails, thus
+# preventing the pull request from being merged. Otherwise, the workflow will
+# succeeds (being skipped), allowing the pull request to be merged.
 
 name: "Do not merge check"
 on:

--- a/.github/workflows/do-not-merge-label-check.yml
+++ b/.github/workflows/do-not-merge-label-check.yml
@@ -1,19 +1,30 @@
 # This GitHub Action workflow is triggered on label changes for pull requests.
 # When a pull request is labeled with "DO NOT MERGE", the workflow fails, thus
 # preventing the pull request from being merged. Otherwise, the workflow will
-# succeeds (being skipped), allowing the pull request to be merged.
+# succeed, allowing the pull request to be merged.
 
-name: "Do not merge check"
+name: "Check labels that prevent merge"
 on:
   pull_request:
     branches: [main]
     types: [labeled, unlabeled]
 
 jobs:
-  do-not-merge-check:
-    if: ${{ github.event.label.name == 'DO NOT MERGE' && github.event.action == 'labeled' }}
+  labels-preventing-merge-check:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        label:
+        # Labels that prevent merging
+        - 'DO NOT MERGE'
     steps:
-      - name: 'Remove the "DO NOT MERGE" label to allow merging'
-        # Fail the workflow if the pull request is labeled with "DO NOT MERGE"
-        run: exit 1
+      - name: 'Check "${{ matrix.label }}" label'
+        run: |
+          echo "Merging permission is diabled for PRs when the `${{ matrix.label }}` label is applied."
+
+          if [ "${{ contains(github.event.pull_request.labels.*.name, matrix.label) }}" = "true" ]; then
+            echo "::error:: Pull request is labeled as '${{ matrix.label }}'. Please remove the label before merging."
+            exit 1
+          else
+            exit 0
+          fi

--- a/.github/workflows/do-not-merge-label-check.yml
+++ b/.github/workflows/do-not-merge-label-check.yml
@@ -1,0 +1,19 @@
+# This GitHub Action workflow is triggered on label changes for pull requests.
+# When a pull request is labeled with "DO NOT MERGE", the workflow will fails, 
+# preventing the pull request from being merged.
+# Otherwise, the workflow will succeed, allowing the pull request to be merged.
+
+name: "Do not merge check"
+on:
+  pull_request:
+    branches: [main]
+    types: [labeled, unlabeled]
+
+jobs:
+  do-not-merge-check:
+    if: ${{ github.event.label.name == 'DO NOT MERGE' && github.event.action == 'labeled' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Remove the "DO NOT MERGE" label to allow merging'
+        # Fail the workflow if the pull request is labeled with "DO NOT MERGE"
+        run: exit 1

--- a/.github/workflows/do-not-merge-label-check.yml
+++ b/.github/workflows/do-not-merge-label-check.yml
@@ -20,10 +20,10 @@ jobs:
     steps:
       - name: 'Check "${{ matrix.label }}" label'
         run: |
-          echo "Merging permission is diabled for PRs when the `${{ matrix.label }}` label is applied."
+          echo "::notice::Merging permission is diabled for PRs when the '${{ matrix.label }}' label is applied."
 
           if [ "${{ contains(github.event.pull_request.labels.*.name, matrix.label) }}" = "true" ]; then
-            echo "::error:: Pull request is labeled as '${{ matrix.label }}'. Please remove the label before merging."
+            echo "::error::Pull request is labeled as '${{ matrix.label }}'. Please remove the label before merging."
             exit 1
           else
             exit 0


### PR DESCRIPTION
## Summary

Add a GitHub Action workflow that fails when PRs are labeled with `DO NOT MERGE`, as a safety net for when non-draft PRs are approved but labeled as do not merge.

Related to:

- This PR was mistakenly merged: #39010
- We need to now revert that change: #39073

This workflow should help to prevent these sorts of things.