### PR TITLE
Update types.md

### DIFF
--- a/docs/csharp/tour-of-csharp/types.md
+++ b/docs/csharp/tour-of-csharp/types.md
@@ -35,8 +35,6 @@ Instances of classes are created using the `new` operator, which allocates memor
 
 The memory occupied by an object is automatically reclaimed when the object is no longer reachable. It's not necessary or possible to explicitly deallocate objects in C#.
 
-:::code language="csharp" source="./snippets/shared/Types.cs" ID="CreatePoints":::
-
 Applications or tests for algorithms might need to create multiple `Point` objects. The following class generates a sequence of random points. The number of points is set by the *primary constructor* parameter. The primary constructor parameter `numberOfPoints` is in scope for all members of the class:
 
 :::code language="csharp" source="./snippets/shared/Types.cs" ID="PointFactoryClass":::


### PR DESCRIPTION
There was some duplicate(?) code, demonstrating the creation of two Point instances twice. Surely, no need for this?

## Summary

Removed the second code demo display box.

<img width="721" alt="Screenshot 2024-01-22 144154" src="https://github.com/dotnet/docs/assets/55443722/712c12f1-4839-42c9-a9a8-6b0aeb13700c">


Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/tour-of-csharp/types.md](https://github.com/dotnet/docs/blob/0b5e447ea19d4a715e90e9a63780057a0761122b/docs/csharp/tour-of-csharp/types.md) | [C# types and members](https://review.learn.microsoft.com/en-us/dotnet/csharp/tour-of-csharp/types?branch=pr-en-us-39214) |

<!-- PREVIEW-TABLE-END -->