### PR TITLE
Add the missing dot in the code snippet

### DIFF
--- a/docs/core/extensions/logging-providers.md
+++ b/docs/core/extensions/logging-providers.md
@@ -143,7 +143,7 @@ builder.Services.Configure<AzureFileLoggerOptions>(options =>
     options.FileSizeLimit = 50 * 1024;
     options.RetainedFileCountLimit = 5;
 });
-builder.ServicesConfigure<AzureBlobLoggerOptions>(options =>
+builder.Services.Configure<AzureBlobLoggerOptions>(options =>
 {
     options.BlobName = "log.txt";
 });


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/logging-providers.md](https://github.com/dotnet/docs/blob/b2e57793b3d847a4f95ab3b28855951b296a3b35/docs/core/extensions/logging-providers.md) | [Logging providers in .NET](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/logging-providers?branch=pr-en-us-39343) |

<!-- PREVIEW-TABLE-END -->