### PR TITLE
Correct spelling mistake of `JsonSerializer`

### DIFF
--- a/docs/core/compatibility/serialization/8.0/publishtrimmed.md
+++ b/docs/core/compatibility/serialization/8.0/publishtrimmed.md
@@ -17,7 +17,7 @@ JsonSerializer.Serialize(new { Value = 42 });
 
 ## New behavior
 
-Starting in .NET 8, projects that have the `PublishTrimmed` property enabled fail serialization outright. The code `JSonSerializer.Serialize(new { Value = 42 });` throws the following exception:
+Starting in .NET 8, projects that have the `PublishTrimmed` property enabled fail serialization outright. The code `JsonSerializer.Serialize(new { Value = 42 });` throws the following exception:
 
 > **System.InvalidOperationException: Reflection-based serialization has been disabled for this application.**
 


### PR DESCRIPTION
## Summary

A small spelling mistake in publishtrimmed.md
Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/serialization/8.0/publishtrimmed.md](https://github.com/dotnet/docs/blob/282d0896b351c9fcfd4c923a8cc7cb9d68fcec84/docs/core/compatibility/serialization/8.0/publishtrimmed.md) | [PublishedTrimmed projects fail reflection-based serialization](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/serialization/8.0/publishtrimmed?branch=pr-en-us-39257) |

<!-- PREVIEW-TABLE-END -->