### PR TITLE
Update cross-compile.md

### DIFF
--- a/docs/core/deploying/native-aot/cross-compile.md
+++ b/docs/core/deploying/native-aot/cross-compile.md
@@ -43,7 +43,7 @@ The following commands may suffice for compiling for `linux-arm64` on Ubuntu 22.
 ```bash
 sudo dpkg --add-architecture arm64
 sudo bash -c 'cat > /etc/apt/sources.list.d/arm64.list <<EOF
-deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy main restricted
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy main restricted ports
 deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main restricted
 deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-backports main restricted universe multiverse
 EOF'


### PR DESCRIPTION
Include ports in the apt source list

## Summary

Ubuntu moved some packages around and it looks like this example now requires `ports`.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/deploying/native-aot/cross-compile.md](https://github.com/dotnet/docs/blob/dcfcae364ff6687022cd3e76a7af0540226fd181/docs/core/deploying/native-aot/cross-compile.md) | [Cross-compilation](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/cross-compile?branch=pr-en-us-39578) |

<!-- PREVIEW-TABLE-END -->