### PR TITLE
Add Smart Control guidance to Install .NET on Windows / Troubleshooting

### DIFF
--- a/docs/core/install/windows.md
+++ b/docs/core/install/windows.md
@@ -417,7 +417,7 @@ Most likely you installed both the x86 (32-bit) and x64 (64-bit) versions of the
 
 ### Building apps is slower than expected
 
-Check if the Smart App Control Windows feature is off. Smart App Control is not recommended to be enabled on machines used for development. It should be off as any other setting may negatively impact SDK performance.
+Ensure that the Smart App Control Windows feature is off. Smart App Control isn't recommended to be enabled on machines used for development. It should be off as any other setting may negatively impact SDK performance.
 
 ## Next steps
 

--- a/docs/core/install/windows.md
+++ b/docs/core/install/windows.md
@@ -417,7 +417,7 @@ Most likely you installed both the x86 (32-bit) and x64 (64-bit) versions of the
 
 ### Building apps is slower than expected
 
-Ensure that the Smart App Control Windows feature is off. Smart App Control isn't recommended to be enabled on machines used for development. It should be off as any other setting may negatively impact SDK performance.
+Ensure that Smart App Control, a Windows feature, is off. Smart App Control isn't recommended to be enabled on machines used for development. Any setting other than "off" might negatively impact SDK performance.
 
 ## Next steps
 

--- a/docs/core/install/windows.md
+++ b/docs/core/install/windows.md
@@ -383,6 +383,7 @@ For more information about using .NET in a Docker container, see [Introduction t
 After installing the .NET SDK, you may run into problems trying to run .NET CLI commands. This section collects those common problems and provides solutions.
 
 - [No .NET SDK was found](#no-net-sdk-was-found)
+- [Building apps is slower than expected](#building-apps-is-slower-than-expected)
 
 ### No .NET SDK was found
 
@@ -413,6 +414,10 @@ Most likely you installed both the x86 (32-bit) and x64 (64-bit) versions of the
 01. Use the **Move Up** and **Move Down** buttons to move the **C:\\Program Files\\dotnet\\** entry above **C:\\Program Files (x86)\\dotnet\\**.
 
     :::image type="content" source="media/windows/edit-vars.png" alt-text="The environment variables list for the system.":::
+
+### Building apps is slower than expected
+
+Check if the Smart App Control Windows feature is off. Smart App Control is not recommended to be enabled on machines used for development. It should be off as any other setting may negatively impact SDK performance.
 
 ## Next steps
 


### PR DESCRIPTION
## Summary

We've recently investigated perf issues caused by the SAC feature, which is not supposed to be used on dev machines. Adding a troubleshooting entry.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/windows.md](https://github.com/dotnet/docs/blob/4c07e7252e0bfafe86190329e95cac4f082da090/docs/core/install/windows.md) | [Install .NET on Windows](https://review.learn.microsoft.com/en-us/dotnet/core/install/windows?branch=pr-en-us-39479) |


<!-- PREVIEW-TABLE-END -->