### PR TITLE
Fix compilation error for AppLogEvents example

### DIFF
--- a/docs/core/extensions/logging.md
+++ b/docs/core/extensions/logging.md
@@ -381,18 +381,18 @@ using Microsoft.Extensions.Logging;
 
 internal static class AppLogEvents
 {
-    internal EventId Create = new(1000, "Created");
-    internal EventId Read = new(1001, "Read");
-    internal EventId Update = new(1002, "Updated");
-    internal EventId Delete = new(1003, "Deleted");
+    internal static EventId Create = new(1000, "Created");
+    internal static EventId Read = new(1001, "Read");
+    internal static EventId Update = new(1002, "Updated");
+    internal static EventId Delete = new(1003, "Deleted");
 
     // These are also valid EventId instances, as there's
     // an implicit conversion from int to an EventId
     internal const int Details = 3000;
     internal const int Error = 3001;
 
-    internal EventId ReadNotFound = 4000;
-    internal EventId UpdateNotFound = 4001;
+    internal static EventId ReadNotFound = 4000;
+    internal static EventId UpdateNotFound = 4001;
 
     // ...
 }


### PR DESCRIPTION
## Summary

Hey,
Found an issue while reading documentation about logging in .NET. The example does not compile because the class is static and members are of instance. 
https://learn.microsoft.com/en-us/dotnet/core/extensions/logging?tabs=command-line#log-event-id


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/logging.md](https://github.com/dotnet/docs/blob/747148c2d2a6a6c5d4c62b178248807f957cabe5/docs/core/extensions/logging.md) | [Logging in C# and .NET](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/logging?branch=pr-en-us-39206) |

<!-- PREVIEW-TABLE-END -->