### PR TITLE
Move permissions up

### DIFF
--- a/.github/workflows/profanity-filter.yml
+++ b/.github/workflows/profanity-filter.yml
@@ -8,13 +8,14 @@ on:
   pull_request:
     types: [opened, edited, reopened]
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   apply-filter:
     name: Apply profanity filter
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      pull-requests: write
 
     steps:
     - name: Profanity filter


### PR DESCRIPTION
I'm seeing odd issues, and when I look at the action run logs it claims that these are the permissions, which it shouldn't be.

![image](https://github.com/dotnet/docs/assets/7679720/90faa135-8d30-4d88-b17b-2f26f0000fcb)
