### PR TITLE
edit remove-runtime-sdk-versions.md: os-macos version: remove reference to Linux distribution

### DIFF
--- a/docs/core/install/remove-runtime-sdk-versions.md
+++ b/docs/core/install/remove-runtime-sdk-versions.md
@@ -103,7 +103,7 @@ sudo rm -rf /usr/share/dotnet/sdk/6.0.406
 
 ::: zone pivot="os-macos"
 
-When you manually install .NET, it's generally installed to the `/usr/local/share/dotnet/` or the `$HOME/.dotnet` directory. The SDK, runtime, and .NET host are installed into separate sub directories. These "component" directories contain a directory for each version of .NET. By removing the versioned directories, you remove that version of .NET from your system. These directories may vary depending on your Linux distribution.
+When you manually install .NET, it's generally installed to the `/usr/local/share/dotnet/` or the `$HOME/.dotnet` directory. The SDK, runtime, and .NET host are installed into separate sub directories. These "component" directories contain a directory for each version of .NET. By removing the versioned directories, you remove that version of .NET from your system. These directories may vary depending on your macOS version.
 
 There are three commands you can use to discover where .NET is installed: `dotnet --list-sdks` for SDKs, `dotnet --list-runtimes` for runtimes, and `dotnet --info` for everything. These commands don't list the .NET host. To determine which hosts are installed, check the `/usr/local/share/dotnet/host/fxr/` directory. The following list represents the directories of a specific version of .NET, where the `$version` variable represents the version of the .NET:
 


### PR DESCRIPTION
This page (remove-runtime-sdk-versions.md) has a toggle to choose from Windows, Linux, and macOS.

![toggle_for_operating_system](https://github.com/dotnet/docs/assets/47086307/5b1bf12d-133d-4061-9ba6-9a36cc046dcf)

When I choose the option for macOS, I see in the 'Uninstall .NET' section a reference to a different operating system: Linux

> These directories may vary depending on your Linux distribution.

![macOS_uninstall_dotnet_refers_to_Linux](https://github.com/dotnet/docs/assets/47086307/23ef8671-9225-470f-baf2-2352c604bf66)

This commit replaces 'Linux distribution' with 'macOS version'.

I claim this edit correctly removes a reference to Linux from the macOS 'Uninstall .NET' section. However, I do not know whether 

'These directories may vary depending on your macOS version'

is true. 

I request a review of this change. 

It may be that a better alternative edit is to remove the whole sentence  'These directories may vary depending on your Linux distribution.' from the macOS section for 'Uninstall .NET'

Thank you :)

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/remove-runtime-sdk-versions.md](https://github.com/dotnet/docs/blob/efd70da7d4d5e0a6a49ecb12feab7a818dd64445/docs/core/install/remove-runtime-sdk-versions.md) | [How to remove the .NET Runtime and SDK](https://review.learn.microsoft.com/en-us/dotnet/core/install/remove-runtime-sdk-versions?branch=pr-en-us-39268) |

<!-- PREVIEW-TABLE-END -->