### PR TITLE
Remove inline arrays as a conversion target

### DIFF
--- a/docs/csharp/language-reference/operators/collection-expressions.md
+++ b/docs/csharp/language-reference/operators/collection-expressions.md
@@ -34,7 +34,6 @@ The spread element `..vowels`, when evaluated, produces five elements: `"a"`, `"
 A *collection expression* can be converted to different collection types, including:
 
 - <xref:System.Span%601?displayProperty=nameWithType> and <xref:System.ReadOnlySpan%601?displayProperty=nameWithType>
-- [Inline arrays](../builtin-types/struct.md#inline-arrays)
 - [Arrays](../builtin-types/arrays.md)
 - Any type with a *create* method whose parameter type is `ReadOnlySpan<T>` where there's an implicit conversion from the collection expression type to `T`.
 - Any type that supports a [collection initializer](../../programming-guide/classes-and-structs/object-and-collection-initializers.md#collection-initializers), such as <xref:System.Collections.Generic.List%601?displayProperty=nameWithType>. Usually, this requirement means the type supports <xref:System.Collections.Generic.IEnumerable%601?displayProperty=nameWithType> and there's an accessible `Add` method to add items to the collection. There must be an implicit conversion from the collection expression elements' type to the collection's element type. For spread elements, there must be an implicit conversion from the spread element's type to the collection's element type.


### PR DESCRIPTION
See dotnet/roslyn#68927

This didn't make it in C# 12.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/collection-expressions.md](https://github.com/dotnet/docs/blob/94342d6d5dd7c4a04da1a18865666a3a8d406b47/docs/csharp/language-reference/operators/collection-expressions.md) | [Collection expressions - C# language reference](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/collection-expressions?branch=pr-en-us-39572) |

<!-- PREVIEW-TABLE-END -->