### PR TITLE
Disable MD056 for tables with needed pipes

### DIFF
--- a/docs/fundamentals/code-analysis/includes/excluded-symbol-names.md
+++ b/docs/fundamentals/code-analysis/includes/excluded-symbol-names.md
@@ -14,9 +14,11 @@ Allowed symbol name formats in the option value (separated by `|`):
 
 Examples:
 
+<!-- markdownlint-disable MD056 -->
 | Option Value | Summary |
 | --- | --- |
 |`dotnet_code_quality.CAXXXX.excluded_symbol_names = MyType` | Matches all symbols named `MyType`. |
-|'dotnet_code_quality.CAXXXX.excluded_symbol_names = MyType1&#124;MyType2' | Matches all symbols named either `MyType1` or `MyType2`. |
+|`dotnet_code_quality.CAXXXX.excluded_symbol_names = MyType1|MyType2` | Matches all symbols named either `MyType1` or `MyType2`. |
 |`dotnet_code_quality.CAXXXX.excluded_symbol_names = M:NS.MyType.MyMethod(ParamType)` | Matches specific method `MyMethod` with the specified fully qualified signature. |
-|'dotnet_code_quality.CAXXXX.excluded_symbol_names = M:NS1.MyType1.MyMethod1(ParamType)&#124;M:NS2.MyType2.MyMethod2(ParamType)' | Matches specific methods `MyMethod1` and `MyMethod2` with the respective fully qualified signatures. |
+|`dotnet_code_quality.CAXXXX.excluded_symbol_names = M:NS1.MyType1.MyMethod1(ParamType)|M:NS2.MyType2.MyMethod2(ParamType)` | Matches specific methods `MyMethod1` and `MyMethod2` with the respective fully qualified signatures. |
+<!-- markdownlint-enable MD056 -->

--- a/docs/fundamentals/code-analysis/includes/excluded-type-names-with-derived-types.md
+++ b/docs/fundamentals/code-analysis/includes/excluded-type-names-with-derived-types.md
@@ -13,9 +13,11 @@ Allowed symbol name formats in the option value (separated by `|`):
 
 Examples:
 
+<!-- markdownlint-disable MD056 -->
 | Option Value | Summary |
 | --- | --- |
 |`dotnet_code_quality.CAXXXX.excluded_type_names_with_derived_types = MyType` | Matches all types named `MyType` and all of their derived types. |
-|'dotnet_code_quality.CAXXXX.excluded_type_names_with_derived_types = MyType1&#124;MyType2' | Matches all types named either `MyType1` or `MyType2` and all of their derived types. |
+|`dotnet_code_quality.CAXXXX.excluded_type_names_with_derived_types = MyType1|MyType2` | Matches all types named either `MyType1` or `MyType2` and all of their derived types. |
 |`dotnet_code_quality.CAXXXX.excluded_type_names_with_derived_types = M:NS.MyType` | Matches specific type `MyType` with given fully qualified name and all of its derived types. |
-|'dotnet_code_quality.CAXXXX.excluded_type_names_with_derived_types = M:NS1.MyType1&#124;M:NS2.MyType2' | Matches specific types `MyType1` and `MyType2` with the respective fully qualified names, and all of their derived types. |
+|`dotnet_code_quality.CAXXXX.excluded_type_names_with_derived_types = M:NS1.MyType1|M:NS2.MyType2` | Matches specific types `MyType1` and `MyType2` with the respective fully qualified names, and all of their derived types. |
+<!-- markdownlint-enable MD056 -->

--- a/docs/fundamentals/code-analysis/quality-rules/ca1031.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1031.md
@@ -68,12 +68,14 @@ Allowed type name formats in the option value (separated by `|`):
 
 Examples:
 
+<!-- markdownlint-disable MD056 -->
 | Option value | Summary |
 | --- | --- |
 |`dotnet_code_quality.CA1031.disallowed_symbol_names = ExceptionType` | Matches all symbols named 'ExceptionType' in the compilation. |
-|'dotnet_code_quality.CA1031.disallowed_symbol_names = ExceptionType1&#124;ExceptionType2' | Matches all symbols named either 'ExceptionType1' or 'ExceptionType2' in the compilation. |
+|`dotnet_code_quality.CA1031.disallowed_symbol_names = ExceptionType1|ExceptionType2` | Matches all symbols named either 'ExceptionType1' or 'ExceptionType2' in the compilation. |
 |`dotnet_code_quality.CA1031.disallowed_symbol_names = T:NS.ExceptionType` | Matches specific types named 'ExceptionType' with given fully qualified name. |
