### PR TITLE
Fix JSON example for resilience config

### DIFF
--- a/docs/core/resilience/snippets/http-resilience/Program.RetryOptions.cs
+++ b/docs/core/resilience/snippets/http-resilience/Program.RetryOptions.cs
@@ -10,7 +10,7 @@ internal partial class Program
         // <options>
         var section = builder.Configuration.GetSection("RetryOptions");
 
-        builder.Services.Configure<HttpRetryStrategyOptions>(section);
+        builder.Services.Configure<HttpStandardResilienceOptions>(section);
         // </options>
     }
 }

--- a/docs/core/resilience/snippets/http-resilience/appsettings.json
+++ b/docs/core/resilience/snippets/http-resilience/appsettings.json
@@ -1,7 +1,7 @@
 {
     "RetryOptions": {
         "Retry": {
-            "Backoff": "Linear",
+            "BackoffType": "Linear",
             "UseJitter": false,
             "MaxRetryAttempts": 7
         }


### PR DESCRIPTION
## Summary

Fix incorrect property name in JSON sample.

It should be named `BackoffType` not `Backoff` ([Polly source](https://github.com/App-vNext/Polly/blob/8cd51d6b951f1e0fe0fd9f961eb167c22c520b53/src/Polly.Core/Retry/RetryStrategyOptions.TResult.cs#L40)).

Otherwise an exception is thrown:

```console
System.InvalidOperationException: 'ErrorOnUnknownConfiguration' was set on the provided BinderOptions, but the following properties were not found on the instance of Microsoft.Extensions.Http.Resilience.HttpRetryStrategyOptions: 'Backoff'
```

Also the JSON given is structured for the entire retry configuration, not just the retry options, so the parent type needs to be used.