### PR TITLE
WinForms breaking changes for .NET 9 Preview 1

### DIFF
--- a/docs/core/compatibility/9.0.md
+++ b/docs/core/compatibility/9.0.md
@@ -21,3 +21,13 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 |-------------------------------------------------------------------------------|-------------------|--------------------|
 | [`dotnet workload` commands output change](sdk/9.0/dotnet-workload-output.md) | Behavioral change | Preview 1          |
 | [Terminal logger is default](sdk/9.0/terminal-logger.md) | Behavioral change | Preview 1          |
+
+## Windows Forms
+
+| Title                                                                                   | Type of change      | Introduced version |
+|-----------------------------------------------------------------------------------------|---------------------|--------------------|
+| [BindingSource.SortDescriptions doesn't return null](windows-forms/9.0/sortdescriptions-return-value.md) | Behavioral change | Preview 1 |
+| [Changes to nullability annotations](windows-forms/9.0/nullability-changes.md)          | Source incompatible | Preview 1          |
+| [ComponentDesigner.Initialize throws ArgumentNullException](windows-forms/9.0/componentdesigner-initialize.md) | Behavioral change | Preview 1          |
+| [DataGridViewRowAccessibleObject.Name starting row index](windows-forms/9.0/datagridviewrowaccessibleobject-name-row.md) | Behavioral change | Preview 1 |
+| [No exception if DataGridView is null](windows-forms/9.0/datagridviewheadercell-nre.md) | Behavioral change   | Preview 1          |

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -14,6 +14,18 @@ items:
         href: sdk/9.0/dotnet-workload-output.md
       - name: Terminal logger is default
         href: sdk/9.0/terminal-logger.md
+    - name: Windows Forms
+      items:
+      - name: BindingSource.SortDescriptions doesn't return null
+        href: windows-forms/9.0/sortdescriptions-return-value.md
+      - name: Changes to nullability annotations
+        href: windows-forms/9.0/nullability-changes.md
+      - name: ComponentDesigner.Initialize throws ArgumentNullException
+        href: windows-forms/9.0/componentdesigner-initialize.md
+      - name: DataGridViewRowAccessibleObject.Name starting row index
+        href: windows-forms/9.0/datagridviewrowaccessibleobject-name-row.md
+      - name: No exception if DataGridView is null
+        href: windows-forms/9.0/datagridviewheadercell-nre.md
   - name: .NET 8
     items:
     - name: Overview
@@ -1724,6 +1736,18 @@ items:
         href: wcf-client/6.0/duplex-synchronization-context.md
   - name: Windows Forms
     items:
+    - name: .NET 9
+      items:
+      - name: BindingSource.SortDescriptions doesn't return null
+        href: windows-forms/9.0/sortdescriptions-return-value.md
+      - name: Changes to nullability annotations
+        href: windows-forms/9.0/nullability-changes.md
+      - name: ComponentDesigner.Initialize throws ArgumentNullException
+        href: windows-forms/9.0/componentdesigner-initialize.md
+      - name: DataGridViewRowAccessibleObject.Name starting row index
+        href: windows-forms/9.0/datagridviewrowaccessibleobject-name-row.md
+      - name: No exception if DataGridView is null
+        href: windows-forms/9.0/datagridviewheadercell-nre.md
     - name: .NET 8
       items:
       - name: Anchor layout changes

--- a/docs/core/compatibility/windows-forms/9.0/componentdesigner-initialize.md
+++ b/docs/core/compatibility/windows-forms/9.0/componentdesigner-initialize.md
@@ -25,7 +25,7 @@ This change is a [*behavioral change*](../../categories.md#behavioral-change).
 
 ## Reason for change
 
-When we enabled nullability in the code file, we found that many methods and properties, both in <xref:System.ComponentModel.Design.ComponentDesigner> and its subclasses, relied on the passed-in component to be initialized to non-`null`. These methods and properties resulted in a <xref:System.NullReferenceException> or another exception later on if they were initialized with a `null` value.
+During the process of enabling nullability in the code file, it was discovered that many methods and properties, both in <xref:System.ComponentModel.Design.ComponentDesigner> and its subclasses, relied on the passed-in component to be initialized to non-`null`. These methods and properties resulted in a <xref:System.NullReferenceException> or another exception later on if they were initialized with a `null` value.
 
 ## Recommended action
 

--- a/docs/core/compatibility/windows-forms/9.0/componentdesigner-initialize.md
+++ b/docs/core/compatibility/windows-forms/9.0/componentdesigner-initialize.md
@@ -1,0 +1,36 @@
+---
+title: "Breaking change: ComponentDesigner.Initialize throws ArgumentNullException"
+description: Learn about the breaking change in .NET 9 for Windows Forms where ComponentDesigner.Initialize now throws ArgumentNullException if the component argument is null.
+ms.date: 01/16/2024
+---
+# ComponentDesigner.Initialize throws ArgumentNullException
+
+<xref:System.ComponentModel.Design.ComponentDesigner.Initialize%2A?displayProperty=nameWithType> was updated to throw an <xref:System.ArgumentNullException> if the component argument is `null`.
+
+## Version introduced
+
+.NET 9 Preview 1
+
+## Previous behavior
+
+Previously, <xref:System.ComponentModel.Design.ComponentDesigner.Initialize%2A?displayProperty=nameWithType> accepted a `null` argument, but resulted in a <xref:System.NullReferenceException> or other exception later on.
+
+## New behavior
+
+Starting in .NET 9, <xref:System.ComponentModel.Design.ComponentDesigner.Initialize%2A?displayProperty=nameWithType> throws an <xref:System.ArgumentNullException> if the argument is `null`.
+
+## Change category
+
+This change is a [*behavioral change*](../../categories.md#behavioral-change).
+
+## Reason for change
+
+When we enabled nullability in the code file, we found that many methods and properties, both in <xref:System.ComponentModel.Design.ComponentDesigner> and its subclasses, relied on the passed-in component to be initialized to non-`null`. These methods and properties resulted in a <xref:System.NullReferenceException> or another exception later on if they were initialized with a `null` value.
+
+## Recommended action
+
+Make sure you don't call <xref:System.ComponentModel.Design.ComponentDesigner.Initialize%2A?displayProperty=nameWithType> with a `null` argument.
+
+## Affected APIs
+
+- <xref:System.ComponentModel.Design.ComponentDesigner.Initialize%2A?displayProperty=fullName>

--- a/docs/core/compatibility/windows-forms/9.0/datagridviewheadercell-nre.md
+++ b/docs/core/compatibility/windows-forms/9.0/datagridviewheadercell-nre.md
@@ -5,7 +5,7 @@ ms.date: 01/16/2024
 ---
 # No exception if DataGridView is null
 
-Previously, a <xref:System.NullReferenceException> was thrown in <xref:System.Windows.Forms.DataGridViewHeaderCell.MouseDownUnsharesRow(System.Windows.Forms.DataGridViewCellMouseEventArgs)?displayProperty=nameWithType>, <xref:System.Windows.Forms.DataGridViewHeaderCell.MouseEnterUnsharesRow(System.Int32)?displayProperty=nameWithType>, <xref:System.Windows.Forms.DataGridViewHeaderCell.MouseLeaveUnsharesRow(System.Int32)?displayProperty=nameWithType>, and <xref:System.Windows.Forms.DataGridViewHeaderCell.MouseUpUnsharesRow(System.Windows.Forms.DataGridViewCellMouseEventArgs)?displayProperty=nameWithType> if the <xref:System.Windows.Forms.DataGridViewElement.DataGridView> property was null. That behavior was unexpected and incorrect. We've updated these methods to simply return `false` if `DataGridView` is `null`.
+Previously, a <xref:System.NullReferenceException> was thrown in <xref:System.Windows.Forms.DataGridViewHeaderCell.MouseDownUnsharesRow(System.Windows.Forms.DataGridViewCellMouseEventArgs)?displayProperty=nameWithType>, <xref:System.Windows.Forms.DataGridViewHeaderCell.MouseEnterUnsharesRow(System.Int32)?displayProperty=nameWithType>, <xref:System.Windows.Forms.DataGridViewHeaderCell.MouseLeaveUnsharesRow(System.Int32)?displayProperty=nameWithType>, and <xref:System.Windows.Forms.DataGridViewHeaderCell.MouseUpUnsharesRow(System.Windows.Forms.DataGridViewCellMouseEventArgs)?displayProperty=nameWithType> if the <xref:System.Windows.Forms.DataGridViewElement.DataGridView> property was null. That behavior was unexpected and incorrect. These methods have been updated to simply return `false` if `DataGridView` is `null`.
 
 ## Version introduced
 

--- a/docs/core/compatibility/windows-forms/9.0/datagridviewheadercell-nre.md
+++ b/docs/core/compatibility/windows-forms/9.0/datagridviewheadercell-nre.md
@@ -1,0 +1,39 @@
+---
+title: "Breaking change: No exception if DataGridView is null"
+description: Learn about the breaking change in .NET 9 for Windows Forms where DataGridViewHeaderCell methods no longer throw an exception if the DataGridView property is null.
+ms.date: 01/16/2024
+---
+# No exception if DataGridView is null
+
+Previously, a <xref:System.NullReferenceException> was thrown in <xref:System.Windows.Forms.DataGridViewHeaderCell.MouseDownUnsharesRow(System.Windows.Forms.DataGridViewCellMouseEventArgs)?displayProperty=nameWithType>, <xref:System.Windows.Forms.DataGridViewHeaderCell.MouseEnterUnsharesRow(System.Int32)?displayProperty=nameWithType>, <xref:System.Windows.Forms.DataGridViewHeaderCell.MouseLeaveUnsharesRow(System.Int32)?displayProperty=nameWithType>, and <xref:System.Windows.Forms.DataGridViewHeaderCell.MouseUpUnsharesRow(System.Windows.Forms.DataGridViewCellMouseEventArgs)?displayProperty=nameWithType> if the <xref:System.Windows.Forms.DataGridViewElement.DataGridView> property was null. That behavior was unexpected and incorrect. We've updated these methods to simply return `false` if `DataGridView` is `null`.
+
+## Version introduced
+
+.NET 9 Preview 1
+
+## Previous behavior
+
+Previously, the [affected methods](#affected-apis) threw a <xref:System.NullReferenceException> when `DataGridViewHeaderCell.DataGridView` was `null`.
+
+## New behavior
+
+Starting in .NET 9, the [affected methods](#affected-apis) return `false` if the `DataGridViewHeaderCell.DataGridView` property is `null`
+
+## Change category
+
+This change is a [*behavioral change*](../../categories.md#behavioral-change).
+
+## Reason for change
+
+The previous behavior was incorrect.
+
+## Recommended action
+
+If you were relying on the code to throw a <xref:System.NullReferenceException> in this scenario, change your code to check the return value instead.
+
+## Affected APIs
+
+- <xref:System.Windows.Forms.DataGridViewHeaderCell.MouseDownUnsharesRow(System.Windows.Forms.DataGridViewCellMouseEventArgs)?displayProperty=fullName>
+- <xref:System.Windows.Forms.DataGridViewHeaderCell.MouseEnterUnsharesRow(System.Int32)?displayProperty=fullName>
+- <xref:System.Windows.Forms.DataGridViewHeaderCell.MouseLeaveUnsharesRow(System.Int32)?displayProperty=fullName>
+- <xref:System.Windows.Forms.DataGridViewHeaderCell.MouseUpUnsharesRow(System.Windows.Forms.DataGridViewCellMouseEventArgs)?displayProperty=fullName>

--- a/docs/core/compatibility/windows-forms/9.0/datagridviewrowaccessibleobject-name-row.md
+++ b/docs/core/compatibility/windows-forms/9.0/datagridviewrowaccessibleobject-name-row.md
@@ -1,0 +1,50 @@
+---
+title: "Breaking change: DataGridViewRowAccessibleObject.Name starting row index"
+description: Learn about the breaking change in .NET 9 for Windows Forms where the starting index for the DataGridViewRowAccessibleObject.Name property is now 1 instead of 0.
+ms.date: 01/16/2024
+---
+# DataGridViewRowAccessibleObject.Name starting row index
+
+<xref:System.Windows.Forms.DataGridViewRow.DataGridViewRowAccessibleObject> has undergone a modification that affects the <xref:System.Windows.Forms.DataGridViewRow.DataGridViewRowAccessibleObject.Name> property. The row index in the `Name` property now starts at 1 instead of 0 by default.
+
+As a result of this change, screen readers announce the selected row of a <xref:System.Windows.Forms.DataGridView> based on a starting index of 1.
+
+## Version introduced
+
+.NET 9 Preview 1
+
+## Previous behavior
+
+Previously, the <xref:System.Windows.Forms.DataGridViewRow.DataGridViewRowAccessibleObject.Name> property based the row index on a starting index of *0*. Screen readers announced the selected row of a <xref:System.Windows.Forms.DataGridView> based on a starting index of 0.
+
+## New behavior
+
+Starting in .NET 9, the index for the <xref:System.Windows.Forms.DataGridViewRow.DataGridViewRowAccessibleObject.Name> property starts at *1*. Screen readers announce the selected row of a <xref:System.Windows.Forms.DataGridView> based on a starting index of 1.
+
+## Change category
+
+This change is a [*behavioral change*](../../categories.md#behavioral-change).
+
+## Reason for change
+
+This modification addresses an accessibility concern highlighted in [GitHub issue #7154](https://github.com/dotnet/winforms/issues/7154). The issue pertains to the row counting in the <xref:System.Windows.Forms.DataGridViewRow.DataGridViewRowAccessibleObject> starting at 0, which creates a discrepancy with user expectations and screen readers.
+
+The change ensures a more intuitive and inclusive experience for users that rely on screen readers and accessibility tools. It also provides developers with the flexibility to maintain the original behavior if necessary.
+
+## Recommended action
+
+If your application relied on the previous behavior and you prefer the row index to start at 0, you can set the new switch `System.Windows.Forms.DataGridViewUIAStartRowCountAtZero`. To maintain the original functionality, create a *runtimeconfig.template.json* file at the root folder of your project and set this switch to `true`. Update your codebase accordingly to accommodate this change and ensure that the <xref:System.Windows.Forms.DataGridViewRow.DataGridViewRowAccessibleObject> displays the row index with a starting point at 0.
+
+Snippet of a *runtimeconfig.template.json* file that sets a switch to revert to the previous behavior:
+
+```json
+{
+    "configProperties": {
+      "System.Windows.Forms.DataGridViewUIAStartRowCountAtZero": true
+    }
+}
+```
+
+## Affected APIs
+
+- <xref:System.Windows.Forms.DataGridViewRow.DataGridViewRowAccessibleObject.Name?displayProperty=fullName>

--- a/docs/core/compatibility/windows-forms/9.0/nullability-changes.md
+++ b/docs/core/compatibility/windows-forms/9.0/nullability-changes.md
@@ -1,9 +1,9 @@
 ---
-title: "Breaking change: Nullable reference type annotation changes"
+title: "Breaking change: Changes to nullability annotations (Windows Forms)"
 description: Learn about the .NET 9 breaking change in Windows Forms where some nullable reference type annotations have changed.
 ms.date: 01/16/2024
 ---
-# Changes to nullability annotations
+# Changes to nullability annotations (Windows Forms)
 
 In .NET 9, some nullability annotations on the Windows Forms APIs have changed.
 

--- a/docs/core/compatibility/windows-forms/9.0/nullability-changes.md
+++ b/docs/core/compatibility/windows-forms/9.0/nullability-changes.md
@@ -1,0 +1,36 @@
+---
+title: "Breaking change: Nullable reference type annotation changes"
+description: Learn about the .NET 9 breaking change in Windows Forms where some nullable reference type annotations have changed.
+ms.date: 01/16/2024
+---
+# Changes to nullability annotations
+
+In .NET 9, some nullability annotations on the Windows Forms APIs have changed.
+
+## Previous behavior
+
+Previously, some parameters were marked as nullable.
+
+## New behavior
+
+Starting in .NET 9, these parameters are marked as non-nullable. If you pass an argument that might be null, you'll get a compiler warning.
+
+## Version introduced
+
+.NET 9 Preview 1
+
+## Type of breaking change
+
+This change can affect [source compatibility](../../categories.md#source-compatibility).
+
+## Reason for change
+
+The parameter on <xref:System.Windows.Forms.Design.IWindowsFormsEditorService.DropDownControl(System.Windows.Forms.Control)?displayProperty=nameWithType> was previously marked as nullable, but there's no guidance for implementers on how they should handle null input. Also, logically this method should not accept `null`.
+
+## Affected APIs
+
+The following table lists the affected APIs:
+
+| API | What changed | Recommended action |
+| - | - | - |
+| <xref:System.Windows.Forms.Design.IWindowsFormsEditorService.DropDownControl(System.Windows.Forms.Control)?displayProperty=nameWithType> | The `control` parameter is non-nullable | Make sure you're not passing a nullable `Control` to this method. Also, update any implementations of <xref:System.Windows.Forms.Design.IWindowsFormsEditorService> to remove nullability of the `DropDownControl` method's parameter. |

--- a/docs/core/compatibility/windows-forms/9.0/sortdescriptions-return-value.md
+++ b/docs/core/compatibility/windows-forms/9.0/sortdescriptions-return-value.md
@@ -1,0 +1,38 @@
+---
+title: "Breaking change: BindingSource.SortDescriptions doesn't return null"
+description: Learn about the breaking change in .NET 9 for Windows Forms where BindingSource.SortDescriptions no longer returns null if the data source is not an IBindingListView.
+ms.date: 01/16/2024
+---
+# BindingSource.SortDescriptions doesn't return null
+
+<xref:System.Windows.Forms.BindingSource.SortDescriptions?displayProperty=nameWithType> has been updated to return an empty <xref:System.ComponentModel.ListSortDescriptionCollection> instead of `null` if the data source is not an <xref:System.ComponentModel.IBindingListView>.
+
+## Version introduced
+
+.NET 9 Preview 1
+
+## Previous behavior
+
+Previously, <xref:System.Windows.Forms.BindingSource.SortDescriptions?displayProperty=nameWithType> returned `null` if the data source wasn't an <xref:System.ComponentModel.IBindingListView>.
+
+## New behavior
+
+Starting in .NET 9, <xref:System.Windows.Forms.BindingSource.SortDescriptions?displayProperty=nameWithType> returns an empty <xref:System.ComponentModel.ListSortDescriptionCollection> if the data source is not an <xref:System.ComponentModel.IBindingListView>.
+
+## Change category
+
+This change is a [*behavioral change*](../../categories.md#behavioral-change).
+
+## Reason for change
+
+The previous behavior was incorrect.
+
+<xref:System.Windows.Forms.BindingSource.SortDescriptions?displayProperty=nameWithType> has historically returned `null` if the data source was not an `IBindingListView`. However `BindingSource.SortDescriptions` implements <xref:System.ComponentModel.IBindingListView.SortDescriptions?displayProperty=nameWithType>, whose return type is non-nullable. To align with the interface it implements, `BindingSource.SortDescriptions` was changed to return an empty `ListSortDescriptionCollection` instead.
+
+## Recommended action
+
+If your code expects `null` from <xref:System.Windows.Forms.BindingSource.SortDescriptions?displayProperty=nameWithType> for any reason, update your code to expect an empty <xref:System.ComponentModel.ListSortDescriptionCollection> instead.
+
+## Affected APIs
+
+- <xref:System.Windows.Forms.BindingSource.SortDescriptions?displayProperty=fullName>


### PR DESCRIPTION
Fixes #38799 
Fixes #38527 
Fixes #38363 
Fixes #38283 
Fixes #37547

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/9.0.md](https://github.com/dotnet/docs/blob/3f3216a95dca99727dd3b8f1e2b3a3fd8703f187/docs/core/compatibility/9.0.md) | [Breaking changes in .NET 9](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/9.0?branch=pr-en-us-39188) |
| [docs/core/compatibility/windows-forms/9.0/componentdesigner-initialize.md](https://github.com/dotnet/docs/blob/3f3216a95dca99727dd3b8f1e2b3a3fd8703f187/docs/core/compatibility/windows-forms/9.0/componentdesigner-initialize.md) | [ComponentDesigner.Initialize throws ArgumentNullException](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/windows-forms/9.0/componentdesigner-initialize?branch=pr-en-us-39188) |
| [docs/core/compatibility/windows-forms/9.0/datagridviewheadercell-nre.md](https://github.com/dotnet/docs/blob/3f3216a95dca99727dd3b8f1e2b3a3fd8703f187/docs/core/compatibility/windows-forms/9.0/datagridviewheadercell-nre.md) | ["Breaking change: No exception if DataGridView is null"](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/windows-forms/9.0/datagridviewheadercell-nre?branch=pr-en-us-39188) |
| [docs/core/compatibility/windows-forms/9.0/datagridviewrowaccessibleobject-name-row.md](https://github.com/dotnet/docs/blob/3f3216a95dca99727dd3b8f1e2b3a3fd8703f187/docs/core/compatibility/windows-forms/9.0/datagridviewrowaccessibleobject-name-row.md) | [DataGridViewRowAccessibleObject.Name starting row index](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/windows-forms/9.0/datagridviewrowaccessibleobject-name-row?branch=pr-en-us-39188) |
| [docs/core/compatibility/windows-forms/9.0/nullability-changes.md](https://github.com/dotnet/docs/blob/3f3216a95dca99727dd3b8f1e2b3a3fd8703f187/docs/core/compatibility/windows-forms/9.0/nullability-changes.md) | [docs/core/compatibility/windows-forms/9.0/nullability-changes](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/windows-forms/9.0/nullability-changes?branch=pr-en-us-39188) |
| [docs/core/compatibility/windows-forms/9.0/sortdescriptions-return-value.md](https://github.com/dotnet/docs/blob/3f3216a95dca99727dd3b8f1e2b3a3fd8703f187/docs/core/compatibility/windows-forms/9.0/sortdescriptions-return-value.md) | [BindingSource.SortDescriptions doesn't return null](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/windows-forms/9.0/sortdescriptions-return-value?branch=pr-en-us-39188) |


<!-- PREVIEW-TABLE-END -->