### PR TITLE
Add info about wildcard dual-sockets on QuicListener

### DIFF
--- a/docs/fundamentals/networking/quic/quic-troubleshooting.md
+++ b/docs/fundamentals/networking/quic/quic-troubleshooting.md
@@ -22,6 +22,10 @@ This behavior is by design as `MsQuic` uses `SO_REUSEPORT` to achieve better per
 > [!NOTE]
 > This problem doesn't occur on Windows, where MsQuic will attempt to do a port reservation. This causes the application trying to open second listener on the same port fail to start.
 
+## QuicListener is always listening on ANY address
+
+Even if a specific address is supplied via the `ListenEndpoint` property, QuicListener will still open a dual-stack wildcard socket. This behavior is by design by `MsQuic`. The listening IP address is still being used to do filtering inside `MsQuic`. For more information, see [ListenerStart](https://github.com/microsoft/msquic/blob/main/docs/api/ListenerStart.md) documentation and the original issue [dotnet/runtime#92812].
+
 ## Client receives unexpected ALPN error
 
 Client attempts to connect, but receives `Application layer protocol negotiation error was encountered` despite using the same ALPN as the server.


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/92812


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/networking/quic/quic-troubleshooting.md](https://github.com/dotnet/docs/blob/2a102485824a7af795e3434ca814fddc2b90edee/docs/fundamentals/networking/quic/quic-troubleshooting.md) | [Troubleshoot QUIC issues in .NET](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-troubleshooting?branch=pr-en-us-39409) |

<!-- PREVIEW-TABLE-END -->