### PR TITLE
Minor correction to --create-manifest-if-needed text

### DIFF
--- a/docs/core/tools/dotnet-tool-install.md
+++ b/docs/core/tools/dotnet-tool-install.md
@@ -1,7 +1,7 @@
 ---
 title: dotnet tool install command
 description: The dotnet tool install command installs the specified .NET tool on your machine.
-ms.date: 07/19/2023
+ms.date: 02/26/2024
 ---
 # dotnet tool install
 
@@ -104,7 +104,7 @@ For more information, see [Install a local tool](global-tools.md#install-a-local
   If a tool-manifest can't be found and the `--create-manifest-if-needed` option is set to true, the tool creates a manifest automatically. It chooses a folder for the manifest as follows:
 
   * Walk up the directory tree searching for a directory that has a `.git` subfolder. If one is found, create the manifest in that directory.
-  * If the previous step doesn't find a directory, walk up the directory tree searching for a directory that has a `.sln/git` file. If one is found, create the manifest in that directory.
+  * If the previous step doesn't find a directory, walk up the directory tree searching for a directory that has a `.sln` or `.git` file. If one is found, create the manifest in that directory.
   * If neither of the previous two steps finds a directory, create the manifest in the current working directory.
 
 - **`--disable-parallel`**


### PR DESCRIPTION
Fixes #39600 

The option was already documented by https://github.com/dotnet/docs/pull/35346 and https://github.com/dotnet/docs/pull/37679
This PR just fixes one error in the text updated by those two.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-tool-install.md](https://github.com/dotnet/docs/blob/bfd961e90840398902259c79833b1fbed0188b1d/docs/core/tools/dotnet-tool-install.md) | [dotnet tool install](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-install?branch=pr-en-us-39668) |

<!-- PREVIEW-TABLE-END -->