### PR TITLE
Make the good-first-issue policy standalone. Limit to Opened action.

### DIFF
--- a/.github/policies/good-first-issue.yml
+++ b/.github/policies/good-first-issue.yml
@@ -1,0 +1,23 @@
+id: good-first-issue
+name: GitOps.PullRequestIssueManagement
+description: Label new "typo" issues as good first issues
+resource: repository
+disabled: false
+where:
+configuration:
+  resourceManagementConfiguration:
+    eventResponderTasks:
+    - if:
+      - payloadType: Issues
+      - isAction:
+          action: Opened
+      - titleContains:
+          pattern: (T|t)ypo
+          isRegex: True
+      then:
+      - addLabel:
+          label: doc-bug
+      - addLabel:
+          label: help wanted
+      - addLabel:
+          label: good first issue

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -87,19 +87,6 @@ configuration:
       - disableAutoMerge
       description: Auto-merge Azure SDK PRs with green builds
     - if:
-      - payloadType: Issues
-      - titleContains:
-          pattern: (T|t)ypo
-          isRegex: True
-      then:
-      - addLabel:
-          label: doc-bug
-      - addLabel:
-          label: help wanted
-      - addLabel:
-          label: good first issue
-      description: Label typo issues as help wanted
-    - if:
       - payloadType: Pull_Request
       then:
       - labelSync:


### PR DESCRIPTION
Update the GitHub Policy Service bot configuration to break the good first issue automation out into a standalone policy. Restrict that behavior to when issues are Opened to avoid the labels getting added back after manual removal, as happened in https://github.com/dotnet/docs-desktop/issues/1762.

This was tested in https://github.com/dotnet/docs-desktop/issues/1766.