### PR TITLE
Update MSTest runner extensions info

### DIFF
--- a/docs/core/testing/unit-testing-mstest-runner-extensions.md
+++ b/docs/core/testing/unit-testing-mstest-runner-extensions.md
@@ -92,10 +92,10 @@ To determine what proportion of your project's code is being tested by coded tes
 
 ### Microsoft code coverage
 
-Microsoft Code Coverage analysis is possible for both managed (CLR) and unmanaged (native) code. Both static and dynamic instrumentation are supported. This extension is shipped as part of [Microsoft.Testing.Extensions.CodeCoverage](https://nuget.org/packages/Microsoft.Testing.Extensions.CodeCoverage) NuGet package. 
+Microsoft Code Coverage analysis is possible for both managed (CLR) and unmanaged (native) code. Both static and dynamic instrumentation are supported. This extension is shipped as part of [Microsoft.Testing.Extensions.CodeCoverage](https://nuget.org/packages/Microsoft.Testing.Extensions.CodeCoverage) NuGet package.
 
 > [!NOTE]
-> Unmanaged (native) code coverage is disabled in the extension by default. Use flags `EnableStaticNativeInstrumentation` and `EnableDynamicNativeInstrumentation` to enable it if needed. 
+> Unmanaged (native) code coverage is disabled in the extension by default. Use flags `EnableStaticNativeInstrumentation` and `EnableDynamicNativeInstrumentation` to enable it if needed.
 > For more information about unmanaged code coverage, see [Static and dynamic native instrumentation](/visualstudio/test/customizing-code-coverage-analysis?#static-and-dynamic-native-instrumentation).
 
 The package is shipped with Microsoft .NET LIBRARY closed-source free to use licensing model.

--- a/docs/core/testing/unit-testing-mstest-runner-extensions.md
+++ b/docs/core/testing/unit-testing-mstest-runner-extensions.md
@@ -92,7 +92,7 @@ To determine what proportion of your project's code is being tested by coded tes
 
 ### Microsoft code coverage
 
-Microsoft Code Coverage analysis is possible for both managed (CLR) and unmanaged (native) code. Both static and dynamic instrumentation are supported. This extension is shipped as part of [Microsoft.Testing.Extensions.CodeCoverage](https://nuget.org/packages/Microsoft.Testing.Extensions.CodeCoverage) NuGet package.
+Microsoft Code Coverage analysis is possible for both managed (CLR) and unmanaged (native) code. Both static and dynamic instrumentation are supported. This extension is shipped as part of [Microsoft.Testing.Extensions.CodeCoverage](https://nuget.org/packages/Microsoft.Testing.Extensions.CodeCoverage) NuGet package. Unmanaged (native) code coverage is disabled in the extension by default. Use flags `EnableStaticNativeInstrumentation` and `EnableDynamicNativeInstrumentation` to enable it if needed. For more information about unmanaged code coverage, see [Static and dynamic native instrumentation](/visualstudio/test/customizing-code-coverage-analysis?#static-and-dynamic-native-instrumentation).
 
 The package is shipped with Microsoft .NET LIBRARY closed-source free to use licensing model.
 
@@ -110,4 +110,4 @@ Microsoft Code Coverage provides the following options:
 | `--coverage-output-format` | Output file format. Supported values: 'coverage', 'xml' and 'cobertura' |
 | `--coverage-settings` | XML code coverage settings |
 
-For more information about the available options, see [settings](../additional-tools/dotnet-coverage.md#settings).
+For more information about the available options, see [settings](../additional-tools/dotnet-coverage.md#settings) and [samples](https://github.com/microsoft/codecoverage/tree/main/samples/Algorithms).

--- a/docs/core/testing/unit-testing-mstest-runner-extensions.md
+++ b/docs/core/testing/unit-testing-mstest-runner-extensions.md
@@ -16,7 +16,9 @@ A test report is a file that contains information about the execution and outcom
 
 ### Visual Studio test reports
 
-The Visual Studio test result file (or TRX) is the default format for publishing test results. This extension is shipped as part of [Microsoft.Testing.Platform.Extensions](https://nuget.org/packages/Microsoft.Testing.Platform.Extensions) package.
+The Visual Studio test result file (or TRX) is the default format for publishing test results. This extension is shipped as part of [Microsoft.Testing.Extensions.TrxReport](https://nuget.org/packages/Microsoft.Testing.Extensions.TrxReport) package.
+
+The package is shipped with Microsoft .NET LIBRARY closed-source free to use licensing model.
 
 The available options as follows:
 
@@ -57,7 +59,9 @@ You can also enable the diagnostics logs using the environment variables:
 
 ### Hang dump files
 
-This extension allows you to create a dump file after a given timeout. This extension is shipped as part of [Microsoft.Testing.Platform.Extensions.HangDump](https://nuget.org/packages/Microsoft.Testing.Platform.Extensions.HangDump) package.
+This extension allows you to create a dump file after a given timeout. This extension is shipped as part of [Microsoft.Testing.Extensions.HangDump](https://nuget.org/packages/Microsoft.Testing.Extensions.HangDump) package.
+
+The package is shipped with Microsoft .NET LIBRARY closed-source free to use licensing model.
 
 To configure the hang dump file generation, use the following options:
 
@@ -70,7 +74,9 @@ To configure the hang dump file generation, use the following options:
 
 ### Crash dump files
 
-This extension allows you to create a crash dump file if the process crashes. This extension is shipped as part of [Microsoft.Testing.Platform.Extensions](https://nuget.org/packages/Microsoft.Testing.Platform.Extensions) NuGet package.
+This extension allows you to create a crash dump file if the process crashes. This extension is shipped as part of [Microsoft.Testing.Extensions.CrashDump](https://nuget.org/packages/Microsoft.Testing.Extensions.CrashDump) NuGet package.
+
+The package is shipped with Microsoft .NET LIBRARY closed-source free to use licensing model.
 
 To configure the crash dump file generation, use the following options:
 
@@ -86,7 +92,9 @@ To determine what proportion of your project's code is being tested by coded tes
 
 ### Microsoft code coverage
 
-Microsoft Code Coverage analysis is possible for both managed (CLR) and unmanaged (native) code. Both static and dynamic instrumentation are supported. This extension is shipped as part of [Microsoft.Testing.Platform.Extensions.CodeCoverage](https://nuget.org/packages/Microsoft.Testing.Platform.Extensions.CodeCoverage) NuGet package.
+Microsoft Code Coverage analysis is possible for both managed (CLR) and unmanaged (native) code. Both static and dynamic instrumentation are supported. This extension is shipped as part of [Microsoft.Testing..Extensions.CodeCoverage](https://nuget.org/packages/Microsoft.Testing.Extensions.CodeCoverage) NuGet package.
+
+The package is shipped with Microsoft .NET LIBRARY closed-source free to use licensing model.
 
 > [!NOTE]
 > Microsoft code coverage is closed source but it's free to use.
@@ -97,9 +105,9 @@ Microsoft Code Coverage provides the following options:
 
 | Option | Description |
 |--|--|
-| `--ms-coverage` | Collect the code coverage using dotnet-coverage tool |
-| `--ms-coverage-output` | Output file |
-| `--ms-coverage-output-format` | Output file format. Supported values: 'coverage', 'xml' and 'cobertura' |
-| `--ms-coverage-settings` | XML code coverage settings |
+| `--coverage` | Collect the code coverage using dotnet-coverage tool |
+| `--coverage-output` | Output file |
+| `--coverage-output-format` | Output file format. Supported values: 'coverage', 'xml' and 'cobertura' |
+| `--coverage-settings` | XML code coverage settings |
 
 For more information about the available options, see [settings](../additional-tools/dotnet-coverage.md#settings).

--- a/docs/core/testing/unit-testing-mstest-runner-extensions.md
+++ b/docs/core/testing/unit-testing-mstest-runner-extensions.md
@@ -92,7 +92,7 @@ To determine what proportion of your project's code is being tested by coded tes
 
 ### Microsoft code coverage
 
-Microsoft Code Coverage analysis is possible for both managed (CLR) and unmanaged (native) code. Both static and dynamic instrumentation are supported. This extension is shipped as part of [Microsoft.Testing..Extensions.CodeCoverage](https://nuget.org/packages/Microsoft.Testing.Extensions.CodeCoverage) NuGet package.
+Microsoft Code Coverage analysis is possible for both managed (CLR) and unmanaged (native) code. Both static and dynamic instrumentation are supported. This extension is shipped as part of [Microsoft.Testing.Extensions.CodeCoverage](https://nuget.org/packages/Microsoft.Testing.Extensions.CodeCoverage) NuGet package.
 
 The package is shipped with Microsoft .NET LIBRARY closed-source free to use licensing model.
 

--- a/docs/core/testing/unit-testing-mstest-runner-extensions.md
+++ b/docs/core/testing/unit-testing-mstest-runner-extensions.md
@@ -10,6 +10,91 @@ ms.date: 12/15/2023
 
 The MSTest runner can be customized through extensions. These extension are either built-in or can be installed as NuGet packages. Extensions installed through NuGet packages will auto-register the extensions they are holding to become available in test execution.
 
+Each and every extension is shipped with its own licensing model (some less permissive), be sure to refer to the license associated with the extensions you want to use.
+
+## Code coverage
+
+To determine what proportion of your project's code is being tested by coded tests such as unit tests, you can use the code coverage feature. To effectively guard against bugs, your tests should exercise or 'cover' a large proportion of your code.
+
+### Coverlet
+
+There is currently no Coverlet extension but you can use [Coverlet .NET global tool](https://github.com/coverlet-coverage/coverlet#net-global-tool-guide-suffers-from-possible-known-issue).
+
+### Microsoft code coverage
+
+Microsoft Code Coverage analysis is possible for both managed (CLR) and unmanaged (native) code. Both static and dynamic instrumentation are supported. This extension is shipped as part of [Microsoft.Testing.Extensions.CodeCoverage](https://nuget.org/packages/Microsoft.Testing.Extensions.CodeCoverage) NuGet package.
+
+> [!NOTE]
+> Unmanaged (native) code coverage is disabled in the extension by default. Use flags `EnableStaticNativeInstrumentation` and `EnableDynamicNativeInstrumentation` to enable it if needed.
+> For more information about unmanaged code coverage, see [Static and dynamic native instrumentation](/visualstudio/test/customizing-code-coverage-analysis?#static-and-dynamic-native-instrumentation).
+
+> [!NOTE]
+> The package is shipped with Microsoft .NET LIBRARY closed-source free to use licensing model.
+
+For more information about Microsoft code coverage, see its [GitHub page](https://github.com/microsoft/codecoverage).
+
+Microsoft Code Coverage provides the following options:
+
+| Option | Description |
+|--|--|
+| `--coverage` | Collect the code coverage using dotnet-coverage tool |
+| `--coverage-output` | Output file |
+| `--coverage-output-format` | Output file format. Supported values: 'coverage', 'xml' and 'cobertura' |
+| `--coverage-settings` | XML code coverage settings |
+
+For more information about the available options, see [settings](../additional-tools/dotnet-coverage.md#settings) and [samples](https://github.com/microsoft/codecoverage/tree/main/samples/Algorithms).
+
+## Hot reload
+
+With Hot Reload you can now modify your apps managed source code while the application is running, without the need to manually pause or hit a breakpoint. Simply make a supported change while your app is running and in our new Visual Studio experience use the `apply code changes` button to apply your edits.
+
+> [!NOTE]
+> Current version is limited to supporting hot reload in "console mode" only. There is currently no support for Hot Reload in Test Explorer for Visual Studio or Visual Studio Code.
+
+This extension is shipped as part of [Microsoft.Testing.Extensions.HotReload](https://nuget.org/packages/Microsoft.Testing.Extensions.HotReload) package.
+
+> [!NOTE]
+> The package is shipped with the restrictive Microsoft Testing Platform Tools license.
+> Full license available at <https://www.nuget.org/packages/Microsoft.Testing.Extensions.HotReload/1.0.0/License>.
+
+You can easily enable Hot Reload support by setting the `TESTINGPLATFORM_HOTRELOAD_ENABLED` environment variable to `"1"`.
+
+For SDK-style projects, this is usually achieved by adding `"TESTINGPLATFORM_HOTRELOAD_ENABLED": "1"` in the `environmentVariables` section of the `launchSettings.json` file. You can find a full example of this file below:
+
+```json
+{
+  "profiles": {
+    "Contoso.MyTests": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "TESTINGPLATFORM_HOTRELOAD_ENABLED": "1"
+      }
+    }
+  }
+}
+
+```
+
+## Retry
+
+A .NET test resilience and transient-fault-handling extension.
+
+This extension is mainly intended for integration tests where the tests heavily depends on the state of the environment and could experience transient-faults.
+
+This extension is shipped as part of [Microsoft.Testing.Extensions.Retry](https://nuget.org/packages/Microsoft.Testing.Extensions.Retry) package.
+
+> [!NOTE]
+> The package is shipped with the restrictive Microsoft Testing Platform Tools license.
+> Full license available at <https://www.nuget.org/packages/Microsoft.Testing.Extensions.Retry/1.0.0/License>.
+
+The available options as follows:
+
+| Option | Description |
+|--|--|
+| retry-failed-tests | Reruns any failed tests until they pass or until the maximum number of attempts is reached. |
+| retry-failed-tests-max-percentage | Avoids rerunning tests when the percentage of failed test cases crosses the specified threshold. |
+| retry-failed-tests-max-tests | Avoids rerunning tests when the number of failed test cases crosses the specified limit. |
+
 ## Test reports
 
 A test report is a file that contains information about the execution and outcome of the tests.
@@ -18,7 +103,8 @@ A test report is a file that contains information about the execution and outcom
 
 The Visual Studio test result file (or TRX) is the default format for publishing test results. This extension is shipped as part of [Microsoft.Testing.Extensions.TrxReport](https://nuget.org/packages/Microsoft.Testing.Extensions.TrxReport) package.
 
-The package is shipped with Microsoft .NET LIBRARY closed-source free to use licensing model.
+> [!NOTE]
+> The package is shipped with Microsoft .NET LIBRARY closed-source free to use licensing model.
 
 The available options as follows:
 
@@ -33,7 +119,7 @@ The report is saved inside the default _TestResults_ folder that can be specifie
 
 The `Microsoft.Testing.Platform` offers some built-in functionalities and extensions that ease the troubleshooting of your test apps.
 
-### Platform options
+### Built-in options
 
 The following [platform options](./unit-testing-mstest-runner-intro.md#options) provide useful information for troubleshooting your test apps:
 
@@ -57,11 +143,27 @@ You can also enable the diagnostics logs using the environment variables:
 > [!NOTE]
 > Environment variables take precedence over the command line arguments.
 
-### Hang dump files
+### Crash dump
+
+This extension allows you to create a crash dump file if the process crashes. This extension is shipped as part of [Microsoft.Testing.Extensions.CrashDump](https://nuget.org/packages/Microsoft.Testing.Extensions.CrashDump) NuGet package.
+
+> [!NOTE]
+> The package is shipped with Microsoft .NET LIBRARY closed-source free to use licensing model.
+
+To configure the crash dump file generation, use the following options:
+
+| Option | Description |
+|--|--|
+| `--crashdump` | Generates a dump file when the test host process crashes. Supported in .NET 6.0+. |
+| `⁠-⁠-⁠crashdump-⁠filename` | Specifies the file name of the dump. |
+| `--crashdump-type` | Specifies the type of the dump. Valid values are `Mini`, `Heap`, `Triage`, `Full`. Defaults as `Full`. For more information, see [Types of mini dumps](../diagnostics/collect-dumps-crash.md#types-of-mini-dumps). |
+
+### Hang dump
 
 This extension allows you to create a dump file after a given timeout. This extension is shipped as part of [Microsoft.Testing.Extensions.HangDump](https://nuget.org/packages/Microsoft.Testing.Extensions.HangDump) package.
 
-The package is shipped with Microsoft .NET LIBRARY closed-source free to use licensing model.
+> [!NOTE]
+> The package is shipped with Microsoft .NET LIBRARY closed-source free to use licensing model.
 
 To configure the hang dump file generation, use the following options:
 
@@ -70,48 +172,4 @@ To configure the hang dump file generation, use the following options:
 | `--hangdump` | Generates a dump file in case the test host process hangs. |
 | `-⁠-⁠hangdump-⁠filename` | Specifies the file name of the dump. |
 | `--hangdump-timeout` | Specifies the timeout after which the dump is generated. The timeout value is specified in one of the following formats:<br/>`1.5h`, `1.5hour`, `1.5hours`<br/>`90m`, `90min`, `90minute`, `90minutes`<br/>`5400s`, `5400sec`, `5400second`, `5400seconds`. Defaults to `30m` (30 minutes). |
-| `--hangdump-type` | Specifies the type of the dump. Valid values are `Mini`, `Heap`, `Triage`, `Full`. Defaults as `Full`. For more information, see [Types of mini dumps](../diagnostics/collect-dumps-crash.md#types-of-mini-dumps).|
-
-### Crash dump files
-
-This extension allows you to create a crash dump file if the process crashes. This extension is shipped as part of [Microsoft.Testing.Extensions.CrashDump](https://nuget.org/packages/Microsoft.Testing.Extensions.CrashDump) NuGet package.
-
-The package is shipped with Microsoft .NET LIBRARY closed-source free to use licensing model.
-
-To configure the crash dump file generation, use the following options:
-
-| Option | Description |
-|--|--|
-| `--crashdump` | Generates a dump file when the test host process crashes. Supported in .NET 6.0+. |
-| `⁠-⁠-⁠crashdump-⁠filename` | Specifies the file name of the dump. |
-| `--crashdump-type` | Specifies the type of the dump. Valid values are `Mini`, `Heap`, `Triage`, `Full`. Defaults as `Full`. For more information, see [Types of mini dumps](../diagnostics/collect-dumps-crash.md#types-of-mini-dumps).|
-
-## Code coverage
-
-To determine what proportion of your project's code is being tested by coded tests such as unit tests, you can use the code coverage feature. To effectively guard against bugs, your tests should exercise or 'cover' a large proportion of your code.
-
-### Microsoft code coverage
-
-Microsoft Code Coverage analysis is possible for both managed (CLR) and unmanaged (native) code. Both static and dynamic instrumentation are supported. This extension is shipped as part of [Microsoft.Testing.Extensions.CodeCoverage](https://nuget.org/packages/Microsoft.Testing.Extensions.CodeCoverage) NuGet package.
-
-> [!NOTE]
-> Unmanaged (native) code coverage is disabled in the extension by default. Use flags `EnableStaticNativeInstrumentation` and `EnableDynamicNativeInstrumentation` to enable it if needed.
-> For more information about unmanaged code coverage, see [Static and dynamic native instrumentation](/visualstudio/test/customizing-code-coverage-analysis?#static-and-dynamic-native-instrumentation).
-
-The package is shipped with Microsoft .NET LIBRARY closed-source free to use licensing model.
-
-> [!NOTE]
-> Microsoft code coverage is closed source but it's free to use.
-
-For more information about Microsoft code coverage, see its [GitHub page](https://github.com/microsoft/codecoverage).
-
-Microsoft Code Coverage provides the following options:
-
-| Option | Description |
-|--|--|
-| `--coverage` | Collect the code coverage using dotnet-coverage tool |
-| `--coverage-output` | Output file |
-| `--coverage-output-format` | Output file format. Supported values: 'coverage', 'xml' and 'cobertura' |
-| `--coverage-settings` | XML code coverage settings |
-
-For more information about the available options, see [settings](../additional-tools/dotnet-coverage.md#settings) and [samples](https://github.com/microsoft/codecoverage/tree/main/samples/Algorithms).
+| `--hangdump-type` | Specifies the type of the dump. Valid values are `Mini`, `Heap`, `Triage`, `Full`. Defaults as `Full`. For more information, see [Types of mini dumps](../diagnostics/collect-dumps-crash.md#types-of-mini-dumps). |

--- a/docs/core/testing/unit-testing-mstest-runner-extensions.md
+++ b/docs/core/testing/unit-testing-mstest-runner-extensions.md
@@ -92,7 +92,9 @@ To determine what proportion of your project's code is being tested by coded tes
 
 ### Microsoft code coverage
 
-Microsoft Code Coverage analysis is possible for both managed (CLR) and unmanaged (native) code. Both static and dynamic instrumentation are supported. This extension is shipped as part of [Microsoft.Testing.Extensions.CodeCoverage](https://nuget.org/packages/Microsoft.Testing.Extensions.CodeCoverage) NuGet package. Unmanaged (native) code coverage is disabled in the extension by default. Use flags `EnableStaticNativeInstrumentation` and `EnableDynamicNativeInstrumentation` to enable it if needed. For more information about unmanaged code coverage, see [Static and dynamic native instrumentation](/visualstudio/test/customizing-code-coverage-analysis?#static-and-dynamic-native-instrumentation).
+Microsoft Code Coverage analysis is possible for both managed (CLR) and unmanaged (native) code. Both static and dynamic instrumentation are supported. This extension is shipped as part of [Microsoft.Testing.Extensions.CodeCoverage](https://nuget.org/packages/Microsoft.Testing.Extensions.CodeCoverage) NuGet package. 
+
+Unmanaged (native) code coverage is disabled in the extension by default. Use flags `EnableStaticNativeInstrumentation` and `EnableDynamicNativeInstrumentation` to enable it if needed. For more information about unmanaged code coverage, see [Static and dynamic native instrumentation](/visualstudio/test/customizing-code-coverage-analysis?#static-and-dynamic-native-instrumentation).
 
 The package is shipped with Microsoft .NET LIBRARY closed-source free to use licensing model.
 

--- a/docs/core/testing/unit-testing-mstest-runner-extensions.md
+++ b/docs/core/testing/unit-testing-mstest-runner-extensions.md
@@ -94,7 +94,9 @@ To determine what proportion of your project's code is being tested by coded tes
 
 Microsoft Code Coverage analysis is possible for both managed (CLR) and unmanaged (native) code. Both static and dynamic instrumentation are supported. This extension is shipped as part of [Microsoft.Testing.Extensions.CodeCoverage](https://nuget.org/packages/Microsoft.Testing.Extensions.CodeCoverage) NuGet package. 
 
-Unmanaged (native) code coverage is disabled in the extension by default. Use flags `EnableStaticNativeInstrumentation` and `EnableDynamicNativeInstrumentation` to enable it if needed. For more information about unmanaged code coverage, see [Static and dynamic native instrumentation](/visualstudio/test/customizing-code-coverage-analysis?#static-and-dynamic-native-instrumentation).
+> [!NOTE]
+> Unmanaged (native) code coverage is disabled in the extension by default. Use flags `EnableStaticNativeInstrumentation` and `EnableDynamicNativeInstrumentation` to enable it if needed. 
+> For more information about unmanaged code coverage, see [Static and dynamic native instrumentation](/visualstudio/test/customizing-code-coverage-analysis?#static-and-dynamic-native-instrumentation).
 
 The package is shipped with Microsoft .NET LIBRARY closed-source free to use licensing model.
 

--- a/docs/core/testing/unit-testing-mstest-runner-intro.md
+++ b/docs/core/testing/unit-testing-mstest-runner-intro.md
@@ -50,7 +50,7 @@ To enable the MSTest runner in a MSTest project, you need to add the `EnableMSTe
       https://github.com/coverlet-coverage/coverlet#net-global-tool-guide-suffers-from-possible-known-issue
     --> 
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" 
-                      Version="17.10.0" />
+                      Version="17.10.1" />
   </ItemGroup>
 
 </Project>

--- a/docs/core/testing/unit-testing-mstest-runner-intro.md
+++ b/docs/core/testing/unit-testing-mstest-runner-intro.md
@@ -41,7 +41,7 @@ To enable the MSTest runner in a MSTest project, you need to add the `EnableMSTe
           MSTest.TestFramework
           MSTest.Analyzers
     -->    
-    <PackageReference Include="MSTest" Version="3.2.0-preview.23623.1" />
+    <PackageReference Include="MSTest" Version="3.2.0" />
 
     <!-- 
       Coverlet collector isn't compatible with MSTest runner, you can 
@@ -49,8 +49,8 @@ To enable the MSTest runner in a MSTest project, you need to add the `EnableMSTe
       or switch to be using coverlet global tool
       https://github.com/coverlet-coverage/coverlet#net-global-tool-guide-suffers-from-possible-known-issue
     --> 
-    <PackageReference Include="Microsoft.Testing.Platform.Extensions.CodeCoverage" 
-                      Version="17.10.0-preview.23622.1" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" 
+                      Version="17.10.0" />
   </ItemGroup>
 
 </Project>

--- a/docs/core/testing/unit-testing-mstest-runner-runsettings.md
+++ b/docs/core/testing/unit-testing-mstest-runner-runsettings.md
@@ -37,7 +37,7 @@ The **RunConfiguration** element can include the following elements. None of the
 
 MSTest runner is not using data collectors. Instead it has the concept of in-process and out-of-process extensions. Each extension is configured by its respective configuration file or through the command line.
 
-Most importantly [hang](unit-testing-mstest-runner-extensions.md#hang-dump-files) and [crash](unit-testing-mstest-runner-extensions.md#crash-dump-files) extension, and [code coverage](unit-testing-mstest-runner-extensions.md#microsoft-code-coverage) extension.
+Most importantly [hang](unit-testing-mstest-runner-extensions.md#hang-dump) and [crash](unit-testing-mstest-runner-extensions.md#crash-dump) extension, and [code coverage](unit-testing-mstest-runner-extensions.md#microsoft-code-coverage) extension.
 
 ### LoggerRunSettings
 


### PR DESCRIPTION
## Summary

- List licensing model for each extension
- Fix Code Coverage command line options
- Use released versions

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-mstest-runner-extensions.md](https://github.com/dotnet/docs/blob/963b522df4cae708222562747ffda1ca72ae4244/docs/core/testing/unit-testing-mstest-runner-extensions.md) | [MSTest runner extensions](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-runner-extensions?branch=pr-en-us-39152) |
| [docs/core/testing/unit-testing-mstest-runner-intro.md](https://github.com/dotnet/docs/blob/963b522df4cae708222562747ffda1ca72ae4244/docs/core/testing/unit-testing-mstest-runner-intro.md) | [MSTest runner overview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-runner-intro?branch=pr-en-us-39152) |
| [docs/core/testing/unit-testing-mstest-runner-runsettings.md](https://github.com/dotnet/docs/blob/963b522df4cae708222562747ffda1ca72ae4244/docs/core/testing/unit-testing-mstest-runner-runsettings.md) | [Use runsettings with MSTest runner](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-runner-runsettings?branch=pr-en-us-39152) |


<!-- PREVIEW-TABLE-END -->