### PR TITLE
Update expressions-in-linq-to-entities-queries.md

### DIFF
--- a/docs/framework/data/adonet/ef/language-reference/expressions-in-linq-to-entities-queries.md
+++ b/docs/framework/data/adonet/ef/language-reference/expressions-in-linq-to-entities-queries.md
@@ -11,7 +11,7 @@ ms.assetid: d70b502f-6a15-4120-b4fe-500b173ad9cc
 
 An expression is a fragment of code that can be evaluated to a single value, object, method, or namespace. Expressions can contain a literal value, a method call, an operator and its operands, or a simple name. Simple names can be the name of a variable, type member, method parameter, namespace or type. Expressions can use operators that in turn use other expressions as parameters, or method calls whose parameters are in turn other method calls. Therefore, expressions can range from simple to very complex.  
   
- In LINQ to Entities queries, expressions can contain anything allowed by the types within the <xref:System.Linq.Expressions> namespace, including lambda expressions. The expressions that can be used in LINQ to Entities queries are a superset of the expressions that can be used to query the Entity Framework.Expressions that are part of queries against the Entity Framework are limited to operations supported by `ObjectQuery<T>` and the underlying data source.  
+ In LINQ to Entities queries, expressions can contain anything allowed by the types within the <xref:System.Linq.Expressions> namespace, including lambda expressions. The expressions that can be used in LINQ to Entities queries are a superset of the expressions that can be used to query the Entity Framework. Expressions that are part of queries against the Entity Framework are limited to operations supported by `ObjectQuery<T>` and the underlying data source.  
   
  In the following example, the comparison in the `Where` clause is an expression:  
   


### PR DESCRIPTION
Typo, space missing

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/data/adonet/ef/language-reference/expressions-in-linq-to-entities-queries.md](https://github.com/dotnet/docs/blob/a63e37dd772f411505e3508e33dc7c0bbbd34f4e/docs/framework/data/adonet/ef/language-reference/expressions-in-linq-to-entities-queries.md) | [Expressions in LINQ to Entities Queries](https://review.learn.microsoft.com/en-us/dotnet/framework/data/adonet/ef/language-reference/expressions-in-linq-to-entities-queries?branch=pr-en-us-39296) |

<!-- PREVIEW-TABLE-END -->