### PR TITLE
Update diagnosticsource-diagnosticlistener.md

### DIFF
--- a/docs/core/diagnostics/diagnosticsource-diagnosticlistener.md
+++ b/docs/core/diagnostics/diagnosticsource-diagnosticlistener.md
@@ -212,6 +212,22 @@ The `listener.Subscribe()` call in the previous example can be replaced with the
 This efficiently subscribes to only the 'RequestStart' events. All other events will cause the `DiagnosticSource.IsEnabled()`
 method to return `false` and thus be efficiently filtered out.
 
+> [!NOTE]
+> Filtering is only designed as a performance optimization. It is possible for a listener to receive events even when they
+> do not satisfy the filter. This could occur because some other listener has subscribed to the event or because the source
+> of the event didn't check IsEnabled() prior to sending it. If you want to be certain that a given event satisfies the filter
+> you will need to check it inside the callback. For example:
+
+```C#
+    Action<KeyValuePair<string, object>> callback = (KeyValuePair<string, object> evnt) =>
+        {
+            if(predicate(evnt.Key)) // only print out events that satisfy our filter
+            {
+                Console.WriteLine("From Listener {0} Received Event {1} with payload {2}", networkListener.Name, evnt.Key, evnt.Value.ToString());
+            }
+        };
+```
+
 ##### Context-based filtering
 
 Some scenarios require advanced filtering based on extended context.


### PR DESCRIPTION
Porting the change in https://github.com/dotnet/runtime/pull/98801

Calling out that DiagnosticListener may receive events that don't satisfy the provided filter.

Fixes [98499](https://github.com/dotnet/runtime/issues/98499)

cc @dotnet/dotnet-diag @tarekgh 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/diagnosticsource-diagnosticlistener.md](https://github.com/dotnet/docs/blob/fd46451cdc3ed56a7a0591648a52ce682f0c75c7/docs/core/diagnostics/diagnosticsource-diagnosticlistener.md) | [DiagnosticSource and DiagnosticListener](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/diagnosticsource-diagnosticlistener?branch=pr-en-us-39653) |

<!-- PREVIEW-TABLE-END -->