### PR TITLE
Two .NET 8 breaking changes

### DIFF
--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -44,6 +44,7 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 | [Backslash mapping in Unix file paths](core-libraries/8.0/file-path-backslash.md)                         | Behavioral change   |
 | [Base64.DecodeFromUtf8 methods ignore whitespace](core-libraries/8.0/decodefromutf8-whitespace.md)        | Behavioral change   |
 | [Boolean-backed enum type support removed](core-libraries/8.0/bool-backed-enum.md)                        | Behavioral change   |
+| [Drive's current directory path enumeration](core-libraries/8.0/drive-current-dir-paths.md)              | Behavioral change   |
 | [Enumerable.Sum throws new OverflowException for some inputs](core-libraries/8.0/enumerable-sum.md)       | Behavioral change   |
 | [FileStream writes when pipe is closed](core-libraries/8.0/filestream-disposed-pipe.md)                   | Behavioral change   |
 | [GC.GetGeneration might return Int32.MaxValue](core-libraries/8.0/getgeneration-return-value.md)          | Behavioral change   |
@@ -119,23 +120,24 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 
 ## SDK
 
-| Title                                                                                              | Type of change                                   |
-| -------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
-| [CLI console output uses UTF-8](sdk/8.0/console-encoding.md)                                       | Behavioral change/Source and binary incompatible |
-| [Console encoding not UTF-8 after completion](sdk/8.0/console-encoding-fix.md)                     | Behavioral change/Binary incompatible            |
-| [Containers default to use the 'latest' tag](sdk/8.0/default-image-tag.md)                         | Behavioral change                                |
-| ['dotnet pack' uses Release configuration](sdk/8.0/dotnet-pack-config.md)                          | Behavioral change/Source incompatible            |
-| ['dotnet publish' uses Release configuration](sdk/8.0/dotnet-publish-config.md)                    | Behavioral change/Source incompatible            |
-| [Implicit `using` for System.Net.Http no longer added](sdk/8.0/implicit-global-using-netfx.md)     | Behavioral change/Source incompatible            |
-| [MSBuild custom derived build events deprecated](sdk/8.0/custombuildeventargs.md)                  | Behavioral change                                |
-| [MSBuild respects DOTNET_CLI_UI_LANGUAGE](sdk/8.0/msbuild-language.md)                             | Behavioral change                                |
-| [Runtime-specific apps not self-contained](sdk/8.0/runtimespecific-app-default.md)                 | Source/binary incompatible                       |
-| [--arch option doesn't imply self-contained](sdk/8.0/arch-option.md)                               | Behavioral change                                |
-| ['dotnet restore' produces security vulnerability warnings](sdk/8.0/dotnet-restore-audit.md)       | Behavioral change                                |
-| [SDK uses a smaller RID graph](sdk/8.0/rid-graph.md)                                               | Behavioral change/Source incompatible            |
-| [Source Link included in the .NET SDK](sdk/8.0/source-link.md)                                     | Source incompatible                              |
+| Title                                                                           | Type of change                                   |
+|---------------------------------------------------------------------------------|--------------------------------------------------|
+| [CLI console output uses UTF-8](sdk/8.0/console-encoding.md)                    | Behavioral change/Source and binary incompatible |
+| [Console encoding not UTF-8 after completion](sdk/8.0/console-encoding-fix.md)  | Behavioral change/Binary incompatible            |
+| [Containers default to use the 'latest' tag](sdk/8.0/default-image-tag.md)      | Behavioral change                                |
+| ['dotnet pack' uses Release configuration](sdk/8.0/dotnet-pack-config.md)       | Behavioral change/Source incompatible            |
+| ['dotnet publish' uses Release configuration](sdk/8.0/dotnet-publish-config.md) | Behavioral change/Source incompatible            |
+| [Implicit `using` for System.Net.Http no longer added](sdk/8.0/implicit-global-using-netfx.md) | Behavioral change/Source incompatible            |
+| [MSBuild custom derived build events deprecated](sdk/8.0/custombuildeventargs.md)              | Behavioral change                                |
+| [MSBuild respects DOTNET_CLI_UI_LANGUAGE](sdk/8.0/msbuild-language.md)                         | Behavioral change                                |
+| [Runtime-specific apps not self-contained](sdk/8.0/runtimespecific-app-default.md)             | Source/binary incompatible                       |
+| [--arch option doesn't imply self-contained](sdk/8.0/arch-option.md)                           | Behavioral change                                |
+| ['dotnet restore' produces security vulnerability warnings](sdk/8.0/dotnet-restore-audit.md)   | Behavioral change                                |
+| [SDK uses a smaller RID graph](sdk/8.0/rid-graph.md)                                           | Behavioral change/Source incompatible            |
+| [Source Link included in the .NET SDK](sdk/8.0/source-link.md)                                 | Source incompatible                              |
 | [Trimming may not be used with .NET Standard or .NET Framework](sdk/8.0/trimming-unsupported-targetframework.md) | Behavioral change                                |
 | [Unlisted packages not installed by default for .NET tools](sdk/8.0/unlisted-versions.md)                         | Behavioral change                                |
+| [.user file imported in outer builds](sdk/8.0/user-file.md)                   | Behavioral change |
 | [Version requirements for .NET 8 SDK](sdk/8.0/version-requirements.md) | Source incompatible               |
 
 ## Serialization

--- a/docs/core/compatibility/9.0.md
+++ b/docs/core/compatibility/9.0.md
@@ -33,7 +33,7 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 | Title                                                                         | Type of change    | Introduced version |
 |-------------------------------------------------------------------------------|-------------------|--------------------|
 | [`dotnet workload` commands output change](sdk/9.0/dotnet-workload-output.md) | Behavioral change | Preview 1          |
-| [Terminal logger is default](sdk/9.0/terminal-logger.md) | Behavioral change | Preview 1          |
+| [Terminal logger is default](sdk/9.0/terminal-logger.md)                      | Behavioral change | Preview 1          |
 
 ## Windows Forms
 

--- a/docs/core/compatibility/core-libraries/8.0/drive-current-dir-paths.md
+++ b/docs/core/compatibility/core-libraries/8.0/drive-current-dir-paths.md
@@ -1,0 +1,85 @@
+---
+title: "Breaking change: Drive's current directory path enumeration"
+description: Learn about the .NET 8 breaking change in core .NET libraries where files are enumerated without a separator after the path when the path is the drive's current directory.
+ms.date: 02/09/2024
+---
+# Drive's current directory path enumeration
+
+File system entries obtained using a path argument in the shape of a "drive's current directory", for example, `C:`, were incorrectly formed by combining `directory path + separator + entry name`. To return the correct path for the entries, the separator is no longer added with such paths.
+
+## Previous behavior
+
+Previously, a separator character was added such that the enumerated file system entries appeared to be in the drive's root.
+
+```csharp
+string pathToEnumerate = "C:";
+
+Console.WriteLine($"Full path of \"{pathToEnumerate}\" is {Path.GetFullPath(pathToEnumerate)}.");
+Path.GetFullPath(pathToEnumerate);
+
+Console.WriteLine($"Enumerating files and folders in \"{pathToEnumerate}\".");
+foreach (string entry in Directory.GetFileSystemEntries(pathToEnumerate))
+{
+    Console.WriteLine(entry);
+}
+```
+
+The output from running this code snippet was as follows.
+
+```output
+Full path of "C:" is C:\Users\myalias\consoleapps\Program
+
+Enumerating files and folders in "C:".
+C:\Program.csproj
+C:\Program.sln
+C:\bin
+C:\obj
+C:\Program.cs
+```
+
+## New behavior
+
+Running the same code snippet in .NET 9 and later versions produces output without a separator character in each path.
+
+```output
+Full path of "C:" is C:\Users\myalias\consoleapps\Program.
+
+Enumerating files and folders in "C:".
+C:Program.csproj
+C:Program.sln
+C:bin
+C:obj
+C:Program.cs
+```
+
+## Version introduced
+
+.NET 8
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+Users reported that the previous behavior was incorrect. It was also a regression from .NET Framework.
+
+## Recommended action
+
+If you're a Windows user who relies on enumeration of paths like `C:`, you should re-evaluate your application's I/O operations. This is an unusual scenario that's unlikely to be used in production. Most users who want to enumerate the current directory use <xref:System.Environment.CurrentDirectory?displayProperty=nameWithType> instead.
+
+## Affected APIs
+
+- <xref:System.IO.Directory.EnumerateFiles%2A?displayProperty=fullName>
+- <xref:System.IO.Directory.EnumerateDirectories%2A?displayProperty=fullName>
+- <xref:System.IO.Directory.EnumerateFileSystemEntries%2A?displayProperty=fullName>
+- <xref:System.IO.Directory.GetFiles%2A?displayProperty=fullName>
+- <xref:System.IO.Directory.GetDirectories%2A?displayProperty=fullName>
+- <xref:System.IO.Directory.GetFileSystemEntries%2A?displayProperty=fullName>
+- <xref:System.IO.DirectoryInfo.EnumerateFiles%2A?displayProperty=fullName>
+- <xref:System.IO.DirectoryInfo.EnumerateDirectories%2A?displayProperty=fullName>
+- <xref:System.IO.DirectoryInfo.EnumerateFileSystemEntries%2A?displayProperty=fullName>
+- <xref:System.IO.DirectoryInfo.GetFiles%2A?displayProperty=fullName>
+- <xref:System.IO.DirectoryInfo.GetDirectories%2A?displayProperty=fullName>
+- <xref:System.IO.DirectoryInfo.GetFileSystemEntries%2A?displayProperty=fullName>
+- <xref:System.IO.Enumeration.FileSystemEnumerable%601.%23ctor(System.String,System.IO.Enumeration.FileSystemEnumerable{%600}.FindTransform,System.IO.EnumerationOptions)>

--- a/docs/core/compatibility/core-libraries/8.0/drive-current-dir-paths.md
+++ b/docs/core/compatibility/core-libraries/8.0/drive-current-dir-paths.md
@@ -78,8 +78,8 @@ If you're a Windows user who relies on enumeration of paths like `C:`, you shoul
 - <xref:System.IO.Directory.GetFileSystemEntries%2A?displayProperty=fullName>
 - <xref:System.IO.DirectoryInfo.EnumerateFiles%2A?displayProperty=fullName>
 - <xref:System.IO.DirectoryInfo.EnumerateDirectories%2A?displayProperty=fullName>
-- <xref:System.IO.DirectoryInfo.EnumerateFileSystemEntries%2A?displayProperty=fullName>
+- <xref:System.IO.DirectoryInfo.EnumerateFileSystemInfos%2A?displayProperty=fullName>
 - <xref:System.IO.DirectoryInfo.GetFiles%2A?displayProperty=fullName>
 - <xref:System.IO.DirectoryInfo.GetDirectories%2A?displayProperty=fullName>
-- <xref:System.IO.DirectoryInfo.GetFileSystemEntries%2A?displayProperty=fullName>
+- <xref:System.IO.DirectoryInfo.GetFileSystemInfos%2A?displayProperty=fullName>
 - <xref:System.IO.Enumeration.FileSystemEnumerable%601.%23ctor(System.String,System.IO.Enumeration.FileSystemEnumerable{%600}.FindTransform,System.IO.EnumerationOptions)>

--- a/docs/core/compatibility/sdk/8.0/user-file.md
+++ b/docs/core/compatibility/sdk/8.0/user-file.md
@@ -1,0 +1,36 @@
+---
+title: "Breaking change: .user file imported in outer builds"
+description: Learn about the breaking change in the .NET 8 SDK where the .user configuration file is now imported in outer builds.
+ms.date: 02/09/2024
+---
+# .user file imported in outer builds
+
+Previously, the SDK only imported *.user* configuration files in inner builds during a cross-targeted build. Now, these files are also imported in outer builds, which might cause breaks when you build projects locally.
+
+## Version introduced
+
+.NET SDK 8
+
+## Previous behavior
+
+Previously, if you added a *.user* file for extra local configurations in cross-targeted builds, the file was only imported in inner builds in some cases. If you defined frameworks with `<TargetFramework>`, the *.user* file was imported as expected. If you defined frameworks using the plural form, `<TargetFrameworks>`, the *.user* file was imported for every internal build for each framework (even if just one was defined). But the file wasn't imported for the outer build, which runs certain targets again.
+
+## New behavior
+
+When using the the plural `<TargetFrameworks>` property to define targeted frameworks, the build imports the *.user* file on all internal builds *and* on the outer build.
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+Users expected the *.user* config file to be imported in outer builds in MSBuild.
+
+## Recommended action
+
+This change shouldn't affect any deployments or CIs; only local builds. If the extra configurations that are imported change how the build is processed, review the configurations that are expected on the outer build.
+
+## Affected APIs
+
+N/A

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -84,6 +84,8 @@ items:
         href: core-libraries/8.0/decodefromutf8-whitespace.md
       - name: Boolean-backed enum type support removed
         href: core-libraries/8.0/bool-backed-enum.md
+      - name: Drive's current directory path enumeration
+        href: core-libraries/8.0/drive-current-dir-paths.md
       - name: Enumerable.Sum throws new OverflowException for some inputs
         href: core-libraries/8.0/enumerable-sum.md
       - name: FileStream writes when pipe is closed
@@ -198,6 +200,8 @@ items:
         href: sdk/8.0/trimming-unsupported-targetframework.md
       - name: Unlisted packages not installed by default
         href: sdk/8.0/unlisted-versions.md
+      - name: .user file imported in outer builds
+        href: sdk/8.0/user-file.md
       - name: Version requirements for .NET 8 SDK
         href: sdk/8.0/version-requirements.md
     - name: Serialization
@@ -1154,6 +1158,8 @@ items:
         href: core-libraries/8.0/decodefromutf8-whitespace.md
       - name: Boolean-backed enum type support removed
         href: core-libraries/8.0/bool-backed-enum.md
+      - name: Drive's current directory path enumeration
+        href: core-libraries/8.0/drive-current-dir-paths.md
       - name: Enumerable.Sum throws new OverflowException for some inputs
         href: core-libraries/8.0/enumerable-sum.md
       - name: FileStream writes when pipe is closed
@@ -1598,6 +1604,8 @@ items:
         href: sdk/8.0/trimming-unsupported-targetframework.md
       - name: Unlisted packages not installed by default
         href: sdk/8.0/unlisted-versions.md
+      - name: .user file imported in outer builds
+        href: sdk/8.0/user-file.md
       - name: Version requirements for .NET 8 SDK
         href: sdk/8.0/version-requirements.md
     - name: .NET 7


### PR DESCRIPTION
Fixes #39186 
Fixes #38792

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/8.0.md](https://github.com/dotnet/docs/blob/56de8e5e65fbcbf25a5ab020d9fd7ed7eac834b8/docs/core/compatibility/8.0.md) | [Breaking changes in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/8.0?branch=pr-en-us-39487) |
| [docs/core/compatibility/9.0.md](https://github.com/dotnet/docs/blob/56de8e5e65fbcbf25a5ab020d9fd7ed7eac834b8/docs/core/compatibility/9.0.md) | [Breaking changes in .NET 9](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/9.0?branch=pr-en-us-39487) |
| [docs/core/compatibility/core-libraries/8.0/drive-current-dir-paths.md](https://github.com/dotnet/docs/blob/56de8e5e65fbcbf25a5ab020d9fd7ed7eac834b8/docs/core/compatibility/core-libraries/8.0/drive-current-dir-paths.md) | [Drive's current directory path enumeration](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/8.0/drive-current-dir-paths?branch=pr-en-us-39487) |
| [docs/core/compatibility/sdk/8.0/user-file.md](https://github.com/dotnet/docs/blob/56de8e5e65fbcbf25a5ab020d9fd7ed7eac834b8/docs/core/compatibility/sdk/8.0/user-file.md) | [docs/core/compatibility/sdk/8.0/user-file](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/user-file?branch=pr-en-us-39487) |


<!-- PREVIEW-TABLE-END -->