### PR TITLE
PictureBox remote image breaking change

### DIFF
--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -151,6 +151,7 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 | Title                                                                                                    | Type of change      |
 | -------------------------------------------------------------------------------------------------------- | ------------------- |
 | [Anchor layout changes](windows-forms/8.0/anchor-layout.md)                                              | Behavioral change   |
+| [Certs checked before loading remote images in PictureBox](windows-forms/8.0/picturebox-remote-image.md) | Behavioral change   |
 | [DefaultValueAttribute removed from some properties](windows-forms/8.0/defaultvalueattribute-removal.md) | Behavioral change   |
 | [ExceptionCollection ctor throws ArgumentException](windows-forms/8.0/exceptioncollection.md)            | Behavioral change   |
 | [Forms scale according to AutoScaleMode](windows-forms/8.0/top-level-window-scaling.md)                  | Behavioral change   |

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -214,6 +214,8 @@ items:
       items:
       - name: Anchor layout changes
         href: windows-forms/8.0/anchor-layout.md
+      - name: Certs checked before loading remote images in PictureBox
+        href: windows-forms/8.0/picturebox-remote-image.md
       - name: DefaultValueAttribute removed from some properties
         href: windows-forms/8.0/defaultvalueattribute-removal.md
       - name: ExceptionCollection ctor throws ArgumentException
@@ -1776,6 +1778,8 @@ items:
       items:
       - name: Anchor layout changes
         href: windows-forms/8.0/anchor-layout.md
+      - name: Certs checked before loading remote images in PictureBox
+        href: windows-forms/8.0/picturebox-remote-image.md
       - name: DefaultValueAttribute removed from some properties
         href: windows-forms/8.0/defaultvalueattribute-removal.md
       - name: ExceptionCollection ctor throws ArgumentException

--- a/docs/core/compatibility/windows-forms/8.0/picturebox-remote-image.md
+++ b/docs/core/compatibility/windows-forms/8.0/picturebox-remote-image.md
@@ -5,7 +5,7 @@ ms.date: 02/12/2024
 ---
 # Certificates checked before loading remote images in PictureBox
 
-A switch that's on by default was added in .NET 8. The switch changes how <xref:System.Windows.Forms.PictureBox> loads a remote image. Now, before an image is loaded via <xref:System.Net.WebClient>, <xref:System.Net.ServicePointManager.CheckCertificateRevocationList?displayProperty=nameWithType> is set to `true`, meaning that `WebClient` will now check certificates against the certificate revocation list (CRL) as part of the validation process.
+The behavior of how <xref:System.Windows.Forms.PictureBox> loads a remote image changed in .NET 8. Now, before an image is loaded via <xref:System.Net.WebClient>, <xref:System.Net.ServicePointManager.CheckCertificateRevocationList?displayProperty=nameWithType> is set to `true`, so `WebClient` checks certificates against the certificate revocation list (CRL) as part of the validation process.
 
 ## Previous behavior
 
@@ -29,7 +29,7 @@ It's considered best practice to set <xref:System.Net.ServicePointManager.CheckC
 
 ## Recommended action
 
-The effects of this change are outlined at [Load behavior changes](/dotnet/api/system.windows.forms.picturebox.load#load-behavior-changes). If you want to revert to the previous behavior, that article also describes how to do so.
+The effects of this change are outlined at [Load behavior changes](/dotnet/api/system.windows.forms.picturebox.load#load-behavior-changes). If you want to revert to the previous behavior, that article also describes how to do so via a switch.
 
 ## Affected APIs
 

--- a/docs/core/compatibility/windows-forms/8.0/picturebox-remote-image.md
+++ b/docs/core/compatibility/windows-forms/8.0/picturebox-remote-image.md
@@ -1,0 +1,36 @@
+---
+title: "Breaking change: Certificates checked before loading remote images in PictureBox"
+description: Learn about the .NET 9 breaking change in Windows Forms where WebClient checks certificates against the revocation list before loading remote images in a PictureBox control.
+ms.date: 02/12/2024
+---
+# Certificates checked before loading remote images in PictureBox
+
+A switch that's on by default was added in .NET 8. The switch changes how <xref:System.Windows.Forms.PictureBox> loads a remote image. Now, before an image is loaded via <xref:System.Net.WebClient>, <xref:System.Net.ServicePointManager.CheckCertificateRevocationList?displayProperty=nameWithType> is set to `true`, meaning that `WebClient` will now check certificates against the certificate revocation list (CRL) as part of the validation process.
+
+## Previous behavior
+
+Previously, <xref:System.Net.ServicePointManager.CheckCertificateRevocationList?displayProperty=nameWithType> was not set to `true`. When `WebClient` loaded the remote image to a <xref:System.Windows.Forms.PictureBox> control, it didn't check certificates against the CRL as part of validation process.
+
+## New behavior
+
+Starting in .NET 8, <xref:System.Net.ServicePointManager.CheckCertificateRevocationList?displayProperty=nameWithType> is set to `true`, and `WebClient` checks certificates against the CRL as part of the validation process when loading a remote image in a `PictureBox` control. After the image is loaded, `CheckCertificateRevocationList` will be `true` for rest of the app's lifetime.
+
+## Version introduced
+
+.NET 8
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+It's considered best practice to set <xref:System.Net.ServicePointManager.CheckCertificateRevocationList?displayProperty=nameWithType> to `true` before creating `WebClient` or `WebRequest` objects, so that those objects don't accept revoked certificates as valid.
+
+## Recommended action
+
+The effects of this change are outlined at [Load behavior changes](/dotnet/api/system.windows.forms.picturebox.load#load-behavior-changes). If you want to revert to the previous behavior, that article also describes how to do so.
+
+## Affected APIs
+
+- <xref:System.Windows.Forms.PictureBox?displayProperty=fullName>


### PR DESCRIPTION
Fixes #39389.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/8.0.md](https://github.com/dotnet/docs/blob/e657b1c303a94725065879cd33837beb11cd4cc0/docs/core/compatibility/8.0.md) | [Breaking changes in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/8.0?branch=pr-en-us-39489) |
| [docs/core/compatibility/windows-forms/8.0/picturebox-remote-image.md](https://github.com/dotnet/docs/blob/e657b1c303a94725065879cd33837beb11cd4cc0/docs/core/compatibility/windows-forms/8.0/picturebox-remote-image.md) | [Certificates checked before loading remote images in PictureBox](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/windows-forms/8.0/picturebox-remote-image?branch=pr-en-us-39489) |


<!-- PREVIEW-TABLE-END -->