### PR TITLE
Remove unnecessary section on getting fx symbols for perfcollect

### DIFF
--- a/docs/core/diagnostics/trace-perfcollect-lttng.md
+++ b/docs/core/diagnostics/trace-perfcollect-lttng.md
@@ -44,7 +44,7 @@ Follow these steps to prepare your machine to collect a performance trace with `
 
     2. `LTTng`: Used to capture event data emitted at run time by CoreCLR. This data is then used to analyze the behavior of various runtime components such as the GC, JIT, and thread pool.
 
-Recent versions of .NET Core and the Linux perf tool support automatic resolution of method names for framework code. If you are working with .NET Core version 3.1 or less, an extra step is necessary. See [Resolving Framework Symbols](#resolve-framework-symbols) for details.
+Recent versions of .NET Core and the Linux perf tool support automatic resolution of method names for framework code.
 
 For resolving method names of native runtime DLLs (such as libcoreclr.so), `perfcollect` will resolve symbols for them when it converts the data, but only if the symbols for these binaries are present. See [Getting Symbols for the Native Runtime](#get-symbols-for-the-native-runtime) section for details.
 

--- a/docs/core/diagnostics/trace-perfcollect-lttng.md
+++ b/docs/core/diagnostics/trace-perfcollect-lttng.md
@@ -183,53 +183,6 @@ You can open the CTF trace file in `TraceCompass` by selecting `File -> Open Tra
 
 For more details, please refer to [`TraceCompass` documentation](https://www.eclipse.org/tracecompass/).
 
-## Resolve framework symbols
-
-Framework symbols need to be manually generated at the time the trace is collected. They are different than app-level symbols because the framework is pre-compiled while app code is just-in-time-compiled. For framework code that was precompiled to native code, you need to call `crossgen` that knows how to generate the mapping from the native code to the name of the methods.
-
-`perfcollect` can handle most of the details for you, but it needs to have `crossgen` available. By default it is not installed with .NET distribution. If `crossgen` is not there, `perfcollect` warns you and refers you to these instructions. To fix things you need to fetch exactly the right version of crossgen for the runtime you are using. If you place the crossgen tool in the same directory as the .NET Runtime DLLs (for example, libcoreclr.so), then `perfcollect` can find it and add the framework symbols to the trace file for you.
-
-Normally when you create a .NET application, it just generates the DLL for the code you wrote, using a shared copy of the runtime for the rest.   However you can also generate what is called a 'self-contained' version of an application and this contains all runtime DLLs. `crossgen` is part of the NuGet package that is used to create self-contained apps, so one way of getting the right version of `crossgen` is to create a self-contained package of your application.
-
-For example:
-
-   >```bash
-   > mkdir helloWorld
-   > cd helloWorld
-   > dotnet new console
-   > dotnet publish --self-contained -r linux-x64
-   >```
-
-This creates a new Hello World application and builds it as a self-contained app.
-
-As a side effect of creating the self-contained application the dotnet tool will download a NuGet package called runtime.linux-x64.microsoft.netcore.app and place it in the directory ~/.nuget/packages/runtime.linux-x64.microsoft.netcore.app/VERSION, where VERSION is the version number of your .NET Core runtime (for example, 2.1.0). Under that is a tools directory and inside there is the crossgen tool you need. Starting with .NET Core 3.0, the package location is ~/.nuget/packages/microsoft.netcore.app.runtime.linux-x64/VERSION.
-
-The `crossgen` tool needs to be put next to the runtime that is actually used by your application. Typically your app uses the shared version of .NET Core that is installed at /usr/share/dotnet/shared/Microsoft.NETCore.App/VERSION where VERSION is the version number of the .NET Runtime. This is a shared location, so you need to be super-user to modify it. If the VERSION is 2.1.0 the commands to update `crossgen` would be:
-
-   >```bash
-   > sudo bash
-   > cp ~/.nuget/packages/runtime.linux-x64.microsoft.netcore.app/2.1.0/tools/crossgen /usr/share/dotnet/shared/Microsoft.NETCore.App/2.1.0
-   >```
-
-Once you have done this, `perfcollect` will use crossgen to include framework symbols. The warning that `perfcollect` used to issue should go away. This only has to be one once per machine (until you update your runtime).
-
-### Alternative: Turn off use of precompiled code
-
-If you don't have the ability to update the .NET Runtime (to add `crossgen`), or if the above procedure did not work for some reason, there is another approach to getting framework symbols. You can tell the runtime to simply not use the precompiled framework code. The code will be Just-In-Time compiled and `crossgen` is not needed.
-
-> [!NOTE]
-> Choosing this approach may increase the startup time for your application.
-
-To do this, you can add the following environment variable:
-
-```bash
-export DOTNET_ZapDisable=1
-```
-
-[!INCLUDE [complus-prefix](../../../includes/complus-prefix.md)]
-
-With this change, you should get the symbols for all .NET code.
-
 ## Get symbols for the native runtime
 
 Most of the time you are interested in your own code, which `perfcollect` resolves by default. Sometimes it is useful to see what is going on inside the .NET DLLs (which is what the last section was about), but sometimes what is going on in the native runtime dlls (typically libcoreclr.so), is interesting.  `perfcollect` will resolve the symbols for these when it converts its data, but only if the symbols for these native DLLs are present (and are beside the library they are for).


### PR DESCRIPTION
## Summary

Remove unnecessary section of the doc


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/trace-perfcollect-lttng.md](https://github.com/dotnet/docs/blob/f9d26fa145ea5683afcdc0a296467e0b50f63436/docs/core/diagnostics/trace-perfcollect-lttng.md) | [Trace .NET applications with PerfCollect](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/trace-perfcollect-lttng?branch=pr-en-us-39200) |


<!-- PREVIEW-TABLE-END -->