### PR TITLE
Add session and runner id to list of telemetry items

### DIFF
--- a/docs/core/testing/unit-testing-mstest-runner-telemetry.md
+++ b/docs/core/testing/unit-testing-mstest-runner-telemetry.md
@@ -74,6 +74,8 @@ The telemetry feature collects the following data points:
 | All | Version of the platform. |
 | All | Version of your extensions. |
 | All | Version of your test adapter. |
+| All | Guid to correlate events from a single runner. |
+| 1.0.2 | Guid to correlate events from a single test run. |
 
 ## Continuous integration detection
 

--- a/docs/core/testing/unit-testing-mstest-runner-telemetry.md
+++ b/docs/core/testing/unit-testing-mstest-runner-telemetry.md
@@ -75,7 +75,7 @@ The telemetry feature collects the following data points:
 | All | Version of your extensions. |
 | All | Version of your test adapter. |
 | All | Guid to correlate events from a single runner. |
-| 1.0.2 | Guid to correlate events from a single test run. |
+| 1.0.3 | Guid to correlate events from a single test run. |
 
 ## Continuous integration detection
 


### PR DESCRIPTION
## Summary

Add runner and session id to list of telemetry items.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-mstest-runner-telemetry.md](https://github.com/dotnet/docs/blob/93a3779ac9ffd08f942809aac4d161b70b5fc10f/docs/core/testing/unit-testing-mstest-runner-telemetry.md) | [MSTest runner telemetry](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-runner-telemetry?branch=pr-en-us-39733) |


<!-- PREVIEW-TABLE-END -->