### PR TITLE
Refine the log category convention

### DIFF
--- a/docs/core/extensions/logging.md
+++ b/docs/core/extensions/logging.md
@@ -270,7 +270,7 @@ The following algorithm is used for each provider when an `ILogger` is created f
 
 ## Log category
 
-When an `ILogger` object is created, a *category* is specified. That category is included with each log message created by that instance of `ILogger`. The category string is arbitrary, but the convention is to use the class name. For example, in an application with a service defined like the following object, the category might be `"Example.DefaultService"`:
+When an `ILogger` object is created, a *category* is specified. That category is included with each log message created by that instance of `ILogger`. The category string is arbitrary, but the convention is to use the fully qualified class name. For example, in an application with a service defined like the following object, the category might be `"Example.DefaultService"`:
 
 ```csharp
 namespace Example
@@ -287,7 +287,7 @@ namespace Example
 }
 ```
 
-To explicitly specify the category, call <xref:Microsoft.Extensions.Logging.LoggerFactory.CreateLogger%2A?displayProperty=nameWithType>:
+If further categorization is desired, the contention is to use a hierarchical name by appending a subcategory to the fully qualified class name, and explicitly specify the category using <xref:Microsoft.Extensions.Logging.LoggerFactory.CreateLogger%2A?displayProperty=nameWithType>:
 
 ```csharp
 namespace Example
@@ -297,7 +297,7 @@ namespace Example
         private readonly ILogger _logger;
 
         public DefaultService(ILoggerFactory loggerFactory) =>
-            _logger = loggerFactory.CreateLogger("CustomCategory");
+            _logger = loggerFactory.CreateLogger("Example.DefaultService.CustomCategory");
 
         // ...
     }

--- a/docs/core/extensions/logging.md
+++ b/docs/core/extensions/logging.md
@@ -287,7 +287,7 @@ namespace Example
 }
 ```
 
-If further categorization is desired, the contention is to use a hierarchical name by appending a subcategory to the fully qualified class name, and explicitly specify the category using <xref:Microsoft.Extensions.Logging.LoggerFactory.CreateLogger%2A?displayProperty=nameWithType>:
+If further categorization is desired, the convention is to use a hierarchical name by appending a subcategory to the fully qualified class name, and explicitly specify the category using <xref:Microsoft.Extensions.Logging.LoggerFactory.CreateLogger%2A?displayProperty=nameWithType>:
 
 ```csharp
 namespace Example


### PR DESCRIPTION
This is a follow up to https://github.com/open-telemetry/opentelemetry-dotnet/pull/5405#discussion_r1508527541 based on discussion with @noahfalk and @tarekgh.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/logging.md](https://github.com/dotnet/docs/blob/792a527c1d60a66024d11c29d33be74c09be73aa/docs/core/extensions/logging.md) | [Logging in C# and .NET](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/logging?branch=pr-en-us-39777) |


<!-- PREVIEW-TABLE-END -->