### PR TITLE
Fix code formatting in ca1008.md

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1008.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1008.md
@@ -81,7 +81,7 @@ In .NET 7 and later versions, you can configure other allowable names for a zero
 | Option value | Summary |
 | --- | --- |
 | `dotnet_code_quality.CA1008.additional_enum_none_names = Never` | Allows both `None` and `Never` |
-| `dotnet_code_quality.CA1008.additional_enum_none_names = Never&#124;Nothing` | Allows `None`, `Never`, and `Nothing` |
+| `dotnet_code_quality.CA1008.additional_enum_none_names = Never\|Nothing` | Allows `None`, `Never`, and `Nothing` |
 
 ## Example
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1008.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1008.md
@@ -81,7 +81,7 @@ In .NET 7 and later versions, you can configure other allowable names for a zero
 | Option value | Summary |
 | --- | --- |
 | `dotnet_code_quality.CA1008.additional_enum_none_names = Never` | Allows both `None` and `Never` |
-| 'dotnet_code_quality.CA1008.additional_enum_none_names = Never&#124;Nothing' | Allows `None`, `Never`, and `Nothing` |
+| `dotnet_code_quality.CA1008.additional_enum_none_names = Never&#124;Nothing` | Allows `None`, `Never`, and `Nothing` |
 
 ## Example
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1008.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1008.md
@@ -78,10 +78,12 @@ You can configure this option for just this rule, for all rules it applies to, o
 
 In .NET 7 and later versions, you can configure other allowable names for a zero-value enumeration field, besides `None`. Separate multiple names by the `|` character. The following table shows some examples.
 
+<!-- markdownlint-disable MD056 -->
 | Option value | Summary |
 | --- | --- |
 | `dotnet_code_quality.CA1008.additional_enum_none_names = Never` | Allows both `None` and `Never` |
-| `dotnet_code_quality.CA1008.additional_enum_none_names = Never\|Nothing` | Allows `None`, `Never`, and `Nothing` |
+| `dotnet_code_quality.CA1008.additional_enum_none_names = Never|Nothing` | Allows `None`, `Never`, and `Nothing` |
+<!-- markdownlint-enable MD056 -->
 
 ## Example
 


### PR DESCRIPTION
## Summary

The code formatting in the second table row under https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1008#additional-zero-value-field-names was broken, so I fixed it.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1008.md](https://github.com/dotnet/docs/blob/317033f8bd8e914681d30dd534abe4e7a24d3115/docs/fundamentals/code-analysis/quality-rules/ca1008.md) | [CA1008: Enums should have zero value](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1008?branch=pr-en-us-39221) |


<!-- PREVIEW-TABLE-END -->