### PR TITLE
Freshness pass on comparing strings

### DIFF
--- a/docs/csharp/how-to/compare-strings.md
+++ b/docs/csharp/how-to/compare-strings.md
@@ -1,7 +1,7 @@
 ---
 title: "How to compare strings - C# Guide"
-description: Learn how to compare and order string values, with or without case, with or without culture specific ordering
-ms.date: 02/15/2022
+description: Learn how to compare and order string values, with or without case, with or without culture specific ordering.
+ms.date: 03/15/2024
 helpviewer_keywords:
     - "strings [C#], comparison"
     - "comparing strings [C#]"
@@ -9,79 +9,61 @@ helpviewer_keywords:
 
 # How to compare strings in C\#
 
-You compare strings to answer one of two questions: "Are these two strings
-equal?" or "In what order should these strings be placed when sorting them?"
+You compare strings to answer one of two questions: "Are these two strings equal?" or "In what order should these strings be placed when sorting them?"
 
-Those two questions are complicated by factors that affect string comparisons:
+Multiple factors that affect string comparisons complicate those two questions:
 
 - You can choose an ordinal or linguistic comparison.
 - You can choose if case matters.
 - You can choose culture-specific comparisons.
 - Linguistic comparisons are culture and platform-dependent.
+
+The <xref:System.StringComparison?displayProperty=fullName> enumeration fields represent these choices:
+
+- **CurrentCulture**: Compare strings using culture-sensitive sort rules and the current culture.
+- **CurrentCultureIgnoreCase**: Compare strings using culture-sensitive sort rules, the current culture, and ignoring the case of the strings being compared.
+- **InvariantCulture**: Compare strings using culture-sensitive sort rules and the invariant culture.
+- **InvariantCultureIgnoreCase**: Compare strings using culture-sensitive sort rules, the invariant culture, and ignoring the case of the strings being compared.
+- **Ordinal**: Compare strings using ordinal (binary) sort rules.
+- **OrdinalIgnoreCase**: Compare strings using ordinal (binary) sort rules and ignoring the case of the strings being compared.
+
 [!INCLUDE[interactive-note](~/includes/csharp-interactive-note.md)]
 
-When you compare strings, you define an order among them. Comparisons are
-used to sort a sequence of strings. Once the sequence is in a known order,
-it is easier to search, both for software and for humans. Other comparisons
-may check if strings are the same. These sameness checks are similar to
-equality, but some differences, such as case differences, may be ignored.
+When you compare strings, you define an order among them. Comparisons are used to sort a sequence of strings. Once the sequence is in a known order, it's easier to search, both for software and for humans. Other comparisons might check if strings are the same. These sameness checks are similar to equality, but some differences, such as case differences, might be ignored.
 
 ## Default ordinal comparisons
 
 By default, the most common operations:
 
 - <xref:System.String.Equals%2A?displayProperty=nameWithType>
-- <xref:System.String.op_Equality%2A?displayProperty=nameWithType> and <xref:System.String.op_Inequality%2A?displayProperty=nameWithType>, that is, [equality operators `==` and `!=`](../language-reference/operators/equality-operators.md#string-equality), respectively
-
-perform a case-sensitive, ordinal comparison. In the case of <xref:System.String.Equals%2A?displayProperty=nameWithType>, a <xref:System.StringComparison> argument can be provided to alter its sorting rules. The following example demonstrates that:
+- <xref:System.String.op_Equality%2A?displayProperty=nameWithType> and <xref:System.String.op_Inequality%2A?displayProperty=nameWithType>, that is, [equality operators `==` and `!=`](../language-reference/operators/equality-operators.md#string-equality), respectively perform a case-sensitive, ordinal comparison. <xref:System.String.Equals%2A?displayProperty=nameWithType> has an overload where a <xref:System.StringComparison> argument can be provided to alter its sorting rules. The following example demonstrates that:
 
 :::code language="csharp" interactive="try-dotnet-method" source="../../../samples/snippets/csharp/how-to/strings/CompareStrings.cs" id="Snippet1":::
 
 The default ordinal comparison doesn't take linguistic rules into account when comparing strings. It compares the binary value of each <xref:System.Char> object in two strings. As a result, the default ordinal comparison is also case-sensitive.
 
-The test for equality with <xref:System.String.Equals%2A?displayProperty=nameWithType> and the `==` and `!=` operators differs from string comparison using the <xref:System.String.CompareTo%2A?displayProperty=nameWithType> and <xref:System.String.Compare(System.String,System.String)?displayProperty=nameWithType)> methods. They all perform a case-sensitive comparison. However, while the tests for equality perform an ordinal comparison, the `CompareTo` and `Compare` methods perform a culture-aware linguistic comparison using the current culture. Because these default comparison methods differ in the ways they compare strings, we recommend that you always make the intent of your code clear by calling an overload that explicitly specifies the type of comparison to perform.
+The test for equality with <xref:System.String.Equals%2A?displayProperty=nameWithType> and the `==` and `!=` operators differs from string comparison using the <xref:System.String.CompareTo%2A?displayProperty=nameWithType> and <xref:System.String.Compare(System.String,System.String)?displayProperty=nameWithType)> methods. They all perform a case-sensitive comparison. However, while the tests for equality perform an ordinal comparison, the `CompareTo` and `Compare` methods perform a culture-aware linguistic comparison using the current culture. Make the intent of your code clear by calling an overload that explicitly specifies the type of comparison to perform.
 
 ## Case-insensitive ordinal comparisons
 
