### PR TITLE
Update unit-testing-mstest-runner-vs-vstest.md

### DIFF
--- a/docs/core/testing/unit-testing-mstest-runner-vs-vstest.md
+++ b/docs/core/testing/unit-testing-mstest-runner-vs-vstest.md
@@ -16,7 +16,7 @@ Tests are executed in different ways depending on the runner.
 
 ### Execute VSTest tests
 
-VSTest ships with Visual Studio, the .NET SDK, and as a standalone tool in the [Microsoft.Testing.Platform](https://www.nuget.org/packages/Microsoft.Testing.Platform) NuGet package. VSTest uses a runner executable to run tests, called `vstest.console.exe`, which can be used directly or through `dotnet test`.
+VSTest ships with Visual Studio, the .NET SDK, and as a standalone tool in the [Microsoft.TestPlatform](https://www.nuget.org/packages/Microsoft.TestPlatform) NuGet package. VSTest uses a runner executable to run tests, called `vstest.console.exe`, which can be used directly or through `dotnet test`.
 
 ### Execute MSTest runner tests
 


### PR DESCRIPTION
Fix link to point to the correct package.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-mstest-runner-vs-vstest.md](https://github.com/dotnet/docs/blob/5fc7e0e6ba36a1f16b40176d57f8d431594bcd8e/docs/core/testing/unit-testing-mstest-runner-vs-vstest.md) | [MSTest runner and VSTest comparison](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-runner-vs-vstest?branch=pr-en-us-39492) |

<!-- PREVIEW-TABLE-END -->