### PR TITLE
Update how-to-count-occurrences-of-a-word-in-a-string-linq.md

### DIFF
--- a/docs/csharp/programming-guide/concepts/linq/how-to-count-occurrences-of-a-word-in-a-string-linq.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-count-occurrences-of-a-word-in-a-string-linq.md
@@ -31,7 +31,7 @@ class CountWords
   
         //Convert the string into an array of words  
         string[] source = text.Split(
-            ['.', '?', '!', ' ', ';', ':', ','],
+            new [] {'.', '?', '!', ' ', ';', ':', ','},
             StringSplitOptions.RemoveEmptyEntries);  
   
         // Create the query.  Use the InvariantCultureIgnoreCase comparison to match "data" and "Data"


### PR DESCRIPTION
## Summary

The example in its current state will not compile as the array declaration of the separator characters in the `Split()` method is declared improperly.

This fix corrects the array declaration allowing the code to compile and run properly producing the expected results.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/concepts/linq/how-to-count-occurrences-of-a-word-in-a-string-linq.md](https://github.com/dotnet/docs/blob/1342d829452998a7a89e49175bc7799da6068ba3/docs/csharp/programming-guide/concepts/linq/how-to-count-occurrences-of-a-word-in-a-string-linq.md) | [How to count occurrences of a word in a string (LINQ) (C#)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/concepts/linq/how-to-count-occurrences-of-a-word-in-a-string-linq?branch=pr-en-us-39783) |

<!-- PREVIEW-TABLE-END -->