### PR TITLE
.NET SDK breaking changes

### DIFF
--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -11,10 +11,6 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 
 [!INCLUDE [binary-source-behavioral](includes/binary-source-behavioral.md)]
 
-> [!NOTE]
->
-> This article is a work in progress. It's not a complete list of breaking changes in .NET 8. To query breaking changes that are still pending publication, see [Issues of .NET](https://issuesof.net/?q=%20is:open%20-label:Documented%20is:issue%20(label:%22Breaking%20Change%22%20or%20label:breaking-change)%20(repo:dotnet/docs%20or%20repo:aspnet/Announcements)%20group:repo%20(label:%22:checkered_flag:%20Release:%20.NET%208%22%20or%20label:8.0.0)%20sort:created-desc).
-
 ## ASP.NET Core
 
 | Title                                                                                                | Type of change      |

--- a/docs/core/compatibility/9.0.md
+++ b/docs/core/compatibility/9.0.md
@@ -20,3 +20,4 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 | Title                                                                         | Type of change    | Introduced version |
 |-------------------------------------------------------------------------------|-------------------|--------------------|
 | [`dotnet workload` commands output change](sdk/9.0/dotnet-workload-output.md) | Behavioral change | Preview 1          |
+| [Terminal logger is default](sdk/9.0/terminal-logger.md) | Behavioral change | Preview 1          |

--- a/docs/core/compatibility/9.0.md
+++ b/docs/core/compatibility/9.0.md
@@ -1,0 +1,22 @@
+---
+title: Breaking changes in .NET 9
+titleSuffix: ""
+description: Navigate to the breaking changes in .NET 9.
+ms.date: 01/09/2024
+no-loc: [Blazor, Razor, Kestrel]
+---
+# Breaking changes in .NET 9
+
+If you're migrating an app to .NET 9, the breaking changes listed here might affect you. Changes are grouped by technology area, such as ASP.NET Core or Windows Forms.
+
+[!INCLUDE [binary-source-behavioral](includes/binary-source-behavioral.md)]
+
+> [!NOTE]
+>
+> This article is a work in progress. It's not a complete list of breaking changes in .NET 9. To query breaking changes that are still pending publication, see [Issues of .NET](https://issuesof.net/?q=%20is:open%20-label:Documented%20is:issue%20(label:%22Breaking%20Change%22%20or%20label:breaking-change)%20(repo:dotnet/docs%20or%20repo:aspnet/Announcements)%20group:repo%20(label:%22:checkered_flag:%20Release:%20.NET%209%22%20or%20label:9.0.0)%20sort:created-desc).
+
+## SDK and MSBuild
+
+| Title                                                                         | Type of change    | Introduced version |
+|-------------------------------------------------------------------------------|-------------------|--------------------|
+| [`dotnet workload` commands output change](sdk/9.0/dotnet-workload-output.md) | Behavioral change | Preview 1          |

