### PR TITLE
Fix `.editorconfig` documentation to include `InternalsVisibleTo`

### DIFF
--- a/docs/fundamentals/code-analysis/includes/ignore-ivt.md
+++ b/docs/fundamentals/code-analysis/includes/ignore-ivt.md
@@ -3,7 +3,7 @@
 By default, this rule is disabled if the assembly being analyzed uses <xref:System.Runtime.CompilerServices.InternalsVisibleToAttribute> to expose its internal symbols. To specify that the rule should run even if the assembly is marked with <xref:System.Runtime.CompilerServices.InternalsVisibleToAttribute>, add the following key-value pair to an *.editorconfig* file in your project:
 
 ```ini
-dotnet_code_quality.CAXXXX.ignore_internalsvisibleto = false
+dotnet_code_quality.CAXXXX.ignore_internalsvisibleto = true
 ```
 
 This option is available starting in .NET 8.


### PR DESCRIPTION
## Summary

The example shows `false`, but it should actually be `true` to let it match with the explanation.

Fixes #Issue_Number (if available)