-The <xref:System.String.Equals(System.String,System.StringComparison)?displayProperty=nameWithType> method
-enables you to specify a <xref:System.StringComparison> value of
-<xref:System.StringComparison.OrdinalIgnoreCase?displayProperty=nameWithType>
-for a case-insensitive ordinal comparison. There is also a static
-<xref:System.String.Compare(System.String,System.String,System.StringComparison)?displayProperty=nameWithType> method that performs a case-insensitive ordinal comparison if you specify a value of <xref:System.StringComparison.OrdinalIgnoreCase?displayProperty=nameWithType> for the <xref:System.StringComparison> argument. These are shown in the following code:
+The <xref:System.String.Equals(System.String,System.StringComparison)?displayProperty=nameWithType> method enables you to specify a <xref:System.StringComparison> value of
+<xref:System.StringComparison.OrdinalIgnoreCase?displayProperty=nameWithType> for a case-insensitive ordinal comparison. There's also a static <xref:System.String.Compare(System.String,System.String,System.StringComparison)?displayProperty=nameWithType> method that performs a case-insensitive ordinal comparison if you specify a value of <xref:System.StringComparison.OrdinalIgnoreCase?displayProperty=nameWithType> for the <xref:System.StringComparison> argument. These comparisons are shown in the following code:
 
 :::code language="csharp" interactive="try-dotnet-method" source="../../../samples/snippets/csharp/how-to/strings/CompareStrings.cs" id="Snippet2":::
 
-When performing a case-insensitive ordinal comparison, these methods use the casing conventions of the [invariant culture](xref:System.Globalization.CultureInfo.InvariantCulture).
+These methods use the casing conventions of the [invariant culture](xref:System.Globalization.CultureInfo.InvariantCulture) when performing a case-insensitive ordinal comparison.
 
 ## Linguistic comparisons
 
-Many string comparison methods (such as <xref:System.String.StartsWith%2A?displayProperty=nameWithType>) use linguistic rules for the _current culture_ by default to order their inputs.
-This is sometimes referred to as "word sort order." When you perform a
-linguistic comparison, some nonalphanumeric Unicode characters might have
-special weights assigned. For example, the hyphen "-" may have a small
-weight assigned to it so that "co-op" and "coop" appear next to each other
-in sort order, while some non-printing control characters might be completely ignored.
-In addition, some Unicode characters may be equivalent to a
-sequence of <xref:System.Char> instances. The following example uses the phrase
-"They dance in the street." in German with the "ss" (U+0073 U+0073) in one string and 'ß' (U+00DF) in another. Linguistically
-(in Windows), "ss" is equal to the German Esszet: 'ß' character in both the "en-US"
-and "de-DE" cultures.
+Many string comparison methods (such as <xref:System.String.StartsWith%2A?displayProperty=nameWithType>) use linguistic rules for the _current culture_ by default to order their inputs. This linguistic comparison is sometimes referred to as "word sort order." When you perform a linguistic comparison, some nonalphanumeric Unicode characters might have special weights assigned. For example, the hyphen "-" might have a small weight assigned to it so that "co-op" and "coop" appear next to each other in sort order. Some nonprinting control characters might be ignored. In addition, some Unicode characters might be equivalent to a sequence of <xref:System.Char> instances. The following example uses the phrase "They dance in the street." in German with the "ss" (U+0073 U+0073) in one string and 'ß' (U+00DF) in another. Linguistically (in Windows), "ss" is equal to the German Esszet: 'ß' character in both the "en-US" and "de-DE" cultures.
 
 :::code language="csharp" interactive="try-dotnet-method" source="../../../samples/snippets/csharp/how-to/strings/CompareStrings.cs" id="Snippet3":::
 