-|'dotnet_code_quality.CA1031.disallowed_symbol_names = T:NS1.ExceptionType1&#124;T:NS1.ExceptionType2' | Matches types named 'ExceptionType1' and 'ExceptionType2' with respective fully qualified names. |
+|`dotnet_code_quality.CA1031.disallowed_symbol_names = T:NS1.ExceptionType1|T:NS1.ExceptionType2` | Matches types named 'ExceptionType1' and 'ExceptionType2' with respective fully qualified names. |
+<!-- markdownlint-enable MD056 -->
 
 You can configure these options for just this rule, for all rules it applies to, or for all rules in this category ([Design](design-warnings.md)) that it applies to. For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1062.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1062.md
@@ -108,12 +108,14 @@ Allowed method name formats in the option value (separated by `|`):
 
 Examples:
 
+<!-- markdownlint-disable MD056 -->
 | Option Value | Summary |
 | --- | --- |
 |`dotnet_code_quality.CA1062.null_check_validation_methods = Validate` | Matches all methods named `Validate` in the compilation. |
-|'dotnet_code_quality.CA1062.null_check_validation_methods = Validate1&#124;Validate2' | Matches all methods named either `Validate1` or `Validate2` in the compilation. |
+|`dotnet_code_quality.CA1062.null_check_validation_methods = Validate1|Validate2` | Matches all methods named either `Validate1` or `Validate2` in the compilation. |
 |`dotnet_code_quality.CA1062.null_check_validation_methods = NS.MyType.Validate(ParamType)` | Matches specific method `Validate` with given fully qualified signature. |
-|'dotnet_code_quality.CA1062.null_check_validation_methods = NS1.MyType1.Validate1(ParamType)&#124;NS2.MyType2.Validate2(ParamType)' | Matches specific methods `Validate1` and `Validate2` with respective fully qualified signature. |
+|`dotnet_code_quality.CA1062.null_check_validation_methods = NS1.MyType1.Validate1(ParamType)|NS2.MyType2.Validate2(ParamType)` | Matches specific methods `Validate1` and `Validate2` with respective fully qualified signature. |
+<!-- markdownlint-enable MD056 -->
 
 ## Example 1
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1501.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1501.md
@@ -107,16 +107,18 @@ You can configure this option for just this rule, for all rules it applies to, o
 
 You can configure the rule to exclude certain types or namespaces from the inheritance hierarchy tree. By default, all types from the `System.*` namespace are excluded. No matter what value you set, this default value is added.
 
+<!-- markdownlint-disable MD056 -->
 | Option Value                                                                                            | Summary                                                                                                                                                                |
 | ------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `dotnet_code_quality.CA1501.additional_inheritance_excluded_symbol_names = MyType`                      | Matches all types named `MyType` or whose containing namespace contains `MyType` (and all types from the `System` namespace)                                           |
-| dotnet_code_quality.CA1501.additional_inheritance_excluded_symbol_names = MyType1&#124;MyType2             | Matches all types named either `MyType1` or `MyType2` or whose containing namespace contains either `MyType1` or `MyType2` (and all types from the `System` namespace) |
+| `dotnet_code_quality.CA1501.additional_inheritance_excluded_symbol_names = MyType1|MyType2`             | Matches all types named either `MyType1` or `MyType2` or whose containing namespace contains either `MyType1` or `MyType2` (and all types from the `System` namespace) |
 | `dotnet_code_quality.CA1501.additional_inheritance_excluded_symbol_names = T:NS.MyType`                 | Matches specific type `MyType` in the namespace `NS` (and all types from the `System` namespace)                                                                       |
-| 'dotnet_code_quality.CA1501.additional_inheritance_excluded_symbol_names = T:NS1.MyType1&#124;T:NS2.MyType2' | Matches specific types `MyType1` and `MyType2` with respective fully qualified names (and all types from the `System` namespace)                                       |
+| `dotnet_code_quality.CA1501.additional_inheritance_excluded_symbol_names = T:NS1.MyType1|T:NS2.MyType2` | Matches specific types `MyType1` and `MyType2` with respective fully qualified names (and all types from the `System` namespace)                                       |
 | `dotnet_code_quality.CA1501.additional_inheritance_excluded_symbol_names = N:NS`                        | Matches all types from the `NS` namespace (and all types from the `System` namespace)                                                                                  |
 | `dotnet_code_quality.CA1501.additional_inheritance_excluded_symbol_names = My*`                         | Matches all types whose name starts with `My` or whose containing namespace parts starts with `My` (and all types from the `System` namespace)                         |
 | `dotnet_code_quality.CA1501.additional_inheritance_excluded_symbol_names = T:NS.My*`                    | Matches all types whose name starts with `My` in the namespace `NS` (and all types from the `System` namespace)                                                        |
 | `dotnet_code_quality.CA1501.additional_inheritance_excluded_symbol_names = N:My*`                       | Matches all types whose containing namespace starts with `My` (and all types from the `System` namespace)                                                              |