--- a/docs/core/compatibility/sdk/9.0/dotnet-workload-output.md
+++ b/docs/core/compatibility/sdk/9.0/dotnet-workload-output.md
@@ -1,0 +1,71 @@
+---
+title: "Breaking change: `dotnet workload` commands output change"
+description: Learn about a breaking change in the .NET 9 SDK where the `dotnet workload` commands output only the JSON body.
+ms.date: 01/09/2024
+---
+# `dotnet workload` commands output change
+
+There's been in a change in the output of the following commands:
+
+- `dotnet workload list --machine-readable`
+- `dotnet workload install --print-download-link-only`
+- `dotnet workload update --print-download-link-only`
+- `dotnet workload update --print-rollback`
+
+Previously, the affected commands outputted the following:
+
+- Start and end boundary lines for custom parsing to locate the JSON body.
+- Any other logging text that the commands outputted during normal operation.
+- The JSON body.
+
+Now, these commands only output the JSON body.
+
+## Previous behavior
+
+Previously, the affected `dotnet workload` commands produced output similar to the following for the command `dotnet workload list --machine-readable`:
+
+```output
+Failed to update the advertising manifest microsoft.net.sdk.tvos: Unable to load the service index for source https://REDACTED/index.json..
+Failed to update the advertising manifest microsoft.net.sdk.android: Unable to load the service index for source https://REDACTED/index.json..
+Failed to update the advertising manifest microsoft.net.sdk.maui: Unable to load the service index for source https://REDACTED/index.json..
+Failed to update the advertising manifest microsoft.net.workload.emscripten: Unable to load the service index for source https://REDACTED/index.json..
+Failed to update the advertising manifest microsoft.net.sdk.macos: Unable to load the service index for source https://REDACTED/index.json..
+Failed to update the advertising manifest microsoft.net.sdk.maccatalyst: Unable to load the service index for source https://REDACTED/index.json..
+Failed to update the advertising manifest microsoft.net.sdk.ios: Unable to load the service index for source https://REDACTED/index.json..
+Failed to update the advertising manifest microsoft.net.workload.mono.toolchain: Unable to load the service index for source https://REDACTED/index.json..
+==workloadListJsonOutputStart==
+{"installed":["macos","ios"],"updateAvailable":[{"existingManifestVersion":"12.0.101-preview.10.249","availableUpdateManifestVersion":"12.0.101-preview.10.251","description":".NET SDK Workload for building macOS applications.","workloadId":"macos"},{"existingManifestVersion":"15.0.101-preview.9.31","availableUpdateManifestVersion":"15.0.101-preview.10.251","description":".NET SDK Workload for building iOS applications.","workloadId":"ios"}]}
+==workloadListJsonOutputEnd==
+```
+
+## New behavior
+
+Starting in .NET 9, the affected `dotnet workload` commands produced output similar to the following for the command `dotnet workload list --machine-readable`:
+
+```output
+{"installed":["macos","ios"],"updateAvailable":[{"existingManifestVersion":"12.0.101-preview.10.249","availableUpdateManifestVersion":"12.0.101-preview.10.251","description":".NET SDK Workload for building macOS applications.","workloadId":"macos"},{"existingManifestVersion":"15.0.101-preview.9.31","availableUpdateManifestVersion":"15.0.101-preview.10.251","description":".NET SDK Workload for building iOS applications.","workloadId":"ios"}]}
+```
+
+## Version introduced
+
+.NET 9 Preview 1
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+When JSON is requested, many CLI products only output JSON. We wanted to follow suit and also output only JSON. With this change, customers that use these commands in their tooling don't require any custom parsing. You can pipe the output of these commands directly into a JSON parser instead of intermediary parsing logic.
+
+## Recommended action
+
+If your code searches for the following start and end boundary text prior to parsing JSON, you no longer need to search the output for these boundaries. Instead, consider the output of these commands to directly be the JSON body.
+
+- `==workloadListJsonOutputStart==/==workloadListJsonOutputEnd==`
+- `==allPackageLinksJsonOutputStart==/==allPackageLinksJsonOutputEnd==`
+- `==workloadRollbackDefinitionJsonOutputStart==/==workloadRollbackDefinitionJsonOutputEnd==`
+
+## Affected APIs
+
+N/A

