### PR TITLE
Update trace-perfcollect-lttng.md

### DIFF
--- a/docs/core/diagnostics/trace-perfcollect-lttng.md
+++ b/docs/core/diagnostics/trace-perfcollect-lttng.md
@@ -18,7 +18,7 @@ When performance problems are encountered on Linux, collecting a trace with `per
 Follow these steps to prepare your machine to collect a performance trace with `perfcollect`.
 
 > [!NOTE]
-> If you are in a container environment, your container needs to have `SYS_ADMIN` capability. For more information on tracing applications inside containers using PerfCollect, see [Collect diagnostics in containers](./diagnostics-in-containers.md).
+> If you are capturing from inside a container, your container must have the appropriate capabilities.  The minimal set of capabilities required are `PERFMON` and `SYS_PTRACE`.  If the capture fails with the minimal set, add the `SYS_ADMIN` capability to the container.  For more information on tracing applications inside containers using PerfCollect, see [Collect diagnostics in containers](./diagnostics-in-containers.md).
 
 1. Download `perfcollect`.
 

--- a/docs/core/diagnostics/trace-perfcollect-lttng.md
+++ b/docs/core/diagnostics/trace-perfcollect-lttng.md
@@ -18,7 +18,7 @@ When performance problems are encountered on Linux, collecting a trace with `per
 Follow these steps to prepare your machine to collect a performance trace with `perfcollect`.
 
 > [!NOTE]
-> If you are capturing from inside a container, your container must have the appropriate capabilities.  The minimal set of capabilities required are `PERFMON` and `SYS_PTRACE`.  If the capture fails with the minimal set, add the `SYS_ADMIN` capability to the container.  For more information on tracing applications inside containers using PerfCollect, see [Collect diagnostics in containers](./diagnostics-in-containers.md).
+> If you're capturing from inside a container, your container must have the appropriate capabilities. The minimal required capabilities are `PERFMON` and `SYS_PTRACE`.  If the capture fails with the minimal set, add the `SYS_ADMIN` capability to the container.  For more information on tracing applications inside containers using PerfCollect, see [Collect diagnostics in containers](./diagnostics-in-containers.md).
 
 1. Download `perfcollect`.
 


### PR DESCRIPTION
Update the minimal set of capabilities required when profiling inside a container.

## Summary

This change updates the minimal set of capabilities required to run inside a container from `SYS_ADMIN` to `PERFMON` and `SYS_PTRACE`.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/trace-perfcollect-lttng.md](https://github.com/dotnet/docs/blob/d2acb1694fbcac0ca16672b0156f5c482162a4a1/docs/core/diagnostics/trace-perfcollect-lttng.md) | [Trace .NET applications with PerfCollect](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/trace-perfcollect-lttng?branch=pr-en-us-39315) |


<!-- PREVIEW-TABLE-END -->