### PR TITLE
Merge 'IDE0023, IDE0024' style rule entrys at code-analysis/language-rules#Expression-bodied members

### DIFF
--- a/docs/fundamentals/code-analysis/style-rules/language-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/language-rules.md
@@ -102,8 +102,7 @@ C# style rules:
 
 - [Use expression body for constructors (IDE0021)](ide0021.md)
 - [Use expression body for methods (IDE0022)](ide0022.md)
-- [Use expression body for operators (IDE0023)](ide0023-ide0024.md)
-- [Use expression body for operators (IDE0024)](ide0023-ide0024.md)
+- [Use expression body for operators (IDE0023, IDE0024)](ide0023-ide0024.md)
 - [Use expression body for properties (IDE0025)](ide0025.md)
 - [Use expression body for indexers (IDE0026)](ide0026.md)
 - [Use expression body for accessors (IDE0027)](ide0027.md)


### PR DESCRIPTION
## Summary

IDE0023 and IDE0024 were merged because they point to the same location `(ide0023-ide0024.md)`, making two lines with the same text unnecessary.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/style-rules/language-rules.md](https://github.com/dotnet/docs/blob/e929ec6efe5e9cfa4d697eac32243a395661435d/docs/fundamentals/code-analysis/style-rules/language-rules.md) | [Language and unnecessary rules](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/language-rules?branch=pr-en-us-39773) |

<!-- PREVIEW-TABLE-END -->