### PR TITLE
fix template name

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -129,7 +129,7 @@
             "open_source_feedback_issueTitle": "",
             "open_source_feedback_productLogoLightUrl": "https://learn.microsoft.com/media/logos/logo_net.svg",
             "open_source_feedback_productLogoDarkUrl": "https://learn.microsoft.com/media/logos/logo_net.svg",
-            "open_source_feedback_issueUrl": "https://github.com/dotnet/docs/issues/new?template=customer-feedback.yml",
+            "open_source_feedback_issueUrl": "https://github.com/dotnet/docs/issues/new?template=z-customer-feedback.ym",
             "open_source_feedback_productName": ".NET",
             "social_image_url": "/dotnet/media/dotnet-logo.png",
             "ms.author": "dotnetcontent",


### PR DESCRIPTION
Fixes #39237

When I renamed the template to put it last in the list, I didn't update the config option. This fixes that.
