### PR TITLE
Fix Incorrect Event Verbosity

### DIFF
--- a/docs/fundamentals/diagnostics/runtime-garbage-collection-events.md
+++ b/docs/fundamentals/diagnostics/runtime-garbage-collection-events.md
@@ -211,7 +211,7 @@ The following table shows the keyword and level:
 
 |Keyword for raising the event|Level|
 |-----------------------------------|-----------|
-|`GCKeyword` (0x1)|Verbose (4)|
+|`GCKeyword` (0x1)|Verbose (5)|
 
 The following table shows the event information:
 


### PR DESCRIPTION
GCAllocationTick_V3 has a verbosity of Verbose (5) but is currently listed as Verbose (4).

## Summary

Update the numeric value for verbosity of the GCAllocationTick_V3 event.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/diagnostics/runtime-garbage-collection-events.md](https://github.com/dotnet/docs/blob/0ad4441f8e25fbfb358f54e5c9f52e44cae1bdac/docs/fundamentals/diagnostics/runtime-garbage-collection-events.md) | [.NET runtime garbage collection events](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/diagnostics/runtime-garbage-collection-events?branch=pr-en-us-39858) |

<!-- PREVIEW-TABLE-END -->