### PR TITLE
Add link to `init` keyword in "See also" section of Properties page

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/properties.md
+++ b/docs/csharp/programming-guide/classes-and-structs/properties.md
@@ -79,5 +79,6 @@ For more information, see [Properties](~/_csharpstandard/standard/classes.md#157
 ## See also
 
 - [Indexers](../indexers/index.md)
+- [init keyword](../../language-reference/keywords/init.md)
 - [get keyword](../../language-reference/keywords/get.md)
 - [set keyword](../../language-reference/keywords/set.md)


### PR DESCRIPTION
This pull request closes #39394 
It adds the link to `init` keyword page according to agreed approach in issue's discussion.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/classes-and-structs/properties.md](https://github.com/dotnet/docs/blob/2c4dad56f5caa263bc71a5684338104eab6d32df/docs/csharp/programming-guide/classes-and-structs/properties.md) | [Properties (C# Programming Guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/properties?branch=pr-en-us-39411) |

<!-- PREVIEW-TABLE-END -->