### PR TITLE
Add assembly attributes using project file

### DIFF
--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -124,42 +124,9 @@ The `GenerateAssemblyInfo` property controls `AssemblyInfo` attribute generation
 
 The [GeneratedAssemblyInfoFile](#generatedassemblyinfofile) setting controls the name of the generated file.
 
-When the `GenerateAssemblyInfo` value is `true`, [package-related project properties](#package-properties) are transformed into assembly attributes. The following table lists the project properties that generate the attributes. It also lists the properties that you can use to disable that generation on a per-attribute basis, for example:
+When the `GenerateAssemblyInfo` value is `true`, [package-related project properties](#package-properties) are transformed into assembly attributes.
 
-```xml
-<PropertyGroup>
-  <GenerateNeutralResourcesLanguageAttribute>false</GenerateNeutralResourcesLanguageAttribute>
-</PropertyGroup>
-```
-
-| MSBuild property       | Assembly attribute                                             | Property to disable attribute generation        |
-| ---------------------- | -------------------------------------------------------------- | ----------------------------------------------- |
-| `Company`              | <xref:System.Reflection.AssemblyCompanyAttribute>              | `GenerateAssemblyCompanyAttribute`              |
-| `Configuration`        | <xref:System.Reflection.AssemblyConfigurationAttribute>        | `GenerateAssemblyConfigurationAttribute`        |
-| `Copyright`            | <xref:System.Reflection.AssemblyCopyrightAttribute>            | `GenerateAssemblyCopyrightAttribute`            |
-| `Description`          | <xref:System.Reflection.AssemblyDescriptionAttribute>          | `GenerateAssemblyDescriptionAttribute`          |
-| `FileVersion`          | <xref:System.Reflection.AssemblyFileVersionAttribute>          | `GenerateAssemblyFileVersionAttribute`          |
-| `InformationalVersion` | <xref:System.Reflection.AssemblyInformationalVersionAttribute> | `GenerateAssemblyInformationalVersionAttribute` |
-| `Product`              | <xref:System.Reflection.AssemblyProductAttribute>              | `GenerateAssemblyProductAttribute`              |
-| `AssemblyTitle`        | <xref:System.Reflection.AssemblyTitleAttribute>                | `GenerateAssemblyTitleAttribute`                |
-| `AssemblyVersion`      | <xref:System.Reflection.AssemblyVersionAttribute>              | `GenerateAssemblyVersionAttribute`              |
-| `NeutralLanguage`      | <xref:System.Resources.NeutralResourcesLanguageAttribute>      | `GenerateNeutralResourcesLanguageAttribute`     |
-
-Notes about these settings:
-
-- `AssemblyVersion` and `FileVersion` default to the value of `$(Version)` without the suffix. For example, if `$(Version)` is `1.2.3-beta.4`, then the value would be `1.2.3`.
-- `InformationalVersion` defaults to the value of `$(Version)`.
-- If the `$(SourceRevisionId)` property is present, it's appended to `InformationalVersion`. You can disable this behavior using `IncludeSourceRevisionInInformationalVersion`.
-- `Copyright` and `Description` properties are also used for NuGet metadata.
-- `Configuration`, which defaults to `Debug`, is shared with all MSBuild targets. You can set it via the `--configuration` option of `dotnet` commands, for example, [dotnet pack](../tools/dotnet-pack.md).
-- Some of the properties are used when creating a NuGet package. For more information, see [Package properties](#package-properties).
-
-#### Migrating from .NET Framework
-
-.NET Framework project templates create a code file with these assembly info attributes set. The file is typically located at *.\Properties\AssemblyInfo.cs* or *.\Properties\AssemblyInfo.vb*. SDK-style projects generate this file for you based on the project settings. **You can't have both.** When porting your code to .NET 6 or later, do one of the following:
-
-- Disable the generation of the temporary code file that contains the assembly info attributes by setting `GenerateAssemblyInfo` to `false` in your project file. This enables you to keep your *AssemblyInfo* file.
-- Migrate the settings in the `AssemblyInfo` file to the project file, and then delete the `AssemblyInfo` file.
+For more information about generating assembly attributes using a project file, see [Set assembly attributes in a project file](../../standard/assembly/set-attributes-project-file.md).
 
 ### GeneratedAssemblyInfoFile
 

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -1224,7 +1224,11 @@ items:
       - name: Assembly location
         href: ../standard/assembly/location.md
       - name: Set assembly attributes
-        href: ../standard/assembly/set-attributes.md
+        items:
+        - name: In code
+          href: ../standard/assembly/set-attributes.md
+        - name: In a project file
+          href: ../standard/assembly/set-attributes-project-file.md
       - name: Strong-named assemblies
         items:
         - name: Overview

--- a/docs/standard/assembly/set-attributes-project-file.md
+++ b/docs/standard/assembly/set-attributes-project-file.md
@@ -1,0 +1,79 @@
+---
+title: "Set assembly attributes in project files"
+description: Learn how you can set assembly attributes using a project file.
+ms.date: 01/19/2024
+---
+
+# Set assembly attributes in a project file
+
+You can use an MSBuild property to [transform package-related project properties](#use-package-properties-as-assembly-attributes) into assembly attributes in a generated code file. Further, you can use MSBuild items to add [arbitrary assembly attributes](#set-arbitrary-attributes) to the generated file.
+
+## Use package properties as assembly attributes
+
+The [`GenerateAssemblyInfo` MSBuild property](../../core/project-sdk/msbuild-props.md#generateassemblyinfo) controls `AssemblyInfo` attribute generation for a project. When the `GenerateAssemblyInfo` value is `true` (which is the default), [package-related project properties](../../core/project-sdk/msbuild-props.md#package-properties) are transformed into assembly attributes. The following table lists the project properties that generate the attributes. It also lists the properties that you can use to disable that generation on a per-attribute basis, for example:
+
+```xml
+<PropertyGroup>
+  <GenerateNeutralResourcesLanguageAttribute>false</GenerateNeutralResourcesLanguageAttribute>
+</PropertyGroup>
+```
+
+| MSBuild property       | Assembly attribute                                             | Property to disable attribute generation        |
+| ---------------------- | -------------------------------------------------------------- | ----------------------------------------------- |
+| `Company`              | <xref:System.Reflection.AssemblyCompanyAttribute>              | `GenerateAssemblyCompanyAttribute`              |
+| `Configuration`        | <xref:System.Reflection.AssemblyConfigurationAttribute>        | `GenerateAssemblyConfigurationAttribute`        |
+| `Copyright`            | <xref:System.Reflection.AssemblyCopyrightAttribute>            | `GenerateAssemblyCopyrightAttribute`            |
+| `Description`          | <xref:System.Reflection.AssemblyDescriptionAttribute>          | `GenerateAssemblyDescriptionAttribute`          |
+| `FileVersion`          | <xref:System.Reflection.AssemblyFileVersionAttribute>          | `GenerateAssemblyFileVersionAttribute`          |
+| `InformationalVersion` | <xref:System.Reflection.AssemblyInformationalVersionAttribute> | `GenerateAssemblyInformationalVersionAttribute` |
+| `Product`              | <xref:System.Reflection.AssemblyProductAttribute>              | `GenerateAssemblyProductAttribute`              |
+| `AssemblyTitle`        | <xref:System.Reflection.AssemblyTitleAttribute>                | `GenerateAssemblyTitleAttribute`                |
+| `AssemblyVersion`      | <xref:System.Reflection.AssemblyVersionAttribute>              | `GenerateAssemblyVersionAttribute`              |
+| `NeutralLanguage`      | <xref:System.Resources.NeutralResourcesLanguageAttribute>      | `GenerateNeutralResourcesLanguageAttribute`     |
+
+Notes about these settings:
+
+- `AssemblyVersion` and `FileVersion` default to the value of `$(Version)` without the suffix. For example, if `$(Version)` is `1.2.3-beta.4`, then the value would be `1.2.3`.
+- `InformationalVersion` defaults to the value of `$(Version)`.
+- If the `$(SourceRevisionId)` property is present, it's appended to `InformationalVersion`. You can disable this behavior using `IncludeSourceRevisionInInformationalVersion`.
+- `Copyright` and `Description` properties are also used for NuGet metadata.
+- `Configuration`, which defaults to `Debug`, is shared with all MSBuild targets. You can set it via the `--configuration` option of `dotnet` commands, for example, [dotnet pack](../tools/dotnet-pack.md).
+- Some of the properties are used when creating a NuGet package. For more information, see [Package properties](#package-properties).
+
+## Set arbitrary attributes
+
+It's possible to add your own assembly attributes to the generated file as well. To do so, define `<AssemblyAttribute>` MSBuild items that tell the SDK what type of attribute to create. These items should also include any constructor parameters that are required for that attribute. For example, the <xref:System.Reflection.AssemblyMetadataAttribute?displayProperty=fullName> attribute has a constructor that takes two strings:
+
+- A name to describe an arbitrary value.
+- The value to store.
+
+If you had a `Date` property in MSBuild that contained the date when an assembly was created, you could use `AssemblyMetadataAttribute` to embed that date into the assembly attributes using the following MSBuild code:
+
+```xml
+<ItemGroup>
+  <!-- Include must be the fully qualified .NET type name of the Attribute to create. -->
+  <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+    <!-- _Parameter1, _Parameter2, etc. correspond to the
+        matching parameter of a constructor of that .NET attribute type -->
+    <_Parameter1>BuildDate</_Parameter1>
+    <_Parameter2>$(Date)</_Parameter2>
+  </AssemblyAttribute>
+</ItemGroup>
+```
+
+This item tells the .NET SDK to emit the following C# (or equivalent F# or Visual Basic) as an assembly-level attribute:
+
+```csharp
+[assembly: System.Reflection.AssemblyMetadataAttribute("BuildDate", "01/19/2024")]
+```
+
+(The actual date string would be whatever you provided at the time of the build.)
+
+## Migrating from .NET Framework
+
+If you migrate your .NET Framework project to .NET 6 or later, you might encounter an error related to duplicate assembly info files. That's because .NET Framework project templates create a code file with assembly info attributes set. The file is typically located at *.\Properties\AssemblyInfo.cs* or *.\Properties\AssemblyInfo.vb*. However, SDK-style projects also *generate* this file for you based on the project settings.
+
+When porting your code to .NET 6 or later, do one of the following:
+
+- Disable the generation of the temporary code file that contains the assembly info attributes by setting `GenerateAssemblyInfo` to `false` in your project file. This enables you to keep your *AssemblyInfo* file.
+- Migrate the settings in the *AssemblyInfo* file to the project file, and then delete the *AssemblyInfo* file.

--- a/docs/standard/assembly/set-attributes-project-file.md
+++ b/docs/standard/assembly/set-attributes-project-file.md
@@ -69,7 +69,7 @@ This item tells the .NET SDK to emit the following C# (or equivalent F# or Visua
 
 (The actual date string would be whatever you provided at the time of the build.)
 
-## Migrating from .NET Framework
+## Migrate from .NET Framework
 
 If you migrate your .NET Framework project to .NET 6 or later, you might encounter an error related to duplicate assembly info files. That's because .NET Framework project templates create a code file with assembly info attributes set. The file is typically located at *.\Properties\AssemblyInfo.cs* or *.\Properties\AssemblyInfo.vb*. However, SDK-style projects also *generate* this file for you based on the project settings.
 

--- a/docs/standard/assembly/set-attributes-project-file.md
+++ b/docs/standard/assembly/set-attributes-project-file.md
@@ -37,8 +37,8 @@ Notes about these settings:
 - `InformationalVersion` defaults to the value of `$(Version)`.
 - If the `$(SourceRevisionId)` property is present, it's appended to `InformationalVersion`. You can disable this behavior using `IncludeSourceRevisionInInformationalVersion`.
 - `Copyright` and `Description` properties are also used for NuGet metadata.
-- `Configuration`, which defaults to `Debug`, is shared with all MSBuild targets. You can set it via the `--configuration` option of `dotnet` commands, for example, [dotnet pack](../tools/dotnet-pack.md).
-- Some of the properties are used when creating a NuGet package. For more information, see [Package properties](#package-properties).
+- `Configuration`, which defaults to `Debug`, is shared with all MSBuild targets. You can set it via the `--configuration` option of `dotnet` commands, for example, [dotnet pack](../../core/tools/dotnet-pack.md).
+- Some of the properties are used when creating a NuGet package. For more information, see [Package properties](../../core/project-sdk/msbuild-props.md#package-properties).
 
 ## Set arbitrary attributes
 

--- a/docs/standard/assembly/set-attributes.md
+++ b/docs/standard/assembly/set-attributes.md
@@ -1,5 +1,5 @@
 ---
-title: "Set assembly attributes"
+title: "Set assembly attributes in code"
 description: You can set assembly attributes for a .NET assembly, including assembly identity, informational, assembly manifest, and strong name attributes.
 ms.date: 10/22/2021
 helpviewer_keywords:
@@ -13,7 +13,7 @@ dev_langs:
     - "cpp"
 ---
 
-# Set assembly attributes
+# Set assembly attributes in code
 
 Assembly attributes are values that provide information about an assembly. They're usually set in an _AssemblyInfo.cs_ file. The attributes are divided into the following sets of information:
 
@@ -22,8 +22,7 @@ Assembly attributes are values that provide information about an assembly. They'
 - Assembly manifest attributes
 - Strong name attributes
 
-> [!TIP]
-> This article is scoped to adding assembly attributes from code. For information on adding assembly attributes to projects (not in code), see [MSBuild reference for .NET SDK projects: Assembly attribute properties](../../core/project-sdk/msbuild-props.md#assembly-attribute-properties).
+This article is scoped to adding assembly attributes from code. For information on adding assembly attributes to projects (not in code), see ...
 
 ## Assembly identity attributes
 
@@ -116,4 +115,4 @@ The following code example shows the attributes to apply when using delay signin
 ## See also
 
 - [Create assemblies](create.md)
-- [MSBuild reference for .NET SDK projects](../../core/project-sdk/msbuild-props.md)
+- [Assembly attribute MSBuild properties](../../core/project-sdk/msbuild-props.md#assembly-attribute-properties)

--- a/docs/standard/assembly/set-attributes.md
+++ b/docs/standard/assembly/set-attributes.md
@@ -22,7 +22,7 @@ Assembly attributes are values that provide information about an assembly. They'
 - Assembly manifest attributes
 - Strong name attributes
 
-This article is scoped to adding assembly attributes from code. For information on adding assembly attributes to projects (not in code), see ...
+This article is scoped to adding assembly attributes from code. For information on adding assembly attributes to projects (not in code), see [Set assembly attributes in a project file](set-attributes-project-file.md).
 
 ## Assembly identity attributes
 


### PR DESCRIPTION
Fixes #37991

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/project-sdk/msbuild-props.md](https://github.com/dotnet/docs/blob/beb3e31fc79d368bff63ff529e62fa98abfa28a4/docs/core/project-sdk/msbuild-props.md) | [MSBuild reference for .NET SDK projects](https://review.learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props?branch=pr-en-us-39208) |
| [docs/standard/assembly/set-attributes-project-file.md](https://github.com/dotnet/docs/blob/beb3e31fc79d368bff63ff529e62fa98abfa28a4/docs/standard/assembly/set-attributes-project-file.md) | ["Set assembly attributes in project files"](https://review.learn.microsoft.com/en-us/dotnet/standard/assembly/set-attributes-project-file?branch=pr-en-us-39208) |
| [docs/standard/assembly/set-attributes.md](https://github.com/dotnet/docs/blob/beb3e31fc79d368bff63ff529e62fa98abfa28a4/docs/standard/assembly/set-attributes.md) | [Set assembly attributes in code](https://review.learn.microsoft.com/en-us/dotnet/standard/assembly/set-attributes?branch=pr-en-us-39208) |


<!-- PREVIEW-TABLE-END -->