### PR TITLE
Updated for .net 9 and 8.0.300

### DIFF
--- a/docs/core/porting/versioning-sdk-msbuild-vs.md
+++ b/docs/core/porting/versioning-sdk-msbuild-vs.md
@@ -40,6 +40,7 @@ The support timeframe for the SDK typically matches that of the Visual Studio ve
 | 7.0.4xx          | 17.7               | Aug '23      | May '24<sup>2</sup>   |
 | 8.0.1xx          | 17.8               | Nov '23      | TBD       |
 | 8.0.2xx          | 17.9<sup>3</sup>   | Feb '24      | TBD       |
+| 8.0.3xx          | 17.10              | May '24      | TBD       |
 
 > [!NOTE]
 > Targeting `net6.0` is officially supported in Visual Studio 17.0+ only.
@@ -76,6 +77,7 @@ Starting with .NET SDK 7.0.100 and .NET SDK 6.0.300, a policy has been put into 
 | 7.0.400 | 17.7 | 17.4 | Net7.0 | Net7.0 |
 | 8.0.100 | 17.8 | 17.7 | Net7.0 | Net8.0 |
 | 8.0.200 | 17.9 | 17.8 | Net8.0 | Net8.0 |
+| 8.0.300 | 17.10 | 17.8 | Net8.0 | Net8.0 |
 
 > [!NOTE]
 > The table depicts how these versioning rules will be applied going forward, starting with .NET SDK 7.0.100 and .NET SDK 6.0.300. It also depicts how the policy would have applied to previously shipped versions of the .NET SDK, had it been in place then. However, the requirements for previous versions of the SDK don't change&mdash;that is, the minimum required version of Visual Studio for .NET SDK 6.0.100 or 6.0.200 remains 16.10.
@@ -90,15 +92,10 @@ Major versions of the .NET SDK are typically released within a few days of a Vis
 
 | SDK preview version | Visual Studio version |
 |-|-|
-| 8.0.100 Preview 1 | 17.6 Preview 1 |
-| 8.0.100 Preview 2 | 17.6 Preview 2 |
-| 8.0.100 Preview 3 | 17.6 Preview 3 |
-| 8.0.100 Preview 4 | 17.7 Preview 1 |
-| 8.0.100 Preview 5 | 17.7 Preview 2 |
-| 8.0.100 Preview 6 | 17.7 Preview 3 |
-| 8.0.100 Preview 7 | 17.8 Preview 1 |
-| 8.0.100 Preview RC 1 | 17.8 Preview 2 |
-| 8.0.100 Preview RC 2 | 17.8 Preview 3 |
+| 8.0.100 Preview 1 | 17.10 Preview 1 |
+| 8.0.100 Preview 2 | 17.10 Preview 2 |
+| 8.0.100 Preview 3 | 17.10 Preview 3 |
+
 
 ## Reference
 

--- a/docs/core/porting/versioning-sdk-msbuild-vs.md
+++ b/docs/core/porting/versioning-sdk-msbuild-vs.md
@@ -96,7 +96,6 @@ Major versions of the .NET SDK are typically released within a few days of a Vis
 | 8.0.100 Preview 2 | 17.10 Preview 2 |
 | 8.0.100 Preview 3 | 17.10 Preview 3 |
 
-
 ## Reference
 
 - [Overview of how .NET is versioned](../versions/index.md)

--- a/docs/core/porting/versioning-sdk-msbuild-vs.md
+++ b/docs/core/porting/versioning-sdk-msbuild-vs.md
@@ -47,7 +47,7 @@ The support timeframe for the SDK typically matches that of the Visual Studio ve
 > Targeting `net7.0` is officially supported in Visual Studio 17.4+ only.
 > Targeting `net8.0` is officially supported in Visual Studio 17.8+ only.
 >
-> <sup>1</<sup>.1xx .NET SDK feature bands are supported throughout the lifecycle of major .NET versions. During the extended support period, support is limited to security fixes and minimal high-priority non-security fixes for Linux only. To learn more about the reasoning for this extended support, see [Source-build support](https://github.com/dotnet/source-build#support).
+> <sup>1</sup> .1xx .NET SDK feature bands are supported throughout the lifecycle of major .NET versions. During the extended support period, support is limited to security fixes and minimal high-priority non-security fixes for Linux only. To learn more about the reasoning for this extended support, see [Source-build support](https://github.com/dotnet/source-build#support).
 >
 > <sup>2</sup> .4xx .NET SDK feature bands are supported for the life of the matching runtime as stand-alone installs.
 >
@@ -92,9 +92,9 @@ Major versions of the .NET SDK are typically released within a few days of a Vis
 
 | SDK preview version | Visual Studio version |
 |-|-|
-| 8.0.100 Preview 1 | 17.10 Preview 1 |
-| 8.0.100 Preview 2 | 17.10 Preview 2 |
-| 8.0.100 Preview 3 | 17.10 Preview 3 |
+| 9.0.100 Preview 1 | 17.10 Preview 1 |
+| 9.0.100 Preview 2 | 17.10 Preview 2 |
+| 9.0.100 Preview 3 | 17.10 Preview 3 |
 
 ## Reference
 


### PR DESCRIPTION
## Summary

I added 8.0.3xx to the tables and updated the preview table for .net 9

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/porting/versioning-sdk-msbuild-vs.md](https://github.com/dotnet/docs/blob/19d7e492a2b0728cecd1b7b2d2b4ea133dcf51ef/docs/core/porting/versioning-sdk-msbuild-vs.md) | [.NET SDK, MSBuild, and Visual Studio versioning](https://review.learn.microsoft.com/en-us/dotnet/core/porting/versioning-sdk-msbuild-vs?branch=pr-en-us-39502) |


<!-- PREVIEW-TABLE-END -->