### PR TITLE
Update unsupported verssions of .NET in diagnostics documentation

### DIFF
--- a/docs/core/diagnostics/available-counters.md
+++ b/docs/core/diagnostics/available-counters.md
@@ -16,27 +16,27 @@ The following counters are published as part of .NET runtime (CoreCLR) and are m
 
 | Counter | Description | First available in |
 |--|--|--|
-| :::no-loc text="% Time in GC since last GC"::: (`time-in-gc`) | The percent of time in GC since the last GC | .NET Core 3.1 |
-| :::no-loc text="Allocation Rate"::: (`alloc-rate`) | The number of bytes allocated per update interval | .NET Core 3.1 |
-| :::no-loc text="CPU Usage"::: (`cpu-usage`) | The percent of the process's CPU usage relative to all of the system CPU resources | .NET Core 3.1 |
-| :::no-loc text="Exception Count"::: (`exception-count`) | The number of exceptions that have occurred | .NET Core 3.1 |
-| :::no-loc text="GC Heap Size"::: (`gc-heap-size`) | The number of megabytes thought to be allocated based on <xref:System.GC.GetTotalMemory(System.Boolean)?displayProperty=nameWithType> | .NET Core 3.1 |
-| :::no-loc text="Gen 0 GC Count"::: (`gen-0-gc-count`) | The number of times GC has occurred for Gen 0 per update interval | .NET Core 3.1 |
-| :::no-loc text="Gen 0 Size"::: (`gen-0-size`) | The number of bytes for Gen 0 GC | .NET Core 3.1 |
-| :::no-loc text="Gen 1 GC Count"::: (`gen-1-gc-count`) | The number of times GC has occurred for Gen 1 per update interval | .NET Core 3.1 |
-| :::no-loc text="Gen 1 Size"::: (`gen-1-size`) | The number of bytes for Gen 1 GC | .NET Core 3.1 |
-| :::no-loc text="Gen 2 GC Count"::: (`gen-2-gc-count`) | The number of times GC has occurred for Gen 2 per update interval | .NET Core 3.1 |
-| :::no-loc text="Gen 2 Size"::: (`gen-2-size`) | The number of bytes for Gen 2 GC | .NET Core 3.1 |
-| :::no-loc text="LOH Size"::: (`loh-size`) | The number of bytes for the large object heap | .NET Core 3.1 |
-| :::no-loc text="POH Size"::: (`poh-size`) | The number of bytes for the pinned object heap (available on .NET 5 and later versions) | .NET Core 3.1 |
-| :::no-loc text="GC Fragmentation"::: (`gc-fragmentation`) | The GC Heap Fragmentation (available on .NET 5 and later versions) | .NET Core 3.1 |
-| :::no-loc text="Monitor Lock Contention Count"::: (`monitor-lock-contention-count`) | The number of times there was contention when trying to take the monitor's lock, based on <xref:System.Threading.Monitor.LockContentionCount?displayProperty=nameWithType> | .NET Core 3.1 |
-| :::no-loc text="Number of Active Timers"::: (`active-timer-count`) | The number of <xref:System.Threading.Timer> instances that are currently active, based on <xref:System.Threading.Timer.ActiveCount?displayProperty=nameWithType> | .NET Core 3.1 |
-| :::no-loc text="Number of Assemblies Loaded"::: (`assembly-count`) | The number of <xref:System.Reflection.Assembly> instances loaded into a process at a point in time | .NET Core 3.1 |
-| :::no-loc text="ThreadPool Completed Work Item Count"::: (`threadpool-completed-items-count`) | The number of work items that have been processed so far in the <xref:System.Threading.ThreadPool> | .NET Core 3.1 |
-| :::no-loc text="ThreadPool Queue Length"::: (`threadpool-queue-length`) | The number of work items that are currently queued to be processed in the <xref:System.Threading.ThreadPool> | .NET Core 3.1 |
-| :::no-loc text="ThreadPool Thread Count"::: (`threadpool-thread-count`) | The number of thread pool threads that currently exist in the <xref:System.Threading.ThreadPool>, based on <xref:System.Threading.ThreadPool.ThreadCount?displayProperty=nameWithType> | .NET Core 3.1 |
-| :::no-loc text="Working Set"::: (`working-set`) | The number of megabytes of physical memory mapped to the process context at a point in time based on <xref:System.Environment.WorkingSet?displayProperty=nameWithType> | .NET Core 3.1 |
+| :::no-loc text="% Time in GC since last GC"::: (`time-in-gc`) | The percent of time in GC since the last GC | .NET 6 |
+| :::no-loc text="Allocation Rate"::: (`alloc-rate`) | The number of bytes allocated per update interval | .NET 6 |
+| :::no-loc text="CPU Usage"::: (`cpu-usage`) | The percent of the process's CPU usage relative to all of the system CPU resources | .NET 6 |
+| :::no-loc text="Exception Count"::: (`exception-count`) | The number of exceptions that have occurred | .NET 6 |
+| :::no-loc text="GC Heap Size"::: (`gc-heap-size`) | The number of megabytes thought to be allocated based on <xref:System.GC.GetTotalMemory(System.Boolean)?displayProperty=nameWithType> | .NET 6 |
+| :::no-loc text="Gen 0 GC Count"::: (`gen-0-gc-count`) | The number of times GC has occurred for Gen 0 per update interval | .NET 6 |
+| :::no-loc text="Gen 0 Size"::: (`gen-0-size`) | The number of bytes for Gen 0 GC | .NET 6 |
+| :::no-loc text="Gen 1 GC Count"::: (`gen-1-gc-count`) | The number of times GC has occurred for Gen 1 per update interval | .NET 6 |
+| :::no-loc text="Gen 1 Size"::: (`gen-1-size`) | The number of bytes for Gen 1 GC | .NET 6 |
+| :::no-loc text="Gen 2 GC Count"::: (`gen-2-gc-count`) | The number of times GC has occurred for Gen 2 per update interval | .NET 6 |
+| :::no-loc text="Gen 2 Size"::: (`gen-2-size`) | The number of bytes for Gen 2 GC | .NET 6 |
+| :::no-loc text="LOH Size"::: (`loh-size`) | The number of bytes for the large object heap | .NET 6 |
+| :::no-loc text="POH Size"::: (`poh-size`) | The number of bytes for the pinned object heap (available on .NET 5 and later versions) | .NET 6 |
+| :::no-loc text="GC Fragmentation"::: (`gc-fragmentation`) | The GC Heap Fragmentation (available on .NET 5 and later versions) | .NET 6 |
+| :::no-loc text="Monitor Lock Contention Count"::: (`monitor-lock-contention-count`) | The number of times there was contention when trying to take the monitor's lock, based on <xref:System.Threading.Monitor.LockContentionCount?displayProperty=nameWithType> | .NET 6 |
+| :::no-loc text="Number of Active Timers"::: (`active-timer-count`) | The number of <xref:System.Threading.Timer> instances that are currently active, based on <xref:System.Threading.Timer.ActiveCount?displayProperty=nameWithType> | .NET 6 |
+| :::no-loc text="Number of Assemblies Loaded"::: (`assembly-count`) | The number of <xref:System.Reflection.Assembly> instances loaded into a process at a point in time | .NET 6 |
+| :::no-loc text="ThreadPool Completed Work Item Count"::: (`threadpool-completed-items-count`) | The number of work items that have been processed so far in the <xref:System.Threading.ThreadPool> | .NET 6 |
+| :::no-loc text="ThreadPool Queue Length"::: (`threadpool-queue-length`) | The number of work items that are currently queued to be processed in the <xref:System.Threading.ThreadPool> | .NET 6 |
+| :::no-loc text="ThreadPool Thread Count"::: (`threadpool-thread-count`) | The number of thread pool threads that currently exist in the <xref:System.Threading.ThreadPool>, based on <xref:System.Threading.ThreadPool.ThreadCount?displayProperty=nameWithType> | .NET 6 |
+| :::no-loc text="Working Set"::: (`working-set`) | The number of megabytes of physical memory mapped to the process context at a point in time based on <xref:System.Environment.WorkingSet?displayProperty=nameWithType> | .NET 6 |
 | :::no-loc text="IL Bytes Jitted"::: (`il-bytes-jitted`) | The total size of ILs that are JIT-compiled, in bytes | .NET 5 |
 | :::no-loc text="Methods Jitted Count"::: (`methods-jitted-count`) | The number of methods that are JIT-compiled | .NET 5 |
 | :::no-loc text="GC Committed Bytes"::: (`gc-committed`) | The number of bytes committed by the GC | .NET 6 |
