### PR TITLE
Clarify [<Literal>]

### DIFF
--- a/docs/fsharp/language-reference/literals.md
+++ b/docs/fsharp/language-reference/literals.md
@@ -37,13 +37,26 @@ The following table shows the literal types in F#. Characters that represent dig
 
 ## Named literals
 
-Values that are intended to be constants can be marked with the [Literal](https://fsharp.github.io/fsharp-core-docs/reference/fsharp-core-literalattribute.html) attribute. This attribute has the effect of causing a value to be compiled as a constant.
+Values that are intended to be constants can be marked with the [Literal](https://fsharp.github.io/fsharp-core-docs/reference/fsharp-core-literalattribute.html) attribute.
 
-Named literals are useful for:
+This attribute has the effect of causing a value to be compiled as a constant: Both `x` and `y` below are immutable values, but `x` is assigned during run-time (but **not** evaluated lazily), whereas `y` is assigned during compile-time.
 
-- Pattern matching without a `when` clause.
-- Attribute arguments.
-- Static type provider arguments.
+```fsharp
+let x = "a" + "b" // assigned at run-time
+
+[<Literal>]
+let y = "a" + "b" // assigned at compile-time
+```
+
+For example, this distinction matters when calling an [external function](functions/external-functions.md), because `DllImport` is an attribute that needs to know the value of `myDLL` during compilation. Without the `[<Literal>]` declaration, this code would fail to compile:
+
+```fsharp
+[<Literal>]
+let myDLL = "foo.dll"
+
+[<DllImport(myDLL, CallingConvention = CallingConvention.Cdecl)>]
+extern void HelloWorld()
+```
 
 In pattern matching expressions, identifiers that begin with lowercase characters are always treated as variables to be bound, rather than as literals, so you should generally use initial capitals when you define literals.
 
@@ -63,6 +76,12 @@ let Literal2 = 1 ||| 64
 [<Literal>]
 let Literal3 = System.IO.FileAccess.Read ||| System.IO.FileAccess.Write
 ```
+
+Named literals are useful for:
+
+- Pattern matching without a `when` clause.
+- Attribute arguments.
+- Static type provider arguments.
 
 ## Remarks
 

--- a/docs/fsharp/language-reference/literals.md
+++ b/docs/fsharp/language-reference/literals.md
@@ -39,13 +39,13 @@ The following table shows the literal types in F#. Characters that represent dig
 
 Values that are intended to be constants can be marked with the [Literal](https://fsharp.github.io/fsharp-core-docs/reference/fsharp-core-literalattribute.html) attribute.
 
-This attribute has the effect of causing a value to be compiled as a constant: Both `x` and `y` below are immutable values, but `x` is assigned during run-time (but **not** evaluated lazily), whereas `y` is assigned during compile-time.
+This attribute has the effect of causing a value to be compiled as a constant. In the following example, both `x` and `y` below are immutable values, but `x` is evaluated at run-time, whereas `y` is a compile-time constant.
 
 ```fsharp
-let x = "a" + "b" // assigned at run-time
+let x = "a" + "b" // evaluated at run-time
 
 [<Literal>]
-let y = "a" + "b" // assigned at compile-time
+let y = "a" + "b" // evaluated at compile-time
 ```
 
 For example, this distinction matters when calling an [external function](functions/external-functions.md), because `DllImport` is an attribute that needs to know the value of `myDLL` during compilation. Without the `[<Literal>]` declaration, this code would fail to compile:
@@ -77,13 +77,13 @@ let Literal2 = 1 ||| 64
 let Literal3 = System.IO.FileAccess.Read ||| System.IO.FileAccess.Write
 ```
 
+## Remarks
+
 Named literals are useful for:
 
 - Pattern matching without a `when` clause.
 - Attribute arguments.
 - Static type provider arguments.
-
-## Remarks
 
 Unicode strings can contain explicit encodings that you can specify by using `\u` followed by a 16-bit hexadecimal code (0000 - FFFF), or UTF-32 encodings that you can specify by using `\U` followed by a 32-bit hexadecimal code that represents any Unicode code point (00000000 - 0010FFFF).
 


### PR DESCRIPTION
F# values are immutable, so it is confusing to read about how immutable values becoming "constants" would be helpful. Most of the additions are from https://stackoverflow.com/questions/25472810/how-does-literal-differ-from-other-constants-in-f that helped clear up this topic.

Affected issue: https://github.com/dotnet/docs/issues/32082


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/literals.md](https://github.com/dotnet/docs/blob/2aaa1193a0082a2c276960ee59c0b8474ae2951a/docs/fsharp/language-reference/literals.md) | [Literals](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/literals?branch=pr-en-us-39895) |


<!-- PREVIEW-TABLE-END -->