### PR TITLE
Minor nit for integral numeric types

### DIFF
--- a/docs/csharp/language-reference/builtin-types/integral-numeric-types.md
+++ b/docs/csharp/language-reference/builtin-types/integral-numeric-types.md
@@ -57,7 +57,7 @@ int a = 123;
 System.Int32 b = 123;
 ```
 
-The `nint` and `nuint` types in the last two rows of the table are native-sized integers. You can use the `nint` and `nuint` keywords to define *native-sized integers*. These are 32-bit integers when running in a 32-bit process, or 64-bit integers when running in a 64-bit process. They can be used for interop scenarios, low-level libraries, and to optimize performance in scenarios where integer math is used extensively.
+The `nint` and `nuint` types in the last two rows of the table are native-sized integers. You can use the `nint` and `nuint` contextual keywords to define *native-sized integers*. These are 32-bit integers when running in a 32-bit process, or 64-bit integers when running in a 64-bit process. They can be used for interop scenarios, low-level libraries, and to optimize performance in scenarios where integer math is used extensively.
 
 The native-sized integer types are represented internally as the .NET types <xref:System.IntPtr?displayProperty=nameWithType> and <xref:System.UIntPtr?displayProperty=nameWithType>. Starting in C# 11, the `nint` and `nuint` types are aliases for the underlying types.
 


### PR DESCRIPTION
## Summary

`nint` and `nuint` are contextual keywords and not actual keywords, hence the minor nit on the wording here.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/builtin-types/integral-numeric-types.md](https://github.com/dotnet/docs/blob/b0cfade69599c48580f4fdc1c4d513275fcfbb5a/docs/csharp/language-reference/builtin-types/integral-numeric-types.md) | [Integral numeric types  (C# reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/integral-numeric-types?branch=pr-en-us-39686) |

<!-- PREVIEW-TABLE-END -->