### PR TITLE
Revert collection expression in example

### DIFF
--- a/docs/csharp/language-reference/statements/snippets/jump-statements/ReturnStatement.cs
+++ b/docs/csharp/language-reference/statements/snippets/jump-statements/ReturnStatement.cs
@@ -52,7 +52,7 @@ public static class ReturnStatement
     private static void RefReturn()
     {
         // <RefReturn>
-        int[] xs = [10, 20, 30, 40];
+        int[] xs = new int [] {10, 20, 30, 40 };
         ref int found = ref FindFirst(xs, s => s == 30);
         found = 0;
         Console.WriteLine(string.Join(" ", xs));  // output: 10 20 0 40


### PR DESCRIPTION
Fixes #39458

This example runs in Try.NET, where collection expressions aren't supported yet.
