### PR TITLE
Fix ordering of config Documents

### DIFF
--- a/docs/core/extensions/configuration.md
+++ b/docs/core/extensions/configuration.md
@@ -56,8 +56,8 @@ The <xref:Microsoft.Extensions.Hosting.Host.CreateApplicationBuilder(System.Stri
 1. Command-line arguments using the [Command-line configuration provider](configuration-providers.md#command-line-configuration-provider).
 1. Environment variables using the [Environment Variables configuration provider](configuration-providers.md#environment-variable-configuration-provider).
 1. [App secrets](/aspnet/core/security/app-secrets) when the app runs in the `Development` environment.
-1. *appsettings.*`Environment`*.json* using the [JSON configuration provider](configuration-providers.md#file-configuration-provider). For example, *appsettings*.***Production***.*json* and *appsettings*.***Development***.*json*.
 1. *appsettings.json* using the [JSON configuration provider](configuration-providers.md#file-configuration-provider).
+1. *appsettings.*`Environment`*.json* using the [JSON configuration provider](configuration-providers.md#file-configuration-provider). For example, *appsettings*.***Production***.*json* and *appsettings*.***Development***.*json*.
 1. [ChainedConfigurationProvider](xref:Microsoft.Extensions.Configuration.ChainedConfigurationSource) : Adds an existing `IConfiguration` as a source.
 
 Adding a configuration provider overrides previous configuration values. For example, the [Command-line configuration provider](configuration-providers.md#command-line-configuration-provider) overrides all values from other providers because it's added last. If `SomeKey` is set in both *appsettings.json* and the environment, the environment value is used because it was added after *appsettings.json*.


### PR DESCRIPTION
## Summary

I was reading the document on Configuration and noticed that the ordering of the appsettings.json seemed a little off (appsettings.json having a higher priority than appsettings.environment.json) so I fired up a new application and tested it out

![image](https://github.com/dotnet/docs/assets/7712876/27210c91-d3b7-4392-a592-341fc7e366c4)

looks like the ordering is backwards, here is a PR fixing that.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/configuration.md](https://github.com/dotnet/docs/blob/51cc0e9ccff735f824b477c6a32ffbf3c5c42e14/docs/core/extensions/configuration.md) | [Configuration in .NET](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/configuration?branch=pr-en-us-39663) |

<!-- PREVIEW-TABLE-END -->