### PR TITLE
Create cli-tool-version.md to include description for `--version` option for tools

### DIFF
--- a/includes/cli-tool-version.md
+++ b/includes/cli-tool-version.md
@@ -1,0 +1,5 @@
+- **`--version <VERSION_NUMBER>`**
+
+  The version of the tool to install. By default, the latest stable package version is installed. Use this option to install preview or older versions of the tool.
+
+  For .NET 8.0, `--version Major.Minor.Patch` refers to a specific `Major.Minor.Patch` version, including unlisted versions. To get the latest version of a certain major/minor version instead, use `--version Major.Minor.*`.


### PR DESCRIPTION
## Summary

Creating a cli-tool-version.md to specify the `--version` option for dotnet tool. 

Fixes [37857](https://github.com/dotnet/sdk/issues/37857)
