### PR TITLE
Add a note on protocol fallback

### DIFF
--- a/docs/core/testing/unit-testing-mstest-runner-vs-vstest.md
+++ b/docs/core/testing/unit-testing-mstest-runner-vs-vstest.md
@@ -38,6 +38,10 @@ The MSTest runner is based on [Microsoft.Testing.Platform](https://www.nuget.org
 
 ## Communication protocol
 
+> [!NOTE]
+> Test Explorer supports the MSTest Runner protocol from version 17.10. If you run/debug your tests using earlier versions of Visual Studio,
+> Test Explorer will use `vstest.console.exe` and the old protocol to run these tests.
+
 The MSTest runner uses a JSON-RPC based protocol to communicate between Visual Studio and the test runner process. The protocol is documented in the [MSTest github repository](https://github.com/microsoft/testfx/tree/main/docs/mstest-runner-protocol).
 
 VSTest also uses a JSON based communication protocol, but it's not JSON-RPC based.

--- a/docs/core/testing/unit-testing-mstest-runner-vs-vstest.md
+++ b/docs/core/testing/unit-testing-mstest-runner-vs-vstest.md
@@ -46,6 +46,16 @@ The MSTest runner uses a JSON-RPC based protocol to communicate between Visual S
 
 VSTest also uses a JSON based communication protocol, but it's not JSON-RPC based.
 
+### Disabling the new protocol
+
+To disable the use of the new protocol in Test Explorer, you can edit the csproj and remove the `TestingPlatformServer` capability.
+
+```xml
+<ItemGroup>
+    <ProjectCapability Remove="TestingPlatformServer" />
+</ItemGroup>
+```
+
 ## Executables
 
 VSTest ships multiple executables, notably `vstest.console.exe`, `testhost.exe`, and `datacollector.exe`. However, MSTest is embedded directly into your test project and doesn't ship any other executables. The executable your test project compiles to is used to host all the testing tools and carry out all the tasks needed to run tests.


### PR DESCRIPTION
Adds a note that the new protocol is only available starting 17.10 and that on older VS versions vstest.console is still going to be used by Test Explorer to run the MSTest Runner enabled projects.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-mstest-runner-vs-vstest.md](https://github.com/dotnet/docs/blob/52eeb96fa1bef065c7e2a3758d5bf20c5d6804ab/docs/core/testing/unit-testing-mstest-runner-vs-vstest.md) | [MSTest runner and VSTest comparison](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-runner-vs-vstest?branch=pr-en-us-39224) |


<!-- PREVIEW-TABLE-END -->