### PR TITLE
Update cs0225.md, "single-dimensional array" grammatical consistency

### DIFF
--- a/docs/csharp/misc/cs0225.md
+++ b/docs/csharp/misc/cs0225.md
@@ -10,7 +10,7 @@ ms.assetid: 0b0cd72b-c47a-44d1-9b27-d1a1fad06807
 ---
 # Compiler Error CS0225
 
-The params parameter must be a single dimensional array  
+The params parameter must be a single-dimensional array
   
  When using the [params](../language-reference/keywords/method-parameters.md#params-modifier) keyword, you must specify a single-dimensional array of the data type. For more information, see [Methods](../programming-guide/classes-and-structs/methods.md).  
   


### PR DESCRIPTION
## Summary

Grammatical consistency based on the current state of the repo, specifically for the term "single-dimensional array".


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/misc/cs0225.md](https://github.com/dotnet/docs/blob/45e0ab076a09c747b48405c52c9c124b1d67fac4/docs/csharp/misc/cs0225.md) | [Compiler Error CS0225](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/cs0225?branch=pr-en-us-39753) |

<!-- PREVIEW-TABLE-END -->