### PR TITLE
There is not a react template for net7.0 or net8.0

### DIFF
--- a/docs/core/tools/dotnet-new-sdk-templates.md
+++ b/docs/core/tools/dotnet-new-sdk-templates.md
@@ -693,10 +693,12 @@ The ability to create a project for an earlier TFM depends on having that versio
 
   The following table lists the default values according to the SDK version number you're using:
 
-  NOTE: There is not a template for net7.0 or net8.0 for react.
+  > [!NOTE]
+  > There isn't a React template for `net8.0`, however, if you're interested in developing React apps with ASP.NET Core, see [Overview of Single Page Apps (SPAs) in ASP.NET Core](/aspnet/core/client-side/spa/intro?view=aspnetcore-8.0&preserve-view=true).
 
   | SDK version | Default value   |
   |-------------|-----------------|
+  | 7.0         | `net7.0`        |
   | 6.0         | `net6.0`        |
   | 5.0         | `net5.0`        |
   | 3.1         | `netcoreapp3.1` |

--- a/docs/core/tools/dotnet-new-sdk-templates.md
+++ b/docs/core/tools/dotnet-new-sdk-templates.md
@@ -696,7 +696,7 @@ The ability to create a project for an earlier TFM depends on having that versio
   NOTE: There is not a template for net7.0 or net8.0 for react.
 
   | SDK version | Default value   |
-  |-------------|-----------------| 
+  |-------------|-----------------|
   | 6.0         | `net6.0`        |
   | 5.0         | `net5.0`        |
   | 3.1         | `netcoreapp3.1` |

--- a/docs/core/tools/dotnet-new-sdk-templates.md
+++ b/docs/core/tools/dotnet-new-sdk-templates.md
@@ -693,10 +693,10 @@ The ability to create a project for an earlier TFM depends on having that versio
 
   The following table lists the default values according to the SDK version number you're using:
 
+  NOTE: There is not a template for net7.0 or net8.0 for react.
+
   | SDK version | Default value   |
-  |-------------|-----------------|
-  | 8.0         | `net8.0`        |
-  | 7.0         | `net7.0`        |
+  |-------------|-----------------| 
   | 6.0         | `net6.0`        |
   | 5.0         | `net5.0`        |
   | 3.1         | `netcoreapp3.1` |


### PR DESCRIPTION
I removed net7.0 and net8.0 from the table for angular, react dotnet new template.  This section needs to be further edited.

I get this error for dotnet new react --framework net8.0

Error: Invalid option(s):
--framework net8.0
   'net8.0' is not a valid value for --framework. The possible values are:
      net6.0   - Target net6.0

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-new-sdk-templates.md](https://github.com/dotnet/docs/blob/f0ba659a984b12eb07ed54f152fe0c846e4a3571/docs/core/tools/dotnet-new-sdk-templates.md) | [.NET default templates for dotnet new](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-new-sdk-templates?branch=pr-en-us-39143) |


<!-- PREVIEW-TABLE-END -->