### PR TITLE
Fix snippet ID

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/constructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/constructors.md
@@ -40,7 +40,7 @@ The previous examples have all shown instance constructors, which create a new o
 
 The following example uses a static constructor to initialize a static field.
 
-:::code source="./snippets/constructors/Program.cs" id="StaticExpression":::
+:::code source="./snippets/constructors/Program.cs" id="StaticCtor":::
 
 You can also define a static constructor with an expression body definition, as the following example shows.
 


### PR DESCRIPTION
Fixes #39826

The snippet ID for the first static constructor reference was incorrect.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/classes-and-structs/constructors.md](https://github.com/dotnet/docs/blob/066558d6b6e8691c573b678d50b559e00e4e6cdd/docs/csharp/programming-guide/classes-and-structs/constructors.md) | [Constructors (C# programming guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/constructors?branch=pr-en-us-39844) |

<!-- PREVIEW-TABLE-END -->