### PR TITLE
Add links to C# compiler breaks

### DIFF
--- a/docs/core/compatibility/5.0.md
+++ b/docs/core/compatibility/5.0.md
@@ -193,4 +193,5 @@ If you're migrating an app to .NET 5, the breaking changes listed here might aff
 
 ## See also
 
+- [C# compiler breaking changes in C# 9 / .NET 5](https://github.com/dotnet/roslyn/blob/main/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%205.md)
 - [What's new in .NET 5](../whats-new/dotnet-5.md)

--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -182,4 +182,5 @@ For information on other breaking changes for containers in .NET 6, see [.NET 6 
 
 ## See also
 
+- [Breaking changes in C# 10](https://github.com/dotnet/roslyn/blob/main/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%206.md)
 - [What's new in .NET 6](../whats-new/dotnet-6.md)

--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -182,5 +182,6 @@ For information on other breaking changes for containers in .NET 6, see [.NET 6 
 
 ## See also
 
-- [Breaking changes in C# 10](https://github.com/dotnet/roslyn/blob/main/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%206.md)
+- [C# compiler breaking changes post C# 9](https://github.com/dotnet/roslyn/blob/main/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20post%20DotNet%205.md)
+- [C# compiler breaking changes in C# 10](https://github.com/dotnet/roslyn/blob/main/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%206.md)
 - [What's new in .NET 6](../whats-new/dotnet-6.md)

--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -164,5 +164,5 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 
 ## See also
 
-- [C# breaking changes in C# 11 / .NET](~/_roslyn/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%207.md)
+- [C# compiler breaking changes in C# 11 / .NET 7](~/_roslyn/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%207.md)
 - [What's new in .NET 7](../whats-new/dotnet-7.md)

--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -164,5 +164,5 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 
 ## See also
 
-- [C# breaking changes in C# 11 / .NET](../../../_roslyn/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%207.md)
+- [C# breaking changes in C# 11 / .NET](~/_roslyn/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%207.md)
 - [What's new in .NET 7](../whats-new/dotnet-7.md)

--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -164,5 +164,5 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 
 ## See also
 
-- [C# breaking changes in C# 11 / .NET](../../_roslyn/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%207.md)
+- [C# breaking changes in C# 11 / .NET](../../../_roslyn/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%207.md)
 - [What's new in .NET 7](../whats-new/dotnet-7.md)

--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -164,4 +164,5 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 
 ## See also
 
+- [C# breaking changes in C# 11 / .NET](../../_roslyn/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%207.md)
 - [What's new in .NET 7](../whats-new/dotnet-7.md)

--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -166,5 +166,5 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 
 ## See also
 
-- [C# breaking changes in C# 12 / .NET 8](~/_roslyn/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%208.md)
+- [C# compiler breaking changes in C# 12 / .NET 8](~/_roslyn/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%208.md)
 - [What's new in .NET 8](../whats-new/dotnet-8/overview.md)

--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -166,5 +166,5 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 
 ## See also
 
-- [C# breaking changes in C# 12 / .NET 8](../../../_roslyn/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%208.md)
+- [C# breaking changes in C# 12 / .NET 8](~/_roslyn/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%208.md)
 - [What's new in .NET 8](../whats-new/dotnet-8/overview.md)

--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -166,5 +166,5 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 
 ## See also
 
-- [C# breaking changes in C# 12 / .NET 8](../../_roslyn/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%208.md)
+- [C# breaking changes in C# 12 / .NET 8](../../../_roslyn/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%208.md)
 - [What's new in .NET 8](../whats-new/dotnet-8/overview.md)

--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -166,4 +166,5 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 
 ## See also
 
+- [C# breaking changes in C# 12 / .NET 8](../../_roslyn/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%208.md)
 - [What's new in .NET 8](../whats-new/dotnet-8/overview.md)


### PR DESCRIPTION
See https://github.com/dotnet/roslyn/issues/72098#issuecomment-1951821578

Add links from the .NET breaking changes articles to the corresponding C# compiler breaking changes articles.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/5.0.md](https://github.com/dotnet/docs/blob/f631c0c011f0c4d47926c7330928677058829a2d/docs/core/compatibility/5.0.md) | [Breaking changes in .NET 5](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/5.0?branch=pr-en-us-39681) |
| [docs/core/compatibility/6.0.md](https://github.com/dotnet/docs/blob/f631c0c011f0c4d47926c7330928677058829a2d/docs/core/compatibility/6.0.md) | [Breaking changes in .NET 6](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/6.0?branch=pr-en-us-39681) |
| [docs/core/compatibility/7.0.md](https://github.com/dotnet/docs/blob/f631c0c011f0c4d47926c7330928677058829a2d/docs/core/compatibility/7.0.md) | [Breaking changes in .NET 7](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/7.0?branch=pr-en-us-39681) |
| [docs/core/compatibility/8.0.md](https://github.com/dotnet/docs/blob/f631c0c011f0c4d47926c7330928677058829a2d/docs/core/compatibility/8.0.md) | [Breaking changes in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/8.0?branch=pr-en-us-39681) |


<!-- PREVIEW-TABLE-END -->