### PR TITLE
Resource-optimized placement

### DIFF
--- a/docs/orleans/grains/grain-placement.md
+++ b/docs/orleans/grains/grain-placement.md
@@ -48,7 +48,7 @@ A deterministic placement strategy that places grains on silos with a specific r
 
 The resource-optimized placement strategy attempts to optimize cluster resources by balancing grain activations across silos based on available memory and CPU usage. It assigns weights to runtime statistics to prioritize different resources and calculates a normalized score for each silo. The silo with the lowest score is chosen for placing the upcoming activation. Normalization ensures that each property contributes proportionally to the overall score. Weights can be adjusted via the <xref:Orleans.Configuration.ResourceOptimizedPlacementOptions> based on user-specific requirements and priorities for different resources.
 
-In addition, this placement strategy exposes an option to build a stronger *preference* to the local silo (*the one which got the request for making a new placement*) to be picked as the target for the activation. This is controlled via the `LocalSiloPreferenceMargin` property which is part of the options.
+Additionally, this placement strategy exposes an option to build a stronger *preference* to the local silo (*the one which got the request for making a new placement*) to be picked as the target for the activation. This is controlled via the `LocalSiloPreferenceMargin` property which is part of the options.
 
 Also, an [*online*](https://en.wikipedia.org/wiki/Online_algorithm), [*adaptive*](https://en.wikipedia.org/wiki/Adaptive_algorithm) algorithm provides a smoothing effect which avoids rapid signal drops by transforming it into a polynomial-like decay process. This is especially important for CPU usage, and overall contributes to avoiding resource saturation on the silos, especially newly joined once.
 

--- a/docs/orleans/grains/grain-placement.md
+++ b/docs/orleans/grains/grain-placement.md
@@ -46,7 +46,7 @@ A deterministic placement strategy that places grains on silos with a specific r
 
 ## Resource-optimized placement
 
-This placement strategy attempts to optimize cluster resources by balancing grain activations across silos based on available memory and CPU usage. It assigns weights to runtime statistics to prioritize different resources and calculates a normalized score for each silo.  The silo with the lowest score is chosen for placing the upcoming activation. Normalization ensures that each property contributes proportionally to the overall score. Weights can be adjusted via the <xref:Orleans.Configuration.ResourceOptimizedPlacementOptions> based on user-specific requirements and priorities for different resources.
+The resource-optimized placement strategy attempts to optimize cluster resources by balancing grain activations across silos based on available memory and CPU usage. It assigns weights to runtime statistics to prioritize different resources and calculates a normalized score for each silo. The silo with the lowest score is chosen for placing the upcoming activation. Normalization ensures that each property contributes proportionally to the overall score. Weights can be adjusted via the <xref:Orleans.Configuration.ResourceOptimizedPlacementOptions> based on user-specific requirements and priorities for different resources.
 
 In addition, this placement strategy exposes an option to build a stronger *preference* to the local silo (*the one which got the request for making a new placement*) to be picked as the target for the activation. This is controlled via the `LocalSiloPreferenceMargin` property which is part of the options.
 

--- a/docs/orleans/grains/grain-placement.md
+++ b/docs/orleans/grains/grain-placement.md
@@ -44,6 +44,18 @@ This placement strategy is configured by adding the <xref:Orleans.Concurrency.St
 
 A deterministic placement strategy that places grains on silos with a specific role. This placement strategy is configured by adding the <xref:Orleans.Placement.SiloRoleBasedPlacementAttribute> to a grain.
 
+## Resource-optimized placement
+
+This placement strategy attempts to optimize cluster resources by balancing grain activations across silos based on available memory and CPU usage. It assigns weights to runtime statistics to prioritize different resources and calculates a normalized score for each silo.  The silo with the lowest score is chosen for placing the upcoming activation. Normalization ensures that each property contributes proportionally to the overall score. Weights can be adjusted via the <xref:Orleans.Runtime.Configuration.Options.ResourceOptimizedPlacementOptions> based on user-specific requirements and priorities for different resources.
+
+In addition, this placement strategy exposes an option to build a stronger *preference* to the local silo (*the one which got the request for making a new placement*) to be picked as the target for the activation. This is controlled via the `LocalSiloPreferenceMargin` property which is part of the options.
+
+Also, an [*online*](https://en.wikipedia.org/wiki/Online_algorithm), [*adaptive*](https://en.wikipedia.org/wiki/Adaptive_algorithm) algorithm provides a smoothing effect which avoids rapid signal drops by transforming it into a polynomial-like decay process. This is especially important for CPU usage, and overall contributes to avoiding resource saturation on the silos, especially newly joined once.
+
+This algorithm is based on: [*Resource-based placement with cooperative dual-mode Kalman filtering*](https://www.ledjonbehluli.com/posts/orleans_resource_placement_kalman/)
+
+This placement strategy is configured by adding the <xref:Orleans.Placement.ResourceOptimizedPlacementAttribute> to a grain.
+
 ## Choose a placement strategy
 
 Choosing the appropriate grain placement strategy, beyond the defaults that Orleans provides, requires monitoring and developer evaluation. The choice of placement strategy should be based on the size and complexity of the app, workload characteristics, and deployment environment.

--- a/docs/orleans/grains/grain-placement.md
+++ b/docs/orleans/grains/grain-placement.md
@@ -46,7 +46,7 @@ A deterministic placement strategy that places grains on silos with a specific r
 
 ## Resource-optimized placement
 
-This placement strategy attempts to optimize cluster resources by balancing grain activations across silos based on available memory and CPU usage. It assigns weights to runtime statistics to prioritize different resources and calculates a normalized score for each silo.  The silo with the lowest score is chosen for placing the upcoming activation. Normalization ensures that each property contributes proportionally to the overall score. Weights can be adjusted via the <xref:Orleans.Runtime.Configuration.Options.ResourceOptimizedPlacementOptions> based on user-specific requirements and priorities for different resources.
+This placement strategy attempts to optimize cluster resources by balancing grain activations across silos based on available memory and CPU usage. It assigns weights to runtime statistics to prioritize different resources and calculates a normalized score for each silo.  The silo with the lowest score is chosen for placing the upcoming activation. Normalization ensures that each property contributes proportionally to the overall score. Weights can be adjusted via the <xref:Orleans.Configuration.ResourceOptimizedPlacementOptions> based on user-specific requirements and priorities for different resources.
 
 In addition, this placement strategy exposes an option to build a stronger *preference* to the local silo (*the one which got the request for making a new placement*) to be picked as the target for the activation. This is controlled via the `LocalSiloPreferenceMargin` property which is part of the options.
 


### PR DESCRIPTION
Adds resource-optimized placement to the grain placement page


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/grains/grain-placement.md](https://github.com/dotnet/docs/blob/01023e88a774095cd40f7633dd10f65aecf1449a/docs/orleans/grains/grain-placement.md) | [Grain placement](https://review.learn.microsoft.com/en-us/dotnet/orleans/grains/grain-placement?branch=pr-en-us-39745) |


<!-- PREVIEW-TABLE-END -->