### PR TITLE
Add note on what methods are exported

### DIFF
--- a/docs/core/deploying/native-aot/interop.md
+++ b/docs/core/deploying/native-aot/interop.md
@@ -79,4 +79,5 @@ Examples:
 
 The Native AOT compiler exports methods annotated with <xref:System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute> with a nonempty `EntryPoint` property as
 public C entry points. This makes it possible to either dynamically or statically link the AOT compiled modules into external
-programs. For more information, see [NativeLibrary sample](https://github.com/dotnet/samples/tree/main/core/nativeaot/NativeLibrary/README.md).
+programs. Only methods marked `UnmanagedCallersOnly` in the published assembly are considered: methods in project references or NuGet packages will not be exported.
+For more information, see [NativeLibrary sample](https://github.com/dotnet/samples/tree/main/core/nativeaot/NativeLibrary/README.md).

--- a/docs/core/deploying/native-aot/interop.md
+++ b/docs/core/deploying/native-aot/interop.md
@@ -79,5 +79,5 @@ Examples:
 
 The Native AOT compiler exports methods annotated with <xref:System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute> with a nonempty `EntryPoint` property as
 public C entry points. This makes it possible to either dynamically or statically link the AOT compiled modules into external
-programs. Only methods marked `UnmanagedCallersOnly` in the published assembly are considered: methods in project references or NuGet packages will not be exported.
+programs. Only methods marked `UnmanagedCallersOnly` in the published assembly are considered. Methods in project references or NuGet packages won't be exported.
 For more information, see [NativeLibrary sample](https://github.com/dotnet/samples/tree/main/core/nativeaot/NativeLibrary/README.md).


### PR DESCRIPTION
## Summary

Customer was puzzled why UCO methods in a ProjectReference wasn't exported.

Cc @dotnet/ilc-contrib 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/deploying/native-aot/interop.md](https://github.com/dotnet/docs/blob/5abd84eff992656f09e3b545bc77d3ebb2ff5549/docs/core/deploying/native-aot/interop.md) | [Native code interop with Native AOT](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/interop?branch=pr-en-us-39362) |


<!-- PREVIEW-TABLE-END -->