### PR TITLE
Add breaking change for https://github.com/dotnet/sdk/pull/38956

### DIFF
--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -127,6 +127,7 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 | [Containers default to use the 'latest' tag](sdk/8.0/default-image-tag.md)      | Behavioral change                                |
 | ['dotnet pack' uses Release configuration](sdk/8.0/dotnet-pack-config.md)       | Behavioral change/Source incompatible            |
 | ['dotnet publish' uses Release configuration](sdk/8.0/dotnet-publish-config.md) | Behavioral change/Source incompatible            |
+| [Duplicate output for -getItem, -getProperty, and -getTargetResult](sdk/8.0/getx-duplicate-output.md) | Behavioral change            |
 | [Implicit `using` for System.Net.Http no longer added](sdk/8.0/implicit-global-using-netfx.md) | Behavioral change/Source incompatible            |
 | [MSBuild custom derived build events deprecated](sdk/8.0/custombuildeventargs.md)              | Behavioral change                                |
 | [MSBuild respects DOTNET_CLI_UI_LANGUAGE](sdk/8.0/msbuild-language.md)                         | Behavioral change                                |

--- a/docs/core/compatibility/sdk/8.0/getx-duplicate-output.md
+++ b/docs/core/compatibility/sdk/8.0/getx-duplicate-output.md
@@ -1,0 +1,48 @@
+---
+title: "Breaking change: Duplicate output for -getItem, -getProperty, and -getTargetResult"
+description: Learn about a breaking change in the .NET 8 SDK where using property, item, and result-returning MSBuild flags in combination with a framework-specific build causes duplicate output of the requested properties, items, and results.
+ms.date: 12/05/2022
+---
+# Duplicate output for -getItem, -getProperty, and -getTargetResult
+
+.NET SDK 8.0.200 introduced a regression in the new `-getItem`, `-getProperty`, and `-getTargetResult` MSBuild CLI options. When the SDK is used to perform an MSBuild operation for a specific TargetFramework, the output would be duplicated, like so:
+
+```terminal
+> dotnet build -r:android-arm64 --getProperty:OutputPath -f:net8.0-android
+bin\Debug/net8.0-android/android-arm64/
+bin\Debug/net8.0-android/android-arm64/
+```
+
+> [!NOTE]
+> We intend to fix this behavior in an upcoming release of the .NET 8.0.200 SDK.
+
+## Version introduced
+
+.NET 8.0.200
+
+## Previous behavior
+
+```terminal
+> dotnet build -r:android-arm64 --getProperty:OutputPath -f:net8.0-android
+bin\Debug/net8.0-android/android-arm64/
+```
+
+## New behavior
+
+Building, loading, or running an affected project fails.
+
+## Type of breaking change
+
+This is a behavioral change that can impact user scripts, especially in CI/CD scenarios.
+
+## Reason for change
+
+These options are intended to return values computed from a single user-requested build. However, SDK-initiated MSBuild operations like `build`, `publish`, etc. can sometimes trigger a second call to MSBuild - particularly when the `-f` option is used to specify that a build should occur for a specific TargetFramework. In that scenario, `-getItem`, `-getProperty`, and `-getTargetResult` options were passed to both MSBuild invocations, instead of only the one that a user expected to be triggered.
+
+## Recommended action
+
+Choose one of the following actions:
+
+- Use an older version of the .NET SDK before the regression was introduced.
+- Use a fixed version of the .NET 8 SDK - which should be any version after 8.0.202.
+- Remove any usege of `-f` from calls that also use `-getItem`, `-getProperty`, or `-getTargetResults`

--- a/docs/core/compatibility/sdk/8.0/getx-duplicate-output.md
+++ b/docs/core/compatibility/sdk/8.0/getx-duplicate-output.md
@@ -7,7 +7,6 @@ ms.date: 12/05/2023
 
 .NET SDK 8.0.200 introduced a regression in the new `-getItem`, `-getProperty`, and `-getTargetResult` MSBuild CLI options. When the SDK is used to perform an MSBuild operation for a specific TargetFramework, the output is duplicated, like so:
 
