### PR TITLE
Sanitize .NET Framework TOCs

### DIFF
--- a/docs/framework/app-domains/toc.yml
+++ b/docs/framework/app-domains/toc.yml
@@ -1,49 +1,49 @@
-- name: Application Domains and Assemblies
+items:
+- name: Application domains and assemblies
   href: index.md
+- name: Assembly placement
+  href: assembly-placement.md
+- name: Global Assembly Cache
+  href: gac.md
+- name: Working with Assemblies and the Global Assembly Cache
+  href: working-with-assemblies-and-the-gac.md
   items:
-  - name: Assembly placement
-    href: assembly-placement.md
-  - name: Global Assembly Cache
-    href: gac.md
-  - name: Working with Assemblies and the Global Assembly Cache
-    href: working-with-assemblies-and-the-gac.md
-    items:
-    - name: "How to: View the Contents of the Global Assembly Cache"
-      href: how-to-view-the-contents-of-the-gac.md
-    - name: "How to: Install an assembly into the global assembly cache"
-      href: install-assembly-into-gac.md
-    - name: "How to: Remove an Assembly from the Global Assembly Cache"
-      href: how-to-remove-an-assembly-from-the-gac.md
-    - name: Using Serviced Components with the Global Assembly Cache
-      href: use-serviced-components-with-the-gac.md
-  - name: Application Domains
-    href: application-domains.md
-  - name: Application Domains and Assemblies How-to Topics
-    href: application-domains-and-assemblies-how-to-topics.md
-  - name: "How to: Build a single-file assembly"
-    href: build-single-file-assembly.md
-  - name: Multifile assemblies
-    href: multifile-assemblies.md
-  - name: "How to: Build a multifile assembly"
-    href: build-multifile-assembly.md
-  - name: "How to: Share an assembly with other applications"
-    href: how-to-share-an-assembly-with-other-applications.md
-  - name: Using Application Domains
-    href: use.md
-    items:
-    - name: "How to: Create an Application Domain"
-      href: how-to-create-an-application-domain.md
-    - name: "How to: Unload an Application Domain"
-      href: how-to-unload-an-application-domain.md
-    - name: "How to: Configure an Application Domain"
-      href: how-to-configure-an-application-domain.md
-    - name: Retrieving Setup Information from an Application Domain
-      href: retrieve-setup-information.md
-    - name: "How to: Load Assemblies into an Application Domain"
-      href: how-to-load-assemblies-into-an-application-domain.md
-    - name: Shadow Copying Assemblies
-      href: shadow-copy-assemblies.md
-    - name: "How to: Receive First-Chance Exception Notifications"
-      href: how-to-receive-first-chance-exception-notifications.md
-  - name: Running Intranet Applications in Full Trust
-    href: running-intranet-applications-in-full-trust.md
+  - name: "How to: View the Contents of the Global Assembly Cache"
+    href: how-to-view-the-contents-of-the-gac.md
+  - name: "How to: Install an assembly into the global assembly cache"
+    href: install-assembly-into-gac.md
+  - name: "How to: Remove an Assembly from the Global Assembly Cache"
+    href: how-to-remove-an-assembly-from-the-gac.md
+  - name: Using Serviced Components with the Global Assembly Cache
+    href: use-serviced-components-with-the-gac.md
+- name: Application Domains
+  href: application-domains.md
+- name: Application Domains and Assemblies How-to Topics
+  href: application-domains-and-assemblies-how-to-topics.md
+- name: "How to: Build a single-file assembly"
+  href: build-single-file-assembly.md
+- name: Multifile assemblies
+  href: multifile-assemblies.md
+- name: "How to: Build a multifile assembly"
+  href: build-multifile-assembly.md
+- name: "How to: Share an assembly with other applications"
+  href: how-to-share-an-assembly-with-other-applications.md
+- name: Using Application Domains
+  href: use.md
+  items:
+  - name: "How to: Create an Application Domain"
+    href: how-to-create-an-application-domain.md
+  - name: "How to: Unload an Application Domain"
+    href: how-to-unload-an-application-domain.md
+  - name: "How to: Configure an Application Domain"
+    href: how-to-configure-an-application-domain.md
+  - name: Retrieving Setup Information from an Application Domain
+    href: retrieve-setup-information.md
+  - name: "How to: Load Assemblies into an Application Domain"
+    href: how-to-load-assemblies-into-an-application-domain.md
+  - name: Shadow Copying Assemblies
+    href: shadow-copy-assemblies.md
+  - name: "How to: Receive First-Chance Exception Notifications"
+    href: how-to-receive-first-chance-exception-notifications.md
+- name: Running Intranet Applications in Full Trust
+  href: running-intranet-applications-in-full-trust.md

--- a/docs/framework/configure-apps/file-schema/appsettings/toc.yml
+++ b/docs/framework/configure-apps/file-schema/appsettings/toc.yml
@@ -1,12 +1,12 @@
+items:
 - name: App settings schema
   href: index.md
+- name: <appSettings> element for <configuration>
+  href: appsettings-element-for-configuration.md
   items:
-  - name: <appSettings> element for <configuration>
-    href: appsettings-element-for-configuration.md
-    items:
-    - name: <add> element
-      href: add-element-for-appsettings.md
-    - name: <clear> element
-      href: clear-element-for-appsettings.md
-    - name: <remove> element
-      href: remove-element-for-appsettings.md
+  - name: <add> element
+    href: add-element-for-appsettings.md
+  - name: <clear> element
+    href: clear-element-for-appsettings.md
+  - name: <remove> element
+    href: remove-element-for-appsettings.md

--- a/docs/framework/configure-apps/file-schema/compiler/toc.yml
+++ b/docs/framework/configure-apps/file-schema/compiler/toc.yml
@@ -1,14 +1,14 @@
-- name: Compiler and Language Provider Settings Schema
+items:
+- name: Compiler and language provider settings schema
   href: index.md
+- name: <system.codedom> element
+  href: system-codedom-element.md
   items:
-  - name: <system.codedom> Element
-    href: system-codedom-element.md
+  - name: <compilers> element
+    href: compilers-element.md
     items:
-    - name: <compilers> Element
-      href: compilers-element.md
+    - name: <compiler> element
+      href: compiler-element.md
       items:
-      - name: <compiler> Element
-        href: compiler-element.md
-        items:
-        - name: <providerOption> Element
-          href: provideroption-element.md
+      - name: <providerOption> element
+        href: provideroption-element.md

--- a/docs/framework/configure-apps/file-schema/cryptography/toc.yml
+++ b/docs/framework/configure-apps/file-schema/cryptography/toc.yml
@@ -1,24 +1,24 @@
-- name: Cryptography Settings Schema
+items:
+- name: Cryptography settings schema
   href: index.md
+- name: <mscorlib> element for cryptography settings
+  href: mscorlib-element-for-cryptography-settings.md
   items:
-  - name: <mscorlib> Element for Cryptography Settings
-    href: mscorlib-element-for-cryptography-settings.md
+  - name: <cryptographySettings> element
+    href: cryptographysettings-element.md
     items:
-    - name: <cryptographySettings> Element
-      href: cryptographysettings-element.md
+    - name: <cryptoNameMapping> element
+      href: cryptonamemapping-element.md
       items:
-      - name: <cryptoNameMapping> Element
-        href: cryptonamemapping-element.md
+      - name: <cryptoClasses> element
+        href: cryptoclasses-element.md
         items:
-        - name: <cryptoClasses> Element
-          href: cryptoclasses-element.md
-          items:
-          - name: <cryptoClass> Element
-            href: cryptoclass-element.md
-        - name: <nameEntry> Element
-          href: nameentry-element.md
-      - name: <oidMap> Element
-        href: oidmap-element.md
-        items:
-        - name: <oidEntry> Element
-          href: oidentry-element.md
+        - name: <cryptoClass> element
+          href: cryptoclass-element.md
+      - name: <nameEntry> element
+        href: nameentry-element.md
+    - name: <oidMap> element
+      href: oidmap-element.md
+      items:
+      - name: <oidEntry> element
+        href: oidentry-element.md

--- a/docs/framework/configure-apps/file-schema/network/toc.yml
+++ b/docs/framework/configure-apps/file-schema/network/toc.yml
@@ -1,99 +1,99 @@
+items:
 - name: Network settings schema
   href: index.md
+- name: <system.Net> element (network settings)
+  href: system-net-element-network-settings.md
   items:
-  - name: <system.Net> element (network settings)
-    href: system-net-element-network-settings.md
+  - name: <authenticationModules> element
+    href: authenticationmodules-element-network-settings.md
     items:
-    - name: <authenticationModules> element
-      href: authenticationmodules-element-network-settings.md
-      items:
-      - name: <add> element for authenticationModules
-        href: add-element-for-authenticationmodules-network-settings.md
-      - name: <remove> element for authenticationModules
-        href: remove-element-for-authenticationmodules-network-settings.md
-      - name: <clear> element for authenticationModules
-        href: clear-element-for-authenticationmodules-network-settings.md
-    - name: <connectionManagement> element
-      href: connectionmanagement-element-network-settings.md
-      items:
-      - name: <add> element for connectionManagement
-        href: add-element-for-connectionmanagement-network-settings.md
-      - name: <clear> element for connectionManagement
-        href: clear-element-for-connectionmanagement-network-settings.md
-      - name: <remove> element for connectionManagement
-        href: remove-element-for-connectionmanagement-network-settings.md
-    - name: <defaultProxy> element
-      href: defaultproxy-element-network-settings.md
-      items:
-      - name: <bypasslist> element
-        href: bypasslist-element-network-settings.md
-        items:
-        - name: <add> element for bypasslist
-          href: add-element-for-bypasslist-network-settings.md
-        - name: <clear> element for bypasslist
-          href: clear-element-for-bypasslist-network-settings.md
-        - name: <remove> element for bypasslist
-          href: remove-element-for-bypasslist-network-settings.md
-      - name: <module> element
-        href: module-element-network-settings.md
-      - name: <proxy> element
-        href: proxy-element-network-settings.md
-    - name: <mailSettings> element
-      href: mailsettings-element-network-settings.md
-      items:
-      - name: <smtp> element
-        href: smtp-element-network-settings.md
-        items:
-        - name: <specifiedPickupDirectory> element
-          href: specifiedpickupdirectory-element-network-settings.md
-        - name: <network> element
-          href: network-element-network-settings.md
-    - name: <requestCaching> element
-      href: requestcaching-element-network-settings.md
-      items:
-      - name: <defaultHttpCachePolicy> element
-        href: defaulthttpcachepolicy-element-network-settings.md
-      - name: <defaultFtpCachePolicy> element
-        href: defaultftpcachepolicy-element-network-settings.md
-    - name: <settings> element
-      href: settings-element-network-settings.md
-      items:
-      - name: <httpWebRequest> element
-        href: httpwebrequest-element-network-settings.md
-      - name: <ipv6> element
-        href: ipv6-element-network-settings.md
-      - name: <performanceCounter> element
-        href: performancecounter-element-network-settings.md
-      - name: <servicePointManager> element
-        href: servicepointmanager-element-network-settings.md
-      - name: <socket> element
-        href: socket-element-network-settings.md
-      - name: <webProxyScript> element
-        href: webproxyscript-element-network-settings.md
-      - name: <httpListener> element
-        href: httplistener-element-network-settings.md
-    - name: <webRequestModules> element
-      href: webrequestmodules-element-network-settings.md
-      items:
-      - name: <add> element for webRequestModules
-        href: add-element-for-webrequestmodules-network-settings.md
-      - name: <remove> element for webRequestModules
-        href: remove-element-for-webrequestmodules-network-settings.md
-      - name: <clear> element for webRequestModules
-        href: clear-element-for-webrequestmodules-network-settings.md
-  - name: <uri> element (Uri settings)
-    href: uri-element-uri-settings.md
+    - name: <add> element for authenticationModules
+      href: add-element-for-authenticationmodules-network-settings.md
+    - name: <remove> element for authenticationModules
+      href: remove-element-for-authenticationmodules-network-settings.md
+    - name: <clear> element for authenticationModules
+      href: clear-element-for-authenticationmodules-network-settings.md
+  - name: <connectionManagement> element
+    href: connectionmanagement-element-network-settings.md
     items:
-    - name: <idn> element
-      href: idn-element-uri-settings.md
-    - name: <iriParsing> element
-      href: iriparsing-element-uri-settings.md
-    - name: <schemeSettings> element
-      href: schemesettings-element-uri-settings.md
+    - name: <add> element for connectionManagement
+      href: add-element-for-connectionmanagement-network-settings.md
+    - name: <clear> element for connectionManagement
+      href: clear-element-for-connectionmanagement-network-settings.md
+    - name: <remove> element for connectionManagement
+      href: remove-element-for-connectionmanagement-network-settings.md
+  - name: <defaultProxy> element
+    href: defaultproxy-element-network-settings.md
+    items:
+    - name: <bypasslist> element
+      href: bypasslist-element-network-settings.md
       items:
-      - name: <add> element for schemeSettings
-        href: add-element-for-schemesettings-uri-settings.md
-      - name: <clear> element for schemeSettings
-        href: clear-element-for-schemesettings-uri-settings.md
-      - name: <remove> element for schemeSettings
-        href: remove-element-for-schemesettings-uri-settings.md
+      - name: <add> element for bypasslist
+        href: add-element-for-bypasslist-network-settings.md
+      - name: <clear> element for bypasslist
+        href: clear-element-for-bypasslist-network-settings.md
+      - name: <remove> element for bypasslist
+        href: remove-element-for-bypasslist-network-settings.md
+    - name: <module> element
+      href: module-element-network-settings.md
+    - name: <proxy> element
+      href: proxy-element-network-settings.md
+  - name: <mailSettings> element
+    href: mailsettings-element-network-settings.md
+    items:
+    - name: <smtp> element
+      href: smtp-element-network-settings.md
+      items:
+      - name: <specifiedPickupDirectory> element
+        href: specifiedpickupdirectory-element-network-settings.md
+      - name: <network> element
+        href: network-element-network-settings.md
+  - name: <requestCaching> element
+    href: requestcaching-element-network-settings.md
+    items:
+    - name: <defaultHttpCachePolicy> element
+      href: defaulthttpcachepolicy-element-network-settings.md
+    - name: <defaultFtpCachePolicy> element
+      href: defaultftpcachepolicy-element-network-settings.md
+  - name: <settings> element
+    href: settings-element-network-settings.md
+    items:
+    - name: <httpWebRequest> element
+      href: httpwebrequest-element-network-settings.md
+    - name: <ipv6> element
+      href: ipv6-element-network-settings.md
+    - name: <performanceCounter> element
+      href: performancecounter-element-network-settings.md
+    - name: <servicePointManager> element
+      href: servicepointmanager-element-network-settings.md
+    - name: <socket> element
+      href: socket-element-network-settings.md
+    - name: <webProxyScript> element
+      href: webproxyscript-element-network-settings.md
+    - name: <httpListener> element
+      href: httplistener-element-network-settings.md
+  - name: <webRequestModules> element
+    href: webrequestmodules-element-network-settings.md
+    items:
+    - name: <add> element for webRequestModules
+      href: add-element-for-webrequestmodules-network-settings.md
+    - name: <remove> element for webRequestModules
+      href: remove-element-for-webrequestmodules-network-settings.md
+    - name: <clear> element for webRequestModules
+      href: clear-element-for-webrequestmodules-network-settings.md
+- name: <uri> element (Uri settings)
+  href: uri-element-uri-settings.md
+  items:
+  - name: <idn> element
+    href: idn-element-uri-settings.md
+  - name: <iriParsing> element
+    href: iriparsing-element-uri-settings.md
+  - name: <schemeSettings> element
+    href: schemesettings-element-uri-settings.md
+    items:
+    - name: <add> element for schemeSettings
+      href: add-element-for-schemesettings-uri-settings.md
+    - name: <clear> element for schemeSettings
+      href: clear-element-for-schemesettings-uri-settings.md
+    - name: <remove> element for schemeSettings
+      href: remove-element-for-schemesettings-uri-settings.md

--- a/docs/framework/configure-apps/file-schema/startup/toc.yml
+++ b/docs/framework/configure-apps/file-schema/startup/toc.yml
@@ -1,10 +1,10 @@
-- name: Startup Settings Schema
+items:
+- name: Startup settings schema
   href: index.md
+- name: <startup> element
+  href: startup-element.md
   items:
-  - name: <startup> Element
-    href: startup-element.md
-    items:
-    - name: <requiredRuntime> Element
-      href: requiredruntime-element.md
-    - name: <supportedRuntime> Element
-      href: supportedruntime-element.md
+  - name: <requiredRuntime> element
+    href: requiredruntime-element.md
+  - name: <supportedRuntime> element
+    href: supportedruntime-element.md

--- a/docs/framework/configure-apps/file-schema/toc.yml
+++ b/docs/framework/configure-apps/file-schema/toc.yml
@@ -1,53 +1,53 @@
-- name: Configuration File Schema
+items:
+- name: Configuration file schema
   href: index.md
-  items:
-  - name: <configuration> Element
-    href: configuration-element.md
-  - name: <assemblyBinding> Element
-    href: assemblybinding-element-for-configuration.md
-  - name: <linkedConfiguration> Element
-    href: linkedconfiguration-element.md
-  - name: <configSections> Element
-    href: configsections-element-for-configuration.md
-  - name: <sectionGroup> Element
-    href: sectiongroup-element-for-configsections.md
-  - name: Custom Element for SingleTagSectionHandler
-    href: custom-element-1.md
-  - name: Custom Element for NameValueSectionHandler and DictionarySectionHandler
-    href: custom-element-2.md
-  - name: <add> Element
-    href: add-element-for-custom-2.md
-  - name: <clear> Element for NameValueSectionHandler and DictionarySectionHandler
-    href: clear-element-for-custom-2.md
-  - name: <remove> Element for NameValueSectionHandler and DictionarySectionHandler
-    href: remove-element-for-custom-2.md
-  - name: <section> Element
-    href: section-element.md
-  - name: App Settings Schema
-    href: appsettings/index.md
-  - name: Application Settings Schema
-    href: application-settings-schema.md
-  - name: Compiler and Language Provider Settings Schema
-    href: compiler/index.md
-  - name: Configuration Sections Schema
-    href: configuration-sections-schema.md
-  - name: Cryptography Settings Schema
-    href: cryptography/index.md
-  - name: Network Settings Schema
-    href: network/index.md
-  - name: Runtime Settings Schema
-    href: runtime/index.md
-  - name: Startup Settings Schema
-    href: startup/index.md
-  - name: Trace and Debug Settings Schema
-    href: trace-debug/index.md
-  - name: Web Settings Schema
-    href: web/index.md
-  - name: WCF Configuration Schema
-    href: wcf/index.md
-  - name: WCF Directive Syntax
-    href: wcf-directive/index.md
-  - name: Windows Forms Configuration Section
-    href: winforms/index.md
-  - name: Windows Workflow Foundation Configuration Schema
-    href: windows-workflow-foundation/index.md
+- name: <configuration> Element
+  href: configuration-element.md
+- name: <assemblyBinding> Element
+  href: assemblybinding-element-for-configuration.md
+- name: <linkedConfiguration> Element
+  href: linkedconfiguration-element.md
+- name: <configSections> Element
+  href: configsections-element-for-configuration.md
+- name: <sectionGroup> Element
+  href: sectiongroup-element-for-configsections.md
+- name: Custom Element for SingleTagSectionHandler
+  href: custom-element-1.md
+- name: Custom Element for NameValueSectionHandler and DictionarySectionHandler
+  href: custom-element-2.md
+- name: <add> Element
+  href: add-element-for-custom-2.md
+- name: <clear> Element for NameValueSectionHandler and DictionarySectionHandler
+  href: clear-element-for-custom-2.md
+- name: <remove> Element for NameValueSectionHandler and DictionarySectionHandler
+  href: remove-element-for-custom-2.md
+- name: <section> Element
+  href: section-element.md
+- name: App Settings Schema
+  href: appsettings/index.md
+- name: Application Settings Schema
+  href: application-settings-schema.md
+- name: Compiler and Language Provider Settings Schema
+  href: compiler/index.md
+- name: Configuration Sections Schema
+  href: configuration-sections-schema.md
+- name: Cryptography Settings Schema
+  href: cryptography/index.md
+- name: Network Settings Schema
+  href: network/index.md
+- name: Runtime Settings Schema
+  href: runtime/index.md
+- name: Startup Settings Schema
+  href: startup/index.md
+- name: Trace and Debug Settings Schema
+  href: trace-debug/index.md
+- name: Web Settings Schema
+  href: web/index.md
+- name: WCF Configuration Schema
+  href: wcf/index.md
+- name: WCF Directive Syntax
+  href: wcf-directive/index.md
+- name: Windows Forms Configuration Section
+  href: winforms/index.md
+- name: Windows Workflow Foundation Configuration Schema
+  href: windows-workflow-foundation/index.md

--- a/docs/framework/configure-apps/file-schema/trace-debug/toc.yml
+++ b/docs/framework/configure-apps/file-schema/trace-debug/toc.yml
@@ -1,56 +1,56 @@
-- name: Trace and Debug Settings Schema
+items:
+- name: Trace and debug settings schema
   href: index.md
+- name: <system.diagnostics>
+  href: system-diagnostics-element.md
   items:
-  - name: <system.diagnostics>
-    href: system-diagnostics-element.md
+  - name: <assert>
+    href: assert-element.md
+  - name: <performanceCounters>
+    href: performancecounters-element.md
+  - name: <sharedListeners>
+    href: sharedlisteners-element.md
     items:
-    - name: <assert>
-      href: assert-element.md
-    - name: <performanceCounters>
-      href: performancecounters-element.md
-    - name: <sharedListeners>
-      href: sharedlisteners-element.md
+    - name: <add>
+      href: add-element-for-sharedlisteners.md
       items:
-      - name: <add>
-        href: add-element-for-sharedlisteners.md
-        items:
-        - name: <filter>
-          href: filter-element-for-add-for-sharedlisteners.md
-    - name: <sources>
-      href: sources-element.md
-      items:
-      - name: <source>
-        href: source-element.md
-        items:
-        - name: <listeners>
-          href: listeners-element-for-source.md
-          items:
-          - name: <add>
-            href: add-element-for-listeners-for-source.md
-            items:
-            - name: <filter>
-              href: filter-element-for-add-for-listeners-for-source.md
-          - name: <clear>
-            href: clear-element-for-listeners-for-source.md
-          - name: <remove>
-            href: remove-element-for-listeners-for-source.md
-    - name: <switches>
-      href: switches-element.md
-      items:
-      - name: <add>
-        href: add-element-for-switches.md
-    - name: <trace>
-      href: trace-element.md
+      - name: <filter>
+        href: filter-element-for-add-for-sharedlisteners.md
+  - name: <sources>
+    href: sources-element.md
+    items:
+    - name: <source>
+      href: source-element.md
       items:
       - name: <listeners>
-        href: listeners-element-for-trace.md
+        href: listeners-element-for-source.md
         items:
         - name: <add>
-          href: add-element-for-listeners-for-trace.md
+          href: add-element-for-listeners-for-source.md
           items:
           - name: <filter>
-            href: filter-element-for-add-for-listeners-for-trace.md
+            href: filter-element-for-add-for-listeners-for-source.md
         - name: <clear>
-          href: clear-element-for-listeners-for-trace.md
+          href: clear-element-for-listeners-for-source.md
         - name: <remove>
-          href: remove-element-for-listeners-for-trace.md
+          href: remove-element-for-listeners-for-source.md
+  - name: <switches>
+    href: switches-element.md
+    items:
+    - name: <add>
+      href: add-element-for-switches.md
+  - name: <trace>
+    href: trace-element.md
+    items:
+    - name: <listeners>
+      href: listeners-element-for-trace.md
+      items:
+      - name: <add>
+        href: add-element-for-listeners-for-trace.md
+        items:
+        - name: <filter>
+          href: filter-element-for-add-for-listeners-for-trace.md
+      - name: <clear>
+        href: clear-element-for-listeners-for-trace.md
+      - name: <remove>
+        href: remove-element-for-listeners-for-trace.md

--- a/docs/framework/configure-apps/file-schema/wcf-directive/toc.yml
+++ b/docs/framework/configure-apps/file-schema/wcf-directive/toc.yml
@@ -1,5 +1,5 @@
-- name: WCF Directive Syntax
+items:
+- name: WCF directive syntax
   href: index.md
-  items:
-  - name: "@ServiceHost"
-    href: servicehost.md
+- name: "@ServiceHost"
+  href: servicehost.md

--- a/docs/framework/configure-apps/file-schema/wcf/toc.yml
+++ b/docs/framework/configure-apps/file-schema/wcf/toc.yml
@@ -1,724 +1,724 @@
-- name: WCF Configuration Schema
+items:
+- name: WCF configuration schema
   href: index.md
+- name: <system.serviceModel>
+  href: system-servicemodel.md
   items:
-  - name: <system.serviceModel>
-    href: system-servicemodel.md
+  - name: <behaviors>
+    href: behaviors.md
     items:
-    - name: <behaviors>
-      href: behaviors.md
+    - name: <endpointBehaviors>
+      href: endpointbehaviors.md
       items:
-      - name: <endpointBehaviors>
-        href: endpointbehaviors.md
+      - name: <behavior>
+        href: behavior-of-endpointbehaviors.md
         items:
-        - name: <behavior>
-          href: behavior-of-endpointbehaviors.md
+        - name: <clientCredentials>
+          href: clientcredentials.md
           items:
-          - name: <clientCredentials>
-            href: clientcredentials.md
+          - name: <clientCertificate>
+            href: clientcertificate-of-clientcredentials-element.md
+          - name: <httpDigest>
+            href: httpdigest-element.md
+          - name: <issuedToken>
+            href: issuedtoken.md
             items:
-            - name: <clientCertificate>
-              href: clientcertificate-of-clientcredentials-element.md
-            - name: <httpDigest>
-              href: httpdigest-element.md
-            - name: <issuedToken>
-              href: issuedtoken.md
-              items:
-              - name: <issuerChannelBehaviors>
-                href: issuerchannelbehaviors-element.md
-                items:
-                - name: <add>
-                  href: add-of-issuerchannelbehaviors.md
-              - name: <localIssuer>
-                href: localissuer.md
-                items:
-                - name: <headers>
-                  href: headers-element.md
-            - name: <peer>
-              href: peer-of-clientcredentials-element.md
-              items:
-              - name: <certificate>
-                href: certificate-element.md
-              - name: <messageSenderAuthentication>
-                href: messagesenderauthentication-element.md
-              - name: <peerAuthentication>
-                href: peerauthentication-element.md
-            - name: <serviceCertificate>
-              href: servicecertificate-of-clientcredentials-element.md
-              items:
-              - name: <authentication>
-                href: authentication-of-servicecertificate-element.md
-              - name: <defaultCertificate>
-                href: defaultcertificate-element.md
-              - name: <scopedCertificates>
-                href: scopedcertificates-element.md
-                items:
-                - name: <add>
-                  href: add-of-scopedcertificates-element.md
-            - name: <windows>
-              href: windows-of-clientcredentials-element.md
-          - name: <callbackDebug>
-            href: callbackdebug.md
-          - name: <callbackTimeouts>
-            href: callbacktimeouts.md
-          - name: <clientVia>
-            href: clientvia.md
-          - name: <dataContractSerializer>
-            href: datacontractserializer.md
-          - name: <dispatcherSynchronization>
-            href: dispatchersynchronization.md
-          - name: <enableWebScript>
-            href: enablewebscript.md
-          - name: <endpointDiscovery>
-            href: endpointdiscovery.md
-            items:
-            - name: <scopes>
-              href: scopes.md
+            - name: <issuerChannelBehaviors>
+              href: issuerchannelbehaviors-element.md
               items:
               - name: <add>
-                href: add-of-scopes.md
-            - name: <extensions>
-              href: extensions.md
-          - name: <soapProcessing>
-            href: soapprocessing.md
-          - name: <synchronousReceive>
-            href: synchronousreceive-element.md
-          - name: <transactedBatching>
-            href: transactedbatching.md
-          - name: <webHttp>
-            href: webhttp.md
-      - name: <serviceBehaviors>
-        href: servicebehaviors.md
-        items:
-        - name: <behavior>
-          href: behavior-of-servicebehaviors.md
+                href: add-of-issuerchannelbehaviors.md
+            - name: <localIssuer>
+              href: localissuer.md
+              items:
+              - name: <headers>
+                href: headers-element.md
+          - name: <peer>
+            href: peer-of-clientcredentials-element.md
+            items:
+            - name: <certificate>
+              href: certificate-element.md
+            - name: <messageSenderAuthentication>
+              href: messagesenderauthentication-element.md
+            - name: <peerAuthentication>
+              href: peerauthentication-element.md
+          - name: <serviceCertificate>
+            href: servicecertificate-of-clientcredentials-element.md
+            items:
+            - name: <authentication>
+              href: authentication-of-servicecertificate-element.md
+            - name: <defaultCertificate>
+              href: defaultcertificate-element.md
+            - name: <scopedCertificates>
+              href: scopedcertificates-element.md
+              items:
+              - name: <add>
+                href: add-of-scopedcertificates-element.md
+          - name: <windows>
+            href: windows-of-clientcredentials-element.md
+        - name: <callbackDebug>
+          href: callbackdebug.md
+        - name: <callbackTimeouts>
+          href: callbacktimeouts.md
+        - name: <clientVia>
+          href: clientvia.md
+        - name: <dataContractSerializer>
+          href: datacontractserializer.md
+        - name: <dispatcherSynchronization>
+          href: dispatchersynchronization.md
+        - name: <enableWebScript>
+          href: enablewebscript.md
+        - name: <endpointDiscovery>
+          href: endpointdiscovery.md
           items:
-          - name: <dataContractSerializer>
-            href: datacontractserializer-element.md
-          - name: <persistenceProvider>
-            href: persistenceprovider.md
-          - name: <routing>
-            href: routing-of-servicebehavior.md
-          - name: <serviceAuthenticationManager>
-            href: serviceauthenticationmanager.md
-          - name: <serviceAuthorization>
-            href: serviceauthorization-element.md
+          - name: <scopes>
+            href: scopes.md
             items:
-            - name: <authorizationPolicies>
-              href: authorizationpolicies.md
-              items:
-              - name: <add>
-                href: add-of-authorizationpolicies.md
-          - name: <serviceCredentials>
-            href: servicecredentials.md
-            items:
-            - name: <clientCertificate>
-              href: clientcertificate-of-servicecredentials.md
-              items:
-              - name: <authentication>
-                href: authentication-of-clientcertificate-element.md
-              - name: <certificate>
-                href: certificate-of-clientcertificate-element.md
-            - name: <issuedTokenAuthentication>
-              href: issuedtokenauthentication-of-servicecredentials.md
-              items:
-              - name: <allowedAudienceUris>
-                href: allowedaudienceuris.md
-                items:
-                - name: <add>
-                  href: add-of-allowedaudienceuris.md
-              - name: <knownCertificates>
-                href: knowncertificates.md
-                items:
-                - name: <add>
-                  href: add-of-knowncertificates.md
-            - name: <peer>
-              href: peer-of-servicecredentials.md
-              items:
-              - name: <certificate>
-                href: certificate-of-peer.md
-              - name: <messageSenderAuthentication>
-                href: messagesenderauthentication.md
-              - name: <peerAuthentication>
-                href: peerauthentication.md
-            - name: <serviceCertificate>
-              href: servicecertificate-of-servicecredentials.md
-            - name: <secureConversationAuthentication>
-              href: secureconversationauthentication-of-servicecredential.md
-            - name: <userNameAuthentication>
-              href: usernameauthentication.md
-            - name: <windowsAuthentication>
-              href: windowsauthentication-of-servicecredentials.md
-          - name: <serviceDebug>
-            href: servicedebug.md
-          - name: <serviceDiscovery>
-            href: servicediscovery.md
-          - name: <serviceMetadata>
-            href: servicemetadata.md
-          - name: <serviceSecurityAudit>
-            href: servicesecurityaudit.md
-          - name: <serviceThrottling>
-            href: servicethrottling.md
-          - name: <serviceTimeouts>
-            href: servicetimeouts.md
-          - name: <workflowRuntime>
-            href: workflowruntime.md
-            items:
-            - name: <commonParameters>
-              href: commonparameters.md
-              items:
-              - name: <add>
-                href: add-of-commonparameters.md
-            - name: <services>
-              href: services-of-workflowruntime.md
-              items:
-              - name: <add>
-                href: add-of-services.md
-          - name: <useRequestHeadersForMetadataAddress>
-            href: userequestheadersformetadataaddress.md
-            items:
-            - name: <defaultPorts>
-              href: defaultports.md
-              items:
-              - name: <add> of <defaultPorts>
-                href: add-of-defaultports.md
-    - name: <bindings>
-      href: bindings.md
+            - name: <add>
+              href: add-of-scopes.md
+          - name: <extensions>
+            href: extensions.md
+        - name: <soapProcessing>
+          href: soapprocessing.md
+        - name: <synchronousReceive>
+          href: synchronousreceive-element.md
+        - name: <transactedBatching>
+          href: transactedbatching.md
+        - name: <webHttp>
+          href: webhttp.md
+    - name: <serviceBehaviors>
+      href: servicebehaviors.md
       items:
-      - name: <basicHttpBinding>
-        href: basichttpbinding.md
+      - name: <behavior>
+        href: behavior-of-servicebehaviors.md
         items:
-        - name: <security>
-          href: security-of-basichttpbinding.md
+        - name: <dataContractSerializer>
+          href: datacontractserializer-element.md
+        - name: <persistenceProvider>
+          href: persistenceprovider.md
+        - name: <routing>
+          href: routing-of-servicebehavior.md
+        - name: <serviceAuthenticationManager>
+          href: serviceauthenticationmanager.md
+        - name: <serviceAuthorization>
+          href: serviceauthorization-element.md
           items:
-          - name: <message>
-            href: message-of-basichttpbinding.md
-          - name: <transport>
-            href: transport-of-basichttpbinding.md
-      - name: <basicHttpContextBinding>
-        href: basichttpcontextbinding.md
-      - name: <mexHttpBinding>
-        href: mexhttpbinding.md
-      - name: <mexHttpsBinding>
-        href: mexhttpsbinding.md
-      - name: <mexNamedPipeBinding>
-        href: mexnamedpipebinding.md
-      - name: <mexTcpBinding>
-        href: mextcpbinding.md
-      - name: <msmqIntegrationBinding>
-        href: msmqintegrationbinding.md
-        items:
-        - name: <security>
-          href: security-of-msmqintegrationbinding.md
-          items:
-          - name: <transport>
-            href: transport-of-msmqintegrationbinding.md
-      - name: <netMsmqBinding>
-        href: netmsmqbinding.md
-        items:
-        - name: <security>
-          href: security-of-netmsmqbinding.md
-          items:
-          - name: <message>
-            href: message-of-netmsmqbinding.md
-          - name: <transport>
-            href: transport-of-netmsmqbinding.md
-      - name: <netNamedPipeBinding>
-        href: netnamedpipebinding.md
-        items:
-        - name: <security>
-          href: security-of-netnamedpipebinding.md
-          items:
-          - name: <transport>
-            href: transport-of-netnamedpipebinding.md
-      - name: <netPeerTcpBinding>
-        href: netpeertcpbinding.md
-        items:
-        - name: <resolver>
-          href: resolver.md
-          items:
-          - name: <custom>
-            href: custom.md
-        - name: <security>
-          href: security-of-netpeerbinding.md
-          items:
-          - name: <transport>
-            href: transport-of-netpeertcpbinding.md
-      - name: <netTcpBinding>
-        href: nettcpbinding.md
-        items:
-        - name: <security>
-          href: security-of-nettcpbinding.md
-          items:
-          - name: <transport>
-            href: transport-of-nettcpbinding.md
-          - name: <message>
-            href: message-element-of-nettcpbinding.md
-      - name: <netTcpContextBinding>
-        href: nettcpcontextbinding.md
-      - name: <webHttpBinding>
-        href: webhttpbinding.md
-        items:
-        - name: <security>
-          href: security-of-webhttpbinding.md
-          items:
-          - name: <transport>
-            href: transport-of-webhttpbinding.md
-      - name: <wsDualHttpBinding>
-        href: wsdualhttpbinding.md
-        items:
-        - name: <security>
-          href: security-of-wsdualhttpbinding.md
-          items:
-          - name: <message>
-            href: message-of-wsdualhttpbinding.md
-      - name: <wsFederationHttpBinding>
-        href: wsfederationhttpbinding.md
-        items:
-        - name: <security>
-          href: security-of-wsfederationhttpbinding.md
-          items:
-          - name: <message>
-            href: message-element-of-wsfederationhttpbinding.md
+          - name: <authorizationPolicies>
+            href: authorizationpolicies.md
             items:
-            - name: <claimTypeRequirements>
-              href: claimtyperequirements-for-message.md
+            - name: <add>
+              href: add-of-authorizationpolicies.md
+        - name: <serviceCredentials>
+          href: servicecredentials.md
+          items:
+          - name: <clientCertificate>
+            href: clientcertificate-of-servicecredentials.md
+            items:
+            - name: <authentication>
+              href: authentication-of-clientcertificate-element.md
+            - name: <certificate>
+              href: certificate-of-clientcertificate-element.md
+          - name: <issuedTokenAuthentication>
+            href: issuedtokenauthentication-of-servicecredentials.md
+            items:
+            - name: <allowedAudienceUris>
+              href: allowedaudienceuris.md
               items:
               - name: <add>
-                href: add-of-claimtyperequirements-element.md
-              - name: <remove>
-                href: remove-of-claimtyperequirements-element.md
-              - name: <clear>
-                href: clear-of-claimtyperequirements-element.md
-            - name: <issuer>
-              href: issuer.md
-            - name: <issuerMetadata>
-              href: issuermetadata.md
-            - name: <tokenRequestParameters>
-              href: tokenrequestparameters.md
-              items:
-              - name: <xmlElement>
-                href: xmlelement.md
-      - name: <wsHttpBinding>
-        href: wshttpbinding.md
-        items:
-        - name: <security>
-          href: security-of-wshttpbinding.md
-          items:
-          - name: <message>
-            href: message-of-wshttpbinding.md
-          - name: <transport>
-            href: transport-of-wshttpbinding.md
-      - name: <wsHttpContextBinding>
-        href: wshttpcontextbinding.md
-      - name: <ws2007FederationHttpBinding>
-        href: ws2007federationhttpbinding.md
-        items:
-        - name: <security>
-          href: security-element-of-ws2007federationhttpbinding.md
-          items:
-          - name: <message>
-            href: message-element-of-ws2007federationhttpbinding.md
-      - name: <ws2007HttpBinding>
-        href: ws2007httpbinding.md
-        items:
-        - name: <security>
-          href: security-of-ws2007httpbinding.md
-          items:
-          - name: <message>
-            href: message-of-ws2007httpbinding.md
-          - name: <transport>
-            href: transport-of-ws2007httpbinding.md
-      - name: <customBinding>
-        href: custombinding.md
-        items:
-        - name: <compositeDuplex>
-          href: compositeduplex.md
-        - name: <discoveryClient>
-          href: discoveryclient.md
-        - name: Message Encoding
-          href: message-encoding.md
-          items:
-          - name: <binaryMessageEncoding>
-            href: binarymessageencoding.md
-          - name: <mtomMessageEncoding>
-            href: mtommessageencoding.md
-          - name: <textMessageEncoding>
-            href: textmessageencoding.md
-          - name: <webMessageEncoding>
-            href: webmessageencoding.md
-          - name: <byteStreamMessageEncoding>
-            href: bytestreammessageencoding.md
-        - name: <oneWay>
-          href: oneway.md
-          items:
-          - name: <channelPoolSettings>
-            href: channelpoolsettings.md
-        - name: <pnrpPeerResolver>
-          href: pnrppeerresolver.md
-        - name: <privacyNoticeAt>
-          href: privacynoticeat.md
-        - name: <reliableSession>
-          href: reliablesession.md
-        - name: <security>
-          href: security-of-custombinding.md
-          items:
-          - name: <issuedTokenParameters>
-            href: issuedtokenparameters.md
-            items:
-            - name: <additionalRequestParameters>
-              href: additionalrequestparameters-element.md
-            - name: <claimTypeRequirements>
-              href: claimtyperequirements-element.md
+                href: add-of-allowedaudienceuris.md
+            - name: <knownCertificates>
+              href: knowncertificates.md
               items:
               - name: <add>
-                href: add-of-claimtyperequirements.md
-            - name: <issuer>
-              href: issuer-of-issuedtokenparameters.md
-            - name: <issuerMetadata>
-              href: issuermetadata-of-issuedtokenparameters.md
-          - name: <localClientSettings>
-            href: localclientsettings-element.md
-          - name: <localServiceSettings>
-            href: localservicesettings-element.md
-          - name: <secureConversationBootstrap>
-            href: secureconversationbootstrap.md
-        - name: <sslStreamSecurity>
-          href: sslstreamsecurity.md
-        - name: <transactionFlow>
-          href: transactionflow.md
-        - name: Transports
-          href: transports.md
+                href: add-of-knowncertificates.md
+          - name: <peer>
+            href: peer-of-servicecredentials.md
+            items:
+            - name: <certificate>
+              href: certificate-of-peer.md
+            - name: <messageSenderAuthentication>
+              href: messagesenderauthentication.md
+            - name: <peerAuthentication>
+              href: peerauthentication.md
+          - name: <serviceCertificate>
+            href: servicecertificate-of-servicecredentials.md
+          - name: <secureConversationAuthentication>
+            href: secureconversationauthentication-of-servicecredential.md
+          - name: <userNameAuthentication>
+            href: usernameauthentication.md
+          - name: <windowsAuthentication>
+            href: windowsauthentication-of-servicecredentials.md
+        - name: <serviceDebug>
+          href: servicedebug.md
+        - name: <serviceDiscovery>
+          href: servicediscovery.md
+        - name: <serviceMetadata>
+          href: servicemetadata.md
+        - name: <serviceSecurityAudit>
+          href: servicesecurityaudit.md
+        - name: <serviceThrottling>
+          href: servicethrottling.md
+        - name: <serviceTimeouts>
+          href: servicetimeouts.md
+        - name: <workflowRuntime>
+          href: workflowruntime.md
           items:
-          - name: <httpTransport>
-            href: httptransport.md
-          - name: <httpsTransport>
-            href: httpstransport.md
-          - name: <msmqIntegration>
-            href: msmqintegration.md
+          - name: <commonParameters>
+            href: commonparameters.md
             items:
-            - name: <msmqTransportSecurity>
-              href: msmqtransportsecurity.md
-          - name: <msmqTransport>
-            href: msmqtransport.md
-          - name: <namedPipeTransport>
-            href: namedpipetransport.md
+            - name: <add>
+              href: add-of-commonparameters.md
+          - name: <services>
+            href: services-of-workflowruntime.md
             items:
-            - name: <connectionPoolSettings> of <namedPipeTransport>
-              href: connectionpoolsettings.md
-          - name: <peerTransport>
-            href: peertransport.md
-            items:
-            - name: <security>
-              href: security-of-peertransport.md
-              items:
-              - name: <transport>
-                href: transport-of-peertransport.md
-          - name: <tcpTransport>
-            href: tcptransport.md
-            items:
-            - name: <connectionPoolSettings>
-              href: connectionpoolsettings-of-tcptransport.md
-        - name: <unrecognizedPolicyAssertion>
-          href: unrecognizedpolicyassertion.md
-        - name: <useManagedPresentation>
-          href: usemanagedpresentation.md
-        - name: <windowsStreamSecurity>
-          href: windowsstreamsecurity.md
-      - name: <netHttpBinding>
-        href: nethttpbinding.md
-        items:
-        - name: <security>
-          href: security-of-nethttpbinding.md
+            - name: <add>
+              href: add-of-services.md
+        - name: <useRequestHeadersForMetadataAddress>
+          href: userequestheadersformetadataaddress.md
           items:
-          - name: <message>
-            href: message-of-nethttpbinding.md
-          - name: <transport>
-            href: transport-of-nethttpbinding.md
-        - name: <webSocketSettings>
-          href: websocketsettings.md
-      - name: <netHttpsBinding>
-        href: nethttpsbinding.md
-      - name: <udpBinding>
-        href: udpbinding.md
-    - name: <client>
-      href: client.md
+          - name: <defaultPorts>
+            href: defaultports.md
+            items:
+            - name: <add> of <defaultPorts>
+              href: add-of-defaultports.md
+  - name: <bindings>
+    href: bindings.md
+    items:
+    - name: <basicHttpBinding>
+      href: basichttpbinding.md
       items:
-      - name: <endpoint>
-        href: endpoint-of-client.md
+      - name: <security>
+        href: security-of-basichttpbinding.md
         items:
-        - name: <headers>
-          href: headers.md
-        - name: <identity>
-          href: identity.md
-          items:
-          - name: <certificate>
-            href: certificate-for-identity.md
-          - name: <certificateReference>
-            href: certificatereference-for-identity.md
-          - name: <dns>
-            href: dns.md
-          - name: <rsa>
-            href: rsa.md
-          - name: <servicePrincipalName>
-            href: serviceprincipalname.md
-          - name: <userPrincipalName>
-            href: userprincipalname.md
-      - name: <metadata>
-        href: metadata.md
-        items:
-        - name: <wsdlImporters>
-          href: wsdlimporters.md
-          items:
-          - name: <wsdlImporter>
-            href: wsdlimporter.md
-        - name: <policyImporters>
-          href: policyimporters.md
-          items:
-          - name: <policyImporter>
-            href: policyimporter.md
-    - name: <comContracts>
-      href: comcontracts.md
+        - name: <message>
+          href: message-of-basichttpbinding.md
+        - name: <transport>
+          href: transport-of-basichttpbinding.md
+    - name: <basicHttpContextBinding>
+      href: basichttpcontextbinding.md
+    - name: <mexHttpBinding>
+      href: mexhttpbinding.md
+    - name: <mexHttpsBinding>
+      href: mexhttpsbinding.md
+    - name: <mexNamedPipeBinding>
+      href: mexnamedpipebinding.md
+    - name: <mexTcpBinding>
+      href: mextcpbinding.md
+    - name: <msmqIntegrationBinding>
+      href: msmqintegrationbinding.md
       items:
-      - name: <comContract>
-        href: comcontract.md
+      - name: <security>
+        href: security-of-msmqintegrationbinding.md
         items:
-        - name: <exposedMethods>
-          href: exposedmethods.md
-          items:
-          - name: <exposedMethod>
-            href: exposedmethod.md
-        - name: <persistableTypes>
-          href: persistabletypes.md
-          items:
-          - name: <persistableType>
-            href: persistabletype.md
-        - name: <userDefinedTypes>
-          href: userdefinedtypes.md
-          items:
-          - name: <userDefinedType>
-            href: userdefinedtype.md
-    - name: <commonBehaviors>
-      href: commonbehaviors.md
-    - name: <diagnostics>
-      href: diagnostics.md
+        - name: <transport>
+          href: transport-of-msmqintegrationbinding.md
+    - name: <netMsmqBinding>
+      href: netmsmqbinding.md
       items:
-      - name: <endToEndTracing>
-        href: endtoendtracing.md
-      - name: <messageLogging>
-        href: messagelogging.md
+      - name: <security>
+        href: security-of-netmsmqbinding.md
         items:
-        - name: <filters>
-          href: filters.md
+        - name: <message>
+          href: message-of-netmsmqbinding.md
+        - name: <transport>
+          href: transport-of-netmsmqbinding.md
+    - name: <netNamedPipeBinding>
+      href: netnamedpipebinding.md
+      items:
+      - name: <security>
+        href: security-of-netnamedpipebinding.md
+        items:
+        - name: <transport>
+          href: transport-of-netnamedpipebinding.md
+    - name: <netPeerTcpBinding>
+      href: netpeertcpbinding.md
+      items:
+      - name: <resolver>
+        href: resolver.md
+        items:
+        - name: <custom>
+          href: custom.md
+      - name: <security>
+        href: security-of-netpeerbinding.md
+        items:
+        - name: <transport>
+          href: transport-of-netpeertcpbinding.md
+    - name: <netTcpBinding>
+      href: nettcpbinding.md
+      items:
+      - name: <security>
+        href: security-of-nettcpbinding.md
+        items:
+        - name: <transport>
+          href: transport-of-nettcpbinding.md
+        - name: <message>
+          href: message-element-of-nettcpbinding.md
+    - name: <netTcpContextBinding>
+      href: nettcpcontextbinding.md
+    - name: <webHttpBinding>
+      href: webhttpbinding.md
+      items:
+      - name: <security>
+        href: security-of-webhttpbinding.md
+        items:
+        - name: <transport>
+          href: transport-of-webhttpbinding.md
+    - name: <wsDualHttpBinding>
+      href: wsdualhttpbinding.md
+      items:
+      - name: <security>
+        href: security-of-wsdualhttpbinding.md
+        items:
+        - name: <message>
+          href: message-of-wsdualhttpbinding.md
+    - name: <wsFederationHttpBinding>
+      href: wsfederationhttpbinding.md
+      items:
+      - name: <security>
+        href: security-of-wsfederationhttpbinding.md
+        items:
+        - name: <message>
+          href: message-element-of-wsfederationhttpbinding.md
+          items:
+          - name: <claimTypeRequirements>
+            href: claimtyperequirements-for-message.md
+            items:
+            - name: <add>
+              href: add-of-claimtyperequirements-element.md
+            - name: <remove>
+              href: remove-of-claimtyperequirements-element.md
+            - name: <clear>
+              href: clear-of-claimtyperequirements-element.md
+          - name: <issuer>
+            href: issuer.md
+          - name: <issuerMetadata>
+            href: issuermetadata.md
+          - name: <tokenRequestParameters>
+            href: tokenrequestparameters.md
+            items:
+            - name: <xmlElement>
+              href: xmlelement.md
+    - name: <wsHttpBinding>
+      href: wshttpbinding.md
+      items:
+      - name: <security>
+        href: security-of-wshttpbinding.md
+        items:
+        - name: <message>
+          href: message-of-wshttpbinding.md
+        - name: <transport>
+          href: transport-of-wshttpbinding.md
+    - name: <wsHttpContextBinding>
+      href: wshttpcontextbinding.md
+    - name: <ws2007FederationHttpBinding>
+      href: ws2007federationhttpbinding.md
+      items:
+      - name: <security>
+        href: security-element-of-ws2007federationhttpbinding.md
+        items:
+        - name: <message>
+          href: message-element-of-ws2007federationhttpbinding.md
+    - name: <ws2007HttpBinding>
+      href: ws2007httpbinding.md
+      items:
+      - name: <security>
+        href: security-of-ws2007httpbinding.md
+        items:
+        - name: <message>
+          href: message-of-ws2007httpbinding.md
+        - name: <transport>
+          href: transport-of-ws2007httpbinding.md
+    - name: <customBinding>
+      href: custombinding.md
+      items:
+      - name: <compositeDuplex>
+        href: compositeduplex.md
+      - name: <discoveryClient>
+        href: discoveryclient.md
+      - name: Message Encoding
+        href: message-encoding.md
+        items:
+        - name: <binaryMessageEncoding>
+          href: binarymessageencoding.md
+        - name: <mtomMessageEncoding>
+          href: mtommessageencoding.md
+        - name: <textMessageEncoding>
+          href: textmessageencoding.md
+        - name: <webMessageEncoding>
+          href: webmessageencoding.md
+        - name: <byteStreamMessageEncoding>
+          href: bytestreammessageencoding.md
+      - name: <oneWay>
+        href: oneway.md
+        items:
+        - name: <channelPoolSettings>
+          href: channelpoolsettings.md
+      - name: <pnrpPeerResolver>
+        href: pnrppeerresolver.md
+      - name: <privacyNoticeAt>
+        href: privacynoticeat.md
+      - name: <reliableSession>
+        href: reliablesession.md
+      - name: <security>
+        href: security-of-custombinding.md
+        items:
+        - name: <issuedTokenParameters>
+          href: issuedtokenparameters.md
+          items:
+          - name: <additionalRequestParameters>
+            href: additionalrequestparameters-element.md
+          - name: <claimTypeRequirements>
+            href: claimtyperequirements-element.md
+            items:
+            - name: <add>
+              href: add-of-claimtyperequirements.md
+          - name: <issuer>
+            href: issuer-of-issuedtokenparameters.md
+          - name: <issuerMetadata>
+            href: issuermetadata-of-issuedtokenparameters.md
+        - name: <localClientSettings>
+          href: localclientsettings-element.md
+        - name: <localServiceSettings>
+          href: localservicesettings-element.md
+        - name: <secureConversationBootstrap>
+          href: secureconversationbootstrap.md
+      - name: <sslStreamSecurity>
+        href: sslstreamsecurity.md
+      - name: <transactionFlow>
+        href: transactionflow.md
+      - name: Transports
+        href: transports.md
+        items:
+        - name: <httpTransport>
+          href: httptransport.md
+        - name: <httpsTransport>
+          href: httpstransport.md
+        - name: <msmqIntegration>
+          href: msmqintegration.md
+          items:
+          - name: <msmqTransportSecurity>
+            href: msmqtransportsecurity.md
+        - name: <msmqTransport>
+          href: msmqtransport.md
+        - name: <namedPipeTransport>
+          href: namedpipetransport.md
+          items:
+          - name: <connectionPoolSettings> of <namedPipeTransport>
+            href: connectionpoolsettings.md
+        - name: <peerTransport>
+          href: peertransport.md
+          items:
+          - name: <security>
+            href: security-of-peertransport.md
+            items:
+            - name: <transport>
+              href: transport-of-peertransport.md
+        - name: <tcpTransport>
+          href: tcptransport.md
+          items:
+          - name: <connectionPoolSettings>
+            href: connectionpoolsettings-of-tcptransport.md
+      - name: <unrecognizedPolicyAssertion>
+        href: unrecognizedpolicyassertion.md
+      - name: <useManagedPresentation>
+        href: usemanagedpresentation.md
+      - name: <windowsStreamSecurity>
+        href: windowsstreamsecurity.md
+    - name: <netHttpBinding>
+      href: nethttpbinding.md
+      items:
+      - name: <security>
+        href: security-of-nethttpbinding.md
+        items:
+        - name: <message>
+          href: message-of-nethttpbinding.md
+        - name: <transport>
+          href: transport-of-nethttpbinding.md
+      - name: <webSocketSettings>
+        href: websocketsettings.md
+    - name: <netHttpsBinding>
+      href: nethttpsbinding.md
+    - name: <udpBinding>
+      href: udpbinding.md
+  - name: <client>
+    href: client.md
+    items:
+    - name: <endpoint>
+      href: endpoint-of-client.md
+      items:
+      - name: <headers>
+        href: headers.md
+      - name: <identity>
+        href: identity.md
+        items:
+        - name: <certificate>
+          href: certificate-for-identity.md
+        - name: <certificateReference>
+          href: certificatereference-for-identity.md
+        - name: <dns>
+          href: dns.md
+        - name: <rsa>
+          href: rsa.md
+        - name: <servicePrincipalName>
+          href: serviceprincipalname.md
+        - name: <userPrincipalName>
+          href: userprincipalname.md
+    - name: <metadata>
+      href: metadata.md
+      items:
+      - name: <wsdlImporters>
+        href: wsdlimporters.md
+        items:
+        - name: <wsdlImporter>
+          href: wsdlimporter.md
+      - name: <policyImporters>
+        href: policyimporters.md
+        items:
+        - name: <policyImporter>
+          href: policyimporter.md
+  - name: <comContracts>
+    href: comcontracts.md
+    items:
+    - name: <comContract>
+      href: comcontract.md
+      items:
+      - name: <exposedMethods>
+        href: exposedmethods.md
+        items:
+        - name: <exposedMethod>
+          href: exposedmethod.md
+      - name: <persistableTypes>
+        href: persistabletypes.md
+        items:
+        - name: <persistableType>
+          href: persistabletype.md
+      - name: <userDefinedTypes>
+        href: userdefinedtypes.md
+        items:
+        - name: <userDefinedType>
+          href: userdefinedtype.md
+  - name: <commonBehaviors>
+    href: commonbehaviors.md
+  - name: <diagnostics>
+    href: diagnostics.md
+    items:
+    - name: <endToEndTracing>
+      href: endtoendtracing.md
+    - name: <messageLogging>
+      href: messagelogging.md
+      items:
+      - name: <filters>
+        href: filters.md
+        items:
+        - name: <add>
+          href: add-of-filters.md
+  - name: <extensions>
+    href: extensions-section.md
+    items:
+    - name: <behaviorExtensions>
+      href: behaviorextensions.md
+    - name: <bindingElementExtensions>
+      href: bindingelementextensions.md
+    - name: <bindingExtensions>
+      href: bindingextensions.md
+    - name: <endpointExtensions>
+      href: endpointextensions.md
+  - name: <protocolMapping>
+    href: protocolmapping.md
+    items:
+    - name: <add>
+      href: add-of-protocolmapping.md
+  - name: <routing>
+    href: routing.md
+    items:
+    - name: <backupLists>
+      href: backuplists.md
+      items:
+      - name: <backupList>
+        href: backuplist.md
+        items:
+        - name: <add>
+          href: add-of-backuplist.md
+    - name: <filters>
+      href: filters-of-routing.md
+      items:
+      - name: <filter>
+        href: filter.md
+    - name: <filterTables>
+      href: filtertables.md
+      items:
+      - name: <filterTable>
+        href: filtertable.md
+        items:
+        - name: <entries>
+          href: entries.md
           items:
           - name: <add>
-            href: add-of-filters.md
-    - name: <extensions>
-      href: extensions-section.md
+            href: add-of-entries.md
+    - name: <namespaceTable>
+      href: namespacetable.md
       items:
-      - name: <behaviorExtensions>
-        href: behaviorextensions.md
-      - name: <bindingElementExtensions>
-        href: bindingelementextensions.md
-      - name: <bindingExtensions>
-        href: bindingextensions.md
-      - name: <endpointExtensions>
-        href: endpointextensions.md
-    - name: <protocolMapping>
-      href: protocolmapping.md
+      - name: <add> of <namespaceTable>
+        href: add-of-namespacetable.md
+  - name: <serviceHostingEnvironment>
+    href: servicehostingenvironment.md
+    items:
+    - name: <baseAddressPrefixFilters>
+      href: baseaddressprefixfilters.md
       items:
       - name: <add>
-        href: add-of-protocolmapping.md
-    - name: <routing>
-      href: routing.md
+        href: add-of-baseaddressprefixfilter.md
+    - name: <serviceActivations>
+      href: serviceactivations.md
       items:
-      - name: <backupLists>
-        href: backuplists.md
+      - name: <add>
+        href: add-of-serviceactivations.md
+    - name: <transportConfigurationTypes>
+      href: transportconfigurationtypes.md
+      items:
+      - name: <add>
+        href: add-of-transportconfigurationtype.md
+  - name: <services>
+    href: services.md
+    items:
+    - name: <service>
+      href: service.md
+      items:
+      - name: <host>
+        href: host.md
         items:
-        - name: <backupList>
-          href: backuplist.md
+        - name: <baseAddresses>
+          href: baseaddresses.md
           items:
           - name: <add>
-            href: add-of-backuplist.md
-      - name: <filters>
-        href: filters-of-routing.md
+            href: add-of-baseaddresses.md
+        - name: <timeOuts>
+          href: timeouts.md
+      - name: <endpoint>
+        href: endpoint-element.md
+  - name: <standardEndpoints>
+    href: standardendpoints.md
+    items:
+    - name: <announcementEndpoint>
+      href: announcementendpoint.md
+    - name: <discoveryEndpoint>
+      href: discoveryendpoint.md
+    - name: <dynamicEndpoint>
+      href: dynamicendpoint.md
+      items:
+      - name: <discoveryClientSettings>
+        href: discoveryclientsettings.md
         items:
-        - name: <filter>
-          href: filter.md
-      - name: <filterTables>
-        href: filtertables.md
-        items:
-        - name: <filterTable>
-          href: filtertable.md
+        - name: <findCriteria>
+          href: findcriteria.md
           items:
-          - name: <entries>
-            href: entries.md
+          - name: <contractTypeNames>
+            href: contracttypenames.md
             items:
             - name: <add>
-              href: add-of-entries.md
-      - name: <namespaceTable>
-        href: namespacetable.md
-        items:
-        - name: <add> of <namespaceTable>
-          href: add-of-namespacetable.md
-    - name: <serviceHostingEnvironment>
-      href: servicehostingenvironment.md
+              href: add-of-contracttypenames.md
+    - name: <mexEndpoint>
+      href: mexendpoint.md
+    - name: <udpAnnouncementEndpoint>
+      href: udpannouncementendpoint.md
       items:
-      - name: <baseAddressPrefixFilters>
-        href: baseaddressprefixfilters.md
-        items:
-        - name: <add>
-          href: add-of-baseaddressprefixfilter.md
-      - name: <serviceActivations>
-        href: serviceactivations.md
-        items:
-        - name: <add>
-          href: add-of-serviceactivations.md
-      - name: <transportConfigurationTypes>
-        href: transportconfigurationtypes.md
-        items:
-        - name: <add>
-          href: add-of-transportconfigurationtype.md
-    - name: <services>
-      href: services.md
+      - name: <udpTransportSettings>
+        href: udptransportsettings-of-udpannouncementendpoint.md
+    - name: <udpDiscoveryEndpoint>
+      href: udpdiscoveryendpoint.md
       items:
-      - name: <service>
-        href: service.md
-        items:
-        - name: <host>
-          href: host.md
-          items:
-          - name: <baseAddresses>
-            href: baseaddresses.md
-            items:
-            - name: <add>
-              href: add-of-baseaddresses.md
-          - name: <timeOuts>
-            href: timeouts.md
-        - name: <endpoint>
-          href: endpoint-element.md
-    - name: <standardEndpoints>
-      href: standardendpoints.md
-      items:
-      - name: <announcementEndpoint>
-        href: announcementendpoint.md
-      - name: <discoveryEndpoint>
-        href: discoveryendpoint.md
-      - name: <dynamicEndpoint>
-        href: dynamicendpoint.md
-        items:
-        - name: <discoveryClientSettings>
-          href: discoveryclientsettings.md
-          items:
-          - name: <findCriteria>
-            href: findcriteria.md
-            items:
-            - name: <contractTypeNames>
-              href: contracttypenames.md
-              items:
-              - name: <add>
-                href: add-of-contracttypenames.md
-      - name: <mexEndpoint>
-        href: mexendpoint.md
-      - name: <udpAnnouncementEndpoint>
-        href: udpannouncementendpoint.md
-        items:
-        - name: <udpTransportSettings>
-          href: udptransportsettings-of-udpannouncementendpoint.md
-      - name: <udpDiscoveryEndpoint>
-        href: udpdiscoveryendpoint.md
-        items:
-        - name: <udpTransportSettings>
-          href: udptransportsettings.md
-      - name: <webHttpEndpoint>
-        href: webhttpendpoint.md
-      - name: <webScriptEndpoint>
-        href: webscriptendpoint.md
-      - name: <workflowControlEndpoint>
-        href: workflowcontrolendpoint.md
-    - name: <tracking>
-      href: tracking-of-wcf.md
-      items:
-      - name: <participants>
-        href: participants-of-wcf.md
-        items:
-        - name: <add>
-          href: add-of-wcf.md
-      - name: <trackingProfile>
-        href: trackingprofile-of-wcf.md
-        items:
-        - name: <workflow>
-          href: workflow-of-wcf.md
-          items:
-          - name: <activityScheduledQueries>
-            href: activityscheduledqueries-of-wcf.md
-            items:
-            - name: <activityScheduledQuery>
-              href: activityscheduledquery-of-wcf.md
-          - name: <activityStateQueries>
-            href: activitystatequeries-of-wcf.md
-            items:
-            - name: <activityStateQuery>
-              href: activitystatequery-of-wcf.md
-          - name: <bookmarkResumptionQueries>
-            href: bookmarkresumptionqueries-of-wcf.md
-            items:
-            - name: <bookmarkResumptionQuery>
-              href: bookmarkresumptionquery-of-wcf.md
-          - name: <cancelRequestedQueries>
-            href: cancelrequestedqueries-of-wcf.md
-            items:
-            - name: <cancelRequestedQuery>
-              href: cancelrequestedquery-of-wcf.md
-          - name: <customTrackingQueries>
-            href: customtrackingqueries-of-wcf.md
-            items:
-            - name: <customTrackingQuery>
-              href: customtrackingquery-of-wcf.md
-          - name: <faultPropagationQueries>
-            href: faultpropagationqueries-of-wcf.md
-            items:
-            - name: <faultPropagationQuery>
-              href: faultpropagationquery-of-wcf.md
-          - name: <workflowInstanceQueries>
-            href: workflowinstancequeries-of-wcf.md
-            items:
-            - name: <workflowInstanceQuery>
-              href: workflowinstancequery-of-wcf.md
-              items:
-              - name: <states>
-                href: states-of-wcf-workflowinstancequery.md
-                items:
-                - name: <state>
-                  href: state-of-wcf-workflowinstancequery.md
-  - name: <system.serviceModel.activation>
-    href: system-servicemodel-activation.md
+      - name: <udpTransportSettings>
+        href: udptransportsettings.md
+    - name: <webHttpEndpoint>
+      href: webhttpendpoint.md
+    - name: <webScriptEndpoint>
+      href: webscriptendpoint.md
+    - name: <workflowControlEndpoint>
+      href: workflowcontrolendpoint.md
+  - name: <tracking>
+    href: tracking-of-wcf.md
     items:
-    - name: <diagnostics>
-      href: diagnostics-for-activation.md
-    - name: <net.pipe>
-      href: net-pipe.md
+    - name: <participants>
+      href: participants-of-wcf.md
       items:
-      - name: <allowAccounts>
-        href: allowaccounts.md
-        items:
-        - name: <add>
-          href: add-of-allowaccounts.md
-    - name: <net.tcp>
-      href: net-tcp.md
-  - name: <system.runtime.serialization>
-    href: system-runtime-serialization.md
-    items:
-    - name: <dataContractSerializer>
-      href: datacontractserializer-of-system-runtime-serialization.md
+      - name: <add>
+        href: add-of-wcf.md
+    - name: <trackingProfile>
+      href: trackingprofile-of-wcf.md
       items:
-      - name: <declaredTypes>
-        href: declaredtypes.md
+      - name: <workflow>
+        href: workflow-of-wcf.md
         items:
-        - name: <add>
-          href: add-of-declaredtypes-element.md
+        - name: <activityScheduledQueries>
+          href: activityscheduledqueries-of-wcf.md
           items:
-          - name: <knownType>
-            href: knowntype.md
+          - name: <activityScheduledQuery>
+            href: activityscheduledquery-of-wcf.md
+        - name: <activityStateQueries>
+          href: activitystatequeries-of-wcf.md
+          items:
+          - name: <activityStateQuery>
+            href: activitystatequery-of-wcf.md
+        - name: <bookmarkResumptionQueries>
+          href: bookmarkresumptionqueries-of-wcf.md
+          items:
+          - name: <bookmarkResumptionQuery>
+            href: bookmarkresumptionquery-of-wcf.md
+        - name: <cancelRequestedQueries>
+          href: cancelrequestedqueries-of-wcf.md
+          items:
+          - name: <cancelRequestedQuery>
+            href: cancelrequestedquery-of-wcf.md
+        - name: <customTrackingQueries>
+          href: customtrackingqueries-of-wcf.md
+          items:
+          - name: <customTrackingQuery>
+            href: customtrackingquery-of-wcf.md
+        - name: <faultPropagationQueries>
+          href: faultpropagationqueries-of-wcf.md
+          items:
+          - name: <faultPropagationQuery>
+            href: faultpropagationquery-of-wcf.md
+        - name: <workflowInstanceQueries>
+          href: workflowinstancequeries-of-wcf.md
+          items:
+          - name: <workflowInstanceQuery>
+            href: workflowinstancequery-of-wcf.md
             items:
-            - name: <parameter>
-              href: parameter.md
+            - name: <states>
+              href: states-of-wcf-workflowinstancequery.md
+              items:
+              - name: <state>
+                href: state-of-wcf-workflowinstancequery.md
+- name: <system.serviceModel.activation>
+  href: system-servicemodel-activation.md
+  items:
+  - name: <diagnostics>
+    href: diagnostics-for-activation.md
+  - name: <net.pipe>
+    href: net-pipe.md
+    items:
+    - name: <allowAccounts>
+      href: allowaccounts.md
+      items:
+      - name: <add>
+        href: add-of-allowaccounts.md
+  - name: <net.tcp>
+    href: net-tcp.md
+- name: <system.runtime.serialization>
+  href: system-runtime-serialization.md
+  items:
+  - name: <dataContractSerializer>
+    href: datacontractserializer-of-system-runtime-serialization.md
+    items:
+    - name: <declaredTypes>
+      href: declaredtypes.md
+      items:
+      - name: <add>
+        href: add-of-declaredtypes-element.md
+        items:
+        - name: <knownType>
+          href: knowntype.md
+          items:
+          - name: <parameter>
+            href: parameter.md

--- a/docs/framework/configure-apps/file-schema/web/toc.yml
+++ b/docs/framework/configure-apps/file-schema/web/toc.yml
@@ -1,8 +1,8 @@
-- name: Web Settings Schema
+items:
+- name: Web settings schema
   href: index.md
+- name: <system.web> element (Web Settings)
+  href: system-web-element-web-settings.md
   items:
-  - name: <system.web> Element (Web Settings)
-    href: system-web-element-web-settings.md
-    items:
-    - name: <applicationPool> Element (Web Settings)
-      href: applicationpool-element-web-settings.md
+  - name: <applicationPool> element (Web Settings)
+    href: applicationpool-element-web-settings.md

--- a/docs/framework/configure-apps/file-schema/windows-workflow-foundation/toc.yml
+++ b/docs/framework/configure-apps/file-schema/windows-workflow-foundation/toc.yml
@@ -1,117 +1,117 @@
-- name: Windows Workflow Foundation Configuration Schema
+items:
+- name: Windows Workflow Foundation configuration schema
   href: index.md
+- name: <system.serviceModel>
+  href: system-servicemodel-of-workflow.md
   items:
-  - name: <system.serviceModel>
-    href: system-servicemodel-of-workflow.md
+  - name: <behaviors>
+    href: behaviors-of-workflow.md
     items:
-    - name: <behaviors>
-      href: behaviors-of-workflow.md
+    - name: <serviceBehaviors>
+      href: servicebehaviors-of-workflow.md
       items:
-      - name: <serviceBehaviors>
-        href: servicebehaviors-of-workflow.md
+      - name: <behavior> of <serviceBehaviors>
+        href: behavior-of-servicebehaviors-of-workflow.md
         items:
-        - name: <behavior> of <serviceBehaviors>
-          href: behavior-of-servicebehaviors-of-workflow.md
+        - name: <bufferReceive>
+          href: bufferreceive.md
+        - name: <etwTracking>
+          href: etwtracking.md
+        - name: <sqlWorkflowInstanceStore>
+          href: sqlworkflowinstancestore.md
+        - name: <workflowIdle>
+          href: workflowidle.md
+        - name: <sendMessageChannelCache>
+          href: sendmessagechannelcache.md
           items:
-          - name: <bufferReceive>
-            href: bufferreceive.md
-          - name: <etwTracking>
-            href: etwtracking.md
-          - name: <sqlWorkflowInstanceStore>
-            href: sqlworkflowinstancestore.md
-          - name: <workflowIdle>
-            href: workflowidle.md
-          - name: <sendMessageChannelCache>
-            href: sendmessagechannelcache.md
-            items:
-            - name: <channelSettings>
-              href: channelsettings.md
-            - name: <factorySettings>
-              href: factorysettings.md
-          - name: <workflowInstanceManagement>
-            href: workflowinstancemanagement.md
-          - name: <workflowUnhandledException>
-            href: workflowunhandledexception.md
-    - name: <tracking>
-      href: tracking.md
-      items:
-      - name: <participants>
-        href: participants.md
-        items:
-        - name: <add>
-          href: add-of-participants.md
-      - name: <trackingProfile>
-        href: trackingprofile.md
-        items:
-        - name: <workflow>
-          href: workflow.md
-          items:
-          - name: <activityScheduledQueries>
-            href: activityscheduledqueries.md
-            items:
-            - name: <activityScheduledQuery>
-              href: activityscheduledquery.md
-          - name: <activityStateQueries>
-            href: activitystatequeries.md
-            items:
-            - name: <activityStateQuery>
-              href: activitystatequery.md
-              items:
-              - name: <arguments>
-                href: arguments.md
-                items:
-                - name: <argument>
-                  href: argument.md
-              - name: <states>
-                href: states-of-activitystatequery.md
-                items:
-                - name: <state>
-                  href: state-of-states.md
-              - name: <variables>
-                href: variables.md
-                items:
-                - name: <variable>
-                  href: variable.md
-          - name: <bookmarkResumptionQueries>
-            href: bookmarkresumptionqueries.md
-            items:
-            - name: <bookmarkResumptionQuery>
-              href: bookmarkresumptionquery.md
-          - name: <cancelRequestedQueries>
-            href: cancelrequestedqueries.md
-            items:
-            - name: <cancelRequestedQuery>
-              href: cancelrequestedquery.md
-          - name: <customTrackingQueries>
-            href: customtrackingqueries.md
-            items:
-            - name: <customTrackingQuery>
-              href: customtrackingquery.md
-          - name: <faultPropagationQueries>
-            href: faultpropagationqueries.md
-            items:
-            - name: <faultPropagationQuery>
-              href: faultpropagationquery.md
-          - name: <workflowInstanceQueries>
-            href: workflowinstancequeries.md
-            items:
-            - name: <workflowInstanceQuery>
-              href: workflowinstancequery.md
-              items:
-              - name: <states>
-                href: states.md
-                items:
-                - name: <state>
-                  href: state.md
-          - name: Using Annotation in Queries
-            href: using-annotation-in-queries.md
-  - name: Additional Managed Reference
-    href: additional-managed-reference.md
+          - name: <channelSettings>
+            href: channelsettings.md
+          - name: <factorySettings>
+            href: factorysettings.md
+        - name: <workflowInstanceManagement>
+          href: workflowinstancemanagement.md
+        - name: <workflowUnhandledException>
+          href: workflowunhandledexception.md
+  - name: <tracking>
+    href: tracking.md
     items:
-    - name: Microsoft.VisualStudio.Activities.Asr.ClientActivityBuilder
-      href: microsoft-visualstudio-activities-asr-clientactivitybuilder.md
+    - name: <participants>
+      href: participants.md
       items:
-      - name: Microsoft.VisualStudio.Activities.Asr.ClientActivityBuilder.Build
-        href: microsoft-visualstudio-activities-asr-clientactivitybuilder-build.md
-      - name: Microsoft.VisualStudio.Activities.Asr.ClientActivityBuilder..ctor
-        href: microsoft-visualstudio-activities-asr-clientactivitybuilder-ctor.md
+      - name: <add>
+        href: add-of-participants.md
+    - name: <trackingProfile>
+      href: trackingprofile.md
+      items:
+      - name: <workflow>
+        href: workflow.md
+        items:
+        - name: <activityScheduledQueries>
+          href: activityscheduledqueries.md
+          items:
+          - name: <activityScheduledQuery>
+            href: activityscheduledquery.md
+        - name: <activityStateQueries>
+          href: activitystatequeries.md
+          items:
+          - name: <activityStateQuery>
+            href: activitystatequery.md
+            items:
+            - name: <arguments>
+              href: arguments.md
+              items:
+              - name: <argument>
+                href: argument.md
+            - name: <states>
+              href: states-of-activitystatequery.md
+              items:
+              - name: <state>
+                href: state-of-states.md
+            - name: <variables>
+              href: variables.md
+              items:
+              - name: <variable>
+                href: variable.md
+        - name: <bookmarkResumptionQueries>
+          href: bookmarkresumptionqueries.md
+          items:
+          - name: <bookmarkResumptionQuery>
+            href: bookmarkresumptionquery.md
+        - name: <cancelRequestedQueries>
+          href: cancelrequestedqueries.md
+          items:
+          - name: <cancelRequestedQuery>
+            href: cancelrequestedquery.md
+        - name: <customTrackingQueries>
+          href: customtrackingqueries.md
+          items:
+          - name: <customTrackingQuery>
+            href: customtrackingquery.md
+        - name: <faultPropagationQueries>
+          href: faultpropagationqueries.md
+          items:
+          - name: <faultPropagationQuery>
+            href: faultpropagationquery.md
+        - name: <workflowInstanceQueries>
+          href: workflowinstancequeries.md
+          items:
+          - name: <workflowInstanceQuery>
+            href: workflowinstancequery.md
+            items:
+            - name: <states>
+              href: states.md
+              items:
+              - name: <state>
+                href: state.md
+        - name: Using Annotation in Queries
+          href: using-annotation-in-queries.md
+- name: Additional managed reference
+  href: additional-managed-reference.md
+  items:
+  - name: Microsoft.VisualStudio.Activities.Asr.ClientActivityBuilder
+    href: microsoft-visualstudio-activities-asr-clientactivitybuilder.md
+    items:
+    - name: Microsoft.VisualStudio.Activities.Asr.ClientActivityBuilder.Build
+      href: microsoft-visualstudio-activities-asr-clientactivitybuilder-build.md
+    - name: Microsoft.VisualStudio.Activities.Asr.ClientActivityBuilder..ctor
+      href: microsoft-visualstudio-activities-asr-clientactivitybuilder-ctor.md

--- a/docs/framework/configure-apps/file-schema/winforms/toc.yml
+++ b/docs/framework/configure-apps/file-schema/winforms/toc.yml
@@ -1,5 +1,5 @@
-- name: Windows Forms Configuration Section
+items:
+- name: Windows Forms configuration section
   href: index.md
-  items:
-  - name: Add Element
-    href: windows-forms-add-configuration-element.md
+- name: Add element
+  href: windows-forms-add-configuration-element.md

--- a/docs/framework/configure-apps/toc.yml
+++ b/docs/framework/configure-apps/toc.yml
@@ -1,29 +1,28 @@
 items:
 - name: Configure apps
   href: index.md
+- name: Read application settings
+  href: read-app-settings.md
+- name: Locate assemblies by using DEVPATH
+  href: how-to-locate-assemblies-by-using-devpath.md
+- name: Redirect assembly versions
   items:
-  - name: Read application settings
-    href: read-app-settings.md
-  - name: Locate assemblies by using DEVPATH
-    href: how-to-locate-assemblies-by-using-devpath.md
-  - name: Redirect assembly versions
-    items:
-    - name: Overview
-      href: redirect-assembly-versions.md
-    - name: "How to: Enable and disable automatic binding redirection"
-      href: how-to-enable-and-disable-automatic-binding-redirection.md
-    - name: Assembly binding redirection security permission
-      href: assembly-binding-redirection-security-permission.md
-  - name: Specify an assembly's location
-    href: specify-assembly-location.md
-  - name: Configure cryptography classes
-    href: configure-cryptography-classes.md
-    items:
-    - name: Map algorithm names to cryptography classes
-      href: map-algorithm-names-to-cryptography-classes.md
-    - name: Map object identifiers to cryptography algorithms
-      href: map-object-identifiers-to-cryptography-algorithms.md
-  - name: Create a publisher policy
-    href: how-to-create-a-publisher-policy.md
-  - name: Configuration file schema
-    href: file-schema/index.md
+  - name: Overview
+    href: redirect-assembly-versions.md
+  - name: "How to: Enable and disable automatic binding redirection"
+    href: how-to-enable-and-disable-automatic-binding-redirection.md
+  - name: Assembly binding redirection security permission
+    href: assembly-binding-redirection-security-permission.md
+- name: Specify an assembly's location
+  href: specify-assembly-location.md
+- name: Configure cryptography classes
+  href: configure-cryptography-classes.md
+  items:
+  - name: Map algorithm names to cryptography classes
+    href: map-algorithm-names-to-cryptography-classes.md
+  - name: Map object identifiers to cryptography algorithms
+    href: map-object-identifiers-to-cryptography-algorithms.md
+- name: Create a publisher policy
+  href: how-to-create-a-publisher-policy.md
+- name: Configuration file schema
+  href: file-schema/index.md

--- a/docs/framework/data/adonet/dataset-datatable-dataview/toc.yml
+++ b/docs/framework/data/adonet/dataset-datatable-dataview/toc.yml
@@ -1,3 +1,4 @@
+items:
 - name: DataSets, DataTables, and DataViews
   href: index.md
   items:

--- a/docs/framework/data/adonet/ef/language-reference/toc.yml
+++ b/docs/framework/data/adonet/ef/language-reference/toc.yml
@@ -1,278 +1,278 @@
-- name: Language Reference
+items:
+- name: Language reference
   href: index.md
+- name: LINQ to Entities
+  href: linq-to-entities.md
   items:
-  - name: LINQ to Entities
-    href: linq-to-entities.md
+  - name: Queries
+    href: queries-in-linq-to-entities.md
     items:
-    - name: Queries
-      href: queries-in-linq-to-entities.md
+    - name: Method-based query syntax examples
       items:
-      - name: Method-based query syntax examples
-        items:
-        - name: Projection
-          href: method-based-query-syntax-examples-projection.md
-        - name: Filtering
-          href: method-based-query-syntax-examples-filtering.md
-        - name: Ordering
-          href: method-based-query-syntax-examples-ordering.md
-        - name: Aggregate Operators
-          href: method-based-query-syntax-examples-aggregate-operators.md
-        - name: Partitioning
-          href: method-based-query-syntax-examples-partitioning.md
-        - name: Conversion
-          href: method-based-query-syntax-examples-conversion.md
-        - name: Join Operators
-          href: method-based-query-syntax-examples-join-operators.md
-        - name: Element Operators
-          href: method-based-query-syntax-examples-element-operators.md
-        - name: Grouping
-          href: method-based-query-syntax-examples-grouping.md
-        - name: Navigating Relationships
-          href: method-based-query-syntax-examples-navigating-relationships.md
-      - name: Query expression syntax examples
-        items:
-        - name: Projection
-          href: query-expression-syntax-examples-projection.md
-        - name: Filtering
-          href: query-expression-syntax-examples-filtering.md
-        - name: Ordering
-          href: query-expression-syntax-examples-ordering.md
-        - name: Aggregate Operators
-          href: query-expression-syntax-examples-aggregate-operators.md
-        - name: Partitioning
-          href: query-expression-syntax-examples-partitioning.md
-        - name: Join Operators
-          href: query-expression-syntax-examples-join-operators.md
-        - name: Element Operators
-          href: query-expression-syntax-examples-element-operators.md
-        - name: Grouping
-          href: query-expression-syntax-examples-grouping.md
-        - name: Navigating Relationships
-          href: query-expression-syntax-examples-navigating-relationships.md
-    - name: Expressions in queries
-      href: expressions-in-linq-to-entities-queries.md
+      - name: Projection
+        href: method-based-query-syntax-examples-projection.md
+      - name: Filtering
+        href: method-based-query-syntax-examples-filtering.md
+      - name: Ordering
+        href: method-based-query-syntax-examples-ordering.md
+      - name: Aggregate Operators
+        href: method-based-query-syntax-examples-aggregate-operators.md
+      - name: Partitioning
+        href: method-based-query-syntax-examples-partitioning.md
+      - name: Conversion
+        href: method-based-query-syntax-examples-conversion.md
+      - name: Join Operators
+        href: method-based-query-syntax-examples-join-operators.md
+      - name: Element Operators
+        href: method-based-query-syntax-examples-element-operators.md
+      - name: Grouping
+        href: method-based-query-syntax-examples-grouping.md
+      - name: Navigating Relationships
+        href: method-based-query-syntax-examples-navigating-relationships.md
+    - name: Query expression syntax examples
       items:
-      - name: Constant Expressions
-        href: constant-expressions.md
-      - name: Comparison Expressions
-        href: comparison-expressions.md
-      - name: Null Comparisons
-        href: null-comparisons.md
-      - name: Initialization Expressions
-        href: initialization-expressions.md
-    - name: Calling functions in queries
-      href: calling-functions-in-linq-to-entities-queries.md
-      items:
-      - name: "How to: Call Canonical Functions"
-        href: how-to-call-canonical-functions.md
-      - name: "How to: Call Database Functions"
-        href: how-to-call-database-functions.md
-      - name: "How to: Call Custom Database Functions"
-        href: how-to-call-custom-database-functions.md
-      - name: "How to: Call Model-Defined Functions in Queries"
-        href: how-to-call-model-defined-functions-in-queries.md
-      - name: "How to: Call Model-Defined Functions as Object Methods"
-        href: how-to-call-model-defined-functions-as-object-methods.md
-    - name: Compiled Queries
-      href: compiled-queries-linq-to-entities.md
-    - name: Query Execution
-      href: query-execution.md
-    - name: Query Results
-      href: query-results.md
-    - name: Standard Query Operators
-      href: standard-query-operators-in-linq-to-entities-queries.md
-    - name: CLR Method to Canonical Function Mapping
-      href: clr-method-to-canonical-function-mapping.md
-    - name: Supported and Unsupported LINQ Methods
-      href: supported-and-unsupported-linq-methods-linq-to-entities.md
-    - name: Known Issues and Considerations
-      href: known-issues-and-considerations-in-linq-to-entities.md
-  - name: Entity SQL Language
-    href: entity-sql-language.md
+      - name: Projection
+        href: query-expression-syntax-examples-projection.md
+      - name: Filtering
+        href: query-expression-syntax-examples-filtering.md
+      - name: Ordering
+        href: query-expression-syntax-examples-ordering.md
+      - name: Aggregate Operators
+        href: query-expression-syntax-examples-aggregate-operators.md
+      - name: Partitioning
+        href: query-expression-syntax-examples-partitioning.md
+      - name: Join Operators
+        href: query-expression-syntax-examples-join-operators.md
+      - name: Element Operators
+        href: query-expression-syntax-examples-element-operators.md
+      - name: Grouping
+        href: query-expression-syntax-examples-grouping.md
+      - name: Navigating Relationships
+        href: query-expression-syntax-examples-navigating-relationships.md
+  - name: Expressions in queries
+    href: expressions-in-linq-to-entities-queries.md
     items:
-    - name: Entity SQL Overview
-      href: entity-sql-overview.md
-      items:
-      - name: How Entity SQL Differs from Transact-SQL
-        href: how-entity-sql-differs-from-transact-sql.md
-      - name: Quick Reference
-        href: entity-sql-quick-reference.md
-      - name: Type System
-        href: type-system-entity-sql.md
-      - name: Type Definitions
-        href: type-definitions-entity-sql.md
-      - name: Constructing Types
-        href: constructing-types-entity-sql.md
-      - name: Query Plan Caching
-        href: query-plan-caching-entity-sql.md
-      - name: Namespaces
-        href: namespaces-entity-sql.md
-      - name: Identifiers
-        href: identifiers-entity-sql.md
-      - name: Parameters
-        href: parameters-entity-sql.md
-      - name: Variables
-        href: variables-entity-sql.md
-      - name: Unsupported Expressions
-        href: unsupported-expressions-entity-sql.md
-      - name: Literals
-        href: literals-entity-sql.md
-      - name: Null Literals and Type Inference
-        href: null-literals-and-type-inference-entity-sql.md
-      - name: Input Character Set
-        href: input-character-set-entity-sql.md
-      - name: Query Expressions
-        href: query-expressions-entity-sql.md
-      - name: Functions
-        href: functions-entity-sql.md
-        items:
-        - name: User-Defined Functions
-          href: user-defined-functions-entity-sql.md
-        - name: Function Overload Resolution
-          href: function-overload-resolution-entity-sql.md
-        - name: Aggregate Functions
-          href: aggregate-functions-entity-sql.md
-      - name: Operator Precedence
-        href: operator-precedence-entity-sql.md
-      - name: Paging
-        href: paging-entity-sql.md
-      - name: Comparison Semantics
-        href: comparison-semantics-entity-sql.md
-      - name: Composing Nested Entity SQL Queries
-        href: composing-nested-entity-sql-queries.md
-      - name: Nullable Structured Types
-        href: nullable-structured-types-entity-sql.md
-    - name: Entity SQL Reference
-      href: entity-sql-reference.md
-      items:
-      - name: + (Add)
-        href: add.md
-      - name: + (String Concatenation)
-        href: string-concatenation-entity-sql.md
-      - name: "- (Negative)"
-        href: negative-entity-sql.md
-      - name: "- (Subtract)"
-        href: subtract-entity-sql.md
-      - name: "* (Multiply)"
-        href: multiply-entity-sql.md
-      - name: / (Divide)
-        href: divide-entity-sql.md
-      - name: Percent (Modulo)
-        href: modulo-entity-sql.md
-      - name: "&& (AND)"
-        href: and-entity-sql.md
-      - name: "|| (OR)"
-        href: or-entity-sql.md
-      - name: "! (NOT)"
-        href: not-entity-sql.md
-      - name: = (Equals)
-        href: equals-entity-sql.md
-      - name: "> (Greater Than)"
-        href: greater-than-entity-sql.md
-      - name: ">= (Greater Than or Equal To)"
-        href: greater-than-or-equal-to-entity-sql.md
-      - name: < (Less Than)
-        href: less-than-entity-sql.md
-      - name: <= (Less Than or Equal To)
-        href: less-than-or-equal-to-entity-sql.md
-      - name: "!= (Not Equal To)"
-        href: not-equal-to-entity-sql.md
-      - name: . (Member Access)
-        href: member-access-entity-sql.md
-      - name: -- (Comment)
-        href: comment-entity-sql.md
-      - name: ANYELEMENT
-        href: anyelement-entity-sql.md
-      - name: BETWEEN
-        href: between-entity-sql.md
-      - name: CASE
-        href: case-entity-sql.md
-      - name: CAST
-        href: cast-entity-sql.md
-      - name: COLLECTION
-        href: collection-entity-sql.md
-      - name: CREATEREF
-        href: createref-entity-sql.md
-      - name: DEREF
-        href: deref-entity-sql.md
-      - name: EXCEPT
-        href: except-entity-sql.md
-      - name: EXISTS
-        href: exists-entity-sql.md
-      - name: FLATTEN
-        href: flatten-entity-sql.md
-      - name: FROM
-        href: from-entity-sql.md
-      - name: FUNCTION
-        href: function-entity-sql.md
-      - name: GROUP BY
-        href: group-by-entity-sql.md
-      - name: GROUPPARTITION
-        href: grouppartition-entity-sql.md
-      - name: HAVING
-        href: having-entity-sql.md
-      - name: KEY
-        href: key-entity-sql.md
-      - name: IN
-        href: in-entity-sql.md
-      - name: INTERSECT
-        href: intersect-entity-sql.md
-      - name: ISNULL
-        href: isnull-entity-sql.md
-      - name: ISOF
-        href: isof-entity-sql.md
-      - name: LIKE
-        href: like-entity-sql.md
-      - name: LIMIT
-        href: limit-entity-sql.md
-      - name: MULTISET
-        href: multiset-entity-sql.md
-      - name: Named Type Constructor
-        href: named-type-constructor-entity-sql.md
-      - name: NAVIGATE
-        href: navigate-entity-sql.md
-      - name: OFTYPE
-        href: oftype-entity-sql.md
-      - name: ORDER BY
-        href: order-by-entity-sql.md
-      - name: OVERLAPS
-        href: overlaps-entity-sql.md
-      - name: REF
-        href: ref-entity-sql.md
-      - name: ROW
-        href: row-entity-sql.md
-      - name: SELECT
-        href: select-entity-sql.md
-      - name: SET
-        href: set-entity-sql.md
-      - name: SKIP
-        href: skip-entity-sql.md
-      - name: THEN
-        href: then-entity-sql.md
-      - name: TOP
-        href: top-entity-sql.md
-      - name: TREAT
-        href: treat-entity-sql.md
-      - name: UNION
-        href: union-entity-sql.md
-      - name: USING
-        href: using-entity-sql.md
-      - name: WHERE
-        href: where-entity-sql.md
-  - name: Canonical Functions
-    href: canonical-functions.md
+    - name: Constant Expressions
+      href: constant-expressions.md
+    - name: Comparison Expressions
+      href: comparison-expressions.md
+    - name: Null Comparisons
+      href: null-comparisons.md
+    - name: Initialization Expressions
+      href: initialization-expressions.md
+  - name: Calling functions in queries
+    href: calling-functions-in-linq-to-entities-queries.md
     items:
-    - name: Aggregate Canonical Functions
-      href: aggregate-canonical-functions.md
-    - name: Math Canonical Functions
-      href: math-canonical-functions.md
-    - name: String Canonical Functions
-      href: string-canonical-functions.md
-    - name: Date and Time Canonical Functions
-      href: date-and-time-canonical-functions.md
-    - name: Bitwise Canonical Functions
-      href: bitwise-canonical-functions.md
-    - name: Spatial Functions
-      href: spatial-functions.md
-    - name: Other Canonical Functions
-      href: other-canonical-functions.md
+    - name: "How to: Call Canonical Functions"
+      href: how-to-call-canonical-functions.md
+    - name: "How to: Call Database Functions"
+      href: how-to-call-database-functions.md
+    - name: "How to: Call Custom Database Functions"
+      href: how-to-call-custom-database-functions.md
+    - name: "How to: Call Model-Defined Functions in Queries"
+      href: how-to-call-model-defined-functions-in-queries.md
+    - name: "How to: Call Model-Defined Functions as Object Methods"
+      href: how-to-call-model-defined-functions-as-object-methods.md
+  - name: Compiled Queries
+    href: compiled-queries-linq-to-entities.md
+  - name: Query Execution
+    href: query-execution.md
+  - name: Query Results
+    href: query-results.md
+  - name: Standard Query Operators
+    href: standard-query-operators-in-linq-to-entities-queries.md
+  - name: CLR Method to Canonical Function Mapping
+    href: clr-method-to-canonical-function-mapping.md
+  - name: Supported and Unsupported LINQ Methods
+    href: supported-and-unsupported-linq-methods-linq-to-entities.md
+  - name: Known Issues and Considerations
+    href: known-issues-and-considerations-in-linq-to-entities.md
+- name: Entity SQL Language
+  href: entity-sql-language.md
+  items:
+  - name: Entity SQL Overview
+    href: entity-sql-overview.md
+    items:
+    - name: How Entity SQL Differs from Transact-SQL
+      href: how-entity-sql-differs-from-transact-sql.md
+    - name: Quick Reference
+      href: entity-sql-quick-reference.md
+    - name: Type System
+      href: type-system-entity-sql.md
+    - name: Type Definitions
+      href: type-definitions-entity-sql.md
+    - name: Constructing Types
+      href: constructing-types-entity-sql.md
+    - name: Query Plan Caching
+      href: query-plan-caching-entity-sql.md
+    - name: Namespaces
+      href: namespaces-entity-sql.md
+    - name: Identifiers
+      href: identifiers-entity-sql.md
+    - name: Parameters
+      href: parameters-entity-sql.md
+    - name: Variables
+      href: variables-entity-sql.md
+    - name: Unsupported Expressions
+      href: unsupported-expressions-entity-sql.md
+    - name: Literals
+      href: literals-entity-sql.md
+    - name: Null Literals and Type Inference
+      href: null-literals-and-type-inference-entity-sql.md
+    - name: Input Character Set
+      href: input-character-set-entity-sql.md
+    - name: Query Expressions
+      href: query-expressions-entity-sql.md
+    - name: Functions
+      href: functions-entity-sql.md
+      items:
+      - name: User-Defined Functions
+        href: user-defined-functions-entity-sql.md
+      - name: Function Overload Resolution
+        href: function-overload-resolution-entity-sql.md
+      - name: Aggregate Functions
+        href: aggregate-functions-entity-sql.md
+    - name: Operator Precedence
+      href: operator-precedence-entity-sql.md
+    - name: Paging
+      href: paging-entity-sql.md
+    - name: Comparison Semantics
+      href: comparison-semantics-entity-sql.md
+    - name: Composing Nested Entity SQL Queries
+      href: composing-nested-entity-sql-queries.md
+    - name: Nullable Structured Types
+      href: nullable-structured-types-entity-sql.md
+  - name: Entity SQL Reference
+    href: entity-sql-reference.md
+    items:
+    - name: + (Add)
+      href: add.md
+    - name: + (String Concatenation)
+      href: string-concatenation-entity-sql.md
+    - name: "- (Negative)"
+      href: negative-entity-sql.md
+    - name: "- (Subtract)"
+      href: subtract-entity-sql.md
+    - name: "* (Multiply)"
+      href: multiply-entity-sql.md
+    - name: / (Divide)
+      href: divide-entity-sql.md
+    - name: Percent (Modulo)
+      href: modulo-entity-sql.md
+    - name: "&& (AND)"
+      href: and-entity-sql.md
+    - name: "|| (OR)"
+      href: or-entity-sql.md
+    - name: "! (NOT)"
+      href: not-entity-sql.md
+    - name: = (Equals)
+      href: equals-entity-sql.md
+    - name: "> (Greater Than)"
+      href: greater-than-entity-sql.md
+    - name: ">= (Greater Than or Equal To)"
+      href: greater-than-or-equal-to-entity-sql.md
+    - name: < (Less Than)
+      href: less-than-entity-sql.md
+    - name: <= (Less Than or Equal To)
+      href: less-than-or-equal-to-entity-sql.md
+    - name: "!= (Not Equal To)"
+      href: not-equal-to-entity-sql.md
+    - name: . (Member Access)
+      href: member-access-entity-sql.md
+    - name: -- (Comment)
+      href: comment-entity-sql.md
+    - name: ANYELEMENT
+      href: anyelement-entity-sql.md
+    - name: BETWEEN
+      href: between-entity-sql.md
+    - name: CASE
+      href: case-entity-sql.md
+    - name: CAST
+      href: cast-entity-sql.md
+    - name: COLLECTION
+      href: collection-entity-sql.md
+    - name: CREATEREF
+      href: createref-entity-sql.md
+    - name: DEREF
+      href: deref-entity-sql.md
+    - name: EXCEPT
+      href: except-entity-sql.md
+    - name: EXISTS
+      href: exists-entity-sql.md
+    - name: FLATTEN
+      href: flatten-entity-sql.md
+    - name: FROM
+      href: from-entity-sql.md
+    - name: FUNCTION
+      href: function-entity-sql.md
+    - name: GROUP BY
+      href: group-by-entity-sql.md
+    - name: GROUPPARTITION
+      href: grouppartition-entity-sql.md
+    - name: HAVING
+      href: having-entity-sql.md
+    - name: KEY
+      href: key-entity-sql.md
+    - name: IN
+      href: in-entity-sql.md
+    - name: INTERSECT
+      href: intersect-entity-sql.md
+    - name: ISNULL
+      href: isnull-entity-sql.md
+    - name: ISOF
+      href: isof-entity-sql.md
+    - name: LIKE
+      href: like-entity-sql.md
+    - name: LIMIT
+      href: limit-entity-sql.md
+    - name: MULTISET
+      href: multiset-entity-sql.md
+    - name: Named Type Constructor
+      href: named-type-constructor-entity-sql.md
+    - name: NAVIGATE
+      href: navigate-entity-sql.md
+    - name: OFTYPE
+      href: oftype-entity-sql.md
+    - name: ORDER BY
+      href: order-by-entity-sql.md
+    - name: OVERLAPS
+      href: overlaps-entity-sql.md
+    - name: REF
+      href: ref-entity-sql.md
+    - name: ROW
+      href: row-entity-sql.md
+    - name: SELECT
+      href: select-entity-sql.md
+    - name: SET
+      href: set-entity-sql.md
+    - name: SKIP
+      href: skip-entity-sql.md
+    - name: THEN
+      href: then-entity-sql.md
+    - name: TOP
+      href: top-entity-sql.md
+    - name: TREAT
+      href: treat-entity-sql.md
+    - name: UNION
+      href: union-entity-sql.md
+    - name: USING
+      href: using-entity-sql.md
+    - name: WHERE
+      href: where-entity-sql.md
+- name: Canonical Functions
+  href: canonical-functions.md
+  items:
+  - name: Aggregate Canonical Functions
+    href: aggregate-canonical-functions.md
+  - name: Math Canonical Functions
+    href: math-canonical-functions.md
+  - name: String Canonical Functions
+    href: string-canonical-functions.md
+  - name: Date and Time Canonical Functions
+    href: date-and-time-canonical-functions.md
+  - name: Bitwise Canonical Functions
+    href: bitwise-canonical-functions.md
+  - name: Spatial Functions
+    href: spatial-functions.md
+  - name: Other Canonical Functions
+    href: other-canonical-functions.md

--- a/docs/framework/data/adonet/ef/toc.yml
+++ b/docs/framework/data/adonet/ef/toc.yml
@@ -1,3 +1,4 @@
+items:
 - name: ADO.NET Entity Framework
   href: index.md
 - name: Entity Framework Overview
@@ -96,4 +97,4 @@
   href: getting-started.md
 - name: Language Reference
   href: language-reference/index.md
-  
+

--- a/docs/framework/data/adonet/sql/linq/toc.yml
+++ b/docs/framework/data/adonet/sql/linq/toc.yml
@@ -1,337 +1,337 @@
+items:
 - name: LINQ to SQL
   href: index.md
+- name: Getting Started
+  href: getting-started.md
   items:
-  - name: Getting Started
-    href: getting-started.md
+  - name: What You Can Do With LINQ to SQL
+    href: what-you-can-do-with-linq-to-sql.md
+  - name: Typical Steps for Using LINQ to SQL
+    href: typical-steps-for-using-linq-to-sql.md
+  - name: Download Sample Databases and Tools
+    href: downloading-sample-databases.md
+  - name: Learning by Walkthroughs
+    href: learning-by-walkthroughs.md
     items:
-    - name: What You Can Do With LINQ to SQL
-      href: what-you-can-do-with-linq-to-sql.md
-    - name: Typical Steps for Using LINQ to SQL
-      href: typical-steps-for-using-linq-to-sql.md
-    - name: Download Sample Databases and Tools
-      href: downloading-sample-databases.md
-    - name: Learning by Walkthroughs
-      href: learning-by-walkthroughs.md
-      items:
-      - name: "Walkthrough: Simple Object Model and Query (Visual Basic)"
-        href: walkthrough-simple-object-model-and-query-visual-basic.md
-      - name: "Walkthrough: Querying Across Relationships (Visual Basic)"
-        href: walkthrough-querying-across-relationships-visual-basic.md
-      - name: "Walkthrough: Manipulating Data (Visual Basic)"
-        href: walkthrough-manipulating-data-visual-basic.md
-      - name: "Walkthrough: Using Only Stored Procedures (Visual Basic)"
-        href: walkthrough-using-only-stored-procedures-visual-basic.md
-      - name: "Walkthrough: Simple Object Model and Query (C#)"
-        href: walkthrough-simple-object-model-and-query-csharp.md
-      - name: "Walkthrough: Querying Across Relationships (C#)"
-        href: walkthrough-querying-across-relationships-csharp.md
-      - name: "Walkthrough: Manipulating Data (C#)"
-        href: walkthrough-manipulating-data-csharp.md
-      - name: "Walkthrough: Using Only Stored Procedures (C#)"
-        href: walkthrough-using-only-stored-procedures-csharp.md
-  - name: Programming Guide
-    href: programming-guide.md
+    - name: "Walkthrough: Simple Object Model and Query (Visual Basic)"
+      href: walkthrough-simple-object-model-and-query-visual-basic.md
+    - name: "Walkthrough: Querying Across Relationships (Visual Basic)"
+      href: walkthrough-querying-across-relationships-visual-basic.md
+    - name: "Walkthrough: Manipulating Data (Visual Basic)"
+      href: walkthrough-manipulating-data-visual-basic.md
+    - name: "Walkthrough: Using Only Stored Procedures (Visual Basic)"
+      href: walkthrough-using-only-stored-procedures-visual-basic.md
+    - name: "Walkthrough: Simple Object Model and Query (C#)"
+      href: walkthrough-simple-object-model-and-query-csharp.md
+    - name: "Walkthrough: Querying Across Relationships (C#)"
+      href: walkthrough-querying-across-relationships-csharp.md
+    - name: "Walkthrough: Manipulating Data (C#)"
+      href: walkthrough-manipulating-data-csharp.md
+    - name: "Walkthrough: Using Only Stored Procedures (C#)"
+      href: walkthrough-using-only-stored-procedures-csharp.md
+- name: Programming Guide
+  href: programming-guide.md
+  items:
+  - name: Creating the Object Model
+    href: creating-the-object-model.md
     items:
-    - name: Creating the Object Model
-      href: creating-the-object-model.md
+    - name: "How to: Generate the Object Model in Visual Basic or C#"
+      href: how-to-generate-the-object-model-in-visual-basic-or-csharp.md
+    - name: "How to: Generate the Object Model as an External File"
+      href: how-to-generate-the-object-model-as-an-external-file.md
+    - name: "How to: Generate Customized Code by Modifying a DBML File"
+      href: how-to-generate-customized-code-by-modifying-a-dbml-file.md
+    - name: "How to: Validate DBML and External Mapping Files"
+      href: how-to-validate-dbml-and-external-mapping-files.md
+    - name: "How to: Make Entities Serializable"
+      href: how-to-make-entities-serializable.md
+    - name: "How to: Customize Entity Classes by Using the Code Editor"
+      href: how-to-customize-entity-classes-by-using-the-code-editor.md
       items:
-      - name: "How to: Generate the Object Model in Visual Basic or C#"
-        href: how-to-generate-the-object-model-in-visual-basic-or-csharp.md
-      - name: "How to: Generate the Object Model as an External File"
-        href: how-to-generate-the-object-model-as-an-external-file.md
-      - name: "How to: Generate Customized Code by Modifying a DBML File"
-        href: how-to-generate-customized-code-by-modifying-a-dbml-file.md
-      - name: "How to: Validate DBML and External Mapping Files"
-        href: how-to-validate-dbml-and-external-mapping-files.md
-      - name: "How to: Make Entities Serializable"
-        href: how-to-make-entities-serializable.md
-      - name: "How to: Customize Entity Classes by Using the Code Editor"
-        href: how-to-customize-entity-classes-by-using-the-code-editor.md
-        items:
-        - name: "How to: Specify Database Names"
-          href: how-to-specify-database-names.md
-        - name: "How to: Represent Tables as Classes"
-          href: how-to-represent-tables-as-classes.md
-        - name: "How to: Represent Columns as Class Members"
-          href: how-to-represent-columns-as-class-members.md
-        - name: "How to: Represent Primary Keys"
-          href: how-to-represent-primary-keys.md
-        - name: "How to: Map Database Relationships"
-          href: how-to-map-database-relationships.md
-        - name: "How to: Represent Columns as Database-Generated"
-          href: how-to-represent-columns-as-database-generated.md
-        - name: "How to: Represent Columns as Timestamp or Version Columns"
-          href: how-to-represent-columns-as-timestamp-or-version-columns.md
-        - name: "How to: Specify Database Data Types"
-          href: how-to-specify-database-data-types.md
-        - name: "How to: Represent Computed Columns"
-          href: how-to-represent-computed-columns.md
-        - name: "How to: Specify Private Storage Fields"
-          href: how-to-specify-private-storage-fields.md
-        - name: "How to: Represent Columns as Allowing Null Values"
-          href: how-to-represent-columns-as-allowing-null-values.md
-        - name: "How to: Map Inheritance Hierarchies"
-          href: how-to-map-inheritance-hierarchies.md
-        - name: "How to: Specify Concurrency-Conflict Checking"
-          href: how-to-specify-concurrency-conflict-checking.md
-    - name: Communicating with the Database
-      href: communicating-with-the-database.md
-      items:
-      - name: "How to: Connect to a Database"
-        href: how-to-connect-to-a-database.md
-      - name: "How to: Directly Execute SQL Commands"
-        href: how-to-directly-execute-sql-commands.md
-      - name: "How to: Reuse a Connection Between an ADO.NET Command and a DataContext"
-        href: how-to-reuse-a-connection-between-an-ado-net-command-and-a-datacontext.md
-    - name: Querying the Database
-      href: querying-the-database.md
-      items:
-      - name: "How to: Query for Information"
-        href: how-to-query-for-information.md
-      - name: "How to: Retrieve Information As Read-Only"
-        href: how-to-retrieve-information-as-read-only.md
-      - name: "How to: Control How Much Related Data Is Retrieved"
-        href: how-to-control-how-much-related-data-is-retrieved.md
-      - name: "How to: Filter Related Data"
-        href: how-to-filter-related-data.md
-      - name: "How to: Turn Off Deferred Loading"
-        href: how-to-turn-off-deferred-loading.md
-      - name: "How to: Directly Execute SQL Queries"
-        href: how-to-directly-execute-sql-queries.md
-      - name: "How to: Store and Reuse Queries"
-        href: how-to-store-and-reuse-queries.md
-      - name: "How to: Handle Composite Keys in Queries"
-        href: how-to-handle-composite-keys-in-queries.md
-      - name: "How to: Retrieve Many Objects At Once"
-        href: how-to-retrieve-many-objects-at-once.md
-      - name: "How to: Filter at the DataContext Level"
-        href: how-to-filter-at-the-datacontext-level.md
-      - name: Query Examples
-        href: query-examples.md
-        items:
-        - name: Aggregate Queries
-          href: aggregate-queries.md
-          items:
-          - name: Return the Average Value From a Numeric Sequence
-            href: return-the-average-value-from-a-numeric-sequence.md
-          - name: Count the Number of Elements in a Sequence
-            href: count-the-number-of-elements-in-a-sequence.md
-          - name: Find the Maximum Value in a Numeric Sequence
-            href: find-the-maximum-value-in-a-numeric-sequence.md
-          - name: Find the Minimum Value in a Numeric Sequence
-            href: find-the-minimum-value-in-a-numeric-sequence.md
-          - name: Compute the Sum of Values in a Numeric Sequence
-            href: compute-the-sum-of-values-in-a-numeric-sequence.md
-        - name: Return the First Element in a Sequence
-          href: return-the-first-element-in-a-sequence.md
-        - name: Return Or Skip Elements in a Sequence
-          href: return-or-skip-elements-in-a-sequence.md
-        - name: Sort Elements in a Sequence
-          href: sort-elements-in-a-sequence.md
-        - name: Group Elements in a Sequence
-          href: group-elements-in-a-sequence.md
-        - name: Eliminate Duplicate Elements from a Sequence
-          href: eliminate-duplicate-elements-from-a-sequence.md
-        - name: Determine if Any or All Elements in a Sequence Satisfy a Condition
-          href: determine-if-any-or-all-elements-in-a-sequence-satisfy-a-condition.md
-        - name: Concatenate Two Sequences
-          href: concatenate-two-sequences.md
-        - name: Return the Set Difference Between Two Sequences
-          href: return-the-set-difference-between-two-sequences.md
-        - name: Return the Set Intersection of Two Sequences
-          href: return-the-set-intersection-of-two-sequences.md
-        - name: Return the Set Union of Two Sequences
-          href: return-the-set-union-of-two-sequences.md
-        - name: Convert a Sequence to an Array
-          href: convert-a-sequence-to-an-array.md
-        - name: Convert a Sequence to a Generic List
-          href: convert-a-sequence-to-a-generic-list.md
-        - name: Convert a Type to a Generic IEnumerable
-          href: convert-a-type-to-a-generic-ienumerable.md
-        - name: Formulate Joins and Cross-Product Queries
-          href: formulate-joins-and-cross-product-queries.md
-        - name: Formulate Projections
-          href: formulate-projections.md
-    - name: Making and Submitting Data Changes
-      href: making-and-submitting-data-changes.md
-      items:
-      - name: "How to: Insert Rows Into the Database"
-        href: how-to-insert-rows-into-the-database.md
-      - name: "How to: Update Rows in the Database"
-        href: how-to-update-rows-in-the-database.md
-      - name: "How to: Delete Rows From the Database"
-        href: how-to-delete-rows-from-the-database.md
-      - name: "How to: Submit Changes to the Database"
-        href: how-to-submit-changes-to-the-database.md
-      - name: "How to: Bracket Data Submissions by Using Transactions"
-        href: how-to-bracket-data-submissions-by-using-transactions.md
-      - name: "How to: Dynamically Create a Database"
-        href: how-to-dynamically-create-a-database.md
-      - name: "How to: Manage Change Conflicts"
-        href: how-to-manage-change-conflicts.md
-        items:
-        - name: "How to: Detect and Resolve Conflicting Submissions"
-          href: how-to-detect-and-resolve-conflicting-submissions.md
-        - name: "How to: Specify When Concurrency Exceptions are Thrown"
-          href: how-to-specify-when-concurrency-exceptions-are-thrown.md
-        - name: "How to: Specify Which Members are Tested for Concurrency Conflicts"
-          href: how-to-specify-which-members-are-tested-for-concurrency-conflicts.md
-        - name: "How to: Retrieve Entity Conflict Information"
-          href: how-to-retrieve-entity-conflict-information.md
-        - name: "How to: Retrieve Member Conflict Information"
-          href: how-to-retrieve-member-conflict-information.md
-        - name: "How to: Resolve Conflicts by Retaining Database Values"
-          href: how-to-resolve-conflicts-by-retaining-database-values.md
-        - name: "How to: Resolve Conflicts by Overwriting Database Values"
-          href: how-to-resolve-conflicts-by-overwriting-database-values.md
-        - name: "How to: Resolve Conflicts by Merging with Database Values"
-          href: how-to-resolve-conflicts-by-merging-with-database-values.md
-    - name: Debugging Support
-      href: debugging-support.md
-      items:
-      - name: "How to: Display Generated SQL"
-        href: how-to-display-generated-sql.md
-      - name: "How to: Display a ChangeSet"
-        href: how-to-display-a-changeset.md
-      - name: "How to: Display LINQ to SQL Commands"
-        href: how-to-display-linq-to-sql-commands.md
-      - name: Troubleshooting
-        href: troubleshooting.md
-    - name: Background Information
-      href: background-information.md
-      items:
-      - name: ADO.NET and LINQ to SQL
-        href: ado-net-and-linq-to-sql.md
-      - name: Analyzing LINQ to SQL Source Code
-        href: analyzing-linq-to-sql-source-code.md
-      - name: Customizing Insert, Update, and Delete Operations
-        href: customizing-insert-update-and-delete-operations.md
-        items:
-        - name: "Customizing Operations: Overview"
-          href: customizing-operations-overview.md
-        - name: Insert, Update, and Delete Operations
-          href: insert-update-and-delete-operations.md
-        - name: Responsibilities of the Developer In Overriding Default Behavior
-          href: responsibilities-of-the-developer-in-overriding-default-behavior.md
-        - name: Adding Business Logic By Using Partial Methods
-          href: adding-business-logic-by-using-partial-methods.md
-      - name: Data Binding
-        href: data-binding.md
-      - name: Inheritance Support
-        href: inheritance-support.md
-      - name: Local Method Calls
-        href: local-method-calls.md
-      - name: N-Tier and Remote Applications with LINQ to SQL
-        href: n-tier-and-remote-applications-with-linq-to-sql.md
-        items:
-        - name: LINQ to SQL N-Tier with ASP.NET
-          href: linq-to-sql-n-tier-with-aspnet.md
-        - name: LINQ to SQL N-Tier with Web Services
-          href: linq-to-sql-n-tier-with-web-services.md
-        - name: Implementing N-Tier Business Logic
-          href: implementing-business-logic-linq-to-sql.md
-        - name: Data Retrieval and CUD Operations in N-Tier Applications (LINQ to SQL)
-          href: data-retrieval-and-cud-operations-in-n-tier-applications.md
-      - name: Object Identity
-        href: object-identity.md
-      - name: The LINQ to SQL Object Model
-        href: the-linq-to-sql-object-model.md
-      - name: Object States and Change-Tracking
-        href: object-states-and-change-tracking.md
-      - name: "Optimistic Concurrency: Overview"
-        href: optimistic-concurrency-overview.md
-      - name: Query Concepts
-        href: query-concepts.md
-        items:
-        - name: LINQ to SQL Queries
-          href: linq-to-sql-queries.md
-        - name: Querying Across Relationships
-          href: querying-across-relationships.md
-        - name: Remote vs. Local Execution
-          href: remote-vs-local-execution.md
-        - name: Deferred versus Immediate Loading
-          href: deferred-versus-immediate-loading.md
-      - name: Retrieving Objects from the Identity Cache
-        href: retrieving-objects-from-the-identity-cache.md
-      - name: Security in LINQ to SQL
-        href: security-in-linq-to-sql.md
-      - name: Serialization
-        href: serialization.md
-      - name: Stored Procedures
-        href: stored-procedures.md
-        items:
-        - name: "How to: Return Rowsets"
-          href: how-to-return-rowsets.md
-        - name: "How to: Use Stored Procedures that Take Parameters"
-          href: how-to-use-stored-procedures-that-take-parameters.md
-        - name: "How to: Use Stored Procedures Mapped for Multiple Result Shapes"
-          href: how-to-use-stored-procedures-mapped-for-multiple-result-shapes.md
-        - name: "How to: Use Stored Procedures Mapped for Sequential Result Shapes"
-          href: how-to-use-stored-procedures-mapped-for-sequential-result-shapes.md
-        - name: Customizing Operations By Using Stored Procedures
-          href: customizing-operations-by-using-stored-procedures.md
-        - name: Customizing Operations by Using Stored Procedures Exclusively
-          href: customizing-operations-by-using-stored-procedures-exclusively.md
-      - name: Transaction Support
-        href: transaction-support.md
-      - name: SQL-CLR Type Mismatches
-        href: sql-clr-type-mismatches.md
-      - name: SQL-CLR Custom Type Mappings
-        href: sql-clr-custom-type-mappings.md
-      - name: User-Defined Functions
-        href: user-defined-functions.md
-        items:
-        - name: "How to: Use Scalar-Valued User-Defined Functions"
-          href: how-to-use-scalar-valued-user-defined-functions.md
-        - name: "How to: Use Table-Valued User-Defined Functions"
-          href: how-to-use-table-valued-user-defined-functions.md
-        - name: "How to: Call User-Defined Functions Inline"
-          href: how-to-call-user-defined-functions-inline.md
-  - name: Reference
-    href: reference.md
+      - name: "How to: Specify Database Names"
+        href: how-to-specify-database-names.md
+      - name: "How to: Represent Tables as Classes"
+        href: how-to-represent-tables-as-classes.md
+      - name: "How to: Represent Columns as Class Members"
+        href: how-to-represent-columns-as-class-members.md
+      - name: "How to: Represent Primary Keys"
+        href: how-to-represent-primary-keys.md
+      - name: "How to: Map Database Relationships"
+        href: how-to-map-database-relationships.md
+      - name: "How to: Represent Columns as Database-Generated"
+        href: how-to-represent-columns-as-database-generated.md
+      - name: "How to: Represent Columns as Timestamp or Version Columns"
+        href: how-to-represent-columns-as-timestamp-or-version-columns.md
+      - name: "How to: Specify Database Data Types"
+        href: how-to-specify-database-data-types.md
+      - name: "How to: Represent Computed Columns"
+        href: how-to-represent-computed-columns.md
+      - name: "How to: Specify Private Storage Fields"
+        href: how-to-specify-private-storage-fields.md
+      - name: "How to: Represent Columns as Allowing Null Values"
+        href: how-to-represent-columns-as-allowing-null-values.md
+      - name: "How to: Map Inheritance Hierarchies"
+        href: how-to-map-inheritance-hierarchies.md
+      - name: "How to: Specify Concurrency-Conflict Checking"
+        href: how-to-specify-concurrency-conflict-checking.md
+  - name: Communicating with the Database
+    href: communicating-with-the-database.md
     items:
-    - name: Data Types and Functions
-      href: data-types-and-functions.md
+    - name: "How to: Connect to a Database"
+      href: how-to-connect-to-a-database.md
+    - name: "How to: Directly Execute SQL Commands"
+      href: how-to-directly-execute-sql-commands.md
+    - name: "How to: Reuse a Connection Between an ADO.NET Command and a DataContext"
+      href: how-to-reuse-a-connection-between-an-ado-net-command-and-a-datacontext.md
+  - name: Querying the Database
+    href: querying-the-database.md
+    items:
+    - name: "How to: Query for Information"
+      href: how-to-query-for-information.md
+    - name: "How to: Retrieve Information As Read-Only"
+      href: how-to-retrieve-information-as-read-only.md
+    - name: "How to: Control How Much Related Data Is Retrieved"
+      href: how-to-control-how-much-related-data-is-retrieved.md
+    - name: "How to: Filter Related Data"
+      href: how-to-filter-related-data.md
+    - name: "How to: Turn Off Deferred Loading"
+      href: how-to-turn-off-deferred-loading.md
+    - name: "How to: Directly Execute SQL Queries"
+      href: how-to-directly-execute-sql-queries.md
+    - name: "How to: Store and Reuse Queries"
+      href: how-to-store-and-reuse-queries.md
+    - name: "How to: Handle Composite Keys in Queries"
+      href: how-to-handle-composite-keys-in-queries.md
+    - name: "How to: Retrieve Many Objects At Once"
+      href: how-to-retrieve-many-objects-at-once.md
+    - name: "How to: Filter at the DataContext Level"
+      href: how-to-filter-at-the-datacontext-level.md
+    - name: Query Examples
+      href: query-examples.md
       items:
-      - name: SQL-CLR Type Mapping
-        href: sql-clr-type-mapping.md
-      - name: Basic Data Types
-        href: basic-data-types.md
-      - name: Boolean Data Types
-        href: boolean-data-types.md
-      - name: Null Semantics
-        href: null-semantics.md
-      - name: Numeric and Comparison Operators
-        href: numeric-and-comparison-operators.md
-      - name: Sequence Operators
-        href: sequence-operators.md
-      - name: System.Convert Methods
-        href: system-convert-methods.md
-      - name: System.DateTime Methods
-        href: system-datetime-methods.md
-      - name: System.Math Methods
-        href: system-math-methods.md
-      - name: System.Object Methods
-        href: system-object-methods.md
-      - name: System.String Methods
-        href: system-string-methods.md
-      - name: System.TimeSpan Methods
-        href: system-timespan-methods.md
-      - name: Unsupported Functionality
-        href: unsupported-functionality.md
-      - name: System.DateTimeOffset Methods
-        href: system-datetimeoffset-methods.md
-    - name: Attribute-Based Mapping
-      href: attribute-based-mapping.md
-    - name: Code Generation in LINQ to SQL
-      href: code-generation-in-linq-to-sql.md
-    - name: External Mapping
-      href: external-mapping.md
-    - name: Frequently Asked Questions
-      href: frequently-asked-questions.yml
-    - name: SQL Server Compact and LINQ to SQL
-      href: sql-server-compact-and-linq-to-sql.md
-    - name: Standard Query Operator Translation
-      href: standard-query-operator-translation.md
-  - name: Samples
-    href: samples.md
+      - name: Aggregate Queries
+        href: aggregate-queries.md
+        items:
+        - name: Return the Average Value From a Numeric Sequence
+          href: return-the-average-value-from-a-numeric-sequence.md
+        - name: Count the Number of Elements in a Sequence
+          href: count-the-number-of-elements-in-a-sequence.md
+        - name: Find the Maximum Value in a Numeric Sequence
+          href: find-the-maximum-value-in-a-numeric-sequence.md
+        - name: Find the Minimum Value in a Numeric Sequence
+          href: find-the-minimum-value-in-a-numeric-sequence.md
+        - name: Compute the Sum of Values in a Numeric Sequence
+          href: compute-the-sum-of-values-in-a-numeric-sequence.md
+      - name: Return the First Element in a Sequence
+        href: return-the-first-element-in-a-sequence.md
+      - name: Return Or Skip Elements in a Sequence
+        href: return-or-skip-elements-in-a-sequence.md
+      - name: Sort Elements in a Sequence
+        href: sort-elements-in-a-sequence.md
+      - name: Group Elements in a Sequence
+        href: group-elements-in-a-sequence.md
+      - name: Eliminate Duplicate Elements from a Sequence
+        href: eliminate-duplicate-elements-from-a-sequence.md
+      - name: Determine if Any or All Elements in a Sequence Satisfy a Condition
+        href: determine-if-any-or-all-elements-in-a-sequence-satisfy-a-condition.md
+      - name: Concatenate Two Sequences
+        href: concatenate-two-sequences.md
+      - name: Return the Set Difference Between Two Sequences
+        href: return-the-set-difference-between-two-sequences.md
+      - name: Return the Set Intersection of Two Sequences
+        href: return-the-set-intersection-of-two-sequences.md
+      - name: Return the Set Union of Two Sequences
+        href: return-the-set-union-of-two-sequences.md
+      - name: Convert a Sequence to an Array
+        href: convert-a-sequence-to-an-array.md
+      - name: Convert a Sequence to a Generic List
+        href: convert-a-sequence-to-a-generic-list.md
+      - name: Convert a Type to a Generic IEnumerable
+        href: convert-a-type-to-a-generic-ienumerable.md
+      - name: Formulate Joins and Cross-Product Queries
+        href: formulate-joins-and-cross-product-queries.md
+      - name: Formulate Projections
+        href: formulate-projections.md
+  - name: Making and Submitting Data Changes
+    href: making-and-submitting-data-changes.md
+    items:
+    - name: "How to: Insert Rows Into the Database"
+      href: how-to-insert-rows-into-the-database.md
+    - name: "How to: Update Rows in the Database"
+      href: how-to-update-rows-in-the-database.md
+    - name: "How to: Delete Rows From the Database"
+      href: how-to-delete-rows-from-the-database.md
+    - name: "How to: Submit Changes to the Database"
+      href: how-to-submit-changes-to-the-database.md
+    - name: "How to: Bracket Data Submissions by Using Transactions"
+      href: how-to-bracket-data-submissions-by-using-transactions.md
+    - name: "How to: Dynamically Create a Database"
+      href: how-to-dynamically-create-a-database.md
+    - name: "How to: Manage Change Conflicts"
+      href: how-to-manage-change-conflicts.md
+      items:
+      - name: "How to: Detect and Resolve Conflicting Submissions"
+        href: how-to-detect-and-resolve-conflicting-submissions.md
+      - name: "How to: Specify When Concurrency Exceptions are Thrown"
+        href: how-to-specify-when-concurrency-exceptions-are-thrown.md
+      - name: "How to: Specify Which Members are Tested for Concurrency Conflicts"
+        href: how-to-specify-which-members-are-tested-for-concurrency-conflicts.md
+      - name: "How to: Retrieve Entity Conflict Information"
+        href: how-to-retrieve-entity-conflict-information.md
+      - name: "How to: Retrieve Member Conflict Information"
+        href: how-to-retrieve-member-conflict-information.md
+      - name: "How to: Resolve Conflicts by Retaining Database Values"
+        href: how-to-resolve-conflicts-by-retaining-database-values.md
+      - name: "How to: Resolve Conflicts by Overwriting Database Values"
+        href: how-to-resolve-conflicts-by-overwriting-database-values.md
+      - name: "How to: Resolve Conflicts by Merging with Database Values"
+        href: how-to-resolve-conflicts-by-merging-with-database-values.md
+  - name: Debugging Support
+    href: debugging-support.md
+    items:
+    - name: "How to: Display Generated SQL"
+      href: how-to-display-generated-sql.md
+    - name: "How to: Display a ChangeSet"
+      href: how-to-display-a-changeset.md
+    - name: "How to: Display LINQ to SQL Commands"
+      href: how-to-display-linq-to-sql-commands.md
+    - name: Troubleshooting
+      href: troubleshooting.md
+  - name: Background Information
+    href: background-information.md
+    items:
+    - name: ADO.NET and LINQ to SQL
+      href: ado-net-and-linq-to-sql.md
+    - name: Analyzing LINQ to SQL Source Code
+      href: analyzing-linq-to-sql-source-code.md
+    - name: Customizing Insert, Update, and Delete Operations
+      href: customizing-insert-update-and-delete-operations.md
+      items:
+      - name: "Customizing Operations: Overview"
+        href: customizing-operations-overview.md
+      - name: Insert, Update, and Delete Operations
+        href: insert-update-and-delete-operations.md
+      - name: Responsibilities of the Developer In Overriding Default Behavior
+        href: responsibilities-of-the-developer-in-overriding-default-behavior.md
+      - name: Adding Business Logic By Using Partial Methods
+        href: adding-business-logic-by-using-partial-methods.md
+    - name: Data Binding
+      href: data-binding.md
+    - name: Inheritance Support
+      href: inheritance-support.md
+    - name: Local Method Calls
+      href: local-method-calls.md
+    - name: N-Tier and Remote Applications with LINQ to SQL
+      href: n-tier-and-remote-applications-with-linq-to-sql.md
+      items:
+      - name: LINQ to SQL N-Tier with ASP.NET
+        href: linq-to-sql-n-tier-with-aspnet.md
+      - name: LINQ to SQL N-Tier with Web Services
+        href: linq-to-sql-n-tier-with-web-services.md
+      - name: Implementing N-Tier Business Logic
+        href: implementing-business-logic-linq-to-sql.md
+      - name: Data Retrieval and CUD Operations in N-Tier Applications (LINQ to SQL)
+        href: data-retrieval-and-cud-operations-in-n-tier-applications.md
+    - name: Object Identity
+      href: object-identity.md
+    - name: The LINQ to SQL Object Model
+      href: the-linq-to-sql-object-model.md
+    - name: Object States and Change-Tracking
+      href: object-states-and-change-tracking.md
+    - name: "Optimistic Concurrency: Overview"
+      href: optimistic-concurrency-overview.md
+    - name: Query Concepts
+      href: query-concepts.md
+      items:
+      - name: LINQ to SQL Queries
+        href: linq-to-sql-queries.md
+      - name: Querying Across Relationships
+        href: querying-across-relationships.md
+      - name: Remote vs. Local Execution
+        href: remote-vs-local-execution.md
+      - name: Deferred versus Immediate Loading
+        href: deferred-versus-immediate-loading.md
+    - name: Retrieving Objects from the Identity Cache
+      href: retrieving-objects-from-the-identity-cache.md
+    - name: Security in LINQ to SQL
+      href: security-in-linq-to-sql.md
+    - name: Serialization
+      href: serialization.md
+    - name: Stored Procedures
+      href: stored-procedures.md
+      items:
+      - name: "How to: Return Rowsets"
+        href: how-to-return-rowsets.md
+      - name: "How to: Use Stored Procedures that Take Parameters"
+        href: how-to-use-stored-procedures-that-take-parameters.md
+      - name: "How to: Use Stored Procedures Mapped for Multiple Result Shapes"
+        href: how-to-use-stored-procedures-mapped-for-multiple-result-shapes.md
+      - name: "How to: Use Stored Procedures Mapped for Sequential Result Shapes"
+        href: how-to-use-stored-procedures-mapped-for-sequential-result-shapes.md
+      - name: Customizing Operations By Using Stored Procedures
+        href: customizing-operations-by-using-stored-procedures.md
+      - name: Customizing Operations by Using Stored Procedures Exclusively
+        href: customizing-operations-by-using-stored-procedures-exclusively.md
+    - name: Transaction Support
+      href: transaction-support.md
+    - name: SQL-CLR Type Mismatches
+      href: sql-clr-type-mismatches.md
+    - name: SQL-CLR Custom Type Mappings
+      href: sql-clr-custom-type-mappings.md
+    - name: User-Defined Functions
+      href: user-defined-functions.md
+      items:
+      - name: "How to: Use Scalar-Valued User-Defined Functions"
+        href: how-to-use-scalar-valued-user-defined-functions.md
+      - name: "How to: Use Table-Valued User-Defined Functions"
+        href: how-to-use-table-valued-user-defined-functions.md
+      - name: "How to: Call User-Defined Functions Inline"
+        href: how-to-call-user-defined-functions-inline.md
+- name: Reference
+  href: reference.md
+  items:
+  - name: Data Types and Functions
+    href: data-types-and-functions.md
+    items:
+    - name: SQL-CLR Type Mapping
+      href: sql-clr-type-mapping.md
+    - name: Basic Data Types
+      href: basic-data-types.md
+    - name: Boolean Data Types
+      href: boolean-data-types.md
+    - name: Null Semantics
+      href: null-semantics.md
+    - name: Numeric and Comparison Operators
+      href: numeric-and-comparison-operators.md
+    - name: Sequence Operators
+      href: sequence-operators.md
+    - name: System.Convert Methods
+      href: system-convert-methods.md
+    - name: System.DateTime Methods
+      href: system-datetime-methods.md
+    - name: System.Math Methods
+      href: system-math-methods.md
+    - name: System.Object Methods
+      href: system-object-methods.md
+    - name: System.String Methods
+      href: system-string-methods.md
+    - name: System.TimeSpan Methods
+      href: system-timespan-methods.md
+    - name: Unsupported Functionality
+      href: unsupported-functionality.md
+    - name: System.DateTimeOffset Methods
+      href: system-datetimeoffset-methods.md
+  - name: Attribute-Based Mapping
+    href: attribute-based-mapping.md
+  - name: Code Generation in LINQ to SQL
+    href: code-generation-in-linq-to-sql.md
+  - name: External Mapping
+    href: external-mapping.md
+  - name: Frequently Asked Questions
+    href: frequently-asked-questions.yml
+  - name: SQL Server Compact and LINQ to SQL
+    href: sql-server-compact-and-linq-to-sql.md
+  - name: Standard Query Operator Translation
+    href: standard-query-operator-translation.md
+- name: Samples
+  href: samples.md

--- a/docs/framework/data/adonet/sql/toc.yml
+++ b/docs/framework/data/adonet/sql/toc.yml
@@ -1,3 +1,4 @@
+items:
 - name: SQL Server and ADO.NET
   href: index.md
 - name: SQL Server Security

--- a/docs/framework/data/adonet/toc.yml
+++ b/docs/framework/data/adonet/toc.yml
@@ -1,3 +1,4 @@
+items:
 - name: ADO.NET
   href: index.md
 - name: What's New in ADO.NET

--- a/docs/framework/data/toc.yml
+++ b/docs/framework/data/toc.yml
@@ -1,3 +1,4 @@
+items:
 - name: Data and modeling
   href: index.md
   items:

--- a/docs/framework/data/transactions/toc.yml
+++ b/docs/framework/data/transactions/toc.yml
@@ -1,38 +1,38 @@
+items:
 - name: Transaction Processing
   href: index.md
+- name: Transaction Fundamentals
+  href: transaction-fundamentals.md
+- name: Features Provided by System.Transactions
+  href: features-provided-by-system-transactions.md
   items:
-  - name: Transaction Fundamentals
-    href: transaction-fundamentals.md
-  - name: Features Provided by System.Transactions
-    href: features-provided-by-system-transactions.md
+  - name: Writing a Transactional Application
+    href: writing-a-transactional-application.md
     items:
-    - name: Writing a Transactional Application
-      href: writing-a-transactional-application.md
-      items:
-      - name: Implementing an Implicit Transaction using Transaction Scope
-        href: implementing-an-implicit-transaction-using-transaction-scope.md
-      - name: Implementing an Explicit Transaction using CommittableTransaction
-        href: implementing-an-explicit-transaction-using-committabletransaction.md
-      - name: Managing Concurrency with DependentTransaction
-        href: managing-concurrency-with-dependenttransaction.md
-      - name: Interoperability with Enterprise Services and COM+ Transactions
-        href: interoperability-with-enterprise-services-and-com-transactions.md
-      - name: Transaction Management Escalation
-        href: transaction-management-escalation.md
-      - name: Diagnostic Traces
-        href: diagnostic-traces.md
-      - name: Using System.Transactions in ASP.NET
-        href: using-system-transactions-in-aspnet.md
-    - name: Implementing a Resource Manager
-      href: implementing-a-resource-manager.md
-      items:
-      - name: Enlisting Resources as Participants in a Transaction
-        href: enlisting-resources-as-participants-in-a-transaction.md
-      - name: Committing a Transaction in Single-Phase and Multi-Phase
-        href: committing-a-transaction-in-single-phase-and-multi-phase.md
-      - name: Performing Recovery
-        href: performing-recovery.md
-      - name: Security Trust Levels in Accessing Resources
-        href: security-trust-levels-in-accessing-resources.md
-      - name: Optimization using Single Phase Commit and Promotable Single Phase Notification
-        href: optimization-spc-and-promotable-spn.md
+    - name: Implementing an Implicit Transaction using Transaction Scope
+      href: implementing-an-implicit-transaction-using-transaction-scope.md
+    - name: Implementing an Explicit Transaction using CommittableTransaction
+      href: implementing-an-explicit-transaction-using-committabletransaction.md
+    - name: Managing Concurrency with DependentTransaction
+      href: managing-concurrency-with-dependenttransaction.md
+    - name: Interoperability with Enterprise Services and COM+ Transactions
+      href: interoperability-with-enterprise-services-and-com-transactions.md
+    - name: Transaction Management Escalation
+      href: transaction-management-escalation.md
+    - name: Diagnostic Traces
+      href: diagnostic-traces.md
+    - name: Using System.Transactions in ASP.NET
+      href: using-system-transactions-in-aspnet.md
+  - name: Implementing a Resource Manager
+    href: implementing-a-resource-manager.md
+    items:
+    - name: Enlisting Resources as Participants in a Transaction
+      href: enlisting-resources-as-participants-in-a-transaction.md
+    - name: Committing a Transaction in Single-Phase and Multi-Phase
+      href: committing-a-transaction-in-single-phase-and-multi-phase.md
+    - name: Performing Recovery
+      href: performing-recovery.md
+    - name: Security Trust Levels in Accessing Resources
+      href: security-trust-levels-in-accessing-resources.md
+    - name: Optimization using Single Phase Commit and Promotable Single Phase Notification
+      href: optimization-spc-and-promotable-spn.md

--- a/docs/framework/debug-trace-profile/toc.yml
+++ b/docs/framework/debug-trace-profile/toc.yml
@@ -1,123 +1,123 @@
-- name: Debugging, Tracing, and Profiling
+items:
+- name: Debugging, tracing, and profiling
   href: index.md
+- name: Enabling JIT-Attach Debugging
+  href: enabling-jit-attach-debugging.md
+- name: Making an Image Easier to Debug
+  href: making-an-image-easier-to-debug.md
+- name: Tracing and Instrumenting Applications
+  href: tracing-and-instrumenting-applications.md
   items:
-  - name: Enabling JIT-Attach Debugging
-    href: enabling-jit-attach-debugging.md
-  - name: Making an Image Easier to Debug
-    href: making-an-image-easier-to-debug.md
-  - name: Tracing and Instrumenting Applications
-    href: tracing-and-instrumenting-applications.md
-    items:
-    - name: Code Contracts
-      href: code-contracts.md
-    - name: Trace Switches
-      href: trace-switches.md
-    - name: "How to: Create, Initialize and Configure Trace Switches"
-      href: how-to-create-initialize-and-configure-trace-switches.md
-    - name: Trace Listeners
-      href: trace-listeners.md
-    - name: "How to: Use TraceSource and Filters with Trace Listeners"
-      href: how-to-use-tracesource-and-filters-with-trace-listeners.md
-    - name: "How to: Create and Initialize Trace Listeners"
-      href: how-to-create-and-initialize-trace-listeners.md
-    - name: "How to: Create and Initialize Trace Sources"
-      href: how-to-create-and-initialize-trace-sources.md
-    - name: "How to: Add Trace Statements to Application Code"
-      href: how-to-add-trace-statements-to-application-code.md
-    - name: "How to: Compile Conditionally with Trace and Debug"
-      href: how-to-compile-conditionally-with-trace-and-debug.md
-  - name: Diagnosing Errors with Managed Debugging Assistants
-    href: diagnosing-errors-with-managed-debugging-assistants.md
-    items:
-    - name: asynchronousThreadAbort
-      href: asynchronousthreadabort-mda.md
-    - name: bindingFailure
-      href: bindingfailure-mda.md
-    - name: callbackOnCollectedDelegate
-      href: callbackoncollecteddelegate-mda.md
-    - name: contextSwitchDeadlock
-      href: contextswitchdeadlock-mda.md
-    - name: dangerousThreadingAPI
-      href: dangerousthreadingapi-mda.md
-    - name: dateTimeInvalidLocalFormat
-      href: datetimeinvalidlocalformat-mda.md
-    - name: dirtyCastAndCallOnInterface
-      href: dirtycastandcalloninterface-mda.md
-    - name: disconnectedContext
-      href: disconnectedcontext-mda.md
-    - name: dllMainReturnsFalse
-      href: dllmainreturnsfalse-mda.md
-    - name: exceptionSwallowedOnCallFromCom
-      href: exceptionswallowedoncallfromcom-mda.md
-    - name: failedQI
-      href: failedqi-mda.md
-    - name: fatalExecutionEngineError
-      href: fatalexecutionengineerror-mda.md
-    - name: gcManagedToUnmanaged
-      href: gcmanagedtounmanaged-mda.md
-    - name: gcUnmanagedToManaged
-      href: gcunmanagedtomanaged-mda.md
-    - name: illegalPrepareConstrainedRegion
-      href: illegalprepareconstrainedregion-mda.md
-    - name: invalidApartmentStateChange
-      href: invalidapartmentstatechange-mda.md
-    - name: invalidCERCall
-      href: invalidcercall-mda.md
-    - name: invalidFunctionPointerInDelegate
-      href: invalidfunctionpointerindelegate-mda.md
-    - name: invalidGCHandleCookie
-      href: invalidgchandlecookie-mda.md
-    - name: invalidIUnknown
-      href: invalidiunknown-mda.md
-    - name: invalidMemberDeclaration
-      href: invalidmemberdeclaration-mda.md
-    - name: invalidOverlappedToPinvoke
-      href: invalidoverlappedtopinvoke-mda.md
-    - name: invalidVariant
-      href: invalidvariant-mda.md
-    - name: jitCompilationStart
-      href: jitcompilationstart-mda.md
-    - name: loaderLock
-      href: loaderlock-mda.md
-    - name: loadFromContext
-      href: loadfromcontext-mda.md
-    - name: marshalCleanupError
-      href: marshalcleanuperror-mda.md
-    - name: marshaling
-      href: marshaling-mda.md
-    - name: memberInfoCacheCreation
-      href: memberinfocachecreation-mda.md
-    - name: moduloObjectHashcode
-      href: moduloobjecthashcode-mda.md
-    - name: nonComVisibleBaseClass
-      href: noncomvisiblebaseclass-mda.md
-    - name: notMarshalable
-      href: notmarshalable-mda.md
-    - name: openGenericCERCall
-      href: opengenericcercall-mda.md
-    - name: overlappedFreeError
-      href: overlappedfreeerror-mda.md
-    - name: pInvokeLog
-      href: pinvokelog-mda.md
-    - name: pInvokeStackImbalance
-      href: pinvokestackimbalance-mda.md
-    - name: raceOnRCWCleanup
-      href: raceonrcwcleanup-mda.md
-    - name: reentrancy
-      href: reentrancy-mda.md
-    - name: releaseHandleFailed
-      href: releasehandlefailed-mda.md
-    - name: reportAvOnComRelease
-      href: reportavoncomrelease-mda.md
-    - name: streamWriterBufferedDataLost
-      href: streamwriterbuffereddatalost-mda.md
-    - name: virtualCERCall
-      href: virtualcercall-mda.md
-  - name: Enhancing Debugging with the Debugger Display Attributes
-    href: enhancing-debugging-with-the-debugger-display-attributes.md
-  - name: Runtime Profiling
-    href: runtime-profiling.md
-  - name: Performance Counters
-    href: performance-counters.md
-  - name: Performance Counters and In-Process Side-By-Side Applications
-    href: performance-counters-and-in-process-side-by-side-applications.md
+  - name: Code Contracts
+    href: code-contracts.md
+  - name: Trace Switches
+    href: trace-switches.md
+  - name: "How to: Create, Initialize and Configure Trace Switches"
+    href: how-to-create-initialize-and-configure-trace-switches.md
+  - name: Trace Listeners
+    href: trace-listeners.md
+  - name: "How to: Use TraceSource and Filters with Trace Listeners"
+    href: how-to-use-tracesource-and-filters-with-trace-listeners.md
+  - name: "How to: Create and Initialize Trace Listeners"
+    href: how-to-create-and-initialize-trace-listeners.md
+  - name: "How to: Create and Initialize Trace Sources"
+    href: how-to-create-and-initialize-trace-sources.md
+  - name: "How to: Add Trace Statements to Application Code"
+    href: how-to-add-trace-statements-to-application-code.md
+  - name: "How to: Compile Conditionally with Trace and Debug"
+    href: how-to-compile-conditionally-with-trace-and-debug.md
+- name: Diagnosing Errors with Managed Debugging Assistants
+  href: diagnosing-errors-with-managed-debugging-assistants.md
+  items:
+  - name: asynchronousThreadAbort
+    href: asynchronousthreadabort-mda.md
+  - name: bindingFailure
+    href: bindingfailure-mda.md
+  - name: callbackOnCollectedDelegate
+    href: callbackoncollecteddelegate-mda.md
+  - name: contextSwitchDeadlock
+    href: contextswitchdeadlock-mda.md
+  - name: dangerousThreadingAPI
+    href: dangerousthreadingapi-mda.md
+  - name: dateTimeInvalidLocalFormat
+    href: datetimeinvalidlocalformat-mda.md
+  - name: dirtyCastAndCallOnInterface
+    href: dirtycastandcalloninterface-mda.md
+  - name: disconnectedContext
+    href: disconnectedcontext-mda.md
+  - name: dllMainReturnsFalse
+    href: dllmainreturnsfalse-mda.md
+  - name: exceptionSwallowedOnCallFromCom
+    href: exceptionswallowedoncallfromcom-mda.md
+  - name: failedQI
+    href: failedqi-mda.md
+  - name: fatalExecutionEngineError
+    href: fatalexecutionengineerror-mda.md
+  - name: gcManagedToUnmanaged
+    href: gcmanagedtounmanaged-mda.md
+  - name: gcUnmanagedToManaged
+    href: gcunmanagedtomanaged-mda.md
+  - name: illegalPrepareConstrainedRegion
+    href: illegalprepareconstrainedregion-mda.md
+  - name: invalidApartmentStateChange
+    href: invalidapartmentstatechange-mda.md
+  - name: invalidCERCall
+    href: invalidcercall-mda.md
+  - name: invalidFunctionPointerInDelegate
+    href: invalidfunctionpointerindelegate-mda.md
+  - name: invalidGCHandleCookie
+    href: invalidgchandlecookie-mda.md
+  - name: invalidIUnknown
+    href: invalidiunknown-mda.md
+  - name: invalidMemberDeclaration
+    href: invalidmemberdeclaration-mda.md
+  - name: invalidOverlappedToPinvoke
+    href: invalidoverlappedtopinvoke-mda.md
+  - name: invalidVariant
+    href: invalidvariant-mda.md
+  - name: jitCompilationStart
+    href: jitcompilationstart-mda.md
+  - name: loaderLock
+    href: loaderlock-mda.md
+  - name: loadFromContext
+    href: loadfromcontext-mda.md
+  - name: marshalCleanupError
+    href: marshalcleanuperror-mda.md
+  - name: marshaling
+    href: marshaling-mda.md
+  - name: memberInfoCacheCreation
+    href: memberinfocachecreation-mda.md
+  - name: moduloObjectHashcode
+    href: moduloobjecthashcode-mda.md
+  - name: nonComVisibleBaseClass
+    href: noncomvisiblebaseclass-mda.md
+  - name: notMarshalable
+    href: notmarshalable-mda.md
+  - name: openGenericCERCall
+    href: opengenericcercall-mda.md
+  - name: overlappedFreeError
+    href: overlappedfreeerror-mda.md
+  - name: pInvokeLog
+    href: pinvokelog-mda.md
+  - name: pInvokeStackImbalance
+    href: pinvokestackimbalance-mda.md
+  - name: raceOnRCWCleanup
+    href: raceonrcwcleanup-mda.md
+  - name: reentrancy
+    href: reentrancy-mda.md
+  - name: releaseHandleFailed
+    href: releasehandlefailed-mda.md
+  - name: reportAvOnComRelease
+    href: reportavoncomrelease-mda.md
+  - name: streamWriterBufferedDataLost
+    href: streamwriterbuffereddatalost-mda.md
+  - name: virtualCERCall
+    href: virtualcercall-mda.md
+- name: Enhancing Debugging with the Debugger Display Attributes
+  href: enhancing-debugging-with-the-debugger-display-attributes.md
+- name: Runtime Profiling
+  href: runtime-profiling.md
+- name: Performance Counters
+  href: performance-counters.md
+- name: Performance Counters and In-Process Side-By-Side Applications
+  href: performance-counters-and-in-process-side-by-side-applications.md

--- a/docs/framework/deployment/toc.yml
+++ b/docs/framework/deployment/toc.yml
@@ -1,36 +1,36 @@
+items:
 - name: Deployment
   href: index.md
+- name: Deploy .NET Framework
+  href: deploying-the-net-framework.md
   items:
-  - name: Deploying the .NET Framework
-    href: deploying-the-net-framework.md
-    items:
-    - name: Deployment Guide for Developers
-      href: deployment-guide-for-developers.md
-    - name: Deployment Guide for Administrators
-      href: guide-for-administrators.md
-    - name: Reducing System Restarts During .NET Framework 4.5 Installations
-      href: reducing-system-restarts.md
-    - name: "How to: Get Progress from the .NET Framework 4.5 Installer"
-      href: how-to-get-progress-from-the-dotnet-installer.md
-    - name: ".NET Framework Initialization Errors: Managing the User Experience"
-      href: initialization-errors-managing-the-user-experience.md
-    - name: "How to: Debug CLR Activation Issues"
-      href: how-to-debug-clr-activation-issues.md
-  - name: Deploying .NET Framework Applications
-    href: net-framework-applications.md
-    items:
-    - name: How the Runtime Locates Assemblies
-      href: how-the-runtime-locates-assemblies.md
-    - name: Best Practices for Assembly Loading
-      href: best-practices-for-assembly-loading.md
-  - name: .NET Framework Client Profile
-    href: client-profile.md
-  - name: Side-by-Side Execution
-    href: side-by-side-execution.md
-    items:
-    - name: Configuring Assembly Binding Redirection
-      href: configuring-assembly-binding-redirection.md
-    - name: Guidelines for Creating Components for Side-by-Side Execution
-      href: guidelines-for-creating-components-for-side-by-side-execution.md
-    - name: In-Process Side-by-Side Execution
-      href: in-process-side-by-side-execution.md
+  - name: Deployment Guide for Developers
+    href: deployment-guide-for-developers.md
+  - name: Deployment Guide for Administrators
+    href: guide-for-administrators.md
+  - name: Reducing System Restarts During .NET Framework 4.5 Installations
+    href: reducing-system-restarts.md
+  - name: "How to: Get Progress from the .NET Framework 4.5 Installer"
+    href: how-to-get-progress-from-the-dotnet-installer.md
+  - name: ".NET Framework Initialization Errors: Managing the User Experience"
+    href: initialization-errors-managing-the-user-experience.md
+  - name: "How to: Debug CLR Activation Issues"
+    href: how-to-debug-clr-activation-issues.md
+- name: Deploying .NET Framework Applications
+  href: net-framework-applications.md
+  items:
+  - name: How the Runtime Locates Assemblies
+    href: how-the-runtime-locates-assemblies.md
+  - name: Best Practices for Assembly Loading
+    href: best-practices-for-assembly-loading.md
+- name: .NET Framework Client Profile
+  href: client-profile.md
+- name: Side-by-Side Execution
+  href: side-by-side-execution.md
+  items:
+  - name: Configuring Assembly Binding Redirection
+    href: configuring-assembly-binding-redirection.md
+  - name: Guidelines for Creating Components for Side-by-Side Execution
+    href: guidelines-for-creating-components-for-side-by-side-execution.md
+  - name: In-Process Side-by-Side Execution
+    href: in-process-side-by-side-execution.md

--- a/docs/framework/interop/toc.yml
+++ b/docs/framework/interop/toc.yml
@@ -1,104 +1,104 @@
-- name: Interoperating with Unmanaged Code
+items:
+- name: Interoperate with unmanaged code
   href: index.md
+- name: Expose COM components to .NET Framework
+  href: exposing-com-components.md
   items:
-  - name: Exposing COM Components to the .NET Framework
-    href: exposing-com-components.md
+  - name: Importing a Type Library as an Assembly
+    href: importing-a-type-library-as-an-assembly.md
+  - name: "How to: Add References to Type Libraries"
+    href: how-to-add-references-to-type-libraries.md
+  - name: "How to: Generate Interop Assemblies from Type Libraries"
+    href: how-to-generate-interop-assemblies-from-type-libraries.md
+  - name: Compiling an Interop Project
+    href: compiling-an-interop-project.md
+  - name: Deploying an Interop Application
+    href: deploying-an-interop-application.md
+  - name: "COM Interop Sample: .NET Client and COM Server"
+    href: com-interop-sample-net-client-and-com-server.md
+- name: Exposing .NET Framework Components to COM
+  href: exposing-dotnet-components-to-com.md
+  items:
+  - name: Packaging an Assembly for COM
+    href: packaging-an-assembly-for-com.md
+  - name: Registering Assemblies with COM
+    href: registering-assemblies-with-com.md
+  - name: "How to: Reference .NET Types from COM"
+    href: how-to-reference-net-types-from-com.md
+  - name: "COM Interop Sample: COM Client and .NET Server"
+    href: com-interop-sample-com-client-and-net-server.md
+- name: Consuming Unmanaged DLL Functions
+  href: consuming-unmanaged-dll-functions.md
+  items:
+  - name: Identifying Functions in DLLs
+    href: identifying-functions-in-dlls.md
+  - name: Creating a Class to Hold DLL Functions
+    href: creating-a-class-to-hold-dll-functions.md
+  - name: Creating Prototypes in Managed Code
+    href: creating-prototypes-in-managed-code.md
     items:
-    - name: Importing a Type Library as an Assembly
-      href: importing-a-type-library-as-an-assembly.md
-    - name: "How to: Add References to Type Libraries"
-      href: how-to-add-references-to-type-libraries.md
-    - name: "How to: Generate Interop Assemblies from Type Libraries"
-      href: how-to-generate-interop-assemblies-from-type-libraries.md
-    - name: Compiling an Interop Project
-      href: compiling-an-interop-project.md
-    - name: Deploying an Interop Application
-      href: deploying-an-interop-application.md
-    - name: "COM Interop Sample: .NET Client and COM Server"
-      href: com-interop-sample-net-client-and-com-server.md
-  - name: Exposing .NET Framework Components to COM
-    href: exposing-dotnet-components-to-com.md
+    - name: Specifying an Entry Point
+      href: specifying-an-entry-point.md
+    - name: Specifying a Character Set
+      href: specifying-a-character-set.md
+    - name: Platform Invoke Examples
+      href: platform-invoke-examples.md
+  - name: Calling a DLL Function
+    href: calling-a-dll-function.md
     items:
-    - name: Packaging an Assembly for COM
-      href: packaging-an-assembly-for-com.md
-    - name: Registering Assemblies with COM
-      href: registering-assemblies-with-com.md
-    - name: "How to: Reference .NET Types from COM"
-      href: how-to-reference-net-types-from-com.md
-    - name: "COM Interop Sample: COM Client and .NET Server"
-      href: com-interop-sample-com-client-and-net-server.md
-  - name: Consuming Unmanaged DLL Functions
-    href: consuming-unmanaged-dll-functions.md
+    - name: Passing Structures
+      href: passing-structures.md
+    - name: Callback Functions
+      href: callback-functions.md
+    - name: "How to: Implement Callback Functions"
+      href: how-to-implement-callback-functions.md
+- name: Interop Marshaling
+  href: interop-marshalling.md
+  items:
+  - name: Default Marshalling Behavior
+    href: default-marshalling-behavior.md
     items:
-    - name: Identifying Functions in DLLs
-      href: identifying-functions-in-dlls.md
-    - name: Creating a Class to Hold DLL Functions
-      href: creating-a-class-to-hold-dll-functions.md
-    - name: Creating Prototypes in Managed Code
-      href: creating-prototypes-in-managed-code.md
-      items:
-      - name: Specifying an Entry Point
-        href: specifying-an-entry-point.md
-      - name: Specifying a Character Set
-        href: specifying-a-character-set.md
-      - name: Platform Invoke Examples
-        href: platform-invoke-examples.md
-    - name: Calling a DLL Function
-      href: calling-a-dll-function.md
-      items:
-      - name: Passing Structures
-        href: passing-structures.md
-      - name: Callback Functions
-        href: callback-functions.md
-      - name: "How to: Implement Callback Functions"
-        href: how-to-implement-callback-functions.md
-  - name: Interop Marshaling
-    href: interop-marshalling.md
+    - name: Blittable and Non-Blittable Types
+      href: blittable-and-non-blittable-types.md
+    - name: Copying and Pinning
+      href: copying-and-pinning.md
+    - name: Default Marshalling for Arrays
+      href: default-marshalling-for-arrays.md
+    - name: Default Marshalling for Objects
+      href: default-marshalling-for-objects.md
+    - name: Default Marshalling for Strings
+      href: default-marshalling-for-strings.md
+  - name: Marshalling Data with Platform Invoke
+    href: marshalling-data-with-platform-invoke.md
     items:
-    - name: Default Marshalling Behavior
-      href: default-marshalling-behavior.md
-      items:
-      - name: Blittable and Non-Blittable Types
-        href: blittable-and-non-blittable-types.md
-      - name: Copying and Pinning
-        href: copying-and-pinning.md
-      - name: Default Marshalling for Arrays
-        href: default-marshalling-for-arrays.md
-      - name: Default Marshalling for Objects
-        href: default-marshalling-for-objects.md
-      - name: Default Marshalling for Strings
-        href: default-marshalling-for-strings.md
-    - name: Marshalling Data with Platform Invoke
-      href: marshalling-data-with-platform-invoke.md
-      items:
-      - name: Marshalling Strings
-        href: marshalling-strings.md
-      - name: MsgBox Sample
-        href: msgbox-sample.md
-      - name: Marshalling Classes, Structures, and Unions
-        href: marshalling-classes-structures-and-unions.md
-      - name: Marshalling Different Types of Arrays
-        href: marshalling-different-types-of-arrays.md
-      - name: Marshalling a Delegate as a Callback Method
-        href: marshalling-a-delegate-as-a-callback-method.md
-    - name: Marshalling Data with COM Interop
-      href: marshalling-data-with-com-interop.md
-      items:
-      - name: "How to: Create Wrappers Manually"
-        href: how-to-create-wrappers-manually.md
-      - name: "How to: Migrate Managed-Code DCOM to WCF"
-        href: how-to-migrate-managed-code-dcom-to-wcf.md
-  - name: "How to: Map HRESULTs and Exceptions"
-    href: how-to-map-hresults-and-exceptions.md
-  - name: "How to: Create COM Wrappers"
-    href: how-to-create-com-wrappers.md
-  - name: Type Equivalence and Embedded Interop Types
-    href: type-equivalence-and-embedded-interop-types.md
-  - name: "How to: Generate Primary Interop Assemblies Using Tlbimp.exe"
-    href: how-to-generate-primary-interop-assemblies-using-tlbimp-exe.md
-  - name: "How to: Register Primary Interop Assemblies"
-    href: how-to-register-primary-interop-assemblies.md
-  - name: Registration-Free COM Interop
-    href: registration-free-com-interop.md
-  - name: "How to: Configure .NET Framework-Based COM Components for Registration-Free Activation"
-    href: configure-net-framework-based-com-components-for-reg.md
+    - name: Marshalling Strings
+      href: marshalling-strings.md
+    - name: MsgBox Sample
+      href: msgbox-sample.md
+    - name: Marshalling Classes, Structures, and Unions
+      href: marshalling-classes-structures-and-unions.md
+    - name: Marshalling Different Types of Arrays
+      href: marshalling-different-types-of-arrays.md
+    - name: Marshalling a Delegate as a Callback Method
+      href: marshalling-a-delegate-as-a-callback-method.md
+  - name: Marshalling Data with COM Interop
+    href: marshalling-data-with-com-interop.md
+    items:
+    - name: "How to: Create Wrappers Manually"
+      href: how-to-create-wrappers-manually.md
+    - name: "How to: Migrate Managed-Code DCOM to WCF"
+      href: how-to-migrate-managed-code-dcom-to-wcf.md
+- name: "How to: Map HRESULTs and Exceptions"
+  href: how-to-map-hresults-and-exceptions.md
+- name: "How to: Create COM Wrappers"
+  href: how-to-create-com-wrappers.md
+- name: Type Equivalence and Embedded Interop Types
+  href: type-equivalence-and-embedded-interop-types.md
+- name: "How to: Generate Primary Interop Assemblies Using Tlbimp.exe"
+  href: how-to-generate-primary-interop-assemblies-using-tlbimp-exe.md
+- name: "How to: Register Primary Interop Assemblies"
+  href: how-to-register-primary-interop-assemblies.md
+- name: Registration-Free COM Interop
+  href: registration-free-com-interop.md
+- name: "How to: Configure .NET Framework-Based COM Components for Registration-Free Activation"
+  href: configure-net-framework-based-com-components-for-reg.md

--- a/docs/framework/mef/toc.yml
+++ b/docs/framework/mef/toc.yml
@@ -1,5 +1,5 @@
+items:
 - name: Managed Extensibility Framework (MEF)
   href: index.md
-  items:
-  - name: Attributed programming model overview (MEF)
-    href: attributed-programming-model-overview-mef.md
+- name: Attributed programming model overview (MEF)
+  href: attributed-programming-model-overview-mef.md

--- a/docs/framework/network-programming/toc.yml
+++ b/docs/framework/network-programming/toc.yml
@@ -1,3 +1,4 @@
+items:
 - name: Network programming in .NET Framework
   items:
   - name: Configuring Internet Applications

--- a/docs/framework/performance/toc.yml
+++ b/docs/framework/performance/toc.yml
@@ -1,64 +1,64 @@
+items:
 - name: Performance
   href: index.md
+- name: Writing Large, Responsive .NET Framework Apps
+  href: writing-large-responsive-apps.md
+- name: Caching in .NET Framework Applications
+  href: caching-in-net-framework-applications.md
+- name: Lazy Initialization
+  href: lazy-initialization.md
   items:
-  - name: Writing Large, Responsive .NET Framework Apps
-    href: writing-large-responsive-apps.md
-  - name: Caching in .NET Framework Applications
-    href: caching-in-net-framework-applications.md
-  - name: Lazy Initialization
-    href: lazy-initialization.md
+  - name: "How to: Perform Lazy Initialization of Objects"
+    href: how-to-perform-lazy-initialization-of-objects.md
+- name: ETW Events in the .NET Framework
+  href: etw-events.md
+  items:
+  - name: ETW Events in Task Parallel Library and PLINQ
+    href: etw-events-in-task-parallel-library-and-plinq.md
+  - name: ETW Events in the Common Language Runtime
+    href: etw-events-in-the-common-language-runtime.md
     items:
-    - name: "How to: Perform Lazy Initialization of Objects"
-      href: how-to-perform-lazy-initialization-of-objects.md
-  - name: ETW Events in the .NET Framework
-    href: etw-events.md
-    items:
-    - name: ETW Events in Task Parallel Library and PLINQ
-      href: etw-events-in-task-parallel-library-and-plinq.md
-    - name: ETW Events in the Common Language Runtime
-      href: etw-events-in-the-common-language-runtime.md
+    - name: Controlling .NET Framework Logging
+      href: controlling-logging.md
+    - name: CLR ETW Providers
+      href: clr-etw-providers.md
+    - name: CLR ETW Keywords and Levels
+      href: clr-etw-keywords-and-levels.md
+    - name: CLR ETW Events
+      href: clr-etw-events.md
       items:
-      - name: Controlling .NET Framework Logging
-        href: controlling-logging.md
-      - name: CLR ETW Providers
-        href: clr-etw-providers.md
-      - name: CLR ETW Keywords and Levels
-        href: clr-etw-keywords-and-levels.md
-      - name: CLR ETW Events
-        href: clr-etw-events.md
-        items:
-        - name: Runtime Information Events
-          href: runtime-information-etw-events.md
-        - name: Exception Thrown_V1 Event
-          href: exception-thrown-v1-etw-event.md
-        - name: Contention Events
-          href: contention-etw-events.md
-        - name: Thread Pool Events
-          href: thread-pool-etw-events.md
-        - name: Loader Events
-          href: loader-etw-events.md
-        - name: Method Events
-          href: method-etw-events.md
-        - name: Garbage Collection Events
-          href: garbage-collection-etw-events.md
-        - name: JIT Tracing Events
-          href: jit-tracing-etw-events.md
-        - name: Interop Events
-          href: interop-etw-events.md
-        - name: ARM Events
-          href: application-domain-resource-monitoring-arm-etw-events.md
-        - name: Security Events
-          href: security-etw-events.md
-        - name: Stack Event
-          href: stack-etw-event.md
-  - name: Reliability
-    href: reliability.md
-    items:
-    - name: SQL Server Programming and Host Protection Attributes
-      href: sql-server-programming-and-host-protection-attributes.md
-    - name: Reliability Best Practices
-      href: reliability-best-practices.md
-    - name: Constrained Execution Regions
-      href: constrained-execution-regions.md
-  - name: Performance Tips
-    href: performance-tips.md
+      - name: Runtime Information Events
+        href: runtime-information-etw-events.md
+      - name: Exception Thrown_V1 Event
+        href: exception-thrown-v1-etw-event.md
+      - name: Contention Events
+        href: contention-etw-events.md
+      - name: Thread Pool Events
+        href: thread-pool-etw-events.md
+      - name: Loader Events
+        href: loader-etw-events.md
+      - name: Method Events
+        href: method-etw-events.md
+      - name: Garbage Collection Events
+        href: garbage-collection-etw-events.md
+      - name: JIT Tracing Events
+        href: jit-tracing-etw-events.md
+      - name: Interop Events
+        href: interop-etw-events.md
+      - name: ARM Events
+        href: application-domain-resource-monitoring-arm-etw-events.md
+      - name: Security Events
+        href: security-etw-events.md
+      - name: Stack Event
+        href: stack-etw-event.md
+- name: Reliability
+  href: reliability.md
+  items:
+  - name: SQL Server Programming and Host Protection Attributes
+    href: sql-server-programming-and-host-protection-attributes.md
+  - name: Reliability Best Practices
+    href: reliability-best-practices.md
+  - name: Constrained Execution Regions
+    href: constrained-execution-regions.md
+- name: Performance Tips
+  href: performance-tips.md

--- a/docs/framework/reflection-and-codedom/toc.yml
+++ b/docs/framework/reflection-and-codedom/toc.yml
@@ -1,57 +1,57 @@
+items:
 - name: Dynamic programming
   href: index.md
+- name: Reflection
+  href: reflection.md
   items:
-  - name: Reflection
-    href: reflection.md
-    items:
-    - name: Viewing Type Information
-      href: viewing-type-information.md
-    - name: Reflection and Generic Types
-      href: reflection-and-generic-types.md
-    - name: "How to: Examine and Instantiate Generic Types with Reflection"
-      href: how-to-examine-and-instantiate-generic-types-with-reflection.md
-    - name: Security Considerations for Reflection
-      href: security-considerations-for-reflection.md
-    - name: Dynamically Loading and Using Types
-      href: dynamically-loading-and-using-types.md
-    - name: "How to: Load Assemblies into the Reflection-Only Context"
-      href: how-to-load-assemblies-into-the-reflection-only-context.md
-    - name: "How to: Get type and member information by using reflection"
-      href: get-type-member-information.md
-    - name: Accessing Custom Attributes
-      href: accessing-custom-attributes.md
-    - name: Specifying Fully Qualified Type Names
-      href: specifying-fully-qualified-type-names.md
-    - name: "How to: Hook Up a Delegate Using Reflection"
-      href: how-to-hook-up-a-delegate-using-reflection.md
-    - name: Reflection in the .NET Framework for Windows Store Apps
-      href: reflection-for-windows-store-apps.md
-  - name: Emit dynamic methods and assemblies
-    href: emitting-dynamic-methods-and-assemblies.md
-    items:
-    - name: Security Issues in Reflection Emit
-      href: security-issues-in-reflection-emit.md
-    - name: "Walkthrough: Emitting Code in Partial Trust Scenarios"
-      href: walkthrough-emitting-code-in-partial-trust-scenarios.md
-    - name: "How to: Define and Execute Dynamic Methods"
-      href: how-to-define-and-execute-dynamic-methods.md
-    - name: "How to: Define a Generic Type with Reflection Emit"
-      href: how-to-define-a-generic-type-with-reflection-emit.md
-    - name: "How to: Define a Generic Method with Reflection Emit"
-      href: how-to-define-a-generic-method-with-reflection-emit.md
-    - name: Collectible assemblies for dynamic type generation
-      href: collectible-assemblies.md
-  - name: Dynamic language runtime overview
-    href: dynamic-language-runtime-overview.md
-  - name: Dynamic source code generation and compilation
-    items:
-    - name: Overview
-      href: dynamic-source-code-generation-and-compilation.md
-    - name: Use the CodeDOM
-      href: using-the-codedom.md
-    - name: Generate and compile source code from a CodeDOM graph
-      href: generating-and-compiling-source-code-from-a-codedom-graph.md
-    - name: Create an XML documentation file using CodeDOM
-      href: how-to-create-an-xml-documentation-file-using-codedom.md
-    - name: Create a class using CodeDOM
-      href: how-to-create-a-class-using-codedom.md
+  - name: Viewing Type Information
+    href: viewing-type-information.md
+  - name: Reflection and Generic Types
+    href: reflection-and-generic-types.md
+  - name: "How to: Examine and Instantiate Generic Types with Reflection"
+    href: how-to-examine-and-instantiate-generic-types-with-reflection.md
+  - name: Security Considerations for Reflection
+    href: security-considerations-for-reflection.md
+  - name: Dynamically Loading and Using Types
+    href: dynamically-loading-and-using-types.md
+  - name: "How to: Load Assemblies into the Reflection-Only Context"
+    href: how-to-load-assemblies-into-the-reflection-only-context.md
+  - name: "How to: Get type and member information by using reflection"
+    href: get-type-member-information.md
+  - name: Accessing Custom Attributes
+    href: accessing-custom-attributes.md
+  - name: Specifying Fully Qualified Type Names
+    href: specifying-fully-qualified-type-names.md
+  - name: "How to: Hook Up a Delegate Using Reflection"
+    href: how-to-hook-up-a-delegate-using-reflection.md
+  - name: Reflection in the .NET Framework for Windows Store Apps
+    href: reflection-for-windows-store-apps.md
+- name: Emit dynamic methods and assemblies
+  href: emitting-dynamic-methods-and-assemblies.md
+  items:
+  - name: Security Issues in Reflection Emit
+    href: security-issues-in-reflection-emit.md
+  - name: "Walkthrough: Emitting Code in Partial Trust Scenarios"
+    href: walkthrough-emitting-code-in-partial-trust-scenarios.md
+  - name: "How to: Define and Execute Dynamic Methods"
+    href: how-to-define-and-execute-dynamic-methods.md
+  - name: "How to: Define a Generic Type with Reflection Emit"
+    href: how-to-define-a-generic-type-with-reflection-emit.md
+  - name: "How to: Define a Generic Method with Reflection Emit"
+    href: how-to-define-a-generic-method-with-reflection-emit.md
+  - name: Collectible assemblies for dynamic type generation
+    href: collectible-assemblies.md
+- name: Dynamic language runtime overview
+  href: dynamic-language-runtime-overview.md
+- name: Dynamic source code generation and compilation
+  items:
+  - name: Overview
+    href: dynamic-source-code-generation-and-compilation.md
+  - name: Use the CodeDOM
+    href: using-the-codedom.md
+  - name: Generate and compile source code from a CodeDOM graph
+    href: generating-and-compiling-source-code-from-a-codedom-graph.md
+  - name: Create an XML documentation file using CodeDOM
+    href: how-to-create-an-xml-documentation-file-using-codedom.md
+  - name: Create a class using CodeDOM
+    href: how-to-create-a-class-using-codedom.md

--- a/docs/framework/ui-automation/toc.yml
+++ b/docs/framework/ui-automation/toc.yml
@@ -1,243 +1,243 @@
+items:
 - name: Accessibility
   href: index.md
+- name: Accessibility Best Practices
+  href: accessibility-best-practices.md
+- name: UI Automation Fundamentals
+  href: ui-automation-fundamentals.md
   items:
-  - name: Accessibility Best Practices
-    href: accessibility-best-practices.md
-  - name: UI Automation Fundamentals
-    href: ui-automation-fundamentals.md
+  - name: UI Automation Overview
+    href: ui-automation-overview.md
+  - name: UI Automation and Microsoft Active Accessibility
+    href: ui-automation-and-microsoft-active-accessibility.md
+  - name: UI Automation Tree Overview
+    href: ui-automation-tree-overview.md
+  - name: UI Automation Control Patterns Overview
+    href: ui-automation-control-patterns-overview.md
+  - name: UI Automation Properties Overview
+    href: ui-automation-properties-overview.md
+  - name: UI Automation Events Overview
+    href: ui-automation-events-overview.md
+  - name: UI Automation Security Overview
+    href: ui-automation-security-overview.md
+  - name: Using UI Automation for Automated Testing
+    href: using-ui-automation-for-automated-testing.md
+- name: UI Automation Providers for Managed Code
+  href: ui-automation-providers-for-managed-code.md
+  items:
+  - name: Server-Side UI Automation Provider Implementation
+    href: server-side-ui-automation-provider-implementation.md
+  - name: UI Automation Providers Overview
+    href: ui-automation-providers-overview.md
+  - name: Client-Side UI Automation Provider Implementation
+    href: client-side-ui-automation-provider-implementation.md
+  - name: How-to Topics
+    href: ui-automation-providers-for-managed-code-how-to-topics.md
     items:
-    - name: UI Automation Overview
-      href: ui-automation-overview.md
-    - name: UI Automation and Microsoft Active Accessibility
-      href: ui-automation-and-microsoft-active-accessibility.md
-    - name: UI Automation Tree Overview
-      href: ui-automation-tree-overview.md
-    - name: UI Automation Control Patterns Overview
-      href: ui-automation-control-patterns-overview.md
-    - name: UI Automation Properties Overview
-      href: ui-automation-properties-overview.md
-    - name: UI Automation Events Overview
-      href: ui-automation-events-overview.md
-    - name: UI Automation Security Overview
-      href: ui-automation-security-overview.md
-    - name: Using UI Automation for Automated Testing
-      href: using-ui-automation-for-automated-testing.md
-  - name: UI Automation Providers for Managed Code
-    href: ui-automation-providers-for-managed-code.md
+    - name: Expose a Server-side UI Automation Provider
+      href: expose-a-server-side-ui-automation-provider.md
+    - name: Return Properties from a UI Automation Provider
+      href: return-properties-from-a-ui-automation-provider.md
+    - name: Raise Events from a UI Automation Provider
+      href: raise-events-from-a-ui-automation-provider.md
+    - name: Enable Navigation in a UI Automation Fragment Provider
+      href: enable-navigation-in-a-ui-automation-fragment-provider.md
+    - name: Support Control Patterns in a UI Automation Provider
+      href: support-control-patterns-in-a-ui-automation-provider.md
+    - name: Create a Client-Side UI Automation Provider
+      href: create-a-client-side-ui-automation-provider.md
+    - name: Implement UI Automation Providers in a Client Application
+      href: implement-ui-automation-providers-in-a-client-application.md
+- name: UI Automation Clients for Managed Code
+  href: ui-automation-clients-for-managed-code.md
+  items:
+  - name: UI Automation and Screen Scaling
+    href: ui-automation-and-screen-scaling.md
+  - name: UI Automation Support for Standard Controls
+    href: ui-automation-support-for-standard-controls.md
+  - name: UI Automation Events for Clients
+    href: ui-automation-events-for-clients.md
+  - name: Caching in UI Automation Clients
+    href: caching-in-ui-automation-clients.md
+  - name: UI Automation Properties for Clients
+    href: ui-automation-properties-for-clients.md
+  - name: Control Pattern Mapping for UI Automation Clients
+    href: control-pattern-mapping-for-ui-automation-clients.md
+  - name: UI Automation Control Patterns for Clients
+    href: ui-automation-control-patterns-for-clients.md
+  - name: Obtaining UI Automation Elements
+    href: obtaining-ui-automation-elements.md
+  - name: UI Automation Threading Issues
+    href: ui-automation-threading-issues.md
+  - name: How-to Topics
+    href: ui-automation-clients-for-managed-code-how-to-topics.md
     items:
-    - name: Server-Side UI Automation Provider Implementation
-      href: server-side-ui-automation-provider-implementation.md
-    - name: UI Automation Providers Overview
-      href: ui-automation-providers-overview.md
-    - name: Client-Side UI Automation Provider Implementation
-      href: client-side-ui-automation-provider-implementation.md
-    - name: How-to Topics
-      href: ui-automation-providers-for-managed-code-how-to-topics.md
-      items:
-      - name: Expose a Server-side UI Automation Provider
-        href: expose-a-server-side-ui-automation-provider.md
-      - name: Return Properties from a UI Automation Provider
-        href: return-properties-from-a-ui-automation-provider.md
-      - name: Raise Events from a UI Automation Provider
-        href: raise-events-from-a-ui-automation-provider.md
-      - name: Enable Navigation in a UI Automation Fragment Provider
-        href: enable-navigation-in-a-ui-automation-fragment-provider.md
-      - name: Support Control Patterns in a UI Automation Provider
-        href: support-control-patterns-in-a-ui-automation-provider.md
-      - name: Create a Client-Side UI Automation Provider
-        href: create-a-client-side-ui-automation-provider.md
-      - name: Implement UI Automation Providers in a Client Application
-        href: implement-ui-automation-providers-in-a-client-application.md
-  - name: UI Automation Clients for Managed Code
-    href: ui-automation-clients-for-managed-code.md
+    - name: Find a UI Automation Element Based on a Property Condition
+      href: find-a-ui-automation-element-based-on-a-property-condition.md
+    - name: Navigate Among UI Automation Elements with TreeWalker
+      href: navigate-among-ui-automation-elements-with-treewalker.md
+    - name: Find a UI Automation Element for a List Item
+      href: find-a-ui-automation-element-for-a-list-item.md
+    - name: Get UI Automation Element Properties
+      href: get-ui-automation-element-properties.md
+    - name: Use Caching in UI Automation
+      href: use-caching-in-ui-automation.md
+    - name: Subscribe to UI Automation Events
+      href: subscribe-to-ui-automation-events.md
+    - name: Register a Client-Side Provider Assembly
+      href: register-a-client-side-provider-assembly.md
+    - name: Use the AutomationID Property
+      href: use-the-automationid-property.md
+- name: UI Automation Control Patterns
+  href: ui-automation-control-patterns.md
+  items:
+  - name: Implementing the UI Automation Dock Control Pattern
+    href: implementing-the-ui-automation-dock-control-pattern.md
+  - name: Implementing the UI Automation ExpandCollapse Control Pattern
+    href: implementing-the-ui-automation-expandcollapse-control-pattern.md
+  - name: Implementing the UI Automation Grid Control Pattern
+    href: implementing-the-ui-automation-grid-control-pattern.md
+  - name: Implementing the UI Automation GridItem Control Pattern
+    href: implementing-the-ui-automation-griditem-control-pattern.md
+  - name: Implementing the UI Automation Invoke Control Pattern
+    href: implementing-the-ui-automation-invoke-control-pattern.md
+  - name: Implementing the UI Automation MultipleView Control Pattern
+    href: implementing-the-ui-automation-multipleview-control-pattern.md
+  - name: Implementing the UI Automation RangeValue Control Pattern
+    href: implementing-the-ui-automation-rangevalue-control-pattern.md
+  - name: Implementing the UI Automation Scroll Control Pattern
+    href: implementing-the-ui-automation-scroll-control-pattern.md
+  - name: Implementing the UI Automation ScrollItem Control Pattern
+    href: implementing-the-ui-automation-scrollitem-control-pattern.md
+  - name: Implementing the UI Automation Selection Control Pattern
+    href: implementing-the-ui-automation-selection-control-pattern.md
+  - name: Implementing the UI Automation SelectionItem Control Pattern
+    href: implementing-the-ui-automation-selectionitem-control-pattern.md
+  - name: Implementing the UI Automation Table Control Pattern
+    href: implementing-the-ui-automation-table-control-pattern.md
+  - name: Implementing the UI Automation TableItem Control Pattern
+    href: implementing-the-ui-automation-tableitem-control-pattern.md
+  - name: Implementing the UI Automation Toggle Control Pattern
+    href: implementing-the-ui-automation-toggle-control-pattern.md
+  - name: Implementing the UI Automation Transform Control Pattern
+    href: implementing-the-ui-automation-transform-control-pattern.md
+  - name: Implementing the UI Automation Value Control Pattern
+    href: implementing-the-ui-automation-value-control-pattern.md
+  - name: Implementing the UI Automation Window Control Pattern
+    href: implementing-the-ui-automation-window-control-pattern.md
+  - name: How-to Topics
+    href: ui-automation-control-patterns-how-to-topics.md
     items:
-    - name: UI Automation and Screen Scaling
-      href: ui-automation-and-screen-scaling.md
-    - name: UI Automation Support for Standard Controls
-      href: ui-automation-support-for-standard-controls.md
-    - name: UI Automation Events for Clients
-      href: ui-automation-events-for-clients.md
-    - name: Caching in UI Automation Clients
-      href: caching-in-ui-automation-clients.md
-    - name: UI Automation Properties for Clients
-      href: ui-automation-properties-for-clients.md
-    - name: Control Pattern Mapping for UI Automation Clients
-      href: control-pattern-mapping-for-ui-automation-clients.md
-    - name: UI Automation Control Patterns for Clients
-      href: ui-automation-control-patterns-for-clients.md
-    - name: Obtaining UI Automation Elements
-      href: obtaining-ui-automation-elements.md
-    - name: UI Automation Threading Issues
-      href: ui-automation-threading-issues.md
-    - name: How-to Topics
-      href: ui-automation-clients-for-managed-code-how-to-topics.md
-      items:
-      - name: Find a UI Automation Element Based on a Property Condition
-        href: find-a-ui-automation-element-based-on-a-property-condition.md
-      - name: Navigate Among UI Automation Elements with TreeWalker
-        href: navigate-among-ui-automation-elements-with-treewalker.md
-      - name: Find a UI Automation Element for a List Item
-        href: find-a-ui-automation-element-for-a-list-item.md
-      - name: Get UI Automation Element Properties
-        href: get-ui-automation-element-properties.md
-      - name: Use Caching in UI Automation
-        href: use-caching-in-ui-automation.md
-      - name: Subscribe to UI Automation Events
-        href: subscribe-to-ui-automation-events.md
-      - name: Register a Client-Side Provider Assembly
-        href: register-a-client-side-provider-assembly.md
-      - name: Use the AutomationID Property
-        href: use-the-automationid-property.md
-  - name: UI Automation Control Patterns
-    href: ui-automation-control-patterns.md
+    - name: Expose the Content of a Table Using UI Automation
+      href: expose-the-content-of-a-table-using-ui-automation.md
+    - name: Get Supported UI Automation Control Patterns
+      href: get-supported-ui-automation-control-patterns.md
+    - name: Get the Toggle State of a Check Box Using UI Automation
+      href: get-the-toggle-state-of-a-check-box-using-ui-automation.md
+    - name: Invoke a Control Using UI Automation
+      href: invoke-a-control-using-ui-automation.md
+    - name: Move a UI Automation Element
+      href: move-a-ui-automation-element.md
+- name: UI Automation Text Pattern
+  href: ui-automation-text-pattern.md
+  items:
+  - name: UI Automation TextPattern Overview
+    href: ui-automation-textpattern-overview.md
+  - name: TextPattern and Embedded Objects Overview
+    href: textpattern-and-embedded-objects-overview.md
+  - name: How-to Topics
+    href: ui-automation-text-pattern-how-to-topics.md
     items:
-    - name: Implementing the UI Automation Dock Control Pattern
-      href: implementing-the-ui-automation-dock-control-pattern.md
-    - name: Implementing the UI Automation ExpandCollapse Control Pattern
-      href: implementing-the-ui-automation-expandcollapse-control-pattern.md
-    - name: Implementing the UI Automation Grid Control Pattern
-      href: implementing-the-ui-automation-grid-control-pattern.md
-    - name: Implementing the UI Automation GridItem Control Pattern
-      href: implementing-the-ui-automation-griditem-control-pattern.md
-    - name: Implementing the UI Automation Invoke Control Pattern
-      href: implementing-the-ui-automation-invoke-control-pattern.md
-    - name: Implementing the UI Automation MultipleView Control Pattern
-      href: implementing-the-ui-automation-multipleview-control-pattern.md
-    - name: Implementing the UI Automation RangeValue Control Pattern
-      href: implementing-the-ui-automation-rangevalue-control-pattern.md
-    - name: Implementing the UI Automation Scroll Control Pattern
-      href: implementing-the-ui-automation-scroll-control-pattern.md
-    - name: Implementing the UI Automation ScrollItem Control Pattern
-      href: implementing-the-ui-automation-scrollitem-control-pattern.md
-    - name: Implementing the UI Automation Selection Control Pattern
-      href: implementing-the-ui-automation-selection-control-pattern.md
-    - name: Implementing the UI Automation SelectionItem Control Pattern
-      href: implementing-the-ui-automation-selectionitem-control-pattern.md
-    - name: Implementing the UI Automation Table Control Pattern
-      href: implementing-the-ui-automation-table-control-pattern.md
-    - name: Implementing the UI Automation TableItem Control Pattern
-      href: implementing-the-ui-automation-tableitem-control-pattern.md
-    - name: Implementing the UI Automation Toggle Control Pattern
-      href: implementing-the-ui-automation-toggle-control-pattern.md
-    - name: Implementing the UI Automation Transform Control Pattern
-      href: implementing-the-ui-automation-transform-control-pattern.md
-    - name: Implementing the UI Automation Value Control Pattern
-      href: implementing-the-ui-automation-value-control-pattern.md
-    - name: Implementing the UI Automation Window Control Pattern
-      href: implementing-the-ui-automation-window-control-pattern.md
-    - name: How-to Topics
-      href: ui-automation-control-patterns-how-to-topics.md
-      items:
-      - name: Expose the Content of a Table Using UI Automation
-        href: expose-the-content-of-a-table-using-ui-automation.md
-      - name: Get Supported UI Automation Control Patterns
-        href: get-supported-ui-automation-control-patterns.md
-      - name: Get the Toggle State of a Check Box Using UI Automation
-        href: get-the-toggle-state-of-a-check-box-using-ui-automation.md
-      - name: Invoke a Control Using UI Automation
-        href: invoke-a-control-using-ui-automation.md
-      - name: Move a UI Automation Element
-        href: move-a-ui-automation-element.md
-  - name: UI Automation Text Pattern
-    href: ui-automation-text-pattern.md
-    items:
-    - name: UI Automation TextPattern Overview
-      href: ui-automation-textpattern-overview.md
-    - name: TextPattern and Embedded Objects Overview
-      href: textpattern-and-embedded-objects-overview.md
-    - name: How-to Topics
-      href: ui-automation-text-pattern-how-to-topics.md
-      items:
-      - name: Add Content to a Text Box Using UI Automation
-        href: add-content-to-a-text-box-using-ui-automation.md
-      - name: Find and Highlight Text Using UI Automation
-        href: find-and-highlight-text-using-ui-automation.md
-      - name: Obtain Text Attributes Using UI Automation
-        href: obtain-text-attributes-using-ui-automation.md
-      - name: Obtain Mixed Text Attribute Details Using UI Automation
-        href: obtain-mixed-text-attribute-details-using-ui-automation.md
-      - name: Traverse Text Using UI Automation
-        href: traverse-text-using-ui-automation.md
-      - name: Access Embedded Objects Using UI Automation
-        href: access-embedded-objects-using-ui-automation.md
-  - name: UI Automation Control Types
-    href: ui-automation-control-types.md
-    items:
-    - name: UI Automation Control Types Overview
-      href: ui-automation-control-types-overview.md
-    - name: UI Automation Support for the Button Control Type
-      href: ui-automation-support-for-the-button-control-type.md
-    - name: UI Automation Support for the Calendar Control Type
-      href: ui-automation-support-for-the-calendar-control-type.md
-    - name: UI Automation Support for the CheckBox Control Type
-      href: ui-automation-support-for-the-checkbox-control-type.md
-    - name: UI Automation Support for the ComboBox Control Type
-      href: ui-automation-support-for-the-combobox-control-type.md
-    - name: UI Automation Support for the DataGrid Control Type
-      href: ui-automation-support-for-the-datagrid-control-type.md
-    - name: UI Automation Support for the DataItem Control Type
-      href: ui-automation-support-for-the-dataitem-control-type.md
-    - name: UI Automation Support for the Document Control Type
-      href: ui-automation-support-for-the-document-control-type.md
-    - name: UI Automation Support for the Edit Control Type
-      href: ui-automation-support-for-the-edit-control-type.md
-    - name: UI Automation Support for the Group Control Type
-      href: ui-automation-support-for-the-group-control-type.md
-    - name: UI Automation Support for the Header Control Type
-      href: ui-automation-support-for-the-header-control-type.md
-    - name: UI Automation Support for the HeaderItem Control Type
-      href: ui-automation-support-for-the-headeritem-control-type.md
-    - name: UI Automation Support for the Hyperlink Control Type
-      href: ui-automation-support-for-the-hyperlink-control-type.md
-    - name: UI Automation Support for the Image Control Type
-      href: ui-automation-support-for-the-image-control-type.md
-    - name: UI Automation Support for the List Control Type
-      href: ui-automation-support-for-the-list-control-type.md
-    - name: UI Automation Support for the ListItem Control Type
-      href: ui-automation-support-for-the-listitem-control-type.md
-    - name: UI Automation Support for the Menu Control Type
-      href: ui-automation-support-for-the-menu-control-type.md
-    - name: UI Automation Support for the MenuBar Control Type
-      href: ui-automation-support-for-the-menubar-control-type.md
-    - name: UI Automation Support for the MenuItem Control Type
-      href: ui-automation-support-for-the-menuitem-control-type.md
-    - name: UI Automation Support for the Pane Control Type
-      href: ui-automation-support-for-the-pane-control-type.md
-    - name: UI Automation Support for the ProgressBar Control Type
-      href: ui-automation-support-for-the-progressbar-control-type.md
-    - name: UI Automation Support for the RadioButton Control Type
-      href: ui-automation-support-for-the-radiobutton-control-type.md
-    - name: UI Automation Support for the ScrollBar Control Type
-      href: ui-automation-support-for-the-scrollbar-control-type.md
-    - name: UI Automation Support for the Separator Control Type
-      href: ui-automation-support-for-the-separator-control-type.md
-    - name: UI Automation Support for the Slider Control Type
-      href: ui-automation-support-for-the-slider-control-type.md
-    - name: UI Automation Support for the Spinner Control Type
-      href: ui-automation-support-for-the-spinner-control-type.md
-    - name: UI Automation Support for the SplitButton Control Type
-      href: ui-automation-support-for-the-splitbutton-control-type.md
-    - name: UI Automation Support for the StatusBar Control Type
-      href: ui-automation-support-for-the-statusbar-control-type.md
-    - name: UI Automation Support for the Tab Control Type
-      href: ui-automation-support-for-the-tab-control-type.md
-    - name: UI Automation Support for the TabItem Control Type
-      href: ui-automation-support-for-the-tabitem-control-type.md
-    - name: UI Automation Support for the Table Control Type
-      href: ui-automation-support-for-the-table-control-type.md
-    - name: UI Automation Support for the Text Control Type
-      href: ui-automation-support-for-the-text-control-type.md
-    - name: UI Automation Support for the Thumb Control Type
-      href: ui-automation-support-for-the-thumb-control-type.md
-    - name: UI Automation Support for the TitleBar Control Type
-      href: ui-automation-support-for-the-titlebar-control-type.md
-    - name: UI Automation Support for the ToolBar Control Type
-      href: ui-automation-support-for-the-toolbar-control-type.md
-    - name: UI Automation Support for the ToolTip Control Type
-      href: ui-automation-support-for-the-tooltip-control-type.md
-    - name: UI Automation Support for the Tree Control Type
-      href: ui-automation-support-for-the-tree-control-type.md
-    - name: UI Automation Support for the TreeItem Control Type
-      href: ui-automation-support-for-the-treeitem-control-type.md
-    - name: UI Automation Support for the Window Control Type
-      href: ui-automation-support-for-the-window-control-type.md
+    - name: Add Content to a Text Box Using UI Automation
+      href: add-content-to-a-text-box-using-ui-automation.md
+    - name: Find and Highlight Text Using UI Automation
+      href: find-and-highlight-text-using-ui-automation.md
+    - name: Obtain Text Attributes Using UI Automation
+      href: obtain-text-attributes-using-ui-automation.md
+    - name: Obtain Mixed Text Attribute Details Using UI Automation
+      href: obtain-mixed-text-attribute-details-using-ui-automation.md
+    - name: Traverse Text Using UI Automation
+      href: traverse-text-using-ui-automation.md
+    - name: Access Embedded Objects Using UI Automation
+      href: access-embedded-objects-using-ui-automation.md
+- name: UI Automation Control Types
+  href: ui-automation-control-types.md
+  items:
+  - name: UI Automation Control Types Overview
+    href: ui-automation-control-types-overview.md
+  - name: UI Automation Support for the Button Control Type
+    href: ui-automation-support-for-the-button-control-type.md
+  - name: UI Automation Support for the Calendar Control Type
+    href: ui-automation-support-for-the-calendar-control-type.md
+  - name: UI Automation Support for the CheckBox Control Type
+    href: ui-automation-support-for-the-checkbox-control-type.md
+  - name: UI Automation Support for the ComboBox Control Type
+    href: ui-automation-support-for-the-combobox-control-type.md
+  - name: UI Automation Support for the DataGrid Control Type
+    href: ui-automation-support-for-the-datagrid-control-type.md
+  - name: UI Automation Support for the DataItem Control Type
+    href: ui-automation-support-for-the-dataitem-control-type.md
+  - name: UI Automation Support for the Document Control Type
+    href: ui-automation-support-for-the-document-control-type.md
+  - name: UI Automation Support for the Edit Control Type
+    href: ui-automation-support-for-the-edit-control-type.md
+  - name: UI Automation Support for the Group Control Type
+    href: ui-automation-support-for-the-group-control-type.md
+  - name: UI Automation Support for the Header Control Type
+    href: ui-automation-support-for-the-header-control-type.md
+  - name: UI Automation Support for the HeaderItem Control Type
+    href: ui-automation-support-for-the-headeritem-control-type.md
+  - name: UI Automation Support for the Hyperlink Control Type
+    href: ui-automation-support-for-the-hyperlink-control-type.md
+  - name: UI Automation Support for the Image Control Type
+    href: ui-automation-support-for-the-image-control-type.md
+  - name: UI Automation Support for the List Control Type
+    href: ui-automation-support-for-the-list-control-type.md
+  - name: UI Automation Support for the ListItem Control Type
+    href: ui-automation-support-for-the-listitem-control-type.md
+  - name: UI Automation Support for the Menu Control Type
+    href: ui-automation-support-for-the-menu-control-type.md
+  - name: UI Automation Support for the MenuBar Control Type
+    href: ui-automation-support-for-the-menubar-control-type.md
+  - name: UI Automation Support for the MenuItem Control Type
+    href: ui-automation-support-for-the-menuitem-control-type.md
+  - name: UI Automation Support for the Pane Control Type
+    href: ui-automation-support-for-the-pane-control-type.md
+  - name: UI Automation Support for the ProgressBar Control Type
+    href: ui-automation-support-for-the-progressbar-control-type.md
+  - name: UI Automation Support for the RadioButton Control Type
+    href: ui-automation-support-for-the-radiobutton-control-type.md
+  - name: UI Automation Support for the ScrollBar Control Type
+    href: ui-automation-support-for-the-scrollbar-control-type.md
+  - name: UI Automation Support for the Separator Control Type
+    href: ui-automation-support-for-the-separator-control-type.md
+  - name: UI Automation Support for the Slider Control Type
+    href: ui-automation-support-for-the-slider-control-type.md
+  - name: UI Automation Support for the Spinner Control Type
+    href: ui-automation-support-for-the-spinner-control-type.md
+  - name: UI Automation Support for the SplitButton Control Type
+    href: ui-automation-support-for-the-splitbutton-control-type.md
+  - name: UI Automation Support for the StatusBar Control Type
+    href: ui-automation-support-for-the-statusbar-control-type.md
+  - name: UI Automation Support for the Tab Control Type
+    href: ui-automation-support-for-the-tab-control-type.md
+  - name: UI Automation Support for the TabItem Control Type
+    href: ui-automation-support-for-the-tabitem-control-type.md
+  - name: UI Automation Support for the Table Control Type
+    href: ui-automation-support-for-the-table-control-type.md
+  - name: UI Automation Support for the Text Control Type
+    href: ui-automation-support-for-the-text-control-type.md
+  - name: UI Automation Support for the Thumb Control Type
+    href: ui-automation-support-for-the-thumb-control-type.md
+  - name: UI Automation Support for the TitleBar Control Type
+    href: ui-automation-support-for-the-titlebar-control-type.md
+  - name: UI Automation Support for the ToolBar Control Type
+    href: ui-automation-support-for-the-toolbar-control-type.md
+  - name: UI Automation Support for the ToolTip Control Type
+    href: ui-automation-support-for-the-tooltip-control-type.md
+  - name: UI Automation Support for the Tree Control Type
+    href: ui-automation-support-for-the-tree-control-type.md
+  - name: UI Automation Support for the TreeItem Control Type
+    href: ui-automation-support-for-the-treeitem-control-type.md
+  - name: UI Automation Support for the Window Control Type
+    href: ui-automation-support-for-the-window-control-type.md

--- a/docs/framework/unmanaged-api/alink/toc.yml
+++ b/docs/framework/unmanaged-api/alink/toc.yml
@@ -1,106 +1,106 @@
+items:
 - name: ALink API
   href: index.md
+- name: AssemblyAttributesGoHere
+  href: assemblyattributesgohere.md
+- name: AssemblyAttributesGoHereM
+  href: assemblyattributesgoherem.md
+- name: AssemblyAttributesGoHereS
+  href: assemblyattributesgoheres.md
+- name: AssemblyAttributesGoHereSM
+  href: assemblyattributesgoheresm.md
+- name: AssemblyOptions Enumeration
+  href: assemblyoptions-enumeration.md
+- name: CreateALink Function
+  href: createalink-function.md
+- name: GetALinkMessageDll Function
+  href: getalinkmessagedll-function.md
+- name: IALink Interface
+  href: ialink-interface.md
   items:
-  - name: AssemblyAttributesGoHere
-    href: assemblyattributesgohere.md
-  - name: AssemblyAttributesGoHereM
-    href: assemblyattributesgoherem.md
-  - name: AssemblyAttributesGoHereS
-    href: assemblyattributesgoheres.md
-  - name: AssemblyAttributesGoHereSM
-    href: assemblyattributesgoheresm.md
-  - name: AssemblyOptions Enumeration
-    href: assemblyoptions-enumeration.md
-  - name: CreateALink Function
-    href: createalink-function.md
-  - name: GetALinkMessageDll Function
-    href: getalinkmessagedll-function.md
-  - name: IALink Interface
-    href: ialink-interface.md
-    items:
-    - name: Init Method
-      href: init-method.md
-    - name: ImportFile Method
-      href: importfile-method.md
-    - name: SetAssemblyFile Method
-      href: setassemblyfile-method.md
-    - name: AddFile Method
-      href: addfile-method.md
-    - name: AddImport Method
-      href: addimport-method.md
-    - name: GetScope Method
-      href: getscope-method.md
-    - name: GetAssemblyRefHash Method
-      href: getassemblyrefhash-method.md
-    - name: ImportTypes Method
-      href: importtypes-method.md
-    - name: EnumCustomAttributes Method
-      href: enumcustomattributes-method.md
-    - name: EnumImportTypes Method
-      href: enumimporttypes-method.md
-    - name: CloseEnum Method
-      href: closeenum-method.md
-    - name: ExportType Method
-      href: exporttype-method.md
-    - name: ExportNestedType Method
-      href: exportnestedtype-method.md
-    - name: EmbedResource Method
-      href: embedresource-method.md
-    - name: LinkResource Method
-      href: linkresource-method.md
-    - name: GetResolutionScope Method
-      href: getresolutionscope-method.md
-    - name: SetAssemblyProps Method
-      href: setassemblyprops-method.md
-    - name: EmitAssemblyCustomAttribute Method
-      href: emitassemblycustomattribute-method.md
-    - name: GetWin32ResBlob Method
-      href: getwin32resblob-method.md
-    - name: FreeWin32ResBlob Method
-      href: freewin32resblob-method.md
-    - name: EmitManifest Method
-      href: emitmanifest-method.md
-    - name: PreCloseAssembly Method
-      href: precloseassembly-method.md
-    - name: CloseAssembly Method
-      href: closeassembly-method.md
-    - name: EndMerge Method
-      href: endmerge-method.md
-    - name: SetNonAssemblyFlags Method
-      href: setnonassemblyflags-method.md
-    - name: ImportFile2 Method
-      href: importfile2-method.md
-    - name: ExportTypeForwarder Method
-      href: exporttypeforwarder-method.md
-    - name: ExportNestedTypeForwarder Method
-      href: exportnestedtypeforwarder-method.md
-  - name: IALink2 Interface
-    href: ialink2-interface.md
-    items:
-    - name: SetAssemblyFile2 Method
-      href: setassemblyfile2-method.md
-    - name: AddFile2 Method
-      href: addfile2-method.md
-    - name: GetScope2 Method
-      href: getscope2-method.md
-    - name: ImportTypes2 Method
-      href: importtypes2-method.md
-    - name: GetFileDef Method
-      href: getfiledef-method.md
-    - name: GetPublicKeyToken Method
-      href: getpublickeytoken-method.md
-    - name: EmitInternalExportedTypes Method
-      href: emitinternalexportedtypes-method.md
-    - name: ImportFileEx Method
-      href: importfileex-method.md
-    - name: ImportFileEx2 Method
-      href: importfileex2-method.md
-    - name: SetPEKind Method
-      href: setpekind-method.md
-    - name: EmitAssembly Method
-      href: emitassembly-method.md
-  - name: IALink3 Interface
-    href: ialink3-interface.md
-    items:
-    - name: SetManifestFile Method
-      href: setmanifestfile-method.md
+  - name: Init Method
+    href: init-method.md
+  - name: ImportFile Method
+    href: importfile-method.md
+  - name: SetAssemblyFile Method
+    href: setassemblyfile-method.md
+  - name: AddFile Method
+    href: addfile-method.md
+  - name: AddImport Method
+    href: addimport-method.md
+  - name: GetScope Method
+    href: getscope-method.md
+  - name: GetAssemblyRefHash Method
+    href: getassemblyrefhash-method.md
+  - name: ImportTypes Method
+    href: importtypes-method.md
+  - name: EnumCustomAttributes Method
+    href: enumcustomattributes-method.md
+  - name: EnumImportTypes Method
+    href: enumimporttypes-method.md
+  - name: CloseEnum Method
+    href: closeenum-method.md
+  - name: ExportType Method
+    href: exporttype-method.md
+  - name: ExportNestedType Method
+    href: exportnestedtype-method.md
+  - name: EmbedResource Method
+    href: embedresource-method.md
+  - name: LinkResource Method
+    href: linkresource-method.md
+  - name: GetResolutionScope Method
+    href: getresolutionscope-method.md
+  - name: SetAssemblyProps Method
+    href: setassemblyprops-method.md
+  - name: EmitAssemblyCustomAttribute Method
+    href: emitassemblycustomattribute-method.md
+  - name: GetWin32ResBlob Method
+    href: getwin32resblob-method.md
+  - name: FreeWin32ResBlob Method
+    href: freewin32resblob-method.md
+  - name: EmitManifest Method
+    href: emitmanifest-method.md
+  - name: PreCloseAssembly Method
+    href: precloseassembly-method.md
+  - name: CloseAssembly Method
+    href: closeassembly-method.md
+  - name: EndMerge Method
+    href: endmerge-method.md
+  - name: SetNonAssemblyFlags Method
+    href: setnonassemblyflags-method.md
+  - name: ImportFile2 Method
+    href: importfile2-method.md
+  - name: ExportTypeForwarder Method
+    href: exporttypeforwarder-method.md
+  - name: ExportNestedTypeForwarder Method
+    href: exportnestedtypeforwarder-method.md
+- name: IALink2 Interface
+  href: ialink2-interface.md
+  items:
+  - name: SetAssemblyFile2 Method
+    href: setassemblyfile2-method.md
+  - name: AddFile2 Method
+    href: addfile2-method.md
+  - name: GetScope2 Method
+    href: getscope2-method.md
+  - name: ImportTypes2 Method
+    href: importtypes2-method.md
+  - name: GetFileDef Method
+    href: getfiledef-method.md
+  - name: GetPublicKeyToken Method
+    href: getpublickeytoken-method.md
+  - name: EmitInternalExportedTypes Method
+    href: emitinternalexportedtypes-method.md
+  - name: ImportFileEx Method
+    href: importfileex-method.md
+  - name: ImportFileEx2 Method
+    href: importfileex2-method.md
+  - name: SetPEKind Method
+    href: setpekind-method.md
+  - name: EmitAssembly Method
+    href: emitassembly-method.md
+- name: IALink3 Interface
+  href: ialink3-interface.md
+  items:
+  - name: SetManifestFile Method
+    href: setmanifestfile-method.md

--- a/docs/framework/unmanaged-api/debugging/toc.yml
+++ b/docs/framework/unmanaged-api/debugging/toc.yml
@@ -1,1672 +1,1671 @@
 items:
-  - name: Debugging
-    href: index.md
-    items:
-      - name: Debugging coclasses
-        href: debugging-coclasses.md
-        items:
-          - name: CorpubPublish coclass
-            href: corpubpublish-coclass.md
-      - name: Debugging interfaces
-        href: debugging-interfaces.md
-        items:
-          - name: ICLRDataEnumMemoryRegions interface
-            href: iclrdataenummemoryregions-interface.md
-            items:
-              - name: EnumMemoryRegions method
-                href: iclrdataenummemoryregions-enummemoryregions-method.md
-          - name: ICLRDataEnumMemoryRegionsCallback interface
-            href: iclrdataenummemoryregionscallback-interface.md
-            items:
-              - name: EnumMemoryRegion method
-                href: iclrdataenummemoryregionscallback-enummemoryregion-method.md
-          - name: ICLRDataTarget interface
-            href: iclrdatatarget-interface.md
-            items:
-              - name: GetCurrentThreadID method
-                href: iclrdatatarget-getcurrentthreadid-method.md
-              - name: GetImageBase method
-                href: iclrdatatarget-getimagebase-method.md
-              - name: GetMachineType method
-                href: iclrdatatarget-getmachinetype-method.md
-              - name: GetPointerSize method
-                href: iclrdatatarget-getpointersize-method.md
-              - name: GetThreadContext method
-                href: iclrdatatarget-getthreadcontext-method.md
-              - name: GetTLSValue method
-                href: iclrdatatarget-gettlsvalue-method.md
-              - name: ReadVirtual method
-                href: iclrdatatarget-readvirtual-method.md
-              - name: Request method
-                href: iclrdatatarget-request-method.md
-              - name: SetThreadContext method
-                href: iclrdatatarget-setthreadcontext-method.md
-              - name: SetTLSValue method
-                href: iclrdatatarget-settlsvalue-method.md
-              - name: WriteVirtual method
-                href: iclrdatatarget-writevirtual-method.md
-          - name: ICLRDataTarget2 interface
-            href: iclrdatatarget2-interface.md
-            items:
-              - name: AllocVirtual method
-                href: iclrdatatarget2-allocvirtual-method.md
-              - name: FreeVirtual method
-                href: iclrdatatarget2-freevirtual-method.md
-          - name: ICLRDataTarget3 interface
-            href: iclrdatatarget3-interface.md
-            items:
-              - name: GetExceptionRecord method
-                href: iclrdatatarget3-getexceptionrecord-method.md
-              - name: GetExceptionContextRecord method
-                href: iclrdatatarget3-getexceptioncontextrecord-method.md
-              - name: GetExceptionThreadID method
-                href: iclrdatatarget3-getexceptionthreadid-method.md
-          - name: ICLRDebugging interface
-            href: iclrdebugging-interface.md
-            items:
-              - name: OpenVirtualProcess method
-                href: iclrdebugging-openvirtualprocess-method.md
-              - name: CanUnloadNow method
-                href: iclrdebugging-canunloadnow-method.md
-          - name: ICLRDebuggingLibraryProvider interface
-            href: iclrdebugginglibraryprovider-interface.md
-            items:
-              - name: ProvideLibrary method
-                href: iclrdebugginglibraryprovider-providelibrary-method.md
-          - name: ICLRMetadataLocator interface
-            href: iclrmetadatalocator-interface.md
-            items:
-              - name: GetMetadata method
-                href: iclrmetadatalocator-getmetadata-method.md
-          - name: ICorDebug interface
-            href: icordebug-interface.md
-            items:
-              - name: CanLaunchOrAttach method
-                href: icordebug-canlaunchorattach-method.md
-              - name: CreateProcess method
-                href: icordebug-createprocess-method.md
-              - name: DebugActiveProcess method
-                href: icordebug-debugactiveprocess-method.md
-              - name: EnumerateProcesses method
-                href: icordebug-enumerateprocesses-method.md
-              - name: GetProcess method
-                href: icordebug-getprocess-method.md
-              - name: Initialize method
-                href: icordebug-initialize-method.md
-              - name: SetManagedHandler method
-                href: icordebug-setmanagedhandler-method.md
-              - name: SetUnmanagedHandler method
-                href: icordebug-setunmanagedhandler-method.md
-              - name: Terminate method
-                href: icordebug-terminate-method.md
-          - name: ICorDebugAppDomain interface
-            href: icordebugappdomain-interface.md
-            items:
-              - name: Attach method
-                href: icordebugappdomain-attach-method.md
-              - name: EnumerateAssemblies method
-                href: icordebugappdomain-enumerateassemblies-method.md
-              - name: EnumerateBreakpoints method
-                href: icordebugappdomain-enumeratebreakpoints-method.md
-              - name: EnumerateSteppers method
-                href: icordebugappdomain-enumeratesteppers-method.md
-              - name: GetId method
-                href: icordebugappdomain-getid-method.md
-              - name: GetModuleFromMetaDataInterface method
-                href: icordebugappdomain-getmodulefrommetadatainterface-method.md
-              - name: GetName method
-                href: icordebugappdomain-getname-method.md
-              - name: GetObject method
-                href: icordebugappdomain-getobject-method.md
-              - name: GetProcess method
-                href: icordebugappdomain-getprocess-method.md
-              - name: IsAttached method
-                href: icordebugappdomain-isattached-method.md
-          - name: ICorDebugAppDomain2 interface
-            href: icordebugappdomain2-interface.md
-            items:
-              - name: GetArrayOrPointerType method
-                href: icordebugappdomain2-getarrayorpointertype-method.md
-              - name: GetFunctionPointerType
-                href: icordebugappdomain2-getfunctionpointertype-method.md
-          - name: ICorDebugAppDomain3 interface
-            href: icordebugappdomain3-interface.md
-            items:
-              - name: GetCachedWinRTTypes method
-                href: icordebugappdomain3-getcachedwinrttypes-method.md
-              - name: GetCachedWinRTTypesForIIDs method
-                href: icordebugappdomain3-getcachedwinrttypesforiids-method.md
-          - name: ICorDebugAppDomain4 interface
-            href: icordebugappdomain4-interface.md
-            items:
-              - name: GetObjectForCCW method
-                href: icordebugappdomain4-getobjectforccw-method.md
-          - name: ICorDebugAppDomainEnum interface
-            href: icordebugappdomainenum-interface.md
-            items:
-              - name: Next method
-                href: icordebugappdomainenum-next-method.md
-          - name: ICorDebugArrayValue interface
-            href: icordebugarrayvalue-interface.md
-            items:
-              - name: GetBaseIndicies method
-                href: icordebugarrayvalue-getbaseindicies-method.md
-              - name: GetCount method
-                href: icordebugarrayvalue-getcount-method.md
-              - name: GetDimensions method
-                href: icordebugarrayvalue-getdimensions-method.md
-              - name: GetElement method
-                href: icordebugarrayvalue-getelement-method.md
-              - name: GetElementAtPosition method
-                href: icordebugarrayvalue-getelementatposition-method.md
-              - name: GetElementType method
-                href: icordebugarrayvalue-getelementtype-method.md
-              - name: GetRank method
-                href: icordebugarrayvalue-getrank-method.md
-              - name: HasBaseIndicies method
-                href: icordebugarrayvalue-hasbaseindicies-method.md
-          - name: ICorDebugAssembly interface
-            href: icordebugassembly-interface.md
-            items:
-              - name: EnumerateModules method
-                href: icordebugassembly-enumeratemodules-method.md
-              - name: GetAppDomain method
-                href: icordebugassembly-getappdomain-method.md
-              - name: GetCodeBase method
-                href: icordebugassembly-getcodebase-method.md
-              - name: GetName method
-                href: icordebugassembly-getname-method.md
-              - name: GetProcess method
-                href: icordebugassembly-getprocess-method.md
-          - name: ICorDebugAssembly2 interface
-            href: icordebugassembly2-interface.md
-            items:
-              - name: IsFullyTrusted method
-                href: icordebugassembly2-isfullytrusted-method.md
-          - name: ICorDebugAssembly3 interface
-            href: icordebugassembly3-interface.md
-            items:
-              - name: EnumerateContainedAssemblies method
-                href: icordebugassembly3-enumeratecontainedassemblies-method.md
-              - name: GetContainerAssembly method
-                href: icordebugassembly3-getcontainerassembly-method.md
-          - name: ICorDebugAssemblyEnum interface
-            href: icordebugassemblyenum-interface.md
-            items:
-              - name: Next method
-                href: icordebugassemblyenum-next-method.md
-          - name: ICorDebugBlockingObjectEnum interface
-            href: icordebugblockingobjectenum-interface.md
-            items:
-              - name: Next method
-                href: icordebugblockingobjectenum-next-method.md
-          - name: ICorDebugBoxValue interface
-            href: icordebugboxvalue-interface.md
-            items:
-              - name: GetObject method
-                href: icordebugboxvalue-getobject-method.md
-          - name: ICorDebugBreakpoint interface
-            href: icordebugbreakpoint-interface.md
-            items:
-              - name: Activate method
-                href: icordebugbreakpoint-activate-method.md
-              - name: IsActive method
-                href: icordebugbreakpoint-isactive-method.md
-          - name: ICorDebugBreakpointEnum interface
-            href: icordebugbreakpointenum-interface.md
-            items:
-              - name: Next method
-                href: icordebugbreakpointenum-next-method.md
-          - name: ICorDebugChain interface
-            href: icordebugchain-interface.md
-            items:
-              - name: EnumerateFrames method
-                href: icordebugchain-enumerateframes-method.md
-              - name: GetActiveFrame method
-                href: icordebugchain-getactiveframe-method.md
-              - name: GetCallee method
-                href: icordebugchain-getcallee-method.md
-              - name: GetCaller method
-                href: icordebugchain-getcaller-method.md
-              - name: GetContext method
-                href: icordebugchain-getcontext-method.md
-              - name: GetNext method
-                href: icordebugchain-getnext-method.md
-              - name: GetPrevious method
-                href: icordebugchain-getprevious-method.md
-              - name: GetReason method
-                href: icordebugchain-getreason-method.md
-              - name: GetRegisterSet method
-                href: icordebugchain-getregisterset-method.md
-              - name: GetStackRange method
-                href: icordebugchain-getstackrange-method.md
-              - name: GetThread method
-                href: icordebugchain-getthread-method.md
-              - name: IsManaged method
-                href: icordebugchain-ismanaged-method.md
-          - name: ICorDebugChainEnum interface
-            href: icordebugchainenum-interface.md
-            items:
-              - name: Next method
-                href: icordebugchainenum-next-method.md
-          - name: ICorDebugClass interface
-            href: icordebugclass-interface.md
-            items:
-              - name: GetModule method
-                href: icordebugclass-getmodule-method.md
-              - name: GetStaticFieldValue method
-                href: icordebugclass-getstaticfieldvalue-method.md
-              - name: GetToken method
-                href: icordebugclass-gettoken-method.md
-          - name: ICorDebugClass2 interface
-            href: icordebugclass2-interface.md
-            items:
-              - name: GetParameterizedType method
-                href: icordebugclass2-getparameterizedtype-method.md
-              - name: SetJMCStatus method
-                href: icordebugclass2-setjmcstatus-method.md
-          - name: ICorDebugCode interface
-            href: icordebugcode-interface1.md
-            items:
-              - name: CreateBreakpoint method
-                href: icordebugcode-createbreakpoint-method.md
-              - name: GetAddress method
-                href: icordebugcode-getaddress-method.md
-              - name: GetCode method
-                href: icordebugcode-getcode-method.md
-              - name: GetEnCRemapSequencePoints method
-                href: icordebugcode-getencremapsequencepoints-method.md
-              - name: GetFunction method
-                href: icordebugcode-getfunction-method.md
-              - name: GetILToNativeMapping method
-                href: icordebugcode-getiltonativemapping-method.md
-              - name: GetSize method
-                href: icordebugcode-getsize-method.md
-              - name: GetVersionNumber method
-                href: icordebugcode-getversionnumber-method.md
-              - name: IsIL method
-                href: icordebugcode-isil-method.md
-          - name: ICorDebugCode2 interface
-            href: icordebugcode2-interface.md
-            items:
-              - name: GetCodeChunks method
-                href: icordebugcode2-getcodechunks-method.md
-              - name: GetCompilerFlags method
-                href: icordebugcode2-getcompilerflags-method.md
-          - name: ICorDebugCode3 interface
-            href: icordebugcode3-interface.md
-            items:
-              - name: GetReturnValueLiveOffset method
-                href: icordebugcode3-getreturnvalueliveoffset-method.md
-          - name: ICorDebugCode4 interface
-            href: icordebugcode4-interface.md
-            items:
-              - name: EnumerateVariableHomes method
-                href: icordebugcode4-enumeratevariablehomes-method.md
-          - name: ICorDebugCodeEnum interface
-            href: icordebugcodeenum-interface.md
-            items:
-              - name: Next method
-                href: icordebugcodeenum-next-method.md
-          - name: ICorDebugComObjectValue interface
-            href: icordebugcomobjectvalue-interface.md
-            items:
-              - name: GetCachedInterfacePointers method
-                href: icordebugcomobjectvalue-getcachedinterfacepointers-method.md
-              - name: GetCachedInterfaceTypes method
-                href: icordebugcomobjectvalue-getcachedinterfacetypes-method.md
-          - name: ICorDebugContext interface
-            href: icordebugcontext-interface.md
-          - name: ICorDebugController interface
-            href: icordebugcontroller-interface.md
-            items:
-              - name: CanCommitChanges method
-                href: icordebugcontroller-cancommitchanges-method.md
-              - name: CommitChanges method
-                href: icordebugcontroller-commitchanges-method.md
-              - name: Continue method
-                href: icordebugcontroller-continue-method.md
-              - name: Detach method
-                href: icordebugcontroller-detach-method.md
-              - name: EnumerateThreads method
-                href: icordebugcontroller-enumeratethreads-method.md
-              - name: HasQueuedCallbacks method
-                href: icordebugcontroller-hasqueuedcallbacks-method.md
-              - name: IsRunning method
-                href: icordebugcontroller-isrunning-method.md
-              - name: SetAllThreadsDebugState method
-                href: icordebugcontroller-setallthreadsdebugstate-method.md
-              - name: Stop method
-                href: icordebugcontroller-stop-method.md
-              - name: Terminate method
-                href: icordebugcontroller-terminate-method.md
-          - name: ICorDebugDataTarget interface
-            href: icordebugdatatarget-interface.md
-            items:
-              - name: GetPlatform method
-                href: icordebugdatatarget-getplatform-method.md
-              - name: ReadVirtual method
-                href: icordebugdatatarget-readvirtual-method.md
-              - name: GetThreadContext method
-                href: icordebugdatatarget-getthreadcontext-method.md
-          - name: ICorDebugDataTarget2 interface
-            href: icordebugdatatarget2-interface.md
-            items:
-              - name: CreateVirtualUnwinder method
-                href: icordebugdatatarget2-createvirtualunwinder-method.md
-              - name: EnumerateThreadIDs method
-                href: icordebugdatatarget2-enumeratethreadids-method.md
-              - name: GetImageFromPointer method
-                href: icordebugdatatarget2-getimagefrompointer-method.md
-              - name: GetImageLocation method
-                href: icordebugdatatarget2-getimagelocation-method.md
-              - name: GetSymbolProviderForImage method
-                href: icordebugdatatarget2-getsymbolproviderforimage-method.md
-          - name: ICorDebugDataTarget3 interface
-            href: icordebugdatatarget3-interface.md
-            items:
-              - name: GetLoadedModules method
-                href: icordebugdatatarget3-getloadedmodules-method.md
-          - name: ICorDebugDebugEvent interface
-            href: icordebugdebugevent-interface.md
-            items:
-              - name: GetEventKind method
-                href: icordebugdebugevent-geteventkind-method.md
-              - name: GetThread method
-                href: icordebugdebugevent-getthread-method.md
-          - name: ICorDebugEditAndContinueErrorInfo interface
-            href: icordebugeditandcontinueerrorinfo-interface.md
-            items:
-              - name: GetErrorCode method
-                href: icordebugeditandcontinueerrorinfo-geterrorcode-method.md
-              - name: GetModule method
-                href: icordebugeditandcontinueerrorinfo-getmodule-method.md
-              - name: GetString method
-                href: icordebugeditandcontinueerrorinfo-getstring-method.md
-              - name: GetToken method
-                href: icordebugeditandcontinueerrorinfo-gettoken-method.md
-          - name: ICorDebugEditAndContinueSnapshot interface
-            href: icordebugeditandcontinuesnapshot-interface.md
-            items:
-              - name: CopyMetaData method
-                href: icordebugeditandcontinuesnapshot-copymetadata-method.md
-              - name: GetMvid method
-                href: icordebugeditandcontinuesnapshot-getmvid-method.md
-              - name: GetRoDataRVA method
-                href: icordebugeditandcontinuesnapshot-getrodatarva-method.md
-              - name: GetRwDataRVA method
-                href: icordebugeditandcontinuesnapshot-getrwdatarva-method.md
-              - name: SetILMap method
-                href: icordebugeditandcontinuesnapshot-setilmap-method.md
-              - name: SetPEBytes method
-                href: icordebugeditandcontinuesnapshot-setpebytes-method.md
-              - name: SetPESymbolBytes method
-                href: icordebugeditandcontinuesnapshot-setpesymbolbytes-method.md
-          - name: ICorDebugEnum interface
-            href: icordebugenum-interface1.md
-            items:
-              - name: Clone method
-                href: icordebugenum-clone-method.md
-              - name: GetCount method
-                href: icordebugenum-getcount-method.md
-              - name: Reset method
-                href: icordebugenum-reset-method.md
-              - name: Skip method
-                href: icordebugenum-skip-method.md
-          - name: ICorDebugErrorInfoEnum interface
-            href: icordebugerrorinfoenum-interface.md
-            items:
-              - name: Next method
-                href: icordebugerrorinfoenum-next-method.md
-          - name: ICorDebugEval interface
-            href: icordebugeval-interface.md
-            items:
-              - name: Abort method
-                href: icordebugeval-abort-method.md
-              - name: CallFunction method
-                href: icordebugeval-callfunction-method.md
-              - name: CreateValue method
-                href: icordebugeval-createvalue-method.md
-              - name: GetResult method
-                href: icordebugeval-getresult-method.md
-              - name: GetThread method
-                href: icordebugeval-getthread-method.md
-              - name: IsActive method
-                href: icordebugeval-isactive-method.md
-              - name: NewArray method
-                href: icordebugeval-newarray-method.md
-              - name: NewObject method
-                href: icordebugeval-newobject-method.md
-              - name: NewObjectNoConstructor method
-                href: icordebugeval-newobjectnoconstructor-method.md
-              - name: NewString method
-                href: icordebugeval-newstring-method.md
-          - name: ICorDebugEval2 interface
-            href: icordebugeval2-interface.md
-            items:
-              - name: CallParameterizedFunction method
-                href: icordebugeval2-callparameterizedfunction-method.md
-              - name: CreateValueForType method
-                href: icordebugeval2-createvaluefortype-method.md
-              - name: NewParameterizedArray method
-                href: icordebugeval2-newparameterizedarray-method.md
-              - name: NewParameterizedObject method
-                href: icordebugeval2-newparameterizedobject-method.md
-              - name: NewParameterizedObjectNoConstructor method
-                href: icordebugeval2-newparameterizedobjectnoconstructor-method.md
-              - name: NewStringWithLength method
-                href: icordebugeval2-newstringwithlength-method.md
-              - name: RudeAbort method
-                href: icordebugeval2-rudeabort-method.md
-          - name: ICorDebugExceptionDebugEvent interface
-            href: icordebugexceptiondebugevent-interface.md
-            items:
-              - name: GetFlags method
-                href: icordebugexceptiondebugevent-getflags-method.md
-              - name: GetNativeIP method
-                href: icordebugexceptiondebugevent-getnativeip-method.md
-              - name: GetStackPointer method
-                href: icordebugexceptiondebugevent-getstackpointer-method.md
-          - name: ICorDebugExceptionObjectCallStackEnum interface
-            href: icordebugexceptionobjectcallstackenum-interface.md
-            items:
-              - name: Next method
-                href: icordebugexceptionobjectcallstackenum-next-method.md
-          - name: ICorDebugExceptionObjectValue interface
-            href: icordebugexceptionobjectvalue-interface.md
-            items:
-              - name: EnumerateExceptionCallStack method
-                href: icordebugexceptionobjectvalue-enumerateexceptioncallstack-method.md
-          - name: ICorDebugFrame interface
-            href: icordebugframe-interface.md
-            items:
-              - name: CreateStepper method
-                href: icordebugframe-createstepper-method.md
-              - name: GetCallee method
-                href: icordebugframe-getcallee-method.md
-              - name: GetCaller method
-                href: icordebugframe-getcaller-method.md
-              - name: GetChain method
-                href: icordebugframe-getchain-method.md
-              - name: GetCode method
-                href: icordebugframe-getcode-method.md
-              - name: GetFunction method
-                href: icordebugframe-getfunction-method.md
-              - name: GetFunctionToken method
-                href: icordebugframe-getfunctiontoken-method.md
-              - name: GetStackRange method
-                href: icordebugframe-getstackrange-method.md
-          - name: ICorDebugFrameEnum interface
-            href: icordebugframeenum-interface.md
-            items:
-              - name: Next method
-                href: icordebugframeenum-next-method.md
-          - name: ICorDebugFunction interface
-            href: icordebugfunction-interface1.md
-            items:
-              - name: CreateBreakpoint method
-                href: icordebugfunction-createbreakpoint-method.md
-              - name: GetClass method
-                href: icordebugfunction-getclass-method.md
-              - name: GetCurrentVersionNumber method
-                href: icordebugfunction-getcurrentversionnumber-method.md
-              - name: GetILCode method
-                href: icordebugfunction-getilcode-method.md
-              - name: GetLocalVarSigToken method
-                href: icordebugfunction-getlocalvarsigtoken-method.md
-              - name: GetModule method
-                href: icordebugfunction-getmodule-method.md
-              - name: GetNativeCode method
-                href: icordebugfunction-getnativecode-method.md
-              - name: GetToken method
-                href: icordebugfunction-gettoken-method.md
-          - name: ICorDebugFunction2 interface
-            href: icordebugfunction2-interface.md
-            items:
-              - name: EnumerateNativeCode method
-                href: icordebugfunction2-enumeratenativecode-method.md
-              - name: GetJMCStatus method
-                href: icordebugfunction2-getjmcstatus-method.md
-              - name: GetVersionNumber method
-                href: icordebugfunction2-getversionnumber-method.md
-              - name: SetJMCStatus method
-                href: icordebugfunction2-setjmcstatus-method.md
-          - name: ICorDebugFunction3 interface
-            href: icordebugfunction3-interface.md
-            items:
-              - name: GetActiveReJitRequestILCode method
-                href: icordebugfunction3-getactiverejitrequestilcode-method.md
-          - name: ICorDebugFunctionBreakpoint interface
-            href: icordebugfunctionbreakpoint-interface.md
-            items:
-              - name: GetFunction method
-                href: icordebugfunctionbreakpoint-getfunction-method.md
-              - name: GetOffset method
-                href: icordebugfunctionbreakpoint-getoffset-method.md
-          - name: ICorDebugGCReferenceEnum interface
-            href: icordebuggcreferenceenum-interface.md
-            items:
-              - name: Next method
-                href: icordebuggcreferenceenum-next-method.md
-          - name: ICorDebugGenericValue interface
-            href: icordebuggenericvalue-interface.md
-            items:
-              - name: GetValue method
-                href: icordebuggenericvalue-getvalue-method.md
-              - name: SetValue method
-                href: icordebuggenericvalue-setvalue-method.md
-          - name: ICorDebugGuidToTypeEnum interface
-            href: icordebugguidtotypeenum-interface.md
-            items:
-              - name: Next method
-                href: icordebugguidtotypeenum-next-method.md
-          - name: ICorDebugHandleValue interface
-            href: icordebughandlevalue-interface.md
-            items:
-              - name: Dispose method
-                href: icordebughandlevalue-dispose-method.md
-              - name: GetHandleType method
-                href: icordebughandlevalue-gethandletype-method.md
-          - name: ICorDebugHeapEnum interface
-            href: icordebugheapenum-interface.md
-            items:
-              - name: Next method
-                href: icordebugheapenum-next-method.md
-          - name: ICorDebugHeapSegmentEnum interface
-            href: icordebugheapsegmentenum-interface.md
-            items:
-              - name: Next method
-                href: icordebugheapsegmentenum-next-method.md
-          - name: ICorDebugHeapValue interface
-            href: icordebugheapvalue-interface.md
-            items:
-              - name: CreateRelocBreakpoint method
-                href: icordebugheapvalue-createrelocbreakpoint-method.md
-              - name: IsValid method
-                href: icordebugheapvalue-isvalid-method.md
-          - name: ICorDebugHeapValue2 interface
-            href: icordebugheapvalue2-interface1.md
-            items:
-              - name: CreateHandle method
-                href: icordebugheapvalue2-createhandle-method.md
-          - name: ICorDebugHeapValue3 interface
-            href: icordebugheapvalue3-interface.md
-            items:
-              - name: GetThreadOwningMonitorLock method
-                href: icordebugheapvalue3-getthreadowningmonitorlock-method.md
-              - name: GetMonitorEventWaitList method
-                href: icordebugheapvalue3-getmonitoreventwaitlist-method.md
-          - name: ICorDebugILCode interface
-            href: icordebugilcode-interface.md
-            items:
-              - name: GetEHClauses method
-                href: icordebugilcode-getehclauses-method.md
-          - name: ICorDebugILCode2 interface
-            href: icordebugilcode2-interface.md
-            items:
-              - name: GetInstrumentedILMap method
-                href: icordebugilcode2-getinstrumentedilmap-method.md
-              - name: GetLocalVarSigToken method
-                href: icordebugilcode2-getlocalvarsigtoken-method.md
-          - name: ICorDebugILFrame interface
-            href: icordebugilframe-interface.md
-            items:
-              - name: CanSetIP method
-                href: icordebugilframe-cansetip-method.md
-              - name: EnumerateArguments method
-                href: icordebugilframe-enumeratearguments-method.md
-              - name: EnumerateLocalVariables method
-                href: icordebugilframe-enumeratelocalvariables-method.md
-              - name: GetArgument method
-                href: icordebugilframe-getargument-method.md
-              - name: GetIP method
-                href: icordebugilframe-getip-method.md
-              - name: GetLocalVariable method
-                href: icordebugilframe-getlocalvariable-method.md
-              - name: GetStackDepth method
-                href: icordebugilframe-getstackdepth-method.md
-              - name: GetStackValue method
-                href: icordebugilframe-getstackvalue-method.md
-              - name: SetIP method
-                href: icordebugilframe-setip-method.md
-          - name: ICorDebugILFrame2 interface
-            href: icordebugilframe2-interface.md
-            items:
-              - name: EnumerateTypeParameters method
-                href: icordebugilframe2-enumeratetypeparameters-method.md
-              - name: RemapFunction method
-                href: icordebugilframe2-remapfunction-method.md
-          - name: ICorDebugILFrame3 interface
-            href: icordebugilframe3-interface.md
-            items:
-              - name: GetReturnValueForILOffset method
-                href: icordebugilframe3-getreturnvalueforiloffset-method.md
-          - name: ICorDebugILFrame4 interface
-            href: icordebugilframe4-interface.md
-            items:
-              - name: EnumerateLocalVariablesEx method
-                href: icordebugilframe4-enumeratelocalvariablesex-method.md
-              - name: GetCodeEx method
-                href: icordebugilframe4-getcodeex-method.md
-              - name: GetLocalVariableEx method
-                href: icordebugilframe4-getlocalvariableex-method.md
-          - name: ICorDebugInstanceFieldSymbol interface
-            href: icordebuginstancefieldsymbol-interface.md
-            items:
-              - name: GetName method
-                href: icordebuginstancefieldsymbol-getname-method.md
-              - name: GetOffset method
-                href: icordebuginstancefieldsymbol-getoffset-method.md
-              - name: GetSize method
-                href: icordebuginstancefieldsymbol-getsize-method.md
-          - name: ICorDebugInternalFrame interface
-            href: icordebuginternalframe-interface.md
-            items:
-              - name: GetFrameType method
-                href: icordebuginternalframe-getframetype-method.md
-          - name: ICorDebugInternalFrame2 interface
-            href: icordebuginternalframe2-interface.md
-            items:
-              - name: GetFrameAddress method
-                href: icordebuginternalframe2-getframeaddress-method.md
-              - name: IsCloserToLeaf method
-                href: icordebuginternalframe2-isclosertoleaf-method.md
-          - name: ICorDebugLoadedModule interface
-            href: icordebugloadedmodule-interface.md
-            items:
-              - name: GetBaseAddress method
-                href: icordebugloadedmodule-getbaseaddress-method.md
-              - name: GetName method
-                href: icordebugloadedmodule-getname-method.md
-              - name: GetSize method
-                href: icordebugloadedmodule-getsize-method.md
-          - name: ICorDebugManagedCallback interface
-            href: icordebugmanagedcallback-interface.md
-            items:
-              - name: Break method
-                href: icordebugmanagedcallback-break-method.md
-              - name: Breakpoint method
-                href: icordebugmanagedcallback-breakpoint-method.md
-              - name: BreakpointSetError method
-                href: icordebugmanagedcallback-breakpointseterror-method.md
-              - name: ControlCTrap method
-                href: icordebugmanagedcallback-controlctrap-method.md
-              - name: CreateAppDomain method
-                href: icordebugmanagedcallback-createappdomain-method.md
-              - name: CreateProcess method
-                href: icordebugmanagedcallback-createprocess-method.md
-              - name: CreateThread method
-                href: icordebugmanagedcallback-createthread-method.md
-              - name: DebuggerError method
-                href: icordebugmanagedcallback-debuggererror-method.md
-              - name: EditAndContinueRemap method
-                href: icordebugmanagedcallback-editandcontinueremap-method.md
-              - name: EvalComplete method
-                href: icordebugmanagedcallback-evalcomplete-method.md
-              - name: EvalException method
-                href: icordebugmanagedcallback-evalexception-method.md
-              - name: Exception method
-                href: icordebugmanagedcallback-exception-method.md
-              - name: ExitAppDomain method
-                href: icordebugmanagedcallback-exitappdomain-method.md
-              - name: ExitProcess method
-                href: icordebugmanagedcallback-exitprocess-method.md
-              - name: ExitThread method
-                href: icordebugmanagedcallback-exitthread-method.md
-              - name: LoadAssembly method
-                href: icordebugmanagedcallback-loadassembly-method.md
-              - name: LoadClass method
-                href: icordebugmanagedcallback-loadclass-method.md
-              - name: LoadModule method
-                href: icordebugmanagedcallback-loadmodule-method.md
-              - name: LogMessage method
-                href: icordebugmanagedcallback-logmessage-method.md
-              - name: LogSwitch method
-                href: icordebugmanagedcallback-logswitch-method.md
-              - name: NameChange method
-                href: icordebugmanagedcallback-namechange-method.md
-              - name: StepComplete method
-                href: icordebugmanagedcallback-stepcomplete-method.md
-              - name: UnloadAssembly method
-                href: icordebugmanagedcallback-unloadassembly-method.md
-              - name: UnloadClass method
-                href: icordebugmanagedcallback-unloadclass-method.md
-              - name: UnloadModule method
-                href: icordebugmanagedcallback-unloadmodule-method.md
-              - name: UpdateModuleSymbols method
-                href: icordebugmanagedcallback-updatemodulesymbols-method.md
-          - name: ICorDebugManagedCallback2 interface
-            href: icordebugmanagedcallback2-interface.md
-            items:
-              - name: ChangeConnection method
-                href: icordebugmanagedcallback2-changeconnection-method.md
-              - name: CreateConnection method
-                href: icordebugmanagedcallback2-createconnection-method.md
-              - name: DestroyConnection method
-                href: icordebugmanagedcallback2-destroyconnection-method.md
-              - name: Exception method
-                href: icordebugmanagedcallback2-exception-method.md
-              - name: ExceptionUnwind method
-                href: icordebugmanagedcallback2-exceptionunwind-method.md
-              - name: FunctionRemapComplete method
-                href: icordebugmanagedcallback2-functionremapcomplete-method.md
-              - name: FunctionRemapOpportunity method
-                href: icordebugmanagedcallback2-functionremapopportunity-method.md
-              - name: MDANotification method
-                href: icordebugmanagedcallback2-mdanotification-method.md
-          - name: ICorDebugManagedCallback3 interface
-            href: icordebugmanagedcallback3-interface.md
-            items:
-              - name: CustomNotification method
-                href: icordebugmanagedcallback3-customnotification-method.md
-          - name: ICorDebugMDA interface
-            href: icordebugmda-interface.md
-            items:
-              - name: GetDescription method
-                href: icordebugmda-getdescription-method.md
-              - name: GetFlags method
-                href: icordebugmda-getflags-method.md
-              - name: GetName method
-                href: icordebugmda-getname-method.md
-              - name: GetOSThreadId method
-                href: icordebugmda-getosthreadid-method.md
-              - name: GetXML method
-                href: icordebugmda-getxml-method.md
-          - name: ICorDebugMemoryBuffer interface
-            href: icordebugmemorybuffer-interface.md
-            items:
-              - name: GetSize method
-                href: icordebugmemorybuffer-getsize-method.md
-              - name: GetStartAddress method
-                href: icordebugmemorybuffer-getstartaddress-method.md
-          - name: ICorDebugMergedAssemblyRecord interface
-            href: icordebugmergedassemblyrecord-interface.md
-            items:
-              - name: GetCulture method
-                href: icordebugmergedassemblyrecord-getculture-method.md
-              - name: GetIndex method
-                href: icordebugmergedassemblyrecord-getindex-method.md
-              - name: GetPublicKey method
-                href: icordebugmergedassemblyrecord-getpublickey-method.md
-              - name: GetPublicKeyToken method
-                href: icordebugmergedassemblyrecord-getpublickeytoken-method.md
-              - name: GetSimpleName method
-                href: icordebugmergedassemblyrecord-getsimplename-method.md
-              - name: GetVersion method
-                href: icordebugmergedassemblyrecord-getversion-method.md
-          - name: ICorDebugMetaDataLocator interface
-            href: icordebugmetadatalocator-interface.md
-            items:
-              - name: GetMetaData method
-                href: icordebugmetadatalocator-getmetadata-method.md
-          - name: ICorDebugModule interface
-            href: icordebugmodule-interface.md
-            items:
-              - name: CreateBreakpoint method
-                href: icordebugmodule-createbreakpoint-method.md
-              - name: EnableClassLoadCallbacks method
-                href: icordebugmodule-enableclassloadcallbacks-method.md
-              - name: EnableJITDebugging method
-                href: icordebugmodule-enablejitdebugging-method.md
-              - name: GetAssembly method
-                href: icordebugmodule-getassembly-method.md
-              - name: GetBaseAddress method
-                href: icordebugmodule-getbaseaddress-method.md
-              - name: GetClassFromToken method
-                href: icordebugmodule-getclassfromtoken-method.md
-              - name: GetEditAndContinueSnapshot method
-                href: icordebugmodule-geteditandcontinuesnapshot-method.md
-              - name: GetFunctionFromRVA method
-                href: icordebugmodule-getfunctionfromrva-method.md
-              - name: GetFunctionFromToken method
-                href: icordebugmodule-getfunctionfromtoken-method.md
-              - name: GetGlobalVariableValue method
-                href: icordebugmodule-getglobalvariablevalue-method.md
-              - name: GetMetaDataInterface method
-                href: icordebugmodule-getmetadatainterface-method.md
-              - name: GetName method
-                href: icordebugmodule-getname-method.md
-              - name: GetProcess method
-                href: icordebugmodule-getprocess-method.md
-              - name: GetSize method
-                href: icordebugmodule-getsize-method.md
-              - name: GetToken method
-                href: icordebugmodule-gettoken-method.md
-              - name: IsDynamic method
-                href: icordebugmodule-isdynamic-method.md
-              - name: IsInMemory method
-                href: icordebugmodule-isinmemory-method.md
-          - name: ICorDebugModule2 interface
-            href: icordebugmodule2-interface.md
-            items:
-              - name: ApplyChanges method
-                href: icordebugmodule2-applychanges-method.md
-              - name: GetJITCompilerFlags method
-                href: icordebugmodule2-getjitcompilerflags-method.md
-              - name: ResolveAssembly method
-                href: icordebugmodule2-resolveassembly-method.md
-              - name: SetJITCompilerFlags method
-                href: icordebugmodule2-setjitcompilerflags-method.md
-              - name: SetJMCStatus method
-                href: icordebugmodule2-setjmcstatus-method.md
-          - name: ICorDebugModule3 interface
-            href: icordebugmodule3-interface.md
-            items:
-              - name: "ICorDebugModule3::CreateReaderForInMemorySymbols method"
-                href: icordebugmodule3-createreaderforinmemorysymbols-method.md
-          - name: ICorDebugModule4 interface
-            href: icordebugmodule4-interface.md
-            items:
-              - name: "ICorDebugModule4::IsMappedLayout method"
-                href: icordebugmodule4-ismappedlayout-method.md
-          - name: ICorDebugModuleBreakpoint interface
-            href: icordebugmodulebreakpoint-interface.md
-            items:
-              - name: GetModule method
-                href: icordebugmodulebreakpoint-getmodule-method.md
-          - name: ICorDebugModuleDebugEvent interface
-            href: icordebugmoduledebugevent-interface.md
-            items:
-              - name: GetModule method
-                href: icordebugmoduledebugevent-getmodule-method.md
-          - name: ICorDebugModuleEnum interface
-            href: icordebugmoduleenum-interface.md
-            items:
-              - name: Next method
-                href: icordebugmoduleenum-next-method.md
-          - name: ICorDebugMutableDataTarget interface
-            href: icordebugmutabledatatarget-interface.md
-            items:
-              - name: ContinueStatusChanged method
-                href: icordebugmutabledatatarget-continuestatuschanged-method.md
-              - name: SetThreadContext method
-                href: icordebugmutabledatatarget-setthreadcontext-method.md
-              - name: WriteVirtual method
-                href: icordebugmutabledatatarget-writevirtual-method.md
-          - name: ICorDebugNativeFrame interface
-            href: icordebugnativeframe-interface.md
-            items:
-              - name: CanSetIP method
-                href: icordebugnativeframe-cansetip-method.md
-              - name: GetIP method
-                href: icordebugnativeframe-getip-method.md
-              - name: GetLocalDoubleRegisterValue method
-                href: icordebugnativeframe-getlocaldoubleregistervalue-method.md
-              - name: GetLocalMemoryRegisterValue method
-                href: icordebugnativeframe-getlocalmemoryregistervalue-method.md
-              - name: GetLocalMemoryValue method
-                href: icordebugnativeframe-getlocalmemoryvalue-method.md
-              - name: GetLocalRegisterMemoryValue method
-                href: icordebugnativeframe-getlocalregistermemoryvalue-method.md
-              - name: GetLocalRegisterValue method
-                href: icordebugnativeframe-getlocalregistervalue-method.md
-              - name: GetRegisterSet method
-                href: icordebugnativeframe-getregisterset-method.md
-              - name: SetIP method
-                href: icordebugnativeframe-setip-method.md
-          - name: ICorDebugNativeFrame2 interface
-            href: icordebugnativeframe2-interface.md
-            items:
-              - name: IsChild method
-                href: icordebugnativeframe2-ischild-method.md
-              - name: IsMatchingParentFrame method
-                href: icordebugnativeframe2-ismatchingparentframe-method.md
-              - name: GetStackParameterSize method
-                href: icordebugnativeframe2-getstackparametersize-method.md
-          - name: ICorDebugObjectEnum interface
-            href: icordebugobjectenum-interface.md
-            items:
-              - name: Next method
-                href: icordebugobjectenum-next-method.md
-          - name: ICorDebugObjectValue interface
-            href: icordebugobjectvalue-interface.md
-            items:
-              - name: GetClass method
-                href: icordebugobjectvalue-getclass-method.md
-              - name: GetContext method
-                href: icordebugobjectvalue-getcontext-method.md
-              - name: GetFieldValue method
-                href: icordebugobjectvalue-getfieldvalue-method.md
-              - name: GetManagedCopy method
-                href: icordebugobjectvalue-getmanagedcopy-method.md
-              - name: GetVirtualMethod method
-                href: icordebugobjectvalue-getvirtualmethod-method.md
-              - name: IsValueClass method
-                href: icordebugobjectvalue-isvalueclass-method.md
-              - name: SetFromManagedCopy method
-                href: icordebugobjectvalue-setfrommanagedcopy-method.md
-          - name: ICorDebugObjectValue2 interface
-            href: icordebugobjectvalue2-interface.md
-            items:
-              - name: GetVirtualMethodAndType method
-                href: icordebugobjectvalue2-getvirtualmethodandtype-method.md
-          - name: ICorDebugProcess interface
-            href: icordebugprocess-interface.md
-            items:
-              - name: ClearCurrentException method
-                href: icordebugprocess-clearcurrentexception-method.md
-              - name: EnableLogMessages method
-                href: icordebugprocess-enablelogmessages-method.md
-              - name: EnumerateAppDomains method
-                href: icordebugprocess-enumerateappdomains-method.md
-              - name: EnumerateObjects method
-                href: icordebugprocess-enumerateobjects-method.md
-              - name: GetHandle method
-                href: icordebugprocess-gethandle-method.md
-              - name: GetHelperThreadID method
-                href: icordebugprocess-gethelperthreadid-method.md
-              - name: GetID method
-                href: icordebugprocess-getid-method.md
-              - name: GetObject method
-                href: icordebugprocess-getobject-method.md
-              - name: GetThread method
-                href: icordebugprocess-getthread-method.md
-              - name: GetThreadContext method
-                href: icordebugprocess-getthreadcontext-method.md
-              - name: IsOSSuspended method
-                href: icordebugprocess-isossuspended-method.md
-              - name: IsTransitionStub method
-                href: icordebugprocess-istransitionstub-method.md
-              - name: ModifyLogSwitch method
-                href: icordebugprocess-modifylogswitch-method.md
-              - name: ReadMemory method
-                href: icordebugprocess-readmemory-method.md
-              - name: SetThreadContext method
-                href: icordebugprocess-setthreadcontext-method.md
-              - name: ThreadForFiberCookie method
-                href: icordebugprocess-threadforfibercookie-method.md
-              - name: WriteMemory method
-                href: icordebugprocess-writememory-method.md
-          - name: ICorDebugProcess2 interface
-            href: icordebugprocess2-interface1.md
-            items:
-              - name: ClearUnmanagedBreakpoint method
-                href: icordebugprocess2-clearunmanagedbreakpoint-method.md
-              - name: GetDesiredNGENCompilerFlags method
-                href: icordebugprocess2-getdesiredngencompilerflags-method.md
-              - name: GetReferenceValueFromGCHandle method
-                href: icordebugprocess2-getreferencevaluefromgchandle-method.md
-              - name: GetThreadForTaskID method
-                href: icordebugprocess2-getthreadfortaskid-method.md
-              - name: GetVersion method
-                href: icordebugprocess2-getversion-method.md
-              - name: SetDesiredNGENCompilerFlags method
-                href: icordebugprocess2-setdesiredngencompilerflags-method.md
-              - name: SetUnmanagedBreakpoint method
-                href: icordebugprocess2-setunmanagedbreakpoint-method.md
-          - name: ICorDebugProcess3 interface
-            href: icordebugprocess3-interface.md
-            items:
-              - name: SetEnableCustomNotification method
-                href: icordebugprocess3-setenablecustomnotification-method.md
-          - name: ICorDebugProcess4 interface
-            href: icordebugprocess4-interface.md
-            items:
-              - name: ProcessStateChanged method
-                href: icordebugprocess4-processstatechanged-method.md
-          - name: ICorDebugProcess5 interface
-            href: icordebugprocess5-interface.md
-            items:
-              - name: EnableNGenPolicy method
-                href: icordebugprocess5-enablengenpolicy-method.md
-              - name: EnumerateGCReferences method
-                href: icordebugprocess5-enumerategcreferences-method.md
-              - name: EnumerateHandles method
-                href: icordebugprocess5-enumeratehandles-method.md
-              - name: EnumerateHeap method
-                href: icordebugprocess5-enumerateheap-method.md
-              - name: EnumerateHeapRegions method
-                href: icordebugprocess5-enumerateheapregions-method.md
-              - name: GetArrayLayout method
-                href: icordebugprocess5-getarraylayout-method.md
-              - name: GetGCHeapInformation method
-                href: icordebugprocess5-getgcheapinformation-method.md
-              - name: GetObject method
-                href: icordebugprocess5-getobject-method.md
-              - name: GetTypeFields method
-                href: icordebugprocess5-gettypefields-method.md
-              - name: GetTypeForTypeID method
-                href: icordebugprocess5-gettypefortypeid-method.md
-              - name: GetTypeID method
-                href: icordebugprocess5-gettypeid-method.md
-              - name: GetTypeLayout method
-                href: icordebugprocess5-gettypelayout-method.md
-          - name: ICorDebugProcess6 interface
-            href: icordebugprocess6-interface.md
-            items:
-              - name: DecodeEvent method
-                href: icordebugprocess6-decodeevent-method.md
-              - name: EnableVirtualModuleSplitting method
-                href: icordebugprocess6-enablevirtualmodulesplitting-method.md
-              - name: GetCode method
-                href: icordebugprocess6-getcode-method.md
-              - name: GetExportStepInfo method
-                href: icordebugprocess6-getexportstepinfo-method.md
-              - name: MarkDebuggerAttached method
-                href: icordebugprocess6-markdebuggerattached-method.md
-              - name: ProcessStateChanged method
-                href: icordebugprocess6-processstatechanged-method.md
-          - name: ICorDebugProcess7 interface
-            href: icordebugprocess7-interface.md
-            items:
-              - name: SetWriteableMetadataUpdateMode method
-                href: icordebugprocess7-setwriteablemetadataupdatemode-method.md
-          - name: ICorDebugProcess8 interface
-            href: icordebugprocess8-interface.md
-            items:
-              - name: EnableExceptionCallbacksOutsideOfMyCode method
-                href: icordebugprocess8-enableexceptioncallbacksoutsideofmycode-method.md
-          - name: ICorDebugProcess11 interface
-            href: icordebugprocess11-interface.md
-            items:
-              - name: EnumerateLoaderHeapMemoryRegions method
-                href: icordebugprocess11-enumerateloaderheapmemoryregions-method.md
-          - name: ICorDebugProcessEnum interface
-            href: icordebugprocessenum-interface.md
-            items:
-              - name: Next method
-                href: icordebugprocessenum-next-method.md
-          - name: ICorDebugReferenceValue interface
-            href: icordebugreferencevalue-interface.md
-            items:
-              - name: Dereference method
-                href: icordebugreferencevalue-dereference-method.md
-              - name: DereferenceStrong method
-                href: icordebugreferencevalue-dereferencestrong-method.md
-              - name: GetValue method
-                href: icordebugreferencevalue-getvalue-method.md
-              - name: IsNull method
-                href: icordebugreferencevalue-isnull-method.md
-              - name: SetValue method
-                href: icordebugreferencevalue-setvalue-method.md
-          - name: ICorDebugRegisterSet interface
-            href: icordebugregisterset-interface.md
-            items:
-              - name: GetRegisters method
-                href: icordebugregisterset-getregisters-method.md
-              - name: GetRegistersAvailable method
-                href: icordebugregisterset-getregistersavailable-method.md
-              - name: GetThreadContext method
-                href: icordebugregisterset-getthreadcontext-method.md
-              - name: SetRegisters method
-                href: icordebugregisterset-setregisters-method.md
-              - name: SetThreadContext method
-                href: icordebugregisterset-setthreadcontext-method.md
-          - name: ICorDebugRegisterSet2 interface
-            href: icordebugregisterset2-interface.md
-            items:
-              - name: GetRegisters method
-                href: icordebugregisterset2-getregisters-method.md
-              - name: GetRegistersAvailable method
-                href: icordebugregisterset2-getregistersavailable-method.md
-              - name: SetRegisters method
-                href: icordebugregisterset2-setregisters-method.md
-          - name: ICorDebugRemote interface
-            href: icordebugremote-interface.md
-            items:
-              - name: "ICorDebugRemote::CreateProcessEx method"
-                href: icordebugremote-createprocessex-method.md
-              - name: "ICorDebugRemote::DebugActiveProcessEx method"
-                href: icordebugremote-debugactiveprocessex-method.md
-          - name: ICorDebugRemoteTarget interface
-            href: icordebugremotetarget-interface.md
-            items:
-              - name: "ICorDebugRemoteTarget::GetHostName method"
-                href: icordebugremotetarget-gethostname-method.md
-          - name: ICorDebugRuntimeUnwindableFrame interface
-            href: icordebugruntimeunwindableframe-interface.md
-          - name: ICorDebugStackWalk interface
-            href: icordebugstackwalk-interface.md
-            items:
-              - name: GetContext method
-                href: icordebugstackwalk-getcontext-method.md
-              - name: SetContext method
-                href: icordebugstackwalk-setcontext-method.md
-              - name: Next method
-                href: icordebugstackwalk-next-method.md
-              - name: GetFrame method
-                href: icordebugstackwalk-getframe-method.md
-          - name: ICorDebugStaticFieldSymbol interface
-            href: icordebugstaticfieldsymbol-interface.md
-            items:
-              - name: GetAddress method
-                href: icordebugstaticfieldsymbol-getaddress-method.md
-              - name: GetName method
-                href: icordebugstaticfieldsymbol-getname-method.md
-              - name: GetSize method
-                href: icordebugstaticfieldsymbol-getsize-method.md
-          - name: ICorDebugStepper interface
-            href: icordebugstepper-interface.md
-            items:
-              - name: Deactivate method
-                href: icordebugstepper-deactivate-method.md
-              - name: IsActive method
-                href: icordebugstepper-isactive-method.md
-              - name: SetInterceptMask method
-                href: icordebugstepper-setinterceptmask-method.md
-              - name: SetRangeIL method
-                href: icordebugstepper-setrangeil-method.md
-              - name: SetUnmappedStopMask method
-                href: icordebugstepper-setunmappedstopmask-method.md
-              - name: Step method
-                href: icordebugstepper-step-method.md
-              - name: StepOut method
-                href: icordebugstepper-stepout-method.md
-              - name: StepRange method
-                href: icordebugstepper-steprange-method.md
-          - name: ICorDebugStepper2 interface
-            href: icordebugstepper2-interface1.md
-            items:
-              - name: SetJMC method
-                href: icordebugstepper2-setjmc-method.md
-          - name: ICorDebugStepperEnum interface
-            href: icordebugstepperenum-interface.md
-            items:
-              - name: Next method
-                href: icordebugstepperenum-next-method.md
-          - name: ICorDebugStringValue interface
-            href: icordebugstringvalue-interface.md
-            items:
-              - name: GetLength method
-                href: icordebugstringvalue-getlength-method.md
-              - name: GetString method
-                href: icordebugstringvalue-getstring-method.md
-          - name: ICorDebugSymbolProvider interface
-            href: icordebugsymbolprovider-interface.md
-            items:
-              - name: GetAssemblyImageBytes method
-                href: icordebugsymbolprovider-getassemblyimagebytes-method.md
-              - name: GetAssemblyImageMetadata method
-                href: icordebugsymbolprovider-getassemblyimagemetadata-method.md
-              - name: GetCodeRange method
-                href: icordebugsymbolprovider-getcoderange-method.md
-              - name: GetInstanceFieldSymbols method
-                href: icordebugsymbolprovider-getinstancefieldsymbols-method.md
-              - name: GetMergedAssemblyRecords method
-                href: icordebugsymbolprovider-getmergedassemblyrecords-method.md
-              - name: GetMethodLocalSymbols method
-                href: icordebugsymbolprovider-getmethodlocalsymbols-method.md
-              - name: GetMethodParameterSymbols method
-                href: icordebugsymbolprovider-getmethodparametersymbols-method.md
-              - name: GetMethodProps method
-                href: icordebugsymbolprovider-getmethodprops-method.md
-              - name: GetObjectSize method
-                href: icordebugsymbolprovider-getobjectsize-method.md
-              - name: GetStaticFieldSymbols method
-                href: icordebugsymbolprovider-getstaticfieldsymbols-method.md
-              - name: GetTypeProps method
-                href: icordebugsymbolprovider-gettypeprops-method.md
-          - name: ICorDebugSymbolProvider2 interface
-            href: icordebugsymbolprovider2-interface.md
-            items:
-              - name: GetFrameProps method
-                href: icordebugsymbolprovider2-getframeprops-method.md
-              - name: GetGenericDictionaryInfo method
-                href: icordebugsymbolprovider2-getgenericdictionaryinfo-method.md
-          - name: ICorDebugThread interface
-            href: icordebugthread-interface.md
-            items:
-              - name: ClearCurrentException method
-                href: icordebugthread-clearcurrentexception-method.md
-              - name: CreateEval method
-                href: icordebugthread-createeval-method.md
-              - name: CreateStepper method
-                href: icordebugthread-createstepper-method.md
-              - name: EnumerateChains method
-                href: icordebugthread-enumeratechains-method.md
-              - name: GetActiveChain method
-                href: icordebugthread-getactivechain-method.md
-              - name: GetActiveFrame method
-                href: icordebugthread-getactiveframe-method.md
-              - name: GetAppDomain method
-                href: icordebugthread-getappdomain-method.md
-              - name: GetCurrentException method
-                href: icordebugthread-getcurrentexception-method.md
-              - name: GetDebugState method
-                href: icordebugthread-getdebugstate-method.md
-              - name: GetHandle method
-                href: icordebugthread-gethandle-method.md
-              - name: GetID method
-                href: icordebugthread-getid-method.md
-              - name: GetObject method
-                href: icordebugthread-getobject-method.md
-              - name: GetProcess method
-                href: icordebugthread-getprocess-method.md
-              - name: GetRegisterSet method
-                href: icordebugthread-getregisterset-method.md
-              - name: GetUserState method
-                href: icordebugthread-getuserstate-method.md
-              - name: SetDebugState method
-                href: icordebugthread-setdebugstate-method.md
-          - name: ICorDebugThread2 interface
-            href: icordebugthread2-interface.md
-            items:
-              - name: GetActiveFunctions method
-                href: icordebugthread2-getactivefunctions-method.md
-              - name: GetConnectionID method
-                href: icordebugthread2-getconnectionid-method.md
-              - name: GetTaskID method
-                href: icordebugthread2-gettaskid-method.md
-              - name: GetVolatileOSThreadID method
-                href: icordebugthread2-getvolatileosthreadid-method.md
-              - name: InterceptCurrentException method
-                href: icordebugthread2-interceptcurrentexception-method.md
-          - name: ICorDebugThread3 interface
-            href: icordebugthread3-interface.md
-            items:
-              - name: CreateStackWalk method
-                href: icordebugthread3-createstackwalk-method.md
-              - name: GetActiveInternalFrames method
-                href: icordebugthread3-getactiveinternalframes-method.md
-          - name: ICorDebugThread4 interface
-            href: icordebugthread4-interface.md
-            items:
-              - name: GetBlockingObjects method
-                href: icordebugthread4-getblockingobjects-method.md
-              - name: HadUnhandledException method
-                href: icordebugthread4-hadunhandledexception-method.md
-              - name: GetCurrentCustomDebuggerNotification method
-                href: icordebugthread4-getcurrentcustomdebuggernotification-method.md
-          - name: ICorDebugThreadEnum interface
-            href: icordebugthreadenum-interface1.md
-            items:
-              - name: Next method
-                href: icordebugthreadenum-next-method.md
-          - name: ICorDebugType interface
-            href: icordebugtype-interface.md
-            items:
-              - name: EnumerateTypeParameters method
-                href: icordebugtype-enumeratetypeparameters-method.md
-              - name: GetBase method
-                href: icordebugtype-getbase-method.md
-              - name: GetClass method
-                href: icordebugtype-getclass-method.md
-              - name: GetFirstTypeParameter method
-                href: icordebugtype-getfirsttypeparameter-method.md
-              - name: GetRank method
-                href: icordebugtype-getrank-method.md
-              - name: GetStaticFieldValue method
-                href: icordebugtype-getstaticfieldvalue-method.md
-              - name: GetType method
-                href: icordebugtype-gettype-method.md
-          - name: ICorDebugType2 interface
-            href: icordebugtype2-interface.md
-            items:
-              - name: GetTypeID method
-                href: icordebugtype2-gettypeid-method.md
-          - name: ICorDebugTypeEnum interface
-            href: icordebugtypeenum-interface.md
-            items:
-              - name: Next method
-                href: icordebugtypeenum-next-method.md
-          - name: ICorDebugUnmanagedCallback interface
-            href: icordebugunmanagedcallback-interface.md
-            items:
-              - name: DebugEvent method
-                href: icordebugunmanagedcallback-debugevent-method.md
-          - name: ICorDebugValue interface
-            href: icordebugvalue-interface.md
-            items:
-              - name: CreateBreakpoint method
-                href: icordebugvalue-createbreakpoint-method.md
-              - name: GetAddress method
-                href: icordebugvalue-getaddress-method.md
-              - name: GetSize method
-                href: icordebugvalue-getsize-method.md
-              - name: GetType method
-                href: icordebugvalue-gettype-method.md
-          - name: ICorDebugValue2 interface
-            href: icordebugvalue2-interface.md
-            items:
-              - name: GetExactType method
-                href: icordebugvalue2-getexacttype-method.md
-          - name: ICorDebugValue3 interface
-            href: icordebugvalue3-interface.md
-            items:
-              - name: GetSize64 method
-                href: icordebugvalue3-getsize64-method.md
-          - name: ICorDebugValueBreakpoint interface
-            href: icordebugvaluebreakpoint-interface.md
-            items:
-              - name: GetValue method
-                href: icordebugvaluebreakpoint-getvalue-method.md
-          - name: ICorDebugValueEnum interface
-            href: icordebugvalueenum-interface.md
-            items:
-              - name: Next method
-                href: icordebugvalueenum-next-method.md
-          - name: ICorDebugVariableHome interface
-            href: icordebugvariablehome-interface.md
-            items:
-              - name: GetArgumentIndex method
-                href: icordebugvariablehome-getargumentindex-method.md
-              - name: GetCode method
-                href: icordebugvariablehome-getcode-method.md
-              - name: GetLiveRange method
-                href: icordebugvariablehome-getliverange-method.md
-              - name: GetLocationType method
-                href: icordebugvariablehome-getlocationtype-method.md
-              - name: GetOffset method
-                href: icordebugvariablehome-getoffset-method.md
-              - name: GetRegister method
-                href: icordebugvariablehome-getregister-method.md
-              - name: GetSlotIndex method
-                href: icordebugvariablehome-getslotindex-method.md
-          - name: ICorDebugVariableHomeEnum interface
-            href: icordebugvariablehomeenum-interface.md
-            items:
-              - name: Next method
-                href: icordebugvariablehomeenum-next-method.md
-          - name: ICorDebugVariableSymbol interface
-            href: icordebugvariablesymbol-interface.md
-            items:
-              - name: GetName method
-                href: icordebugvariablesymbol-getname-method.md
-              - name: GetSize method
-                href: icordebugvariablesymbol-getsize-method.md
-              - name: GetSlotIndex method
-                href: icordebugvariablesymbol-getslotindex-method.md
-              - name: GetValue method
-                href: icordebugvariablesymbol-getvalue-method.md
-              - name: SetValue method
-                href: icordebugvariablesymbol-setvalue-method.md
-          - name: ICorDebugVirtualUnwinder interface
-            href: icordebugvirtualunwinder-interface.md
-            items:
-              - name: GetContext method
-                href: icordebugvirtualunwinder-getcontext-method.md
-              - name: Next method
-                href: icordebugvirtualunwinder-next-method.md
-          - name: ICorPublish interface
-            href: icorpublish-interface.md
-            items:
-              - name: EnumProcesses method
-                href: icorpublish-enumprocesses-method.md
-              - name: GetProcess method
-                href: icorpublish-getprocess-method.md
-          - name: ICorPublishAppDomain interface
-            href: icorpublishappdomain-interface.md
-            items:
-              - name: GetID method
-                href: icorpublishappdomain-getid-method.md
-              - name: GetName method
-                href: icorpublishappdomain-getname-method.md
-          - name: ICorPublishAppDomainEnum interface
-            href: icorpublishappdomainenum-interface.md
-            items:
-              - name: Next method
-                href: icorpublishappdomainenum-next-method.md
-          - name: ICorPublishEnum interface
-            href: icorpublishenum-interface.md
-            items:
-              - name: Clone method
-                href: icorpublishenum-clone-method.md
-              - name: GetCount method
-                href: icorpublishenum-getcount-method.md
-              - name: Reset method
-                href: icorpublishenum-reset-method.md
-              - name: Skip method
-                href: icorpublishenum-skip-method.md
-          - name: ICorPublishProcess interface
-            href: icorpublishprocess-interface.md
-            items:
-              - name: EnumAppDomains method
-                href: icorpublishprocess-enumappdomains-method.md
-              - name: GetDisplayName method
-                href: icorpublishprocess-getdisplayname-method.md
-              - name: GetProcessID method
-                href: icorpublishprocess-getprocessid-method.md
-              - name: IsManaged method
-                href: icorpublishprocess-ismanaged-method.md
-          - name: ICorPublishProcessEnum interface
-            href: icorpublishprocessenum-interface.md
-            items:
-              - name: Next method
-                href: icorpublishprocessenum-next-method.md
-          - name: ISOSDacInterface interface
-            href: isosdacinterface-interface.md
-            items:
-              - name: GetMethodDescData
-                href: isosdacinterface-getmethoddescdata-method.md
-              - name: GetMethodDescPtrFromIP
-                href: isosdacinterface-getmethoddescptrfromip-method.md
-              - name: GetModuleData
-                href: isosdacinterface-getmoduledata-method.md
-          - name: IXCLRDataMethodDefinition interface
-            href: ixclrdatamethoddefinition-interface.md
-            items:
-              - name: StartEnumInstances
-                href: ixclrdatamethoddefinition-startenuminstances-method.md
-              - name: EnumInstance
-                href: ixclrdatamethoddefinition-enuminstance-method.md
-              - name: EndEnumInstances
-                href: ixclrdatamethoddefinition-endenuminstances-method.md
-          - name: IXCLRDataMethodInstance interface
-            href: ixclrdatamethodinstance-interface.md
-            items:
-              - name: GetILAddressMap
-                href: ixclrdatamethodinstance-getiladdressmap-method.md
-              - name: GetRepresentativeEntryAddress
-                href: ixclrdatamethodinstance-getrepresentativeentryaddress-method.md
-          - name: IXCLRDataModule interface
-            href: ixclrdatamodule-interface.md
-            items:
-              - name: GetMethodDefinitionByToken
-                href: ixclrdatamodule-getmethoddefinitionbytoken-method.md
-              - name: Request
-                href: ixclrdatamodule-request-method.md
-              - name: GetVersionId
-                href: ixclrdatamodule-getversionid-method.md
-          - name: IXCLRDataProcess interface
-            href: ixclrdataprocess-interface.md
-            items:
-              - name: GetRuntimeNameByAddress
-                href: ixclrdataprocess-getruntimenamebyaddress-method.md
-              - name: GetAppDomainByUniqueId
-                href: ixclrdataprocess-getappdomainbyuniqueid-method.md
-              - name: StartEnumModules
-                href: ixclrdataprocess-startenummodules-method.md
-              - name: EnumModule
-                href: ixclrdataprocess-enummodule-method.md
-              - name: EndEnumModules
-                href: ixclrdataprocess-endenummodules-method.md
-              - name: StartEnumMethodInstancesByAddress
-                href: ixclrdataprocess-startenummethodinstancesbyaddress-method.md
-              - name: EnumMethodInstanceByAddress
-                href: ixclrdataprocess-enummethodinstancebyaddress-method.md
-              - name: EndEnumMethodInstancesByAddress
-                href: ixclrdataprocess-endenummethodinstancesbyaddress-method.md
-      - name: Debugging global static functions
-        href: debugging-global-static-functions.md
-        items:
-          - name: _EFN_GetManagedExcepStack function
-            href: efn-getmanagedexcepstack-function.md
-          - name: _EFN_GetManagedObjectFieldInfo function
-            href: efn-getmanagedobjectfieldinfo-function.md
-          - name: _EFN_GetManagedObjectName function
-            href: efn-getmanagedobjectname-function.md
-          - name: _EFN_StackTrace function
-            href: efn-stacktrace-function.md
-          - name: CLRDataCreateInstance function
-            href: clrdatacreateinstance-function.md
-          - name: PFN_CLRDataCreateInstance function pointer
-            href: pfn-clrdatacreateinstance-function-pointer.md
-      - name: Debugging enumerations
-        href: debugging-enumerations.md
-        items:
-          - name: CLR_DEBUGGING_PROCESS_FLAGS enumeration
-            href: clr-debugging-process-flags-enumeration.md
-          - name: CLRDataEnumMemoryFlags enumeration
-            href: clrdataenummemoryflags-enumeration.md
-          - name: ClrDataSourceType enumeration
-            href: clrdatasourcetype-enumeration.md
-          - name: COR_PUB_ENUMPROCESS enumeration
-            href: cor-pub-enumprocess-enumeration.md
-          - name: CorDebugBlockingReason enumeration
-            href: cordebugblockingreason-enumeration.md
-          - name: CorDebugChainReason enumeration
-            href: cordebugchainreason-enumeration.md
-          - name: CorDebugCodeInvokeKind enumeration
-            href: cordebugcodeinvokekind-enumeration.md
-          - name: CorDebugCodeInvokePurpose enumeration
-            href: cordebugcodeinvokepurpose-enumeration.md
-          - name: CorDebugCreateProcessFlags enumeration
-            href: cordebugcreateprocessflags-enumeration.md
-          - name: CorDebugDebugEventKind enumeration
-            href: cordebugdebugeventkind-enumeration.md
-          - name: CorDebugDecodeEventFlagsWindows enumeration
-            href: cordebugdecodeeventflagswindows-enumeration.md
-          - name: CorDebugExceptionCallbackType enumeration
-            href: cordebugexceptioncallbacktype-enumeration.md
-          - name: CorDebugExceptionFlags enumeration
-            href: cordebugexceptionflags-enumeration.md
-          - name: CorDebugExceptionUnwindCallbackType enumeration
-            href: cordebugexceptionunwindcallbacktype-enumeration.md
-          - name: CorDebugGCType enumeration
-            href: cordebuggctype-enumeration.md
-          - name: CorDebugGenerationTypes enumeration
-            href: cordebuggenerationtypes-enumeration.md
-          - name: CorDebugHandleType enumeration
-            href: cordebughandletype-enumeration.md
-          - name: CorDebugIlToNativeMappingTypes enumeration
-            href: cordebugiltonativemappingtypes-enumeration.md
-          - name: CorDebugIntercept enumeration
-            href: cordebugintercept-enumeration.md
-          - name: CorDebugInterfaceVersion enumeration
-            href: cordebuginterfaceversion-enumeration.md
-          - name: CorDebugInternalFrameType enumeration
-            href: cordebuginternalframetype-enumeration.md
-          - name: CorDebugJITCompilerFlags enumeration
-            href: cordebugjitcompilerflags-enumeration.md
-          - name: CorDebugJITCompilerFlagsDeprecated enumeration
-            href: cordebugjitcompilerflagsdeprecated-enumeration.md
-          - name: CorDebugMappingResult enumeration
-            href: cordebugmappingresult-enumeration.md
-          - name: CorDebugMDAFlags enumeration
-            href: cordebugmdaflags-enumeration.md
-          - name: CorDebugNGenPolicy enumeration
-            href: cordebugngenpolicy-enumeration.md
-          - name: CorDebugPlatform enumeration
-            href: cordebugplatform-enumeration.md
-          - name: CorDebugRecordFormat enumeration
-            href: cordebugrecordformat-enumeration.md
-          - name: CorDebugRegister enumeration
-            href: cordebugregister-enumeration.md
-          - name: CorDebugSetContextFlag enumeration
-            href: cordebugsetcontextflag-enumeration.md
-          - name: CorDebugStateChange enumeration
-            href: cordebugstatechange-enumeration.md
-          - name: CorDebugStepReason enumeration
-            href: cordebugstepreason-enumeration.md
-          - name: CorDebugThreadState enumeration
-            href: cordebugthreadstate-enumeration.md
-          - name: CorDebugUnmappedStop enumeration
-            href: cordebugunmappedstop-enumeration.md
-          - name: CorDebugUserState enumeration
-            href: cordebuguserstate-enumeration.md
-          - name: CorGCReferenceType enumeration
-            href: corgcreferencetype-enumeration.md
-          - name: ILCodeKind enumeration
-            href: ilcodekind-enumeration.md
-          - name: LoggingLevelEnum enumeration
-            href: logginglevelenum-enumeration.md
-          - name: LogSwitchCallReason enumeration
-            href: logswitchcallreason-enumeration.md
-          - name: VariableLocationType enumeration
-            href: variablelocationtype-enumeration.md
-          - name: WriteableMetadataUpdateMode enumeration
-            href: writeablemetadataupdatemode-enumeration.md
-      - name: Debugging structures
-        href: debugging-structures.md
-        items:
-          - name: CLRDATA_ADDRESS_RANGE structure
-            href: clrdata-address-range-structure.md
-          - name: CLRDATA_IL_ADDRESS_MAP structure
-            href: clrdata-il-address-map-structure.md
-          - name: CLR_DEBUGGING_VERSION structure
-            href: clr-debugging-version-structure.md
-          - name: CodeChunkInfo structure
-            href: codechunkinfo-structure.md
-          - name: COR_ACTIVE_FUNCTION structure
-            href: cor-active-function-structure.md
-          - name: COR_ARRAY_LAYOUT structure
-            href: cor-array-layout-structure.md
-          - name: COR_DEBUG_IL_TO_NATIVE_MAP structure
-            href: cor-debug-il-to-native-map-structure.md
-          - name: COR_DEBUG_STEP_RANGE structure
-            href: cor-debug-step-range-structure.md
-          - name: COR_FIELD structure
-            href: cor-field-structure.md
-          - name: COR_GC_REFERENCE structure
-            href: cor-gc-reference-structure.md
-          - name: COR_HEAPINFO structure
-            href: cor-heapinfo-structure.md
-          - name: COR_HEAPOBJECT structure
-            href: cor-heapobject-structure.md
-          - name: COR_IL_MAP structure
-            href: cor-il-map-structure.md
-          - name: COR_SEGMENT structure
-            href: cor-segment-structure.md
-          - name: COR_TYPEID structure
-            href: cor-typeid-structure.md
-          - name: COR_TYPE_LAYOUT structure
-            href: cor-type-layout-structure.md
-          - name: COR_VERSION structure
-            href: cor-version-structure.md
-          - name: CorDebugBlockingObject structure
-            href: cordebugblockingobject-structure.md
-          - name: CorDebugEHClause structure
-            href: cordebugehclause-structure.md
-          - name: CorDebugExceptionObjectStackFrame structure
-            href: cordebugexceptionobjectstackframe-structure.md
-          - name: CorDebugGuidToTypeMapping structure
-            href: cordebugguidtotypemapping-structure.md
-          - name: DacpGetModuleAddress structure
-            href: dacpgetmoduleaddress-structure.md
-            items:
-              - name: "DacpGetModuleAddress::Request method"
-                href: dacpgetmoduleaddress-request-method.md
-          - name: DacpMethodDescData structure
-            href: dacpmethoddescdata-structure.md
-          - name: DacpModuleData structure
-            href: dacpmoduledata-structure.md
-          - name: DacpReJitData structure
-            href: dacprejitdata-structure.md
-          - name: StackTrace_SimpleContext structure
-            href: stacktrace-simplecontext-structure.md
-      - name: .NET Core debugging
-        href: ../../../core/unmanaged-api/debugging/index.md
-      - name: Silverlight debugging
-        href: silverlight-debugging.md
-        items:
-          - name: CloseCLREnumeration function
-            href: closeclrenumeration-function-for-silverlight.md
-          - name: CreateCoreClrDebugTarget function
-            href: createcoreclrdebugtarget-function.md
-          - name: CreateCordbObject function
-            href: createcordbobject-function.md
-          - name: CreateVersionStringFromModule function
-            href: createversionstringfrommodule-function-for-silverlight.md
-          - name: CreateDebuggingInterfaceFromVersion function
-            href: createdebugginginterfacefromversion-function-for-silverlight.md
-          - name: CoreClrDebugProcInfo structure
-            href: coreclrdebugprocinfo-structure.md
-          - name: CoreClrDebugRuntimeInfo structure
-            href: coreclrdebugruntimeinfo-structure.md
-          - name: EnumerateCLRs function
-            href: enumerateclrs-function-for-silverlight.md
-          - name: GetStartupNotificationEvent function
-            href: getstartupnotificationevent-function-for-silverlight.md
-          - name: ICoreClrDebugTarget interface
-            href: icoreclrdebugtarget-interface.md
-            items:
-              - name: "ICoreClrDebugTarget::EnumProcesses method"
-                href: icoreclrdebugtarget-enumprocesses-method.md
-              - name: "ICoreClrDebugTarget::EnumRuntimes method"
-                href: icoreclrdebugtarget-enumruntimes-method.md
-              - name: "ICoreClrDebugTarget::FreeMemory method"
-                href: icoreclrdebugtarget-freememory-method.md
-          - name: InitDbgTransportManager function
-            href: initdbgtransportmanager-function.md
-          - name: ShutdownDbgTransportManager function
-            href: shutdowndbgtransportmanager-function.md
+- name: Debugging
+  href: index.md
+- name: Debugging coclasses
+  href: debugging-coclasses.md
+  items:
+    - name: CorpubPublish coclass
+      href: corpubpublish-coclass.md
+- name: Debugging interfaces
+  href: debugging-interfaces.md
+  items:
+    - name: ICLRDataEnumMemoryRegions interface
+      href: iclrdataenummemoryregions-interface.md
+      items:
+        - name: EnumMemoryRegions method
+          href: iclrdataenummemoryregions-enummemoryregions-method.md
+    - name: ICLRDataEnumMemoryRegionsCallback interface
+      href: iclrdataenummemoryregionscallback-interface.md
+      items:
+        - name: EnumMemoryRegion method
+          href: iclrdataenummemoryregionscallback-enummemoryregion-method.md
+    - name: ICLRDataTarget interface
+      href: iclrdatatarget-interface.md
+      items:
+        - name: GetCurrentThreadID method
+          href: iclrdatatarget-getcurrentthreadid-method.md
+        - name: GetImageBase method
+          href: iclrdatatarget-getimagebase-method.md
+        - name: GetMachineType method
+          href: iclrdatatarget-getmachinetype-method.md
+        - name: GetPointerSize method
+          href: iclrdatatarget-getpointersize-method.md
+        - name: GetThreadContext method
+          href: iclrdatatarget-getthreadcontext-method.md
+        - name: GetTLSValue method
+          href: iclrdatatarget-gettlsvalue-method.md
+        - name: ReadVirtual method
+          href: iclrdatatarget-readvirtual-method.md
+        - name: Request method
+          href: iclrdatatarget-request-method.md
+        - name: SetThreadContext method
+          href: iclrdatatarget-setthreadcontext-method.md
+        - name: SetTLSValue method
+          href: iclrdatatarget-settlsvalue-method.md
+        - name: WriteVirtual method
+          href: iclrdatatarget-writevirtual-method.md
+    - name: ICLRDataTarget2 interface
+      href: iclrdatatarget2-interface.md
+      items:
+        - name: AllocVirtual method
+          href: iclrdatatarget2-allocvirtual-method.md
+        - name: FreeVirtual method
+          href: iclrdatatarget2-freevirtual-method.md
+    - name: ICLRDataTarget3 interface
+      href: iclrdatatarget3-interface.md
+      items:
+        - name: GetExceptionRecord method
+          href: iclrdatatarget3-getexceptionrecord-method.md
+        - name: GetExceptionContextRecord method
+          href: iclrdatatarget3-getexceptioncontextrecord-method.md
+        - name: GetExceptionThreadID method
+          href: iclrdatatarget3-getexceptionthreadid-method.md
+    - name: ICLRDebugging interface
+      href: iclrdebugging-interface.md
+      items:
+        - name: OpenVirtualProcess method
+          href: iclrdebugging-openvirtualprocess-method.md
+        - name: CanUnloadNow method
+          href: iclrdebugging-canunloadnow-method.md
+    - name: ICLRDebuggingLibraryProvider interface
+      href: iclrdebugginglibraryprovider-interface.md
+      items:
+        - name: ProvideLibrary method
+          href: iclrdebugginglibraryprovider-providelibrary-method.md
+    - name: ICLRMetadataLocator interface
+      href: iclrmetadatalocator-interface.md
+      items:
+        - name: GetMetadata method
+          href: iclrmetadatalocator-getmetadata-method.md
+    - name: ICorDebug interface
+      href: icordebug-interface.md
+      items:
+        - name: CanLaunchOrAttach method
+          href: icordebug-canlaunchorattach-method.md
+        - name: CreateProcess method
+          href: icordebug-createprocess-method.md
+        - name: DebugActiveProcess method
+          href: icordebug-debugactiveprocess-method.md
+        - name: EnumerateProcesses method
+          href: icordebug-enumerateprocesses-method.md
+        - name: GetProcess method
+          href: icordebug-getprocess-method.md
+        - name: Initialize method
+          href: icordebug-initialize-method.md
+        - name: SetManagedHandler method
+          href: icordebug-setmanagedhandler-method.md
+        - name: SetUnmanagedHandler method
+          href: icordebug-setunmanagedhandler-method.md
+        - name: Terminate method
+          href: icordebug-terminate-method.md
+    - name: ICorDebugAppDomain interface
+      href: icordebugappdomain-interface.md
+      items:
+        - name: Attach method
+          href: icordebugappdomain-attach-method.md
+        - name: EnumerateAssemblies method
+          href: icordebugappdomain-enumerateassemblies-method.md
+        - name: EnumerateBreakpoints method
+          href: icordebugappdomain-enumeratebreakpoints-method.md
+        - name: EnumerateSteppers method
+          href: icordebugappdomain-enumeratesteppers-method.md
+        - name: GetId method
+          href: icordebugappdomain-getid-method.md
+        - name: GetModuleFromMetaDataInterface method
+          href: icordebugappdomain-getmodulefrommetadatainterface-method.md
+        - name: GetName method
+          href: icordebugappdomain-getname-method.md
+        - name: GetObject method
+          href: icordebugappdomain-getobject-method.md
+        - name: GetProcess method
+          href: icordebugappdomain-getprocess-method.md
+        - name: IsAttached method
+          href: icordebugappdomain-isattached-method.md
+    - name: ICorDebugAppDomain2 interface
+      href: icordebugappdomain2-interface.md
+      items:
+        - name: GetArrayOrPointerType method
+          href: icordebugappdomain2-getarrayorpointertype-method.md
+        - name: GetFunctionPointerType
+          href: icordebugappdomain2-getfunctionpointertype-method.md
+    - name: ICorDebugAppDomain3 interface
+      href: icordebugappdomain3-interface.md
+      items:
+        - name: GetCachedWinRTTypes method
+          href: icordebugappdomain3-getcachedwinrttypes-method.md
+        - name: GetCachedWinRTTypesForIIDs method
+          href: icordebugappdomain3-getcachedwinrttypesforiids-method.md
+    - name: ICorDebugAppDomain4 interface
+      href: icordebugappdomain4-interface.md
+      items:
+        - name: GetObjectForCCW method
+          href: icordebugappdomain4-getobjectforccw-method.md
+    - name: ICorDebugAppDomainEnum interface
+      href: icordebugappdomainenum-interface.md
+      items:
+        - name: Next method
+          href: icordebugappdomainenum-next-method.md
+    - name: ICorDebugArrayValue interface
+      href: icordebugarrayvalue-interface.md
+      items:
+        - name: GetBaseIndicies method
+          href: icordebugarrayvalue-getbaseindicies-method.md
+        - name: GetCount method
+          href: icordebugarrayvalue-getcount-method.md
+        - name: GetDimensions method
+          href: icordebugarrayvalue-getdimensions-method.md
+        - name: GetElement method
+          href: icordebugarrayvalue-getelement-method.md
+        - name: GetElementAtPosition method
+          href: icordebugarrayvalue-getelementatposition-method.md
+        - name: GetElementType method
+          href: icordebugarrayvalue-getelementtype-method.md
+        - name: GetRank method
+          href: icordebugarrayvalue-getrank-method.md
+        - name: HasBaseIndicies method
+          href: icordebugarrayvalue-hasbaseindicies-method.md
+    - name: ICorDebugAssembly interface
+      href: icordebugassembly-interface.md
+      items:
+        - name: EnumerateModules method
+          href: icordebugassembly-enumeratemodules-method.md
+        - name: GetAppDomain method
+          href: icordebugassembly-getappdomain-method.md
+        - name: GetCodeBase method
+          href: icordebugassembly-getcodebase-method.md
+        - name: GetName method
+          href: icordebugassembly-getname-method.md
+        - name: GetProcess method
+          href: icordebugassembly-getprocess-method.md
+    - name: ICorDebugAssembly2 interface
+      href: icordebugassembly2-interface.md
+      items:
+        - name: IsFullyTrusted method
+          href: icordebugassembly2-isfullytrusted-method.md
+    - name: ICorDebugAssembly3 interface
+      href: icordebugassembly3-interface.md
+      items:
+        - name: EnumerateContainedAssemblies method
+          href: icordebugassembly3-enumeratecontainedassemblies-method.md
+        - name: GetContainerAssembly method
+          href: icordebugassembly3-getcontainerassembly-method.md
+    - name: ICorDebugAssemblyEnum interface
+      href: icordebugassemblyenum-interface.md
+      items:
+        - name: Next method
+          href: icordebugassemblyenum-next-method.md
+    - name: ICorDebugBlockingObjectEnum interface
+      href: icordebugblockingobjectenum-interface.md
+      items:
+        - name: Next method
+          href: icordebugblockingobjectenum-next-method.md
+    - name: ICorDebugBoxValue interface
+      href: icordebugboxvalue-interface.md
+      items:
+        - name: GetObject method
+          href: icordebugboxvalue-getobject-method.md
+    - name: ICorDebugBreakpoint interface
+      href: icordebugbreakpoint-interface.md
+      items:
+        - name: Activate method
+          href: icordebugbreakpoint-activate-method.md
+        - name: IsActive method
+          href: icordebugbreakpoint-isactive-method.md
+    - name: ICorDebugBreakpointEnum interface
+      href: icordebugbreakpointenum-interface.md
+      items:
+        - name: Next method
+          href: icordebugbreakpointenum-next-method.md
+    - name: ICorDebugChain interface
+      href: icordebugchain-interface.md
+      items:
+        - name: EnumerateFrames method
+          href: icordebugchain-enumerateframes-method.md
+        - name: GetActiveFrame method
+          href: icordebugchain-getactiveframe-method.md
+        - name: GetCallee method
+          href: icordebugchain-getcallee-method.md
+        - name: GetCaller method
+          href: icordebugchain-getcaller-method.md
+        - name: GetContext method
+          href: icordebugchain-getcontext-method.md
+        - name: GetNext method
+          href: icordebugchain-getnext-method.md
+        - name: GetPrevious method
+          href: icordebugchain-getprevious-method.md
+        - name: GetReason method
+          href: icordebugchain-getreason-method.md
+        - name: GetRegisterSet method
+          href: icordebugchain-getregisterset-method.md
+        - name: GetStackRange method
+          href: icordebugchain-getstackrange-method.md
+        - name: GetThread method
+          href: icordebugchain-getthread-method.md
+        - name: IsManaged method
+          href: icordebugchain-ismanaged-method.md
+    - name: ICorDebugChainEnum interface
+      href: icordebugchainenum-interface.md
+      items:
+        - name: Next method
+          href: icordebugchainenum-next-method.md
+    - name: ICorDebugClass interface
+      href: icordebugclass-interface.md
+      items:
+        - name: GetModule method
+          href: icordebugclass-getmodule-method.md
+        - name: GetStaticFieldValue method
+          href: icordebugclass-getstaticfieldvalue-method.md
+        - name: GetToken method
+          href: icordebugclass-gettoken-method.md
+    - name: ICorDebugClass2 interface
+      href: icordebugclass2-interface.md
+      items:
+        - name: GetParameterizedType method
+          href: icordebugclass2-getparameterizedtype-method.md
+        - name: SetJMCStatus method
+          href: icordebugclass2-setjmcstatus-method.md
+    - name: ICorDebugCode interface
+      href: icordebugcode-interface1.md
+      items:
+        - name: CreateBreakpoint method
+          href: icordebugcode-createbreakpoint-method.md
+        - name: GetAddress method
+          href: icordebugcode-getaddress-method.md
+        - name: GetCode method
+          href: icordebugcode-getcode-method.md
+        - name: GetEnCRemapSequencePoints method
+          href: icordebugcode-getencremapsequencepoints-method.md
+        - name: GetFunction method
+          href: icordebugcode-getfunction-method.md
+        - name: GetILToNativeMapping method
+          href: icordebugcode-getiltonativemapping-method.md
+        - name: GetSize method
+          href: icordebugcode-getsize-method.md
+        - name: GetVersionNumber method
+          href: icordebugcode-getversionnumber-method.md
+        - name: IsIL method
+          href: icordebugcode-isil-method.md
+    - name: ICorDebugCode2 interface
+      href: icordebugcode2-interface.md
+      items:
+        - name: GetCodeChunks method
+          href: icordebugcode2-getcodechunks-method.md
+        - name: GetCompilerFlags method
+          href: icordebugcode2-getcompilerflags-method.md
+    - name: ICorDebugCode3 interface
+      href: icordebugcode3-interface.md
+      items:
+        - name: GetReturnValueLiveOffset method
+          href: icordebugcode3-getreturnvalueliveoffset-method.md
+    - name: ICorDebugCode4 interface
+      href: icordebugcode4-interface.md
+      items:
+        - name: EnumerateVariableHomes method
+          href: icordebugcode4-enumeratevariablehomes-method.md
+    - name: ICorDebugCodeEnum interface
+      href: icordebugcodeenum-interface.md
+      items:
+        - name: Next method
+          href: icordebugcodeenum-next-method.md
+    - name: ICorDebugComObjectValue interface
+      href: icordebugcomobjectvalue-interface.md
+      items:
+        - name: GetCachedInterfacePointers method
+          href: icordebugcomobjectvalue-getcachedinterfacepointers-method.md
+        - name: GetCachedInterfaceTypes method
+          href: icordebugcomobjectvalue-getcachedinterfacetypes-method.md
+    - name: ICorDebugContext interface
+      href: icordebugcontext-interface.md
+    - name: ICorDebugController interface
+      href: icordebugcontroller-interface.md
+      items:
+        - name: CanCommitChanges method
+          href: icordebugcontroller-cancommitchanges-method.md
+        - name: CommitChanges method
+          href: icordebugcontroller-commitchanges-method.md
+        - name: Continue method
+          href: icordebugcontroller-continue-method.md
+        - name: Detach method
+          href: icordebugcontroller-detach-method.md
+        - name: EnumerateThreads method
+          href: icordebugcontroller-enumeratethreads-method.md
+        - name: HasQueuedCallbacks method
+          href: icordebugcontroller-hasqueuedcallbacks-method.md
+        - name: IsRunning method
+          href: icordebugcontroller-isrunning-method.md
+        - name: SetAllThreadsDebugState method
+          href: icordebugcontroller-setallthreadsdebugstate-method.md
+        - name: Stop method
+          href: icordebugcontroller-stop-method.md
+        - name: Terminate method
+          href: icordebugcontroller-terminate-method.md
+    - name: ICorDebugDataTarget interface
+      href: icordebugdatatarget-interface.md
+      items:
+        - name: GetPlatform method
+          href: icordebugdatatarget-getplatform-method.md
+        - name: ReadVirtual method
+          href: icordebugdatatarget-readvirtual-method.md
+        - name: GetThreadContext method
+          href: icordebugdatatarget-getthreadcontext-method.md
+    - name: ICorDebugDataTarget2 interface
+      href: icordebugdatatarget2-interface.md
+      items:
+        - name: CreateVirtualUnwinder method
+          href: icordebugdatatarget2-createvirtualunwinder-method.md
+        - name: EnumerateThreadIDs method
+          href: icordebugdatatarget2-enumeratethreadids-method.md
+        - name: GetImageFromPointer method
+          href: icordebugdatatarget2-getimagefrompointer-method.md
+        - name: GetImageLocation method
+          href: icordebugdatatarget2-getimagelocation-method.md
+        - name: GetSymbolProviderForImage method
+          href: icordebugdatatarget2-getsymbolproviderforimage-method.md
+    - name: ICorDebugDataTarget3 interface
+      href: icordebugdatatarget3-interface.md
+      items:
+        - name: GetLoadedModules method
+          href: icordebugdatatarget3-getloadedmodules-method.md
+    - name: ICorDebugDebugEvent interface
+      href: icordebugdebugevent-interface.md
+      items:
+        - name: GetEventKind method
+          href: icordebugdebugevent-geteventkind-method.md
+        - name: GetThread method
+          href: icordebugdebugevent-getthread-method.md
+    - name: ICorDebugEditAndContinueErrorInfo interface
+      href: icordebugeditandcontinueerrorinfo-interface.md
+      items:
+        - name: GetErrorCode method
+          href: icordebugeditandcontinueerrorinfo-geterrorcode-method.md
+        - name: GetModule method
+          href: icordebugeditandcontinueerrorinfo-getmodule-method.md
+        - name: GetString method
+          href: icordebugeditandcontinueerrorinfo-getstring-method.md
+        - name: GetToken method
+          href: icordebugeditandcontinueerrorinfo-gettoken-method.md
+    - name: ICorDebugEditAndContinueSnapshot interface
+      href: icordebugeditandcontinuesnapshot-interface.md
+      items:
+        - name: CopyMetaData method
+          href: icordebugeditandcontinuesnapshot-copymetadata-method.md
+        - name: GetMvid method
+          href: icordebugeditandcontinuesnapshot-getmvid-method.md
+        - name: GetRoDataRVA method
+          href: icordebugeditandcontinuesnapshot-getrodatarva-method.md
+        - name: GetRwDataRVA method
+          href: icordebugeditandcontinuesnapshot-getrwdatarva-method.md
+        - name: SetILMap method
+          href: icordebugeditandcontinuesnapshot-setilmap-method.md
+        - name: SetPEBytes method
+          href: icordebugeditandcontinuesnapshot-setpebytes-method.md
+        - name: SetPESymbolBytes method
+          href: icordebugeditandcontinuesnapshot-setpesymbolbytes-method.md
+    - name: ICorDebugEnum interface
+      href: icordebugenum-interface1.md
+      items:
+        - name: Clone method
+          href: icordebugenum-clone-method.md
+        - name: GetCount method
+          href: icordebugenum-getcount-method.md
+        - name: Reset method
+          href: icordebugenum-reset-method.md
+        - name: Skip method
+          href: icordebugenum-skip-method.md
+    - name: ICorDebugErrorInfoEnum interface
+      href: icordebugerrorinfoenum-interface.md
+      items:
+        - name: Next method
+          href: icordebugerrorinfoenum-next-method.md
+    - name: ICorDebugEval interface
+      href: icordebugeval-interface.md
+      items:
+        - name: Abort method
+          href: icordebugeval-abort-method.md
+        - name: CallFunction method
+          href: icordebugeval-callfunction-method.md
+        - name: CreateValue method
+          href: icordebugeval-createvalue-method.md
+        - name: GetResult method
+          href: icordebugeval-getresult-method.md
+        - name: GetThread method
+          href: icordebugeval-getthread-method.md
+        - name: IsActive method
+          href: icordebugeval-isactive-method.md
+        - name: NewArray method
+          href: icordebugeval-newarray-method.md
+        - name: NewObject method
+          href: icordebugeval-newobject-method.md
+        - name: NewObjectNoConstructor method
+          href: icordebugeval-newobjectnoconstructor-method.md
+        - name: NewString method
+          href: icordebugeval-newstring-method.md
+    - name: ICorDebugEval2 interface
+      href: icordebugeval2-interface.md
+      items:
+        - name: CallParameterizedFunction method
+          href: icordebugeval2-callparameterizedfunction-method.md
+        - name: CreateValueForType method
+          href: icordebugeval2-createvaluefortype-method.md
+        - name: NewParameterizedArray method
+          href: icordebugeval2-newparameterizedarray-method.md
+        - name: NewParameterizedObject method
+          href: icordebugeval2-newparameterizedobject-method.md
+        - name: NewParameterizedObjectNoConstructor method
+          href: icordebugeval2-newparameterizedobjectnoconstructor-method.md
+        - name: NewStringWithLength method
+          href: icordebugeval2-newstringwithlength-method.md
+        - name: RudeAbort method
+          href: icordebugeval2-rudeabort-method.md
+    - name: ICorDebugExceptionDebugEvent interface
+      href: icordebugexceptiondebugevent-interface.md
+      items:
+        - name: GetFlags method
+          href: icordebugexceptiondebugevent-getflags-method.md
+        - name: GetNativeIP method
+          href: icordebugexceptiondebugevent-getnativeip-method.md
+        - name: GetStackPointer method
+          href: icordebugexceptiondebugevent-getstackpointer-method.md
+    - name: ICorDebugExceptionObjectCallStackEnum interface
+      href: icordebugexceptionobjectcallstackenum-interface.md
+      items:
+        - name: Next method
+          href: icordebugexceptionobjectcallstackenum-next-method.md
+    - name: ICorDebugExceptionObjectValue interface
+      href: icordebugexceptionobjectvalue-interface.md
+      items:
+        - name: EnumerateExceptionCallStack method
+          href: icordebugexceptionobjectvalue-enumerateexceptioncallstack-method.md
+    - name: ICorDebugFrame interface
+      href: icordebugframe-interface.md
+      items:
+        - name: CreateStepper method
+          href: icordebugframe-createstepper-method.md
+        - name: GetCallee method
+          href: icordebugframe-getcallee-method.md
+        - name: GetCaller method
+          href: icordebugframe-getcaller-method.md
+        - name: GetChain method
+          href: icordebugframe-getchain-method.md
+        - name: GetCode method
+          href: icordebugframe-getcode-method.md
+        - name: GetFunction method
+          href: icordebugframe-getfunction-method.md
+        - name: GetFunctionToken method
+          href: icordebugframe-getfunctiontoken-method.md
+        - name: GetStackRange method
+          href: icordebugframe-getstackrange-method.md
+    - name: ICorDebugFrameEnum interface
+      href: icordebugframeenum-interface.md
+      items:
+        - name: Next method
+          href: icordebugframeenum-next-method.md
+    - name: ICorDebugFunction interface
+      href: icordebugfunction-interface1.md
+      items:
+        - name: CreateBreakpoint method
+          href: icordebugfunction-createbreakpoint-method.md
+        - name: GetClass method
+          href: icordebugfunction-getclass-method.md
+        - name: GetCurrentVersionNumber method
+          href: icordebugfunction-getcurrentversionnumber-method.md
+        - name: GetILCode method
+          href: icordebugfunction-getilcode-method.md
+        - name: GetLocalVarSigToken method
+          href: icordebugfunction-getlocalvarsigtoken-method.md
+        - name: GetModule method
+          href: icordebugfunction-getmodule-method.md
+        - name: GetNativeCode method
+          href: icordebugfunction-getnativecode-method.md
+        - name: GetToken method
+          href: icordebugfunction-gettoken-method.md
+    - name: ICorDebugFunction2 interface
+      href: icordebugfunction2-interface.md
+      items:
+        - name: EnumerateNativeCode method
+          href: icordebugfunction2-enumeratenativecode-method.md
+        - name: GetJMCStatus method
+          href: icordebugfunction2-getjmcstatus-method.md
+        - name: GetVersionNumber method
+          href: icordebugfunction2-getversionnumber-method.md
+        - name: SetJMCStatus method
+          href: icordebugfunction2-setjmcstatus-method.md
+    - name: ICorDebugFunction3 interface
+      href: icordebugfunction3-interface.md
+      items:
+        - name: GetActiveReJitRequestILCode method
+          href: icordebugfunction3-getactiverejitrequestilcode-method.md
+    - name: ICorDebugFunctionBreakpoint interface
+      href: icordebugfunctionbreakpoint-interface.md
+      items:
+        - name: GetFunction method
+          href: icordebugfunctionbreakpoint-getfunction-method.md
+        - name: GetOffset method
+          href: icordebugfunctionbreakpoint-getoffset-method.md
+    - name: ICorDebugGCReferenceEnum interface
+      href: icordebuggcreferenceenum-interface.md
+      items:
+        - name: Next method
+          href: icordebuggcreferenceenum-next-method.md
+    - name: ICorDebugGenericValue interface
+      href: icordebuggenericvalue-interface.md
+      items:
+        - name: GetValue method
+          href: icordebuggenericvalue-getvalue-method.md
+        - name: SetValue method
+          href: icordebuggenericvalue-setvalue-method.md
+    - name: ICorDebugGuidToTypeEnum interface
+      href: icordebugguidtotypeenum-interface.md
+      items:
+        - name: Next method
+          href: icordebugguidtotypeenum-next-method.md
+    - name: ICorDebugHandleValue interface
+      href: icordebughandlevalue-interface.md
+      items:
+        - name: Dispose method
+          href: icordebughandlevalue-dispose-method.md
+        - name: GetHandleType method
+          href: icordebughandlevalue-gethandletype-method.md
+    - name: ICorDebugHeapEnum interface
+      href: icordebugheapenum-interface.md
+      items:
+        - name: Next method
+          href: icordebugheapenum-next-method.md
+    - name: ICorDebugHeapSegmentEnum interface
+      href: icordebugheapsegmentenum-interface.md
+      items:
+        - name: Next method
+          href: icordebugheapsegmentenum-next-method.md
+    - name: ICorDebugHeapValue interface
+      href: icordebugheapvalue-interface.md
+      items:
+        - name: CreateRelocBreakpoint method
+          href: icordebugheapvalue-createrelocbreakpoint-method.md
+        - name: IsValid method
+          href: icordebugheapvalue-isvalid-method.md
+    - name: ICorDebugHeapValue2 interface
+      href: icordebugheapvalue2-interface1.md
+      items:
+        - name: CreateHandle method
+          href: icordebugheapvalue2-createhandle-method.md
+    - name: ICorDebugHeapValue3 interface
+      href: icordebugheapvalue3-interface.md
+      items:
+        - name: GetThreadOwningMonitorLock method
+          href: icordebugheapvalue3-getthreadowningmonitorlock-method.md
+        - name: GetMonitorEventWaitList method
+          href: icordebugheapvalue3-getmonitoreventwaitlist-method.md
+    - name: ICorDebugILCode interface
+      href: icordebugilcode-interface.md
+      items:
+        - name: GetEHClauses method
+          href: icordebugilcode-getehclauses-method.md
+    - name: ICorDebugILCode2 interface
+      href: icordebugilcode2-interface.md
+      items:
+        - name: GetInstrumentedILMap method
+          href: icordebugilcode2-getinstrumentedilmap-method.md
+        - name: GetLocalVarSigToken method
+          href: icordebugilcode2-getlocalvarsigtoken-method.md
+    - name: ICorDebugILFrame interface
+      href: icordebugilframe-interface.md
+      items:
+        - name: CanSetIP method
+          href: icordebugilframe-cansetip-method.md
+        - name: EnumerateArguments method
+          href: icordebugilframe-enumeratearguments-method.md
+        - name: EnumerateLocalVariables method
+          href: icordebugilframe-enumeratelocalvariables-method.md
+        - name: GetArgument method
+          href: icordebugilframe-getargument-method.md
+        - name: GetIP method
+          href: icordebugilframe-getip-method.md
+        - name: GetLocalVariable method
+          href: icordebugilframe-getlocalvariable-method.md
+        - name: GetStackDepth method
+          href: icordebugilframe-getstackdepth-method.md
+        - name: GetStackValue method
+          href: icordebugilframe-getstackvalue-method.md
+        - name: SetIP method
+          href: icordebugilframe-setip-method.md
+    - name: ICorDebugILFrame2 interface
+      href: icordebugilframe2-interface.md
+      items:
+        - name: EnumerateTypeParameters method
+          href: icordebugilframe2-enumeratetypeparameters-method.md
+        - name: RemapFunction method
+          href: icordebugilframe2-remapfunction-method.md
+    - name: ICorDebugILFrame3 interface
+      href: icordebugilframe3-interface.md
+      items:
+        - name: GetReturnValueForILOffset method
+          href: icordebugilframe3-getreturnvalueforiloffset-method.md
+    - name: ICorDebugILFrame4 interface
+      href: icordebugilframe4-interface.md
+      items:
+        - name: EnumerateLocalVariablesEx method
+          href: icordebugilframe4-enumeratelocalvariablesex-method.md
+        - name: GetCodeEx method
+          href: icordebugilframe4-getcodeex-method.md
+        - name: GetLocalVariableEx method
+          href: icordebugilframe4-getlocalvariableex-method.md
+    - name: ICorDebugInstanceFieldSymbol interface
+      href: icordebuginstancefieldsymbol-interface.md
+      items:
+        - name: GetName method
+          href: icordebuginstancefieldsymbol-getname-method.md
+        - name: GetOffset method
+          href: icordebuginstancefieldsymbol-getoffset-method.md
+        - name: GetSize method
+          href: icordebuginstancefieldsymbol-getsize-method.md
+    - name: ICorDebugInternalFrame interface
+      href: icordebuginternalframe-interface.md
+      items:
+        - name: GetFrameType method
+          href: icordebuginternalframe-getframetype-method.md
+    - name: ICorDebugInternalFrame2 interface
+      href: icordebuginternalframe2-interface.md
+      items:
+        - name: GetFrameAddress method
+          href: icordebuginternalframe2-getframeaddress-method.md
+        - name: IsCloserToLeaf method
+          href: icordebuginternalframe2-isclosertoleaf-method.md
+    - name: ICorDebugLoadedModule interface
+      href: icordebugloadedmodule-interface.md
+      items:
+        - name: GetBaseAddress method
+          href: icordebugloadedmodule-getbaseaddress-method.md
+        - name: GetName method
+          href: icordebugloadedmodule-getname-method.md
+        - name: GetSize method
+          href: icordebugloadedmodule-getsize-method.md
+    - name: ICorDebugManagedCallback interface
+      href: icordebugmanagedcallback-interface.md
+      items:
+        - name: Break method
+          href: icordebugmanagedcallback-break-method.md
+        - name: Breakpoint method
+          href: icordebugmanagedcallback-breakpoint-method.md
+        - name: BreakpointSetError method
+          href: icordebugmanagedcallback-breakpointseterror-method.md
+        - name: ControlCTrap method
+          href: icordebugmanagedcallback-controlctrap-method.md
+        - name: CreateAppDomain method
+          href: icordebugmanagedcallback-createappdomain-method.md
+        - name: CreateProcess method
+          href: icordebugmanagedcallback-createprocess-method.md
+        - name: CreateThread method
+          href: icordebugmanagedcallback-createthread-method.md
+        - name: DebuggerError method
+          href: icordebugmanagedcallback-debuggererror-method.md
+        - name: EditAndContinueRemap method
+          href: icordebugmanagedcallback-editandcontinueremap-method.md
+        - name: EvalComplete method
+          href: icordebugmanagedcallback-evalcomplete-method.md
+        - name: EvalException method
+          href: icordebugmanagedcallback-evalexception-method.md
+        - name: Exception method
+          href: icordebugmanagedcallback-exception-method.md
+        - name: ExitAppDomain method
+          href: icordebugmanagedcallback-exitappdomain-method.md
+        - name: ExitProcess method
+          href: icordebugmanagedcallback-exitprocess-method.md
+        - name: ExitThread method
+          href: icordebugmanagedcallback-exitthread-method.md
+        - name: LoadAssembly method
+          href: icordebugmanagedcallback-loadassembly-method.md
+        - name: LoadClass method
+          href: icordebugmanagedcallback-loadclass-method.md
+        - name: LoadModule method
+          href: icordebugmanagedcallback-loadmodule-method.md
+        - name: LogMessage method
+          href: icordebugmanagedcallback-logmessage-method.md
+        - name: LogSwitch method
+          href: icordebugmanagedcallback-logswitch-method.md
+        - name: NameChange method
+          href: icordebugmanagedcallback-namechange-method.md
+        - name: StepComplete method
+          href: icordebugmanagedcallback-stepcomplete-method.md
+        - name: UnloadAssembly method
+          href: icordebugmanagedcallback-unloadassembly-method.md
+        - name: UnloadClass method
+          href: icordebugmanagedcallback-unloadclass-method.md
+        - name: UnloadModule method
+          href: icordebugmanagedcallback-unloadmodule-method.md
+        - name: UpdateModuleSymbols method
+          href: icordebugmanagedcallback-updatemodulesymbols-method.md
+    - name: ICorDebugManagedCallback2 interface
+      href: icordebugmanagedcallback2-interface.md
+      items:
+        - name: ChangeConnection method
+          href: icordebugmanagedcallback2-changeconnection-method.md
+        - name: CreateConnection method
+          href: icordebugmanagedcallback2-createconnection-method.md
+        - name: DestroyConnection method
+          href: icordebugmanagedcallback2-destroyconnection-method.md
+        - name: Exception method
+          href: icordebugmanagedcallback2-exception-method.md
+        - name: ExceptionUnwind method
+          href: icordebugmanagedcallback2-exceptionunwind-method.md
+        - name: FunctionRemapComplete method
+          href: icordebugmanagedcallback2-functionremapcomplete-method.md
+        - name: FunctionRemapOpportunity method
+          href: icordebugmanagedcallback2-functionremapopportunity-method.md
+        - name: MDANotification method
+          href: icordebugmanagedcallback2-mdanotification-method.md
+    - name: ICorDebugManagedCallback3 interface
+      href: icordebugmanagedcallback3-interface.md
+      items:
+        - name: CustomNotification method
+          href: icordebugmanagedcallback3-customnotification-method.md
+    - name: ICorDebugMDA interface
+      href: icordebugmda-interface.md
+      items:
+        - name: GetDescription method
+          href: icordebugmda-getdescription-method.md
+        - name: GetFlags method
+          href: icordebugmda-getflags-method.md
+        - name: GetName method
+          href: icordebugmda-getname-method.md
+        - name: GetOSThreadId method
+          href: icordebugmda-getosthreadid-method.md
+        - name: GetXML method
+          href: icordebugmda-getxml-method.md
+    - name: ICorDebugMemoryBuffer interface
+      href: icordebugmemorybuffer-interface.md
+      items:
+        - name: GetSize method
+          href: icordebugmemorybuffer-getsize-method.md
+        - name: GetStartAddress method
+          href: icordebugmemorybuffer-getstartaddress-method.md
+    - name: ICorDebugMergedAssemblyRecord interface
+      href: icordebugmergedassemblyrecord-interface.md
+      items:
+        - name: GetCulture method
+          href: icordebugmergedassemblyrecord-getculture-method.md
+        - name: GetIndex method
+          href: icordebugmergedassemblyrecord-getindex-method.md
+        - name: GetPublicKey method
+          href: icordebugmergedassemblyrecord-getpublickey-method.md
+        - name: GetPublicKeyToken method
+          href: icordebugmergedassemblyrecord-getpublickeytoken-method.md
+        - name: GetSimpleName method
+          href: icordebugmergedassemblyrecord-getsimplename-method.md
+        - name: GetVersion method
+          href: icordebugmergedassemblyrecord-getversion-method.md
+    - name: ICorDebugMetaDataLocator interface
+      href: icordebugmetadatalocator-interface.md
+      items:
+        - name: GetMetaData method
+          href: icordebugmetadatalocator-getmetadata-method.md
+    - name: ICorDebugModule interface
+      href: icordebugmodule-interface.md
+      items:
+        - name: CreateBreakpoint method
+          href: icordebugmodule-createbreakpoint-method.md
+        - name: EnableClassLoadCallbacks method
+          href: icordebugmodule-enableclassloadcallbacks-method.md
+        - name: EnableJITDebugging method
+          href: icordebugmodule-enablejitdebugging-method.md
+        - name: GetAssembly method
+          href: icordebugmodule-getassembly-method.md
+        - name: GetBaseAddress method
+          href: icordebugmodule-getbaseaddress-method.md
+        - name: GetClassFromToken method
+          href: icordebugmodule-getclassfromtoken-method.md
+        - name: GetEditAndContinueSnapshot method
+          href: icordebugmodule-geteditandcontinuesnapshot-method.md
+        - name: GetFunctionFromRVA method
+          href: icordebugmodule-getfunctionfromrva-method.md
+        - name: GetFunctionFromToken method
+          href: icordebugmodule-getfunctionfromtoken-method.md
+        - name: GetGlobalVariableValue method
+          href: icordebugmodule-getglobalvariablevalue-method.md
+        - name: GetMetaDataInterface method
+          href: icordebugmodule-getmetadatainterface-method.md
+        - name: GetName method
+          href: icordebugmodule-getname-method.md
+        - name: GetProcess method
+          href: icordebugmodule-getprocess-method.md
+        - name: GetSize method
+          href: icordebugmodule-getsize-method.md
+        - name: GetToken method
+          href: icordebugmodule-gettoken-method.md
+        - name: IsDynamic method
+          href: icordebugmodule-isdynamic-method.md
+        - name: IsInMemory method
+          href: icordebugmodule-isinmemory-method.md
+    - name: ICorDebugModule2 interface
+      href: icordebugmodule2-interface.md
+      items:
+        - name: ApplyChanges method
+          href: icordebugmodule2-applychanges-method.md
+        - name: GetJITCompilerFlags method
+          href: icordebugmodule2-getjitcompilerflags-method.md
+        - name: ResolveAssembly method
+          href: icordebugmodule2-resolveassembly-method.md
+        - name: SetJITCompilerFlags method
+          href: icordebugmodule2-setjitcompilerflags-method.md
+        - name: SetJMCStatus method
+          href: icordebugmodule2-setjmcstatus-method.md
+    - name: ICorDebugModule3 interface
+      href: icordebugmodule3-interface.md
+      items:
+        - name: "ICorDebugModule3::CreateReaderForInMemorySymbols method"
+          href: icordebugmodule3-createreaderforinmemorysymbols-method.md
+    - name: ICorDebugModule4 interface
+      href: icordebugmodule4-interface.md
+      items:
+        - name: "ICorDebugModule4::IsMappedLayout method"
+          href: icordebugmodule4-ismappedlayout-method.md
+    - name: ICorDebugModuleBreakpoint interface
+      href: icordebugmodulebreakpoint-interface.md
+      items:
+        - name: GetModule method
+          href: icordebugmodulebreakpoint-getmodule-method.md
+    - name: ICorDebugModuleDebugEvent interface
+      href: icordebugmoduledebugevent-interface.md
+      items:
+        - name: GetModule method
+          href: icordebugmoduledebugevent-getmodule-method.md
+    - name: ICorDebugModuleEnum interface
+      href: icordebugmoduleenum-interface.md
+      items:
+        - name: Next method
+          href: icordebugmoduleenum-next-method.md
+    - name: ICorDebugMutableDataTarget interface
+      href: icordebugmutabledatatarget-interface.md
+      items:
+        - name: ContinueStatusChanged method
+          href: icordebugmutabledatatarget-continuestatuschanged-method.md
+        - name: SetThreadContext method
+          href: icordebugmutabledatatarget-setthreadcontext-method.md
+        - name: WriteVirtual method
+          href: icordebugmutabledatatarget-writevirtual-method.md
+    - name: ICorDebugNativeFrame interface
+      href: icordebugnativeframe-interface.md
+      items:
+        - name: CanSetIP method
+          href: icordebugnativeframe-cansetip-method.md
+        - name: GetIP method
+          href: icordebugnativeframe-getip-method.md
+        - name: GetLocalDoubleRegisterValue method
+          href: icordebugnativeframe-getlocaldoubleregistervalue-method.md
+        - name: GetLocalMemoryRegisterValue method
+          href: icordebugnativeframe-getlocalmemoryregistervalue-method.md
+        - name: GetLocalMemoryValue method
+          href: icordebugnativeframe-getlocalmemoryvalue-method.md
+        - name: GetLocalRegisterMemoryValue method
+          href: icordebugnativeframe-getlocalregistermemoryvalue-method.md
+        - name: GetLocalRegisterValue method
+          href: icordebugnativeframe-getlocalregistervalue-method.md
+        - name: GetRegisterSet method
+          href: icordebugnativeframe-getregisterset-method.md
+        - name: SetIP method
+          href: icordebugnativeframe-setip-method.md
+    - name: ICorDebugNativeFrame2 interface
+      href: icordebugnativeframe2-interface.md
+      items:
+        - name: IsChild method
+          href: icordebugnativeframe2-ischild-method.md
+        - name: IsMatchingParentFrame method
+          href: icordebugnativeframe2-ismatchingparentframe-method.md
+        - name: GetStackParameterSize method
+          href: icordebugnativeframe2-getstackparametersize-method.md
+    - name: ICorDebugObjectEnum interface
+      href: icordebugobjectenum-interface.md
+      items:
+        - name: Next method
+          href: icordebugobjectenum-next-method.md
+    - name: ICorDebugObjectValue interface
+      href: icordebugobjectvalue-interface.md
+      items:
+        - name: GetClass method
+          href: icordebugobjectvalue-getclass-method.md
+        - name: GetContext method
+          href: icordebugobjectvalue-getcontext-method.md
+        - name: GetFieldValue method
+          href: icordebugobjectvalue-getfieldvalue-method.md
+        - name: GetManagedCopy method
+          href: icordebugobjectvalue-getmanagedcopy-method.md
+        - name: GetVirtualMethod method
+          href: icordebugobjectvalue-getvirtualmethod-method.md
+        - name: IsValueClass method
+          href: icordebugobjectvalue-isvalueclass-method.md
+        - name: SetFromManagedCopy method
+          href: icordebugobjectvalue-setfrommanagedcopy-method.md
+    - name: ICorDebugObjectValue2 interface
+      href: icordebugobjectvalue2-interface.md
+      items:
+        - name: GetVirtualMethodAndType method
+          href: icordebugobjectvalue2-getvirtualmethodandtype-method.md
+    - name: ICorDebugProcess interface
+      href: icordebugprocess-interface.md
+      items:
+        - name: ClearCurrentException method
+          href: icordebugprocess-clearcurrentexception-method.md
+        - name: EnableLogMessages method
+          href: icordebugprocess-enablelogmessages-method.md
+        - name: EnumerateAppDomains method
+          href: icordebugprocess-enumerateappdomains-method.md
+        - name: EnumerateObjects method
+          href: icordebugprocess-enumerateobjects-method.md
+        - name: GetHandle method
+          href: icordebugprocess-gethandle-method.md
+        - name: GetHelperThreadID method
+          href: icordebugprocess-gethelperthreadid-method.md
+        - name: GetID method
+          href: icordebugprocess-getid-method.md
+        - name: GetObject method
+          href: icordebugprocess-getobject-method.md
+        - name: GetThread method
+          href: icordebugprocess-getthread-method.md
+        - name: GetThreadContext method
+          href: icordebugprocess-getthreadcontext-method.md
+        - name: IsOSSuspended method
+          href: icordebugprocess-isossuspended-method.md
+        - name: IsTransitionStub method
+          href: icordebugprocess-istransitionstub-method.md
+        - name: ModifyLogSwitch method
+          href: icordebugprocess-modifylogswitch-method.md
+        - name: ReadMemory method
+          href: icordebugprocess-readmemory-method.md
+        - name: SetThreadContext method
+          href: icordebugprocess-setthreadcontext-method.md
+        - name: ThreadForFiberCookie method
+          href: icordebugprocess-threadforfibercookie-method.md
+        - name: WriteMemory method
+          href: icordebugprocess-writememory-method.md
+    - name: ICorDebugProcess2 interface
+      href: icordebugprocess2-interface1.md
+      items:
+        - name: ClearUnmanagedBreakpoint method
+          href: icordebugprocess2-clearunmanagedbreakpoint-method.md
+        - name: GetDesiredNGENCompilerFlags method
+          href: icordebugprocess2-getdesiredngencompilerflags-method.md
+        - name: GetReferenceValueFromGCHandle method
+          href: icordebugprocess2-getreferencevaluefromgchandle-method.md
+        - name: GetThreadForTaskID method
+          href: icordebugprocess2-getthreadfortaskid-method.md
+        - name: GetVersion method
+          href: icordebugprocess2-getversion-method.md
+        - name: SetDesiredNGENCompilerFlags method
+          href: icordebugprocess2-setdesiredngencompilerflags-method.md
+        - name: SetUnmanagedBreakpoint method
+          href: icordebugprocess2-setunmanagedbreakpoint-method.md
+    - name: ICorDebugProcess3 interface
+      href: icordebugprocess3-interface.md
+      items:
+        - name: SetEnableCustomNotification method
+          href: icordebugprocess3-setenablecustomnotification-method.md
+    - name: ICorDebugProcess4 interface
+      href: icordebugprocess4-interface.md
+      items:
+        - name: ProcessStateChanged method
+          href: icordebugprocess4-processstatechanged-method.md
+    - name: ICorDebugProcess5 interface
+      href: icordebugprocess5-interface.md
+      items:
+        - name: EnableNGenPolicy method
+          href: icordebugprocess5-enablengenpolicy-method.md
+        - name: EnumerateGCReferences method
+          href: icordebugprocess5-enumerategcreferences-method.md
+        - name: EnumerateHandles method
+          href: icordebugprocess5-enumeratehandles-method.md
+        - name: EnumerateHeap method
+          href: icordebugprocess5-enumerateheap-method.md
+        - name: EnumerateHeapRegions method
+          href: icordebugprocess5-enumerateheapregions-method.md
+        - name: GetArrayLayout method
+          href: icordebugprocess5-getarraylayout-method.md
+        - name: GetGCHeapInformation method
+          href: icordebugprocess5-getgcheapinformation-method.md
+        - name: GetObject method
+          href: icordebugprocess5-getobject-method.md
+        - name: GetTypeFields method
+          href: icordebugprocess5-gettypefields-method.md
+        - name: GetTypeForTypeID method
+          href: icordebugprocess5-gettypefortypeid-method.md
+        - name: GetTypeID method
+          href: icordebugprocess5-gettypeid-method.md
+        - name: GetTypeLayout method
+          href: icordebugprocess5-gettypelayout-method.md
+    - name: ICorDebugProcess6 interface
+      href: icordebugprocess6-interface.md
+      items:
+        - name: DecodeEvent method
+          href: icordebugprocess6-decodeevent-method.md
+        - name: EnableVirtualModuleSplitting method
+          href: icordebugprocess6-enablevirtualmodulesplitting-method.md
+        - name: GetCode method
+          href: icordebugprocess6-getcode-method.md
+        - name: GetExportStepInfo method
+          href: icordebugprocess6-getexportstepinfo-method.md
+        - name: MarkDebuggerAttached method
+          href: icordebugprocess6-markdebuggerattached-method.md
+        - name: ProcessStateChanged method
+          href: icordebugprocess6-processstatechanged-method.md
+    - name: ICorDebugProcess7 interface
+      href: icordebugprocess7-interface.md
+      items:
+        - name: SetWriteableMetadataUpdateMode method
+          href: icordebugprocess7-setwriteablemetadataupdatemode-method.md
+    - name: ICorDebugProcess8 interface
+      href: icordebugprocess8-interface.md
+      items:
+        - name: EnableExceptionCallbacksOutsideOfMyCode method
+          href: icordebugprocess8-enableexceptioncallbacksoutsideofmycode-method.md
+    - name: ICorDebugProcess11 interface
+      href: icordebugprocess11-interface.md
+      items:
+        - name: EnumerateLoaderHeapMemoryRegions method
+          href: icordebugprocess11-enumerateloaderheapmemoryregions-method.md
+    - name: ICorDebugProcessEnum interface
+      href: icordebugprocessenum-interface.md
+      items:
+        - name: Next method
+          href: icordebugprocessenum-next-method.md
+    - name: ICorDebugReferenceValue interface
+      href: icordebugreferencevalue-interface.md
+      items:
+        - name: Dereference method
+          href: icordebugreferencevalue-dereference-method.md
+        - name: DereferenceStrong method
+          href: icordebugreferencevalue-dereferencestrong-method.md
+        - name: GetValue method
+          href: icordebugreferencevalue-getvalue-method.md
+        - name: IsNull method
+          href: icordebugreferencevalue-isnull-method.md
+        - name: SetValue method
+          href: icordebugreferencevalue-setvalue-method.md
+    - name: ICorDebugRegisterSet interface
+      href: icordebugregisterset-interface.md
+      items:
+        - name: GetRegisters method
+          href: icordebugregisterset-getregisters-method.md
+        - name: GetRegistersAvailable method
+          href: icordebugregisterset-getregistersavailable-method.md
+        - name: GetThreadContext method
+          href: icordebugregisterset-getthreadcontext-method.md
+        - name: SetRegisters method
+          href: icordebugregisterset-setregisters-method.md
+        - name: SetThreadContext method
+          href: icordebugregisterset-setthreadcontext-method.md
+    - name: ICorDebugRegisterSet2 interface
+      href: icordebugregisterset2-interface.md
+      items:
+        - name: GetRegisters method
+          href: icordebugregisterset2-getregisters-method.md
+        - name: GetRegistersAvailable method
+          href: icordebugregisterset2-getregistersavailable-method.md
+        - name: SetRegisters method
+          href: icordebugregisterset2-setregisters-method.md
+    - name: ICorDebugRemote interface
+      href: icordebugremote-interface.md
+      items:
+        - name: "ICorDebugRemote::CreateProcessEx method"
+          href: icordebugremote-createprocessex-method.md
+        - name: "ICorDebugRemote::DebugActiveProcessEx method"
+          href: icordebugremote-debugactiveprocessex-method.md
+    - name: ICorDebugRemoteTarget interface
+      href: icordebugremotetarget-interface.md
+      items:
+        - name: "ICorDebugRemoteTarget::GetHostName method"
+          href: icordebugremotetarget-gethostname-method.md
+    - name: ICorDebugRuntimeUnwindableFrame interface
+      href: icordebugruntimeunwindableframe-interface.md
+    - name: ICorDebugStackWalk interface
+      href: icordebugstackwalk-interface.md
+      items:
+        - name: GetContext method
+          href: icordebugstackwalk-getcontext-method.md
+        - name: SetContext method
+          href: icordebugstackwalk-setcontext-method.md
+        - name: Next method
+          href: icordebugstackwalk-next-method.md
+        - name: GetFrame method
+          href: icordebugstackwalk-getframe-method.md
+    - name: ICorDebugStaticFieldSymbol interface
+      href: icordebugstaticfieldsymbol-interface.md
+      items:
+        - name: GetAddress method
+          href: icordebugstaticfieldsymbol-getaddress-method.md
+        - name: GetName method
+          href: icordebugstaticfieldsymbol-getname-method.md
+        - name: GetSize method
+          href: icordebugstaticfieldsymbol-getsize-method.md
+    - name: ICorDebugStepper interface
+      href: icordebugstepper-interface.md
+      items:
+        - name: Deactivate method
+          href: icordebugstepper-deactivate-method.md
+        - name: IsActive method
+          href: icordebugstepper-isactive-method.md
+        - name: SetInterceptMask method
+          href: icordebugstepper-setinterceptmask-method.md
+        - name: SetRangeIL method
+          href: icordebugstepper-setrangeil-method.md
+        - name: SetUnmappedStopMask method
+          href: icordebugstepper-setunmappedstopmask-method.md
+        - name: Step method
+          href: icordebugstepper-step-method.md
+        - name: StepOut method
+          href: icordebugstepper-stepout-method.md
+        - name: StepRange method
+          href: icordebugstepper-steprange-method.md
+    - name: ICorDebugStepper2 interface
+      href: icordebugstepper2-interface1.md
+      items:
+        - name: SetJMC method
+          href: icordebugstepper2-setjmc-method.md
+    - name: ICorDebugStepperEnum interface
+      href: icordebugstepperenum-interface.md
+      items:
+        - name: Next method
+          href: icordebugstepperenum-next-method.md
+    - name: ICorDebugStringValue interface
+      href: icordebugstringvalue-interface.md
+      items:
+        - name: GetLength method
+          href: icordebugstringvalue-getlength-method.md
+        - name: GetString method
+          href: icordebugstringvalue-getstring-method.md
+    - name: ICorDebugSymbolProvider interface
+      href: icordebugsymbolprovider-interface.md
+      items:
+        - name: GetAssemblyImageBytes method
+          href: icordebugsymbolprovider-getassemblyimagebytes-method.md
+        - name: GetAssemblyImageMetadata method
+          href: icordebugsymbolprovider-getassemblyimagemetadata-method.md
+        - name: GetCodeRange method
+          href: icordebugsymbolprovider-getcoderange-method.md
+        - name: GetInstanceFieldSymbols method
+          href: icordebugsymbolprovider-getinstancefieldsymbols-method.md
+        - name: GetMergedAssemblyRecords method
+          href: icordebugsymbolprovider-getmergedassemblyrecords-method.md
+        - name: GetMethodLocalSymbols method
+          href: icordebugsymbolprovider-getmethodlocalsymbols-method.md
+        - name: GetMethodParameterSymbols method
+          href: icordebugsymbolprovider-getmethodparametersymbols-method.md
+        - name: GetMethodProps method
+          href: icordebugsymbolprovider-getmethodprops-method.md
+        - name: GetObjectSize method
+          href: icordebugsymbolprovider-getobjectsize-method.md
+        - name: GetStaticFieldSymbols method
+          href: icordebugsymbolprovider-getstaticfieldsymbols-method.md
+        - name: GetTypeProps method
+          href: icordebugsymbolprovider-gettypeprops-method.md
+    - name: ICorDebugSymbolProvider2 interface
+      href: icordebugsymbolprovider2-interface.md
+      items:
+        - name: GetFrameProps method
+          href: icordebugsymbolprovider2-getframeprops-method.md
+        - name: GetGenericDictionaryInfo method
+          href: icordebugsymbolprovider2-getgenericdictionaryinfo-method.md
+    - name: ICorDebugThread interface
+      href: icordebugthread-interface.md
+      items:
+        - name: ClearCurrentException method
+          href: icordebugthread-clearcurrentexception-method.md
+        - name: CreateEval method
+          href: icordebugthread-createeval-method.md
+        - name: CreateStepper method
+          href: icordebugthread-createstepper-method.md
+        - name: EnumerateChains method
+          href: icordebugthread-enumeratechains-method.md
+        - name: GetActiveChain method
+          href: icordebugthread-getactivechain-method.md
+        - name: GetActiveFrame method
+          href: icordebugthread-getactiveframe-method.md
+        - name: GetAppDomain method
+          href: icordebugthread-getappdomain-method.md
+        - name: GetCurrentException method
+          href: icordebugthread-getcurrentexception-method.md
+        - name: GetDebugState method
+          href: icordebugthread-getdebugstate-method.md
+        - name: GetHandle method
+          href: icordebugthread-gethandle-method.md
+        - name: GetID method
+          href: icordebugthread-getid-method.md
+        - name: GetObject method
+          href: icordebugthread-getobject-method.md
+        - name: GetProcess method
+          href: icordebugthread-getprocess-method.md
+        - name: GetRegisterSet method
+          href: icordebugthread-getregisterset-method.md
+        - name: GetUserState method
+          href: icordebugthread-getuserstate-method.md
+        - name: SetDebugState method
+          href: icordebugthread-setdebugstate-method.md
+    - name: ICorDebugThread2 interface
+      href: icordebugthread2-interface.md
+      items:
+        - name: GetActiveFunctions method
+          href: icordebugthread2-getactivefunctions-method.md
+        - name: GetConnectionID method
+          href: icordebugthread2-getconnectionid-method.md
+        - name: GetTaskID method
+          href: icordebugthread2-gettaskid-method.md
+        - name: GetVolatileOSThreadID method
+          href: icordebugthread2-getvolatileosthreadid-method.md
+        - name: InterceptCurrentException method
+          href: icordebugthread2-interceptcurrentexception-method.md
+    - name: ICorDebugThread3 interface
+      href: icordebugthread3-interface.md
+      items:
+        - name: CreateStackWalk method
+          href: icordebugthread3-createstackwalk-method.md
+        - name: GetActiveInternalFrames method
+          href: icordebugthread3-getactiveinternalframes-method.md
+    - name: ICorDebugThread4 interface
+      href: icordebugthread4-interface.md
+      items:
+        - name: GetBlockingObjects method
+          href: icordebugthread4-getblockingobjects-method.md
+        - name: HadUnhandledException method
+          href: icordebugthread4-hadunhandledexception-method.md
+        - name: GetCurrentCustomDebuggerNotification method
+          href: icordebugthread4-getcurrentcustomdebuggernotification-method.md
+    - name: ICorDebugThreadEnum interface
+      href: icordebugthreadenum-interface1.md
+      items:
+        - name: Next method
+          href: icordebugthreadenum-next-method.md
+    - name: ICorDebugType interface
+      href: icordebugtype-interface.md
+      items:
+        - name: EnumerateTypeParameters method
+          href: icordebugtype-enumeratetypeparameters-method.md
+        - name: GetBase method
+          href: icordebugtype-getbase-method.md
+        - name: GetClass method
+          href: icordebugtype-getclass-method.md
+        - name: GetFirstTypeParameter method
+          href: icordebugtype-getfirsttypeparameter-method.md
+        - name: GetRank method
+          href: icordebugtype-getrank-method.md
+        - name: GetStaticFieldValue method
+          href: icordebugtype-getstaticfieldvalue-method.md
+        - name: GetType method
+          href: icordebugtype-gettype-method.md
+    - name: ICorDebugType2 interface
+      href: icordebugtype2-interface.md
+      items:
+        - name: GetTypeID method
+          href: icordebugtype2-gettypeid-method.md
+    - name: ICorDebugTypeEnum interface
+      href: icordebugtypeenum-interface.md
+      items:
+        - name: Next method
+          href: icordebugtypeenum-next-method.md
+    - name: ICorDebugUnmanagedCallback interface
+      href: icordebugunmanagedcallback-interface.md
+      items:
+        - name: DebugEvent method
+          href: icordebugunmanagedcallback-debugevent-method.md
+    - name: ICorDebugValue interface
+      href: icordebugvalue-interface.md
+      items:
+        - name: CreateBreakpoint method
+          href: icordebugvalue-createbreakpoint-method.md
+        - name: GetAddress method
+          href: icordebugvalue-getaddress-method.md
+        - name: GetSize method
+          href: icordebugvalue-getsize-method.md
+        - name: GetType method
+          href: icordebugvalue-gettype-method.md
+    - name: ICorDebugValue2 interface
+      href: icordebugvalue2-interface.md
+      items:
+        - name: GetExactType method
+          href: icordebugvalue2-getexacttype-method.md
+    - name: ICorDebugValue3 interface
+      href: icordebugvalue3-interface.md
+      items:
+        - name: GetSize64 method
+          href: icordebugvalue3-getsize64-method.md
+    - name: ICorDebugValueBreakpoint interface
+      href: icordebugvaluebreakpoint-interface.md
+      items:
+        - name: GetValue method
+          href: icordebugvaluebreakpoint-getvalue-method.md
+    - name: ICorDebugValueEnum interface
+      href: icordebugvalueenum-interface.md
+      items:
+        - name: Next method
+          href: icordebugvalueenum-next-method.md
+    - name: ICorDebugVariableHome interface
+      href: icordebugvariablehome-interface.md
+      items:
+        - name: GetArgumentIndex method
+          href: icordebugvariablehome-getargumentindex-method.md
+        - name: GetCode method
+          href: icordebugvariablehome-getcode-method.md
+        - name: GetLiveRange method
+          href: icordebugvariablehome-getliverange-method.md
+        - name: GetLocationType method
+          href: icordebugvariablehome-getlocationtype-method.md
+        - name: GetOffset method
+          href: icordebugvariablehome-getoffset-method.md
+        - name: GetRegister method
+          href: icordebugvariablehome-getregister-method.md
+        - name: GetSlotIndex method
+          href: icordebugvariablehome-getslotindex-method.md
+    - name: ICorDebugVariableHomeEnum interface
+      href: icordebugvariablehomeenum-interface.md
+      items:
+        - name: Next method
+          href: icordebugvariablehomeenum-next-method.md
+    - name: ICorDebugVariableSymbol interface
+      href: icordebugvariablesymbol-interface.md
+      items:
+        - name: GetName method
+          href: icordebugvariablesymbol-getname-method.md
+        - name: GetSize method
+          href: icordebugvariablesymbol-getsize-method.md
+        - name: GetSlotIndex method
+          href: icordebugvariablesymbol-getslotindex-method.md
+        - name: GetValue method
+          href: icordebugvariablesymbol-getvalue-method.md
+        - name: SetValue method
+          href: icordebugvariablesymbol-setvalue-method.md
+    - name: ICorDebugVirtualUnwinder interface
+      href: icordebugvirtualunwinder-interface.md
+      items:
+        - name: GetContext method
+          href: icordebugvirtualunwinder-getcontext-method.md
+        - name: Next method
+          href: icordebugvirtualunwinder-next-method.md
+    - name: ICorPublish interface
+      href: icorpublish-interface.md
+      items:
+        - name: EnumProcesses method
+          href: icorpublish-enumprocesses-method.md
+        - name: GetProcess method
+          href: icorpublish-getprocess-method.md
+    - name: ICorPublishAppDomain interface
+      href: icorpublishappdomain-interface.md
+      items:
+        - name: GetID method
+          href: icorpublishappdomain-getid-method.md
+        - name: GetName method
+          href: icorpublishappdomain-getname-method.md
+    - name: ICorPublishAppDomainEnum interface
+      href: icorpublishappdomainenum-interface.md
+      items:
+        - name: Next method
+          href: icorpublishappdomainenum-next-method.md
+    - name: ICorPublishEnum interface
+      href: icorpublishenum-interface.md
+      items:
+        - name: Clone method
+          href: icorpublishenum-clone-method.md
+        - name: GetCount method
+          href: icorpublishenum-getcount-method.md
+        - name: Reset method
+          href: icorpublishenum-reset-method.md
+        - name: Skip method
+          href: icorpublishenum-skip-method.md
+    - name: ICorPublishProcess interface
+      href: icorpublishprocess-interface.md
+      items:
+        - name: EnumAppDomains method
+          href: icorpublishprocess-enumappdomains-method.md
+        - name: GetDisplayName method
+          href: icorpublishprocess-getdisplayname-method.md
+        - name: GetProcessID method
+          href: icorpublishprocess-getprocessid-method.md
+        - name: IsManaged method
+          href: icorpublishprocess-ismanaged-method.md
+    - name: ICorPublishProcessEnum interface
+      href: icorpublishprocessenum-interface.md
+      items:
+        - name: Next method
+          href: icorpublishprocessenum-next-method.md
+    - name: ISOSDacInterface interface
+      href: isosdacinterface-interface.md
+      items:
+        - name: GetMethodDescData
+          href: isosdacinterface-getmethoddescdata-method.md
+        - name: GetMethodDescPtrFromIP
+          href: isosdacinterface-getmethoddescptrfromip-method.md
+        - name: GetModuleData
+          href: isosdacinterface-getmoduledata-method.md
+    - name: IXCLRDataMethodDefinition interface
+      href: ixclrdatamethoddefinition-interface.md
+      items:
+        - name: StartEnumInstances
+          href: ixclrdatamethoddefinition-startenuminstances-method.md
+        - name: EnumInstance
+          href: ixclrdatamethoddefinition-enuminstance-method.md
+        - name: EndEnumInstances
+          href: ixclrdatamethoddefinition-endenuminstances-method.md
+    - name: IXCLRDataMethodInstance interface
+      href: ixclrdatamethodinstance-interface.md
+      items:
+        - name: GetILAddressMap
+          href: ixclrdatamethodinstance-getiladdressmap-method.md
+        - name: GetRepresentativeEntryAddress
+          href: ixclrdatamethodinstance-getrepresentativeentryaddress-method.md
+    - name: IXCLRDataModule interface
+      href: ixclrdatamodule-interface.md
+      items:
+        - name: GetMethodDefinitionByToken
+          href: ixclrdatamodule-getmethoddefinitionbytoken-method.md
+        - name: Request
+          href: ixclrdatamodule-request-method.md
+        - name: GetVersionId
+          href: ixclrdatamodule-getversionid-method.md
+    - name: IXCLRDataProcess interface
+      href: ixclrdataprocess-interface.md
+      items:
+        - name: GetRuntimeNameByAddress
+          href: ixclrdataprocess-getruntimenamebyaddress-method.md
+        - name: GetAppDomainByUniqueId
+          href: ixclrdataprocess-getappdomainbyuniqueid-method.md
+        - name: StartEnumModules
+          href: ixclrdataprocess-startenummodules-method.md
+        - name: EnumModule
+          href: ixclrdataprocess-enummodule-method.md
+        - name: EndEnumModules
+          href: ixclrdataprocess-endenummodules-method.md
+        - name: StartEnumMethodInstancesByAddress
+          href: ixclrdataprocess-startenummethodinstancesbyaddress-method.md
+        - name: EnumMethodInstanceByAddress
+          href: ixclrdataprocess-enummethodinstancebyaddress-method.md
+        - name: EndEnumMethodInstancesByAddress
+          href: ixclrdataprocess-endenummethodinstancesbyaddress-method.md
+- name: Debugging global static functions
+  href: debugging-global-static-functions.md
+  items:
+    - name: _EFN_GetManagedExcepStack function
+      href: efn-getmanagedexcepstack-function.md
+    - name: _EFN_GetManagedObjectFieldInfo function
+      href: efn-getmanagedobjectfieldinfo-function.md
+    - name: _EFN_GetManagedObjectName function
+      href: efn-getmanagedobjectname-function.md
+    - name: _EFN_StackTrace function
+      href: efn-stacktrace-function.md
+    - name: CLRDataCreateInstance function
+      href: clrdatacreateinstance-function.md
+    - name: PFN_CLRDataCreateInstance function pointer
+      href: pfn-clrdatacreateinstance-function-pointer.md
+- name: Debugging enumerations
+  href: debugging-enumerations.md
+  items:
+    - name: CLR_DEBUGGING_PROCESS_FLAGS enumeration
+      href: clr-debugging-process-flags-enumeration.md
+    - name: CLRDataEnumMemoryFlags enumeration
+      href: clrdataenummemoryflags-enumeration.md
+    - name: ClrDataSourceType enumeration
+      href: clrdatasourcetype-enumeration.md
+    - name: COR_PUB_ENUMPROCESS enumeration
+      href: cor-pub-enumprocess-enumeration.md
+    - name: CorDebugBlockingReason enumeration
+      href: cordebugblockingreason-enumeration.md
+    - name: CorDebugChainReason enumeration
+      href: cordebugchainreason-enumeration.md
+    - name: CorDebugCodeInvokeKind enumeration
+      href: cordebugcodeinvokekind-enumeration.md
+    - name: CorDebugCodeInvokePurpose enumeration
+      href: cordebugcodeinvokepurpose-enumeration.md
+    - name: CorDebugCreateProcessFlags enumeration
+      href: cordebugcreateprocessflags-enumeration.md
+    - name: CorDebugDebugEventKind enumeration
+      href: cordebugdebugeventkind-enumeration.md
+    - name: CorDebugDecodeEventFlagsWindows enumeration
+      href: cordebugdecodeeventflagswindows-enumeration.md
+    - name: CorDebugExceptionCallbackType enumeration
+      href: cordebugexceptioncallbacktype-enumeration.md
+    - name: CorDebugExceptionFlags enumeration
+      href: cordebugexceptionflags-enumeration.md
+    - name: CorDebugExceptionUnwindCallbackType enumeration
+      href: cordebugexceptionunwindcallbacktype-enumeration.md
+    - name: CorDebugGCType enumeration
+      href: cordebuggctype-enumeration.md
+    - name: CorDebugGenerationTypes enumeration
+      href: cordebuggenerationtypes-enumeration.md
+    - name: CorDebugHandleType enumeration
+      href: cordebughandletype-enumeration.md
+    - name: CorDebugIlToNativeMappingTypes enumeration
+      href: cordebugiltonativemappingtypes-enumeration.md
+    - name: CorDebugIntercept enumeration
+      href: cordebugintercept-enumeration.md
+    - name: CorDebugInterfaceVersion enumeration
+      href: cordebuginterfaceversion-enumeration.md
+    - name: CorDebugInternalFrameType enumeration
+      href: cordebuginternalframetype-enumeration.md
+    - name: CorDebugJITCompilerFlags enumeration
+      href: cordebugjitcompilerflags-enumeration.md
+    - name: CorDebugJITCompilerFlagsDeprecated enumeration
+      href: cordebugjitcompilerflagsdeprecated-enumeration.md
+    - name: CorDebugMappingResult enumeration
+      href: cordebugmappingresult-enumeration.md
+    - name: CorDebugMDAFlags enumeration
+      href: cordebugmdaflags-enumeration.md
+    - name: CorDebugNGenPolicy enumeration
+      href: cordebugngenpolicy-enumeration.md
+    - name: CorDebugPlatform enumeration
+      href: cordebugplatform-enumeration.md
+    - name: CorDebugRecordFormat enumeration
+      href: cordebugrecordformat-enumeration.md
+    - name: CorDebugRegister enumeration
+      href: cordebugregister-enumeration.md
+    - name: CorDebugSetContextFlag enumeration
+      href: cordebugsetcontextflag-enumeration.md
+    - name: CorDebugStateChange enumeration
+      href: cordebugstatechange-enumeration.md
+    - name: CorDebugStepReason enumeration
+      href: cordebugstepreason-enumeration.md
+    - name: CorDebugThreadState enumeration
+      href: cordebugthreadstate-enumeration.md
+    - name: CorDebugUnmappedStop enumeration
+      href: cordebugunmappedstop-enumeration.md
+    - name: CorDebugUserState enumeration
+      href: cordebuguserstate-enumeration.md
+    - name: CorGCReferenceType enumeration
+      href: corgcreferencetype-enumeration.md
+    - name: ILCodeKind enumeration
+      href: ilcodekind-enumeration.md
+    - name: LoggingLevelEnum enumeration
+      href: logginglevelenum-enumeration.md
+    - name: LogSwitchCallReason enumeration
+      href: logswitchcallreason-enumeration.md
+    - name: VariableLocationType enumeration
+      href: variablelocationtype-enumeration.md
+    - name: WriteableMetadataUpdateMode enumeration
+      href: writeablemetadataupdatemode-enumeration.md
+- name: Debugging structures
+  href: debugging-structures.md
+  items:
+    - name: CLRDATA_ADDRESS_RANGE structure
+      href: clrdata-address-range-structure.md
+    - name: CLRDATA_IL_ADDRESS_MAP structure
+      href: clrdata-il-address-map-structure.md
+    - name: CLR_DEBUGGING_VERSION structure
+      href: clr-debugging-version-structure.md
+    - name: CodeChunkInfo structure
+      href: codechunkinfo-structure.md
+    - name: COR_ACTIVE_FUNCTION structure
+      href: cor-active-function-structure.md
+    - name: COR_ARRAY_LAYOUT structure
+      href: cor-array-layout-structure.md
+    - name: COR_DEBUG_IL_TO_NATIVE_MAP structure
+      href: cor-debug-il-to-native-map-structure.md
+    - name: COR_DEBUG_STEP_RANGE structure
+      href: cor-debug-step-range-structure.md
+    - name: COR_FIELD structure
+      href: cor-field-structure.md
+    - name: COR_GC_REFERENCE structure
+      href: cor-gc-reference-structure.md
+    - name: COR_HEAPINFO structure
+      href: cor-heapinfo-structure.md
+    - name: COR_HEAPOBJECT structure
+      href: cor-heapobject-structure.md
+    - name: COR_IL_MAP structure
+      href: cor-il-map-structure.md
+    - name: COR_SEGMENT structure
+      href: cor-segment-structure.md
+    - name: COR_TYPEID structure
+      href: cor-typeid-structure.md
+    - name: COR_TYPE_LAYOUT structure
+      href: cor-type-layout-structure.md
+    - name: COR_VERSION structure
+      href: cor-version-structure.md
+    - name: CorDebugBlockingObject structure
+      href: cordebugblockingobject-structure.md
+    - name: CorDebugEHClause structure
+      href: cordebugehclause-structure.md
+    - name: CorDebugExceptionObjectStackFrame structure
+      href: cordebugexceptionobjectstackframe-structure.md
+    - name: CorDebugGuidToTypeMapping structure
+      href: cordebugguidtotypemapping-structure.md
+    - name: DacpGetModuleAddress structure
+      href: dacpgetmoduleaddress-structure.md
+      items:
+        - name: "DacpGetModuleAddress::Request method"
+          href: dacpgetmoduleaddress-request-method.md
+    - name: DacpMethodDescData structure
+      href: dacpmethoddescdata-structure.md
+    - name: DacpModuleData structure
+      href: dacpmoduledata-structure.md
+    - name: DacpReJitData structure
+      href: dacprejitdata-structure.md
+    - name: StackTrace_SimpleContext structure
+      href: stacktrace-simplecontext-structure.md
+- name: .NET Core debugging
+  href: ../../../core/unmanaged-api/debugging/index.md
+- name: Silverlight debugging
+  href: silverlight-debugging.md
+  items:
+    - name: CloseCLREnumeration function
+      href: closeclrenumeration-function-for-silverlight.md
+    - name: CreateCoreClrDebugTarget function
+      href: createcoreclrdebugtarget-function.md
+    - name: CreateCordbObject function
+      href: createcordbobject-function.md
+    - name: CreateVersionStringFromModule function
+      href: createversionstringfrommodule-function-for-silverlight.md
+    - name: CreateDebuggingInterfaceFromVersion function
+      href: createdebugginginterfacefromversion-function-for-silverlight.md
+    - name: CoreClrDebugProcInfo structure
+      href: coreclrdebugprocinfo-structure.md
+    - name: CoreClrDebugRuntimeInfo structure
+      href: coreclrdebugruntimeinfo-structure.md
+    - name: EnumerateCLRs function
+      href: enumerateclrs-function-for-silverlight.md
+    - name: GetStartupNotificationEvent function
+      href: getstartupnotificationevent-function-for-silverlight.md
+    - name: ICoreClrDebugTarget interface
+      href: icoreclrdebugtarget-interface.md
+      items:
+        - name: "ICoreClrDebugTarget::EnumProcesses method"
+          href: icoreclrdebugtarget-enumprocesses-method.md
+        - name: "ICoreClrDebugTarget::EnumRuntimes method"
+          href: icoreclrdebugtarget-enumruntimes-method.md
+        - name: "ICoreClrDebugTarget::FreeMemory method"
+          href: icoreclrdebugtarget-freememory-method.md
+    - name: InitDbgTransportManager function
+      href: initdbgtransportmanager-function.md
+    - name: ShutdownDbgTransportManager function
+      href: shutdowndbgtransportmanager-function.md

--- a/docs/framework/unmanaged-api/diagnostics/toc.yml
+++ b/docs/framework/unmanaged-api/diagnostics/toc.yml
@@ -1,399 +1,399 @@
-- name: Diagnostics Symbol Store
+items:
+- name: Diagnostics symbol store
   href: index.md
+- name: Diagnostics Symbol Store Interfaces
+  href: diagnostics-symbol-store-interfaces.md
   items:
-  - name: Diagnostics Symbol Store Interfaces
-    href: diagnostics-symbol-store-interfaces.md
+  - name: IBindingDisplay Interface
+    href: ibindingdisplay-interface.md
     items:
-    - name: IBindingDisplay Interface
-      href: ibindingdisplay-interface.md
-      items:
-      - name: GetCurrentDisplay Method
-        href: ibindingdisplay-getcurrentdisplay-method.md
-      - name: InitializeForProcess Method
-        href: ibindingdisplay-initializeforprocess-method.md
-    - name: IDebugAutoAttach Interface
-      href: idebugautoattach-interface.md
-      items:
-      - name: AutoAttach Method
-        href: idebugautoattach-autoattach-method.md
-    - name: INotifyConnection2 Interface
-      href: inotifyconnection2-interface.md
-      items:
-      - name: RegisterNotifySource Method
-        href: inotifyconnection2-registernotifysource-method.md
-      - name: UnregisterNotifySource Method
-        href: inotifyconnection2-unregisternotifysource-method.md
-    - name: INotifySink2 Interface
-      href: inotifysink2-interface.md
-      items:
-      - name: OnSyncCallEnter Method
-        href: inotifysink2-onsynccallenter-method.md
-      - name: OnSyncCallExit Method
-        href: inotifysink2-onsynccallexit-method.md
-      - name: OnSyncCallOut Method
-        href: inotifysink2-onsynccallout-method.md
-      - name: OnSyncCallReturn Method
-        href: inotifysink2-onsynccallreturn-method.md
-    - name: INotifySource2 Interface
-      href: inotifysource2-interface.md
-      items:
-      - name: SetNotifyFilter Method
-        href: inotifysource2-setnotifyfilter-method.md
-    - name: ISymENCUnmanagedMethod Interface
-      href: isymencunmanagedmethod-interface.md
-      items:
-      - name: GetDocumentsForMethod Method
-        href: isymencunmanagedmethod-getdocumentsformethod-method.md
-      - name: GetDocumentsForMethodCount Method
-        href: isymencunmanagedmethod-getdocumentsformethodcount-method.md
-      - name: GetFileNameFromOffset Method
-        href: isymencunmanagedmethod-getfilenamefromoffset-method.md
-      - name: GetLineFromOffset Method
-        href: isymencunmanagedmethod-getlinefromoffset-method.md
-      - name: GetSourceExtentInDocument Method
-        href: isymencunmanagedmethod-getsourceextentindocument-method.md
-    - name: ISymUnmanagedAsyncMethod Interface
-      href: isymunmanagedasyncmethod-interface.md
-      items:
-      - name: GetAsyncStepInfo Method
-        href: isymunmanagedasyncmethod-getasyncstepinfo-method.md
-      - name: GetAsyncStepInfoCount Method
-        href: isymunmanagedasyncmethod-getasyncstepinfocount-method.md
-      - name: GetCatchHandlerILOffset Method
-        href: isymunmanagedasyncmethod-getcatchhandleriloffset-method.md
-      - name: GetKickoffMethod Method
-        href: isymunmanagedasyncmethod-getkickoffmethod-method.md
-      - name: HasCatchHandlerILOffset Method
-        href: isymunmanagedasyncmethod-hascatchhandleriloffset-method.md
-      - name: IsAsyncMethod Method
-        href: isymunmanagedasyncmethod-isasyncmethod-method.md
-    - name: ISymUnmanagedAsyncMethodPropertiesWriter Interface
-      href: isymunmanagedasyncmethodpropertieswriter-interface.md
-      items:
-      - name: DefineAsyncStepInfo Method
-        href: isymunmanagedasyncmethodpropertieswriter-defineasyncstepinfo-method.md
-      - name: DefineCatchHandlerILOffset Method
-        href: isymunmanagedasyncmethodpropertieswriter-definecatchhandleriloffset-method.md
-      - name: DefineKickoffMethod Method
-        href: isymunmanagedasyncmethodpropertieswriter-definekickoffmethod-method.md
-    - name: ISymUnmanagedBinder Interface
-      href: isymunmanagedbinder-interface.md
-      items:
-      - name: GetReaderForFile Method
-        href: isymunmanagedbinder-getreaderforfile-method.md
-      - name: GetReaderFromStream Method
-        href: isymunmanagedbinder-getreaderfromstream-method.md
-    - name: ISymUnmanagedBinder2 Interface
-      href: isymunmanagedbinder2-interface.md
-      items:
-      - name: GetReaderForFile2 Method
-        href: isymunmanagedbinder2-getreaderforfile2-method.md
-    - name: ISymUnmanagedBinder3 Interface
-      href: isymunmanagedbinder3-interface.md
-      items:
-      - name: GetReaderFromCallback Method
-        href: isymunmanagedbinder3-getreaderfromcallback-method.md
-    - name: ISymUnmanagedConstant Interface
-      href: isymunmanagedconstant-interface.md
-      items:
-      - name: GetName Method
-        href: isymunmanagedconstant-getname-method.md
-      - name: GetSignature Method
-        href: isymunmanagedconstant-getsignature-method.md
-      - name: GetValue Method
-        href: isymunmanagedconstant-getvalue-method.md
-    - name: ISymUnmanagedDispose Interface
-      href: isymunmanageddispose-interface.md
-      items:
-      - name: Destroy Method
-        href: isymunmanageddispose-destroy-method.md
-    - name: ISymUnmanagedDocument Interface
-      href: isymunmanageddocument-interface.md
-      items:
-      - name: FindClosestLine Method
-        href: isymunmanageddocument-findclosestline-method.md
-      - name: GetCheckSum Method
-        href: isymunmanageddocument-getchecksum-method.md
-      - name: GetCheckSumAlgorithmId Method
-        href: isymunmanageddocument-getchecksumalgorithmid-method.md
-      - name: GetDocumentType Method
-        href: isymunmanageddocument-getdocumenttype-method.md
-      - name: GetLanguage Method
-        href: isymunmanageddocument-getlanguage-method.md
-      - name: GetLanguageVendor Method
-        href: isymunmanageddocument-getlanguagevendor-method.md
-      - name: GetSourceLength Method
-        href: isymunmanageddocument-getsourcelength-method.md
-      - name: GetSourceRange Method
-        href: isymunmanageddocument-getsourcerange-method.md
-      - name: GetURL Method
-        href: isymunmanageddocument-geturl-method.md
-      - name: HasEmbeddedSource Method
-        href: isymunmanageddocument-hasembeddedsource-method.md
-    - name: ISymUnmanagedDocumentWriter Interface
-      href: isymunmanageddocumentwriter-interface.md
-      items:
-      - name: SetCheckSum Method
-        href: isymunmanageddocumentwriter-setchecksum-method.md
-      - name: SetSource Method
-        href: isymunmanageddocumentwriter-setsource-method.md
-    - name: ISymUnmanagedENCUpdate Interface
-      href: isymunmanagedencupdate-interface.md
-      items:
-      - name: GetLocalVariableCount Method
-        href: isymunmanagedencupdate-getlocalvariablecount-method.md
-      - name: GetLocalVariables Method
-        href: isymunmanagedencupdate-getlocalvariables-method.md
-      - name: InitializeForEnc Method
-        href: isymunmanagedencupdate-initializeforenc-method.md
-      - name: UpdateMethodLines Method
-        href: isymunmanagedencupdate-updatemethodlines-method.md
-      - name: UpdateSymbolStore2 Method
-        href: isymunmanagedencupdate-updatesymbolstore2-method.md
-    - name: ISymUnmanagedMethod Interface
-      href: isymunmanagedmethod-interface.md
-      items:
-      - name: GetNamespace Method
-        href: isymunmanagedmethod-getnamespace-method.md
-      - name: GetOffset Method
-        href: isymunmanagedmethod-getoffset-method.md
-      - name: GetParameters Method
-        href: isymunmanagedmethod-getparameters-method.md
-      - name: GetRanges Method
-        href: isymunmanagedmethod-getranges-method.md
-      - name: GetRootScope Method
-        href: isymunmanagedmethod-getrootscope-method.md
-      - name: GetScopeFromOffset Method
-        href: isymunmanagedmethod-getscopefromoffset-method.md
-      - name: GetSequencePointCount Method
-        href: isymunmanagedmethod-getsequencepointcount-method.md
-      - name: GetSequencePoints Method
-        href: isymunmanagedmethod-getsequencepoints-method.md
-      - name: GetSourceStartEnd Method
-        href: isymunmanagedmethod-getsourcestartend-method.md
-      - name: GetToken Method
-        href: isymunmanagedmethod-gettoken-method.md
-    - name: ISymUnmanagedNamespace Interface
-      href: isymunmanagednamespace-interface.md
-      items:
-      - name: GetName Method
-        href: isymunmanagednamespace-getname-method.md
-      - name: GetNamespaces Method
-        href: isymunmanagednamespace-getnamespaces-method.md
-      - name: GetVariables Method
-        href: isymunmanagednamespace-getvariables-method.md
-    - name: ISymUnmanagedReader Interface
-      href: isymunmanagedreader-interface.md
-      items:
-      - name: GetDocument Method
-        href: isymunmanagedreader-getdocument-method.md
-      - name: GetDocuments Method
-        href: isymunmanagedreader-getdocuments-method.md
-      - name: GetDocumentVersion Method
-        href: isymunmanagedreader-getdocumentversion-method.md
-      - name: GetGlobalVariables Method
-        href: isymunmanagedreader-getglobalvariables-method.md
-      - name: GetMethod Method
-        href: isymunmanagedreader-getmethod-method.md
-      - name: GetMethodByVersion Method
-        href: isymunmanagedreader-getmethodbyversion-method.md
-      - name: GetMethodFromDocumentPosition Method
-        href: isymunmanagedreader-getmethodfromdocumentposition-method.md
-      - name: GetMethodsFromDocumentPosition Method
-        href: isymunmanagedreader-getmethodsfromdocumentposition-method.md
-      - name: GetMethodVersion Method
-        href: isymunmanagedreader-getmethodversion-method.md
-      - name: GetNamespaces Method
-        href: isymunmanagedreader-getnamespaces-method.md
-      - name: GetSymAttribute Method
-        href: isymunmanagedreader-getsymattribute-method.md
-      - name: GetSymbolStoreFileName Method
-        href: isymunmanagedreader-getsymbolstorefilename-method.md
-      - name: GetUserEntryPoint Method
-        href: isymunmanagedreader-getuserentrypoint-method.md
-      - name: GetVariables Method
-        href: isymunmanagedreader-getvariables-method.md
-      - name: Initialize Method
-        href: isymunmanagedreader-initialize-method.md
-      - name: ReplaceSymbolStore Method
-        href: isymunmanagedreader-replacesymbolstore-method.md
-      - name: UpdateSymbolStore Method
-        href: isymunmanagedreader-updatesymbolstore-method.md
-    - name: ISymUnmanagedReader2 Interface
-      href: isymunmanagedreader2-interface.md
-      items:
-      - name: GetMethodByVersionPreRemap Method
-        href: isymunmanagedreader2-getmethodbyversionpreremap-method.md
-      - name: GetMethodsInDocument Method
-        href: isymunmanagedreader2-getmethodsindocument-method.md
-      - name: GetSymAttributePreRemap Method
-        href: isymunmanagedreader2-getsymattributepreremap-method.md
-    - name: ISymUnmanagedReaderSymbolSearchInfo Interface
-      href: isymunmanagedreadersymbolsearchinfo-interface.md
-      items:
-      - name: GetSymbolSearchInfoCount Method
-        href: isymunmanagedreadersymbolsearchinfo-getsymbolsearchinfocount-method.md
-      - name: GetSymbolSearchInfo Method
-        href: isymunmanagedreadersymbolsearchinfo-getsymbolsearchinfo-method.md
-    - name: ISymUnmanagedScope Interface
-      href: isymunmanagedscope-interface.md
-      items:
-      - name: GetChildren Method
-        href: isymunmanagedscope-getchildren-method.md
-      - name: GetEndOffset Method
-        href: isymunmanagedscope-getendoffset-method.md
-      - name: GetLocalCount Method
-        href: isymunmanagedscope-getlocalcount-method.md
-      - name: GetLocals Method
-        href: isymunmanagedscope-getlocals-method.md
-      - name: GetMethod Method
-        href: isymunmanagedscope-getmethod-method.md
-      - name: GetNamespaces Method
-        href: isymunmanagedscope-getnamespaces-method.md
-      - name: GetParent Method
-        href: isymunmanagedscope-getparent-method.md
-      - name: GetStartOffset Method
-        href: isymunmanagedscope-getstartoffset-method.md
-    - name: ISymUnmanagedScope2 Interface
-      href: isymunmanagedscope2-interface.md
-      items:
-      - name: GetConstantCount Method
-        href: isymunmanagedscope2-getconstantcount-method.md
-      - name: GetConstants Method
-        href: isymunmanagedscope2-getconstants-method.md
-    - name: ISymUnmanagedSourceServerModule Interface
-      href: isymunmanagedsourceservermodule-interface.md
-      items:
-      - name: GetSourceServerData Method
-        href: isymunmanagedsourceservermodule-getsourceserverdata-method.md
-    - name: ISymUnmanagedSymbolSearchInfo Interface
-      href: isymunmanagedsymbolsearchinfo-interface.md
-      items:
-      - name: GetHRESULT Method
-        href: isymunmanagedsymbolsearchinfo-gethresult-method.md
-      - name: GetSearchPath Method
-        href: isymunmanagedsymbolsearchinfo-getsearchpath-method.md
-      - name: GetSearchPathLength Method
-        href: isymunmanagedsymbolsearchinfo-getsearchpathlength-method.md
-    - name: ISymUnmanagedVariable Interface
-      href: isymunmanagedvariable-interface.md
-      items:
-      - name: GetAddressField1 Method
-        href: isymunmanagedvariable-getaddressfield1-method.md
-      - name: GetAddressField2 Method
-        href: isymunmanagedvariable-getaddressfield2-method.md
-      - name: GetAddressField3 Method
-        href: isymunmanagedvariable-getaddressfield3-method.md
-      - name: GetAddressKind Method
-        href: isymunmanagedvariable-getaddresskind-method.md
-      - name: GetAttributes Method
-        href: isymunmanagedvariable-getattributes-method.md
-      - name: GetEndOffset Method
-        href: isymunmanagedvariable-getendoffset-method.md
-      - name: GetName Method
-        href: isymunmanagedvariable-getname-method.md
-      - name: GetSignature Method
-        href: isymunmanagedvariable-getsignature-method.md
-      - name: GetStartOffset Method
-        href: isymunmanagedvariable-getstartoffset-method.md
-    - name: ISymUnmanagedWriter Interface
-      href: isymunmanagedwriter-interface.md
-      items:
-      - name: Abort Method
-        href: isymunmanagedwriter-abort-method.md
-      - name: Close Method
-        href: isymunmanagedwriter-close-method.md
-      - name: CloseMethod Method
-        href: isymunmanagedwriter-closemethod-method.md
-      - name: CloseNamespace Method
-        href: isymunmanagedwriter-closenamespace-method.md
-      - name: CloseScope Method
-        href: isymunmanagedwriter-closescope-method.md
-      - name: DefineConstant Method
-        href: isymunmanagedwriter-defineconstant-method.md
-      - name: DefineDocument Method
-        href: isymunmanagedwriter-definedocument-method.md
-      - name: DefineField Method
-        href: isymunmanagedwriter-definefield-method.md
-      - name: DefineGlobalVariable Method
-        href: isymunmanagedwriter-defineglobalvariable-method.md
-      - name: DefineLocalVariable Method
-        href: isymunmanagedwriter-definelocalvariable-method.md
-      - name: DefineParameter Method
-        href: isymunmanagedwriter-defineparameter-method.md
-      - name: DefineSequencePoints Method
-        href: isymunmanagedwriter-definesequencepoints-method.md
-      - name: GetDebugInfo Method
-        href: isymunmanagedwriter-getdebuginfo-method.md
-      - name: Initialize Method
-        href: isymunmanagedwriter-initialize-method.md
-      - name: Initialize2 Method
-        href: isymunmanagedwriter-initialize2-method.md
-      - name: OpenMethod Method
-        href: isymunmanagedwriter-openmethod-method.md
-      - name: OpenNamespace Method
-        href: isymunmanagedwriter-opennamespace-method.md
-      - name: OpenScope Method
-        href: isymunmanagedwriter-openscope-method.md
-      - name: RemapToken Method
-        href: isymunmanagedwriter-remaptoken-method.md
-      - name: SetMethodSourceRange Method
-        href: isymunmanagedwriter-setmethodsourcerange-method.md
-      - name: SetScopeRange Method
-        href: isymunmanagedwriter-setscoperange-method.md
-      - name: SetSymAttribute Method
-        href: isymunmanagedwriter-setsymattribute-method.md
-      - name: SetUserEntryPoint Method
-        href: isymunmanagedwriter-setuserentrypoint-method.md
-      - name: UsingNamespace Method
-        href: isymunmanagedwriter-usingnamespace-method.md
-    - name: ISymUnmanagedWriter2 Interface
-      href: isymunmanagedwriter2-interface.md
-      items:
-      - name: DefineConstant2 Method
-        href: isymunmanagedwriter2-defineconstant2-method.md
-      - name: DefineGlobalVariable2 Method
-        href: isymunmanagedwriter2-defineglobalvariable2-method.md
-      - name: DefineLocalVariable2 Method
-        href: isymunmanagedwriter2-definelocalvariable2-method.md
-    - name: ISymUnmanagedWriter3 Interface
-      href: isymunmanagedwriter3-interface.md
-      items:
-      - name: Commit Method
-        href: isymunmanagedwriter3-commit-method.md
-      - name: OpenMethod2 Method
-        href: isymunmanagedwriter3-openmethod2-method.md
-    - name: ISymUnmanagedWriter4 Interface
-      href: isymunmanagedwriter4-interface.md
-      items:
-      - name: GetDebugInfoWithPadding Method
-        href: isymunmanagedwriter4-getdebuginfowithpadding-method.md
-    - name: ISymUnmanagedWriter5 Interface
-      href: isymunmanagedwriter5-interface.md
-      items:
-      - name: CloseMapTokensToSourceSpans Method
-        href: isymunmanagedwriter5-closemaptokenstosourcespans-method.md
-      - name: MapTokenToSourceSpan Method
-        href: isymunmanagedwriter5-maptokentosourcespan-method.md
-      - name: OpenMapTokensToSourceSpans Method
-        href: isymunmanagedwriter5-openmaptokenstosourcespans-method.md
-  - name: Diagnostics Symbol Store Enumerations
-    href: diagnostics-symbol-store-enumerations.md
+    - name: GetCurrentDisplay Method
+      href: ibindingdisplay-getcurrentdisplay-method.md
+    - name: InitializeForProcess Method
+      href: ibindingdisplay-initializeforprocess-method.md
+  - name: IDebugAutoAttach Interface
+    href: idebugautoattach-interface.md
     items:
-    - name: CorSymAddrKind Enumeration
-      href: corsymaddrkind-enumeration.md
-    - name: CorSymSearchPolicyAttributes Enumeration
-      href: corsymsearchpolicyattributes-enumeration.md
-    - name: CorSymVarFlag Enumeration
-      href: corsymvarflag-enumeration.md
-    - name: NOTIFY_FILTER Enumeration
-      href: notify-filter-enumeration.md
-  - name: Diagnostics Symbol Store Structures
-    href: diagnostics-symbol-store-structures.md
+    - name: AutoAttach Method
+      href: idebugautoattach-autoattach-method.md
+  - name: INotifyConnection2 Interface
+    href: inotifyconnection2-interface.md
     items:
-    - name: CALL_ID Structure
-      href: call-id-structure.md
-    - name: SYMLINEDELTA Structure
-      href: symlinedelta-structure.md
-    - name: USER_THREAD Structure
-      href: user-thread-structure.md
+    - name: RegisterNotifySource Method
+      href: inotifyconnection2-registernotifysource-method.md
+    - name: UnregisterNotifySource Method
+      href: inotifyconnection2-unregisternotifysource-method.md
+  - name: INotifySink2 Interface
+    href: inotifysink2-interface.md
+    items:
+    - name: OnSyncCallEnter Method
+      href: inotifysink2-onsynccallenter-method.md
+    - name: OnSyncCallExit Method
+      href: inotifysink2-onsynccallexit-method.md
+    - name: OnSyncCallOut Method
+      href: inotifysink2-onsynccallout-method.md
+    - name: OnSyncCallReturn Method
+      href: inotifysink2-onsynccallreturn-method.md
+  - name: INotifySource2 Interface
+    href: inotifysource2-interface.md
+    items:
+    - name: SetNotifyFilter Method
+      href: inotifysource2-setnotifyfilter-method.md
+  - name: ISymENCUnmanagedMethod Interface
+    href: isymencunmanagedmethod-interface.md
+    items:
+    - name: GetDocumentsForMethod Method
+      href: isymencunmanagedmethod-getdocumentsformethod-method.md
+    - name: GetDocumentsForMethodCount Method
+      href: isymencunmanagedmethod-getdocumentsformethodcount-method.md
+    - name: GetFileNameFromOffset Method
+      href: isymencunmanagedmethod-getfilenamefromoffset-method.md
+    - name: GetLineFromOffset Method
+      href: isymencunmanagedmethod-getlinefromoffset-method.md
+    - name: GetSourceExtentInDocument Method
+      href: isymencunmanagedmethod-getsourceextentindocument-method.md
+  - name: ISymUnmanagedAsyncMethod Interface
+    href: isymunmanagedasyncmethod-interface.md
+    items:
+    - name: GetAsyncStepInfo Method
+      href: isymunmanagedasyncmethod-getasyncstepinfo-method.md
+    - name: GetAsyncStepInfoCount Method
+      href: isymunmanagedasyncmethod-getasyncstepinfocount-method.md
+    - name: GetCatchHandlerILOffset Method
+      href: isymunmanagedasyncmethod-getcatchhandleriloffset-method.md
+    - name: GetKickoffMethod Method
+      href: isymunmanagedasyncmethod-getkickoffmethod-method.md
+    - name: HasCatchHandlerILOffset Method
+      href: isymunmanagedasyncmethod-hascatchhandleriloffset-method.md
+    - name: IsAsyncMethod Method
+      href: isymunmanagedasyncmethod-isasyncmethod-method.md
+  - name: ISymUnmanagedAsyncMethodPropertiesWriter Interface
+    href: isymunmanagedasyncmethodpropertieswriter-interface.md
+    items:
+    - name: DefineAsyncStepInfo Method
+      href: isymunmanagedasyncmethodpropertieswriter-defineasyncstepinfo-method.md
+    - name: DefineCatchHandlerILOffset Method
+      href: isymunmanagedasyncmethodpropertieswriter-definecatchhandleriloffset-method.md
+    - name: DefineKickoffMethod Method
+      href: isymunmanagedasyncmethodpropertieswriter-definekickoffmethod-method.md
+  - name: ISymUnmanagedBinder Interface
+    href: isymunmanagedbinder-interface.md
+    items:
+    - name: GetReaderForFile Method
+      href: isymunmanagedbinder-getreaderforfile-method.md
+    - name: GetReaderFromStream Method
+      href: isymunmanagedbinder-getreaderfromstream-method.md
+  - name: ISymUnmanagedBinder2 Interface
+    href: isymunmanagedbinder2-interface.md
+    items:
+    - name: GetReaderForFile2 Method
+      href: isymunmanagedbinder2-getreaderforfile2-method.md
+  - name: ISymUnmanagedBinder3 Interface
+    href: isymunmanagedbinder3-interface.md
+    items:
+    - name: GetReaderFromCallback Method
+      href: isymunmanagedbinder3-getreaderfromcallback-method.md
+  - name: ISymUnmanagedConstant Interface
+    href: isymunmanagedconstant-interface.md
+    items:
+    - name: GetName Method
+      href: isymunmanagedconstant-getname-method.md
+    - name: GetSignature Method
+      href: isymunmanagedconstant-getsignature-method.md
+    - name: GetValue Method
+      href: isymunmanagedconstant-getvalue-method.md
+  - name: ISymUnmanagedDispose Interface
+    href: isymunmanageddispose-interface.md
+    items:
+    - name: Destroy Method
+      href: isymunmanageddispose-destroy-method.md
+  - name: ISymUnmanagedDocument Interface
+    href: isymunmanageddocument-interface.md
+    items:
+    - name: FindClosestLine Method
+      href: isymunmanageddocument-findclosestline-method.md
+    - name: GetCheckSum Method
+      href: isymunmanageddocument-getchecksum-method.md
+    - name: GetCheckSumAlgorithmId Method
+      href: isymunmanageddocument-getchecksumalgorithmid-method.md
+    - name: GetDocumentType Method
+      href: isymunmanageddocument-getdocumenttype-method.md
+    - name: GetLanguage Method
+      href: isymunmanageddocument-getlanguage-method.md
+    - name: GetLanguageVendor Method
+      href: isymunmanageddocument-getlanguagevendor-method.md
+    - name: GetSourceLength Method
+      href: isymunmanageddocument-getsourcelength-method.md
+    - name: GetSourceRange Method
+      href: isymunmanageddocument-getsourcerange-method.md
+    - name: GetURL Method
+      href: isymunmanageddocument-geturl-method.md
+    - name: HasEmbeddedSource Method
+      href: isymunmanageddocument-hasembeddedsource-method.md
+  - name: ISymUnmanagedDocumentWriter Interface
+    href: isymunmanageddocumentwriter-interface.md
+    items:
+    - name: SetCheckSum Method
+      href: isymunmanageddocumentwriter-setchecksum-method.md
+    - name: SetSource Method
+      href: isymunmanageddocumentwriter-setsource-method.md
+  - name: ISymUnmanagedENCUpdate Interface
+    href: isymunmanagedencupdate-interface.md
+    items:
+    - name: GetLocalVariableCount Method
+      href: isymunmanagedencupdate-getlocalvariablecount-method.md
+    - name: GetLocalVariables Method
+      href: isymunmanagedencupdate-getlocalvariables-method.md
+    - name: InitializeForEnc Method
+      href: isymunmanagedencupdate-initializeforenc-method.md
+    - name: UpdateMethodLines Method
+      href: isymunmanagedencupdate-updatemethodlines-method.md
+    - name: UpdateSymbolStore2 Method
+      href: isymunmanagedencupdate-updatesymbolstore2-method.md
+  - name: ISymUnmanagedMethod Interface
+    href: isymunmanagedmethod-interface.md
+    items:
+    - name: GetNamespace Method
+      href: isymunmanagedmethod-getnamespace-method.md
+    - name: GetOffset Method
+      href: isymunmanagedmethod-getoffset-method.md
+    - name: GetParameters Method
+      href: isymunmanagedmethod-getparameters-method.md
+    - name: GetRanges Method
+      href: isymunmanagedmethod-getranges-method.md
+    - name: GetRootScope Method
+      href: isymunmanagedmethod-getrootscope-method.md
+    - name: GetScopeFromOffset Method
+      href: isymunmanagedmethod-getscopefromoffset-method.md
+    - name: GetSequencePointCount Method
+      href: isymunmanagedmethod-getsequencepointcount-method.md
+    - name: GetSequencePoints Method
+      href: isymunmanagedmethod-getsequencepoints-method.md
+    - name: GetSourceStartEnd Method
+      href: isymunmanagedmethod-getsourcestartend-method.md
+    - name: GetToken Method
+      href: isymunmanagedmethod-gettoken-method.md
+  - name: ISymUnmanagedNamespace Interface
+    href: isymunmanagednamespace-interface.md
+    items:
+    - name: GetName Method
+      href: isymunmanagednamespace-getname-method.md
+    - name: GetNamespaces Method
+      href: isymunmanagednamespace-getnamespaces-method.md
+    - name: GetVariables Method
+      href: isymunmanagednamespace-getvariables-method.md
+  - name: ISymUnmanagedReader Interface
+    href: isymunmanagedreader-interface.md
+    items:
+    - name: GetDocument Method
+      href: isymunmanagedreader-getdocument-method.md
+    - name: GetDocuments Method
+      href: isymunmanagedreader-getdocuments-method.md
+    - name: GetDocumentVersion Method
+      href: isymunmanagedreader-getdocumentversion-method.md
+    - name: GetGlobalVariables Method
+      href: isymunmanagedreader-getglobalvariables-method.md
+    - name: GetMethod Method
+      href: isymunmanagedreader-getmethod-method.md
+    - name: GetMethodByVersion Method
+      href: isymunmanagedreader-getmethodbyversion-method.md
+    - name: GetMethodFromDocumentPosition Method
+      href: isymunmanagedreader-getmethodfromdocumentposition-method.md
+    - name: GetMethodsFromDocumentPosition Method
+      href: isymunmanagedreader-getmethodsfromdocumentposition-method.md
+    - name: GetMethodVersion Method
+      href: isymunmanagedreader-getmethodversion-method.md
+    - name: GetNamespaces Method
+      href: isymunmanagedreader-getnamespaces-method.md
+    - name: GetSymAttribute Method
+      href: isymunmanagedreader-getsymattribute-method.md
+    - name: GetSymbolStoreFileName Method
+      href: isymunmanagedreader-getsymbolstorefilename-method.md
+    - name: GetUserEntryPoint Method
+      href: isymunmanagedreader-getuserentrypoint-method.md
+    - name: GetVariables Method
+      href: isymunmanagedreader-getvariables-method.md
+    - name: Initialize Method
+      href: isymunmanagedreader-initialize-method.md
+    - name: ReplaceSymbolStore Method
+      href: isymunmanagedreader-replacesymbolstore-method.md
+    - name: UpdateSymbolStore Method
+      href: isymunmanagedreader-updatesymbolstore-method.md
+  - name: ISymUnmanagedReader2 Interface
+    href: isymunmanagedreader2-interface.md
+    items:
+    - name: GetMethodByVersionPreRemap Method
+      href: isymunmanagedreader2-getmethodbyversionpreremap-method.md
+    - name: GetMethodsInDocument Method
+      href: isymunmanagedreader2-getmethodsindocument-method.md
+    - name: GetSymAttributePreRemap Method
+      href: isymunmanagedreader2-getsymattributepreremap-method.md
+  - name: ISymUnmanagedReaderSymbolSearchInfo Interface
+    href: isymunmanagedreadersymbolsearchinfo-interface.md
+    items:
+    - name: GetSymbolSearchInfoCount Method
+      href: isymunmanagedreadersymbolsearchinfo-getsymbolsearchinfocount-method.md
+    - name: GetSymbolSearchInfo Method
+      href: isymunmanagedreadersymbolsearchinfo-getsymbolsearchinfo-method.md
+  - name: ISymUnmanagedScope Interface
+    href: isymunmanagedscope-interface.md
+    items:
+    - name: GetChildren Method
+      href: isymunmanagedscope-getchildren-method.md
+    - name: GetEndOffset Method
+      href: isymunmanagedscope-getendoffset-method.md
+    - name: GetLocalCount Method
+      href: isymunmanagedscope-getlocalcount-method.md
+    - name: GetLocals Method
+      href: isymunmanagedscope-getlocals-method.md
+    - name: GetMethod Method
+      href: isymunmanagedscope-getmethod-method.md
+    - name: GetNamespaces Method
+      href: isymunmanagedscope-getnamespaces-method.md
+    - name: GetParent Method
+      href: isymunmanagedscope-getparent-method.md
+    - name: GetStartOffset Method
+      href: isymunmanagedscope-getstartoffset-method.md
+  - name: ISymUnmanagedScope2 Interface
+    href: isymunmanagedscope2-interface.md
+    items:
+    - name: GetConstantCount Method
+      href: isymunmanagedscope2-getconstantcount-method.md
+    - name: GetConstants Method
+      href: isymunmanagedscope2-getconstants-method.md
+  - name: ISymUnmanagedSourceServerModule Interface
+    href: isymunmanagedsourceservermodule-interface.md
+    items:
+    - name: GetSourceServerData Method
+      href: isymunmanagedsourceservermodule-getsourceserverdata-method.md
+  - name: ISymUnmanagedSymbolSearchInfo Interface
+    href: isymunmanagedsymbolsearchinfo-interface.md
+    items:
+    - name: GetHRESULT Method
+      href: isymunmanagedsymbolsearchinfo-gethresult-method.md
+    - name: GetSearchPath Method
+      href: isymunmanagedsymbolsearchinfo-getsearchpath-method.md
+    - name: GetSearchPathLength Method
+      href: isymunmanagedsymbolsearchinfo-getsearchpathlength-method.md
+  - name: ISymUnmanagedVariable Interface
+    href: isymunmanagedvariable-interface.md
+    items:
+    - name: GetAddressField1 Method
+      href: isymunmanagedvariable-getaddressfield1-method.md
+    - name: GetAddressField2 Method
+      href: isymunmanagedvariable-getaddressfield2-method.md
+    - name: GetAddressField3 Method
+      href: isymunmanagedvariable-getaddressfield3-method.md
+    - name: GetAddressKind Method
+      href: isymunmanagedvariable-getaddresskind-method.md
+    - name: GetAttributes Method
+      href: isymunmanagedvariable-getattributes-method.md
+    - name: GetEndOffset Method
+      href: isymunmanagedvariable-getendoffset-method.md
+    - name: GetName Method
+      href: isymunmanagedvariable-getname-method.md
+    - name: GetSignature Method
+      href: isymunmanagedvariable-getsignature-method.md
+    - name: GetStartOffset Method
+      href: isymunmanagedvariable-getstartoffset-method.md
+  - name: ISymUnmanagedWriter Interface
+    href: isymunmanagedwriter-interface.md
+    items:
+    - name: Abort Method
+      href: isymunmanagedwriter-abort-method.md
+    - name: Close Method
+      href: isymunmanagedwriter-close-method.md
+    - name: CloseMethod Method
+      href: isymunmanagedwriter-closemethod-method.md
+    - name: CloseNamespace Method
+      href: isymunmanagedwriter-closenamespace-method.md
+    - name: CloseScope Method
+      href: isymunmanagedwriter-closescope-method.md
+    - name: DefineConstant Method
+      href: isymunmanagedwriter-defineconstant-method.md
+    - name: DefineDocument Method
+      href: isymunmanagedwriter-definedocument-method.md
+    - name: DefineField Method
+      href: isymunmanagedwriter-definefield-method.md
+    - name: DefineGlobalVariable Method
+      href: isymunmanagedwriter-defineglobalvariable-method.md
+    - name: DefineLocalVariable Method
+      href: isymunmanagedwriter-definelocalvariable-method.md
+    - name: DefineParameter Method
+      href: isymunmanagedwriter-defineparameter-method.md
+    - name: DefineSequencePoints Method
+      href: isymunmanagedwriter-definesequencepoints-method.md
+    - name: GetDebugInfo Method
+      href: isymunmanagedwriter-getdebuginfo-method.md
+    - name: Initialize Method
+      href: isymunmanagedwriter-initialize-method.md
+    - name: Initialize2 Method
+      href: isymunmanagedwriter-initialize2-method.md
+    - name: OpenMethod Method
+      href: isymunmanagedwriter-openmethod-method.md
+    - name: OpenNamespace Method
+      href: isymunmanagedwriter-opennamespace-method.md
+    - name: OpenScope Method
+      href: isymunmanagedwriter-openscope-method.md
+    - name: RemapToken Method
+      href: isymunmanagedwriter-remaptoken-method.md
+    - name: SetMethodSourceRange Method
+      href: isymunmanagedwriter-setmethodsourcerange-method.md
+    - name: SetScopeRange Method
+      href: isymunmanagedwriter-setscoperange-method.md
+    - name: SetSymAttribute Method
+      href: isymunmanagedwriter-setsymattribute-method.md
+    - name: SetUserEntryPoint Method
+      href: isymunmanagedwriter-setuserentrypoint-method.md
+    - name: UsingNamespace Method
+      href: isymunmanagedwriter-usingnamespace-method.md
+  - name: ISymUnmanagedWriter2 Interface
+    href: isymunmanagedwriter2-interface.md
+    items:
+    - name: DefineConstant2 Method
+      href: isymunmanagedwriter2-defineconstant2-method.md
+    - name: DefineGlobalVariable2 Method
+      href: isymunmanagedwriter2-defineglobalvariable2-method.md
+    - name: DefineLocalVariable2 Method
+      href: isymunmanagedwriter2-definelocalvariable2-method.md
+  - name: ISymUnmanagedWriter3 Interface
+    href: isymunmanagedwriter3-interface.md
+    items:
+    - name: Commit Method
+      href: isymunmanagedwriter3-commit-method.md
+    - name: OpenMethod2 Method
+      href: isymunmanagedwriter3-openmethod2-method.md
+  - name: ISymUnmanagedWriter4 Interface
+    href: isymunmanagedwriter4-interface.md
+    items:
+    - name: GetDebugInfoWithPadding Method
+      href: isymunmanagedwriter4-getdebuginfowithpadding-method.md
+  - name: ISymUnmanagedWriter5 Interface
+    href: isymunmanagedwriter5-interface.md
+    items:
+    - name: CloseMapTokensToSourceSpans Method
+      href: isymunmanagedwriter5-closemaptokenstosourcespans-method.md
+    - name: MapTokenToSourceSpan Method
+      href: isymunmanagedwriter5-maptokentosourcespan-method.md
+    - name: OpenMapTokensToSourceSpans Method
+      href: isymunmanagedwriter5-openmaptokenstosourcespans-method.md
+- name: Diagnostics Symbol Store Enumerations
+  href: diagnostics-symbol-store-enumerations.md
+  items:
+  - name: CorSymAddrKind Enumeration
+    href: corsymaddrkind-enumeration.md
+  - name: CorSymSearchPolicyAttributes Enumeration
+    href: corsymsearchpolicyattributes-enumeration.md
+  - name: CorSymVarFlag Enumeration
+    href: corsymvarflag-enumeration.md
+  - name: NOTIFY_FILTER Enumeration
+    href: notify-filter-enumeration.md
+- name: Diagnostics Symbol Store Structures
+  href: diagnostics-symbol-store-structures.md
+  items:
+  - name: CALL_ID Structure
+    href: call-id-structure.md
+  - name: SYMLINEDELTA Structure
+    href: symlinedelta-structure.md
+  - name: USER_THREAD Structure
+    href: user-thread-structure.md

--- a/docs/framework/unmanaged-api/fusion/toc.yml
+++ b/docs/framework/unmanaged-api/fusion/toc.yml
@@ -1,145 +1,145 @@
+items:
 - name: Fusion
   href: index.md
+- name: Fusion Interfaces
+  href: fusion-interfaces.md
   items:
-  - name: Fusion Interfaces
-    href: fusion-interfaces.md
+  - name: IAppIdAuthority Interface
+    href: iappidauthority-interface.md
+  - name: IAssemblyCache Interface
+    href: iassemblycache-interface.md
     items:
-    - name: IAppIdAuthority Interface
-      href: iappidauthority-interface.md
-    - name: IAssemblyCache Interface
-      href: iassemblycache-interface.md
-      items:
-      - name: CreateAssemblyCacheItem Method
-        href: iassemblycache-createassemblycacheitem-method.md
-      - name: CreateAssemblyScavenger Method
-        href: iassemblycache-createassemblyscavenger-method.md
-      - name: InstallAssembly Method
-        href: iassemblycache-installassembly-method.md
-      - name: QueryAssemblyInfo Method
-        href: iassemblycache-queryassemblyinfo-method.md
-      - name: UninstallAssembly Method
-        href: iassemblycache-uninstallassembly-method.md
-    - name: IAssemblyCacheItem Interface
-      href: iassemblycacheitem-interface.md
-      items:
-      - name: AbortItem Method
-        href: iassemblycacheitem-abortitem-method.md
-      - name: Commit Method
-        href: iassemblycacheitem-commit-method.md
-      - name: CreateStream Method
-        href: iassemblycacheitem-createstream-method.md
-    - name: IAssemblyEnum Interface
-      href: iassemblyenum-interface.md
-      items:
-      - name: Clone Method
-        href: iassemblyenum-clone-method.md
-      - name: GetNextAssembly Method
-        href: iassemblyenum-getnextassembly-method.md
-      - name: Reset Method
-        href: iassemblyenum-reset-method.md
-    - name: IAssemblyName Interface
-      href: iassemblyname-interface.md
-      items:
-      - name: Clone Method
-        href: iassemblyname-clone-method.md
-      - name: Finalize Method
-        href: iassemblyname-finalize-method.md
-      - name: GetDisplayName Method
-        href: iassemblyname-getdisplayname-method.md
-      - name: GetName Method
-        href: iassemblyname-getname-method.md
-      - name: GetProperty Method
-        href: iassemblyname-getproperty-method.md
-      - name: GetVersion Method
-        href: iassemblyname-getversion-method.md
-      - name: IsEqual Method
-        href: iassemblyname-isequal-method.md
-      - name: SetProperty Method
-        href: iassemblyname-setproperty-method.md
-    - name: IDefinitionAppId Interface
-      href: idefinitionappid-interface.md
-    - name: IDefinitionIdentity Interface
-      href: idefinitionidentity-interface.md
-    - name: IEnumDefinitionIdentity Interface
-      href: ienumdefinitionidentity-interface.md
-    - name: IEnumIDENTITY_ATTRIBUTE Interface
-      href: ienumidentity-attribute-interface.md
-    - name: IEnumReferenceIdentity Interface
-      href: ienumreferenceidentity-interface.md
-    - name: IIdentityAuthority Interface
-      href: iidentityauthority-interface.md
-    - name: IInstallReferenceEnum Interface
-      href: iinstallreferenceenum-interface.md
-      items:
-      - name: GetNextInstallReferenceItem Method
-        href: iinstallreferenceenum-getnextinstallreferenceitem-method.md
-    - name: IInstallReferenceItem Interface
-      href: iinstallreferenceitem-interface.md
-      items:
-      - name: GetReference Method
-        href: iinstallreferenceitem-getreference-method.md
-    - name: IReferenceAppId Interface
-      href: ireferenceappid-interface.md
-    - name: IReferenceIdentity Interface
-      href: ireferenceidentity-interface.md
-  - name: Fusion Global Static Functions
-    href: fusion-global-static-functions.md
+    - name: CreateAssemblyCacheItem Method
+      href: iassemblycache-createassemblycacheitem-method.md
+    - name: CreateAssemblyScavenger Method
+      href: iassemblycache-createassemblyscavenger-method.md
+    - name: InstallAssembly Method
+      href: iassemblycache-installassembly-method.md
+    - name: QueryAssemblyInfo Method
+      href: iassemblycache-queryassemblyinfo-method.md
+    - name: UninstallAssembly Method
+      href: iassemblycache-uninstallassembly-method.md
+  - name: IAssemblyCacheItem Interface
+    href: iassemblycacheitem-interface.md
     items:
-    - name: ClearDownloadCache Function
-      href: cleardownloadcache-function.md
-    - name: CompareAssemblyIdentity Function
-      href: compareassemblyidentity-function.md
-    - name: CreateApplicationContext Function
-      href: createapplicationcontext-function.md
-    - name: CreateAssemblyCache Function
-      href: createassemblycache-function.md
-    - name: CreateAssemblyEnum Function
-      href: createassemblyenum-function.md
-    - name: CreateAssemblyNameObject Function
-      href: createassemblynameobject-function.md
-    - name: CreateHistoryReader Function
-      href: createhistoryreader-function.md
-    - name: CreateInstallReferenceEnum Function
-      href: createinstallreferenceenum-function.md
-    - name: GetAppIdAuthority Function
-      href: getappidauthority-function.md
-    - name: GetAssemblyIdentityFromFile Function
-      href: getassemblyidentityfromfile-function.md
-    - name: GetCachePath Function
-      href: getcachepath-function.md
-    - name: GetHistoryFileDirectory Function
-      href: gethistoryfiledirectory-function.md
-    - name: GetIdentityAuthority Function
-      href: getidentityauthority-function.md
-    - name: IsFrameworkAssembly Function
-      href: isframeworkassembly-function.md
-    - name: NukeDownloadedCache Function
-      href: nukedownloadedcache-function.md
-    - name: PreBindAssemblyEx Function
-      href: prebindassemblyex-function.md
-  - name: Fusion Enumerations
-    href: fusion-enumerations.md
+    - name: AbortItem Method
+      href: iassemblycacheitem-abortitem-method.md
+    - name: Commit Method
+      href: iassemblycacheitem-commit-method.md
+    - name: CreateStream Method
+      href: iassemblycacheitem-createstream-method.md
+  - name: IAssemblyEnum Interface
+    href: iassemblyenum-interface.md
     items:
-    - name: ASM_CACHE_FLAGS Enumeration
-      href: asm-cache-flags-enumeration.md
-    - name: ASM_CMP_FLAGS Enumeration
-      href: asm-cmp-flags-enumeration.md
-    - name: ASM_DISPLAY_FLAGS Enumeration
-      href: asm-display-flags-enumeration.md
-    - name: ASM_NAME Enumeration
-      href: asm-name-enumeration.md
-    - name: AssemblyComparisonResult Enumeration
-      href: assemblycomparisonresult-enumeration.md
-    - name: CREATE_ASM_NAME_OBJ_FLAGS Enumeration
-      href: create-asm-name-obj-flags-enumeration.md
-  - name: Fusion Structures
-    href: fusion-structures.md
+    - name: Clone Method
+      href: iassemblyenum-clone-method.md
+    - name: GetNextAssembly Method
+      href: iassemblyenum-getnextassembly-method.md
+    - name: Reset Method
+      href: iassemblyenum-reset-method.md
+  - name: IAssemblyName Interface
+    href: iassemblyname-interface.md
     items:
-    - name: ASSEMBLY_INFO Structure
-      href: assembly-info-structure.md
-    - name: FUSION_INSTALL_REFERENCE Structure
-      href: fusion-install-reference-structure.md
-    - name: IDENTITY_ATTRIBUTE Structure
-      href: identity-attribute-structure.md
-    - name: IDENTITY_ATTRIBUTE_BLOB Structure
-      href: identity-attribute-blob-structure.md
+    - name: Clone Method
+      href: iassemblyname-clone-method.md
+    - name: Finalize Method
+      href: iassemblyname-finalize-method.md
+    - name: GetDisplayName Method
+      href: iassemblyname-getdisplayname-method.md
+    - name: GetName Method
+      href: iassemblyname-getname-method.md
+    - name: GetProperty Method
+      href: iassemblyname-getproperty-method.md
+    - name: GetVersion Method
+      href: iassemblyname-getversion-method.md
+    - name: IsEqual Method
+      href: iassemblyname-isequal-method.md
+    - name: SetProperty Method
+      href: iassemblyname-setproperty-method.md
+  - name: IDefinitionAppId Interface
+    href: idefinitionappid-interface.md
+  - name: IDefinitionIdentity Interface
+    href: idefinitionidentity-interface.md
+  - name: IEnumDefinitionIdentity Interface
+    href: ienumdefinitionidentity-interface.md
+  - name: IEnumIDENTITY_ATTRIBUTE Interface
+    href: ienumidentity-attribute-interface.md
+  - name: IEnumReferenceIdentity Interface
+    href: ienumreferenceidentity-interface.md
+  - name: IIdentityAuthority Interface
+    href: iidentityauthority-interface.md
+  - name: IInstallReferenceEnum Interface
+    href: iinstallreferenceenum-interface.md
+    items:
+    - name: GetNextInstallReferenceItem Method
+      href: iinstallreferenceenum-getnextinstallreferenceitem-method.md
+  - name: IInstallReferenceItem Interface
+    href: iinstallreferenceitem-interface.md
+    items:
+    - name: GetReference Method
+      href: iinstallreferenceitem-getreference-method.md
+  - name: IReferenceAppId Interface
+    href: ireferenceappid-interface.md
+  - name: IReferenceIdentity Interface
+    href: ireferenceidentity-interface.md
+- name: Fusion Global Static Functions
+  href: fusion-global-static-functions.md
+  items:
+  - name: ClearDownloadCache Function
+    href: cleardownloadcache-function.md
+  - name: CompareAssemblyIdentity Function
+    href: compareassemblyidentity-function.md
+  - name: CreateApplicationContext Function
+    href: createapplicationcontext-function.md
+  - name: CreateAssemblyCache Function
+    href: createassemblycache-function.md
+  - name: CreateAssemblyEnum Function
+    href: createassemblyenum-function.md
+  - name: CreateAssemblyNameObject Function
+    href: createassemblynameobject-function.md
+  - name: CreateHistoryReader Function
+    href: createhistoryreader-function.md
+  - name: CreateInstallReferenceEnum Function
+    href: createinstallreferenceenum-function.md
+  - name: GetAppIdAuthority Function
+    href: getappidauthority-function.md
+  - name: GetAssemblyIdentityFromFile Function
+    href: getassemblyidentityfromfile-function.md
+  - name: GetCachePath Function
+    href: getcachepath-function.md
+  - name: GetHistoryFileDirectory Function
+    href: gethistoryfiledirectory-function.md
+  - name: GetIdentityAuthority Function
+    href: getidentityauthority-function.md
+  - name: IsFrameworkAssembly Function
+    href: isframeworkassembly-function.md
+  - name: NukeDownloadedCache Function
+    href: nukedownloadedcache-function.md
+  - name: PreBindAssemblyEx Function
+    href: prebindassemblyex-function.md
+- name: Fusion Enumerations
+  href: fusion-enumerations.md
+  items:
+  - name: ASM_CACHE_FLAGS Enumeration
+    href: asm-cache-flags-enumeration.md
+  - name: ASM_CMP_FLAGS Enumeration
+    href: asm-cmp-flags-enumeration.md
+  - name: ASM_DISPLAY_FLAGS Enumeration
+    href: asm-display-flags-enumeration.md
+  - name: ASM_NAME Enumeration
+    href: asm-name-enumeration.md
+  - name: AssemblyComparisonResult Enumeration
+    href: assemblycomparisonresult-enumeration.md
+  - name: CREATE_ASM_NAME_OBJ_FLAGS Enumeration
+    href: create-asm-name-obj-flags-enumeration.md
+- name: Fusion Structures
+  href: fusion-structures.md
+  items:
+  - name: ASSEMBLY_INFO Structure
+    href: assembly-info-structure.md
+  - name: FUSION_INSTALL_REFERENCE Structure
+    href: fusion-install-reference-structure.md
+  - name: IDENTITY_ATTRIBUTE Structure
+    href: identity-attribute-structure.md
+  - name: IDENTITY_ATTRIBUTE_BLOB Structure
+    href: identity-attribute-blob-structure.md

--- a/docs/framework/unmanaged-api/hosting/toc.yml
+++ b/docs/framework/unmanaged-api/hosting/toc.yml
@@ -1,1000 +1,1000 @@
+items:
 - name: Hosting
   href: index.md
+- name: Hosting Coclasses
+  href: hosting-coclasses.md
   items:
-  - name: Hosting Coclasses
-    href: hosting-coclasses.md
+  - name: CLRRuntimeHost Coclass
+    href: clrruntimehost-coclass.md
+  - name: ComCallUnmarshal Coclass
+    href: comcallunmarshal-coclass.md
+  - name: CorRuntimeHost Coclass
+    href: corruntimehost-coclass.md
+  - name: TypeNameFactory Coclass
+    href: typenamefactory-coclass.md
+- name: Hosting Enumerations
+  href: hosting-enumerations.md
+  items:
+  - name: CLSID_RESOLUTION_FLAGS Enumeration
+    href: clsid-resolution-flags-enumeration.md
+  - name: COR_GC_STAT_TYPES Enumeration
+    href: cor-gc-stat-types-enumeration.md
+  - name: COR_GC_THREAD_STATS_TYPES Enumeration
+    href: cor-gc-thread-stats-types-enumeration.md
+  - name: EApiCategories Enumeration
+    href: eapicategories-enumeration.md
+  - name: EBindPolicyLevels Enumeration
+    href: ebindpolicylevels-enumeration.md
+  - name: ECLRAssemblyIdentityFlags Enumeration
+    href: eclrassemblyidentityflags-enumeration.md
+  - name: EClrEvent Enumeration
+    href: eclrevent-enumeration.md
+  - name: EClrFailure Enumeration
+    href: eclrfailure-enumeration.md
+  - name: EClrOperation Enumeration
+    href: eclroperation-enumeration.md
+  - name: EClrUnhandledException Enumeration
+    href: eclrunhandledexception-enumeration.md
+  - name: EContextType Enumeration
+    href: econtexttype-enumeration.md
+  - name: ECustomDumpFlavor Enumeration
+    href: ecustomdumpflavor-enumeration.md
+  - name: ECustomDumpItemKind Enumeration
+    href: ecustomdumpitemkind-enumeration.md
+  - name: EHostApplicationPolicy Enumeration
+    href: ehostapplicationpolicy-enumeration.md
+  - name: EHostBindingPolicyModifyFlags Enumeration
+    href: ehostbindingpolicymodifyflags-enumeration.md
+  - name: EInitializeNewDomainFlags Enumeration
+    href: einitializenewdomainflags-enumeration.md
+  - name: EMemoryAvailable Enumeration
+    href: ememoryavailable-enumeration.md
+  - name: EMemoryCriticalLevel Enumeration
+    href: ememorycriticallevel-enumeration.md
+  - name: EPolicyAction Enumeration
+    href: epolicyaction-enumeration.md
+  - name: ESymbolReadingPolicy Enumeration
+    href: esymbolreadingpolicy-enumeration.md
+  - name: ETaskType Enumeration
+    href: etasktype-enumeration.md
+  - name: HOST_TYPE Enumeration
+    href: host-type-enumeration.md
+  - name: MALLOC_TYPE Enumeration
+    href: malloc-type-enumeration.md
+  - name: METAHOST_CONFIG_FLAGS Enumeration
+    href: metahost-config-flags-enumeration.md
+  - name: METAHOST_POLICY_FLAGS Enumeration
+    href: metahost-policy-flags-enumeration.md
+  - name: RUNTIME_INFO_FLAGS Enumeration
+    href: runtime-info-flags-enumeration.md
+  - name: StackOverflowType Enumeration
+    href: stackoverflowtype-enumeration.md
+  - name: STARTUP_FLAGS Enumeration
+    href: startup-flags-enumeration.md
+  - name: ValidatorFlags Enumeration
+    href: validatorflags-enumeration.md
+  - name: WAIT_OPTION Enumeration
+    href: wait-option-enumeration.md
+- name: Hosting Global Static Functions
+  href: hosting-global-static-functions.md
+  items:
+  - name: .NET Framework 4 Hosting Global Static Functions
+    href: net-framework-4-hosting-global-static-functions.md
     items:
-    - name: CLRRuntimeHost Coclass
-      href: clrruntimehost-coclass.md
-    - name: ComCallUnmarshal Coclass
-      href: comcallunmarshal-coclass.md
-    - name: CorRuntimeHost Coclass
-      href: corruntimehost-coclass.md
-    - name: TypeNameFactory Coclass
-      href: typenamefactory-coclass.md
-  - name: Hosting Enumerations
-    href: hosting-enumerations.md
+    - name: CLRCreateInstance Function
+      href: clrcreateinstance-function.md
+  - name: Deprecated CLR Hosting Functions
+    href: deprecated-clr-hosting-functions.md
     items:
-    - name: CLSID_RESOLUTION_FLAGS Enumeration
-      href: clsid-resolution-flags-enumeration.md
-    - name: COR_GC_STAT_TYPES Enumeration
-      href: cor-gc-stat-types-enumeration.md
-    - name: COR_GC_THREAD_STATS_TYPES Enumeration
-      href: cor-gc-thread-stats-types-enumeration.md
-    - name: EApiCategories Enumeration
-      href: eapicategories-enumeration.md
-    - name: EBindPolicyLevels Enumeration
-      href: ebindpolicylevels-enumeration.md
-    - name: ECLRAssemblyIdentityFlags Enumeration
-      href: eclrassemblyidentityflags-enumeration.md
-    - name: EClrEvent Enumeration
-      href: eclrevent-enumeration.md
-    - name: EClrFailure Enumeration
-      href: eclrfailure-enumeration.md
-    - name: EClrOperation Enumeration
-      href: eclroperation-enumeration.md
-    - name: EClrUnhandledException Enumeration
-      href: eclrunhandledexception-enumeration.md
-    - name: EContextType Enumeration
-      href: econtexttype-enumeration.md
-    - name: ECustomDumpFlavor Enumeration
-      href: ecustomdumpflavor-enumeration.md
-    - name: ECustomDumpItemKind Enumeration
-      href: ecustomdumpitemkind-enumeration.md
-    - name: EHostApplicationPolicy Enumeration
-      href: ehostapplicationpolicy-enumeration.md
-    - name: EHostBindingPolicyModifyFlags Enumeration
-      href: ehostbindingpolicymodifyflags-enumeration.md
-    - name: EInitializeNewDomainFlags Enumeration
-      href: einitializenewdomainflags-enumeration.md
-    - name: EMemoryAvailable Enumeration
-      href: ememoryavailable-enumeration.md
-    - name: EMemoryCriticalLevel Enumeration
-      href: ememorycriticallevel-enumeration.md
-    - name: EPolicyAction Enumeration
-      href: epolicyaction-enumeration.md
-    - name: ESymbolReadingPolicy Enumeration
-      href: esymbolreadingpolicy-enumeration.md
-    - name: ETaskType Enumeration
-      href: etasktype-enumeration.md
-    - name: HOST_TYPE Enumeration
-      href: host-type-enumeration.md
-    - name: MALLOC_TYPE Enumeration
-      href: malloc-type-enumeration.md
-    - name: METAHOST_CONFIG_FLAGS Enumeration
-      href: metahost-config-flags-enumeration.md
-    - name: METAHOST_POLICY_FLAGS Enumeration
-      href: metahost-policy-flags-enumeration.md
-    - name: RUNTIME_INFO_FLAGS Enumeration
-      href: runtime-info-flags-enumeration.md
-    - name: StackOverflowType Enumeration
-      href: stackoverflowtype-enumeration.md
-    - name: STARTUP_FLAGS Enumeration
-      href: startup-flags-enumeration.md
-    - name: ValidatorFlags Enumeration
-      href: validatorflags-enumeration.md
-    - name: WAIT_OPTION Enumeration
-      href: wait-option-enumeration.md
-  - name: Hosting Global Static Functions
-    href: hosting-global-static-functions.md
+    - name: _CorDllMain Function
+      href: cordllmain-function.md
+    - name: _CorExeMain Function
+      href: corexemain-function.md
+    - name: _CorExeMain2 Function
+      href: corexemain2-function.md
+    - name: _CorImageUnloading Function
+      href: corimageunloading-function.md
+    - name: _CorValidateImage Function
+      href: corvalidateimage-function.md
+    - name: CallFunctionShim Function
+      href: callfunctionshim-function.md
+    - name: ClrCreateManagedInstance Function
+      href: clrcreatemanagedinstance-function.md
+    - name: CoEEShutDownCOM Function
+      href: coeeshutdowncom-function.md
+    - name: CoInitializeCor Function
+      href: coinitializecor-function.md
+    - name: CoInitializeEE Function
+      href: coinitializeee-function.md
+    - name: CorBindToCurrentRuntime Function
+      href: corbindtocurrentruntime-function.md
+    - name: CorBindToRuntime Function
+      href: corbindtoruntime-function.md
+    - name: CorBindToRuntimeByCfg Function
+      href: corbindtoruntimebycfg-function.md
+    - name: CorBindToRuntimeEx Function
+      href: corbindtoruntimeex-function.md
+    - name: CorBindToRuntimeHost Function
+      href: corbindtoruntimehost-function.md
+    - name: CorExitProcess Function
+      href: corexitprocess-function.md
+    - name: CorLaunchApplication Function
+      href: corlaunchapplication-function.md
+    - name: CorMarkThreadInThreadPool Function
+      href: cormarkthreadinthreadpool-function.md
+    - name: CoUninitializeCor Function
+      href: couninitializecor-function.md
+    - name: CoUninitializeEE Function
+      href: couninitializeee-function.md
+    - name: CreateDebuggingInterfaceFromVersion Function
+      href: createdebugginginterfacefromversion-function.md
+    - name: CreateICeeFileGen Function
+      href: createiceefilegen-function.md
+    - name: DestroyICeeFileGen Function
+      href: destroyiceefilegen-function.md
+    - name: FExecuteInAppDomainCallback Function Pointer
+      href: fexecuteinappdomaincallback-function-pointer.md
+    - name: FLockClrVersionCallback Function Pointer
+      href: flockclrversioncallback-function-pointer.md
+    - name: GetCLRIdentityManager Function
+      href: getclridentitymanager-function.md
+    - name: GetCORRequiredVersion Function
+      href: getcorrequiredversion-function.md
+    - name: GetCORSystemDirectory Function
+      href: getcorsystemdirectory-function.md
+    - name: GetCORVersion Function
+      href: getcorversion-function.md
+    - name: GetFileVersion Function
+      href: getfileversion-function.md
+    - name: GetRealProcAddress Function
+      href: getrealprocaddress-function.md
+    - name: GetRequestedRuntimeInfo Function
+      href: getrequestedruntimeinfo-function.md
+    - name: GetRequestedRuntimeVersion Function
+      href: getrequestedruntimeversion-function.md
+    - name: GetRequestedRuntimeVersionForCLSID Function
+      href: getrequestedruntimeversionforclsid-function.md
+    - name: GetVersionFromProcess Function
+      href: getversionfromprocess-function.md
+    - name: LoadLibraryShim Function
+      href: loadlibraryshim-function.md
+    - name: LoadStringRC Function
+      href: loadstringrc-function.md
+    - name: LoadStringRCEx Function
+      href: loadstringrcex-function.md
+    - name: LockClrVersion Function
+      href: lockclrversion-function.md
+    - name: LPOVERLAPPED_COMPLETION_ROUTINE Function Pointer
+      href: lpoverlapped-completion-routine-function-pointer.md
+    - name: LPTHREAD_START_ROUTINE Function Pointer
+      href: lpthread-start-routine-function-pointer.md
+    - name: RunDll32ShimW Function
+      href: rundll32shimw-function.md
+    - name: WAITORTIMERCALLBACK Function Pointer
+      href: waitortimercallback-function-pointer.md
+- name: Hosting Interfaces
+  href: hosting-interfaces.md
+  items:
+  - name: Deprecated CLR Hosting Interfaces and Coclasses
+    href: deprecated-clr-hosting-interfaces-and-coclasses.md
     items:
-    - name: .NET Framework 4 Hosting Global Static Functions
-      href: net-framework-4-hosting-global-static-functions.md
+    - name: IAppDomainSetup Interface
+      href: iappdomainsetup-interface.md
+    - name: ICeeFileGen Class
+      href: iceefilegen-class.md
+    - name: ICorRuntimeHost Interface
+      href: icorruntimehost-interface.md
       items:
-      - name: CLRCreateInstance Function
-        href: clrcreateinstance-function.md
-    - name: Deprecated CLR Hosting Functions
-      href: deprecated-clr-hosting-functions.md
-      items:
-      - name: _CorDllMain Function
-        href: cordllmain-function.md
-      - name: _CorExeMain Function
-        href: corexemain-function.md
-      - name: _CorExeMain2 Function
-        href: corexemain2-function.md
-      - name: _CorImageUnloading Function
-        href: corimageunloading-function.md
-      - name: _CorValidateImage Function
-        href: corvalidateimage-function.md
-      - name: CallFunctionShim Function
-        href: callfunctionshim-function.md
-      - name: ClrCreateManagedInstance Function
-        href: clrcreatemanagedinstance-function.md
-      - name: CoEEShutDownCOM Function
-        href: coeeshutdowncom-function.md
-      - name: CoInitializeCor Function
-        href: coinitializecor-function.md
-      - name: CoInitializeEE Function
-        href: coinitializeee-function.md
-      - name: CorBindToCurrentRuntime Function
-        href: corbindtocurrentruntime-function.md
-      - name: CorBindToRuntime Function
-        href: corbindtoruntime-function.md
-      - name: CorBindToRuntimeByCfg Function
-        href: corbindtoruntimebycfg-function.md
-      - name: CorBindToRuntimeEx Function
-        href: corbindtoruntimeex-function.md
-      - name: CorBindToRuntimeHost Function
-        href: corbindtoruntimehost-function.md
-      - name: CorExitProcess Function
-        href: corexitprocess-function.md
-      - name: CorLaunchApplication Function
-        href: corlaunchapplication-function.md
-      - name: CorMarkThreadInThreadPool Function
-        href: cormarkthreadinthreadpool-function.md
-      - name: CoUninitializeCor Function
-        href: couninitializecor-function.md
-      - name: CoUninitializeEE Function
-        href: couninitializeee-function.md
-      - name: CreateDebuggingInterfaceFromVersion Function
-        href: createdebugginginterfacefromversion-function.md
-      - name: CreateICeeFileGen Function
-        href: createiceefilegen-function.md
-      - name: DestroyICeeFileGen Function
-        href: destroyiceefilegen-function.md
-      - name: FExecuteInAppDomainCallback Function Pointer
-        href: fexecuteinappdomaincallback-function-pointer.md
-      - name: FLockClrVersionCallback Function Pointer
-        href: flockclrversioncallback-function-pointer.md
-      - name: GetCLRIdentityManager Function
-        href: getclridentitymanager-function.md
-      - name: GetCORRequiredVersion Function
-        href: getcorrequiredversion-function.md
-      - name: GetCORSystemDirectory Function
-        href: getcorsystemdirectory-function.md
-      - name: GetCORVersion Function
-        href: getcorversion-function.md
-      - name: GetFileVersion Function
-        href: getfileversion-function.md
-      - name: GetRealProcAddress Function
-        href: getrealprocaddress-function.md
-      - name: GetRequestedRuntimeInfo Function
-        href: getrequestedruntimeinfo-function.md
-      - name: GetRequestedRuntimeVersion Function
-        href: getrequestedruntimeversion-function.md
-      - name: GetRequestedRuntimeVersionForCLSID Function
-        href: getrequestedruntimeversionforclsid-function.md
-      - name: GetVersionFromProcess Function
-        href: getversionfromprocess-function.md
-      - name: LoadLibraryShim Function
-        href: loadlibraryshim-function.md
-      - name: LoadStringRC Function
-        href: loadstringrc-function.md
-      - name: LoadStringRCEx Function
-        href: loadstringrcex-function.md
-      - name: LockClrVersion Function
-        href: lockclrversion-function.md
-      - name: LPOVERLAPPED_COMPLETION_ROUTINE Function Pointer
-        href: lpoverlapped-completion-routine-function-pointer.md
-      - name: LPTHREAD_START_ROUTINE Function Pointer
-        href: lpthread-start-routine-function-pointer.md
-      - name: RunDll32ShimW Function
-        href: rundll32shimw-function.md
-      - name: WAITORTIMERCALLBACK Function Pointer
-        href: waitortimercallback-function-pointer.md
-  - name: Hosting Interfaces
-    href: hosting-interfaces.md
+      - name: CloseEnum Method
+        href: icorruntimehost-closeenum-method.md
+      - name: CreateDomain Method
+        href: icorruntimehost-createdomain-method.md
+      - name: CreateDomainSetup Method
+        href: icorruntimehost-createdomainsetup-method.md
+      - name: CreateDomainEx Method
+        href: icorruntimehost-createdomainex-method.md
+      - name: CreateEvidence Method
+        href: icorruntimehost-createevidence-method.md
+      - name: CreateLogicalThreadState Method
+        href: icorruntimehost-createlogicalthreadstate-method.md
+      - name: CurrentDomain Method
+        href: icorruntimehost-currentdomain-method.md
+      - name: DeleteLogicalThreadState Method
+        href: icorruntimehost-deletelogicalthreadstate-method.md
+      - name: EnumDomains Method
+        href: icorruntimehost-enumdomains-method.md
+      - name: GetConfiguration Method
+        href: icorruntimehost-getconfiguration-method.md
+      - name: GetDefaultDomain Method
+        href: icorruntimehost-getdefaultdomain-method.md
+      - name: LocksHeldByLogicalThread Method
+        href: icorruntimehost-locksheldbylogicalthread-method.md
+      - name: MapFile Method
+        href: icorruntimehost-mapfile-method.md
+      - name: NextDomain Method
+        href: icorruntimehost-nextdomain-method.md
+      - name: Start Method
+        href: icorruntimehost-start-method.md
+      - name: Stop Method
+        href: icorruntimehost-stop-method.md
+      - name: SwitchInLogicalThreadState Method
+        href: icorruntimehost-switchinlogicalthreadstate-method.md
+      - name: SwitchOutLogicalThreadState Method
+        href: icorruntimehost-switchoutlogicalthreadstate-method.md
+      - name: UnloadDomain Method
+        href: icorruntimehost-unloaddomain-method.md
+  - name: CLR Hosting Interfaces
+    href: clr-hosting-interfaces.md
     items:
-    - name: Deprecated CLR Hosting Interfaces and Coclasses
-      href: deprecated-clr-hosting-interfaces-and-coclasses.md
+    - name: IActionOnCLREvent Interface
+      href: iactiononclrevent-interface.md
       items:
-      - name: IAppDomainSetup Interface
-        href: iappdomainsetup-interface.md
-      - name: ICeeFileGen Class
-        href: iceefilegen-class.md
-      - name: ICorRuntimeHost Interface
-        href: icorruntimehost-interface.md
-        items:
-        - name: CloseEnum Method
-          href: icorruntimehost-closeenum-method.md
-        - name: CreateDomain Method
-          href: icorruntimehost-createdomain-method.md
-        - name: CreateDomainSetup Method
-          href: icorruntimehost-createdomainsetup-method.md
-        - name: CreateDomainEx Method
-          href: icorruntimehost-createdomainex-method.md
-        - name: CreateEvidence Method
-          href: icorruntimehost-createevidence-method.md
-        - name: CreateLogicalThreadState Method
-          href: icorruntimehost-createlogicalthreadstate-method.md
-        - name: CurrentDomain Method
-          href: icorruntimehost-currentdomain-method.md
-        - name: DeleteLogicalThreadState Method
-          href: icorruntimehost-deletelogicalthreadstate-method.md
-        - name: EnumDomains Method
-          href: icorruntimehost-enumdomains-method.md
-        - name: GetConfiguration Method
-          href: icorruntimehost-getconfiguration-method.md
-        - name: GetDefaultDomain Method
-          href: icorruntimehost-getdefaultdomain-method.md
-        - name: LocksHeldByLogicalThread Method
-          href: icorruntimehost-locksheldbylogicalthread-method.md
-        - name: MapFile Method
-          href: icorruntimehost-mapfile-method.md
-        - name: NextDomain Method
-          href: icorruntimehost-nextdomain-method.md
-        - name: Start Method
-          href: icorruntimehost-start-method.md
-        - name: Stop Method
-          href: icorruntimehost-stop-method.md
-        - name: SwitchInLogicalThreadState Method
-          href: icorruntimehost-switchinlogicalthreadstate-method.md
-        - name: SwitchOutLogicalThreadState Method
-          href: icorruntimehost-switchoutlogicalthreadstate-method.md
-        - name: UnloadDomain Method
-          href: icorruntimehost-unloaddomain-method.md
-    - name: CLR Hosting Interfaces
-      href: clr-hosting-interfaces.md
+      - name: OnEvent Method
+        href: iactiononclrevent-onevent-method.md
+    - name: IApartmentCallback Interface
+      href: iapartmentcallback-interface.md
       items:
-      - name: IActionOnCLREvent Interface
-        href: iactiononclrevent-interface.md
-        items:
-        - name: OnEvent Method
-          href: iactiononclrevent-onevent-method.md
-      - name: IApartmentCallback Interface
-        href: iapartmentcallback-interface.md
-        items:
-        - name: DoCallback Method
-          href: iapartmentcallback-docallback-method.md
-      - name: IAppDomainBinding Interface
-        href: iappdomainbinding-interface.md
-        items:
-        - name: OnAppDomain Method
-          href: iappdomainbinding-onappdomain-method.md
-      - name: ICatalogServices Interface
-        href: icatalogservices-interface.md
-        items:
-        - name: Autodone Method
-          href: icatalogservices-autodone-method.md
-        - name: NotAutodone Method
-          href: icatalogservices-notautodone-method.md
-      - name: ICLRAssemblyIdentityManager Interface
-        href: iclrassemblyidentitymanager-interface.md
-        items:
-        - name: GetBindingIdentityFromFile Method
-          href: iclrassemblyidentitymanager-getbindingidentityfromfile-method.md
-        - name: GetBindingIdentityFromStream Method
-          href: iclrassemblyidentitymanager-getbindingidentityfromstream-method.md
-        - name: GetCLRAssemblyReferenceList Method
-          href: iclrassemblyidentitymanager-getclrassemblyreferencelist-method.md
-        - name: GetProbingAssembliesFromReference Method
-          href: iclrassemblyidentitymanager-getprobingassembliesfromreference-method.md
-        - name: GetReferencedAssembliesFromFile Method
-          href: iclrassemblyidentitymanager-getreferencedassembliesfromfile-method.md
-        - name: GetReferencedAssembliesFromStream Method
-          href: iclrassemblyidentitymanager-getreferencedassembliesfromstream-method.md
-        - name: IsStronglyNamed Method
-          href: iclrassemblyidentitymanager-isstronglynamed-method.md
-      - name: ICLRAssemblyReferenceList Interface
-        href: iclrassemblyreferencelist-interface.md
-        items:
-        - name: IsAssemblyReferenceInList Method
-          href: iclrassemblyreferencelist-isassemblyreferenceinlist-method.md
-        - name: IsStringAssemblyReferenceInList Method
-          href: iclrassemblyreferencelist-isstringassemblyreferenceinlist-method.md
-      - name: ICLRControl Interface
-        href: iclrcontrol-interface.md
-        items:
-        - name: GetCLRManager Method
-          href: iclrcontrol-getclrmanager-method.md
-        - name: SetAppDomainManagerType Method
-          href: iclrcontrol-setappdomainmanagertype-method.md
-      - name: ICLRDebugManager Interface
-        href: iclrdebugmanager-interface.md
-        items:
-        - name: BeginConnection Method
-          href: iclrdebugmanager-beginconnection-method.md
-        - name: EndConnection Method
-          href: iclrdebugmanager-endconnection-method.md
-        - name: GetDacl Method
-          href: iclrdebugmanager-getdacl-method.md
-        - name: IsDebuggerAttached Method
-          href: iclrdebugmanager-isdebuggerattached-method.md
-        - name: SetConnectionTasks Method
-          href: iclrdebugmanager-setconnectiontasks-method.md
-        - name: SetDacl Method
-          href: iclrdebugmanager-setdacl-method.md
-        - name: SetSymbolReadingPolicy Method
-          href: iclrdebugmanager-setsymbolreadingpolicy-method.md
-      - name: ICLRErrorReportingManager Interface
-        href: iclrerrorreportingmanager-interface.md
-        items:
-        - name: BeginCustomDump Method
-          href: iclrerrorreportingmanager-begincustomdump-method.md
-        - name: EndCustomDump Method
-          href: iclrerrorreportingmanager-endcustomdump-method.md
-        - name: GetBucketParametersForCurrentException Method
-          href: iclrerrorreportingmanager-getbucketparametersforcurrentexception-method.md
-      - name: ICLRGCManager Interface
-        href: iclrgcmanager-interface.md
-        items:
-        - name: Collect Method
-          href: iclrgcmanager-collect-method.md
-        - name: GetStats Method
-          href: iclrgcmanager-getstats-method.md
-        - name: SetGCStartupLimits Method
-          href: iclrgcmanager-setgcstartuplimits-method.md
-      - name: ICLRHostBindingPolicyManager Interface
-        href: iclrhostbindingpolicymanager-interface.md
-        items:
-        - name: EvaluatePolicy Method
-          href: iclrhostbindingpolicymanager-evaluatepolicy-method.md
-        - name: ModifyApplicationPolicy Method
-          href: iclrhostbindingpolicymanager-modifyapplicationpolicy-method.md
-      - name: ICLRHostProtectionManager Interface
-        href: iclrhostprotectionmanager-interface.md
-        items:
-        - name: SetEagerSerializeGrantSets
-          href: iclrhostprotectionmanager-seteagerserializegrantsets-method.md
-        - name: SetProtectedCategories Method
-          href: iclrhostprotectionmanager-setprotectedcategories-method.md
-      - name: ICLRIoCompletionManager Interface
-        href: iclriocompletionmanager-interface.md
-        items:
-        - name: OnComplete Method
-          href: iclriocompletionmanager-oncomplete-method.md
-      - name: ICLRMemoryNotificationCallback Interface
-        href: iclrmemorynotificationcallback-interface.md
-        items:
-        - name: OnMemoryNotification Method
-          href: iclrmemorynotificationcallback-onmemorynotification-method.md
-      - name: ICLROnEventManager Interface
-        href: iclroneventmanager-interface.md
-        items:
-        - name: RegisterActionOnEvent Method
-          href: iclroneventmanager-registeractiononevent-method.md
-        - name: UnregisterActionOnEvent Method
-          href: iclroneventmanager-unregisteractiononevent-method.md
-      - name: ICLRPolicyManager Interface
-        href: iclrpolicymanager-interface.md
-        items:
-        - name: SetActionOnFailure Method
-          href: iclrpolicymanager-setactiononfailure-method.md
-        - name: SetActionOnTimeout Method
-          href: iclrpolicymanager-setactionontimeout-method.md
-        - name: SetDefaultAction Method
-          href: iclrpolicymanager-setdefaultaction-method.md
-        - name: SetTimeout Method
-          href: iclrpolicymanager-settimeout-method.md
-        - name: SetTimeoutAndAction Method
-          href: iclrpolicymanager-settimeoutandaction-method.md
-        - name: SetUnhandledExceptionPolicy Method
-          href: iclrpolicymanager-setunhandledexceptionpolicy-method.md
-      - name: ICLRProbingAssemblyEnum Interface
-        href: iclrprobingassemblyenum-interface.md
-        items:
-        - name: Get Method
-          href: iclrprobingassemblyenum-get-method.md
-      - name: ICLRReferenceAssemblyEnum Interface
-        href: iclrreferenceassemblyenum-interface.md
-        items:
-        - name: Get Method
-          href: iclrreferenceassemblyenum-get-method.md
-      - name: ICLRRuntimeHost Interface
-        href: iclrruntimehost-interface.md
-        items:
-        - name: ExecuteApplication Method
-          href: iclrruntimehost-executeapplication-method.md
-        - name: ExecuteInAppDomain Method
-          href: iclrruntimehost-executeinappdomain-method.md
-        - name: ExecuteInDefaultAppDomain Method
-          href: iclrruntimehost-executeindefaultappdomain-method.md
-        - name: GetCLRControl Method
-          href: iclrruntimehost-getclrcontrol-method.md
-        - name: GetCurrentAppDomainId Method
-          href: iclrruntimehost-getcurrentappdomainid-method.md
-        - name: SetHostControl Method
-          href: iclrruntimehost-sethostcontrol-method.md
-        - name: Start Method
-          href: iclrruntimehost-start-method.md
-        - name: Stop Method
-          href: iclrruntimehost-stop-method.md
-        - name: UnloadAppDomain Method
-          href: iclrruntimehost-unloadappdomain-method.md
-      - name: ICLRSyncManager Interface
-        href: iclrsyncmanager-interface.md
-        items:
-        - name: CreateRWLockOwnerIterator Method
-          href: iclrsyncmanager-createrwlockowneriterator-method.md
-        - name: DeleteRWLockOwnerIterator Method
-          href: iclrsyncmanager-deleterwlockowneriterator-method.md
-        - name: GetMonitorOwner Method
-          href: iclrsyncmanager-getmonitorowner-method.md
-        - name: GetRWLockOwnerNext Method
-          href: iclrsyncmanager-getrwlockownernext-method.md
-      - name: ICLRTask Interface
-        href: iclrtask-interface.md
-        items:
-        - name: Abort Method
-          href: iclrtask-abort-method.md
-        - name: ExitTask Method
-          href: iclrtask-exittask-method.md
-        - name: GetMemStats Method
-          href: iclrtask-getmemstats-method.md
-        - name: LocksHeld Method
-          href: iclrtask-locksheld-method.md
-        - name: NeedsPriorityScheduling Method
-          href: iclrtask-needspriorityscheduling-method.md
-        - name: Reset Method
-          href: iclrtask-reset-method.md
-        - name: RudeAbort Method
-          href: iclrtask-rudeabort-method.md
-        - name: SetTaskIdentifier Method
-          href: iclrtask-settaskidentifier-method.md
-        - name: SwitchIn Method
-          href: iclrtask-switchin-method.md
-        - name: SwitchOut Method
-          href: iclrtask-switchout-method.md
-        - name: YieldTask Method
-          href: iclrtask-yieldtask-method.md
-      - name: ICLRTaskManager Interface
-        href: iclrtaskmanager-interface.md
-        items:
-        - name: CreateTask Method
-          href: iclrtaskmanager-createtask-method.md
-        - name: GetCurrentTask Method
-          href: iclrtaskmanager-getcurrenttask-method.md
-        - name: GetCurrentTaskType Method
-          href: iclrtaskmanager-getcurrenttasktype-method.md
-        - name: SetLocale Method
-          href: iclrtaskmanager-setlocale-method.md
-        - name: SetUILocale Method
-          href: iclrtaskmanager-setuilocale-method.md
-      - name: ICLRValidator Interface
-        href: iclrvalidator-interface.md
-        items:
-        - name: FormatEventInfo Method
-          href: iclrvalidator-formateventinfo-method.md
-        - name: Validate Method
-          href: iclrvalidator-validate-method.md
-      - name: ICorConfiguration Interface
-        href: icorconfiguration-interface.md
-        items:
-        - name: AddDebuggerSpecialThread Method
-          href: icorconfiguration-adddebuggerspecialthread-method.md
-        - name: SetDebuggerThreadControl Method
-          href: icorconfiguration-setdebuggerthreadcontrol-method.md
-        - name: SetGCHostControl Method
-          href: icorconfiguration-setgchostcontrol-method.md
-        - name: SetGCThreadControl Method
-          href: icorconfiguration-setgcthreadcontrol-method.md
-      - name: ICorThreadpool Interface
-        href: icorthreadpool-interface.md
-        items:
-        - name: CorBindIoCompletionCallback Method
-          href: icorthreadpool-corbindiocompletioncallback-method.md
-        - name: CorCallOrQueueUserWorkItem Method
-          href: icorthreadpool-corcallorqueueuserworkitem-method.md
-        - name: CorChangeTimer Method
-          href: icorthreadpool-corchangetimer-method.md
-        - name: CorCreateTimer Method
-          href: icorthreadpool-corcreatetimer-method.md
-        - name: CorDeleteTimer Method
-          href: icorthreadpool-cordeletetimer-method.md
-        - name: CorGetAvailableThreads Method
-          href: icorthreadpool-corgetavailablethreads-method.md
-        - name: CorGetMaxThreads Method
-          href: icorthreadpool-corgetmaxthreads-method.md
-        - name: CorQueueUserWorkItem Method
-          href: icorthreadpool-corqueueuserworkitem-method.md
-        - name: CorRegisterWaitForSingleObject Method
-          href: icorthreadpool-corregisterwaitforsingleobject-method.md
-        - name: CorSetMaxThreads Method
-          href: icorthreadpool-corsetmaxthreads-method.md
-        - name: CorUnregisterWait Method
-          href: icorthreadpool-corunregisterwait-method.md
-      - name: IDebuggerInfo Interface
-        href: idebuggerinfo-interface.md
-        items:
-        - name: IsDebuggerAttached Method
-          href: idebuggerinfo-isdebuggerattached-method.md
-      - name: IDebuggerThreadControl Interface
-        href: idebuggerthreadcontrol-interface.md
-        items:
-        - name: ReleaseAllRuntimeThreads Method
-          href: idebuggerthreadcontrol-releaseallruntimethreads-method.md
-        - name: StartBlockingForDebugger Method
-          href: idebuggerthreadcontrol-startblockingfordebugger-method.md
-        - name: ThreadIsBlockingForDebugger Method
-          href: idebuggerthreadcontrol-threadisblockingfordebugger-method.md
-      - name: IGCHost Interface
-        href: igchost-interface.md
-        items:
-        - name: Collect Method
-          href: igchost-collect-method.md
-        - name: GetStats Method
-          href: igchost-getstats-method.md
-        - name: GetThreadStats Method
-          href: igchost-getthreadstats-method.md
-        - name: SetGCStartupLimits Method
-          href: igchost-setgcstartuplimits-method.md
-        - name: SetVirtualMemLimit Method
-          href: igchost-setvirtualmemlimit-method.md
-      - name: IGCHost2 Interface
-        href: igchost2-interface.md
-        items:
-        - name: SetGCStartupLimitsEx Method
-          href: igchost2-setgcstartuplimitsex-method.md
-      - name: IGCHostControl Interface
-        href: igchostcontrol-interface.md
-        items:
-        - name: RequestVirtualMemLimit Method
-          href: igchostcontrol-requestvirtualmemlimit-method.md
-      - name: IGCThreadControl Interface
-        href: igcthreadcontrol-interface.md
-        items:
-        - name: SuspensionEnding Method
-          href: igcthreadcontrol-suspensionending-method.md
-        - name: SuspensionStarting Method
-          href: igcthreadcontrol-suspensionstarting-method.md
-        - name: ThreadIsBlockingForSuspension Method
-          href: igcthreadcontrol-threadisblockingforsuspension-method.md
-      - name: IHostAssemblyManager Interface
-        href: ihostassemblymanager-interface.md
-        items:
-        - name: GetAssemblyStore Method
-          href: ihostassemblymanager-getassemblystore-method.md
-        - name: GetNonHostStoreAssemblies Method
-          href: ihostassemblymanager-getnonhoststoreassemblies-method.md
-      - name: IHostAssemblyStore Interface
-        href: ihostassemblystore-interface.md
-        items:
-        - name: ProvideAssembly Method
-          href: ihostassemblystore-provideassembly-method.md
-        - name: ProvideModule Method
-          href: ihostassemblystore-providemodule-method.md
-      - name: IHostAutoEvent Interface
-        href: ihostautoevent-interface.md
-        items:
-        - name: Set Method
-          href: ihostautoevent-set-method.md
-        - name: Wait Method
-          href: ihostautoevent-wait-method.md
-      - name: IHostControl Interface
-        href: ihostcontrol-interface.md
-        items:
-        - name: GetHostManager Method
-          href: ihostcontrol-gethostmanager-method.md
-        - name: SetAppDomainManager Method
-          href: ihostcontrol-setappdomainmanager-method.md
-      - name: IHostCrst Interface
-        href: ihostcrst-interface.md
-        items:
-        - name: Enter Method
-          href: ihostcrst-enter-method.md
-        - name: Leave Method
-          href: ihostcrst-leave-method.md
-        - name: SetSpinCount Method
-          href: ihostcrst-setspincount-method.md
-        - name: TryEnter Method
-          href: ihostcrst-tryenter-method.md
-      - name: IHostGCManager Interface
-        href: ihostgcmanager-interface.md
-        items:
-        - name: SuspensionEnding Method
-          href: ihostgcmanager-suspensionending-method.md
-        - name: SuspensionStarting Method
-          href: ihostgcmanager-suspensionstarting-method.md
-        - name: ThreadIsBlockingForSuspension Method
-          href: ihostgcmanager-threadisblockingforsuspension-method.md
-      - name: IHostIoCompletionManager Interface
-        href: ihostiocompletionmanager-interface.md
-        items:
-        - name: Bind Method
-          href: ihostiocompletionmanager-bind-method.md
-        - name: CloseIoCompletionPort Method
-          href: ihostiocompletionmanager-closeiocompletionport-method.md
-        - name: CreateIoCompletionPort Method
-          href: ihostiocompletionmanager-createiocompletionport-method.md
-        - name: GetAvailableThreads Method
-          href: ihostiocompletionmanager-getavailablethreads-method.md
-        - name: GetHostOverlappedSize Method
-          href: ihostiocompletionmanager-gethostoverlappedsize-method.md
-        - name: GetMaxThreads Method
-          href: ihostiocompletionmanager-getmaxthreads-method.md
-        - name: GetMinThreads Method
-          href: ihostiocompletionmanager-getminthreads-method.md
-        - name: InitializeHostOverlapped Method
-          href: ihostiocompletionmanager-initializehostoverlapped-method.md
-        - name: SetCLRIoCompletionManager Method
-          href: ihostiocompletionmanager-setclriocompletionmanager-method.md
-        - name: SetMaxThreads Method
-          href: ihostiocompletionmanager-setmaxthreads-method.md
-        - name: SetMinThreads Method
-          href: ihostiocompletionmanager-setminthreads-method.md
-      - name: IHostMalloc Interface
-        href: ihostmalloc-interface.md
-        items:
-        - name: Alloc Method
-          href: ihostmalloc-alloc-method.md
-        - name: DebugAlloc Method
-          href: ihostmalloc-debugalloc-method.md
-        - name: Free Method
-          href: ihostmalloc-free-method.md
-      - name: IHostManualEvent Interface
-        href: ihostmanualevent-interface.md
-        items:
-        - name: Reset Method
-          href: ihostmanualevent-reset-method.md
-        - name: Set Method
-          href: ihostmanualevent-set-method.md
-        - name: Wait Method
-          href: ihostmanualevent-wait-method.md
-      - name: IHostMemoryManager Interface
-        href: ihostmemorymanager-interface.md
-        items:
-        - name: AcquiredVirtualAddressSpace Method
-          href: ihostmemorymanager-acquiredvirtualaddressspace-method.md
-        - name: CreateMAlloc Method
-          href: ihostmemorymanager-createmalloc-method.md
-        - name: GetMemoryLoad Method
-          href: ihostmemorymanager-getmemoryload-method.md
-        - name: NeedsVirtualAddressSpace Method
-          href: ihostmemorymanager-needsvirtualaddressspace-method.md
-        - name: RegisterMemoryNotificationCallback Method
-          href: ihostmemorymanager-registermemorynotificationcallback-method.md
-        - name: ReleasedVirtualAddressSpace Method
-          href: ihostmemorymanager-releasedvirtualaddressspace-method.md
-        - name: VirtualAlloc Method
-          href: ihostmemorymanager-virtualalloc-method.md
-        - name: VirtualFree Method
-          href: ihostmemorymanager-virtualfree-method.md
-        - name: VirtualProtect Method
-          href: ihostmemorymanager-virtualprotect-method.md
-        - name: VirtualQuery Method
-          href: ihostmemorymanager-virtualquery-method.md
-      - name: IHostPolicyManager Interface
-        href: ihostpolicymanager-interface.md
-        items:
-        - name: OnDefaultAction Method
-          href: ihostpolicymanager-ondefaultaction-method.md
-        - name: OnFailure Method
-          href: ihostpolicymanager-onfailure-method.md
-        - name: OnTimeout Method
-          href: ihostpolicymanager-ontimeout-method.md
-      - name: IHostSecurityContext Interface
-        href: ihostsecuritycontext-interface.md
-        items:
-        - name: Capture Method
-          href: ihostsecuritycontext-capture-method.md
-      - name: IHostSecurityManager Interface
-        href: ihostsecuritymanager-interface.md
-        items:
-        - name: GetSecurityContext Method
-          href: ihostsecuritymanager-getsecuritycontext-method.md
-        - name: ImpersonateLoggedOnUser Method
-          href: ihostsecuritymanager-impersonateloggedonuser-method.md
-        - name: OpenThreadToken Method
-          href: ihostsecuritymanager-openthreadtoken-method.md
-        - name: RevertToSelf Method
-          href: ihostsecuritymanager-reverttoself-method.md
-        - name: SetSecurityContext Method
-          href: ihostsecuritymanager-setsecuritycontext-method.md
-        - name: SetThreadToken Method
-          href: ihostsecuritymanager-setthreadtoken-method.md
-      - name: IHostSemaphore Interface
-        href: ihostsemaphore-interface.md
-        items:
-        - name: ReleaseSemaphore Method
-          href: ihostsemaphore-releasesemaphore-method.md
-        - name: Wait Method
-          href: ihostsemaphore-wait-method.md
-      - name: IHostSyncManager Interface
-        href: ihostsyncmanager-interface.md
-        items:
-        - name: CreateAutoEvent Method
-          href: ihostsyncmanager-createautoevent-method.md
-        - name: CreateCrst Method
-          href: ihostsyncmanager-createcrst-method.md
-        - name: CreateCrstWithSpinCount Method
-          href: ihostsyncmanager-createcrstwithspincount-method.md
-        - name: CreateManualEvent Method
-          href: ihostsyncmanager-createmanualevent-method.md
-        - name: CreateMonitorEvent Method
-          href: ihostsyncmanager-createmonitorevent-method.md
-        - name: CreateRWLockReaderEvent Method
-          href: ihostsyncmanager-createrwlockreaderevent-method.md
-        - name: CreateRWLockWriterEvent Method
-          href: ihostsyncmanager-createrwlockwriterevent-method.md
-        - name: CreateSemaphore Method
-          href: ihostsyncmanager-createsemaphore-method.md
-        - name: SetCLRSyncManager Method
-          href: ihostsyncmanager-setclrsyncmanager-method.md
-      - name: IHostTask Interface
-        href: ihosttask-interface.md
-        items:
-        - name: Alert Method
-          href: ihosttask-alert-method.md
-        - name: GetPriority Method
-          href: ihosttask-getpriority-method.md
-        - name: Join Method
-          href: ihosttask-join-method.md
-        - name: SetCLRTask Method
-          href: ihosttask-setclrtask-method.md
-        - name: SetPriority Method
-          href: ihosttask-setpriority-method.md
-        - name: Start Method
-          href: ihosttask-start-method.md
-      - name: IHostTaskManager Interface
-        href: ihosttaskmanager-interface.md
-        items:
-        - name: BeginDelayAbort Method
-          href: ihosttaskmanager-begindelayabort-method.md
-        - name: BeginThreadAffinity Method
-          href: ihosttaskmanager-beginthreadaffinity-method.md
-        - name: CallNeedsHostHook Method
-          href: ihosttaskmanager-callneedshosthook-method.md
-        - name: CreateTask Method
-          href: ihosttaskmanager-createtask-method.md
-        - name: EndDelayAbort Method
-          href: ihosttaskmanager-enddelayabort-method.md
-        - name: EndThreadAffinity Method
-          href: ihosttaskmanager-endthreadaffinity-method.md
-        - name: EnterRuntime Method
-          href: ihosttaskmanager-enterruntime-method.md
-        - name: GetCurrentTask Method
-          href: ihosttaskmanager-getcurrenttask-method.md
-        - name: GetStackGuarantee Method
-          href: ihosttaskmanager-getstackguarantee-method.md
-        - name: LeaveRuntime Method
-          href: ihosttaskmanager-leaveruntime-method.md
-        - name: ReverseEnterRuntime Method
-          href: ihosttaskmanager-reverseenterruntime-method.md
-        - name: ReverseLeaveRuntime Method
-          href: ihosttaskmanager-reverseleaveruntime-method.md
-        - name: SetCLRTaskManager Method
-          href: ihosttaskmanager-setclrtaskmanager-method.md
-        - name: SetLocale Method
-          href: ihosttaskmanager-setlocale-method.md
-        - name: SetStackGuarantee Method
-          href: ihosttaskmanager-setstackguarantee-method.md
-        - name: SetUILocale Method
-          href: ihosttaskmanager-setuilocale-method.md
-        - name: Sleep Method
-          href: ihosttaskmanager-sleep-method.md
-        - name: SwitchToTask Method
-          href: ihosttaskmanager-switchtotask-method.md
-      - name: IHostThreadPoolManager Interface
-        href: ihostthreadpoolmanager-interface.md
-        items:
-        - name: GetAvailableThreads Method
-          href: ihostthreadpoolmanager-getavailablethreads-method.md
-        - name: GetMaxThreads Method
-          href: ihostthreadpoolmanager-getmaxthreads-method.md
-        - name: GetMinThreads Method
-          href: ihostthreadpoolmanager-getminthreads-method.md
-        - name: QueueUserWorkItem Method
-          href: ihostthreadpoolmanager-queueuserworkitem-method.md
-        - name: SetMaxThreads Method
-          href: ihostthreadpoolmanager-setmaxthreads-method.md
-        - name: SetMinThreads Method
-          href: ihostthreadpoolmanager-setminthreads-method.md
-      - name: IManagedObject Interface
-        href: imanagedobject-interface.md
-        items:
-        - name: GetObjectIdentity Method
-          href: imanagedobject-getobjectidentity-method.md
-        - name: GetSerializedBuffer Method
-          href: imanagedobject-getserializedbuffer-method.md
-      - name: IObjectHandle Interface
-        href: iobjecthandle-interface.md
-        items:
-        - name: Unwrap Method
-          href: iobjecthandle-unwrap-method.md
-      - name: ITypeName Interface
-        href: itypename-interface.md
-        items:
-        - name: GetAssemblyName Method
-          href: itypename-getassemblyname-method.md
-        - name: GetModifierLength Method
-          href: itypename-getmodifierlength-method.md
-        - name: GetModifiers Method
-          href: itypename-getmodifiers-method.md
-        - name: GetNameCount Method
-          href: itypename-getnamecount-method.md
-        - name: GetNames Method
-          href: itypename-getnames-method.md
-        - name: GetTypeArgumentCount Method
-          href: itypename-gettypeargumentcount-method.md
-        - name: GetTypeArguments Method
-          href: itypename-gettypearguments-method.md
-      - name: ITypeNameBuilder Interface
-        href: itypenamebuilder-interface.md
-        items:
-        - name: AddArray Method
-          href: itypenamebuilder-addarray-method.md
-        - name: AddAssemblySpec Method
-          href: itypenamebuilder-addassemblyspec-method.md
-        - name: AddByRef Method
-          href: itypenamebuilder-addbyref-method.md
-        - name: AddName Method
-          href: itypenamebuilder-addname-method.md
-        - name: AddPointer Method
-          href: itypenamebuilder-addpointer-method.md
-        - name: AddSzArray Method
-          href: itypenamebuilder-addszarray-method.md
-        - name: Clear Method
-          href: itypenamebuilder-clear-method.md
-        - name: CloseGenericArgument Method
-          href: itypenamebuilder-closegenericargument-method.md
-        - name: CloseGenericArguments Method
-          href: itypenamebuilder-closegenericarguments-method.md
-        - name: OpenGenericArgument Method
-          href: itypenamebuilder-opengenericargument-method.md
-        - name: OpenGenericArguments Method
-          href: itypenamebuilder-opengenericarguments-method.md
-        - name: ToString Method
-          href: itypenamebuilder-tostring-method.md
-      - name: ITypeNameFactory Interface
-        href: itypenamefactory-interface.md
-        items:
-        - name: GetTypeNameBuilder Method
-          href: itypenamefactory-gettypenamebuilder-method.md
-        - name: ParseTypeName Method
-          href: itypenamefactory-parsetypename-method.md
-      - name: IValidator Interface
-        href: ivalidator-interface.md
-        items:
-        - name: FormatEventInfo Method
-          href: ivalidator-formateventinfo-method.md
-        - name: Validate Method
-          href: ivalidator-validate-method.md
-    - name: CLR Hosting Interfaces Added in the .NET Framework 4 and 4.5
-      href: clr-hosting-interfaces-added-in-the-net-framework-4-and-4-5.md
+      - name: DoCallback Method
+        href: iapartmentcallback-docallback-method.md
+    - name: IAppDomainBinding Interface
+      href: iappdomainbinding-interface.md
       items:
-      - name: ICLRAppDomainResourceMonitor Interface
-        href: iclrappdomainresourcemonitor-interface.md
-        items:
-        - name: GetCurrentAllocated Method
-          href: iclrappdomainresourcemonitor-getcurrentallocated-method.md
-        - name: GetCurrentSurvived Method
-          href: iclrappdomainresourcemonitor-getcurrentsurvived-method.md
-        - name: GetCurrentCpuTime Method
-          href: iclrappdomainresourcemonitor-getcurrentcputime-method.md
-      - name: ICLRDomainManager Interface
-        href: iclrdomainmanager-interface.md
-        items:
-        - name: SetAppDomainManagerType Method
-          href: iclrdomainmanager-setappdomainmanagertype-method.md
-        - name: SetPropertiesForDefaultAppDomain Method
-          href: iclrdomainmanager-setpropertiesfordefaultappdomain-method.md
-      - name: ICLRGCManager2 Interface
-        href: iclrgcmanager2-interface.md
-        items:
-        - name: SetGCStartupLimitsEx Method
-          href: iclrgcmanager2-setgcstartuplimitsex-method.md
-      - name: ICLRMetaHost Interface
-        href: iclrmetahost-interface.md
-        items:
-        - name: EnumerateInstalledRuntimes Method
-          href: iclrmetahost-enumerateinstalledruntimes-method.md
-        - name: EnumerateLoadedRuntimes Method
-          href: iclrmetahost-enumerateloadedruntimes-method.md
-        - name: ExitProcess Method
-          href: iclrmetahost-exitprocess-method.md
-        - name: GetRuntime Method
-          href: iclrmetahost-getruntime-method.md
-        - name: GetVersionFromFile Method
-          href: iclrmetahost-getversionfromfile-method.md
-        - name: QueryLegacyV2RuntimeBinding Method
-          href: iclrmetahost-querylegacyv2runtimebinding-method.md
-        - name: RequestRuntimeLoadedNotification Method
-          href: iclrmetahost-requestruntimeloadednotification-method.md
-      - name: ICLRMetaHostPolicy Interface
-        href: iclrmetahostpolicy-interface.md
-        items:
-        - name: GetRequestedRuntime Method
-          href: iclrmetahostpolicy-getrequestedruntime-method.md
-      - name: ICLRRuntimeInfo Interface
-        href: iclrruntimeinfo-interface.md
-        items:
-        - name: BindAsLegacyV2Runtime Method
-          href: iclrruntimeinfo-bindaslegacyv2runtime-method.md
-        - name: GetDefaultStartupFlags Method
-          href: iclrruntimeinfo-getdefaultstartupflags-method.md
-        - name: GetInterface Method
-          href: iclrruntimeinfo-getinterface-method.md
-        - name: GetProcAddress Method
-          href: iclrruntimeinfo-getprocaddress-method.md
-        - name: GetRuntimeDirectory Method
-          href: iclrruntimeinfo-getruntimedirectory-method.md
-        - name: GetVersionString Method
-          href: iclrruntimeinfo-getversionstring-method.md
-        - name: IsLoadable Method
-          href: iclrruntimeinfo-isloadable-method.md
-        - name: IsLoaded Method
-          href: iclrruntimeinfo-isloaded-method.md
-        - name: IsStarted Method
-          href: iclrruntimeinfo-isstarted-method.md
-        - name: LoadErrorString Method
-          href: iclrruntimeinfo-loaderrorstring-method.md
-        - name: LoadLibrary Method
-          href: iclrruntimeinfo-loadlibrary-method.md
-        - name: SetDefaultStartupFlags Method
-          href: iclrruntimeinfo-setdefaultstartupflags-method.md
-      - name: ICLRStrongName Interface
-        href: iclrstrongname-interface.md
-        items:
-        - name: GetHashFromAssemblyFile Method
-          href: iclrstrongname-gethashfromassemblyfile-method.md
-        - name: GetHashFromAssemblyFileW Method
-          href: iclrstrongname-gethashfromassemblyfilew-method.md
-        - name: GetHashFromBlob Method
-          href: iclrstrongname-gethashfromblob-method.md
-        - name: GetHashFromFile Method
-          href: iclrstrongname-gethashfromfile-method.md
-        - name: GetHashFromFileW Method
-          href: iclrstrongname-gethashfromfilew-method.md
-        - name: GetHashFromHandle Method
-          href: iclrstrongname-gethashfromhandle-method.md
-        - name: StrongNameCompareAssemblies Method
-          href: iclrstrongname-strongnamecompareassemblies-method.md
-        - name: StrongNameFreeBuffer Method
-          href: iclrstrongname-strongnamefreebuffer-method.md
-        - name: StrongNameGetBlob Method
-          href: iclrstrongname-strongnamegetblob-method.md
-        - name: StrongNameGetBlobFromImage Method
-          href: iclrstrongname-strongnamegetblobfromimage-method.md
-        - name: StrongNameGetPublicKey Method
-          href: iclrstrongname-strongnamegetpublickey-method.md
-        - name: StrongNameHashSize Method
-          href: iclrstrongname-strongnamehashsize-method.md
-        - name: StrongNameKeyDelete Method
-          href: iclrstrongname-strongnamekeydelete-method.md
-        - name: StrongNameKeyGen Method
-          href: iclrstrongname-strongnamekeygen-method.md
-        - name: StrongNameKeyGenEx Method
-          href: iclrstrongname-strongnamekeygenex-method.md
-        - name: StrongNameKeyInstall Method
-          href: iclrstrongname-strongnamekeyinstall-method.md
-        - name: StrongNameSignatureGeneration Method
-          href: iclrstrongname-strongnamesignaturegeneration-method.md
-        - name: StrongNameSignatureGenerationEx Method
-          href: iclrstrongname-strongnamesignaturegenerationex-method.md
-        - name: StrongNameSignatureSize Method
-          href: iclrstrongname-strongnamesignaturesize-method.md
-        - name: StrongNameSignatureVerification Method
-          href: iclrstrongname-strongnamesignatureverification-method.md
-        - name: StrongNameSignatureVerificationEx Method
-          href: iclrstrongname-strongnamesignatureverificationex-method.md
-        - name: StrongNameSignatureVerificationFromImage Method
-          href: iclrstrongname-strongnamesignatureverificationfromimage-method.md
-        - name: StrongNameTokenFromAssembly Method
-          href: iclrstrongname-strongnametokenfromassembly-method.md
-        - name: StrongNameTokenFromAssemblyEx Method
-          href: iclrstrongname-strongnametokenfromassemblyex-method.md
-        - name: StrongNameTokenFromPublicKey Method
-          href: iclrstrongname-strongnametokenfrompublickey-method.md
-      - name: ICLRStrongName2 Interface
-        href: iclrstrongname2-interface.md
-        items:
-        - name: StrongNameGetPublicKeyEx Method
-          href: strongnamegetpublickeyex-method.md
-        - name: StrongNameSignatureVerificationEx2 Method
-          href: strongnamesignatureverificationex2-method.md
-      - name: ICLRTask2 Interface
-        href: iclrtask2-interface.md
-        items:
-        - name: BeginPreventAsyncAbort Method
-          href: iclrtask2-beginpreventasyncabort-method.md
-        - name: EndPreventAsyncAbort Method
-          href: iclrtask2-endpreventasyncabort-method.md
-  - name: Hosting Structures
-    href: hosting-structures.md
+      - name: OnAppDomain Method
+        href: iappdomainbinding-onappdomain-method.md
+    - name: ICatalogServices Interface
+      href: icatalogservices-interface.md
+      items:
+      - name: Autodone Method
+        href: icatalogservices-autodone-method.md
+      - name: NotAutodone Method
+        href: icatalogservices-notautodone-method.md
+    - name: ICLRAssemblyIdentityManager Interface
+      href: iclrassemblyidentitymanager-interface.md
+      items:
+      - name: GetBindingIdentityFromFile Method
+        href: iclrassemblyidentitymanager-getbindingidentityfromfile-method.md
+      - name: GetBindingIdentityFromStream Method
+        href: iclrassemblyidentitymanager-getbindingidentityfromstream-method.md
+      - name: GetCLRAssemblyReferenceList Method
+        href: iclrassemblyidentitymanager-getclrassemblyreferencelist-method.md
+      - name: GetProbingAssembliesFromReference Method
+        href: iclrassemblyidentitymanager-getprobingassembliesfromreference-method.md
+      - name: GetReferencedAssembliesFromFile Method
+        href: iclrassemblyidentitymanager-getreferencedassembliesfromfile-method.md
+      - name: GetReferencedAssembliesFromStream Method
+        href: iclrassemblyidentitymanager-getreferencedassembliesfromstream-method.md
+      - name: IsStronglyNamed Method
+        href: iclrassemblyidentitymanager-isstronglynamed-method.md
+    - name: ICLRAssemblyReferenceList Interface
+      href: iclrassemblyreferencelist-interface.md
+      items:
+      - name: IsAssemblyReferenceInList Method
+        href: iclrassemblyreferencelist-isassemblyreferenceinlist-method.md
+      - name: IsStringAssemblyReferenceInList Method
+        href: iclrassemblyreferencelist-isstringassemblyreferenceinlist-method.md
+    - name: ICLRControl Interface
+      href: iclrcontrol-interface.md
+      items:
+      - name: GetCLRManager Method
+        href: iclrcontrol-getclrmanager-method.md
+      - name: SetAppDomainManagerType Method
+        href: iclrcontrol-setappdomainmanagertype-method.md
+    - name: ICLRDebugManager Interface
+      href: iclrdebugmanager-interface.md
+      items:
+      - name: BeginConnection Method
+        href: iclrdebugmanager-beginconnection-method.md
+      - name: EndConnection Method
+        href: iclrdebugmanager-endconnection-method.md
+      - name: GetDacl Method
+        href: iclrdebugmanager-getdacl-method.md
+      - name: IsDebuggerAttached Method
+        href: iclrdebugmanager-isdebuggerattached-method.md
+      - name: SetConnectionTasks Method
+        href: iclrdebugmanager-setconnectiontasks-method.md
+      - name: SetDacl Method
+        href: iclrdebugmanager-setdacl-method.md
+      - name: SetSymbolReadingPolicy Method
+        href: iclrdebugmanager-setsymbolreadingpolicy-method.md
+    - name: ICLRErrorReportingManager Interface
+      href: iclrerrorreportingmanager-interface.md
+      items:
+      - name: BeginCustomDump Method
+        href: iclrerrorreportingmanager-begincustomdump-method.md
+      - name: EndCustomDump Method
+        href: iclrerrorreportingmanager-endcustomdump-method.md
+      - name: GetBucketParametersForCurrentException Method
+        href: iclrerrorreportingmanager-getbucketparametersforcurrentexception-method.md
+    - name: ICLRGCManager Interface
+      href: iclrgcmanager-interface.md
+      items:
+      - name: Collect Method
+        href: iclrgcmanager-collect-method.md
+      - name: GetStats Method
+        href: iclrgcmanager-getstats-method.md
+      - name: SetGCStartupLimits Method
+        href: iclrgcmanager-setgcstartuplimits-method.md
+    - name: ICLRHostBindingPolicyManager Interface
+      href: iclrhostbindingpolicymanager-interface.md
+      items:
+      - name: EvaluatePolicy Method
+        href: iclrhostbindingpolicymanager-evaluatepolicy-method.md
+      - name: ModifyApplicationPolicy Method
+        href: iclrhostbindingpolicymanager-modifyapplicationpolicy-method.md
+    - name: ICLRHostProtectionManager Interface
+      href: iclrhostprotectionmanager-interface.md
+      items:
+      - name: SetEagerSerializeGrantSets
+        href: iclrhostprotectionmanager-seteagerserializegrantsets-method.md
+      - name: SetProtectedCategories Method
+        href: iclrhostprotectionmanager-setprotectedcategories-method.md
+    - name: ICLRIoCompletionManager Interface
+      href: iclriocompletionmanager-interface.md
+      items:
+      - name: OnComplete Method
+        href: iclriocompletionmanager-oncomplete-method.md
+    - name: ICLRMemoryNotificationCallback Interface
+      href: iclrmemorynotificationcallback-interface.md
+      items:
+      - name: OnMemoryNotification Method
+        href: iclrmemorynotificationcallback-onmemorynotification-method.md
+    - name: ICLROnEventManager Interface
+      href: iclroneventmanager-interface.md
+      items:
+      - name: RegisterActionOnEvent Method
+        href: iclroneventmanager-registeractiononevent-method.md
+      - name: UnregisterActionOnEvent Method
+        href: iclroneventmanager-unregisteractiononevent-method.md
+    - name: ICLRPolicyManager Interface
+      href: iclrpolicymanager-interface.md
+      items:
+      - name: SetActionOnFailure Method
+        href: iclrpolicymanager-setactiononfailure-method.md
+      - name: SetActionOnTimeout Method
+        href: iclrpolicymanager-setactionontimeout-method.md
+      - name: SetDefaultAction Method
+        href: iclrpolicymanager-setdefaultaction-method.md
+      - name: SetTimeout Method
+        href: iclrpolicymanager-settimeout-method.md
+      - name: SetTimeoutAndAction Method
+        href: iclrpolicymanager-settimeoutandaction-method.md
+      - name: SetUnhandledExceptionPolicy Method
+        href: iclrpolicymanager-setunhandledexceptionpolicy-method.md
+    - name: ICLRProbingAssemblyEnum Interface
+      href: iclrprobingassemblyenum-interface.md
+      items:
+      - name: Get Method
+        href: iclrprobingassemblyenum-get-method.md
+    - name: ICLRReferenceAssemblyEnum Interface
+      href: iclrreferenceassemblyenum-interface.md
+      items:
+      - name: Get Method
+        href: iclrreferenceassemblyenum-get-method.md
+    - name: ICLRRuntimeHost Interface
+      href: iclrruntimehost-interface.md
+      items:
+      - name: ExecuteApplication Method
+        href: iclrruntimehost-executeapplication-method.md
+      - name: ExecuteInAppDomain Method
+        href: iclrruntimehost-executeinappdomain-method.md
+      - name: ExecuteInDefaultAppDomain Method
+        href: iclrruntimehost-executeindefaultappdomain-method.md
+      - name: GetCLRControl Method
+        href: iclrruntimehost-getclrcontrol-method.md
+      - name: GetCurrentAppDomainId Method
+        href: iclrruntimehost-getcurrentappdomainid-method.md
+      - name: SetHostControl Method
+        href: iclrruntimehost-sethostcontrol-method.md
+      - name: Start Method
+        href: iclrruntimehost-start-method.md
+      - name: Stop Method
+        href: iclrruntimehost-stop-method.md
+      - name: UnloadAppDomain Method
+        href: iclrruntimehost-unloadappdomain-method.md
+    - name: ICLRSyncManager Interface
+      href: iclrsyncmanager-interface.md
+      items:
+      - name: CreateRWLockOwnerIterator Method
+        href: iclrsyncmanager-createrwlockowneriterator-method.md
+      - name: DeleteRWLockOwnerIterator Method
+        href: iclrsyncmanager-deleterwlockowneriterator-method.md
+      - name: GetMonitorOwner Method
+        href: iclrsyncmanager-getmonitorowner-method.md
+      - name: GetRWLockOwnerNext Method
+        href: iclrsyncmanager-getrwlockownernext-method.md
+    - name: ICLRTask Interface
+      href: iclrtask-interface.md
+      items:
+      - name: Abort Method
+        href: iclrtask-abort-method.md
+      - name: ExitTask Method
+        href: iclrtask-exittask-method.md
+      - name: GetMemStats Method
+        href: iclrtask-getmemstats-method.md
+      - name: LocksHeld Method
+        href: iclrtask-locksheld-method.md
+      - name: NeedsPriorityScheduling Method
+        href: iclrtask-needspriorityscheduling-method.md
+      - name: Reset Method
+        href: iclrtask-reset-method.md
+      - name: RudeAbort Method
+        href: iclrtask-rudeabort-method.md
+      - name: SetTaskIdentifier Method
+        href: iclrtask-settaskidentifier-method.md
+      - name: SwitchIn Method
+        href: iclrtask-switchin-method.md
+      - name: SwitchOut Method
+        href: iclrtask-switchout-method.md
+      - name: YieldTask Method
+        href: iclrtask-yieldtask-method.md
+    - name: ICLRTaskManager Interface
+      href: iclrtaskmanager-interface.md
+      items:
+      - name: CreateTask Method
+        href: iclrtaskmanager-createtask-method.md
+      - name: GetCurrentTask Method
+        href: iclrtaskmanager-getcurrenttask-method.md
+      - name: GetCurrentTaskType Method
+        href: iclrtaskmanager-getcurrenttasktype-method.md
+      - name: SetLocale Method
+        href: iclrtaskmanager-setlocale-method.md
+      - name: SetUILocale Method
+        href: iclrtaskmanager-setuilocale-method.md
+    - name: ICLRValidator Interface
+      href: iclrvalidator-interface.md
+      items:
+      - name: FormatEventInfo Method
+        href: iclrvalidator-formateventinfo-method.md
+      - name: Validate Method
+        href: iclrvalidator-validate-method.md
+    - name: ICorConfiguration Interface
+      href: icorconfiguration-interface.md
+      items:
+      - name: AddDebuggerSpecialThread Method
+        href: icorconfiguration-adddebuggerspecialthread-method.md
+      - name: SetDebuggerThreadControl Method
+        href: icorconfiguration-setdebuggerthreadcontrol-method.md
+      - name: SetGCHostControl Method
+        href: icorconfiguration-setgchostcontrol-method.md
+      - name: SetGCThreadControl Method
+        href: icorconfiguration-setgcthreadcontrol-method.md
+    - name: ICorThreadpool Interface
+      href: icorthreadpool-interface.md
+      items:
+      - name: CorBindIoCompletionCallback Method
+        href: icorthreadpool-corbindiocompletioncallback-method.md
+      - name: CorCallOrQueueUserWorkItem Method
+        href: icorthreadpool-corcallorqueueuserworkitem-method.md
+      - name: CorChangeTimer Method
+        href: icorthreadpool-corchangetimer-method.md
+      - name: CorCreateTimer Method
+        href: icorthreadpool-corcreatetimer-method.md
+      - name: CorDeleteTimer Method
+        href: icorthreadpool-cordeletetimer-method.md
+      - name: CorGetAvailableThreads Method
+        href: icorthreadpool-corgetavailablethreads-method.md
+      - name: CorGetMaxThreads Method
+        href: icorthreadpool-corgetmaxthreads-method.md
+      - name: CorQueueUserWorkItem Method
+        href: icorthreadpool-corqueueuserworkitem-method.md
+      - name: CorRegisterWaitForSingleObject Method
+        href: icorthreadpool-corregisterwaitforsingleobject-method.md
+      - name: CorSetMaxThreads Method
+        href: icorthreadpool-corsetmaxthreads-method.md
+      - name: CorUnregisterWait Method
+        href: icorthreadpool-corunregisterwait-method.md
+    - name: IDebuggerInfo Interface
+      href: idebuggerinfo-interface.md
+      items:
+      - name: IsDebuggerAttached Method
+        href: idebuggerinfo-isdebuggerattached-method.md
+    - name: IDebuggerThreadControl Interface
+      href: idebuggerthreadcontrol-interface.md
+      items:
+      - name: ReleaseAllRuntimeThreads Method
+        href: idebuggerthreadcontrol-releaseallruntimethreads-method.md
+      - name: StartBlockingForDebugger Method
+        href: idebuggerthreadcontrol-startblockingfordebugger-method.md
+      - name: ThreadIsBlockingForDebugger Method
+        href: idebuggerthreadcontrol-threadisblockingfordebugger-method.md
+    - name: IGCHost Interface
+      href: igchost-interface.md
+      items:
+      - name: Collect Method
+        href: igchost-collect-method.md
+      - name: GetStats Method
+        href: igchost-getstats-method.md
+      - name: GetThreadStats Method
+        href: igchost-getthreadstats-method.md
+      - name: SetGCStartupLimits Method
+        href: igchost-setgcstartuplimits-method.md
+      - name: SetVirtualMemLimit Method
+        href: igchost-setvirtualmemlimit-method.md
+    - name: IGCHost2 Interface
+      href: igchost2-interface.md
+      items:
+      - name: SetGCStartupLimitsEx Method
+        href: igchost2-setgcstartuplimitsex-method.md
+    - name: IGCHostControl Interface
+      href: igchostcontrol-interface.md
+      items:
+      - name: RequestVirtualMemLimit Method
+        href: igchostcontrol-requestvirtualmemlimit-method.md
+    - name: IGCThreadControl Interface
+      href: igcthreadcontrol-interface.md
+      items:
+      - name: SuspensionEnding Method
+        href: igcthreadcontrol-suspensionending-method.md
+      - name: SuspensionStarting Method
+        href: igcthreadcontrol-suspensionstarting-method.md
+      - name: ThreadIsBlockingForSuspension Method
+        href: igcthreadcontrol-threadisblockingforsuspension-method.md
+    - name: IHostAssemblyManager Interface
+      href: ihostassemblymanager-interface.md
+      items:
+      - name: GetAssemblyStore Method
+        href: ihostassemblymanager-getassemblystore-method.md
+      - name: GetNonHostStoreAssemblies Method
+        href: ihostassemblymanager-getnonhoststoreassemblies-method.md
+    - name: IHostAssemblyStore Interface
+      href: ihostassemblystore-interface.md
+      items:
+      - name: ProvideAssembly Method
+        href: ihostassemblystore-provideassembly-method.md
+      - name: ProvideModule Method
+        href: ihostassemblystore-providemodule-method.md
+    - name: IHostAutoEvent Interface
+      href: ihostautoevent-interface.md
+      items:
+      - name: Set Method
+        href: ihostautoevent-set-method.md
+      - name: Wait Method
+        href: ihostautoevent-wait-method.md
+    - name: IHostControl Interface
+      href: ihostcontrol-interface.md
+      items:
+      - name: GetHostManager Method
+        href: ihostcontrol-gethostmanager-method.md
+      - name: SetAppDomainManager Method
+        href: ihostcontrol-setappdomainmanager-method.md
+    - name: IHostCrst Interface
+      href: ihostcrst-interface.md
+      items:
+      - name: Enter Method
+        href: ihostcrst-enter-method.md
+      - name: Leave Method
+        href: ihostcrst-leave-method.md
+      - name: SetSpinCount Method
+        href: ihostcrst-setspincount-method.md
+      - name: TryEnter Method
+        href: ihostcrst-tryenter-method.md
+    - name: IHostGCManager Interface
+      href: ihostgcmanager-interface.md
+      items:
+      - name: SuspensionEnding Method
+        href: ihostgcmanager-suspensionending-method.md
+      - name: SuspensionStarting Method
+        href: ihostgcmanager-suspensionstarting-method.md
+      - name: ThreadIsBlockingForSuspension Method
+        href: ihostgcmanager-threadisblockingforsuspension-method.md
+    - name: IHostIoCompletionManager Interface
+      href: ihostiocompletionmanager-interface.md
+      items:
+      - name: Bind Method
+        href: ihostiocompletionmanager-bind-method.md
+      - name: CloseIoCompletionPort Method
+        href: ihostiocompletionmanager-closeiocompletionport-method.md
+      - name: CreateIoCompletionPort Method
+        href: ihostiocompletionmanager-createiocompletionport-method.md
+      - name: GetAvailableThreads Method
+        href: ihostiocompletionmanager-getavailablethreads-method.md
+      - name: GetHostOverlappedSize Method
+        href: ihostiocompletionmanager-gethostoverlappedsize-method.md
+      - name: GetMaxThreads Method
+        href: ihostiocompletionmanager-getmaxthreads-method.md
+      - name: GetMinThreads Method
+        href: ihostiocompletionmanager-getminthreads-method.md
+      - name: InitializeHostOverlapped Method
+        href: ihostiocompletionmanager-initializehostoverlapped-method.md
+      - name: SetCLRIoCompletionManager Method
+        href: ihostiocompletionmanager-setclriocompletionmanager-method.md
+      - name: SetMaxThreads Method
+        href: ihostiocompletionmanager-setmaxthreads-method.md
+      - name: SetMinThreads Method
+        href: ihostiocompletionmanager-setminthreads-method.md
+    - name: IHostMalloc Interface
+      href: ihostmalloc-interface.md
+      items:
+      - name: Alloc Method
+        href: ihostmalloc-alloc-method.md
+      - name: DebugAlloc Method
+        href: ihostmalloc-debugalloc-method.md
+      - name: Free Method
+        href: ihostmalloc-free-method.md
+    - name: IHostManualEvent Interface
+      href: ihostmanualevent-interface.md
+      items:
+      - name: Reset Method
+        href: ihostmanualevent-reset-method.md
+      - name: Set Method
+        href: ihostmanualevent-set-method.md
+      - name: Wait Method
+        href: ihostmanualevent-wait-method.md
+    - name: IHostMemoryManager Interface
+      href: ihostmemorymanager-interface.md
+      items:
+      - name: AcquiredVirtualAddressSpace Method
+        href: ihostmemorymanager-acquiredvirtualaddressspace-method.md
+      - name: CreateMAlloc Method
+        href: ihostmemorymanager-createmalloc-method.md
+      - name: GetMemoryLoad Method
+        href: ihostmemorymanager-getmemoryload-method.md
+      - name: NeedsVirtualAddressSpace Method
+        href: ihostmemorymanager-needsvirtualaddressspace-method.md
+      - name: RegisterMemoryNotificationCallback Method
+        href: ihostmemorymanager-registermemorynotificationcallback-method.md
+      - name: ReleasedVirtualAddressSpace Method
+        href: ihostmemorymanager-releasedvirtualaddressspace-method.md
+      - name: VirtualAlloc Method
+        href: ihostmemorymanager-virtualalloc-method.md
+      - name: VirtualFree Method
+        href: ihostmemorymanager-virtualfree-method.md
+      - name: VirtualProtect Method
+        href: ihostmemorymanager-virtualprotect-method.md
+      - name: VirtualQuery Method
+        href: ihostmemorymanager-virtualquery-method.md
+    - name: IHostPolicyManager Interface
+      href: ihostpolicymanager-interface.md
+      items:
+      - name: OnDefaultAction Method
+        href: ihostpolicymanager-ondefaultaction-method.md
+      - name: OnFailure Method
+        href: ihostpolicymanager-onfailure-method.md
+      - name: OnTimeout Method
+        href: ihostpolicymanager-ontimeout-method.md
+    - name: IHostSecurityContext Interface
+      href: ihostsecuritycontext-interface.md
+      items:
+      - name: Capture Method
+        href: ihostsecuritycontext-capture-method.md
+    - name: IHostSecurityManager Interface
+      href: ihostsecuritymanager-interface.md
+      items:
+      - name: GetSecurityContext Method
+        href: ihostsecuritymanager-getsecuritycontext-method.md
+      - name: ImpersonateLoggedOnUser Method
+        href: ihostsecuritymanager-impersonateloggedonuser-method.md
+      - name: OpenThreadToken Method
+        href: ihostsecuritymanager-openthreadtoken-method.md
+      - name: RevertToSelf Method
+        href: ihostsecuritymanager-reverttoself-method.md
+      - name: SetSecurityContext Method
+        href: ihostsecuritymanager-setsecuritycontext-method.md
+      - name: SetThreadToken Method
+        href: ihostsecuritymanager-setthreadtoken-method.md
+    - name: IHostSemaphore Interface
+      href: ihostsemaphore-interface.md
+      items:
+      - name: ReleaseSemaphore Method
+        href: ihostsemaphore-releasesemaphore-method.md
+      - name: Wait Method
+        href: ihostsemaphore-wait-method.md
+    - name: IHostSyncManager Interface
+      href: ihostsyncmanager-interface.md
+      items:
+      - name: CreateAutoEvent Method
+        href: ihostsyncmanager-createautoevent-method.md
+      - name: CreateCrst Method
+        href: ihostsyncmanager-createcrst-method.md
+      - name: CreateCrstWithSpinCount Method
+        href: ihostsyncmanager-createcrstwithspincount-method.md
+      - name: CreateManualEvent Method
+        href: ihostsyncmanager-createmanualevent-method.md
+      - name: CreateMonitorEvent Method
+        href: ihostsyncmanager-createmonitorevent-method.md
+      - name: CreateRWLockReaderEvent Method
+        href: ihostsyncmanager-createrwlockreaderevent-method.md
+      - name: CreateRWLockWriterEvent Method
+        href: ihostsyncmanager-createrwlockwriterevent-method.md
+      - name: CreateSemaphore Method
+        href: ihostsyncmanager-createsemaphore-method.md
+      - name: SetCLRSyncManager Method
+        href: ihostsyncmanager-setclrsyncmanager-method.md
+    - name: IHostTask Interface
+      href: ihosttask-interface.md
+      items:
+      - name: Alert Method
+        href: ihosttask-alert-method.md
+      - name: GetPriority Method
+        href: ihosttask-getpriority-method.md
+      - name: Join Method
+        href: ihosttask-join-method.md
+      - name: SetCLRTask Method
+        href: ihosttask-setclrtask-method.md
+      - name: SetPriority Method
+        href: ihosttask-setpriority-method.md
+      - name: Start Method
+        href: ihosttask-start-method.md
+    - name: IHostTaskManager Interface
+      href: ihosttaskmanager-interface.md
+      items:
+      - name: BeginDelayAbort Method
+        href: ihosttaskmanager-begindelayabort-method.md
+      - name: BeginThreadAffinity Method
+        href: ihosttaskmanager-beginthreadaffinity-method.md
+      - name: CallNeedsHostHook Method
+        href: ihosttaskmanager-callneedshosthook-method.md
+      - name: CreateTask Method
+        href: ihosttaskmanager-createtask-method.md
+      - name: EndDelayAbort Method
+        href: ihosttaskmanager-enddelayabort-method.md
+      - name: EndThreadAffinity Method
+        href: ihosttaskmanager-endthreadaffinity-method.md
+      - name: EnterRuntime Method
+        href: ihosttaskmanager-enterruntime-method.md
+      - name: GetCurrentTask Method
+        href: ihosttaskmanager-getcurrenttask-method.md
+      - name: GetStackGuarantee Method
+        href: ihosttaskmanager-getstackguarantee-method.md
+      - name: LeaveRuntime Method
+        href: ihosttaskmanager-leaveruntime-method.md
+      - name: ReverseEnterRuntime Method
+        href: ihosttaskmanager-reverseenterruntime-method.md
+      - name: ReverseLeaveRuntime Method
+        href: ihosttaskmanager-reverseleaveruntime-method.md
+      - name: SetCLRTaskManager Method
+        href: ihosttaskmanager-setclrtaskmanager-method.md
+      - name: SetLocale Method
+        href: ihosttaskmanager-setlocale-method.md
+      - name: SetStackGuarantee Method
+        href: ihosttaskmanager-setstackguarantee-method.md
+      - name: SetUILocale Method
+        href: ihosttaskmanager-setuilocale-method.md
+      - name: Sleep Method
+        href: ihosttaskmanager-sleep-method.md
+      - name: SwitchToTask Method
+        href: ihosttaskmanager-switchtotask-method.md
+    - name: IHostThreadPoolManager Interface
+      href: ihostthreadpoolmanager-interface.md
+      items:
+      - name: GetAvailableThreads Method
+        href: ihostthreadpoolmanager-getavailablethreads-method.md
+      - name: GetMaxThreads Method
+        href: ihostthreadpoolmanager-getmaxthreads-method.md
+      - name: GetMinThreads Method
+        href: ihostthreadpoolmanager-getminthreads-method.md
+      - name: QueueUserWorkItem Method
+        href: ihostthreadpoolmanager-queueuserworkitem-method.md
+      - name: SetMaxThreads Method
+        href: ihostthreadpoolmanager-setmaxthreads-method.md
+      - name: SetMinThreads Method
+        href: ihostthreadpoolmanager-setminthreads-method.md
+    - name: IManagedObject Interface
+      href: imanagedobject-interface.md
+      items:
+      - name: GetObjectIdentity Method
+        href: imanagedobject-getobjectidentity-method.md
+      - name: GetSerializedBuffer Method
+        href: imanagedobject-getserializedbuffer-method.md
+    - name: IObjectHandle Interface
+      href: iobjecthandle-interface.md
+      items:
+      - name: Unwrap Method
+        href: iobjecthandle-unwrap-method.md
+    - name: ITypeName Interface
+      href: itypename-interface.md
+      items:
+      - name: GetAssemblyName Method
+        href: itypename-getassemblyname-method.md
+      - name: GetModifierLength Method
+        href: itypename-getmodifierlength-method.md
+      - name: GetModifiers Method
+        href: itypename-getmodifiers-method.md
+      - name: GetNameCount Method
+        href: itypename-getnamecount-method.md
+      - name: GetNames Method
+        href: itypename-getnames-method.md
+      - name: GetTypeArgumentCount Method
+        href: itypename-gettypeargumentcount-method.md
+      - name: GetTypeArguments Method
+        href: itypename-gettypearguments-method.md
+    - name: ITypeNameBuilder Interface
+      href: itypenamebuilder-interface.md
+      items:
+      - name: AddArray Method
+        href: itypenamebuilder-addarray-method.md
+      - name: AddAssemblySpec Method
+        href: itypenamebuilder-addassemblyspec-method.md
+      - name: AddByRef Method
+        href: itypenamebuilder-addbyref-method.md
+      - name: AddName Method
+        href: itypenamebuilder-addname-method.md
+      - name: AddPointer Method
+        href: itypenamebuilder-addpointer-method.md
+      - name: AddSzArray Method
+        href: itypenamebuilder-addszarray-method.md
+      - name: Clear Method
+        href: itypenamebuilder-clear-method.md
+      - name: CloseGenericArgument Method
+        href: itypenamebuilder-closegenericargument-method.md
+      - name: CloseGenericArguments Method
+        href: itypenamebuilder-closegenericarguments-method.md
+      - name: OpenGenericArgument Method
+        href: itypenamebuilder-opengenericargument-method.md
+      - name: OpenGenericArguments Method
+        href: itypenamebuilder-opengenericarguments-method.md
+      - name: ToString Method
+        href: itypenamebuilder-tostring-method.md
+    - name: ITypeNameFactory Interface
+      href: itypenamefactory-interface.md
+      items:
+      - name: GetTypeNameBuilder Method
+        href: itypenamefactory-gettypenamebuilder-method.md
+      - name: ParseTypeName Method
+        href: itypenamefactory-parsetypename-method.md
+    - name: IValidator Interface
+      href: ivalidator-interface.md
+      items:
+      - name: FormatEventInfo Method
+        href: ivalidator-formateventinfo-method.md
+      - name: Validate Method
+        href: ivalidator-validate-method.md
+  - name: CLR Hosting Interfaces Added in the .NET Framework 4 and 4.5
+    href: clr-hosting-interfaces-added-in-the-net-framework-4-and-4-5.md
     items:
-    - name: AssemblyBindInfo Structure
-      href: assemblybindinfo-structure.md
-    - name: BucketParameters Structure
-      href: bucketparameters-structure.md
-    - name: COR_GC_STATS Structure
-      href: cor-gc-stats-structure.md
-    - name: COR_GC_THREAD_STATS Structure
-      href: cor-gc-thread-stats-structure.md
-    - name: CustomDumpItem Structure
-      href: customdumpitem-structure.md
-    - name: MDAInfo Structure
-      href: mdainfo-structure.md
-    - name: ModuleBindInfo Structure
-      href: modulebindinfo-structure.md
-    - name: StackOverflowInfo Structure
-      href: stackoverflowinfo-structure.md
+    - name: ICLRAppDomainResourceMonitor Interface
+      href: iclrappdomainresourcemonitor-interface.md
+      items:
+      - name: GetCurrentAllocated Method
+        href: iclrappdomainresourcemonitor-getcurrentallocated-method.md
+      - name: GetCurrentSurvived Method
+        href: iclrappdomainresourcemonitor-getcurrentsurvived-method.md
+      - name: GetCurrentCpuTime Method
+        href: iclrappdomainresourcemonitor-getcurrentcputime-method.md
+    - name: ICLRDomainManager Interface
+      href: iclrdomainmanager-interface.md
+      items:
+      - name: SetAppDomainManagerType Method
+        href: iclrdomainmanager-setappdomainmanagertype-method.md
+      - name: SetPropertiesForDefaultAppDomain Method
+        href: iclrdomainmanager-setpropertiesfordefaultappdomain-method.md
+    - name: ICLRGCManager2 Interface
+      href: iclrgcmanager2-interface.md
+      items:
+      - name: SetGCStartupLimitsEx Method
+        href: iclrgcmanager2-setgcstartuplimitsex-method.md
+    - name: ICLRMetaHost Interface
+      href: iclrmetahost-interface.md
+      items:
+      - name: EnumerateInstalledRuntimes Method
+        href: iclrmetahost-enumerateinstalledruntimes-method.md
+      - name: EnumerateLoadedRuntimes Method
+        href: iclrmetahost-enumerateloadedruntimes-method.md
+      - name: ExitProcess Method
+        href: iclrmetahost-exitprocess-method.md
+      - name: GetRuntime Method
+        href: iclrmetahost-getruntime-method.md
+      - name: GetVersionFromFile Method
+        href: iclrmetahost-getversionfromfile-method.md
+      - name: QueryLegacyV2RuntimeBinding Method
+        href: iclrmetahost-querylegacyv2runtimebinding-method.md
+      - name: RequestRuntimeLoadedNotification Method
+        href: iclrmetahost-requestruntimeloadednotification-method.md
+    - name: ICLRMetaHostPolicy Interface
+      href: iclrmetahostpolicy-interface.md
+      items:
+      - name: GetRequestedRuntime Method
+        href: iclrmetahostpolicy-getrequestedruntime-method.md
+    - name: ICLRRuntimeInfo Interface
+      href: iclrruntimeinfo-interface.md
+      items:
+      - name: BindAsLegacyV2Runtime Method
+        href: iclrruntimeinfo-bindaslegacyv2runtime-method.md
+      - name: GetDefaultStartupFlags Method
+        href: iclrruntimeinfo-getdefaultstartupflags-method.md
+      - name: GetInterface Method
+        href: iclrruntimeinfo-getinterface-method.md
+      - name: GetProcAddress Method
+        href: iclrruntimeinfo-getprocaddress-method.md
+      - name: GetRuntimeDirectory Method
+        href: iclrruntimeinfo-getruntimedirectory-method.md
+      - name: GetVersionString Method
+        href: iclrruntimeinfo-getversionstring-method.md
+      - name: IsLoadable Method
+        href: iclrruntimeinfo-isloadable-method.md
+      - name: IsLoaded Method
+        href: iclrruntimeinfo-isloaded-method.md
+      - name: IsStarted Method
+        href: iclrruntimeinfo-isstarted-method.md
+      - name: LoadErrorString Method
+        href: iclrruntimeinfo-loaderrorstring-method.md
+      - name: LoadLibrary Method
+        href: iclrruntimeinfo-loadlibrary-method.md
+      - name: SetDefaultStartupFlags Method
+        href: iclrruntimeinfo-setdefaultstartupflags-method.md
+    - name: ICLRStrongName Interface
+      href: iclrstrongname-interface.md
+      items:
+      - name: GetHashFromAssemblyFile Method
+        href: iclrstrongname-gethashfromassemblyfile-method.md
+      - name: GetHashFromAssemblyFileW Method
+        href: iclrstrongname-gethashfromassemblyfilew-method.md
+      - name: GetHashFromBlob Method
+        href: iclrstrongname-gethashfromblob-method.md
+      - name: GetHashFromFile Method
+        href: iclrstrongname-gethashfromfile-method.md
+      - name: GetHashFromFileW Method
+        href: iclrstrongname-gethashfromfilew-method.md
+      - name: GetHashFromHandle Method
+        href: iclrstrongname-gethashfromhandle-method.md
+      - name: StrongNameCompareAssemblies Method
+        href: iclrstrongname-strongnamecompareassemblies-method.md
+      - name: StrongNameFreeBuffer Method
+        href: iclrstrongname-strongnamefreebuffer-method.md
+      - name: StrongNameGetBlob Method
+        href: iclrstrongname-strongnamegetblob-method.md
+      - name: StrongNameGetBlobFromImage Method
+        href: iclrstrongname-strongnamegetblobfromimage-method.md
+      - name: StrongNameGetPublicKey Method
+        href: iclrstrongname-strongnamegetpublickey-method.md
+      - name: StrongNameHashSize Method
+        href: iclrstrongname-strongnamehashsize-method.md
+      - name: StrongNameKeyDelete Method
+        href: iclrstrongname-strongnamekeydelete-method.md
+      - name: StrongNameKeyGen Method
+        href: iclrstrongname-strongnamekeygen-method.md
+      - name: StrongNameKeyGenEx Method
+        href: iclrstrongname-strongnamekeygenex-method.md
+      - name: StrongNameKeyInstall Method
+        href: iclrstrongname-strongnamekeyinstall-method.md
+      - name: StrongNameSignatureGeneration Method
+        href: iclrstrongname-strongnamesignaturegeneration-method.md
+      - name: StrongNameSignatureGenerationEx Method
+        href: iclrstrongname-strongnamesignaturegenerationex-method.md
+      - name: StrongNameSignatureSize Method
+        href: iclrstrongname-strongnamesignaturesize-method.md
+      - name: StrongNameSignatureVerification Method
+        href: iclrstrongname-strongnamesignatureverification-method.md
+      - name: StrongNameSignatureVerificationEx Method
+        href: iclrstrongname-strongnamesignatureverificationex-method.md
+      - name: StrongNameSignatureVerificationFromImage Method
+        href: iclrstrongname-strongnamesignatureverificationfromimage-method.md
+      - name: StrongNameTokenFromAssembly Method
+        href: iclrstrongname-strongnametokenfromassembly-method.md
+      - name: StrongNameTokenFromAssemblyEx Method
+        href: iclrstrongname-strongnametokenfromassemblyex-method.md
+      - name: StrongNameTokenFromPublicKey Method
+        href: iclrstrongname-strongnametokenfrompublickey-method.md
+    - name: ICLRStrongName2 Interface
+      href: iclrstrongname2-interface.md
+      items:
+      - name: StrongNameGetPublicKeyEx Method
+        href: strongnamegetpublickeyex-method.md
+      - name: StrongNameSignatureVerificationEx2 Method
+        href: strongnamesignatureverificationex2-method.md
+    - name: ICLRTask2 Interface
+      href: iclrtask2-interface.md
+      items:
+      - name: BeginPreventAsyncAbort Method
+        href: iclrtask2-beginpreventasyncabort-method.md
+      - name: EndPreventAsyncAbort Method
+        href: iclrtask2-endpreventasyncabort-method.md
+- name: Hosting Structures
+  href: hosting-structures.md
+  items:
+  - name: AssemblyBindInfo Structure
+    href: assemblybindinfo-structure.md
+  - name: BucketParameters Structure
+    href: bucketparameters-structure.md
+  - name: COR_GC_STATS Structure
+    href: cor-gc-stats-structure.md
+  - name: COR_GC_THREAD_STATS Structure
+    href: cor-gc-thread-stats-structure.md
+  - name: CustomDumpItem Structure
+    href: customdumpitem-structure.md
+  - name: MDAInfo Structure
+    href: mdainfo-structure.md
+  - name: ModuleBindInfo Structure
+    href: modulebindinfo-structure.md
+  - name: StackOverflowInfo Structure
+    href: stackoverflowinfo-structure.md

--- a/docs/framework/unmanaged-api/metadata/toc.yml
+++ b/docs/framework/unmanaged-api/metadata/toc.yml
@@ -1,591 +1,591 @@
+items:
 - name: Metadata
   href: index.md
+- name: Metadata Interfaces
+  href: metadata-interfaces.md
   items:
-  - name: Metadata Interfaces
-    href: metadata-interfaces.md
+  - name: ICeeGen Interface
+    href: iceegen-interface.md
     items:
-    - name: ICeeGen Interface
-      href: iceegen-interface.md
-      items:
-      - name: AddSectionReloc Method
-        href: iceegen-addsectionreloc-method.md
-      - name: AllocateMethodBuffer Method
-        href: iceegen-allocatemethodbuffer-method.md
-      - name: ComputePointer Method
-        href: iceegen-computepointer-method.md
-      - name: EmitString Method
-        href: iceegen-emitstring-method.md
-      - name: GenerateCeeFile Method
-        href: iceegen-generateceefile-method.md
-      - name: GenerateCeeMemoryImage Method
-        href: iceegen-generateceememoryimage-method.md
-      - name: GetIlSection Method
-        href: iceegen-getilsection-method.md
-      - name: GetIMapTokenIface Method
-        href: iceegen-getimaptokeniface-method.md
-      - name: GetMethodBuffer Method
-        href: iceegen-getmethodbuffer-method.md
-      - name: GetSectionBlock Method
-        href: iceegen-getsectionblock-method.md
-      - name: GetSectionCreate Method
-        href: iceegen-getsectioncreate-method.md
-      - name: GetSectionDataLen Method
-        href: iceegen-getsectiondatalen-method.md
-      - name: GetString Method
-        href: iceegen-getstring-method.md
-      - name: GetStringSection Method
-        href: iceegen-getstringsection-method.md
-      - name: TruncateSection Method
-        href: iceegen-truncatesection-method.md
-    - name: IHostFilter Interface
-      href: ihostfilter-interface.md
-      items:
-      - name: MarkToken Method
-        href: ihostfilter-marktoken-method.md
-    - name: IMapToken Interface
-      href: imaptoken-interface.md
-      items:
-      - name: Map Method
-        href: imaptoken-map-method.md
-    - name: IMetaDataAssemblyEmit Interface
-      href: imetadataassemblyemit-interface.md
-      items:
-      - name: DefineAssembly Method
-        href: imetadataassemblyemit-defineassembly-method.md
-      - name: DefineAssemblyRef Method
-        href: imetadataassemblyemit-defineassemblyref-method.md
-      - name: DefineExportedType Method
-        href: imetadataassemblyemit-defineexportedtype-method.md
-      - name: DefineFile Method
-        href: imetadataassemblyemit-definefile-method.md
-      - name: DefineManifestResource Method
-        href: imetadataassemblyemit-definemanifestresource-method.md
-      - name: SetAssemblyProps Method
-        href: imetadataassemblyemit-setassemblyprops-method.md
-      - name: SetAssemblyRefProps Method
-        href: imetadataassemblyemit-setassemblyrefprops-method.md
-      - name: SetExportedTypeProps Method
-        href: imetadataassemblyemit-setexportedtypeprops-method.md
-      - name: SetFileProps Method
-        href: imetadataassemblyemit-setfileprops-method.md
-      - name: SetManifestResourceProps Method
-        href: imetadataassemblyemit-setmanifestresourceprops-method.md
-    - name: IMetaDataAssemblyImport Interface
-      href: imetadataassemblyimport-interface.md
-      items:
-      - name: CloseEnum Method
-        href: imetadataassemblyimport-closeenum-method.md
-      - name: EnumAssemblyRefs Method
-        href: imetadataassemblyimport-enumassemblyrefs-method.md
-      - name: EnumExportedTypes Method
-        href: imetadataassemblyimport-enumexportedtypes-method.md
-      - name: EnumFiles Method
-        href: imetadataassemblyimport-enumfiles-method.md
-      - name: EnumManifestResources Method
-        href: imetadataassemblyimport-enummanifestresources-method.md
-      - name: FindAssembliesByName Method
-        href: imetadataassemblyimport-findassembliesbyname-method.md
-      - name: FindExportedTypeByName Method
-        href: imetadataassemblyimport-findexportedtypebyname-method.md
-      - name: FindManifestResourceByName Method
-        href: imetadataassemblyimport-findmanifestresourcebyname-method.md
-      - name: GetAssemblyFromScope Method
-        href: imetadataassemblyimport-getassemblyfromscope-method.md
-      - name: GetAssemblyProps Method
-        href: imetadataassemblyimport-getassemblyprops-method.md
-      - name: GetAssemblyRefProps Method
-        href: imetadataassemblyimport-getassemblyrefprops-method.md
-      - name: GetExportedTypeProps Method
-        href: imetadataassemblyimport-getexportedtypeprops-method.md
-      - name: GetFileProps Method
-        href: imetadataassemblyimport-getfileprops-method.md
-      - name: GetManifestResourceProps Method
-        href: imetadataassemblyimport-getmanifestresourceprops-method.md
-    - name: IMetaDataConverter Interface
-      href: imetadataconverter-interface.md
-      items:
-      - name: GetMetaDataFromTypeInfo Method
-        href: imetadataconverter-getmetadatafromtypeinfo-method.md
-      - name: GetMetaDataFromTypeLib Method
-        href: imetadataconverter-getmetadatafromtypelib-method.md
-      - name: GetTypeLibFromMetaData Method
-        href: imetadataconverter-gettypelibfrommetadata-method.md
-    - name: IMetaDataDispenser Interface
-      href: imetadatadispenser-interface.md
-      items:
-      - name: DefineScope Method
-        href: imetadatadispenser-definescope-method.md
-      - name: OpenScope Method
-        href: imetadatadispenser-openscope-method.md
-      - name: OpenScopeOnMemory Method
-        href: imetadatadispenser-openscopeonmemory-method.md
-    - name: IMetaDataDispenserEx Interface
-      href: imetadatadispenserex-interface.md
-      items:
-      - name: FindAssembly Method
-        href: imetadatadispenserex-findassembly-method.md
-      - name: FindAssemblyModule Method
-        href: imetadatadispenserex-findassemblymodule-method.md
-      - name: GetCORSystemDirectory Method
-        href: imetadatadispenserex-getcorsystemdirectory-method.md
-      - name: GetOption Method
-        href: imetadatadispenserex-getoption-method.md
-      - name: OpenScopeOnITypeInfo Method
-        href: imetadatadispenserex-openscopeonitypeinfo-method.md
-      - name: SetOption Method
-        href: imetadatadispenserex-setoption-method.md
-    - name: IMetaDataEmit Interface
-      href: imetadataemit-interface.md
-      items:
-      - name: ApplyEditAndContinue Method
-        href: imetadataemit-applyeditandcontinue-method.md
-      - name: DefineCustomAttribute Method
-        href: imetadataemit-definecustomattribute-method.md
-      - name: DefineEvent Method
-        href: imetadataemit-defineevent-method.md
-      - name: DefineField Method
-        href: imetadataemit-definefield-method.md
-      - name: DefineImportMember Method
-        href: imetadataemit-defineimportmember-method.md
-      - name: DefineImportType Method
-        href: imetadataemit-defineimporttype-method.md
-      - name: DefineMemberRef Method
-        href: imetadataemit-definememberref-method.md
-      - name: DefineMethod Method
-        href: imetadataemit-definemethod-method.md
-      - name: DefineMethodImpl Method
-        href: imetadataemit-definemethodimpl-method.md
-      - name: DefineModuleRef Method
-        href: imetadataemit-definemoduleref-method.md
-      - name: DefineNestedType Method
-        href: imetadataemit-definenestedtype-method.md
-      - name: DefineParam Method
-        href: imetadataemit-defineparam-method.md
-      - name: DefinePermissionSet Method
-        href: imetadataemit-definepermissionset-method.md
-      - name: DefinePinvokeMap Method
-        href: imetadataemit-definepinvokemap-method.md
-      - name: DefineProperty Method
-        href: imetadataemit-defineproperty-method.md
-      - name: DefineSecurityAttributeSet Method
-        href: imetadataemit-definesecurityattributeset-method.md
-      - name: DefineTypeDef Method
-        href: imetadataemit-definetypedef-method.md
-      - name: DefineTypeRefByName Method
-        href: imetadataemit-definetyperefbyname-method.md
-      - name: DefineUserString Method
-        href: imetadataemit-defineuserstring-method.md
-      - name: DeleteClassLayout Method
-        href: imetadataemit-deleteclasslayout-method.md
-      - name: DeleteFieldMarshal Method
-        href: imetadataemit-deletefieldmarshal-method.md
-      - name: DeletePinvokeMap Method
-        href: imetadataemit-deletepinvokemap-method.md
-      - name: DeleteToken Method
-        href: imetadataemit-deletetoken-method.md
-      - name: GetSaveSize Method
-        href: imetadataemit-getsavesize-method.md
-      - name: GetTokenFromSig Method
-        href: imetadataemit-gettokenfromsig-method.md
-      - name: GetTokenFromTypeSpec Method
-        href: imetadataemit-gettokenfromtypespec-method.md
-      - name: Merge Method
-        href: imetadataemit-merge-method.md
-      - name: MergeEnd Method
-        href: imetadataemit-mergeend-method.md
-      - name: Save Method
-        href: imetadataemit-save-method.md
-      - name: SaveToMemory Method
-        href: imetadataemit-savetomemory-method.md
-      - name: SaveToStream Method
-        href: imetadataemit-savetostream-method.md
-      - name: SetClassLayout Method
-        href: imetadataemit-setclasslayout-method.md
-      - name: SetCustomAttributeValue Method
-        href: imetadataemit-setcustomattributevalue-method.md
-      - name: SetEventProps Method
-        href: imetadataemit-seteventprops-method.md
-      - name: SetFieldMarshal Method
-        href: imetadataemit-setfieldmarshal-method.md
-      - name: SetFieldProps Method
-        href: imetadataemit-setfieldprops-method.md
-      - name: SetFieldRVA Method
-        href: imetadataemit-setfieldrva-method.md
-      - name: SetHandler Method
-        href: imetadataemit-sethandler-method.md
-      - name: SetMethodImplFlags Method
-        href: imetadataemit-setmethodimplflags-method.md
-      - name: SetMethodProps Method
-        href: imetadataemit-setmethodprops-method.md
-      - name: SetModuleProps Method
-        href: imetadataemit-setmoduleprops-method.md
-      - name: SetParamProps Method
-        href: imetadataemit-setparamprops-method.md
-      - name: SetParent Method
-        href: imetadataemit-setparent-method.md
-      - name: SetPermissionSetProps Method
-        href: imetadataemit-setpermissionsetprops-method.md
-      - name: SetPinvokeMap Method
-        href: imetadataemit-setpinvokemap-method.md
-      - name: SetPropertyProps Method
-        href: imetadataemit-setpropertyprops-method.md
-      - name: SetRVA Method
-        href: imetadataemit-setrva-method.md
-      - name: SetTypeDefProps Method
-        href: imetadataemit-settypedefprops-method.md
-      - name: TranslateSigWithScope Method
-        href: imetadataemit-translatesigwithscope-method.md
-    - name: IMetaDataEmit2 Interface
-      href: imetadataemit2-interface.md
-      items:
-      - name: DefineGenericParam Method
-        href: imetadataemit2-definegenericparam-method.md
-      - name: DefineMethodSpec Method
-        href: imetadataemit2-definemethodspec-method.md
-      - name: GetDeltaSaveSize Method
-        href: imetadataemit2-getdeltasavesize-method.md
-      - name: ResetENCLog Method
-        href: imetadataemit2-resetenclog-method.md
-      - name: SaveDelta Method
-        href: imetadataemit2-savedelta-method.md
-      - name: SaveDeltaToMemory Method
-        href: imetadataemit2-savedeltatomemory-method.md
-      - name: SaveDeltaToStream Method
-        href: imetadataemit2-savedeltatostream-method.md
-      - name: SetGenericParamProps Method
-        href: imetadataemit2-setgenericparamprops-method.md
-    - name: IMetaDataError Interface
-      href: imetadataerror-interface.md
-      items:
-      - name: OnError Method
-        href: imetadataerror-onerror-method.md
-    - name: IMetaDataFilter Interface
-      href: imetadatafilter-interface.md
-      items:
-      - name: IsTokenMarked Method
-        href: imetadatafilter-istokenmarked-method.md
-      - name: MarkToken Method
-        href: imetadatafilter-marktoken-method.md
-      - name: UnmarkAll Method
-        href: imetadatafilter-unmarkall-method.md
-    - name: IMetaDataImport Interface
-      href: imetadataimport-interface.md
-      items:
-      - name: CloseEnum Method
-        href: imetadataimport-closeenum-method.md
-      - name: CountEnum Method
-        href: imetadataimport-countenum-method.md
-      - name: EnumCustomAttributes Method
-        href: imetadataimport-enumcustomattributes-method.md
-      - name: EnumEvents Method
-        href: imetadataimport-enumevents-method.md
-      - name: EnumFields Method
-        href: imetadataimport-enumfields-method.md
-      - name: EnumFieldsWithName Method
-        href: imetadataimport-enumfieldswithname-method.md
-      - name: EnumInterfaceImpls Method
-        href: imetadataimport-enuminterfaceimpls-method.md
-      - name: EnumMemberRefs Method
-        href: imetadataimport-enummemberrefs-method.md
-      - name: EnumMembers Method
-        href: imetadataimport-enummembers-method.md
-      - name: EnumMembersWithName Method
-        href: imetadataimport-enummemberswithname-method.md
-      - name: EnumMethodImpls Method
-        href: imetadataimport-enummethodimpls-method.md
-      - name: EnumMethods Method
-        href: imetadataimport-enummethods-method.md
-      - name: EnumMethodSemantics Method
-        href: imetadataimport-enummethodsemantics-method.md
-      - name: EnumMethodsWithName Method
-        href: imetadataimport-enummethodswithname-method.md
-      - name: EnumModuleRefs Method
-        href: imetadataimport-enummodulerefs-method.md
-      - name: EnumParams Method
-        href: imetadataimport-enumparams-method.md
-      - name: EnumPermissionSets Method
-        href: imetadataimport-enumpermissionsets-method.md
-      - name: EnumProperties Method
-        href: imetadataimport-enumproperties-method.md
-      - name: EnumSignatures Method
-        href: imetadataimport-enumsignatures-method.md
-      - name: EnumTypeDefs Method
-        href: imetadataimport-enumtypedefs-method.md
-      - name: EnumTypeRefs Method
-        href: imetadataimport-enumtyperefs-method.md
-      - name: EnumTypeSpecs Method
-        href: imetadataimport-enumtypespecs-method.md
-      - name: EnumUnresolvedMethods Method
-        href: imetadataimport-enumunresolvedmethods-method.md
-      - name: EnumUserStrings Method
-        href: imetadataimport-enumuserstrings-method.md
-      - name: FindField Method
-        href: imetadataimport-findfield-method.md
-      - name: FindMember Method
-        href: imetadataimport-findmember-method.md
-      - name: FindMemberRef Method
-        href: imetadataimport-findmemberref-method.md
-      - name: FindMethod Method
-        href: imetadataimport-findmethod-method.md
-      - name: FindTypeDefByName Method
-        href: imetadataimport-findtypedefbyname-method.md
-      - name: FindTypeRef Method
-        href: imetadataimport-findtyperef-method.md
-      - name: GetClassLayout Method
-        href: imetadataimport-getclasslayout-method.md
-      - name: GetCustomAttributeByName Method
-        href: imetadataimport-getcustomattributebyname-method.md
-      - name: GetCustomAttributeProps Method
-        href: imetadataimport-getcustomattributeprops-method.md
-      - name: GetEventProps Method
-        href: imetadataimport-geteventprops-method.md
-      - name: GetFieldMarshal Method
-        href: imetadataimport-getfieldmarshal-method.md
-      - name: GetFieldProps Method
-        href: imetadataimport-getfieldprops-method.md
-      - name: GetInterfaceImplProps Method
-        href: imetadataimport-getinterfaceimplprops-method.md
-      - name: GetMemberProps Method
-        href: imetadataimport-getmemberprops-method.md
-      - name: GetMemberRefProps Method
-        href: imetadataimport-getmemberrefprops-method.md
-      - name: GetMethodProps Method
-        href: imetadataimport-getmethodprops-method.md
-      - name: GetMethodSemantics Method
-        href: imetadataimport-getmethodsemantics-method.md
-      - name: GetModuleFromScope Method
-        href: imetadataimport-getmodulefromscope-method.md
-      - name: GetModuleRefProps Method
-        href: imetadataimport-getmodulerefprops-method.md
-      - name: GetNameFromToken Method
-        href: imetadataimport-getnamefromtoken-method.md
-      - name: GetNativeCallConvFromSig Method
-        href: imetadataimport-getnativecallconvfromsig-method.md
-      - name: GetNestedClassProps Method
-        href: imetadataimport-getnestedclassprops-method.md
-      - name: GetParamForMethodIndex Method
-        href: imetadataimport-getparamformethodindex-method.md
-      - name: GetParamProps Method
-        href: imetadataimport-getparamprops-method.md
-      - name: GetPermissionSetProps Method
-        href: imetadataimport-getpermissionsetprops-method.md
-      - name: GetPinvokeMap
-        href: imetadataimport-getpinvokemap-method.md
-      - name: GetPropertyProps Method
-        href: imetadataimport-getpropertyprops-method.md
-      - name: GetRVA Method
-        href: imetadataimport-getrva-method.md
-      - name: GetScopeProps Method
-        href: imetadataimport-getscopeprops-method.md
-      - name: GetSigFromToken Method
-        href: imetadataimport-getsigfromtoken-method.md
-      - name: GetTypeDefProps Method
-        href: imetadataimport-gettypedefprops-method.md
-      - name: GetTypeRefProps Method
-        href: imetadataimport-gettyperefprops-method.md
-      - name: GetTypeSpecFromToken Method
-        href: imetadataimport-gettypespecfromtoken-method.md
-      - name: GetUserString Method
-        href: imetadataimport-getuserstring-method.md
-      - name: IsGlobal Method
-        href: imetadataimport-isglobal-method.md
-      - name: IsValidToken Method
-        href: imetadataimport-isvalidtoken-method.md
-      - name: ResetEnum Method
-        href: imetadataimport-resetenum-method.md
-      - name: ResolveTypeRef Method
-        href: imetadataimport-resolvetyperef-method.md
-    - name: IMetaDataImport2 Interface
-      href: imetadataimport2-interface.md
-      items:
-      - name: EnumGenericParamConstraints Method
-        href: imetadataimport2-enumgenericparamconstraints-method.md
-      - name: EnumGenericParams Method
-        href: imetadataimport2-enumgenericparams-method.md
-      - name: EnumMethodSpecs Method
-        href: imetadataimport2-enummethodspecs-method.md
-      - name: GetGenericParamConstraintProps Method
-        href: imetadataimport2-getgenericparamconstraintprops-method.md
-      - name: GetGenericParamProps Method
-        href: imetadataimport2-getgenericparamprops-method.md
-      - name: GetMethodSpecProps Method
-        href: imetadataimport2-getmethodspecprops-method.md
-      - name: GetPEKind Method
-        href: imetadataimport2-getpekind-method.md
-      - name: GetVersionString Method
-        href: imetadataimport2-getversionstring-method.md
-    - name: IMetaDataInfo Interface
-      href: imetadatainfo-interface.md
-      items:
-      - name: GetFileMapping Method
-        href: imetadatainfo-getfilemapping-method.md
-    - name: IMetaDataTables Interface
-      href: imetadatatables-interface.md
-      items:
-      - name: GetBlob Method
-        href: imetadatatables-getblob-method.md
-      - name: GetBlobHeapSize Method
-        href: imetadatatables-getblobheapsize-method.md
-      - name: GetCodedTokenInfo Method
-        href: imetadatatables-getcodedtokeninfo-method.md
-      - name: GetColumn Method
-        href: imetadatatables-getcolumn-method.md
-      - name: GetColumnInfo Method
-        href: imetadatatables-getcolumninfo-method.md
-      - name: GetGuid Method
-        href: imetadatatables-getguid-method.md
-      - name: GetGuidHeapSize Method
-        href: imetadatatables-getguidheapsize-method.md
-      - name: GetNextBlob Method
-        href: imetadatatables-getnextblob-method.md
-      - name: GetNextGuid Method
-        href: imetadatatables-getnextguid-method.md
-      - name: GetNextString Method
-        href: imetadatatables-getnextstring-method.md
-      - name: GetNextUserString Method
-        href: imetadatatables-getnextuserstring-method.md
-      - name: GetNumTables Method
-        href: imetadatatables-getnumtables-method.md
-      - name: GetRow Method
-        href: imetadatatables-getrow-method.md
-      - name: GetString Method
-        href: imetadatatables-getstring-method.md
-      - name: GetStringHeapSize Method
-        href: imetadatatables-getstringheapsize-method.md
-      - name: GetTableIndex Method
-        href: imetadatatables-gettableindex-method.md
-      - name: GetTableInfo Method
-        href: imetadatatables-gettableinfo-method.md
-      - name: GetUserString Method
-        href: imetadatatables-getuserstring-method.md
-      - name: GetUserStringHeapSize Method
-        href: imetadatatables-getuserstringheapsize-method.md
-    - name: IMetaDataTables2 Interface
-      href: imetadatatables2-interface.md
-      items:
-      - name: GetMetaDataStorage Method
-        href: imetadatatables2-getmetadatastorage-method.md
-      - name: GetMetaDataStreamInfo Method
-        href: imetadatatables2-getmetadatastreaminfo-method.md
-    - name: IMetaDataValidate Interface
-      href: imetadatavalidate-interface.md
-      items:
-      - name: ValidateMetaData Method
-        href: imetadatavalidate-validatemetadata-method.md
-      - name: ValidatorInit Method
-        href: imetadatavalidate-validatorinit-method.md
-  - name: Metadata Global Static Functions
-    href: metadata-global-static-functions.md
-  - name: Metadata Enumerations
-    href: metadata-enumerations.md
+    - name: AddSectionReloc Method
+      href: iceegen-addsectionreloc-method.md
+    - name: AllocateMethodBuffer Method
+      href: iceegen-allocatemethodbuffer-method.md
+    - name: ComputePointer Method
+      href: iceegen-computepointer-method.md
+    - name: EmitString Method
+      href: iceegen-emitstring-method.md
+    - name: GenerateCeeFile Method
+      href: iceegen-generateceefile-method.md
+    - name: GenerateCeeMemoryImage Method
+      href: iceegen-generateceememoryimage-method.md
+    - name: GetIlSection Method
+      href: iceegen-getilsection-method.md
+    - name: GetIMapTokenIface Method
+      href: iceegen-getimaptokeniface-method.md
+    - name: GetMethodBuffer Method
+      href: iceegen-getmethodbuffer-method.md
+    - name: GetSectionBlock Method
+      href: iceegen-getsectionblock-method.md
+    - name: GetSectionCreate Method
+      href: iceegen-getsectioncreate-method.md
+    - name: GetSectionDataLen Method
+      href: iceegen-getsectiondatalen-method.md
+    - name: GetString Method
+      href: iceegen-getstring-method.md
+    - name: GetStringSection Method
+      href: iceegen-getstringsection-method.md
+    - name: TruncateSection Method
+      href: iceegen-truncatesection-method.md
+  - name: IHostFilter Interface
+    href: ihostfilter-interface.md
     items:
-    - name: AssemblyFlags Enumeration
-      href: assemblyflags-enumeration.md
-    - name: AssemblyRefFlags Enumeration
-      href: assemblyrefflags-enumeration.md
-    - name: CeeSectionAttr Enumeration
-      href: ceesectionattr-enumeration.md
-    - name: CeeSectionRelocType Enumeration
-      href: ceesectionreloctype-enumeration.md
-    - name: COINITICOR Enumeration
-      href: coiniticor-enumeration.md
-    - name: COINITIEE Enumeration
-      href: coinitiee-enumeration.md
-    - name: CorArgType Enumeration
-      href: corargtype-enumeration.md
-    - name: CorAssemblyFlags Enumeration
-      href: corassemblyflags-enumeration.md
-    - name: CorAttributeTargets Enumeration
-      href: corattributetargets-enumeration.md
-    - name: CorCallingConvention Enumeration
-      href: corcallingconvention-enumeration.md
-    - name: CorCheckDuplicatesFor Enumeration
-      href: corcheckduplicatesfor-enumeration.md
-    - name: CorDeclSecurity Enumeration
-      href: cordeclsecurity-enumeration.md
-    - name: CorElementType Enumeration1
-      href: corelementtype-enumeration.md
-    - name: CorErrorIfEmitOutOfOrder Enumeration
-      href: corerrorifemitoutoforder-enumeration.md
-    - name: CorEventAttr Enumeration
-      href: coreventattr-enumeration.md
-    - name: CorFieldAttr Enumeration
-      href: corfieldattr-enumeration.md
-    - name: CorFileFlags Enumeration
-      href: corfileflags-enumeration.md
-    - name: CorFileMapping Enumeration
-      href: corfilemapping-enumeration.md
-    - name: CorGenericParamAttr Enumeration
-      href: corgenericparamattr-enumeration.md
-    - name: CorImportOptions Enumeration
-      href: corimportoptions-enumeration.md
-    - name: CorLinkerOptions Enumeration
-      href: corlinkeroptions-enumeration.md
-    - name: CorLocalRefPreservation Enumeration
-      href: corlocalrefpreservation-enumeration.md
-    - name: CorManifestResourceFlags Enumeration
-      href: cormanifestresourceflags-enumeration.md
-    - name: CorMethodAttr Enumeration
-      href: cormethodattr-enumeration.md
-    - name: CorMethodImpl Enumeration
-      href: cormethodimpl-enumeration.md
-    - name: CorMethodSemanticsAttr Enumeration
-      href: cormethodsemanticsattr-enumeration.md
-    - name: CorNativeLinkFlags Enumeration
-      href: cornativelinkflags-enumeration.md
-    - name: CorNativeLinkType Enumeration
-      href: cornativelinktype-enumeration.md
-    - name: CorNativeType Enumeration
-      href: cornativetype-enumeration.md
-    - name: CorNotificationForTokenMovement Enumeration
-      href: cornotificationfortokenmovement-enumeration.md
-    - name: CorOpenFlags Enumeration
-      href: coropenflags-enumeration.md
-    - name: CorParamAttr Enumeration
-      href: corparamattr-enumeration.md
-    - name: CorPEKind Enumeration
-      href: corpekind-enumeration.md
-    - name: CorPinvokeMap Enumeration
-      href: corpinvokemap-enumeration.md
-    - name: CorPropertyAttr Enumeration
-      href: corpropertyattr-enumeration.md
-    - name: CorRefToDefCheck Enumeration
-      href: correftodefcheck-enumeration.md
-    - name: CorRegFlags Enumeration
-      href: corregflags-enumeration.md
-    - name: CorSaveSize Enumeration
-      href: corsavesize-enumeration.md
-    - name: CorSerializationType Enumeration
-      href: corserializationtype-enumeration.md
-    - name: CorSetENC Enumeration
-      href: corsetenc-enumeration.md
-    - name: CorThreadSafetyOptions Enumeration
-      href: corthreadsafetyoptions-enumeration.md
-    - name: CorTokenType Enumeration
-      href: cortokentype-enumeration.md
-    - name: CorTypeAttr Enumeration
-      href: cortypeattr-enumeration.md
-    - name: CorUnmanagedCallingConvention Enumeration
-      href: corunmanagedcallingconvention-enumeration.md
-    - name: CorValidatorModuleType Enumeration
-      href: corvalidatormoduletype-enumeration.md
-    - name: COUNINITIEE Enumeration
-      href: couninitiee-enumeration.md
-  - name: Metadata Structures
-    href: metadata-structures.md
+    - name: MarkToken Method
+      href: ihostfilter-marktoken-method.md
+  - name: IMapToken Interface
+    href: imaptoken-interface.md
     items:
-    - name: ASSEMBLYMETADATA Structure
-      href: assemblymetadata-structure.md
-    - name: COR_FIELD_OFFSET Structure
-      href: cor-field-offset-structure.md
-    - name: COR_NATIVE_LINK Structure
-      href: cor-native-link-structure.md
-    - name: CVStruct Structure
-      href: cvstruct-structure.md
-    - name: OSINFO Structure
-      href: osinfo-structure.md
-  - name: Metadata Unions
-    href: metadata-unions.md
+    - name: Map Method
+      href: imaptoken-map-method.md
+  - name: IMetaDataAssemblyEmit Interface
+    href: imetadataassemblyemit-interface.md
     items:
-    - name: CeeSectionRelocExtra Union
-      href: ceesectionrelocextra-union.md
+    - name: DefineAssembly Method
+      href: imetadataassemblyemit-defineassembly-method.md
+    - name: DefineAssemblyRef Method
+      href: imetadataassemblyemit-defineassemblyref-method.md
+    - name: DefineExportedType Method
+      href: imetadataassemblyemit-defineexportedtype-method.md
+    - name: DefineFile Method
+      href: imetadataassemblyemit-definefile-method.md
+    - name: DefineManifestResource Method
+      href: imetadataassemblyemit-definemanifestresource-method.md
+    - name: SetAssemblyProps Method
+      href: imetadataassemblyemit-setassemblyprops-method.md
+    - name: SetAssemblyRefProps Method
+      href: imetadataassemblyemit-setassemblyrefprops-method.md
+    - name: SetExportedTypeProps Method
+      href: imetadataassemblyemit-setexportedtypeprops-method.md
+    - name: SetFileProps Method
+      href: imetadataassemblyemit-setfileprops-method.md
+    - name: SetManifestResourceProps Method
+      href: imetadataassemblyemit-setmanifestresourceprops-method.md
+  - name: IMetaDataAssemblyImport Interface
+    href: imetadataassemblyimport-interface.md
+    items:
+    - name: CloseEnum Method
+      href: imetadataassemblyimport-closeenum-method.md
+    - name: EnumAssemblyRefs Method
+      href: imetadataassemblyimport-enumassemblyrefs-method.md
+    - name: EnumExportedTypes Method
+      href: imetadataassemblyimport-enumexportedtypes-method.md
+    - name: EnumFiles Method
+      href: imetadataassemblyimport-enumfiles-method.md
+    - name: EnumManifestResources Method
+      href: imetadataassemblyimport-enummanifestresources-method.md
+    - name: FindAssembliesByName Method
+      href: imetadataassemblyimport-findassembliesbyname-method.md
+    - name: FindExportedTypeByName Method
+      href: imetadataassemblyimport-findexportedtypebyname-method.md
+    - name: FindManifestResourceByName Method
+      href: imetadataassemblyimport-findmanifestresourcebyname-method.md
+    - name: GetAssemblyFromScope Method
+      href: imetadataassemblyimport-getassemblyfromscope-method.md
+    - name: GetAssemblyProps Method
+      href: imetadataassemblyimport-getassemblyprops-method.md
+    - name: GetAssemblyRefProps Method
+      href: imetadataassemblyimport-getassemblyrefprops-method.md
+    - name: GetExportedTypeProps Method
+      href: imetadataassemblyimport-getexportedtypeprops-method.md
+    - name: GetFileProps Method
+      href: imetadataassemblyimport-getfileprops-method.md
+    - name: GetManifestResourceProps Method
+      href: imetadataassemblyimport-getmanifestresourceprops-method.md
+  - name: IMetaDataConverter Interface
+    href: imetadataconverter-interface.md
+    items:
+    - name: GetMetaDataFromTypeInfo Method
+      href: imetadataconverter-getmetadatafromtypeinfo-method.md
+    - name: GetMetaDataFromTypeLib Method
+      href: imetadataconverter-getmetadatafromtypelib-method.md
+    - name: GetTypeLibFromMetaData Method
+      href: imetadataconverter-gettypelibfrommetadata-method.md
+  - name: IMetaDataDispenser Interface
+    href: imetadatadispenser-interface.md
+    items:
+    - name: DefineScope Method
+      href: imetadatadispenser-definescope-method.md
+    - name: OpenScope Method
+      href: imetadatadispenser-openscope-method.md
+    - name: OpenScopeOnMemory Method
+      href: imetadatadispenser-openscopeonmemory-method.md
+  - name: IMetaDataDispenserEx Interface
+    href: imetadatadispenserex-interface.md
+    items:
+    - name: FindAssembly Method
+      href: imetadatadispenserex-findassembly-method.md
+    - name: FindAssemblyModule Method
+      href: imetadatadispenserex-findassemblymodule-method.md
+    - name: GetCORSystemDirectory Method
+      href: imetadatadispenserex-getcorsystemdirectory-method.md
+    - name: GetOption Method
+      href: imetadatadispenserex-getoption-method.md
+    - name: OpenScopeOnITypeInfo Method
+      href: imetadatadispenserex-openscopeonitypeinfo-method.md
+    - name: SetOption Method
+      href: imetadatadispenserex-setoption-method.md
+  - name: IMetaDataEmit Interface
+    href: imetadataemit-interface.md
+    items:
+    - name: ApplyEditAndContinue Method
+      href: imetadataemit-applyeditandcontinue-method.md
+    - name: DefineCustomAttribute Method
+      href: imetadataemit-definecustomattribute-method.md
+    - name: DefineEvent Method
+      href: imetadataemit-defineevent-method.md
+    - name: DefineField Method
+      href: imetadataemit-definefield-method.md
+    - name: DefineImportMember Method
+      href: imetadataemit-defineimportmember-method.md
+    - name: DefineImportType Method
+      href: imetadataemit-defineimporttype-method.md
+    - name: DefineMemberRef Method
+      href: imetadataemit-definememberref-method.md
+    - name: DefineMethod Method
+      href: imetadataemit-definemethod-method.md
+    - name: DefineMethodImpl Method
+      href: imetadataemit-definemethodimpl-method.md
+    - name: DefineModuleRef Method
+      href: imetadataemit-definemoduleref-method.md
+    - name: DefineNestedType Method
+      href: imetadataemit-definenestedtype-method.md
+    - name: DefineParam Method
+      href: imetadataemit-defineparam-method.md
+    - name: DefinePermissionSet Method
+      href: imetadataemit-definepermissionset-method.md
+    - name: DefinePinvokeMap Method
+      href: imetadataemit-definepinvokemap-method.md
+    - name: DefineProperty Method
+      href: imetadataemit-defineproperty-method.md
+    - name: DefineSecurityAttributeSet Method
+      href: imetadataemit-definesecurityattributeset-method.md
+    - name: DefineTypeDef Method
+      href: imetadataemit-definetypedef-method.md
+    - name: DefineTypeRefByName Method
+      href: imetadataemit-definetyperefbyname-method.md
+    - name: DefineUserString Method
+      href: imetadataemit-defineuserstring-method.md
+    - name: DeleteClassLayout Method
+      href: imetadataemit-deleteclasslayout-method.md
+    - name: DeleteFieldMarshal Method
+      href: imetadataemit-deletefieldmarshal-method.md
+    - name: DeletePinvokeMap Method
+      href: imetadataemit-deletepinvokemap-method.md
+    - name: DeleteToken Method
+      href: imetadataemit-deletetoken-method.md
+    - name: GetSaveSize Method
+      href: imetadataemit-getsavesize-method.md
+    - name: GetTokenFromSig Method
+      href: imetadataemit-gettokenfromsig-method.md
+    - name: GetTokenFromTypeSpec Method
+      href: imetadataemit-gettokenfromtypespec-method.md
+    - name: Merge Method
+      href: imetadataemit-merge-method.md
+    - name: MergeEnd Method
+      href: imetadataemit-mergeend-method.md
+    - name: Save Method
+      href: imetadataemit-save-method.md
+    - name: SaveToMemory Method
+      href: imetadataemit-savetomemory-method.md
+    - name: SaveToStream Method
+      href: imetadataemit-savetostream-method.md
+    - name: SetClassLayout Method
+      href: imetadataemit-setclasslayout-method.md
+    - name: SetCustomAttributeValue Method
+      href: imetadataemit-setcustomattributevalue-method.md
+    - name: SetEventProps Method
+      href: imetadataemit-seteventprops-method.md
+    - name: SetFieldMarshal Method
+      href: imetadataemit-setfieldmarshal-method.md
+    - name: SetFieldProps Method
+      href: imetadataemit-setfieldprops-method.md
+    - name: SetFieldRVA Method
+      href: imetadataemit-setfieldrva-method.md
+    - name: SetHandler Method
+      href: imetadataemit-sethandler-method.md
+    - name: SetMethodImplFlags Method
+      href: imetadataemit-setmethodimplflags-method.md
+    - name: SetMethodProps Method
+      href: imetadataemit-setmethodprops-method.md
+    - name: SetModuleProps Method
+      href: imetadataemit-setmoduleprops-method.md
+    - name: SetParamProps Method
+      href: imetadataemit-setparamprops-method.md
+    - name: SetParent Method
+      href: imetadataemit-setparent-method.md
+    - name: SetPermissionSetProps Method
+      href: imetadataemit-setpermissionsetprops-method.md
+    - name: SetPinvokeMap Method
+      href: imetadataemit-setpinvokemap-method.md
+    - name: SetPropertyProps Method
+      href: imetadataemit-setpropertyprops-method.md
+    - name: SetRVA Method
+      href: imetadataemit-setrva-method.md
+    - name: SetTypeDefProps Method
+      href: imetadataemit-settypedefprops-method.md
+    - name: TranslateSigWithScope Method
+      href: imetadataemit-translatesigwithscope-method.md
+  - name: IMetaDataEmit2 Interface
+    href: imetadataemit2-interface.md
+    items:
+    - name: DefineGenericParam Method
+      href: imetadataemit2-definegenericparam-method.md
+    - name: DefineMethodSpec Method
+      href: imetadataemit2-definemethodspec-method.md
+    - name: GetDeltaSaveSize Method
+      href: imetadataemit2-getdeltasavesize-method.md
+    - name: ResetENCLog Method
+      href: imetadataemit2-resetenclog-method.md
+    - name: SaveDelta Method
+      href: imetadataemit2-savedelta-method.md
+    - name: SaveDeltaToMemory Method
+      href: imetadataemit2-savedeltatomemory-method.md
+    - name: SaveDeltaToStream Method
+      href: imetadataemit2-savedeltatostream-method.md
+    - name: SetGenericParamProps Method
+      href: imetadataemit2-setgenericparamprops-method.md
+  - name: IMetaDataError Interface
+    href: imetadataerror-interface.md
+    items:
+    - name: OnError Method
+      href: imetadataerror-onerror-method.md
+  - name: IMetaDataFilter Interface
+    href: imetadatafilter-interface.md
+    items:
+    - name: IsTokenMarked Method
+      href: imetadatafilter-istokenmarked-method.md
+    - name: MarkToken Method
+      href: imetadatafilter-marktoken-method.md
+    - name: UnmarkAll Method
+      href: imetadatafilter-unmarkall-method.md
+  - name: IMetaDataImport Interface
+    href: imetadataimport-interface.md
+    items:
+    - name: CloseEnum Method
+      href: imetadataimport-closeenum-method.md
+    - name: CountEnum Method
+      href: imetadataimport-countenum-method.md
+    - name: EnumCustomAttributes Method
+      href: imetadataimport-enumcustomattributes-method.md
+    - name: EnumEvents Method
+      href: imetadataimport-enumevents-method.md
+    - name: EnumFields Method
+      href: imetadataimport-enumfields-method.md
+    - name: EnumFieldsWithName Method
+      href: imetadataimport-enumfieldswithname-method.md
+    - name: EnumInterfaceImpls Method
+      href: imetadataimport-enuminterfaceimpls-method.md
+    - name: EnumMemberRefs Method
+      href: imetadataimport-enummemberrefs-method.md
+    - name: EnumMembers Method
+      href: imetadataimport-enummembers-method.md
+    - name: EnumMembersWithName Method
+      href: imetadataimport-enummemberswithname-method.md
+    - name: EnumMethodImpls Method
+      href: imetadataimport-enummethodimpls-method.md
+    - name: EnumMethods Method
+      href: imetadataimport-enummethods-method.md
+    - name: EnumMethodSemantics Method
+      href: imetadataimport-enummethodsemantics-method.md
+    - name: EnumMethodsWithName Method
+      href: imetadataimport-enummethodswithname-method.md
+    - name: EnumModuleRefs Method
+      href: imetadataimport-enummodulerefs-method.md
+    - name: EnumParams Method
+      href: imetadataimport-enumparams-method.md
+    - name: EnumPermissionSets Method
+      href: imetadataimport-enumpermissionsets-method.md
+    - name: EnumProperties Method
+      href: imetadataimport-enumproperties-method.md
+    - name: EnumSignatures Method
+      href: imetadataimport-enumsignatures-method.md
+    - name: EnumTypeDefs Method
+      href: imetadataimport-enumtypedefs-method.md
+    - name: EnumTypeRefs Method
+      href: imetadataimport-enumtyperefs-method.md
+    - name: EnumTypeSpecs Method
+      href: imetadataimport-enumtypespecs-method.md
+    - name: EnumUnresolvedMethods Method
+      href: imetadataimport-enumunresolvedmethods-method.md
+    - name: EnumUserStrings Method
+      href: imetadataimport-enumuserstrings-method.md
+    - name: FindField Method
+      href: imetadataimport-findfield-method.md
+    - name: FindMember Method
+      href: imetadataimport-findmember-method.md
+    - name: FindMemberRef Method
+      href: imetadataimport-findmemberref-method.md
+    - name: FindMethod Method
+      href: imetadataimport-findmethod-method.md
+    - name: FindTypeDefByName Method
+      href: imetadataimport-findtypedefbyname-method.md
+    - name: FindTypeRef Method
+      href: imetadataimport-findtyperef-method.md
+    - name: GetClassLayout Method
+      href: imetadataimport-getclasslayout-method.md
+    - name: GetCustomAttributeByName Method
+      href: imetadataimport-getcustomattributebyname-method.md
+    - name: GetCustomAttributeProps Method
+      href: imetadataimport-getcustomattributeprops-method.md
+    - name: GetEventProps Method
+      href: imetadataimport-geteventprops-method.md
+    - name: GetFieldMarshal Method
+      href: imetadataimport-getfieldmarshal-method.md
+    - name: GetFieldProps Method
+      href: imetadataimport-getfieldprops-method.md
+    - name: GetInterfaceImplProps Method
+      href: imetadataimport-getinterfaceimplprops-method.md
+    - name: GetMemberProps Method
+      href: imetadataimport-getmemberprops-method.md
+    - name: GetMemberRefProps Method
+      href: imetadataimport-getmemberrefprops-method.md
+    - name: GetMethodProps Method
+      href: imetadataimport-getmethodprops-method.md
+    - name: GetMethodSemantics Method
+      href: imetadataimport-getmethodsemantics-method.md
+    - name: GetModuleFromScope Method
+      href: imetadataimport-getmodulefromscope-method.md
+    - name: GetModuleRefProps Method
+      href: imetadataimport-getmodulerefprops-method.md
+    - name: GetNameFromToken Method
+      href: imetadataimport-getnamefromtoken-method.md
+    - name: GetNativeCallConvFromSig Method
+      href: imetadataimport-getnativecallconvfromsig-method.md
+    - name: GetNestedClassProps Method
+      href: imetadataimport-getnestedclassprops-method.md
+    - name: GetParamForMethodIndex Method
+      href: imetadataimport-getparamformethodindex-method.md
+    - name: GetParamProps Method
+      href: imetadataimport-getparamprops-method.md
+    - name: GetPermissionSetProps Method
+      href: imetadataimport-getpermissionsetprops-method.md
+    - name: GetPinvokeMap
+      href: imetadataimport-getpinvokemap-method.md
+    - name: GetPropertyProps Method
+      href: imetadataimport-getpropertyprops-method.md
+    - name: GetRVA Method
+      href: imetadataimport-getrva-method.md
+    - name: GetScopeProps Method
+      href: imetadataimport-getscopeprops-method.md
+    - name: GetSigFromToken Method
+      href: imetadataimport-getsigfromtoken-method.md
+    - name: GetTypeDefProps Method
+      href: imetadataimport-gettypedefprops-method.md
+    - name: GetTypeRefProps Method
+      href: imetadataimport-gettyperefprops-method.md
+    - name: GetTypeSpecFromToken Method
+      href: imetadataimport-gettypespecfromtoken-method.md
+    - name: GetUserString Method
+      href: imetadataimport-getuserstring-method.md
+    - name: IsGlobal Method
+      href: imetadataimport-isglobal-method.md
+    - name: IsValidToken Method
+      href: imetadataimport-isvalidtoken-method.md
+    - name: ResetEnum Method
+      href: imetadataimport-resetenum-method.md
+    - name: ResolveTypeRef Method
+      href: imetadataimport-resolvetyperef-method.md
+  - name: IMetaDataImport2 Interface
+    href: imetadataimport2-interface.md
+    items:
+    - name: EnumGenericParamConstraints Method
+      href: imetadataimport2-enumgenericparamconstraints-method.md
+    - name: EnumGenericParams Method
+      href: imetadataimport2-enumgenericparams-method.md
+    - name: EnumMethodSpecs Method
+      href: imetadataimport2-enummethodspecs-method.md
+    - name: GetGenericParamConstraintProps Method
+      href: imetadataimport2-getgenericparamconstraintprops-method.md
+    - name: GetGenericParamProps Method
+      href: imetadataimport2-getgenericparamprops-method.md
+    - name: GetMethodSpecProps Method
+      href: imetadataimport2-getmethodspecprops-method.md
+    - name: GetPEKind Method
+      href: imetadataimport2-getpekind-method.md
+    - name: GetVersionString Method
+      href: imetadataimport2-getversionstring-method.md
+  - name: IMetaDataInfo Interface
+    href: imetadatainfo-interface.md
+    items:
+    - name: GetFileMapping Method
+      href: imetadatainfo-getfilemapping-method.md
+  - name: IMetaDataTables Interface
+    href: imetadatatables-interface.md
+    items:
+    - name: GetBlob Method
+      href: imetadatatables-getblob-method.md
+    - name: GetBlobHeapSize Method
+      href: imetadatatables-getblobheapsize-method.md
+    - name: GetCodedTokenInfo Method
+      href: imetadatatables-getcodedtokeninfo-method.md
+    - name: GetColumn Method
+      href: imetadatatables-getcolumn-method.md
+    - name: GetColumnInfo Method
+      href: imetadatatables-getcolumninfo-method.md
+    - name: GetGuid Method
+      href: imetadatatables-getguid-method.md
+    - name: GetGuidHeapSize Method
+      href: imetadatatables-getguidheapsize-method.md
+    - name: GetNextBlob Method
+      href: imetadatatables-getnextblob-method.md
+    - name: GetNextGuid Method
+      href: imetadatatables-getnextguid-method.md
+    - name: GetNextString Method
+      href: imetadatatables-getnextstring-method.md
+    - name: GetNextUserString Method
+      href: imetadatatables-getnextuserstring-method.md
+    - name: GetNumTables Method
+      href: imetadatatables-getnumtables-method.md
+    - name: GetRow Method
+      href: imetadatatables-getrow-method.md
+    - name: GetString Method
+      href: imetadatatables-getstring-method.md
+    - name: GetStringHeapSize Method
+      href: imetadatatables-getstringheapsize-method.md
+    - name: GetTableIndex Method
+      href: imetadatatables-gettableindex-method.md
+    - name: GetTableInfo Method
+      href: imetadatatables-gettableinfo-method.md
+    - name: GetUserString Method
+      href: imetadatatables-getuserstring-method.md
+    - name: GetUserStringHeapSize Method
+      href: imetadatatables-getuserstringheapsize-method.md
+  - name: IMetaDataTables2 Interface
+    href: imetadatatables2-interface.md
+    items:
+    - name: GetMetaDataStorage Method
+      href: imetadatatables2-getmetadatastorage-method.md
+    - name: GetMetaDataStreamInfo Method
+      href: imetadatatables2-getmetadatastreaminfo-method.md
+  - name: IMetaDataValidate Interface
+    href: imetadatavalidate-interface.md
+    items:
+    - name: ValidateMetaData Method
+      href: imetadatavalidate-validatemetadata-method.md
+    - name: ValidatorInit Method
+      href: imetadatavalidate-validatorinit-method.md
+- name: Metadata Global Static Functions
+  href: metadata-global-static-functions.md
+- name: Metadata Enumerations
+  href: metadata-enumerations.md
+  items:
+  - name: AssemblyFlags Enumeration
+    href: assemblyflags-enumeration.md
+  - name: AssemblyRefFlags Enumeration
+    href: assemblyrefflags-enumeration.md
+  - name: CeeSectionAttr Enumeration
+    href: ceesectionattr-enumeration.md
+  - name: CeeSectionRelocType Enumeration
+    href: ceesectionreloctype-enumeration.md
+  - name: COINITICOR Enumeration
+    href: coiniticor-enumeration.md
+  - name: COINITIEE Enumeration
+    href: coinitiee-enumeration.md
+  - name: CorArgType Enumeration
+    href: corargtype-enumeration.md
+  - name: CorAssemblyFlags Enumeration
+    href: corassemblyflags-enumeration.md
+  - name: CorAttributeTargets Enumeration
+    href: corattributetargets-enumeration.md
+  - name: CorCallingConvention Enumeration
+    href: corcallingconvention-enumeration.md
+  - name: CorCheckDuplicatesFor Enumeration
+    href: corcheckduplicatesfor-enumeration.md
+  - name: CorDeclSecurity Enumeration
+    href: cordeclsecurity-enumeration.md
+  - name: CorElementType Enumeration1
+    href: corelementtype-enumeration.md
+  - name: CorErrorIfEmitOutOfOrder Enumeration
+    href: corerrorifemitoutoforder-enumeration.md
+  - name: CorEventAttr Enumeration
+    href: coreventattr-enumeration.md
+  - name: CorFieldAttr Enumeration
+    href: corfieldattr-enumeration.md
+  - name: CorFileFlags Enumeration
+    href: corfileflags-enumeration.md
+  - name: CorFileMapping Enumeration
+    href: corfilemapping-enumeration.md
+  - name: CorGenericParamAttr Enumeration
+    href: corgenericparamattr-enumeration.md
+  - name: CorImportOptions Enumeration
+    href: corimportoptions-enumeration.md
+  - name: CorLinkerOptions Enumeration
+    href: corlinkeroptions-enumeration.md
+  - name: CorLocalRefPreservation Enumeration
+    href: corlocalrefpreservation-enumeration.md
+  - name: CorManifestResourceFlags Enumeration
+    href: cormanifestresourceflags-enumeration.md
+  - name: CorMethodAttr Enumeration
+    href: cormethodattr-enumeration.md
+  - name: CorMethodImpl Enumeration
+    href: cormethodimpl-enumeration.md
+  - name: CorMethodSemanticsAttr Enumeration
+    href: cormethodsemanticsattr-enumeration.md
+  - name: CorNativeLinkFlags Enumeration
+    href: cornativelinkflags-enumeration.md
+  - name: CorNativeLinkType Enumeration
+    href: cornativelinktype-enumeration.md
+  - name: CorNativeType Enumeration
+    href: cornativetype-enumeration.md
+  - name: CorNotificationForTokenMovement Enumeration
+    href: cornotificationfortokenmovement-enumeration.md
+  - name: CorOpenFlags Enumeration
+    href: coropenflags-enumeration.md
+  - name: CorParamAttr Enumeration
+    href: corparamattr-enumeration.md
+  - name: CorPEKind Enumeration
+    href: corpekind-enumeration.md
+  - name: CorPinvokeMap Enumeration
+    href: corpinvokemap-enumeration.md
+  - name: CorPropertyAttr Enumeration
+    href: corpropertyattr-enumeration.md
+  - name: CorRefToDefCheck Enumeration
+    href: correftodefcheck-enumeration.md
+  - name: CorRegFlags Enumeration
+    href: corregflags-enumeration.md
+  - name: CorSaveSize Enumeration
+    href: corsavesize-enumeration.md
+  - name: CorSerializationType Enumeration
+    href: corserializationtype-enumeration.md
+  - name: CorSetENC Enumeration
+    href: corsetenc-enumeration.md
+  - name: CorThreadSafetyOptions Enumeration
+    href: corthreadsafetyoptions-enumeration.md
+  - name: CorTokenType Enumeration
+    href: cortokentype-enumeration.md
+  - name: CorTypeAttr Enumeration
+    href: cortypeattr-enumeration.md
+  - name: CorUnmanagedCallingConvention Enumeration
+    href: corunmanagedcallingconvention-enumeration.md
+  - name: CorValidatorModuleType Enumeration
+    href: corvalidatormoduletype-enumeration.md
+  - name: COUNINITIEE Enumeration
+    href: couninitiee-enumeration.md
+- name: Metadata Structures
+  href: metadata-structures.md
+  items:
+  - name: ASSEMBLYMETADATA Structure
+    href: assemblymetadata-structure.md
+  - name: COR_FIELD_OFFSET Structure
+    href: cor-field-offset-structure.md
+  - name: COR_NATIVE_LINK Structure
+    href: cor-native-link-structure.md
+  - name: CVStruct Structure
+    href: cvstruct-structure.md
+  - name: OSINFO Structure
+    href: osinfo-structure.md
+- name: Metadata Unions
+  href: metadata-unions.md
+  items:
+  - name: CeeSectionRelocExtra Union
+    href: ceesectionrelocextra-union.md

--- a/docs/framework/unmanaged-api/profiling/toc.yml
+++ b/docs/framework/unmanaged-api/profiling/toc.yml
@@ -1,589 +1,588 @@
 items:
 - name: Profiling
   href: index.md
+- name: Overview
+  href: profiling-overview.md
+- name: Set up a profiling environment
+  href: setting-up-a-profiling-environment.md
+- name: CLR profilers and Windows Store apps
+  href: clr-profilers-and-windows-store-apps.md
+- name: CORPROF_E_UNSUPPORTED_CALL_SEQUENCE HRESULT
+  href: corprof-e-unsupported-call-sequence-hresult.md
+- name: Profiling interfaces
+  href: profiling-interfaces.md
   items:
-  - name: Overview
-    href: profiling-overview.md
-  - name: Set up a profiling environment
-    href: setting-up-a-profiling-environment.md
-  - name: CLR profilers and Windows Store apps
-    href: clr-profilers-and-windows-store-apps.md
-  - name: CORPROF_E_UNSUPPORTED_CALL_SEQUENCE HRESULT
-    href: corprof-e-unsupported-call-sequence-hresult.md
-  - name: Profiling interfaces
-    href: profiling-interfaces.md
+  - name: ICLRProfiling Interface
+    href: iclrprofiling-interface.md
     items:
-    - name: ICLRProfiling Interface
-      href: iclrprofiling-interface.md
-      items:
-      - name: AttachProfiler Method
-        href: iclrprofiling-attachprofiler-method.md
-    - name: ICorProfilerAssemblyReferenceProvider Interface
-      href: icorprofilerassemblyreferenceprovider-interface.md
-      items:
-      - name: AddAssemblyReference Method
-        href: icorprofilerassemblyreferenceprovider-addassemblyreference-method.md
-    - name: ICorProfilerCallback Interface
-      href: icorprofilercallback-interface.md
-      items:
-      - name: AppDomainCreationFinished Method
-        href: icorprofilercallback-appdomaincreationfinished-method.md
-      - name: AppDomainCreationStarted Method
-        href: icorprofilercallback-appdomaincreationstarted-method.md
-      - name: AppDomainShutdownFinished Method
-        href: icorprofilercallback-appdomainshutdownfinished-method.md
-      - name: AppDomainShutdownStarted Method
-        href: icorprofilercallback-appdomainshutdownstarted-method.md
-      - name: AssemblyLoadFinished Method
-        href: icorprofilercallback-assemblyloadfinished-method.md
-      - name: AssemblyLoadStarted Method
-        href: icorprofilercallback-assemblyloadstarted-method.md
-      - name: AssemblyUnloadFinished Method
-        href: icorprofilercallback-assemblyunloadfinished-method.md
-      - name: AssemblyUnloadStarted Method
-        href: icorprofilercallback-assemblyunloadstarted-method.md
-      - name: ClassLoadFinished Method
-        href: icorprofilercallback-classloadfinished-method.md
-      - name: ClassLoadStarted Method
-        href: icorprofilercallback-classloadstarted-method.md
-      - name: ClassUnloadFinished Method
-        href: icorprofilercallback-classunloadfinished-method.md
-      - name: ClassUnloadStarted Method
-        href: icorprofilercallback-classunloadstarted-method.md
-      - name: COMClassicVTableCreated Method
-        href: icorprofilercallback-comclassicvtablecreated-method.md
-      - name: COMClassicVTableDestroyed Method
-        href: icorprofilercallback-comclassicvtabledestroyed-method.md
-      - name: ExceptionCatcherEnter Method
-        href: icorprofilercallback-exceptioncatcherenter-method.md
-      - name: ExceptionCatcherLeave Method
-        href: icorprofilercallback-exceptioncatcherleave-method.md
-      - name: ExceptionCLRCatcherExecute Method
-        href: icorprofilercallback-exceptionclrcatcherexecute-method.md
-      - name: ExceptionCLRCatcherFound Method
-        href: icorprofilercallback-exceptionclrcatcherfound-method.md
-      - name: ExceptionOSHandlerEnter Method
-        href: icorprofilercallback-exceptionoshandlerenter-method.md
-      - name: ExceptionOSHandlerLeave Method
-        href: icorprofilercallback-exceptionoshandlerleave-method.md
-      - name: ExceptionSearchCatcherFound Method
-        href: icorprofilercallback-exceptionsearchcatcherfound-method.md
-      - name: ExceptionSearchFilterEnter Method
-        href: icorprofilercallback-exceptionsearchfilterenter-method.md
-      - name: ExceptionSearchFilterLeave Method
-        href: icorprofilercallback-exceptionsearchfilterleave-method.md
-      - name: ExceptionSearchFunctionEnter Method
-        href: icorprofilercallback-exceptionsearchfunctionenter-method.md
-      - name: ExceptionSearchFunctionLeave Method
-        href: icorprofilercallback-exceptionsearchfunctionleave-method.md
-      - name: ExceptionThrown Method
-        href: icorprofilercallback-exceptionthrown-method.md
-      - name: ExceptionUnwindFinallyEnter Method
-        href: icorprofilercallback-exceptionunwindfinallyenter-method.md
-      - name: ExceptionUnwindFinallyLeave Method
-        href: icorprofilercallback-exceptionunwindfinallyleave-method.md
-      - name: ExceptionUnwindFunctionEnter Method
-        href: icorprofilercallback-exceptionunwindfunctionenter-method.md
-      - name: ExceptionUnwindFunctionLeave Method
-        href: icorprofilercallback-exceptionunwindfunctionleave-method.md
-      - name: FunctionUnloadStarted Method
-        href: icorprofilercallback-functionunloadstarted-method.md
-      - name: Initialize Method
-        href: icorprofilercallback-initialize-method.md
-      - name: JITCachedFunctionSearchFinished Method
-        href: icorprofilercallback-jitcachedfunctionsearchfinished-method.md
-      - name: JITCachedFunctionSearchStarted Method
-        href: icorprofilercallback-jitcachedfunctionsearchstarted-method.md
-      - name: JITCompilationFinished Method
-        href: icorprofilercallback-jitcompilationfinished-method.md
-      - name: JITCompilationStarted Method
-        href: icorprofilercallback-jitcompilationstarted-method.md
-      - name: JITFunctionPitched Method
-        href: icorprofilercallback-jitfunctionpitched-method.md
-      - name: JITInlining Method
-        href: icorprofilercallback-jitinlining-method.md
-      - name: ManagedToUnmanagedTransition Method
-        href: icorprofilercallback-managedtounmanagedtransition-method.md
-      - name: ModuleAttachedToAssembly Method
-        href: icorprofilercallback-moduleattachedtoassembly-method.md
-      - name: ModuleLoadFinished Method
-        href: icorprofilercallback-moduleloadfinished-method.md
-      - name: ModuleLoadStarted Method
-        href: icorprofilercallback-moduleloadstarted-method.md
-      - name: ModuleUnloadFinished Method
-        href: icorprofilercallback-moduleunloadfinished-method.md
-      - name: ModuleUnloadStarted Method
-        href: icorprofilercallback-moduleunloadstarted-method.md
-      - name: MovedReferences Method
-        href: icorprofilercallback-movedreferences-method.md
-      - name: ObjectAllocated Method
-        href: icorprofilercallback-objectallocated-method.md
-      - name: ObjectReferences Method
-        href: icorprofilercallback-objectreferences-method.md
-      - name: ObjectsAllocatedByClass Method
-        href: icorprofilercallback-objectsallocatedbyclass-method.md
-      - name: RemotingClientInvocationFinished Method
-        href: icorprofilercallback-remotingclientinvocationfinished-method.md
-      - name: RemotingClientInvocationStarted Method
-        href: icorprofilercallback-remotingclientinvocationstarted-method.md
-      - name: RemotingClientReceivingReply Method
-        href: icorprofilercallback-remotingclientreceivingreply-method.md
-      - name: RemotingClientSendingMessage Method
-        href: icorprofilercallback-remotingclientsendingmessage-method.md
-      - name: RemotingServerInvocationReturned Method
-        href: icorprofilercallback-remotingserverinvocationreturned-method.md
-      - name: RemotingServerInvocationStarted Method
-        href: icorprofilercallback-remotingserverinvocationstarted-method.md
-      - name: RemotingServerReceivingMessage Method
-        href: icorprofilercallback-remotingserverreceivingmessage-method.md
-      - name: RemotingServerSendingReply Method
-        href: icorprofilercallback-remotingserversendingreply-method.md
-      - name: RootReferences Method
-        href: icorprofilercallback-rootreferences-method.md
-      - name: RuntimeResumeFinished Method
-        href: icorprofilercallback-runtimeresumefinished-method.md
-      - name: RuntimeResumeStarted Method
-        href: icorprofilercallback-runtimeresumestarted-method.md
-      - name: RuntimeSuspendAborted Method
-        href: icorprofilercallback-runtimesuspendaborted-method.md
-      - name: RuntimeSuspendFinished Method
-        href: icorprofilercallback-runtimesuspendfinished-method.md
-      - name: RuntimeSuspendStarted Method
-        href: icorprofilercallback-runtimesuspendstarted-method.md
-      - name: RuntimeThreadResumed Method
-        href: icorprofilercallback-runtimethreadresumed-method.md
-      - name: RuntimeThreadSuspended Method
-        href: icorprofilercallback-runtimethreadsuspended-method.md
-      - name: Shutdown Method
-        href: icorprofilercallback-shutdown-method.md
-      - name: ThreadAssignedToOSThread Method
-        href: icorprofilercallback-threadassignedtoosthread-method.md
-      - name: ThreadCreated Method
-        href: icorprofilercallback-threadcreated-method.md
-      - name: ThreadDestroyed Method
-        href: icorprofilercallback-threaddestroyed-method.md
-      - name: UnmanagedToManagedTransition Method
-        href: icorprofilercallback-unmanagedtomanagedtransition-method.md
-    - name: ICorProfilerCallback2 Interface
-      href: icorprofilercallback2-interface.md
-      items:
-      - name: FinalizeableObjectQueued Method
-        href: icorprofilercallback2-finalizeableobjectqueued-method.md
-      - name: GarbageCollectionFinished Method
-        href: icorprofilercallback2-garbagecollectionfinished-method.md
-      - name: GarbageCollectionStarted Method
-        href: icorprofilercallback2-garbagecollectionstarted-method.md
-      - name: HandleCreated Method
-        href: icorprofilercallback2-handlecreated-method.md
-      - name: HandleDestroyed Method
-        href: icorprofilercallback2-handledestroyed-method.md
-      - name: RootReferences2 Method
-        href: icorprofilercallback2-rootreferences2-method.md
-      - name: SurvivingReferences Method
-        href: icorprofilercallback2-survivingreferences-method.md
-      - name: ThreadNameChanged Method
-        href: icorprofilercallback2-threadnamechanged-method.md
-    - name: ICorProfilerCallback3 Interface
-      href: icorprofilercallback3-interface.md
-      items:
-      - name: InitializeForAttach Method
-        href: icorprofilercallback3-initializeforattach-method.md
-      - name: ProfilerAttachComplete Method
-        href: icorprofilercallback3-profilerattachcomplete-method.md
-      - name: ProfilerDetachSucceeded Method
-        href: icorprofilercallback3-profilerdetachsucceeded-method.md
-    - name: ICorProfilerCallback4 Interface
-      href: icorprofilercallback4-interface.md
-      items:
-      - name: GetReJITParameters Method
-        href: icorprofilercallback4-getrejitparameters-method.md
-      - name: MovedReferences2 Method
-        href: icorprofilercallback4-movedreferences2-method.md
-      - name: ReJITCompilationFinished Method
-        href: icorprofilercallback4-rejitcompilationfinished-method.md
-      - name: ReJITCompilationStarted Method
-        href: icorprofilercallback4-rejitcompilationstarted-method.md
-      - name: ReJITError Method
-        href: icorprofilercallback4-rejiterror-method.md
-      - name: SurvivingReferences2 Method
-        href: icorprofilercallback4-survivingreferences2-method.md
-    - name: ICorProfilerCallback5 Interface
-      href: icorprofilercallback5-interface.md
-      items:
-      - name: ConditionalWeakTableElementReferences Method
-        href: icorprofilercallback5-conditionalweaktableelementreferences-method.md
-    - name: ICorProfilerCallback6 Interface
-      href: icorprofilercallback6-interface.md
-      items:
-      - name: GetAssemblyReferences Method
-        href: icorprofilercallback6-getassemblyreferences-method.md
-    - name: ICorProfilerCallback7 Interface
-      href: icorprofilercallback7-interface.md
-      items:
-      - name: ModuleInMemorySymbolsUpdated Method
-        href: icorprofilercallback7-moduleinmemorysymbolsupdated-method.md
-    - name: ICorProfilerFunctionControl Interface
-      href: icorprofilerfunctioncontrol-interface.md
-      items:
-      - name: SetCodegenFlags Method
-        href: icorprofilerfunctioncontrol-setcodegenflags-method.md
-      - name: SetILFunctionBody Method
-        href: icorprofilerfunctioncontrol-setilfunctionbody-method.md
-      - name: SetILInstrumentedCodeMap Method
-        href: icorprofilerfunctioncontrol-setilinstrumentedcodemap-method.md
-    - name: ICorProfilerCallback8 Interface
-      href: icorprofilercallback8-interface.md
-      items:
-      - name: DynamicMethodJITCompilationStarted Method
-        href: icorprofilercallback8-dynamicmethodjitcompilationstarted-method.md
-      - name: DynamicMethodJITCompilationFinished Method
-        href: icorprofilercallback8-dynamicmethodjitcompilationfinished-method.md
-    - name: ICorProfilerCallback9 Interface
-      href: icorprofilercallback9-interface.md
-      items:
-      - name: DynamicMethodUnloaded Method
-        href: icorprofilercallback9-dynamicmethodunloaded-method.md
-    - name: ICorProfilerFunctionEnum Interface
-      href: icorprofilerfunctionenum-interface.md
-      items:
-      - name: Clone Method
-        href: icorprofilerfunctionenum-clone-method.md
-      - name: GetCount Method
-        href: icorprofilerfunctionenum-getcount-method.md
-      - name: Next Method
-        href: icorprofilerfunctionenum-next-method.md
-      - name: Reset Method
-        href: icorprofilerfunctionenum-reset-method.md
-      - name: Skip Method
-        href: icorprofilerfunctionenum-skip-method.md
-    - name: ICorProfilerInfo Interface
-      href: icorprofilerinfo-interface.md
-      items:
-      - name: BeginInprocDebugging Method
-        href: icorprofilerinfo-begininprocdebugging-method.md
-      - name: EndInprocDebugging Method
-        href: icorprofilerinfo-endinprocdebugging-method.md
-      - name: ForceGC Method
-        href: icorprofilerinfo-forcegc-method.md
-      - name: GetAppDomainInfo Method
-        href: icorprofilerinfo-getappdomaininfo-method.md
-      - name: GetAssemblyInfo Method
-        href: icorprofilerinfo-getassemblyinfo-method.md
-      - name: GetClassFromObject Method
-        href: icorprofilerinfo-getclassfromobject-method.md
-      - name: GetClassFromToken Method
-        href: icorprofilerinfo-getclassfromtoken-method.md
-      - name: GetClassIDInfo Method
-        href: icorprofilerinfo-getclassidinfo-method.md
-      - name: GetCodeInfo Method
-        href: icorprofilerinfo-getcodeinfo-method.md
-      - name: GetCurrentThreadID Method
-        href: icorprofilerinfo-getcurrentthreadid-method.md
-      - name: GetEventMask Method
-        href: icorprofilerinfo-geteventmask-method.md
-      - name: GetFunctionFromIP Method
-        href: icorprofilerinfo-getfunctionfromip-method.md
-      - name: GetFunctionFromToken Method
-        href: icorprofilerinfo-getfunctionfromtoken-method.md
-      - name: GetFunctionInfo Method
-        href: icorprofilerinfo-getfunctioninfo-method.md
-      - name: GetHandleFromThread Method
-        href: icorprofilerinfo-gethandlefromthread-method.md
-      - name: GetILFunctionBody Method
-        href: icorprofilerinfo-getilfunctionbody-method.md
-      - name: GetILFunctionBodyAllocator Method
-        href: icorprofilerinfo-getilfunctionbodyallocator-method.md
-      - name: GetILToNativeMapping Method
-        href: icorprofilerinfo-getiltonativemapping-method.md
-      - name: GetInprocInspectionInterface Method
-        href: icorprofilerinfo-getinprocinspectioninterface-method.md
-      - name: GetInprocInspectionIThisThread Method
-        href: icorprofilerinfo-getinprocinspectionithisthread-method.md
-      - name: GetModuleInfo Method
-        href: icorprofilerinfo-getmoduleinfo-method.md
-      - name: GetModuleMetaData Method
-        href: icorprofilerinfo-getmodulemetadata-method.md
-      - name: GetObjectSize Method
-        href: icorprofilerinfo-getobjectsize-method.md
-      - name: GetThreadContext Method
-        href: icorprofilerinfo-getthreadcontext-method.md
-      - name: GetThreadInfo Method
-        href: icorprofilerinfo-getthreadinfo-method.md
-      - name: GetTokenAndMetadataFromFunction Method
-        href: icorprofilerinfo-gettokenandmetadatafromfunction-method.md
-      - name: IsArrayClass Method
-        href: icorprofilerinfo-isarrayclass-method.md
-      - name: SetEnterLeaveFunctionHooks Method
-        href: icorprofilerinfo-setenterleavefunctionhooks-method.md
-      - name: SetEventMask Method
-        href: icorprofilerinfo-seteventmask-method.md
-      - name: SetFunctionIDMapper Method
-        href: icorprofilerinfo-setfunctionidmapper-method.md
-      - name: SetFunctionReJIT Method
-        href: icorprofilerinfo-setfunctionrejit-method.md
-      - name: SetILFunctionBody Method
-        href: icorprofilerinfo-setilfunctionbody-method.md
-      - name: SetILInstrumentedCodeMap Method
-        href: icorprofilerinfo-setilinstrumentedcodemap-method.md
-    - name: ICorProfilerInfo2 Interface
-      href: icorprofilerinfo2-interface.md
-      items:
-      - name: DoStackSnapshot Method
-        href: icorprofilerinfo2-dostacksnapshot-method.md
-      - name: EnumModuleFrozenObjects Method
-        href: icorprofilerinfo2-enummodulefrozenobjects-method.md
-      - name: GetAppDomainStaticAddress Method
-        href: icorprofilerinfo2-getappdomainstaticaddress-method.md
-      - name: GetArrayObjectInfo Method
-        href: icorprofilerinfo2-getarrayobjectinfo-method.md
-      - name: GetBoxClassLayout Method
-        href: icorprofilerinfo2-getboxclasslayout-method.md
-      - name: GetClassFromTokenAndTypeArgs Method
-        href: icorprofilerinfo2-getclassfromtokenandtypeargs-method.md
-      - name: GetClassIDInfo2 Method
-        href: icorprofilerinfo2-getclassidinfo2-method.md
-      - name: GetClassLayout Method
-        href: icorprofilerinfo2-getclasslayout-method.md
-      - name: GetCodeInfo2 Method
-        href: icorprofilerinfo2-getcodeinfo2-method.md
-      - name: GetContextStaticAddress Method
-        href: icorprofilerinfo2-getcontextstaticaddress-method.md
-      - name: GetFunctionFromTokenAndTypeArgs Method
-        href: icorprofilerinfo2-getfunctionfromtokenandtypeargs-method.md
-      - name: GetFunctionInfo2 Method
-        href: icorprofilerinfo2-getfunctioninfo2-method.md
-      - name: GetGenerationBounds Method
-        href: icorprofilerinfo2-getgenerationbounds-method.md
-      - name: GetNotifiedExceptionClauseInfo Method
-        href: icorprofilerinfo2-getnotifiedexceptionclauseinfo-method.md
-      - name: GetObjectGeneration Method
-        href: icorprofilerinfo2-getobjectgeneration-method.md
-      - name: GetRVAStaticAddress Method
-        href: icorprofilerinfo2-getrvastaticaddress-method.md
-      - name: GetStaticFieldInfo Method
-        href: icorprofilerinfo2-getstaticfieldinfo-method.md
-      - name: GetStringLayout Method
-        href: icorprofilerinfo2-getstringlayout-method.md
-      - name: GetThreadAppDomain Method
-        href: icorprofilerinfo2-getthreadappdomain-method.md
-      - name: GetThreadStaticAddress Method
-        href: icorprofilerinfo2-getthreadstaticaddress-method.md
-      - name: SetEnterLeaveFunctionHooks2 Method
-        href: icorprofilerinfo2-setenterleavefunctionhooks2-method.md
-    - name: ICorProfilerInfo3 Interface
-      href: icorprofilerinfo3-interface.md
-      items:
-      - name: EnumJITedFunctions Method
-        href: icorprofilerinfo3-enumjitedfunctions-method.md
-      - name: EnumModules Method
-        href: icorprofilerinfo3-enummodules-method.md
-      - name: GetAppDomainsContainingModule Method
-        href: icorprofilerinfo3-getappdomainscontainingmodule-method.md
-      - name: GetFunctionEnter3Info Method
-        href: icorprofilerinfo3-getfunctionenter3info-method.md
-      - name: GetFunctionLeave3Info Method
-        href: icorprofilerinfo3-getfunctionleave3info-method.md
-      - name: GetFunctionTailcall3Info Method
-        href: icorprofilerinfo3-getfunctiontailcall3info-method.md
-      - name: GetModuleInfo2 Method
-        href: icorprofilerinfo3-getmoduleinfo2-method.md
-      - name: GetRuntimeInformation Method
-        href: icorprofilerinfo3-getruntimeinformation-method.md
-      - name: GetStringLayout2 Method
-        href: icorprofilerinfo3-getstringlayout2-method.md
-      - name: GetThreadStaticAddress2 Method
-        href: icorprofilerinfo3-getthreadstaticaddress2-method.md
-      - name: RequestProfilerDetach Method
-        href: icorprofilerinfo3-requestprofilerdetach-method.md
-      - name: SetEnterLeaveFunctionHooks3 Method
-        href: icorprofilerinfo3-setenterleavefunctionhooks3-method.md
-      - name: SetEnterLeaveFunctionHooks3WithInfo Method
-        href: icorprofilerinfo3-setenterleavefunctionhooks3withinfo-method.md
-      - name: SetFunctionIDMapper2 Method
-        href: icorprofilerinfo3-setfunctionidmapper2-method.md
-    - name: ICorProfilerInfo4 Interface
-      href: icorprofilerinfo4-interface.md
-      items:
-      - name: EnumJITedFunctions2 Method
-        href: icorprofilerinfo4-enumjitedfunctions2-method.md
-      - name: EnumThreads Method
-        href: icorprofilerinfo4-enumthreads-method.md
-      - name: GetCodeInfo3 Method
-        href: icorprofilerinfo4-getcodeinfo3-method.md
-      - name: GetFunctionFromIP2 Method
-        href: icorprofilerinfo4-getfunctionfromip2-method.md
-      - name: GetILToNativeMapping2 Method
-        href: icorprofilerinfo4-getiltonativemapping2-method.md
-      - name: GetObjectSize2 Method
-        href: icorprofilerinfo4-getobjectsize2-method.md
-      - name: GetReJITIDs Method
-        href: icorprofilerinfo4-getrejitids-method.md
-      - name: InitializeCurrentThread Method
-        href: icorprofilerinfo4-initializecurrentthread-method.md
-      - name: RequestReJIT Method
-        href: icorprofilerinfo4-requestrejit-method.md
-      - name: RequestRevert Method
-        href: icorprofilerinfo4-requestrevert-method.md
-    - name: ICorProfilerInfo5 Interface
-      href: icorprofilerinfo5-interface.md
-      items:
-      - name: GetEventMask2 Method
-        href: icorprofilerinfo5-geteventmask2-method.md
-      - name: SetEventMask2 Method
-        href: icorprofilerinfo5-seteventmask2-method.md
-    - name: ICorProfilerInfo6 Interface
-      href: icorprofilerinfo6-interface.md
-      items:
-      - name: "ICorProfilerInfo6::EnumNgenModuleMethodsInliningThisMethod Method"
-        href: icorprofilerinfo6-enumngenmodulemethodsinliningthismethod-method.md
-    - name: ICorProfilerInfo7 Interface
-      href: icorprofilerinfo7-interface.md
-      items:
-      - name: ApplyMetaData Method
-        href: icorprofilerinfo7-applymetadata-method.md
-      - name: GetInMemorySymbolsLength Method
-        href: icorprofilerinfo7-getinmemorysymbolslength-method.md
-      - name: ReadInMemorySymbols
-        href: icorprofilerinfo7-readinmemorysymbols.md
-    - name: ICorProfilerInfo8 Interface
-      href: icorprofilerinfo8-interface.md
-      items:
-      - name: GetDynamicFunctionInfo Method
-        href: icorprofilerinfo8-getdynamicfunctioninfo-method.md
-      - name: GetFunctionFromIP3 Method
-        href: icorprofilerinfo8-getfunctionfromip3-method.md
-      - name: IsFunctionDynamic Method
-        href: icorprofilerinfo8-isfunctiondynamic-method.md
-    - name: ICorProfilerModuleEnum Interface
-      href: icorprofilermoduleenum-interface.md
-      items:
-      - name: Clone Method
-        href: icorprofilermoduleenum-clone-method.md
-      - name: GetCount Method
-        href: icorprofilermoduleenum-getcount-method.md
-      - name: Next Method
-        href: icorprofilermoduleenum-next-method.md
-      - name: Reset Method
-        href: icorprofilermoduleenum-reset-method.md
-      - name: Skip Method
-        href: icorprofilermoduleenum-skip-method.md
-    - name: ICorProfilerObjectEnum Interface
-      href: icorprofilerobjectenum-interface.md
-      items:
-      - name: Clone Method
-        href: icorprofilerobjectenum-clone-method.md
-      - name: GetCount Method
-        href: icorprofilerobjectenum-getcount-method.md
-      - name: Next Method
-        href: icorprofilerobjectenum-next-method.md
-      - name: Reset Method
-        href: icorprofilerobjectenum-reset-method.md
-      - name: Skip Method
-        href: icorprofilerobjectenum-skip-method.md
-    - name: ICorProfilerThreadEnum Interface
-      href: icorprofilerthreadenum-interface.md
-      items:
-      - name: Clone Method
-        href: icorprofilerthreadenum-clone-method.md
-      - name: GetCount Method
-        href: icorprofilerthreadenum-getcount-method.md
-      - name: Next Method
-        href: icorprofilerthreadenum-next-method.md
-      - name: Reset Method
-        href: icorprofilerthreadenum-reset-method.md
-      - name: Skip Method
-        href: icorprofilerthreadenum-skip-method.md
-    - name: IMethodMalloc Interface
-      href: imethodmalloc-interface.md
-      items:
-      - name: Alloc Method
-        href: imethodmalloc-alloc-method.md
-  - name: Profiling global static functions
-    href: profiling-global-static-functions.md
+    - name: AttachProfiler Method
+      href: iclrprofiling-attachprofiler-method.md
+  - name: ICorProfilerAssemblyReferenceProvider Interface
+    href: icorprofilerassemblyreferenceprovider-interface.md
     items:
-    - name: FunctionEnter Function
-      href: functionenter-function.md
-    - name: FunctionEnter2 Function
-      href: functionenter2-function.md
-    - name: FunctionEnter3 Function
-      href: functionenter3-function.md
-    - name: FunctionEnter3WithInfo Function
-      href: functionenter3withinfo-function.md
-    - name: FunctionIDMapper Function
-      href: functionidmapper-function.md
-    - name: FunctionIDMapper2 Function
-      href: functionidmapper2-function.md
-    - name: FunctionLeave Function
-      href: functionleave-function.md
-    - name: FunctionLeave2 Function
-      href: functionleave2-function.md
-    - name: FunctionLeave3 Function
-      href: functionleave3-function.md
-    - name: FunctionLeave3WithInfo Function
-      href: functionleave3withinfo-function.md
-    - name: FunctionTailcall Function
-      href: functiontailcall-function.md
-    - name: FunctionTailcall2 Function
-      href: functiontailcall2-function.md
-    - name: FunctionTailcall3 Function
-      href: functiontailcall3-function.md
-    - name: FunctionTailcall3WithInfo Function
-      href: functiontailcall3withinfo-function.md
-    - name: StackSnapshotCallback Function
-      href: stacksnapshotcallback-function.md
-  - name: Profiling enumerations
-    href: profiling-enumerations.md
+    - name: AddAssemblyReference Method
+      href: icorprofilerassemblyreferenceprovider-addassemblyreference-method.md
+  - name: ICorProfilerCallback Interface
+    href: icorprofilercallback-interface.md
     items:
-    - name: COR_PRF_CLAUSE_TYPE Enumeration
-      href: cor-prf-clause-type-enumeration.md
-    - name: COR_PRF_CODEGEN_FLAGS Enumeration
-      href: cor-prf-codegen-flags-enumeration.md
-    - name: COR_PRF_FINALIZER_FLAGS Enumeration
-      href: cor-prf-finalizer-flags-enumeration.md
-    - name: COR_PRF_GC_GENERATION Enumeration
-      href: cor-prf-gc-generation-enumeration.md
-    - name: COR_PRF_GC_REASON Enumeration
-      href: cor-prf-gc-reason-enumeration.md
-    - name: COR_PRF_GC_ROOT_FLAGS Enumeration
-      href: cor-prf-gc-root-flags-enumeration.md
-    - name: COR_PRF_GC_ROOT_KIND Enumeration
-      href: cor-prf-gc-root-kind-enumeration.md
-    - name: COR_PRF_HIGH_MONITOR Enumeration
-      href: cor-prf-high-monitor-enumeration.md
-    - name: COR_PRF_JIT_CACHE Enumeration
-      href: cor-prf-jit-cache-enumeration.md
-    - name: COR_PRF_MISC Enumeration
-      href: cor-prf-misc-enumeration.md
-    - name: COR_PRF_MODULE_FLAGS Enumeration
-      href: cor-prf-module-flags-enumeration.md
-    - name: COR_PRF_MONITOR Enumeration
-      href: cor-prf-monitor-enumeration.md
-    - name: COR_PRF_RUNTIME_TYPE Enumeration
-      href: cor-prf-runtime-type-enumeration.md
-    - name: COR_PRF_SNAPSHOT_INFO Enumeration
-      href: cor-prf-snapshot-info-enumeration.md
-    - name: COR_PRF_STATIC_TYPE Enumeration
-      href: cor-prf-static-type-enumeration.md
-    - name: COR_PRF_SUSPEND_REASON Enumeration
-      href: cor-prf-suspend-reason-enumeration.md
-    - name: COR_PRF_TRANSITION_REASON Enumeration
-      href: cor-prf-transition-reason-enumeration.md
-  - name: Profiling structures
-    href: profiling-structures.md
+    - name: AppDomainCreationFinished Method
+      href: icorprofilercallback-appdomaincreationfinished-method.md
+    - name: AppDomainCreationStarted Method
+      href: icorprofilercallback-appdomaincreationstarted-method.md
+    - name: AppDomainShutdownFinished Method
+      href: icorprofilercallback-appdomainshutdownfinished-method.md
+    - name: AppDomainShutdownStarted Method
+      href: icorprofilercallback-appdomainshutdownstarted-method.md
+    - name: AssemblyLoadFinished Method
+      href: icorprofilercallback-assemblyloadfinished-method.md
+    - name: AssemblyLoadStarted Method
+      href: icorprofilercallback-assemblyloadstarted-method.md
+    - name: AssemblyUnloadFinished Method
+      href: icorprofilercallback-assemblyunloadfinished-method.md
+    - name: AssemblyUnloadStarted Method
+      href: icorprofilercallback-assemblyunloadstarted-method.md
+    - name: ClassLoadFinished Method
+      href: icorprofilercallback-classloadfinished-method.md
+    - name: ClassLoadStarted Method
+      href: icorprofilercallback-classloadstarted-method.md
+    - name: ClassUnloadFinished Method
+      href: icorprofilercallback-classunloadfinished-method.md
+    - name: ClassUnloadStarted Method
+      href: icorprofilercallback-classunloadstarted-method.md
+    - name: COMClassicVTableCreated Method
+      href: icorprofilercallback-comclassicvtablecreated-method.md
+    - name: COMClassicVTableDestroyed Method
+      href: icorprofilercallback-comclassicvtabledestroyed-method.md
+    - name: ExceptionCatcherEnter Method
+      href: icorprofilercallback-exceptioncatcherenter-method.md
+    - name: ExceptionCatcherLeave Method
+      href: icorprofilercallback-exceptioncatcherleave-method.md
+    - name: ExceptionCLRCatcherExecute Method
+      href: icorprofilercallback-exceptionclrcatcherexecute-method.md
+    - name: ExceptionCLRCatcherFound Method
+      href: icorprofilercallback-exceptionclrcatcherfound-method.md
+    - name: ExceptionOSHandlerEnter Method
+      href: icorprofilercallback-exceptionoshandlerenter-method.md
+    - name: ExceptionOSHandlerLeave Method
+      href: icorprofilercallback-exceptionoshandlerleave-method.md
+    - name: ExceptionSearchCatcherFound Method
+      href: icorprofilercallback-exceptionsearchcatcherfound-method.md
+    - name: ExceptionSearchFilterEnter Method
+      href: icorprofilercallback-exceptionsearchfilterenter-method.md
+    - name: ExceptionSearchFilterLeave Method
+      href: icorprofilercallback-exceptionsearchfilterleave-method.md
+    - name: ExceptionSearchFunctionEnter Method
+      href: icorprofilercallback-exceptionsearchfunctionenter-method.md
+    - name: ExceptionSearchFunctionLeave Method
+      href: icorprofilercallback-exceptionsearchfunctionleave-method.md
+    - name: ExceptionThrown Method
+      href: icorprofilercallback-exceptionthrown-method.md
+    - name: ExceptionUnwindFinallyEnter Method
+      href: icorprofilercallback-exceptionunwindfinallyenter-method.md
+    - name: ExceptionUnwindFinallyLeave Method
+      href: icorprofilercallback-exceptionunwindfinallyleave-method.md
+    - name: ExceptionUnwindFunctionEnter Method
+      href: icorprofilercallback-exceptionunwindfunctionenter-method.md
+    - name: ExceptionUnwindFunctionLeave Method
+      href: icorprofilercallback-exceptionunwindfunctionleave-method.md
+    - name: FunctionUnloadStarted Method
+      href: icorprofilercallback-functionunloadstarted-method.md
+    - name: Initialize Method
+      href: icorprofilercallback-initialize-method.md
+    - name: JITCachedFunctionSearchFinished Method
+      href: icorprofilercallback-jitcachedfunctionsearchfinished-method.md
+    - name: JITCachedFunctionSearchStarted Method
+      href: icorprofilercallback-jitcachedfunctionsearchstarted-method.md
+    - name: JITCompilationFinished Method
+      href: icorprofilercallback-jitcompilationfinished-method.md
+    - name: JITCompilationStarted Method
+      href: icorprofilercallback-jitcompilationstarted-method.md
+    - name: JITFunctionPitched Method
+      href: icorprofilercallback-jitfunctionpitched-method.md
+    - name: JITInlining Method
+      href: icorprofilercallback-jitinlining-method.md
+    - name: ManagedToUnmanagedTransition Method
+      href: icorprofilercallback-managedtounmanagedtransition-method.md
+    - name: ModuleAttachedToAssembly Method
+      href: icorprofilercallback-moduleattachedtoassembly-method.md
+    - name: ModuleLoadFinished Method
+      href: icorprofilercallback-moduleloadfinished-method.md
+    - name: ModuleLoadStarted Method
+      href: icorprofilercallback-moduleloadstarted-method.md
+    - name: ModuleUnloadFinished Method
+      href: icorprofilercallback-moduleunloadfinished-method.md
+    - name: ModuleUnloadStarted Method
+      href: icorprofilercallback-moduleunloadstarted-method.md
+    - name: MovedReferences Method
+      href: icorprofilercallback-movedreferences-method.md
+    - name: ObjectAllocated Method
+      href: icorprofilercallback-objectallocated-method.md
+    - name: ObjectReferences Method
+      href: icorprofilercallback-objectreferences-method.md
+    - name: ObjectsAllocatedByClass Method
+      href: icorprofilercallback-objectsallocatedbyclass-method.md
+    - name: RemotingClientInvocationFinished Method
+      href: icorprofilercallback-remotingclientinvocationfinished-method.md
+    - name: RemotingClientInvocationStarted Method
+      href: icorprofilercallback-remotingclientinvocationstarted-method.md
+    - name: RemotingClientReceivingReply Method
+      href: icorprofilercallback-remotingclientreceivingreply-method.md
+    - name: RemotingClientSendingMessage Method
+      href: icorprofilercallback-remotingclientsendingmessage-method.md
+    - name: RemotingServerInvocationReturned Method
+      href: icorprofilercallback-remotingserverinvocationreturned-method.md
+    - name: RemotingServerInvocationStarted Method
+      href: icorprofilercallback-remotingserverinvocationstarted-method.md
+    - name: RemotingServerReceivingMessage Method
+      href: icorprofilercallback-remotingserverreceivingmessage-method.md
+    - name: RemotingServerSendingReply Method
+      href: icorprofilercallback-remotingserversendingreply-method.md
+    - name: RootReferences Method
+      href: icorprofilercallback-rootreferences-method.md
+    - name: RuntimeResumeFinished Method
+      href: icorprofilercallback-runtimeresumefinished-method.md
+    - name: RuntimeResumeStarted Method
+      href: icorprofilercallback-runtimeresumestarted-method.md
+    - name: RuntimeSuspendAborted Method
+      href: icorprofilercallback-runtimesuspendaborted-method.md
+    - name: RuntimeSuspendFinished Method
+      href: icorprofilercallback-runtimesuspendfinished-method.md
+    - name: RuntimeSuspendStarted Method
+      href: icorprofilercallback-runtimesuspendstarted-method.md
+    - name: RuntimeThreadResumed Method
+      href: icorprofilercallback-runtimethreadresumed-method.md
+    - name: RuntimeThreadSuspended Method
+      href: icorprofilercallback-runtimethreadsuspended-method.md
+    - name: Shutdown Method
+      href: icorprofilercallback-shutdown-method.md
+    - name: ThreadAssignedToOSThread Method
+      href: icorprofilercallback-threadassignedtoosthread-method.md
+    - name: ThreadCreated Method
+      href: icorprofilercallback-threadcreated-method.md
+    - name: ThreadDestroyed Method
+      href: icorprofilercallback-threaddestroyed-method.md
+    - name: UnmanagedToManagedTransition Method
+      href: icorprofilercallback-unmanagedtomanagedtransition-method.md
+  - name: ICorProfilerCallback2 Interface
+    href: icorprofilercallback2-interface.md
     items:
-    - name: COR_PRF_ASSEMBLY_REFERENCE_INFO Structure
-      href: cor-prf-assembly-reference-info-structure.md
-    - name: COR_PRF_CODE_INFO Structure
-      href: cor-prf-code-info-structure.md
-    - name: COR_PRF_EX_CLAUSE_INFO Structure
-      href: cor-prf-ex-clause-info-structure.md
-    - name: COR_PRF_FUNCTION Structure
-      href: cor-prf-function-structure.md
-    - name: COR_PRF_FUNCTION_ARGUMENT_INFO Structure
-      href: cor-prf-function-argument-info-structure.md
-    - name: COR_PRF_FUNCTION_ARGUMENT_RANGE Structure
-      href: cor-prf-function-argument-range-structure.md
-    - name: COR_PRF_GC_GENERATION_RANGE Structure
-      href: cor-prf-gc-generation-range-structure.md
-  - name: .NET Core profiling
-    href: ../../../core/unmanaged-api/profiling/index.md
+    - name: FinalizeableObjectQueued Method
+      href: icorprofilercallback2-finalizeableobjectqueued-method.md
+    - name: GarbageCollectionFinished Method
+      href: icorprofilercallback2-garbagecollectionfinished-method.md
+    - name: GarbageCollectionStarted Method
+      href: icorprofilercallback2-garbagecollectionstarted-method.md
+    - name: HandleCreated Method
+      href: icorprofilercallback2-handlecreated-method.md
+    - name: HandleDestroyed Method
+      href: icorprofilercallback2-handledestroyed-method.md
+    - name: RootReferences2 Method
+      href: icorprofilercallback2-rootreferences2-method.md
+    - name: SurvivingReferences Method
+      href: icorprofilercallback2-survivingreferences-method.md
+    - name: ThreadNameChanged Method
+      href: icorprofilercallback2-threadnamechanged-method.md
+  - name: ICorProfilerCallback3 Interface
+    href: icorprofilercallback3-interface.md
+    items:
+    - name: InitializeForAttach Method
+      href: icorprofilercallback3-initializeforattach-method.md
+    - name: ProfilerAttachComplete Method
+      href: icorprofilercallback3-profilerattachcomplete-method.md
+    - name: ProfilerDetachSucceeded Method
+      href: icorprofilercallback3-profilerdetachsucceeded-method.md
+  - name: ICorProfilerCallback4 Interface
+    href: icorprofilercallback4-interface.md
+    items:
+    - name: GetReJITParameters Method
+      href: icorprofilercallback4-getrejitparameters-method.md
+    - name: MovedReferences2 Method
+      href: icorprofilercallback4-movedreferences2-method.md
+    - name: ReJITCompilationFinished Method
+      href: icorprofilercallback4-rejitcompilationfinished-method.md
+    - name: ReJITCompilationStarted Method
+      href: icorprofilercallback4-rejitcompilationstarted-method.md
+    - name: ReJITError Method
+      href: icorprofilercallback4-rejiterror-method.md
+    - name: SurvivingReferences2 Method
+      href: icorprofilercallback4-survivingreferences2-method.md
+  - name: ICorProfilerCallback5 Interface
+    href: icorprofilercallback5-interface.md
+    items:
+    - name: ConditionalWeakTableElementReferences Method
+      href: icorprofilercallback5-conditionalweaktableelementreferences-method.md
+  - name: ICorProfilerCallback6 Interface
+    href: icorprofilercallback6-interface.md
+    items:
+    - name: GetAssemblyReferences Method
+      href: icorprofilercallback6-getassemblyreferences-method.md
+  - name: ICorProfilerCallback7 Interface
+    href: icorprofilercallback7-interface.md
+    items:
+    - name: ModuleInMemorySymbolsUpdated Method
+      href: icorprofilercallback7-moduleinmemorysymbolsupdated-method.md
+  - name: ICorProfilerFunctionControl Interface
+    href: icorprofilerfunctioncontrol-interface.md
+    items:
+    - name: SetCodegenFlags Method
+      href: icorprofilerfunctioncontrol-setcodegenflags-method.md
+    - name: SetILFunctionBody Method
+      href: icorprofilerfunctioncontrol-setilfunctionbody-method.md
+    - name: SetILInstrumentedCodeMap Method
+      href: icorprofilerfunctioncontrol-setilinstrumentedcodemap-method.md
+  - name: ICorProfilerCallback8 Interface
+    href: icorprofilercallback8-interface.md
+    items:
+    - name: DynamicMethodJITCompilationStarted Method
+      href: icorprofilercallback8-dynamicmethodjitcompilationstarted-method.md
+    - name: DynamicMethodJITCompilationFinished Method
+      href: icorprofilercallback8-dynamicmethodjitcompilationfinished-method.md
+  - name: ICorProfilerCallback9 Interface
+    href: icorprofilercallback9-interface.md
+    items:
+    - name: DynamicMethodUnloaded Method
+      href: icorprofilercallback9-dynamicmethodunloaded-method.md
+  - name: ICorProfilerFunctionEnum Interface
+    href: icorprofilerfunctionenum-interface.md
+    items:
+    - name: Clone Method
+      href: icorprofilerfunctionenum-clone-method.md
+    - name: GetCount Method
+      href: icorprofilerfunctionenum-getcount-method.md
+    - name: Next Method
+      href: icorprofilerfunctionenum-next-method.md
+    - name: Reset Method
+      href: icorprofilerfunctionenum-reset-method.md
+    - name: Skip Method
+      href: icorprofilerfunctionenum-skip-method.md
+  - name: ICorProfilerInfo Interface
+    href: icorprofilerinfo-interface.md
+    items:
+    - name: BeginInprocDebugging Method
+      href: icorprofilerinfo-begininprocdebugging-method.md
+    - name: EndInprocDebugging Method
+      href: icorprofilerinfo-endinprocdebugging-method.md
+    - name: ForceGC Method
+      href: icorprofilerinfo-forcegc-method.md
+    - name: GetAppDomainInfo Method
+      href: icorprofilerinfo-getappdomaininfo-method.md
+    - name: GetAssemblyInfo Method
+      href: icorprofilerinfo-getassemblyinfo-method.md
+    - name: GetClassFromObject Method
+      href: icorprofilerinfo-getclassfromobject-method.md
+    - name: GetClassFromToken Method
+      href: icorprofilerinfo-getclassfromtoken-method.md
+    - name: GetClassIDInfo Method
+      href: icorprofilerinfo-getclassidinfo-method.md
+    - name: GetCodeInfo Method
+      href: icorprofilerinfo-getcodeinfo-method.md
+    - name: GetCurrentThreadID Method
+      href: icorprofilerinfo-getcurrentthreadid-method.md
+    - name: GetEventMask Method
+      href: icorprofilerinfo-geteventmask-method.md
+    - name: GetFunctionFromIP Method
+      href: icorprofilerinfo-getfunctionfromip-method.md
+    - name: GetFunctionFromToken Method
+      href: icorprofilerinfo-getfunctionfromtoken-method.md
+    - name: GetFunctionInfo Method
+      href: icorprofilerinfo-getfunctioninfo-method.md
+    - name: GetHandleFromThread Method
+      href: icorprofilerinfo-gethandlefromthread-method.md
+    - name: GetILFunctionBody Method
+      href: icorprofilerinfo-getilfunctionbody-method.md
+    - name: GetILFunctionBodyAllocator Method
+      href: icorprofilerinfo-getilfunctionbodyallocator-method.md
+    - name: GetILToNativeMapping Method
+      href: icorprofilerinfo-getiltonativemapping-method.md
+    - name: GetInprocInspectionInterface Method
+      href: icorprofilerinfo-getinprocinspectioninterface-method.md
+    - name: GetInprocInspectionIThisThread Method
+      href: icorprofilerinfo-getinprocinspectionithisthread-method.md
+    - name: GetModuleInfo Method
+      href: icorprofilerinfo-getmoduleinfo-method.md
+    - name: GetModuleMetaData Method
+      href: icorprofilerinfo-getmodulemetadata-method.md
+    - name: GetObjectSize Method
+      href: icorprofilerinfo-getobjectsize-method.md
+    - name: GetThreadContext Method
+      href: icorprofilerinfo-getthreadcontext-method.md
+    - name: GetThreadInfo Method
+      href: icorprofilerinfo-getthreadinfo-method.md
+    - name: GetTokenAndMetadataFromFunction Method
+      href: icorprofilerinfo-gettokenandmetadatafromfunction-method.md
+    - name: IsArrayClass Method
+      href: icorprofilerinfo-isarrayclass-method.md
+    - name: SetEnterLeaveFunctionHooks Method
+      href: icorprofilerinfo-setenterleavefunctionhooks-method.md
+    - name: SetEventMask Method
+      href: icorprofilerinfo-seteventmask-method.md
+    - name: SetFunctionIDMapper Method
+      href: icorprofilerinfo-setfunctionidmapper-method.md
+    - name: SetFunctionReJIT Method
+      href: icorprofilerinfo-setfunctionrejit-method.md
+    - name: SetILFunctionBody Method
+      href: icorprofilerinfo-setilfunctionbody-method.md
+    - name: SetILInstrumentedCodeMap Method
+      href: icorprofilerinfo-setilinstrumentedcodemap-method.md
+  - name: ICorProfilerInfo2 Interface
+    href: icorprofilerinfo2-interface.md
+    items:
+    - name: DoStackSnapshot Method
+      href: icorprofilerinfo2-dostacksnapshot-method.md
+    - name: EnumModuleFrozenObjects Method
+      href: icorprofilerinfo2-enummodulefrozenobjects-method.md
+    - name: GetAppDomainStaticAddress Method
+      href: icorprofilerinfo2-getappdomainstaticaddress-method.md
+    - name: GetArrayObjectInfo Method
+      href: icorprofilerinfo2-getarrayobjectinfo-method.md
+    - name: GetBoxClassLayout Method
+      href: icorprofilerinfo2-getboxclasslayout-method.md
+    - name: GetClassFromTokenAndTypeArgs Method
+      href: icorprofilerinfo2-getclassfromtokenandtypeargs-method.md
+    - name: GetClassIDInfo2 Method
+      href: icorprofilerinfo2-getclassidinfo2-method.md
+    - name: GetClassLayout Method
+      href: icorprofilerinfo2-getclasslayout-method.md
+    - name: GetCodeInfo2 Method
+      href: icorprofilerinfo2-getcodeinfo2-method.md
+    - name: GetContextStaticAddress Method
+      href: icorprofilerinfo2-getcontextstaticaddress-method.md
+    - name: GetFunctionFromTokenAndTypeArgs Method
+      href: icorprofilerinfo2-getfunctionfromtokenandtypeargs-method.md
+    - name: GetFunctionInfo2 Method
+      href: icorprofilerinfo2-getfunctioninfo2-method.md
+    - name: GetGenerationBounds Method
+      href: icorprofilerinfo2-getgenerationbounds-method.md
+    - name: GetNotifiedExceptionClauseInfo Method
+      href: icorprofilerinfo2-getnotifiedexceptionclauseinfo-method.md
+    - name: GetObjectGeneration Method
+      href: icorprofilerinfo2-getobjectgeneration-method.md
+    - name: GetRVAStaticAddress Method
+      href: icorprofilerinfo2-getrvastaticaddress-method.md
+    - name: GetStaticFieldInfo Method
+      href: icorprofilerinfo2-getstaticfieldinfo-method.md
+    - name: GetStringLayout Method
+      href: icorprofilerinfo2-getstringlayout-method.md
+    - name: GetThreadAppDomain Method
+      href: icorprofilerinfo2-getthreadappdomain-method.md
+    - name: GetThreadStaticAddress Method
+      href: icorprofilerinfo2-getthreadstaticaddress-method.md
+    - name: SetEnterLeaveFunctionHooks2 Method
+      href: icorprofilerinfo2-setenterleavefunctionhooks2-method.md
+  - name: ICorProfilerInfo3 Interface
+    href: icorprofilerinfo3-interface.md
+    items:
+    - name: EnumJITedFunctions Method
+      href: icorprofilerinfo3-enumjitedfunctions-method.md
+    - name: EnumModules Method
+      href: icorprofilerinfo3-enummodules-method.md
+    - name: GetAppDomainsContainingModule Method
+      href: icorprofilerinfo3-getappdomainscontainingmodule-method.md
+    - name: GetFunctionEnter3Info Method
+      href: icorprofilerinfo3-getfunctionenter3info-method.md
+    - name: GetFunctionLeave3Info Method
+      href: icorprofilerinfo3-getfunctionleave3info-method.md
+    - name: GetFunctionTailcall3Info Method
+      href: icorprofilerinfo3-getfunctiontailcall3info-method.md
+    - name: GetModuleInfo2 Method
+      href: icorprofilerinfo3-getmoduleinfo2-method.md
+    - name: GetRuntimeInformation Method
+      href: icorprofilerinfo3-getruntimeinformation-method.md
+    - name: GetStringLayout2 Method
+      href: icorprofilerinfo3-getstringlayout2-method.md
+    - name: GetThreadStaticAddress2 Method
+      href: icorprofilerinfo3-getthreadstaticaddress2-method.md
+    - name: RequestProfilerDetach Method
+      href: icorprofilerinfo3-requestprofilerdetach-method.md
+    - name: SetEnterLeaveFunctionHooks3 Method
+      href: icorprofilerinfo3-setenterleavefunctionhooks3-method.md
+    - name: SetEnterLeaveFunctionHooks3WithInfo Method
+      href: icorprofilerinfo3-setenterleavefunctionhooks3withinfo-method.md
+    - name: SetFunctionIDMapper2 Method
+      href: icorprofilerinfo3-setfunctionidmapper2-method.md
+  - name: ICorProfilerInfo4 Interface
+    href: icorprofilerinfo4-interface.md
+    items:
+    - name: EnumJITedFunctions2 Method
+      href: icorprofilerinfo4-enumjitedfunctions2-method.md
+    - name: EnumThreads Method
+      href: icorprofilerinfo4-enumthreads-method.md
+    - name: GetCodeInfo3 Method
+      href: icorprofilerinfo4-getcodeinfo3-method.md
+    - name: GetFunctionFromIP2 Method
+      href: icorprofilerinfo4-getfunctionfromip2-method.md
+    - name: GetILToNativeMapping2 Method
+      href: icorprofilerinfo4-getiltonativemapping2-method.md
+    - name: GetObjectSize2 Method
+      href: icorprofilerinfo4-getobjectsize2-method.md
+    - name: GetReJITIDs Method
+      href: icorprofilerinfo4-getrejitids-method.md
+    - name: InitializeCurrentThread Method
+      href: icorprofilerinfo4-initializecurrentthread-method.md
+    - name: RequestReJIT Method
+      href: icorprofilerinfo4-requestrejit-method.md
+    - name: RequestRevert Method
+      href: icorprofilerinfo4-requestrevert-method.md
+  - name: ICorProfilerInfo5 Interface
+    href: icorprofilerinfo5-interface.md
+    items:
+    - name: GetEventMask2 Method
+      href: icorprofilerinfo5-geteventmask2-method.md
+    - name: SetEventMask2 Method
+      href: icorprofilerinfo5-seteventmask2-method.md
+  - name: ICorProfilerInfo6 Interface
+    href: icorprofilerinfo6-interface.md
+    items:
+    - name: "ICorProfilerInfo6::EnumNgenModuleMethodsInliningThisMethod Method"
+      href: icorprofilerinfo6-enumngenmodulemethodsinliningthismethod-method.md
+  - name: ICorProfilerInfo7 Interface
+    href: icorprofilerinfo7-interface.md
+    items:
+    - name: ApplyMetaData Method
+      href: icorprofilerinfo7-applymetadata-method.md
+    - name: GetInMemorySymbolsLength Method
+      href: icorprofilerinfo7-getinmemorysymbolslength-method.md
+    - name: ReadInMemorySymbols
+      href: icorprofilerinfo7-readinmemorysymbols.md
+  - name: ICorProfilerInfo8 Interface
+    href: icorprofilerinfo8-interface.md
+    items:
+    - name: GetDynamicFunctionInfo Method
+      href: icorprofilerinfo8-getdynamicfunctioninfo-method.md
+    - name: GetFunctionFromIP3 Method
+      href: icorprofilerinfo8-getfunctionfromip3-method.md
+    - name: IsFunctionDynamic Method
+      href: icorprofilerinfo8-isfunctiondynamic-method.md
+  - name: ICorProfilerModuleEnum Interface
+    href: icorprofilermoduleenum-interface.md
+    items:
+    - name: Clone Method
+      href: icorprofilermoduleenum-clone-method.md
+    - name: GetCount Method
+      href: icorprofilermoduleenum-getcount-method.md
+    - name: Next Method
+      href: icorprofilermoduleenum-next-method.md
+    - name: Reset Method
+      href: icorprofilermoduleenum-reset-method.md
+    - name: Skip Method
+      href: icorprofilermoduleenum-skip-method.md
+  - name: ICorProfilerObjectEnum Interface
+    href: icorprofilerobjectenum-interface.md
+    items:
+    - name: Clone Method
+      href: icorprofilerobjectenum-clone-method.md
+    - name: GetCount Method
+      href: icorprofilerobjectenum-getcount-method.md
+    - name: Next Method
+      href: icorprofilerobjectenum-next-method.md
+    - name: Reset Method
+      href: icorprofilerobjectenum-reset-method.md
+    - name: Skip Method
+      href: icorprofilerobjectenum-skip-method.md
+  - name: ICorProfilerThreadEnum Interface
+    href: icorprofilerthreadenum-interface.md
+    items:
+    - name: Clone Method
+      href: icorprofilerthreadenum-clone-method.md
+    - name: GetCount Method
+      href: icorprofilerthreadenum-getcount-method.md
+    - name: Next Method
+      href: icorprofilerthreadenum-next-method.md
+    - name: Reset Method
+      href: icorprofilerthreadenum-reset-method.md
+    - name: Skip Method
+      href: icorprofilerthreadenum-skip-method.md
+  - name: IMethodMalloc Interface
+    href: imethodmalloc-interface.md
+    items:
+    - name: Alloc Method
+      href: imethodmalloc-alloc-method.md
+- name: Profiling global static functions
+  href: profiling-global-static-functions.md
+  items:
+  - name: FunctionEnter Function
+    href: functionenter-function.md
+  - name: FunctionEnter2 Function
+    href: functionenter2-function.md
+  - name: FunctionEnter3 Function
+    href: functionenter3-function.md
+  - name: FunctionEnter3WithInfo Function
+    href: functionenter3withinfo-function.md
+  - name: FunctionIDMapper Function
+    href: functionidmapper-function.md
+  - name: FunctionIDMapper2 Function
+    href: functionidmapper2-function.md
+  - name: FunctionLeave Function
+    href: functionleave-function.md
+  - name: FunctionLeave2 Function
+    href: functionleave2-function.md
+  - name: FunctionLeave3 Function
+    href: functionleave3-function.md
+  - name: FunctionLeave3WithInfo Function
+    href: functionleave3withinfo-function.md
+  - name: FunctionTailcall Function
+    href: functiontailcall-function.md
+  - name: FunctionTailcall2 Function
+    href: functiontailcall2-function.md
+  - name: FunctionTailcall3 Function
+    href: functiontailcall3-function.md
+  - name: FunctionTailcall3WithInfo Function
+    href: functiontailcall3withinfo-function.md
+  - name: StackSnapshotCallback Function
+    href: stacksnapshotcallback-function.md
+- name: Profiling enumerations
+  href: profiling-enumerations.md
+  items:
+  - name: COR_PRF_CLAUSE_TYPE Enumeration
+    href: cor-prf-clause-type-enumeration.md
+  - name: COR_PRF_CODEGEN_FLAGS Enumeration
+    href: cor-prf-codegen-flags-enumeration.md
+  - name: COR_PRF_FINALIZER_FLAGS Enumeration
+    href: cor-prf-finalizer-flags-enumeration.md
+  - name: COR_PRF_GC_GENERATION Enumeration
+    href: cor-prf-gc-generation-enumeration.md
+  - name: COR_PRF_GC_REASON Enumeration
+    href: cor-prf-gc-reason-enumeration.md
+  - name: COR_PRF_GC_ROOT_FLAGS Enumeration
+    href: cor-prf-gc-root-flags-enumeration.md
+  - name: COR_PRF_GC_ROOT_KIND Enumeration
+    href: cor-prf-gc-root-kind-enumeration.md
+  - name: COR_PRF_HIGH_MONITOR Enumeration
+    href: cor-prf-high-monitor-enumeration.md
+  - name: COR_PRF_JIT_CACHE Enumeration
+    href: cor-prf-jit-cache-enumeration.md
+  - name: COR_PRF_MISC Enumeration
+    href: cor-prf-misc-enumeration.md
+  - name: COR_PRF_MODULE_FLAGS Enumeration
+    href: cor-prf-module-flags-enumeration.md
+  - name: COR_PRF_MONITOR Enumeration
+    href: cor-prf-monitor-enumeration.md
+  - name: COR_PRF_RUNTIME_TYPE Enumeration
+    href: cor-prf-runtime-type-enumeration.md
+  - name: COR_PRF_SNAPSHOT_INFO Enumeration
+    href: cor-prf-snapshot-info-enumeration.md
+  - name: COR_PRF_STATIC_TYPE Enumeration
+    href: cor-prf-static-type-enumeration.md
+  - name: COR_PRF_SUSPEND_REASON Enumeration
+    href: cor-prf-suspend-reason-enumeration.md
+  - name: COR_PRF_TRANSITION_REASON Enumeration
+    href: cor-prf-transition-reason-enumeration.md
+- name: Profiling structures
+  href: profiling-structures.md
+  items:
+  - name: COR_PRF_ASSEMBLY_REFERENCE_INFO Structure
+    href: cor-prf-assembly-reference-info-structure.md
+  - name: COR_PRF_CODE_INFO Structure
+    href: cor-prf-code-info-structure.md
+  - name: COR_PRF_EX_CLAUSE_INFO Structure
+    href: cor-prf-ex-clause-info-structure.md
+  - name: COR_PRF_FUNCTION Structure
+    href: cor-prf-function-structure.md
+  - name: COR_PRF_FUNCTION_ARGUMENT_INFO Structure
+    href: cor-prf-function-argument-info-structure.md
+  - name: COR_PRF_FUNCTION_ARGUMENT_RANGE Structure
+    href: cor-prf-function-argument-range-structure.md
+  - name: COR_PRF_GC_GENERATION_RANGE Structure
+    href: cor-prf-gc-generation-range-structure.md
+- name: .NET Core profiling
+  href: ../../../core/unmanaged-api/profiling/index.md

--- a/docs/framework/unmanaged-api/strong-naming/toc.yml
+++ b/docs/framework/unmanaged-api/strong-naming/toc.yml
@@ -1,57 +1,57 @@
-- name: Strong Naming
+items:
+- name: Strong naming
   href: index.md
-  items:
-  - name: GetHashFromAssemblyFile Function
-    href: gethashfromassemblyfile-function.md
-  - name: GetHashFromAssemblyFileW Function
-    href: gethashfromassemblyfilew-function.md
-  - name: GetHashFromBlob Function
-    href: gethashfromblob-function.md
-  - name: GetHashFromFile Function
-    href: gethashfromfile-function.md
-  - name: GetHashFromFileW Function
-    href: gethashfromfilew-function.md
-  - name: GetHashFromHandle Function
-    href: gethashfromhandle-function.md
-  - name: PublicKeyBlob Structure
-    href: publickeyblob-structure.md
-  - name: StrongNameCompareAssemblies Function
-    href: strongnamecompareassemblies-function.md
-  - name: StrongNameErrorInfo Function
-    href: strongnameerrorinfo-function.md
-  - name: StrongNameFreeBuffer Function
-    href: strongnamefreebuffer-function.md
-  - name: StrongNameGetBlob Function
-    href: strongnamegetblob-function.md
-  - name: StrongNameGetBlobFromImage Function
-    href: strongnamegetblobfromimage-function.md
-  - name: StrongNameGetPublicKey Function
-    href: strongnamegetpublickey-function.md
-  - name: StrongNameHashSize Function
-    href: strongnamehashsize-function.md
-  - name: StrongNameKeyDelete Function
-    href: strongnamekeydelete-function.md
-  - name: StrongNameKeyGen Function
-    href: strongnamekeygen-function.md
-  - name: StrongNameKeyGenEx Function
-    href: strongnamekeygenex-function.md
-  - name: StrongNameKeyInstall Function
-    href: strongnamekeyinstall-function.md
-  - name: StrongNameSignatureGeneration Function
-    href: strongnamesignaturegeneration-function.md
-  - name: StrongNameSignatureGenerationEx Function
-    href: strongnamesignaturegenerationex-function.md
-  - name: StrongNameSignatureSize Function
-    href: strongnamesignaturesize-function.md
-  - name: StrongNameSignatureVerification Function
-    href: strongnamesignatureverification-function.md
-  - name: StrongNameSignatureVerificationEx Function
-    href: strongnamesignatureverificationex-function.md
-  - name: StrongNameSignatureVerificationFromImage Function
-    href: strongnamesignatureverificationfromimage-function.md
-  - name: StrongNameTokenFromAssembly Function
-    href: strongnametokenfromassembly-function.md
-  - name: StrongNameTokenFromAssemblyEx Function
-    href: strongnametokenfromassemblyex-function.md
-  - name: StrongNameTokenFromPublicKey Function
-    href: strongnametokenfrompublickey-function.md
+- name: GetHashFromAssemblyFile Function
+  href: gethashfromassemblyfile-function.md
+- name: GetHashFromAssemblyFileW Function
+  href: gethashfromassemblyfilew-function.md
+- name: GetHashFromBlob Function
+  href: gethashfromblob-function.md
+- name: GetHashFromFile Function
+  href: gethashfromfile-function.md
+- name: GetHashFromFileW Function
+  href: gethashfromfilew-function.md
+- name: GetHashFromHandle Function
+  href: gethashfromhandle-function.md
+- name: PublicKeyBlob Structure
+  href: publickeyblob-structure.md
+- name: StrongNameCompareAssemblies Function
+  href: strongnamecompareassemblies-function.md
+- name: StrongNameErrorInfo Function
+  href: strongnameerrorinfo-function.md
+- name: StrongNameFreeBuffer Function
+  href: strongnamefreebuffer-function.md
+- name: StrongNameGetBlob Function
+  href: strongnamegetblob-function.md
+- name: StrongNameGetBlobFromImage Function
+  href: strongnamegetblobfromimage-function.md
+- name: StrongNameGetPublicKey Function
+  href: strongnamegetpublickey-function.md
+- name: StrongNameHashSize Function
+  href: strongnamehashsize-function.md
+- name: StrongNameKeyDelete Function
+  href: strongnamekeydelete-function.md
+- name: StrongNameKeyGen Function
+  href: strongnamekeygen-function.md
+- name: StrongNameKeyGenEx Function
+  href: strongnamekeygenex-function.md
+- name: StrongNameKeyInstall Function
+  href: strongnamekeyinstall-function.md
+- name: StrongNameSignatureGeneration Function
+  href: strongnamesignaturegeneration-function.md
+- name: StrongNameSignatureGenerationEx Function
+  href: strongnamesignaturegenerationex-function.md
+- name: StrongNameSignatureSize Function
+  href: strongnamesignaturesize-function.md
+- name: StrongNameSignatureVerification Function
+  href: strongnamesignatureverification-function.md
+- name: StrongNameSignatureVerificationEx Function
+  href: strongnamesignatureverificationex-function.md
+- name: StrongNameSignatureVerificationFromImage Function
+  href: strongnamesignatureverificationfromimage-function.md
+- name: StrongNameTokenFromAssembly Function
+  href: strongnametokenfromassembly-function.md
+- name: StrongNameTokenFromAssemblyEx Function
+  href: strongnametokenfromassemblyex-function.md
+- name: StrongNameTokenFromPublicKey Function
+  href: strongnametokenfrompublickey-function.md

--- a/docs/framework/unmanaged-api/toc.yml
+++ b/docs/framework/unmanaged-api/toc.yml
@@ -1,68 +1,66 @@
 items:
 - name: Unmanaged API reference
+  href: index.md
+- name: Common data types
+  href: common-data-types-unmanaged-api-reference.md
+- name: ALink API
+  href: alink/
+- name: Authenticode
   items:
   - name: Overview
     href: index.md
-  - name: Common data types
-    href: common-data-types-unmanaged-api-reference.md
-  - name: ALink API
-    href: alink/
-  - name: Authenticode
+    displayName: authenticode
+  - name: _AxlGetIssuerPublicKeyHash function
+    href: authenticode/axlgetissuerpublickeyhash-function.md
+  - name: _AxlPublicKeyBlobToPublicKeyToken function
+    href: authenticode/axlpublickeyblobtopublickeytoken-function.md
+  - name: _AxlRSAKeyValueToPublicKeyToken function
+    href: authenticode/axlrsakeyvaluetopublickeytoken-function.md
+  - name: CertFreeAuthenticodeSignerInfo function
+    href: authenticode/certfreeauthenticodesignerinfo-function.md
+  - name: CertFreeAuthenticodeTimestamperInfo function
+    href: authenticode/certfreeauthenticodetimestamperinfo-function.md
+  - name: CertTimestampAuthenticodeLicense function
+    href: authenticode/certtimestampauthenticodelicense-function.md
+  - name: CertVerifyAuthenticodeLicense function
+    href: authenticode/certverifyauthenticodelicense-function.md
+  - name: AXL_AUTHENTICODE_SIGNER_INFO structure
+    href: authenticode/axl-authenticode-signer-info-structure.md
+  - name: AXL_AUTHENTICODE_TIMESTAMPER_INFO structure
+    href: authenticode/axl-authenticode-timestamper-info-structure.md
+- name: Constants
+  href: constants-unmanaged-api-reference.md
+- name: Debugging
+  href: debugging/
+- name: Diagnostics symbol store
+  href: diagnostics/
+- name: Fusion
+  href: fusion/
+- name: Hosting
+  href: hosting/
+- name: Metadata
+  href: metadata/
+- name: Profiling
+  href: profiling/
+- name: Strong naming
+  href: strong-naming/
+- name: WMI and performance counters
+  href: wmi/
+- name: Tlbexp helper functions
+  items:
+  - name: Overview
+    href: tlbexp/index.md
+    displayName: tlbexp
+  - name: GetTypeLibInfo function
+    href: tlbexp/gettypelibinfo-function.md
+  - name: LoadTypeLibWithResolver function
+    href: tlbexp/loadtypelibwithresolver-function.md
+  - name: ITypeLibResolver interface
     items:
     - name: Overview
-      href: index.md
-      displayName: authenticode
-    - name: _AxlGetIssuerPublicKeyHash function
-      href: authenticode/axlgetissuerpublickeyhash-function.md
-    - name: _AxlPublicKeyBlobToPublicKeyToken function
-      href: authenticode/axlpublickeyblobtopublickeytoken-function.md
-    - name: _AxlRSAKeyValueToPublicKeyToken function
-      href: authenticode/axlrsakeyvaluetopublickeytoken-function.md
-    - name: CertFreeAuthenticodeSignerInfo function
-      href: authenticode/certfreeauthenticodesignerinfo-function.md
-    - name: CertFreeAuthenticodeTimestamperInfo function
-      href: authenticode/certfreeauthenticodetimestamperinfo-function.md
-    - name: CertTimestampAuthenticodeLicense function
-      href: authenticode/certtimestampauthenticodelicense-function.md
-    - name: CertVerifyAuthenticodeLicense function
-      href: authenticode/certverifyauthenticodelicense-function.md
-    - name: AXL_AUTHENTICODE_SIGNER_INFO structure
-      href: authenticode/axl-authenticode-signer-info-structure.md
-    - name: AXL_AUTHENTICODE_TIMESTAMPER_INFO structure
-      href: authenticode/axl-authenticode-timestamper-info-structure.md
-  - name: Constants
-    href: constants-unmanaged-api-reference.md
-  - name: Debugging
-    href: debugging/
-  - name: Diagnostics symbol store
-    href: diagnostics/
-  - name: Fusion
-    href: fusion/
-  - name: Hosting
-    href: hosting/
-  - name: Metadata
-    href: metadata/
-  - name: Profiling
-    href: profiling/
-  - name: Strong naming
-    href: strong-naming/
-  - name: WMI and performance counters
-    href: wmi/
-  - name: Tlbexp helper functions
-    items:
-    - name: Overview
-      href: tlbexp/index.md
-      displayName: tlbexp
-    - name: GetTypeLibInfo function
-      href: tlbexp/gettypelibinfo-function.md
-    - name: LoadTypeLibWithResolver function
-      href: tlbexp/loadtypelibwithresolver-function.md
-    - name: ITypeLibResolver interface
-      items:
-      - name: Overview
-        href: tlbexp/itypelibresolver-interface.md
-        displayName: itypelibresolver
-      - name: ResolveTypeLib method
-        href: tlbexp/resolvetypelib-method.md
-  - name: GUID_ManagedName attribute
-    href: guid-managedname-attribute.md
+      href: tlbexp/itypelibresolver-interface.md
+      displayName: itypelibresolver
+    - name: ResolveTypeLib method
+      href: tlbexp/resolvetypelib-method.md
+- name: GUID_ManagedName attribute
+  href: guid-managedname-attribute.md

--- a/docs/framework/unmanaged-api/wmi/toc.yml
+++ b/docs/framework/unmanaged-api/wmi/toc.yml
@@ -1,105 +1,105 @@
-- name: WMI and Performance Counters
+items:
+- name: WMI and performance counters
   href: index.md
-  items:
-  - name: BeginEnumeration function
-    href: beginenumeration.md
-  - name: BeginMethodEnumeration function
-    href: beginmethodenumeration.md
-  - name: BlessIWbemServices function
-    href: blessiwbemservices.md
-  - name: BlessIWbemServicesObject function
-    href: blessiwbemservicesobject.md
-  - name: Clone function
-    href: clone.md
-  - name: CloneEnumWbemClassObject function
-    href: cloneenumwbemclassobject.md
-  - name: CompareTo function
-    href: compareto.md
-  - name: ConnectServerWmi
-    href: connectserverwmi.md
-  - name: CreateClassEnumWmi
-    href: createclassenumwmi.md
-  - name: CreateInstanceEnumWmi
-    href: createinstanceenumwmi.md
-  - name: Delete function
-    href: delete.md
-  - name: DeleteMethod function
-    href: deletemethod.md
-  - name: EndEnumeration function
-    href: endenumeration.md
-  - name: EndMethodEnumeration function
-    href: endmethodenumeration.md
-  - name: ExecQueryWmi function
-    href: execquerywmi.md
-  - name: ExecNotificationQueryWmi function
-    href: execnotificationquerywmi.md
-  - name: FormatFromRawValue function
-    href: formatfromrawvalue.md
-  - name: Get function
-    href: get.md
-  - name: GetCurrentApartmentType
-    href: getcurrentapartmenttype.md
-  - name: GetDemultiplexedStub
-    href: getdemultiplexedstub.md
-  - name: GetErrorInfo
-    href: geterrorinfo.md
-  - name: GetMethod function
-    href: getmethod.md
-  - name: GetMethodOrigin function
-    href: getmethodorigin.md
-  - name: GetMethodQualifierSet function
-    href: getmethodqualifierset.md
-  - name: GetNames function
-    href: getnames.md
-  - name: GetObjectText function
-    href: getobjecttext.md
-  - name: GetPropertyHandle function
-    href: getpropertyhandle.md
-  - name: GetPropertyOrigin function
-    href: getpropertyorigin.md
-  - name: GetPropertyQualifierSet
-    href: getpropertyqualifierset.md
-  - name: GetQualifierSet
-    href: getqualifierset.md
-  - name: InheritsFrom
-    href: inheritsfrom.md
-  - name: Initialize
-    href: initialize.md
-  - name: Next
-    href: next.md
-  - name: NextMethod
-    href: nextmethod.md
-  - name: Put
-    href: put.md
-  - name: PubClassWmi
-    href: putclasswmi.md
-  - name: PutInstanceWmi
-    href: putinstancewmi.md
-  - name: PutMethod
-    href: putmethod.md
-  - name: QualifierSet_BeginEnumeration
-    href: qualifierset-beginenumeration.md
-  - name: QualifierSet_Delete
-    href: qualifierset-delete.md
-  - name: QualifierSet_EndEnumeration
-    href: qualifierset-endenumeration.md
-  - name: QualifierSet_Get
-    href: qualifierset-get.md
-  - name: QualifierSet_GetNames
-    href: qualifierset-getnames.md
-  - name: QualifierSet_Next
-    href: qualifierset-next.md
-  - name: QualifierSet_Put
-    href: qualifierset-put.md
-  - name: ResetSecurity
-    href: resetsecurity.md
-  - name: SetSecurity
-    href: setsecurity.md
-  - name: SpawnDerivedClass
-    href: spawnderivedclass.md
-  - name: SpawnInstance
-    href: spawninstance.md
-  - name: VerifyClientKey
-    href: verifyclientkey.md
-  - name: WritePropertyValue
-    href: writepropertyvalue.md
+- name: BeginEnumeration function
+  href: beginenumeration.md
+- name: BeginMethodEnumeration function
+  href: beginmethodenumeration.md
+- name: BlessIWbemServices function
+  href: blessiwbemservices.md
+- name: BlessIWbemServicesObject function
+  href: blessiwbemservicesobject.md
+- name: Clone function
+  href: clone.md
+- name: CloneEnumWbemClassObject function
+  href: cloneenumwbemclassobject.md
+- name: CompareTo function
+  href: compareto.md
+- name: ConnectServerWmi
+  href: connectserverwmi.md
+- name: CreateClassEnumWmi
+  href: createclassenumwmi.md
+- name: CreateInstanceEnumWmi
+  href: createinstanceenumwmi.md
+- name: Delete function
+  href: delete.md
+- name: DeleteMethod function
+  href: deletemethod.md
+- name: EndEnumeration function
+  href: endenumeration.md
+- name: EndMethodEnumeration function
+  href: endmethodenumeration.md
+- name: ExecQueryWmi function
+  href: execquerywmi.md
+- name: ExecNotificationQueryWmi function
+  href: execnotificationquerywmi.md
+- name: FormatFromRawValue function
+  href: formatfromrawvalue.md
+- name: Get function
+  href: get.md
+- name: GetCurrentApartmentType
+  href: getcurrentapartmenttype.md
+- name: GetDemultiplexedStub
+  href: getdemultiplexedstub.md
+- name: GetErrorInfo
+  href: geterrorinfo.md
+- name: GetMethod function
+  href: getmethod.md
+- name: GetMethodOrigin function
+  href: getmethodorigin.md
+- name: GetMethodQualifierSet function
+  href: getmethodqualifierset.md
+- name: GetNames function
+  href: getnames.md
+- name: GetObjectText function
+  href: getobjecttext.md
+- name: GetPropertyHandle function
+  href: getpropertyhandle.md
+- name: GetPropertyOrigin function
+  href: getpropertyorigin.md
+- name: GetPropertyQualifierSet
+  href: getpropertyqualifierset.md
+- name: GetQualifierSet
+  href: getqualifierset.md
+- name: InheritsFrom
+  href: inheritsfrom.md
+- name: Initialize
+  href: initialize.md
+- name: Next
+  href: next.md
+- name: NextMethod
+  href: nextmethod.md
+- name: Put
+  href: put.md
+- name: PubClassWmi
+  href: putclasswmi.md
+- name: PutInstanceWmi
+  href: putinstancewmi.md
+- name: PutMethod
+  href: putmethod.md
+- name: QualifierSet_BeginEnumeration
+  href: qualifierset-beginenumeration.md
+- name: QualifierSet_Delete
+  href: qualifierset-delete.md
+- name: QualifierSet_EndEnumeration
+  href: qualifierset-endenumeration.md
+- name: QualifierSet_Get
+  href: qualifierset-get.md
+- name: QualifierSet_GetNames
+  href: qualifierset-getnames.md
+- name: QualifierSet_Next
+  href: qualifierset-next.md
+- name: QualifierSet_Put
+  href: qualifierset-put.md
+- name: ResetSecurity
+  href: resetsecurity.md
+- name: SetSecurity
+  href: setsecurity.md
+- name: SpawnDerivedClass
+  href: spawnderivedclass.md
+- name: SpawnInstance
+  href: spawninstance.md
+- name: VerifyClientKey
+  href: verifyclientkey.md
+- name: WritePropertyValue
+  href: writepropertyvalue.md

--- a/docs/framework/wcf/diagnostics/etw/toc.yml
+++ b/docs/framework/wcf/diagnostics/etw/toc.yml
@@ -1,718 +1,718 @@
-- name: Analytic Tracing with ETW
+items:
+- name: Analytic tracing with ETW
   href: index.md
+- name: Analytic Tracing Overview
+  href: analytic-tracing-overview.md
+- name: Dynamically Enabling Analytic Tracing
+  href: dynamically-enabling-analytic-tracing.md
+- name: Configuring Message Flow Tracing
+  href: configuring-message-flow-tracing.md
+- name: Analytic Trace Event Reference
+  href: analytic-trace-event-reference.md
   items:
-  - name: Analytic Tracing Overview
-    href: analytic-tracing-overview.md
-  - name: Dynamically Enabling Analytic Tracing
-    href: dynamically-enabling-analytic-tracing.md
-  - name: Configuring Message Flow Tracing
-    href: configuring-message-flow-tracing.md
-  - name: Analytic Trace Event Reference
-    href: analytic-trace-event-reference.md
-    items:
-    - name: 131 - BufferPoolAllocation
-      href: 131-bufferpoolallocation.md
-    - name: 132 - BufferPoolChangeQuota
-      href: 132-bufferpoolchangequota.md
-    - name: 133 - ActionItemScheduled
-      href: 133-actionitemscheduled.md
-    - name: 134 - ActionItemCallbackInvoked
-      href: 134-actionitemcallbackinvoked.md
-    - name: 201 - ClientMessageInspectorAfterReceiveInvoked
-      href: 201-clientmessageinspectorafterreceiveinvoked.md
-    - name: 202 - ClientMessageInspectorBeforeSendInvoked
-      href: 202-clientmessageinspectorbeforesendinvoked.md
-    - name: 203 - ClientParameterInspectorAfterCallInvoked
-      href: 203-clientparameterinspectoraftercallinvoked.md
-    - name: 204 - ClientParameterInspectorBeforeCallInvoked
-      href: 204-clientparameterinspectorbeforecallinvoked.md
-    - name: 205 - OperationInvoked
-      href: 205-operationinvoked.md
-    - name: 206 - ErrorHandlerInvoked
-      href: 206-errorhandlerinvoked.md
-    - name: 207 - FaultProviderInvoked
-      href: 207-faultproviderinvoked.md
-    - name: 208 - MessageInspectorAfterReceiveInvoked
-      href: 208-messageinspectorafterreceiveinvoked.md
-    - name: 209 - MessageInspectorBeforeSendInvoked
-      href: 209-messageinspectorbeforesendinvoked.md
-    - name: 210 - MessageThrottleExceeded
-      href: 210-messagethrottleexceeded.md
-    - name: 211 - ParameterInspectorAfterCallInvoked
-      href: 211-parameterinspectoraftercallinvoked.md
-    - name: 212 - ParameterInspectorBeforeCallInvoked
-      href: 212-parameterinspectorbeforecallinvoked.md
-    - name: 213 - ServiceHostStarted
-      href: 213-servicehoststarted.md
-    - name: 214 - OperationCompleted
-      href: 214-operationcompleted.md
-    - name: 215 - MessageReceivedByTransport
-      href: 215-messagereceivedbytransport.md
-    - name: 216 - MessageSentByTransport
-      href: 216-messagesentbytransport.md
-    - name: 217 - ClientOperationPrepared
-      href: 217-clientoperationprepared.md
-    - name: 218 - ClientOperationCompleted
-      href: 218-clientoperationcompleted.md
-    - name: 219 - ServiceException
-      href: 219-serviceexception.md
-    - name: 220 - MessageSentToTransport
-      href: 220-messagesenttotransport.md
-    - name: 221 - MessageReceivedFromTransport
-      href: 221-messagereceivedfromtransport.md
-    - name: 222 - OperationFailed
-      href: 222-operationfailed.md
-    - name: 223 - OperationFaulted
-      href: 223-operationfaulted.md
-    - name: 224 - MessageThrottleAtSeventyPercent
-      href: 224-messagethrottleatseventypercent.md
-    - name: 226 - IdleServicesClosed
-      href: 226-idleservicesclosed.md
-    - name: 301 - UserDefinedErrorOccurred
-      href: 301-userdefinederroroccurred.md
-    - name: 302 - UserDefinedWarningOccurred
-      href: 302-userdefinedwarningoccurred.md
-    - name: 303 - UserDefinedInformationEventOccured
-      href: 303-userdefinedinformationeventoccured.md
-    - name: 401- StopSignPostEvent
-      href: 401-stopsignpostevent.md
-    - name: 402 - StartSignpostEvent
-      href: 402-startsignpostevent.md
-    - name: 403 - SuspendSignpostEvent
-      href: 403-suspendsignpostevent.md
-    - name: 404 - ResumeSignpostEvent
-      href: 404-resumesignpostevent.md
-    - name: 451 - MessageLogInfo
-      href: 451-messageloginfo.md
-    - name: 452 - MessageLogWarning
-      href: 452-messagelogwarning.md
-    - name: 499 - TransferEmitted
-      href: 499-transferemitted.md
-    - name: 501 - CompilationStart
-      href: 501-compilationstart.md
-    - name: 502 - CompilationStop
-      href: 502-compilationstop.md
-    - name: 503 - ServiceHostFactoryCreationStart
-      href: 503-servicehostfactorycreationstart.md
-    - name: 504 - ServiceHostFactoryCreationStop
-      href: 504-servicehostfactorycreationstop.md
-    - name: 505 - CreateServiceHostStart
-      href: 505-createservicehoststart.md
-    - name: 506 - CreateServiceHostStop
-      href: 506-createservicehoststop.md
-    - name: 507 - HostedTransportConfigurationManagerConfigInitStart
-      href: 507-hostedtransportconfigurationmanagerconfiginitstart.md
-    - name: 508 - HostedTransportConfigurationManagerConfigInitStop
-      href: 508-hostedtransportconfigurationmanagerconfiginitstop.md
-    - name: 509 - ServiceHostOpenStart
-      href: 509-servicehostopenstart.md
-    - name: 510 - ServiceHostOpenStop
-      href: 510-servicehostopenstop.md
-    - name: 513 - WebHostRequestStart
-      href: 513-webhostrequeststart.md
-    - name: 514 - WebHostRequestStop
-      href: 514-webhostrequeststop.md
-    - name: 601 - CBAEntryRead
-      href: 601-cbaentryread.md
-    - name: 602 - CBAMatchFound
-      href: 602-cbamatchfound.md
-    - name: 603 - AspNetRoutingService
-      href: 603-aspnetroutingservice.md
-    - name: 604 - AspNetRoute
-      href: 604-aspnetroute.md
-    - name: 605 - IncrementBusyCount
-      href: 605-incrementbusycount.md
-    - name: 606 - DecrementBusyCount
-      href: 606-decrementbusycount.md
-    - name: 701 - ServiceChannelOpenStart
-      href: 701-servicechannelopenstart.md
-    - name: 702 - ServiceChannelOpenStop
-      href: 702-servicechannelopenstop.md
-    - name: 703 - ServiceChannelCallStart
-      href: 703-servicechannelcallstart.md
-    - name: 704 - ServiceChannelBeginCallStart
-      href: 704-servicechannelbegincallstart.md
-    - name: 706 - HttpSendMessageStart
-      href: 706-httpsendmessagestart.md
-    - name: 707 - HttpSendStop
-      href: 707-httpsendstop.md
-    - name: 708 - HttpMessageReceiveStart
-      href: 708-httpmessagereceivestart.md
-    - name: 709 - DispatchMessageStart
-      href: 709-dispatchmessagestart.md
-    - name: 710 - HttpContextBeforeProcessAuthentication
-      href: 710-httpcontextbeforeprocessauthentication.md
-    - name: 711 - DispatchMessageBeforeAuthorization
-      href: 711-dispatchmessagebeforeauthorization.md
-    - name: 712 - DispatchMessageStop
-      href: 712-dispatchmessagestop.md
-    - name: 715 - ClientChannelOpenStart
-      href: 715-clientchannelopenstart.md
-    - name: 716 - ClientChannelOpenStop
-      href: 716-clientchannelopenstop.md
-    - name: 717 - HttpSendStreamedMessageStart
-      href: 717-httpsendstreamedmessagestart.md
-    - name: 1400 - ChannelInitializationTimeout
-      href: 1400-channelinitializationtimeout.md
-    - name: 1401 - CloseTimeout
-      href: 1401-closetimeout.md
-    - name: 1402 - IdleTimeout
-      href: 1402-idletimeout.md
-    - name: 1403 - LeaseTimeout
-      href: 1403-leasetimeout.md
-    - name: 1405 - OpenTimeout
-      href: 1405-opentimeout.md
-    - name: 1406 - ReceiveTimeout
-      href: 1406-receivetimeout.md
-    - name: 1407 - SendTimeout
-      href: 1407-sendtimeout.md
-    - name: 1409 - InactivityTimeout
-      href: 1409-inactivitytimeout.md
-    - name: 1416 - MaxReceivedMessageSizeExceeded
-      href: 1416-maxreceivedmessagesizeexceeded.md
-    - name: 1417 - MaxSentMessageSizeExceeded
-      href: 1417-maxsentmessagesizeexceeded.md
-    - name: 1418 - MaxOutboundConnectionsPerEndpointExceeded
-      href: 1418-maxoutboundconnectionsperendpointexceeded.md
-    - name: 1419 - MaxPendingConnectionsExceeded
-      href: 1419-maxpendingconnectionsexceeded.md
-    - name: 1420 - ReaderQuotaExceeded
-      href: 1420-readerquotaexceeded.md
-    - name: 1422 - NegotiateTokenAuthenticatorStateCacheExceeded
-      href: 1422-negotiatetokenauthenticatorstatecacheexceeded.md
-    - name: 1423 - NegotiateTokenAuthenticatorStateCacheRatio
-      href: 1423-negotiatetokenauthenticatorstatecacheratio.md
-    - name: 1424 - SecuritySessionRatio
-      href: 1424-securitysessionratio.md
-    - name: 1430 - PendingConnectionsRatio
-      href: 1430-pendingconnectionsratio.md
-    - name: 1431 - ConcurrentCallsRatio
-      href: 1431-concurrentcallsratio.md
-    - name: 1432 - ConcurrentSessionsRatio
-      href: 1432-concurrentsessionsratio.md
-    - name: 1433 - OutboundConnectionsPerEndpointRatio
-      href: 1433-outboundconnectionsperendpointratio.md
-    - name: 1436 - PendingMessagesPerChannelRatio
-      href: 1436-pendingmessagesperchannelratio.md
-    - name: 1438 - ConcurrentInstancesRatio
-      href: 1438-concurrentinstancesratio.md
-    - name: 1439 - PendingAcceptsAtZero
-      href: 1439-pendingacceptsatzero.md
-    - name: 1441 - MaxSessionSizeReached
-      href: 1441-maxsessionsizereached.md
-    - name: 1442 - ReceiveRetryCountReached
-      href: 1442-receiveretrycountreached.md
-    - name: 1443 - MaxRetryCyclesExceededMsmq
-      href: 1443-maxretrycyclesexceededmsmq.md
-    - name: 1445 - ReadPoolMiss
-      href: 1445-readpoolmiss.md
-    - name: 1446 - WritePoolMiss
-      href: 1446-writepoolmiss.md
-    - name: 1451 - MaxRetryCyclesExceeded
-      href: 1451-maxretrycyclesexceeded.md
-    - name: 3300 - ReceiveContextCompleteFailed
-      href: 3300-receivecontextcompletefailed.md
-    - name: 3301 - ReceiveContextAbandonFailed
-      href: 3301-receivecontextabandonfailed.md
-    - name: 3302 - ReceiveContextFaulted
-      href: 3302-receivecontextfaulted.md
-    - name: 3303 - ReceiveContextAbandonWithException
-      href: 3303-receivecontextabandonwithexception.md
-    - name: 3305 - ClientBaseCachedChannelFactoryCount
-      href: 3305-clientbasecachedchannelfactorycount.md
-    - name: 3306 - ClientBaseChannelFactoryAgedOutofCache
-      href: 3306-clientbasechannelfactoryagedoutofcache.md
-    - name: 3307 - ClientBaseChannelFactoryCacheHit
-      href: 3307-clientbasechannelfactorycachehit.md
-    - name: 3308 - ClientBaseUsingLocalChannelFactory
-      href: 3308-clientbaseusinglocalchannelfactory.md
-    - name: 3309 - QueryCompositionExecuted
-      href: 3309-querycompositionexecuted.md
-    - name: 3310 - DispatchFailed
-      href: 3310-dispatchfailed.md
-    - name: 3311 - DispatchSuccessful
-      href: 3311-dispatchsuccessful.md
-    - name: 3312 - MessageReadByEncoder
-      href: 3312-messagereadbyencoder.md
-    - name: 3313 - MessageWrittenByEncoder
-      href: 3313-messagewrittenbyencoder.md
-    - name: 3314 - SessionIdleTimeout
-      href: 3314-sessionidletimeout.md
-    - name: 3319 - SocketAcceptEnqueued
-      href: 3319-socketacceptenqueued.md
-    - name: 3320 - SocketAccepted
-      href: 3320-socketaccepted.md
-    - name: 3321 - ConnectionPoolMiss
-      href: 3321-connectionpoolmiss.md
-    - name: 3322 - DispatchFormatterDeserializeRequestStart
-      href: 3322-dispatchformatterdeserializerequeststart.md
-    - name: 3323 - DispatchFormatterDeserializeRequestStop
-      href: 3323-dispatchformatterdeserializerequeststop.md
-    - name: 3324 - DispatchFormatterSerializeReplyStart
-      href: 3324-dispatchformatterserializereplystart.md
-    - name: 3325 - DispatchFormatterSerializeReplyStop
-      href: 3325-dispatchformatterserializereplystop.md
-    - name: 3326 - ClientFormatterSerializeRequestStart
-      href: 3326-clientformatterserializerequeststart.md
-    - name: 3327 - ClientFormatterSerializeRequestStop
-      href: 3327-clientformatterserializerequeststop.md
-    - name: 3328 - ClientFormatterDeserializeReplyStart
-      href: 3328-clientformatterdeserializereplystart.md
-    - name: 3329 - ClientFormatterDeserializeReplyStop
-      href: 3329-clientformatterdeserializereplystop.md
-    - name: 3330 - SecurityNegotiationStart
-      href: 3330-securitynegotiationstart.md
-    - name: 3331 - SecurityNegotiationStop
-      href: 3331-securitynegotiationstop.md
-    - name: 3332 - SecurityTokenProviderOpened
-      href: 3332-securitytokenprovideropened.md
-    - name: 3333 - OutgoingMessageSecured
-      href: 3333-outgoingmessagesecured.md
-    - name: 3334 - IncomingMessageVerified
-      href: 3334-incomingmessageverified.md
-    - name: 3335 - GetServiceInstanceStart
-      href: 3335-getserviceinstancestart.md
-    - name: 3336 - GetServiceInstanceStop
-      href: 3336-getserviceinstancestop.md
-    - name: 3337 - ChannelReceiveStart
-      href: 3337-channelreceivestart.md
-    - name: 3338 - ChannelReceiveStop
-      href: 3338-channelreceivestop.md
-    - name: 3339 - ChannelFactoryCreated
-      href: 3339-channelfactorycreated.md
-    - name: 3340 - PipeConnectionAcceptStart
-      href: 3340-pipeconnectionacceptstart.md
-    - name: 3341 - PipeConnectionAcceptStop
-      href: 3341-pipeconnectionacceptstop.md
-    - name: 3342 - EstablishConnectionStart
-      href: 3342-establishconnectionstart.md
-    - name: 3343 - EstablishConnectionStop
-      href: 3343-establishconnectionstop.md
-    - name: 3345 - SessionPreambleUnderstood
-      href: 3345-sessionpreambleunderstood.md
-    - name: 3346 - ConnectionReaderSendFault
-      href: 3346-connectionreadersendfault.md
-    - name: 3347 - SocketAcceptClosed
-      href: 3347-socketacceptclosed.md
-    - name: 3348 - ServiceHostFaulted
-      href: 3348-servicehostfaulted.md
-    - name: 3349 - ListenerOpenStart
-      href: 3349-listeneropenstart.md
-    - name: 3350 - ListenerOpenStop
-      href: 3350-listeneropenstop.md
-    - name: 3351 - ServerMaxPooledConnectionsQuotaReached
-      href: 3351-servermaxpooledconnectionsquotareached.md
-    - name: 3352 - TcpConnectionTimedOut
-      href: 3352-tcpconnectiontimedout.md
-    - name: 3353 - TcpConnectionResetError
-      href: 3353-tcpconnectionreseterror.md
-    - name: 3354 - ServiceSecurityNegotiationCompleted
-      href: 3354-servicesecuritynegotiationcompleted.md
-    - name: 3355 - SecurityNegotiationProcessingFailure
-      href: 3355-securitynegotiationprocessingfailure.md
-    - name: 3356 - SecurityIdentityVerificationSuccess
-      href: 3356-securityidentityverificationsuccess.md
-    - name: 3357 - SecurityIdentityVerificationFailure
-      href: 3357-securityidentityverificationfailure.md
-    - name: 3358 - PortSharingDuplicatedSocket
-      href: 3358-portsharingduplicatedsocket.md
-    - name: 3359 - SecurityImpersonationSuccess
-      href: 3359-securityimpersonationsuccess.md
-    - name: 3360 - SecurityImpersonationFailure
-      href: 3360-securityimpersonationfailure.md
-    - name: 3361 - HttpChannelRequestAborted
-      href: 3361-httpchannelrequestaborted.md
-    - name: 3362 - HttpChannelResponseAborted
-      href: 3362-httpchannelresponseaborted.md
-    - name: 3363 - HttpAuthFailed
-      href: 3363-httpauthfailed.md
-    - name: 3364 - SharedListenerProxyRegisterStart
-      href: 3364-sharedlistenerproxyregisterstart.md
-    - name: 3365 - SharedListenerProxyRegisterStop
-      href: 3365-sharedlistenerproxyregisterstop.md
-    - name: 3366 - SharedListenerProxyRegisterFailed
-      href: 3366-sharedlistenerproxyregisterfailed.md
-    - name: 3367 - ConnectionPoolPreambleFailed
-      href: 3367-connectionpoolpreamblefailed.md
-    - name: 3368 - SslOnInitiateUpgrade
-      href: 3368-ssloninitiateupgrade.md
-    - name: 3369 - SslOnAcceptUpgrade
-      href: 3369-sslonacceptupgrade.md
-    - name: 3370 - BinaryMessageEncodingStart
-      href: 3370-binarymessageencodingstart.md
-    - name: 3371 - MtomMessageEncodingStart
-      href: 3371-mtommessageencodingstart.md
-    - name: 3372 - TextMessageEncodingStart
-      href: 3372-textmessageencodingstart.md
-    - name: 3373 - BinaryMessageDecodingStart
-      href: 3373-binarymessagedecodingstart.md
-    - name: 3374 - MtomMessageDecodingStart
-      href: 3374-mtommessagedecodingstart.md
-    - name: 3375 - TextMessageDecodingStart
-      href: 3375-textmessagedecodingstart.md
-    - name: 3376 - HttpResponseReceiveStart
-      href: 3376-httpresponsereceivestart.md
-    - name: 3377 - SocketReadStop
-      href: 3377-socketreadstop.md
-    - name: 3378 - SocketAsyncReadStop
-      href: 3378-socketasyncreadstop.md
-    - name: 3379 - SocketWriteStart
-      href: 3379-socketwritestart.md
-    - name: 3380 - SocketAsyncWriteStart
-      href: 3380-socketasyncwritestart.md
-    - name: 3381 - SequenceAcknowledgementSent
-      href: 3381-sequenceacknowledgementsent.md
-    - name: 3382 - ClientReliableSessionReconnect
-      href: 3382-clientreliablesessionreconnect.md
-    - name: 3383 - ReliableSessionChannelFaulted
-      href: 3383-reliablesessionchannelfaulted.md
-    - name: 3384 - WindowsStreamSecurityOnInitiateUpgrade
-      href: 3384-windowsstreamsecurityoninitiateupgrade.md
-    - name: 3385 - WindowsStreamSecurityOnAcceptUpgrade
-      href: 3385-windowsstreamsecurityonacceptupgrade.md
-    - name: 3386 - SocketConnectionAbort
-      href: 3386-socketconnectionabort.md
-    - name: 3388 - HttpGetContextStart
-      href: 3388-httpgetcontextstart.md
-    - name: 3389 - ClientSendPreambleStart
-      href: 3389-clientsendpreamblestart.md
-    - name: 3390 - ClientSendPreambleStop
-      href: 3390-clientsendpreamblestop.md
-    - name: 3391 - HttpMessageReceiveFailed
-      href: 3391-httpmessagereceivefailed.md
-    - name: 3392 - TransactionScopeCreate
-      href: 3392-transactionscopecreate.md
-    - name: 3393 - StreamedMessageReadByEncoder
-      href: 3393-streamedmessagereadbyencoder.md
-    - name: 3394 - StreamedMessageWrittenByEncoder
-      href: 3394-streamedmessagewrittenbyencoder.md
-    - name: 3395 - MessageWrittenAsynchronouslyByEncoder
-      href: 3395-messagewrittenasynchronouslybyencoder.md
-    - name: 3396 - BufferedAsyncWriteStart
-      href: 3396-bufferedasyncwritestart.md
-    - name: 3397 - BufferedAsyncWriteStop
-      href: 3397-bufferedasyncwritestop.md
-    - name: 3398 - PipeSharedMemoryCreated
-      href: 3398-pipesharedmemorycreated.md
-    - name: 3399 - NamedPipeCreated
-      href: 3399-namedpipecreated.md
-    - name: 3401 - SignatureVerificationStart
-      href: 3401-signatureverificationstart.md
-    - name: 3402 - SignatureVerificationSuccess
-      href: 3402-signatureverificationsuccess.md
-    - name: 3403 - WrappedKeyDecryptionStart
-      href: 3403-wrappedkeydecryptionstart.md
-    - name: 3404 - WrappedKeyDecryptionSuccess
-      href: 3404-wrappedkeydecryptionsuccess.md
-    - name: 3405 - EncryptedDataProcessingStart
-      href: 3405-encrypteddataprocessingstart.md
-    - name: 3406 - EncryptedDataProcessingSuccess
-      href: 3406-encrypteddataprocessingsuccess.md
-    - name: 3407 - HttpPipelineProcessInboundRequestStart
-      href: 3407-httppipelineprocessinboundrequeststart.md
-    - name: 3408 - HttpPipelineBeginProcessInboundRequestStart
-      href: 3408-httppipelinebeginprocessinboundrequeststart.md
-    - name: 3409 - HttpPipelineProcessInboundRequestStop
-      href: 3409-httppipelineprocessinboundrequeststop.md
-    - name: 3410 - HttpPipelineFaulted
-      href: 3410-httppipelinefaulted.md
-    - name: 3411 - HttpPipelineTimeoutException
-      href: 3411-httppipelinetimeoutexception.md
-    - name: 3412 - HttpPipelineProcessResponseStart
-      href: 3412-httppipelineprocessresponsestart.md
-    - name: 3413 - HttpPipelineBeginProcessResponseStart
-      href: 3413-httppipelinebeginprocessresponsestart.md
-    - name: 3414 - HttpPipelineProcessResponseStop
-      href: 3414-httppipelineprocessresponsestop.md
-    - name: 3415 - WebSocketConnectionRequestSendStart
-      href: 3415-websocketconnectionrequestsendstart.md
-    - name: 3416 - WebSocketConnectionRequestSendStop
-      href: 3416-websocketconnectionrequestsendstop.md
-    - name: 3417 - WebSocketConnectionAcceptStart
-      href: 3417-websocketconnectionacceptstart.md
-    - name: 3418 - WebSocketConnectionAccepted
-      href: 3418-websocketconnectionaccepted.md
-    - name: 3419 - WebSocketConnectionDeclined
-      href: 3419-websocketconnectiondeclined.md
-    - name: 3420 - WebSocketConnectionFailed
-      href: 3420-websocketconnectionfailed.md
-    - name: 3421 - WebSocketConnectionAborted
-      href: 3421-websocketconnectionaborted.md
-    - name: 3422 - WebSocketAsyncWriteStart
-      href: 3422-websocketasyncwritestart.md
-    - name: 3423 - WebSocketAsyncWriteStop
-      href: 3423-websocketasyncwritestop.md
-    - name: 3424 - WebSocketAsyncReadStart
-      href: 3424-websocketasyncreadstart.md
-    - name: 3425 - WebSocketAsyncReadStop
-      href: 3425-websocketasyncreadstop.md
-    - name: 3426 - WebSocketCloseSent
-      href: 3426-websocketclosesent.md
-    - name: 3427 - WebSocketCloseOutputSent
-      href: 3427-websocketcloseoutputsent.md
-    - name: 3428 - WebSocketConnectionClosed
-      href: 3428-websocketconnectionclosed.md
-    - name: 3429 - WebSocketCloseStatusReceived
-      href: 3429-websocketclosestatusreceived.md
-    - name: 3430 - WebSocketUseVersionFromClientWebSocketFactory
-      href: 3430-websocketuseversionfromclientwebsocketfactory.md
-    - name: 3431 - WebSocketCreateClientWebSocketWithFactory
-      href: 3431-websocketcreateclientwebsocketwithfactory.md
-    - name: 3553 - XamlServicesLoadStart
-      href: 3553-xamlservicesloadstart.md
-    - name: 3554 - XamlServicesLoadStop
-      href: 3554-xamlservicesloadstop.md
-    - name: 3555 - CreateWorkflowServiceHostStart
-      href: 3555-createworkflowservicehoststart.md
-    - name: 3556 - CreateWorkflowServiceHostStop
-      href: 3556-createworkflowservicehoststop.md
-    - name: 3558 - ServiceActivationStart
-      href: 3558-serviceactivationstart.md
-    - name: 3559 - ServiceActivationStop
-      href: 3559-serviceactivationstop.md
-    - name: 3560 - ServiceActivationAvailableMemory
-      href: 3560-serviceactivationavailablememory.md
-    - name: 3800 - RoutingServiceClosingClient
-      href: 3800-routingserviceclosingclient.md
-    - name: 3801 - RoutingServiceChannelFaulted
-      href: 3801-routingservicechannelfaulted.md
-    - name: 3802 - RoutingServiceCompletingOneWay
-      href: 3802-routingservicecompletingoneway.md
-    - name: 3803 - RoutingServiceProcessingFailure
-      href: 3803-routingserviceprocessingfailure.md
-    - name: 3804 - RoutingServiceCreatingClientForEndpoint
-      href: 3804-routingservicecreatingclientforendpoint.md
-    - name: 3805 - RoutingServiceDisplayConfig
-      href: 3805-routingservicedisplayconfig.md
-    - name: 3807 - RoutingServiceCompletingTwoWay
-      href: 3807-routingservicecompletingtwoway.md
-    - name: 3809 - RoutingServiceMessageRoutedToEndpoints
-      href: 3809-routingservicemessageroutedtoendpoints.md
-    - name: 3810 - RoutingServiceConfigurationApplied
-      href: 3810-routingserviceconfigurationapplied.md
-    - name: 3815 - RoutingServiceProcessingMessage
-      href: 3815-routingserviceprocessingmessage.md
-    - name: 3816 - RoutingServiceTransmittingMessage
-      href: 3816-routingservicetransmittingmessage.md
-    - name: 3817 - RoutingServiceCommittingTransaction
-      href: 3817-routingservicecommittingtransaction.md
-    - name: 3818 - RoutingServiceDuplexCallbackException
-      href: 3818-routingserviceduplexcallbackexception.md
-    - name: 3819 - RoutingServiceMovedToBackup
-      href: 3819-routingservicemovedtobackup.md
-    - name: 3820 - RoutingServiceCreatingTransaction
-      href: 3820-routingservicecreatingtransaction.md
-    - name: 3821 - RoutingServiceCloseFailed
-      href: 3821-routingserviceclosefailed.md
-    - name: 3822 - RoutingServiceSendingResponse
-      href: 3822-routingservicesendingresponse.md
-    - name: 3823 - RoutingServiceSendingFaultResponse
-      href: 3823-routingservicesendingfaultresponse.md
-    - name: 3824 - RoutingServiceCompletingReceiveContext
-      href: 3824-routingservicecompletingreceivecontext.md
-    - name: 3825 - RoutingServiceAbandoningReceiveContext
-      href: 3825-routingserviceabandoningreceivecontext.md
-    - name: 3826 - RoutingServiceUsingExistingTransaction
-      href: 3826-routingserviceusingexistingtransaction.md
-    - name: 3827 - RoutingServiceTransmitFailed
-      href: 3827-routingservicetransmitfailed.md
-    - name: 3828 - RoutingServiceFilterTableMatchStart
-      href: 3828-routingservicefiltertablematchstart.md
-    - name: 3829 - RoutingServiceFilterTableMatchStop
-      href: 3829-routingservicefiltertablematchstop.md
-    - name: 3830 - RoutingServiceAbortingChannel
-      href: 3830-routingserviceabortingchannel.md
-    - name: 3831 - RoutingServiceHandledException
-      href: 3831-routingservicehandledexception.md
-    - name: 3832 - RoutingServiceTransmitSucceeded
-      href: 3832-routingservicetransmitsucceeded.md
-    - name: 4001 - TransportListenerSessionsReceived
-      href: 4001-transportlistenersessionsreceived.md
-    - name: 4002 - FailFastException
-      href: 4002-failfastexception.md
-    - name: 4003 - ServiceStartPipeError
-      href: 4003-servicestartpipeerror.md
-    - name: 4008 - DispatchSessionStart
-      href: 4008-dispatchsessionstart.md
-    - name: 4010 - PendingSessionQueueFull
-      href: 4010-pendingsessionqueuefull.md
-    - name: 4011 - MessageQueueRegisterStart
-      href: 4011-messagequeueregisterstart.md
-    - name: 4012 - MessageQueueRegisterAbort
-      href: 4012-messagequeueregisterabort.md
-    - name: 4013 - MessageQueueUnregisterSucceeded
-      href: 4013-messagequeueunregistersucceeded.md
-    - name: 4014 - MessageQueueRegisterFailed
-      href: 4014-messagequeueregisterfailed.md
-    - name: 4015 - MessageQueueRegisterCompleted
-      href: 4015-messagequeueregistercompleted.md
-    - name: 4016 - MessageQueueDuplicatedSocketError
-      href: 4016-messagequeueduplicatedsocketerror.md
-    - name: 4019 - MessageQueueDuplicatedSocketComplete
-      href: 4019-messagequeueduplicatedsocketcomplete.md
-    - name: 4020 - TcpTransportListenerListeningStart
-      href: 4020-tcptransportlistenerlisteningstart.md
-    - name: 4021 - TcpTransportListenerListeningStop
-      href: 4021-tcptransportlistenerlisteningstop.md
-    - name: 4022 - WebhostUnregisterProtocolFailed
-      href: 4022-webhostunregisterprotocolfailed.md
-    - name: 4023 - WasCloseAllListenerChannelInstancesCompleted
-      href: 4023-wasclosealllistenerchannelinstancescompleted.md
-    - name: 4024 - WasCloseAllListenerChannelInstancesFailed
-      href: 4024-wasclosealllistenerchannelinstancesfailed.md
-    - name: 4025 - OpenListenerChannelInstanceFailed
-      href: 4025-openlistenerchannelinstancefailed.md
-    - name: 4026 - WasConnected
-      href: 4026-wasconnected.md
-    - name: 4027 - WasDisconnected
-      href: 4027-wasdisconnected.md
-    - name: 4028 - PipeTransportListenerListeningStart
-      href: 4028-pipetransportlistenerlisteningstart.md
-    - name: 4029 - PipeTransportListenerListeningStop
-      href: 4029-pipetransportlistenerlisteningstop.md
-    - name: 4030 - DispatchSessionSuccess
-      href: 4030-dispatchsessionsuccess.md
-    - name: 4031 - DispatchSessionFailed
-      href: 4031-dispatchsessionfailed.md
-    - name: 4032 - WasConnectionTimedout
-      href: 4032-wasconnectiontimedout.md
-    - name: 4033 - RoutingTableLookupStart
-      href: 4033-routingtablelookupstart.md
-    - name: 4034 - RoutingTableLookupStop
-      href: 4034-routingtablelookupstop.md
-    - name: 4035 - PendingSessionQueueRatio
-      href: 4035-pendingsessionqueueratio.md
-    - name: 4600 - MessageLogEventSizeExceeded
-      href: 4600-messagelogeventsizeexceeded.md
-    - name: 4801 - DiscoveryClientInClientChannelFailedToClose
-      href: 4801-discoveryclientinclientchannelfailedtoclose.md
-    - name: 4802 - DiscoveryClientProtocolExceptionSuppressed
-      href: 4802-discoveryclientprotocolexceptionsuppressed.md
-    - name: 4803 - DiscoveryClientReceivedMulticastSuppression
-      href: 4803-discoveryclientreceivedmulticastsuppression.md
-    - name: 4804 - DiscoveryMessageReceivedAfterOperationCompleted
-      href: 4804-discoverymessagereceivedafteroperationcompleted.md
-    - name: 4805 - DiscoveryMessageWithInvalidContent
-      href: 4805-discoverymessagewithinvalidcontent.md
-    - name: 4806 - DiscoveryMessageWithInvalidRelatesToOrOperationCompleted
-      href: 4806-discoverymessagewithinvalidrelatestooroperationcompleted.md
-    - name: 4807 - DiscoveryMessageWithInvalidReplyTo
-      href: 4807-discoverymessagewithinvalidreplyto.md
-    - name: 4808 - DiscoveryMessageWithNoContent
-      href: 4808-discoverymessagewithnocontent.md
-    - name: 4809 - DiscoveryMessageWithNullMessageId
-      href: 4809-discoverymessagewithnullmessageid.md
-    - name: 4810 - DiscoveryMessageWithNullMessageSequence
-      href: 4810-discoverymessagewithnullmessagesequence.md
-    - name: 4811 - DiscoveryMessageWithNullRelatesTo
-      href: 4811-discoverymessagewithnullrelatesto.md
-    - name: 4812 - DiscoveryMessageWithNullReplyTo
-      href: 4812-discoverymessagewithnullreplyto.md
-    - name: 4813 - DuplicateDiscoveryMessage
-      href: 4813-duplicatediscoverymessage.md
-    - name: 4814 - EndpointDiscoverabilityDisabled
-      href: 4814-endpointdiscoverabilitydisabled.md
-    - name: 4815 - EndpointDiscoverabilityEnabled
-      href: 4815-endpointdiscoverabilityenabled.md
-    - name: 4816 - FindInitiatedInDiscoveryClientChannel
-      href: 4816-findinitiatedindiscoveryclientchannel.md
-    - name: 4817 - InnerChannelCreationFailed
-      href: 4817-innerchannelcreationfailed.md
-    - name: 4818 - InnerChannelOpenFailed
-      href: 4818-innerchannelopenfailed.md
-    - name: 4819 - InnerChannelOpenSucceeded
-      href: 4819-innerchannelopensucceeded.md
-    - name: 4820 - SynchronizationContextReset
-      href: 4820-synchronizationcontextreset.md
-    - name: 4821 - SynchronizationContextSetToNull
-      href: 4821-synchronizationcontextsettonull.md
-    - name: 5001 - DCSerializeWithSurrogateStart
-      href: 5001-dcserializewithsurrogatestart.md
-    - name: 5002 - DCSerializeWithSurrogateStop
-      href: 5002-dcserializewithsurrogatestop.md
-    - name: 5003 - DCDeserializeWithSurrogateStart
-      href: 5003-dcdeserializewithsurrogatestart.md
-    - name: 5004 - DCDeserializeWithSurrogateStop
-      href: 5004-dcdeserializewithsurrogatestop.md
-    - name: 5005 - ImportKnownTypesStart
-      href: 5005-importknowntypesstart.md
-    - name: 5006 - ImportKnownTypesStop
-      href: 5006-importknowntypesstop.md
-    - name: 5007 - DCResolverResolve
-      href: 5007-dcresolverresolve.md
-    - name: 5008 - DCGenWriterStart
-      href: 5008-dcgenwriterstart.md
-    - name: 5009 - DCGenWriterStop
-      href: 5009-dcgenwriterstop.md
-    - name: 5010 - DCGenReaderStart
-      href: 5010-dcgenreaderstart.md
-    - name: 5011 - DCGenReaderStop
-      href: 5011-dcgenreaderstop.md
-    - name: 5012 - DCJsonGenReaderStart
-      href: 5012-dcjsongenreaderstart.md
-    - name: 5013 - DCJsonGenReaderStop
-      href: 5013-dcjsongenreaderstop.md
-    - name: 5014 - DCJsonGenWriterStart
-      href: 5014-dcjsongenwriterstart.md
-    - name: 5015 - DCJsonGenWriterStop
-      href: 5015-dcjsongenwriterstop.md
-    - name: 5016 - GenXmlSerializableStart
-      href: 5016-genxmlserializablestart.md
-    - name: 5017 - GenXmlSerializableStop
-      href: 5017-genxmlserializablestop.md
-    - name: 5203 - JsonMessageDecodingStart
-      href: 5203-jsonmessagedecodingstart.md
-    - name: 5204 - JsonMessageEncodingStart
-      href: 5204-jsonmessageencodingstart.md
-    - name: 5402 - TokenValidationStarted
-      href: 5402-tokenvalidationstarted.md
-    - name: 5403 - TokenValidationSuccess
-      href: 5403-tokenvalidationsuccess.md
-    - name: 5404 - TokenValidationFailure
-      href: 5404-tokenvalidationfailure.md
-    - name: 5405 - GetIssuerNameSuccess
-      href: 5405-getissuernamesuccess.md
-    - name: 5406 - GetIssuerNameFailure
-      href: 5406-getissuernamefailure.md
-    - name: 5600 - FederationMessageProcessingStarted
-      href: 5600-federationmessageprocessingstarted.md
-    - name: 5601 - FederationMessageProcessingSuccess
-      href: 5601-federationmessageprocessingsuccess.md
-    - name: 5602 - FederationMessageCreationStarted
-      href: 5602-federationmessagecreationstarted.md
-    - name: 5603 - FederationMessageCreationSuccess
-      href: 5603-federationmessagecreationsuccess.md
-    - name: 5604 - SessionCookieReadingStarted
-      href: 5604-sessioncookiereadingstarted.md
-    - name: 5605 - SessionCookieReadingSuccess
-      href: 5605-sessioncookiereadingsuccess.md
-    - name: 5606 - PrincipalSettingFromSessionTokenStarted
-      href: 5606-principalsettingfromsessiontokenstarted.md
-    - name: 5607 - PrincipalSettingFromSessionTokenSuccess
-      href: 5607-principalsettingfromsessiontokensuccess.md
-    - name: 57393 - AppDomainUnload
-      href: 57393-appdomainunload.md
-    - name: 57394 - HandledException
-      href: 57394-handledexception.md
-    - name: 57395 - ShipAssertExceptionMessage
-      href: 57395-shipassertexceptionmessage.md
-    - name: 57396 - ThrowingException
-      href: 57396-throwingexception.md
-    - name: 57397 - UnhandledException
-      href: 57397-unhandledexception.md
-    - name: 57399 - TraceCodeEventLogCritical
-      href: 57399-tracecodeeventlogcritical.md
-    - name: 57400 - TraceCodeEventLogError
-      href: 57400-tracecodeeventlogerror.md
-    - name: 57401 - TraceCodeEventLogInfo
-      href: 57401-tracecodeeventloginfo.md
-    - name: 57402 - TraceCodeEventLogVerbose
-      href: 57402-tracecodeeventlogverbose.md
-    - name: 57403 - TraceCodeEventLogWarning
-      href: 57403-tracecodeeventlogwarning.md
-    - name: 57404 - HandledExceptionWarning
-      href: 57404-handledexceptionwarning.md
-    - name: 62326 - HttpHandlerPickedForUrl
-      href: 62326-httphandlerpickedforurl.md
-  - name: Determine service operation duration
-    href: determining-service-operation-duration.md
+  - name: 131 - BufferPoolAllocation
+    href: 131-bufferpoolallocation.md
+  - name: 132 - BufferPoolChangeQuota
+    href: 132-bufferpoolchangequota.md
+  - name: 133 - ActionItemScheduled
+    href: 133-actionitemscheduled.md
+  - name: 134 - ActionItemCallbackInvoked
+    href: 134-actionitemcallbackinvoked.md
+  - name: 201 - ClientMessageInspectorAfterReceiveInvoked
+    href: 201-clientmessageinspectorafterreceiveinvoked.md
+  - name: 202 - ClientMessageInspectorBeforeSendInvoked
+    href: 202-clientmessageinspectorbeforesendinvoked.md
+  - name: 203 - ClientParameterInspectorAfterCallInvoked
+    href: 203-clientparameterinspectoraftercallinvoked.md
+  - name: 204 - ClientParameterInspectorBeforeCallInvoked
+    href: 204-clientparameterinspectorbeforecallinvoked.md
+  - name: 205 - OperationInvoked
+    href: 205-operationinvoked.md
+  - name: 206 - ErrorHandlerInvoked
+    href: 206-errorhandlerinvoked.md
+  - name: 207 - FaultProviderInvoked
+    href: 207-faultproviderinvoked.md
+  - name: 208 - MessageInspectorAfterReceiveInvoked
+    href: 208-messageinspectorafterreceiveinvoked.md
+  - name: 209 - MessageInspectorBeforeSendInvoked
+    href: 209-messageinspectorbeforesendinvoked.md
+  - name: 210 - MessageThrottleExceeded
+    href: 210-messagethrottleexceeded.md
+  - name: 211 - ParameterInspectorAfterCallInvoked
+    href: 211-parameterinspectoraftercallinvoked.md
+  - name: 212 - ParameterInspectorBeforeCallInvoked
+    href: 212-parameterinspectorbeforecallinvoked.md
+  - name: 213 - ServiceHostStarted
+    href: 213-servicehoststarted.md
+  - name: 214 - OperationCompleted
+    href: 214-operationcompleted.md
+  - name: 215 - MessageReceivedByTransport
+    href: 215-messagereceivedbytransport.md
+  - name: 216 - MessageSentByTransport
+    href: 216-messagesentbytransport.md
+  - name: 217 - ClientOperationPrepared
+    href: 217-clientoperationprepared.md
+  - name: 218 - ClientOperationCompleted
+    href: 218-clientoperationcompleted.md
+  - name: 219 - ServiceException
+    href: 219-serviceexception.md
+  - name: 220 - MessageSentToTransport
+    href: 220-messagesenttotransport.md
+  - name: 221 - MessageReceivedFromTransport
+    href: 221-messagereceivedfromtransport.md
+  - name: 222 - OperationFailed
+    href: 222-operationfailed.md
+  - name: 223 - OperationFaulted
+    href: 223-operationfaulted.md
+  - name: 224 - MessageThrottleAtSeventyPercent
+    href: 224-messagethrottleatseventypercent.md
+  - name: 226 - IdleServicesClosed
+    href: 226-idleservicesclosed.md
+  - name: 301 - UserDefinedErrorOccurred
+    href: 301-userdefinederroroccurred.md
+  - name: 302 - UserDefinedWarningOccurred
+    href: 302-userdefinedwarningoccurred.md
+  - name: 303 - UserDefinedInformationEventOccured
+    href: 303-userdefinedinformationeventoccured.md
+  - name: 401- StopSignPostEvent
+    href: 401-stopsignpostevent.md
+  - name: 402 - StartSignpostEvent
+    href: 402-startsignpostevent.md
+  - name: 403 - SuspendSignpostEvent
+    href: 403-suspendsignpostevent.md
+  - name: 404 - ResumeSignpostEvent
+    href: 404-resumesignpostevent.md
+  - name: 451 - MessageLogInfo
+    href: 451-messageloginfo.md
+  - name: 452 - MessageLogWarning
+    href: 452-messagelogwarning.md
+  - name: 499 - TransferEmitted
+    href: 499-transferemitted.md
+  - name: 501 - CompilationStart
+    href: 501-compilationstart.md
+  - name: 502 - CompilationStop
+    href: 502-compilationstop.md
+  - name: 503 - ServiceHostFactoryCreationStart
+    href: 503-servicehostfactorycreationstart.md
+  - name: 504 - ServiceHostFactoryCreationStop
+    href: 504-servicehostfactorycreationstop.md
+  - name: 505 - CreateServiceHostStart
+    href: 505-createservicehoststart.md
+  - name: 506 - CreateServiceHostStop
+    href: 506-createservicehoststop.md
+  - name: 507 - HostedTransportConfigurationManagerConfigInitStart
+    href: 507-hostedtransportconfigurationmanagerconfiginitstart.md
+  - name: 508 - HostedTransportConfigurationManagerConfigInitStop
+    href: 508-hostedtransportconfigurationmanagerconfiginitstop.md
+  - name: 509 - ServiceHostOpenStart
+    href: 509-servicehostopenstart.md
+  - name: 510 - ServiceHostOpenStop
+    href: 510-servicehostopenstop.md
+  - name: 513 - WebHostRequestStart
+    href: 513-webhostrequeststart.md
+  - name: 514 - WebHostRequestStop
+    href: 514-webhostrequeststop.md
+  - name: 601 - CBAEntryRead
+    href: 601-cbaentryread.md
+  - name: 602 - CBAMatchFound
+    href: 602-cbamatchfound.md
+  - name: 603 - AspNetRoutingService
+    href: 603-aspnetroutingservice.md
+  - name: 604 - AspNetRoute
+    href: 604-aspnetroute.md
+  - name: 605 - IncrementBusyCount
+    href: 605-incrementbusycount.md
+  - name: 606 - DecrementBusyCount
+    href: 606-decrementbusycount.md
+  - name: 701 - ServiceChannelOpenStart
+    href: 701-servicechannelopenstart.md
+  - name: 702 - ServiceChannelOpenStop
+    href: 702-servicechannelopenstop.md
+  - name: 703 - ServiceChannelCallStart
+    href: 703-servicechannelcallstart.md
+  - name: 704 - ServiceChannelBeginCallStart
+    href: 704-servicechannelbegincallstart.md
+  - name: 706 - HttpSendMessageStart
+    href: 706-httpsendmessagestart.md
+  - name: 707 - HttpSendStop
+    href: 707-httpsendstop.md
+  - name: 708 - HttpMessageReceiveStart
+    href: 708-httpmessagereceivestart.md
+  - name: 709 - DispatchMessageStart
+    href: 709-dispatchmessagestart.md
+  - name: 710 - HttpContextBeforeProcessAuthentication
+    href: 710-httpcontextbeforeprocessauthentication.md
+  - name: 711 - DispatchMessageBeforeAuthorization
+    href: 711-dispatchmessagebeforeauthorization.md
+  - name: 712 - DispatchMessageStop
+    href: 712-dispatchmessagestop.md
+  - name: 715 - ClientChannelOpenStart
+    href: 715-clientchannelopenstart.md
+  - name: 716 - ClientChannelOpenStop
+    href: 716-clientchannelopenstop.md
+  - name: 717 - HttpSendStreamedMessageStart
+    href: 717-httpsendstreamedmessagestart.md
+  - name: 1400 - ChannelInitializationTimeout
+    href: 1400-channelinitializationtimeout.md
+  - name: 1401 - CloseTimeout
+    href: 1401-closetimeout.md
+  - name: 1402 - IdleTimeout
+    href: 1402-idletimeout.md
+  - name: 1403 - LeaseTimeout
+    href: 1403-leasetimeout.md
+  - name: 1405 - OpenTimeout
+    href: 1405-opentimeout.md
+  - name: 1406 - ReceiveTimeout
+    href: 1406-receivetimeout.md
+  - name: 1407 - SendTimeout
+    href: 1407-sendtimeout.md
+  - name: 1409 - InactivityTimeout
+    href: 1409-inactivitytimeout.md
+  - name: 1416 - MaxReceivedMessageSizeExceeded
+    href: 1416-maxreceivedmessagesizeexceeded.md
+  - name: 1417 - MaxSentMessageSizeExceeded
+    href: 1417-maxsentmessagesizeexceeded.md
+  - name: 1418 - MaxOutboundConnectionsPerEndpointExceeded
+    href: 1418-maxoutboundconnectionsperendpointexceeded.md
+  - name: 1419 - MaxPendingConnectionsExceeded
+    href: 1419-maxpendingconnectionsexceeded.md
+  - name: 1420 - ReaderQuotaExceeded
+    href: 1420-readerquotaexceeded.md
+  - name: 1422 - NegotiateTokenAuthenticatorStateCacheExceeded
+    href: 1422-negotiatetokenauthenticatorstatecacheexceeded.md
+  - name: 1423 - NegotiateTokenAuthenticatorStateCacheRatio
+    href: 1423-negotiatetokenauthenticatorstatecacheratio.md
+  - name: 1424 - SecuritySessionRatio
+    href: 1424-securitysessionratio.md
+  - name: 1430 - PendingConnectionsRatio
+    href: 1430-pendingconnectionsratio.md
+  - name: 1431 - ConcurrentCallsRatio
+    href: 1431-concurrentcallsratio.md
+  - name: 1432 - ConcurrentSessionsRatio
+    href: 1432-concurrentsessionsratio.md
+  - name: 1433 - OutboundConnectionsPerEndpointRatio
+    href: 1433-outboundconnectionsperendpointratio.md
+  - name: 1436 - PendingMessagesPerChannelRatio
+    href: 1436-pendingmessagesperchannelratio.md
+  - name: 1438 - ConcurrentInstancesRatio
+    href: 1438-concurrentinstancesratio.md
+  - name: 1439 - PendingAcceptsAtZero
+    href: 1439-pendingacceptsatzero.md
+  - name: 1441 - MaxSessionSizeReached
+    href: 1441-maxsessionsizereached.md
+  - name: 1442 - ReceiveRetryCountReached
+    href: 1442-receiveretrycountreached.md
+  - name: 1443 - MaxRetryCyclesExceededMsmq
+    href: 1443-maxretrycyclesexceededmsmq.md
+  - name: 1445 - ReadPoolMiss
+    href: 1445-readpoolmiss.md
+  - name: 1446 - WritePoolMiss
+    href: 1446-writepoolmiss.md
+  - name: 1451 - MaxRetryCyclesExceeded
+    href: 1451-maxretrycyclesexceeded.md
+  - name: 3300 - ReceiveContextCompleteFailed
+    href: 3300-receivecontextcompletefailed.md
+  - name: 3301 - ReceiveContextAbandonFailed
+    href: 3301-receivecontextabandonfailed.md
+  - name: 3302 - ReceiveContextFaulted
+    href: 3302-receivecontextfaulted.md
+  - name: 3303 - ReceiveContextAbandonWithException
+    href: 3303-receivecontextabandonwithexception.md
+  - name: 3305 - ClientBaseCachedChannelFactoryCount
+    href: 3305-clientbasecachedchannelfactorycount.md
+  - name: 3306 - ClientBaseChannelFactoryAgedOutofCache
+    href: 3306-clientbasechannelfactoryagedoutofcache.md
+  - name: 3307 - ClientBaseChannelFactoryCacheHit
+    href: 3307-clientbasechannelfactorycachehit.md
+  - name: 3308 - ClientBaseUsingLocalChannelFactory
+    href: 3308-clientbaseusinglocalchannelfactory.md
+  - name: 3309 - QueryCompositionExecuted
+    href: 3309-querycompositionexecuted.md
+  - name: 3310 - DispatchFailed
+    href: 3310-dispatchfailed.md
+  - name: 3311 - DispatchSuccessful
+    href: 3311-dispatchsuccessful.md
+  - name: 3312 - MessageReadByEncoder
+    href: 3312-messagereadbyencoder.md
+  - name: 3313 - MessageWrittenByEncoder
+    href: 3313-messagewrittenbyencoder.md
+  - name: 3314 - SessionIdleTimeout
+    href: 3314-sessionidletimeout.md
+  - name: 3319 - SocketAcceptEnqueued
+    href: 3319-socketacceptenqueued.md
+  - name: 3320 - SocketAccepted
+    href: 3320-socketaccepted.md
+  - name: 3321 - ConnectionPoolMiss
+    href: 3321-connectionpoolmiss.md
+  - name: 3322 - DispatchFormatterDeserializeRequestStart
+    href: 3322-dispatchformatterdeserializerequeststart.md
+  - name: 3323 - DispatchFormatterDeserializeRequestStop
+    href: 3323-dispatchformatterdeserializerequeststop.md
+  - name: 3324 - DispatchFormatterSerializeReplyStart
+    href: 3324-dispatchformatterserializereplystart.md
+  - name: 3325 - DispatchFormatterSerializeReplyStop
+    href: 3325-dispatchformatterserializereplystop.md
+  - name: 3326 - ClientFormatterSerializeRequestStart
+    href: 3326-clientformatterserializerequeststart.md
+  - name: 3327 - ClientFormatterSerializeRequestStop
+    href: 3327-clientformatterserializerequeststop.md
+  - name: 3328 - ClientFormatterDeserializeReplyStart
+    href: 3328-clientformatterdeserializereplystart.md
+  - name: 3329 - ClientFormatterDeserializeReplyStop
+    href: 3329-clientformatterdeserializereplystop.md
+  - name: 3330 - SecurityNegotiationStart
+    href: 3330-securitynegotiationstart.md
+  - name: 3331 - SecurityNegotiationStop
+    href: 3331-securitynegotiationstop.md
+  - name: 3332 - SecurityTokenProviderOpened
+    href: 3332-securitytokenprovideropened.md
+  - name: 3333 - OutgoingMessageSecured
+    href: 3333-outgoingmessagesecured.md
+  - name: 3334 - IncomingMessageVerified
+    href: 3334-incomingmessageverified.md
+  - name: 3335 - GetServiceInstanceStart
+    href: 3335-getserviceinstancestart.md
+  - name: 3336 - GetServiceInstanceStop
+    href: 3336-getserviceinstancestop.md
+  - name: 3337 - ChannelReceiveStart
+    href: 3337-channelreceivestart.md
+  - name: 3338 - ChannelReceiveStop
+    href: 3338-channelreceivestop.md
+  - name: 3339 - ChannelFactoryCreated
+    href: 3339-channelfactorycreated.md
+  - name: 3340 - PipeConnectionAcceptStart
+    href: 3340-pipeconnectionacceptstart.md
+  - name: 3341 - PipeConnectionAcceptStop
+    href: 3341-pipeconnectionacceptstop.md
+  - name: 3342 - EstablishConnectionStart
+    href: 3342-establishconnectionstart.md
+  - name: 3343 - EstablishConnectionStop
+    href: 3343-establishconnectionstop.md
+  - name: 3345 - SessionPreambleUnderstood
+    href: 3345-sessionpreambleunderstood.md
+  - name: 3346 - ConnectionReaderSendFault
+    href: 3346-connectionreadersendfault.md
+  - name: 3347 - SocketAcceptClosed
+    href: 3347-socketacceptclosed.md
+  - name: 3348 - ServiceHostFaulted
+    href: 3348-servicehostfaulted.md
+  - name: 3349 - ListenerOpenStart
+    href: 3349-listeneropenstart.md
+  - name: 3350 - ListenerOpenStop
+    href: 3350-listeneropenstop.md
+  - name: 3351 - ServerMaxPooledConnectionsQuotaReached
+    href: 3351-servermaxpooledconnectionsquotareached.md
+  - name: 3352 - TcpConnectionTimedOut
+    href: 3352-tcpconnectiontimedout.md
+  - name: 3353 - TcpConnectionResetError
+    href: 3353-tcpconnectionreseterror.md
+  - name: 3354 - ServiceSecurityNegotiationCompleted
+    href: 3354-servicesecuritynegotiationcompleted.md
+  - name: 3355 - SecurityNegotiationProcessingFailure
+    href: 3355-securitynegotiationprocessingfailure.md
+  - name: 3356 - SecurityIdentityVerificationSuccess
+    href: 3356-securityidentityverificationsuccess.md
+  - name: 3357 - SecurityIdentityVerificationFailure
+    href: 3357-securityidentityverificationfailure.md
+  - name: 3358 - PortSharingDuplicatedSocket
+    href: 3358-portsharingduplicatedsocket.md
+  - name: 3359 - SecurityImpersonationSuccess
+    href: 3359-securityimpersonationsuccess.md
+  - name: 3360 - SecurityImpersonationFailure
+    href: 3360-securityimpersonationfailure.md
+  - name: 3361 - HttpChannelRequestAborted
+    href: 3361-httpchannelrequestaborted.md
+  - name: 3362 - HttpChannelResponseAborted
+    href: 3362-httpchannelresponseaborted.md
+  - name: 3363 - HttpAuthFailed
+    href: 3363-httpauthfailed.md
+  - name: 3364 - SharedListenerProxyRegisterStart
+    href: 3364-sharedlistenerproxyregisterstart.md
+  - name: 3365 - SharedListenerProxyRegisterStop
+    href: 3365-sharedlistenerproxyregisterstop.md
+  - name: 3366 - SharedListenerProxyRegisterFailed
+    href: 3366-sharedlistenerproxyregisterfailed.md
+  - name: 3367 - ConnectionPoolPreambleFailed
+    href: 3367-connectionpoolpreamblefailed.md
+  - name: 3368 - SslOnInitiateUpgrade
+    href: 3368-ssloninitiateupgrade.md
+  - name: 3369 - SslOnAcceptUpgrade
+    href: 3369-sslonacceptupgrade.md
+  - name: 3370 - BinaryMessageEncodingStart
+    href: 3370-binarymessageencodingstart.md
+  - name: 3371 - MtomMessageEncodingStart
+    href: 3371-mtommessageencodingstart.md
+  - name: 3372 - TextMessageEncodingStart
+    href: 3372-textmessageencodingstart.md
+  - name: 3373 - BinaryMessageDecodingStart
+    href: 3373-binarymessagedecodingstart.md
+  - name: 3374 - MtomMessageDecodingStart
+    href: 3374-mtommessagedecodingstart.md
+  - name: 3375 - TextMessageDecodingStart
+    href: 3375-textmessagedecodingstart.md
+  - name: 3376 - HttpResponseReceiveStart
+    href: 3376-httpresponsereceivestart.md
+  - name: 3377 - SocketReadStop
+    href: 3377-socketreadstop.md
+  - name: 3378 - SocketAsyncReadStop
+    href: 3378-socketasyncreadstop.md
+  - name: 3379 - SocketWriteStart
+    href: 3379-socketwritestart.md
+  - name: 3380 - SocketAsyncWriteStart
+    href: 3380-socketasyncwritestart.md
+  - name: 3381 - SequenceAcknowledgementSent
+    href: 3381-sequenceacknowledgementsent.md
+  - name: 3382 - ClientReliableSessionReconnect
+    href: 3382-clientreliablesessionreconnect.md
+  - name: 3383 - ReliableSessionChannelFaulted
+    href: 3383-reliablesessionchannelfaulted.md
+  - name: 3384 - WindowsStreamSecurityOnInitiateUpgrade
+    href: 3384-windowsstreamsecurityoninitiateupgrade.md
+  - name: 3385 - WindowsStreamSecurityOnAcceptUpgrade
+    href: 3385-windowsstreamsecurityonacceptupgrade.md
+  - name: 3386 - SocketConnectionAbort
+    href: 3386-socketconnectionabort.md
+  - name: 3388 - HttpGetContextStart
+    href: 3388-httpgetcontextstart.md
+  - name: 3389 - ClientSendPreambleStart
+    href: 3389-clientsendpreamblestart.md
+  - name: 3390 - ClientSendPreambleStop
+    href: 3390-clientsendpreamblestop.md
+  - name: 3391 - HttpMessageReceiveFailed
+    href: 3391-httpmessagereceivefailed.md
+  - name: 3392 - TransactionScopeCreate
+    href: 3392-transactionscopecreate.md
+  - name: 3393 - StreamedMessageReadByEncoder
+    href: 3393-streamedmessagereadbyencoder.md
+  - name: 3394 - StreamedMessageWrittenByEncoder
+    href: 3394-streamedmessagewrittenbyencoder.md
+  - name: 3395 - MessageWrittenAsynchronouslyByEncoder
+    href: 3395-messagewrittenasynchronouslybyencoder.md
+  - name: 3396 - BufferedAsyncWriteStart
+    href: 3396-bufferedasyncwritestart.md
+  - name: 3397 - BufferedAsyncWriteStop
+    href: 3397-bufferedasyncwritestop.md
+  - name: 3398 - PipeSharedMemoryCreated
+    href: 3398-pipesharedmemorycreated.md
+  - name: 3399 - NamedPipeCreated
+    href: 3399-namedpipecreated.md
+  - name: 3401 - SignatureVerificationStart
+    href: 3401-signatureverificationstart.md
+  - name: 3402 - SignatureVerificationSuccess
+    href: 3402-signatureverificationsuccess.md
+  - name: 3403 - WrappedKeyDecryptionStart
+    href: 3403-wrappedkeydecryptionstart.md
+  - name: 3404 - WrappedKeyDecryptionSuccess
+    href: 3404-wrappedkeydecryptionsuccess.md
+  - name: 3405 - EncryptedDataProcessingStart
+    href: 3405-encrypteddataprocessingstart.md
+  - name: 3406 - EncryptedDataProcessingSuccess
+    href: 3406-encrypteddataprocessingsuccess.md
+  - name: 3407 - HttpPipelineProcessInboundRequestStart
+    href: 3407-httppipelineprocessinboundrequeststart.md
+  - name: 3408 - HttpPipelineBeginProcessInboundRequestStart
+    href: 3408-httppipelinebeginprocessinboundrequeststart.md
+  - name: 3409 - HttpPipelineProcessInboundRequestStop
+    href: 3409-httppipelineprocessinboundrequeststop.md
+  - name: 3410 - HttpPipelineFaulted
+    href: 3410-httppipelinefaulted.md
+  - name: 3411 - HttpPipelineTimeoutException
+    href: 3411-httppipelinetimeoutexception.md
+  - name: 3412 - HttpPipelineProcessResponseStart
+    href: 3412-httppipelineprocessresponsestart.md
+  - name: 3413 - HttpPipelineBeginProcessResponseStart
+    href: 3413-httppipelinebeginprocessresponsestart.md
+  - name: 3414 - HttpPipelineProcessResponseStop
+    href: 3414-httppipelineprocessresponsestop.md
+  - name: 3415 - WebSocketConnectionRequestSendStart
+    href: 3415-websocketconnectionrequestsendstart.md
+  - name: 3416 - WebSocketConnectionRequestSendStop
+    href: 3416-websocketconnectionrequestsendstop.md
+  - name: 3417 - WebSocketConnectionAcceptStart
+    href: 3417-websocketconnectionacceptstart.md
+  - name: 3418 - WebSocketConnectionAccepted
+    href: 3418-websocketconnectionaccepted.md
+  - name: 3419 - WebSocketConnectionDeclined
+    href: 3419-websocketconnectiondeclined.md
+  - name: 3420 - WebSocketConnectionFailed
+    href: 3420-websocketconnectionfailed.md
+  - name: 3421 - WebSocketConnectionAborted
+    href: 3421-websocketconnectionaborted.md
+  - name: 3422 - WebSocketAsyncWriteStart
+    href: 3422-websocketasyncwritestart.md
+  - name: 3423 - WebSocketAsyncWriteStop
+    href: 3423-websocketasyncwritestop.md
+  - name: 3424 - WebSocketAsyncReadStart
+    href: 3424-websocketasyncreadstart.md
+  - name: 3425 - WebSocketAsyncReadStop
+    href: 3425-websocketasyncreadstop.md
+  - name: 3426 - WebSocketCloseSent
+    href: 3426-websocketclosesent.md
+  - name: 3427 - WebSocketCloseOutputSent
+    href: 3427-websocketcloseoutputsent.md
+  - name: 3428 - WebSocketConnectionClosed
+    href: 3428-websocketconnectionclosed.md
+  - name: 3429 - WebSocketCloseStatusReceived
+    href: 3429-websocketclosestatusreceived.md
+  - name: 3430 - WebSocketUseVersionFromClientWebSocketFactory
+    href: 3430-websocketuseversionfromclientwebsocketfactory.md
+  - name: 3431 - WebSocketCreateClientWebSocketWithFactory
+    href: 3431-websocketcreateclientwebsocketwithfactory.md
+  - name: 3553 - XamlServicesLoadStart
+    href: 3553-xamlservicesloadstart.md
+  - name: 3554 - XamlServicesLoadStop
+    href: 3554-xamlservicesloadstop.md
+  - name: 3555 - CreateWorkflowServiceHostStart
+    href: 3555-createworkflowservicehoststart.md
+  - name: 3556 - CreateWorkflowServiceHostStop
+    href: 3556-createworkflowservicehoststop.md
+  - name: 3558 - ServiceActivationStart
+    href: 3558-serviceactivationstart.md
+  - name: 3559 - ServiceActivationStop
+    href: 3559-serviceactivationstop.md
+  - name: 3560 - ServiceActivationAvailableMemory
+    href: 3560-serviceactivationavailablememory.md
+  - name: 3800 - RoutingServiceClosingClient
+    href: 3800-routingserviceclosingclient.md
+  - name: 3801 - RoutingServiceChannelFaulted
+    href: 3801-routingservicechannelfaulted.md
+  - name: 3802 - RoutingServiceCompletingOneWay
+    href: 3802-routingservicecompletingoneway.md
+  - name: 3803 - RoutingServiceProcessingFailure
+    href: 3803-routingserviceprocessingfailure.md
+  - name: 3804 - RoutingServiceCreatingClientForEndpoint
+    href: 3804-routingservicecreatingclientforendpoint.md
+  - name: 3805 - RoutingServiceDisplayConfig
+    href: 3805-routingservicedisplayconfig.md
+  - name: 3807 - RoutingServiceCompletingTwoWay
+    href: 3807-routingservicecompletingtwoway.md
+  - name: 3809 - RoutingServiceMessageRoutedToEndpoints
+    href: 3809-routingservicemessageroutedtoendpoints.md
+  - name: 3810 - RoutingServiceConfigurationApplied
+    href: 3810-routingserviceconfigurationapplied.md
+  - name: 3815 - RoutingServiceProcessingMessage
+    href: 3815-routingserviceprocessingmessage.md
+  - name: 3816 - RoutingServiceTransmittingMessage
+    href: 3816-routingservicetransmittingmessage.md
+  - name: 3817 - RoutingServiceCommittingTransaction
+    href: 3817-routingservicecommittingtransaction.md
+  - name: 3818 - RoutingServiceDuplexCallbackException
+    href: 3818-routingserviceduplexcallbackexception.md
+  - name: 3819 - RoutingServiceMovedToBackup
+    href: 3819-routingservicemovedtobackup.md
+  - name: 3820 - RoutingServiceCreatingTransaction
+    href: 3820-routingservicecreatingtransaction.md
+  - name: 3821 - RoutingServiceCloseFailed
+    href: 3821-routingserviceclosefailed.md
+  - name: 3822 - RoutingServiceSendingResponse
+    href: 3822-routingservicesendingresponse.md
+  - name: 3823 - RoutingServiceSendingFaultResponse
+    href: 3823-routingservicesendingfaultresponse.md
+  - name: 3824 - RoutingServiceCompletingReceiveContext
+    href: 3824-routingservicecompletingreceivecontext.md
+  - name: 3825 - RoutingServiceAbandoningReceiveContext
+    href: 3825-routingserviceabandoningreceivecontext.md
+  - name: 3826 - RoutingServiceUsingExistingTransaction
+    href: 3826-routingserviceusingexistingtransaction.md
+  - name: 3827 - RoutingServiceTransmitFailed
+    href: 3827-routingservicetransmitfailed.md
+  - name: 3828 - RoutingServiceFilterTableMatchStart
+    href: 3828-routingservicefiltertablematchstart.md
+  - name: 3829 - RoutingServiceFilterTableMatchStop
+    href: 3829-routingservicefiltertablematchstop.md
+  - name: 3830 - RoutingServiceAbortingChannel
+    href: 3830-routingserviceabortingchannel.md
+  - name: 3831 - RoutingServiceHandledException
+    href: 3831-routingservicehandledexception.md
+  - name: 3832 - RoutingServiceTransmitSucceeded
+    href: 3832-routingservicetransmitsucceeded.md
+  - name: 4001 - TransportListenerSessionsReceived
+    href: 4001-transportlistenersessionsreceived.md
+  - name: 4002 - FailFastException
+    href: 4002-failfastexception.md
+  - name: 4003 - ServiceStartPipeError
+    href: 4003-servicestartpipeerror.md
+  - name: 4008 - DispatchSessionStart
+    href: 4008-dispatchsessionstart.md
+  - name: 4010 - PendingSessionQueueFull
+    href: 4010-pendingsessionqueuefull.md
+  - name: 4011 - MessageQueueRegisterStart
+    href: 4011-messagequeueregisterstart.md
+  - name: 4012 - MessageQueueRegisterAbort
+    href: 4012-messagequeueregisterabort.md
+  - name: 4013 - MessageQueueUnregisterSucceeded
+    href: 4013-messagequeueunregistersucceeded.md
+  - name: 4014 - MessageQueueRegisterFailed
+    href: 4014-messagequeueregisterfailed.md
+  - name: 4015 - MessageQueueRegisterCompleted
+    href: 4015-messagequeueregistercompleted.md
+  - name: 4016 - MessageQueueDuplicatedSocketError
+    href: 4016-messagequeueduplicatedsocketerror.md
+  - name: 4019 - MessageQueueDuplicatedSocketComplete
+    href: 4019-messagequeueduplicatedsocketcomplete.md
+  - name: 4020 - TcpTransportListenerListeningStart
+    href: 4020-tcptransportlistenerlisteningstart.md
+  - name: 4021 - TcpTransportListenerListeningStop
+    href: 4021-tcptransportlistenerlisteningstop.md
+  - name: 4022 - WebhostUnregisterProtocolFailed
+    href: 4022-webhostunregisterprotocolfailed.md
+  - name: 4023 - WasCloseAllListenerChannelInstancesCompleted
+    href: 4023-wasclosealllistenerchannelinstancescompleted.md
+  - name: 4024 - WasCloseAllListenerChannelInstancesFailed
+    href: 4024-wasclosealllistenerchannelinstancesfailed.md
+  - name: 4025 - OpenListenerChannelInstanceFailed
+    href: 4025-openlistenerchannelinstancefailed.md
+  - name: 4026 - WasConnected
+    href: 4026-wasconnected.md
+  - name: 4027 - WasDisconnected
+    href: 4027-wasdisconnected.md
+  - name: 4028 - PipeTransportListenerListeningStart
+    href: 4028-pipetransportlistenerlisteningstart.md
+  - name: 4029 - PipeTransportListenerListeningStop
+    href: 4029-pipetransportlistenerlisteningstop.md
+  - name: 4030 - DispatchSessionSuccess
+    href: 4030-dispatchsessionsuccess.md
+  - name: 4031 - DispatchSessionFailed
+    href: 4031-dispatchsessionfailed.md
+  - name: 4032 - WasConnectionTimedout
+    href: 4032-wasconnectiontimedout.md
+  - name: 4033 - RoutingTableLookupStart
+    href: 4033-routingtablelookupstart.md
+  - name: 4034 - RoutingTableLookupStop
+    href: 4034-routingtablelookupstop.md
+  - name: 4035 - PendingSessionQueueRatio
+    href: 4035-pendingsessionqueueratio.md
+  - name: 4600 - MessageLogEventSizeExceeded
+    href: 4600-messagelogeventsizeexceeded.md
+  - name: 4801 - DiscoveryClientInClientChannelFailedToClose
+    href: 4801-discoveryclientinclientchannelfailedtoclose.md
+  - name: 4802 - DiscoveryClientProtocolExceptionSuppressed
+    href: 4802-discoveryclientprotocolexceptionsuppressed.md
+  - name: 4803 - DiscoveryClientReceivedMulticastSuppression
+    href: 4803-discoveryclientreceivedmulticastsuppression.md
+  - name: 4804 - DiscoveryMessageReceivedAfterOperationCompleted
+    href: 4804-discoverymessagereceivedafteroperationcompleted.md
+  - name: 4805 - DiscoveryMessageWithInvalidContent
+    href: 4805-discoverymessagewithinvalidcontent.md
+  - name: 4806 - DiscoveryMessageWithInvalidRelatesToOrOperationCompleted
+    href: 4806-discoverymessagewithinvalidrelatestooroperationcompleted.md
+  - name: 4807 - DiscoveryMessageWithInvalidReplyTo
+    href: 4807-discoverymessagewithinvalidreplyto.md
+  - name: 4808 - DiscoveryMessageWithNoContent
+    href: 4808-discoverymessagewithnocontent.md
+  - name: 4809 - DiscoveryMessageWithNullMessageId
+    href: 4809-discoverymessagewithnullmessageid.md
+  - name: 4810 - DiscoveryMessageWithNullMessageSequence
+    href: 4810-discoverymessagewithnullmessagesequence.md
+  - name: 4811 - DiscoveryMessageWithNullRelatesTo
+    href: 4811-discoverymessagewithnullrelatesto.md
+  - name: 4812 - DiscoveryMessageWithNullReplyTo
+    href: 4812-discoverymessagewithnullreplyto.md
+  - name: 4813 - DuplicateDiscoveryMessage
+    href: 4813-duplicatediscoverymessage.md
+  - name: 4814 - EndpointDiscoverabilityDisabled
+    href: 4814-endpointdiscoverabilitydisabled.md
+  - name: 4815 - EndpointDiscoverabilityEnabled
+    href: 4815-endpointdiscoverabilityenabled.md
+  - name: 4816 - FindInitiatedInDiscoveryClientChannel
+    href: 4816-findinitiatedindiscoveryclientchannel.md
+  - name: 4817 - InnerChannelCreationFailed
+    href: 4817-innerchannelcreationfailed.md
+  - name: 4818 - InnerChannelOpenFailed
+    href: 4818-innerchannelopenfailed.md
+  - name: 4819 - InnerChannelOpenSucceeded
+    href: 4819-innerchannelopensucceeded.md
+  - name: 4820 - SynchronizationContextReset
+    href: 4820-synchronizationcontextreset.md
+  - name: 4821 - SynchronizationContextSetToNull
+    href: 4821-synchronizationcontextsettonull.md
+  - name: 5001 - DCSerializeWithSurrogateStart
+    href: 5001-dcserializewithsurrogatestart.md
+  - name: 5002 - DCSerializeWithSurrogateStop
+    href: 5002-dcserializewithsurrogatestop.md
+  - name: 5003 - DCDeserializeWithSurrogateStart
+    href: 5003-dcdeserializewithsurrogatestart.md
+  - name: 5004 - DCDeserializeWithSurrogateStop
+    href: 5004-dcdeserializewithsurrogatestop.md
+  - name: 5005 - ImportKnownTypesStart
+    href: 5005-importknowntypesstart.md
+  - name: 5006 - ImportKnownTypesStop
+    href: 5006-importknowntypesstop.md
+  - name: 5007 - DCResolverResolve
+    href: 5007-dcresolverresolve.md
+  - name: 5008 - DCGenWriterStart
+    href: 5008-dcgenwriterstart.md
+  - name: 5009 - DCGenWriterStop
+    href: 5009-dcgenwriterstop.md
+  - name: 5010 - DCGenReaderStart
+    href: 5010-dcgenreaderstart.md
+  - name: 5011 - DCGenReaderStop
+    href: 5011-dcgenreaderstop.md
+  - name: 5012 - DCJsonGenReaderStart
+    href: 5012-dcjsongenreaderstart.md
+  - name: 5013 - DCJsonGenReaderStop
+    href: 5013-dcjsongenreaderstop.md
+  - name: 5014 - DCJsonGenWriterStart
+    href: 5014-dcjsongenwriterstart.md
+  - name: 5015 - DCJsonGenWriterStop
+    href: 5015-dcjsongenwriterstop.md
+  - name: 5016 - GenXmlSerializableStart
+    href: 5016-genxmlserializablestart.md
+  - name: 5017 - GenXmlSerializableStop
+    href: 5017-genxmlserializablestop.md
+  - name: 5203 - JsonMessageDecodingStart
+    href: 5203-jsonmessagedecodingstart.md
+  - name: 5204 - JsonMessageEncodingStart
+    href: 5204-jsonmessageencodingstart.md
+  - name: 5402 - TokenValidationStarted
+    href: 5402-tokenvalidationstarted.md
+  - name: 5403 - TokenValidationSuccess
+    href: 5403-tokenvalidationsuccess.md
+  - name: 5404 - TokenValidationFailure
+    href: 5404-tokenvalidationfailure.md
+  - name: 5405 - GetIssuerNameSuccess
+    href: 5405-getissuernamesuccess.md
+  - name: 5406 - GetIssuerNameFailure
+    href: 5406-getissuernamefailure.md
+  - name: 5600 - FederationMessageProcessingStarted
+    href: 5600-federationmessageprocessingstarted.md
+  - name: 5601 - FederationMessageProcessingSuccess
+    href: 5601-federationmessageprocessingsuccess.md
+  - name: 5602 - FederationMessageCreationStarted
+    href: 5602-federationmessagecreationstarted.md
+  - name: 5603 - FederationMessageCreationSuccess
+    href: 5603-federationmessagecreationsuccess.md
+  - name: 5604 - SessionCookieReadingStarted
+    href: 5604-sessioncookiereadingstarted.md
+  - name: 5605 - SessionCookieReadingSuccess
+    href: 5605-sessioncookiereadingsuccess.md
+  - name: 5606 - PrincipalSettingFromSessionTokenStarted
+    href: 5606-principalsettingfromsessiontokenstarted.md
+  - name: 5607 - PrincipalSettingFromSessionTokenSuccess
+    href: 5607-principalsettingfromsessiontokensuccess.md
+  - name: 57393 - AppDomainUnload
+    href: 57393-appdomainunload.md
+  - name: 57394 - HandledException
+    href: 57394-handledexception.md
+  - name: 57395 - ShipAssertExceptionMessage
+    href: 57395-shipassertexceptionmessage.md
+  - name: 57396 - ThrowingException
+    href: 57396-throwingexception.md
+  - name: 57397 - UnhandledException
+    href: 57397-unhandledexception.md
+  - name: 57399 - TraceCodeEventLogCritical
+    href: 57399-tracecodeeventlogcritical.md
+  - name: 57400 - TraceCodeEventLogError
+    href: 57400-tracecodeeventlogerror.md
+  - name: 57401 - TraceCodeEventLogInfo
+    href: 57401-tracecodeeventloginfo.md
+  - name: 57402 - TraceCodeEventLogVerbose
+    href: 57402-tracecodeeventlogverbose.md
+  - name: 57403 - TraceCodeEventLogWarning
+    href: 57403-tracecodeeventlogwarning.md
+  - name: 57404 - HandledExceptionWarning
+    href: 57404-handledexceptionwarning.md
+  - name: 62326 - HttpHandlerPickedForUrl
+    href: 62326-httphandlerpickedforurl.md
+- name: Determine service operation duration
+  href: determining-service-operation-duration.md

--- a/docs/framework/wcf/diagnostics/event-logging/toc.yml
+++ b/docs/framework/wcf/diagnostics/event-logging/toc.yml
@@ -1,160 +1,160 @@
-- name: Event Logging
+items:
+- name: Event logging
   href: index.md
+- name: Events general reference
+  href: events-general-reference.md
   items:
-  - name: Events General Reference
-    href: events-general-reference.md
-    items:
-    - name: BindingError
-      href: bindingerror.md
-    - name: ComPlusDllHostInitializerStartingError
-      href: complusdllhostinitializerstartingerror.md
-    - name: ComPlusInstanceCreationError
-      href: complusinstancecreationerror.md
-    - name: ComPlusInvokingMethodFailed
-      href: complusinvokingmethodfailed.md
-    - name: ComPlusInvokingMethodFailedMismatchedTransactions
-      href: complusinvokingmethodfailedmismatchedtransactions.md
-    - name: ComPlusServiceHostStartingServiceError
-      href: complusservicehoststartingserviceerror.md
-    - name: ComPlusTLBImportError
-      href: complustlbimporterror.md
-    - name: CoordinatorRecoveryLogEntryCorrupt
-      href: coordinatorrecoverylogentrycorrupt.md
-    - name: CoordinatorRecoveryLogEntryCreationFailure
-      href: coordinatorrecoverylogentrycreationfailure.md
-    - name: FailedToCreateMessageLoggingTraceSource
-      href: failedtocreatemessageloggingtracesource.md
-    - name: FailedToInitializeTraceSource
-      href: failedtoinitializetracesource.md
-    - name: FailedToLoadPerformanceCounter
-      href: failedtoloadperformancecounter.md
-    - name: FailedToLogMessage
-      href: failedtologmessage.md
-    - name: FailedToRemovePerformanceCounter
-      href: failedtoremoveperformancecounter.md
-    - name: FailedToSetupTracing
-      href: failedtosetuptracing.md
-    - name: FailedToTraceEvent
-      href: failedtotraceevent.md
-    - name: FailedToTraceEventWithException
-      href: failedtotraceeventwithexception.md
-    - name: FailFastException
-      href: failfastexception.md
-    - name: FailFast
-      href: failfast.md
-    - name: FatalUnexpectedStateMachineEvent
-      href: fatalunexpectedstatemachineevent.md
-    - name: ImpersonationFailure
-      href: impersonationfailure.md
-    - name: ImpersonationSuccess
-      href: impersonationsuccess.md
-    - name: InvariantAssertionFailed
-      href: invariantassertionfailed.md
-    - name: LAFailedToListenForApp
-      href: lafailedtolistenforapp.md
-    - name: MessageAuthenticationFailure
-      href: messageauthenticationfailure.md
-    - name: MessageAuthenticationSuccess
-      href: messageauthenticationsuccess.md
-    - name: MessageLoggingOff
-      href: messageloggingoff.md
-    - name: MessageLoggingOn
-      href: messageloggingon.md
-    - name: MessageQueueDuplicatedSocketLeak
-      href: messagequeueduplicatedsocketleak.md
-    - name: MessageQueueDuplicatedPipeLeak
-      href: messagequeueduplicatedpipeleak.md
-    - name: MissingNecessaryEnhancedKeyUsage
-      href: missingnecessaryenhancedkeyusage.md
-    - name: MissingNecessaryKeyUsage
-      href: missingnecessarykeyusage.md
-    - name: NonFatalUnexpectedStateMachineEvent
-      href: nonfatalunexpectedstatemachineevent.md
-    - name: ParticipantRecoveryLogEntryCorrupt
-      href: participantrecoverylogentrycorrupt.md
-    - name: ParticipantRecoveryLogEntryCreationFailure
-      href: participantrecoverylogentrycreationfailure.md
-    - name: PerformanceCounterInitializationFailure
-      href: performancecounterinitializationfailure.md
-    - name: PiiLoggingNotAllowed
-      href: piiloggingnotallowed.md
-    - name: PiiLoggingOn
-      href: piiloggingon.md
-    - name: ProtocolInitializationFailure
-      href: protocolinitializationfailure.md
-    - name: ProtocolRecoveryBeginningFailure
-      href: protocolrecoverybeginningfailure.md
-    - name: ProtocolRecoveryComplete
-      href: protocolrecoverycomplete.md
-    - name: ProtocolRecoveryCompleteFailure
-      href: protocolrecoverycompletefailure.md
-    - name: ProtocolStartFailure
-      href: protocolstartfailure.md
-    - name: ProtocolStopFailure
-      href: protocolstopfailure.md
-    - name: ProtocolStopped
-      href: protocolstopped.md
-    - name: ServiceAuthorizationFailure
-      href: serviceauthorizationfailure.md
-    - name: ServiceAuthorizationSuccess
-      href: serviceauthorizationsuccess.md
-    - name: SecurityNegotiationFailure
-      href: securitynegotiationfailure.md
-    - name: SecurityNegotiationSuccess
-      href: securitynegotiationsuccess.md
-    - name: ServiceStartFailed
-      href: servicestartfailed.md
-    - name: SslNoAccessiblePrivateKey
-      href: sslnoaccessibleprivatekey.md
-    - name: SslNoPrivateKey
-      href: sslnoprivatekey.md
-    - name: StartErrorPublish
-      href: starterrorpublish.md
-    - name: ThumbPrintNotFound
-      href: thumbprintnotfound.md
-    - name: ThumbPrintNotValidated
-      href: thumbprintnotvalidated.md
-    - name: TraceCodeRemovedBadFilter
-      href: tracecoderemovedbadfilter.md
-    - name: TransportAuthenticationFailure
-      href: transportauthenticationfailure.md
-    - name: TransportAuthenticationSuccess
-      href: transportauthenticationsuccess.md
-    - name: TransactionBridgeRecoveryFailure
-      href: transactionbridgerecoveryfailure.md
-    - name: UnhandledStateMachineExceptionRecordDescription
-      href: unhandledstatemachineexceptionrecorddescription.md
-    - name: UnknownListenerAdapterError
-      href: unknownlisteneradaptererror.md
-    - name: WmiAdminTypeMismatch
-      href: wmiadmintypemismatch.md
-    - name: WasConnectionTimedout
-      href: wasconnectiontimedout.md
-    - name: WmiCreateInstanceFailed
-      href: wmicreateinstancefailed.md
-    - name: WmiDeleteInstanceFailed
-      href: wmideleteinstancefailed.md
-    - name: WasDisconnected
-      href: wasdisconnected.md
-    - name: WmiExecMethodFailed
-      href: wmiexecmethodfailed.md
-    - name: WmiExecQueryFailed
-      href: wmiexecqueryfailed.md
-    - name: WmiGetObjectFailed
-      href: wmigetobjectfailed.md
-    - name: WebHostFailedToListen
-      href: webhostfailedtolisten.md
-    - name: WebHostFailedToProcessRequest
-      href: webhostfailedtoprocessrequest.md
-    - name: WebHostHttpError
-      href: webhosthttperror.md
-    - name: WebHostUnhandledException
-      href: webhostunhandledexception.md
-    - name: WmiPropertyMissing
-      href: wmipropertymissing.md
-    - name: WmiPutInstanceFailed
-      href: wmiputinstancefailed.md
-    - name: WmiRegistrationFailed
-      href: wmiregistrationfailed.md
-    - name: WmiUnregistrationFailed
-      href: wmiunregistrationfailed.md
+  - name: BindingError
+    href: bindingerror.md
+  - name: ComPlusDllHostInitializerStartingError
+    href: complusdllhostinitializerstartingerror.md
+  - name: ComPlusInstanceCreationError
+    href: complusinstancecreationerror.md
+  - name: ComPlusInvokingMethodFailed
+    href: complusinvokingmethodfailed.md
+  - name: ComPlusInvokingMethodFailedMismatchedTransactions
+    href: complusinvokingmethodfailedmismatchedtransactions.md
+  - name: ComPlusServiceHostStartingServiceError
+    href: complusservicehoststartingserviceerror.md
+  - name: ComPlusTLBImportError
+    href: complustlbimporterror.md
+  - name: CoordinatorRecoveryLogEntryCorrupt
+    href: coordinatorrecoverylogentrycorrupt.md
+  - name: CoordinatorRecoveryLogEntryCreationFailure
+    href: coordinatorrecoverylogentrycreationfailure.md
+  - name: FailedToCreateMessageLoggingTraceSource
+    href: failedtocreatemessageloggingtracesource.md
+  - name: FailedToInitializeTraceSource
+    href: failedtoinitializetracesource.md
+  - name: FailedToLoadPerformanceCounter
+    href: failedtoloadperformancecounter.md
+  - name: FailedToLogMessage
+    href: failedtologmessage.md
+  - name: FailedToRemovePerformanceCounter
+    href: failedtoremoveperformancecounter.md
+  - name: FailedToSetupTracing
+    href: failedtosetuptracing.md
+  - name: FailedToTraceEvent
+    href: failedtotraceevent.md
+  - name: FailedToTraceEventWithException
+    href: failedtotraceeventwithexception.md
+  - name: FailFastException
+    href: failfastexception.md
+  - name: FailFast
+    href: failfast.md
+  - name: FatalUnexpectedStateMachineEvent
+    href: fatalunexpectedstatemachineevent.md
+  - name: ImpersonationFailure
+    href: impersonationfailure.md
+  - name: ImpersonationSuccess
+    href: impersonationsuccess.md
+  - name: InvariantAssertionFailed
+    href: invariantassertionfailed.md
+  - name: LAFailedToListenForApp
+    href: lafailedtolistenforapp.md
+  - name: MessageAuthenticationFailure
+    href: messageauthenticationfailure.md
+  - name: MessageAuthenticationSuccess
+    href: messageauthenticationsuccess.md
+  - name: MessageLoggingOff
+    href: messageloggingoff.md
+  - name: MessageLoggingOn
+    href: messageloggingon.md
+  - name: MessageQueueDuplicatedSocketLeak
+    href: messagequeueduplicatedsocketleak.md
+  - name: MessageQueueDuplicatedPipeLeak
+    href: messagequeueduplicatedpipeleak.md
+  - name: MissingNecessaryEnhancedKeyUsage
+    href: missingnecessaryenhancedkeyusage.md
+  - name: MissingNecessaryKeyUsage
+    href: missingnecessarykeyusage.md
+  - name: NonFatalUnexpectedStateMachineEvent
+    href: nonfatalunexpectedstatemachineevent.md
+  - name: ParticipantRecoveryLogEntryCorrupt
+    href: participantrecoverylogentrycorrupt.md
+  - name: ParticipantRecoveryLogEntryCreationFailure
+    href: participantrecoverylogentrycreationfailure.md
+  - name: PerformanceCounterInitializationFailure
+    href: performancecounterinitializationfailure.md
+  - name: PiiLoggingNotAllowed
+    href: piiloggingnotallowed.md
+  - name: PiiLoggingOn
+    href: piiloggingon.md
+  - name: ProtocolInitializationFailure
+    href: protocolinitializationfailure.md
+  - name: ProtocolRecoveryBeginningFailure
+    href: protocolrecoverybeginningfailure.md
+  - name: ProtocolRecoveryComplete
+    href: protocolrecoverycomplete.md
+  - name: ProtocolRecoveryCompleteFailure
+    href: protocolrecoverycompletefailure.md
+  - name: ProtocolStartFailure
+    href: protocolstartfailure.md
+  - name: ProtocolStopFailure
+    href: protocolstopfailure.md
+  - name: ProtocolStopped
+    href: protocolstopped.md
+  - name: ServiceAuthorizationFailure
+    href: serviceauthorizationfailure.md
+  - name: ServiceAuthorizationSuccess
+    href: serviceauthorizationsuccess.md
+  - name: SecurityNegotiationFailure
+    href: securitynegotiationfailure.md
+  - name: SecurityNegotiationSuccess
+    href: securitynegotiationsuccess.md
+  - name: ServiceStartFailed
+    href: servicestartfailed.md
+  - name: SslNoAccessiblePrivateKey
+    href: sslnoaccessibleprivatekey.md
+  - name: SslNoPrivateKey
+    href: sslnoprivatekey.md
+  - name: StartErrorPublish
+    href: starterrorpublish.md
+  - name: ThumbPrintNotFound
+    href: thumbprintnotfound.md
+  - name: ThumbPrintNotValidated
+    href: thumbprintnotvalidated.md
+  - name: TraceCodeRemovedBadFilter
+    href: tracecoderemovedbadfilter.md
+  - name: TransportAuthenticationFailure
+    href: transportauthenticationfailure.md
+  - name: TransportAuthenticationSuccess
+    href: transportauthenticationsuccess.md
+  - name: TransactionBridgeRecoveryFailure
+    href: transactionbridgerecoveryfailure.md
+  - name: UnhandledStateMachineExceptionRecordDescription
+    href: unhandledstatemachineexceptionrecorddescription.md
+  - name: UnknownListenerAdapterError
+    href: unknownlisteneradaptererror.md
+  - name: WmiAdminTypeMismatch
+    href: wmiadmintypemismatch.md
+  - name: WasConnectionTimedout
+    href: wasconnectiontimedout.md
+  - name: WmiCreateInstanceFailed
+    href: wmicreateinstancefailed.md
+  - name: WmiDeleteInstanceFailed
+    href: wmideleteinstancefailed.md
+  - name: WasDisconnected
+    href: wasdisconnected.md
+  - name: WmiExecMethodFailed
+    href: wmiexecmethodfailed.md
+  - name: WmiExecQueryFailed
+    href: wmiexecqueryfailed.md
+  - name: WmiGetObjectFailed
+    href: wmigetobjectfailed.md
+  - name: WebHostFailedToListen
+    href: webhostfailedtolisten.md
+  - name: WebHostFailedToProcessRequest
+    href: webhostfailedtoprocessrequest.md
+  - name: WebHostHttpError
+    href: webhosthttperror.md
+  - name: WebHostUnhandledException
+    href: webhostunhandledexception.md
+  - name: WmiPropertyMissing
+    href: wmipropertymissing.md
+  - name: WmiPutInstanceFailed
+    href: wmiputinstancefailed.md
+  - name: WmiRegistrationFailed
+    href: wmiregistrationfailed.md
+  - name: WmiUnregistrationFailed
+    href: wmiunregistrationfailed.md

--- a/docs/framework/wcf/diagnostics/exceptions-reference/toc.yml
+++ b/docs/framework/wcf/diagnostics/exceptions-reference/toc.yml
@@ -1,51 +1,51 @@
-- name: Exceptions Reference
+items:
+- name: Exceptions reference
   href: index.md
-  items:
-  - name: COM+ Integration
-    href: com-integration.md
-  - name: Configuration
-    href: configuration.md
-  - name: "Core Communications: Channel Framework"
-    href: core-communications-channel-framework.md
-  - name: "Core Communications: Connection Framework"
-    href: core-communications-connection-framework.md
-  - name: "Core Communications: HTTP/HTTPS Transport Channels"
-    href: core-communications-http-https-transport-channels.md
-  - name: "Core Communications: Internal Duplex Transport Channels"
-    href: core-communications-internal-duplex-transport-channels.md
-  - name: "Core Communications: Named Pipe Transport Channels"
-    href: core-communications-named-pipe-transport-channels.md
-  - name: "Core Communications: TCP Transport Channels"
-    href: core-communications-tcp-transport-channels.md
-  - name: "Core Communications: Transport Framework"
-    href: core-communications-transport-framework.md
-  - name: "Core Communications: Utilities"
-    href: core-communications-utilities.md
-  - name: "Core Communications: Webhost Support"
-    href: core-communications-webhost-support.md
-  - name: Hosting
-    href: hosting-exceptions.md
-  - name: IdentityModel
-    href: identitymodel-exceptions.md
-  - name: MSMQ Integration Transport
-    href: msmq-integration-transport.md
-  - name: MSMQ Transport
-    href: msmq-transport.md
-  - name: Peer Channel
-    href: peer-channel.md
-  - name: Reliable Messaging
-    href: reliable-messaging.md
-  - name: Security Exceptions
-    href: security-exceptions.md
-  - name: Service Framework
-    href: service-framework.md
-  - name: Service Framework Data
-    href: service-framework-data.md
-  - name: Service Framework Metadata
-    href: service-framework-metadata.md
-  - name: Transaction
-    href: transaction-exceptions.md
-  - name: Transaction Formatter
-    href: transaction-formatter.md
-  - name: Tools
-    href: tools.md
+- name: COM+ Integration
+  href: com-integration.md
+- name: Configuration
+  href: configuration.md
+- name: "Core Communications: Channel Framework"
+  href: core-communications-channel-framework.md
+- name: "Core Communications: Connection Framework"
+  href: core-communications-connection-framework.md
+- name: "Core Communications: HTTP/HTTPS Transport Channels"
+  href: core-communications-http-https-transport-channels.md
+- name: "Core Communications: Internal Duplex Transport Channels"
+  href: core-communications-internal-duplex-transport-channels.md
+- name: "Core Communications: Named Pipe Transport Channels"
+  href: core-communications-named-pipe-transport-channels.md
+- name: "Core Communications: TCP Transport Channels"
+  href: core-communications-tcp-transport-channels.md
+- name: "Core Communications: Transport Framework"
+  href: core-communications-transport-framework.md
+- name: "Core Communications: Utilities"
+  href: core-communications-utilities.md
+- name: "Core Communications: Webhost Support"
+  href: core-communications-webhost-support.md
+- name: Hosting
+  href: hosting-exceptions.md
+- name: IdentityModel
+  href: identitymodel-exceptions.md
+- name: MSMQ Integration Transport
+  href: msmq-integration-transport.md
+- name: MSMQ Transport
+  href: msmq-transport.md
+- name: Peer Channel
+  href: peer-channel.md
+- name: Reliable Messaging
+  href: reliable-messaging.md
+- name: Security Exceptions
+  href: security-exceptions.md
+- name: Service Framework
+  href: service-framework.md
+- name: Service Framework Data
+  href: service-framework-data.md
+- name: Service Framework Metadata
+  href: service-framework-metadata.md
+- name: Transaction
+  href: transaction-exceptions.md
+- name: Transaction Formatter
+  href: transaction-formatter.md
+- name: Tools
+  href: tools.md

--- a/docs/framework/wcf/diagnostics/performance-counters/toc.yml
+++ b/docs/framework/wcf/diagnostics/performance-counters/toc.yml
@@ -1,146 +1,146 @@
-- name: Performance Counters
+items:
+- name: Performance counters
   href: index.md
+- name: Operation Performance Counters
+  href: operation-performance-counters.md
   items:
-  - name: Operation Performance Counters
-    href: operation-performance-counters.md
-    items:
-    - name: Calls
-      href: calls.md
-    - name: Calls Per Second
-      href: calls-per-second.md
-    - name: Calls Outstanding
-      href: calls-outstanding.md
-    - name: Calls Failed
-      href: calls-failed.md
-    - name: Calls Failed Per Second
-      href: calls-failed-per-second.md
-    - name: Calls Faulted
-      href: calls-faulted.md
-    - name: Calls Faulted Per Second
-      href: calls-faulted-per-second.md
-    - name: Calls Duration
-      href: calls-duration.md
-    - name: Security Validation and Authentication Failures
-      href: security-validation-and-authentication-failures.md
-    - name: Security Validation and Authentication Failures Per Second
-      href: security-validation-and-authentication-failures-per-second.md
-    - name: Security Calls Not Authorized
-      href: security-calls-not-authorized.md
-    - name: Security Calls Not Authorized Per Second
-      href: security-calls-not-authorized-per-second.md
-    - name: Transactions Flowed
-      href: transactions-flowed.md
-    - name: Transactions Flowed Per Second
-      href: transactions-flowed-per-second.md
-  - name: Service Performance Counters
-    href: service-performance-counters.md
-    items:
-    - name: Calls
-      href: service-calls.md
-    - name: Calls Per Second
-      href: service-calls-per-second.md
-    - name: Calls Outstanding
-      href: service-calls-outstanding.md
-    - name: Calls Failed
-      href: service-calls-failed.md
-    - name: Calls Failed Per Second
-      href: service-calls-failed-per-second.md
-    - name: Calls Faulted
-      href: service-calls-faulted.md
-    - name: Calls Faulted Per Second
-      href: service-calls-faulted-per-second.md
-    - name: Calls Duration
-      href: service-calls-duration.md
-    - name: Instances
-      href: instances.md
-    - name: Instances Per Second
-      href: instances-per-second.md
-    - name: Percent of Max Concurrent Calls
-      href: percent-of-max-concurrent-calls.md
-    - name: Percent of Max Concurrent Instances
-      href: percent-of-max-concurrent-instances.md
-    - name: Percent of Max Concurrent Sessions
-      href: percent-of-max-concurrent-sessions.md
-    - name: Queue Dropped Messages
-      href: queue-dropped-messages.md
-    - name: Queue Dropped Messages Per Second
-      href: queue-dropped-messages-per-second.md
-    - name: Queued Poison Messages
-      href: queued-poison-messages.md
-    - name: Queued Poison Messages Per Second
-      href: queued-poison-messages-per-second.md
-    - name: Queued Rejected Messages
-      href: queued-rejected-messages.md
-    - name: Queued Rejected Messages Per Second
-      href: queued-rejected-messages-per-second.md
-    - name: Reliable Messaging Messages Dropped
-      href: reliable-messaging-messages-dropped.md
-    - name: Reliable Messaging Messages Dropped Per Second
-      href: reliable-messaging-messages-dropped-per-second.md
-    - name: Reliable Messaging Sessions Faulted
-      href: reliable-messaging-sessions-faulted.md
-    - name: Reliable Messaging Sessions Faulted Per Second
-      href: reliable-messaging-sessions-faulted-per-second.md
-    - name: Security Calls Not Authorized
-      href: service-security-calls-not-authorized.md
-    - name: Security Calls Not Authorized Per Second
-      href: service-security-calls-not-authorized-per-second.md
-    - name: Security Validation and Authentication Failures
-      href: service-security-validation-and-authentication-failures.md
-    - name: Security Validation and Authentication Failures Per Second
-      href: service-security-validation-and-authentication-failures-per-second.md
-    - name: Transactions Flowed
-      href: service-transactions-flowed.md
-    - name: Transactions Flowed Per Second
-      href: service-transactions-flowed-per-second.md
-    - name: Transacted Operations Aborted
-      href: transacted-operations-aborted.md
-    - name: Transacted Operations Aborted Per Second
-      href: transacted-operations-aborted-per-second.md
-    - name: Transacted Operations Committed
-      href: transacted-operations-committed.md
-    - name: Transacted Operations Committed Per Second
-      href: transacted-operations-committed-per-second.md
-    - name: Transacted Operations In Doubt
-      href: transacted-operations-in-doubt.md
-    - name: Transacted Operations In Doubt Per Second
-      href: transacted-operations-in-doubt-per-second.md
-  - name: Endpoint Performance Counters
-    href: endpoint-performance-counters.md
-    items:
-    - name: Calls
-      href: endpoint-calls.md
-    - name: Calls Per Second
-      href: endpoint-calls-per-second.md
-    - name: Calls Outstanding
-      href: endpoint-calls-outstanding.md
-    - name: Calls Failed
-      href: endpoint-calls-failed.md
-    - name: Calls Failed Per Second
-      href: endpoint-calls-failed-per-second.md
-    - name: Calls Faulted
-      href: endpoint-calls-faulted.md
-    - name: Calls Faulted Per Second
-      href: endpoint-calls-faulted-per-second.md
-    - name: Calls Duration
-      href: endpoint-calls-duration.md
-    - name: Reliable Messaging Messages Dropped
-      href: endpoint-reliable-messaging-messages-dropped.md
-    - name: Reliable Messaging Messages Dropped Per Second
-      href: endpoint-reliable-messaging-messages-dropped-per-second.md
-    - name: Reliable Messaging Sessions Faulted
-      href: endpoint-reliable-messaging-sessions-faulted.md
-    - name: Reliable Messaging Sessions Faulted Per Second
-      href: endpoint-reliable-messaging-sessions-faulted-per-second.md
-    - name: Security Calls Not Authorized
-      href: endpoint-security-calls-not-authorized.md
-    - name: Security Calls Not Authorized Per Second
-      href: endpoint-security-calls-not-authorized-per-second.md
-    - name: Security Validation and Authentication Failures
-      href: endpoint-security-validation-and-authentication-failures.md
-    - name: Security Validation and Authentication Failures Per Second
-      href: endpoint-security-validation-and-authentication-failures-per-second.md
-    - name: Transactions Flowed
-      href: endpoint-transactions-flowed.md
-    - name: Transactions Flowed Per Second
-      href: endpoint-transactions-flowed-per-second.md
+  - name: Calls
+    href: calls.md
+  - name: Calls Per Second
+    href: calls-per-second.md
+  - name: Calls Outstanding
+    href: calls-outstanding.md
+  - name: Calls Failed
+    href: calls-failed.md
+  - name: Calls Failed Per Second
+    href: calls-failed-per-second.md
+  - name: Calls Faulted
+    href: calls-faulted.md
+  - name: Calls Faulted Per Second
+    href: calls-faulted-per-second.md
+  - name: Calls Duration
+    href: calls-duration.md
+  - name: Security Validation and Authentication Failures
+    href: security-validation-and-authentication-failures.md
+  - name: Security Validation and Authentication Failures Per Second
+    href: security-validation-and-authentication-failures-per-second.md
+  - name: Security Calls Not Authorized
+    href: security-calls-not-authorized.md
+  - name: Security Calls Not Authorized Per Second
+    href: security-calls-not-authorized-per-second.md
+  - name: Transactions Flowed
+    href: transactions-flowed.md
+  - name: Transactions Flowed Per Second
+    href: transactions-flowed-per-second.md
+- name: Service Performance Counters
+  href: service-performance-counters.md
+  items:
+  - name: Calls
+    href: service-calls.md
+  - name: Calls Per Second
+    href: service-calls-per-second.md
+  - name: Calls Outstanding
+    href: service-calls-outstanding.md
+  - name: Calls Failed
+    href: service-calls-failed.md
+  - name: Calls Failed Per Second
+    href: service-calls-failed-per-second.md
+  - name: Calls Faulted
+    href: service-calls-faulted.md
+  - name: Calls Faulted Per Second
+    href: service-calls-faulted-per-second.md
+  - name: Calls Duration
+    href: service-calls-duration.md
+  - name: Instances
+    href: instances.md
+  - name: Instances Per Second
+    href: instances-per-second.md
+  - name: Percent of Max Concurrent Calls
+    href: percent-of-max-concurrent-calls.md
+  - name: Percent of Max Concurrent Instances
+    href: percent-of-max-concurrent-instances.md
+  - name: Percent of Max Concurrent Sessions
+    href: percent-of-max-concurrent-sessions.md
+  - name: Queue Dropped Messages
+    href: queue-dropped-messages.md
+  - name: Queue Dropped Messages Per Second
+    href: queue-dropped-messages-per-second.md
+  - name: Queued Poison Messages
+    href: queued-poison-messages.md
+  - name: Queued Poison Messages Per Second
+    href: queued-poison-messages-per-second.md
+  - name: Queued Rejected Messages
+    href: queued-rejected-messages.md
+  - name: Queued Rejected Messages Per Second
+    href: queued-rejected-messages-per-second.md
+  - name: Reliable Messaging Messages Dropped
+    href: reliable-messaging-messages-dropped.md
+  - name: Reliable Messaging Messages Dropped Per Second
+    href: reliable-messaging-messages-dropped-per-second.md
+  - name: Reliable Messaging Sessions Faulted
+    href: reliable-messaging-sessions-faulted.md
+  - name: Reliable Messaging Sessions Faulted Per Second
+    href: reliable-messaging-sessions-faulted-per-second.md
+  - name: Security Calls Not Authorized
+    href: service-security-calls-not-authorized.md
+  - name: Security Calls Not Authorized Per Second
+    href: service-security-calls-not-authorized-per-second.md
+  - name: Security Validation and Authentication Failures
+    href: service-security-validation-and-authentication-failures.md
+  - name: Security Validation and Authentication Failures Per Second
+    href: service-security-validation-and-authentication-failures-per-second.md
+  - name: Transactions Flowed
+    href: service-transactions-flowed.md
+  - name: Transactions Flowed Per Second
+    href: service-transactions-flowed-per-second.md
+  - name: Transacted Operations Aborted
+    href: transacted-operations-aborted.md
+  - name: Transacted Operations Aborted Per Second
+    href: transacted-operations-aborted-per-second.md
+  - name: Transacted Operations Committed
+    href: transacted-operations-committed.md
+  - name: Transacted Operations Committed Per Second
+    href: transacted-operations-committed-per-second.md
+  - name: Transacted Operations In Doubt
+    href: transacted-operations-in-doubt.md
+  - name: Transacted Operations In Doubt Per Second
+    href: transacted-operations-in-doubt-per-second.md
+- name: Endpoint Performance Counters
+  href: endpoint-performance-counters.md
+  items:
+  - name: Calls
+    href: endpoint-calls.md
+  - name: Calls Per Second
+    href: endpoint-calls-per-second.md
+  - name: Calls Outstanding
+    href: endpoint-calls-outstanding.md
+  - name: Calls Failed
+    href: endpoint-calls-failed.md
+  - name: Calls Failed Per Second
+    href: endpoint-calls-failed-per-second.md
+  - name: Calls Faulted
+    href: endpoint-calls-faulted.md
+  - name: Calls Faulted Per Second
+    href: endpoint-calls-faulted-per-second.md
+  - name: Calls Duration
+    href: endpoint-calls-duration.md
+  - name: Reliable Messaging Messages Dropped
+    href: endpoint-reliable-messaging-messages-dropped.md
+  - name: Reliable Messaging Messages Dropped Per Second
+    href: endpoint-reliable-messaging-messages-dropped-per-second.md
+  - name: Reliable Messaging Sessions Faulted
+    href: endpoint-reliable-messaging-sessions-faulted.md
+  - name: Reliable Messaging Sessions Faulted Per Second
+    href: endpoint-reliable-messaging-sessions-faulted-per-second.md
+  - name: Security Calls Not Authorized
+    href: endpoint-security-calls-not-authorized.md
+  - name: Security Calls Not Authorized Per Second
+    href: endpoint-security-calls-not-authorized-per-second.md
+  - name: Security Validation and Authentication Failures
+    href: endpoint-security-validation-and-authentication-failures.md
+  - name: Security Validation and Authentication Failures Per Second
+    href: endpoint-security-validation-and-authentication-failures-per-second.md
+  - name: Transactions Flowed
+    href: endpoint-transactions-flowed.md
+  - name: Transactions Flowed Per Second
+    href: endpoint-transactions-flowed-per-second.md

--- a/docs/framework/wcf/diagnostics/toc.yml
+++ b/docs/framework/wcf/diagnostics/toc.yml
@@ -1,4 +1,5 @@
-- name: Administration and Diagnostics
+items:
+- name: Administration and diagnostics
   href: index.md
 - name: Message Logging
   href: message-logging.md

--- a/docs/framework/wcf/diagnostics/tracing/toc.yml
+++ b/docs/framework/wcf/diagnostics/tracing/toc.yml
@@ -1,851 +1,851 @@
+items:
 - name: Tracing
   href: index.md
+- name: Configuring Tracing
+  href: configuring-tracing.md
+- name: End-to-End Tracing
+  href: end-to-end-tracing.md
   items:
-  - name: Configuring Tracing
-    href: configuring-tracing.md
-  - name: End-to-End Tracing
-    href: end-to-end-tracing.md
+  - name: Activity
+    href: activity.md
+  - name: Transfer
+    href: transfer.md
+  - name: Propagation
+    href: propagation.md
+  - name: Trace Type Summary
+    href: trace-type-summary.md
+- name: Using Tracing to Troubleshoot Your Application
+  href: using-tracing-to-troubleshoot-your-application.md
+  items:
+  - name: Using Service Trace Viewer for Viewing Correlated Traces and Troubleshooting
+    href: using-service-trace-viewer-for-viewing-correlated-traces-and-troubleshooting.md
+  - name: End-To-End Tracing Scenarios
+    href: end-to-end-tracing-scenarios.md
     items:
-    - name: Activity
-      href: activity.md
-    - name: Transfer
-      href: transfer.md
-    - name: Propagation
-      href: propagation.md
-    - name: Trace Type Summary
-      href: trace-type-summary.md
-  - name: Using Tracing to Troubleshoot Your Application
-    href: using-tracing-to-troubleshoot-your-application.md
-    items:
-    - name: Using Service Trace Viewer for Viewing Correlated Traces and Troubleshooting
-      href: using-service-trace-viewer-for-viewing-correlated-traces-and-troubleshooting.md
-    - name: End-To-End Tracing Scenarios
-      href: end-to-end-tracing-scenarios.md
-      items:
-      - name: Activity List
-        href: activity-list.md
-      - name: Activity ID Propagation
-        href: activity-id-propagation.md
-      - name: Synchronous Scenarios using HTTP, TCP or Named-Pipe
-        href: synchronous-scenarios-using-http-tcp-or-named-pipe.md
-      - name: Asynchronous Scenarios using HTTP, TCP, or Named-Pipe
-        href: asynchronous-scenarios-using-http-tcp-or-named-pipe.md
-      - name: Activity Tracing in Message Security
-        href: activity-tracing-in-message-security.md
-      - name: MSMQ
-        href: msmq.md
-      - name: COM+
-        href: com.md
-    - name: Significant Traces
-      href: significant-traces.md
-    - name: Debugging on the Client
-      href: debugging-on-the-client.md
-    - name: Emitting User-Code Traces
-      href: emitting-user-code-traces.md
-  - name: Recommended Settings for Tracing and Message Logging
-    href: recommended-settings-for-tracing-and-message-logging.md
-  - name: Security Concerns and Useful Tips for Tracing
-    href: security-concerns-and-useful-tips-for-tracing.md
-  - name: Traces Reference
-    href: traces-reference.md
-    items:
-    - name: Microsoft.Transactions.TransactionBridge.CommitMessageRetry
-      href: microsoft-transactions-transactionbridge-commitmessageretry.md
-    - name: Microsoft.Transactions.TransactionBridge.CoordinatorRecovered
-      href: microsoft-transactions-transactionbridge-coordinatorrecovered.md
-    - name: Microsoft.Transactions.TransactionBridge.CoordinatorStateMachineFinished
-      href: microsoft-transactions-transactionbridge-coordinatorstatemachinefinished.md
-    - name: Microsoft.Transactions.TransactionBridge.CreateTransactionFailure
-      href: microsoft-transactions-transactionbridge-createtransactionfailure.md
-    - name: Microsoft.Transactions.TransactionBridge.DurableParticipantReplayWhilePreparing
-      href: mtt-durableparticipantreplaywhilepreparing.md
-    - name: Microsoft.Transactions.TransactionBridge.EnlistmentIdentityCheckFailed
-      href: microsoft-transactions-transactionbridge-enlistmentidentitycheckfailed.md
-    - name: Microsoft.Transactions.TransactionBridge.EnlistTransaction
-      href: microsoft-transactions-transactionbridge-enlisttransaction.md
-    - name: Microsoft.Transactions.TransactionBridge.EnlistTransactionFailure
-      href: system-servicemodel-channels-connectionpoolmaxoutboundconnectionsperendpointquotareached.md
-    - name: Microsoft.Transactions.TransactionBridge.ParticipantRecovered
-      href: microsoft-transactions-transactionbridge-participantrecovered.md
-    - name: Microsoft.Transactions.TransactionBridge.ParticipantStateMachineFinished
-      href: microsoft-transactions-transactionbridge-participantstatemachinefinished.md
-    - name: Microsoft.Transactions.TransactionBridge.PrepareMessageRetry
-      href: microsoft-transactions-transactionbridge-preparemessageretry.md
-    - name: Microsoft.Transactions.TransactionBridge.PreparedMessageRetry
-      href: microsoft-transactions-transactionbridge-preparedmessageretry.md
-    - name: Microsoft.Transactions.TransactionBridge.ProtocolInitialized
-      href: microsoft-transactions-transactionbridge-protocolinitialized.md
-    - name: Microsoft.Transactions.TransactionBridge.ProtocolStarted
-      href: microsoft-transactions-transactionbridge-protocolstarted.md
-    - name: Microsoft.Transactions.TransactionBridge.RecoveredCoordinatorInvalidMetadata
-      href: microsoft-transactions-transactionbridge-recoveredcoordinatorinvalidmetadata.md
-    - name: Microsoft.Transactions.TransactionBridge.RecoveredParticipantInvalidMetadata
-      href: microsoft-transactions-transactionbridge-recoveredparticipantinvalidmetadata.md
-    - name: Microsoft.Transactions.TransactionBridge.RegisterCoordinator
-      href: microsoft-transactions-transactionbridge-registercoordinator.md
-    - name: Microsoft.Transactions.TransactionBridge.RegisterParticipant
-      href: microsoft-transactions-transactionbridge-registerparticipant.md
-    - name: Microsoft.Transactions.TransactionBridge.RegisterParticipantFailure
-      href: microsoft-transactions-transactionbridge-registerparticipantfailure.md
-    - name: Microsoft.Transactions.TransactionBridge.RegistrationCoordinatorFailed
-      href: microsoft-transactions-transactionbridge-registrationcoordinatorfailed.md
-    - name: Microsoft.Transactions.TransactionBridge.RegistrationCoordinatorFaulted
-      href: microsoft-transactions-transactionbridge-registrationcoordinatorfaulted.md
-    - name: Microsoft.Transactions.TransactionBridge.RegistrationCoordinatorResponseInvalidMetadata
-      href: mts-registrationcoordinatorresponseinvalidmetadata.md
-    - name: Microsoft.Transactions.TransactionBridge.ReplayMessageRetry
-      href: microsoft-transactions-transactionbridge-replaymessageretry.md
-    - name: Microsoft.Transactions.TransactionBridge.VolatileOutcomeTimeout
-      href: microsoft-transactions-transactionbridge-volatileoutcometimeout.md
-    - name: Microsoft.Transactions.TransactionBridge.VolatileParticipantInDoubt
-      href: microsoft-transactions-transactionbridge-volatileparticipantindoubt.md
-    - name: System.IdentityModel.AuthorizationContextCreated
-      href: system-identitymodel-authorizationcontextcreated.md
-    - name: System.IdentityModel.AuthorizationPolicyEvaluated
-      href: system-identitymodel-authorizationpolicyevaluated.md
-    - name: System.IdentityModel.IdentityModelAsyncCallbackThrewException
-      href: system-identitymodel-identitymodelasynccallbackthrewexception.md
-    - name: System.IdentityModel.Selectors.GeneralInformation
-      href: system-identitymodel-selectors-generalinformation.md
-    - name: System.IdentityModel.Selectors.StoreBeginTransaction
-      href: system-identitymodel-selectors-storebegintransaction.md
-    - name: System.IdentityModel.Selectors.StoreClosing
-      href: system-identitymodel-selectors-storeclosing.md
-    - name: System.IdentityModel.Selectors.StoreCommitTransaction
-      href: system-identitymodel-selectors-storecommittransaction.md
-    - name: System.IdentityModel.Selectors.StoreDeleting
-      href: system-identitymodel-selectors-storedeleting.md
-    - name: System.IdentityModel.Selectors.StoreFailedToOpenStore
-      href: system-identitymodel-selectors-storefailedtoopenstore.md
-    - name: System.IdentityModel.Selectors.StoreLoading
-      href: system-identitymodel-selectors-storeloading.md
-    - name: System.IdentityModel.Selectors.StoreRollbackTransaction
-      href: system-identitymodel-selectors-storerollbacktransaction.md
-    - name: System.IdentityModel.Selectors.StoreSignatureNotValid
-      href: system-identitymodel-selectors-storesignaturenotvalid.md
-    - name: System.Runtime.Serialization.ElementIgnored
-      href: system-runtime-serialization-elementignored.md
-    - name: System.Runtime.Serialization.FactoryTypeNotFound
-      href: system-runtime-serialization-factorytypenotfound.md
-    - name: System.Runtime.Serialization.ObjectWithLargeDepth
-      href: system-runtime-serialization-objectwithlargedepth.md
-    - name: System.Runtime.Serialization.ReadObjectBegin
-      href: system-runtime-serialization-readobjectbegin.md
-    - name: System.Runtime.Serialization.ReadObjectEnd
-      href: system-servicemodel-comintegration-comintegrationmexmonikermetadataexchangecomplete.md
-    - name: System.Runtime.Serialization.WriteObjectBegin
-      href: system-runtime-serialization-writeobjectbegin.md
-    - name: System.Runtime.Serialization.WriteObjectContentBegin
-      href: system-runtime-serialization-writeobjectcontentbegin.md
-    - name: System.Runtime.Serialization.WriteObjectContentEnd
-      href: system-runtime-serialization-writeobjectcontentend.md
-    - name: System.Runtime.Serialization.WriteObjectEnd
-      href: system-runtime-serialization-writeobjectend.md
-    - name: System.Runtime.Serialization.XsdExportAnnotationFailed
-      href: system-runtime-serialization-xsdexportannotationfailed.md
-    - name: System.Runtime.Serialization.XsdExportBegin
-      href: system-runtime-serialization-xsdexportbegin.md
-    - name: System.Runtime.Serialization.XsdExportDupItems
-      href: system-runtime-serialization-xsdexportdupitems.md
-    - name: System.Runtime.Serialization.XsdExportEnd
-      href: system-runtime-serialization-xsdexportend.md
-    - name: System.Runtime.Serialization.XsdExportError
-      href: system-runtime-serialization-xsdexporterror.md
-    - name: System.Runtime.Serialization.XsdImportAnnotationFailed
-      href: system-runtime-serialization-xsdimportannotationfailed.md
-    - name: System.Runtime.Serialization.XsdImportBegin
-      href: system-runtime-serialization-xsdimportbegin.md
-    - name: System.Runtime.Serialization.XsdImportEnd
-      href: system-runtime-serialization-xsdimportend.md
-    - name: System.Runtime.Serialization.XsdImportError
-      href: system-runtime-serialization-xsdimporterror.md
-    - name: System.ServiceModel.Activation.MessageQueueClosed
-      href: system-servicemodel-activation-messagequeueclosed.md
-    - name: System.ServiceModel.Activation.MessageQueueDuplicatedPipe
-      href: system-servicemodel-activation-messagequeueduplicatedpipe.md
-    - name: System.ServiceModel.Activation.MessageQueueDuplicatedPipeError
-      href: system-servicemodel-activation-messagequeueduplicatedpipeerror.md
-    - name: System.ServiceModel.Activation.MessageQueueDuplicatedSocket
-      href: system-servicemodel-activation-messagequeueduplicatedsocket.md
-    - name: System.ServiceModel.Activation.MessageQueueDuplicatedSocketError
-      href: system-servicemodel-activation-messagequeueduplicatedsocketerror.md
-    - name: System.ServiceModel.Activation.MessageQueueRegisterCalled
-      href: system-servicemodel-activation-messagequeueregistercalled.md
-    - name: System.ServiceModel.Activation.MessageQueueRegisterSucceeded
-      href: system-servicemodel-activation-messagequeueregistersucceeded.md
-    - name: System.ServiceModel.Activation.MessageQueueRegisterFailed
-      href: system-servicemodel-activation-messagequeueregisterfailed.md
-    - name: System.ServiceModel.Activation.MessageQueueUnregisterSucceeded
-      href: system-servicemodel-activation-messagequeueunregistersucceeded.md
-    - name: System.ServiceModel.Activation.ServiceContinue
-      href: system-servicemodel-activation-servicecontinue.md
-    - name: System.ServiceModel.Activation.ServicePause
-      href: system-servicemodel-activation-servicepause.md
-    - name: System.ServiceModel.Activation.ServiceShutdown
-      href: system-servicemodel-activation-serviceshutdown.md
-    - name: System.ServiceModel.Activation.ServiceShutdownError
-      href: system-servicemodel-activation-serviceshutdownerror.md
-    - name: System.ServiceModel.Activation.ServiceStart
-      href: system-servicemodel-activation-servicestart.md
-    - name: System.ServiceModel.Activation.ServiceStartPipeError
-      href: system-servicemodel-activation-servicestartpipeerror.md
-    - name: System.ServiceModel.Activation.ServiceStop
-      href: system-servicemodel-activation-servicestop.md
-    - name: System.ServiceModel.Activation.WebHostCompilation
-      href: system-servicemodel-activation-webhostcompilation.md
-    - name: System.ServiceModel.Activation.WebHostDebugRequest
-      href: system-servicemodel-activation-webhostdebugrequest.md
-    - name: System.ServiceModel.Activation.WebHostProtocolMisconfigured
-      href: system-servicemodel-activation-webhostprotocolmisconfigured.md
-    - name: System.ServiceModel.Activation.WebHostServiceActivated
-      href: system-servicemodel-activation-webhostserviceactivated.md
-    - name: System.ServiceModel.Activation.WebHostServiceCloseFailed
-      href: system-servicemodel-activation-webhostserviceclosefailed.md
-    - name: System.ServiceModel.Administration.WmiPut
-      href: system-servicemodel-administration-wmiput.md
-    - name: System.ServiceModel.AsyncCallbackThrewException
-      href: system-servicemodel-asynccallbackthrewexception.md
-    - name: System.ServiceModel.BeginExecuteMethod
-      href: system-servicemodel-beginexecutemethod.md
-    - name: System.ServiceModel.CannotBeImportedInCurrentFormat
-      href: system-servicemodel-cannotbeimportedincurrentformat.md
-    - name: System.ServiceModel.Channels.ChannelCreated
-      href: system-servicemodel-channels-channelcreated.md
-    - name: System.ServiceModel.Channels.ChannelDisposed
-      href: system-servicemodel-channels-channeldisposed.md
-    - name: System.ServiceModel.Channels.ConnectionAbandoned
-      href: system-servicemodel-channels-connectionabandoned.md
-    - name: System.ServiceModel.Channels.ConnectionPoolCloseException
-      href: system-servicemodel-channels-connectionpoolcloseexception.md
-    - name: System.ServiceModel.Channels.ConnectionPoolIdleTimeoutReached
-      href: system-servicemodel-channels-connectionpoolidletimeoutreached.md
-    - name: System.ServiceModel.Channels.ConnectionPoolLeaseTimeoutReached
-      href: system-servicemodel-channels-connectionpoolleasetimeoutreached.md
-    - name: System.ServiceModel.Channels.ConnectionPoolMaxOutboundConnectionsPerEndpointQuotaReached
-      href: connectionpoolmaxoutboundconnectionsperendpointquotareached.md
-    - name: System.ServiceModel.Channels.ConnectToIPEndpoint
-      href: system-servicemodel-channels-connecttoipendpoint.md
-    - name: System.ServiceModel.Channels.EndpointListenerClose
-      href: system-servicemodel-channels-endpointlistenerclose.md
-    - name: System.ServiceModel.Channels.EndpointListenerOpen
-      href: system-servicemodel-channels-endpointlisteneropen.md
-    - name: System.ServiceModel.Channels.FailedAcceptFromPool
-      href: system-servicemodel-channels-failedacceptfrompool.md
-    - name: System.ServiceModel.Channels.FailedPipeConnect
-      href: system-servicemodel-channels-failedpipeconnect.md
-    - name: System.ServiceModel.Channels.HttpAuthFailed
-      href: system-servicemodel-channels-httpauthfailed.md
-    - name: System.ServiceModel.Channels.HttpChannelConcurrentReceiveQuotaReached
-      href: system-servicemodel-channels-httpchannelconcurrentreceivequotareached.md
-    - name: System.ServiceModel.Channels.HttpChannelMessageReceiveFailed
-      href: system-servicemodel-channels-httpchannelmessagereceivefailed.md
-    - name: System.ServiceModel.Channels.HttpChannelRequestAborted
-      href: system-servicemodel-channels-httpchannelrequestaborted.md
-    - name: System.ServiceModel.Channels.HttpChannelResponseAborted
-      href: system-servicemodel-channels-httpchannelresponseaborted.md
-    - name: System.ServiceModel.Channels.HttpChannelUnexpectedResponse
-      href: system-servicemodel-channels-httpchannelunexpectedresponse.md
-    - name: System.ServiceModel.Channels.HttpResponseReceived
-      href: system-servicemodel-channels-httpresponsereceived.md
-    - name: System.ServiceModel.Channels.HttpsClientCertificateInvalid
-      href: system-servicemodel-channels-httpsclientcertificateinvalid.md
-    - name: System.ServiceModel.Channels.HttpsClientCertificateNotPresent
-      href: system-servicemodel-channels-httpsclientcertificatenotpresent.md
-    - name: System.ServiceModel.Channels.IncompatibleExistingTransportManager
-      href: system-servicemodel-channels-incompatibleexistingtransportmanager.md
-    - name: System.ServiceModel.Channels.InitiatingNamedPipeConnection
-      href: system-servicemodel-channels-initiatingnamedpipeconnection.md
-    - name: System.ServiceModel.Channels.InitiatingTcpConnection
-      href: system-servicemodel-channels-initiatingtcpconnection.md
-    - name: System.ServiceModel.Channels.ListenerCreated
-      href: system-servicemodel-channels-listenercreated.md
-    - name: System.ServiceModel.Channels.ListenerDisposed
-      href: system-servicemodel-channels-listenerdisposed.md
-    - name: System.ServiceModel.Channels.PrematureDatagramEof
-      href: system-servicemodel-channels-prematuredatagrameof.md
-    - name: System.ServiceModel.Channels.MaxAcceptedChannelsReached
-      href: system-servicemodel-channels-maxacceptedchannelsreached.md
-    - name: System.ServiceModel.Channels.MaxPendingConnectionsReached
-      href: system-servicemodel-channels-maxpendingconnectionsreached.md
-    - name: System.ServiceModel.Channels.MessageReceived
-      href: system-servicemodel-channels-messagereceived.md
-    - name: System.ServiceModel.Channels.MessageSent
-      href: system-servicemodel-channels-messagesent.md
-    - name: System.ServiceModel.Channels.MsmqCannotPeekOnQueue
-      href: system-servicemodel-channels-msmqcannotpeekonqueue.md
-    - name: System.ServiceModel.Channels.MsmqCannotReadQueues
-      href: system-servicemodel-channels-msmqcannotreadqueues.md
-    - name: System.ServiceModel.Channels.MsmqDatagramSent
-      href: system-servicemodel-channels-msmqdatagramsent.md
-    - name: System.ServiceModel.Channels.MsmqDatagramReceived
-      href: system-servicemodel-channels-msmqdatagramreceived.md
-    - name: System.ServiceModel.Channels.MsmqDetected
-      href: system-servicemodel-channels-msmqdetected.md
-    - name: System.ServiceModel.Channels.MsmqEnteredBatch
-      href: system-servicemodel-channels-msmqenteredbatch.md
-    - name: System.ServiceModel.Channels.MsmqFoundBaseAddress
-      href: system-servicemodel-channels-msmqfoundbaseaddress.md
-    - name: System.ServiceModel.Channels.MsmqLeftBatch
-      href: system-servicemodel-channels-msmqleftbatch.md
-    - name: System.ServiceModel.Channels.MsmqMatchedApplicationFound
-      href: system-servicemodel-channels-msmqmatchedapplicationfound.md
-    - name: System.ServiceModel.Channels.MsmqMessageDropped
-      href: system-servicemodel-channels-msmqmessagedropped.md
-    - name: System.ServiceModel.Channels.MsmqMessageLockedUnderTheTransaction
-      href: system-servicemodel-channels-msmqmessagelockedunderthetransaction.md
-    - name: System.ServiceModel.Channels.MsmqMessageRejected
-      href: system-servicemodel-channels-msmqmessagerejected.md
-    - name: System.ServiceModel.Channels.MsmqMoveOrDeleteAttemptFailed
-      href: system-servicemodel-comintegration-comintegrationservicehostcreatedserviceendpoint.md
-    - name: System.ServiceModel.Channels.MsmqPoisonMessageMovedPoison
-      href: system-servicemodel-channels-msmqpoisonmessagemovedpoison.md
-    - name: System.ServiceModel.Channels.MsmqPoisonMessageMovedRetry
-      href: system-servicemodel-channels-msmqpoisonmessagemovedretry.md
-    - name: System.ServiceModel.Channels.MsmqPoisonMessageRejected
-      href: system-servicemodel-channels-msmqpoisonmessagerejected.md
-    - name: System.ServiceModel.Channels.MsmqPoolFull
-      href: system-servicemodel-channels-msmqpoolfull.md
-    - name: System.ServiceModel.Channels.MsmqPotentiallyPoisonMessageDetected
-      href: system-servicemodel-channels-msmqpotentiallypoisonmessagedetected.md
-    - name: System.ServiceModel.Channels.MsmqQueueClosed
-      href: system-servicemodel-channels-msmqqueueclosed.md
-    - name: System.ServiceModel.Channels.MsmqQueueOpened
-      href: system-servicemodel-channels-msmqqueueopened.md
-    - name: System.ServiceModel.Channels.MsmqQueueTransactionalStatusUnknown
-      href: system-servicemodel-channels-msmqqueuetransactionalstatusunknown.md
-    - name: System.ServiceModel.Channels.MsmqUnexpectedAcknowledgment
-      href: system-servicemodel-channels-msmqunexpectedacknowledgment.md
-    - name: System.ServiceModel.Channels.MsmqSessiongramReceived
-      href: system-servicemodel-channels-msmqsessiongramreceived.md
-    - name: System.ServiceModel.Channels.MsmqSessiongramSent
-      href: system-servicemodel-channels-msmqsessiongramsent.md
-    - name: System.ServiceModel.Channels.MsmqScanStarted
-      href: system-servicemodel-channels-msmqscanstarted.md
-    - name: System.ServiceModel.Channels.MsmqStartingApplication
-      href: system-servicemodel-channels-msmqstartingapplication.md
-    - name: System.ServiceModel.Channels.MsmqStartingService
-      href: system-servicemodel-channels-msmqstartingservice.md
-    - name: System.ServiceModel.Channels.NamedPipeChannelMessageReceived
-      href: system-servicemodel-channels-namedpipechannelmessagereceived.md
-    - name: System.ServiceModel.Channels.NamedPipeChannelMessageReceiveFailed
-      href: system-servicemodel-channels-namedpipechannelmessagereceivefailed.md
-    - name: System.ServiceModel.Channels.NoExistingTransportManager
-      href: system-servicemodel-channels-noexistingtransportmanager.md
-    - name: System.ServiceModel.Channels.OpenedListener
-      href: system-servicemodel-channels-openedlistener.md
-    - name: System.ServiceModel.Channels.PeerChannelMessageReceived
-      href: system-servicemodel-channels-peerchannelmessagereceived.md
-    - name: System.ServiceModel.Channels.PeerChannelMessageSent
-      href: system-servicemodel-channels-peerchannelmessagesent.md
-    - name: System.ServiceModel.Channels.PeerFloodedMessageReceived
-      href: system-servicemodel-channels-peerfloodedmessagereceived.md
-    - name: System.ServiceModel.Channels.PeerFloodedMessageNotMatched
-      href: system-servicemodel-channels-peerfloodedmessagenotmatched.md
-    - name: System.ServiceModel.Channels.PeerFloodedMessageNotPropagated
-      href: system-servicemodel-channels-peerfloodedmessagenotpropagated.md
-    - name: System.ServiceModel.Channels.PeerFlooderReceiveMessageQuotaExceeded
-      href: system-servicemodel-channels-peerflooderreceivemessagequotaexceeded.md
-    - name: System.ServiceModel.Channels.PeerMaintainerActivity
-      href: system-servicemodel-channels-peermaintaineractivity.md
-    - name: System.ServiceModel.Channels.PeerNeighborManagerOffline
-      href: system-servicemodel-channels-peerneighbormanageroffline.md
-    - name: System.ServiceModel.Channels.PeerNeighborManagerOnline
-      href: system-servicemodel-channels-peerneighbormanageronline.md
-    - name: System.ServiceModel.Channels.PeerNeighborMessageReceived
-      href: system-servicemodel-channels-peerneighbormessagereceived.md
-    - name: System.ServiceModel.Channels.PeerNeighborNotAccepted
-      href: system-servicemodel-channels-peerneighbornotaccepted.md
-    - name: System.ServiceModel.Channels.PeerNeighborNotFound
-      href: system-servicemodel-channels-peerneighbornotfound.md
-    - name: System.ServiceModel.Channels.PeerNeighborStateChanged
-      href: system-servicemodel-channels-peerneighborstatechanged.md
-    - name: System.ServiceModel.Channels.PeerNeighborStateChangeFailed
-      href: system-servicemodel-channels-peerneighborstatechangefailed.md
-    - name: System.ServiceModel.Channels.PeerNodeAddressChanged
-      href: system-servicemodel-channels-peernodeaddresschanged.md
-    - name: System.ServiceModel.Channels.PeerNodeAuthenticationFailure
-      href: system-servicemodel-channels-peernodeauthenticationfailure.md
-    - name: System.ServiceModel.Channels.PeerNodeAuthenticationTimeout
-      href: system-servicemodel-channels-peernodeauthenticationtimeout.md
-    - name: System.ServiceModel.Channels.PeerNodeOpened
-      href: system-servicemodel-channels-peernodeopened.md
-    - name: System.ServiceModel.Channels.PeerNodeOpening
-      href: system-servicemodel-channels-peernodeopening.md
-    - name: System.ServiceModel.Channels.PeerNodeOpenFailed
-      href: system-servicemodel-channels-peernodeopenfailed.md
-    - name: System.ServiceModel.Channels.PeerNodeClosed
-      href: system-servicemodel-channels-peernodeclosed.md
-    - name: System.ServiceModel.Channels.PeerNodeClosing
-      href: system-servicemodel-channels-peernodeclosing.md
-    - name: System.ServiceModel.Channels.PeerReceiveMessageAuthenticationFailure
-      href: system-servicemodel-channels-peerreceivemessageauthenticationfailure.md
-    - name: System.ServiceModel.Channels.PeerServiceOpened
-      href: system-servicemodel-channels-peerserviceopened.md
-    - name: System.ServiceModel.Channels.PipeConnectionAbort
-      href: system-servicemodel-channels-pipeconnectionabort.md
-    - name: System.ServiceModel.Channels.PnrpRegisteredAddresses
-      href: system-servicemodel-channels-pnrpregisteredaddresses.md
-    - name: System.ServiceModel.Channels.PnrpResolvedAddresses
-      href: system-servicemodel-channels-pnrpresolvedaddresses.md
-    - name: System.ServiceModel.Channels.PnrpUnregisteredAddresses
-      href: system-servicemodel-channels-pnrpunregisteredaddresses.md
-    - name: System.ServiceModel.Channels.PnrpResolveException
-      href: system-servicemodel-channels-pnrpresolveexception.md
-    - name: System.ServiceModel.Channels.RequestChannelReplyReceived
-      href: system-servicemodel-channels-requestchannelreplyreceived.md
-    - name: System.ServiceModel.Channels.RequestContextAbort
-      href: system-servicemodel-channels-requestcontextabort.md
-    - name: System.ServiceModel.Channels.ServerMaxPooledConnectionsQuotaReached
-      href: system-servicemodel-channels-servermaxpooledconnectionsquotareached.md
-    - name: System.ServiceModel.Channels.SocketConnectionAbort
-      href: system-servicemodel-channels-socketconnectionabort.md
-    - name: System.ServiceModel.Channels.SocketConnectionAbortClose
-      href: system-servicemodel-channels-socketconnectionabortclose.md
-    - name: System.ServiceModel.Channels.SocketConnectionClose
-      href: system-servicemodel-channels-socketconnectionclose.md
-    - name: System.ServiceModel.Channels.SocketConnectionCreate
-      href: system-servicemodel-channels-socketconnectioncreate.md
-    - name: System.ServiceModel.Channels.SslClientCertMissing
-      href: system-servicemodel-channels-sslclientcertmissing.md
-    - name: System.ServiceModel.Channels.StreamSecurityUpgradeAccepted
-      href: system-servicemodel-channels-streamsecurityupgradeaccepted.md
-    - name: System.ServiceModel.Channels.SystemTimeResolution
-      href: system-servicemodel-channels-systemtimeresolution.md
-    - name: System.ServiceModel.Channels.TcpChannelMessageReceived
-      href: system-servicemodel-channels-tcpchannelmessagereceived.md
-    - name: System.ServiceModel.Channels.TcpConnectError
-      href: system-servicemodel-channels-tcpconnecterror.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationChannelCreated
-      href: system-servicemodel-comintegration-comintegrationchannelcreated.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationDispatchMethod
-      href: system-servicemodel-comintegration-comintegrationdispatchmethod.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationDllHostInitializerAddingHost
-      href: system-servicemodel-comintegration-comintegrationdllhostinitializeraddinghost.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationDllHostInitializerStarted
-      href: system-servicemodel-comintegration-comintegrationdllhostinitializerstarted.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationDllHostInitializerStarting
-      href: system-servicemodel-comintegration-comintegrationdllhostinitializerstarting.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationDllHostInitializerStopped
-      href: system-servicemodel-comintegration-comintegrationdllhostinitializerstopped.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationDllHostInitializerStopping
-      href: system-servicemodel-comintegration-comintegrationdllhostinitializerstopping.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationEnteringActivity
-      href: system-servicemodel-comintegration-comintegrationenteringactivity.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationExecutingCall
-      href: system-servicemodel-comintegration-comintegrationexecutingcall.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationInstanceCreationRequest
-      href: system-servicemodel-comintegration-comintegrationinstancecreationrequest.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationInstanceCreationSuccess
-      href: system-servicemodel-comintegration-comintegrationinstancecreationsuccess.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationInstanceReleased
-      href: system-servicemodel-comintegration-comintegrationinstancereleased.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationInvokedMethod
-      href: system-servicemodel-comintegration-comintegrationinvokedmethod.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationInvokingMethod
-      href: system-servicemodel-comintegration-comintegrationinvokingmethod.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationInvokingMethodContextTransaction
-      href: ssc-comintegrationinvokingmethodcontexttransaction.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationInvokingMethodNewTransaction
-      href: system-servicemodel-comintegration-comintegrationinvokingmethodnewtransaction.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationLeftActivity
-      href: system-servicemodel-comintegration-comintegrationleftactivity.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationMexChannelBuilderLoaded
-      href: system-servicemodel-comintegration-comintegrationmexchannelbuilderloaded.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationMexMonikerMetadataExchangeComplete
-      href: ssc--comintegrationmexmonikermetadataexchangecomplete.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationServiceHostCreatedServiceContract
-      href: ssc-comintegrationservicehostcreatedservicecontract.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationServiceHostCreatedServiceEndpoint
-      href: ssc--comintegrationservicehostcreatedserviceendpoint.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationServiceHostStartedService
-      href: system-servicemodel-comintegration-comintegrationservicehoststartedservice.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationServiceHostStartedServiceDetails
-      href: ssc-comintegration.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationServiceHostStartingService
-      href: system-servicemodel-comintegration-comintegrationservicehoststartingservice.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationServiceHostStoppedService
-      href: system-servicemodel-comintegration-comintegrationservicehoststoppedservice.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationServiceHostStoppingService
-      href: system-servicemodel-comintegration-comintegrationservicehoststoppingservice.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationServiceMonikerParsed
-      href: system-servicemodel-comintegration-comintegrationservicemonikerparsed.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationTLBImportConverterEvent
-      href: system-servicemodel-comintegration-comintegrationtlbimportconverterevent.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationTLBImportFinished
-      href: system-servicemodel-comintegration-comintegrationtlbimportfinished.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationTLBImportFromAssembly
-      href: system-servicemodel-comintegration-comintegrationtlbimportfromassembly.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationTLBImportFromTypelib
-      href: system-servicemodel-comintegration-comintegrationtlbimportfromtypelib.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationTLBImportStarting
-      href: system-servicemodel-comintegration-comintegrationtlbimportstarting.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationTxProxyTxAbortedByContext
-      href: system-servicemodel-comintegration-comintegrationtxproxytxabortedbycontext.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationTxProxyTxAbortedByTM
-      href: system-servicemodel-comintegration-comintegrationtxproxytxabortedbytm.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationTxProxyTxCommitted
-      href: system-servicemodel-comintegration-comintegrationtxproxytxcommitted.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationTypedChannelBuilderLoaded
-      href: system-servicemodel-comintegration-comintegrationtypedchannelbuilderloaded.md
-    - name: System.ServiceModel.ComIntegration.ComIntegrationWsdlChannelBuilderLoaded
-      href: system-servicemodel-comintegration-comintegrationwsdlchannelbuilderloaded.md
-    - name: System.ServiceModel.CommunicationObjectAborted
-      href: system-servicemodel-communicationobjectaborted.md
-    - name: System.ServiceModel.CommunicationObjectAbortFailed
-      href: system-servicemodel-communicationobjectabortfailed.md
-    - name: System.ServiceModel.CommunicationObjectClosed
-      href: system-servicemodel-communicationobjectclosed.md
-    - name: System.ServiceModel.CommunicationObjectCloseFailed
-      href: system-servicemodel-communicationobjectclosefailed.md
-    - name: System.ServiceModel.CommunicationObjectClosing
-      href: system-servicemodel-communicationobjectclosing.md
-    - name: System.ServiceModel.CommunicationObjectCreated
-      href: system-servicemodel-communicationobjectcreated.md
-    - name: System.ServiceModel.CommunicationObjectDisposing
-      href: system-servicemodel-communicationobjectdisposing.md
-    - name: System.ServiceModel.CommunicationObjectFaulted
-      href: system-servicemodel-communicationobjectfaulted.md
-    - name: System.ServiceModel.CommunicationObjectFaultReason
-      href: system-servicemodel-communicationobjectfaultreason.md
-    - name: System.ServiceModel.CommunicationObjectOpened
-      href: system-servicemodel-communicationobjectopened.md
-    - name: System.ServiceModel.CommunicationObjectOpenFailed
-      href: system-servicemodel-communicationobjectopenfailed.md
-    - name: System.ServiceModel.CommunicationObjectOpening
-      href: system-servicemodel-communicationobjectopening.md
-    - name: System.ServiceModel.ConfigurationIsReadOnly
-      href: system-servicemodel-configurationisreadonly.md
-    - name: System.ServiceModel.ConfiguredExtensionTypeNotFound
-      href: system-servicemodel-configuredextensiontypenotfound.md
-    - name: System.ServiceModel.Diagnostics.ActivityBoundary
-      href: system-servicemodel-diagnostics-activityboundary.md
-    - name: System.ServiceModel.Diagnostics.AppDomainUnload
-      href: system-servicemodel-diagnostics-appdomainunload.md
-    - name: System.ServiceModel.Diagnostics.DiagnosticsFailedMessageTrace
-      href: system-servicemodel-diagnostics-diagnosticsfailedmessagetrace.md
-    - name: System.ServiceModel.Diagnostics.EventLog
-      href: system-servicemodel-diagnostics-eventlog.md
-    - name: System.ServiceModel.Diagnostics.FailedToAddAnActivityIdHeader
-      href: system-servicemodel-diagnostics-failedtoaddanactivityidheader.md
-    - name: System.ServiceModel.Diagnostics.FailedToReadAnActivityIdHeader
-      href: system-servicemodel-diagnostics-failedtoreadanactivityidheader.md
-    - name: System.ServiceModel.Diagnostics.FilterNotMatchedNodeQuotaExceeded
-      href: system-servicemodel-diagnostics-filternotmatchednodequotaexceeded.md
-    - name: System.ServiceModel.Diagnostics.MessageNotLoggedQuotaExceeded
-      href: system-servicemodel-diagnostics-messagenotloggedquotaexceeded.md
-    - name: System.ServiceModel.Diagnostics.MessageCountLimitExceeded
-      href: microsoft-transactions-transactionbridge-registrationcoordinatorresponseinvalidmetadata.md
-    - name: System.ServiceModel.Diagnostics.ThrowingException
-      href: system-servicemodel-diagnostics-throwingexception.md
-    - name: System.ServiceModel.Diagnostics.TraceHandledException
-      href: system-servicemodel-diagnostics-tracehandledexception.md
-    - name: System.ServiceModel.Diagnostics.TraceTruncatedQuotaExceeded
-      href: system-servicemodel-diagnostics-tracetruncatedquotaexceeded.md
-    - name: System.ServiceModel.Diagnostics.UnhandledException
-      href: system-servicemodel-diagnostics-unhandledexception.md
-    - name: System.ServiceModel.DidNotUnderstandMessageHeader
-      href: system-servicemodel-didnotunderstandmessageheader.md
-    - name: System.ServiceModel.DroppedAMessage
-      href: system-servicemodel-droppedamessage.md
-    - name: System.ServiceModel.ElementTypeDoesntMatchConfiguredType
-      href: system-servicemodel-elementtypedoesntmatchconfiguredtype.md
-    - name: System.ServiceModel.EndExecuteMethod
-      href: system-servicemodel-endexecutemethod.md
-    - name: System.ServiceModel.ErrorInvokingUserCode
-      href: system-servicemodel-errorinvokingusercode.md
-    - name: System.ServiceModel.EvaluationContextNotFound
-      href: system-servicemodel-evaluationcontextnotfound.md
-    - name: System.ServiceModel.ExtensionCollectionDoesNotExist
-      href: system-servicemodel-extensioncollectiondoesnotexist.md
-    - name: System.ServiceModel.ExtensionCollectionIsEmpty
-      href: system-servicemodel-extensioncollectionisempty.md
-    - name: System.ServiceModel.ExtensionCollectionNameNotFound
-      href: system-servicemodel-extensioncollectionnamenotfound.md
-    - name: System.ServiceModel.ExtensionElementAlreadyExistsInCollection
-      href: system-servicemodel-extensionelementalreadyexistsincollection.md
-    - name: System.ServiceModel.FailedToOpenIncomingChannel
-      href: system-servicemodel-failedtoopenincomingchannel.md
-    - name: System.ServiceModel.GetBehaviorElement
-      href: system-servicemodel-getbehaviorelement.md
-    - name: System.ServiceModel.GetChannelEndpointElement
-      href: system-servicemodel-getchannelendpointelement.md
-    - name: System.ServiceModel.GetCommonBehaviors
-      href: system-servicemodel-getcommonbehaviors.md
-    - name: System.ServiceModel.GetConfigurationSection
-      href: system-servicemodel-getconfigurationsection.md
-    - name: System.ServiceModel.GetConfiguredBinding
-      href: system-servicemodel-getconfiguredbinding.md
-    - name: System.ServiceModel.GetDefaultConfiguredBinding
-      href: system-servicemodel-getdefaultconfiguredbinding.md
-    - name: System.ServiceModel.GetServiceElement
-      href: system-servicemodel-getserviceelement.md
-    - name: System.ServiceModel.ManualFlowThrottleLimitReached
-      href: system-servicemodel-manualflowthrottlelimitreached.md
-    - name: System.ServiceModel.MetadataExchangeClientReceiveReply
-      href: system-servicemodel-metadataexchangeclientreceivereply.md
-    - name: System.ServiceModel.MetadataExchangeClientSendRequest
-      href: system-servicemodel-metadataexchangeclientsendrequest.md
-    - name: System.ServiceModel.MessageClosed
-      href: system-servicemodel-messageclosed.md
-    - name: System.ServiceModel.MessageClosedAgain
-      href: system-servicemodel-messageclosedagain.md
-    - name: System.ServiceModel.MessageCopied
-      href: system-servicemodel-messagecopied.md
-    - name: System.ServiceModel.MessageProcessingPaused
-      href: system-servicemodel-messageprocessingpaused.md
-    - name: System.ServiceModel.MessageRead
-      href: system-servicemodel-messageread.md
-    - name: System.ServiceModel.MessageWritten
-      href: system-servicemodel-messagewritten.md
-    - name: System.ServiceModel.OverridingDuplicateConfigurationKey
-      href: system-servicemodel-overridingduplicateconfigurationkey.md
-    - name: System.ServiceModel.PerformanceCountersFailed
-      href: system-servicemodel-performancecountersfailed.md
-    - name: System.ServiceModel.PerformanceCountersFailedDuringUpdate
-      href: system-servicemodel-performancecountersfailedduringupdate.md
-    - name: System.ServiceModel.PerformanceCountersFailedForService
-      href: system-servicemodel-performancecountersfailedforservice.md
-    - name: System.ServiceModel.PerformanceCountersFailedOnRelease
-      href: system-servicemodel-performancecountersfailedonrelease.md
-    - name: System.ServiceModel.PerformanceCounterFailedToLoad
-      href: system-servicemodel-performancecounterfailedtoload.md
-    - name: System.ServiceModel.PortSharing.PortSharingClosed
-      href: system-servicemodel-portsharing-portsharingclosed.md
-    - name: System.ServiceModel.PortSharing.PortSharingDupHandleGranted
-      href: system-servicemodel-portsharing-portsharingduphandlegranted.md
-    - name: System.ServiceModel.PortSharing.PortSharingDuplicatedPipe
-      href: system-servicemodel-portsharing-portsharingduplicatedpipe.md
-    - name: System.ServiceModel.PortSharing.PortSharingDuplicatedSocket
-      href: system-servicemodel-portsharing-portsharingduplicatedsocket.md
-    - name: System.ServiceModel.PortSharing.PortSharingListening
-      href: system-servicemodel-portsharing-portsharinglistening.md
-    - name: System.ServiceModel.PortSharing.RoutingTableCannotListen
-      href: system-servicemodel-portsharing-routingtablecannotlisten.md
-    - name: System.ServiceModel.PortSharing.RoutingTableLookup
-      href: system-servicemodel-portsharing-routingtablelookup.md
-    - name: System.ServiceModel.PortSharing.RoutingTableNamespaceConflict
-      href: system-servicemodel-portsharing-routingtablenamespaceconflict.md
-    - name: System.ServiceModel.PortSharing.RoutingTablePathTooLong
-      href: system-servicemodel-portsharing-routingtablepathtoolong.md
-    - name: System.ServiceModel.PortSharing.RoutingTableRegisterSuccess
-      href: system-servicemodel-portsharing-routingtableregistersuccess.md
-    - name: System.ServiceModel.PortSharing.RoutingTableUnsupportedProtocol
-      href: system-servicemodel-portsharing-routingtableunsupportedprotocol.md
-    - name: System.ServiceModel.PortSharing.ReadNetPipeConfig
-      href: system-servicemodel-portsharing-readnetpipeconfig.md
-    - name: System.ServiceModel.PortSharing.ReadNetTcpConfig
-      href: system-servicemodel-portsharing-readnettcpconfig.md
-    - name: System.ServiceModel.PortSharing.SharedManagerServiceEndpointNotExist
-      href: system-servicemodel-portsharing-sharedmanagerserviceendpointnotexist.md
-    - name: System.ServiceModel.PortSharing.TransportListenerListening
-      href: system-servicemodel-portsharing-transportlistenerlistening.md
-    - name: System.ServiceModel.PortSharing.TransportListenerListenRequest
-      href: system-servicemodel-portsharing-transportlistenerlistenrequest.md
-    - name: System.ServiceModel.PortSharing.TransportListenerSessionsReceived
-      href: system-servicemodel-portsharing-transportlistenersessionsreceived.md
-    - name: System.ServiceModel.PortSharing.TransportListenerStop
-      href: system-servicemodel-portsharing-transportlistenerstop.md
-    - name: System.ServiceModel.PortSharing.WasCloseAllListenerChannelInstances
-      href: system-servicemodel-portsharing-wasclosealllistenerchannelinstances.md
-    - name: System.ServiceModel.PortSharing.WasConnected
-      href: system-servicemodel-portsharing-wasconnected.md
-    - name: System.ServiceModel.PortSharing.WasWebHostAPIFailed
-      href: system-servicemodel-portsharing-waswebhostapifailed.md
-    - name: System.ServiceModel.RemoveBehavior
-      href: system-servicemodel-removebehavior.md
-    - name: System.ServiceModel.Security.ExportSecurityChannelBindingEntry
-      href: system-servicemodel-security-exportsecuritychannelbindingentry.md
-    - name: System.ServiceModel.Security.ExportSecurityChannelBindingExit
-      href: system-servicemodel-security-exportsecuritychannelbindingexit.md
-    - name: System.ServiceModel.Security.ImportSecurityChannelBindingEntry
-      href: system-servicemodel-security-importsecuritychannelbindingentry.md
-    - name: System.ServiceModel.Security.ImportSecurityChannelBindingExit
-      href: system-servicemodel-security-importsecuritychannelbindingexit.md
-    - name: System.ServiceModel.Security.IssuanceTokenProviderBeginSecurityNegotiation
-      href: system-servicemodel-security-issuancetokenproviderbeginsecuritynegotiation.md
-    - name: System.ServiceModel.Security.IssuanceTokenProviderEndSecurityNegotiation
-      href: system-servicemodel-security-issuancetokenproviderendsecuritynegotiation.md
-    - name: System.ServiceModel.Security.IssuanceTokenProviderRedirectApplied
-      href: system-servicemodel-security-issuancetokenproviderredirectapplied.md
-    - name: System.ServiceModel.Security.IssuanceTokenProviderRemovedCachedToken
-      href: system-servicemodel-security-issuancetokenproviderremovedcachedtoken.md
-    - name: System.ServiceModel.Security.IssuanceTokenProviderServiceTokenCacheFull
-      href: system-servicemodel-security-issuancetokenproviderservicetokencachefull.md
-    - name: System.ServiceModel.Security.IssuanceTokenProviderUsingCachedToken
-      href: system-servicemodel-security-issuancetokenproviderusingcachedtoken.md
-    - name: System.ServiceModel.Security.NegotiationAuthenticatorAttached
-      href: system-servicemodel-security-negotiationauthenticatorattached.md
-    - name: System.ServiceModel.Security.NegotiationTokenProviderAttached
-      href: system-servicemodel-security-negotiationtokenproviderattached.md
-    - name: System.ServiceModel.Security.SecurityActiveServerSessionRemoved
-      href: system-servicemodel-security-securityactiveserversessionremoved.md
-    - name: System.ServiceModel.Security.SecurityAuditWrittenFailure
-      href: system-servicemodel-security-securityauditwrittenfailure.md
-    - name: System.ServiceModel.Security.SecurityAuditWrittenSuccess
-      href: system-servicemodel-security-securityauditwrittensuccess.md
-    - name: System.ServiceModel.Security.SecurityBindingIncomingMessageVerified
-      href: system-servicemodel-security-securitybindingincomingmessageverified.md
-    - name: System.ServiceModel.Security.SecurityBindingOutgoingMessageSecured
-      href: system-servicemodel-security-securitybindingoutgoingmessagesecured.md
-    - name: System.ServiceModel.Security.SecurityBindingSecureOutgoingMessageFailure
-      href: system-servicemodel-security-securitybindingsecureoutgoingmessagefailure.md
-    - name: System.ServiceModel.Security.SecurityBindingVerifyIncomingMessageFailure
-      href: system-servicemodel-security-securitybindingverifyincomingmessagefailure.md
-    - name: System.ServiceModel.Security.SecurityClientSessionCloseMessageReceived
-      href: system-servicemodel-security-securityclientsessionclosemessagereceived.md
-    - name: System.ServiceModel.Security.SecurityClientSessionCloseResponseSent
-      href: system-servicemodel-security-securityclientsessioncloseresponsesent.md
-    - name: System.ServiceModel.Security.SecurityClientSessionCloseSent
-      href: system-servicemodel-security-securityclientsessionclosesent.md
-    - name: System.ServiceModel.Security.SecurityClientSessionKeyRenewed
-      href: system-servicemodel-security-securityclientsessionkeyrenewed.md
-    - name: System.ServiceModel.Security.SecurityClientSessionPreviousKeyDiscarded
-      href: system-servicemodel-security-securityclientsessionpreviouskeydiscarded.md
-    - name: System.ServiceModel.Security.SecurityContextTokenCacheFull
-      href: system-servicemodel-security-securitycontexttokencachefull.md
-    - name: System.ServiceModel.Security.SecurityIdentityDeterminationFailure
-      href: system-servicemodel-security-securityidentitydeterminationfailure.md
-    - name: System.ServiceModel.Security.SecurityIdentityDeterminationSuccess
-      href: system-servicemodel-security-securityidentitydeterminationsuccess.md
-    - name: System.ServiceModel.Security.SecurityIdentityHostNameNormalizationFailure
-      href: system-servicemodel-security-securityidentityhostnamenormalizationfailure.md
-    - name: System.ServiceModel.Security.SecurityIdentityVerificationFailure
-      href: system-servicemodel-security-securityidentityverificationfailure.md
-    - name: System.ServiceModel.Security.SecurityIdentityVerificationSuccess
-      href: system-servicemodel-security-securityidentityverificationsuccess.md
-    - name: System.ServiceModel.Security.SecurityImpersonationFailure
-      href: system-servicemodel-security-securityimpersonationfailure.md
-    - name: System.ServiceModel.Security.SecurityImpersonationSuccess
-      href: system-servicemodel-security-securityimpersonationsuccess.md
-    - name: System.ServiceModel.Security.SecurityInactiveSessionFaulted
-      href: system-servicemodel-security-securityinactivesessionfaulted.md
-    - name: System.ServiceModel.Security.SecurityNegotiationProcessingFailure
-      href: system-servicemodel-security-securitynegotiationprocessingfailure.md
-    - name: System.ServiceModel.Security.SecurityNewServerSessionKeyIssued
-      href: system-servicemodel-security-securitynewserversessionkeyissued.md
-    - name: System.ServiceModel.Security.SecurityPendingServerSessionActivated
-      href: system-servicemodel-security-securitypendingserversessionactivated.md
-    - name: System.ServiceModel.Security.SecurityPendingServerSessionAdded
-      href: system-servicemodel-security-securitypendingserversessionadded.md
-    - name: System.ServiceModel.Security.SecurityPendingServerSessionClosed
-      href: system-servicemodel-security-securitypendingserversessionclosed.md
-    - name: System.ServiceModel.Security.SecurityServerSessionAbortedFaultSent
-      href: system-servicemodel-security-securityserversessionabortedfaultsent.md
-    - name: System.ServiceModel.Security.SecurityServerSessionCloseReceived
-      href: system-servicemodel-security-securityserversessionclosereceived.md
-    - name: System.ServiceModel.Security.SecurityServerSessionCloseResponseReceived
-      href: system-servicemodel-security-securityserversessioncloseresponsereceived.md
-    - name: System.ServiceModel.Security.SecurityServerSessionKeyUpdated
-      href: system-servicemodel-security-securityserversessionkeyupdated.md
-    - name: System.ServiceModel.Security.SecurityServerSessionRenewalFaultSent
-      href: system-servicemodel-security-securityserversessionrenewalfaultsent.md
-    - name: System.ServiceModel.Security.SecuritySessionAbortedFaultReceived
-      href: system-servicemodel-security-securitysessionabortedfaultreceived.md
-    - name: System.ServiceModel.Security.SecuritySessionAbortedFaultSendFailure
-      href: system-servicemodel-security-securitysessionabortedfaultsendfailure.md
-    - name: System.ServiceModel.Security.SecuritySessionClosedResponseReceived
-      href: system-servicemodel-security-securitysessionclosedresponsereceived.md
-    - name: System.ServiceModel.Security.SecuritySessionCloseResponseSent
-      href: system-servicemodel-security-securitysessioncloseresponsesent.md
-    - name: System.ServiceModel.Security.SecuritySessionClosedResponseSendFailure
-      href: system-servicemodel-security-securitysessionclosedresponsesendfailure.md
-    - name: System.ServiceModel.Security.SecuritySessionDemuxFailure
-      href: system-servicemodel-security-securitysessiondemuxfailure.md
-    - name: System.ServiceModel.Security.SecuritySessionKeyRenewalFaultReceived
-      href: system-servicemodel-security-securitysessionkeyrenewalfaultreceived.md
-    - name: System.ServiceModel.Security.SecuritySessionRedirectApplied
-      href: system-servicemodel-security-securitysessionredirectapplied.md
-    - name: System.ServiceModel.Security.SecuritySessionRenewFaultSendFailure
-      href: system-servicemodel-security-securitysessionrenewfaultsendfailure.md
-    - name: System.ServiceModel.Security.SecuritySessionRequestorOperationFailure
-      href: system-servicemodel-security-securitysessionrequestoroperationfailure.md
-    - name: System.ServiceModel.Security.SecuritySessionRequestorOperationSuccess
-      href: system-servicemodel-security-securitysessionrequestoroperationsuccess.md
-    - name: System.ServiceModel.Security.SecuritySessionResponderOperationFailure
-      href: system-servicemodel-security-securitysessionresponderoperationfailure.md
-    - name: System.ServiceModel.Security.SecuritySessionServerCloseSent
-      href: system-servicemodel-security-securitysessionserverclosesent.md
-    - name: System.ServiceModel.Security.SecuritySessionServerCloseSendFailure
-      href: system-servicemodel-security-securitysessionserverclosesendfailure.md
-    - name: System.ServiceModel.Security.SecuritySpnToSidMappingFailure
-      href: system-servicemodel-security-securityspntosidmappingfailure.md
-    - name: System.ServiceModel.Security.SecurityTokenAuthenticatorClosed
-      href: system-servicemodel-security-securitytokenauthenticatorclosed.md
-    - name: System.ServiceModel.Security.SecurityTokenAuthenticatorOpened
-      href: system-servicemodel-security-securitytokenauthenticatoropened.md
-    - name: System.ServiceModel.Security.SecurityTokenProviderClosed
-      href: system-servicemodel-security-securitytokenproviderclosed.md
-    - name: System.ServiceModel.Security.SecurityTokenProviderOpened
-      href: system-servicemodel-security-securitytokenprovideropened.md
-    - name: System.ServiceModel.Security.ServiceSecurityNegotiationCompleted
-      href: system-servicemodel-security-servicesecuritynegotiationcompleted.md
-    - name: System.ServiceModel.Security.SpnegoClientNegotiationCompleted
-      href: system-servicemodel-security-spnegoclientnegotiationcompleted.md
-    - name: System.ServiceModel.Security.SpnegoServiceNegotiationCompleted
-      href: system-servicemodel-security-spnegoservicenegotiationcompleted.md
-    - name: System.ServiceModel.ServiceChannelLifetime
-      href: system-servicemodel-servicechannellifetime.md
-    - name: System.ServiceModel.ServiceHostBaseAddresses
-      href: system-servicemodel-servicehostbaseaddresses.md
-    - name: System.ServiceModel.ServiceHostCreation
-      href: system-servicemodel-servicehostcreation.md
-    - name: System.ServiceModel.ServiceHostErrorOnReleasePerformanceCounter
-      href: system-servicemodel-servicehosterroronreleaseperformancecounter.md
-    - name: System.ServiceModel.ServiceHostFaulted
-      href: system-servicemodel-servicehostfaulted.md
-    - name: System.ServiceModel.ServiceHostTimeoutOnClose
-      href: system-servicemodel-servicehosttimeoutonclose.md
-    - name: System.ServiceModel.ServiceOperationExceptionOnReply
-      href: system-servicemodel-serviceoperationexceptiononreply.md
-    - name: System.ServiceModel.ServiceOperationMissingReply
-      href: system-servicemodel-serviceoperationmissingreply.md
-    - name: System.ServiceModel.ServiceOperationMissingReplyContext
-      href: system-servicemodel-serviceoperationmissingreplycontext.md
-    - name: System.ServiceModel.ServiceThrottleLimitReached
-      href: system-servicemodel-servicethrottlelimitreached.md
-    - name: System.ServiceModel.SkipBehavior
-      href: system-servicemodel-skipbehavior.md
-    - name: System.ServiceModel.TransportListen
-      href: system-servicemodel-transportlisten.md
-    - name: System.ServiceModel.TxAsyncAbort
-      href: system-servicemodel-txasyncabort.md
-    - name: System.ServiceModel.TxCompletionStatusAbortedOnSessionClose
-      href: system-servicemodel-txcompletionstatusabortedonsessionclose.md
-    - name: System.ServiceModel.TxCompletionStatusCompletedForAsyncAbort
-      href: system-servicemodel-txcompletionstatuscompletedforasyncabort.md
-    - name: System.ServiceModel.TxCompletionStatusCompletedForAutocomplete
-      href: system-servicemodel-txcompletionstatuscompletedforautocomplete.md
-    - name: System.ServiceModel.TxCompletionStatusCompletedForError
-      href: system-servicemodel-txcompletionstatuscompletedforerror.md
-    - name: System.ServiceModel.TxCompletionStatusCompletedForSetComplete
-      href: system-servicemodel-txcompletionstatuscompletedforsetcomplete.md
-    - name: System.ServiceModel.TxCompletionStatusCompletedForTACOSC
-      href: system-servicemodel-txcompletionstatuscompletedfortacosc.md
-    - name: System.ServiceModel.TxCompletionStatusRemainsAttached
-      href: system-servicemodel-txcompletionstatusremainsattached.md
-    - name: System.ServiceModel.TxFailedToNegotiateOleTx
-      href: system-servicemodel-txfailedtonegotiateoletx.md
-    - name: System.ServiceModel.TxReleaseServiceInstanceOnCompletion
-      href: system-servicemodel-txreleaseserviceinstanceoncompletion.md
-    - name: System.ServiceModel.TxSourceTxScopeRequiredIsAttachedTransaction
-      href: system-servicemodel-txsourcetxscoperequiredisattachedtransaction.md
-    - name: System.ServiceModel.TxSourceTxScopeRequiredIsCreateNewTransaction
-      href: system-servicemodel-txsourcetxscoperequirediscreatenewtransaction.md
-    - name: System.ServiceModel.TxSourceTxScopeRequiredIsTransactionFlow
-      href: system-servicemodel-txsourcetxscoperequiredistransactionflow.md
-    - name: System.ServiceModel.TxSourceTxScopeRequiredIsTransactedTransport
-      href: system-servicemodel-txsourcetxscoperequiredistransactedtransport.md
-    - name: System.ServiceModel.UnderstoodMessageHeader
-      href: system-servicemodel-understoodmessageheader.md
-    - name: System.ServiceModel.UnhandledAction
-      href: system-servicemodel-unhandledaction.md
-    - name: System.ServiceModel.UnhandledExceptionInUserOperation
-      href: system-servicemodel-unhandledexceptioninuseroperation.md
-    - name: System.ServiceModel.WarnHelpPageEnabledNoBaseAddress
-      href: system-servicemodel-warnhelppageenablednobaseaddress.md
-    - name: System.ServiceModel.WarnServiceHealthEnabledNoBaseAddress
-      href: system-servicemodel-warnservicehealthenablednobaseaddress.md
-    - name: System.ServiceModel.WsmexNonCriticalWsdlExportError
-      href: system-servicemodel-wsmexnoncriticalwsdlexporterror.md
-    - name: System.ServiceModel.WsmexNonCriticalWsdlImportError
-      href: system-servicemodel-wsmexnoncriticalwsdlimporterror.md
+    - name: Activity List
+      href: activity-list.md
+    - name: Activity ID Propagation
+      href: activity-id-propagation.md
+    - name: Synchronous Scenarios using HTTP, TCP or Named-Pipe
+      href: synchronous-scenarios-using-http-tcp-or-named-pipe.md
+    - name: Asynchronous Scenarios using HTTP, TCP, or Named-Pipe
+      href: asynchronous-scenarios-using-http-tcp-or-named-pipe.md
+    - name: Activity Tracing in Message Security
+      href: activity-tracing-in-message-security.md
+    - name: MSMQ
+      href: msmq.md
+    - name: COM+
+      href: com.md
+  - name: Significant Traces
+    href: significant-traces.md
+  - name: Debugging on the Client
+    href: debugging-on-the-client.md
+  - name: Emitting User-Code Traces
+    href: emitting-user-code-traces.md
+- name: Recommended Settings for Tracing and Message Logging
+  href: recommended-settings-for-tracing-and-message-logging.md
+- name: Security Concerns and Useful Tips for Tracing
+  href: security-concerns-and-useful-tips-for-tracing.md
+- name: Traces Reference
+  href: traces-reference.md
+  items:
+  - name: Microsoft.Transactions.TransactionBridge.CommitMessageRetry
+    href: microsoft-transactions-transactionbridge-commitmessageretry.md
+  - name: Microsoft.Transactions.TransactionBridge.CoordinatorRecovered
+    href: microsoft-transactions-transactionbridge-coordinatorrecovered.md
+  - name: Microsoft.Transactions.TransactionBridge.CoordinatorStateMachineFinished
+    href: microsoft-transactions-transactionbridge-coordinatorstatemachinefinished.md
+  - name: Microsoft.Transactions.TransactionBridge.CreateTransactionFailure
+    href: microsoft-transactions-transactionbridge-createtransactionfailure.md
+  - name: Microsoft.Transactions.TransactionBridge.DurableParticipantReplayWhilePreparing
+    href: mtt-durableparticipantreplaywhilepreparing.md
+  - name: Microsoft.Transactions.TransactionBridge.EnlistmentIdentityCheckFailed
+    href: microsoft-transactions-transactionbridge-enlistmentidentitycheckfailed.md
+  - name: Microsoft.Transactions.TransactionBridge.EnlistTransaction
+    href: microsoft-transactions-transactionbridge-enlisttransaction.md
+  - name: Microsoft.Transactions.TransactionBridge.EnlistTransactionFailure
+    href: system-servicemodel-channels-connectionpoolmaxoutboundconnectionsperendpointquotareached.md
+  - name: Microsoft.Transactions.TransactionBridge.ParticipantRecovered
+    href: microsoft-transactions-transactionbridge-participantrecovered.md
+  - name: Microsoft.Transactions.TransactionBridge.ParticipantStateMachineFinished
+    href: microsoft-transactions-transactionbridge-participantstatemachinefinished.md
+  - name: Microsoft.Transactions.TransactionBridge.PrepareMessageRetry
+    href: microsoft-transactions-transactionbridge-preparemessageretry.md
+  - name: Microsoft.Transactions.TransactionBridge.PreparedMessageRetry
+    href: microsoft-transactions-transactionbridge-preparedmessageretry.md
+  - name: Microsoft.Transactions.TransactionBridge.ProtocolInitialized
+    href: microsoft-transactions-transactionbridge-protocolinitialized.md
+  - name: Microsoft.Transactions.TransactionBridge.ProtocolStarted
+    href: microsoft-transactions-transactionbridge-protocolstarted.md
+  - name: Microsoft.Transactions.TransactionBridge.RecoveredCoordinatorInvalidMetadata
+    href: microsoft-transactions-transactionbridge-recoveredcoordinatorinvalidmetadata.md
+  - name: Microsoft.Transactions.TransactionBridge.RecoveredParticipantInvalidMetadata
+    href: microsoft-transactions-transactionbridge-recoveredparticipantinvalidmetadata.md
+  - name: Microsoft.Transactions.TransactionBridge.RegisterCoordinator
+    href: microsoft-transactions-transactionbridge-registercoordinator.md
+  - name: Microsoft.Transactions.TransactionBridge.RegisterParticipant
+    href: microsoft-transactions-transactionbridge-registerparticipant.md
+  - name: Microsoft.Transactions.TransactionBridge.RegisterParticipantFailure
+    href: microsoft-transactions-transactionbridge-registerparticipantfailure.md
+  - name: Microsoft.Transactions.TransactionBridge.RegistrationCoordinatorFailed
+    href: microsoft-transactions-transactionbridge-registrationcoordinatorfailed.md
+  - name: Microsoft.Transactions.TransactionBridge.RegistrationCoordinatorFaulted
+    href: microsoft-transactions-transactionbridge-registrationcoordinatorfaulted.md
+  - name: Microsoft.Transactions.TransactionBridge.RegistrationCoordinatorResponseInvalidMetadata
+    href: mts-registrationcoordinatorresponseinvalidmetadata.md
+  - name: Microsoft.Transactions.TransactionBridge.ReplayMessageRetry
+    href: microsoft-transactions-transactionbridge-replaymessageretry.md
+  - name: Microsoft.Transactions.TransactionBridge.VolatileOutcomeTimeout
+    href: microsoft-transactions-transactionbridge-volatileoutcometimeout.md
+  - name: Microsoft.Transactions.TransactionBridge.VolatileParticipantInDoubt
+    href: microsoft-transactions-transactionbridge-volatileparticipantindoubt.md
+  - name: System.IdentityModel.AuthorizationContextCreated
+    href: system-identitymodel-authorizationcontextcreated.md
+  - name: System.IdentityModel.AuthorizationPolicyEvaluated
+    href: system-identitymodel-authorizationpolicyevaluated.md
+  - name: System.IdentityModel.IdentityModelAsyncCallbackThrewException
+    href: system-identitymodel-identitymodelasynccallbackthrewexception.md
+  - name: System.IdentityModel.Selectors.GeneralInformation
+    href: system-identitymodel-selectors-generalinformation.md
+  - name: System.IdentityModel.Selectors.StoreBeginTransaction
+    href: system-identitymodel-selectors-storebegintransaction.md
+  - name: System.IdentityModel.Selectors.StoreClosing
+    href: system-identitymodel-selectors-storeclosing.md
+  - name: System.IdentityModel.Selectors.StoreCommitTransaction
+    href: system-identitymodel-selectors-storecommittransaction.md
+  - name: System.IdentityModel.Selectors.StoreDeleting
+    href: system-identitymodel-selectors-storedeleting.md
+  - name: System.IdentityModel.Selectors.StoreFailedToOpenStore
+    href: system-identitymodel-selectors-storefailedtoopenstore.md
+  - name: System.IdentityModel.Selectors.StoreLoading
+    href: system-identitymodel-selectors-storeloading.md
+  - name: System.IdentityModel.Selectors.StoreRollbackTransaction
+    href: system-identitymodel-selectors-storerollbacktransaction.md
+  - name: System.IdentityModel.Selectors.StoreSignatureNotValid
+    href: system-identitymodel-selectors-storesignaturenotvalid.md
+  - name: System.Runtime.Serialization.ElementIgnored
+    href: system-runtime-serialization-elementignored.md
+  - name: System.Runtime.Serialization.FactoryTypeNotFound
+    href: system-runtime-serialization-factorytypenotfound.md
+  - name: System.Runtime.Serialization.ObjectWithLargeDepth
+    href: system-runtime-serialization-objectwithlargedepth.md
+  - name: System.Runtime.Serialization.ReadObjectBegin
+    href: system-runtime-serialization-readobjectbegin.md
+  - name: System.Runtime.Serialization.ReadObjectEnd
+    href: system-servicemodel-comintegration-comintegrationmexmonikermetadataexchangecomplete.md
+  - name: System.Runtime.Serialization.WriteObjectBegin
+    href: system-runtime-serialization-writeobjectbegin.md
+  - name: System.Runtime.Serialization.WriteObjectContentBegin
+    href: system-runtime-serialization-writeobjectcontentbegin.md
+  - name: System.Runtime.Serialization.WriteObjectContentEnd
+    href: system-runtime-serialization-writeobjectcontentend.md
+  - name: System.Runtime.Serialization.WriteObjectEnd
+    href: system-runtime-serialization-writeobjectend.md
+  - name: System.Runtime.Serialization.XsdExportAnnotationFailed
+    href: system-runtime-serialization-xsdexportannotationfailed.md
+  - name: System.Runtime.Serialization.XsdExportBegin
+    href: system-runtime-serialization-xsdexportbegin.md
+  - name: System.Runtime.Serialization.XsdExportDupItems
+    href: system-runtime-serialization-xsdexportdupitems.md
+  - name: System.Runtime.Serialization.XsdExportEnd
+    href: system-runtime-serialization-xsdexportend.md
+  - name: System.Runtime.Serialization.XsdExportError
+    href: system-runtime-serialization-xsdexporterror.md
+  - name: System.Runtime.Serialization.XsdImportAnnotationFailed
+    href: system-runtime-serialization-xsdimportannotationfailed.md
+  - name: System.Runtime.Serialization.XsdImportBegin
+    href: system-runtime-serialization-xsdimportbegin.md
+  - name: System.Runtime.Serialization.XsdImportEnd
+    href: system-runtime-serialization-xsdimportend.md
+  - name: System.Runtime.Serialization.XsdImportError
+    href: system-runtime-serialization-xsdimporterror.md
+  - name: System.ServiceModel.Activation.MessageQueueClosed
+    href: system-servicemodel-activation-messagequeueclosed.md
+  - name: System.ServiceModel.Activation.MessageQueueDuplicatedPipe
+    href: system-servicemodel-activation-messagequeueduplicatedpipe.md
+  - name: System.ServiceModel.Activation.MessageQueueDuplicatedPipeError
+    href: system-servicemodel-activation-messagequeueduplicatedpipeerror.md
+  - name: System.ServiceModel.Activation.MessageQueueDuplicatedSocket
+    href: system-servicemodel-activation-messagequeueduplicatedsocket.md
+  - name: System.ServiceModel.Activation.MessageQueueDuplicatedSocketError
+    href: system-servicemodel-activation-messagequeueduplicatedsocketerror.md
+  - name: System.ServiceModel.Activation.MessageQueueRegisterCalled
+    href: system-servicemodel-activation-messagequeueregistercalled.md
+  - name: System.ServiceModel.Activation.MessageQueueRegisterSucceeded
+    href: system-servicemodel-activation-messagequeueregistersucceeded.md
+  - name: System.ServiceModel.Activation.MessageQueueRegisterFailed
+    href: system-servicemodel-activation-messagequeueregisterfailed.md
+  - name: System.ServiceModel.Activation.MessageQueueUnregisterSucceeded
+    href: system-servicemodel-activation-messagequeueunregistersucceeded.md
+  - name: System.ServiceModel.Activation.ServiceContinue
+    href: system-servicemodel-activation-servicecontinue.md
+  - name: System.ServiceModel.Activation.ServicePause
+    href: system-servicemodel-activation-servicepause.md
+  - name: System.ServiceModel.Activation.ServiceShutdown
+    href: system-servicemodel-activation-serviceshutdown.md
+  - name: System.ServiceModel.Activation.ServiceShutdownError
+    href: system-servicemodel-activation-serviceshutdownerror.md
+  - name: System.ServiceModel.Activation.ServiceStart
+    href: system-servicemodel-activation-servicestart.md
+  - name: System.ServiceModel.Activation.ServiceStartPipeError
+    href: system-servicemodel-activation-servicestartpipeerror.md
+  - name: System.ServiceModel.Activation.ServiceStop
+    href: system-servicemodel-activation-servicestop.md
+  - name: System.ServiceModel.Activation.WebHostCompilation
+    href: system-servicemodel-activation-webhostcompilation.md
+  - name: System.ServiceModel.Activation.WebHostDebugRequest
+    href: system-servicemodel-activation-webhostdebugrequest.md
+  - name: System.ServiceModel.Activation.WebHostProtocolMisconfigured
+    href: system-servicemodel-activation-webhostprotocolmisconfigured.md
+  - name: System.ServiceModel.Activation.WebHostServiceActivated
+    href: system-servicemodel-activation-webhostserviceactivated.md
+  - name: System.ServiceModel.Activation.WebHostServiceCloseFailed
+    href: system-servicemodel-activation-webhostserviceclosefailed.md
+  - name: System.ServiceModel.Administration.WmiPut
+    href: system-servicemodel-administration-wmiput.md
+  - name: System.ServiceModel.AsyncCallbackThrewException
+    href: system-servicemodel-asynccallbackthrewexception.md
+  - name: System.ServiceModel.BeginExecuteMethod
+    href: system-servicemodel-beginexecutemethod.md
+  - name: System.ServiceModel.CannotBeImportedInCurrentFormat
+    href: system-servicemodel-cannotbeimportedincurrentformat.md
+  - name: System.ServiceModel.Channels.ChannelCreated
+    href: system-servicemodel-channels-channelcreated.md
+  - name: System.ServiceModel.Channels.ChannelDisposed
+    href: system-servicemodel-channels-channeldisposed.md
+  - name: System.ServiceModel.Channels.ConnectionAbandoned
+    href: system-servicemodel-channels-connectionabandoned.md
+  - name: System.ServiceModel.Channels.ConnectionPoolCloseException
+    href: system-servicemodel-channels-connectionpoolcloseexception.md
+  - name: System.ServiceModel.Channels.ConnectionPoolIdleTimeoutReached
+    href: system-servicemodel-channels-connectionpoolidletimeoutreached.md
+  - name: System.ServiceModel.Channels.ConnectionPoolLeaseTimeoutReached
+    href: system-servicemodel-channels-connectionpoolleasetimeoutreached.md
+  - name: System.ServiceModel.Channels.ConnectionPoolMaxOutboundConnectionsPerEndpointQuotaReached
+    href: connectionpoolmaxoutboundconnectionsperendpointquotareached.md
+  - name: System.ServiceModel.Channels.ConnectToIPEndpoint
+    href: system-servicemodel-channels-connecttoipendpoint.md
+  - name: System.ServiceModel.Channels.EndpointListenerClose
+    href: system-servicemodel-channels-endpointlistenerclose.md
+  - name: System.ServiceModel.Channels.EndpointListenerOpen
+    href: system-servicemodel-channels-endpointlisteneropen.md
+  - name: System.ServiceModel.Channels.FailedAcceptFromPool
+    href: system-servicemodel-channels-failedacceptfrompool.md
+  - name: System.ServiceModel.Channels.FailedPipeConnect
+    href: system-servicemodel-channels-failedpipeconnect.md
+  - name: System.ServiceModel.Channels.HttpAuthFailed
+    href: system-servicemodel-channels-httpauthfailed.md
+  - name: System.ServiceModel.Channels.HttpChannelConcurrentReceiveQuotaReached
+    href: system-servicemodel-channels-httpchannelconcurrentreceivequotareached.md
+  - name: System.ServiceModel.Channels.HttpChannelMessageReceiveFailed
+    href: system-servicemodel-channels-httpchannelmessagereceivefailed.md
+  - name: System.ServiceModel.Channels.HttpChannelRequestAborted
+    href: system-servicemodel-channels-httpchannelrequestaborted.md
+  - name: System.ServiceModel.Channels.HttpChannelResponseAborted
+    href: system-servicemodel-channels-httpchannelresponseaborted.md
+  - name: System.ServiceModel.Channels.HttpChannelUnexpectedResponse
+    href: system-servicemodel-channels-httpchannelunexpectedresponse.md
+  - name: System.ServiceModel.Channels.HttpResponseReceived
+    href: system-servicemodel-channels-httpresponsereceived.md
+  - name: System.ServiceModel.Channels.HttpsClientCertificateInvalid
+    href: system-servicemodel-channels-httpsclientcertificateinvalid.md
+  - name: System.ServiceModel.Channels.HttpsClientCertificateNotPresent
+    href: system-servicemodel-channels-httpsclientcertificatenotpresent.md
+  - name: System.ServiceModel.Channels.IncompatibleExistingTransportManager
+    href: system-servicemodel-channels-incompatibleexistingtransportmanager.md
+  - name: System.ServiceModel.Channels.InitiatingNamedPipeConnection
+    href: system-servicemodel-channels-initiatingnamedpipeconnection.md
+  - name: System.ServiceModel.Channels.InitiatingTcpConnection
+    href: system-servicemodel-channels-initiatingtcpconnection.md
+  - name: System.ServiceModel.Channels.ListenerCreated
+    href: system-servicemodel-channels-listenercreated.md
+  - name: System.ServiceModel.Channels.ListenerDisposed
+    href: system-servicemodel-channels-listenerdisposed.md
+  - name: System.ServiceModel.Channels.PrematureDatagramEof
+    href: system-servicemodel-channels-prematuredatagrameof.md
+  - name: System.ServiceModel.Channels.MaxAcceptedChannelsReached
+    href: system-servicemodel-channels-maxacceptedchannelsreached.md
+  - name: System.ServiceModel.Channels.MaxPendingConnectionsReached
+    href: system-servicemodel-channels-maxpendingconnectionsreached.md
+  - name: System.ServiceModel.Channels.MessageReceived
+    href: system-servicemodel-channels-messagereceived.md
+  - name: System.ServiceModel.Channels.MessageSent
+    href: system-servicemodel-channels-messagesent.md
+  - name: System.ServiceModel.Channels.MsmqCannotPeekOnQueue
+    href: system-servicemodel-channels-msmqcannotpeekonqueue.md
+  - name: System.ServiceModel.Channels.MsmqCannotReadQueues
+    href: system-servicemodel-channels-msmqcannotreadqueues.md
+  - name: System.ServiceModel.Channels.MsmqDatagramSent
+    href: system-servicemodel-channels-msmqdatagramsent.md
+  - name: System.ServiceModel.Channels.MsmqDatagramReceived
+    href: system-servicemodel-channels-msmqdatagramreceived.md
+  - name: System.ServiceModel.Channels.MsmqDetected
+    href: system-servicemodel-channels-msmqdetected.md
+  - name: System.ServiceModel.Channels.MsmqEnteredBatch
+    href: system-servicemodel-channels-msmqenteredbatch.md
+  - name: System.ServiceModel.Channels.MsmqFoundBaseAddress
+    href: system-servicemodel-channels-msmqfoundbaseaddress.md
+  - name: System.ServiceModel.Channels.MsmqLeftBatch
+    href: system-servicemodel-channels-msmqleftbatch.md
+  - name: System.ServiceModel.Channels.MsmqMatchedApplicationFound
+    href: system-servicemodel-channels-msmqmatchedapplicationfound.md
+  - name: System.ServiceModel.Channels.MsmqMessageDropped
+    href: system-servicemodel-channels-msmqmessagedropped.md
+  - name: System.ServiceModel.Channels.MsmqMessageLockedUnderTheTransaction
+    href: system-servicemodel-channels-msmqmessagelockedunderthetransaction.md
+  - name: System.ServiceModel.Channels.MsmqMessageRejected
+    href: system-servicemodel-channels-msmqmessagerejected.md
+  - name: System.ServiceModel.Channels.MsmqMoveOrDeleteAttemptFailed
+    href: system-servicemodel-comintegration-comintegrationservicehostcreatedserviceendpoint.md
+  - name: System.ServiceModel.Channels.MsmqPoisonMessageMovedPoison
+    href: system-servicemodel-channels-msmqpoisonmessagemovedpoison.md
+  - name: System.ServiceModel.Channels.MsmqPoisonMessageMovedRetry
+    href: system-servicemodel-channels-msmqpoisonmessagemovedretry.md
+  - name: System.ServiceModel.Channels.MsmqPoisonMessageRejected
+    href: system-servicemodel-channels-msmqpoisonmessagerejected.md
+  - name: System.ServiceModel.Channels.MsmqPoolFull
+    href: system-servicemodel-channels-msmqpoolfull.md
+  - name: System.ServiceModel.Channels.MsmqPotentiallyPoisonMessageDetected
+    href: system-servicemodel-channels-msmqpotentiallypoisonmessagedetected.md
+  - name: System.ServiceModel.Channels.MsmqQueueClosed
+    href: system-servicemodel-channels-msmqqueueclosed.md
+  - name: System.ServiceModel.Channels.MsmqQueueOpened
+    href: system-servicemodel-channels-msmqqueueopened.md
+  - name: System.ServiceModel.Channels.MsmqQueueTransactionalStatusUnknown
+    href: system-servicemodel-channels-msmqqueuetransactionalstatusunknown.md
+  - name: System.ServiceModel.Channels.MsmqUnexpectedAcknowledgment
+    href: system-servicemodel-channels-msmqunexpectedacknowledgment.md
+  - name: System.ServiceModel.Channels.MsmqSessiongramReceived
+    href: system-servicemodel-channels-msmqsessiongramreceived.md
+  - name: System.ServiceModel.Channels.MsmqSessiongramSent
+    href: system-servicemodel-channels-msmqsessiongramsent.md
+  - name: System.ServiceModel.Channels.MsmqScanStarted
+    href: system-servicemodel-channels-msmqscanstarted.md
+  - name: System.ServiceModel.Channels.MsmqStartingApplication
+    href: system-servicemodel-channels-msmqstartingapplication.md
+  - name: System.ServiceModel.Channels.MsmqStartingService
+    href: system-servicemodel-channels-msmqstartingservice.md
+  - name: System.ServiceModel.Channels.NamedPipeChannelMessageReceived
+    href: system-servicemodel-channels-namedpipechannelmessagereceived.md
+  - name: System.ServiceModel.Channels.NamedPipeChannelMessageReceiveFailed
+    href: system-servicemodel-channels-namedpipechannelmessagereceivefailed.md
+  - name: System.ServiceModel.Channels.NoExistingTransportManager
+    href: system-servicemodel-channels-noexistingtransportmanager.md
+  - name: System.ServiceModel.Channels.OpenedListener
+    href: system-servicemodel-channels-openedlistener.md
+  - name: System.ServiceModel.Channels.PeerChannelMessageReceived
+    href: system-servicemodel-channels-peerchannelmessagereceived.md
+  - name: System.ServiceModel.Channels.PeerChannelMessageSent
+    href: system-servicemodel-channels-peerchannelmessagesent.md
+  - name: System.ServiceModel.Channels.PeerFloodedMessageReceived
+    href: system-servicemodel-channels-peerfloodedmessagereceived.md
+  - name: System.ServiceModel.Channels.PeerFloodedMessageNotMatched
+    href: system-servicemodel-channels-peerfloodedmessagenotmatched.md
+  - name: System.ServiceModel.Channels.PeerFloodedMessageNotPropagated
+    href: system-servicemodel-channels-peerfloodedmessagenotpropagated.md
+  - name: System.ServiceModel.Channels.PeerFlooderReceiveMessageQuotaExceeded
+    href: system-servicemodel-channels-peerflooderreceivemessagequotaexceeded.md
+  - name: System.ServiceModel.Channels.PeerMaintainerActivity
+    href: system-servicemodel-channels-peermaintaineractivity.md
+  - name: System.ServiceModel.Channels.PeerNeighborManagerOffline
+    href: system-servicemodel-channels-peerneighbormanageroffline.md
+  - name: System.ServiceModel.Channels.PeerNeighborManagerOnline
+    href: system-servicemodel-channels-peerneighbormanageronline.md
+  - name: System.ServiceModel.Channels.PeerNeighborMessageReceived
+    href: system-servicemodel-channels-peerneighbormessagereceived.md
+  - name: System.ServiceModel.Channels.PeerNeighborNotAccepted
+    href: system-servicemodel-channels-peerneighbornotaccepted.md
+  - name: System.ServiceModel.Channels.PeerNeighborNotFound
+    href: system-servicemodel-channels-peerneighbornotfound.md
+  - name: System.ServiceModel.Channels.PeerNeighborStateChanged
+    href: system-servicemodel-channels-peerneighborstatechanged.md
+  - name: System.ServiceModel.Channels.PeerNeighborStateChangeFailed
+    href: system-servicemodel-channels-peerneighborstatechangefailed.md
+  - name: System.ServiceModel.Channels.PeerNodeAddressChanged
+    href: system-servicemodel-channels-peernodeaddresschanged.md
+  - name: System.ServiceModel.Channels.PeerNodeAuthenticationFailure
+    href: system-servicemodel-channels-peernodeauthenticationfailure.md
+  - name: System.ServiceModel.Channels.PeerNodeAuthenticationTimeout
+    href: system-servicemodel-channels-peernodeauthenticationtimeout.md
+  - name: System.ServiceModel.Channels.PeerNodeOpened
+    href: system-servicemodel-channels-peernodeopened.md
+  - name: System.ServiceModel.Channels.PeerNodeOpening
+    href: system-servicemodel-channels-peernodeopening.md
+  - name: System.ServiceModel.Channels.PeerNodeOpenFailed
+    href: system-servicemodel-channels-peernodeopenfailed.md
+  - name: System.ServiceModel.Channels.PeerNodeClosed
+    href: system-servicemodel-channels-peernodeclosed.md
+  - name: System.ServiceModel.Channels.PeerNodeClosing
+    href: system-servicemodel-channels-peernodeclosing.md
+  - name: System.ServiceModel.Channels.PeerReceiveMessageAuthenticationFailure
+    href: system-servicemodel-channels-peerreceivemessageauthenticationfailure.md
+  - name: System.ServiceModel.Channels.PeerServiceOpened
+    href: system-servicemodel-channels-peerserviceopened.md
+  - name: System.ServiceModel.Channels.PipeConnectionAbort
+    href: system-servicemodel-channels-pipeconnectionabort.md
+  - name: System.ServiceModel.Channels.PnrpRegisteredAddresses
+    href: system-servicemodel-channels-pnrpregisteredaddresses.md
+  - name: System.ServiceModel.Channels.PnrpResolvedAddresses
+    href: system-servicemodel-channels-pnrpresolvedaddresses.md
+  - name: System.ServiceModel.Channels.PnrpUnregisteredAddresses
+    href: system-servicemodel-channels-pnrpunregisteredaddresses.md
+  - name: System.ServiceModel.Channels.PnrpResolveException
+    href: system-servicemodel-channels-pnrpresolveexception.md
+  - name: System.ServiceModel.Channels.RequestChannelReplyReceived
+    href: system-servicemodel-channels-requestchannelreplyreceived.md
+  - name: System.ServiceModel.Channels.RequestContextAbort
+    href: system-servicemodel-channels-requestcontextabort.md
+  - name: System.ServiceModel.Channels.ServerMaxPooledConnectionsQuotaReached
+    href: system-servicemodel-channels-servermaxpooledconnectionsquotareached.md
+  - name: System.ServiceModel.Channels.SocketConnectionAbort
+    href: system-servicemodel-channels-socketconnectionabort.md
+  - name: System.ServiceModel.Channels.SocketConnectionAbortClose
+    href: system-servicemodel-channels-socketconnectionabortclose.md
+  - name: System.ServiceModel.Channels.SocketConnectionClose
+    href: system-servicemodel-channels-socketconnectionclose.md
+  - name: System.ServiceModel.Channels.SocketConnectionCreate
+    href: system-servicemodel-channels-socketconnectioncreate.md
+  - name: System.ServiceModel.Channels.SslClientCertMissing
+    href: system-servicemodel-channels-sslclientcertmissing.md
+  - name: System.ServiceModel.Channels.StreamSecurityUpgradeAccepted
+    href: system-servicemodel-channels-streamsecurityupgradeaccepted.md
+  - name: System.ServiceModel.Channels.SystemTimeResolution
+    href: system-servicemodel-channels-systemtimeresolution.md
+  - name: System.ServiceModel.Channels.TcpChannelMessageReceived
+    href: system-servicemodel-channels-tcpchannelmessagereceived.md
+  - name: System.ServiceModel.Channels.TcpConnectError
+    href: system-servicemodel-channels-tcpconnecterror.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationChannelCreated
+    href: system-servicemodel-comintegration-comintegrationchannelcreated.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationDispatchMethod
+    href: system-servicemodel-comintegration-comintegrationdispatchmethod.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationDllHostInitializerAddingHost
+    href: system-servicemodel-comintegration-comintegrationdllhostinitializeraddinghost.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationDllHostInitializerStarted
+    href: system-servicemodel-comintegration-comintegrationdllhostinitializerstarted.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationDllHostInitializerStarting
+    href: system-servicemodel-comintegration-comintegrationdllhostinitializerstarting.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationDllHostInitializerStopped
+    href: system-servicemodel-comintegration-comintegrationdllhostinitializerstopped.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationDllHostInitializerStopping
+    href: system-servicemodel-comintegration-comintegrationdllhostinitializerstopping.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationEnteringActivity
+    href: system-servicemodel-comintegration-comintegrationenteringactivity.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationExecutingCall
+    href: system-servicemodel-comintegration-comintegrationexecutingcall.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationInstanceCreationRequest
+    href: system-servicemodel-comintegration-comintegrationinstancecreationrequest.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationInstanceCreationSuccess
+    href: system-servicemodel-comintegration-comintegrationinstancecreationsuccess.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationInstanceReleased
+    href: system-servicemodel-comintegration-comintegrationinstancereleased.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationInvokedMethod
+    href: system-servicemodel-comintegration-comintegrationinvokedmethod.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationInvokingMethod
+    href: system-servicemodel-comintegration-comintegrationinvokingmethod.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationInvokingMethodContextTransaction
+    href: ssc-comintegrationinvokingmethodcontexttransaction.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationInvokingMethodNewTransaction
+    href: system-servicemodel-comintegration-comintegrationinvokingmethodnewtransaction.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationLeftActivity
+    href: system-servicemodel-comintegration-comintegrationleftactivity.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationMexChannelBuilderLoaded
+    href: system-servicemodel-comintegration-comintegrationmexchannelbuilderloaded.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationMexMonikerMetadataExchangeComplete
+    href: ssc--comintegrationmexmonikermetadataexchangecomplete.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationServiceHostCreatedServiceContract
+    href: ssc-comintegrationservicehostcreatedservicecontract.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationServiceHostCreatedServiceEndpoint
+    href: ssc--comintegrationservicehostcreatedserviceendpoint.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationServiceHostStartedService
+    href: system-servicemodel-comintegration-comintegrationservicehoststartedservice.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationServiceHostStartedServiceDetails
+    href: ssc-comintegration.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationServiceHostStartingService
+    href: system-servicemodel-comintegration-comintegrationservicehoststartingservice.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationServiceHostStoppedService
+    href: system-servicemodel-comintegration-comintegrationservicehoststoppedservice.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationServiceHostStoppingService
+    href: system-servicemodel-comintegration-comintegrationservicehoststoppingservice.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationServiceMonikerParsed
+    href: system-servicemodel-comintegration-comintegrationservicemonikerparsed.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationTLBImportConverterEvent
+    href: system-servicemodel-comintegration-comintegrationtlbimportconverterevent.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationTLBImportFinished
+    href: system-servicemodel-comintegration-comintegrationtlbimportfinished.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationTLBImportFromAssembly
+    href: system-servicemodel-comintegration-comintegrationtlbimportfromassembly.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationTLBImportFromTypelib
+    href: system-servicemodel-comintegration-comintegrationtlbimportfromtypelib.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationTLBImportStarting
+    href: system-servicemodel-comintegration-comintegrationtlbimportstarting.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationTxProxyTxAbortedByContext
+    href: system-servicemodel-comintegration-comintegrationtxproxytxabortedbycontext.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationTxProxyTxAbortedByTM
+    href: system-servicemodel-comintegration-comintegrationtxproxytxabortedbytm.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationTxProxyTxCommitted
+    href: system-servicemodel-comintegration-comintegrationtxproxytxcommitted.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationTypedChannelBuilderLoaded
+    href: system-servicemodel-comintegration-comintegrationtypedchannelbuilderloaded.md
+  - name: System.ServiceModel.ComIntegration.ComIntegrationWsdlChannelBuilderLoaded
+    href: system-servicemodel-comintegration-comintegrationwsdlchannelbuilderloaded.md
+  - name: System.ServiceModel.CommunicationObjectAborted
+    href: system-servicemodel-communicationobjectaborted.md
+  - name: System.ServiceModel.CommunicationObjectAbortFailed
+    href: system-servicemodel-communicationobjectabortfailed.md
+  - name: System.ServiceModel.CommunicationObjectClosed
+    href: system-servicemodel-communicationobjectclosed.md
+  - name: System.ServiceModel.CommunicationObjectCloseFailed
+    href: system-servicemodel-communicationobjectclosefailed.md
+  - name: System.ServiceModel.CommunicationObjectClosing
+    href: system-servicemodel-communicationobjectclosing.md
+  - name: System.ServiceModel.CommunicationObjectCreated
+    href: system-servicemodel-communicationobjectcreated.md
+  - name: System.ServiceModel.CommunicationObjectDisposing
+    href: system-servicemodel-communicationobjectdisposing.md
+  - name: System.ServiceModel.CommunicationObjectFaulted
+    href: system-servicemodel-communicationobjectfaulted.md
+  - name: System.ServiceModel.CommunicationObjectFaultReason
+    href: system-servicemodel-communicationobjectfaultreason.md
+  - name: System.ServiceModel.CommunicationObjectOpened
+    href: system-servicemodel-communicationobjectopened.md
+  - name: System.ServiceModel.CommunicationObjectOpenFailed
+    href: system-servicemodel-communicationobjectopenfailed.md
+  - name: System.ServiceModel.CommunicationObjectOpening
+    href: system-servicemodel-communicationobjectopening.md
+  - name: System.ServiceModel.ConfigurationIsReadOnly
+    href: system-servicemodel-configurationisreadonly.md
+  - name: System.ServiceModel.ConfiguredExtensionTypeNotFound
+    href: system-servicemodel-configuredextensiontypenotfound.md
+  - name: System.ServiceModel.Diagnostics.ActivityBoundary
+    href: system-servicemodel-diagnostics-activityboundary.md
+  - name: System.ServiceModel.Diagnostics.AppDomainUnload
+    href: system-servicemodel-diagnostics-appdomainunload.md
+  - name: System.ServiceModel.Diagnostics.DiagnosticsFailedMessageTrace
+    href: system-servicemodel-diagnostics-diagnosticsfailedmessagetrace.md
+  - name: System.ServiceModel.Diagnostics.EventLog
+    href: system-servicemodel-diagnostics-eventlog.md
+  - name: System.ServiceModel.Diagnostics.FailedToAddAnActivityIdHeader
+    href: system-servicemodel-diagnostics-failedtoaddanactivityidheader.md
+  - name: System.ServiceModel.Diagnostics.FailedToReadAnActivityIdHeader
+    href: system-servicemodel-diagnostics-failedtoreadanactivityidheader.md
+  - name: System.ServiceModel.Diagnostics.FilterNotMatchedNodeQuotaExceeded
+    href: system-servicemodel-diagnostics-filternotmatchednodequotaexceeded.md
+  - name: System.ServiceModel.Diagnostics.MessageNotLoggedQuotaExceeded
+    href: system-servicemodel-diagnostics-messagenotloggedquotaexceeded.md
+  - name: System.ServiceModel.Diagnostics.MessageCountLimitExceeded
+    href: microsoft-transactions-transactionbridge-registrationcoordinatorresponseinvalidmetadata.md
+  - name: System.ServiceModel.Diagnostics.ThrowingException
+    href: system-servicemodel-diagnostics-throwingexception.md
+  - name: System.ServiceModel.Diagnostics.TraceHandledException
+    href: system-servicemodel-diagnostics-tracehandledexception.md
+  - name: System.ServiceModel.Diagnostics.TraceTruncatedQuotaExceeded
+    href: system-servicemodel-diagnostics-tracetruncatedquotaexceeded.md
+  - name: System.ServiceModel.Diagnostics.UnhandledException
+    href: system-servicemodel-diagnostics-unhandledexception.md
+  - name: System.ServiceModel.DidNotUnderstandMessageHeader
+    href: system-servicemodel-didnotunderstandmessageheader.md
+  - name: System.ServiceModel.DroppedAMessage
+    href: system-servicemodel-droppedamessage.md
+  - name: System.ServiceModel.ElementTypeDoesntMatchConfiguredType
+    href: system-servicemodel-elementtypedoesntmatchconfiguredtype.md
+  - name: System.ServiceModel.EndExecuteMethod
+    href: system-servicemodel-endexecutemethod.md
+  - name: System.ServiceModel.ErrorInvokingUserCode
+    href: system-servicemodel-errorinvokingusercode.md
+  - name: System.ServiceModel.EvaluationContextNotFound
+    href: system-servicemodel-evaluationcontextnotfound.md
+  - name: System.ServiceModel.ExtensionCollectionDoesNotExist
+    href: system-servicemodel-extensioncollectiondoesnotexist.md
+  - name: System.ServiceModel.ExtensionCollectionIsEmpty
+    href: system-servicemodel-extensioncollectionisempty.md
+  - name: System.ServiceModel.ExtensionCollectionNameNotFound
+    href: system-servicemodel-extensioncollectionnamenotfound.md
+  - name: System.ServiceModel.ExtensionElementAlreadyExistsInCollection
+    href: system-servicemodel-extensionelementalreadyexistsincollection.md
+  - name: System.ServiceModel.FailedToOpenIncomingChannel
+    href: system-servicemodel-failedtoopenincomingchannel.md
+  - name: System.ServiceModel.GetBehaviorElement
+    href: system-servicemodel-getbehaviorelement.md
+  - name: System.ServiceModel.GetChannelEndpointElement
+    href: system-servicemodel-getchannelendpointelement.md
+  - name: System.ServiceModel.GetCommonBehaviors
+    href: system-servicemodel-getcommonbehaviors.md
+  - name: System.ServiceModel.GetConfigurationSection
+    href: system-servicemodel-getconfigurationsection.md
+  - name: System.ServiceModel.GetConfiguredBinding
+    href: system-servicemodel-getconfiguredbinding.md
+  - name: System.ServiceModel.GetDefaultConfiguredBinding
+    href: system-servicemodel-getdefaultconfiguredbinding.md
+  - name: System.ServiceModel.GetServiceElement
+    href: system-servicemodel-getserviceelement.md
+  - name: System.ServiceModel.ManualFlowThrottleLimitReached
+    href: system-servicemodel-manualflowthrottlelimitreached.md
+  - name: System.ServiceModel.MetadataExchangeClientReceiveReply
+    href: system-servicemodel-metadataexchangeclientreceivereply.md
+  - name: System.ServiceModel.MetadataExchangeClientSendRequest
+    href: system-servicemodel-metadataexchangeclientsendrequest.md
+  - name: System.ServiceModel.MessageClosed
+    href: system-servicemodel-messageclosed.md
+  - name: System.ServiceModel.MessageClosedAgain
+    href: system-servicemodel-messageclosedagain.md
+  - name: System.ServiceModel.MessageCopied
+    href: system-servicemodel-messagecopied.md
+  - name: System.ServiceModel.MessageProcessingPaused
+    href: system-servicemodel-messageprocessingpaused.md
+  - name: System.ServiceModel.MessageRead
+    href: system-servicemodel-messageread.md
+  - name: System.ServiceModel.MessageWritten
+    href: system-servicemodel-messagewritten.md
+  - name: System.ServiceModel.OverridingDuplicateConfigurationKey
+    href: system-servicemodel-overridingduplicateconfigurationkey.md
+  - name: System.ServiceModel.PerformanceCountersFailed
+    href: system-servicemodel-performancecountersfailed.md
+  - name: System.ServiceModel.PerformanceCountersFailedDuringUpdate
+    href: system-servicemodel-performancecountersfailedduringupdate.md
+  - name: System.ServiceModel.PerformanceCountersFailedForService
+    href: system-servicemodel-performancecountersfailedforservice.md
+  - name: System.ServiceModel.PerformanceCountersFailedOnRelease
+    href: system-servicemodel-performancecountersfailedonrelease.md
+  - name: System.ServiceModel.PerformanceCounterFailedToLoad
+    href: system-servicemodel-performancecounterfailedtoload.md
+  - name: System.ServiceModel.PortSharing.PortSharingClosed
+    href: system-servicemodel-portsharing-portsharingclosed.md
+  - name: System.ServiceModel.PortSharing.PortSharingDupHandleGranted
+    href: system-servicemodel-portsharing-portsharingduphandlegranted.md
+  - name: System.ServiceModel.PortSharing.PortSharingDuplicatedPipe
+    href: system-servicemodel-portsharing-portsharingduplicatedpipe.md
+  - name: System.ServiceModel.PortSharing.PortSharingDuplicatedSocket
+    href: system-servicemodel-portsharing-portsharingduplicatedsocket.md
+  - name: System.ServiceModel.PortSharing.PortSharingListening
+    href: system-servicemodel-portsharing-portsharinglistening.md
+  - name: System.ServiceModel.PortSharing.RoutingTableCannotListen
+    href: system-servicemodel-portsharing-routingtablecannotlisten.md
+  - name: System.ServiceModel.PortSharing.RoutingTableLookup
+    href: system-servicemodel-portsharing-routingtablelookup.md
+  - name: System.ServiceModel.PortSharing.RoutingTableNamespaceConflict
+    href: system-servicemodel-portsharing-routingtablenamespaceconflict.md
+  - name: System.ServiceModel.PortSharing.RoutingTablePathTooLong
+    href: system-servicemodel-portsharing-routingtablepathtoolong.md
+  - name: System.ServiceModel.PortSharing.RoutingTableRegisterSuccess
+    href: system-servicemodel-portsharing-routingtableregistersuccess.md
+  - name: System.ServiceModel.PortSharing.RoutingTableUnsupportedProtocol
+    href: system-servicemodel-portsharing-routingtableunsupportedprotocol.md
+  - name: System.ServiceModel.PortSharing.ReadNetPipeConfig
+    href: system-servicemodel-portsharing-readnetpipeconfig.md
+  - name: System.ServiceModel.PortSharing.ReadNetTcpConfig
+    href: system-servicemodel-portsharing-readnettcpconfig.md
+  - name: System.ServiceModel.PortSharing.SharedManagerServiceEndpointNotExist
+    href: system-servicemodel-portsharing-sharedmanagerserviceendpointnotexist.md
+  - name: System.ServiceModel.PortSharing.TransportListenerListening
+    href: system-servicemodel-portsharing-transportlistenerlistening.md
+  - name: System.ServiceModel.PortSharing.TransportListenerListenRequest
+    href: system-servicemodel-portsharing-transportlistenerlistenrequest.md
+  - name: System.ServiceModel.PortSharing.TransportListenerSessionsReceived
+    href: system-servicemodel-portsharing-transportlistenersessionsreceived.md
+  - name: System.ServiceModel.PortSharing.TransportListenerStop
+    href: system-servicemodel-portsharing-transportlistenerstop.md
+  - name: System.ServiceModel.PortSharing.WasCloseAllListenerChannelInstances
+    href: system-servicemodel-portsharing-wasclosealllistenerchannelinstances.md
+  - name: System.ServiceModel.PortSharing.WasConnected
+    href: system-servicemodel-portsharing-wasconnected.md
+  - name: System.ServiceModel.PortSharing.WasWebHostAPIFailed
+    href: system-servicemodel-portsharing-waswebhostapifailed.md
+  - name: System.ServiceModel.RemoveBehavior
+    href: system-servicemodel-removebehavior.md
+  - name: System.ServiceModel.Security.ExportSecurityChannelBindingEntry
+    href: system-servicemodel-security-exportsecuritychannelbindingentry.md
+  - name: System.ServiceModel.Security.ExportSecurityChannelBindingExit
+    href: system-servicemodel-security-exportsecuritychannelbindingexit.md
+  - name: System.ServiceModel.Security.ImportSecurityChannelBindingEntry
+    href: system-servicemodel-security-importsecuritychannelbindingentry.md
+  - name: System.ServiceModel.Security.ImportSecurityChannelBindingExit
+    href: system-servicemodel-security-importsecuritychannelbindingexit.md
+  - name: System.ServiceModel.Security.IssuanceTokenProviderBeginSecurityNegotiation
+    href: system-servicemodel-security-issuancetokenproviderbeginsecuritynegotiation.md
+  - name: System.ServiceModel.Security.IssuanceTokenProviderEndSecurityNegotiation
+    href: system-servicemodel-security-issuancetokenproviderendsecuritynegotiation.md
+  - name: System.ServiceModel.Security.IssuanceTokenProviderRedirectApplied
+    href: system-servicemodel-security-issuancetokenproviderredirectapplied.md
+  - name: System.ServiceModel.Security.IssuanceTokenProviderRemovedCachedToken
+    href: system-servicemodel-security-issuancetokenproviderremovedcachedtoken.md
+  - name: System.ServiceModel.Security.IssuanceTokenProviderServiceTokenCacheFull
+    href: system-servicemodel-security-issuancetokenproviderservicetokencachefull.md
+  - name: System.ServiceModel.Security.IssuanceTokenProviderUsingCachedToken
+    href: system-servicemodel-security-issuancetokenproviderusingcachedtoken.md
+  - name: System.ServiceModel.Security.NegotiationAuthenticatorAttached
+    href: system-servicemodel-security-negotiationauthenticatorattached.md
+  - name: System.ServiceModel.Security.NegotiationTokenProviderAttached
+    href: system-servicemodel-security-negotiationtokenproviderattached.md
+  - name: System.ServiceModel.Security.SecurityActiveServerSessionRemoved
+    href: system-servicemodel-security-securityactiveserversessionremoved.md
+  - name: System.ServiceModel.Security.SecurityAuditWrittenFailure
+    href: system-servicemodel-security-securityauditwrittenfailure.md
+  - name: System.ServiceModel.Security.SecurityAuditWrittenSuccess
+    href: system-servicemodel-security-securityauditwrittensuccess.md
+  - name: System.ServiceModel.Security.SecurityBindingIncomingMessageVerified
+    href: system-servicemodel-security-securitybindingincomingmessageverified.md
+  - name: System.ServiceModel.Security.SecurityBindingOutgoingMessageSecured
+    href: system-servicemodel-security-securitybindingoutgoingmessagesecured.md
+  - name: System.ServiceModel.Security.SecurityBindingSecureOutgoingMessageFailure
+    href: system-servicemodel-security-securitybindingsecureoutgoingmessagefailure.md
+  - name: System.ServiceModel.Security.SecurityBindingVerifyIncomingMessageFailure
+    href: system-servicemodel-security-securitybindingverifyincomingmessagefailure.md
+  - name: System.ServiceModel.Security.SecurityClientSessionCloseMessageReceived
+    href: system-servicemodel-security-securityclientsessionclosemessagereceived.md
+  - name: System.ServiceModel.Security.SecurityClientSessionCloseResponseSent
+    href: system-servicemodel-security-securityclientsessioncloseresponsesent.md
+  - name: System.ServiceModel.Security.SecurityClientSessionCloseSent
+    href: system-servicemodel-security-securityclientsessionclosesent.md
+  - name: System.ServiceModel.Security.SecurityClientSessionKeyRenewed
+    href: system-servicemodel-security-securityclientsessionkeyrenewed.md
+  - name: System.ServiceModel.Security.SecurityClientSessionPreviousKeyDiscarded
+    href: system-servicemodel-security-securityclientsessionpreviouskeydiscarded.md
+  - name: System.ServiceModel.Security.SecurityContextTokenCacheFull
+    href: system-servicemodel-security-securitycontexttokencachefull.md
+  - name: System.ServiceModel.Security.SecurityIdentityDeterminationFailure
+    href: system-servicemodel-security-securityidentitydeterminationfailure.md
+  - name: System.ServiceModel.Security.SecurityIdentityDeterminationSuccess
+    href: system-servicemodel-security-securityidentitydeterminationsuccess.md
+  - name: System.ServiceModel.Security.SecurityIdentityHostNameNormalizationFailure
+    href: system-servicemodel-security-securityidentityhostnamenormalizationfailure.md
+  - name: System.ServiceModel.Security.SecurityIdentityVerificationFailure
+    href: system-servicemodel-security-securityidentityverificationfailure.md
+  - name: System.ServiceModel.Security.SecurityIdentityVerificationSuccess
+    href: system-servicemodel-security-securityidentityverificationsuccess.md
+  - name: System.ServiceModel.Security.SecurityImpersonationFailure
+    href: system-servicemodel-security-securityimpersonationfailure.md
+  - name: System.ServiceModel.Security.SecurityImpersonationSuccess
+    href: system-servicemodel-security-securityimpersonationsuccess.md
+  - name: System.ServiceModel.Security.SecurityInactiveSessionFaulted
+    href: system-servicemodel-security-securityinactivesessionfaulted.md
+  - name: System.ServiceModel.Security.SecurityNegotiationProcessingFailure
+    href: system-servicemodel-security-securitynegotiationprocessingfailure.md
+  - name: System.ServiceModel.Security.SecurityNewServerSessionKeyIssued
+    href: system-servicemodel-security-securitynewserversessionkeyissued.md
+  - name: System.ServiceModel.Security.SecurityPendingServerSessionActivated
+    href: system-servicemodel-security-securitypendingserversessionactivated.md
+  - name: System.ServiceModel.Security.SecurityPendingServerSessionAdded
+    href: system-servicemodel-security-securitypendingserversessionadded.md
+  - name: System.ServiceModel.Security.SecurityPendingServerSessionClosed
+    href: system-servicemodel-security-securitypendingserversessionclosed.md
+  - name: System.ServiceModel.Security.SecurityServerSessionAbortedFaultSent
+    href: system-servicemodel-security-securityserversessionabortedfaultsent.md
+  - name: System.ServiceModel.Security.SecurityServerSessionCloseReceived
+    href: system-servicemodel-security-securityserversessionclosereceived.md
+  - name: System.ServiceModel.Security.SecurityServerSessionCloseResponseReceived
+    href: system-servicemodel-security-securityserversessioncloseresponsereceived.md
+  - name: System.ServiceModel.Security.SecurityServerSessionKeyUpdated
+    href: system-servicemodel-security-securityserversessionkeyupdated.md
+  - name: System.ServiceModel.Security.SecurityServerSessionRenewalFaultSent
+    href: system-servicemodel-security-securityserversessionrenewalfaultsent.md
+  - name: System.ServiceModel.Security.SecuritySessionAbortedFaultReceived
+    href: system-servicemodel-security-securitysessionabortedfaultreceived.md
+  - name: System.ServiceModel.Security.SecuritySessionAbortedFaultSendFailure
+    href: system-servicemodel-security-securitysessionabortedfaultsendfailure.md
+  - name: System.ServiceModel.Security.SecuritySessionClosedResponseReceived
+    href: system-servicemodel-security-securitysessionclosedresponsereceived.md
+  - name: System.ServiceModel.Security.SecuritySessionCloseResponseSent
+    href: system-servicemodel-security-securitysessioncloseresponsesent.md
+  - name: System.ServiceModel.Security.SecuritySessionClosedResponseSendFailure
+    href: system-servicemodel-security-securitysessionclosedresponsesendfailure.md
+  - name: System.ServiceModel.Security.SecuritySessionDemuxFailure
+    href: system-servicemodel-security-securitysessiondemuxfailure.md
+  - name: System.ServiceModel.Security.SecuritySessionKeyRenewalFaultReceived
+    href: system-servicemodel-security-securitysessionkeyrenewalfaultreceived.md
+  - name: System.ServiceModel.Security.SecuritySessionRedirectApplied
+    href: system-servicemodel-security-securitysessionredirectapplied.md
+  - name: System.ServiceModel.Security.SecuritySessionRenewFaultSendFailure
+    href: system-servicemodel-security-securitysessionrenewfaultsendfailure.md
+  - name: System.ServiceModel.Security.SecuritySessionRequestorOperationFailure
+    href: system-servicemodel-security-securitysessionrequestoroperationfailure.md
+  - name: System.ServiceModel.Security.SecuritySessionRequestorOperationSuccess
+    href: system-servicemodel-security-securitysessionrequestoroperationsuccess.md
+  - name: System.ServiceModel.Security.SecuritySessionResponderOperationFailure
+    href: system-servicemodel-security-securitysessionresponderoperationfailure.md
+  - name: System.ServiceModel.Security.SecuritySessionServerCloseSent
+    href: system-servicemodel-security-securitysessionserverclosesent.md
+  - name: System.ServiceModel.Security.SecuritySessionServerCloseSendFailure
+    href: system-servicemodel-security-securitysessionserverclosesendfailure.md
+  - name: System.ServiceModel.Security.SecuritySpnToSidMappingFailure
+    href: system-servicemodel-security-securityspntosidmappingfailure.md
+  - name: System.ServiceModel.Security.SecurityTokenAuthenticatorClosed
+    href: system-servicemodel-security-securitytokenauthenticatorclosed.md
+  - name: System.ServiceModel.Security.SecurityTokenAuthenticatorOpened
+    href: system-servicemodel-security-securitytokenauthenticatoropened.md
+  - name: System.ServiceModel.Security.SecurityTokenProviderClosed
+    href: system-servicemodel-security-securitytokenproviderclosed.md
+  - name: System.ServiceModel.Security.SecurityTokenProviderOpened
+    href: system-servicemodel-security-securitytokenprovideropened.md
+  - name: System.ServiceModel.Security.ServiceSecurityNegotiationCompleted
+    href: system-servicemodel-security-servicesecuritynegotiationcompleted.md
+  - name: System.ServiceModel.Security.SpnegoClientNegotiationCompleted
+    href: system-servicemodel-security-spnegoclientnegotiationcompleted.md
+  - name: System.ServiceModel.Security.SpnegoServiceNegotiationCompleted
+    href: system-servicemodel-security-spnegoservicenegotiationcompleted.md
+  - name: System.ServiceModel.ServiceChannelLifetime
+    href: system-servicemodel-servicechannellifetime.md
+  - name: System.ServiceModel.ServiceHostBaseAddresses
+    href: system-servicemodel-servicehostbaseaddresses.md
+  - name: System.ServiceModel.ServiceHostCreation
+    href: system-servicemodel-servicehostcreation.md
+  - name: System.ServiceModel.ServiceHostErrorOnReleasePerformanceCounter
+    href: system-servicemodel-servicehosterroronreleaseperformancecounter.md
+  - name: System.ServiceModel.ServiceHostFaulted
+    href: system-servicemodel-servicehostfaulted.md
+  - name: System.ServiceModel.ServiceHostTimeoutOnClose
+    href: system-servicemodel-servicehosttimeoutonclose.md
+  - name: System.ServiceModel.ServiceOperationExceptionOnReply
+    href: system-servicemodel-serviceoperationexceptiononreply.md
+  - name: System.ServiceModel.ServiceOperationMissingReply
+    href: system-servicemodel-serviceoperationmissingreply.md
+  - name: System.ServiceModel.ServiceOperationMissingReplyContext
+    href: system-servicemodel-serviceoperationmissingreplycontext.md
+  - name: System.ServiceModel.ServiceThrottleLimitReached
+    href: system-servicemodel-servicethrottlelimitreached.md
+  - name: System.ServiceModel.SkipBehavior
+    href: system-servicemodel-skipbehavior.md
+  - name: System.ServiceModel.TransportListen
+    href: system-servicemodel-transportlisten.md
+  - name: System.ServiceModel.TxAsyncAbort
+    href: system-servicemodel-txasyncabort.md
+  - name: System.ServiceModel.TxCompletionStatusAbortedOnSessionClose
+    href: system-servicemodel-txcompletionstatusabortedonsessionclose.md
+  - name: System.ServiceModel.TxCompletionStatusCompletedForAsyncAbort
+    href: system-servicemodel-txcompletionstatuscompletedforasyncabort.md
+  - name: System.ServiceModel.TxCompletionStatusCompletedForAutocomplete
+    href: system-servicemodel-txcompletionstatuscompletedforautocomplete.md
+  - name: System.ServiceModel.TxCompletionStatusCompletedForError
+    href: system-servicemodel-txcompletionstatuscompletedforerror.md
+  - name: System.ServiceModel.TxCompletionStatusCompletedForSetComplete
+    href: system-servicemodel-txcompletionstatuscompletedforsetcomplete.md
+  - name: System.ServiceModel.TxCompletionStatusCompletedForTACOSC
+    href: system-servicemodel-txcompletionstatuscompletedfortacosc.md
+  - name: System.ServiceModel.TxCompletionStatusRemainsAttached
+    href: system-servicemodel-txcompletionstatusremainsattached.md
+  - name: System.ServiceModel.TxFailedToNegotiateOleTx
+    href: system-servicemodel-txfailedtonegotiateoletx.md
+  - name: System.ServiceModel.TxReleaseServiceInstanceOnCompletion
+    href: system-servicemodel-txreleaseserviceinstanceoncompletion.md
+  - name: System.ServiceModel.TxSourceTxScopeRequiredIsAttachedTransaction
+    href: system-servicemodel-txsourcetxscoperequiredisattachedtransaction.md
+  - name: System.ServiceModel.TxSourceTxScopeRequiredIsCreateNewTransaction
+    href: system-servicemodel-txsourcetxscoperequirediscreatenewtransaction.md
+  - name: System.ServiceModel.TxSourceTxScopeRequiredIsTransactionFlow
+    href: system-servicemodel-txsourcetxscoperequiredistransactionflow.md
+  - name: System.ServiceModel.TxSourceTxScopeRequiredIsTransactedTransport
+    href: system-servicemodel-txsourcetxscoperequiredistransactedtransport.md
+  - name: System.ServiceModel.UnderstoodMessageHeader
+    href: system-servicemodel-understoodmessageheader.md
+  - name: System.ServiceModel.UnhandledAction
+    href: system-servicemodel-unhandledaction.md
+  - name: System.ServiceModel.UnhandledExceptionInUserOperation
+    href: system-servicemodel-unhandledexceptioninuseroperation.md
+  - name: System.ServiceModel.WarnHelpPageEnabledNoBaseAddress
+    href: system-servicemodel-warnhelppageenablednobaseaddress.md
+  - name: System.ServiceModel.WarnServiceHealthEnabledNoBaseAddress
+    href: system-servicemodel-warnservicehealthenablednobaseaddress.md
+  - name: System.ServiceModel.WsmexNonCriticalWsdlExportError
+    href: system-servicemodel-wsmexnoncriticalwsdlexporterror.md
+  - name: System.ServiceModel.WsmexNonCriticalWsdlImportError
+    href: system-servicemodel-wsmexnoncriticalwsdlimporterror.md

--- a/docs/framework/wcf/diagnostics/wmi/toc.yml
+++ b/docs/framework/wcf/diagnostics/wmi/toc.yml
@@ -1,157 +1,157 @@
-- name: Using Windows Management Instrumentation for Diagnostics
+items:
+- name: Using Windows Management Instrumentation for diagnostics
   href: index.md
+- name: WMI Class Reference
+  href: wmi-class-reference.md
   items:
-  - name: WMI Class Reference
-    href: wmi-class-reference.md
+  - name: ActivityTransfer
+    href: activitytransfer.md
+  - name: AppDomainInfo
+    href: appdomaininfo.md
+  - name: AspNetCompatibilityRequirementsAttribute
+    href: aspnetcompatibilityrequirementsattribute.md
+  - name: AsymmetricSecurityBindingElement
+    href: asymmetricsecuritybindingelement.md
+  - name: Behavior class
+    href: behavior-class.md
+  - name: BinaryMessageEncodingBindingElement
+    href: binarymessageencodingbindingelement.md
+  - name: Binding
+    href: binding.md
+  - name: BindingElement
+    href: bindingelement.md
+  - name: CallbackBehavior
+    href: callbackbehavior.md
+  - name: Channel class
+    href: channel-class.md
+  - name: ChannelPoolSettings
+    href: channelpoolsettings.md
+  - name: ClientCredentials
+    href: clientcredentials.md
+  - name: ClientViaBehavior
+    href: clientviabehavior.md
+  - name: CompositeDuplexBindingElement
+    href: compositeduplexbindingelement.md
+  - name: ConnectionOrientedTransportBindingElement
+    href: connectionorientedtransportbindingelement.md
+  - name: Contract
+    href: contract.md
+  - name: CustomBindingElement
+    href: custombindingelement.md
+  - name: DeliveryRequirementsAttribute
+    href: deliveryrequirementsattribute.md
+  - name: Endpoint
+    href: endpoint.md
     items:
-    - name: ActivityTransfer
-      href: activitytransfer.md
-    - name: AppDomainInfo
-      href: appdomaininfo.md
-    - name: AspNetCompatibilityRequirementsAttribute
-      href: aspnetcompatibilityrequirementsattribute.md
-    - name: AsymmetricSecurityBindingElement
-      href: asymmetricsecuritybindingelement.md
-    - name: Behavior class
-      href: behavior-class.md
-    - name: BinaryMessageEncodingBindingElement
-      href: binarymessageencodingbindingelement.md
-    - name: Binding
-      href: binding.md
-    - name: BindingElement
-      href: bindingelement.md
-    - name: CallbackBehavior
-      href: callbackbehavior.md
-    - name: Channel class
-      href: channel-class.md
-    - name: ChannelPoolSettings
-      href: channelpoolsettings.md
-    - name: ClientCredentials
-      href: clientcredentials.md
-    - name: ClientViaBehavior
-      href: clientviabehavior.md
-    - name: CompositeDuplexBindingElement
-      href: compositeduplexbindingelement.md
-    - name: ConnectionOrientedTransportBindingElement
-      href: connectionorientedtransportbindingelement.md
-    - name: Contract
-      href: contract.md
-    - name: CustomBindingElement
-      href: custombindingelement.md
-    - name: DeliveryRequirementsAttribute
-      href: deliveryrequirementsattribute.md
-    - name: Endpoint
-      href: endpoint.md
-      items:
-      - name: GetOperationCounterInstanceName
-        href: getoperationcounterinstancename.md
-    - name: HttpsTransportBindingElement
-      href: httpstransportbindingelement.md
-    - name: HttpTransportBindingElement
-      href: httptransportbindingelement.md
-    - name: LocalServiceSecuritySettings
-      href: localservicesecuritysettings.md
-    - name: MatchAllEndpointBehavior
-      href: matchallendpointbehavior.md
-    - name: MessageEncodingBindingElement
-      href: messageencodingbindingelement.md
-    - name: MsmqBindingElementBase
-      href: msmqbindingelementbase.md
-    - name: MsmqIntegrationBindingElement
-      href: msmqintegrationbindingelement.md
-    - name: MsmqTransportBindingElement
-      href: msmqtransportbindingelement.md
-    - name: MtomMessageEncodingBindingElement
-      href: mtommessageencodingbindingelement.md
-    - name: MustUnderstandBehavior
-      href: mustunderstandbehavior.md
-    - name: NamedPipeConnectionPoolSettings
-      href: namedpipeconnectionpoolsettings.md
-    - name: NamedPipeTransportBindingElement
-      href: namedpipetransportbindingelement.md
-    - name: OneWayBindingElement
-      href: onewaybindingelement.md
-    - name: Operation class
-      href: operation-class.md
-    - name: OperationBehaviorAttribute
-      href: operationbehaviorattribute.md
-    - name: PeerCustomResolverBindingElement
-      href: peercustomresolverbindingelement.md
-    - name: PeerResolverBindingElement
-      href: peerresolverbindingelement.md
-    - name: PeerSecuritySettings
-      href: peersecuritysettings.md
-    - name: PeerTransportBindingElement
-      href: peertransportbindingelement.md
-    - name: PeerTransportSecuritySettings
-      href: peertransportsecuritysettings.md
-    - name: PnrpPeerResolverBindingElement
-      href: pnrppeerresolverbindingelement.md
-    - name: PrivacyNoticeBindingElement
-      href: privacynoticebindingelement.md
-    - name: ReliableSessionBindingElement
-      href: reliablesessionbindingelement.md
-    - name: SecurityBindingElement
-      href: securitybindingelement.md
-    - name: Service
-      href: service.md
-    - name: ServiceAppDomain
-      href: serviceappdomain.md
-    - name: ServiceAuthorizationBehavior
-      href: serviceauthorizationbehavior.md
-    - name: ServiceBehaviorAttribute
-      href: servicebehaviorattribute.md
-    - name: ServiceCredentials
-      href: servicecredentials.md
-    - name: ServiceDebugBehavior
-      href: servicedebugbehavior.md
-    - name: ServiceMetadataBehavior
-      href: servicemetadatabehavior.md
-    - name: ServiceSecurityAuditBehavior
-      href: servicesecurityauditbehavior.md
-    - name: ServiceThrottlingBehavior
-      href: servicethrottlingbehavior.md
-    - name: ServiceTimeoutsBehavior
-      href: servicetimeoutsbehavior.md
-    - name: ServiceToEndpointAssociation
-      href: servicetoendpointassociation.md
-    - name: SslStreamSecurityBindingElement
-      href: sslstreamsecuritybindingelement.md
-    - name: SymmetricSecurityBindingElement
-      href: symmetricsecuritybindingelement.md
-    - name: SynchronousReceiveBehavior
-      href: synchronousreceivebehavior.md
-    - name: TcpConnectionPoolSettings
-      href: tcpconnectionpoolsettings.md
-    - name: TcpTransportBindingElement
-      href: tcptransportbindingelement.md
-    - name: TextMessageEncodingBindingElement
-      href: textmessageencodingbindingelement.md
-    - name: TraceListener
-      href: tracelistener.md
-    - name: TraceListenerArgument
-      href: tracelistenerargument.md
-    - name: TransactedBatchingBehavior
-      href: transactedbatchingbehavior.md
-    - name: TransactionFlowAttribute
-      href: transactionflowattribute.md
-    - name: TransactionFlowBindingElement
-      href: transactionflowbindingelement.md
-    - name: TransportBindingElement
-      href: transportbindingelement.md
-    - name: TransportSecurityBindingElement
-      href: transportsecuritybindingelement.md
-    - name: UseManagedPresentationBindingElement
-      href: usemanagedpresentationbindingelement.md
-    - name: WindowsStreamSecurityBindingElement
-      href: windowsstreamsecuritybindingelement.md
-    - name: WSAT_TraceEvent
-      href: wsat-traceevent.md
-    - name: WSAT_TraceProvider
-      href: wsat-traceprovider.md
-    - name: WSAT_TraceRecord
-      href: wsat-tracerecord.md
-    - name: XmlDictionaryReaderQuotas
-      href: xmldictionaryreaderquotas.md
-    - name: XmlSerializerOperationBehavior
-      href: xmlserializeroperationbehavior.md
+    - name: GetOperationCounterInstanceName
+      href: getoperationcounterinstancename.md
+  - name: HttpsTransportBindingElement
+    href: httpstransportbindingelement.md
+  - name: HttpTransportBindingElement
+    href: httptransportbindingelement.md
+  - name: LocalServiceSecuritySettings
+    href: localservicesecuritysettings.md
+  - name: MatchAllEndpointBehavior
+    href: matchallendpointbehavior.md
+  - name: MessageEncodingBindingElement
+    href: messageencodingbindingelement.md
+  - name: MsmqBindingElementBase
+    href: msmqbindingelementbase.md
+  - name: MsmqIntegrationBindingElement
+    href: msmqintegrationbindingelement.md
+  - name: MsmqTransportBindingElement
+    href: msmqtransportbindingelement.md
+  - name: MtomMessageEncodingBindingElement
+    href: mtommessageencodingbindingelement.md
+  - name: MustUnderstandBehavior
+    href: mustunderstandbehavior.md
+  - name: NamedPipeConnectionPoolSettings
+    href: namedpipeconnectionpoolsettings.md
+  - name: NamedPipeTransportBindingElement
+    href: namedpipetransportbindingelement.md
+  - name: OneWayBindingElement
+    href: onewaybindingelement.md
+  - name: Operation class
+    href: operation-class.md
+  - name: OperationBehaviorAttribute
+    href: operationbehaviorattribute.md
+  - name: PeerCustomResolverBindingElement
+    href: peercustomresolverbindingelement.md
+  - name: PeerResolverBindingElement
+    href: peerresolverbindingelement.md
+  - name: PeerSecuritySettings
+    href: peersecuritysettings.md
+  - name: PeerTransportBindingElement
+    href: peertransportbindingelement.md
+  - name: PeerTransportSecuritySettings
+    href: peertransportsecuritysettings.md
+  - name: PnrpPeerResolverBindingElement
+    href: pnrppeerresolverbindingelement.md
+  - name: PrivacyNoticeBindingElement
+    href: privacynoticebindingelement.md
+  - name: ReliableSessionBindingElement
+    href: reliablesessionbindingelement.md
+  - name: SecurityBindingElement
+    href: securitybindingelement.md
+  - name: Service
+    href: service.md
+  - name: ServiceAppDomain
+    href: serviceappdomain.md
+  - name: ServiceAuthorizationBehavior
+    href: serviceauthorizationbehavior.md
+  - name: ServiceBehaviorAttribute
+    href: servicebehaviorattribute.md
+  - name: ServiceCredentials
+    href: servicecredentials.md
+  - name: ServiceDebugBehavior
+    href: servicedebugbehavior.md
+  - name: ServiceMetadataBehavior
+    href: servicemetadatabehavior.md
+  - name: ServiceSecurityAuditBehavior
+    href: servicesecurityauditbehavior.md
+  - name: ServiceThrottlingBehavior
+    href: servicethrottlingbehavior.md
+  - name: ServiceTimeoutsBehavior
+    href: servicetimeoutsbehavior.md
+  - name: ServiceToEndpointAssociation
+    href: servicetoendpointassociation.md
+  - name: SslStreamSecurityBindingElement
+    href: sslstreamsecuritybindingelement.md
+  - name: SymmetricSecurityBindingElement
+    href: symmetricsecuritybindingelement.md
+  - name: SynchronousReceiveBehavior
+    href: synchronousreceivebehavior.md
+  - name: TcpConnectionPoolSettings
+    href: tcpconnectionpoolsettings.md
+  - name: TcpTransportBindingElement
+    href: tcptransportbindingelement.md
+  - name: TextMessageEncodingBindingElement
+    href: textmessageencodingbindingelement.md
+  - name: TraceListener
+    href: tracelistener.md
+  - name: TraceListenerArgument
+    href: tracelistenerargument.md
+  - name: TransactedBatchingBehavior
+    href: transactedbatchingbehavior.md
+  - name: TransactionFlowAttribute
+    href: transactionflowattribute.md
+  - name: TransactionFlowBindingElement
+    href: transactionflowbindingelement.md
+  - name: TransportBindingElement
+    href: transportbindingelement.md
+  - name: TransportSecurityBindingElement
+    href: transportsecuritybindingelement.md
+  - name: UseManagedPresentationBindingElement
+    href: usemanagedpresentationbindingelement.md
+  - name: WindowsStreamSecurityBindingElement
+    href: windowsstreamsecuritybindingelement.md
+  - name: WSAT_TraceEvent
+    href: wsat-traceevent.md
+  - name: WSAT_TraceProvider
+    href: wsat-traceprovider.md
+  - name: WSAT_TraceRecord
+    href: wsat-tracerecord.md
+  - name: XmlDictionaryReaderQuotas
+    href: xmldictionaryreaderquotas.md
+  - name: XmlSerializerOperationBehavior
+    href: xmlserializeroperationbehavior.md

--- a/docs/framework/wcf/extending/toc.yml
+++ b/docs/framework/wcf/extending/toc.yml
@@ -1,146 +1,146 @@
-- name: Extending WCF
+items:
+- name: Extend WCF
   href: index.md
+- name: Extending ServiceHost and the Service Model Layer
+  href: extending-servicehost-and-the-service-model-layer.md
   items:
-  - name: Extending ServiceHost and the Service Model Layer
-    href: extending-servicehost-and-the-service-model-layer.md
+  - name: Extending Clients
+    href: extending-clients.md
     items:
-    - name: Extending Clients
-      href: extending-clients.md
-      items:
-      - name: "How to: Inspect or Modify Messages on the Client"
-        href: how-to-inspect-or-modify-messages-on-the-client.md
-      - name: "How to: Inspect or Modify Parameters"
-        href: how-to-inspect-or-modify-parameters.md
-    - name: Extending Dispatchers
-      href: extending-dispatchers.md
-      items:
-      - name: "How to: Inspect and Modify Messages on the Service"
-        href: how-to-inspect-and-modify-messages-on-the-service.md
-      - name: "How to: Lock Down Endpoints in the Enterprise"
-        href: how-to-lock-down-endpoints-in-the-enterprise.md
-    - name: Extensible Objects
-      href: extensible-objects.md
-    - name: Configuring and Extending the Runtime with Behaviors
-      href: configuring-and-extending-the-runtime-with-behaviors.md
-    - name: Extending Hosting Using ServiceHostFactory
-      href: extending-hosting-using-servicehostfactory.md
-  - name: Extending Bindings
-    href: extending-bindings.md
+    - name: "How to: Inspect or Modify Messages on the Client"
+      href: how-to-inspect-or-modify-messages-on-the-client.md
+    - name: "How to: Inspect or Modify Parameters"
+      href: how-to-inspect-or-modify-parameters.md
+  - name: Extending Dispatchers
+    href: extending-dispatchers.md
     items:
-    - name: Bindings and Binding Elements
-      href: bindings-and-binding-elements.md
-    - name: Custom Bindings
-      href: custom-bindings.md
-      items:
-      - name: "How to: Customize a System-Provided Binding"
-        href: how-to-customize-a-system-provided-binding.md
-    - name: Creating User-Defined Bindings
-      href: creating-user-defined-bindings.md
-  - name: Extending the Channel Layer
-    href: extending-the-channel-layer.md
+    - name: "How to: Inspect and Modify Messages on the Service"
+      href: how-to-inspect-and-modify-messages-on-the-service.md
+    - name: "How to: Lock Down Endpoints in the Enterprise"
+      href: how-to-lock-down-endpoints-in-the-enterprise.md
+  - name: Extensible Objects
+    href: extensible-objects.md
+  - name: Configuring and Extending the Runtime with Behaviors
+    href: configuring-and-extending-the-runtime-with-behaviors.md
+  - name: Extending Hosting Using ServiceHostFactory
+    href: extending-hosting-using-servicehostfactory.md
+- name: Extending Bindings
+  href: extending-bindings.md
+  items:
+  - name: Bindings and Binding Elements
+    href: bindings-and-binding-elements.md
+  - name: Custom Bindings
+    href: custom-bindings.md
     items:
-    - name: Channel Model Overview
-      href: channel-model-overview.md
-      items:
-      - name: Client Channel-Level Programming
-        href: client-channel-level-programming.md
-      - name: Service Channel-Level Programming
-        href: service-channel-level-programming.md
-      - name: Understanding State Changes
-        href: understanding-state-changes.md
-      - name: Choosing a Message Exchange Pattern
-        href: choosing-a-message-exchange-pattern.md
-      - name: Handling Exceptions and Faults
-        href: handling-exceptions-and-faults.md
-    - name: Developing Channels
-      href: developing-channels.md
-      items:
-      - name: "Service: Channel Listeners and Channels"
-        href: service-channel-listeners-and-channels.md
-      - name: "Client: Channel Factories and Channels"
-        href: client-channel-factories-and-channels.md
-      - name: Creating a BindingElement
-        href: creating-a-bindingelement.md
-      - name: Configuration and Metadata Support
-        href: configuration-and-metadata-support.md
-    - name: Custom Encoders
-      href: custom-encoders.md
-    - name: Custom Stream Upgrades
-      href: custom-stream-upgrades.md
-  - name: Extending Security
-    href: extending-security.md
+    - name: "How to: Customize a System-Provided Binding"
+      href: how-to-customize-a-system-provided-binding.md
+  - name: Creating User-Defined Bindings
+    href: creating-user-defined-bindings.md
+- name: Extending the Channel Layer
+  href: extending-the-channel-layer.md
+  items:
+  - name: Channel Model Overview
+    href: channel-model-overview.md
     items:
-    - name: Specifying a Custom Crypto Algorithm
-      href: specifying-a-custom-crypto-algorithm.md
-    - name: Custom Credential and Credential Validation
-      href: custom-credential-and-credential-validation.md
-      items:
-      - name: "Walkthrough: Creating Custom Client and Service Credentials"
-        href: walkthrough-creating-custom-client-and-service-credentials.md
-      - name: "How to: Create a Service that Employs a Custom Certificate Validator"
-        href: how-to-create-a-service-that-employs-a-custom-certificate-validator.md
-      - name: "How to: Create a Custom Security Token Provider"
-        href: how-to-create-a-custom-security-token-provider.md
-      - name: "How to: Create a Custom Security Token Authenticator"
-        href: how-to-create-a-custom-security-token-authenticator.md
-    - name: Custom Tokens
-      href: custom-tokens.md
-      items:
-      - name: "How to: Create a Custom Token"
-        href: how-to-create-a-custom-token.md
-    - name: Custom Authorization
-      href: custom-authorization.md
-      items:
-      - name: "How to: Create a Custom Authorization Policy"
-        href: how-to-create-a-custom-authorization-policy.md
-      - name: "How to: Create a Custom Authorization Manager for a Service"
-        href: how-to-create-a-custom-authorization-manager-for-a-service.md
-      - name: "How to: Create a Custom Claim"
-        href: how-to-create-a-custom-claim.md
-      - name: "How to: Compare Claims"
-        href: how-to-compare-claims.md
-      - name: "How to: Create a Custom Principal Identity"
-        href: how-to-create-a-custom-principal-identity.md
-    - name: Overriding the Identity of a Service for Authentication
-      href: overriding-the-identity-of-a-service-for-authentication.md
-    - name: "How to: Create a Custom Client Identity Verifier"
-      href: how-to-create-a-custom-client-identity-verifier.md
-    - name: "How to: Use Separate X.509 Certificates for Signing and Encryption"
-      href: how-to-use-separate-x-509-certificates-for-signing-and-encryption.md
-    - name: "How to: Change the Cryptographic Provider for an X.509 Certificate's Private Key"
-      href: change-cryptographic-provider-x509-certificate-private-key.md
-  - name: Extending the Metadata System
-    href: extending-the-metadata-system.md
+    - name: Client Channel-Level Programming
+      href: client-channel-level-programming.md
+    - name: Service Channel-Level Programming
+      href: service-channel-level-programming.md
+    - name: Understanding State Changes
+      href: understanding-state-changes.md
+    - name: Choosing a Message Exchange Pattern
+      href: choosing-a-message-exchange-pattern.md
+    - name: Handling Exceptions and Faults
+      href: handling-exceptions-and-faults.md
+  - name: Developing Channels
+    href: developing-channels.md
     items:
-    - name: Exporting Custom Metadata for a WCF Extension
-      href: exporting-custom-metadata-for-a-wcf-extension.md
-      items:
-      - name: "How to: Export Custom WSDL"
-        href: how-to-export-custom-wsdl.md
-      - name: "How to: Export Custom Policy Assertions"
-        href: how-to-export-custom-policy-assertions.md
-    - name: Importing Custom Metadata for a WCF Extension
-      href: importing-custom-metadata-for-a-wcf-extension.md
-      items:
-      - name: "How to: Import Custom WSDL"
-        href: how-to-import-custom-wsdl.md
-      - name: "How to: Import Custom Policy Assertions"
-        href: how-to-import-custom-policy-assertions.md
-      - name: "How to: Write an Extension for the ServiceContractGenerator"
-        href: how-to-write-an-extension-for-the-servicecontractgenerator.md
-    - name: Publishing and Retrieving Metadata Over a Custom Binding
-      href: publishing-and-retrieving-metadata-over-a-custom-binding.md
-      items:
-      - name: WS-MetadataExchange Bindings
-        href: ws-metadataexchange-bindings.md
-      - name: "How to: Configure a Custom WS-Metadata Exchange Binding"
-        href: how-to-configure-a-custom-ws-metadata-exchange-binding.md
-      - name: "How to: Retrieve Metadata Over a non-MEX Binding"
-        href: how-to-retrieve-metadata-over-a-non-mex-binding.md
-  - name: Extending Encoders and Serializers
-    href: extending-encoders-and-serializers.md
+    - name: "Service: Channel Listeners and Channels"
+      href: service-channel-listeners-and-channels.md
+    - name: "Client: Channel Factories and Channels"
+      href: client-channel-factories-and-channels.md
+    - name: Creating a BindingElement
+      href: creating-a-bindingelement.md
+    - name: Configuration and Metadata Support
+      href: configuration-and-metadata-support.md
+  - name: Custom Encoders
+    href: custom-encoders.md
+  - name: Custom Stream Upgrades
+    href: custom-stream-upgrades.md
+- name: Extending Security
+  href: extending-security.md
+  items:
+  - name: Specifying a Custom Crypto Algorithm
+    href: specifying-a-custom-crypto-algorithm.md
+  - name: Custom Credential and Credential Validation
+    href: custom-credential-and-credential-validation.md
     items:
-    - name: Data Contract Surrogates
-      href: data-contract-surrogates.md
-    - name: Custom Message Formatters
-      href: custom-message-formatters.md
+    - name: "Walkthrough: Creating Custom Client and Service Credentials"
+      href: walkthrough-creating-custom-client-and-service-credentials.md
+    - name: "How to: Create a Service that Employs a Custom Certificate Validator"
+      href: how-to-create-a-service-that-employs-a-custom-certificate-validator.md
+    - name: "How to: Create a Custom Security Token Provider"
+      href: how-to-create-a-custom-security-token-provider.md
+    - name: "How to: Create a Custom Security Token Authenticator"
+      href: how-to-create-a-custom-security-token-authenticator.md
+  - name: Custom Tokens
+    href: custom-tokens.md
+    items:
+    - name: "How to: Create a Custom Token"
+      href: how-to-create-a-custom-token.md
+  - name: Custom Authorization
+    href: custom-authorization.md
+    items:
+    - name: "How to: Create a Custom Authorization Policy"
+      href: how-to-create-a-custom-authorization-policy.md
+    - name: "How to: Create a Custom Authorization Manager for a Service"
+      href: how-to-create-a-custom-authorization-manager-for-a-service.md
+    - name: "How to: Create a Custom Claim"
+      href: how-to-create-a-custom-claim.md
+    - name: "How to: Compare Claims"
+      href: how-to-compare-claims.md
+    - name: "How to: Create a Custom Principal Identity"
+      href: how-to-create-a-custom-principal-identity.md
+  - name: Overriding the Identity of a Service for Authentication
+    href: overriding-the-identity-of-a-service-for-authentication.md
+  - name: "How to: Create a Custom Client Identity Verifier"
+    href: how-to-create-a-custom-client-identity-verifier.md
+  - name: "How to: Use Separate X.509 Certificates for Signing and Encryption"
+    href: how-to-use-separate-x-509-certificates-for-signing-and-encryption.md
+  - name: "How to: Change the Cryptographic Provider for an X.509 Certificate's Private Key"
+    href: change-cryptographic-provider-x509-certificate-private-key.md
+- name: Extending the Metadata System
+  href: extending-the-metadata-system.md
+  items:
+  - name: Exporting Custom Metadata for a WCF Extension
+    href: exporting-custom-metadata-for-a-wcf-extension.md
+    items:
+    - name: "How to: Export Custom WSDL"
+      href: how-to-export-custom-wsdl.md
+    - name: "How to: Export Custom Policy Assertions"
+      href: how-to-export-custom-policy-assertions.md
+  - name: Importing Custom Metadata for a WCF Extension
+    href: importing-custom-metadata-for-a-wcf-extension.md
+    items:
+    - name: "How to: Import Custom WSDL"
+      href: how-to-import-custom-wsdl.md
+    - name: "How to: Import Custom Policy Assertions"
+      href: how-to-import-custom-policy-assertions.md
+    - name: "How to: Write an Extension for the ServiceContractGenerator"
+      href: how-to-write-an-extension-for-the-servicecontractgenerator.md
+  - name: Publishing and Retrieving Metadata Over a Custom Binding
+    href: publishing-and-retrieving-metadata-over-a-custom-binding.md
+    items:
+    - name: WS-MetadataExchange Bindings
+      href: ws-metadataexchange-bindings.md
+    - name: "How to: Configure a Custom WS-Metadata Exchange Binding"
+      href: how-to-configure-a-custom-ws-metadata-exchange-binding.md
+    - name: "How to: Retrieve Metadata Over a non-MEX Binding"
+      href: how-to-retrieve-metadata-over-a-non-mex-binding.md
+- name: Extending Encoders and Serializers
+  href: extending-encoders-and-serializers.md
+  items:
+  - name: Data Contract Surrogates
+    href: data-contract-surrogates.md
+  - name: Custom Message Formatters
+    href: custom-message-formatters.md

--- a/docs/framework/wcf/feature-details/toc.yml
+++ b/docs/framework/wcf/feature-details/toc.yml
@@ -1,927 +1,926 @@
 items:
-- name: WCF Feature Details
+- name: WCF feature details
   href: index.md
+- name: Workflow Services
+  href: workflow-services.md
   items:
-  - name: Workflow Services
-    href: workflow-services.md
+  - name: Workflow Services Overview
+    href: workflow-services-overview.md
+  - name: Creating a Long-running Workflow Service
+    href: creating-a-long-running-workflow-service.md
+  - name: Messaging Activities
+    href: messaging-activities.md
+  - name: "How to: Create a Workflow Service with Messaging Activities"
+    href: how-to-create-a-workflow-service-with-messaging-activities.md
+  - name: Using Contracts in Workflow
+    href: using-contracts-in-workflow.md
+  - name: Hosting Workflow Services Overview
+    href: hosting-workflow-services-overview.md
     items:
-    - name: Workflow Services Overview
-      href: workflow-services-overview.md
-    - name: Creating a Long-running Workflow Service
-      href: creating-a-long-running-workflow-service.md
-    - name: Messaging Activities
-      href: messaging-activities.md
-    - name: "How to: Create a Workflow Service with Messaging Activities"
-      href: how-to-create-a-workflow-service-with-messaging-activities.md
-    - name: Using Contracts in Workflow
-      href: using-contracts-in-workflow.md
-    - name: Hosting Workflow Services Overview
-      href: hosting-workflow-services-overview.md
+    - name: Hosting Workflow Services
+      href: hosting-workflow-services.md
+    - name: Workflow Service Host Internals
+      href: workflow-service-host-internals.md
+    - name: Workflow Service Host Extensibility
+      href: workflow-service-host-extensibility.md
+    - name: Workflow Control Endpoint
+      href: workflow-control-endpoint.md
+    - name: "How to: Host a Workflow Service with Windows Server App Fabric"
+      href: how-to-host-a-workflow-service-with-windows-server-app-fabric.md
+    - name: Configuring WorkflowServiceHost
+      href: configuring-workflowservicehost.md
       items:
-      - name: Hosting Workflow Services
-        href: hosting-workflow-services.md
-      - name: Workflow Service Host Internals
-        href: workflow-service-host-internals.md
-      - name: Workflow Service Host Extensibility
-        href: workflow-service-host-extensibility.md
-      - name: Workflow Control Endpoint
-        href: workflow-control-endpoint.md
-      - name: "How to: Host a Workflow Service with Windows Server App Fabric"
-        href: how-to-host-a-workflow-service-with-windows-server-app-fabric.md
-      - name: Configuring WorkflowServiceHost
-        href: configuring-workflowservicehost.md
-        items:
-        - name: "How to: Configure Persistence with WorkflowServiceHost"
-          href: how-to-configure-persistence-with-workflowservicehost.md
-        - name: "How to: Configure Tracking with WorkflowServiceHost"
-          href: how-to-configure-tracking-with-workflowservicehost.md
-        - name: "How to: Configure Idle Behavior with WorkflowServiceHost"
-          href: how-to-configure-idle-behavior-with-workflowservicehost.md
-        - name: "How to: Configure Workflow Unhandled Exception Behavior with WorkflowServiceHost"
-          href: config-workflow-unhandled-exception-workflowservicehost.md
-    - name: Correlation
-      href: correlation.md
-      items:
-      - name: Correlation Overview
-        href: correlation-overview.md
-      - name: Durable Duplex
-        href: durable-duplex-correlation.md
-      - name: Request-Reply
-        href: request-reply-correlation.md
-      - name: Troubleshooting Correlation
-        href: troubleshooting-correlation.md
-    - name: Configuring Serialization in a Workflow Service
-      href: configuring-serialization-in-a-workflow-service.md
-    - name: "How To: Access a Service From a Workflow Application"
-      href: how-to-access-a-service-from-a-workflow-application.md
-    - name: Out-of-Order Message Processing
-      href: out-of-order-message-processing.md
-    - name: Flowing Transactions into and out of Workflow Services
-      href: flowing-transactions-into-and-out-of-workflow-services.md
-    - name: Changing the Cache Sharing Levels for Send Activities
-      href: changing-the-cache-sharing-levels-for-send-activities.md
-    - name: Adding a Service Reference in a Workflow Solution
-      href: adding-a-service-reference-in-a-workflow-solution.md
-    - name: Side by Side Versioning in WorkflowServiceHost
-      href: side-by-side-versioning-in-workflowservicehost.md
-  - name: "Endpoints: Addresses, Bindings, and Contracts"
-    href: endpoints-addresses-bindings-and-contracts.md
+      - name: "How to: Configure Persistence with WorkflowServiceHost"
+        href: how-to-configure-persistence-with-workflowservicehost.md
+      - name: "How to: Configure Tracking with WorkflowServiceHost"
+        href: how-to-configure-tracking-with-workflowservicehost.md
+      - name: "How to: Configure Idle Behavior with WorkflowServiceHost"
+        href: how-to-configure-idle-behavior-with-workflowservicehost.md
+      - name: "How to: Configure Workflow Unhandled Exception Behavior with WorkflowServiceHost"
+        href: config-workflow-unhandled-exception-workflowservicehost.md
+  - name: Correlation
+    href: correlation.md
     items:
-    - name: Addresses
-      href: endpoint-addresses.md
-    - name: Bindings
-      href: bindings.md
-      items:
-      - name: Configuring System-Provided Bindings
-        href: configuring-system-provided-bindings.md
-      - name: Configuring Timeout Values on a Binding
-        href: configuring-timeout-values-on-a-binding.md
-      - name: Creating Multicasting Applications using the UDP Transport
-        href: creating-multicasting-applications-using-the-udp-transport.md
-    - name: Contracts
-      href: contracts.md
-      items:
-      - name: ServiceModel Attributes and ServiceDescription Reference
-        href: servicemodel-attributes-and-servicedescription-reference.md
-      - name: Request-Reply Services
-        href: request-reply-services.md
-      - name: "How to: Create a Request-Reply Contract"
-        href: how-to-create-a-request-reply-contract.md
-      - name: One-Way Services
-        href: one-way-services.md
-      - name: "How to: Create a One-Way Contract"
-        href: how-to-create-a-one-way-contract.md
-      - name: Duplex Services
-        href: duplex-services.md
-      - name: "How to: Create a Duplex Contract"
-        href: how-to-create-a-duplex-contract.md
-      - name: "How to: Create a Service with a Contract Class"
-        href: how-to-create-a-wcf-contract-with-a-class.md
-      - name: "How to: Create a Service with a Contract Interface"
-        href: how-to-create-a-service-with-a-contract-interface.md
-      - name: Using ServiceThrottlingBehavior to Control WCF Service Performance
-        href: using-servicethrottlingbehavior-to-control-wcf-service-performance.md
-    - name: "How to: Create a Service Endpoint in Configuration"
-      href: how-to-create-a-service-endpoint-in-configuration.md
-    - name: "How to: Create a Service Endpoint in Code"
-      href: how-to-create-a-service-endpoint-in-code.md
-    - name: "How to: Use Svcutil.exe to Validate Compiled Service Code"
-      href: how-to-use-svcutil-exe-to-validate-compiled-service-code.md
-    - name: Standard Endpoints
-      href: standard-endpoints.md
-  - name: Data Transfer and Serialization
-    href: data-transfer-and-serialization.md
+    - name: Correlation Overview
+      href: correlation-overview.md
+    - name: Durable Duplex
+      href: durable-duplex-correlation.md
+    - name: Request-Reply
+      href: request-reply-correlation.md
+    - name: Troubleshooting Correlation
+      href: troubleshooting-correlation.md
+  - name: Configuring Serialization in a Workflow Service
+    href: configuring-serialization-in-a-workflow-service.md
+  - name: "How To: Access a Service From a Workflow Application"
+    href: how-to-access-a-service-from-a-workflow-application.md
+  - name: Out-of-Order Message Processing
+    href: out-of-order-message-processing.md
+  - name: Flowing Transactions into and out of Workflow Services
+    href: flowing-transactions-into-and-out-of-workflow-services.md
+  - name: Changing the Cache Sharing Levels for Send Activities
+    href: changing-the-cache-sharing-levels-for-send-activities.md
+  - name: Adding a Service Reference in a Workflow Solution
+    href: adding-a-service-reference-in-a-workflow-solution.md
+  - name: Side by Side Versioning in WorkflowServiceHost
+    href: side-by-side-versioning-in-workflowservicehost.md
+- name: "Endpoints: Addresses, Bindings, and Contracts"
+  href: endpoints-addresses-bindings-and-contracts.md
+  items:
+  - name: Addresses
+    href: endpoint-addresses.md
+  - name: Bindings
+    href: bindings.md
     items:
-    - name: Specifying Data Transfer in Service Contracts
-      href: specifying-data-transfer-in-service-contracts.md
-    - name: Using Data Contracts
-      href: using-data-contracts.md
-      items:
-      - name: "How to: Create a Basic Data Contract for a Class or Structure"
-        href: how-to-create-a-basic-data-contract-for-a-class-or-structure.md
-      - name: Serializable Types
-        href: serializable-types.md
-      - name: Data Contract Names
-        href: data-contract-names.md
-      - name: Data Contract Equivalence
-        href: data-contract-equivalence.md
-      - name: Data Member Order
-        href: data-member-order.md
-      - name: Data Contract Known Types
-        href: data-contract-known-types.md
-      - name: Forward-Compatible Data Contracts
-        href: forward-compatible-data-contracts.md
-      - name: Data Contract Versioning
-        href: data-contract-versioning.md
-      - name: Version-Tolerant Serialization Callbacks
-        href: version-tolerant-serialization-callbacks.md
-      - name: Data Member Default Values
-        href: data-member-default-values.md
-      - name: Interoperable Object References
-        href: interoperable-object-references.md
-      - name: Types Supported by the Data Contract Serializer
-        href: types-supported-by-the-data-contract-serializer.md
-        items:
-        - name: Collection Types in Data Contracts
-          href: collection-types-in-data-contracts.md
-        - name: XML and ADO.NET Types in Data Contracts
-          href: xml-and-ado-net-types-in-data-contracts.md
-        - name: Enumeration Types in Data Contracts
-          href: enumeration-types-in-data-contracts.md
-    - name: Data Contract Serializer
-      href: data-contract-serializer.md
-      items:
-      - name: Serialization and Deserialization
-        href: serialization-and-deserialization.md
-      - name: Schema Import and Export
-        href: schema-import-and-export.md
-        items:
-        - name: Importing Schema to Generate Classes
-          href: importing-schema-to-generate-classes.md
-        - name: Exporting Schemas from Classes
-          href: exporting-schemas-from-classes.md
-      - name: Using a Data Contract Resolver
-        href: using-a-data-contract-resolver.md
-    - name: Using the XmlSerializer Class
-      href: using-the-xmlserializer-class.md
-      items:
-      - name: "How to: Improve the Startup Time of WCF Client Applications using the XmlSerializer"
-        href: startup-time-of-wcf-client-applications-using-the-xmlserializer.md
-    - name: Using Message Contracts
-      href: using-message-contracts.md
-    - name: Creating a custom header that is signed and-or encrypted
-      href: creating-a-custom-header-that-is-signed-and-or-encrypted.md
-    - name: Using the Message Class
-      href: using-the-message-class.md
-    - name: Filtering
-      href: filtering.md
-    - name: Large Data and Streaming
-      href: large-data-and-streaming.md
-      items:
-      - name: "How to: Enable Streaming"
-        href: how-to-enable-streaming.md
-    - name: Security Considerations for Data
-      href: security-considerations-for-data.md
-    - name: Data Transfer Architectural Overview
-      href: data-transfer-architectural-overview.md
-  - name: Sessions, Instancing, and Concurrency
-    href: sessions-instancing-and-concurrency.md
+    - name: Configuring System-Provided Bindings
+      href: configuring-system-provided-bindings.md
+    - name: Configuring Timeout Values on a Binding
+      href: configuring-timeout-values-on-a-binding.md
+    - name: Creating Multicasting Applications using the UDP Transport
+      href: creating-multicasting-applications-using-the-udp-transport.md
+  - name: Contracts
+    href: contracts.md
     items:
-    - name: "How to: Create a Service That Requires Sessions"
-      href: how-to-create-a-service-that-requires-sessions.md
-    - name: "How to: Control Service Instancing"
-      href: how-to-control-service-instancing.md
-    - name: Ordered Processing of Messages in Single Concurrency Mode
-      href: ordered-processing-of-messages-in-single-concurrency-mode.md
-  - name: Transports
-    href: transports.md
+    - name: ServiceModel Attributes and ServiceDescription Reference
+      href: servicemodel-attributes-and-servicedescription-reference.md
+    - name: Request-Reply Services
+      href: request-reply-services.md
+    - name: "How to: Create a Request-Reply Contract"
+      href: how-to-create-a-request-reply-contract.md
+    - name: One-Way Services
+      href: one-way-services.md
+    - name: "How to: Create a One-Way Contract"
+      href: how-to-create-a-one-way-contract.md
+    - name: Duplex Services
+      href: duplex-services.md
+    - name: "How to: Create a Duplex Contract"
+      href: how-to-create-a-duplex-contract.md
+    - name: "How to: Create a Service with a Contract Class"
+      href: how-to-create-a-wcf-contract-with-a-class.md
+    - name: "How to: Create a Service with a Contract Interface"
+      href: how-to-create-a-service-with-a-contract-interface.md
+    - name: Using ServiceThrottlingBehavior to Control WCF Service Performance
+      href: using-servicethrottlingbehavior-to-control-wcf-service-performance.md
+  - name: "How to: Create a Service Endpoint in Configuration"
+    href: how-to-create-a-service-endpoint-in-configuration.md
+  - name: "How to: Create a Service Endpoint in Code"
+    href: how-to-create-a-service-endpoint-in-code.md
+  - name: "How to: Use Svcutil.exe to Validate Compiled Service Code"
+    href: how-to-use-svcutil-exe-to-validate-compiled-service-code.md
+  - name: Standard Endpoints
+    href: standard-endpoints.md
+- name: Data Transfer and Serialization
+  href: data-transfer-and-serialization.md
+  items:
+  - name: Specifying Data Transfer in Service Contracts
+    href: specifying-data-transfer-in-service-contracts.md
+  - name: Using Data Contracts
+    href: using-data-contracts.md
     items:
-    - name: Choosing a Transport
-      href: choosing-a-transport.md
-    - name: Choosing a Message Encoder
-      href: choosing-a-message-encoder.md
-    - name: Streaming Message Transfer
-      href: streaming-message-transfer.md
-    - name: Configuring HTTP and HTTPS
-      href: configuring-http-and-https.md
-    - name: "How to: Replace the WCF URL Reservation with a Restricted Reservation"
-      href: how-to-replace-the-wcf-url-reservation-with-a-restricted-reservation.md
-    - name: Transport Quotas
-      href: transport-quotas.md
-    - name: Working with NATs and Firewalls
-      href: working-with-nats-and-firewalls.md
-    - name: Net.TCP Port Sharing
-      href: net-tcp-port-sharing.md
+    - name: "How to: Create a Basic Data Contract for a Class or Structure"
+      href: how-to-create-a-basic-data-contract-for-a-class-or-structure.md
+    - name: Serializable Types
+      href: serializable-types.md
+    - name: Data Contract Names
+      href: data-contract-names.md
+    - name: Data Contract Equivalence
+      href: data-contract-equivalence.md
+    - name: Data Member Order
+      href: data-member-order.md
+    - name: Data Contract Known Types
+      href: data-contract-known-types.md
+    - name: Forward-Compatible Data Contracts
+      href: forward-compatible-data-contracts.md
+    - name: Data Contract Versioning
+      href: data-contract-versioning.md
+    - name: Version-Tolerant Serialization Callbacks
+      href: version-tolerant-serialization-callbacks.md
+    - name: Data Member Default Values
+      href: data-member-default-values.md
+    - name: Interoperable Object References
+      href: interoperable-object-references.md
+    - name: Types Supported by the Data Contract Serializer
+      href: types-supported-by-the-data-contract-serializer.md
       items:
-      - name: "How to: Enable the Net.TCP Port Sharing Service"
-        href: how-to-enable-the-net-tcp-port-sharing-service.md
-      - name: "How to: Configure a WCF Service to Use Port Sharing"
-        href: how-to-configure-a-wcf-service-to-use-port-sharing.md
-      - name: Configuring the Net.TCP Port Sharing Service
-        href: configuring-the-net-tcp-port-sharing-service.md
-    - name: Encoding Binary Objects with ByteStream Encoder
-      href: encoding-binary-objects-with-bytestream-encoder.md
-  - name: Queues and Reliable Sessions
-    href: queues-and-reliable-sessions.md
+      - name: Collection Types in Data Contracts
+        href: collection-types-in-data-contracts.md
+      - name: XML and ADO.NET Types in Data Contracts
+        href: xml-and-ado-net-types-in-data-contracts.md
+      - name: Enumeration Types in Data Contracts
+        href: enumeration-types-in-data-contracts.md
+  - name: Data Contract Serializer
+    href: data-contract-serializer.md
     items:
-    - name: Reliable Sessions
-      href: reliable-sessions.md
+    - name: Serialization and Deserialization
+      href: serialization-and-deserialization.md
+    - name: Schema Import and Export
+      href: schema-import-and-export.md
       items:
-      - name: Reliable Sessions Overview
-        href: reliable-sessions-overview.md
-      - name: "How to: Exchange Messages Within a Reliable Session"
-        href: how-to-exchange-messages-within-a-reliable-session.md
-      - name: "How to: Secure Messages within Reliable Sessions"
-        href: how-to-secure-messages-within-reliable-sessions.md
-      - name: "How to: Create a Custom Reliable Session Binding with HTTPS"
-        href: how-to-create-a-custom-reliable-session-binding-with-https.md
-      - name: Best Practices for Reliable Sessions
-        href: best-practices-for-reliable-sessions.md
-    - name: Queues in WCF
-      href: queues-in-wcf.md
-      items:
-      - name: Queues Overview
-        href: queues-overview.md
-      - name: Queuing in WCF
-        href: queuing-in-wcf.md
-        items:
-        - name: Service Endpoints and Queue Addressing
-          href: service-endpoints-and-queue-addressing.md
-        - name: Web Hosting a Queued Application
-          href: web-hosting-a-queued-application.md
-      - name: "How to: Exchange Queued Messages with WCF Endpoints"
-        href: how-to-exchange-queued-messages-with-wcf-endpoints.md
-      - name: "How to: Exchange Messages with WCF Endpoints and Message Queuing Applications"
-        href: how-to-exchange-messages-with-wcf-endpoints-and-message-queuing-applications.md
-      - name: Grouping Queued Messages in a Session
-        href: grouping-queued-messages-in-a-session.md
-      - name: Batching Messages in a Transaction
-        href: batching-messages-in-a-transaction.md
-      - name: Using Dead-Letter Queues to Handle Message Transfer Failures
-        href: using-dead-letter-queues-to-handle-message-transfer-failures.md
-      - name: Poison Message Handling
-        href: poison-message-handling.md
-      - name: Securing Messages Using Transport Security
-        href: securing-messages-using-transport-security.md
-      - name: Securing Messages Using Message Security
-        href: securing-messages-using-message-security.md
-      - name: Troubleshooting Queued Messaging
-        href: troubleshooting-queued-messaging.md
-      - name: Best Practices for Queued Communication
-        href: best-practices-for-queued-communication.md
-  - name: Transactions
-    href: transactions-in-wcf.md
+      - name: Importing Schema to Generate Classes
+        href: importing-schema-to-generate-classes.md
+      - name: Exporting Schemas from Classes
+        href: exporting-schemas-from-classes.md
+    - name: Using a Data Contract Resolver
+      href: using-a-data-contract-resolver.md
+  - name: Using the XmlSerializer Class
+    href: using-the-xmlserializer-class.md
     items:
-    - name: Windows Communication Foundation Transactions Overview
-      href: transactions-overview.md
-    - name: Transaction Models
-      href: transaction-models.md
-    - name: Transactional Support in System.ServiceModel
-      href: transactional-support-in-system-servicemodel.md
-      items:
-      - name: ServiceModel Transaction Attributes
-        href: servicemodel-transaction-attributes.md
-      - name: ServiceModel Transaction Configuration
-        href: servicemodel-transaction-configuration.md
-      - name: Enabling Transaction Flow
-        href: enabling-transaction-flow.md
-      - name: "How to: Create a Transactional Service"
-        href: how-to-create-a-transactional-service.md
-      - name: Diagnosing Transactional Applications
-        href: diagnosing-transactional-applications.md
-      - name: Comparing Transactions in COM+ and ServiceModel
-        href: comparing-transactions-in-com-and-servicemodel.md
-      - name: Integrating Enterprise Services Transactional Components
-        href: integrating-enterprise-services-transactional-components.md
-    - name: Using WS-AtomicTransaction
-      href: using-ws-atomictransaction.md
-      items:
-      - name: Configuring WS-Atomic Transaction Support
-        href: configuring-ws-atomic-transaction-support.md
-  - name: Security
-    href: security.md
+    - name: "How to: Improve the Startup Time of WCF Client Applications using the XmlSerializer"
+      href: startup-time-of-wcf-client-applications-using-the-xmlserializer.md
+  - name: Using Message Contracts
+    href: using-message-contracts.md
+  - name: Creating a custom header that is signed and-or encrypted
+    href: creating-a-custom-header-that-is-signed-and-or-encrypted.md
+  - name: Using the Message Class
+    href: using-the-message-class.md
+  - name: Filtering
+    href: filtering.md
+  - name: Large Data and Streaming
+    href: large-data-and-streaming.md
     items:
-    - name: Security Overview
-      href: security-overview.md
-    - name: Security Concepts
-      href: security-concepts.md
-      items:
-      - name: Security Concepts Used in WCF
-        href: security-concepts-used-in-wcf.md
-      - name: Distributed Application Security
-        href: distributed-application-security.md
-      - name: Security Terminology
-        href: wcf-security-terminology.md
-    - name: Common Security Scenarios
-      href: common-security-scenarios.md
-      items:
-      - name: Internet Unsecured Client and Service
-        href: internet-unsecured-client-and-service.md
-      - name: Intranet Unsecured Client and Service
-        href: intranet-unsecured-client-and-service.md
-      - name: Transport Security with an Anonymous Client
-        href: transport-security-with-an-anonymous-client.md
-      - name: Transport Security with Basic Authentication
-        href: transport-security-with-basic-authentication.md
-      - name: Transport Security with Windows Authentication
-        href: transport-security-with-windows-authentication.md
-      - name: Transport Security with Certificate Authentication
-        href: transport-security-with-certificate-authentication.md
-      - name: Message Security with an Anonymous Client
-        href: message-security-with-an-anonymous-client.md
-      - name: Message Security with a User Name Client
-        href: message-security-with-a-user-name-client.md
-      - name: Message Security with a Certificate Client
-        href: message-security-with-a-certificate-client.md
-      - name: Message Security with a Windows Client
-        href: message-security-with-a-windows-client.md
-      - name: Message Security with a Windows Client without Credential Negotiation
-        href: message-security-with-a-windows-client-without-credential-negotiation.md
-      - name: Message Security with Mutual Certificates
-        href: message-security-with-mutual-certificates.md
-      - name: Message Security with Issued Tokens
-        href: message-security-with-issued-tokens.md
-      - name: Trusted Subsystem
-        href: trusted-subsystem.md
-    - name: Security Behaviors
-      href: security-behaviors-in-wcf.md
-    - name: Bindings and Security
-      href: bindings-and-security.md
-      items:
-      - name: Security Capabilities with Custom Bindings
-        href: security-capabilities-with-custom-bindings.md
-        items:
-        - name: SecurityBindingElement Authentication Modes
-          href: securitybindingelement-authentication-modes.md
-        - name: "How to: Create a Custom Binding Using the SecurityBindingElement"
-          href: how-to-create-a-custom-binding-using-the-securitybindingelement.md
-        - name: "How to: Create a SecurityBindingElement for a Specified Authentication Mode"
-          href: how-to-create-a-securitybindingelement-for-a-specified-authentication-mode.md
-        - name: "How to: Disable Secure Sessions on a WSFederationHttpBinding"
-          href: how-to-disable-secure-sessions-on-a-wsfederationhttpbinding.md
-        - name: "How to: Enable Message Replay Detection"
-          href: how-to-enable-message-replay-detection.md
-        - name: "How to: Create a Supporting Credential"
-          href: how-to-create-a-supporting-credential.md
-        - name: "How to: Set Up a Signature Confirmation"
-          href: how-to-set-up-a-signature-confirmation.md
-        - name: "How to: Set a Max Clock Skew"
-          href: how-to-set-a-max-clock-skew.md
-        - name: "How to: Disable Encryption of Digital Signatures"
-          href: how-to-disable-encryption-of-digital-signatures.md
-    - name: Securing Services and Clients
-      href: securing-services-and-clients.md
-      items:
-      - name: Programming WCF Security
-        href: programming-wcf-security.md
-        items:
-        - name: Selecting a Credential Type
-          href: selecting-a-credential-type.md
-        - name: "How to: Authenticate with a User Name and Password"
-          href: how-to-authenticate-with-a-user-name-and-password.md
-      - name: Transport Security
-        href: transport-security.md
-        items:
-        - name: Transport Security Overview
-          href: transport-security-overview.md
-        - name: HTTP Transport Security
-          href: http-transport-security.md
-        - name: Understanding HTTP Authentication
-          href: understanding-http-authentication.md
-        - name: Using Impersonation with Transport Security
-          href: using-impersonation-with-transport-security.md
-        - name: "How to: Configure a Port with an SSL Certificate"
-          href: how-to-configure-a-port-with-an-ssl-certificate.md
-        - name: "How to: Configure an IIS-hosted WCF service with SSL"
-          href: how-to-configure-an-iis-hosted-wcf-service-with-ssl.md
-      - name: Message Security
-        href: message-security-in-wcf.md
-        items:
-        - name: "How to: Secure a Service with an X.509 Certificate"
-          href: how-to-secure-a-service-with-an-x-509-certificate.md
-        - name: "How to: Use Transport Security and Message Credentials"
-          href: how-to-use-transport-security-and-message-credentials.md
-        - name: Preventing Replay Attacks When a WCF Service is Hosted in a Web Farm
-          href: preventing-replay-attacks-when-a-wcf-service-is-hosted-in-a-web-farm.md
-      - name: Secure Sessions
-        href: secure-sessions.md
-        items:
-        - name: Secure Conversations and Secure Sessions
-          href: secure-conversations-and-secure-sessions.md
-        - name: "How to: Create a Secure Session"
-          href: how-to-create-a-secure-session.md
-        - name: "How to: Create a Security Context Token for a Secure Session"
-          href: how-to-create-a-security-context-token-for-a-secure-session.md
-        - name: Security Considerations for Secure Sessions
-          href: security-considerations-for-secure-sessions.md
-      - name: Working with Certificates
-        href: working-with-certificates.md
-        items:
-        - name: "How to: Obtain a Certificate"
-          href: how-to-obtain-a-certificate-wcf.md
-        - name: "How to: View Certificates with the MMC Snap-in"
-          href: how-to-view-certificates-with-the-mmc-snap-in.md
-        - name: "How to: Retrieve the Thumbprint of a Certificate"
-          href: how-to-retrieve-the-thumbprint-of-a-certificate.md
-        - name: "How to: Make X.509 Certificates Accessible to WCF"
-          href: how-to-make-x-509-certificates-accessible-to-wcf.md
-        - name: "How to: Create Temporary Certificates for Use During Development"
-          href: how-to-create-temporary-certificates-for-use-during-development.md
-        - name: "How to: Specify the Certificate Authority Certificate Chain Used to Verify Signatures"
-          href: specify-the-certificate-authority-chain-verify-signatures-wcf.md
-        - name: Certificate Validation Differences Between HTTPS, SSL over TCP, and SOAP Security
-          href: cert-val-diff-https-ssl-over-tcp-and-soap.md
-        - name: "How to: Consistently Reference X.509 Certificates"
-          href: how-to-consistently-reference-x-509-certificates.md
-    - name: Authentication
-      href: authentication-in-wcf.md
-      items:
-      - name: "How to: Use the ASP.NET Membership Provider"
-        href: how-to-use-the-aspnet-membership-provider.md
-      - name: "How to: Use a Custom User Name and Password Validator"
-        href: how-to-use-a-custom-user-name-and-password-validator.md
-      - name: "How to: Use Multiple Security Tokens of the Same Type"
-        href: how-to-use-multiple-security-tokens-of-the-same-type.md
-      - name: Service Identity and Authentication
-        href: service-identity-and-authentication.md
-      - name: Security Negotiation and Timeouts
-        href: security-negotiation-and-timeouts.md
-      - name: Debugging Windows Authentication Errors
-        href: debugging-windows-authentication-errors.md
-      - name: Using Multiple Authentication Schemes with WCF
-        href: using-multiple-authentication-schemes-with-wcf.md
-    - name: Authorization
-      href: authorization-in-wcf.md
-      items:
-      - name: Access Control Mechanisms
-        href: access-control-mechanisms.md
-      - name: "How to: Use the ASP.NET Role Provider with a Service"
-        href: how-to-use-the-aspnet-role-provider-with-a-service.md
-      - name: "How to: Use the ASP.NET Authorization Manager Role Provider with a Service"
-        href: how-to-use-the-aspnet-authorization-manager-role-provider-with-a-service.md
-      - name: Managing Claims and Authorization with the Identity Model
-        href: managing-claims-and-authorization-with-the-identity-model.md
-        items:
-        - name: Claims and Tokens
-          href: claims-and-tokens.md
-        - name: Claims and Denying Access to Resources
-          href: claims-and-denying-access-to-resources.md
-        - name: Claim Creation and Resource Values
-          href: claim-creation-and-resource-values.md
-      - name: Delegation and Impersonation
-        href: delegation-and-impersonation-with-wcf.md
-    - name: Federation and Issued Tokens
-      href: federation-and-issued-tokens.md
-      items:
-      - name: Federation
-        href: federation.md
-      - name: Federation and Trust
-        href: federation-and-trust.md
-      - name: "How to: Create a Federated Client"
-        href: how-to-create-a-federated-client.md
-      - name: "How to: Configure Credentials on a Federation Service"
-        href: how-to-configure-credentials-on-a-federation-service.md
-      - name: "How to: Create a WSFederationHttpBinding"
-        href: how-to-create-a-wsfederationhttpbinding.md
-      - name: "How to: Create a Security Token Service"
-        href: how-to-create-a-security-token-service.md
-      - name: Security Assertions Markup Language (SAML) Tokens and Claims
-        href: saml-tokens-and-claims.md
-      - name: "How to: Configure a Local Issuer"
-        href: how-to-configure-a-local-issuer.md
-      - name: "How to: Create a Duplex Federated Binding"
-        href: how-to-create-a-duplex-federated-binding.md
-    - name: Auditing
-      href: auditing-security-events.md
-      items:
-      - name: "How to: Audit Security Events"
-        href: how-to-audit-wcf-security-events.md
-    - name: Security Guidance and Best Practices
-      href: security-guidance-and-best-practices.md
-      items:
-      - name: Best Practices for Security
-        href: best-practices-for-security-in-wcf.md
-      - name: Security Considerations
-        href: security-considerations-in-wcf.md
-        items:
-        - name: Information Disclosure
-          href: information-disclosure.md
-        - name: Elevation of Privilege
-          href: elevation-of-privilege.md
-        - name: Denial of Service
-          href: denial-of-service.md
-        - name: Tampering
-          href: tampering.md
-        - name: Replay Attacks
-          href: replay-attacks.md
-        - name: Unsupported Scenarios
-          href: unsupported-scenarios.md
-      - name: Performance Considerations
-        href: performance-considerations.md
-        items:
-        - name: Finding Claims in a ClaimSet
-          href: finding-claims-in-a-claimset.md
-        - name: Encryption of Digital Signatures
-          href: encryption-of-digital-signatures.md
-    - name: Extended Protection for Authentication Overview
-      href: extended-protection-for-authentication-overview.md
-      items:
-      - name: ReadMe for Extended Protection Authentication Sample
-        href: readme-for-extended-protection-authentication-sample.md
-  - name: Peer-to-Peer Networking
-    href: peer-to-peer-networking.md
+    - name: "How to: Enable Streaming"
+      href: how-to-enable-streaming.md
+  - name: Security Considerations for Data
+    href: security-considerations-for-data.md
+  - name: Data Transfer Architectural Overview
+    href: data-transfer-architectural-overview.md
+- name: Sessions, Instancing, and Concurrency
+  href: sessions-instancing-and-concurrency.md
+  items:
+  - name: "How to: Create a Service That Requires Sessions"
+    href: how-to-create-a-service-that-requires-sessions.md
+  - name: "How to: Control Service Instancing"
+    href: how-to-control-service-instancing.md
+  - name: Ordered Processing of Messages in Single Concurrency Mode
+    href: ordered-processing-of-messages-in-single-concurrency-mode.md
+- name: Transports
+  href: transports.md
+  items:
+  - name: Choosing a Transport
+    href: choosing-a-transport.md
+  - name: Choosing a Message Encoder
+    href: choosing-a-message-encoder.md
+  - name: Streaming Message Transfer
+    href: streaming-message-transfer.md
+  - name: Configuring HTTP and HTTPS
+    href: configuring-http-and-https.md
+  - name: "How to: Replace the WCF URL Reservation with a Restricted Reservation"
+    href: how-to-replace-the-wcf-url-reservation-with-a-restricted-reservation.md
+  - name: Transport Quotas
+    href: transport-quotas.md
+  - name: Working with NATs and Firewalls
+    href: working-with-nats-and-firewalls.md
+  - name: Net.TCP Port Sharing
+    href: net-tcp-port-sharing.md
     items:
-    - name: Peer Channel Scenarios
-      href: peer-channel-scenarios.md
-    - name: Peer Channel Concepts
-      href: peer-channel-concepts.md
-      items:
-      - name: Peer Meshes
-        href: peer-meshes.md
-      - name: Peer Nodes
-        href: peer-nodes.md
-      - name: Peer Channel Security
-        href: peer-channel-security.md
-      - name: Peer Resolvers
-        href: peer-resolvers.md
-        items:
-        - name: "Inside the CustomPeerResolverService: Client Registrations"
-          href: inside-the-custompeerresolverservice-client-registrations.md
-    - name: Building a Peer Channel Application
-      href: building-a-peer-channel-application.md
-      items:
-      - name: Converting a NetTcpBinding Application to a Peer Channel Application
-        href: converting-a-nettcpbinding-application-to-a-peer-channel-application.md
-      - name: Limiting Message Distribution
-        href: limiting-message-distribution.md
-      - name: Adding Online and Offline Status
-        href: adding-online-and-offline-status.md
-      - name: Securing Peer Channel Applications
-        href: securing-peer-channel-applications.md
-  - name: Metadata
-    href: metadata.md
+    - name: "How to: Enable the Net.TCP Port Sharing Service"
+      href: how-to-enable-the-net-tcp-port-sharing-service.md
+    - name: "How to: Configure a WCF Service to Use Port Sharing"
+      href: how-to-configure-a-wcf-service-to-use-port-sharing.md
+    - name: Configuring the Net.TCP Port Sharing Service
+      href: configuring-the-net-tcp-port-sharing-service.md
+  - name: Encoding Binary Objects with ByteStream Encoder
+    href: encoding-binary-objects-with-bytestream-encoder.md
+- name: Queues and Reliable Sessions
+  href: queues-and-reliable-sessions.md
+  items:
+  - name: Reliable Sessions
+    href: reliable-sessions.md
     items:
-    - name: Metadata Architecture Overview
-      href: metadata-architecture-overview.md
-    - name: Metadata Formats
-      href: metadata-formats.md
-    - name: Exporting and Importing Metadata
-      href: exporting-and-importing-metadata.md
-      items:
-      - name: "How to: Import Metadata into Service Endpoints"
-        href: how-to-import-metadata-into-service-endpoints.md
-      - name: "How to: Export Metadata from Service Endpoints"
-        href: how-to-export-metadata-from-service-endpoints.md
-      - name: ServiceDescription and WSDL Reference
-        href: servicedescription-and-wsdl-reference.md
-      - name: "How to: Use Svcutil.exe to Export Metadata from Compiled Service Code"
-        href: how-to-use-svcutil-exe-to-export-metadata-from-compiled-service-code.md
-    - name: Publishing Metadata
-      href: publishing-metadata.md
-      items:
-      - name: "How to: Publish Metadata for a Service Using a Configuration File"
-        href: how-to-publish-metadata-for-a-service-using-a-configuration-file.md
-      - name: "How to: Publish Metadata for a Service Using Code"
-        href: how-to-publish-metadata-for-a-service-using-code.md
-    - name: Retrieving Metadata
-      href: retrieving-metadata.md
-      items:
-      - name: "How to: Use Svcutil.exe to Download Metadata Documents"
-        href: how-to-use-svcutil-exe-to-download-metadata-documents.md
-      - name: "How to: Use MetadataResolver to Obtain Binding Metadata Dynamically"
-        href: how-to-use-metadataresolver-to-obtain-binding-metadata-dynamically.md
-      - name: "How to: Use MetadataExchangeClient to Retrieve Metadata"
-        href: how-to-use-metadataexchangeclient-to-retrieve-metadata.md
-    - name: Using Metadata
-      href: using-metadata.md
-      items:
-      - name: Understanding Generated Client Code
-        href: understanding-generated-client-code.md
-      - name: "How to: Retrieve Metadata and Implement a Compliant Service"
-        href: how-to-retrieve-metadata-and-implement-a-compliant-service.md
-      - name: Generating a WCF Client from Service Metadata
-        href: generating-a-wcf-client-from-service-metadata.md
-    - name: Security Considerations with Metadata
-      href: security-considerations-with-metadata.md
-      items:
-      - name: "How to: Secure Metadata Endpoints"
-        href: how-to-secure-metadata-endpoints.md
-      - name: "How To: Allow Metadata Requests While Authorizing"
-        href: how-to-allow-metadata-requests-while-authorizing.md
-  - name: Clients
-    href: clients.md
+    - name: Reliable Sessions Overview
+      href: reliable-sessions-overview.md
+    - name: "How to: Exchange Messages Within a Reliable Session"
+      href: how-to-exchange-messages-within-a-reliable-session.md
+    - name: "How to: Secure Messages within Reliable Sessions"
+      href: how-to-secure-messages-within-reliable-sessions.md
+    - name: "How to: Create a Custom Reliable Session Binding with HTTPS"
+      href: how-to-create-a-custom-reliable-session-binding-with-https.md
+    - name: Best Practices for Reliable Sessions
+      href: best-practices-for-reliable-sessions.md
+  - name: Queues in WCF
+    href: queues-in-wcf.md
     items:
-    - name: WCF Client Architecture
-      href: client-architecture.md
-    - name: Accessing Services Using a WCF Client
-      href: accessing-services-using-a-client.md
+    - name: Queues Overview
+      href: queues-overview.md
+    - name: Queuing in WCF
+      href: queuing-in-wcf.md
       items:
-      - name: "How to: Access Services with One-Way and Request-Reply Contracts"
-        href: how-to-access-wcf-services-with-one-way-and-request-reply-contracts.md
-      - name: "How to: Access Services with a Duplex Contract"
-        href: how-to-access-services-with-a-duplex-contract.md
-      - name: "How to: Access a WSE 3.0 Service"
-        href: how-to-access-a-wse-3-0-service-with-a-wcf-client.md
-      - name: "How to: Use the ChannelFactory"
-        href: how-to-use-the-channelfactory.md
-      - name: Channel Factory and Caching
-        href: channel-factory-and-caching.md
-      - name: "How to: Call Service Operations Asynchronously"
-        href: how-to-call-wcf-service-operations-asynchronously.md
-      - name: Middle-Tier Client Applications
-        href: middle-tier-client-applications.md
-      - name: "How to: Call Operations Asynchronously Using a Channel Factory"
-        href: how-to-call-operations-asynchronously-using-a-channel-factory.md
-      - name: Accessing WCF Services with a Windows Store Client App
-        href: accessing-wcf-services-with-a-windows-store-client-app.md
-      - name: "How to: Create a Channel Factory and Use it to Create and Manage Channels"
-        href: how-to-create-a-channel-factory-and-use-it-to-create-and-manage-channels.md
-    - name: WCF Client Configuration
-      href: client-configuration.md
-  - name: Hosting
-    href: hosting.md
+      - name: Service Endpoints and Queue Addressing
+        href: service-endpoints-and-queue-addressing.md
+      - name: Web Hosting a Queued Application
+        href: web-hosting-a-queued-application.md
+    - name: "How to: Exchange Queued Messages with WCF Endpoints"
+      href: how-to-exchange-queued-messages-with-wcf-endpoints.md
+    - name: "How to: Exchange Messages with WCF Endpoints and Message Queuing Applications"
+      href: how-to-exchange-messages-with-wcf-endpoints-and-message-queuing-applications.md
+    - name: Grouping Queued Messages in a Session
+      href: grouping-queued-messages-in-a-session.md
+    - name: Batching Messages in a Transaction
+      href: batching-messages-in-a-transaction.md
+    - name: Using Dead-Letter Queues to Handle Message Transfer Failures
+      href: using-dead-letter-queues-to-handle-message-transfer-failures.md
+    - name: Poison Message Handling
+      href: poison-message-handling.md
+    - name: Securing Messages Using Transport Security
+      href: securing-messages-using-transport-security.md
+    - name: Securing Messages Using Message Security
+      href: securing-messages-using-message-security.md
+    - name: Troubleshooting Queued Messaging
+      href: troubleshooting-queued-messaging.md
+    - name: Best Practices for Queued Communication
+      href: best-practices-for-queued-communication.md
+- name: Transactions
+  href: transactions-in-wcf.md
+  items:
+  - name: Windows Communication Foundation Transactions Overview
+    href: transactions-overview.md
+  - name: Transaction Models
+    href: transaction-models.md
+  - name: Transactional Support in System.ServiceModel
+    href: transactional-support-in-system-servicemodel.md
     items:
-    - name: Hosting in Internet Information Services
-      href: hosting-in-internet-information-services.md
-      items:
-      - name: Deploying an Internet Information Services-Hosted WCF Service
-        href: deploying-an-internet-information-services-hosted-wcf-service.md
-      - name: WCF Services and ASP.NET
-        href: wcf-services-and-aspnet.md
-      - name: Internet Information Services Hosting Best Practices
-        href: internet-information-services-hosting-best-practices.md
-      - name: "How to: Host a WCF Service in IIS"
-        href: how-to-host-a-wcf-service-in-iis.md
-      - name: Configuring Internet Information Services 7.0 for Windows Communication Foundation
-        href: configuring-iis-for-wcf.md
-    - name: Hosting in Windows Process Activation Service
-      href: hosting-in-windows-process-activation-service.md
-      items:
-      - name: WAS Activation Architecture
-        href: was-activation-architecture.md
-      - name: Configuring WAS for Use with WCF
-        href: configuring-the-wpa--service-for-use-with-wcf.md
-      - name: "How to: Install and Configure WCF Activation Components"
-        href: how-to-install-and-configure-wcf-activation-components.md
-      - name: "How to: Host a WCF Service in WAS"
-        href: how-to-host-a-wcf-service-in-was.md
-    - name: Hosting in a Windows Service Application
-      href: hosting-in-a-windows-service-application.md
-      items:
-      - name: "How to: Host a WCF Service in a Managed Windows Service"
-        href: how-to-host-a-wcf-service-in-a-managed-windows-service.md
-    - name: Hosting in a Managed Application
-      href: hosting-in-a-managed-application.md
-    - name: Configuration-Based Activation in IIS and WAS
-      href: configuration-based-activation-in-iis-and-was.md
-    - name: Supporting Multiple IIS Site Bindings
-      href: supporting-multiple-iis-site-bindings.md
-    - name: System.Web.Routing Integration
-      href: system-web-routing-integration.md
-  - name: Partial Trust
-    href: partial-trust.md
+    - name: ServiceModel Transaction Attributes
+      href: servicemodel-transaction-attributes.md
+    - name: ServiceModel Transaction Configuration
+      href: servicemodel-transaction-configuration.md
+    - name: Enabling Transaction Flow
+      href: enabling-transaction-flow.md
+    - name: "How to: Create a Transactional Service"
+      href: how-to-create-a-transactional-service.md
+    - name: Diagnosing Transactional Applications
+      href: diagnosing-transactional-applications.md
+    - name: Comparing Transactions in COM+ and ServiceModel
+      href: comparing-transactions-in-com-and-servicemodel.md
+    - name: Integrating Enterprise Services Transactional Components
+      href: integrating-enterprise-services-transactional-components.md
+  - name: Using WS-AtomicTransaction
+    href: using-ws-atomictransaction.md
     items:
-    - name: Supported Deployment Scenarios
-      href: supported-deployment-scenarios.md
-    - name: Partial Trust Feature Compatibility
-      href: partial-trust-feature-compatibility.md
-    - name: Partial Trust Best Practices
-      href: partial-trust-best-practices.md
-  - name: Interoperability and Integration
-    href: interoperability-and-integration.md
+    - name: Configuring WS-Atomic Transaction Support
+      href: configuring-ws-atomic-transaction-support.md
+- name: Security
+  href: security.md
+  items:
+  - name: Security Overview
+    href: security-overview.md
+  - name: Security Concepts
+    href: security-concepts.md
     items:
-    - name: Web Services Protocols Interoperability Guide
-      href: web-services-protocols-interoperability-guide.md
-      items:
-      - name: Web Services Protocols Supported by System-Provided Interoperability Bindings
-        href: web-services-protocols-supported-by-system-provided-interoperability-bindings.md
-      - name: Messaging Protocols
-        href: messaging-protocols.md
-      - name: Data Contract Schema Reference
-        href: data-contract-schema-reference.md
-      - name: WSDL and Policy
-        href: wsdl-and-policy.md
-      - name: Security Protocols version 1.0
-        href: security-protocols-version-1-0.md
-      - name: Security Protocols
-        href: security-protocols.md
-      - name: Reliable Messaging Protocol version 1.0
-        href: reliable-messaging-protocol-version-1-0.md
-      - name: Reliable Messaging Protocol version 1.1
-        href: reliable-messaging-protocol-version-1-1.md
-      - name: Transaction Protocols version 1.0
-        href: transaction-protocols-version-1-0.md
-      - name: Transaction Protocols
-        href: transaction-protocols.md
-      - name: Context Exchange Protocol
-        href: context-exchange-protocol.md
-      - name: Mixing Trust Protocols in Federated Scenarios
-        href: mixing-trust-protocols-in-federated-scenarios.md
-    - name: Integrating with COM+ Applications
-      href: integrating-with-com-plus-applications.md
-      items:
-      - name: Integrating with COM+ Applications Overview
-        href: integrating-with-com-plus-applications-overview.md
-      - name: "How to: Use the COM+ Service Model Configuration Tool"
-        href: how-to-use-the-com-service-model-configuration-tool.md
-      - name: "How to: Configure COM+ Service Settings"
-        href: how-to-configure-com-service-settings.md
-      - name: "How to: Deploy a COM+ Integration Application"
-        href: how-to-deploy-a-com-integration-application.md
-    - name: Integrating with COM Applications
-      href: integrating-with-com-applications.md
-      items:
-      - name: Integrating with COM Applications Overview
-        href: integrating-with-com-applications-overview.md
-      - name: "How to: Register and Configure a Service Moniker"
-        href: how-to-register-and-configure-a-service-moniker.md
-      - name: "How to: Use the Windows Communication Foundation Service Moniker without Registration"
-        href: use-the-wcf-service-moniker-without-registration.md
-      - name: "How to: Use a Service Moniker with WSDL Contracts"
-        href: how-to-use-a-service-moniker-with-wsdl-contracts.md
-      - name: "How to: Use a Service Moniker with Metadata Exchange Contracts"
-        href: how-to-use-a-service-moniker-with-metadata-exchange-contracts.md
-      - name: "How to: Specify Channel Security Credentials"
-        href: how-to-specify-channel-security-credentials.md
-    - name: Migrating .NET Remoting Applications to WCF
-      href: migrating-net-remoting-applications-to-wcf.md
-    - name: Interoperability with Web Services Enhancements 3.0
-      href: interoperability-with-web-services-enhancements-3-0.md
-      items:
-      - name: "How to: Configure WCF Services to Interoperate with WSE 3.0 Clients"
-        href: how-to-configure-wcf-services-to-interoperate-with-wse-3-0-clients.md
-      - name: "How to: Configure a WCF Client to interoperate with WSE3.0 Services"
-        href: how-to-configure-a-wcf-client-to-interoperate-with-wse3-0-services.md
-    - name: Migrating WSE 3.0 Web Services to WCF
-      href: migrating-wse-3-0-web-services-to-wcf.md
-    - name: Interoperability with ASP.NET Web Services
-      href: interop-with-aspnet-web-services.md
-      items:
-      - name: "How to: Configure WCF Service to Interoperate with ASP.NET Web Service Clients"
-        href: config-wcf-service-with-aspnet-web-service.md
-    - name: Migrating ASP.NET Web Services to WCF
-      href: migrating-aspnet-web-services-to-wcf.md
-      items:
-      - name: Comparing ASP.NET Web Services to WCF Based on Purpose and Standards Used
-        href: comparing-aspnet-web-services-to-wcf-based-on-purpose-and-standards-used.md
-      - name: Comparing ASP.NET Web Services to WCF Based on Development
-        href: comparing-aspnet-web-services-to-wcf-based-on-development.md
-      - name: "Anticipating Adopting the Windows Communication Foundation: Easing Future Integration"
-        href: anticipating-adopting-the-wcf-easing-future-integration.md
-      - name: "Anticipating Adopting the Windows Communication Foundation: Easing Future Migration"
-        href: anticipating-adopting-wcf-migration.md
-      - name: Adopting Windows Communication Foundation
-        href: adopting-wcf.md
-    - name: Interoperability with POX Applications
-      href: interoperability-with-pox-applications.md
-  - name: WCF Web HTTP Programming Model
-    href: wcf-web-http-programming-model.md
+    - name: Security Concepts Used in WCF
+      href: security-concepts-used-in-wcf.md
+    - name: Distributed Application Security
+      href: distributed-application-security.md
+    - name: Security Terminology
+      href: wcf-security-terminology.md
+  - name: Common Security Scenarios
+    href: common-security-scenarios.md
     items:
-    - name: WCF Web HTTP Programming Model Overview
-      href: wcf-web-http-programming-model-overview.md
-    - name: WCF Web HTTP Programming Object Model
-      href: wcf-web-http-programming-object-model.md
-    - name: "How to: Create a Basic WCF Web HTTP Service"
-      href: how-to-create-a-basic-wcf-web-http-service.md
-    - name: "How to: Expose a Contract to SOAP and Web Clients"
-      href: how-to-expose-a-contract-to-soap-and-web-clients.md
-    - name: UriTemplate and UriTemplateTable
-      href: uritemplate-and-uritemplatetable.md
-    - name: "How to: Create a Service That Returns Arbitrary Data Using The WCF Web HTTP Programming Model"
-      href: service-returns-arbitrary-data-using-the-wcf-web.md
-    - name: "How to: Create a Service That Accepts Arbitrary Data using the WCF REST Programming Model"
-      href: create-a-service-arbitrary-data-using-wcf.md
-    - name: Caching Support for WCF Web HTTP Services
-      href: caching-support-for-wcf-web-http-services.md
-    - name: WCF Web HTTP Service Help Page
-      href: wcf-web-http-service-help-page.md
-    - name: WCF Web HTTP Formatting
-      href: wcf-web-http-formatting.md
-    - name: WCF Web HTTP Error Handling
-      href: wcf-web-http-error-handling.md
-    - name: Using JSONP
-      href: using-jsonp.md
-    - name: Calling a REST-style service from a WCF service
-      href: calling-a-rest-style-service-from-a-wcf-service.md
-  - name: WCF Syndication
-    href: wcf-syndication.md
+    - name: Internet Unsecured Client and Service
+      href: internet-unsecured-client-and-service.md
+    - name: Intranet Unsecured Client and Service
+      href: intranet-unsecured-client-and-service.md
+    - name: Transport Security with an Anonymous Client
+      href: transport-security-with-an-anonymous-client.md
+    - name: Transport Security with Basic Authentication
+      href: transport-security-with-basic-authentication.md
+    - name: Transport Security with Windows Authentication
+      href: transport-security-with-windows-authentication.md
+    - name: Transport Security with Certificate Authentication
+      href: transport-security-with-certificate-authentication.md
+    - name: Message Security with an Anonymous Client
+      href: message-security-with-an-anonymous-client.md
+    - name: Message Security with a User Name Client
+      href: message-security-with-a-user-name-client.md
+    - name: Message Security with a Certificate Client
+      href: message-security-with-a-certificate-client.md
+    - name: Message Security with a Windows Client
+      href: message-security-with-a-windows-client.md
+    - name: Message Security with a Windows Client without Credential Negotiation
+      href: message-security-with-a-windows-client-without-credential-negotiation.md
+    - name: Message Security with Mutual Certificates
+      href: message-security-with-mutual-certificates.md
+    - name: Message Security with Issued Tokens
+      href: message-security-with-issued-tokens.md
+    - name: Trusted Subsystem
+      href: trusted-subsystem.md
+  - name: Security Behaviors
+    href: security-behaviors-in-wcf.md
+  - name: Bindings and Security
+    href: bindings-and-security.md
     items:
-    - name: WCF Syndication Overview
-      href: wcf-syndication-overview.md
-    - name: Architecture of Syndication
-      href: architecture-of-syndication.md
-    - name: How the WCF Syndication Object Model Maps to Atom and RSS
-      href: how-the-wcf-syndication-object-model-maps-to-atom-and-rss.md
-    - name: "How to: Create a Basic RSS Feed"
-      href: how-to-create-a-basic-rss-feed.md
-    - name: "How to: Create a Basic Atom Feed"
-      href: how-to-create-a-basic-atom-feed.md
-    - name: "How to: Expose a Feed as Both Atom and RSS"
-      href: how-to-expose-a-feed-as-both-atom-and-rss.md
-    - name: Syndication Extensibility
-      href: syndication-extensibility.md
-  - name: AJAX Integration and JSON Support
-    href: ajax-integration-and-json-support.md
+    - name: Security Capabilities with Custom Bindings
+      href: security-capabilities-with-custom-bindings.md
+      items:
+      - name: SecurityBindingElement Authentication Modes
+        href: securitybindingelement-authentication-modes.md
+      - name: "How to: Create a Custom Binding Using the SecurityBindingElement"
+        href: how-to-create-a-custom-binding-using-the-securitybindingelement.md
+      - name: "How to: Create a SecurityBindingElement for a Specified Authentication Mode"
+        href: how-to-create-a-securitybindingelement-for-a-specified-authentication-mode.md
+      - name: "How to: Disable Secure Sessions on a WSFederationHttpBinding"
+        href: how-to-disable-secure-sessions-on-a-wsfederationhttpbinding.md
+      - name: "How to: Enable Message Replay Detection"
+        href: how-to-enable-message-replay-detection.md
+      - name: "How to: Create a Supporting Credential"
+        href: how-to-create-a-supporting-credential.md
+      - name: "How to: Set Up a Signature Confirmation"
+        href: how-to-set-up-a-signature-confirmation.md
+      - name: "How to: Set a Max Clock Skew"
+        href: how-to-set-a-max-clock-skew.md
+      - name: "How to: Disable Encryption of Digital Signatures"
+        href: how-to-disable-encryption-of-digital-signatures.md
+  - name: Securing Services and Clients
+    href: securing-services-and-clients.md
     items:
-    - name: Creating WCF Services for ASP.NET AJAX
-      href: creating-wcf-services-for-aspnet-ajax.md
+    - name: Programming WCF Security
+      href: programming-wcf-security.md
       items:
-      - name: "How to: Create and Access an AJAX-Enabled WCF Service"
-        href: create-an-ajax-wcf-asp-net-client.md
-      - name: "How to: Add an ASP.NET AJAX Endpoint Without Using Configuration"
-        href: how-to-add-an-aspnet-ajax-endpoint-without-using-configuration.md
-      - name: "How to: Use Configuration to Add an ASP.NET AJAX Endpoint"
-        href: how-to-use-configuration-to-add-an-aspnet-ajax-endpoint.md
-      - name: "How to: Choose between HTTP POST and HTTP GET requests for ASP.NET AJAX Endpoints"
-        href: http-post-and-http-get-requests-for-aspnet-ajax-endpoints.md
-    - name: Creating WCF AJAX Services without ASP.NET
-      href: creating-wcf-ajax-services-without-aspnet.md
-    - name: Support for JSON and Other Data Transfer Formats
-      href: support-for-json-and-other-data-transfer-formats.md
+      - name: Selecting a Credential Type
+        href: selecting-a-credential-type.md
+      - name: "How to: Authenticate with a User Name and Password"
+        href: how-to-authenticate-with-a-user-name-and-password.md
+    - name: Transport Security
+      href: transport-security.md
       items:
-      - name: Stand-Alone JSON Serialization
-        href: stand-alone-json-serialization.md
-      - name: "How to: Serialize and Deserialize JSON Data"
-        href: how-to-serialize-and-deserialize-json-data.md
-      - name: Mapping Between JSON and XML
-        href: mapping-between-json-and-xml.md
-      - name: Serializing in Json with Message Level Programming
-        href: serializing-in-json-with-message-level-programming.md
-    - name: "How to: Migrate AJAX-Enabled ASP.NET Web Services to WCF"
-      href: how-to-migrate-ajax-enabled-aspnet-web-services-to-wcf.md
-  - name: WCF Discovery
-    href: wcf-discovery.md
+      - name: Transport Security Overview
+        href: transport-security-overview.md
+      - name: HTTP Transport Security
+        href: http-transport-security.md
+      - name: Understanding HTTP Authentication
+        href: understanding-http-authentication.md
+      - name: Using Impersonation with Transport Security
+        href: using-impersonation-with-transport-security.md
+      - name: "How to: Configure a Port with an SSL Certificate"
+        href: how-to-configure-a-port-with-an-ssl-certificate.md
+      - name: "How to: Configure an IIS-hosted WCF service with SSL"
+        href: how-to-configure-an-iis-hosted-wcf-service-with-ssl.md
+    - name: Message Security
+      href: message-security-in-wcf.md
+      items:
+      - name: "How to: Secure a Service with an X.509 Certificate"
+        href: how-to-secure-a-service-with-an-x-509-certificate.md
+      - name: "How to: Use Transport Security and Message Credentials"
+        href: how-to-use-transport-security-and-message-credentials.md
+      - name: Preventing Replay Attacks When a WCF Service is Hosted in a Web Farm
+        href: preventing-replay-attacks-when-a-wcf-service-is-hosted-in-a-web-farm.md
+    - name: Secure Sessions
+      href: secure-sessions.md
+      items:
+      - name: Secure Conversations and Secure Sessions
+        href: secure-conversations-and-secure-sessions.md
+      - name: "How to: Create a Secure Session"
+        href: how-to-create-a-secure-session.md
+      - name: "How to: Create a Security Context Token for a Secure Session"
+        href: how-to-create-a-security-context-token-for-a-secure-session.md
+      - name: Security Considerations for Secure Sessions
+        href: security-considerations-for-secure-sessions.md
+    - name: Working with Certificates
+      href: working-with-certificates.md
+      items:
+      - name: "How to: Obtain a Certificate"
+        href: how-to-obtain-a-certificate-wcf.md
+      - name: "How to: View Certificates with the MMC Snap-in"
+        href: how-to-view-certificates-with-the-mmc-snap-in.md
+      - name: "How to: Retrieve the Thumbprint of a Certificate"
+        href: how-to-retrieve-the-thumbprint-of-a-certificate.md
+      - name: "How to: Make X.509 Certificates Accessible to WCF"
+        href: how-to-make-x-509-certificates-accessible-to-wcf.md
+      - name: "How to: Create Temporary Certificates for Use During Development"
+        href: how-to-create-temporary-certificates-for-use-during-development.md
+      - name: "How to: Specify the Certificate Authority Certificate Chain Used to Verify Signatures"
+        href: specify-the-certificate-authority-chain-verify-signatures-wcf.md
+      - name: Certificate Validation Differences Between HTTPS, SSL over TCP, and SOAP Security
+        href: cert-val-diff-https-ssl-over-tcp-and-soap.md
+      - name: "How to: Consistently Reference X.509 Certificates"
+        href: how-to-consistently-reference-x-509-certificates.md
+  - name: Authentication
+    href: authentication-in-wcf.md
     items:
-    - name: WCF Discovery Overview
-      href: wcf-discovery-overview.md
-    - name: WCF Discovery Object Model
-      href: wcf-discovery-object-model.md
-    - name: Discovery Find and FindCriteria
-      href: discovery-find-and-findcriteria.md
-    - name: "How to: Programmatically Add Discoverability to a WCF Service and Client"
-      href: how-to-programmatically-add-discoverability-to-a-wcf-service-and-client.md
-    - name: Implementing a Discovery Proxy
-      href: implementing-a-discovery-proxy.md
-      items:
-      - name: "How to: Implement a Discovery Proxy"
-        href: how-to-implement-a-discovery-proxy.md
-      - name: "How to: Implement a Discoverable Service that Registers with the Discovery Proxy"
-        href: discoverable-service-that-registers-with-the-discovery-proxy.md
-      - name: "How to: Implement a Client Application that Uses the Discovery Proxy to Find a Service"
-        href: client-app-discovery-proxy-to-find-a-service.md
-      - name: "How to: Test the Discovery Proxy"
-        href: how-to-test-the-discovery-proxy.md
-      - name: "How to:Determine the Discovery Version of a Probe Request"
-        href: how-to-determine-the-discovery-version-of-a-probe-request.md
-    - name: Discovery Versioning
-      href: discovery-versioning.md
-    - name: Configuring Discovery in a Configuration File
-      href: configuring-discovery-in-a-configuration-file.md
-    - name: Using the Discovery Client Channel
-      href: using-the-discovery-client-channel.md
-    - name: Using a Custom Binding with the Discovery Client Channel
-      href: using-a-custom-binding-with-the-discovery-client-channel.md
-    - name: Discovery Announcements and Announcement Client
-      href: discovery-announcements-and-announcement-client.md
-    - name: DiscoveryClient and DynamicEndpoint
-      href: discoveryclient-and-dynamicendpoint.md
-  - name: Routing
-    href: routing.md
+    - name: "How to: Use the ASP.NET Membership Provider"
+      href: how-to-use-the-aspnet-membership-provider.md
+    - name: "How to: Use a Custom User Name and Password Validator"
+      href: how-to-use-a-custom-user-name-and-password-validator.md
+    - name: "How to: Use Multiple Security Tokens of the Same Type"
+      href: how-to-use-multiple-security-tokens-of-the-same-type.md
+    - name: Service Identity and Authentication
+      href: service-identity-and-authentication.md
+    - name: Security Negotiation and Timeouts
+      href: security-negotiation-and-timeouts.md
+    - name: Debugging Windows Authentication Errors
+      href: debugging-windows-authentication-errors.md
+    - name: Using Multiple Authentication Schemes with WCF
+      href: using-multiple-authentication-schemes-with-wcf.md
+  - name: Authorization
+    href: authorization-in-wcf.md
     items:
-    - name: Routing Introduction
-      href: routing-introduction.md
-    - name: Routing Service
-      href: routing-service.md
-    - name: Routing Contracts
-      href: routing-contracts.md
-    - name: Message Filters
-      href: message-filters.md
+    - name: Access Control Mechanisms
+      href: access-control-mechanisms.md
+    - name: "How to: Use the ASP.NET Role Provider with a Service"
+      href: how-to-use-the-aspnet-role-provider-with-a-service.md
+    - name: "How to: Use the ASP.NET Authorization Manager Role Provider with a Service"
+      href: how-to-use-the-aspnet-authorization-manager-role-provider-with-a-service.md
+    - name: Managing Claims and Authorization with the Identity Model
+      href: managing-claims-and-authorization-with-the-identity-model.md
       items:
-      - name: Choosing a Filter
-        href: choosing-a-filter.md
-      - name: Custom Filters
-        href: custom-filters.md
-      - name: "How To: Use Filters"
-        href: how-to-use-filters.md
-    - name: Routing Scenarios
-      href: routing-scenarios.md
-      items:
-      - name: "How To: Service Versioning"
-        href: how-to-service-versioning.md
-      - name: "How To: Service Data Partitioning"
-        href: how-to-service-data-partitioning.md
-      - name: "How To: Dynamic Update"
-        href: how-to-dynamic-update.md
-      - name: "How To: Error Handling"
-        href: how-to-error-handling.md
-  - name: WCF and Internationalized Domain Names
-    href: wcf-and-internationalized-domain-names.md
-  - name: WCF and WebSockets
-    href: wcf-and-websockets.md
+      - name: Claims and Tokens
+        href: claims-and-tokens.md
+      - name: Claims and Denying Access to Resources
+        href: claims-and-denying-access-to-resources.md
+      - name: Claim Creation and Resource Values
+        href: claim-creation-and-resource-values.md
+    - name: Delegation and Impersonation
+      href: delegation-and-impersonation-with-wcf.md
+  - name: Federation and Issued Tokens
+    href: federation-and-issued-tokens.md
     items:
-    - name: Using the NetHttpBinding
-      href: using-the-nethttpbinding.md
-    - name: "How to: Create a WCF Service that Communicates over WebSockets"
-      href: how-to-create-a-wcf-service-that-communicates-over-websockets.md
-  - name: Error handling
-    href: error-handling.md
+    - name: Federation
+      href: federation.md
+    - name: Federation and Trust
+      href: federation-and-trust.md
+    - name: "How to: Create a Federated Client"
+      href: how-to-create-a-federated-client.md
+    - name: "How to: Configure Credentials on a Federation Service"
+      href: how-to-configure-credentials-on-a-federation-service.md
+    - name: "How to: Create a WSFederationHttpBinding"
+      href: how-to-create-a-wsfederationhttpbinding.md
+    - name: "How to: Create a Security Token Service"
+      href: how-to-create-a-security-token-service.md
+    - name: Security Assertions Markup Language (SAML) Tokens and Claims
+      href: saml-tokens-and-claims.md
+    - name: "How to: Configure a Local Issuer"
+      href: how-to-configure-a-local-issuer.md
+    - name: "How to: Create a Duplex Federated Binding"
+      href: how-to-create-a-duplex-federated-binding.md
+  - name: Auditing
+    href: auditing-security-events.md
+    items:
+    - name: "How to: Audit Security Events"
+      href: how-to-audit-wcf-security-events.md
+  - name: Security Guidance and Best Practices
+    href: security-guidance-and-best-practices.md
+    items:
+    - name: Best Practices for Security
+      href: best-practices-for-security-in-wcf.md
+    - name: Security Considerations
+      href: security-considerations-in-wcf.md
+      items:
+      - name: Information Disclosure
+        href: information-disclosure.md
+      - name: Elevation of Privilege
+        href: elevation-of-privilege.md
+      - name: Denial of Service
+        href: denial-of-service.md
+      - name: Tampering
+        href: tampering.md
+      - name: Replay Attacks
+        href: replay-attacks.md
+      - name: Unsupported Scenarios
+        href: unsupported-scenarios.md
+    - name: Performance Considerations
+      href: performance-considerations.md
+      items:
+      - name: Finding Claims in a ClaimSet
+        href: finding-claims-in-a-claimset.md
+      - name: Encryption of Digital Signatures
+        href: encryption-of-digital-signatures.md
+  - name: Extended Protection for Authentication Overview
+    href: extended-protection-for-authentication-overview.md
+    items:
+    - name: ReadMe for Extended Protection Authentication Sample
+      href: readme-for-extended-protection-authentication-sample.md
+- name: Peer-to-Peer Networking
+  href: peer-to-peer-networking.md
+  items:
+  - name: Peer Channel Scenarios
+    href: peer-channel-scenarios.md
+  - name: Peer Channel Concepts
+    href: peer-channel-concepts.md
+    items:
+    - name: Peer Meshes
+      href: peer-meshes.md
+    - name: Peer Nodes
+      href: peer-nodes.md
+    - name: Peer Channel Security
+      href: peer-channel-security.md
+    - name: Peer Resolvers
+      href: peer-resolvers.md
+      items:
+      - name: "Inside the CustomPeerResolverService: Client Registrations"
+        href: inside-the-custompeerresolverservice-client-registrations.md
+  - name: Building a Peer Channel Application
+    href: building-a-peer-channel-application.md
+    items:
+    - name: Converting a NetTcpBinding Application to a Peer Channel Application
+      href: converting-a-nettcpbinding-application-to-a-peer-channel-application.md
+    - name: Limiting Message Distribution
+      href: limiting-message-distribution.md
+    - name: Adding Online and Offline Status
+      href: adding-online-and-offline-status.md
+    - name: Securing Peer Channel Applications
+      href: securing-peer-channel-applications.md
+- name: Metadata
+  href: metadata.md
+  items:
+  - name: Metadata Architecture Overview
+    href: metadata-architecture-overview.md
+  - name: Metadata Formats
+    href: metadata-formats.md
+  - name: Exporting and Importing Metadata
+    href: exporting-and-importing-metadata.md
+    items:
+    - name: "How to: Import Metadata into Service Endpoints"
+      href: how-to-import-metadata-into-service-endpoints.md
+    - name: "How to: Export Metadata from Service Endpoints"
+      href: how-to-export-metadata-from-service-endpoints.md
+    - name: ServiceDescription and WSDL Reference
+      href: servicedescription-and-wsdl-reference.md
+    - name: "How to: Use Svcutil.exe to Export Metadata from Compiled Service Code"
+      href: how-to-use-svcutil-exe-to-export-metadata-from-compiled-service-code.md
+  - name: Publishing Metadata
+    href: publishing-metadata.md
+    items:
+    - name: "How to: Publish Metadata for a Service Using a Configuration File"
+      href: how-to-publish-metadata-for-a-service-using-a-configuration-file.md
+    - name: "How to: Publish Metadata for a Service Using Code"
+      href: how-to-publish-metadata-for-a-service-using-code.md
+  - name: Retrieving Metadata
+    href: retrieving-metadata.md
+    items:
+    - name: "How to: Use Svcutil.exe to Download Metadata Documents"
+      href: how-to-use-svcutil-exe-to-download-metadata-documents.md
+    - name: "How to: Use MetadataResolver to Obtain Binding Metadata Dynamically"
+      href: how-to-use-metadataresolver-to-obtain-binding-metadata-dynamically.md
+    - name: "How to: Use MetadataExchangeClient to Retrieve Metadata"
+      href: how-to-use-metadataexchangeclient-to-retrieve-metadata.md
+  - name: Using Metadata
+    href: using-metadata.md
+    items:
+    - name: Understanding Generated Client Code
+      href: understanding-generated-client-code.md
+    - name: "How to: Retrieve Metadata and Implement a Compliant Service"
+      href: how-to-retrieve-metadata-and-implement-a-compliant-service.md
+    - name: Generating a WCF Client from Service Metadata
+      href: generating-a-wcf-client-from-service-metadata.md
+  - name: Security Considerations with Metadata
+    href: security-considerations-with-metadata.md
+    items:
+    - name: "How to: Secure Metadata Endpoints"
+      href: how-to-secure-metadata-endpoints.md
+    - name: "How To: Allow Metadata Requests While Authorizing"
+      href: how-to-allow-metadata-requests-while-authorizing.md
+- name: Clients
+  href: clients.md
+  items:
+  - name: WCF Client Architecture
+    href: client-architecture.md
+  - name: Accessing Services Using a WCF Client
+    href: accessing-services-using-a-client.md
+    items:
+    - name: "How to: Access Services with One-Way and Request-Reply Contracts"
+      href: how-to-access-wcf-services-with-one-way-and-request-reply-contracts.md
+    - name: "How to: Access Services with a Duplex Contract"
+      href: how-to-access-services-with-a-duplex-contract.md
+    - name: "How to: Access a WSE 3.0 Service"
+      href: how-to-access-a-wse-3-0-service-with-a-wcf-client.md
+    - name: "How to: Use the ChannelFactory"
+      href: how-to-use-the-channelfactory.md
+    - name: Channel Factory and Caching
+      href: channel-factory-and-caching.md
+    - name: "How to: Call Service Operations Asynchronously"
+      href: how-to-call-wcf-service-operations-asynchronously.md
+    - name: Middle-Tier Client Applications
+      href: middle-tier-client-applications.md
+    - name: "How to: Call Operations Asynchronously Using a Channel Factory"
+      href: how-to-call-operations-asynchronously-using-a-channel-factory.md
+    - name: Accessing WCF Services with a Windows Store Client App
+      href: accessing-wcf-services-with-a-windows-store-client-app.md
+    - name: "How to: Create a Channel Factory and Use it to Create and Manage Channels"
+      href: how-to-create-a-channel-factory-and-use-it-to-create-and-manage-channels.md
+  - name: WCF Client Configuration
+    href: client-configuration.md
+- name: Hosting
+  href: hosting.md
+  items:
+  - name: Hosting in Internet Information Services
+    href: hosting-in-internet-information-services.md
+    items:
+    - name: Deploying an Internet Information Services-Hosted WCF Service
+      href: deploying-an-internet-information-services-hosted-wcf-service.md
+    - name: WCF Services and ASP.NET
+      href: wcf-services-and-aspnet.md
+    - name: Internet Information Services Hosting Best Practices
+      href: internet-information-services-hosting-best-practices.md
+    - name: "How to: Host a WCF Service in IIS"
+      href: how-to-host-a-wcf-service-in-iis.md
+    - name: Configuring Internet Information Services 7.0 for Windows Communication Foundation
+      href: configuring-iis-for-wcf.md
+  - name: Hosting in Windows Process Activation Service
+    href: hosting-in-windows-process-activation-service.md
+    items:
+    - name: WAS Activation Architecture
+      href: was-activation-architecture.md
+    - name: Configuring WAS for Use with WCF
+      href: configuring-the-wpa--service-for-use-with-wcf.md
+    - name: "How to: Install and Configure WCF Activation Components"
+      href: how-to-install-and-configure-wcf-activation-components.md
+    - name: "How to: Host a WCF Service in WAS"
+      href: how-to-host-a-wcf-service-in-was.md
+  - name: Hosting in a Windows Service Application
+    href: hosting-in-a-windows-service-application.md
+    items:
+    - name: "How to: Host a WCF Service in a Managed Windows Service"
+      href: how-to-host-a-wcf-service-in-a-managed-windows-service.md
+  - name: Hosting in a Managed Application
+    href: hosting-in-a-managed-application.md
+  - name: Configuration-Based Activation in IIS and WAS
+    href: configuration-based-activation-in-iis-and-was.md
+  - name: Supporting Multiple IIS Site Bindings
+    href: supporting-multiple-iis-site-bindings.md
+  - name: System.Web.Routing Integration
+    href: system-web-routing-integration.md
+- name: Partial Trust
+  href: partial-trust.md
+  items:
+  - name: Supported Deployment Scenarios
+    href: supported-deployment-scenarios.md
+  - name: Partial Trust Feature Compatibility
+    href: partial-trust-feature-compatibility.md
+  - name: Partial Trust Best Practices
+    href: partial-trust-best-practices.md
+- name: Interoperability and Integration
+  href: interoperability-and-integration.md
+  items:
+  - name: Web Services Protocols Interoperability Guide
+    href: web-services-protocols-interoperability-guide.md
+    items:
+    - name: Web Services Protocols Supported by System-Provided Interoperability Bindings
+      href: web-services-protocols-supported-by-system-provided-interoperability-bindings.md
+    - name: Messaging Protocols
+      href: messaging-protocols.md
+    - name: Data Contract Schema Reference
+      href: data-contract-schema-reference.md
+    - name: WSDL and Policy
+      href: wsdl-and-policy.md
+    - name: Security Protocols version 1.0
+      href: security-protocols-version-1-0.md
+    - name: Security Protocols
+      href: security-protocols.md
+    - name: Reliable Messaging Protocol version 1.0
+      href: reliable-messaging-protocol-version-1-0.md
+    - name: Reliable Messaging Protocol version 1.1
+      href: reliable-messaging-protocol-version-1-1.md
+    - name: Transaction Protocols version 1.0
+      href: transaction-protocols-version-1-0.md
+    - name: Transaction Protocols
+      href: transaction-protocols.md
+    - name: Context Exchange Protocol
+      href: context-exchange-protocol.md
+    - name: Mixing Trust Protocols in Federated Scenarios
+      href: mixing-trust-protocols-in-federated-scenarios.md
+  - name: Integrating with COM+ Applications
+    href: integrating-with-com-plus-applications.md
+    items:
+    - name: Integrating with COM+ Applications Overview
+      href: integrating-with-com-plus-applications-overview.md
+    - name: "How to: Use the COM+ Service Model Configuration Tool"
+      href: how-to-use-the-com-service-model-configuration-tool.md
+    - name: "How to: Configure COM+ Service Settings"
+      href: how-to-configure-com-service-settings.md
+    - name: "How to: Deploy a COM+ Integration Application"
+      href: how-to-deploy-a-com-integration-application.md
+  - name: Integrating with COM Applications
+    href: integrating-with-com-applications.md
+    items:
+    - name: Integrating with COM Applications Overview
+      href: integrating-with-com-applications-overview.md
+    - name: "How to: Register and Configure a Service Moniker"
+      href: how-to-register-and-configure-a-service-moniker.md
+    - name: "How to: Use the Windows Communication Foundation Service Moniker without Registration"
+      href: use-the-wcf-service-moniker-without-registration.md
+    - name: "How to: Use a Service Moniker with WSDL Contracts"
+      href: how-to-use-a-service-moniker-with-wsdl-contracts.md
+    - name: "How to: Use a Service Moniker with Metadata Exchange Contracts"
+      href: how-to-use-a-service-moniker-with-metadata-exchange-contracts.md
+    - name: "How to: Specify Channel Security Credentials"
+      href: how-to-specify-channel-security-credentials.md
+  - name: Migrating .NET Remoting Applications to WCF
+    href: migrating-net-remoting-applications-to-wcf.md
+  - name: Interoperability with Web Services Enhancements 3.0
+    href: interoperability-with-web-services-enhancements-3-0.md
+    items:
+    - name: "How to: Configure WCF Services to Interoperate with WSE 3.0 Clients"
+      href: how-to-configure-wcf-services-to-interoperate-with-wse-3-0-clients.md
+    - name: "How to: Configure a WCF Client to interoperate with WSE3.0 Services"
+      href: how-to-configure-a-wcf-client-to-interoperate-with-wse3-0-services.md
+  - name: Migrating WSE 3.0 Web Services to WCF
+    href: migrating-wse-3-0-web-services-to-wcf.md
+  - name: Interoperability with ASP.NET Web Services
+    href: interop-with-aspnet-web-services.md
+    items:
+    - name: "How to: Configure WCF Service to Interoperate with ASP.NET Web Service Clients"
+      href: config-wcf-service-with-aspnet-web-service.md
+  - name: Migrating ASP.NET Web Services to WCF
+    href: migrating-aspnet-web-services-to-wcf.md
+    items:
+    - name: Comparing ASP.NET Web Services to WCF Based on Purpose and Standards Used
+      href: comparing-aspnet-web-services-to-wcf-based-on-purpose-and-standards-used.md
+    - name: Comparing ASP.NET Web Services to WCF Based on Development
+      href: comparing-aspnet-web-services-to-wcf-based-on-development.md
+    - name: "Anticipating Adopting the Windows Communication Foundation: Easing Future Integration"
+      href: anticipating-adopting-the-wcf-easing-future-integration.md
+    - name: "Anticipating Adopting the Windows Communication Foundation: Easing Future Migration"
+      href: anticipating-adopting-wcf-migration.md
+    - name: Adopting Windows Communication Foundation
+      href: adopting-wcf.md
+  - name: Interoperability with POX Applications
+    href: interoperability-with-pox-applications.md
+- name: WCF Web HTTP Programming Model
+  href: wcf-web-http-programming-model.md
+  items:
+  - name: WCF Web HTTP Programming Model Overview
+    href: wcf-web-http-programming-model-overview.md
+  - name: WCF Web HTTP Programming Object Model
+    href: wcf-web-http-programming-object-model.md
+  - name: "How to: Create a Basic WCF Web HTTP Service"
+    href: how-to-create-a-basic-wcf-web-http-service.md
+  - name: "How to: Expose a Contract to SOAP and Web Clients"
+    href: how-to-expose-a-contract-to-soap-and-web-clients.md
+  - name: UriTemplate and UriTemplateTable
+    href: uritemplate-and-uritemplatetable.md
+  - name: "How to: Create a Service That Returns Arbitrary Data Using The WCF Web HTTP Programming Model"
+    href: service-returns-arbitrary-data-using-the-wcf-web.md
+  - name: "How to: Create a Service That Accepts Arbitrary Data using the WCF REST Programming Model"
+    href: create-a-service-arbitrary-data-using-wcf.md
+  - name: Caching Support for WCF Web HTTP Services
+    href: caching-support-for-wcf-web-http-services.md
+  - name: WCF Web HTTP Service Help Page
+    href: wcf-web-http-service-help-page.md
+  - name: WCF Web HTTP Formatting
+    href: wcf-web-http-formatting.md
+  - name: WCF Web HTTP Error Handling
+    href: wcf-web-http-error-handling.md
+  - name: Using JSONP
+    href: using-jsonp.md
+  - name: Calling a REST-style service from a WCF service
+    href: calling-a-rest-style-service-from-a-wcf-service.md
+- name: WCF Syndication
+  href: wcf-syndication.md
+  items:
+  - name: WCF Syndication Overview
+    href: wcf-syndication-overview.md
+  - name: Architecture of Syndication
+    href: architecture-of-syndication.md
+  - name: How the WCF Syndication Object Model Maps to Atom and RSS
+    href: how-the-wcf-syndication-object-model-maps-to-atom-and-rss.md
+  - name: "How to: Create a Basic RSS Feed"
+    href: how-to-create-a-basic-rss-feed.md
+  - name: "How to: Create a Basic Atom Feed"
+    href: how-to-create-a-basic-atom-feed.md
+  - name: "How to: Expose a Feed as Both Atom and RSS"
+    href: how-to-expose-a-feed-as-both-atom-and-rss.md
+  - name: Syndication Extensibility
+    href: syndication-extensibility.md
+- name: AJAX Integration and JSON Support
+  href: ajax-integration-and-json-support.md
+  items:
+  - name: Creating WCF Services for ASP.NET AJAX
+    href: creating-wcf-services-for-aspnet-ajax.md
+    items:
+    - name: "How to: Create and Access an AJAX-Enabled WCF Service"
+      href: create-an-ajax-wcf-asp-net-client.md
+    - name: "How to: Add an ASP.NET AJAX Endpoint Without Using Configuration"
+      href: how-to-add-an-aspnet-ajax-endpoint-without-using-configuration.md
+    - name: "How to: Use Configuration to Add an ASP.NET AJAX Endpoint"
+      href: how-to-use-configuration-to-add-an-aspnet-ajax-endpoint.md
+    - name: "How to: Choose between HTTP POST and HTTP GET requests for ASP.NET AJAX Endpoints"
+      href: http-post-and-http-get-requests-for-aspnet-ajax-endpoints.md
+  - name: Creating WCF AJAX Services without ASP.NET
+    href: creating-wcf-ajax-services-without-aspnet.md
+  - name: Support for JSON and Other Data Transfer Formats
+    href: support-for-json-and-other-data-transfer-formats.md
+    items:
+    - name: Stand-Alone JSON Serialization
+      href: stand-alone-json-serialization.md
+    - name: "How to: Serialize and Deserialize JSON Data"
+      href: how-to-serialize-and-deserialize-json-data.md
+    - name: Mapping Between JSON and XML
+      href: mapping-between-json-and-xml.md
+    - name: Serializing in Json with Message Level Programming
+      href: serializing-in-json-with-message-level-programming.md
+  - name: "How to: Migrate AJAX-Enabled ASP.NET Web Services to WCF"
+    href: how-to-migrate-ajax-enabled-aspnet-web-services-to-wcf.md
+- name: WCF Discovery
+  href: wcf-discovery.md
+  items:
+  - name: WCF Discovery Overview
+    href: wcf-discovery-overview.md
+  - name: WCF Discovery Object Model
+    href: wcf-discovery-object-model.md
+  - name: Discovery Find and FindCriteria
+    href: discovery-find-and-findcriteria.md
+  - name: "How to: Programmatically Add Discoverability to a WCF Service and Client"
+    href: how-to-programmatically-add-discoverability-to-a-wcf-service-and-client.md
+  - name: Implementing a Discovery Proxy
+    href: implementing-a-discovery-proxy.md
+    items:
+    - name: "How to: Implement a Discovery Proxy"
+      href: how-to-implement-a-discovery-proxy.md
+    - name: "How to: Implement a Discoverable Service that Registers with the Discovery Proxy"
+      href: discoverable-service-that-registers-with-the-discovery-proxy.md
+    - name: "How to: Implement a Client Application that Uses the Discovery Proxy to Find a Service"
+      href: client-app-discovery-proxy-to-find-a-service.md
+    - name: "How to: Test the Discovery Proxy"
+      href: how-to-test-the-discovery-proxy.md
+    - name: "How to:Determine the Discovery Version of a Probe Request"
+      href: how-to-determine-the-discovery-version-of-a-probe-request.md
+  - name: Discovery Versioning
+    href: discovery-versioning.md
+  - name: Configuring Discovery in a Configuration File
+    href: configuring-discovery-in-a-configuration-file.md
+  - name: Using the Discovery Client Channel
+    href: using-the-discovery-client-channel.md
+  - name: Using a Custom Binding with the Discovery Client Channel
+    href: using-a-custom-binding-with-the-discovery-client-channel.md
+  - name: Discovery Announcements and Announcement Client
+    href: discovery-announcements-and-announcement-client.md
+  - name: DiscoveryClient and DynamicEndpoint
+    href: discoveryclient-and-dynamicendpoint.md
+- name: Routing
+  href: routing.md
+  items:
+  - name: Routing Introduction
+    href: routing-introduction.md
+  - name: Routing Service
+    href: routing-service.md
+  - name: Routing Contracts
+    href: routing-contracts.md
+  - name: Message Filters
+    href: message-filters.md
+    items:
+    - name: Choosing a Filter
+      href: choosing-a-filter.md
+    - name: Custom Filters
+      href: custom-filters.md
+    - name: "How To: Use Filters"
+      href: how-to-use-filters.md
+  - name: Routing Scenarios
+    href: routing-scenarios.md
+    items:
+    - name: "How To: Service Versioning"
+      href: how-to-service-versioning.md
+    - name: "How To: Service Data Partitioning"
+      href: how-to-service-data-partitioning.md
+    - name: "How To: Dynamic Update"
+      href: how-to-dynamic-update.md
+    - name: "How To: Error Handling"
+      href: how-to-error-handling.md
+- name: WCF and Internationalized Domain Names
+  href: wcf-and-internationalized-domain-names.md
+- name: WCF and WebSockets
+  href: wcf-and-websockets.md
+  items:
+  - name: Using the NetHttpBinding
+    href: using-the-nethttpbinding.md
+  - name: "How to: Create a WCF Service that Communicates over WebSockets"
+    href: how-to-create-a-wcf-service-that-communicates-over-websockets.md
+- name: Error handling
+  href: error-handling.md

--- a/docs/framework/wcf/samples/toc.yml
+++ b/docs/framework/wcf/samples/toc.yml
@@ -1,516 +1,515 @@
 items:
 - name: Windows Communication Foundation Samples
   href: index.md
+- name: Set-Up Instructions
   items:
-  - name: Set-Up Instructions
+  - name: One-Time Setup Procedure for the Windows Communication Foundation Samples
+    href: one-time-setup-procedure-for-the-wcf-samples.md
     items:
-    - name: One-Time Setup Procedure for the Windows Communication Foundation Samples
-      href: one-time-setup-procedure-for-the-wcf-samples.md
-      items:
-      - name: Firewall Instructions
-        href: firewall-instructions.md
-      - name: Internet Information Service Hosting Instructions
-        href: internet-information-service-hosting-instructions.md
-      - name: Internet Information Services (IIS) Server Certificate Installation Instructions
-        href: iis-server-certificate-installation-instructions.md
-      - name: Virtual Directory Setup Instructions
-        href: virtual-directory-setup-instructions.md
-      - name: Installing Message Queuing (MSMQ)
-        href: installing-message-queuing-msmq.md
-    - name: Building the Windows Communication Foundation Samples
-      href: building-the-samples.md
-    - name: Running the Windows Communication Foundation Samples
-      href: running-the-samples.md
-  - name: Basic
-    href: basic.md
+    - name: Firewall Instructions
+      href: firewall-instructions.md
+    - name: Internet Information Service Hosting Instructions
+      href: internet-information-service-hosting-instructions.md
+    - name: Internet Information Services (IIS) Server Certificate Installation Instructions
+      href: iis-server-certificate-installation-instructions.md
+    - name: Virtual Directory Setup Instructions
+      href: virtual-directory-setup-instructions.md
+    - name: Installing Message Queuing (MSMQ)
+      href: installing-message-queuing-msmq.md
+  - name: Building the Windows Communication Foundation Samples
+    href: building-the-samples.md
+  - name: Running the Windows Communication Foundation Samples
+    href: running-the-samples.md
+- name: Basic
+  href: basic.md
+  items:
+  - name: Getting Started
+    href: getting-started-sample.md
+  - name: AJAX
+    href: ajax.md
     items:
-    - name: Getting Started
-      href: getting-started-sample.md
-    - name: AJAX
-      href: ajax.md
-      items:
-      - name: JSONP
-        href: jsonp.md
-      - name: JSON Serialization
-        href: json-serialization.md
-      - name: Basic AJAX Service
-        href: basic-ajax-service.md
-      - name: AJAX Service Using HTTP POST
-        href: ajax-service-using-http-post.md
-      - name: AJAX Service Without Configuration
-        href: ajax-service-without-configuration.md
-      - name: AJAX Service Using Complex Types
-        href: ajax-service-using-complex-types-sample.md
-      - name: AJAX Service with JSON and XML
-        href: ajax-service-with-json-and-xml-sample.md
-    - name: Binding
-      href: binding.md
-      items:
-      - name: Basic Binding
-        href: basic-binding.md
-        items:
-        - name: Message Security Sample
-          href: message-security-sample.md
-        - name: BasicBinding with Transport Security
-          href: basicbinding-with-transport-security.md
-        - name: BasicBinding
-          href: basicbinding.md
-      - name: Custom Binding
-        href: custom-binding.md
-        items:
-        - name: Custom Binding Imperative
-          href: custom-binding-imperative.md
-        - name: Custom Binding Transport and Encoding
-          href: custom-binding-transport-and-encoding.md
-        - name: Custom Binding Reliable Session
-          href: custom-binding-reliable-session.md
-        - name: Custom Binding Reliable Session over HTTPS
-          href: custom-binding-reliable-session-over-https.md
-        - name: Custom Binding Security
-          href: custom-binding-security.md
-      - name: Net Binding
-        href: net-binding.md
-        items:
-        - name: Net MSMQ Binding
-          href: net-msmq-binding.md
-          items:
-          - name: Transacted MSMQ Binding
-            href: transacted-msmq-binding.md
-          - name: Volatile Queued Communication
-            href: volatile-queued-communication.md
-          - name: Dead Letter Queues
-            href: dead-letter-queues.md
-          - name: Poison Message Handling in MSMQ 4.0
-            href: poison-message-handling-in-msmq-4-0.md
-          - name: Sessions and Queues
-            href: sessions-and-queues.md
-          - name: Two-Way Communication
-            href: two-way-communication.md
-          - name: SRMP
-            href: srmp.md
-          - name: Message Security over Message Queuing
-            href: message-security-over-message-queuing.md
-        - name: Message Queueing Integration
-          href: message-queueing-integration.md
-          items:
-          - name: Message Queuing to Windows Communication Foundation
-            href: message-queuing-to-wcf.md
-          - name: Windows Communication Foundation to Message Queuing
-            href: wcf-to-message-queuing.md
-          - name: Message Correlation
-            href: message-correlation.md
-        - name: NetTCPBinding
-          href: nettcpbinding.md
-          items:
-          - name: Default NetTcpBinding
-            href: default-nettcpbinding.md
-          - name: Net.TCP Port Sharing Sample
-            href: net-tcp-port-sharing-sample.md
-        - name: NetNamedPipeBinding
-          href: netnamedpipebinding.md
-      - name: WS Binding
-        href: ws-binding.md
-        items:
-        - name: WS 2007 Federation HTTP Binding
-          href: ws-2007-federation-http-binding.md
-        - name: WS Dual Http
-          href: ws-dual-http.md
-        - name: MTOM Encoding
-          href: mtom-encoding.md
-        - name: WSHttpBinding
-          href: wshttpbinding.md
-        - name: WS Reliable Session
-          href: ws-reliable-session.md
-        - name: WS Transport Security
-          href: ws-transport-security.md
-        - name: Message Security Binding
-          href: message-security-binding.md
-          items:
-          - name: Message Security Anonymous
-            href: message-security-anonymous.md
-          - name: Message Security Certificate
-            href: message-security-certificate.md
-          - name: Message Security User Name
-            href: message-security-user-name.md
-          - name: Message Security Windows
-            href: message-security-windows.md
-        - name: WS Transport With Message Credential
-          href: ws-transport-with-message-credential.md
-        - name: WS Transaction Flow
-          href: ws-transaction-flow.md
-    - name: Client
-      href: client.md
-      items:
-      - name: Client Interoperability
-        href: client-interoperability.md
-        items:
-        - name: Interoperating with ASMX Web Services
-          href: interoperating-with-asmx-web-services.md
-        - name: XMLSerializer Sample
-          href: xmlserializer-sample.md
-      - name: Address Headers
-        href: address-headers.md
-      - name: Channel Factory
-        href: channel-factory.md
-      - name: Expected Exceptions
-        href: expected-exceptions.md
-      - name: Retrieve Metadata
-        href: retrieve-metadata.md
-      - name: Use Close and Abort to release WCF client resources
-        href: use-close-abort-release-wcf-client-resources.md
-      - name: Typed Client
-        href: typed-client.md
-    - name: Contract
-      href: contract.md
-      items:
-      - name: Data Contracts
-        href: data-contracts.md
-        items:
-        - name: Basic Data Contract
-          href: basic-data-contract.md
-        - name: DataContractSerializer Sample
-          href: datacontractserializer-sample.md
-        - name: Known Types
-          href: known-types.md
-        - name: Object References
-          href: object-references.md
-        - name: POCO Support
-          href: poco-support.md
-      - name: Message Contracts
-        href: message-contracts.md
-        items:
-        - name: Default Message Contract
-          href: default-message-contract.md
-        - name: Untyped Request/Reply
-          href: untyped-request-reply.md
-        - name: Unwrapped Messages
-          href: unwrapped-messages.md
-        - name: Setting the Use and Style Properties
-          href: setting-the-use-and-style-properties.md
-        - name: XmlReader Sample
-          href: xmlreader-sample.md
-      - name: Service Contracts
-        href: service-contracts.md
-        items:
-        - name: Duplex
-          href: duplex.md
-        - name: Fault Contract
-          href: fault-contract.md
-        - name: One-Way
-          href: one-way.md
-        - name: Session
-          href: session.md
-        - name: Stream
-          href: stream.md
-        - name: XmlSerializer Faults
-          href: xmlserializer-faults.md
-      - name: DataContractResolver
-        href: datacontractresolver.md
-      - name: KnownAssemblyAttribute
-        href: knownassemblyattribute.md
-      - name: Using DataContractSerializer and DataContractResolver to Provide the Functionality of NetDataContractSerializer
-        href: datacontractserializer-datacontractresolver-netdatacontractserializer.md
-    - name: Discovery
-      href: discovery-samples.md
-      items:
-      - name: Announcements
-        href: announcements-sample.md
-      - name: Basic
-        href: basic-sample.md
-      - name: Configuration
-        href: configuration-sample.md
-      - name: Discovery with Scopes
-        href: discovery-with-scopes-sample.md
-      - name: Custom Find Criteria
-        href: custom-find-criteria.md
-      - name: Workflow Discovery Sample
-        href: workflow-discovery-sample.md
-      - name: Discovery Router Service
-        href: discovery-router-service.md
-    - name: Management
-      href: management.md
-      items:
-      - name: WCF Services and Event Tracing for Windows
-        href: wcf-services-and-event-tracing-for-windows.md
-      - name: WCF Analytic Tracing
-        href: wcf-analytic-tracing.md
-      - name: Circular Tracing
-        href: circular-tracing.md
-      - name: ETW Tracing
-        href: etw-tracing.md
-      - name: Extending Tracing
-        href: extending-tracing.md
-      - name: PII Security Lockdown
-        href: pii-security-lockdown.md
-      - name: Using Performance Counters
-        href: using-performance-counters.md
-      - name: Tracing and Message Logging
-        href: tracing-and-message-logging.md
-      - name: Security Validation
-        href: security-validation.md
-      - name: WMI Provider
-        href: wmi-provider.md
-    - name: Routing Services
-      href: routing-services.md
-      items:
-      - name: Hello World with the Routing Service
-        href: hello-world-with-the-routing-service.md
-    - name: Security
-      href: security-in-wcf.md
-      items:
-      - name: Cryptographic Agility in WCF Security
-        href: cryptographic-agility-in-wcf-security.md
-    - name: Services
-      href: services.md
-      items:
-      - name: Hosting
-        href: hosting.md
-        items:
-        - name: Windows Process Activation
-          href: windows-process-activation.md
-          items:
-          - name: NamedPipe Activation
-            href: namedpipe-activation.md
-          - name: TCP Activation
-            href: tcp-activation.md
-          - name: MSMQ Activation
-            href: msmq-activation.md
-        - name: SystemWebRouting Integration Sample
-          href: systemwebrouting-integration-sample.md
-        - name: ASP.NET Compatibility
-          href: aspnet-compatibility.md
-        - name: IIS Hosting Using Inline Code
-          href: iis-hosting-using-inline-code.md
-        - name: Windows Service Host
-          href: windows-service-host.md
-        - name: Self-Host
-          href: self-host.md
-      - name: Service Interoperability
-        href: service-interoperability.md
-        items:
-        - name: Using the WCF Moniker with COM Clients
-          href: using-the-wcf-moniker-with-com-clients.md
-        - name: ASMX Client with a WCF Service
-          href: asmx-client-with-a-wcf-service.md
-      - name: Behaviors
-        href: behaviors.md
-        items:
-        - name: Concurrency
-          href: concurrency.md
-        - name: Default Service Behavior
-          href: default-service-behavior.md
-        - name: Instancing
-          href: instancing.md
-        - name: Metadata Publishing Behavior
-          href: metadata-publishing-behavior.md
-        - name: Service Transaction Behavior
-          href: service-transaction-behavior.md
-        - name: Service Debug Behavior
-          href: service-debug-behavior.md
-        - name: Throttling
-          href: throttling.md
-        - name: Behavior Security
-          href: behavior-security.md
-          items:
-          - name: Service Auditing Behavior
-            href: service-auditing-behavior.md
-          - name: Membership and Role Provider
-            href: membership-and-role-provider.md
-          - name: Authorizing Access to Service Operations
-            href: authorizing-access-to-service-operations.md
-          - name: Impersonating the Client
-            href: impersonating-the-client.md
-      - name: Simplified Configuration for WCF Services
-        href: simplified-configuration-for-wcf-services.md
-      - name: Usage of Standard Endpoints
-        href: usage-of-standard-endpoints.md
-      - name: Extended Protection Policy
-        href: extended-protection-policy.md
-      - name: Configuration Channel Factory
-        href: configuration-channel-factory.md
-      - name: Addressing
-        href: addressing.md
-      - name: Imperative
-        href: imperative.md
-      - name: Multiple Contracts
-        href: multiple-contracts.md
-      - name: Multiple Endpoints
-        href: multiple-endpoints.md
-      - name: Multiple Endpoints at a Single ListenUri
-        href: multiple-endpoints-at-a-single-listenuri.md
-      - name: OperationContextScope
-        href: operationcontextscope.md
-      - name: Service Description
-        href: service-description.md
-      - name: ConcurrencyMode.Reentrant
-        href: concurrencymode-reentrant.md
-      - name: Service Security
-        href: service-security.md
-        items:
-        - name: Service Identity Sample
-          href: service-identity-sample.md
-    - name: Syndication
-      href: syndication.md
-      items:
-      - name: Stand-Alone Diagnostics Feed
-        href: stand-alone-diagnostics-feed-sample.md
-      - name: Loosely-Typed Extensions
-        href: loosely-typed-extensions-sample.md
-    - name: Web
-      href: web.md
-      items:
-      - name: Basic HTTP Service
-        href: basic-http-service.md
-      - name: SOAP and HTTP Endpoints
-        href: soap-and-http-endpoints.md
-      - name: ASP.NET Caching Integration
-        href: aspnet-caching-integration.md
-      - name: UriTemplate
-        href: uritemplate-sample.md
-      - name: UriTemplate Table
-        href: uritemplate-table-sample.md
-      - name: UriTemplate Table Dispatcher
-        href: uritemplate-table-dispatcher-sample.md
-  - name: Extensibility
-    href: extensibility.md
+    - name: JSONP
+      href: jsonp.md
+    - name: JSON Serialization
+      href: json-serialization.md
+    - name: Basic AJAX Service
+      href: basic-ajax-service.md
+    - name: AJAX Service Using HTTP POST
+      href: ajax-service-using-http-post.md
+    - name: AJAX Service Without Configuration
+      href: ajax-service-without-configuration.md
+    - name: AJAX Service Using Complex Types
+      href: ajax-service-using-complex-types-sample.md
+    - name: AJAX Service with JSON and XML
+      href: ajax-service-with-json-and-xml-sample.md
+  - name: Binding
+    href: binding.md
     items:
-    - name: Binding Extensibility
-      href: binding-extensibility.md
+    - name: Basic Binding
+      href: basic-binding.md
       items:
-      - name: WSStreamedHttpBinding
-        href: wsstreamedhttpbinding.md
-    - name: Channels Extensibility
-      href: channels-extensibility.md
+      - name: Message Security Sample
+        href: message-security-sample.md
+      - name: BasicBinding with Transport Security
+        href: basicbinding-with-transport-security.md
+      - name: BasicBinding
+        href: basicbinding.md
+    - name: Custom Binding
+      href: custom-binding.md
       items:
-      - name: Local Channel
-        href: local-channel.md
-      - name: Reliable Secure Profile
-        href: reliable-secure-profile.md
-      - name: Custom Channel Dispatcher
-        href: custom-channel-dispatcher.md
-      - name: Chunking Channel
-        href: chunking-channel.md
-      - name: HttpCookieSession
-        href: httpcookiesession.md
-      - name: Custom Message Interceptor
-        href: custom-message-interceptor.md
-    - name: Instancing Extensibility
-      href: instancing-extensibility.md
+      - name: Custom Binding Imperative
+        href: custom-binding-imperative.md
+      - name: Custom Binding Transport and Encoding
+        href: custom-binding-transport-and-encoding.md
+      - name: Custom Binding Reliable Session
+        href: custom-binding-reliable-session.md
+      - name: Custom Binding Reliable Session over HTTPS
+        href: custom-binding-reliable-session-over-https.md
+      - name: Custom Binding Security
+        href: custom-binding-security.md
+    - name: Net Binding
+      href: net-binding.md
       items:
-      - name: Durable Instance Context
-        href: durable-instance-context.md
-      - name: Custom Lifetime
-        href: custom-lifetime.md
-      - name: Instancing Initialization
-        href: instancing-initialization.md
-      - name: Pooling
-        href: pooling.md
-    - name: Interop Extensibility
-      href: interop-extensibility.md
+      - name: Net MSMQ Binding
+        href: net-msmq-binding.md
+        items:
+        - name: Transacted MSMQ Binding
+          href: transacted-msmq-binding.md
+        - name: Volatile Queued Communication
+          href: volatile-queued-communication.md
+        - name: Dead Letter Queues
+          href: dead-letter-queues.md
+        - name: Poison Message Handling in MSMQ 4.0
+          href: poison-message-handling-in-msmq-4-0.md
+        - name: Sessions and Queues
+          href: sessions-and-queues.md
+        - name: Two-Way Communication
+          href: two-way-communication.md
+        - name: SRMP
+          href: srmp.md
+        - name: Message Security over Message Queuing
+          href: message-security-over-message-queuing.md
+      - name: Message Queueing Integration
+        href: message-queueing-integration.md
+        items:
+        - name: Message Queuing to Windows Communication Foundation
+          href: message-queuing-to-wcf.md
+        - name: Windows Communication Foundation to Message Queuing
+          href: wcf-to-message-queuing.md
+        - name: Message Correlation
+          href: message-correlation.md
+      - name: NetTCPBinding
+        href: nettcpbinding.md
+        items:
+        - name: Default NetTcpBinding
+          href: default-nettcpbinding.md
+        - name: Net.TCP Port Sharing Sample
+          href: net-tcp-port-sharing-sample.md
+      - name: NetNamedPipeBinding
+        href: netnamedpipebinding.md
+    - name: WS Binding
+      href: ws-binding.md
       items:
-      - name: Dispatch by Body Element
-        href: dispatch-by-body-element.md
-      - name: Route by Body
-        href: route-by-body.md
-    - name: Message Encoder Extensibility
-      href: message-encoder-extensibility.md
-      items:
-      - name: "Custom Message Encoder: Custom Text Encoder"
-        href: custom-message-encoder-custom-text-encoder.md
-      - name: "Custom Message Encoder: Compression Encoder"
-        href: custom-message-encoder-compression-encoder.md
-    - name: Metadata Extensibility
-      href: metadata-extensibility.md
-      items:
-      - name: Custom Secure Metadata Endpoint
-        href: custom-secure-metadata-endpoint.md
-      - name: Custom WSDL Publication
-        href: custom-wsdl-publication.md
-    - name: Security Extensibility
-      href: security-extensibility.md
-      items:
-      - name: Durable Issued Token Provider
-        href: durable-issued-token-provider.md
-      - name: SAML Token Provider
-        href: saml-token-provider.md
-      - name: Supporting Tokens
-        href: supporting-tokens.md
-      - name: Token Authenticator
-        href: token-authenticator.md
-      - name: Token Provider
-        href: token-provider.md
-      - name: User Name Password Validator
-        href: user-name-password-validator.md
-      - name: X.509 Certificate Validator
-        href: x-509-certificate-validator.md
-      - name: Authorization Policy
-        href: authorization-policy.md
-      - name: Custom Token
-        href: custom-token.md
-      - name: Client Validation
-        href: client-validation.md
-    - name: Syndication Extensibility Samples
-      href: syndication-extensibility-samples.md
-      items:
-      - name: Strongly Typed Extensions
-        href: strongly-typed-extensions-sample.md
-      - name: Feed Formatter (JSON)
-        href: feed-formatter-json.md
-      - name: Streaming Feeds
-        href: streaming-feeds-sample.md
-    - name: Transport Extensibility
-      href: transport-extensibility.md
-      items:
-      - name: UDP Activation
-        href: udp-activation.md
-      - name: "Transport: Custom Transactions over UDP"
-        href: transport-custom-transactions-over-udp-sample.md
-      - name: "Transport: UDP"
-        href: transport-udp.md
-      - name: "Transport: WSE 3.0 TCP Interoperability"
-        href: transport-wse-3-0-tcp-interoperability.md
-    - name: Operation Formatter and Operation Selector
-      href: operation-formatter-and-operation-selector.md
-    - name: Custom Message Filter
-      href: custom-message-filter.md
-    - name: Custom Service Host
-      href: custom-service-host.md
-    - name: DataContract Surrogate
-      href: datacontract-surrogate.md
-    - name: Extending Control Over Error Handling and Reporting
-      href: extending-control-over-error-handling-and-reporting.md
-    - name: Message Inspectors
-      href: message-inspectors.md
-    - name: WebContentTypeMapper
-      href: webcontenttypemapper-sample.md
-  - name: Scenario
-    href: scenario.md
+      - name: WS 2007 Federation HTTP Binding
+        href: ws-2007-federation-http-binding.md
+      - name: WS Dual Http
+        href: ws-dual-http.md
+      - name: MTOM Encoding
+        href: mtom-encoding.md
+      - name: WSHttpBinding
+        href: wshttpbinding.md
+      - name: WS Reliable Session
+        href: ws-reliable-session.md
+      - name: WS Transport Security
+        href: ws-transport-security.md
+      - name: Message Security Binding
+        href: message-security-binding.md
+        items:
+        - name: Message Security Anonymous
+          href: message-security-anonymous.md
+        - name: Message Security Certificate
+          href: message-security-certificate.md
+        - name: Message Security User Name
+          href: message-security-user-name.md
+        - name: Message Security Windows
+          href: message-security-windows.md
+      - name: WS Transport With Message Credential
+        href: ws-transport-with-message-credential.md
+      - name: WS Transaction Flow
+        href: ws-transaction-flow.md
+  - name: Client
+    href: client.md
     items:
-    - name: Data Binding Scenarios
-      href: data-binding-scenarios.md
+    - name: Client Interoperability
+      href: client-interoperability.md
       items:
-      - name: Data Binding in a Windows Forms Client
-        href: data-binding-in-a-windows-forms-client.md
-      - name: Data Binding in an ASP.NET Client
-        href: data-binding-in-an-aspnet-client.md
-      - name: Data Binding in a Windows Presentation Foundation Client
-        href: data-binding-in-a-wpf-client.md
-    - name: Discovery Security Sample
-      href: discovery-security-sample.md
-    - name: Federation Sample
-      href: federation-sample.md
-    - name: Weakly-typed JSON Serialization (AJAX)
-      href: weakly-typed-json-serialization-sample.md
-    - name: Trusted Facade Service
-      href: trusted-facade-service.md
-    - name: "Design Patterns: List-Based Publish-Subscribe"
-      href: design-patterns-list-based-publish-subscribe.md
-  - name: Tool Samples
-    href: tool-samples.md
+      - name: Interoperating with ASMX Web Services
+        href: interoperating-with-asmx-web-services.md
+      - name: XMLSerializer Sample
+        href: xmlserializer-sample.md
+    - name: Address Headers
+      href: address-headers.md
+    - name: Channel Factory
+      href: channel-factory.md
+    - name: Expected Exceptions
+      href: expected-exceptions.md
+    - name: Retrieve Metadata
+      href: retrieve-metadata.md
+    - name: Use Close and Abort to release WCF client resources
+      href: use-close-abort-release-wcf-client-resources.md
+    - name: Typed Client
+      href: typed-client.md
+  - name: Contract
+    href: contract.md
     items:
-    - name: ConfigurationCodeGenerator
-      href: configurationcodegenerator.md
-    - name: CustomChannelsTester
-      href: customchannelstester.md
-    - name: FindPrivateKey
-      href: findprivatekey.md
+    - name: Data Contracts
+      href: data-contracts.md
+      items:
+      - name: Basic Data Contract
+        href: basic-data-contract.md
+      - name: DataContractSerializer Sample
+        href: datacontractserializer-sample.md
+      - name: Known Types
+        href: known-types.md
+      - name: Object References
+        href: object-references.md
+      - name: POCO Support
+        href: poco-support.md
+    - name: Message Contracts
+      href: message-contracts.md
+      items:
+      - name: Default Message Contract
+        href: default-message-contract.md
+      - name: Untyped Request/Reply
+        href: untyped-request-reply.md
+      - name: Unwrapped Messages
+        href: unwrapped-messages.md
+      - name: Setting the Use and Style Properties
+        href: setting-the-use-and-style-properties.md
+      - name: XmlReader Sample
+        href: xmlreader-sample.md
+    - name: Service Contracts
+      href: service-contracts.md
+      items:
+      - name: Duplex
+        href: duplex.md
+      - name: Fault Contract
+        href: fault-contract.md
+      - name: One-Way
+        href: one-way.md
+      - name: Session
+        href: session.md
+      - name: Stream
+        href: stream.md
+      - name: XmlSerializer Faults
+        href: xmlserializer-faults.md
+    - name: DataContractResolver
+      href: datacontractresolver.md
+    - name: KnownAssemblyAttribute
+      href: knownassemblyattribute.md
+    - name: Using DataContractSerializer and DataContractResolver to Provide the Functionality of NetDataContractSerializer
+      href: datacontractserializer-datacontractresolver-netdatacontractserializer.md
+  - name: Discovery
+    href: discovery-samples.md
+    items:
+    - name: Announcements
+      href: announcements-sample.md
+    - name: Basic
+      href: basic-sample.md
+    - name: Configuration
+      href: configuration-sample.md
+    - name: Discovery with Scopes
+      href: discovery-with-scopes-sample.md
+    - name: Custom Find Criteria
+      href: custom-find-criteria.md
+    - name: Workflow Discovery Sample
+      href: workflow-discovery-sample.md
+    - name: Discovery Router Service
+      href: discovery-router-service.md
+  - name: Management
+    href: management.md
+    items:
+    - name: WCF Services and Event Tracing for Windows
+      href: wcf-services-and-event-tracing-for-windows.md
+    - name: WCF Analytic Tracing
+      href: wcf-analytic-tracing.md
+    - name: Circular Tracing
+      href: circular-tracing.md
+    - name: ETW Tracing
+      href: etw-tracing.md
+    - name: Extending Tracing
+      href: extending-tracing.md
+    - name: PII Security Lockdown
+      href: pii-security-lockdown.md
+    - name: Using Performance Counters
+      href: using-performance-counters.md
+    - name: Tracing and Message Logging
+      href: tracing-and-message-logging.md
+    - name: Security Validation
+      href: security-validation.md
+    - name: WMI Provider
+      href: wmi-provider.md
+  - name: Routing Services
+    href: routing-services.md
+    items:
+    - name: Hello World with the Routing Service
+      href: hello-world-with-the-routing-service.md
+  - name: Security
+    href: security-in-wcf.md
+    items:
+    - name: Cryptographic Agility in WCF Security
+      href: cryptographic-agility-in-wcf-security.md
+  - name: Services
+    href: services.md
+    items:
+    - name: Hosting
+      href: hosting.md
+      items:
+      - name: Windows Process Activation
+        href: windows-process-activation.md
+        items:
+        - name: NamedPipe Activation
+          href: namedpipe-activation.md
+        - name: TCP Activation
+          href: tcp-activation.md
+        - name: MSMQ Activation
+          href: msmq-activation.md
+      - name: SystemWebRouting Integration Sample
+        href: systemwebrouting-integration-sample.md
+      - name: ASP.NET Compatibility
+        href: aspnet-compatibility.md
+      - name: IIS Hosting Using Inline Code
+        href: iis-hosting-using-inline-code.md
+      - name: Windows Service Host
+        href: windows-service-host.md
+      - name: Self-Host
+        href: self-host.md
+    - name: Service Interoperability
+      href: service-interoperability.md
+      items:
+      - name: Using the WCF Moniker with COM Clients
+        href: using-the-wcf-moniker-with-com-clients.md
+      - name: ASMX Client with a WCF Service
+        href: asmx-client-with-a-wcf-service.md
+    - name: Behaviors
+      href: behaviors.md
+      items:
+      - name: Concurrency
+        href: concurrency.md
+      - name: Default Service Behavior
+        href: default-service-behavior.md
+      - name: Instancing
+        href: instancing.md
+      - name: Metadata Publishing Behavior
+        href: metadata-publishing-behavior.md
+      - name: Service Transaction Behavior
+        href: service-transaction-behavior.md
+      - name: Service Debug Behavior
+        href: service-debug-behavior.md
+      - name: Throttling
+        href: throttling.md
+      - name: Behavior Security
+        href: behavior-security.md
+        items:
+        - name: Service Auditing Behavior
+          href: service-auditing-behavior.md
+        - name: Membership and Role Provider
+          href: membership-and-role-provider.md
+        - name: Authorizing Access to Service Operations
+          href: authorizing-access-to-service-operations.md
+        - name: Impersonating the Client
+          href: impersonating-the-client.md
+    - name: Simplified Configuration for WCF Services
+      href: simplified-configuration-for-wcf-services.md
+    - name: Usage of Standard Endpoints
+      href: usage-of-standard-endpoints.md
+    - name: Extended Protection Policy
+      href: extended-protection-policy.md
+    - name: Configuration Channel Factory
+      href: configuration-channel-factory.md
+    - name: Addressing
+      href: addressing.md
+    - name: Imperative
+      href: imperative.md
+    - name: Multiple Contracts
+      href: multiple-contracts.md
+    - name: Multiple Endpoints
+      href: multiple-endpoints.md
+    - name: Multiple Endpoints at a Single ListenUri
+      href: multiple-endpoints-at-a-single-listenuri.md
+    - name: OperationContextScope
+      href: operationcontextscope.md
+    - name: Service Description
+      href: service-description.md
+    - name: ConcurrencyMode.Reentrant
+      href: concurrencymode-reentrant.md
+    - name: Service Security
+      href: service-security.md
+      items:
+      - name: Service Identity Sample
+        href: service-identity-sample.md
+  - name: Syndication
+    href: syndication.md
+    items:
+    - name: Stand-Alone Diagnostics Feed
+      href: stand-alone-diagnostics-feed-sample.md
+    - name: Loosely-Typed Extensions
+      href: loosely-typed-extensions-sample.md
+  - name: Web
+    href: web.md
+    items:
+    - name: Basic HTTP Service
+      href: basic-http-service.md
+    - name: SOAP and HTTP Endpoints
+      href: soap-and-http-endpoints.md
+    - name: ASP.NET Caching Integration
+      href: aspnet-caching-integration.md
+    - name: UriTemplate
+      href: uritemplate-sample.md
+    - name: UriTemplate Table
+      href: uritemplate-table-sample.md
+    - name: UriTemplate Table Dispatcher
+      href: uritemplate-table-dispatcher-sample.md
+- name: Extensibility
+  href: extensibility.md
+  items:
+  - name: Binding Extensibility
+    href: binding-extensibility.md
+    items:
+    - name: WSStreamedHttpBinding
+      href: wsstreamedhttpbinding.md
+  - name: Channels Extensibility
+    href: channels-extensibility.md
+    items:
+    - name: Local Channel
+      href: local-channel.md
+    - name: Reliable Secure Profile
+      href: reliable-secure-profile.md
+    - name: Custom Channel Dispatcher
+      href: custom-channel-dispatcher.md
+    - name: Chunking Channel
+      href: chunking-channel.md
+    - name: HttpCookieSession
+      href: httpcookiesession.md
+    - name: Custom Message Interceptor
+      href: custom-message-interceptor.md
+  - name: Instancing Extensibility
+    href: instancing-extensibility.md
+    items:
+    - name: Durable Instance Context
+      href: durable-instance-context.md
+    - name: Custom Lifetime
+      href: custom-lifetime.md
+    - name: Instancing Initialization
+      href: instancing-initialization.md
+    - name: Pooling
+      href: pooling.md
+  - name: Interop Extensibility
+    href: interop-extensibility.md
+    items:
+    - name: Dispatch by Body Element
+      href: dispatch-by-body-element.md
+    - name: Route by Body
+      href: route-by-body.md
+  - name: Message Encoder Extensibility
+    href: message-encoder-extensibility.md
+    items:
+    - name: "Custom Message Encoder: Custom Text Encoder"
+      href: custom-message-encoder-custom-text-encoder.md
+    - name: "Custom Message Encoder: Compression Encoder"
+      href: custom-message-encoder-compression-encoder.md
+  - name: Metadata Extensibility
+    href: metadata-extensibility.md
+    items:
+    - name: Custom Secure Metadata Endpoint
+      href: custom-secure-metadata-endpoint.md
+    - name: Custom WSDL Publication
+      href: custom-wsdl-publication.md
+  - name: Security Extensibility
+    href: security-extensibility.md
+    items:
+    - name: Durable Issued Token Provider
+      href: durable-issued-token-provider.md
+    - name: SAML Token Provider
+      href: saml-token-provider.md
+    - name: Supporting Tokens
+      href: supporting-tokens.md
+    - name: Token Authenticator
+      href: token-authenticator.md
+    - name: Token Provider
+      href: token-provider.md
+    - name: User Name Password Validator
+      href: user-name-password-validator.md
+    - name: X.509 Certificate Validator
+      href: x-509-certificate-validator.md
+    - name: Authorization Policy
+      href: authorization-policy.md
+    - name: Custom Token
+      href: custom-token.md
+    - name: Client Validation
+      href: client-validation.md
+  - name: Syndication Extensibility Samples
+    href: syndication-extensibility-samples.md
+    items:
+    - name: Strongly Typed Extensions
+      href: strongly-typed-extensions-sample.md
+    - name: Feed Formatter (JSON)
+      href: feed-formatter-json.md
+    - name: Streaming Feeds
+      href: streaming-feeds-sample.md
+  - name: Transport Extensibility
+    href: transport-extensibility.md
+    items:
+    - name: UDP Activation
+      href: udp-activation.md
+    - name: "Transport: Custom Transactions over UDP"
+      href: transport-custom-transactions-over-udp-sample.md
+    - name: "Transport: UDP"
+      href: transport-udp.md
+    - name: "Transport: WSE 3.0 TCP Interoperability"
+      href: transport-wse-3-0-tcp-interoperability.md
+  - name: Operation Formatter and Operation Selector
+    href: operation-formatter-and-operation-selector.md
+  - name: Custom Message Filter
+    href: custom-message-filter.md
+  - name: Custom Service Host
+    href: custom-service-host.md
+  - name: DataContract Surrogate
+    href: datacontract-surrogate.md
+  - name: Extending Control Over Error Handling and Reporting
+    href: extending-control-over-error-handling-and-reporting.md
+  - name: Message Inspectors
+    href: message-inspectors.md
+  - name: WebContentTypeMapper
+    href: webcontenttypemapper-sample.md
+- name: Scenario
+  href: scenario.md
+  items:
+  - name: Data Binding Scenarios
+    href: data-binding-scenarios.md
+    items:
+    - name: Data Binding in a Windows Forms Client
+      href: data-binding-in-a-windows-forms-client.md
+    - name: Data Binding in an ASP.NET Client
+      href: data-binding-in-an-aspnet-client.md
+    - name: Data Binding in a Windows Presentation Foundation Client
+      href: data-binding-in-a-wpf-client.md
+  - name: Discovery Security Sample
+    href: discovery-security-sample.md
+  - name: Federation Sample
+    href: federation-sample.md
+  - name: Weakly-typed JSON Serialization (AJAX)
+    href: weakly-typed-json-serialization-sample.md
+  - name: Trusted Facade Service
+    href: trusted-facade-service.md
+  - name: "Design Patterns: List-Based Publish-Subscribe"
+    href: design-patterns-list-based-publish-subscribe.md
+- name: Tool Samples
+  href: tool-samples.md
+  items:
+  - name: ConfigurationCodeGenerator
+    href: configurationcodegenerator.md
+  - name: CustomChannelsTester
+    href: customchannelstester.md
+  - name: FindPrivateKey
+    href: findprivatekey.md

--- a/docs/framework/wcf/toc.yml
+++ b/docs/framework/wcf/toc.yml
@@ -1,245 +1,245 @@
-- name: Service-Oriented Applications with WCF
+items:
+- name: Service-oriented applications with WCF
   href: index.md
+- name: What's New in Windows Communication Foundation 4.5
+  href: whats-new.md
+- name: WCF Simplification Features
+  href: wcf-simplification-features.md
+- name: Guide to the Documentation
+  href: guide-to-the-documentation.md
+- name: Conceptual Overview
+  href: conceptual-overview.md
   items:
-  - name: What's New in Windows Communication Foundation 4.5
-    href: whats-new.md
-  - name: WCF Simplification Features
-    href: wcf-simplification-features.md
-  - name: Guide to the Documentation
-    href: guide-to-the-documentation.md
-  - name: Conceptual Overview
-    href: conceptual-overview.md
+  - name: What Is Windows Communication Foundation
+    href: whats-wcf.md
+  - name: Fundamental Windows Communication Foundation Concepts
+    href: fundamental-concepts.md
+  - name: Windows Communication Foundation Architecture
+    href: architecture.md
+  - name: WCF and .NET Framework Client Profile
+    href: wcf-and-net-framework-client-profile.md
+- name: Get Started Tutorial
+  href: getting-started-tutorial.md
+  items:
+  - name: Define a Service Contract
+    href: how-to-define-a-wcf-service-contract.md
+  - name: Implement a Service Contract
+    href: how-to-implement-a-wcf-contract.md
+  - name: Host and Run a Basic Service
+    href: how-to-host-and-run-a-basic-wcf-service.md
+  - name: Create a Client
+    href: how-to-create-a-wcf-client.md
+  - name: Use a Client
+    href: how-to-use-a-wcf-client.md
+  - name: Troubleshoot the Get Started Tutorial
+    href: troubleshooting-the-getting-started-tutorial.md
+- name: Basic WCF Programming
+  href: basic-wcf-programming.md
+  items:
+  - name: Basic Programming Lifecycle
+    href: basic-programming-lifecycle.md
+  - name: Designing and Implementing Services
+    href: designing-and-implementing-services.md
     items:
-    - name: What Is Windows Communication Foundation
-      href: whats-wcf.md
-    - name: Fundamental Windows Communication Foundation Concepts
-      href: fundamental-concepts.md
-    - name: Windows Communication Foundation Architecture
-      href: architecture.md
-    - name: WCF and .NET Framework Client Profile
-      href: wcf-and-net-framework-client-profile.md
-  - name: Get Started Tutorial
-    href: getting-started-tutorial.md
-    items:
-    - name: Define a Service Contract
-      href: how-to-define-a-wcf-service-contract.md
-    - name: Implement a Service Contract
-      href: how-to-implement-a-wcf-contract.md
-    - name: Host and Run a Basic Service
-      href: how-to-host-and-run-a-basic-wcf-service.md
-    - name: Create a Client
-      href: how-to-create-a-wcf-client.md
-    - name: Use a Client
-      href: how-to-use-a-wcf-client.md
-    - name: Troubleshoot the Get Started Tutorial
-      href: troubleshooting-the-getting-started-tutorial.md
-  - name: Basic WCF Programming
-    href: basic-wcf-programming.md
-    items:
-    - name: Basic Programming Lifecycle
-      href: basic-programming-lifecycle.md
-    - name: Designing and Implementing Services
-      href: designing-and-implementing-services.md
+    - name: Designing Service Contracts
+      href: designing-service-contracts.md
       items:
-      - name: Designing Service Contracts
-        href: designing-service-contracts.md
+      - name: Specifying and Handling Faults in Contracts and Services
+        href: specifying-and-handling-faults-in-contracts-and-services.md
         items:
-        - name: Specifying and Handling Faults in Contracts and Services
-          href: specifying-and-handling-faults-in-contracts-and-services.md
+        - name: Defining and Specifying Faults
+          href: defining-and-specifying-faults.md
           items:
-          - name: Defining and Specifying Faults
-            href: defining-and-specifying-faults.md
-            items:
-            - name: "How to: Declare Faults in Service Contracts"
-              href: how-to-declare-faults-in-service-contracts.md
-          - name: Sending and Receiving Faults
-            href: sending-and-receiving-faults.md
-        - name: Using Sessions
-          href: using-sessions.md
-        - name: Synchronous and Asynchronous Operations
-          href: synchronous-and-asynchronous-operations.md
-          items:
-          - name: "How to: Implement an Asynchronous Service Operation"
-            href: how-to-implement-an-asynchronous-service-operation.md
-        - name: Reliable Services
-          href: reliable-services.md
-        - name: Services and Transactions
-          href: services-and-transactions.md
-      - name: Implementing Service Contracts
-        href: implementing-service-contracts.md
+          - name: "How to: Declare Faults in Service Contracts"
+            href: how-to-declare-faults-in-service-contracts.md
+        - name: Sending and Receiving Faults
+          href: sending-and-receiving-faults.md
+      - name: Using Sessions
+        href: using-sessions.md
+      - name: Synchronous and Asynchronous Operations
+        href: synchronous-and-asynchronous-operations.md
         items:
-        - name: Specifying Service Run-Time Behavior
-          href: specifying-service-run-time-behavior.md
-    - name: Configuring Services
-      href: configuring-services.md
+        - name: "How to: Implement an Asynchronous Service Operation"
+          href: how-to-implement-an-asynchronous-service-operation.md
+      - name: Reliable Services
+        href: reliable-services.md
+      - name: Services and Transactions
+        href: services-and-transactions.md
+    - name: Implementing Service Contracts
+      href: implementing-service-contracts.md
       items:
-      - name: Simplified Configuration
-        href: simplified-configuration.md
-      - name: Configuring Services Using Configuration Files
-        href: configuring-services-using-configuration-files.md
-      - name: Configuring WCF Services in Code
-        href: configuring-wcf-services-in-code.md
-      - name: Bindings
-        href: bindings.md
-        items:
-        - name: WCF Bindings Overview
-          href: bindings-overview.md
-        - name: System-Provided Bindings
-          href: system-provided-bindings.md
-        - name: Using Bindings to Configure Services and Clients
-          href: using-bindings-to-configure-services-and-clients.md
-          items:
-          - name: "How to: Specify a Client Binding in Code"
-            href: how-to-specify-a-client-binding-in-code.md
-          - name: "How to: Specify a Client Binding in Configuration"
-            href: how-to-specify-a-client-binding-in-configuration.md
-          - name: "How to: Specify a Service Binding in Code"
-            href: how-to-specify-a-service-binding-in-code.md
-          - name: "How to: Specify a Service Binding in Configuration"
-            href: how-to-specify-a-service-binding-in-configuration.md
-        - name: Configuring Bindings for Services
-          href: configuring-bindings-for-wcf-services.md
-      - name: Endpoints
-        href: endpoints.md
-        items:
-        - name: Endpoint Creation Overview
-          href: endpoint-creation-overview.md
-        - name: Specifying an Endpoint Address
-          href: specifying-an-endpoint-address.md
-        - name: Publishing Metadata Endpoints
-          href: publishing-metadata-endpoints.md
-      - name: Securing Services
-        href: securing-services.md
-        items:
-        - name: "How to: Secure a Service with Windows Credentials"
-          href: how-to-secure-a-service-with-windows-credentials.md
-        - name: "How to: Set the Security Mode"
-          href: how-to-set-the-security-mode.md
-        - name: "How to: Specify the Client Credential Type"
-          href: how-to-specify-the-client-credential-type.md
-        - name: "How to: Restrict Access with the PrincipalPermissionAttribute Class"
-          href: how-to-restrict-access-with-the-principalpermissionattribute-class.md
-        - name: "How to: Impersonate a Client on a Service"
-          href: how-to-impersonate-a-client-on-a-service.md
-        - name: "How to: Examine the Security Context"
-          href: how-to-examine-the-security-context.md
-        - name: Understanding Protection Level
-          href: understanding-protection-level.md
-        - name: "How to: Set the ProtectionLevel Property"
-          href: how-to-set-the-protectionlevel-property.md
-      - name: Creating WS-I Basic Profile 1.1 Interoperable Services
-        href: creating-ws-i-basic-profile-1-1-interoperable-services.md
-    - name: Hosting Services
-      href: hosting-services.md
-      items:
-      - name: "How to: Host a WCF Service in a Managed Application"
-        href: how-to-host-a-wcf-service-in-a-managed-application.md
-      - name: "How to: Host a WCF Service Written with .NET Framework 3.5 in IIS Running Under .NET Framework 4"
-        href: host-a-wcf-service-net-framework-3-5-iis--net-framework-4.md
-    - name: Building Clients
-      href: building-clients.md
-      items:
-      - name: WCF Client Overview
-        href: wcf-client-overview.md
-      - name: Accessing Services Using a WCF Client
-        href: accessing-services-using-a-wcf-client.md
-        items:
-        - name: Add Service Reference in a Portable Subset Project
-          href: add-service-reference-in-a-portable-subset-project.md
-        - name: Specifying Client Run-Time Behavior
-          href: specifying-client-run-time-behavior.md
-        - name: Configuring Client Behaviors
-          href: configuring-client-behaviors.md
-      - name: Securing Clients
-        href: securing-clients.md
-        items:
-        - name: "How to: Specify Client Credential Values"
-          href: how-to-specify-client-credential-values.md
-    - name: Introduction to Extensibility
-      href: introduction-to-extensibility.md
-    - name: WCF Troubleshooting Quickstart
-      href: wcf-troubleshooting-quickstart.md
-    - name: WCF Error Handling
-      href: wcf-error-handling.md
-    - name: WCF and ASP.NET Web API
-      href: wcf-and-aspnet-web-api.md
-  - name: WCF Feature Details
-    href: feature-details/
-  - name: Extending WCF
-    href: extending/
-  - name: Guidelines and Best Practices
-    href: guidelines-and-best-practices.md
+      - name: Specifying Service Run-Time Behavior
+        href: specifying-service-run-time-behavior.md
+  - name: Configuring Services
+    href: configuring-services.md
     items:
-    - name: "Best Practices: Data Contract Versioning"
-      href: best-practices-data-contract-versioning.md
-    - name: "Best Practices: Intermediaries"
-      href: best-practices-intermediaries.md
-    - name: Service Versioning
-      href: service-versioning.md
-    - name: Load Balancing
-      href: load-balancing.md
-    - name: Controlling Resource Consumption and Improving Performance
-      href: controlling-resource-consumption-and-improving-performance.md
-    - name: Deploying WCF Applications with ClickOnce
-      href: deploying-wcf-applications-with-clickonce.md
-  - name: Administration and Diagnostics
-    href: diagnostics/
-  - name: Operating System Resources Required by WCF
-    href: operating-system-resources-required-by-wcf.md
-  - name: Troubleshooting Setup Issues
-    href: troubleshooting-setup-issues.md
-  - name: Migrating from .NET Remoting to WCF
-    href: migrating-from-net-remoting-to-wcf.md
-  - name: Using the WCF Development Tools
-    href: using-the-wcf-development-tools.md
-    items:
-    - name: WCF Service Host (WcfSvcHost.exe)
-      href: wcf-service-host-wcfsvchost-exe.md
-    - name: WCF Test Client (WcfTestClient.exe)
-      href: wcf-test-client-wcftestclient-exe.md
-    - name: WCF Visual Studio Templates
-      href: wcf-vs-templates.md
-    - name: WCF Service Publishing
-      href: wcf-service-publishing.md
-    - name: Renaming a WCF Service
-      href: renaming-a-wcf-service.md
-    - name: Deploying a WCF Library Project
-      href: deploying-a-wcf-library-project.md
-    - name: Controlling Auto-launching of WCF Service Host
-      href: controlling-auto-launching-of-wcf-service-host.md
-    - name: Generating Data Type Classes from XML
-      href: generating-data-type-classes-from-xml.md
-  - name: Windows Communication Foundation Tools
-    href: tools.md
-    items:
-    - name: ServiceModel Metadata Utility Tool (Svcutil.exe)
-      href: servicemodel-metadata-utility-tool-svcutil-exe.md
-    - name: Find Private Key Tool (FindPrivateKey.exe)
-      href: find-private-key-tool-findprivatekey-exe.md
-    - name: ServiceModel Registration Tool (ServiceModelReg.exe)
-      href: servicemodelreg-exe.md
-    - name: Service Trace Viewer Tool (SvcTraceViewer.exe)
-      href: service-trace-viewer-tool-svctraceviewer-exe.md
-    - name: Configuration Editor Tool (SvcConfigEditor.exe)
-      href: configuration-editor-tool-svcconfigeditor-exe.md
-    - name: COM+ Service Model Configuration Tool (ComSvcConfig.exe)
-      href: com-service-model-configuration-tool-comsvcconfig-exe.md
-    - name: WS-AtomicTransaction Configuration Utility (wsatConfig.exe)
-      href: ws-atomictransaction-configuration-utility-wsatconfig-exe.md
+    - name: Simplified Configuration
+      href: simplified-configuration.md
+    - name: Configuring Services Using Configuration Files
+      href: configuring-services-using-configuration-files.md
+    - name: Configuring WCF Services in Code
+      href: configuring-wcf-services-in-code.md
+    - name: Bindings
+      href: bindings.md
       items:
-      - name: Interpreting Error Codes Returned by wsatConfig.exe
-        href: interpreting-error-codes-returned-by-wsatconfig-exe.md
-    - name: WS-AtomicTransaction Configuration MMC Snap-in
-      href: ws-atomictransaction-configuration-mmc-snap-in.md
-    - name: WorkFlow Service Registration Tool (WFServicesReg.exe)
-      href: workflow-service-registration-tool-wfservicesreg-exe.md
-    - name: Contract-First Tool
-      href: contract-first-tool.md
-  - name: Windows Communication Foundation Samples
-    href: samples/
-  - name: Windows Communication Foundation Glossary
-    href: glossary.md
-  - name: General Reference
-    href: general-reference.md
-  - name: Privacy Information
-    href: privacy-information.md
+      - name: WCF Bindings Overview
+        href: bindings-overview.md
+      - name: System-Provided Bindings
+        href: system-provided-bindings.md
+      - name: Using Bindings to Configure Services and Clients
+        href: using-bindings-to-configure-services-and-clients.md
+        items:
+        - name: "How to: Specify a Client Binding in Code"
+          href: how-to-specify-a-client-binding-in-code.md
+        - name: "How to: Specify a Client Binding in Configuration"
+          href: how-to-specify-a-client-binding-in-configuration.md
+        - name: "How to: Specify a Service Binding in Code"
+          href: how-to-specify-a-service-binding-in-code.md
+        - name: "How to: Specify a Service Binding in Configuration"
+          href: how-to-specify-a-service-binding-in-configuration.md
+      - name: Configuring Bindings for Services
+        href: configuring-bindings-for-wcf-services.md
+    - name: Endpoints
+      href: endpoints.md
+      items:
+      - name: Endpoint Creation Overview
+        href: endpoint-creation-overview.md
+      - name: Specifying an Endpoint Address
+        href: specifying-an-endpoint-address.md
+      - name: Publishing Metadata Endpoints
+        href: publishing-metadata-endpoints.md
+    - name: Securing Services
+      href: securing-services.md
+      items:
+      - name: "How to: Secure a Service with Windows Credentials"
+        href: how-to-secure-a-service-with-windows-credentials.md
+      - name: "How to: Set the Security Mode"
+        href: how-to-set-the-security-mode.md
+      - name: "How to: Specify the Client Credential Type"
+        href: how-to-specify-the-client-credential-type.md
+      - name: "How to: Restrict Access with the PrincipalPermissionAttribute Class"
+        href: how-to-restrict-access-with-the-principalpermissionattribute-class.md
+      - name: "How to: Impersonate a Client on a Service"
+        href: how-to-impersonate-a-client-on-a-service.md
+      - name: "How to: Examine the Security Context"
+        href: how-to-examine-the-security-context.md
+      - name: Understanding Protection Level
+        href: understanding-protection-level.md
+      - name: "How to: Set the ProtectionLevel Property"
+        href: how-to-set-the-protectionlevel-property.md
+    - name: Creating WS-I Basic Profile 1.1 Interoperable Services
+      href: creating-ws-i-basic-profile-1-1-interoperable-services.md
+  - name: Hosting Services
+    href: hosting-services.md
+    items:
+    - name: "How to: Host a WCF Service in a Managed Application"
+      href: how-to-host-a-wcf-service-in-a-managed-application.md
+    - name: "How to: Host a WCF Service Written with .NET Framework 3.5 in IIS Running Under .NET Framework 4"
+      href: host-a-wcf-service-net-framework-3-5-iis--net-framework-4.md
+  - name: Building Clients
+    href: building-clients.md
+    items:
+    - name: WCF Client Overview
+      href: wcf-client-overview.md
+    - name: Accessing Services Using a WCF Client
+      href: accessing-services-using-a-wcf-client.md
+      items:
+      - name: Add Service Reference in a Portable Subset Project
+        href: add-service-reference-in-a-portable-subset-project.md
+      - name: Specifying Client Run-Time Behavior
+        href: specifying-client-run-time-behavior.md
+      - name: Configuring Client Behaviors
+        href: configuring-client-behaviors.md
+    - name: Securing Clients
+      href: securing-clients.md
+      items:
+      - name: "How to: Specify Client Credential Values"
+        href: how-to-specify-client-credential-values.md
+  - name: Introduction to Extensibility
+    href: introduction-to-extensibility.md
+  - name: WCF Troubleshooting Quickstart
+    href: wcf-troubleshooting-quickstart.md
+  - name: WCF Error Handling
+    href: wcf-error-handling.md
+  - name: WCF and ASP.NET Web API
+    href: wcf-and-aspnet-web-api.md
+- name: WCF Feature Details
+  href: feature-details/
+- name: Extending WCF
+  href: extending/
+- name: Guidelines and Best Practices
+  href: guidelines-and-best-practices.md
+  items:
+  - name: "Best Practices: Data Contract Versioning"
+    href: best-practices-data-contract-versioning.md
+  - name: "Best Practices: Intermediaries"
+    href: best-practices-intermediaries.md
+  - name: Service Versioning
+    href: service-versioning.md
+  - name: Load Balancing
+    href: load-balancing.md
+  - name: Controlling Resource Consumption and Improving Performance
+    href: controlling-resource-consumption-and-improving-performance.md
+  - name: Deploying WCF Applications with ClickOnce
+    href: deploying-wcf-applications-with-clickonce.md
+- name: Administration and Diagnostics
+  href: diagnostics/
+- name: Operating System Resources Required by WCF
+  href: operating-system-resources-required-by-wcf.md
+- name: Troubleshooting Setup Issues
+  href: troubleshooting-setup-issues.md
+- name: Migrating from .NET Remoting to WCF
+  href: migrating-from-net-remoting-to-wcf.md
+- name: Using the WCF Development Tools
+  href: using-the-wcf-development-tools.md
+  items:
+  - name: WCF Service Host (WcfSvcHost.exe)
+    href: wcf-service-host-wcfsvchost-exe.md
+  - name: WCF Test Client (WcfTestClient.exe)
+    href: wcf-test-client-wcftestclient-exe.md
+  - name: WCF Visual Studio Templates
+    href: wcf-vs-templates.md
+  - name: WCF Service Publishing
+    href: wcf-service-publishing.md
+  - name: Renaming a WCF Service
+    href: renaming-a-wcf-service.md
+  - name: Deploying a WCF Library Project
+    href: deploying-a-wcf-library-project.md
+  - name: Controlling Auto-launching of WCF Service Host
+    href: controlling-auto-launching-of-wcf-service-host.md
+  - name: Generating Data Type Classes from XML
+    href: generating-data-type-classes-from-xml.md
+- name: Windows Communication Foundation Tools
+  href: tools.md
+  items:
+  - name: ServiceModel Metadata Utility Tool (Svcutil.exe)
+    href: servicemodel-metadata-utility-tool-svcutil-exe.md
+  - name: Find Private Key Tool (FindPrivateKey.exe)
+    href: find-private-key-tool-findprivatekey-exe.md
+  - name: ServiceModel Registration Tool (ServiceModelReg.exe)
+    href: servicemodelreg-exe.md
+  - name: Service Trace Viewer Tool (SvcTraceViewer.exe)
+    href: service-trace-viewer-tool-svctraceviewer-exe.md
+  - name: Configuration Editor Tool (SvcConfigEditor.exe)
+    href: configuration-editor-tool-svcconfigeditor-exe.md
+  - name: COM+ Service Model Configuration Tool (ComSvcConfig.exe)
+    href: com-service-model-configuration-tool-comsvcconfig-exe.md
+  - name: WS-AtomicTransaction Configuration Utility (wsatConfig.exe)
+    href: ws-atomictransaction-configuration-utility-wsatconfig-exe.md
+    items:
+    - name: Interpreting Error Codes Returned by wsatConfig.exe
+      href: interpreting-error-codes-returned-by-wsatconfig-exe.md
+  - name: WS-AtomicTransaction Configuration MMC Snap-in
+    href: ws-atomictransaction-configuration-mmc-snap-in.md
+  - name: WorkFlow Service Registration Tool (WFServicesReg.exe)
+    href: workflow-service-registration-tool-wfservicesreg-exe.md
+  - name: Contract-First Tool
+    href: contract-first-tool.md
+- name: Windows Communication Foundation Samples
+  href: samples/
+- name: Windows Communication Foundation Glossary
+  href: glossary.md
+- name: General Reference
+  href: general-reference.md
+- name: Privacy Information
+  href: privacy-information.md

--- a/docs/framework/windows-services/toc.yml
+++ b/docs/framework/windows-services/toc.yml
@@ -1,34 +1,34 @@
+items:
 - name: Windows Service Applications
   href: index.md
+- name: Introduction to Windows Service Applications
+  href: introduction-to-windows-service-applications.md
+- name: "Walkthrough: Create a Windows Service App"
+  href: walkthrough-creating-a-windows-service-application-in-the-component-designer.md
+- name: Service Application Programming Architecture
+  href: service-application-programming-architecture.md
+- name: "How to: Create Windows Services"
+  href: how-to-create-windows-services.md
   items:
-  - name: Introduction to Windows Service Applications
-    href: introduction-to-windows-service-applications.md
-  - name: "Walkthrough: Create a Windows Service App"
-    href: walkthrough-creating-a-windows-service-application-in-the-component-designer.md
-  - name: Service Application Programming Architecture
-    href: service-application-programming-architecture.md
-  - name: "How to: Create Windows Services"
-    href: how-to-create-windows-services.md
-    items:
-    - name: "How to: Write Services Programmatically"
-      href: how-to-write-services-programmatically.md
-    - name: "How to: Add Installers to Your Service Application"
-      href: how-to-add-installers-to-your-service-application.md
-    - name: "How to: Specify the Security Context for Services"
-      href: how-to-specify-the-security-context-for-services.md
-    - name: "How to: Install and Uninstall Services"
-      href: how-to-install-and-uninstall-services.md
-    - name: "How to: Start Services"
-      href: how-to-start-services.md
-    - name: "How to: Pause a Windows Service (Visual Basic)"
-      href: how-to-pause-a-windows-service-visual-basic.md
-    - name: "How to: Continue a Windows Service (Visual Basic)"
-      href: how-to-continue-a-windows-service-visual-basic.md
-    - name: "How to: Debug Windows Service Applications"
-      href: how-to-debug-windows-service-applications.md
-    - name: "How to: Log Information About Services"
-      href: how-to-log-information-about-services.md
-    - name: "Troubleshooting: Debug Windows Services"
-      href: troubleshooting-debugging-windows-services.md
-    - name: "Troubleshooting: Service Application Won't Install"
-      href: troubleshooting-service-application-wont-install.md
+  - name: "How to: Write Services Programmatically"
+    href: how-to-write-services-programmatically.md
+  - name: "How to: Add Installers to Your Service Application"
+    href: how-to-add-installers-to-your-service-application.md
+  - name: "How to: Specify the Security Context for Services"
+    href: how-to-specify-the-security-context-for-services.md
+  - name: "How to: Install and Uninstall Services"
+    href: how-to-install-and-uninstall-services.md
+  - name: "How to: Start Services"
+    href: how-to-start-services.md
+  - name: "How to: Pause a Windows Service (Visual Basic)"
+    href: how-to-pause-a-windows-service-visual-basic.md
+  - name: "How to: Continue a Windows Service (Visual Basic)"
+    href: how-to-continue-a-windows-service-visual-basic.md
+  - name: "How to: Debug Windows Service Applications"
+    href: how-to-debug-windows-service-applications.md
+  - name: "How to: Log Information About Services"
+    href: how-to-log-information-about-services.md
+  - name: "Troubleshooting: Debug Windows Services"
+    href: troubleshooting-debugging-windows-services.md
+  - name: "Troubleshooting: Service Application Won't Install"
+    href: troubleshooting-service-application-wont-install.md

--- a/docs/framework/windows-workflow-foundation/samples/toc.yml
+++ b/docs/framework/windows-workflow-foundation/samples/toc.yml
@@ -1,107 +1,106 @@
 items:
 - name: Windows Workflow Samples
   href: index.md
+- name: Application
+  href: application.md
   items:
-  - name: Application
-    href: application.md
+  - name: Document Approval Process
+    href: document-approval-process.md
+  - name: Corporate Purchase Process
+    href: corporate-purchase-process.md
+  - name: Hiring Process
+    href: hiring-process.md
+  - name: Visual Workflow Tracking
+    href: visual-workflow-tracking.md
+  - name: Suspended Instance Management
+    href: suspended-instance-management.md
+- name: Basic
+  href: basic.md
+  items:
+  - name: Built-in Activities
+    href: built-in-activities.md
     items:
-    - name: Document Approval Process
-      href: document-approval-process.md
-    - name: Corporate Purchase Process
-      href: corporate-purchase-process.md
-    - name: Hiring Process
-      href: hiring-process.md
-    - name: Visual Workflow Tracking
-      href: visual-workflow-tracking.md
-    - name: Suspended Instance Management
-      href: suspended-instance-management.md
-  - name: Basic
-    href: basic.md
+    - name: Fault Handling in a Flowchart Activity Using TryCatch
+      href: fault-handling-in-a-flowchart-activity-using-trycatch.md
+    - name: Load From XAML
+      href: load-from-xaml.md
+    - name: Use the Pick Activity
+      href: using-the-pick-activity.md
+  - name: Custom Activities
+    href: custom-activities.md
     items:
-    - name: Built-in Activities
-      href: built-in-activities.md
+    - name: Code-Bodied
+      href: code-bodied.md
       items:
-      - name: Fault Handling in a Flowchart Activity Using TryCatch
-        href: fault-handling-in-a-flowchart-activity-using-trycatch.md
-      - name: Load From XAML
-        href: load-from-xaml.md
-      - name: Use the Pick Activity
-        href: using-the-pick-activity.md
-    - name: Custom Activities
-      href: custom-activities.md
+      - name: Custom Composite using Native Activity
+        href: custom-composite-using-native-activity.md
+    - name: Custom Activity Designers
+      href: custom-activity-designers.md
       items:
-      - name: Code-Bodied
-        href: code-bodied.md
-        items:
-        - name: Custom Composite using Native Activity
-          href: custom-composite-using-native-activity.md
-      - name: Custom Activity Designers
-        href: custom-activity-designers.md
-        items:
-        - name: Custom Composite Designers - Workflow Item Presenter
-          href: custom-composite-designers-workflow-item-presenter.md
-        - name: Custom Composite Designers - Workflow Items Presenter
-          href: custom-composite-designers-workflow-items-presenter.md
-        - name: Using the ExpressionTextBox in a Custom Activity Designer
-          href: using-the-expressiontextbox-in-a-custom-activity-designer.md
-        - name: Using Editing Scope
-          href: using-editing-scope.md
-    - name: Designer
-      href: designer.md
-      items:
-      - name: Removing the View State the Designer Adds to an XAML File
-        href: removing-the-view-state-the-designer-adds-to-an-xaml-file.md
-      - name: Programming Model Item Tree
-        href: programming-model-item-tree.md
-      - name: Property Grid Extensibility
-        href: property-grid-extensibility.md
-    - name: Designer Rehosting
-      href: designer-rehosting.md
-    - name: Execution
-      href: execution.md
-      items:
-      - name: Creating and Running a Workflow Instance
-        href: creating-and-running-a-workflow-instance.md
-      - name: Bookmark Resolver for WorkflowHostingEndpoint
-        href: bookmark-resolver-for-workflowhostingendpoint.md
-    - name: Tracking
-      href: tracking.md
-      items:
-      - name: Custom Tracking
-        href: custom-tracking.md
-      - name: Tracking Events into Event Tracing in Windows
-        href: tracking-events-into-event-tracing-in-windows.md
-      - name: SQL Tracking
-        href: sql-tracking.md
-  - name: Scenario
-    href: scenario.md
+      - name: Custom Composite Designers - Workflow Item Presenter
+        href: custom-composite-designers-workflow-item-presenter.md
+      - name: Custom Composite Designers - Workflow Items Presenter
+        href: custom-composite-designers-workflow-items-presenter.md
+      - name: Using the ExpressionTextBox in a Custom Activity Designer
+        href: using-the-expressiontextbox-in-a-custom-activity-designer.md
+      - name: Using Editing Scope
+        href: using-editing-scope.md
+  - name: Designer
+    href: designer.md
     items:
-    - name: Activity Library
-      href: activity-library.md
-      items:
-      - name: SendMail Custom Activity
-        href: sendmail-custom-activity.md
-      - name: Throttled Parallel ForEach
-        href: throttled-parallel-foreach.md
-      - name: Database Access Activities
-        href: database-access-activities.md
-      - name: Externalized Policy Activity in .NET Framework 4.5
-        href: externalized-policy-activity-in-net-framework-4-5.md
-      - name: Non-Generic ForEach
-        href: non-generic-foreach.md
-      - name: Non-Generic ParallelForEach
-        href: non-generic-parallelforeach.md
-      - name: Get WorkflowInstanceId
-        href: get-workflowinstanceid.md
-    - name: Services
-      items:
-      - name: Accessing OperationContext
-        href: accessing-operationcontext.md
-      - name: LINQ Message Query Correlation
-        href: linq-message-query-correlation.md
-      - name: Asynchronous Communication
-        href: asynchronous-communication.md
-    - name: WPF and WF Integration in XAML
-      href: wpf-and-wf-integration-in-xaml.md
-    - name: External Ruleset Toolkit
-      href: external-ruleset-toolkit.md
+    - name: Removing the View State the Designer Adds to an XAML File
+      href: removing-the-view-state-the-designer-adds-to-an-xaml-file.md
+    - name: Programming Model Item Tree
+      href: programming-model-item-tree.md
+    - name: Property Grid Extensibility
+      href: property-grid-extensibility.md
+  - name: Designer Rehosting
+    href: designer-rehosting.md
+  - name: Execution
+    href: execution.md
+    items:
+    - name: Creating and Running a Workflow Instance
+      href: creating-and-running-a-workflow-instance.md
+    - name: Bookmark Resolver for WorkflowHostingEndpoint
+      href: bookmark-resolver-for-workflowhostingendpoint.md
+  - name: Tracking
+    href: tracking.md
+    items:
+    - name: Custom Tracking
+      href: custom-tracking.md
+    - name: Tracking Events into Event Tracing in Windows
+      href: tracking-events-into-event-tracing-in-windows.md
+    - name: SQL Tracking
+      href: sql-tracking.md
+- name: Scenario
+  href: scenario.md
+  items:
+  - name: Activity Library
+    href: activity-library.md
+    items:
+    - name: SendMail Custom Activity
+      href: sendmail-custom-activity.md
+    - name: Throttled Parallel ForEach
+      href: throttled-parallel-foreach.md
+    - name: Database Access Activities
+      href: database-access-activities.md
+    - name: Externalized Policy Activity in .NET Framework 4.5
+      href: externalized-policy-activity-in-net-framework-4-5.md
+    - name: Non-Generic ForEach
+      href: non-generic-foreach.md
+    - name: Non-Generic ParallelForEach
+      href: non-generic-parallelforeach.md
+    - name: Get WorkflowInstanceId
+      href: get-workflowinstanceid.md
+  - name: Services
+    items:
+    - name: Accessing OperationContext
+      href: accessing-operationcontext.md
+    - name: LINQ Message Query Correlation
+      href: linq-message-query-correlation.md
+    - name: Asynchronous Communication
+      href: asynchronous-communication.md
+  - name: WPF and WF Integration in XAML
+    href: wpf-and-wf-integration-in-xaml.md
+  - name: External Ruleset Toolkit
+    href: external-ruleset-toolkit.md

--- a/docs/framework/windows-workflow-foundation/toc.yml
+++ b/docs/framework/windows-workflow-foundation/toc.yml
@@ -1,555 +1,554 @@
 items:
 - name: Windows Workflow Foundation
   href: index.md
+- name: Guide to the Windows Workflow Documentation
+  href: guide-to-the-documentation.md
+- name: What's New in Windows Workflow Foundation
+  href: whats-new.md
+- name: What's New in Windows Workflow Foundation in .NET 4.5
+  href: whats-new-in-wf-in-dotnet.md
+- name: Obsolete types and tools
+  href: deprecated-types.md
   items:
-  - name: Guide to the Windows Workflow Documentation
-    href: guide-to-the-documentation.md
-  - name: What's New in Windows Workflow Foundation
-    href: whats-new.md
-  - name: What's New in Windows Workflow Foundation in .NET 4.5
-    href: whats-new-in-wf-in-dotnet.md
-  - name: Obsolete types and tools
-    href: deprecated-types.md
+  - name: "wfc.exe Workflow Compiler Tool"
+    href: "wfc-exe-workflow-compiler-tool.md"
+- name: Windows Workflow Foundation Feature Specifics
+  href: feature-specifics.md
+- name: Windows Workflow Conceptual Overview
+  href: conceptual-overview.md
+  items:
+  - name: Windows Workflow Overview
+    href: overview.md
+  - name: Fundamental Windows Workflow Concepts
+    href: fundamental-concepts.md
+  - name: Windows Workflow Architecture
+    href: architecture.md
+- name: Getting Started Tutorial
+  href: getting-started-tutorial.md
+  items:
+  - name: "How to: Create an Activity"
+    href: how-to-create-an-activity.md
+  - name: "How to: Create a Workflow"
+    href: how-to-create-a-workflow.md
     items:
-    - name: "wfc.exe Workflow Compiler Tool"
-      href: "wfc-exe-workflow-compiler-tool.md" 
-  - name: Windows Workflow Foundation Feature Specifics
-    href: feature-specifics.md
-  - name: Windows Workflow Conceptual Overview
-    href: conceptual-overview.md
+    - name: "How to: Create a Flowchart Workflow"
+      href: how-to-create-a-flowchart-workflow.md
+    - name: "How to: Create a Sequential Workflow"
+      href: how-to-create-a-sequential-workflow.md
+    - name: "How to: Create a State Machine Workflow"
+      href: how-to-create-a-state-machine-workflow.md
+  - name: "How to: Run a Workflow"
+    href: how-to-run-a-workflow.md
+  - name: "How to: Create and Run a Long Running Workflow"
+    href: how-to-create-and-run-a-long-running-workflow.md
+  - name: "How to: Create a Custom Tracking Participant"
+    href: how-to-create-a-custom-tracking-participant.md
+  - name: "How to: Host Multiple Versions of a Workflow Side-by-Side"
+    href: how-to-host-multiple-versions-of-a-workflow-side-by-side.md
+  - name: "How to: Update the Definition of a Running Workflow Instance"
+    href: how-to-update-the-definition-of-a-running-workflow-instance.md
+- name: Windows Workflow Foundation Programming
+  href: programming.md
+  items:
+  - name: Designing Workflows
+    href: designing-workflows.md
     items:
-    - name: Windows Workflow Overview
-      href: overview.md
-    - name: Fundamental Windows Workflow Concepts
-      href: fundamental-concepts.md
-    - name: Windows Workflow Architecture
-      href: architecture.md
-  - name: Getting Started Tutorial
-    href: getting-started-tutorial.md
+    - name: Flowchart Workflows
+      href: flowchart-workflows.md
+    - name: Procedural Workflows
+      href: procedural-workflows.md
+    - name: State Machine Workflows
+      href: state-machine-workflows.md
+    - name: Authoring Workflows, Activities, and Expressions Using Imperative Code
+      href: authoring-workflows-activities-and-expressions-using-imperative-code.md
+  - name: Using and Creating Activities
+    href: using-and-creating-activities.md
     items:
-    - name: "How to: Create an Activity"
-      href: how-to-create-an-activity.md
-    - name: "How to: Create a Workflow"
-      href: how-to-create-a-workflow.md
+    - name: Built-In Activity Library
+      href: net-framework-4-5-built-in-activity-library.md
       items:
-      - name: "How to: Create a Flowchart Workflow"
-        href: how-to-create-a-flowchart-workflow.md
-      - name: "How to: Create a Sequential Workflow"
-        href: how-to-create-a-sequential-workflow.md
-      - name: "How to: Create a State Machine Workflow"
-        href: how-to-create-a-state-machine-workflow.md
-    - name: "How to: Run a Workflow"
-      href: how-to-run-a-workflow.md
-    - name: "How to: Create and Run a Long Running Workflow"
-      href: how-to-create-and-run-a-long-running-workflow.md
-    - name: "How to: Create a Custom Tracking Participant"
-      href: how-to-create-a-custom-tracking-participant.md
-    - name: "How to: Host Multiple Versions of a Workflow Side-by-Side"
-      href: how-to-host-multiple-versions-of-a-workflow-side-by-side.md
-    - name: "How to: Update the Definition of a Running Workflow Instance"
-      href: how-to-update-the-definition-of-a-running-workflow-instance.md
-  - name: Windows Workflow Foundation Programming
-    href: programming.md
+      - name: Control Flow
+        href: control-flow-activities-in-wf.md
+        items:
+        - name: Pick Activity
+          href: pick-activity.md
+      - name: Flowchart
+        href: flowchart-activities-in-wf.md
+      - name: State Machine
+        href: state-machine-activities-in-wf.md
+      - name: Runtime
+        href: runtime-activities-in-wf.md
+      - name: Primitives
+        href: primitives-activities-in-wf.md
+      - name: Transaction
+        href: transaction-activities-in-wf.md
+      - name: Collection
+        href: collection-activities-in-wf.md
+      - name: Error Handling
+        href: error-handling-activities-in-wf.md
+      - name: Migration
+        href: migration-activity-in-wf.md
+    - name: Designing and Implementing Custom Activities
+      href: designing-and-implementing-custom-activities.md
+      items:
+      - name: Activity Authoring Options
+        href: activity-authoring-options-in-wf.md
+        items:
+        - name: Activity Base Class
+          href: workflow-activity-authoring-using-the-activity-class.md
+        - name: CodeActivity Base Class
+          href: workflow-activity-authoring-using-the-codeactivity-class.md
+        - name: NativeActivity Base Class
+          href: nativeactivity-base-class.md
+      - name: Using a custom activity
+        href: using-a-custom-activity.md
+      - name: Creating Asynchronous Activities
+        href: creating-asynchronous-activities-in-wf.md
+        items:
+        - name: Error handling in asynchronous activities
+          href: error-handling-in-asynchronous-activities.md
+      - name: Configuring Activity Validation
+        href: configuring-activity-validation.md
+        items:
+        - name: Required Arguments and Overload Groups
+          href: required-arguments-and-overload-groups.md
+        - name: Imperative Code-Based Validation
+          href: imperative-code-based-validation.md
+        - name: Declarative Constraints
+          href: declarative-constraints.md
+        - name: Invoking Activity Validation
+          href: invoking-activity-validation.md
+      - name: Creating an Activity at Runtime
+        href: creating-an-activity-at-runtime-with-dynamicactivity.md
+      - name: Workflow Execution Properties
+        href: workflow-execution-properties.md
+      - name: Using Activity Delegates
+        href: using-activity-delegates.md
+      - name: Using Activity Extensions
+        href: using-activity-extensions.md
+      - name: Consuming OData Feeds from a Workflow
+        href: consuming-odata-feeds-from-a-workflow.md
+      - name: Activity Definition Scoping and Visibility
+        href: activity-definition-scoping-and-visibility.md
+      - name: Creating custom flow control activities
+        href: creating-custom-flow-control-activities.md
+  - name: Windows Workflow Foundation Data Model
+    href: data-model.md
     items:
-    - name: Designing Workflows
-      href: designing-workflows.md
-      items:
-      - name: Flowchart Workflows
-        href: flowchart-workflows.md
-      - name: Procedural Workflows
-        href: procedural-workflows.md
-      - name: State Machine Workflows
-        href: state-machine-workflows.md
-      - name: Authoring Workflows, Activities, and Expressions Using Imperative Code
-        href: authoring-workflows-activities-and-expressions-using-imperative-code.md
-    - name: Using and Creating Activities
-      href: using-and-creating-activities.md
-      items:
-      - name: Built-In Activity Library
-        href: net-framework-4-5-built-in-activity-library.md
-        items:
-        - name: Control Flow
-          href: control-flow-activities-in-wf.md
-          items:
-          - name: Pick Activity
-            href: pick-activity.md
-        - name: Flowchart
-          href: flowchart-activities-in-wf.md
-        - name: State Machine
-          href: state-machine-activities-in-wf.md
-        - name: Runtime
-          href: runtime-activities-in-wf.md
-        - name: Primitives
-          href: primitives-activities-in-wf.md
-        - name: Transaction
-          href: transaction-activities-in-wf.md
-        - name: Collection
-          href: collection-activities-in-wf.md
-        - name: Error Handling
-          href: error-handling-activities-in-wf.md
-        - name: Migration
-          href: migration-activity-in-wf.md
-      - name: Designing and Implementing Custom Activities
-        href: designing-and-implementing-custom-activities.md
-        items:
-        - name: Activity Authoring Options
-          href: activity-authoring-options-in-wf.md
-          items:
-          - name: Activity Base Class
-            href: workflow-activity-authoring-using-the-activity-class.md
-          - name: CodeActivity Base Class
-            href: workflow-activity-authoring-using-the-codeactivity-class.md
-          - name: NativeActivity Base Class
-            href: nativeactivity-base-class.md
-        - name: Using a custom activity
-          href: using-a-custom-activity.md
-        - name: Creating Asynchronous Activities
-          href: creating-asynchronous-activities-in-wf.md
-          items:
-          - name: Error handling in asynchronous activities
-            href: error-handling-in-asynchronous-activities.md
-        - name: Configuring Activity Validation
-          href: configuring-activity-validation.md
-          items:
-          - name: Required Arguments and Overload Groups
-            href: required-arguments-and-overload-groups.md
-          - name: Imperative Code-Based Validation
-            href: imperative-code-based-validation.md
-          - name: Declarative Constraints
-            href: declarative-constraints.md
-          - name: Invoking Activity Validation
-            href: invoking-activity-validation.md
-        - name: Creating an Activity at Runtime
-          href: creating-an-activity-at-runtime-with-dynamicactivity.md
-        - name: Workflow Execution Properties
-          href: workflow-execution-properties.md
-        - name: Using Activity Delegates
-          href: using-activity-delegates.md
-        - name: Using Activity Extensions
-          href: using-activity-extensions.md
-        - name: Consuming OData Feeds from a Workflow
-          href: consuming-odata-feeds-from-a-workflow.md
-        - name: Activity Definition Scoping and Visibility
-          href: activity-definition-scoping-and-visibility.md
-        - name: Creating custom flow control activities
-          href: creating-custom-flow-control-activities.md
-    - name: Windows Workflow Foundation Data Model
-      href: data-model.md
-      items:
-      - name: Variables and Arguments
-        href: variables-and-arguments.md
-      - name: Expressions
-        href: expressions.md
-      - name: C# Expressions
-        href: csharp-expressions.md
-      - name: Properties vs. Arguments
-        href: properties-vs-arguments.md
-      - name: Exposing data with CacheMetadata
-        href: exposing-data-with-cachemetadata.md
-    - name: Waiting for Input in a Workflow
-      href: waiting-for-input-in-a-workflow.md
-      items:
-      - name: Bookmarks
-        href: bookmarks.md
-    - name: Exceptions, Transactions, and Compensation
-      href: exceptions-transactions-and-compensation.md
-      items:
-      - name: Exceptions
-        href: exceptions.md
-      - name: Transactions
-        href: workflow-transactions.md
-      - name: Compensation
-        href: compensation.md
-      - name: Cancellation
-        href: modeling-cancellation-behavior-in-workflows.md
-      - name: Debugging Workflows
-        href: debugging-workflows.md
-    - name: Hosting Workflows
-      href: hosting-workflows.md
-      items:
-      - name: Workflow Hosting Options
-        href: workflow-hosting-options.md
-      - name: Using WorkflowInvoker and WorkflowApplication
-        href: using-workflowinvoker-and-workflowapplication.md
-      - name: Activity Tree Inspection
-        href: activity-tree-inspection.md
-      - name: Serializing Workflows and Activities to and from XAML
-        href: serializing-workflows-and-activities-to-and-from-xaml.md
-      - name: Using WorkflowIdentity and Versioning
-        href: using-workflowidentity-and-versioning.md
-    - name: Dynamic Update
-      href: dynamic-update.md
-    - name: Contract First Workflow Service Development
-      href: contract-first-workflow-service-development.md
-    - name: "How to: Create a workflow service that consumes an existing service contract"
-      href: how-to-create-a-workflow-service-that-consumes-an-existing-service-contract.md
-    - name: Workflow Persistence
-      href: workflow-persistence.md
-      items:
-      - name: SQL Workflow Instance Store
-        href: sql-workflow-instance-store.md
-        items:
-        - name: Properties of SQL Workflow Instance Store
-          href: properties-of-sql-workflow-instance-store.md
-          items:
-          - name: Instance Encoding Option
-            href: instance-encoding-option.md
-          - name: Instance Completion Action
-            href: instance-completion-action.md
-          - name: Instance Locked Exception Action
-            href: instance-locked-exception-action.md
-          - name: Host Lock Renewal Period
-            href: host-lock-renewal-period.md
-          - name: Runnable Instances Detection Period
-            href: runnable-instances-detection-period.md
-          - name: Connection String and Connection String Name
-            href: connection-string-and-connection-string-name.md
-        - name: "How to: Enable SQL Persistence for Workflows and Workflow Services"
-          href: how-to-enable-sql-persistence-for-workflows-and-workflow-services.md
-        - name: Instance Activation
-          href: instance-activation.md
-        - name: Support for Queries
-          href: support-for-queries.md
-        - name: Store Extensibility
-          href: store-extensibility.md
-        - name: Security
-          href: security.md
-        - name: SQL Server Persistence Database
-          href: sql-server-persistence-database.md
-          items:
-          - name: Persistence Database Schema
-            href: persistence-database-schema.md
-          - name: "How to: Deserialize Instance Data Properties"
-            href: how-to-deserialize-instance-data-properties.md
-          - name: "How to: Query for Non-persisted Instances"
-            href: how-to-query-for-non-persisted-instances.md
-      - name: Instance Stores
-        href: instance-stores.md
-        items:
-        - name: "How to: Enable Persistence for Workflows and Workflow Services"
-          href: how-to-enable-persistence-for-workflows-and-workflow-services.md
-        - name: "How to: Create a Custom Instance Store"
-          href: how-to-create-a-custom-instance-store.md
-      - name: Persistence Participants
-        href: persistence-participants.md
-        items:
-        - name: "How to: Create a Custom Persistence Participant"
-          href: how-to-create-a-custom-persistence-participant.md
-      - name: Persistence Best Practices
-        href: persistence-best-practices.md
-      - name: Non-Persisted Workflow Instances
-        href: non-persisted-workflow-instances.md
-      - name: Pausing and Resuming a Workflow
-        href: pausing-and-resuming-a-workflow.md
-    - name: Migration Guidance
-      items:
-      - name: Overview
-        href: migration-guidance.md
-      - name: Using .NET Framework 3.0 WF Activities in .NET Framework 4 with the Interop Activity
-        href: net-framework-3-0-wf-in-net-framework-4-interop.md
-    - name: Workflow Tracking and Tracing
-      href: workflow-tracking-and-tracing.md
-      items:
-      - name: Tracking Records
-        href: tracking-records.md
-      - name: Tracking Profiles
-        href: tracking-profiles.md
-      - name: Tracking Participants
-        href: tracking-participants.md
-      - name: Configuring Tracking for a Workflow
-        href: configuring-tracking-for-a-workflow.md
-      - name: Using Tracking to Troubleshoot Applications
-        href: using-tracking-to-troubleshoot-applications.md
-      - name: Workflow Tracing
-        href: workflow-tracing.md
-      - name: Tracking Events Reference
-        href: tracking-events-reference.md
-        items:
-        - name: 100 - WorkflowInstanceRecord
-          href: 100-workflowinstancerecord.md
-        - name: 101 - WorkflowInstanceUnhandledExceptionRecord
-          href: 101-workflowinstanceunhandledexceptionrecord.md
-        - name: 102 - WorkflowInstanceAbortedRecord
-          href: 102-workflowinstanceabortedrecord.md
-        - name: 103 - ActivityStateRecord
-          href: 103-activitystaterecord.md
-        - name: 104 - ActivityScheduledRecord
-          href: 104-activityscheduledrecord.md
-        - name: 105 - FaultPropagationRecord
-          href: 105-faultpropagationrecord.md
-        - name: 106 - CancelRequestRecord
-          href: 106-cancelrequestrecord.md
-        - name: 107 -- BookmarkResumptionRecord
-          href: 107-bookmarkresumptionrecord.md
-        - name: 108 - CustomTrackingRecordInfo
-          href: 108-customtrackingrecordinfo.md
-        - name: 110 - CustomTrackingRecordWarning
-          href: 110-customtrackingrecordwarning.md
-        - name: 111 - CustomTrackingRecordError
-          href: 111-customtrackingrecorderror.md
-        - name: 112 - WorkflowInstanceSuspendedRecord
-          href: 112-workflowinstancesuspendedrecord.md
-        - name: 113 - WorkflowInstanceTerminatedRecord
-          href: 113-workflowinstanceterminatedrecord.md
-        - name: 114 - WorkflowInstanceRecordWithId
-          href: 114-workflowinstancerecordwithid.md
-        - name: 115 - WorkflowInstanceAbortedRecordWithId
-          href: 115-workflowinstanceabortedrecordwithid.md
-        - name: 116 - WorkflowInstanceSuspendedRecordWithId
-          href: 116-workflowinstancesuspendedrecordwithid.md
-        - name: 117 - WorkflowInstanceTerminatedRecordWithId
-          href: 117-workflowinstanceterminatedrecordwithid.md
-        - name: 118 - WorkflowInstanceUnhandledExceptionRecordWithId
-          href: 118-workflowinstanceunhandledexceptionrecordwithid.md
-        - name: 119 - WorkflowInstanceUpdatedRecord
-          href: 119-workflowinstanceupdatedrecord.md
-        - name: 225 - TraceCorrelationKeys
-          href: 225-tracecorrelationkeys.md
-        - name: 440 - StartSignpostEvent1
-          href: 440-startsignpostevent.md
-        - name: 441- StopSignpostEvent1
-          href: 441-stopsignpostevent.md
-        - name: 1001 - WorkflowApplicationCompleted
-          href: 1001-workflowapplicationcompleted.md
-        - name: 1002 - WorkflowApplicationTerminated
-          href: 1002-workflowapplicationterminated.md
-        - name: 1003 - WorkflowInstanceCanceled
-          href: 1003-workflowinstancecanceled.md
-        - name: 1004 - WorkflowInstanceAborted
-          href: 1004-workflowinstanceaborted.md
-        - name: 1005 - WorkflowApplicationIdled
-          href: 1005-workflowapplicationidled.md
-        - name: 1006 - WorkflowApplicationUnhandledException
-          href: 1006-workflowapplicationunhandledexception.md
-        - name: 1007 - WorkflowApplicationPersisted
-          href: 1007-workflowapplicationpersisted.md
-        - name: 1008 - WorkflowApplicationUnloaded
-          href: 1008-workflowapplicationunloaded.md
-        - name: 1009 - ActivityScheduled
-          href: 1009-activityscheduled.md
-        - name: 1010 - ActivityCompleted
-          href: 1010-activitycompleted.md
-        - name: 1011 - ScheduleExecuteActivityWorkItem
-          href: 1011-scheduleexecuteactivityworkitem.md
-        - name: 1012 - StartExecuteActivityWorkItem
-          href: 1012-startexecuteactivityworkitem.md
-        - name: 1013 - CompleteExecuteActivityWorkItem
-          href: 1013-completeexecuteactivityworkitem.md
-        - name: 1014 - ScheduleCompletionWorkItem
-          href: 1014-schedulecompletionworkitem.md
-        - name: 1015 - StartCompletionWorkItem
-          href: 1015-startcompletionworkitem.md
-        - name: 1016 - CompleteCompletionWorkItem
-          href: 1016-completecompletionworkitem.md
-        - name: 1017 - ScheduleCancelActivityWorkItem
-          href: 1017-schedulecancelactivityworkitem.md
-        - name: 1018 - StartCancelActivityWorkItem
-          href: 1018-startcancelactivityworkitem.md
-        - name: 1019 - CompleteCancelActivityWorkItem
-          href: 1019-completecancelactivityworkitem.md
-        - name: 1020 - CreateBookmark
-          href: 1020-createbookmark.md
-        - name: 1021 - ScheduleBookmarkWorkItem
-          href: 1021-schedulebookmarkworkitem.md
-        - name: 1022 - StartBookmarkWorkItem
-          href: 1022-startbookmarkworkitem.md
-        - name: 1023 - CompleteBookmarkWorkItem
-          href: 1023-completebookmarkworkitem.md
-        - name: 1024 - CreateBookmarkScope
-          href: 1024-createbookmarkscope.md
-        - name: 1025 - BookmarkScopeInitialized
-          href: 1025-bookmarkscopeinitialized.md
-        - name: 1026 - ScheduleTransactionContextWorkItem
-          href: 1026-scheduletransactioncontextworkitem.md
-        - name: 1027 - StartTransactionContextWorkItem
-          href: 1027-starttransactioncontextworkitem.md
-        - name: 1028 - CompleteTransactionContextWorkItem
-          href: 1028-completetransactioncontextworkitem.md
-        - name: 1029 - ScheduleFaultWorkItem
-          href: 1029-schedulefaultworkitem.md
-        - name: 1030 - StartFaultWorkItem
-          href: 1030-startfaultworkitem.md
-        - name: 1031 - CompleteFaultWorkItem
-          href: 1031-completefaultworkitem.md
-        - name: 1032 - ScheduleRuntimeWorkItem
-          href: 1032-scheduleruntimeworkitem.md
-        - name: 1033 - StartRuntimeWorkItem
-          href: 1033-startruntimeworkitem.md
-        - name: 1034 - CompleteRuntimeWorkItem
-          href: 1034-completeruntimeworkitem.md
-        - name: 1035 - RuntimeTransactionSet
-          href: 1035-runtimetransactionset.md
-        - name: 1036 - RuntimeTransactionCompletionRequested
-          href: 1036-runtimetransactioncompletionrequested.md
-        - name: 1037 - RuntimeTransactionComplete
-          href: 1037-runtimetransactioncomplete.md
-        - name: 1038 - EnterNoPersistBlock
-          href: 1038-enternopersistblock.md
-        - name: 1039 - ExitNoPersistBlock
-          href: 1039-exitnopersistblock.md
-        - name: 1040 - InArgumentBound
-          href: 1040-inargumentbound.md
-        - name: 1041 - WorkflowApplicationPersistableIdle
-          href: 1041-workflowapplicationpersistableidle.md
-        - name: 1101 - WorkflowActivityStart
-          href: 1101-workflowactivitystart.md
-        - name: 1102 - WorkflowActivityStop
-          href: 1102-workflowactivitystop.md
-        - name: 1103 - WorkflowActivitySuspend
-          href: 1103-workflowactivitysuspend.md
-        - name: 1104 - WorkflowActivityResume
-          href: 1104-workflowactivityresume.md
-        - name: 1124 - InvokeMethodIsStatic
-          href: 1124-invokemethodisstatic.md
-        - name: 1125 - InvokeMethodIsNotStatic
-          href: 1125-invokemethodisnotstatic.md
-        - name: 1126 - InvokedMethodThrewException
-          href: 1126-invokedmethodthrewexception.md
-        - name: 1131 - InvokeMethodUseAsyncPattern
-          href: 1131-invokemethoduseasyncpattern.md
-        - name: 1132 - InvokeMethodDoesNotUseAsyncPattern
-          href: 1132-invokemethoddoesnotuseasyncpattern.md
-        - name: 1140 - FlowchartStart
-          href: 1140-flowchartstart.md
-        - name: 1141 - FlowchartEmpty
-          href: 1141-flowchartempty.md
-        - name: 1143 - FlowchartNextNull
-          href: 1143-flowchartnextnull.md
-        - name: 1146 - FlowchartSwitchCase
-          href: 1146-flowchartswitchcase.md
-        - name: 1147 - FlowchartSwitchDefault
-          href: 1147-flowchartswitchdefault.md
-        - name: 1148 - FlowchartSwitchCaseNotFound
-          href: 1148-flowchartswitchcasenotfound.md
-        - name: 1150 - CompensationState
-          href: 1150-compensationstate.md
-        - name: 1223 - SwitchCaseNotFound
-          href: 1223-switchcasenotfound.md
-        - name: 1449 - WfMessageReceived
-          href: 1449-wfmessagereceived.md
-        - name: 1450 - WfMessageSent
-          href: 1450-wfmessagesent.md
-        - name: 2021 - ExecuteWorkItemStart
-          href: 2021-executeworkitemstart.md
-        - name: 2022 - ExecuteWorkItemStop
-          href: 2022-executeworkitemstop.md
-        - name: 2023 - SendMessageChannelCacheMiss
-          href: 2023-sendmessagechannelcachemiss.md
-        - name: 2024 - InternalCacheMetadataStart
-          href: 2024-internalcachemetadatastart.md
-        - name: 2025 - InternalCacheMetadataStop
-          href: 2025-internalcachemetadatastop.md
-        - name: 2026 - CompileVbExpressionStart
-          href: 2026-compilevbexpressionstart.md
-        - name: 2027 - CacheRootMetadataStart
-          href: 2027-cacherootmetadatastart.md
-        - name: 2028 - CacheRootMetadataStop
-          href: 2028-cacherootmetadatastop.md
-        - name: 2029 - CompileVbExpressionStop
-          href: 2029-compilevbexpressionstop.md
-        - name: 2576 - TryCatchExceptionFromTry
-          href: 2576-trycatchexceptionfromtry.md
-        - name: 2577 - TryCatchExceptionDuringCancelation
-          href: 2577-trycatchexceptionduringcancelation.md
-        - name: 2578 - TryCatchExceptionFromCatchOrFinally
-          href: 2578-trycatchexceptionfromcatchorfinally.md
-        - name: 3501 - InferredContractDescription
-          href: 3501-inferredcontractdescription.md
-        - name: 3502 - InferredOperationDescription
-          href: 3502-inferredoperationdescription.md
-        - name: 3503 - DuplicateCorrelationQuery
-          href: 3503-duplicatecorrelationquery.md
-        - name: 3507 - ServiceEndpointAdded
-          href: 3507-serviceendpointadded.md
-        - name: 3508 - TrackingProfileNotFound
-          href: 3508-trackingprofilenotfound.md
-        - name: 3550 - BufferOutOfOrderMessageNoInstance
-          href: 3550-bufferoutofordermessagenoinstance.md
-        - name: 3551 - BufferOutOfOrderMessageNoBookmark
-          href: 3551-bufferoutofordermessagenobookmark.md
-        - name: 3552 - MaxPendingMessagesPerChannelExceeded
-          href: 3552-maxpendingmessagesperchannelexceeded.md
-        - name: 3557 - TransactedReceiveScopeEndCommitFailed
-          href: 3557-transactedreceivescopeendcommitfailed.md
-        - name: 4201 - EndSqlCommandExecute
-          href: 4201-endsqlcommandexecute.md
-        - name: 4202 - StartSqlCommandExecute
-          href: 4202-startsqlcommandexecute.md
-        - name: 4203 - RenewLockSystemError
-          href: 4203-renewlocksystemerror.md
-        - name: 4205 - FoundProcessingError
-          href: 4205-foundprocessingerror.md
-        - name: 4206 - UnlockInstanceException
-          href: 4206-unlockinstanceexception.md
-        - name: 4207 - MaximumRetriesExceededForSqlCommand
-          href: 4207-maximumretriesexceededforsqlcommand.md
-        - name: 4208 - RetryingSqlCommandDueToSqlError
-          href: 4208-retryingsqlcommandduetosqlerror.md
-        - name: 4209 - TimeoutOpeningSqlConnection
-          href: 4209-timeoutopeningsqlconnection.md
-        - name: 4210 - SqlExceptionCaught
-          href: 4210-sqlexceptioncaught.md
-        - name: 4211 - QueuingSqlRetry
-          href: 4211-queuingsqlretry.md
-        - name: 4212 - LockRetryTimeout
-          href: 4212-lockretrytimeout.md
-        - name: 4213 - RunnableInstancesDetectionError
-          href: 4213-runnableinstancesdetectionerror.md
-        - name: 4214 - InstanceLocksRecoveryError
-          href: 4214-instancelocksrecoveryerror.md
-        - name: 39456 - TrackingRecordDropped
-          href: 39456-trackingrecorddropped.md
-        - name: 39457 - TrackingRecordRaised
-          href: 39457-trackingrecordraised.md
-        - name: 39458 - TrackingRecordTruncated
-          href: 39458-trackingrecordtruncated.md
-        - name: 39459 - TrackingDataExtracted
-          href: 39459-trackingdataextracted.md
-        - name: 39460 - TrackingValueNotSerializable
-          href: 39460-trackingvaluenotserializable.md
-        - name: 57398 - MaxInstancesExceeded
-          href: 57398-maxinstancesexceeded.md
-      - name: Custom Tracking Records
-        href: custom-tracking-records.md
-      - name: Variable and Argument Tracking
-        href: variable-and-argument-tracking.md
-    - name: Workflow Security
-      href: workflow-security.md
-    - name: Windows Workflow Foundation 4 Performance
-      href: performance.md
-  - name: Extending Windows Workflow Foundation
-    href: extend.md
+    - name: Variables and Arguments
+      href: variables-and-arguments.md
+    - name: Expressions
+      href: expressions.md
+    - name: C# Expressions
+      href: csharp-expressions.md
+    - name: Properties vs. Arguments
+      href: properties-vs-arguments.md
+    - name: Exposing data with CacheMetadata
+      href: exposing-data-with-cachemetadata.md
+  - name: Waiting for Input in a Workflow
+    href: waiting-for-input-in-a-workflow.md
     items:
-    - name: Customizing the Workflow Design Experience
-      href: customizing-the-workflow-design-experience.md
+    - name: Bookmarks
+      href: bookmarks.md
+  - name: Exceptions, Transactions, and Compensation
+    href: exceptions-transactions-and-compensation.md
+    items:
+    - name: Exceptions
+      href: exceptions.md
+    - name: Transactions
+      href: workflow-transactions.md
+    - name: Compensation
+      href: compensation.md
+    - name: Cancellation
+      href: modeling-cancellation-behavior-in-workflows.md
+    - name: Debugging Workflows
+      href: debugging-workflows.md
+  - name: Hosting Workflows
+    href: hosting-workflows.md
+    items:
+    - name: Workflow Hosting Options
+      href: workflow-hosting-options.md
+    - name: Using WorkflowInvoker and WorkflowApplication
+      href: using-workflowinvoker-and-workflowapplication.md
+    - name: Activity Tree Inspection
+      href: activity-tree-inspection.md
+    - name: Serializing Workflows and Activities to and from XAML
+      href: serializing-workflows-and-activities-to-and-from-xaml.md
+    - name: Using WorkflowIdentity and Versioning
+      href: using-workflowidentity-and-versioning.md
+  - name: Dynamic Update
+    href: dynamic-update.md
+  - name: Contract First Workflow Service Development
+    href: contract-first-workflow-service-development.md
+  - name: "How to: Create a workflow service that consumes an existing service contract"
+    href: how-to-create-a-workflow-service-that-consumes-an-existing-service-contract.md
+  - name: Workflow Persistence
+    href: workflow-persistence.md
+    items:
+    - name: SQL Workflow Instance Store
+      href: sql-workflow-instance-store.md
       items:
-      - name: Using Custom Activity Designers and Templates
-        href: using-custom-activity-designers-and-templates.md
+      - name: Properties of SQL Workflow Instance Store
+        href: properties-of-sql-workflow-instance-store.md
         items:
-        - name: "How to: Create a Custom Activity Designer"
-          href: how-to-create-a-custom-activity-designer.md
-        - name: "How to: Create a Custom Activity Template"
-          href: how-to-create-a-custom-activity-template.md
-        - name: Using the ModelItem Editing Context
-          href: using-the-modelitem-editing-context.md
-        - name: Binding a custom activity property to a designer control
-          href: binding-a-custom-activity-property-to-a-designer-control.md
-      - name: Rehosting the Workflow Designer
-        href: rehosting-the-workflow-designer.md
+        - name: Instance Encoding Option
+          href: instance-encoding-option.md
+        - name: Instance Completion Action
+          href: instance-completion-action.md
+        - name: Instance Locked Exception Action
+          href: instance-locked-exception-action.md
+        - name: Host Lock Renewal Period
+          href: host-lock-renewal-period.md
+        - name: Runnable Instances Detection Period
+          href: runnable-instances-detection-period.md
+        - name: Connection String and Connection String Name
+          href: connection-string-and-connection-string-name.md
+      - name: "How to: Enable SQL Persistence for Workflows and Workflow Services"
+        href: how-to-enable-sql-persistence-for-workflows-and-workflow-services.md
+      - name: Instance Activation
+        href: instance-activation.md
+      - name: Support for Queries
+        href: support-for-queries.md
+      - name: Store Extensibility
+        href: store-extensibility.md
+      - name: Security
+        href: security.md
+      - name: SQL Server Persistence Database
+        href: sql-server-persistence-database.md
         items:
-        - name: "Task 1: Create a New Windows Presentation Foundation Application"
-          href: task-1-create-a-new-wpf-app.md
-        - name: "Task 2: Host the Workflow Designer"
-          href: task-2-host-the-workflow-designer.md
-        - name: "Task 3: Create the Toolbox and PropertyGrid Panes"
-          href: task-3-create-the-toolbox-and-propertygrid-panes.md
-        - name: "How to: Display Validation Errors in a Rehosted Designer"
-          href: how-to-display-validation-errors-in-a-rehosted-designer.md
-        - name: Support for New Workflow Foundation 4.5 Features in the Rehosted Workflow Designer
-          href: wf-features-in-the-rehosted-workflow-designer.md
-      - name: Using a Custom Expression Editor
-        href: using-a-custom-expression-editor.md
-  - name: Windows Workflow Foundation Glossary
-    href: glossary.md
-  - name: Windows Workflow Samples
-    href: ./samples/
+        - name: Persistence Database Schema
+          href: persistence-database-schema.md
+        - name: "How to: Deserialize Instance Data Properties"
+          href: how-to-deserialize-instance-data-properties.md
+        - name: "How to: Query for Non-persisted Instances"
+          href: how-to-query-for-non-persisted-instances.md
+    - name: Instance Stores
+      href: instance-stores.md
+      items:
+      - name: "How to: Enable Persistence for Workflows and Workflow Services"
+        href: how-to-enable-persistence-for-workflows-and-workflow-services.md
+      - name: "How to: Create a Custom Instance Store"
+        href: how-to-create-a-custom-instance-store.md
+    - name: Persistence Participants
+      href: persistence-participants.md
+      items:
+      - name: "How to: Create a Custom Persistence Participant"
+        href: how-to-create-a-custom-persistence-participant.md
+    - name: Persistence Best Practices
+      href: persistence-best-practices.md
+    - name: Non-Persisted Workflow Instances
+      href: non-persisted-workflow-instances.md
+    - name: Pausing and Resuming a Workflow
+      href: pausing-and-resuming-a-workflow.md
+  - name: Migration Guidance
+    items:
+    - name: Overview
+      href: migration-guidance.md
+    - name: Using .NET Framework 3.0 WF Activities in .NET Framework 4 with the Interop Activity
+      href: net-framework-3-0-wf-in-net-framework-4-interop.md
+  - name: Workflow Tracking and Tracing
+    href: workflow-tracking-and-tracing.md
+    items:
+    - name: Tracking Records
+      href: tracking-records.md
+    - name: Tracking Profiles
+      href: tracking-profiles.md
+    - name: Tracking Participants
+      href: tracking-participants.md
+    - name: Configuring Tracking for a Workflow
+      href: configuring-tracking-for-a-workflow.md
+    - name: Using Tracking to Troubleshoot Applications
+      href: using-tracking-to-troubleshoot-applications.md
+    - name: Workflow Tracing
+      href: workflow-tracing.md
+    - name: Tracking Events Reference
+      href: tracking-events-reference.md
+      items:
+      - name: 100 - WorkflowInstanceRecord
+        href: 100-workflowinstancerecord.md
+      - name: 101 - WorkflowInstanceUnhandledExceptionRecord
+        href: 101-workflowinstanceunhandledexceptionrecord.md
+      - name: 102 - WorkflowInstanceAbortedRecord
+        href: 102-workflowinstanceabortedrecord.md
+      - name: 103 - ActivityStateRecord
+        href: 103-activitystaterecord.md
+      - name: 104 - ActivityScheduledRecord
+        href: 104-activityscheduledrecord.md
+      - name: 105 - FaultPropagationRecord
+        href: 105-faultpropagationrecord.md
+      - name: 106 - CancelRequestRecord
+        href: 106-cancelrequestrecord.md
+      - name: 107 -- BookmarkResumptionRecord
+        href: 107-bookmarkresumptionrecord.md
+      - name: 108 - CustomTrackingRecordInfo
+        href: 108-customtrackingrecordinfo.md
+      - name: 110 - CustomTrackingRecordWarning
+        href: 110-customtrackingrecordwarning.md
+      - name: 111 - CustomTrackingRecordError
+        href: 111-customtrackingrecorderror.md
+      - name: 112 - WorkflowInstanceSuspendedRecord
+        href: 112-workflowinstancesuspendedrecord.md
+      - name: 113 - WorkflowInstanceTerminatedRecord
+        href: 113-workflowinstanceterminatedrecord.md
+      - name: 114 - WorkflowInstanceRecordWithId
+        href: 114-workflowinstancerecordwithid.md
+      - name: 115 - WorkflowInstanceAbortedRecordWithId
+        href: 115-workflowinstanceabortedrecordwithid.md
+      - name: 116 - WorkflowInstanceSuspendedRecordWithId
+        href: 116-workflowinstancesuspendedrecordwithid.md
+      - name: 117 - WorkflowInstanceTerminatedRecordWithId
+        href: 117-workflowinstanceterminatedrecordwithid.md
+      - name: 118 - WorkflowInstanceUnhandledExceptionRecordWithId
+        href: 118-workflowinstanceunhandledexceptionrecordwithid.md
+      - name: 119 - WorkflowInstanceUpdatedRecord
+        href: 119-workflowinstanceupdatedrecord.md
+      - name: 225 - TraceCorrelationKeys
+        href: 225-tracecorrelationkeys.md
+      - name: 440 - StartSignpostEvent1
+        href: 440-startsignpostevent.md
+      - name: 441- StopSignpostEvent1
+        href: 441-stopsignpostevent.md
+      - name: 1001 - WorkflowApplicationCompleted
+        href: 1001-workflowapplicationcompleted.md
+      - name: 1002 - WorkflowApplicationTerminated
+        href: 1002-workflowapplicationterminated.md
+      - name: 1003 - WorkflowInstanceCanceled
+        href: 1003-workflowinstancecanceled.md
+      - name: 1004 - WorkflowInstanceAborted
+        href: 1004-workflowinstanceaborted.md
+      - name: 1005 - WorkflowApplicationIdled
+        href: 1005-workflowapplicationidled.md
+      - name: 1006 - WorkflowApplicationUnhandledException
+        href: 1006-workflowapplicationunhandledexception.md
+      - name: 1007 - WorkflowApplicationPersisted
+        href: 1007-workflowapplicationpersisted.md
+      - name: 1008 - WorkflowApplicationUnloaded
+        href: 1008-workflowapplicationunloaded.md
+      - name: 1009 - ActivityScheduled
+        href: 1009-activityscheduled.md
+      - name: 1010 - ActivityCompleted
+        href: 1010-activitycompleted.md
+      - name: 1011 - ScheduleExecuteActivityWorkItem
+        href: 1011-scheduleexecuteactivityworkitem.md
+      - name: 1012 - StartExecuteActivityWorkItem
+        href: 1012-startexecuteactivityworkitem.md
+      - name: 1013 - CompleteExecuteActivityWorkItem
+        href: 1013-completeexecuteactivityworkitem.md
+      - name: 1014 - ScheduleCompletionWorkItem
+        href: 1014-schedulecompletionworkitem.md
+      - name: 1015 - StartCompletionWorkItem
+        href: 1015-startcompletionworkitem.md
+      - name: 1016 - CompleteCompletionWorkItem
+        href: 1016-completecompletionworkitem.md
+      - name: 1017 - ScheduleCancelActivityWorkItem
+        href: 1017-schedulecancelactivityworkitem.md
+      - name: 1018 - StartCancelActivityWorkItem
+        href: 1018-startcancelactivityworkitem.md
+      - name: 1019 - CompleteCancelActivityWorkItem
+        href: 1019-completecancelactivityworkitem.md
+      - name: 1020 - CreateBookmark
+        href: 1020-createbookmark.md
+      - name: 1021 - ScheduleBookmarkWorkItem
+        href: 1021-schedulebookmarkworkitem.md
+      - name: 1022 - StartBookmarkWorkItem
+        href: 1022-startbookmarkworkitem.md
+      - name: 1023 - CompleteBookmarkWorkItem
+        href: 1023-completebookmarkworkitem.md
+      - name: 1024 - CreateBookmarkScope
+        href: 1024-createbookmarkscope.md
+      - name: 1025 - BookmarkScopeInitialized
+        href: 1025-bookmarkscopeinitialized.md
+      - name: 1026 - ScheduleTransactionContextWorkItem
+        href: 1026-scheduletransactioncontextworkitem.md
+      - name: 1027 - StartTransactionContextWorkItem
+        href: 1027-starttransactioncontextworkitem.md
+      - name: 1028 - CompleteTransactionContextWorkItem
+        href: 1028-completetransactioncontextworkitem.md
+      - name: 1029 - ScheduleFaultWorkItem
+        href: 1029-schedulefaultworkitem.md
+      - name: 1030 - StartFaultWorkItem
+        href: 1030-startfaultworkitem.md
+      - name: 1031 - CompleteFaultWorkItem
+        href: 1031-completefaultworkitem.md
+      - name: 1032 - ScheduleRuntimeWorkItem
+        href: 1032-scheduleruntimeworkitem.md
+      - name: 1033 - StartRuntimeWorkItem
+        href: 1033-startruntimeworkitem.md
+      - name: 1034 - CompleteRuntimeWorkItem
+        href: 1034-completeruntimeworkitem.md
+      - name: 1035 - RuntimeTransactionSet
+        href: 1035-runtimetransactionset.md
+      - name: 1036 - RuntimeTransactionCompletionRequested
+        href: 1036-runtimetransactioncompletionrequested.md
+      - name: 1037 - RuntimeTransactionComplete
+        href: 1037-runtimetransactioncomplete.md
+      - name: 1038 - EnterNoPersistBlock
+        href: 1038-enternopersistblock.md
+      - name: 1039 - ExitNoPersistBlock
+        href: 1039-exitnopersistblock.md
+      - name: 1040 - InArgumentBound
+        href: 1040-inargumentbound.md
+      - name: 1041 - WorkflowApplicationPersistableIdle
+        href: 1041-workflowapplicationpersistableidle.md
+      - name: 1101 - WorkflowActivityStart
+        href: 1101-workflowactivitystart.md
+      - name: 1102 - WorkflowActivityStop
+        href: 1102-workflowactivitystop.md
+      - name: 1103 - WorkflowActivitySuspend
+        href: 1103-workflowactivitysuspend.md
+      - name: 1104 - WorkflowActivityResume
+        href: 1104-workflowactivityresume.md
+      - name: 1124 - InvokeMethodIsStatic
+        href: 1124-invokemethodisstatic.md
+      - name: 1125 - InvokeMethodIsNotStatic
+        href: 1125-invokemethodisnotstatic.md
+      - name: 1126 - InvokedMethodThrewException
+        href: 1126-invokedmethodthrewexception.md
+      - name: 1131 - InvokeMethodUseAsyncPattern
+        href: 1131-invokemethoduseasyncpattern.md
+      - name: 1132 - InvokeMethodDoesNotUseAsyncPattern
+        href: 1132-invokemethoddoesnotuseasyncpattern.md
+      - name: 1140 - FlowchartStart
+        href: 1140-flowchartstart.md
+      - name: 1141 - FlowchartEmpty
+        href: 1141-flowchartempty.md
+      - name: 1143 - FlowchartNextNull
+        href: 1143-flowchartnextnull.md
+      - name: 1146 - FlowchartSwitchCase
+        href: 1146-flowchartswitchcase.md
+      - name: 1147 - FlowchartSwitchDefault
+        href: 1147-flowchartswitchdefault.md
+      - name: 1148 - FlowchartSwitchCaseNotFound
+        href: 1148-flowchartswitchcasenotfound.md
+      - name: 1150 - CompensationState
+        href: 1150-compensationstate.md
+      - name: 1223 - SwitchCaseNotFound
+        href: 1223-switchcasenotfound.md
+      - name: 1449 - WfMessageReceived
+        href: 1449-wfmessagereceived.md
+      - name: 1450 - WfMessageSent
+        href: 1450-wfmessagesent.md
+      - name: 2021 - ExecuteWorkItemStart
+        href: 2021-executeworkitemstart.md
+      - name: 2022 - ExecuteWorkItemStop
+        href: 2022-executeworkitemstop.md
+      - name: 2023 - SendMessageChannelCacheMiss
+        href: 2023-sendmessagechannelcachemiss.md
+      - name: 2024 - InternalCacheMetadataStart
+        href: 2024-internalcachemetadatastart.md
+      - name: 2025 - InternalCacheMetadataStop
+        href: 2025-internalcachemetadatastop.md
+      - name: 2026 - CompileVbExpressionStart
+        href: 2026-compilevbexpressionstart.md
+      - name: 2027 - CacheRootMetadataStart
+        href: 2027-cacherootmetadatastart.md
+      - name: 2028 - CacheRootMetadataStop
+        href: 2028-cacherootmetadatastop.md
+      - name: 2029 - CompileVbExpressionStop
+        href: 2029-compilevbexpressionstop.md
+      - name: 2576 - TryCatchExceptionFromTry
+        href: 2576-trycatchexceptionfromtry.md
+      - name: 2577 - TryCatchExceptionDuringCancelation
+        href: 2577-trycatchexceptionduringcancelation.md
+      - name: 2578 - TryCatchExceptionFromCatchOrFinally
+        href: 2578-trycatchexceptionfromcatchorfinally.md
+      - name: 3501 - InferredContractDescription
+        href: 3501-inferredcontractdescription.md
+      - name: 3502 - InferredOperationDescription
+        href: 3502-inferredoperationdescription.md
+      - name: 3503 - DuplicateCorrelationQuery
+        href: 3503-duplicatecorrelationquery.md
+      - name: 3507 - ServiceEndpointAdded
+        href: 3507-serviceendpointadded.md
+      - name: 3508 - TrackingProfileNotFound
+        href: 3508-trackingprofilenotfound.md
+      - name: 3550 - BufferOutOfOrderMessageNoInstance
+        href: 3550-bufferoutofordermessagenoinstance.md
+      - name: 3551 - BufferOutOfOrderMessageNoBookmark
+        href: 3551-bufferoutofordermessagenobookmark.md
+      - name: 3552 - MaxPendingMessagesPerChannelExceeded
+        href: 3552-maxpendingmessagesperchannelexceeded.md
+      - name: 3557 - TransactedReceiveScopeEndCommitFailed
+        href: 3557-transactedreceivescopeendcommitfailed.md
+      - name: 4201 - EndSqlCommandExecute
+        href: 4201-endsqlcommandexecute.md
+      - name: 4202 - StartSqlCommandExecute
+        href: 4202-startsqlcommandexecute.md
+      - name: 4203 - RenewLockSystemError
+        href: 4203-renewlocksystemerror.md
+      - name: 4205 - FoundProcessingError
+        href: 4205-foundprocessingerror.md
+      - name: 4206 - UnlockInstanceException
+        href: 4206-unlockinstanceexception.md
+      - name: 4207 - MaximumRetriesExceededForSqlCommand
+        href: 4207-maximumretriesexceededforsqlcommand.md
+      - name: 4208 - RetryingSqlCommandDueToSqlError
+        href: 4208-retryingsqlcommandduetosqlerror.md
+      - name: 4209 - TimeoutOpeningSqlConnection
+        href: 4209-timeoutopeningsqlconnection.md
+      - name: 4210 - SqlExceptionCaught
+        href: 4210-sqlexceptioncaught.md
+      - name: 4211 - QueuingSqlRetry
+        href: 4211-queuingsqlretry.md
+      - name: 4212 - LockRetryTimeout
+        href: 4212-lockretrytimeout.md
+      - name: 4213 - RunnableInstancesDetectionError
+        href: 4213-runnableinstancesdetectionerror.md
+      - name: 4214 - InstanceLocksRecoveryError
+        href: 4214-instancelocksrecoveryerror.md
+      - name: 39456 - TrackingRecordDropped
+        href: 39456-trackingrecorddropped.md
+      - name: 39457 - TrackingRecordRaised
+        href: 39457-trackingrecordraised.md
+      - name: 39458 - TrackingRecordTruncated
+        href: 39458-trackingrecordtruncated.md
+      - name: 39459 - TrackingDataExtracted
+        href: 39459-trackingdataextracted.md
+      - name: 39460 - TrackingValueNotSerializable
+        href: 39460-trackingvaluenotserializable.md
+      - name: 57398 - MaxInstancesExceeded
+        href: 57398-maxinstancesexceeded.md
+    - name: Custom Tracking Records
+      href: custom-tracking-records.md
+    - name: Variable and Argument Tracking
+      href: variable-and-argument-tracking.md
+  - name: Workflow Security
+    href: workflow-security.md
+  - name: Windows Workflow Foundation 4 Performance
+    href: performance.md
+- name: Extending Windows Workflow Foundation
+  href: extend.md
+  items:
+  - name: Customizing the Workflow Design Experience
+    href: customizing-the-workflow-design-experience.md
+    items:
+    - name: Using Custom Activity Designers and Templates
+      href: using-custom-activity-designers-and-templates.md
+      items:
+      - name: "How to: Create a Custom Activity Designer"
+        href: how-to-create-a-custom-activity-designer.md
+      - name: "How to: Create a Custom Activity Template"
+        href: how-to-create-a-custom-activity-template.md
+      - name: Using the ModelItem Editing Context
+        href: using-the-modelitem-editing-context.md
+      - name: Binding a custom activity property to a designer control
+        href: binding-a-custom-activity-property-to-a-designer-control.md
+    - name: Rehosting the Workflow Designer
+      href: rehosting-the-workflow-designer.md
+      items:
+      - name: "Task 1: Create a New Windows Presentation Foundation Application"
+        href: task-1-create-a-new-wpf-app.md
+      - name: "Task 2: Host the Workflow Designer"
+        href: task-2-host-the-workflow-designer.md
+      - name: "Task 3: Create the Toolbox and PropertyGrid Panes"
+        href: task-3-create-the-toolbox-and-propertygrid-panes.md
+      - name: "How to: Display Validation Errors in a Rehosted Designer"
+        href: how-to-display-validation-errors-in-a-rehosted-designer.md
+      - name: Support for New Workflow Foundation 4.5 Features in the Rehosted Workflow Designer
+        href: wf-features-in-the-rehosted-workflow-designer.md
+    - name: Using a Custom Expression Editor
+      href: using-a-custom-expression-editor.md
+- name: Windows Workflow Foundation Glossary
+  href: glossary.md
+- name: Windows Workflow Samples
+  href: ./samples/


### PR DESCRIPTION
- adds `items:` as first line
- bump all subnodes up a level so there's not a single collapsible top-level node

*[Hide whitespace changes in diff](https://github.com/dotnet/docs/pull/39269/files?diff=unified&w=1)*