### PR TITLE
Fix SSN example

### DIFF
--- a/docs/fsharp/language-reference/literals.md
+++ b/docs/fsharp/language-reference/literals.md
@@ -107,5 +107,5 @@ let value = 0xDEAD_BEEF
 
 let valueAsBits = 0b1101_1110_1010_1101_1011_1110_1110_1111
 
-let exampleSSN = 123_456_7890
+let exampleSSN = 123_45_6789
 ```


### PR DESCRIPTION
SSN (Social Security Numbers) in the US are 9 digits, typically in the format of 123-45-6789 so the example was not an accurate depiction.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/literals.md](https://github.com/dotnet/docs/blob/ef51bf8de602a29bc7cbfb784f615f41aaff2882/docs/fsharp/language-reference/literals.md) | [Literals](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/literals?branch=pr-en-us-40014) |

<!-- PREVIEW-TABLE-END -->