--- a/docs/core/compatibility/sdk/9.0/terminal-logger.md
+++ b/docs/core/compatibility/sdk/9.0/terminal-logger.md
@@ -1,0 +1,43 @@
+---
+title: "Breaking change: Terminal logger is default"
+description: Learn about a breaking change in the .NET 9 SDK where the terminal logger is used by default for interactive MSBuild invocations.
+ms.date: 01/10/2024
+---
+# Terminal logger is default
+
+The terminal logger is now enabled by default for all "interactive" terminal sessions. The terminal logger formats the console output for builds differently to the console logger. For more information about the terminal logger, see ['dotnet build' options](../tools/dotnet-build.md#options), specifically the `--tl` option.
+
+## Previous behavior
+
+`dotnet build` and other build-related CLI commands used the 'minimal' verbosity console logger by default for user-driven builds.
+
+## New behavior
+
+If the terminal supports various layout and colorization features, `dotnet build` and other build-related CLI commands use the terminal logger by default for user-triggered builds. If the command is part of a shell script or has had input or output redirected in any way, or if the terminal doesn't support some of the enhanced layout features that terminal logger has, then the terminal logger isn't used.
+
+## Version introduced
+
+.NET 9 Preview 1
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+The terminal logger output about the progress of a build is more information dense and actionable than the console logger output. The MSBuild team wants to encourage the use of terminal logger early in the .NET 9 release cycle so that there's time to gather feedback about the quality and functionality of the feature.
+
+## Recommended action
+
+If you need to revert to the console logger, you can disable the terminal logger can be disabled in the following ways:
+
+- To disable terminal logger for a single build, specify `--tl:off` on the command line or via an MSBuild response file.
+- To disable terminal logger for all builds, set the `MSBUILDTERMINALLOGGER` environment variable to `off` to accomplish this.
+
+## Affected APIs
+
+N/A
+
+## See also
+
+- ['dotnet build' options](../tools/dotnet-build.md#options)

--- a/docs/core/compatibility/sdk/9.0/terminal-logger.md
+++ b/docs/core/compatibility/sdk/9.0/terminal-logger.md
@@ -5,7 +5,7 @@ ms.date: 01/10/2024
 ---
 # Terminal logger is default
 
-The terminal logger is now enabled by default for all "interactive" terminal sessions. The terminal logger formats the console output for builds differently to the console logger. For more information about the terminal logger, see ['dotnet build' options](../tools/dotnet-build.md#options), specifically the `--tl` option.
+The terminal logger is now enabled by default for all "interactive" terminal sessions. The terminal logger formats the console output for builds differently to the console logger. For more information about the terminal logger, see ['dotnet build' options](../../../tools/dotnet-build.md#options), specifically the `--tl` option.
 
 ## Previous behavior
 
@@ -40,4 +40,4 @@ N/A
 
 ## See also
 
-- ['dotnet build' options](../tools/dotnet-build.md#options)
+- ['dotnet build' options](../../../tools/dotnet-build.md#options)

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -4,6 +4,14 @@ items:
 - name: Breaking changes by version
   expanded: true
   items:
+  - name: .NET 9
+    items:
+    - name: Overview
+      href: 9.0.md
+    - name: SDK and MSBuild
+      items:
+      - name: "'dotnet workload' commands output change"
+        href: sdk/9.0/dotnet-workload-output.md
   - name: .NET 8
     items:
     - name: Overview
@@ -1518,6 +1526,10 @@ items:
         href: reflection/8.0/function-pointer-reflection.md
   - name: SDK and MSBuild
     items:
+    - name: .NET 9
+      items:
+      - name: "'dotnet workload' commands output change"
+        href: sdk/9.0/dotnet-workload-output.md
     - name: .NET 8
       items:
       - name: CLI console output uses UTF-8

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -12,6 +12,8 @@ items:
       items:
       - name: "'dotnet workload' commands output change"
         href: sdk/9.0/dotnet-workload-output.md
+      - name: Terminal logger is default
+        href: sdk/9.0/terminal-logger.md
   - name: .NET 8
     items:
     - name: Overview
@@ -1530,6 +1532,8 @@ items:
       items:
       - name: "'dotnet workload' commands output change"
         href: sdk/9.0/dotnet-workload-output.md
+      - name: Terminal logger is default
+        href: sdk/9.0/terminal-logger.md
     - name: .NET 8
       items:
       - name: CLI console output uses UTF-8


### PR DESCRIPTION
Fixes #38959 
Fixes #37278

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/8.0.md](https://github.com/dotnet/docs/blob/adc3bb7ffb2d6a43943a4d5bc537ed95640a2cd6/docs/core/compatibility/8.0.md) | [Breaking changes in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/8.0?branch=pr-en-us-39090) |
| [docs/core/compatibility/9.0.md](https://github.com/dotnet/docs/blob/adc3bb7ffb2d6a43943a4d5bc537ed95640a2cd6/docs/core/compatibility/9.0.md) | [Breaking changes in .NET 9](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/9.0?branch=pr-en-us-39090) |
| [docs/core/compatibility/sdk/9.0/dotnet-workload-output.md](https://github.com/dotnet/docs/blob/adc3bb7ffb2d6a43943a4d5bc537ed95640a2cd6/docs/core/compatibility/sdk/9.0/dotnet-workload-output.md) | [`dotnet workload` commands output change](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/9.0/dotnet-workload-output?branch=pr-en-us-39090) |
| [docs/core/compatibility/sdk/9.0/terminal-logger.md](https://github.com/dotnet/docs/blob/adc3bb7ffb2d6a43943a4d5bc537ed95640a2cd6/docs/core/compatibility/sdk/9.0/terminal-logger.md) | [docs/core/compatibility/sdk/9.0/terminal-logger](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/9.0/terminal-logger?branch=pr-en-us-39090) |


<!-- PREVIEW-TABLE-END -->