### PR TITLE
Create webapi app rather than webapp.

### DIFF
--- a/docs/orleans/quickstarts/build-your-first-orleans-app.md
+++ b/docs/orleans/quickstarts/build-your-first-orleans-app.md
@@ -51,7 +51,7 @@ At the end of the quickstart, you have an app that creates and handles redirects
 1. Run the following commands:
 
    ```dotnetcli
-   dotnet new webapp -o OrleansURLShortener
+   dotnet new webapi -o OrleansURLShortener
    code -r OrleansURLShortener
    ```
 


### PR DESCRIPTION
## Summary

This PR makes a simple change to use the "webapi" template, to get a minimal API app, instead of "webapp", which  creates a Web/MVC/Razor Pages app.

![image](https://github.com/dotnet/docs/assets/85643503/9801e4a4-97f7-438a-973f-492a65168961)



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/quickstarts/build-your-first-orleans-app.md](https://github.com/dotnet/docs/blob/bfb702151ab3bf22d36808d7a07d78cad95009b5/docs/orleans/quickstarts/build-your-first-orleans-app.md) | [Quickstart: Build your first Orleans app with ASP.NET Core](https://review.learn.microsoft.com/en-us/dotnet/orleans/quickstarts/build-your-first-orleans-app?branch=pr-en-us-39098) |

<!-- PREVIEW-TABLE-END -->