@@ -47,10 +47,10 @@ The following counters are published as part of [ASP.NET Core](/aspnet/core) and
 
 | Counter | Description | First available in |
 |--|--|--|
-| :::no-loc text="Current Requests"::: (`current-requests`) | The total number of requests that have started, but not yet stopped | .NET Core 3.1 |
-| :::no-loc text="Failed Requests"::: (`failed-requests`) | The total number of failed requests that have occurred for the life of the app | .NET Core 3.1 |
-| :::no-loc text="Request Rate"::: (`requests-per-second`) | The number of requests that occur per update interval | .NET Core 3.1 |
-| :::no-loc text="Total Requests"::: (`total-requests`) | The total number of requests that have occurred for the life of the app | .NET Core 3.1 |
+| :::no-loc text="Current Requests"::: (`current-requests`) | The total number of requests that have started, but not yet stopped | .NET 6 |
+| :::no-loc text="Failed Requests"::: (`failed-requests`) | The total number of failed requests that have occurred for the life of the app | .NET 6 |
+| :::no-loc text="Request Rate"::: (`requests-per-second`) | The number of requests that occur per update interval | .NET 6 |
+| :::no-loc text="Total Requests"::: (`total-requests`) | The total number of requests that have occurred for the life of the app | .NET 6 |
 
 ## Microsoft.AspNetCore.Http.Connections counters
 
