### PR TITLE
Fast follow to #39867

### DIFF
--- a/docs/csharp/language-reference/operators/collection-expressions.md
+++ b/docs/csharp/language-reference/operators/collection-expressions.md
@@ -33,16 +33,16 @@ The spread element `..vowels`, when evaluated, produces five elements: `"a"`, `"
 
 A *collection expression* can be converted to different collection types, including:
 
-- <xref:System.Span%601?displayProperty=nameWithType> and <xref:System.ReadOnlySpan%601?displayProperty=nameWithType>
-- [Arrays](../builtin-types/arrays.md)
-- Any type with a *create* method whose parameter type is `ReadOnlySpan<T>` where there's an implicit conversion from the collection expression type to `T`
-- Any type that supports a [collection initializer](../../programming-guide/classes-and-structs/object-and-collection-initializers.md#collection-initializers), such as <xref:System.Collections.Generic.List%601?displayProperty=nameWithType>. Usually, this requirement means the type supports <xref:System.Collections.Generic.IEnumerable%601?displayProperty=nameWithType> and there's an accessible `Add` method to add items to the collection. There must be an implicit conversion from the collection expression elements' type to the collection's element type. For spread elements, there must be an implicit conversion from the spread element's type to the collection's element type
+- <xref:System.Span%601?displayProperty=nameWithType> and <xref:System.ReadOnlySpan%601?displayProperty=nameWithType>.
+- [Arrays](../builtin-types/arrays.md).
+- Any type with a *create* method whose parameter type is `ReadOnlySpan<T>` where there's an implicit conversion from the collection expression type to `T`.
+- Any type that supports a [collection initializer](../../programming-guide/classes-and-structs/object-and-collection-initializers.md#collection-initializers), such as <xref:System.Collections.Generic.List%601?displayProperty=nameWithType>. Usually, this requirement means the type supports <xref:System.Collections.Generic.IEnumerable%601?displayProperty=nameWithType> and there's an accessible `Add` method to add items to the collection. There must be an implicit conversion from the collection expression elements' type to the collection's element type. For spread elements, there must be an implicit conversion from the spread element's type to the collection's element type.
 - Any of the following interfaces:
-  - <xref:System.Collections.Generic.IEnumerable%601?displayProperty=fullName>
-  - <xref:System.Collections.Generic.IReadOnlyCollection%601?displayProperty=fullName>
-  - <xref:System.Collections.Generic.IReadOnlyList%601?displayProperty=fullName>
-  - <xref:System.Collections.Generic.ICollection%601?displayProperty=fullName>
-  - <xref:System.Collections.Generic.IList%601?displayProperty=fullName>
+  - <xref:System.Collections.Generic.IEnumerable%601?displayProperty=fullName>.
+  - <xref:System.Collections.Generic.IReadOnlyCollection%601?displayProperty=fullName>.
+  - <xref:System.Collections.Generic.IReadOnlyList%601?displayProperty=fullName>.
+  - <xref:System.Collections.Generic.ICollection%601?displayProperty=fullName>.
+  - <xref:System.Collections.Generic.IList%601?displayProperty=fullName>.
 
 > [!IMPORTANT]
 > A collection expression always creates a collection that includes all elements in the collection expression, regardless of the target type of the conversion. For example, when the target of the conversion is <xref:System.Collections.Generic.IEnumerable%601?displayProperty=nameWithType>, the generated code evaluates the collection expression and stores the results in an in-memory collection.

--- a/docs/csharp/language-reference/operators/member-access-operators.md
+++ b/docs/csharp/language-reference/operators/member-access-operators.md
@@ -182,7 +182,7 @@ You also use parentheses to adjust the order in which to evaluate operations in 
 
 ## Index from end operator ^
 
-Index and range operators can be used with a type that is *Countable*. A *Countable* type is a type that has an `int` property named either `Count` or `Length` with an accessible `get` accessor. [Collection expressions](./collection-expressions.md) also rely on *Countable* types.
+Index and range operators can be used with a type that is *countable*. A *countable* type is a type that has an `int` property named either `Count` or `Length` with an accessible `get` accessor. [Collection expressions](./collection-expressions.md) also rely on *countable* types.
 
 The `^` operator indicates the element position from the end of a sequence. For a sequence of length `length`, `^n` points to the element with offset `length - n` from the start of a sequence. For example, `^1` points to the last element of a sequence and `^length` points to the first element of a sequence.
 


### PR DESCRIPTION
I'd marked the conversations on edits as "resolved" before I'd pushed my edits.

Auto-merge burned me.

These respond to the two edit requests without suggestions.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/collection-expressions.md](https://github.com/dotnet/docs/blob/aaa42327f0057ce6f224e9f4699be5fed1f8a1cb/docs/csharp/language-reference/operators/collection-expressions.md) | [Collection expressions - C# language reference](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/collection-expressions?branch=pr-en-us-39907) |
| [docs/csharp/language-reference/operators/member-access-operators.md](https://github.com/dotnet/docs/blob/aaa42327f0057ce6f224e9f4699be5fed1f8a1cb/docs/csharp/language-reference/operators/member-access-operators.md) | [Member access operators and expressions - the dot, indexer, and invocation operators.](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/member-access-operators?branch=pr-en-us-39907) |

<!-- PREVIEW-TABLE-END -->