### PR TITLE
Fix access modifier of Grain.RegisterTimer method

### DIFF
--- a/docs/orleans/grains/timers-and-reminders.md
+++ b/docs/orleans/grains/timers-and-reminders.md
@@ -19,7 +19,7 @@ Each activation may have zero or more timers associated with it. The runtime exe
 To start a timer, use the <xref:Orleans.Grain.RegisterTimer%2A?displayProperty=nameWithType> method, which returns an <xref:System.IDisposable> reference:
 
 ```csharp
-public IDisposable RegisterTimer(
+protected IDisposable RegisterTimer(
     Func<object, Task> asyncCallback, // function invoked when the timer ticks
     object state,                     // object to pass to asyncCallback
     TimeSpan dueTime,                 // time to wait before the first timer tick


### PR DESCRIPTION
This method is protected, not public.

# Relevant links
- https://learn.microsoft.com/en-us/dotnet/api/orleans.grain.registertimer?view=orleans-7.0


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/grains/timers-and-reminders.md](https://github.com/dotnet/docs/blob/af495112083370b2986c773423168cabd761826a/docs/orleans/grains/timers-and-reminders.md) | [Timers and reminders](https://review.learn.microsoft.com/en-us/dotnet/orleans/grains/timers-and-reminders?branch=pr-en-us-40047) |


<!-- PREVIEW-TABLE-END -->