### PR TITLE
add possible cause for CS2012

### DIFF
--- a/docs/csharp/misc/cs2012.md
+++ b/docs/csharp/misc/cs2012.md
@@ -13,6 +13,7 @@ ms.assetid: 34cf0564-125b-47ed-ac39-d3b707be0ff3
 Cannot open 'file' for writing  
   
 While using the `-bugreport:`, `file` compiler option, the file could not be opened for writing. Make sure you specified a valid file name and that the file is not read-only.
+One possible cause of this error is that the file is used in another process, for example a debugger or an antivirus program. 
 
 > [!IMPORTANT]
 > The `bugreport` option is no longer supported.

--- a/docs/csharp/misc/cs2012.md
+++ b/docs/csharp/misc/cs2012.md
@@ -13,7 +13,7 @@ ms.assetid: 34cf0564-125b-47ed-ac39-d3b707be0ff3
 Cannot open 'file' for writing  
   
 While using the `-bugreport:`, `file` compiler option, the file could not be opened for writing. Make sure you specified a valid file name and that the file is not read-only.
-One possible cause of this error is that the file is used in another process, for example a debugger or an antivirus program. 
+One possible cause of this error is that the file is used in another process, for example a debugger or an antivirus program.
 
 > [!IMPORTANT]
 > The `bugreport` option is no longer supported.


### PR DESCRIPTION
## Summary

Adds a possible cause to the error `cs2012`.
I also added an antivirus as possible cause after I found this [StackOverflow question](https://stackoverflow.com/questions/37552769/error-cs2012-cannot-open-executable-path-access-to-executable-path-denied).

Fixes #39480


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/misc/cs2012.md](https://github.com/dotnet/docs/blob/99856819a3b3e77f0e4bba3c5cd52a05d5ac3ee5/docs/csharp/misc/cs2012.md) | [Compiler Error CS2012](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/cs2012?branch=pr-en-us-39564) |


<!-- PREVIEW-TABLE-END -->