-
 ```terminal
 > dotnet build -r:android-arm64 --getProperty:OutputPath -f:net8.0-android
 bin\Debug/net8.0-android/android-arm64/
@@ -40,12 +39,10 @@ This is a behavioral change that can impact user scripts, especially in CI/CD sc
 
 These options are intended to return values computed from a single user-requested build. However, SDK-initiated MSBuild operations like `build` and `publish` can sometimes trigger a second call to MSBuild&mdash;particularly when the `-f` option is used to specify that a build should occur for a specific TargetFramework. In that scenario, `-getItem`, `-getProperty`, and `-getTargetResult` options were passed to both MSBuild invocations, instead of only the one that a user expected to be triggered.
 
-
 ## Recommended action
 
 Choose one of the following actions:
 
-- Use an older version of the .NET SDK before the regression was introduced.
+- Use an older version of the .NET SDK (before the regression was introduced).
 - Use a version of the .NET 8 SDK that contains the fix, which should be any version after 8.0.202.
-
 - Remove any usage of `-f` from calls that also use `-getItem`, `-getProperty`, or `-getTargetResults`.

--- a/docs/core/compatibility/sdk/8.0/getx-duplicate-output.md
+++ b/docs/core/compatibility/sdk/8.0/getx-duplicate-output.md
@@ -1,11 +1,12 @@
 ---
 title: "Breaking change: Duplicate output for -getItem, -getProperty, and -getTargetResult"
 description: Learn about a breaking change in the .NET 8 SDK where using property, item, and result-returning MSBuild flags in combination with a framework-specific build causes duplicate output of the requested properties, items, and results.
-ms.date: 12/05/2022
+ms.date: 12/05/2023
 ---
 # Duplicate output for -getItem, -getProperty, and -getTargetResult
 
-.NET SDK 8.0.200 introduced a regression in the new `-getItem`, `-getProperty`, and `-getTargetResult` MSBuild CLI options. When the SDK is used to perform an MSBuild operation for a specific TargetFramework, the output would be duplicated, like so:
+.NET SDK 8.0.200 introduced a regression in the new `-getItem`, `-getProperty`, and `-getTargetResult` MSBuild CLI options. When the SDK is used to perform an MSBuild operation for a specific TargetFramework, the output is duplicated, like so:
+
 
 ```terminal
 > dotnet build -r:android-arm64 --getProperty:OutputPath -f:net8.0-android
@@ -37,12 +38,14 @@ This is a behavioral change that can impact user scripts, especially in CI/CD sc
 
 ## Reason for change
 
-These options are intended to return values computed from a single user-requested build. However, SDK-initiated MSBuild operations like `build`, `publish`, etc. can sometimes trigger a second call to MSBuild - particularly when the `-f` option is used to specify that a build should occur for a specific TargetFramework. In that scenario, `-getItem`, `-getProperty`, and `-getTargetResult` options were passed to both MSBuild invocations, instead of only the one that a user expected to be triggered.
+These options are intended to return values computed from a single user-requested build. However, SDK-initiated MSBuild operations like `build` and `publish` can sometimes trigger a second call to MSBuild&mdash;particularly when the `-f` option is used to specify that a build should occur for a specific TargetFramework. In that scenario, `-getItem`, `-getProperty`, and `-getTargetResult` options were passed to both MSBuild invocations, instead of only the one that a user expected to be triggered.
+
 
 ## Recommended action
 
 Choose one of the following actions:
 
 - Use an older version of the .NET SDK before the regression was introduced.
-- Use a fixed version of the .NET 8 SDK - which should be any version after 8.0.202.
-- Remove any usege of `-f` from calls that also use `-getItem`, `-getProperty`, or `-getTargetResults`
+- Use a version of the .NET 8 SDK that contains the fix, which should be any version after 8.0.202.
+
+- Remove any usage of `-f` from calls that also use `-getItem`, `-getProperty`, or `-getTargetResults`.

--- a/docs/core/compatibility/sdk/8.0/getx-duplicate-output.md
+++ b/docs/core/compatibility/sdk/8.0/getx-duplicate-output.md
@@ -6,6 +6,7 @@ ms.date: 12/05/2023
 # Duplicate output for -getItem, -getProperty, and -getTargetResult
 
 .NET SDK 8.0.200 introduced a regression in the new `-getItem`, `-getProperty`, and `-getTargetResult` MSBuild CLI options. When the SDK is used to perform an MSBuild operation for a specific TargetFramework, the output is duplicated, like so:
