### PR TITLE
Clarify nullable behavior

### DIFF
--- a/docs/csharp/nullable-references.md
+++ b/docs/csharp/nullable-references.md
@@ -6,7 +6,7 @@ ms.date: 01/16/2024
 ---
 # Nullable reference types
 
-In a nullable oblivious context, all reference types were nullable. *Nullable reference types* refers to a group of features enabled in a nullable aware context that minimize the likelihood that your code causes the runtime to throw <xref:System.NullReferenceException?displayProperty=nameWithType>. *Nullable reference types* includes three features that help you avoid these exceptions, including the ability to explicitly mark a reference type as *nullable*:
+In a nullable-oblivious context, all reference types were nullable. *Nullable reference types* refers to a group of features enabled in a nullable aware context that minimize the likelihood that your code causes the runtime to throw <xref:System.NullReferenceException?displayProperty=nameWithType>. *Nullable reference types* includes three features that help you avoid these exceptions, including the ability to explicitly mark a reference type as *nullable*:
 
 - Improved static flow analysis that determines if a variable might be `null` before dereferencing it.
 - Attributes that annotate APIs so that the flow analysis determines *null-state*.
@@ -39,21 +39,21 @@ When you dereference a variable whose value is `null`, the runtime throws a <xre
 
 You'll learn about:
 
