### PR TITLE
Remove .NET 8 from alpine package manager table

### DIFF
--- a/docs/core/install/linux-alpine.md
+++ b/docs/core/install/linux-alpine.md
@@ -42,8 +42,8 @@ The following table is a list of currently supported .NET releases and the versi
 
 | Alpine | Supported Version  | Available in Package Manager |
 |--------|--------------------| -----------------------------|
-| 3.18   | .NET 7.0, .NET 6.0 | .NET 8.0, .NET 7.0, .NET 6.0 |
-| 3.17   | .NET 7.0, .NET 6.0 | .NET 8.0, .NET 7.0, .NET 6.0 |
+| 3.18   | .NET 8.0, .NET 7.0, .NET 6.0 | .NET 7.0, .NET 6.0 |
+| 3.17   | .NET 8.0, .NET 7.0, .NET 6.0 | .NET 7.0, .NET 6.0 |
 | 3.16   | .NET 7.0, .NET 6.0 | .NET 6.0 |
 | 3.15   | .NET 7.0, .NET 6.0 | None |
 


### PR DESCRIPTION
## Summary

- Add .NET 8 as a supported version
- Remove .NET 8 from package manager

Fixes #38904


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/linux-alpine.md](https://github.com/dotnet/docs/blob/823a5d62d2666452ff824e87f62ce95674cac396/docs/core/install/linux-alpine.md) | [Install the .NET SDK or the .NET Runtime on Alpine](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-alpine?branch=pr-en-us-39631) |

<!-- PREVIEW-TABLE-END -->