### PR TITLE
Fix ClusterFixtureWithConfig.cs

### DIFF
--- a/docs/orleans/implementation/snippets/testing/orleans-testing/Sample.OrleansTesting/ClusterFixtureWithConfig.cs
+++ b/docs/orleans/implementation/snippets/testing/orleans-testing/Sample.OrleansTesting/ClusterFixtureWithConfig.cs
@@ -6,7 +6,7 @@ namespace Tests;
 public sealed class ClusterFixtureWithConfig : IDisposable
 {
     public TestCluster Cluster { get; } = new TestClusterBuilder()
-        .AddClientBuilderConfigurator<TestSiloConfigurations>()
+        .AddSiloBuilderConfigurator<TestSiloConfigurations>()
         .Build();
 
     public ClusterFixtureWithConfig() => Cluster.Deploy();


### PR DESCRIPTION
## Summary
This PR fixes issue with unit testing docs in Orleans.

In file ClusterFixtureWithConfig.cs `ISiloConfigurator` was added with `AddClientBuilderConfigurator<>` when it should have been added with `AddSiloBuilderConfigurator<>`.
Using `AddClientBuilderConfigurator<>` results in System.ArgumentException: The type ... TestSiloConfiguration is not assignable to either IClientBuilderConfigurator or IHostConfigurator.

## Relevant links
- doc page https://learn.microsoft.com/en-us/dotnet/orleans/implementation/testing
- found this issue when making this app https://github.com/TortillaZHawaii/agenCI/blob/4a83cd3e56b12d21e285e9399d058dbdc53dae25/Agenci.UnitTests/ClusterFixture.cs