-On Windows, prior to .NET 5, the sort order of "cop", "coop", and "co-op" changes when you
-change from a linguistic comparison to an ordinal comparison. The two
-German sentences also compare differently using the different comparison types.
-This is because prior to .NET 5, the .NET globalization APIs used [National Language Support (NLS)](/windows/win32/intl/national-language-support) libraries. In .NET 5 and later versions, the .NET globalization APIs use [International Components for Unicode (ICU)](https://icu.unicode.org/) libraries, which unifies .NET's globalization behavior across all supported operating systems.
+On Windows, prior to .NET 5, the sort order of "cop", "coop", and "co-op" changes when you change from a linguistic comparison to an ordinal comparison. The two German sentences also compare differently using the different comparison types. Prior to .NET 5, the .NET globalization APIs used [National Language Support (NLS)](/windows/win32/intl/national-language-support) libraries. In .NET 5 and later versions, the .NET globalization APIs use [International Components for Unicode (ICU)](https://icu.unicode.org/) libraries, which unifies .NET's globalization behavior across all supported operating systems.
 
 ## Comparisons using specific cultures
 
-This sample stores <xref:System.Globalization.CultureInfo> objects for the en-US and de-DE cultures.
-The comparisons are performed using a <xref:System.Globalization.CultureInfo> object to ensure a culture-specific comparison.
-
-The culture used affects linguistic comparisons. The following example
-shows the results of comparing the two German sentences using the "en-US" culture
-and the "de-DE" culture:
+The following example stores <xref:System.Globalization.CultureInfo> objects for the en-US and de-DE cultures. The comparisons are performed using a <xref:System.Globalization.CultureInfo> object to ensure a culture-specific comparison. The culture used affects linguistic comparisons. The following example shows the results of comparing the two German sentences using the "en-US" culture and the "de-DE" culture:
 
 :::code language="csharp" interactive="try-dotnet-method" source="../../../samples/snippets/csharp/how-to/strings/CompareStrings.cs" id="Snippet4":::
 
@@ -91,7 +73,7 @@ Culture-sensitive comparisons are typically used to compare and sort strings inp
 
 The following examples show how to sort and search for strings in an array using a linguistic comparison dependent on the current culture. You use the static <xref:System.Array> methods that take a <xref:System.StringComparer?displayProperty=nameWithType> parameter.
 
-This example shows how to sort an array of strings using the current culture:
+The following example shows how to sort an array of strings using the current culture:
 
 :::code language="csharp" interactive="try-dotnet-method" source="../../../samples/snippets/csharp/how-to/strings/CompareStrings.cs" id="Snippet5":::
 

--- a/docs/csharp/how-to/compare-strings.md
+++ b/docs/csharp/how-to/compare-strings.md
@@ -11,7 +11,7 @@ helpviewer_keywords:
 
 You compare strings to answer one of two questions: "Are these two strings equal?" or "In what order should these strings be placed when sorting them?"
 
-Multiple factors that affect string comparisons complicate those two questions:
+Those two questions are complicated by factors that affect string comparisons:
 
 - You can choose an ordinal or linguistic comparison.
 - You can choose if case matters.


### PR DESCRIPTION
Fixes #32071:  Add a quick table with the string comparison enums.

Do an edit pass, and check for accuracy.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/how-to/compare-strings.md](https://github.com/dotnet/docs/blob/3258eb358d22891f1b0877327724db6b07e9fba8/docs/csharp/how-to/compare-strings.md) | [How to compare strings in C\#](https://review.learn.microsoft.com/en-us/dotnet/csharp/how-to/compare-strings?branch=pr-en-us-40030) |


<!-- PREVIEW-TABLE-END -->