### PR TITLE
document security best practices for managing package source credentials in NuGet docs

### DIFF
--- a/docs/core/tools/dotnet-nuget-add-source.md
+++ b/docs/core/tools/dotnet-nuget-add-source.md
@@ -47,7 +47,7 @@ The `dotnet nuget add source` command adds a new package source to your NuGet co
   Password to be used when connecting to an authenticated source.
 
 > [!NOTE]
-> Be aware that encrypted passwords are only supported on Windows. 
+> Be aware that encrypted passwords are only supported on Windows.
 > Moreover, they can only be decrypted on the same machine and by the same user who originally encrypted them.
 
 - **`--store-password-in-clear-text`**
@@ -93,6 +93,8 @@ The `dotnet nuget add source` command adds a new package source to your NuGet co
   ```
 
 ## See also
+
+- [Security best practices for managing package source credentials](/nuget/consume-packages/consuming-packages-authenticated-feeds#security-best-practices-for-managing-credentials)
 
 - [Package source sections in NuGet.config files](/nuget/reference/nuget-config-file#package-source-sections)
 

--- a/docs/core/tools/dotnet-nuget-add-source.md
+++ b/docs/core/tools/dotnet-nuget-add-source.md
@@ -26,7 +26,7 @@ dotnet nuget add source -h|--help
 The `dotnet nuget add source` command adds a new package source to your NuGet configuration files.
 
 > [!WARNING]
-> When adding multiple package sources, be careful not to introduce a [dependency confusion vulnerability](https://aka.ms/pkg-sec-wp).
+> When adding multiple package sources, be careful not to introduce a [dependency confusion vulnerability](/nuget/concepts/security-best-practices#nuget-feeds).
 
 ## Arguments
 
@@ -46,9 +46,17 @@ The `dotnet nuget add source` command adds a new package source to your NuGet co
 
   Password to be used when connecting to an authenticated source.
 
+> [!NOTE]
+> Be aware that encrypted passwords are only supported on Windows. 
+> Moreover, they can only be decrypted on the same machine and by the same user who originally encrypted them.
+
 - **`--store-password-in-clear-text`**
 
   Enables storing portable package source credentials by disabling password encryption.
+
+> [!WARNING]
+> Storing passwords in clear text is strongly discouraged.
+> For more information on managing credentials securely, refer to the [security best practices for consuming packages from private feeds](/nuget/consume-packages/consuming-packages-authenticated-feeds#security-best-practices-for-managing-credentials).
 
 - **`-u|--username <USER>`**
 
@@ -75,7 +83,7 @@ The `dotnet nuget add source` command adds a new package source to your NuGet co
 - Add a source that needs authentication:
 
   ```dotnetcli
-  dotnet nuget add source https://someServer/myTeam -n myTeam -u myUsername -p myPassword --store-password-in-clear-text
+  dotnet nuget add source https://someServer/myTeam -n myTeam -u myUsername -p myPassword
   ```
 
 - Add a source that needs authentication (then go install credential provider):

--- a/docs/core/tools/dotnet-nuget-update-source.md
+++ b/docs/core/tools/dotnet-nuget-update-source.md
@@ -39,6 +39,10 @@ The `dotnet nuget update source` command updates an existing source in your NuGe
 
   Password to be used when connecting to an authenticated source.
 
+> [!NOTE]
+> Be aware that encrypted passwords are only supported on Windows.
+> Moreover, they can only be decrypted on the same machine and by the same user who originally encrypted them.
+
 - **`-s|--source <SOURCE>`**
 
   Path to the package source.
@@ -46,6 +50,10 @@ The `dotnet nuget update source` command updates an existing source in your NuGe
 - **`--store-password-in-clear-text`**
 
   Enables storing portable package source credentials by disabling password encryption.
+  
+> [!WARNING]
+> Storing passwords in clear text is strongly discouraged.
+> For more information on managing credentials securely, refer to the [security best practices for consuming packages from private feeds](/nuget/consume-packages/consuming-packages-authenticated-feeds#security-best-practices-for-managing-credentials).
 
 - **`-u|--username <USER>`**
 
@@ -64,6 +72,8 @@ The `dotnet nuget update source` command updates an existing source in your NuGe
   ```
 
 ## See also
+
+- [Security best practices for managing package source credentials](/nuget/consume-packages/consuming-packages-authenticated-feeds#security-best-practices-for-managing-credentials)
 
 - [Package source sections in NuGet.config files](/nuget/reference/nuget-config-file#package-source-sections)
 


### PR DESCRIPTION
## Summary

Describe your changes here.

Fixes https://github.com/NuGet/Client.Engineering/issues/2583

Updated the documentation to include a warning about setting credentials in plain text and raise awareness about the lack of encrypted password support in non-Windows platforms.

Follow up PR for https://github.com/NuGet/docs.microsoft.com-nuget/pull/3240


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-nuget-add-source.md](https://github.com/dotnet/docs/blob/44ae41db8288ce0a340b5801cc4c0c6aaa9af523/docs/core/tools/dotnet-nuget-add-source.md) | [dotnet nuget add source](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-add-source?branch=pr-en-us-39652) |
| [docs/core/tools/dotnet-nuget-update-source.md](https://github.com/dotnet/docs/blob/44ae41db8288ce0a340b5801cc4c0c6aaa9af523/docs/core/tools/dotnet-nuget-update-source.md) | [dotnet nuget update source command](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-update-source?branch=pr-en-us-39652) |

<!-- PREVIEW-TABLE-END -->