### PR TITLE
Fix order configuration loaded on startup in default WebApplicationBuilder

### DIFF
--- a/docs/core/extensions/configuration.md
+++ b/docs/core/extensions/configuration.md
@@ -56,8 +56,8 @@ The <xref:Microsoft.Extensions.Hosting.Host.CreateApplicationBuilder(System.Stri
 1. Command-line arguments using the [Command-line configuration provider](configuration-providers.md#command-line-configuration-provider).
 1. Environment variables using the [Environment Variables configuration provider](configuration-providers.md#environment-variable-configuration-provider).
 1. [App secrets](/aspnet/core/security/app-secrets) when the app runs in the `Development` environment.
-1. *appsettings.json* using the [JSON configuration provider](configuration-providers.md#file-configuration-provider).
 1. *appsettings.*`Environment`*.json* using the [JSON configuration provider](configuration-providers.md#file-configuration-provider). For example, *appsettings*.***Production***.*json* and *appsettings*.***Development***.*json*.
+1. *appsettings.json* using the [JSON configuration provider](configuration-providers.md#file-configuration-provider).
 1. [ChainedConfigurationProvider](xref:Microsoft.Extensions.Configuration.ChainedConfigurationSource) : Adds an existing `IConfiguration` as a source.
 
 Adding a configuration provider overrides previous configuration values. For example, the [Command-line configuration provider](configuration-providers.md#command-line-configuration-provider) overrides all values from other providers because it's added last. If `SomeKey` is set in both *appsettings.json* and the environment, the environment value is used because it was added after *appsettings.json*.


### PR DESCRIPTION
## Summary

The order of configuration providers read on startup of the application was incorrect. `appsettings.<env>.json` has higher priority that `appsettings.json`.

Proof: https://github.com/dotnet/aspnetcore/blob/6a8083a9c4a6f28c21c8564e08d56bbe48e6b16b/src/DefaultBuilder/src/WebApplicationBuilder.cs#L273

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/configuration.md](https://github.com/dotnet/docs/blob/b958e8295e270a8857ec81f8343c973ef6cd016f/docs/core/extensions/configuration.md) | [Configuration in .NET](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/configuration?branch=pr-en-us-39672) |

<!-- PREVIEW-TABLE-END -->