### PR TITLE
Add -a|--arch option to dotnet restore

### DIFF
--- a/docs/core/tools/dotnet-restore.md
+++ b/docs/core/tools/dotnet-restore.md
@@ -92,6 +92,8 @@ There are three specific settings that `dotnet restore` ignores:
 
 ## Options
 
+[!INCLUDE [arch](../../../includes/cli-arch.md)]
+
 [!INCLUDE [configfile](../../../includes/cli-configfile.md)]
 
 [!INCLUDE [disable-build-servers](../../../includes/cli-disable-build-servers.md)]


### PR DESCRIPTION
Fixes #39156 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-restore.md](https://github.com/dotnet/docs/blob/e288db2a40f74d4b658179acf8c0efb6d0421348/docs/core/tools/dotnet-restore.md) | [dotnet restore](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-restore?branch=pr-en-us-39162) |

<!-- PREVIEW-TABLE-END -->