### PR TITLE
Orleans - Add link to referenced docs

### DIFF
--- a/docs/orleans/streaming/streams-quick-start.md
+++ b/docs/orleans/streaming/streams-quick-start.md
@@ -117,7 +117,7 @@ TimeSpan.FromMilliseconds(1_000));
 
 ## Subscribe to and receive streaming data
 
-For receiving data, you can use implicit/explicit subscriptions, which are fully described in other pages of the docs. This example uses implicit subscriptions, which are easier. When a grain type wants to implicitly subscribe to a stream, it uses the attribute [[ImplicitStreamSubscription(namespace)]](xref:Orleans.ImplicitStreamSubscriptionAttribute).
+For receiving data, you can use implicit/explicit subscriptions, which are described in more detail [here](https://learn.microsoft.com/en-us/dotnet/orleans/streaming/streams-programming-apis?pivots=orleans-7-0#explicit-and-implicit-subscriptions). This example uses implicit subscriptions, which are easier. When a grain type wants to implicitly subscribe to a stream, it uses the attribute [[ImplicitStreamSubscription(namespace)]](xref:Orleans.ImplicitStreamSubscriptionAttribute).
 
 For your case, define a `ReceiverGrain` like this:
 

--- a/docs/orleans/streaming/streams-quick-start.md
+++ b/docs/orleans/streaming/streams-quick-start.md
@@ -117,7 +117,7 @@ TimeSpan.FromMilliseconds(1_000));
 
 ## Subscribe to and receive streaming data
 
-For receiving data, you can use implicit/explicit subscriptions, which are described in more detail [here](https://learn.microsoft.com/en-us/dotnet/orleans/streaming/streams-programming-apis?pivots=orleans-7-0#explicit-and-implicit-subscriptions). This example uses implicit subscriptions, which are easier. When a grain type wants to implicitly subscribe to a stream, it uses the attribute [[ImplicitStreamSubscription(namespace)]](xref:Orleans.ImplicitStreamSubscriptionAttribute).
+For receiving data, you can use implicit/explicit subscriptions, which are described in more detail [here](https://learn.microsoft.com/dotnet/orleans/streaming/streams-programming-apis?pivots=orleans-7-0#explicit-and-implicit-subscriptions). This example uses implicit subscriptions, which are easier. When a grain type wants to implicitly subscribe to a stream, it uses the attribute [[ImplicitStreamSubscription(namespace)]](xref:Orleans.ImplicitStreamSubscriptionAttribute).
 
 For your case, define a `ReceiverGrain` like this:
 


### PR DESCRIPTION
Change the sentence 

"For receiving data, you can use implicit/explicit subscriptions, which are fully described in other pages of the docs" 

to link to the docs.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/streaming/streams-quick-start.md](https://github.com/dotnet/docs/blob/65ea8308b263776ad6dc2b2f7828d0bd7da05707/docs/orleans/streaming/streams-quick-start.md) | [Orleans streaming quickstart](https://review.learn.microsoft.com/en-us/dotnet/orleans/streaming/streams-quick-start?branch=pr-en-us-39641) |


<!-- PREVIEW-TABLE-END -->