### PR TITLE
Add pr rights.

### DIFF
--- a/.github/workflows/quest.yml
+++ b/.github/workflows/quest.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      pull-requests: write
 
     steps:
       - name: "Print manual run reason"


### PR DESCRIPTION
This is an experiment. The bulk quest import is failing when run as an action on the PR query. However, when I run it locally, it runs to completion without issue.

Maybe it's the perms in the yml file?
