### PR TITLE
Enable F1 for TFM in Visual Studio project files

### DIFF
--- a/docs/standard/frameworks.md
+++ b/docs/standard/frameworks.md
@@ -5,6 +5,8 @@ ms.date: 12/12/2023
 ms.service: dotnet
 ms.custom: updateeachrelease
 ms.subservice: standard-library
+f1_keywords:
+- http://schemas.microsoft.com/developer/msbuild/2003#TargetFramework
 ---
 # Target frameworks in SDK-style projects
 


### PR DESCRIPTION
## Summary

The F1 keyword is already emitted, but is not found, so the F1 service takes users to the page for the parent element, PropertyGroup, which is in the MSBuild docs. A better experience is to take users to this page describing the various values of the property.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/frameworks.md](https://github.com/dotnet/docs/blob/ea8a2cc5fb97764a53528185304cee333f88184b/docs/standard/frameworks.md) | [Target frameworks in SDK-style projects](https://review.learn.microsoft.com/en-us/dotnet/standard/frameworks?branch=pr-en-us-39644) |

<!-- PREVIEW-TABLE-END -->