+<!-- markdownlint-enable MD056 -->
 
 ## Example
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1710.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1710.md
@@ -139,11 +139,13 @@ Separate multiple values with a `|` character. Types can be specified in either 
 
 Examples:
 
+<!-- markdownlint-disable MD056 -->
 | Option Value | Summary |
 | --- | --- |
 |`dotnet_code_quality.CA1710.additional_required_suffixes = MyClass->Class` | All types that inherit from 'MyClass' are required to have the 'Class' suffix. |
-|'dotnet_code_quality.CA1710.additional_required_suffixes = MyClass->Class&#124;MyNamespace.IPath->Path' | All types that inherit from 'MyClass' are required to have the 'Class' suffix AND all types that implement 'MyNamespace.IPath' are required to have the 'Path' suffix. |
+|`dotnet_code_quality.CA1710.additional_required_suffixes = MyClass->Class|MyNamespace.IPath->Path` | All types that inherit from 'MyClass' are required to have the 'Class' suffix AND all types that implement 'MyNamespace.IPath' are required to have the 'Path' suffix. |
 |`dotnet_code_quality.CA1710.additional_required_suffixes = T:System.Data.IDataReader->{}` | Overrides built-in suffixes. In this case, all types that implement 'IDataReader' are no longer required to end in 'Collection'. |
+<!-- markdownlint-enable MD056 -->
 
 ## Related rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca2241.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2241.md
@@ -65,12 +65,14 @@ Allowed method name formats in the option value (separated by `|`):
 
 Examples:
 
+<!-- markdownlint-disable MD056 -->
 | Option Value | Summary |
 | --- | --- |
 |`dotnet_code_quality.CA2241.additional_string_formatting_methods = MyFormat` | Matches all methods named `MyFormat` in the compilation. |
-|'dotnet_code_quality.CA2241.additional_string_formatting_methods = MyFormat1&#124;MyFormat2' | Matches all methods named either `MyFormat1` or `MyFormat2` in the compilation. |
+|`dotnet_code_quality.CA2241.additional_string_formatting_methods = MyFormat1|MyFormat2` | Matches all methods named either `MyFormat1` or `MyFormat2` in the compilation. |
 |`dotnet_code_quality.CA2241.additional_string_formatting_methods = NS.MyType.MyFormat(ParamType)` | Matches specific method `MyFormat` with given fully qualified signature. |
-|'dotnet_code_quality.CA2241.additional_string_formatting_methods = NS1.MyType1.MyFormat1(ParamType)&#124;NS2.MyType2.MyFormat2(ParamType)' | Matches specific methods `MyFormat1` and `MyFormat2` with respective fully qualified signature. |
+|`dotnet_code_quality.CA2241.additional_string_formatting_methods = NS1.MyType1.MyFormat1(ParamType)|NS2.MyType2.MyFormat2(ParamType)` | Matches specific methods `MyFormat1` and `MyFormat2` with respective fully qualified signature. |
+<!-- markdownlint-enable MD056 -->
 
 ### Determine additional string formatting methods automatically
 


### PR DESCRIPTION
Follow up to #39221.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1031.md](https://github.com/dotnet/docs/blob/50d33c68d79850ead5a6a4b127234360f99c914e/docs/fundamentals/code-analysis/quality-rules/ca1031.md) | [CA1031: Do not catch general exception types](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1031?branch=pr-en-us-39472) |
| [docs/fundamentals/code-analysis/quality-rules/ca1062.md](https://github.com/dotnet/docs/blob/50d33c68d79850ead5a6a4b127234360f99c914e/docs/fundamentals/code-analysis/quality-rules/ca1062.md) | ["CA1062: Validate arguments of public methods (code analysis)"](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1062?branch=pr-en-us-39472) |
| [docs/fundamentals/code-analysis/quality-rules/ca1501.md](https://github.com/dotnet/docs/blob/50d33c68d79850ead5a6a4b127234360f99c914e/docs/fundamentals/code-analysis/quality-rules/ca1501.md) | [CA1501: Avoid excessive inheritance](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1501?branch=pr-en-us-39472) |
| [docs/fundamentals/code-analysis/quality-rules/ca1710.md](https://github.com/dotnet/docs/blob/50d33c68d79850ead5a6a4b127234360f99c914e/docs/fundamentals/code-analysis/quality-rules/ca1710.md) | [docs/fundamentals/code-analysis/quality-rules/ca1710](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1710?branch=pr-en-us-39472) |
| [docs/fundamentals/code-analysis/quality-rules/ca2241.md](https://github.com/dotnet/docs/blob/50d33c68d79850ead5a6a4b127234360f99c914e/docs/fundamentals/code-analysis/quality-rules/ca2241.md) | [CA2241: Provide correct arguments to formatting methods](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2241?branch=pr-en-us-39472) |

<!-- PREVIEW-TABLE-END -->