### PR TITLE
Updated shared snippet for Array with correct C# syntax

### DIFF
--- a/docs/csharp/language-reference/builtin-types/snippets/shared/Arrays.cs
+++ b/docs/csharp/language-reference/builtin-types/snippets/shared/Arrays.cs
@@ -328,15 +328,17 @@
         //<LINQInit>
         var contacts = new[]
         {
-                new {
-                    Name = " Eugene Zabokritski",
-                    PhoneNumbers = new[] { "206-555-0108", "425-555-0001" }
-                },
-                new {
-                    Name = " Hanying Feng",
-                    PhoneNumbers = new[] { "650-555-0199" }
-                }
-            };
+            new
+            {
+                Name = "Eugene Zabokritski",
+                PhoneNumbers = new[] { "206-555-0108", "425-555-0001" }
+            },
+            new
+            {
+                Name = "Hanying Feng",
+                PhoneNumbers = new[] { "650-555-0199" }
+            }
+        };
         //</LINQInit>
     }
 }


### PR DESCRIPTION
## Summary

This [doc](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/arrays) and others reference to this snippet which has an unusual syntax (line breaks and curly braces position) to declare arrays and anonymous objects.