### PR TITLE
Add subsection header for combinations "what type" and "how is passed"

### DIFF
--- a/docs/csharp/language-reference/keywords/method-parameters.md
+++ b/docs/csharp/language-reference/keywords/method-parameters.md
@@ -24,7 +24,7 @@ The output of the following example illustrates the difference. The method `Clas
 
 :::code language="csharp" source="./snippets/PassParameters.cs" id="PassByValueOrReference":::
 
-### Combinations of how argument is passed and argument type
+## Combinations of parameter type and argument mode
 
 How an argument is passed, and whether it's a reference type or value type controls what modifications made to the argument are visible from the caller:
 

--- a/docs/csharp/language-reference/keywords/method-parameters.md
+++ b/docs/csharp/language-reference/keywords/method-parameters.md
@@ -24,6 +24,8 @@ The output of the following example illustrates the difference. The method `Clas
 
 :::code language="csharp" source="./snippets/PassParameters.cs" id="PassByValueOrReference":::
 
+### Combinations of how argument is passed and argument type
+
 How an argument is passed, and whether it's a reference type or value type controls what modifications made to the argument are visible from the caller:
 
 - When you pass a *value* type *by value*:


### PR DESCRIPTION
Add subsection header.

I deeply believe that official C# documentation should enable public link to the fact that all 4 combinations ``value type passed by value'', ``value type passed by reference'', ``reference type passed by value'' and ``reference type passed by reference'' are possible and different.

Without this, a lot of students don't understand, for example, why Array.Sort doesn't require ref, but Array.Resize does.

As far as I understand, creating link to specific place of page requires subsection header. So, I propose to add such subsection header. 

I'm not sure, if the proposed subsection header name really good. If smbd can propose a better name, please fix. But I'm begging to create some subsection name here, to allow direct link here.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/method-parameters.md](https://github.com/dotnet/docs/blob/68ad5b8e2df1112a1d59ca380ee238ffdfa0b2b6/docs/csharp/language-reference/keywords/method-parameters.md) | [Method Parameters](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/method-parameters?branch=pr-en-us-39660) |


<!-- PREVIEW-TABLE-END -->