@@ -58,11 +58,11 @@ The following counters are published as part of [ASP.NET Core SignalR](/aspnet/c
 
 | Counter | Description | First available in |
 |--|--|--|
-| :::no-loc text="Average Connection Duration"::: (`connections-duration`) | The average duration of a connection in milliseconds | .NET Core 3.1 |
-| :::no-loc text="Current Connections"::: (`current-connections`) | The number of active connections that have started, but not yet stopped | .NET Core 3.1 |
-| :::no-loc text="Total Connections Started"::: (`connections-started`) | The total number of connections that have started | .NET Core 3.1 |
-| :::no-loc text="Total Connections Stopped"::: (`connections-stopped`) | The total number of connections that have stopped | .NET Core 3.1 |
-| :::no-loc text="Total Connections Timed Out"::: (`connections-timed-out`) | The total number of connections that have timed out | .NET Core 3.1 |
+| :::no-loc text="Average Connection Duration"::: (`connections-duration`) | The average duration of a connection in milliseconds | .NET 6 |
+| :::no-loc text="Current Connections"::: (`current-connections`) | The number of active connections that have started, but not yet stopped | .NET 6 |
+| :::no-loc text="Total Connections Started"::: (`connections-started`) | The total number of connections that have started | .NET 6 |
+| :::no-loc text="Total Connections Stopped"::: (`connections-stopped`) | The total number of connections that have stopped | .NET 6 |
+| :::no-loc text="Total Connections Timed Out"::: (`connections-timed-out`) | The total number of connections that have timed out | .NET 6 |
 
 ## Microsoft-AspNetCore-Server-Kestrel counters
 

--- a/docs/core/diagnostics/compare-metric-apis.md
+++ b/docs/core/diagnostics/compare-metric-apis.md
@@ -57,7 +57,7 @@ For more information, see [Performance counters in .NET Framework](../../framewo
 ### EventCounters
 
 The [EventCounters](event-counters.md) API came next after `PerformanceCounters`. This API aimed to provide a uniform
-cross-platform experience. The APIs are available by targeting .NET Core 3.1+, and a small subset is available on .NET Framework 4.7.1
+cross-platform experience. The APIs are available by targeting .NET 6+, and a small subset is available on .NET Framework 4.7.1
 and above. These APIs are fully supported and are actively used by key .NET libraries, but they
 have less functionality than the newer <xref:System.Diagnostics.Metrics?displayProperty=nameWithType> APIs. EventCounters are able to report
 rates of change and averages, but do not support histograms and percentiles. There is also no support for multi-dimensional metrics. Custom

--- a/docs/core/diagnostics/compare-metric-apis.md
+++ b/docs/core/diagnostics/compare-metric-apis.md
@@ -57,7 +57,7 @@ For more information, see [Performance counters in .NET Framework](../../framewo
 ### EventCounters
 
 The [EventCounters](event-counters.md) API came next after `PerformanceCounters`. This API aimed to provide a uniform
-cross-platform experience. The APIs are available by targeting .NET 6+, and a small subset is available on .NET Framework 4.7.1
+cross-platform experience. The APIs were first introduced in .NET Core 3.1, and a small subset was introduced on .NET Framework 4.7.1
 and above. These APIs are fully supported and are actively used by key .NET libraries, but they
 have less functionality than the newer <xref:System.Diagnostics.Metrics?displayProperty=nameWithType> APIs. EventCounters are able to report
 rates of change and averages, but do not support histograms and percentiles. There is also no support for multi-dimensional metrics. Custom

--- a/docs/core/diagnostics/debug-deadlock.md
+++ b/docs/core/diagnostics/debug-deadlock.md
@@ -7,7 +7,7 @@ ms.date: 07/20/2020
 
 # Debug a deadlock in .NET Core
 
-**This article applies to: ✔️** .NET Core 3.1 SDK and later versions
+**This article applies to: ✔️** .NET 6 SDK and later versions
 
 In this tutorial, you'll learn how to debug a deadlock scenario. Using the provided example [ASP.NET Core web app](/samples/dotnet/samples/diagnostic-scenarios) source code repository, you can cause a deadlock intentionally. The endpoint will stop responding and experience thread accumulation. You'll learn how you can use various tools to analyze the problem, such as core dumps, core dump analysis, and process tracing.
 
@@ -25,7 +25,7 @@ In this tutorial, you will:
 
 The tutorial uses:
 
-- [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download/dotnet) or a later version
+- [.NET 6 SDK](https://dotnet.microsoft.com/download/dotnet) or a later version
 - [Sample debug target - web app](/samples/dotnet/samples/diagnostic-scenarios) to trigger the scenario
 - [dotnet-trace](dotnet-trace.md) to list processes
 - [dotnet-dump](dotnet-dump.md) to collect, and analyze a dump file

--- a/docs/core/diagnostics/debug-highcpu.md
+++ b/docs/core/diagnostics/debug-highcpu.md
@@ -7,7 +7,7 @@ ms.date: 07/20/2020
 
 # Debug high CPU usage in .NET Core
 
-**This article applies to: ✔️** .NET Core 3.1 SDK and later versions
+**This article applies to: ✔️** .NET 6 SDK and later versions
 
 In this tutorial, you'll learn how to debug an excessive CPU usage scenario. Using the provided example [ASP.NET Core web app](/samples/dotnet/samples/diagnostic-scenarios) source code repository, you can cause a deadlock intentionally. The endpoint will stop responding and experience thread accumulation. You'll learn how you can use various tools to diagnose this scenario with several key pieces of diagnostics data.
 
@@ -25,7 +25,7 @@ In this tutorial, you will:
 
 The tutorial uses:
 
-- [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download/dotnet) or a later version.
+- [.NET 6 SDK](https://dotnet.microsoft.com/download/dotnet) or a later version.
 - [Sample debug target](/samples/dotnet/samples/diagnostic-scenarios) to trigger the scenario.
 - [dotnet-trace](dotnet-trace.md) to list processes and generate a profile.
 - [dotnet-counters](dotnet-counters.md) to monitor cpu usage.

--- a/docs/core/diagnostics/debug-linux-dumps.md
+++ b/docs/core/diagnostics/debug-linux-dumps.md
@@ -49,7 +49,7 @@ Once LLDB starts, it may be necessary to use the `setsymbolserver` command to po
 Dumps collected from a Linux machine can also be analyzed on a Windows machine using [Visual Studio](/visualstudio/debugger/using-dump-files), [Windbg](/windows-hardware/drivers/debugger/analyzing-a-user-mode-dump-file), or the [dotnet-dump](dotnet-dump.md) tool. Both Visual Studio and Windbg can analyze native and managed code, while dotnet-dump only analyzes managed code.
 
 > [!NOTE]
-> Visual Studio version 16.8 and later allows you to [open and analyze Linux dumps](https://devblogs.microsoft.com/visualstudio/linux-managed-memory-dump-debugging/) generated on .NET Core 3.1.7 or later.
+> Visual Studio version 16.8 and later allows you to [open and analyze Linux dumps](https://devblogs.microsoft.com/visualstudio/linux-managed-memory-dump-debugging/) generated on .NET 6 or later.
 
 - **Visual Studio** - See the [Visual Studio dump debugging guide](/visualstudio/debugger/using-dump-files).
 - **Windbg** - You can debug Linux dumps on windbg using the [same instructions](/windows-hardware/drivers/debugger/analyzing-a-user-mode-dump-file) you would use to debug a Windows user-mode dump. Use the x64 version of windbg for dumps collected from a Linux x64 or Arm64 environment and the

--- a/docs/core/diagnostics/debug-linux-dumps.md
+++ b/docs/core/diagnostics/debug-linux-dumps.md
@@ -49,7 +49,7 @@ Once LLDB starts, it may be necessary to use the `setsymbolserver` command to po
 Dumps collected from a Linux machine can also be analyzed on a Windows machine using [Visual Studio](/visualstudio/debugger/using-dump-files), [Windbg](/windows-hardware/drivers/debugger/analyzing-a-user-mode-dump-file), or the [dotnet-dump](dotnet-dump.md) tool. Both Visual Studio and Windbg can analyze native and managed code, while dotnet-dump only analyzes managed code.
 
 > [!NOTE]
-> Visual Studio version 16.8 and later allows you to [open and analyze Linux dumps](https://devblogs.microsoft.com/visualstudio/linux-managed-memory-dump-debugging/) generated on .NET 6 or later.
+> Visual Studio version 16.8 and later allows you to [open and analyze Linux dumps](https://devblogs.microsoft.com/visualstudio/linux-managed-memory-dump-debugging/).
 
 - **Visual Studio** - See the [Visual Studio dump debugging guide](/visualstudio/debugger/using-dump-files).
 - **Windbg** - You can debug Linux dumps on windbg using the [same instructions](/windows-hardware/drivers/debugger/analyzing-a-user-mode-dump-file) you would use to debug a Windows user-mode dump. Use the x64 version of windbg for dumps collected from a Linux x64 or Arm64 environment and the

--- a/docs/core/diagnostics/debug-memory-leak.md
+++ b/docs/core/diagnostics/debug-memory-leak.md
@@ -7,7 +7,7 @@ ms.date: 11/13/2023
 
 # Debug a memory leak in .NET
 
-**This article applies to:** ✔️ .NET Core 3.1 SDK and later versions
+**This article applies to:** ✔️ .NET 6 SDK and later versions
 
 Memory can leak when your app references objects that it no longer needs to perform the desired task. Referencing these objects prevents the garbage collector from reclaiming the memory used. That can result in performance degradation and an <xref:System.OutOfMemoryException> exception being thrown.
 
@@ -27,7 +27,7 @@ In this tutorial, you will:
 
 The tutorial uses:
 
-- [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download/dotnet) or a later version.
+- [.NET 6 SDK](https://dotnet.microsoft.com/download/dotnet) or a later version.
 - [dotnet-counters](dotnet-counters.md) to check managed memory usage.
 - [dotnet-dump](dotnet-dump.md) to collect and analyze a dump file (includes the [SOS debugging extension](sos-debugging-extension.md)).
 - A [sample debug target](/samples/dotnet/samples/diagnostic-scenarios/) app to diagnose.

--- a/docs/core/diagnostics/debug-threadpool-starvation.md
+++ b/docs/core/diagnostics/debug-threadpool-starvation.md
@@ -7,7 +7,7 @@ ms.date: 04/19/2022
 
 # Debug ThreadPool Starvation
 
-**This article applies to: ✔️** .NET Core 3.1 and later versions
+**This article applies to: ✔️** .NET 6 and later versions
 
 In this tutorial, you'll learn how to debug a ThreadPool starvation scenario. ThreadPool starvation occurs when the pool has no available threads to process new work items and it often causes applications to respond slowly. Using the provided example [ASP.NET Core web app](/samples/dotnet/samples/diagnostic-scenarios), you can cause ThreadPool starvation intentionally and learn how to diagnose it.
 

--- a/docs/core/diagnostics/debug-windows-dumps.md
+++ b/docs/core/diagnostics/debug-windows-dumps.md
@@ -6,7 +6,7 @@ ms.date: 01/11/2023
 
 # Debug Windows dumps
 
-**This article applies to: ✔️** .NET Core 3.1 and later versions
+**This article applies to: ✔️** .NET 6 and later versions
 
 ## Analyze dumps on Windows
 

--- a/docs/core/diagnostics/diagnostic-port.md
+++ b/docs/core/diagnostics/diagnostic-port.md
@@ -7,7 +7,7 @@ ms.topic: overview
 
 # Diagnostic ports
 
-**This article applies to: ✔️** .NET Core 3.1 and later versions
+**This article applies to: ✔️** .NET 6 and later versions
 
 The .NET runtime exposes a service endpoint that allows other processes to send diagnostic commands and receive responses over an [IPC channel](https://en.wikipedia.org/wiki/Inter-process_communication). This endpoint is called a *diagnostic port*. Commands can be sent to the diagnostic port to:
 

--- a/docs/core/diagnostics/diagnostics-in-containers.md
+++ b/docs/core/diagnostics/diagnostics-in-containers.md
@@ -10,9 +10,9 @@ The same diagnostics tools that are useful for diagnosing .NET Core issues in ot
 
 ## Using .NET CLI tools in a container
 
-**These tools apply to: ✔️** .NET Core 3.1 SDK and later versions
+**These tools apply to: ✔️** .NET 6 SDK and later versions
 
-The .NET Core global CLI diagnostic tools ([dotnet-counters](dotnet-counters.md), [dotnet-dump](dotnet-dump.md), [dotnet-gcdump](dotnet-gcdump.md), [dotnet-monitor](dotnet-monitor.md), and [dotnet-trace](dotnet-trace.md)) are designed to work in a wide variety of environments and should all work directly in Docker containers. Because of this, these tools are the preferred method of collecting diagnostic information for .NET Core scenarios targeting .NET Core 3.1 or later in containers.
+The .NET Core global CLI diagnostic tools ([dotnet-counters](dotnet-counters.md), [dotnet-dump](dotnet-dump.md), [dotnet-gcdump](dotnet-gcdump.md), [dotnet-monitor](dotnet-monitor.md), and [dotnet-trace](dotnet-trace.md)) are designed to work in a wide variety of environments and should all work directly in Docker containers. Because of this, these tools are the preferred method of collecting diagnostic information for .NET Core scenarios targeting .NET 6 or later in containers.
 
 You can also install these tools without the .NET SDK by downloading the single-file variants from the links in the previous paragraph. These installs require a global install of the .NET runtime version 3.1 or later, which you can acquire following any of the prescribed methods in the [.NET installation documentation](../install/index.yml) or by consuming any of the official runtime containers.
 

--- a/docs/core/diagnostics/diagnosticsource-diagnosticlistener.md
+++ b/docs/core/diagnostics/diagnosticsource-diagnosticlistener.md
@@ -5,7 +5,7 @@ ms.date: 05/12/2022
 ---
 # DiagnosticSource and DiagnosticListener
 
-**This article applies to: ✔️** .NET Core 3.1 and later versions **✔️** .NET Framework 4.5 and later versions
+**This article applies to: ✔️** .NET 6 and later versions **✔️** .NET Framework 4.5 and later versions
 
 <xref:System.Diagnostics.DiagnosticSource?displayProperty=nameWithType> is a module that allows code to be instrumented for production-time
 logging of rich data payloads for consumption within the process that was instrumented. At run time, consumers can dynamically discover

--- a/docs/core/diagnostics/dotnet-gcdump.md
+++ b/docs/core/diagnostics/dotnet-gcdump.md
@@ -164,11 +164,11 @@ dotnet-gcdump report [-h|--help] [-p|--process-id <pid>] [-t|--report-type <Heap
 
 - There is no type information in the gcdump.
 
-   Prior to .NET Core 3.1, there was an issue where a type cache was not cleared between gcdumps when they were invoked with EventPipe. This resulted in the events needed for determining type information not being sent for the second and subsequent gcdumps. This was fixed in .NET Core 3.1-preview2.
+   Prior to .NET 6, there was an issue where a type cache was not cleared between gcdumps when they were invoked with EventPipe. This resulted in the events needed for determining type information not being sent for the second and subsequent gcdumps. This was fixed in .NET 6-preview2.
 
 - COM and static types aren't in the GC dump.
 
-   Prior to .NET Core 3.1, there was an issue where static and COM types weren't sent when the GC dump was invoked via EventPipe. This has been fixed in .NET Core 3.1.
+   Prior to .NET 6, there was an issue where static and COM types weren't sent when the GC dump was invoked via EventPipe. This has been fixed in .NET 6.
 
 - `dotnet-gcdump` is unable to generate a `.gcdump` file due to missing information, for example, **[Error] Exception during gcdump: System.ApplicationException: ETL file shows the start of a heap dump but not its completion.**. Or, the `.gcdump` file doesn't include the entire heap.
 

--- a/docs/core/diagnostics/event-counter-perf.md
+++ b/docs/core/diagnostics/event-counter-perf.md
@@ -22,7 +22,7 @@ In this tutorial, you will:
 
 The tutorial uses:
 
-- [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download/dotnet) or a later version.
+- [.NET 6 SDK](https://dotnet.microsoft.com/download/dotnet) or a later version.
 - [dotnet-counters](dotnet-counters.md) to monitor event counters.
 - A [sample debug target](/samples/dotnet/samples/diagnostic-scenarios) app to diagnose.
 

--- a/docs/core/diagnostics/eventsource-activity-ids.md
+++ b/docs/core/diagnostics/eventsource-activity-ids.md
@@ -6,7 +6,7 @@ ms.date: 03/24/2022
 
 # EventSource Activity IDs
 
-**This article applies to: ✔️** .NET Core 3.1 and later versions **✔️** .NET Framework 4.5 and later versions
+**This article applies to: ✔️** .NET 6 and later versions **✔️** .NET Framework 4.5 and later versions
 
 This guide explains Activity IDs, an optional identifier that can be logged with each event generated using
 <xref:System.Diagnostics.Tracing.EventSource?displayProperty=nameWithType>. For an introduction, see

--- a/docs/core/diagnostics/eventsource-collect-and-view-traces.md
+++ b/docs/core/diagnostics/eventsource-collect-and-view-traces.md
@@ -7,7 +7,7 @@ ms.date: 03/03/2022
 
 # Collect and View EventSource Traces
 
-**This article applies to: ✔️** .NET Core 3.1 and later versions **✔️** .NET Framework 4.5 and later versions
+**This article applies to: ✔️** .NET 6 and later versions **✔️** .NET Framework 4.5 and later versions
 
 The [Getting started guide](./eventsource-getting-started.md) showed you how to create a minimal EventSource and collect events in a trace file.
 This tutorial shows how different tools can configure which events are collected in a trace and then view the traces.

--- a/docs/core/diagnostics/eventsource-getting-started.md
+++ b/docs/core/diagnostics/eventsource-getting-started.md
@@ -5,7 +5,7 @@ ms.date: 02/17/2022
 ---
 # Getting Started with EventSource
 
-**This article applies to: ✔️** .NET Core 3.1 and later versions **✔️** .NET Framework 4.5 and later versions
+**This article applies to: ✔️** .NET 6 and later versions **✔️** .NET Framework 4.5 and later versions
 
 This walkthrough shows how to log a new event with <xref:System.Diagnostics.Tracing.EventSource?displayProperty=nameWithType>,
 collect events in a trace file, view the trace, and understand basic EventSource concepts.

--- a/docs/core/diagnostics/eventsource-instrumentation.md
+++ b/docs/core/diagnostics/eventsource-instrumentation.md
@@ -6,7 +6,7 @@ ms.date: 03/03/2022
 
 # Instrument Code to Create EventSource Events
 
-**This article applies to: ✔️** .NET Core 3.1 and later versions **✔️** .NET Framework 4.5 and later versions
+**This article applies to: ✔️** .NET 6 and later versions **✔️** .NET Framework 4.5 and later versions
 
 The [Getting Started guide](./eventsource-getting-started.md) showed you how to create a minimal EventSource and collect events in a trace file.
 This tutorial goes into more detail about creating events using <xref:System.Diagnostics.Tracing.EventSource?displayProperty=nameWithType>.

--- a/docs/core/diagnostics/eventsource.md
+++ b/docs/core/diagnostics/eventsource.md
@@ -5,7 +5,7 @@ ms.date: 02/17/2022
 ---
 # EventSource
 
-**This article applies to: ✔️** .NET Core 3.1 and later versions **✔️** .NET Framework 4.5 and later versions
+**This article applies to: ✔️** .NET 6 and later versions **✔️** .NET Framework 4.5 and later versions
 
 <xref:System.Diagnostics.Tracing.EventSource?displayProperty=nameWithType> is a fast structured logging solution
 built into the .NET runtime. On .NET Framework EventSource can send events to

--- a/docs/core/diagnostics/metrics-collection.md
+++ b/docs/core/diagnostics/metrics-collection.md
@@ -7,7 +7,7 @@ ms.date: 10/27/2021
 
 # Collect metrics
 
-**This article applies to: ✔️** .NET Core 3.1 and later **✔️** .NET Framework 4.6.1 and later
+**This article applies to: ✔️** .NET 6 and later **✔️** .NET Framework 4.6.2 and later
 
 Instrumented code can record numeric measurements, but the measurements usually need to be aggregated, transmitted, and stored to create useful metrics for monitoring. The process of aggregating, transmitting, and storing data is called collection. This tutorial shows several examples of collecting metrics:
 
@@ -19,7 +19,7 @@ For more information on custom metric instrumentation and options, see [Compare 
 
 ## Prerequisites
 
-- [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download/dotnet) or a later
+- [.NET 6 SDK](https://dotnet.microsoft.com/download/dotnet) or a later
 
 ## Create an example app
 

--- a/docs/core/diagnostics/metrics-instrumentation.md
+++ b/docs/core/diagnostics/metrics-instrumentation.md
@@ -7,7 +7,7 @@ ms.date: 10/31/2023
 
 # Creating metrics
 
-**This article applies to: ✔️** .NET Core 6 and later versions **✔️** .NET Framework 4.6.1 and later versions
+**This article applies to: ✔️** .NET Core 6 and later versions **✔️** .NET Framework 2 and later versions
 
 .NET applications can be instrumented using the <xref:System.Diagnostics.Metrics?displayProperty=nameWithType> APIs to track
 important metrics. Some metrics are included in standard .NET libraries, but you may want to add new custom metrics that are relevant for

--- a/docs/core/diagnostics/metrics-instrumentation.md
+++ b/docs/core/diagnostics/metrics-instrumentation.md
@@ -7,7 +7,7 @@ ms.date: 10/31/2023
 
 # Creating metrics
 
-**This article applies to: ✔️** .NET Core 6 and later versions **✔️** .NET Framework 2 and later versions
+**This article applies to: ✔️** .NET Core 6 and later versions **✔️** .NET Framework 4.6.2 and later versions
 
 .NET applications can be instrumented using the <xref:System.Diagnostics.Metrics?displayProperty=nameWithType> APIs to track
 important metrics. Some metrics are included in standard .NET libraries, but you may want to add new custom metrics that are relevant for

--- a/docs/core/diagnostics/microsoft-diagnostics-netcore-client.md
+++ b/docs/core/diagnostics/microsoft-diagnostics-netcore-client.md
@@ -297,7 +297,7 @@ Gets an `IDictionary` of key-value pair strings representing optional arguments 
 
 ### Remarks
 
-This class is immutable, because EventPipe does not allow a provider's configuration to be modified during an EventPipe session as of .NET Core 3.1.
+This class is immutable, because EventPipe does not allow a provider's configuration to be modified during an EventPipe session as of .NET 6.
 
 ## EventPipeSession class
 

--- a/docs/core/unmanaged-api/debugging/createdebugginginterfacefromversion2-function.md
+++ b/docs/core/unmanaged-api/debugging/createdebugginginterfacefromversion2-function.md
@@ -72,4 +72,4 @@ HRESULT CreateDebuggingInterfaceFromVersion2 (
 
  **Library:** dbgshim.dll, libdbgshim.so, libdbgshim.dylib
 
- **.NET Versions:** Available since .NET Core 3.1
+ **.NET Versions:** Available since .NET 6

--- a/docs/core/unmanaged-api/profiling/icorprofilerinfo11-getenvironmentvariable-method.md
+++ b/docs/core/unmanaged-api/profiling/icorprofilerinfo11-getenvironmentvariable-method.md
@@ -45,7 +45,7 @@ Gets an environment variable from the process. On non-Windows platforms the runt
 
 **Header:** CorProf.idl, CorProf.h
 
-**.NET Versions:** Available since .NET Core 3.1
+**.NET Versions:** Available since .NET 6
 
 ## See also
 

--- a/docs/core/unmanaged-api/profiling/icorprofilerinfo11-interface.md
+++ b/docs/core/unmanaged-api/profiling/icorprofilerinfo11-interface.md
@@ -27,4 +27,4 @@ api_type:
 
 **Header:** CorProf.idl, CorProf.h
 
-**.NET Versions:** Available since .NET Core 3.1
+**.NET Versions:** Available since .NET 6

--- a/docs/core/unmanaged-api/profiling/icorprofilerinfo11-setenvironmentvariable-method.md
+++ b/docs/core/unmanaged-api/profiling/icorprofilerinfo11-setenvironmentvariable-method.md
@@ -36,4 +36,4 @@ Sets an environment variable in the process. On non-Windows platforms the runtim
 
 **Header:** CorProf.idl, CorProf.h
 
-**.NET Versions:** Available since .NET Core 3.1
+**.NET Versions:** Available since .NET 6


### PR DESCRIPTION
## Summary

Change references to unsupported and out of date versions of .NET to currently supported versions.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

<details><summary><strong>Toggle expand/collapse</strong></summary><br/>

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/available-counters.md](https://github.com/dotnet/docs/blob/a8e35f0e5d9389e4aa4f592c32db926712f26228/docs/core/diagnostics/available-counters.md) | [docs/core/diagnostics/available-counters](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/available-counters?branch=pr-en-us-39651) |
| [docs/core/diagnostics/compare-metric-apis.md](https://github.com/dotnet/docs/blob/a8e35f0e5d9389e4aa4f592c32db926712f26228/docs/core/diagnostics/compare-metric-apis.md) | [docs/core/diagnostics/compare-metric-apis](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/compare-metric-apis?branch=pr-en-us-39651) |
| [docs/core/diagnostics/debug-deadlock.md](https://github.com/dotnet/docs/blob/a8e35f0e5d9389e4aa4f592c32db926712f26228/docs/core/diagnostics/debug-deadlock.md) | [docs/core/diagnostics/debug-deadlock](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/debug-deadlock?branch=pr-en-us-39651) |
| [docs/core/diagnostics/debug-highcpu.md](https://github.com/dotnet/docs/blob/a8e35f0e5d9389e4aa4f592c32db926712f26228/docs/core/diagnostics/debug-highcpu.md) | [docs/core/diagnostics/debug-highcpu](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/debug-highcpu?branch=pr-en-us-39651) |
| [docs/core/diagnostics/debug-linux-dumps.md](https://github.com/dotnet/docs/blob/a8e35f0e5d9389e4aa4f592c32db926712f26228/docs/core/diagnostics/debug-linux-dumps.md) | [docs/core/diagnostics/debug-linux-dumps](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/debug-linux-dumps?branch=pr-en-us-39651) |
| [docs/core/diagnostics/debug-memory-leak.md](https://github.com/dotnet/docs/blob/a8e35f0e5d9389e4aa4f592c32db926712f26228/docs/core/diagnostics/debug-memory-leak.md) | [docs/core/diagnostics/debug-memory-leak](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/debug-memory-leak?branch=pr-en-us-39651) |
| [docs/core/diagnostics/debug-threadpool-starvation.md](https://github.com/dotnet/docs/blob/a8e35f0e5d9389e4aa4f592c32db926712f26228/docs/core/diagnostics/debug-threadpool-starvation.md) | [docs/core/diagnostics/debug-threadpool-starvation](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/debug-threadpool-starvation?branch=pr-en-us-39651) |
| [docs/core/diagnostics/debug-windows-dumps.md](https://github.com/dotnet/docs/blob/a8e35f0e5d9389e4aa4f592c32db926712f26228/docs/core/diagnostics/debug-windows-dumps.md) | [docs/core/diagnostics/debug-windows-dumps](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/debug-windows-dumps?branch=pr-en-us-39651) |
| [docs/core/diagnostics/diagnostic-port.md](https://github.com/dotnet/docs/blob/a8e35f0e5d9389e4aa4f592c32db926712f26228/docs/core/diagnostics/diagnostic-port.md) | [docs/core/diagnostics/diagnostic-port](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/diagnostic-port?branch=pr-en-us-39651) |
| [docs/core/diagnostics/diagnostics-in-containers.md](https://github.com/dotnet/docs/blob/a8e35f0e5d9389e4aa4f592c32db926712f26228/docs/core/diagnostics/diagnostics-in-containers.md) | [docs/core/diagnostics/diagnostics-in-containers](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/diagnostics-in-containers?branch=pr-en-us-39651) |
| [docs/core/diagnostics/diagnosticsource-diagnosticlistener.md](https://github.com/dotnet/docs/blob/a8e35f0e5d9389e4aa4f592c32db926712f26228/docs/core/diagnostics/diagnosticsource-diagnosticlistener.md) | [docs/core/diagnostics/diagnosticsource-diagnosticlistener](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/diagnosticsource-diagnosticlistener?branch=pr-en-us-39651) |
| [docs/core/diagnostics/dotnet-gcdump.md](https://github.com/dotnet/docs/blob/a8e35f0e5d9389e4aa4f592c32db926712f26228/docs/core/diagnostics/dotnet-gcdump.md) | [docs/core/diagnostics/dotnet-gcdump](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-gcdump?branch=pr-en-us-39651) |
| [docs/core/diagnostics/event-counter-perf.md](https://github.com/dotnet/docs/blob/a8e35f0e5d9389e4aa4f592c32db926712f26228/docs/core/diagnostics/event-counter-perf.md) | [docs/core/diagnostics/event-counter-perf](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/event-counter-perf?branch=pr-en-us-39651) |
| [docs/core/diagnostics/eventsource-activity-ids.md](https://github.com/dotnet/docs/blob/a8e35f0e5d9389e4aa4f592c32db926712f26228/docs/core/diagnostics/eventsource-activity-ids.md) | [docs/core/diagnostics/eventsource-activity-ids](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/eventsource-activity-ids?branch=pr-en-us-39651) |
| [docs/core/diagnostics/eventsource-collect-and-view-traces.md](https://github.com/dotnet/docs/blob/a8e35f0e5d9389e4aa4f592c32db926712f26228/docs/core/diagnostics/eventsource-collect-and-view-traces.md) | [docs/core/diagnostics/eventsource-collect-and-view-traces](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/eventsource-collect-and-view-traces?branch=pr-en-us-39651) |
| [docs/core/diagnostics/eventsource-getting-started.md](https://github.com/dotnet/docs/blob/a8e35f0e5d9389e4aa4f592c32db926712f26228/docs/core/diagnostics/eventsource-getting-started.md) | [docs/core/diagnostics/eventsource-getting-started](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/eventsource-getting-started?branch=pr-en-us-39651) |
| [docs/core/diagnostics/eventsource-instrumentation.md](https://github.com/dotnet/docs/blob/a8e35f0e5d9389e4aa4f592c32db926712f26228/docs/core/diagnostics/eventsource-instrumentation.md) | [docs/core/diagnostics/eventsource-instrumentation](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/eventsource-instrumentation?branch=pr-en-us-39651) |
| [docs/core/diagnostics/eventsource.md](https://github.com/dotnet/docs/blob/a8e35f0e5d9389e4aa4f592c32db926712f26228/docs/core/diagnostics/eventsource.md) | [docs/core/diagnostics/eventsource](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/eventsource?branch=pr-en-us-39651) |
| [docs/core/diagnostics/metrics-collection.md](https://github.com/dotnet/docs/blob/a8e35f0e5d9389e4aa4f592c32db926712f26228/docs/core/diagnostics/metrics-collection.md) | [docs/core/diagnostics/metrics-collection](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/metrics-collection?branch=pr-en-us-39651) |
| [docs/core/diagnostics/metrics-instrumentation.md](https://github.com/dotnet/docs/blob/a8e35f0e5d9389e4aa4f592c32db926712f26228/docs/core/diagnostics/metrics-instrumentation.md) | [docs/core/diagnostics/metrics-instrumentation](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/metrics-instrumentation?branch=pr-en-us-39651) |
| [docs/core/diagnostics/microsoft-diagnostics-netcore-client.md](https://github.com/dotnet/docs/blob/a8e35f0e5d9389e4aa4f592c32db926712f26228/docs/core/diagnostics/microsoft-diagnostics-netcore-client.md) | [docs/core/diagnostics/microsoft-diagnostics-netcore-client](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/microsoft-diagnostics-netcore-client?branch=pr-en-us-39651) |
| [docs/core/unmanaged-api/debugging/createdebugginginterfacefromversion2-function.md](https://github.com/dotnet/docs/blob/a8e35f0e5d9389e4aa4f592c32db926712f26228/docs/core/unmanaged-api/debugging/createdebugginginterfacefromversion2-function.md) | [docs/core/unmanaged-api/debugging/createdebugginginterfacefromversion2-function](https://review.learn.microsoft.com/en-us/dotnet/core/unmanaged-api/debugging/createdebugginginterfacefromversion2-function?branch=pr-en-us-39651) |
| [docs/core/unmanaged-api/profiling/icorprofilerinfo11-getenvironmentvariable-method.md](https://github.com/dotnet/docs/blob/a8e35f0e5d9389e4aa4f592c32db926712f26228/docs/core/unmanaged-api/profiling/icorprofilerinfo11-getenvironmentvariable-method.md) | [docs/core/unmanaged-api/profiling/icorprofilerinfo11-getenvironmentvariable-method](https://review.learn.microsoft.com/en-us/dotnet/core/unmanaged-api/profiling/icorprofilerinfo11-getenvironmentvariable-method?branch=pr-en-us-39651) |
| [docs/core/unmanaged-api/profiling/icorprofilerinfo11-interface.md](https://github.com/dotnet/docs/blob/a8e35f0e5d9389e4aa4f592c32db926712f26228/docs/core/unmanaged-api/profiling/icorprofilerinfo11-interface.md) | [docs/core/unmanaged-api/profiling/icorprofilerinfo11-interface](https://review.learn.microsoft.com/en-us/dotnet/core/unmanaged-api/profiling/icorprofilerinfo11-interface?branch=pr-en-us-39651) |
| [docs/core/unmanaged-api/profiling/icorprofilerinfo11-setenvironmentvariable-method.md](https://github.com/dotnet/docs/blob/a8e35f0e5d9389e4aa4f592c32db926712f26228/docs/core/unmanaged-api/profiling/icorprofilerinfo11-setenvironmentvariable-method.md) | [docs/core/unmanaged-api/profiling/icorprofilerinfo11-setenvironmentvariable-method](https://review.learn.microsoft.com/en-us/dotnet/core/unmanaged-api/profiling/icorprofilerinfo11-setenvironmentvariable-method?branch=pr-en-us-39651) |

</details>


<!-- PREVIEW-TABLE-END -->