### PR TITLE
XmlNamespacesMap breaking change

### DIFF
--- a/docs/core/compatibility/9.0.md
+++ b/docs/core/compatibility/9.0.md
@@ -46,3 +46,9 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 | [ComponentDesigner.Initialize throws ArgumentNullException](windows-forms/9.0/componentdesigner-initialize.md) | Behavioral change | Preview 1          |
 | [DataGridViewRowAccessibleObject.Name starting row index](windows-forms/9.0/datagridviewrowaccessibleobject-name-row.md) | Behavioral change | Preview 1 |
 | [No exception if DataGridView is null](windows-forms/9.0/datagridviewheadercell-nre.md) | Behavioral change   | Preview 1          |
+
+## WPF
+
+| Title                                                                                   | Type of change      | Introduced version |
+|-----------------------------------------------------------------------------------------|---------------------|--------------------|
+| [`GetXmlNamespaceMaps` type change](wpf/9.0/xml-namespace-maps.md) | Behavioral change/Source incompatible | Preview 3 |

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -40,6 +40,10 @@ items:
         href: windows-forms/9.0/datagridviewrowaccessibleobject-name-row.md
       - name: No exception if DataGridView is null
         href: windows-forms/9.0/datagridviewheadercell-nre.md
+    - name: WPF
+      items:
+      - name: "'GetXmlNamespaceMaps' type change"
+        href: wpf/9.0/xml-namespace-maps.md
   - name: .NET 8
     items:
     - name: Overview
@@ -1870,6 +1874,10 @@ items:
         href: winforms.md
   - name: WPF
     items:
+    - name: .NET 9
+      items:
+      - name: "'GetXmlNamespaceMaps' type change"
+        href: wpf/9.0/xml-namespace-maps.md
     - name: .NET 5
       items:
       - name: OutputType set to WinExe

--- a/docs/core/compatibility/wpf/9.0/xml-namespace-maps.md
+++ b/docs/core/compatibility/wpf/9.0/xml-namespace-maps.md
@@ -1,0 +1,39 @@
+---
+title: "Breaking change: 'GetXmlNamespaceMaps' type change"
+description: Learn about the breaking change in .NET 9 for WPF where the backing property of 'XmlNamespaceMaps' has been changed from 'String' to 'Hashtable'.
+ms.date: 03/15/2024
+---
+# `GetXmlNamespaceMaps` type change
+
+The backing property of <xref:System.Windows.Markup.XmlAttributeProperties.XmlNamespaceMaps?displayProperty=nameWithType> has been changed from <xref:System.String> to <xref:System.Collections.Hashtable>.
+
+## Version introduced
+
+.NET 9 Preview 3
+
+## Previous behavior
+
+Previously, the backing property of <xref:System.Windows.Markup.XmlAttributeProperties.XmlNamespaceMaps> was <xref:System.String>. However, the value returned by `dependencyObject.GetValue(XmlNamespaceMapsProperty)` is of type <xref:System.Collections.Hashtable> and the <xref:System.Windows.Markup.XmlAttributeProperties.GetXmlNamespaceMaps(System.Windows.DependencyObject)> implementation tried to type cast it to <xref:System.String>, which resulted in an <xref:System.InvalidCastException>.
+
+In addition, the <xref:System.Windows.Markup.XmlAttributeProperties.SetXmlNamespaceMaps(System.Windows.DependencyObject,System.String)> method accepted a <xref:System.String> argument.
+
+## New behavior
+
+Starting in .NET 9, the backing property of <xref:System.Windows.Markup.XmlAttributeProperties.XmlNamespaceMaps> is <xref:System.Collections.Hashtable>, and the <xref:System.InvalidCastException> is no longer thrown by <xref:System.Windows.Markup.XmlAttributeProperties.GetXmlNamespaceMaps(System.Windows.DependencyObject)>.
+
+In addition, the <xref:System.Windows.Markup.XmlAttributeProperties.SetXmlNamespaceMaps(System.Windows.DependencyObject,System.Collections.Hashtable)> method now accepts a <xref:System.Collections.Hashtable> argument.
+
+## Change category
+
+This change is a [*behavioral change*](../../categories.md#behavioral-change) and can also affect [*source compatibility*](../../categories.md#source-compatibility).
+
+## Reason for change
+
+## Recommended action
+
+Pass `Hashtable` instead of a string to the <xref:System.Windows.Markup.XmlAttributeProperties.SetXmlNamespaceMaps%2A> API.
+
+## Affected APIs
+
+- <xref:System.Windows.Markup.XmlAttributeProperties.GetXmlNamespaceMaps(System.Windows.DependencyObject)?displayProperty=fullName>
+- <xref:System.Windows.Markup.XmlAttributeProperties.SetXmlNamespaceMaps%2A?displayProperty=fullName>

--- a/docs/core/compatibility/wpf/9.0/xml-namespace-maps.md
+++ b/docs/core/compatibility/wpf/9.0/xml-namespace-maps.md
@@ -29,6 +29,8 @@ This change is a [*behavioral change*](../../categories.md#behavioral-change) an
 
 ## Reason for change
 
+This change was made to prevent the <xref:System.InvalidCastException> from being thrown.
+
 ## Recommended action
 
 Pass `Hashtable` instead of a string to the <xref:System.Windows.Markup.XmlAttributeProperties.SetXmlNamespaceMaps%2A> API.


### PR DESCRIPTION
Fixes #39750

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/9.0.md](https://github.com/dotnet/docs/blob/7c43eae97f44ffdc9c331f7a71db61c40599ad0b/docs/core/compatibility/9.0.md) | [Breaking changes in .NET 9](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/9.0?branch=pr-en-us-40034) |
| [docs/core/compatibility/wpf/9.0/xml-namespace-maps.md](https://github.com/dotnet/docs/blob/7c43eae97f44ffdc9c331f7a71db61c40599ad0b/docs/core/compatibility/wpf/9.0/xml-namespace-maps.md) | [`GetXmlNamespaceMaps` type change](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/wpf/9.0/xml-namespace-maps?branch=pr-en-us-40034) |

<!-- PREVIEW-TABLE-END -->