### PR TITLE
Include and present the data source and output for examples in "Query expression basics" article

### DIFF
--- a/docs/csharp/linq/get-started/query-expression-basics.md
+++ b/docs/csharp/linq/get-started/query-expression-basics.md
@@ -51,6 +51,11 @@ A query expression must begin with a [from](../../language-reference/keywords/fr
 
 In LINQ, a query variable is any variable that stores a *query* instead of the *results* of a query. More specifically, a query variable is always an enumerable type that produces a sequence of elements when iterated over in a `foreach` statement or a direct call to its <xref:System.Collections.IEnumerator.MoveNext?displayProperty=nameWithType> method.
 
+> [!NOTE]
+> Examples in this article uses the following data source
+
+:::code language="csharp" source="./snippets/SnippetApp/DataSources.cs" id="basics_datasource":::
+
 The following code example shows a simple query expression with one data source, one filtering clause, one ordering clause, and no transformation of the source elements. The `select` clause ends the query.
 
 :::code language="csharp" source="./snippets/SnippetApp/Basics.cs" id="basics5":::

--- a/docs/csharp/linq/get-started/snippets/SnippetApp/Basics.cs
+++ b/docs/csharp/linq/get-started/snippets/SnippetApp/Basics.cs
@@ -4,7 +4,7 @@ public static class Basics
 {
     // We're not displaying the output, so these could be filled with dummy data
     static readonly int[] scores = [0]; // Max is called on this, so one value is needed
-    static readonly City[] cities = [];
+    static readonly City[] cities = [new City(200000), new City(120000), new City(112000), new City(150340), new City(23000)];
     static readonly Country[] countries = [];
 
     public static void Basics1()
@@ -78,11 +78,24 @@ public static class Basics
     public static void Basics6()
     {
         // <basics6>
+        City[] cities = [new City(20000), new City(120000), new City(112000), new City(150340), new City(23000)];
+
         //Query syntax
         IEnumerable<City> queryMajorCities =
             from city in cities
             where city.Population > 100000
             select city;
+
+        // Execute the query to produce the results
+        foreach (City city in queryMajorCities)
+        {
+            Console.WriteLine(city);
+        }
+
+        // Output:
+        // City { Population = 120000 }
+        // City { Population = 112000 }
+        // City { Population = 150340 }
 
         // Method-based syntax
         IEnumerable<City> queryMajorCities2 = cities.Where(c => c.Population > 100000);

--- a/docs/csharp/linq/get-started/snippets/SnippetApp/DataSources.cs
+++ b/docs/csharp/linq/get-started/snippets/SnippetApp/DataSources.cs
@@ -1,8 +1,10 @@
 ﻿namespace Linq.GetStarted;
 
+// <basics_datasource>
 record City(long Population);
 record Country(string Name, List<City> Cities, long Area, long Population);
 record Product(string Name, string Category);
+// </basics_datasource>
 
 class Student
 {


### PR DESCRIPTION
This pull request closes #39655 

It links and presents the data source, used for the examples, in the article.
I used the same template as is already used in Basics5 example.

Also, the data source is presented before the first example so that reader can always refer to the types used in examples.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/linq/get-started/query-expression-basics.md](https://github.com/dotnet/docs/blob/696ba629095288ae7da10d32e5814f7a3ab77e68/docs/csharp/linq/get-started/query-expression-basics.md) | [Query expression basics](https://review.learn.microsoft.com/en-us/dotnet/csharp/linq/get-started/query-expression-basics?branch=pr-en-us-39659) |

<!-- PREVIEW-TABLE-END -->