### PR TITLE
Add bullet points with semantics for `true` and `false` operator to follow

### DIFF
--- a/docs/csharp/language-reference/operators/true-false-operators.md
+++ b/docs/csharp/language-reference/operators/true-false-operators.md
@@ -8,7 +8,13 @@ helpviewer_keywords:
 ---
 # true and false operators - treat your objects as a Boolean value
 
-The `true` operator returns the [bool](../builtin-types/bool.md) value `true` to indicate that its operand is definitely true. The `false` operator returns the `bool` value `true` to indicate that its operand is definitely false. The `true` and `false` operators aren't guaranteed to complement each other. That is, both the `true` and `false` operator might return the `bool` value `false` for the same operand. If a type defines one of the two operators, it must also define another operator.
+The `true` operator returns the [bool](../builtin-types/bool.md) value `true` to indicate that its operand is definitely true, while the `false` operator returns the `bool` value `true` to indicate that its operand is definitely false.
+<br/>Note that a type implementing both `true` and `false` operators has to follow these semantics:
+
+* "Is this object true?" resolves to operator `true`. Operator `true` returns `true` if the object is `true`. The answer is "Yes, this object is true".
+* "Is this object false?" resolves to operator `false`. Operator `false` returns `true` if the object is `false`. The answer is "Yes, this object is false"
+
+The `true` and `false` operators aren't guaranteed to complement each other. That is, both the `true` and `false` operator might return the `bool` value `false` for the same operand. If a type defines one of the two operators, it must also define another operator.
 
 > [!TIP]
 > Use the `bool?` type, if you need to support the three-valued logic (for example, when you work with databases that support a three-valued Boolean type). C# provides the `&` and `|` operators that support the three-valued logic with the `bool?` operands. For more information, see the [Nullable Boolean logical operators](boolean-logical-operators.md#nullable-boolean-logical-operators) section of the [Boolean logical operators](boolean-logical-operators.md) article.

--- a/docs/csharp/language-reference/operators/true-false-operators.md
+++ b/docs/csharp/language-reference/operators/true-false-operators.md
@@ -14,7 +14,7 @@ The `true` operator returns the [bool](../builtin-types/bool.md) value `true` to
 * "Is this object true?" resolves to operator `true`. Operator `true` returns `true` if the object is `true`. The answer is "Yes, this object is true".
 * "Is this object false?" resolves to operator `false`. Operator `false` returns `true` if the object is `false`. The answer is "Yes, this object is false"
 
-The `true` and `false` operators aren't guaranteed to complement each other. That is, both the `true` and `false` operator might return the `bool` value `false` for the same operand. If a type defines one of the two operators, it must also define another operator.
+The `true` and `false` operators aren't guaranteed to complement each other. That is, both the `true` and `false` operator might return the `bool` value `false` for the same operand. If a type defines one of these two operators, it must also define the other operator.
 
 > [!TIP]
 > Use the `bool?` type, if you need to support the three-valued logic (for example, when you work with databases that support a three-valued Boolean type). C# provides the `&` and `|` operators that support the three-valued logic with the `bool?` operands. For more information, see the [Nullable Boolean logical operators](boolean-logical-operators.md#nullable-boolean-logical-operators) section of the [Boolean logical operators](boolean-logical-operators.md) article.


### PR DESCRIPTION
This pull request closes #39267 

It adds the semantics for `true` and `false` operators, as additional explanation of logic behind the values returned by these operators.
As per original idea in the issue.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/true-false-operators.md](https://github.com/dotnet/docs/blob/c67fa5a96945f1a7d1e6132b692eb2468af13856/docs/csharp/language-reference/operators/true-false-operators.md) | [true and false operators - treat your objects as a Boolean value](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/true-false-operators?branch=pr-en-us-39632) |


<!-- PREVIEW-TABLE-END -->