### PR TITLE
Add C# 12 to the history article.

### DIFF
--- a/docs/csharp/whats-new/csharp-version-history.md
+++ b/docs/csharp/whats-new/csharp-version-history.md
@@ -1,6 +1,6 @@
 ---
 title: The history of C# - C# Guide
-description: Learn how has the C# language changed over its many releases. Learn when different features were introduced in the language,
+description: Learn how the C# language has changed over its many releases. Learn when different features were introduced in the language.
 author: erikdietrich
 ms.date: 03/06/2024
 ms.custom: "updateeachrelease, UpdateFrequency1"
@@ -20,8 +20,8 @@ This article provides a history of each major release of the C# language. The C#
 The following features were added in C# 12:
 
 - [Primary constructors](./csharp-12.md#primary-constructors) - You can create primary constructors in any `class` or `struct` type.
-- [Collection expressions](./csharp-12.md#collection-expressions) - A new syntax to specify collection expressions, including the spread operator, (`..`) to expand any collection.
-- [Inline arrays](./csharp-12.md#inline-arrays) - Inline arrays enable a developer to create an array of fixed size in a `struct` type.
+- [Collection expressions](./csharp-12.md#collection-expressions) - A new syntax to specify collection expressions, including the spread operator, (`..`), to expand any collection.
+- [Inline arrays](./csharp-12.md#inline-arrays) - Inline arrays enable you to create an array of fixed size in a `struct` type.
 - [Optional parameters in lambda expressions](./csharp-12.md#default-lambda-parameters) - You can define default values for parameters on lambda expressions.
 - [`ref readonly` parameters](./csharp-12.md#ref-readonly-parameters) - `ref readonly` parameters enables more clarity for APIs that might be using `ref` parameters or `in` parameters.
 - [Alias any type](./csharp-12.md#alias-any-type) - You can use the `using` alias directive to alias any type, not just named types.
@@ -243,7 +243,7 @@ C# 7.2 added several small language features:
 - Add the `in` modifier on parameters, to specify that an argument is passed by reference but not modified by the called method.
 - Use the `ref readonly` modifier on method returns, to indicate that a method returns its value by reference but doesn't allow writes to that object.
 - Declare `ref struct` types, to indicate that a struct type accesses managed memory directly and must always be stack allocated.
-- Use more generic constraints.
+- Use additional generic constraints.
 - [Non-trailing named arguments](../programming-guide/classes-and-structs/named-and-optional-arguments.md):
   - Positional arguments can follow named arguments.
 - Leading underscores in numeric literals:
@@ -337,7 +337,7 @@ But `async` and `await` are the real stars of this release. When these features 
 
 *Released April 2010*
 
-C# version 4.0, released with Visual Studio 2010 introduced some interesting new features:
+C# version 4.0, released with Visual Studio 2010, introduced some interesting new features:
 
 - [Dynamic binding](../language-reference/builtin-types/reference-types.md)
 - [Named/optional arguments](../programming-guide/classes-and-structs/named-and-optional-arguments.md)
@@ -366,7 +366,7 @@ C# version 3.0 came in late 2007, along with Visual Studio 2008, though the full
 - [Partial methods](../language-reference/keywords/partial-method.md)
 - [Object and collection initializers](../programming-guide/classes-and-structs/object-and-collection-initializers.md)
 
-In retrospect, many of these features seem both inevitable and inseparable. They all fit together strategically. That C# version's killer feature was the query expression, also known as Language-Integrated Query (LINQ).
+In retrospect, many of these features seem both inevitable and inseparable. They all fit together strategically. This C# version's killer feature was the query expression, also known as Language-Integrated Query (LINQ).
 
 A more nuanced view examines expression trees, lambda expressions, and anonymous types as the foundation upon which LINQ is constructed. But, in either case, C# 3.0 presented a revolutionary concept. C# 3.0 began to lay the groundwork for turning C# into a hybrid Object-Oriented / Functional language.
 

--- a/docs/csharp/whats-new/csharp-version-history.md
+++ b/docs/csharp/whats-new/csharp-version-history.md
@@ -1,8 +1,8 @@
 ---
 title: The history of C# - C# Guide
-description: What did the language look like in its earliest versions, and how has it evolved since?
+description: Learn how has the C# language changed over its many releases. Learn when different features were introduced in the language,
 author: erikdietrich
-ms.date: 06/18/2021
+ms.date: 03/06/2024
 ms.custom: "updateeachrelease, UpdateFrequency1"
 ---
 
@@ -13,9 +13,27 @@ This article provides a history of each major release of the C# language. The C#
 > [!IMPORTANT]
 > The C# language relies on types and methods in what the C# specification defines as a *standard library* for some of the features. The .NET platform delivers those types and methods in a number of packages. One example is exception processing. Every `throw` statement or expression is checked to ensure the object being thrown is derived from <xref:System.Exception>. Similarly, every `catch` is checked to ensure that the type being caught is derived from <xref:System.Exception>. Each version may add new requirements. To use the latest language features in older environments, you may need to install specific libraries. These dependencies are documented in the page for each specific version. You can learn more about the [relationships between language and library](relationships-between-language-and-library.md) for background on this dependency.
 
+## C# version 12
+
+*Released November 2023*
+
+The following features were added in C# 12:
+
+- [Primary constructors](./csharp-12.md#primary-constructors) - You can create primary constructors in any `class` or `struct` type.
+- [Collection expressions](./csharp-12.md#collection-expressions) - A new syntax to specify collection expressions, including the spread operator, (`..`) to expand any collection.
+- [Inline arrays](./csharp-12.md#inline-arrays) - Inline arrays enable a developer to create an array of fixed size in a `struct` type.
+- [Optional parameters in lambda expressions](./csharp-12.md#default-lambda-parameters) - You can define default values for parameters on lambda expressions.
+- [`ref readonly` parameters](./csharp-12.md#ref-readonly-parameters) - `ref readonly` parameters enables more clarity for APIs that might be using `ref` parameters or `in` parameters.
+- [Alias any type](./csharp-12.md#alias-any-type) - You can use the `using` alias directive to alias any type, not just named types.
+- [Experimental attribute](./csharp-12.md#experimental-attribute) - Indicate an experimental feature.
+
+And, [Interceptors](./csharp-12.md#interceptors) - was released as a *Preview feature*.
+
+Overall, C# 12 provides new features that make you more productive writing C# code. Syntax you already knew is available in more places. Other syntax enables consistency for related concepts.
+
 ## C# version 11
 
-*Released November, 2022*
+*Released November 2022*
 
 The following features were added in C# 11:
 
@@ -39,7 +57,7 @@ C# 11 introduces *generic math* and several features that support that goal. You
 
 ## C# version 10
 
-*Released November, 2021*
+*Released November 2021*
 
 C# 10 adds the following features and enhancements to the C# language:
 
@@ -61,19 +79,19 @@ C# 10 adds the following features and enhancements to the C# language:
 More features were available in *preview* mode. In order to use these features, you must [set `<LangVersion>` to `Preview`](../language-reference/compiler-options/language.md#langversion) in your project:
 
 - [Generic attributes](./csharp-11.md#generic-attributes) later in this article.
-- [static abstract members in interfaces](./csharp-11.md#generic-math-support)
+- [static abstract members in interfaces](./csharp-11.md#generic-math-support).
 
 C# 10 continues work on themes of removing ceremony, separating data from algorithms, and improved performance for the .NET Runtime.
 
-Many of the features mean you'll type less code to express the same concepts. *Record structs* synthesize many of the same methods that *record classes* do. Structs and anonymous types support *with expressions*. *Global using directives* and *file scoped namespace declarations* mean you express dependencies and namespace organization more clearly. *Lambda improvements* makes it easier to declare lambda expressions where they're used. New property patterns and deconstruction improvements create more concise code.
+Many of the features mean you type less code to express the same concepts. *Record structs* synthesize many of the same methods that *record classes* do. Structs and anonymous types support *with expressions*. *Global using directives* and *file scoped namespace declarations* mean you express dependencies and namespace organization more clearly. *Lambda improvements* make it easier to declare lambda expressions where they're used. New property patterns and deconstruction improvements create more concise code.
 
 The new interpolated string handlers and `AsyncMethodBuilder` behavior can improve performance. These language features were applied in the .NET Runtime to achieve performance improvements in .NET 6.
 
-C# 10 also marks more of a shift to the yearly cadence for .NET releases. Because not every feature can be completed in a yearly timeframe, you can try a couple of "preview" features in C# 10. Both *generic attributes* and *static abstract members in interfaces* can be used, but these preview features may change before their final release.
+C# 10 also marks more of a shift to the yearly cadence for .NET releases. Because not every feature can be completed in a yearly timeframe, you can try a couple of "preview" features in C# 10. Both *generic attributes* and *static abstract members in interfaces* can be used, but these preview features might change before their final release.
 
 ## C# version 9
 
-*Released November, 2020*
+*Released November 2020*
 
 C# 9 was released with .NET 5. It's the default language version for any assembly that targets the .NET 5 release. It contains the following new and enhanced features:
 
@@ -100,9 +118,9 @@ C# 9 continues three of the themes from previous releases: removing ceremony, se
 
 [Top level statements](../fundamentals/program-structure/top-level-statements.md) means your main program is simpler to read. There's less need for ceremony: a namespace, a `Program` class, and `static void Main()` are all unnecessary.
 
-The introduction of [`records`](../language-reference/builtin-types/record.md) provides a concise syntax for reference types that follow value semantics for equality. You'll use these types to define data containers that typically define minimal behavior. [Init-only setters](../language-reference/keywords/init.md) provide the capability for non-destructive mutation (`with` expressions) in records. C# 9 also adds [covariant return types](~/_csharplang/proposals/csharp-9.0/covariant-returns.md) so that derived records can override virtual methods and return a type derived from the base method's return type.
+The introduction of [`records`](../language-reference/builtin-types/record.md) provides a concise syntax for reference types that follow value semantics for equality. You use these types to define data containers that typically define minimal behavior. [Init-only setters](../language-reference/keywords/init.md) provide the capability for nondestructive mutation (`with` expressions) in records. C# 9 also adds [covariant return types](~/_csharplang/proposals/csharp-9.0/covariant-returns.md) so that derived records can override virtual methods and return a type derived from the base method's return type.
 
-The [pattern matching](../fundamentals/functional/pattern-matching.md) capabilities have been expanded in several ways. Numeric types now support *range patterns*. Patterns can be combined using `and`, `or`, and `not` patterns. Parentheses can be added to clarify more complex patterns:
+The [pattern matching](../fundamentals/functional/pattern-matching.md) capabilities expanded in several ways. Numeric types now support *range patterns*. Patterns can be combined using `and`, `or`, and `not` patterns. Parentheses can be added to clarify more complex patterns:
 
 C# 9 includes new pattern matching improvements:
 
@@ -111,7 +129,7 @@ C# 9 includes new pattern matching improvements:
 - ***Conjunctive `and` patterns*** require both patterns to match
 - ***Disjunctive `or` patterns*** require either pattern to match
 - ***Negated `not` patterns*** require that a pattern doesn't match
-- ***Relational patterns*** require the input be less than, greater than, less than or equal, or greater than or equal to a given constant.
+- ***Relational patterns*** require the input be less than, greater than, less than or equal, or greater than or equal to a given constant
 
 These patterns enrich the syntax for patterns. Consider these examples:
 
@@ -160,9 +178,9 @@ The C# 9 release continues the work to keep C# a modern, general-purpose program
 
 ## C# version 8.0
 
-*Released September, 2019*
+*Released September 2019*
 
-C# 8.0 is the first major C# release that specifically targets .NET Core. Some features rely on new CLR capabilities, others on library types added only in .NET Core. C# 8.0 adds the following features and enhancements to the C# language:
+C# 8.0 is the first major C# release that specifically targets .NET Core. Some features rely on new Common Language Runtime (CLR) capabilities, others on library types added only in .NET Core. C# 8.0 adds the following features and enhancements to the C# language:
 
 - [Readonly members](../language-reference/builtin-types/struct.md#readonly-instance-members)
 - [Default interface methods](../language-reference/keywords/interface.md#default-interface-members)
@@ -186,7 +204,7 @@ Default interface members require enhancements in the CLR. Those features were a
 
 ## C# version 7.3
 
-*Released May, 2018*
+*Released May 2018*
 
 There are two main themes to the C# 7.3 release. One theme provides features that enable safe code to be as performant as unsafe code. The second theme provides incremental improvements to existing features. New compiler options were also added in this release.
 
@@ -202,8 +220,8 @@ The following enhancements were made to existing features:
 
 - You can test `==` and `!=` with tuple types.
 - You can use expression variables in more locations.
-- You may attach attributes to the backing field of auto-implemented properties.
-- Method resolution when arguments differ by `in` has been improved.
+- You can attach attributes to the backing field of auto-implemented properties.
+- Method resolution when arguments differ by `in` was improved.
 - Overload resolution now has fewer ambiguous cases.
 
 The new compiler options are:
@@ -213,7 +231,7 @@ The new compiler options are:
 
 ## C# version 7.2
 
-*Released November, 2017*
+*Released November 2017*
 
 C# 7.2 added several small language features:
 
@@ -225,19 +243,19 @@ C# 7.2 added several small language features:
 - Add the `in` modifier on parameters, to specify that an argument is passed by reference but not modified by the called method.
 - Use the `ref readonly` modifier on method returns, to indicate that a method returns its value by reference but doesn't allow writes to that object.
 - Declare `ref struct` types, to indicate that a struct type accesses managed memory directly and must always be stack allocated.
-- Use additional generic constraints.
-- [Non-trailing named arguments](../programming-guide/classes-and-structs/named-and-optional-arguments.md)
-  - Named arguments can be followed by positional arguments.
-- Leading underscores in numeric literals
+- Use more generic constraints.
+- [Non-trailing named arguments](../programming-guide/classes-and-structs/named-and-optional-arguments.md):
+  - Positional arguments can follow named arguments.
+- Leading underscores in numeric literals:
   - Numeric literals can now have leading underscores before any printed digits.
-- [`private protected` access modifier](../language-reference/keywords/access-modifiers.md)
+- [`private protected` access modifier](../language-reference/keywords/access-modifiers.md):
   - The `private protected` access modifier enables access for derived classes in the same assembly.
-- Conditional `ref` expressions
+- Conditional `ref` expressions:
   - The result of a conditional expression (`?:`) can now be a reference.
 
 ## C# version 7.1
 
-*Released August, 2017*
+*Released August 2017*
 
 C# started releasing *point releases* with C# 7.1. This version added the [language version selection](../language-reference/configure-language-version.md) configuration element, three new language features, and new compiler behavior.
 
@@ -253,11 +271,11 @@ The new language features in this release are:
   - You can use pattern match expressions on variables whose type is a generic type parameter.
 
 Finally, the compiler has two options [`-refout`](../language-reference/compiler-options/output.md#producereferenceassembly) and [`-refonly`](../language-reference/compiler-options/code-generation.md#produceonlyreferenceassembly) that
-control reference assembly generation
+control reference assembly generation.
 
 ## C# version 7.0
 
-*Released March, 2017*
+*Released March 2017*
 
 C# version 7.0 was released with Visual Studio 2017. This version has some evolutionary and cool stuff in the vein of C# 6.0. Here are some of the new features:
 
@@ -279,7 +297,7 @@ All of these features offer new capabilities for developers and the opportunity 
 
 ## C# version 6.0
 
-*Released July, 2015*
+*Released July 2015*
 
 Version 6.0, released with Visual Studio 2015, released many smaller features that made C# programming more productive. Here are some of them:
 
@@ -297,15 +315,15 @@ Other new features include:
 - Await in catch/finally blocks
 - Default values for getter-only properties
 
-Each of these features is interesting in its own right. But if you look at them altogether, you see an interesting pattern. In this version, C# started to eliminate language boilerplate to make code more terse and readable. So for fans of clean, simple code, this language version was a huge win.
+If you look at these features together, you see an interesting pattern. In this version, C# started to eliminate language boilerplate to make code more terse and readable. So for fans of clean, simple code, this language version was a huge win.
 
 They did one other thing along with this version, though it's not a traditional language feature in itself. They released [Roslyn the compiler as a service](https://github.com/dotnet/roslyn). The C# compiler is now written in C#, and you can use the compiler as part of your programming efforts.
 
 ## C# version 5.0
 
-*Released August, 2012*
+*Released August 2012*
 
-C# version 5.0, released with Visual Studio 2012, was a focused version of the language. Nearly all of the effort for that version went into another groundbreaking language concept: the `async` and `await` model for asynchronous programming.  Here's the major features list:
+C# version 5.0, released with Visual Studio 2012, was a focused version of the language. Nearly all of the effort for that version went into another groundbreaking language concept: the `async` and `await` model for asynchronous programming. Here's the major features list:
 
 - [Asynchronous members](../asynchronous-programming/index.md)
 - [Caller info attributes](../language-reference/attributes/caller-information.md)
@@ -313,13 +331,13 @@ C# version 5.0, released with Visual Studio 2012, was a focused version of the l
 
 The caller info attribute lets you easily retrieve information about the context in which you're running without resorting to a ton of boilerplate reflection code. It has many uses in diagnostics and logging tasks.
 
-But `async` and `await` are the real stars of this release. When these features came out in 2012, C# changed the game again by baking asynchrony into the language as a first-class participant. If you've ever dealt with long running operations and the implementation of webs of callbacks, you probably loved this language feature.
+But `async` and `await` are the real stars of this release. When these features came out in 2012, C# changed the game again by baking asynchrony into the language as a first-class participant.
 
 ## C# version 4.0
 
-*Released April, 2010*
+*Released April 2010*
 
-C# version 4.0, released with Visual Studio 2010, would have had a difficult time living up to the groundbreaking status of version 3.0. This version introduced some interesting new features:
+C# version 4.0, released with Visual Studio 2010 introduced some interesting new features:
 
 - [Dynamic binding](../language-reference/builtin-types/reference-types.md)
 - [Named/optional arguments](../programming-guide/classes-and-structs/named-and-optional-arguments.md)
@@ -334,7 +352,7 @@ Dynamic binding gives you the potential for errors but also great power within t
 
 ## C# version 3.0
 
-*Released November, 2007*
+*Released November 2007*
 
 C# version 3.0 came in late 2007, along with Visual Studio 2008, though the full boat of language features would actually come with .NET Framework version 3.5. This version marked a major change in the growth of C#. It established C# as a truly formidable programming language. Let's take a look at some major features in this version:
 
@@ -348,15 +366,15 @@ C# version 3.0 came in late 2007, along with Visual Studio 2008, though the full
 - [Partial methods](../language-reference/keywords/partial-method.md)
 - [Object and collection initializers](../programming-guide/classes-and-structs/object-and-collection-initializers.md)
 
-In retrospect, many of these features seem both inevitable and inseparable. They all fit together strategically. It's thought that C# version's killer feature was the query expression, also known as Language-Integrated Query (LINQ).
+In retrospect, many of these features seem both inevitable and inseparable. They all fit together strategically. That C# version's killer feature was the query expression, also known as Language-Integrated Query (LINQ).
 
-A more nuanced view examines expression trees, lambda expressions, and anonymous types as the foundation upon which LINQ is constructed. But, in either case, C# 3.0 presented a revolutionary concept. C# 3.0 had begun to lay the groundwork for turning C# into a hybrid Object-Oriented / Functional language.
+A more nuanced view examines expression trees, lambda expressions, and anonymous types as the foundation upon which LINQ is constructed. But, in either case, C# 3.0 presented a revolutionary concept. C# 3.0 began to lay the groundwork for turning C# into a hybrid Object-Oriented / Functional language.
 
 Specifically, you could now write SQL-style, declarative queries to perform operations on collections, among other things. Instead of writing a `for` loop to compute the average of a list of integers, you could now do that as simply as `list.Average()`. The combination of query expressions and extension methods made a list of integers a whole lot smarter.
 
 ## C# version 2.0
 
-*Released November, 2005*
+*Released November 2005*
 
 Let's take a look at some major features of C# 2.0, released in 2005, along with Visual Studio 2005:
 
@@ -374,25 +392,23 @@ Other C# 2.0 features added capabilities to existing features:
 - Static classes
 - Delegate inference
 
-While C# may have started as a generic Object-Oriented (OO) language, C# version 2.0 changed that in a hurry. With generics, types and methods can operate on an arbitrary type while still retaining type safety. For instance, having a <xref:System.Collections.Generic.List%601> lets you have `List<string>` or `List<int>` and perform type-safe operations on those strings or integers while you iterate through them. Using generics is better than creating a `ListInt` type that derives from `ArrayList`  or casting from `Object` for every operation.
+While C# began as a generic Object-Oriented (OO) language, C# version 2.0 changed that in a hurry. With generics, types and methods can operate on an arbitrary type while still retaining type safety. For instance, having a <xref:System.Collections.Generic.List%601> lets you have `List<string>` or `List<int>` and perform type-safe operations on those strings or integers while you iterate through them. Using generics is better than creating a `ListInt` type that derives from `ArrayList` or casting from `Object` for every operation.
 
 C# version 2.0 brought iterators. To put it succinctly, iterators let you examine all the items in a `List` (or other Enumerable types) with a `foreach` loop. Having iterators as a first-class part of the language dramatically enhanced readability of the language and people's ability to reason about the code.
 
-And yet, C# continued to play a bit of catch-up with Java. Java had already released versions that included generics and iterators. But that would soon change as the languages continued to evolve apart.
-
 ## C# version 1.2
 
-*Released April, 2003*
+*Released April 2003*
 
 C# version 1.2 shipped with Visual Studio .NET 2003. It contained a few small enhancements to the language. Most notable is that starting with this version, the code generated in a `foreach` loop called <xref:System.IDisposable.Dispose%2A> on an <xref:System.Collections.IEnumerator> when that <xref:System.Collections.IEnumerator> implemented <xref:System.IDisposable>.
 
 ## C# version 1.0
 
-*Released January, 2002*
+*Released January 2002*
 
-When you go back and look, C# version 1.0, released with Visual Studio .NET 2002, looked a lot like Java. As [part of its stated design goals for ECMA](https://feeldotneteasy.blogspot.com/2011/01/c-design-goals.html), it sought to be a "simple, modern, general-purpose object-oriented language."  At the time, looking like Java meant it achieved those early design goals.
+When you go back and look, C# version 1.0, released with Visual Studio .NET 2002, looked a lot like Java. As [part of its stated design goals for ECMA](https://feeldotneteasy.blogspot.com/2011/01/c-design-goals.html), it sought to be a "simple, modern, general-purpose object-oriented language." At the time, looking like Java meant it achieved those early design goals.
 
-But if you look back on C# 1.0 now, you'd find yourself a little dizzy. It lacked the built-in async capabilities and some of the slick functionality around generics you take for granted. As a matter of fact, it lacked generics altogether.  And [LINQ](../linq/index.md)? Not available yet. Those additions would take some years to come out.
+But if you look back on C# 1.0 now, you'd find yourself a little dizzy. It lacked the built-in async capabilities and some of the slick functionality around generics you take for granted. As a matter of fact, it lacked generics altogether. And [LINQ](../linq/index.md)? Not available yet. Those additions would take some years to come out.
 
 C# version 1.0 looked stripped of features, compared to today. You'd find yourself writing some verbose code. But yet, you have to start somewhere. C# version 1.0 was a viable alternative to Java on the Windows platform.
 


### PR DESCRIPTION
Fixes #39817

Add information and links about C# 12 to the history of C# article.

Perform an edit pass, and update the date field.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/whats-new/csharp-version-history.md](https://github.com/dotnet/docs/blob/36edfad7dd505c8b8dbd9359407d9acb7b13a7f0/docs/csharp/whats-new/csharp-version-history.md) | [The history of C\#](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-version-history?branch=pr-en-us-39851) |


<!-- PREVIEW-TABLE-END -->