### PR TITLE
update labels to those that still exist

### DIFF
--- a/.github/ISSUE_TEMPLATE/04-new-feature-csharp.yml
+++ b/.github/ISSUE_TEMPLATE/04-new-feature-csharp.yml
@@ -5,7 +5,7 @@ labels:
   - ":checkered_flag: Release: .NET 9" 
   - Pri1
   - csharp-whats-new/tech
-  - dotnet-csharp/prod
+  - whats-new/subsvc
 assignees:
  - billwagner
 body:


### PR DESCRIPTION
When we changed from "prod" and "tech" to "svc" and "subsvc" we didn't update the labels in this issue template. As a result, you an't validate it.
