### PR TITLE
reword CS0108 description

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs0108.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0108.md
@@ -12,33 +12,37 @@ ms.assetid: 04330ed2-80d5-4bf2-b0c1-a0c2bec03074
 
 'member1' hides inherited member 'member2'. Use the new keyword if hiding was intended.
 
- A variable was declared with the same name as a variable in a base class. However, the [new](../keywords/new-modifier.md) keyword was not used. This warning informs you that you should use **new**; the variable is declared as if **new** had been used in the declaration.
+A member was declared with the same name as a member in a base class.
+However, the [new modifier](../keywords/new-modifier.md) was not used. 
 
- The following sample generates CS0108:
+The following sample generates CS0108. You can resolve CS0108 in one of two ways:
+
+- Rename the member in the derived class if member hiding was not intended.
+
+- Use the `new` modifier to declare that the derived member hiding of the base member was intentional.
 
 ```csharp
 // CS0108.cs
 // compile with: /W:2
 using System;
 
-namespace x
+namespace MyNamespace;
+
+public class BaseClass
 {
-    public class clx
+    public int i = 1;
+}
+
+public class DerivedClass : BaseClass
+{
+    public static int i = 2;   // CS0108
+    // Use the following line instead:
+    // public static new int i = 2;
+
+    public static void Main()
     {
-        public int i = 1;
+        Console.WriteLine(i);
     }
-
-    public class cly : clx
-    {
-        public static int i = 2;   // CS0108, use the new keyword
-        // Use the following line instead:
-        // public static new int i = 2;
-
-      public static void Main()
-      {
-         Console.WriteLine(i);
-      }
-   }
 }
 ```
 

--- a/docs/csharp/language-reference/compiler-messages/cs0108.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0108.md
@@ -13,7 +13,7 @@ ms.assetid: 04330ed2-80d5-4bf2-b0c1-a0c2bec03074
 'member1' hides inherited member 'member2'. Use the new keyword if hiding was intended.
 
 A member was declared with the same name as a member in a base class.
-However, the [new modifier](../keywords/new-modifier.md) was not used. 
+However, the [new modifier](../keywords/new-modifier.md) was not used.
 
 The following sample generates CS0108. You can resolve CS0108 in one of two ways:
 


### PR DESCRIPTION
## Summary

- Rename `variable` to `member`
- Change the description to make the intention of the `new` modifier clear, using the "you can resolve CS in ..." from other pages of compiler messages
- Update the snippet (file-scope namespace, PascalCase class names) 

PS: I hope it's OK if I go through the older "help wanted" issues.

Fixes #35288 (if available)



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-messages/cs0108.md](https://github.com/dotnet/docs/blob/8ecce2ce87a7a1393195a908215e9d5a098d9a05/docs/csharp/language-reference/compiler-messages/cs0108.md) | [Compiler Warning (level 2) CS0108](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0108?branch=pr-en-us-39576) |


<!-- PREVIEW-TABLE-END -->