### PR TITLE
Fix typo in introduction.md

### DIFF
--- a/docs/core/introduction.md
+++ b/docs/core/introduction.md
@@ -76,7 +76,7 @@ There are multiple variants of .NET, each supporting a different type of app. Th
 
 .NET implementations:
 
-* **.NET Framework** -- The original .NET. It provides access to the broad capabilities of Windows and Windows Server. It is actively supported, in maintainenance.
+* **.NET Framework** -- The original .NET. It provides access to the broad capabilities of Windows and Windows Server. It is actively supported, in maintenance.
 * **Mono** -- The original community and open source .NET. A cross-platform implementation of .NET Framework. Actively supported for Android, iOS, and WebAssembly.
 * **.NET (Core)** -- Modern .NET. A cross-platform and open source implementation of .NET, rethought for the cloud age while remaining significantly compatible with .NET Framework. Actively supported for Linux, macOS, and Windows.
 


### PR DESCRIPTION
Small typo fix:
`maintainenance` -> `maintenance`

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/introduction.md](https://github.com/dotnet/docs/blob/1529fc98501906903d8872260fd0ec3754bca495/docs/core/introduction.md) | [Introduction to NET](https://review.learn.microsoft.com/en-us/dotnet/core/introduction?branch=pr-en-us-39148) |

<!-- PREVIEW-TABLE-END -->