### PR TITLE
MSTEST0015: Add missing toc and table link

### DIFF
--- a/docs/core/testing/mstest-analyzers/design-rules.md
+++ b/docs/core/testing/mstest-analyzers/design-rules.md
@@ -14,3 +14,4 @@ Identifier | Name | Description
 -----------|------|------------
 [MSTEST0004](mstest0004.md) | PublicTypeShouldBeTestClassAnalyzer | It's considered a good practice to have only test classes marked public in a test project.
 [MSTEST0006](mstest0006.md) | AvoidExpectedExceptionAttributeAnalyzer | Prefer `Assert.ThrowsException` or `Assert.ThrowsExceptionAsync` over `[ExpectedException]` as it ensures that only the expected call throws the expected exception. The assert APIs also provide more flexibility and allow you to assert extra properties of the exception.
+[MSTEST0015](mstest0015.md) | TestMethodShouldNotBeIgnored | Test methods should not be ignored (marked with `[Ignore]`).

--- a/docs/navigate/devops-testing/toc.yml
+++ b/docs/navigate/devops-testing/toc.yml
@@ -95,6 +95,8 @@ items:
                     href: ../../core/testing/mstest-analyzers/mstest0004.md
                   - name: MSTEST0006
                     href: ../../core/testing/mstest-analyzers/mstest0006.md
+                  - name: MSTEST0015
+                    href: ../../core/testing/mstest-analyzers/mstest0015.md
               - name: Performance
                 items:
                   - name: Overview
@@ -125,7 +127,7 @@ items:
                     href: ../../core/testing/mstest-analyzers/mstest0012.md
                   - name: MSTEST0013
                     href: ../../core/testing/mstest-analyzers/mstest0013.md
-                    
+
       - name: Run selective unit tests
         href: ../../core/testing/selective-unit-tests.md
       - name: Order unit tests


### PR DESCRIPTION
## Summary

Follow-up from #39782 where some toc and table were not updated.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/mstest-analyzers/design-rules.md](https://github.com/dotnet/docs/blob/2ccb0f8a4c2544d4b8c6677f81d1b9bfa6895c18/docs/core/testing/mstest-analyzers/design-rules.md) | [MSTest design rules](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/design-rules?branch=pr-en-us-39891) |

<!-- PREVIEW-TABLE-END -->