### PR TITLE
F# - Add an example for formatting long secondary constructor

### DIFF
--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -1651,6 +1651,16 @@ type TypeWithLongConstructor
         aThirdVeryLongCtorParam: AVeryLongTypeThatYouNeedToUse
     ) =
     // ... the body of the class follows
+
+// ✔️ OK
+type TypeWithLongSecondaryConstructor () =
+    new
+        (
+            aVeryLongCtorParam: AVeryLongTypeThatYouNeedToUse,
+            aSecondVeryLongCtorParam: AVeryLongTypeThatYouNeedToUse,
+            aThirdVeryLongCtorParam: AVeryLongTypeThatYouNeedToUse
+        ) =
+        // ... the body of the constructor follows
 ```
 
 If the parameters are curried, place the `=` character along with any return type on a new line:


### PR DESCRIPTION
## Summary

Add an explicit example of how to format secondary constructors.

This PR is a follow up to [an issue I opened on Fantomas](https://github.com/fsprojects/fantomas/issues/3037) (an F# formatter tool) and they asked to add an example to address any potential concerns from the community.

*Edit: Added Fantomas issue link*



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/style-guide/formatting.md](https://github.com/dotnet/docs/blob/43064c63a9314d731b4e75f9e0ba0dba1ca5abea/docs/fsharp/style-guide/formatting.md) | [F# code formatting guidelines](https://review.learn.microsoft.com/en-us/dotnet/fsharp/style-guide/formatting?branch=pr-en-us-39096) |

<!-- PREVIEW-TABLE-END -->