-- The compiler's [null state analysis](#null-state-analysis): how the compiler determines if an expression is not null, or maybe null.
-- [Attributes](#attributes-on-api-signatures) that are applied to APIs that provide more context for the compiler's null state analysis.
-- [Nullable variable annotations](#nullable-variable-annotations) that provide information about your intent for variables.  Annotations are useful for fields to set the default null state at the beginning of member methods.
+- The compiler's [null-state analysis](#null-state-analysis): how the compiler determines if an expression is not-null, or maybe-null.
+- [Attributes](#attributes-on-api-signatures) that are applied to APIs that provide more context for the compiler's null-state analysis.
+- [Nullable variable annotations](#nullable-variable-annotations) that provide information about your intent for variables.  Annotations are useful for fields to set the default null-state at the beginning of member methods.
 - The rules governing [generic type arguments](#generics). New constraints were added because type parameters can be reference types or value types. The `?` suffix is implemented differently for nullable value types and nullable reference types.
 - [Nullable contexts](#nullable-contexts) help you migrate large projects. You can enable nullable contexts or warnings in parts of your app as you migrate. After you address more warnings, you can enable nullable reference types for the entire project.
 
-Finally, you learn known pitfalls for null state analysis in `struct` types and arrays.
+Finally, you learn known pitfalls for null-state analysis in `struct` types and arrays.
 
 You can also explore these concepts in our Learn module on [Nullable safety in C#](/training/modules/csharp-null-safety).
 
-## Null state analysis
+## null-state analysis
 
 When nullable reference types are enabled, ***Null-state analysis*** tracks the *null-state* of references. An expression is either *not-null* or *maybe-null*. The compiler determines that a variable is *not-null* in two ways:
 
-1. The variable has been assigned a value that is known to be *not null*.
+1. The variable has been assigned a value that is known to be *not-null*.
 1. The variable has been checked against `null` and hasn't been modified since that check.
 
 When nullable reference types aren't enabled, all expressions have the null-state of *oblivious*. The rest of the section describes the behavior when nullable reference types are enabled.
@@ -74,7 +74,7 @@ Console.WriteLine($"The length of the message is {message.Length}");
 var originalMessage = message;
 message = "Hello, World!";
 
-// No warning. Analysis determined "message" is not null.
+// No warning. Analysis determined "message" is not-null.
 Console.WriteLine($"The length of the message is {message.Length}");
 
 // warning!
@@ -95,7 +95,7 @@ void FindRoot(Node node, Action<Node> processNode)
 
 The previous code doesn't generate any warnings for dereferencing the variable `current`. Static analysis determines that `current` is never dereferenced when it's *maybe-null*. The variable `current` is checked against `null` before `current.Parent` is accessed, and before passing `current` to the `ProcessNode` action. The previous examples show how the compiler determines *null-state* for local variables when initialized, assigned, or compared to `null`.
 
-The null state analysis doesn't trace into called methods. As a result, fields initialized in a common helper method called by all constructors generates a warning with the following template:
+The null-state analysis doesn't trace into called methods. As a result, fields initialized in a common helper method called by all constructors generates a warning with the following template:
 
 > Non-nullable property '*name*' must contain a non-null value when exiting constructor.
 
@@ -104,13 +104,13 @@ You can address these warnings in one of two ways: *Constructor chaining*, or *n
 :::code language="csharp" source="./language-reference/compiler-messages/snippets/null-warnings/PersonExamples.cs" id="ConstructorChainingAndMemberNotNull":::
 
 > [!NOTE]
-> A number of improvements to definite assignment and null state analysis were added in C# 10. When you upgrade to C# 10, you may find fewer nullable warnings that are false positives. You can learn more about the improvements in the [features specification for definite assignment improvements](~/_csharplang/proposals/csharp-10.0/improved-definite-assignment.md).
+> A number of improvements to definite assignment and null-state analysis were added in C# 10. When you upgrade to C# 10, you may find fewer nullable warnings that are false positives. You can learn more about the improvements in the [features specification for definite assignment improvements](~/_csharplang/proposals/csharp-10.0/improved-definite-assignment.md).
 
 Nullable state analysis and the warnings the compiler generates help you avoid program errors by dereferencing `null`. The article on [resolving nullable warnings](language-reference/compiler-messages/nullable-warnings.md) provides techniques for correcting the warnings most likely seen in your code.
 
 ## Attributes on API signatures
 
-The null state analysis needs hints from developers to understand the semantics of APIs. Some APIs provide null checks, and should change the *null-state* of a variable from *maybe-null* to *not-null*. Other APIs return expressions that are *not-null* or *maybe-null* depending on the *null-state* of the input arguments. For example, consider the following code that displays a message in upper case:
+The null-state analysis needs hints from developers to understand the semantics of APIs. Some APIs provide null checks, and should change the *null-state* of a variable from *maybe-null* to *not-null*. Other APIs return expressions that are *not-null* or *maybe-null* depending on the *null-state* of the input arguments. For example, consider the following code that displays a message in upper case:
 
 ```csharp
 void PrintMessageUpper(string? message)
@@ -132,7 +132,7 @@ bool IsNull([NotNullWhen(false)] string? s) => s == null;
 
 This attribute informs the compiler, that, if `IsNull` returns `false`, the parameter `s` isn't null. The compiler changes the *null-state* of `message` to *not-null* inside the `if (!IsNull(message)) {...}` block. No warnings are issued.
 
-Attributes provide detailed information about the null state of arguments, return values, and members of the object instance used to invoke a member. The details on each attribute can be found in the language reference article on [nullable reference attributes](language-reference/attributes/nullable-analysis.md). As of .NET 5, all .NET runtime APIs are annotated. You improve the static analysis by annotating your APIs to provide semantic information about the *null-state* of arguments and return values.
+Attributes provide detailed information about the null-state of arguments, return values, and members of the object instance used to invoke a member. The details on each attribute can be found in the language reference article on [nullable reference attributes](language-reference/attributes/nullable-analysis.md). As of .NET 5, all .NET runtime APIs are annotated. You improve the static analysis by annotating your APIs to provide semantic information about the *null-state* of arguments and return values.
 
 ## Nullable variable annotations
 
@@ -173,7 +173,7 @@ Nullable reference types are a compile time feature. That means it's possible fo
 
 ## Generics
 
-Generics requires detailed rules to handle `T?` for any type parameter `T`. The rules are necessarily detailed because of history and the different implementation for a nullable value type and a nullable reference type. [Nullable value types](language-reference/builtin-types/nullable-value-types.md) are implemented using the <xref:System.Nullable%601?displayProperty=nameWithType> struct. [Nullable reference types](language-reference/builtin-types/nullable-reference-types.md) are implemented as type annotations that provide semantic rules to the compiler.
+Generics require detailed rules to handle `T?` for any type parameter `T`. The rules are necessarily detailed because of history and the different implementation for a nullable value type and a nullable reference type. [Nullable value types](language-reference/builtin-types/nullable-value-types.md) are implemented using the <xref:System.Nullable%601?displayProperty=nameWithType> struct. [Nullable reference types](language-reference/builtin-types/nullable-reference-types.md) are implemented as type annotations that provide semantic rules to the compiler.
 
 - If the type argument for `T` is a reference type, `T?` references the corresponding nullable reference type. For example, if `T` is a `string`, then `T?` is a `string?`.
 - If the type argument for `T` is a value type, `T?` references the same value type, `T`. For example, if `T` is an `int`, the `T?` is also an `int`.
@@ -200,7 +200,7 @@ For small projects, you can enable nullable reference types, fix warnings, and c
 
 The **nullable annotation context** determines the compiler's behavior. There are four values for the **nullable annotation context**:
 
-- *disable*: The code is *nullable oblivious*. *Disable* matches the behavior before nullable reference types were enabled, except the new syntax produces warnings instead of errors.
+- *disable*: The code is *nullable-oblivious*. *Disable* matches the behavior before nullable reference types were enabled, except the new syntax produces warnings instead of errors.
   - Nullable warnings are disabled.
   - All reference type variables are nullable reference types.
   - Use of the `?` suffix to declare a nullable reference type produces a warning.
@@ -215,7 +215,7 @@ The **nullable annotation context** determines the compiler's behavior. There ar
   - Use of the `?` suffix to declare a nullable reference type produces a warning.
   - All reference type variables are allowed to be null. However, members have the *null-state* of *not-null* at the opening brace of all methods unless declared with the `?` suffix.
   - You can use the null forgiving operator, `!`.
-- *annotations*: The compiler doesn't emit warnings when code might dereference `null`, or when you assign a maybe null expression to a non-nullable variable.
+- *annotations*: The compiler doesn't emit warnings when code might dereference `null`, or when you assign a maybe-null expression to a non-nullable variable.
   - All new nullable warnings are disabled.
   - You can use the `?` suffix to declare a nullable reference type.
   - Reference type variables without the `?` suffix are non-nullable reference types.
@@ -227,10 +227,10 @@ The nullable annotation context and nullable warning context can be set for a pr
 | - | - | - | - | - |
 | `disable` | Disabled | Disabled | All are nullable | Produces a warning | Has no effect |
 | `enable` | Enabled | Enabled | Non-nullable unless declared with `?` | Declares nullable type | Suppresses warnings for possible `null` assignment |
-| `warnings` | Enabled | Not applicable | All are nullable, but members are considered *not null* at opening brace of methods | Produces a warning |  Suppresses warnings for possible `null` assignment |
+| `warnings` | Enabled | Not applicable | All are nullable, but members are considered *not-null* at opening brace of methods | Produces a warning |  Suppresses warnings for possible `null` assignment |
 | `annotations` | Disabled | Disabled | Non-nullable unless declared with `?` | Declares nullable type | Has no effect |
 
-Reference type variables in code compiled in a *disabled* context are *nullable-oblivious*. You can assign a `null` literal or a *maybe-null* variable to a variable that is *nullable oblivious*. However, the default state of a *nullable-oblivious* variable is *not-null*.
+Reference type variables in code compiled in a *disabled* context are *nullable-oblivious*. You can assign a `null` literal or a *maybe-null* variable to a variable that is *nullable-oblivious*. However, the default state of a *nullable-oblivious* variable is *not-null*.
 
 You can choose which setting is best for your project:
 

--- a/docs/csharp/nullable-references.md
+++ b/docs/csharp/nullable-references.md
@@ -43,7 +43,7 @@ You'll learn about:
 - [Attributes](#attributes-on-api-signatures) that are applied to APIs that provide more context for the compiler's null state analysis.
 - [Nullable variable annotations](#nullable-variable-annotations) that provide information about your intent for variables.  Annotations are useful for fields to set the default null state at the beginning of member methods.
 - The rules governing [generic type arguments](#generics). New constraints were added because type parameters can be reference types or value types. The `?` suffix is implemented differently for nullable value types and nullable reference types.
-- [Nullable contexts](#nullable-contexts) help you migrate large projects. You can enable nullable contexts or warnings in parts of your app as migrate. After you address more warnings, you can enable nullable reference types for the entire project.
+- [Nullable contexts](#nullable-contexts) help you migrate large projects. You can enable nullable contexts or warnings in parts of your app as you migrate. After you address more warnings, you can enable nullable reference types for the entire project.
 
 Finally, you learn known pitfalls for null state analysis in `struct` types and arrays.
 
@@ -192,7 +192,7 @@ These constraints help provide more information to the compiler on how `T` is us
 
 ## Nullable contexts
 
-For small projects, you can enable nullable reference types, fix warnings, and continue. However, for larger projects and multi-project solutions, that might generate a large number of warnings. You can use pragmas to enable nullable reference file-by-file as you begin using nullable reference types. The new features that protect against throwing a <xref:System.NullReferenceException?displayProperty=nameWithType> can be disruptive when turned on in an existing codebase:
+For small projects, you can enable nullable reference types, fix warnings, and continue. However, for larger projects and multi-project solutions, that might generate a large number of warnings. You can use pragmas to enable nullable reference types file-by-file as you begin using nullable reference types. The new features that protect against throwing a <xref:System.NullReferenceException?displayProperty=nameWithType> can be disruptive when turned on in an existing codebase:
 
 - All explicitly typed reference variables are interpreted as non-nullable reference types.
 - The meaning of the `class` constraint in generics changed to mean a non-nullable reference type.

--- a/docs/csharp/nullable-references.md
+++ b/docs/csharp/nullable-references.md
@@ -1,20 +1,34 @@
 ---
 title: Nullable reference types
-description: This article provides an overview of nullable reference types. You'll learn how the feature provides safety against null reference exceptions, for new and existing projects.
+description: This article provides an overview of nullable reference types. Learn how the feature provides safety against null reference exceptions, for new and existing projects.
 ms.subservice: null-safety
-ms.date: 09/01/2021
+ms.date: 01/16/2024
 ---
 # Nullable reference types
 
-In a nullable oblivious context, all reference types were nullable. *Nullable reference types* refers to a group of features enabled in a nullable aware context that  minimize the likelihood that your code causes the runtime to throw <xref:System.NullReferenceException?displayProperty=nameWithType>. *Nullable reference types* includes three features that help you avoid these exceptions, including the ability to explicitly mark a reference type as *nullable*:
+In a nullable oblivious context, all reference types were nullable. *Nullable reference types* refers to a group of features enabled in a nullable aware context that minimize the likelihood that your code causes the runtime to throw <xref:System.NullReferenceException?displayProperty=nameWithType>. *Nullable reference types* includes three features that help you avoid these exceptions, including the ability to explicitly mark a reference type as *nullable*:
 
-- Improved static flow analysis that determines if a variable may be `null` before dereferencing it.
+- Improved static flow analysis that determines if a variable might be `null` before dereferencing it.
 - Attributes that annotate APIs so that the flow analysis determines *null-state*.
 - Variable annotations that developers use to explicitly declare the intended *null-state* for a variable.
 
+The compiler tracks the *null-state* of every expression in your code at compile time. The *null-state* has one of three values:
+
+- *not-null*: The expression is known to be not-`null`.
+- *maybe-null*: The expression might be `null`.
+- *oblivious*: The compiler can't determine the null-state of the expression.
+
+Variable annotations determine the *nullability* of a reference type variable:
+
+- *non-nullable*: If you assign a `null` value or a *maybe-null* expression to the variable, the compiler issues a warning. Variables that are *non-nullable* have a default null-state of *not-null*.
+- *nullable*: You can assign a `null` value or a *maybe-null* expression to the variable. When the variable's null-state is *maybe-null*, the compiler issues a warning if you dereference the variable. The default null-state for the variable is *maybe-null*.
+- *oblivious*: You can assign a `null` value or a *maybe-null* expression to the variable. The compiler doesn't issue warnings when you dereference the variable, or when you assign a *maybe-null* expression to the variable.
+
+The *oblivious* null-state and *oblivious* nullability match the behavior before nullable reference types were introduced. Those values are useful during migration, or when your app uses a library that hasn't enabled nullable reference types.
+
 Null-state analysis and variable annotations are disabled by default for existing projects&mdash;meaning that all reference types continue to be nullable. Starting in .NET 6, they're enabled by default for *new* projects. For information about enabling these features by declaring a *nullable annotation context*, see [Nullable contexts](#nullable-contexts).
 
-The rest of this article describes how those three feature areas work to produce warnings when your code may be **dereferencing** a `null` value. Dereferencing a variable means to access one of its members using the `.` (dot) operator, as shown in the following example:
+The rest of this article describes how those three feature areas work to produce warnings when your code might be **dereferencing** a `null` value. Dereferencing a variable means to access one of its members using the `.` (dot) operator, as shown in the following example:
 
 ```csharp
 string message = "Hello, World!";
@@ -23,18 +37,30 @@ int length = message.Length; // dereferencing "message"
 
 When you dereference a variable whose value is `null`, the runtime throws a <xref:System.NullReferenceException?displayProperty=nameWithType>.
 
+You'll learn about:
+
+- The compiler's [null state analysis](#null-state-analysis): how the compiler determines if an expression is not null, or maybe null.
+- [Attributes](#attributes-on-api-signatures) that are applied to APIs that provide more context for the compiler's null state analysis.
+- [Nullable variable annotations](#nullable-variable-annotations) that provide information about your intent for variables.  Annotations are useful for fields to set the default null state at the beginning of member methods.
+- The rules governing [generic type arguments](#generics). New constraints were added because type parameters can be reference types or value types. The `?` suffix is implemented differently for nullable value types and nullable reference types.
+- [Nullable contexts](#nullable-contexts) help you migrate large projects. You can enable nullable contexts or warnings in parts of your app as migrate. After you address more warnings, you can enable nullable reference types for the entire project.
+
+Finally, you learn known pitfalls for null state analysis in `struct` types and arrays.
+
 You can also explore these concepts in our Learn module on [Nullable safety in C#](/training/modules/csharp-null-safety).
 
 ## Null state analysis
 
-***Null-state analysis*** tracks the *null-state* of references. This static analysis emits warnings when your code may dereference `null`. You can address these warnings to minimize incidences when the runtime throws a <xref:System.NullReferenceException?displayProperty=nameWithType>. The compiler uses static analysis to determine the *null-state* of a variable. A variable is either *not-null* or *maybe-null*. The compiler determines that a variable is *not-null* in two ways:
+When nullable reference types are enabled, ***Null-state analysis*** tracks the *null-state* of references. An expression is either *not-null* or *maybe-null*. The compiler determines that a variable is *not-null* in two ways:
 
 1. The variable has been assigned a value that is known to be *not null*.
 1. The variable has been checked against `null` and hasn't been modified since that check.
 
-Any variable that the compiler hasn't determined as *not-null* is considered *maybe-null*. The analysis provides warnings in situations where you may accidentally dereference a `null` value. The compiler produces warnings based on the *null-state*.
+When nullable reference types aren't enabled, all expressions have the null-state of *oblivious*. The rest of the section describes the behavior when nullable reference types are enabled.
 
-- When a variable is *not-null*, that variable may be dereferenced safely.
+Any variable that the compiler hasn't determined as *not-null* is considered *maybe-null*. The analysis provides warnings in situations where you might accidentally dereference a `null` value. The compiler produces warnings based on the *null-state*.
+
+- When a variable is *not-null*, that variable might be dereferenced safely.
 - When a variable is *maybe-null*, that variable must be checked to ensure that it isn't `null` before dereferencing it.
 
 Consider the following example:
@@ -69,7 +95,7 @@ void FindRoot(Node node, Action<Node> processNode)
 
 The previous code doesn't generate any warnings for dereferencing the variable `current`. Static analysis determines that `current` is never dereferenced when it's *maybe-null*. The variable `current` is checked against `null` before `current.Parent` is accessed, and before passing `current` to the `ProcessNode` action. The previous examples show how the compiler determines *null-state* for local variables when initialized, assigned, or compared to `null`.
 
-The null state analysis doesn't trace into called methods. As a result, fields initialized in a common helper method called by constructors will generate a warning with the following template:
+The null state analysis doesn't trace into called methods. As a result, fields initialized in a common helper method called by all constructors generates a warning with the following template:
 
 > Non-nullable property '*name*' must contain a non-null value when exiting constructor.
 
@@ -80,7 +106,7 @@ You can address these warnings in one of two ways: *Constructor chaining*, or *n
 > [!NOTE]
 > A number of improvements to definite assignment and null state analysis were added in C# 10. When you upgrade to C# 10, you may find fewer nullable warnings that are false positives. You can learn more about the improvements in the [features specification for definite assignment improvements](~/_csharplang/proposals/csharp-10.0/improved-definite-assignment.md).
 
-Nullable state analysis and the warnings the compiler generates help you avoid program errors by dereferencing `null`. The article on [resolving nullable warnings](language-reference/compiler-messages/nullable-warnings.md) provides techniques for correcting the warnings you'll likely see in your code.
+Nullable state analysis and the warnings the compiler generates help you avoid program errors by dereferencing `null`. The article on [resolving nullable warnings](language-reference/compiler-messages/nullable-warnings.md) provides techniques for correcting the warnings most likely seen in your code.
 
 ## Attributes on API signatures
 
@@ -98,31 +124,31 @@ void PrintMessageUpper(string? message)
 bool IsNull(string? s) => s == null;
 ```
 
-Based on inspection, any developer would consider this code safe, and one that shouldn't generate warnings. However the compiler doesn't know that `IsNull` provides a null check and will issue a warning for the `message.ToUpper()` statement, considering `message` to be a *maybe-null* variable. To fix this, we can use the [`NotNullWhen`](xref:System.Diagnostics.CodeAnalysis.NotNullWhenAttribute) attribute:
+Based on inspection, any developer would consider this code safe, and shouldn't generate warnings. However the compiler doesn't know that `IsNull` provides a null check and issues a warning for the `message.ToUpper()` statement, considering `message` to be a *maybe-null* variable. Use the [`NotNullWhen`](xref:System.Diagnostics.CodeAnalysis.NotNullWhenAttribute) attribute to fix this warning:
 
 ```csharp
 bool IsNull([NotNullWhen(false)] string? s) => s == null;
 ```
 
-This informs the compiler, that, if `IsNull` returns `false`, the parameter `s` is not null. This allows the compiler to change the *null-state* of `message` to *not-null* inside the `if (!IsNull(message)) {...}` block. Thanks to this, no warnings will be issued.
+This attribute informs the compiler, that, if `IsNull` returns `false`, the parameter `s` isn't null. The compiler changes the *null-state* of `message` to *not-null* inside the `if (!IsNull(message)) {...}` block. No warnings are issued.
 
-Attributes provide detailed information about the null state of arguments, return values, and members of the object instance used to invoke a member. The details on each attribute can be found in the language reference article on [nullable reference attributes](language-reference/attributes/nullable-analysis.md). The .NET runtime APIs have all been annotated in .NET 5. You improve the static analysis by annotating your APIs to provide semantic information about the *null-state* of arguments and return values.
+Attributes provide detailed information about the null state of arguments, return values, and members of the object instance used to invoke a member. The details on each attribute can be found in the language reference article on [nullable reference attributes](language-reference/attributes/nullable-analysis.md). As of .NET 5, all .NET runtime APIs are annotated. You improve the static analysis by annotating your APIs to provide semantic information about the *null-state* of arguments and return values.
 
 ## Nullable variable annotations
 
-The *null-state* analysis provides robust analysis for most variables. The compiler needs more information from you for member variables. The compiler can't make assumptions about the order in which public members are accessed. Any public member could be accessed in any order. Any of the accessible constructors could be used to initialize the object. If a member field might ever be set to `null`, the compiler must assume its *null-state* is *maybe-null* at the start of each method.
+The *null-state* analysis provides robust analysis for local variables. The compiler needs more information from you for member variables. The compiler needs more information to set the *null-state* of all fields at the opening bracket of a member. Any of the accessible constructors could be used to initialize the object. If a member field might ever be set to `null`, the compiler must assume its *null-state* is *maybe-null* at the start of each method.
 
 You use annotations that can declare whether a variable is a **nullable reference type** or a **non-nullable reference type**. These annotations make important statements about the *null-state* for variables:
 
-- **A reference isn't supposed to be null**. The default state of a nonnullable reference variable is *not-null*. The compiler enforces rules that ensure it's safe to dereference these variables without first checking that it isn't null:
+- **A reference isn't supposed to be null**. The default state of a non-nullable reference variable is *not-null*. The compiler enforces rules that ensure it's safe to dereference these variables without first checking that it isn't null:
   - The variable must be initialized to a non-null value.
   - The variable can never be assigned the value `null`. The compiler issues a warning when code assigns a *maybe-null* expression to a variable that shouldn't be null.
-- **A reference may be null**. The default state of a nullable reference variable is *maybe-null*. The compiler enforces rules to ensure that you've correctly checked for a `null` reference:
-  - The variable may only be dereferenced when the compiler can guarantee that the value isn't `null`.
-  - These variables may be initialized with the default `null` value and may be assigned the value `null` in other code.
-  - The compiler doesn't issue warnings when code assigns a *maybe-null* expression to a variable that may be null.
+- **A reference might be null**. The default state of a nullable reference variable is *maybe-null*. The compiler enforces rules to ensure that you correctly check for a `null` reference:
+  - The variable might only be dereferenced when the compiler can guarantee that the value isn't `null`.
+  - These variables might be initialized with the default `null` value and might be assigned the value `null` in other code.
+  - The compiler doesn't issue warnings when code assigns a *maybe-null* expression to a variable that might be null.
 
-Any reference variable that isn't supposed to be `null` has a *null-state* of *not-null*. Any reference variable that may be `null` initially has the *null-state* of *maybe-null*.
+Any non-nullable reference variable  has a default *null-state* of *not-null*. Any nullable reference variable has the initial *null-state* of *maybe-null*.
 
 A **nullable reference type** is noted using the same syntax as [nullable value types](language-reference/builtin-types/nullable-value-types.md): a `?` is appended to the type of the variable. For example, the following variable declaration represents a nullable string variable, `name`:
 
@@ -130,7 +156,7 @@ A **nullable reference type** is noted using the same syntax as [nullable value 
 string? name;
 ```
 
-Any variable where the `?` isn't appended to the type name is a **non-nullable reference type**. That includes all reference type variables in existing code when you've enabled this feature. However, any implicitly typed local variables (declared using `var`) are **nullable reference types**. As the preceding sections showed, static analysis determines the *null-state* of local variables to determine if they're *maybe-null*.
+When nullable reference types are enabled, any variable where the `?` isn't appended to the type name is a **non-nullable reference type**. That includes all reference type variables in existing code once you enable this feature. However, any implicitly typed local variables (declared using `var`) are **nullable reference types**. As the preceding sections showed, static analysis determines the *null-state* of local variables to determine if they're *maybe-null* before dereferencing it.
 
 Sometimes you must override a warning when you know a variable isn't null, but the compiler determines its *null-state* is *maybe-null*. You use the [null-forgiving operator](language-reference/operators/null-forgiving.md) `!` following a variable name to force the *null-state* to be *not-null*. For example, if you know the `name` variable isn't `null` but the compiler issues a warning, you can write the following code to override the compiler's analysis:
 
@@ -138,7 +164,7 @@ Sometimes you must override a warning when you know a variable isn't null, but t
 name!.Length;
 ```
 
-Nullable reference types and nullable value types provide a similar semantic concept: A variable can represent a value or object, or that variable may be `null`. However, nullable reference types and nullable value types are implemented differently: nullable value types are implemented using <xref:System.Nullable%601?displayProperty=nameWithType>, and nullable reference types are implemented by attributes read by the compiler. For example, `string?` and `string` are both represented by the same type: <xref:System.String?displayProperty=nameWithType>. However, `int?` and `int` are represented by `System.Nullable<System.Int32>` and <xref:System.Int32?displayProperty=nameWithType>, respectively.
+Nullable reference types and nullable value types provide a similar semantic concept: A variable can represent a value or object, or that variable might be `null`. However, nullable reference types and nullable value types are implemented differently: nullable value types are implemented using <xref:System.Nullable%601?displayProperty=nameWithType>, and nullable reference types are implemented by attributes read by the compiler. For example, `string?` and `string` are both represented by the same type: <xref:System.String?displayProperty=nameWithType>. However, `int?` and `int` are represented by `System.Nullable<System.Int32>` and <xref:System.Int32?displayProperty=nameWithType>, respectively.
 
 Nullable reference types are a compile time feature. That means it's possible for callers to ignore warnings, intentionally use `null` as an argument to a method expecting a non nullable reference. Library authors should include runtime checks against null argument values. The <xref:System.ArgumentNullException.ThrowIfNull%2A?displayProperty=nameWithType> is the preferred option for checking a parameter against null at run time.
 
@@ -147,7 +173,7 @@ Nullable reference types are a compile time feature. That means it's possible fo
 
 ## Generics
 
-Generics require detailed rules to handle `T?` for any type parameter `T`. The rules are necessarily detailed because of history and the different implementation for a nullable value type and a nullable reference type. [Nullable value types](language-reference/builtin-types/nullable-value-types.md) are implemented using the <xref:System.Nullable%601?displayProperty=nameWithType> struct. [Nullable reference types](language-reference/builtin-types/nullable-reference-types.md) are implemented as type annotations that provide semantic rules to the compiler.
+Generics requires detailed rules to handle `T?` for any type parameter `T`. The rules are necessarily detailed because of history and the different implementation for a nullable value type and a nullable reference type. [Nullable value types](language-reference/builtin-types/nullable-value-types.md) are implemented using the <xref:System.Nullable%601?displayProperty=nameWithType> struct. [Nullable reference types](language-reference/builtin-types/nullable-reference-types.md) are implemented as type annotations that provide semantic rules to the compiler.
 
 - If the type argument for `T` is a reference type, `T?` references the corresponding nullable reference type. For example, if `T` is a `string`, then `T?` is a `string?`.
 - If the type argument for `T` is a value type, `T?` references the same value type, `T`. For example, if `T` is an `int`, the `T?` is also an `int`.
@@ -162,19 +188,19 @@ You can specify different behavior using [constraints](programming-guide/generic
 - The `class?` constraint means that `T` must be a reference type, either non-nullable (`string`) or a nullable reference type (for example `string?`). When the type parameter is a nullable reference type, such as `string?`, an expression of `T?` references that same nullable reference type, such as `string?`.
 - The `notnull` constraint means that `T` must be a non-nullable reference type, or a non-nullable value type. If you use a nullable reference type or a nullable value type for the type parameter, the compiler produces a warning. Furthermore, when `T` is a value type, the return value is that value type, not the corresponding nullable value type.
 
-These constraints help provide more information to the compiler on how `T` will be used. That helps when developers choose the type for `T`, and provides better *null-state* analysis when an instance of the generic type is used.
+These constraints help provide more information to the compiler on how `T` is used. That helps when developers choose the type for `T` and provides better *null-state* analysis when an instance of the generic type is used.
 
 ## Nullable contexts
 
-The new features that protect against throwing a <xref:System.NullReferenceException?displayProperty=nameWithType> can be disruptive when turned on in an existing codebase:
+For small projects, you can enable nullable reference types, fix warnings, and continue. However, for larger projects and multi-project solutions, that might generate a large number of warnings. You can use pragmas to enable nullable reference file-by-file as you begin using nullable reference types. The new features that protect against throwing a <xref:System.NullReferenceException?displayProperty=nameWithType> can be disruptive when turned on in an existing codebase:
 
 - All explicitly typed reference variables are interpreted as non-nullable reference types.
 - The meaning of the `class` constraint in generics changed to mean a non-nullable reference type.
 - New warnings are generated because of these new rules.
 
-You must explicitly opt in to use these features in your existing projects. That provides a migration path and preserves backwards compatibility. Nullable contexts enable fine-grained control for how the compiler interprets reference type variables. The **nullable annotation context** determines the compiler's behavior. There are four values for the **nullable annotation context**:
+The **nullable annotation context** determines the compiler's behavior. There are four values for the **nullable annotation context**:
 
-- *disable*: The code is *nullable oblivious*.
+- *disable*: The code is *nullable oblivious*. *Disable* matches the behavior before nullable reference types were enabled, except the new syntax produces warnings instead of errors.
   - Nullable warnings are disabled.
   - All reference type variables are nullable reference types.
   - Use of the `?` suffix to declare a nullable reference type produces a warning.
@@ -182,17 +208,17 @@ You must explicitly opt in to use these features in your existing projects. That
 - *enable*: The compiler enables all null reference analysis and all language features.
   - All new nullable warnings are enabled.
   - You can use the `?` suffix to declare a nullable reference type.
-  - All other reference type variables are non-nullable reference types.
+  - Reference type variables without the `?` suffix are non-nullable reference types.
   - The null forgiving operator suppresses warnings for a possible assignment to `null`.
 - *warnings*: The compiler performs all null analysis and emits warnings when code might dereference `null`.
   - All new nullable warnings are enabled.
   - Use of the `?` suffix to declare a nullable reference type produces a warning.
   - All reference type variables are allowed to be null. However, members have the *null-state* of *not-null* at the opening brace of all methods unless declared with the `?` suffix.
   - You can use the null forgiving operator, `!`.
-- *annotations*: The compiler doesn't perform null analysis or emit warnings when code might dereference `null`.
+- *annotations*: The compiler doesn't emit warnings when code might dereference `null`, or when you assign a maybe null expression to a non-nullable variable.
   - All new nullable warnings are disabled.
   - You can use the `?` suffix to declare a nullable reference type.
-  - All other reference type variables are non-nullable reference types.
+  - Reference type variables without the `?` suffix are non-nullable reference types.
   - You can use the null forgiving operator, `!`, but it has no effect.
 
 The nullable annotation context and nullable warning context can be set for a project using the [`<Nullable>` element](language-reference/compiler-options/language.md) in your *.csproj* file. This element configures how the compiler interprets the nullability of types and what warnings are emitted. The following table shows the allowable values and summarizes the contexts they specify.
@@ -209,7 +235,7 @@ Reference type variables in code compiled in a *disabled* context are *nullable-
 You can choose which setting is best for your project:
 
 - Choose *disable* for legacy projects that you don't want to update based on diagnostics or new features.
-- Choose *warnings* to determine where your code may throw <xref:System.NullReferenceException?displayProperty=nameWithType>s. You can address those warnings before modifying code to enable non-nullable reference types.
+- Choose *warnings* to determine where your code might throw <xref:System.NullReferenceException?displayProperty=nameWithType>s. You can address those warnings before modifying code to enable non-nullable reference types.
 - Choose *annotations* to express your design intent before enabling warnings.
 - Choose *enable* for new projects and active projects where you want to protect against null reference exceptions.
 
@@ -219,7 +245,7 @@ You can choose which setting is best for your project:
 <Nullable>enable</Nullable>
 ```
 
-You can also use directives to set these same contexts anywhere in your source code. These are most useful when you're migrating a large codebase.
+You can also use directives to set these same contexts anywhere in your source code. These directives are most useful when you're migrating a large codebase.
 
 - `#nullable enable`: Sets the nullable annotation context and nullable warning context to **enable**.
 - `#nullable disable`: Sets the nullable annotation context and nullable warning context to **disable**.
@@ -245,7 +271,7 @@ For any line of code, you can set any of the following combinations:
 | project default | disable            | Rarely                                 |
 | disable         | project default    | Rarely                                 |
 
-Those nine combinations provide you with fine-grained control over the diagnostics the compiler emits for your code. You can enable more features in any area you're updating, without seeing additional warnings you aren't ready to address yet.
+Those nine combinations provide you with fine-grained control over the diagnostics the compiler emits for your code. You can enable more features in any area you're updating, without seeing more warnings you aren't ready to address yet.
 
 > [!IMPORTANT]
 > The global nullable context does not apply for generated code files. Under either strategy, the nullable context is *disabled* for any source file marked as generated. This means any APIs in generated files are not annotated. There are four ways a file is marked as generated:
@@ -263,7 +289,7 @@ These options provide two distinct strategies to [update an existing codebase](n
 
 ## Known pitfalls
 
-Arrays and structs that contain reference types are known pitfalls in nullable references and the static analysis that determines null safety. In both situations, a non-nullable reference may be initialized to `null`, without generating warnings.
+Arrays and structs that contain reference types are known pitfalls in nullable references and the static analysis that determines null safety. In both situations, a non-nullable reference might be initialized to `null`, without generating warnings.
 
 ### Structs
 
@@ -301,21 +327,21 @@ Another more common case is when you deal with generic structs. Consider the fol
 ```csharp
 #nullable enable
 
-public struct Foo<T>
+public struct S<T>
 {
-    public T Bar { get; set; }
+    public T Prop { get; set; }
 }
 
 public static class Program
 {
     public static void Main()
     {
-        string s = default(Foo<string>).Bar;
+        string s = default(s<string>).Prop;
     }
 }
 ```
 
-In the preceding example, the property `Bar` is going to be `null` at run time, and it's assigned to non-nullable string without any warnings.
+In the preceding example, the property `Prop` is `null` at run time. It's assigned to non-nullable string without any warnings.
 
 ### Arrays
 


### PR DESCRIPTION
Fixes #38682

Add more of an introduction to the concepts for nullable reference types.

Clarify the use of nullable contexts as a migration strategy.

Finally, do a general edit pass.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/nullable-references.md](https://github.com/dotnet/docs/blob/ba2c466571d49dd213411641271943989899ef9e/docs/csharp/nullable-references.md) | [Nullable reference types](https://review.learn.microsoft.com/en-us/dotnet/csharp/nullable-references?branch=pr-en-us-39118) |


<!-- PREVIEW-TABLE-END -->