### PR TITLE
Improve last sentence

### DIFF
--- a/docs/csharp/whats-new/tutorials/primary-constructors.md
+++ b/docs/csharp/whats-new/tutorials/primary-constructors.md
@@ -101,7 +101,7 @@ There's one potential concern with class hierarchies and primary constructors: i
 
 :::code source="./snippets/primary-constructors/BankAccount.cs" id="DuplicatedPrimaryConstructorStorage" highlight="33":::
 
-The highlighted line shows that the `ToString` method uses the *primary constructor parameters* (`owner` and `accountID`) rather than the *base class properties* (`Owner` and `AccountID`). The result is that the derived class, `SavingsAccount` creates storage for those copies. The copy in the derived class is different than the property in the base class. If the base class property could be modified, the instance of the derived class won't see that modification. The compiler issues a warning for primary constructor parameters that are used in a derived class and passed to a base class constructor. In this instance, the fix is to use the properties in the base class interface.
+The highlighted line shows that the `ToString` method uses the *primary constructor parameters* (`owner` and `accountID`) rather than the *base class properties* (`Owner` and `AccountID`). The result is that the derived class, `SavingsAccount` creates storage for those copies. The copy in the derived class is different than the property in the base class. If the base class property could be modified, the instance of the derived class won't see that modification. The compiler issues a warning for primary constructor parameters that are used in a derived class and passed to a base class constructor. In this instance, the fix is to use the properties of the base class.
 
 ## Summary
 


### PR DESCRIPTION
## Summary

The last sentence describes the fix for (accidentally) using primary constructor parameters. The way that the fix is described is misleading. This wording should make it clearer.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/whats-new/tutorials/primary-constructors.md](https://github.com/dotnet/docs/blob/2dbd8b94e21299f44fe8b1e9638497838a931bef/docs/csharp/whats-new/tutorials/primary-constructors.md) | [Tutorial: Explore primary constructors](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/tutorials/primary-constructors?branch=pr-en-us-39146) |

<!-- PREVIEW-TABLE-END -->