### PR TITLE
Reduce metric name text size

### DIFF
--- a/docs/core/diagnostics/built-in-metrics-aspnetcore.md
+++ b/docs/core/diagnostics/built-in-metrics-aspnetcore.md
@@ -65,7 +65,7 @@ Available starting in: .NET 8.0.
 
 ## `Microsoft.AspNetCore.Routing`
 
-The `Microsoft.AspNetCore.Hosting` metrics report information about [routing HTTP requests](/aspnet/core/fundamentals/routing) to ASP.NET Core endpoints:
+The `Microsoft.AspNetCore.Routing` metrics report information about [routing HTTP requests](/aspnet/core/fundamentals/routing) to ASP.NET Core endpoints:
 
 - [`aspnetcore.routing.match_attempts`](#metric-aspnetcoreroutingmatch_attempts)
 

--- a/docs/core/diagnostics/built-in-metrics-aspnetcore.md
+++ b/docs/core/diagnostics/built-in-metrics-aspnetcore.md
@@ -21,7 +21,7 @@ The `Microsoft.AspNetCore.Hosting` metrics report high-level information about H
 - [`http.server.request.duration`](#metric-httpserverrequestduration)
 - [`http.server.active_requests`](#metric-httpserveractive_requests)
 
-#### Metric: `http.server.request.duration`
+##### Metric: `http.server.request.duration`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -50,7 +50,7 @@ The time ends when:
 
 Available starting in: .NET 8.0.
 
-#### Metric: `http.server.active_requests`
+##### Metric: `http.server.active_requests`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -69,7 +69,7 @@ The `Microsoft.AspNetCore.Hosting` metrics report information about [routing HTT
 
 - [`aspnetcore.routing.match_attempts`](#metric-aspnetcoreroutingmatch_attempts)
 
-#### Metric: `aspnetcore.routing.match_attempts`
+##### Metric: `aspnetcore.routing.match_attempts`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -89,7 +89,7 @@ The `Microsoft.AspNetCore.Diagnostics` metrics report diagnostics information fr
 
 - [`aspnetcore.diagnostics.exceptions`](#metric-aspnetcorediagnosticsexceptions)
 
-#### Metric: `aspnetcore.diagnostics.exceptions`
+##### Metric: `aspnetcore.diagnostics.exceptions`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -113,7 +113,7 @@ The `Microsoft.AspNetCore.RateLimiting` metrics report rate limiting information
 - [`aspnetcore.rate_limiting.request.time_in_queue`](#metric-aspnetcorerate_limitingrequesttime_in_queue)
 - [`aspnetcore.rate_limiting.requests`](#metric-aspnetcorerate_limitingrequests)
 
-#### Metric: `aspnetcore.rate_limiting.active_request_leases`
+##### Metric: `aspnetcore.rate_limiting.active_request_leases`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -125,7 +125,7 @@ The `Microsoft.AspNetCore.RateLimiting` metrics report rate limiting information
 
 Available starting in: .NET 8.0.
 
-#### Metric: `aspnetcore.rate_limiting.request_lease.duration`
+##### Metric: `aspnetcore.rate_limiting.request_lease.duration`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -137,7 +137,7 @@ Available starting in: .NET 8.0.
 
 Available starting in: .NET 8.0.
 
-#### Metric: `aspnetcore.rate_limiting.queued_requests`
+##### Metric: `aspnetcore.rate_limiting.queued_requests`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -149,7 +149,7 @@ Available starting in: .NET 8.0.
 
 Available starting in: .NET 8.0.
 
-#### Metric: `aspnetcore.rate_limiting.request.time_in_queue`
+##### Metric: `aspnetcore.rate_limiting.request.time_in_queue`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -162,7 +162,7 @@ Available starting in: .NET 8.0.
 
 Available starting in: .NET 8.0.
 
-#### Metric: `aspnetcore.rate_limiting.requests`
+##### Metric: `aspnetcore.rate_limiting.requests`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -182,7 +182,7 @@ The `Microsoft.AspNetCore.HeaderParsing` metrics report information about [ASP.N
 - [`aspnetcore.header_parsing.parse_errors`](#metric-aspnetcoreheader_parsingparse_errors)
 - [`aspnetcore.header_parsing.cache_accesses`](#metric-aspnetcoreheader_parsingcache_accesses)
 
-#### Metric: `aspnetcore.header_parsing.parse_errors`
+##### Metric: `aspnetcore.header_parsing.parse_errors`
 
 | Name | Instrument Type | Unit (UCUM) | Description |
 |--|--|--|--|
@@ -195,7 +195,7 @@ The `Microsoft.AspNetCore.HeaderParsing` metrics report information about [ASP.N
 
 Available starting in: .NET 8.0.
 
-#### Metric: `aspnetcore.header_parsing.cache_accesses`
+##### Metric: `aspnetcore.header_parsing.cache_accesses`
 
 The metric is emitted only for HTTP request header parsers that support caching.
 
@@ -223,7 +223,7 @@ The `Microsoft.AspNetCore.Server.Kestrel` metrics report HTTP connection informa
 - [`kestrel.tls_handshake.duration`](#metric-kestreltls_handshakeduration)
 - [`kestrel.active_tls_handshakes`](#metric-kestrelactive_tls_handshakes)
 
-#### Metric: `kestrel.active_connections`
+##### Metric: `kestrel.active_connections`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -238,7 +238,7 @@ The `Microsoft.AspNetCore.Server.Kestrel` metrics report HTTP connection informa
 
 Available starting in: .NET 8.0.
 
-#### Metric: `kestrel.connection.duration`
+##### Metric: `kestrel.connection.duration`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -257,7 +257,7 @@ Available starting in: .NET 8.0.
 
 Available starting in: .NET 8.0.
 
-#### Metric: `kestrel.rejected_connections`
+##### Metric: `kestrel.rejected_connections`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -274,7 +274,7 @@ Connections are rejected when the currently active count exceeds the value confi
 
 Available starting in: .NET 8.0.
 
-#### Metric: `kestrel.queued_connections`
+##### Metric: `kestrel.queued_connections`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -289,7 +289,7 @@ Available starting in: .NET 8.0.
 
 Available starting in: .NET 8.0.
 
-#### Metric: `kestrel.queued_requests`
+##### Metric: `kestrel.queued_requests`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -306,7 +306,7 @@ Available starting in: .NET 8.0.
 
 Available starting in: .NET 8.0.
 
-#### Metric: `kestrel.upgraded_connections`
+##### Metric: `kestrel.upgraded_connections`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -323,7 +323,7 @@ The counter only tracks HTTP/1.1 connections.
 
 Available starting in: .NET 8.0.
 
-#### Metric: `kestrel.tls_handshake.duration`
+##### Metric: `kestrel.tls_handshake.duration`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -340,7 +340,7 @@ Available starting in: .NET 8.0.
 
 Available starting in: .NET 8.0.
 
-#### Metric: `kestrel.active_tls_handshakes`
+##### Metric: `kestrel.active_tls_handshakes`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -362,7 +362,7 @@ The `Microsoft.AspNetCore.Http.Connections` metrics report connection informatio
 - [`signalr.server.connection.duration`](#metric-signalrserverconnectionduration)
 - [`signalr.server.active_connections`](#metric-signalrserveractive_connections)
 
-#### Metric: `signalr.server.connection.duration`
+##### Metric: `signalr.server.connection.duration`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -375,7 +375,7 @@ The `Microsoft.AspNetCore.Http.Connections` metrics report connection informatio
 
 Available starting in: .NET 8.0.
 
-#### Metric: `signalr.server.active_connections`
+##### Metric: `signalr.server.active_connections`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |

--- a/docs/core/diagnostics/built-in-metrics-aspnetcore.md
+++ b/docs/core/diagnostics/built-in-metrics-aspnetcore.md
@@ -21,7 +21,7 @@ The `Microsoft.AspNetCore.Hosting` metrics report high-level information about H
 - [`http.server.request.duration`](#metric-httpserverrequestduration)
 - [`http.server.active_requests`](#metric-httpserveractive_requests)
 
-### Metric: `http.server.request.duration`
+#### Metric: `http.server.request.duration`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -50,7 +50,7 @@ The time ends when:
 
 Available starting in: .NET 8.0.
 
-### Metric: `http.server.active_requests`
+#### Metric: `http.server.active_requests`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -69,7 +69,7 @@ The `Microsoft.AspNetCore.Hosting` metrics report information about [routing HTT
 
 - [`aspnetcore.routing.match_attempts`](#metric-aspnetcoreroutingmatch_attempts)
 
-### Metric: `aspnetcore.routing.match_attempts`
+#### Metric: `aspnetcore.routing.match_attempts`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -89,7 +89,7 @@ The `Microsoft.AspNetCore.Diagnostics` metrics report diagnostics information fr
 
 - [`aspnetcore.diagnostics.exceptions`](#metric-aspnetcorediagnosticsexceptions)
 
-### Metric: `aspnetcore.diagnostics.exceptions`
+#### Metric: `aspnetcore.diagnostics.exceptions`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -113,7 +113,7 @@ The `Microsoft.AspNetCore.RateLimiting` metrics report rate limiting information
 - [`aspnetcore.rate_limiting.request.time_in_queue`](#metric-aspnetcorerate_limitingrequesttime_in_queue)
 - [`aspnetcore.rate_limiting.requests`](#metric-aspnetcorerate_limitingrequests)
 
-### Metric: `aspnetcore.rate_limiting.active_request_leases`
+#### Metric: `aspnetcore.rate_limiting.active_request_leases`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -125,7 +125,7 @@ The `Microsoft.AspNetCore.RateLimiting` metrics report rate limiting information
 
 Available starting in: .NET 8.0.
 
-### Metric: `aspnetcore.rate_limiting.request_lease.duration`
+#### Metric: `aspnetcore.rate_limiting.request_lease.duration`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -137,7 +137,7 @@ Available starting in: .NET 8.0.
 
 Available starting in: .NET 8.0.
 
-### Metric: `aspnetcore.rate_limiting.queued_requests`
+#### Metric: `aspnetcore.rate_limiting.queued_requests`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -149,7 +149,7 @@ Available starting in: .NET 8.0.
 
 Available starting in: .NET 8.0.
 
-### Metric: `aspnetcore.rate_limiting.request.time_in_queue`
+#### Metric: `aspnetcore.rate_limiting.request.time_in_queue`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -162,7 +162,7 @@ Available starting in: .NET 8.0.
 
 Available starting in: .NET 8.0.
 
-### Metric: `aspnetcore.rate_limiting.requests`
+#### Metric: `aspnetcore.rate_limiting.requests`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -182,7 +182,7 @@ The `Microsoft.AspNetCore.HeaderParsing` metrics report information about [ASP.N
 - [`aspnetcore.header_parsing.parse_errors`](#metric-aspnetcoreheader_parsingparse_errors)
 - [`aspnetcore.header_parsing.cache_accesses`](#metric-aspnetcoreheader_parsingcache_accesses)
 
-### Metric: `aspnetcore.header_parsing.parse_errors`
+#### Metric: `aspnetcore.header_parsing.parse_errors`
 
 | Name | Instrument Type | Unit (UCUM) | Description |
 |--|--|--|--|
@@ -195,7 +195,7 @@ The `Microsoft.AspNetCore.HeaderParsing` metrics report information about [ASP.N
 
 Available starting in: .NET 8.0.
 
-### Metric: `aspnetcore.header_parsing.cache_accesses`
+#### Metric: `aspnetcore.header_parsing.cache_accesses`
 
 The metric is emitted only for HTTP request header parsers that support caching.
 
@@ -223,7 +223,7 @@ The `Microsoft.AspNetCore.Server.Kestrel` metrics report HTTP connection informa
 - [`kestrel.tls_handshake.duration`](#metric-kestreltls_handshakeduration)
 - [`kestrel.active_tls_handshakes`](#metric-kestrelactive_tls_handshakes)
 
-### Metric: `kestrel.active_connections`
+#### Metric: `kestrel.active_connections`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -238,7 +238,7 @@ The `Microsoft.AspNetCore.Server.Kestrel` metrics report HTTP connection informa
 
 Available starting in: .NET 8.0.
 
-### Metric: `kestrel.connection.duration`
+#### Metric: `kestrel.connection.duration`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -257,7 +257,7 @@ Available starting in: .NET 8.0.
 
 Available starting in: .NET 8.0.
 
-### Metric: `kestrel.rejected_connections`
+#### Metric: `kestrel.rejected_connections`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -274,7 +274,7 @@ Connections are rejected when the currently active count exceeds the value confi
 
 Available starting in: .NET 8.0.
 
-### Metric: `kestrel.queued_connections`
+#### Metric: `kestrel.queued_connections`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -289,7 +289,7 @@ Available starting in: .NET 8.0.
 
 Available starting in: .NET 8.0.
 
-### Metric: `kestrel.queued_requests`
+#### Metric: `kestrel.queued_requests`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -306,7 +306,7 @@ Available starting in: .NET 8.0.
 
 Available starting in: .NET 8.0.
 
-### Metric: `kestrel.upgraded_connections`
+#### Metric: `kestrel.upgraded_connections`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -323,7 +323,7 @@ The counter only tracks HTTP/1.1 connections.
 
 Available starting in: .NET 8.0.
 
-### Metric: `kestrel.tls_handshake.duration`
+#### Metric: `kestrel.tls_handshake.duration`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -340,7 +340,7 @@ Available starting in: .NET 8.0.
 
 Available starting in: .NET 8.0.
 
-### Metric: `kestrel.active_tls_handshakes`
+#### Metric: `kestrel.active_tls_handshakes`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -362,7 +362,7 @@ The `Microsoft.AspNetCore.Http.Connections` metrics report connection informatio
 - [`signalr.server.connection.duration`](#metric-signalrserverconnectionduration)
 - [`signalr.server.active_connections`](#metric-signalrserveractive_connections)
 
-### Metric: `signalr.server.connection.duration`
+#### Metric: `signalr.server.connection.duration`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -375,7 +375,7 @@ The `Microsoft.AspNetCore.Http.Connections` metrics report connection informatio
 
 Available starting in: .NET 8.0.
 
-### Metric: `signalr.server.active_connections`
+#### Metric: `signalr.server.active_connections`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |

--- a/docs/core/diagnostics/built-in-metrics-diagnostics.md
+++ b/docs/core/diagnostics/built-in-metrics-diagnostics.md
@@ -17,7 +17,7 @@ The `Microsoft.Extensions.Diagnostics.HealthChecks` metrics report health check 
 - [`dotnet.health_check.reports`](#metric-dotnethealth_checkreports)
 - [`dotnet.health_check.unhealthy_checks`](#metric-dotnethealth_checkunhealthy_checks)
 
-### Metric: `dotnet.health_check.reports`
+##### Metric: `dotnet.health_check.reports`
 
 | Name | Instrument Type | Unit (UCUM) | Description |
 | ---- | --------------- | ----------- | ----------- |
@@ -37,7 +37,7 @@ The `Microsoft.Extensions.Diagnostics.HealthChecks` metrics report health check 
 
 Available starting in: .NET 8.0.
 
-### Metric: `dotnet.health_check.unhealthy_checks`
+##### Metric: `dotnet.health_check.unhealthy_checks`
 
 | Name | Instrument Type | Unit (UCUM) | Description |
 | ---- | --------------- | ----------- | ----------- |
@@ -69,7 +69,7 @@ The `Microsoft.Extensions.Diagnostics.ResourceMonitoring` metrics report resourc
 > [!NOTE]
 > Metrics emitted by the `Microsoft.Extensions.Diagnostics.ResourceMonitoring` meter are in experimental stage. This means that there could be breaking changes to them.
 
-### Metric: `process.cpu.utilization`
+##### Metric: `process.cpu.utilization`
 
 The instrument is available only on Linux.
 
@@ -79,7 +79,7 @@ The instrument is available only on Linux.
 
 Available starting in: .NET 8.0.
 
-### Metric: `dotnet.process.memory.virtual.utilization`
+##### Metric: `dotnet.process.memory.virtual.utilization`
 
 The instrument is available only on Linux.
 
@@ -89,7 +89,7 @@ The instrument is available only on Linux.
 
 Available starting in: .NET 8.0.
 
-### Metric: `system.network.connections`
+##### Metric: `system.network.connections`
 
 The instrument is available only on Windows.
 

--- a/docs/core/diagnostics/built-in-metrics-system-net.md
+++ b/docs/core/diagnostics/built-in-metrics-system-net.md
@@ -19,7 +19,7 @@ The `System.Net.NameResolution` metrics report DNS name resolution from <xref:Sy
 
 - [`dns.lookup.duration`](#metric-dnslookupduration)
 
-### Metric: `dns.lookup.duration`
+##### Metric: `dns.lookup.duration`
 
 | Name     | Instrument Type | Unit | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -56,7 +56,7 @@ The `System.Net.Http` metrics report HTTP request and connection information fro
 - [`http.client.request.time_in_queue`](#metric-httpclientrequesttime_in_queue)
 - [`http.client.active_requests`](#metric-httpclientactive_requests)
 
-### Metric: `http.client.open_connections`
+##### Metric: `http.client.open_connections`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -75,7 +75,7 @@ The `System.Net.Http` metrics report HTTP request and connection information fro
 
 Available starting in: .NET 8
 
-### Metric: `http.client.connection.duration`
+##### Metric: `http.client.connection.duration`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -93,7 +93,7 @@ This metric is only captured when <xref:System.Net.Http.HttpClient> is configure
 
 Available starting in: .NET 8
 
-### Metric: `http.client.request.duration`
+##### Metric: `http.client.request.duration`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -116,7 +116,7 @@ Available starting in: .NET 8
 > [!TIP]
 > [Enrichment](../../fundamentals/networking/telemetry/metrics.md#enrichment) is possible for this metric.
 
-### Metric: `http.client.request.time_in_queue`
+##### Metric: `http.client.request.time_in_queue`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
@@ -134,7 +134,7 @@ Available starting in: .NET 8
 
 Available starting in: .NET 8
 
-### Metric: `http.client.active_requests`
+##### Metric: `http.client.active_requests`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |


### PR DESCRIPTION
Reduce metric name text size to differentiate them from meter name.

I think it is easier to read with smaller headings for each metric.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/built-in-metrics-aspnetcore.md](https://github.com/dotnet/docs/blob/489f5acb5aa926450f298bdc0d553b1e7a6cbe16/docs/core/diagnostics/built-in-metrics-aspnetcore.md) | [ASP.NET Core metrics](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/built-in-metrics-aspnetcore?branch=pr-en-us-39211) |
| [docs/core/diagnostics/built-in-metrics-diagnostics.md](https://github.com/dotnet/docs/blob/489f5acb5aa926450f298bdc0d553b1e7a6cbe16/docs/core/diagnostics/built-in-metrics-diagnostics.md) | [.NET extensions metrics](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/built-in-metrics-diagnostics?branch=pr-en-us-39211) |
| [docs/core/diagnostics/built-in-metrics-system-net.md](https://github.com/dotnet/docs/blob/489f5acb5aa926450f298bdc0d553b1e7a6cbe16/docs/core/diagnostics/built-in-metrics-system-net.md) | [System.Net metrics](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/built-in-metrics-system-net?branch=pr-en-us-39211) |


<!-- PREVIEW-TABLE-END -->