### PR TITLE
Edit publishing-with-visual-studio-code.md

### DIFF
--- a/docs/core/tutorials/publishing-with-visual-studio-code.md
+++ b/docs/core/tutorials/publishing-with-visual-studio-code.md
@@ -67,7 +67,7 @@ In the following steps, you'll look at the files created by the publish process.
 
       This is the [framework-dependent deployment](../deploying/deploy-with-cli.md#framework-dependent-deployment) version of the application. To run this dynamic link library, enter `dotnet HelloWorld.dll` at a command prompt. This method of running the app works on any platform that has the .NET runtime installed.
 
-   - *HelloWorld.exe* (*HelloWorld* on Linux, not created on macOS.)
+   - *HelloWorld.exe* (*HelloWorld* on Linux or macOS.)
 
       This is the [framework-dependent executable](../deploying/deploy-with-cli.md#framework-dependent-executable) version of the application. The file is operating-system-specific.
 

--- a/docs/core/tutorials/publishing-with-visual-studio-code.md
+++ b/docs/core/tutorials/publishing-with-visual-studio-code.md
@@ -303,11 +303,11 @@ In the following steps, you'll look at the files created by the publish process.
 
    :::image type="content" source="media/publishing-with-visual-studio-code/open-in-terminal.png" alt-text="Context menu showing Open in Terminal":::
 
-1. On Windows or Linux, run the app by using the executable.
+1. Run the app by using the executable.
 
    1. On Windows, enter `.\HelloWorld.exe` and press <kbd>Enter</kbd>.
 
-   1. On Linux, enter `./HelloWorld` and press <kbd>Enter</kbd>.
+   1. On Linux or macOS, enter `./HelloWorld` and press <kbd>Enter</kbd>.
 
    1. Enter a name in response to the prompt, and press any key to exit.
 


### PR DESCRIPTION
### Edit I propose
This commit edits 
```
HelloWorld.exe (HelloWorld on Linux, not created on macOS.)
```
-> 
```
HelloWorld.exe (HelloWorld on Linux or macOS.)
```

When I followed the steps in this tutorial (publishing-with-visual-studio-code.md), 
```bash
$ dotnet publish --configuration Release
```
made an executable file with the name of the project directory / namespace in `bin/release/net8.0` and in `bin/release/net8.0/publish`.

`publish` created an executable file; that contradicts
> not created on macOS

So, this commit removes the note that `publish` does not create this file on macOS. 

### Environment where I observe this
```
$ dotnet --version
8.0.101
```
macOS Big Sur (version 11.7.10)

The version of the text before this commit (`not created on macOS`) may be true for some environments. I make this pull request to share that it is not true in all environments.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tutorials/publishing-with-visual-studio-code.md](https://github.com/dotnet/docs/blob/98f342281eef446e48183f2cde7b8d2a3fac5dd7/docs/core/tutorials/publishing-with-visual-studio-code.md) | [Tutorial: Publish a .NET console application using Visual Studio Code](https://review.learn.microsoft.com/en-us/dotnet/core/tutorials/publishing-with-visual-studio-code?branch=pr-en-us-39285) |


<!-- PREVIEW-TABLE-END -->