### PR TITLE
Clarify that read-only collection type properties are serialized

### DIFF
--- a/docs/standard/serialization/system-text-json/ignore-properties.md
+++ b/docs/standard/serialization/system-text-json/ignore-properties.md
@@ -74,6 +74,9 @@ The following example shows a type to serialize. It also shows the JSON output:
 
 This option applies only to properties. To ignore read-only fields when [serializing fields](fields.md), use the <xref:System.Text.Json.JsonSerializerOptions.IgnoreReadOnlyFields%2A?displayProperty=nameWithType> global setting.
 
+> [!NOTE]
+> Read-only collection-type properties are still serialized even if <xref:System.Text.Json.JsonSerializerOptions.IgnoreReadOnlyProperties?displayProperty=nameWithType> is set to `true`.
+
 ## Ignore all null-value properties
 
 To ignore all null-value properties, set the <xref:System.Text.Json.JsonSerializerOptions.DefaultIgnoreCondition> property to <xref:System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull>, as shown in the following example:


### PR DESCRIPTION
Fixes #38575

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/serialization/system-text-json/ignore-properties.md](https://github.com/dotnet/docs/blob/8fa19c6da90cd1ac1c6accb9084a459958db703e/docs/standard/serialization/system-text-json/ignore-properties.md) | [How to ignore properties with System.Text.Json](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/ignore-properties?branch=pr-en-us-39568) |

<!-- PREVIEW-TABLE-END -->