### PR TITLE
Update the snippets5000 yml

### DIFF
--- a/.github/workflows/snippets5000.yml
+++ b/.github/workflows/snippets5000.yml
@@ -1,4 +1,3 @@
-# This is a basic workflow to help you get started with Actions
 name: 'Snippets 5000'
 
 # Controls when the action will run. Triggers the workflow on push or pull request
@@ -15,33 +14,29 @@ on:
         default: 'Manual run'
 
 env:
-  DOTNET_INSTALLER_CHANNEL: '9.0'
-  DOTNET_DO_INSTALL: 'true' # True to install preview versions, False to use the pre-installed (released) SDK
+  DOTNET_VERSION: '9.0.*'
+  DOTNET_QUALITY: 'preview'
+  DOTNET_DO_INSTALL: 'true' # To install a version of .NET not provided by the runner, set to true
   EnableNuGetPackageRestore: 'True'
-  repo: 'docs'
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "snippets-build"
   snippets-build:
-    # The type of runner that the job will run on
     runs-on: windows-2022
     permissions:
         statuses: write
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v4.1.1 #@v3.1.0
+    # Checkout the repository for the PR
+    - name: Checkout repository
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #@v4.1.1
 
     # Get the latest preview SDK (or sdk not installed by the runner)
-    - name: Setup .NET SDK
+    - name: Setup .NET
       if: ${{ env.DOTNET_DO_INSTALL == 'true' }}
-      run: |
-        echo "Downloading dotnet-install.ps1"
-        Invoke-WebRequest https://raw.githubusercontent.com/dotnet/install-scripts/master/src/dotnet-install.ps1 -OutFile dotnet-install.ps1
-        echo "Installing dotnet version ${{ env.DOTNET_INSTALLER_CHANNEL }}"
-        .\dotnet-install.ps1 -InstallDir "c:\program files\dotnet" -Channel "${{ env.DOTNET_INSTALLER_CHANNEL }}" -Quality preview
+      uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 #@4.0.0
+      with:
+        dotnet-version: ${{ env.DOTNET_VERSION }}
+        dotnet-quality: ${{ env.DOTNET_QUALITY }}
 
     # Print dotnet info
     - name: Display .NET info
@@ -51,18 +46,11 @@ jobs:
     # Clone docs tools repo
     - name: Clone docs-tools repository
       run: |
-        git clone https://github.com/dotnet/docs-tools
+        git clone --depth 1 https://github.com/dotnet/docs-tools
 
     # Run snippets 5000
     - name: Run snippets 5000 for PR
       env:
         GitHubKey: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        dotnet run --project docs-tools\snippets5000\Snippets5000\Snippets5000.csproj -- --sourcepath "${{ github.workspace }}" --pullrequest ${{ github.event.number }} --owner ${{ github.repository_owner }} --repo ${{ github.event.repository.name }}
-
-    # Update build output json file
-    - name: Upload build results
-      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 #@v4.3.1
-      with:
-        name: build
-        path: ./output.json
+        dotnet run --project docs-tools/snippets5000/Snippets5000/Snippets5000.csproj -- --sourcepath "${{ github.workspace }}" --pullrequest ${{ github.event.number }} --owner ${{ github.repository_owner }} --repo ${{ github.event.repository.name }}


### PR DESCRIPTION
## Summary

- Removed useless comments
- Updated .NET installer to use the setup-dotnet action
- Changed actions to commits instead of tags
- Clone docs-tools depth at 1
- Remove the build artifact upload, the latest version of snippets5000 doesn't use build artifacts
- .NET 9 Preview is enabled
- Forward slashes are OK in the file path to the project to compile