### PR TITLE
Fix .NET SDK tarball name

### DIFF
--- a/docs/core/distribution-packaging.md
+++ b/docs/core/distribution-packaging.md
@@ -219,7 +219,7 @@ In the `{dotnet_root/shared/Microsoft.AspNetCore.App/<aspnetcore version>` direc
 - `Microsoft.AspNetCore.Routing.dll` - installed with `aspnetcore-runtime-[major].[minor]` packages
 - `Microsoft.AspNetCore.Routing.pdb` - installed with `aspnetcore-runtime-dbg-[major].[minor]` packages
 
-Starting with .NET 8.0, all .NET debug content (PDB files), produced by source-build, is available in a tarball named `dotnet-symbols-sdk-<version>-<rid>.tar.gz`. This archive contains PDBs in subdirectories that match the directory structure of the .NET SDK tarball - `dotnet-symbols-<version>-<rid>.tar.gz`.
+Starting with .NET 8.0, all .NET debug content (PDB files), produced by source-build, is available in a tarball named `dotnet-symbols-sdk-<version>-<rid>.tar.gz`. This archive contains PDBs in subdirectories that match the directory structure of the .NET SDK tarball - `dotnet-sdk-<version>-<rid>.tar.gz`.
 
 While all debug content is available in the debug tarball, not all debug content is equally important. End users are mostly interested in the content of the `shared/Microsoft.AspNetCore.App/<aspnetcore version>` and `shared/Microsoft.NETCore.App/<runtime version>` directories.
 


### PR DESCRIPTION
## Summary

When describing the content of the dotnet symbols tarball, the doc erroneously names the .NET SDK tarball as `dotnet-symbols-<version>-<rid>.tar.gz`.

This fixes the name to `dotnet-sdk-<version>-<rid>.tar.gz`.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/distribution-packaging.md](https://github.com/dotnet/docs/blob/809efed69dbb0b68e1efcb202d71052b5c6c379f/docs/core/distribution-packaging.md) | [.NET distribution packaging](https://review.learn.microsoft.com/en-us/dotnet/core/distribution-packaging?branch=pr-en-us-39161) |

<!-- PREVIEW-TABLE-END -->