### PR TITLE
Explains how protected internal works with the virtual and override keywords in different assemblies.

### DIFF
--- a/docs/csharp/language-reference/keywords/protected-internal.md
+++ b/docs/csharp/language-reference/keywords/protected-internal.md
@@ -58,6 +58,46 @@ In the second file, an attempt to access `myValue` through an instance of `BaseC
 
 Struct members cannot be `protected internal` because the struct cannot be inherited.
 
+## Override
+
+When overriding a virtual member, the accessibility modifier of the overriden method will depend on if it defined in the same assembly as the class it is deriving from.
+If the derived class is defined in the same assembly that the base class is defined in, all overriden members will have the accessibility modifier `protected internal`. If the derived class is defined in a different assembly from where the base class is defined, overriden members will only have the `protected` accessibility modifier.
+
+```csharp
+// Assembly1.cs
+// Compile with: /target:library
+public class BaseClass
+{
+    protected internal virtual int GetExampleValue()
+    {
+        return 5;
+    }
+}
+
+public class DerivedClassSameAssembly : BaseClass
+{
+    // Override to return a different example value, accessibility modifiers remain the same.
+    protected internal override int GetExampleValue()
+    {
+        return 9;
+    }
+}
+```
+
+```csharp
+// Assembly2.cs
+// Compile with: /reference:Assembly1.dll
+class DerivedClassDifferentAssembly : BaseClass
+{
+    // Override to return a different example value, since this override method is defined in another assembly, the accessibility
+    // modifiers are only protected, instead of protected internal.
+    protected override int GetExampleValue()
+    {
+        return 2;
+    }
+}
+```
+
 ## C# language specification
 
 [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]

--- a/docs/csharp/language-reference/keywords/protected-internal.md
+++ b/docs/csharp/language-reference/keywords/protected-internal.md
@@ -89,8 +89,9 @@ public class DerivedClassSameAssembly : BaseClass
 // Compile with: /reference:Assembly1.dll
 class DerivedClassDifferentAssembly : BaseClass
 {
-    // Override to return a different example value, since this override method is defined in another assembly, the accessibility
-    // modifiers are only protected, instead of protected internal.
+    // Override to return a different example value, since this override
+    // method is defined in another assembly, the accessibility modifiers
+    // are only protected, instead of protected internal.
     protected override int GetExampleValue()
     {
         return 2;

--- a/docs/csharp/language-reference/keywords/protected-internal.md
+++ b/docs/csharp/language-reference/keywords/protected-internal.md
@@ -60,8 +60,9 @@ Struct members cannot be `protected internal` because the struct cannot be inher
 
 ## Overriding protected internal members
 
-When overriding a virtual member, the accessibility modifier of the overriden method will depend on if it defined in the same assembly as the class it is deriving from.
-If the derived class is defined in the same assembly that the base class is defined in, all overriden members will have the accessibility modifier `protected internal`. If the derived class is defined in a different assembly from where the base class is defined, overriden members will only have the `protected` accessibility modifier.
+When overriding a virtual member, the accessibility modifier of the overridden method depends on the assembly where the derived class is defined.
+
+When the derived class is defined in the same assembly as the base class, all overridden members have `protected internal` access. If the derived class is defined in a different assembly from the base class, overridden members have `protected` access.
 
 ```csharp
 // Assembly1.cs

--- a/docs/csharp/language-reference/keywords/protected-internal.md
+++ b/docs/csharp/language-reference/keywords/protected-internal.md
@@ -58,7 +58,7 @@ In the second file, an attempt to access `myValue` through an instance of `BaseC
 
 Struct members cannot be `protected internal` because the struct cannot be inherited.
 
-## Override
+## Overriding protected internal members
 
 When overriding a virtual member, the accessibility modifier of the overriden method will depend on if it defined in the same assembly as the class it is deriving from.
 If the derived class is defined in the same assembly that the base class is defined in, all overriden members will have the accessibility modifier `protected internal`. If the derived class is defined in a different assembly from where the base class is defined, overriden members will only have the `protected` accessibility modifier.


### PR DESCRIPTION
## Summary

Adds an explanation of how the `protected internal` accessibility modifier operates when overriding a member defined in some base class defined in another assembly.
- If the base class is defined in the same assembly, the accessibility modifiers of an overriden member needs to be `protected internal`.
- If the base class is defined in another assembly, the accessibility modifiers of an overriden member needs to be `protected` only.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/protected-internal.md](https://github.com/dotnet/docs/blob/51bad5577fa95b8c2ed734d9d26885ff206e98bd/docs/csharp/language-reference/keywords/protected-internal.md) | [protected internal (C# Reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/protected-internal?branch=pr-en-us-39192) |


<!-- PREVIEW-TABLE-END -->