### PR TITLE
Add links for Extended* MSBuild API pages

### DIFF
--- a/docs/core/compatibility/sdk/8.0/custombuildeventargs.md
+++ b/docs/core/compatibility/sdk/8.0/custombuildeventargs.md
@@ -35,10 +35,10 @@ This change is a [behavioral change](../../categories.md#behavioral-change).
 
 Use one of the following newly introduced, built-in events for extensibility instead of your custom derived build event:
 
-- `Microsoft.Build.Framework.ExtendedCustomBuildEventArgs`
-- `Microsoft.Build.Framework.ExtendedBuildErrorEventArgs`
-- `Microsoft.Build.Framework.ExtendedBuildMessageEventArgs`
-- `Microsoft.Build.Framework.ExtendedBuildWarningEventArgs`
+- <xref:Microsoft.Build.Framework.ExtendedCustomBuildEventArgs>
+- <xref:Microsoft.Build.Framework.ExtendedBuildErrorEventArgs>
+- <xref:Microsoft.Build.Framework.ExtendedBuildMessageEventArgs>
+- <xref:Microsoft.Build.Framework.ExtendedBuildWarningEventArgs>
 
 Alternatively, you can temporarily disable the check by explicitly setting the environment variable `MSBUILDCUSTOMBUILDEVENTWARNING` to something other than `1`.
 


### PR DESCRIPTION
## Summary

Describe your changes here.
Replace fully-qualified type names with links to the pages in the MSBuild API Reference.

Fixes https://github.com/MicrosoftDocs/visualstudio-docs/issues/9623


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/sdk/8.0/custombuildeventargs.md](https://github.com/dotnet/docs/blob/90b87363917ada84c254479416e8207ce90e514f/docs/core/compatibility/sdk/8.0/custombuildeventargs.md) | [MSBuild custom derived build events deprecated](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/custombuildeventargs?branch=pr-en-us-39580) |

<!-- PREVIEW-TABLE-END -->