### PR TITLE
Add suppression note for CA1862

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1862.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1862.md
@@ -90,7 +90,7 @@ Dim i As Integer = StringComparer.CurrentCultureIgnoreCase.Compare(s1, s2)
 
 It's safe to suppress warnings from this rule if performance isn't a concern.
 
-If you're using Entity Framework Core (EF Core), you should suppress this rule for scenarios where you're querying a database by comparing a string. EF Core throws an exception if you use an overload of <xref:String.Equals%2A> that takes a <xref:System.StringComparison> argument in a query, as it won't translate such queries to SQL. For more information, see [Translation of built-in .NET string operations](/ef/core/miscellaneous/collations-and-case-sensitivity#translation-of-built-in-net-string-operations).
+If you're using Entity Framework Core (EF Core), you should suppress this rule for scenarios where you're querying a database by comparing a string. EF Core throws an exception if you use a method such as <xref:System.String.Equals(System.String,System.StringComparison)?displayProperty=nameWithType> that takes a <xref:System.StringComparison> argument, as it won't translate such queries to SQL. For more information, see [Translation of built-in .NET string operations](/ef/core/miscellaneous/collations-and-case-sensitivity#translation-of-built-in-net-string-operations).
 
 ## Suppress a warning
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1862.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1862.md
@@ -90,6 +90,8 @@ Dim i As Integer = StringComparer.CurrentCultureIgnoreCase.Compare(s1, s2)
 
 It's safe to suppress warnings from this rule if performance isn't a concern.
 
+If you're using Entity Framework Core (EF Core), you should suppress this rule for scenarios where you're querying a database by comparing a string. EF Core throws an exception if you use an overload of <xref:String.Equals%2A> that takes a <xref:System.StringComparison> argument in a query, as it won't translate such queries to SQL. For more information, see [Translation of built-in .NET string operations](/ef/core/miscellaneous/collations-and-case-sensitivity#translation-of-built-in-net-string-operations).
+
 ## Suppress a warning
 
 If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.


### PR DESCRIPTION
Fixes #38996

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1862.md](https://github.com/dotnet/docs/blob/d888b7a1442d5889c3c5f42ee449a0924e23c5f2/docs/fundamentals/code-analysis/quality-rules/ca1862.md) | [CA1862: Use the 'StringComparison' method overloads to perform case-insensitive string comparisons](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1862?branch=pr-en-us-39122) |


<!-- PREVIEW-TABLE-END -->