### PR TITLE
change the order of circle, cylinder, and sphere

### DIFF
--- a/docs/csharp/language-reference/keywords/virtual.md
+++ b/docs/csharp/language-reference/keywords/virtual.md
@@ -42,7 +42,7 @@ Virtual properties behave like virtual methods, except for the differences in de
 
 In this example, the `Shape` class contains the two coordinates `x`, `y`, and the `Area()` virtual method. Different shape classes such as `Circle`, `Cylinder`, and `Sphere` inherit the `Shape` class, and the surface area is calculated for each figure. Each derived class has its own override implementation of `Area()`.
 
-Notice that the inherited classes `Circle`, `Sphere`, and `Cylinder` all use constructors that initialize the base class, as shown in the following declaration.
+Notice that the inherited classes `Circle`, `Cylinder`, and `Sphere` all use constructors that initialize the base class, as shown in the following declaration.
 
 ```csharp
 public Cylinder(double r, double h): base(r, h) {}


### PR DESCRIPTION
I changed the order of the order of `Circle`, `Cylinder`, and `Sphere` to match the the order in the first paragraph under `Example` heading to not confuse readers

## Summary

The  order in the first paragraph: `Circle`, `Cylinder`, and `Sphere` 
The order in the second paragraph: `Circle`, `Sphere`, and `Cylinder` 
Update: I updated both paragraph to maintain the same order

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/virtual.md](https://github.com/dotnet/docs/blob/7c1652bf47f817f97bdbf27a2eae3cab0f9d377f/docs/csharp/language-reference/keywords/virtual.md) | [virtual (C# Reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/virtual?branch=pr-en-us-39395) |

<!-- PREVIEW-TABLE-END -->