### PR TITLE
Improve CS1597

### DIFF
--- a/docs/csharp/misc/cs1597.md
+++ b/docs/csharp/misc/cs1597.md
@@ -1,27 +1,29 @@
 ---
 description: "Compiler Error CS1597"
 title: "Compiler Error CS1597"
-ms.date: 07/20/2015
-f1_keywords: 
+ms.date: 02/28/2024
+f1_keywords:
   - "CS1597"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS1597"
 ms.assetid: 735e7cde-38de-4e15-96cc-ce75ffe34ff2
 ---
 # Compiler Error CS1597
 
-Semicolon after method or accessor block is not valid  
-  
- Semicolons are not needed (or allowed) to end a method or accessor block.  
-  
- The following sample generates CS1597:  
-  
-```csharp  
-// CS1597.cs  
-class TestClass  
-{  
-   public static void Main()  
-   {  
-   };   // CS1597, remove semicolon  
-}  
+Semicolon after method or accessor block is not valid
+
+ Semicolons are not needed (or allowed) to end a method or accessor block.
+
+ The following sample generates CS1597:
+
+```csharp
+// CS1597.cs
+class MyClass
+{
+    public int Prop { get; };   // CS1597
+
+    public static void Main() { };   // CS1597
+}
 ```
+
+To resolve this error, remove the extra trailing semicolon.


### PR DESCRIPTION
## Summary

Cleaned up superfluous trailing spaces across the page and added a property with extra semicolon example.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/misc/cs1597.md](https://github.com/dotnet/docs/blob/621597b851f06ab3edf294059d468d9a77a76c35/docs/csharp/misc/cs1597.md) | [Compiler Error CS1597](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/cs1597?branch=pr-en-us-39685) |

<!-- PREVIEW-TABLE-END -->