### PR TITLE
Correct the typo: TreatWarningsAsErrors -> WarningsAsError

### DIFF
--- a/docs/csharp/language-reference/compiler-options/errors-warnings.md
+++ b/docs/csharp/language-reference/compiler-options/errors-warnings.md
@@ -74,7 +74,7 @@ To get information about an error or warning, you can look up the error code in 
 
 ## TreatWarningsAsErrors
 
-The **TreatWarningsAsErrors** option treats all warnings as errors. You can also use the **TreatWarningsAsErrors** to set only some warnings as errors. If you turn on **TreatWarningsAsErrors**, you can use **WarningsNotAsErrors** to list warnings that shouldn't be treated as errors.
+The **TreatWarningsAsErrors** option treats all warnings as errors. You can also use the **WarningsAsErrors** to set only some warnings as errors. If you turn on **TreatWarningsAsErrors**, you can use **WarningsNotAsErrors** to list warnings that shouldn't be treated as errors.
 
 ```xml
 <TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION
This pull request fixes #39119 
It renames `TreatWarningsAsErrors` to `WarningsAsError` as per findings in the issue.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-options/errors-warnings.md](https://github.com/dotnet/docs/blob/6e3b6bbf737fa0509a295f6a508b9d9c2f5fd081/docs/csharp/language-reference/compiler-options/errors-warnings.md) | [C# Compiler Options to report errors and warnings](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/errors-warnings?branch=pr-en-us-39219) |

<!-- PREVIEW-TABLE-END -->