### PR TITLE
Add logging with Azure.Monitor.OpenTelemetry.AspNetCore section

### DIFF
--- a/docs/azure/sdk/logging.md
+++ b/docs/azure/sdk/logging.md
@@ -188,7 +188,7 @@ For more information, see [Logging in .NET Core and ASP.NET Core](/aspnet/core/f
 
 ## Logging using Azure.Monitor.OpenTelemetry.AspNetCore
 
-[Azure Monitor OpenTelemetry Distro](https://www.nuget.org/packages/Azure.Monitor.OpenTelemetry.AspNetCore),starting with version `1.2.0`, supports capturing logs coming from Azure client libraries.
+[Azure Monitor OpenTelemetry Distro](https://www.nuget.org/packages/Azure.Monitor.OpenTelemetry.AspNetCore), starting with version `1.2.0`, supports capturing logs coming from Azure client libraries.
 You can control logging using any of the configuration options discussed in [Logging in .NET Core and ASP.NET Core](/aspnet/core/fundamentals/logging/).
 
 Using the Azure Service Bus library as an example, complete the following steps:

--- a/docs/azure/sdk/logging.md
+++ b/docs/azure/sdk/logging.md
@@ -193,7 +193,7 @@ You can control logging using any of the [Logging in .NET Core and ASP.NET Core 
 
 Using the Azure Service Bus library as an example, complete the following steps:
 
-1. Install the [/Azure.Monitor.OpenTelemetry.AspNetCore](https://www.nuget.org/packages/Azure.Monitor.OpenTelemetry.AspNetCore) NuGet package:
+1. Install the [Azure.Monitor.OpenTelemetry.AspNetCore](https://www.nuget.org/packages/Azure.Monitor.OpenTelemetry.AspNetCore) NuGet package:
 
     ```dotnetcli
     dotnet add package Azure.Monitor.OpenTelemetry.AspNetCore

--- a/docs/azure/sdk/logging.md
+++ b/docs/azure/sdk/logging.md
@@ -188,7 +188,7 @@ For more information, see [Logging in .NET Core and ASP.NET Core](/aspnet/core/f
 
 ## Logging using Azure.Monitor.OpenTelemetry.AspNetCore
 
-[Azure Monitor OpenTelemetry Distro](https://www.nuget.org/packages/Azure.Monitor.OpenTelemetry.AspNetCore),starting with version `1.2.0`, supports capturing logs coming from Azure client libraries. 
+[Azure Monitor OpenTelemetry Distro](https://www.nuget.org/packages/Azure.Monitor.OpenTelemetry.AspNetCore),starting with version `1.2.0`, supports capturing logs coming from Azure client libraries.
 You can control logging using any of the configuration options discussed in [Logging in .NET Core and ASP.NET Core](/aspnet/core/fundamentals/logging/).
 
 Using the Azure Service Bus library as an example, complete the following steps:
@@ -204,12 +204,13 @@ Using the Azure Service Bus library as an example, complete the following steps:
    ```csharp
    await using var client = new ServiceBusClient("<connection_string>");
    ```
+
 1. In *appsettings.json*, change the Service Bus library's default log level. For example, toggle it to `Debug` by setting the `Logging:LogLevel:Azure.Messaging.ServiceBus` key as follows:
 
     :::code language="json" source="snippets/logging/appsettings.Development.json" highlight="9":::
 
     Since the `Logging:LogLevel:Azure.Messaging.ServiceBus` key is set to `Debug`, Service Bus client events up to `EventLevel.Verbose` will be logged.
-   
+
 ## Log HTTP request and response bodies
 
 When troubleshooting unexpected behavior with a client library, it's helpful to inspect the following items:

--- a/docs/azure/sdk/logging.md
+++ b/docs/azure/sdk/logging.md
@@ -188,8 +188,8 @@ For more information, see [Logging in .NET Core and ASP.NET Core](/aspnet/core/f
 
 ## Logging using Azure.Monitor.OpenTelemetry.AspNetCore
 
-[Azure Monitor OpenTelemetry Distro](https://www.nuget.org/packages/Azure.Monitor.OpenTelemetry.AspNetCore) starting with version `1.2.0` supports capturing logs coming from Azure client libraris. 
-You can control logging using any of the [Logging in .NET Core and ASP.NET Core configuration options](/aspnet/core/fundamentals/logging/). 
+[Azure Monitor OpenTelemetry Distro](https://www.nuget.org/packages/Azure.Monitor.OpenTelemetry.AspNetCore),starting with version `1.2.0`, supports capturing logs coming from Azure client libraries. 
+You can control logging using any of the configuration options discussed in [Logging in .NET Core and ASP.NET Core](/aspnet/core/fundamentals/logging/).
 
 Using the Azure Service Bus library as an example, complete the following steps:
 
@@ -204,7 +204,6 @@ Using the Azure Service Bus library as an example, complete the following steps:
    ```csharp
    await using var client = new ServiceBusClient("<connection_string>");
    ```
-   
 1. In *appsettings.json*, change the Service Bus library's default log level. For example, toggle it to `Debug` by setting the `Logging:LogLevel:Azure.Messaging.ServiceBus` key as follows:
 
     :::code language="json" source="snippets/logging/appsettings.Development.json" highlight="9":::

--- a/docs/azure/sdk/logging.md
+++ b/docs/azure/sdk/logging.md
@@ -186,6 +186,31 @@ In these scenarios, complete the following steps:
 
 For more information, see [Logging in .NET Core and ASP.NET Core](/aspnet/core/fundamentals/logging/).
 
+## Logging using Azure.Monitor.OpenTelemetry.AspNetCore
+
+[Azure Monitor OpenTelemetry Distro](https://www.nuget.org/packages/Azure.Monitor.OpenTelemetry.AspNetCore) starting with version `1.2.0` supports capturing logs coming from Azure client libraris. 
+You can control logging using any of the [Logging in .NET Core and ASP.NET Core configuration options](/aspnet/core/fundamentals/logging/). 
+
+Using the Azure Service Bus library as an example, complete the following steps:
+
+1. Install the [/Azure.Monitor.OpenTelemetry.AspNetCore](https://www.nuget.org/packages/Azure.Monitor.OpenTelemetry.AspNetCore) NuGet package:
+
+    ```dotnetcli
+    dotnet add package Azure.Monitor.OpenTelemetry.AspNetCore
+    ```
+
+1. Create or register the Azure SDK library's client - the distro supports both cases
+
+   ```csharp
+   await using var client = new ServiceBusClient("<connection_string>");
+   ```
+   
+1. In *appsettings.json*, change the Service Bus library's default log level. For example, toggle it to `Debug` by setting the `Logging:LogLevel:Azure.Messaging.ServiceBus` key as follows:
+
+    :::code language="json" source="snippets/logging/appsettings.Development.json" highlight="9":::
+
+    Since the `Logging:LogLevel:Azure.Messaging.ServiceBus` key is set to `Debug`, Service Bus client events up to `EventLevel.Verbose` will be logged.
+   
 ## Log HTTP request and response bodies
 
 When troubleshooting unexpected behavior with a client library, it's helpful to inspect the following items:

--- a/docs/azure/sdk/logging.md
+++ b/docs/azure/sdk/logging.md
@@ -199,7 +199,7 @@ Using the Azure Service Bus library as an example, complete the following steps:
     dotnet add package Azure.Monitor.OpenTelemetry.AspNetCore
     ```
 
-1. Create or register the Azure SDK library's client - the distro supports both cases
+1. Create or register the Azure SDK library's client - the distro supports both cases.
 
    ```csharp
    await using var client = new ServiceBusClient("<connection_string>");


### PR DESCRIPTION
Updates Azure SDK .NET logging article according to https://github.com/Azure/azure-sdk-for-net/pull/42374

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/azure/sdk/logging.md](https://github.com/dotnet/docs/blob/c29284cbcad3cbe70c50e51bae28a5a3a54faf60/docs/azure/sdk/logging.md) | [Logging with the Azure SDK for .NET](https://review.learn.microsoft.com/en-us/dotnet/azure/sdk/logging?branch=pr-en-us-39854) |


<!-- PREVIEW-TABLE-END -->