### PR TITLE
Update dotnet-add-reference.md

### DIFF
--- a/docs/core/tools/dotnet-add-reference.md
+++ b/docs/core/tools/dotnet-add-reference.md
@@ -39,7 +39,7 @@ There's no CLI command to add a reference to an assembly that isn't in a project
 ```xml
 <ItemGroup>
   <Reference Include="MyAssembly">
-    <HintPath>".\MyDLLFolder\MyAssembly.dll</HintPath>
+    <HintPath>.\MyDLLFolder\MyAssembly.dll</HintPath>
   </Reference>
 </ItemGroup>
 ```


### PR DESCRIPTION
## Summary

Fix documentation snippet.

The typo in dll reference in csproj will cause compilation error and `dotnet` warning: `warning MSB3245: Could not resolve this reference.`


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-add-reference.md](https://github.com/dotnet/docs/blob/ce5d3a419c403e3fdfb5393a9a12832c2ce6e803/docs/core/tools/dotnet-add-reference.md) | [dotnet add reference](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-add-reference?branch=pr-en-us-39195) |

<!-- PREVIEW-TABLE-END -->