### PR TITLE
clarify instance constructors

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/constructor-errors.md
+++ b/docs/csharp/language-reference/compiler-messages/constructor-errors.md
@@ -89,7 +89,7 @@ helpviewer_keywords:
  - "CS9124"
  - "CS9136"
  - "CS9179"
-ms.date: 11/02/2023
+ms.date: 01/11/2024
 ---
 # Resolve errors and warnings in constructor declarations
 
@@ -182,9 +182,9 @@ When a constructor is marked `extern`, the compiler can't guarantee the construc
 - **CS8982**: *A constructor declared in a 'struct' with parameter list must have a 'this' initializer that calls the primary constructor or an explicitly declared constructor.*
 - **CS8983**: *A 'struct' with field initializers must include an explicitly declared constructor.*
 
-Recent features in C# remove earlier restrictions to `struct` types. **CS0568** is generated when you declare a parameterless constructor in older versions of C#. Once you're using C# 10, you can declare an explicit parameterless constructor. That explicit parameterless constructor must be `public`. If your `struct` declares any [field initializers](../../programming-guide/classes-and-structs/fields.md), you must also declare an explicit constructor. This constructor can be a parameterless constructor with an empty body.
+Recent features in C# remove earlier restrictions to `struct` types. **CS0568** is generated when you declare a parameterless instance constructor in older versions of C#. Once you're using C# 10, you can declare an explicit parameterless instance constructor. That explicit parameterless constructor must be `public`. If your `struct` declares any [field initializers](../../programming-guide/classes-and-structs/fields.md), you must also declare an explicit instance constructor. This constructor can be a parameterless constructor with an empty body.
 
-When a `struct` type declares a primary constructor, including `record struct` types, all other constructors except a parameterless constructor must call the primary constructor or another explicitly declared constructor using `this()`.
+When a `struct` type declares a primary constructor, including `record struct` types, all other instance constructors except a parameterless constructor must call the primary constructor or another explicitly declared constructor using `this()`.
 
 ## Constructor calls with `base` and `this`
 


### PR DESCRIPTION
Fixes #38848

The requirement for constructors in struct types pertains to instance constructors. Static constructors don't satisfy the requirements.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-messages/constructor-errors.md](https://github.com/dotnet/docs/blob/1cd45186883c61f912da61a07942c223a51281bd/docs/csharp/language-reference/compiler-messages/constructor-errors.md) | [Resolve errors and warnings in constructor declarations](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/constructor-errors?branch=pr-en-us-39103) |

<!-- PREVIEW-TABLE-END -->