### PR TITLE
MSTest: add version introducing the analyzer

### DIFF
--- a/docs/core/testing/mstest-analyzers/mstest0001.md
+++ b/docs/core/testing/mstest-analyzers/mstest0001.md
@@ -24,6 +24,7 @@ dev_langs:
 | **Fix is breaking or non-breaking** | Non-breaking                                       |
 | **Enabled by default**              | Yes                                                |
 | **Default severity**                | Info                                               |
+| **Introduced in version**           | 3.2.0                                              |
 
 ## Cause
 

--- a/docs/core/testing/mstest-analyzers/mstest0002.md
+++ b/docs/core/testing/mstest-analyzers/mstest0002.md
@@ -24,6 +24,7 @@ dev_langs:
 | **Fix is breaking or non-breaking** | Breaking                                           |
 | **Enabled by default**              | Yes                                                |
 | **Default severity**                | Warning                                            |
+| **Introduced in version**           | 3.2.0                                              |
 
 ## Cause
 

--- a/docs/core/testing/mstest-analyzers/mstest0003.md
+++ b/docs/core/testing/mstest-analyzers/mstest0003.md
@@ -24,6 +24,7 @@ dev_langs:
 | **Fix is breaking or non-breaking** | Breaking                                           |
 | **Enabled by default**              | Yes                                                |
 | **Default severity**                | Warning                                            |
+| **Introduced in version**           | 3.2.0                                              |
 
 ## Cause
 

--- a/docs/core/testing/mstest-analyzers/mstest0004.md
+++ b/docs/core/testing/mstest-analyzers/mstest0004.md
@@ -24,6 +24,7 @@ dev_langs:
 | **Fix is breaking or non-breaking** | Breaking                                           |
 | **Enabled by default**              | No                                                 |
 | **Default severity**                | Disabled                                           |
+| **Introduced in version**           | 3.2.0                                              |
 
 ## Cause
 

--- a/docs/core/testing/mstest-analyzers/mstest0005.md
+++ b/docs/core/testing/mstest-analyzers/mstest0005.md
@@ -24,6 +24,7 @@ dev_langs:
 | **Fix is breaking or non-breaking** | Non-breaking                                       |
 | **Enabled by default**              | Yes                                                |
 | **Default severity**                | Warning                                            |
+| **Introduced in version**           | 3.2.0                                              |
 
 ## Cause
 

--- a/docs/core/testing/mstest-analyzers/mstest0006.md
+++ b/docs/core/testing/mstest-analyzers/mstest0006.md
@@ -24,6 +24,7 @@ dev_langs:
 | **Fix is breaking or non-breaking** | Non-breaking                                       |
 | **Enabled by default**              | Yes                                                |
 | **Default severity**                | Info                                               |
+| **Introduced in version**           | 3.2.0                                              |
 
 ## Cause
 


### PR DESCRIPTION
## Summary

We will start creating the analyzer docs as soon as it's available in code so that doc doesn't fall behind. To avoid confusion for users, I think that adding the version introducing the analyzer is interesting but I am open to other suggestions.

I don't think it's worth precising exactly the preview version.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/mstest-analyzers/mstest0001.md](https://github.com/dotnet/docs/blob/7b10ce2322d2052649b39495aa4b80af37b29336/docs/core/testing/mstest-analyzers/mstest0001.md) | [MSTEST0001: Explicitly enable or disable tests parallelization](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0001?branch=pr-en-us-39312) |
| [docs/core/testing/mstest-analyzers/mstest0002.md](https://github.com/dotnet/docs/blob/7b10ce2322d2052649b39495aa4b80af37b29336/docs/core/testing/mstest-analyzers/mstest0002.md) | ["MSTEST0002: Test classes should have valid layout"](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0002?branch=pr-en-us-39312) |
| [docs/core/testing/mstest-analyzers/mstest0003.md](https://github.com/dotnet/docs/blob/7b10ce2322d2052649b39495aa4b80af37b29336/docs/core/testing/mstest-analyzers/mstest0003.md) | [MSTEST0003: Test methods should have valid layout](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0003?branch=pr-en-us-39312) |
| [docs/core/testing/mstest-analyzers/mstest0004.md](https://github.com/dotnet/docs/blob/7b10ce2322d2052649b39495aa4b80af37b29336/docs/core/testing/mstest-analyzers/mstest0004.md) | [docs/core/testing/mstest-analyzers/mstest0004](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0004?branch=pr-en-us-39312) |
| [docs/core/testing/mstest-analyzers/mstest0005.md](https://github.com/dotnet/docs/blob/7b10ce2322d2052649b39495aa4b80af37b29336/docs/core/testing/mstest-analyzers/mstest0005.md) | [MSTEST0005: Test context property should have valid layout](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0005?branch=pr-en-us-39312) |
| [docs/core/testing/mstest-analyzers/mstest0006.md](https://github.com/dotnet/docs/blob/7b10ce2322d2052649b39495aa4b80af37b29336/docs/core/testing/mstest-analyzers/mstest0006.md) | ["MSTEST0006: Avoid '[ExpectedException]'"](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0006?branch=pr-en-us-39312) |

<!-- PREVIEW-TABLE-END -->