### PR TITLE
Erroneous semicolon causes CS1513 compile error

### DIFF
--- a/docs/standard/serialization/system-text-json/source-generation.md
+++ b/docs/standard/serialization/system-text-json/source-generation.md
@@ -156,7 +156,7 @@ internal partial class MyJsonContext : JsonSerializerContext { }
 ```csharp
 var serializerOptions = new JsonSerializerOptions
 {
-    TypeInfoResolver = MyJsonContext.Default;
+    TypeInfoResolver = MyJsonContext.Default
 };
 
 services.AddControllers().AddJsonOptions(
@@ -178,7 +178,7 @@ internal partial class MyJsonContext : JsonSerializerContext { }
 ```csharp
 var serializerOptions = new JsonSerializerOptions
 {
-    TypeInfoResolver = MyJsonContext.Default;
+    TypeInfoResolver = MyJsonContext.Default
 };
 
 services.AddControllers().AddJsonOptions(


### PR DESCRIPTION
## Summary

As title says, errorneous semicolon in a initializer will cause a CS1513 compile error.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/serialization/system-text-json/source-generation.md](https://github.com/dotnet/docs/blob/667a4dbb5444149f21744a0c89c9d0a121fcddbb/docs/standard/serialization/system-text-json/source-generation.md) | [How to use source generation in System.Text.Json](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/source-generation?branch=pr-en-us-39251) |

<!-- PREVIEW-TABLE-END -->