### PR TITLE
Include `Address-of operator` in `CS8812` page

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs8812.md
+++ b/docs/csharp/language-reference/compiler-messages/cs8812.md
@@ -13,7 +13,7 @@ Cannot convert `&Method` group to non-function pointer type.
 
 The address of an expression (for example, `&Method`) has no type and thus cannot be assigned to a non-function pointer variable.
 
-The `&` operator is the [address-of](../operators/pointer-related-operators.md#address-of-operator) operator, used to return the address of its operand.
+The `&` operator is the [address-of](../operators/pointer-related-operators.md#address-of-operator-) operator, used to return the address of its operand.
 
 ## Example
 
@@ -49,4 +49,4 @@ unsafe class C
 
 - [Shouldn't method addresses be implicitly convertible to void* and thus allowing direct casts to function pointers with mismatched signatures?](https://github.com/dotnet/csharplang/discussions/5720)
 - [Casting function pointer directly to void and then a function pointer type causes crash.](https://github.com/dotnet/roslyn/issues/44489)
-- [Address-of operator &amp;](../operators/pointer-related-operators.md#address-of-operator)
+- [Address-of operator &amp;](../operators/pointer-related-operators.md#address-of-operator-)

--- a/docs/csharp/language-reference/compiler-messages/cs8812.md
+++ b/docs/csharp/language-reference/compiler-messages/cs8812.md
@@ -11,6 +11,8 @@ helpviewer_keywords:
 
 Cannot convert `&Method` group to non-function pointer type.
 
+The address of an expression (for example, `&Method`) has no type and thus cannot be assigned to a non-function pointer variable.
+
 ## Example
 
  The following sample generates CS8812:
@@ -20,14 +22,12 @@ Cannot convert `&Method` group to non-function pointer type.
 
 unsafe class C
 {
-    static void M()
+    static void Method()
     {
-        void* ptr1 = &M;
+        void* ptr1 = &Method;
     }
 }
 ```
-
-The address of an expression (for example, `&M`) has no type and thus cannot be assigned to a non-function pointer variable.
 
 ## To correct this error
 
@@ -36,9 +36,9 @@ Explicitly convert the expression to the required type (for example, a `void` `d
 ```csharp
 unsafe class C
 {
-    static void M()
+    static void Method()
     {
-        void* ptr1 = (delegate*<void>)&M;
+        void* ptr1 = (delegate*<void>)&Method;
     }
 }
 ```

--- a/docs/csharp/language-reference/compiler-messages/cs8812.md
+++ b/docs/csharp/language-reference/compiler-messages/cs8812.md
@@ -9,7 +9,7 @@ helpviewer_keywords:
 ---
 # Compiler Error CS8812
 
-Cannot convert &method group to non-function pointer type.
+Cannot convert `&Method` group to non-function pointer type.
 
 ## Example
 

--- a/docs/csharp/language-reference/compiler-messages/cs8812.md
+++ b/docs/csharp/language-reference/compiler-messages/cs8812.md
@@ -13,6 +13,8 @@ Cannot convert `&Method` group to non-function pointer type.
 
 The address of an expression (for example, `&Method`) has no type and thus cannot be assigned to a non-function pointer variable.
 
+The `&` operator is the [address-of](../operators/pointer-related-operators.md#address-of-operator) operator, used to return the address of its operand.
+
 ## Example
 
  The following sample generates CS8812:
@@ -47,3 +49,4 @@ unsafe class C
 
 - [Shouldn't method addresses be implicitly convertible to void* and thus allowing direct casts to function pointers with mismatched signatures?](https://github.com/dotnet/csharplang/discussions/5720)
 - [Casting function pointer directly to void and then a function pointer type causes crash.](https://github.com/dotnet/roslyn/issues/44489)
+- [Address-of operator &amp;](../operators/pointer-related-operators.md#address-of-operator)


### PR DESCRIPTION
This pull request closes #39150 
It:
* Wraps the `&Method` in code fences to avoid issues with translations considering it an ordinary word
* Refactors the page a bit to keep it consistent when it comes to `Method` naming and sections
* Links to `&` operator in "See also" section and adds the brief explanation about it.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-messages/cs8812.md](https://github.com/dotnet/docs/blob/fa22ccf3394fbc815fdcf84675bae225306e92da/docs/csharp/language-reference/compiler-messages/cs8812.md) | [Compiler Error CS8812](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs8812?branch=pr-en-us-39159) |


<!-- PREVIEW-TABLE-END -->