### PR TITLE
Inline array size limit breaking change

### DIFF
--- a/docs/core/compatibility/9.0.md
+++ b/docs/core/compatibility/9.0.md
@@ -20,6 +20,7 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 | Title                                                                                    | Type of change      | Introduced version |
 |------------------------------------------------------------------------------------------|---------------------|--------------------|
 | [Creating type of array of System.Void not allowed](core-libraries/9.0/type-instance.md) | Behavioral change   | Preview 1          |
+| [Inline array struct size limit is enforced](core-libraries/9.0/inlinearray-size.md) | Behavioral change   | Preview 1          |
 | [RuntimeHelpers.GetSubArray returns different type](core-libraries/9.0/getsubarray-return.md) | Behavioral change   | Preview 1          |
 
 ## Networking

--- a/docs/core/compatibility/core-libraries/9.0/inlinearray-size.md
+++ b/docs/core/compatibility/core-libraries/9.0/inlinearray-size.md
@@ -1,0 +1,36 @@
+---
+title: "Breaking change: Inline array struct size limit is enforced"
+description: Learn about the .NET 9 breaking change in core .NET libraries where the size limit for inline arrays is now enforced.
+ms.date: 02/09/2024
+---
+# Inline array struct size limit is enforced
+
+The <xref:System.Runtime.CompilerServices.InlineArrayAttribute> attribute was introduced in .NET 8 to annotate struct types that have a single field. Inline array structs were intended to have a size limit of 1 MiB. However, due to a bug, the limit wasn't enforced for inline array structs that have a sequential layout, which is also the default layout as emitted by C#. This change enforces the size limit.
+
+## Previous behavior
+
+In .NET 8, you could declare an inline array struct with any positive, non-zero size. In extreme cases, the effective size was unpredictable. For example, a struct whose size was declared as `Int32.MaxValue + 1` ended up having a size of 1 due to wrap-around.
+
+## New behavior
+
+Starting in .NET 9, the size limit of 1 MiB is enforced.
+
+## Version introduced
+
+.NET 9 Preview 1
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+This change fixes a bug in the implementation where the size limit wasn't enforced.
+
+## Recommended action
+
+If you have code that uses inline array structs with very large instances that exceed the limit, reduce the size of these structs.
+
+## Affected APIs
+
+- <xref:System.Runtime.CompilerServices.InlineArrayAttribute?displayProperty=fullName>

--- a/docs/core/compatibility/core-libraries/9.0/inlinearray-size.md
+++ b/docs/core/compatibility/core-libraries/9.0/inlinearray-size.md
@@ -5,7 +5,7 @@ ms.date: 02/09/2024
 ---
 # Inline array struct size limit is enforced
 
-The <xref:System.Runtime.CompilerServices.InlineArrayAttribute> attribute was introduced in .NET 8 to annotate struct types that have a single field. Inline array structs were intended to have a size limit of 1 MiB. However, due to a bug, the limit wasn't enforced for inline array structs that have a sequential layout, which is also the default layout as emitted by C#. This change enforces the size limit.
+The <xref:System.Runtime.CompilerServices.InlineArrayAttribute> attribute was introduced in .NET 8 to annotate struct types that have a single field. Inline array structs were intended to have a size limit of 1 mebibyte (MiB). However, due to a bug, the limit wasn't enforced for inline array structs that have a sequential layout, which is also the default layout as emitted by C#. This change enforces the size limit.
 
 ## Previous behavior
 

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -12,6 +12,8 @@ items:
       items:
       - name: Creating type of array of System.Void not allowed
         href: core-libraries/9.0/type-instance.md
+      - name: Inline array struct size limit is enforced
+        href: core-libraries/9.0/inlinearray-size.md
       - name: RuntimeHelpers.GetSubArray returns different type
         href: core-libraries/9.0/getsubarray-return.md
     - name: Networking
@@ -1138,6 +1140,8 @@ items:
       items:
       - name: Creating type of array of System.Void not allowed
         href: core-libraries/9.0/type-instance.md
+      - name: Inline array struct size limit is enforced
+        href: core-libraries/9.0/inlinearray-size.md
       - name: RuntimeHelpers.GetSubArray returns different type
         href: core-libraries/9.0/getsubarray-return.md
     - name: .NET 8


### PR DESCRIPTION
Fixes #39273.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/9.0.md](https://github.com/dotnet/docs/blob/49d09d2885d7959c30aba43ab517ecbef42c6c2f/docs/core/compatibility/9.0.md) | [Breaking changes in .NET 9](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/9.0?branch=pr-en-us-39475) |
| [docs/core/compatibility/core-libraries/9.0/inlinearray-size.md](https://github.com/dotnet/docs/blob/49d09d2885d7959c30aba43ab517ecbef42c6c2f/docs/core/compatibility/core-libraries/9.0/inlinearray-size.md) | [Inline array struct size limit is enforced](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/9.0/inlinearray-size?branch=pr-en-us-39475) |


<!-- PREVIEW-TABLE-END -->