### PR TITLE
Remove additional text

### DIFF
--- a/docs/csharp/fundamentals/coding-style/identifier-names.md
+++ b/docs/csharp/fundamentals/coding-style/identifier-names.md
@@ -19,7 +19,7 @@ You can declare identifiers that match C# keywords by using the `@` prefix on th
 For a complete definition of valid identifiers, see the [Identifiers article in the C# Language Specification](~/_csharpstandard/standard/lexical-structure.md#643-identifiers).
 
 > [!IMPORTANT]
-> [The C# language specification](~/_csharpstandard/standard/lexical-structure.md#643-identifiers) only allows letter (Lu, Ll, Lt, Lm, Lo or Nl), digit (Nd), connecting (Pc), combining (Mn or Mc) and formatting (Cf) categories. Anything outside that is automatically replaced using `_`. This may impact certain Unicode characters.
+> [The C# language specification](~/_csharpstandard/standard/lexical-structure.md#643-identifiers) only allows letter (Lu, Ll, Lt, Lm, Lo or Nl), digit (Nd), connecting (Pc), combining (Mn or Mc), and formatting (Cf) categories. Anything outside that is automatically replaced using `_`. This might impact certain Unicode characters.
 
 ## Naming conventions
 

--- a/docs/csharp/fundamentals/coding-style/identifier-names.md
+++ b/docs/csharp/fundamentals/coding-style/identifier-names.md
@@ -19,7 +19,7 @@ You can declare identifiers that match C# keywords by using the `@` prefix on th
 For a complete definition of valid identifiers, see the [Identifiers article in the C# Language Specification](~/_csharpstandard/standard/lexical-structure.md#643-identifiers).
 
 > [!IMPORTANT]
-> [The C# language specification](~/_csharpstandard/standard/lexical-structure.md#643-identifiers) only allows letter (Lu, Ll, Lt, Lm, Lo or Nl), digit (Nd), connecting (Pc), combining (Mn or Mc) and formatting (Cf) categories. Anything outside that is automatically replaced using `_`. This may impact certain Unicode characters, including those within the GB18030-2022 Chinese government standard.
+> [The C# language specification](~/_csharpstandard/standard/lexical-structure.md#643-identifiers) only allows letter (Lu, Ll, Lt, Lm, Lo or Nl), digit (Nd), connecting (Pc), combining (Mn or Mc) and formatting (Cf) categories. Anything outside that is automatically replaced using `_`. This may impact certain Unicode characters.
 
 ## Naming conventions
 


### PR DESCRIPTION
The additional phrase referencing the Chinese government standard isn't needed here.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/fundamentals/coding-style/identifier-names.md](https://github.com/dotnet/docs/blob/b49f55bce90bc5f8e12308547b06119c0135cc84/docs/csharp/fundamentals/coding-style/identifier-names.md) | [C# identifier naming rules and conventions](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/identifier-names?branch=pr-en-us-39083) |


<!-- PREVIEW-TABLE-END -->