### PR TITLE
Add VS severity info

### DIFF
--- a/docs/fundamentals/code-analysis/configuration-options.md
+++ b/docs/fundamentals/code-analysis/configuration-options.md
@@ -79,9 +79,9 @@ The following table shows the different rule severities that you can configure f
 |-|-|
 | `error` | Violations appear as build *errors* and cause builds to fail.|
 | `warning` | Violations appear as build *warnings* but do not cause builds to fail (unless you have an option set to treat warnings as errors). |
-| `suggestion` | Violations appear as build *messages* and as suggestions in the Visual Studio IDE.<br/>(In Visual Studio, suggestions appear as three gray dots under the first two characters.) |
-| `silent` | Violations aren't visible to the user.<br/>However, for code-style rules, Visual Studio code-generation features still generate code in this style. These rules also participate in cleanup and appear in the **Quick Actions and Refactorings** menu in Visual Studio. |
-| `none` | Rule is suppressed completely.<br/>However, for code-style rules, Visual Studio code-generation features still generate code in this style. |
+| `suggestion` | Violations appear as build *messages* and as suggestions in the Visual Studio IDE. (In Visual Studio, suggestions appear as three gray dots under the first two characters.) |
+| `silent` | Violations aren't visible to the user.<br/><br/>However, for code-style rules, Visual Studio code-generation features still generate code in this style. These rules also participate in cleanup and appear in the **Quick Actions and Refactorings** menu in Visual Studio. |
+| `none` | Rule is suppressed completely.<br/><br/>However, for code-style rules, Visual Studio code-generation features still generate code in this style. |
 | `default` | The default severity of the rule is used. The default severities for each .NET release are listed in the [roslyn-analyzers repo](https://github.com/dotnet/roslyn-analyzers/blob/main/src/NetAnalyzers/Core/AnalyzerReleases.Shipped.md). In that table, "Disabled" corresponds to `none`, "Hidden" corresponds to `silent`, and "Info" corresponds to `suggestion`. |
 
 #### Scope

--- a/docs/fundamentals/code-analysis/configuration-options.md
+++ b/docs/fundamentals/code-analysis/configuration-options.md
@@ -79,13 +79,10 @@ The following table shows the different rule severities that you can configure f
 |-|-|
 | `error` | Violations appear as build *errors* and cause builds to fail.|
 | `warning` | Violations appear as build *warnings* but do not cause builds to fail (unless you have an option set to treat warnings as errors). |
-| `suggestion` | Violations appear as build *messages* and as suggestions in the Visual Studio IDE. |
-| `silent` | Violations aren't visible to the user. |
-| `none` | Rule is suppressed completely. |
+| `suggestion` | Violations appear as build *messages* and as suggestions in the Visual Studio IDE.<br/>(In Visual Studio, suggestions appear as three gray dots under the first two characters.) |
+| `silent` | Violations aren't visible to the user.<br/>However, for code-style rules, Visual Studio code-generation features still generate code in this style. These rules also participate in cleanup and appear in the **Quick Actions and Refactorings** menu in Visual Studio. |
+| `none` | Rule is suppressed completely.<br/>However, for code-style rules, Visual Studio code-generation features still generate code in this style. |
 | `default` | The default severity of the rule is used. The default severities for each .NET release are listed in the [roslyn-analyzers repo](https://github.com/dotnet/roslyn-analyzers/blob/main/src/NetAnalyzers/Core/AnalyzerReleases.Shipped.md). In that table, "Disabled" corresponds to `none`, "Hidden" corresponds to `silent`, and "Info" corresponds to `suggestion`. |
-
-> [!TIP]
-> For information about how rule severities surface in Visual Studio, see [Severity levels](/visualstudio/ide/editorconfig-language-conventions#severity-levels).
 
 #### Scope
 

--- a/docs/fundamentals/code-analysis/style-rules/language-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/language-rules.md
@@ -51,7 +51,7 @@ or
 
 > [!TIP]
 >
-> Starting in Visual Studio 2019, you can configure code style rules from the [Quick Actions](/visualstudio/ide/quick-actions) light bulb menu after a style violation occurs. For more information, see [Automatically configure code styles in Visual Studio](/visualstudio/ide/editorconfig-language-conventions#automatically-configure-code-styles-in-visual-studio).
+> Starting in Visual Studio 2019, you can configure code style rules from the [Quick Actions](/visualstudio/ide/quick-actions) light bulb menu after a style violation occurs.
 
 ## Rule index
 


### PR DESCRIPTION
Fixes #39684

@Mikejo5000 can you review? I didn't realize the linked VS page had gone away.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/configuration-options.md](https://github.com/dotnet/docs/blob/f6fccc78c7fb13ac560c79c84f3e1e9b349e6ab0/docs/fundamentals/code-analysis/configuration-options.md) | [Configuration options for code analysis](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/configuration-options?branch=pr-en-us-39775) |
| [docs/fundamentals/code-analysis/style-rules/language-rules.md](https://github.com/dotnet/docs/blob/f6fccc78c7fb13ac560c79c84f3e1e9b349e6ab0/docs/fundamentals/code-analysis/style-rules/language-rules.md) | [Language and unnecessary rules](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/language-rules?branch=pr-en-us-39775) |


<!-- PREVIEW-TABLE-END -->