### PR TITLE
Update MSBuild setting that restores previous behavior

### DIFF
--- a/docs/core/compatibility/deployment/8.0/rid-asset-list.md
+++ b/docs/core/compatibility/deployment/8.0/rid-asset-list.md
@@ -63,12 +63,12 @@ The RID graph was costly to maintain and understand, requiring .NET itself to be
 
 Use portable RIDs, for example, `linux`, `linux-musl`, `osx`, and `win`. For specialized use cases, you can use APIs like <xref:System.Runtime.InteropServices.NativeLibrary.SetDllImportResolver(System.Reflection.Assembly,System.Runtime.InteropServices.DllImportResolver)?displayProperty=nameWithType> or <xref:System.Runtime.Loader.AssemblyLoadContext.ResolvingUnmanagedDll?displayProperty=nameWithType> for custom loading logic.
 
-If you need to revert to the previous behavior, set the backwards compatibility switch `System.Runtime.Loader.UseRidGraph` to `true` in your *runtimeconfig.json* file. Setting the switch to `true` instructs the host to use the previous behavior of reading the RID graph. Alternatively, you can add a `RuntimeHostConfigurationOption` MSBuild item in your project file. For example:
+If you need to revert to the previous behavior, set the backwards compatibility switch `System.Runtime.Loader.UseRidGraph` to `true` in your *runtimeconfig.json* file. Setting the switch to `true` instructs the host to use the previous behavior of reading the RID graph. Alternatively, you can set the `UseRidGraph` MSBuild property to `true` in your project file. For example
 
 ```xml
-<ItemGroup>
-  <RuntimeHostConfigurationOption Include="System.Runtime.Loader.UseRidGraph" Value="true" />
-</ItemGroup>
+<PropertyGroup>
+  <UseRidGraph>true</UseRidGraph>
+</PropertyGroup>
 ```
 
 ## Affected APIs


### PR DESCRIPTION
## Summary
Adding `RuntimeHostConfigurationOption` as in current docs doesn't work. Setting `UseRidGraph` to true works.

Fixes #39803


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/deployment/8.0/rid-asset-list.md](https://github.com/dotnet/docs/blob/0b09854a9e8daaa2bbf1d27eb678c58cf0e11c21/docs/core/compatibility/deployment/8.0/rid-asset-list.md) | [Host determines RID-specific assets](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/deployment/8.0/rid-asset-list?branch=pr-en-us-39804) |

<!-- PREVIEW-TABLE-END -->