### PR TITLE
Note memory allocators used by interop outside Windows

### DIFF
--- a/docs/framework/interop/default-marshalling-behavior.md
+++ b/docs/framework/interop/default-marshalling-behavior.md
@@ -36,7 +36,7 @@ BSTR MethodOne (BSTR b) {
   
  However, if you define the method as a platform invoke prototype, replace each **BSTR** type with a <xref:System.String> type, and call `MethodOne`, the common language runtime attempts to free `b` twice. You can change the marshalling behavior by using <xref:System.IntPtr> types rather than **String** types.  
   
- The runtime always uses the **CoTaskMemFree** method to free memory. If the memory you are working with was not allocated with the **CoTaskMemAlloc** method, you must use an **IntPtr** and free the memory manually using the appropriate method. Similarly, you can avoid automatic memory freeing in situations where memory should never be freed, such as when using the **GetCommandLine** function from Kernel32.dll, which returns a pointer to kernel memory. For details on manually freeing memory, see the [Buffers Sample](/previous-versions/dotnet/netframework-4.0/x3txb6xc(v=vs.100)).  
+ The runtime always uses the **CoTaskMemFree** method on Windows and **free** method on other platforms to free memory. If the memory you are working with was not allocated with the **CoTaskMemAlloc** method on Windows or **malloc** method on other platforms, you must use an **IntPtr** and free the memory manually using the appropriate method. Similarly, you can avoid automatic memory freeing in situations where memory should never be freed, such as when using the **GetCommandLine** function from Kernel32.dll, which returns a pointer to kernel memory. For details on manually freeing memory, see the [Buffers Sample](/previous-versions/dotnet/netframework-4.0/x3txb6xc(v=vs.100)).  
   
 ## Default marshalling for classes  
 

--- a/docs/framework/interop/default-marshalling-for-arrays.md
+++ b/docs/framework/interop/default-marshalling-for-arrays.md
@@ -176,7 +176,7 @@ void New3(ref String ar);
 > [!NOTE]
 > The **MarshalAsAttribute** has no effect on marshalling managed arrays to unmanaged code. In that direction, the array size is determined by examination. There is no way to marshal a subset of a managed array.  
   
- The interop marshaller uses the **CoTaskMemAlloc** and **CoTaskMemFree** methods to allocate and retrieve memory. Memory allocation performed by unmanaged code must also use these methods.  
+ The interop marshaller uses the **CoTaskMemAlloc** and **CoTaskMemFree** methods on Windows or **malloc** and **free** methods on other operating systems to allocate and retrieve memory. Memory allocation performed by unmanaged code must also use these methods.  
   
 ## Passing Arrays to COM  
 


### PR DESCRIPTION
## Summary

Note memory allocators used by interop outside Windows

Follow up on https://github.com/dotnet/runtime/issues/98995#issuecomment-1973784263

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/interop/default-marshalling-behavior.md](https://github.com/dotnet/docs/blob/719f163e5099c176f73c489cf42f840b6bb6b0ef/docs/framework/interop/default-marshalling-behavior.md) | [Default Marshalling Behavior](https://review.learn.microsoft.com/en-us/dotnet/framework/interop/default-marshalling-behavior?branch=pr-en-us-39823) |
| [docs/framework/interop/default-marshalling-for-arrays.md](https://github.com/dotnet/docs/blob/719f163e5099c176f73c489cf42f840b6bb6b0ef/docs/framework/interop/default-marshalling-for-arrays.md) | ["Default Marshalling for Arrays"](https://review.learn.microsoft.com/en-us/dotnet/framework/interop/default-marshalling-for-arrays?branch=pr-en-us-39823) |


<!-- PREVIEW-TABLE-END -->