### PR TITLE
Clarify IDE0020 option values

### DIFF
--- a/docs/fundamentals/code-analysis/style-rules/ide0020-ide0038.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0020-ide0038.md
@@ -55,8 +55,8 @@ For more information about configuring options, see [Option format](language-rul
 | Property                 | Value                                                 | Description                                                         |
 | ------------------------ | ----------------------------------------------------- | ------------------------------------------------------------------- |
 | **Option name**          | csharp_style_pattern_matching_over_is_with_cast_check |                                                                     |
-| **Option values**        | `true`                                                | Prefer pattern matching instead of `is` expressions with type casts |
-|                          | `false`                                               | Prefer `is` expressions with type casts instead of pattern matching |
+| **Option values**        | `true`                                                | Prefer pattern matching instead of `is` expressions with type casts. |
+|                          | `false`                                               | Disables the rule. |
 | **Default option value** | `true`                                                |                                                                     |
 
 ```csharp


### PR DESCRIPTION
Fixes #38778

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/style-rules/ide0020-ide0038.md](https://github.com/dotnet/docs/blob/4ac1d5c67e38b46890d722c7d593a368c55145ca/docs/fundamentals/code-analysis/style-rules/ide0020-ide0038.md) | [Use pattern matching to avoid 'is' check followed by a cast (IDE0020 and IDE0038)](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0020-ide0038?branch=pr-en-us-39167) |

<!-- PREVIEW-TABLE-END -->