### PR TITLE
'new' keyword disambiguation page

### DIFF
--- a/.openpublishing.redirection.csharp.json
+++ b/.openpublishing.redirection.csharp.json
@@ -892,10 +892,6 @@
             "redirect_url": "/dotnet/csharp/language-reference/operators/new-operator"
         },
         {
-            "source_path_from_root": "/docs/csharp/language-reference/keywords/new.md",
-            "redirect_url": "/dotnet/csharp/language-reference/operators/new-operator"
-        },
-        {
             "source_path_from_root": "/docs/csharp/language-reference/keywords/object.md",
             "redirect_url": "/dotnet/csharp/language-reference/builtin-types/reference-types"
         },

--- a/docs/csharp/language-reference/keywords/index.md
+++ b/docs/csharp/language-reference/keywords/index.md
@@ -63,7 +63,7 @@ The first table in this article lists keywords that are reserved identifiers in 
     :::column-end:::
     :::column:::
         [`namespace`](namespace.md)  
-        [`new`](../operators/new-operator.md)  
+        [`new`](new.md)  
         [`null`](null.md)  
         [`object`](../builtin-types/reference-types.md)  
         [`operator`](../operators/operator-overloading.md)  

--- a/docs/csharp/language-reference/keywords/new.md
+++ b/docs/csharp/language-reference/keywords/new.md
@@ -1,0 +1,19 @@
+---
+description: "new - C# Reference"
+title: "new - C# Reference"
+ms.date: 01/02/2024
+f1_keywords:
+  - "new"
+  - "new_CSharpKeyword"
+helpviewer_keywords:
+  - "new keyword [C#]"
+---
+
+# new (C# Reference)
+
+The `new` keyword is used in the following contexts:
+  
+## See also
+
+- [C# Keywords](index.md)
+- [C# Reference](../index.md)

--- a/docs/csharp/language-reference/keywords/new.md
+++ b/docs/csharp/language-reference/keywords/new.md
@@ -11,8 +11,12 @@ helpviewer_keywords:
 
 # new (C# Reference)
 
-The `new` keyword is used in the following contexts:
-  
+The `new` keyword is used as:
+
+- [new operator](../operators/new-operator.md)
+- [new modifier](new-modifier.md)
+- [new constraint](new-constraint.md)
+
 ## See also
 
 - [C# Keywords](index.md)


### PR DESCRIPTION
This pull request closes #38541 

It adds the disambiguation page for the `new` keyword, but also links that page in the keywords index page instead of misleading operator.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/index.md](https://github.com/dotnet/docs/blob/44052b9fb32cbb92bec603ee52d544dd86e6ca65/docs/csharp/language-reference/keywords/index.md) | [C# Keywords](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/index?branch=pr-en-us-39370) |
| [docs/csharp/language-reference/keywords/new.md](https://github.com/dotnet/docs/blob/44052b9fb32cbb92bec603ee52d544dd86e6ca65/docs/csharp/language-reference/keywords/new.md) | ["new - C# Reference"](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/new?branch=pr-en-us-39370) |


<!-- PREVIEW-TABLE-END -->