### PR TITLE
Updates for collection expressions clarity

### DIFF
--- a/docs/csharp/language-reference/operators/collection-expressions.md
+++ b/docs/csharp/language-reference/operators/collection-expressions.md
@@ -1,6 +1,6 @@
 ---
 title: "Collection expressions (Collection literals)"
-description: Collection expressions are expressions that convert to many different collection types. They enable you to write literal values for collection elements, or import other collection elements into a new collection.
+description: Collection expressions convert to many collection types. You can write literal values, expressions, or other collections to create a new collection.
 ms.date: 03/07/2024
 helpviewer_keywords:
   - "Collection expressions"
@@ -35,21 +35,23 @@ A *collection expression* can be converted to different collection types, includ
 
 - <xref:System.Span%601?displayProperty=nameWithType> and <xref:System.ReadOnlySpan%601?displayProperty=nameWithType>
 - [Arrays](../builtin-types/arrays.md)
-- Any type with a *create* method whose parameter type is `ReadOnlySpan<T>` where there's an implicit conversion from the collection expression type to `T`.
-- Any type that supports a [collection initializer](../../programming-guide/classes-and-structs/object-and-collection-initializers.md#collection-initializers), such as <xref:System.Collections.Generic.List%601?displayProperty=nameWithType>. Usually, this requirement means the type supports <xref:System.Collections.Generic.IEnumerable%601?displayProperty=nameWithType> and there's an accessible `Add` method to add items to the collection. There must be an implicit conversion from the collection expression elements' type to the collection's element type. For spread elements, there must be an implicit conversion from the spread element's type to the collection's element type.
+- Any type with a *create* method whose parameter type is `ReadOnlySpan<T>` where there's an implicit conversion from the collection expression type to `T`
+- Any type that supports a [collection initializer](../../programming-guide/classes-and-structs/object-and-collection-initializers.md#collection-initializers), such as <xref:System.Collections.Generic.List%601?displayProperty=nameWithType>. Usually, this requirement means the type supports <xref:System.Collections.Generic.IEnumerable%601?displayProperty=nameWithType> and there's an accessible `Add` method to add items to the collection. There must be an implicit conversion from the collection expression elements' type to the collection's element type. For spread elements, there must be an implicit conversion from the spread element's type to the collection's element type
 - Any of the following interfaces:
   - <xref:System.Collections.Generic.IEnumerable%601?displayProperty=fullName>
   - <xref:System.Collections.Generic.IReadOnlyCollection%601?displayProperty=fullName>
   - <xref:System.Collections.Generic.IReadOnlyList%601?displayProperty=fullName>
-  - <xref:System.Collections.Generic.ICollection%601?displayProperty=fullName> 
+  - <xref:System.Collections.Generic.ICollection%601?displayProperty=fullName>
   - <xref:System.Collections.Generic.IList%601?displayProperty=fullName>
 
 > [!IMPORTANT]
-> A collection expression always creates a collection, regardless of the target type of the conversion. For example, when the target of the conversion is <xref:System.Collections.Generic.IEnumerable%601?displayProperty=nameWithType>, the generated code evaluates the collection expression and stores the results in an in-memory collection.
+> A collection expression always creates a collection that includes all elements in the collection expression, regardless of the target type of the conversion. For example, when the target of the conversion is <xref:System.Collections.Generic.IEnumerable%601?displayProperty=nameWithType>, the generated code evaluates the collection expression and stores the results in an in-memory collection.
+>
+> This behavior is distinct from LINQ, where a sequence might not be instantiated until it is enumerated. You can't use collection expressions to generate an infinite sequence that won't be enumerated.
 
-The compiler uses static analysis to determine the most performant way to create the collection declared with a collection expression. For example, the empty collection expression, `[]`, can be realized as <xref:System.Array.Empty%60%601?displayProperty=nameWithType> if the target won't be modified after initialization. When the target is a <xref:System.Span%601?displayProperty=nameWithType> or <xref:System.ReadOnlySpan%601?displayProperty=nameWithType>, the storage may be stack allocated. The [collection expressions feature specification](~/_csharplang/proposals/csharp-12.0/collection-expressions.md) specifies the rules the compiler must follow.
+The compiler uses static analysis to determine the most performant way to create the collection declared with a collection expression. For example, the empty collection expression, `[]`, can be realized as <xref:System.Array.Empty%60%601?displayProperty=nameWithType> if the target won't be modified after initialization. When the target is a <xref:System.Span%601?displayProperty=nameWithType> or <xref:System.ReadOnlySpan%601?displayProperty=nameWithType>, the storage might be stack allocated. The [collection expressions feature specification](~/_csharplang/proposals/csharp-12.0/collection-expressions.md) specifies the rules the compiler must follow.
 
-Many APIs are overloaded with multiple collection types as parameters. Because a collection expression can be converted to many different expression types, these APIs may require casts on the collection expression to specify the correct conversion. The following conversion rules resolve some of the ambiguities:
+Many APIs are overloaded with multiple collection types as parameters. Because a collection expression can be converted to many different expression types, these APIs might require casts on the collection expression to specify the correct conversion. The following conversion rules resolve some of the ambiguities:
 
 - Conversion to <xref:System.Span%601>, <xref:System.ReadOnlySpan%601>, or another [`ref struct`](../builtin-types/ref-struct.md) type is better than a conversion to a non-ref struct type.
 - Conversion to a noninterface type is better than a conversion to an interface type.
@@ -60,7 +62,7 @@ When a collection expression is converted to a `Span` or `ReadOnlySpan`, the spa
 
 Collection expressions work with any collection type that is *well-behaved*. A well-behaved collection has the following properties:
 
-- The value of a `Count` or `Length` on a [countable](./member-access-operators.md#index-from-end-operator) collection will produce that same value as the number of elements when enumerated.
+- The value of a `Count` or `Length` on a [countable](./member-access-operators.md#index-from-end-operator-) collection produces that same value as the number of elements when enumerated.
 - The types in the <xref:System.Collections.Generic?displayProperty=fullName> namespace are presumed to be side-effect free. As such, the compiler can optimize scenarios where such types might be used as intermediary values, but otherwise not be exposed. The collections in the .NET Runtime satisfy this constraint.
 - A call to some applicable `.AddRange(x)` member on a collection will result in the same final value as iterating over `x` and adding all of its enumerated values individually to the collection with `.Add`.
 

--- a/docs/csharp/language-reference/operators/collection-expressions.md
+++ b/docs/csharp/language-reference/operators/collection-expressions.md
@@ -60,16 +60,16 @@ When a collection expression is converted to a `Span` or `ReadOnlySpan`, the spa
 
 ## Collection builder
 
-Collection expressions work with any collection type that is *well-behaved*. A well-behaved collection has the following properties:
+Collection expressions work with any collection type that's *well-behaved*. A well-behaved collection has the following characteristics:
 
-- The value of a `Count` or `Length` on a [countable](./member-access-operators.md#index-from-end-operator-) collection produces that same value as the number of elements when enumerated.
-- The types in the <xref:System.Collections.Generic?displayProperty=fullName> namespace are presumed to be side-effect free. As such, the compiler can optimize scenarios where such types might be used as intermediary values, but otherwise not be exposed. The collections in the .NET Runtime satisfy this constraint.
+- The value of `Count` or `Length` on a [countable](./member-access-operators.md#index-from-end-operator-) collection produces the same value as the number of elements when enumerated.
+- The types in the <xref:System.Collections.Generic?displayProperty=fullName> namespace are presumed to be side-effect free. As such, the compiler can optimize scenarios where such types might be used as intermediary values, but otherwise not be exposed.
 - A call to some applicable `.AddRange(x)` member on a collection will result in the same final value as iterating over `x` and adding all of its enumerated values individually to the collection with `.Add`.
 
 All the collection types in the .NET runtime are well-behaved.
 
 > [!WARNING]
-> If a custom collection type isn't well-behaved, the behavior using that collection type with collection expressions is undefined.
+> If a custom collection type isn't well-behaved, the behavior when you use that collection type with collection expressions is undefined.
 
 Your types opt in to collection expression support by writing a `Create()` method and applying the <xref:System.Runtime.CompilerServices.CollectionBuilderAttribute?displayProperty=fullName> on the collection type to indicate the builder method. For example, consider an application that uses fixed length buffers of 80 characters. That class might look something like the following code:
 

--- a/docs/csharp/language-reference/operators/collection-expressions.md
+++ b/docs/csharp/language-reference/operators/collection-expressions.md
@@ -1,7 +1,7 @@
 ---
 title: "Collection expressions (Collection literals)"
 description: Collection expressions are expressions that convert to many different collection types. They enable you to write literal values for collection elements, or import other collection elements into a new collection.
-ms.date: 08/25/2023
+ms.date: 03/07/2024
 helpviewer_keywords:
   - "Collection expressions"
 ---
@@ -37,6 +37,15 @@ A *collection expression* can be converted to different collection types, includ
 - [Arrays](../builtin-types/arrays.md)
 - Any type with a *create* method whose parameter type is `ReadOnlySpan<T>` where there's an implicit conversion from the collection expression type to `T`.
 - Any type that supports a [collection initializer](../../programming-guide/classes-and-structs/object-and-collection-initializers.md#collection-initializers), such as <xref:System.Collections.Generic.List%601?displayProperty=nameWithType>. Usually, this requirement means the type supports <xref:System.Collections.Generic.IEnumerable%601?displayProperty=nameWithType> and there's an accessible `Add` method to add items to the collection. There must be an implicit conversion from the collection expression elements' type to the collection's element type. For spread elements, there must be an implicit conversion from the spread element's type to the collection's element type.
+- Any of the following interfaces:
+  - <xref:System.Collections.Generic.IEnumerable%601?displayProperty=fullName>
+  - <xref:System.Collections.Generic.IReadOnlyCollection%601?displayProperty=fullName>
+  - <xref:System.Collections.Generic.IReadOnlyList%601?displayProperty=fullName>
+  - <xref:System.Collections.Generic.ICollection%601?displayProperty=fullName> 
+  - <xref:System.Collections.Generic.IList%601?displayProperty=fullName>
+
+> [!IMPORTANT]
+> A collection expression always creates a collection, regardless of the target type of the conversion. For example, when the target of the conversion is <xref:System.Collections.Generic.IEnumerable%601?displayProperty=nameWithType>, the generated code evaluates the collection expression and stores the results in an in-memory collection.
 
 The compiler uses static analysis to determine the most performant way to create the collection declared with a collection expression. For example, the empty collection expression, `[]`, can be realized as <xref:System.Array.Empty%60%601?displayProperty=nameWithType> if the target won't be modified after initialization. When the target is a <xref:System.Span%601?displayProperty=nameWithType> or <xref:System.ReadOnlySpan%601?displayProperty=nameWithType>, the storage may be stack allocated. The [collection expressions feature specification](~/_csharplang/proposals/csharp-12.0/collection-expressions.md) specifies the rules the compiler must follow.
 
@@ -49,7 +58,18 @@ When a collection expression is converted to a `Span` or `ReadOnlySpan`, the spa
 
 ## Collection builder
 
-A type opts in to collection expression support by writing a `Create()` method and applying the <xref:System.Runtime.CompilerServices.CollectionBuilderAttribute?displayProperty=fullName> on the collection type to indicate the builder method. For example, consider an application that uses fixed length buffers of 80 characters. That class might look something like the following code:
+Collection expressions work with any collection type that is *well-behaved*. A well-behaved collection has the following properties:
+
+- The value of a `Count` or `Length` on a [countable](./member-access-operators.md#index-from-end-operator) collection will produce that same value as the number of elements when enumerated.
+- The types in the <xref:System.Collections.Generic?displayProperty=fullName> namespace are presumed to be side-effect free. As such, the compiler can optimize scenarios where such types might be used as intermediary values, but otherwise not be exposed. The collections in the .NET Runtime satisfy this constraint.
+- A call to some applicable `.AddRange(x)` member on a collection will result in the same final value as iterating over `x` and adding all of its enumerated values individually to the collection with `.Add`.
+
+All the collection types in the .NET runtime are well-behaved.
+
+> [!WARNING]
+> If a custom collection type isn't well-behaved, the behavior using that collection type with collection expressions is undefined.
+
+Your types opt in to collection expression support by writing a `Create()` method and applying the <xref:System.Runtime.CompilerServices.CollectionBuilderAttribute?displayProperty=fullName> on the collection type to indicate the builder method. For example, consider an application that uses fixed length buffers of 80 characters. That class might look something like the following code:
 
 :::code language="csharp" source="./snippets/shared/CollectionExpressionExamples.cs" id="BufferDeclaration":::
 

--- a/docs/csharp/language-reference/operators/member-access-operators.md
+++ b/docs/csharp/language-reference/operators/member-access-operators.md
@@ -1,7 +1,7 @@
 ---
 title: "Member access and null-conditional operators and expressions:"
 description: "C# operators that you use to access type members or null-conditionally access type members. These operators include the dot operator - `.`, indexers - `[`, `]`, `^` and `..`, and invocation - `(`, `)`."
-ms.date: 11/28/2022
+ms.date: 03/07/2024
 author: pkulikov
 f1_keywords:
   - "._CSharpKeyword"
@@ -181,6 +181,8 @@ You also use parentheses to adjust the order in which to evaluate operations in 
 [Cast expressions](type-testing-and-cast.md#cast-expression), which perform explicit type conversions, also use parentheses.
 
 ## Index from end operator ^
+
+Index and range operators can be used with a type that is *Countable*. A *Countable* type is a type that has an `int` property named either `Count` or `Length` with an accessible `get` accessor. [Collection expressions](./collection-expressions.md) also rely on *Countable* types.
 
 The `^` operator indicates the element position from the end of a sequence. For a sequence of length `length`, `^n` points to the element with offset `length - n` from the start of a sequence. For example, `^1` points to the last element of a sequence and `^length` points to the first element of a sequence.
 


### PR DESCRIPTION
Fixes #39586

This issue lists several elements. Here are the updates for each of them:

1. Add the list of potential interface types that a collection can be converted into. In addition, add an alert that in all cases, the collection is materialzed.
1. I didn't add a lot here. I think the addition about instantiating the collection is enough.
1. The additional list of interfaces as conversion targets has been added. I didn't specify the type generated, because that's an implementation detail that may not be visible, and may change.
1. I added a definition of a *Countable* type in the member access operator article. I linked between both. I don't think more is needed, as this fact is also emphasized in the definition of a *well behaved* collection.
1. Add the definition of a well-behaved collection.

Finally, do a general edit pass.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/collection-expressions.md](https://github.com/dotnet/docs/blob/1dc944ab27ba76a529edb836b675b3e1975a6862/docs/csharp/language-reference/operators/collection-expressions.md) | [Collection expressions - C# language reference](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/collection-expressions?branch=pr-en-us-39867) |
| [docs/csharp/language-reference/operators/member-access-operators.md](https://github.com/dotnet/docs/blob/1dc944ab27ba76a529edb836b675b3e1975a6862/docs/csharp/language-reference/operators/member-access-operators.md) | [Member access operators and expressions - the dot, indexer, and invocation operators.](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/member-access-operators?branch=pr-en-us-39867) |


<!-- PREVIEW-TABLE-END -->