+
 ```terminal
 > dotnet build -r:android-arm64 --getProperty:OutputPath -f:net8.0-android
 bin\Debug/net8.0-android/android-arm64/
@@ -41,6 +42,7 @@ These options are intended to return values computed from a single user-requeste
 ## Recommended action
 
 Choose one of the following actions:
+
 - Use an older version of the .NET SDK (before the regression was introduced).
 - Use a version of the .NET 8 SDK that contains the fix, which should be any version after 8.0.202.
 - Remove any usage of `-f` from calls that also use `-getItem`, `-getProperty`, or `-getTargetResults`.

--- a/docs/core/compatibility/sdk/8.0/getx-duplicate-output.md
+++ b/docs/core/compatibility/sdk/8.0/getx-duplicate-output.md
@@ -6,7 +6,6 @@ ms.date: 12/05/2023
 # Duplicate output for -getItem, -getProperty, and -getTargetResult
 
 .NET SDK 8.0.200 introduced a regression in the new `-getItem`, `-getProperty`, and `-getTargetResult` MSBuild CLI options. When the SDK is used to perform an MSBuild operation for a specific TargetFramework, the output is duplicated, like so:
-
 ```terminal
 > dotnet build -r:android-arm64 --getProperty:OutputPath -f:net8.0-android
 bin\Debug/net8.0-android/android-arm64/
@@ -42,7 +41,6 @@ These options are intended to return values computed from a single user-requeste
 ## Recommended action
 
 Choose one of the following actions:
-
 - Use an older version of the .NET SDK (before the regression was introduced).
 - Use a version of the .NET 8 SDK that contains the fix, which should be any version after 8.0.202.
 - Remove any usage of `-f` from calls that also use `-getItem`, `-getProperty`, or `-getTargetResults`.

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -186,6 +186,8 @@ items:
         href: sdk/8.0/dotnet-publish-config.md
       - name: "'dotnet restore' produces security vulnerability warnings"
         href: sdk/8.0/dotnet-restore-audit.md
+      - name: Duplicate output for -getItem, -getProperty, and -getTargetResult
+        href: sdk/8.0/getx-duplicate-output.md
       - name: Implicit `using` for System.Net.Http no longer added
         href: sdk/8.0/implicit-global-using-netfx.md
       - name: MSBuild custom derived build events deprecated
@@ -1596,6 +1598,8 @@ items:
         href: sdk/8.0/dotnet-publish-config.md
       - name: "'dotnet restore' produces security vulnerability warnings"
         href: sdk/8.0/dotnet-restore-audit.md
+      - name: Duplicate output for -getItem, -getProperty, and -getTargetResult
+        href: sdk/8.0/getx-duplicate-output.md
       - name: Implicit `using` for System.Net.Http no longer added
         href: sdk/8.0/implicit-global-using-netfx.md
       - name: MSBuild custom derived build events deprecated


### PR DESCRIPTION
## Summary

We had an accidental breaking change that we will fix in a future version of .NET 8.0.2xx, but we want to make sure that users know about it in the meantime. This doc describes the issue and workarounds that will be fixed by https://github.com/dotnet/sdk/pull/38956.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/8.0.md](https://github.com/dotnet/docs/blob/0e69ffa4dfd66ebaf2c6bf7e47490dad6cb77ca0/docs/core/compatibility/8.0.md) | [Breaking changes in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/8.0?branch=pr-en-us-39676) |
| [docs/core/compatibility/sdk/8.0/getx-duplicate-output.md](https://github.com/dotnet/docs/blob/0e69ffa4dfd66ebaf2c6bf7e47490dad6cb77ca0/docs/core/compatibility/sdk/8.0/getx-duplicate-output.md) | [Duplicate output for -getItem, -getProperty, and -getTargetResult](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/getx-duplicate-output?branch=pr-en-us-39676) |


<!-- PREVIEW-TABLE-END -->