### PR TITLE
Type.GetType breaking change

### DIFF
--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -55,6 +55,7 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 | [Method builders generate parameters with HasDefaultValue set to false](core-libraries/8.0/parameterinfo-hasdefaultvalue.md) | Behavioral change   |
 | [ProcessStartInfo.WindowStyle honored when UseShellExecute is false](core-libraries/8.0/processstartinfo-windowstyle.md) | Behavioral change    |
 | [RuntimeIdentifier returns platform for which runtime was built](core-libraries/8.0/runtimeidentifier.md) | Behavioral change   |
+| [`Type.GetType` throws exception for all invalid element types](core-libraries/8.0/type-gettype.md) | Behavioral change   |
 
 ## Cryptography
 

--- a/docs/core/compatibility/core-libraries/8.0/type-gettype.md
+++ b/docs/core/compatibility/core-libraries/8.0/type-gettype.md
@@ -1,0 +1,52 @@
+---
+title: ".NET 8 breaking change: 'Type.GetType' throws exception for all invalid element types"
+description: Learn about the .NET 8 breaking change in core .NET libraries where 'Type.GetType' throws a TypeLoadException for all invalid element types.
+ms.date: 03/12/2024
+---
+# `Type.GetType` throws exception for all invalid element types
+
+<xref:System.Type.GetType(System.String)?displayProperty=nameWithType> now throws a <xref:System.TypeLoadException> for *all* types with an invalid element type, including byref-of-byref. Previously, this method returned `null` for some corner cases.
+
+## Previous behavior
+
+<xref:System.Type.GetType(System.String)?displayProperty=nameWithType> threw a <xref:System.TypeLoadException> for most types with an invalid element type, except a few corner cases such as byref-of-byref. For example, the following code returned `null` in .NET 7:
+
+```csharp
+Type.GetType("System.Object&&")
+```
+
+## New behavior
+
+<xref:System.Type.GetType(System.String)?displayProperty=nameWithType> throws a <xref:System.TypeLoadException> for all types with an invalid element type, including byref-of-byref. For example, the following code (which returned `null` in .NET 7) throws an exception in .NET 8:
+
+```csharp
+Type.GetType("System.Object&&")
+```
+
+## Version introduced
+
+.NET 8
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+.NET had multiple type-name parsers, and it was not unusual for them to have different behavior in corner cases like this one. The behavior was unified on:
+
+- If the type with the given name is not found, return `null`.
+- If the type is invalid, throw <xref:System.TypeLoadException>. "Invalid" types include types with generic constraint violations or invalid composition of parameter types.
+
+## Recommended action
+
+If your code relied on a `null` return value for these corner cases, change it to catch a <xref:System.TypeLoadException> instead.
+
+## Affected APIs
+
+- <xref:System.Type.GetType(System.String)>
+- <xref:System.Type.GetType(System.String,System.Boolean)>
+- <xref:System.Type.GetType(System.String,System.Boolean,System.Boolean)>
+- <xref:System.Type.GetType(System.String,System.Func{System.Reflection.AssemblyName,System.Reflection.Assembly},System.Func{System.Reflection.Assembly,System.String,System.Boolean,System.Type})>
+- <xref:System.Type.GetType(System.String,System.Func{System.Reflection.AssemblyName,System.Reflection.Assembly},System.Func{System.Reflection.Assembly,System.String,System.Boolean,System.Type},System.Boolean)>
+- <xref:System.Type.GetType(System.String,System.Func{System.Reflection.AssemblyName,System.Reflection.Assembly},System.Func{System.Reflection.Assembly,System.String,System.Boolean,System.Type},System.Boolean,System.Boolean)>

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -110,6 +110,8 @@ items:
         href: core-libraries/8.0/processstartinfo-windowstyle.md
       - name: RuntimeIdentifier returns platform for which runtime was built
         href: core-libraries/8.0/runtimeidentifier.md
+      - name: Type.GetType() throws exception for all invalid element types
+        href: core-libraries/8.0/type-gettype.md
     - name: Cryptography
       items:
       - name: AesGcm authentication tag size on macOS
@@ -1192,6 +1194,8 @@ items:
         href: core-libraries/8.0/processstartinfo-windowstyle.md
       - name: RuntimeIdentifier returns platform for which runtime was built
         href: core-libraries/8.0/runtimeidentifier.md
+      - name: Type.GetType() throws exception for all invalid element types
+        href: core-libraries/8.0/type-gettype.md
     - name: .NET 7
       items:
       - name: API obsoletions with default diagnostic ID


### PR DESCRIPTION
Fixes #39594

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/8.0.md](https://github.com/dotnet/docs/blob/db8636ec775c01d1be902455c660b57533ef96e8/docs/core/compatibility/8.0.md) | [Breaking changes in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/8.0?branch=pr-en-us-39915) |
| [docs/core/compatibility/core-libraries/8.0/type-gettype.md](https://github.com/dotnet/docs/blob/db8636ec775c01d1be902455c660b57533ef96e8/docs/core/compatibility/core-libraries/8.0/type-gettype.md) | [`Type.GetType` throws exception for all invalid element types](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/8.0/type-gettype?branch=pr-en-us-39915) |

<!-- PREVIEW-TABLE-END -->