### PR TITLE
Update info about uninstall tool

### DIFF
--- a/docs/core/additional-tools/uninstall-tool.md
+++ b/docs/core/additional-tools/uninstall-tool.md
@@ -18,7 +18,10 @@ On Windows, the tool can only uninstall SDKs and runtimes that were installed us
 
 On macOS, the tool can only uninstall SDKs and runtimes located in the */usr/local/share/dotnet* folder.
 
-Because of these limitations, the tool might not be able to uninstall all of the .NET SDKs and runtimes on your machine. You can use the `dotnet --info` command to find all of the .NET SDKs and runtimes installed, including those SDKs and runtimes that the tool can't remove. The `dotnet-core-uninstall list` command displays which SDKs can be uninstalled with the tool. Versions 1.2 and later can uninstall SDKs and runtimes with version 5.0 or earlier, and previous versions of the tool can uninstall 3.1 and earlier.
+Because of these limitations, the tool might not be able to uninstall all of the .NET SDKs and runtimes on your machine. You can use the `dotnet --info` command to find all of the .NET SDKs and runtimes installed, including those SDKs and runtimes that the tool can't remove. The `dotnet-core-uninstall list` command displays which SDKs can be uninstalled with the tool.
+
+> [!NOTE]
+> Currently, the .NET Uninstall Tool doesn't support .NET 8+. For more information about the release schedule of the tool, see [GitHub - dotnet-uninstall-tool Roadmap](https://github.com/dotnet/cli-lab/issues/279).
 
 ## Install the tool
 
@@ -53,7 +56,7 @@ For more information, see [`dry-run` and `whatif` commands](#dry-run-and-whatif-
 
 ### Step 3 - Uninstall .NET SDKs and Runtimes
 
-`dotnet-core-uninstall remove` uninstalls .NET SDKs and Runtimes that are specified by a collection of options. Versions 1.2 and later can uninstall SDKs and runtimes with version 5.0 or earlier, and previous versions of the tool can uninstall 3.1 and earlier.
+`dotnet-core-uninstall remove` uninstalls .NET SDKs and Runtimes that are specified by a collection of options.
 
 Since this tool has a destructive behavior, it's **highly** recommended that you do a dry run before running the remove command. The dry run will show you what .NET SDKs and runtimes will be removed when you use the `remove` command. Refer to [Should I remove a version?](../install/remove-runtime-sdk-versions.md#should-i-remove-a-version) to learn which SDKs and runtimes are safe to remove.
 

--- a/docs/core/install/remove-runtime-sdk-versions.md
+++ b/docs/core/install/remove-runtime-sdk-versions.md
@@ -60,7 +60,7 @@ If you installed .NET using a package manager, use that same package manager to 
 
 In almost all cases, the command to remove a package is `remove`.
 
-The package name for the .NET SDK installation for most package managers is `dotnet-sdk`, followed by the version number. Starting with the version 2.1.300 of the .NET SDK and version `2.1` of the runtime, only the major and minor version numbers are necessary: for example, the .NET SDK version 2.1.300 can be referenced as the package `dotnet-sdk-2.1`. Prior versions require the entire version string: for example, `dotnet-sdk-2.1.200` would be required for version 2.1.200 of the .NET SDK.
+The package name for the .NET SDK installation for most package managers is `dotnet-sdk`, followed by the version number. Only the major and minor version numbers are necessary: for example, the .NET SDK version 8.0.200 can be referenced as the package `dotnet-sdk-8.0`.
 
 For machines that have installed only the runtime, and not the SDK, the package name is `dotnet-runtime-<version>` for the .NET runtime, and `aspnetcore-runtime-<version>` for the entire runtime stack.
 
@@ -142,6 +142,9 @@ sudo rm -rf /usr/local/share/dotnet/sdk/6.0.406
 ## .NET Uninstall Tool
 
 The [.NET Uninstall Tool](../additional-tools/uninstall-tool.md) (`dotnet-core-uninstall`) lets you remove .NET SDKs and runtimes from a system. A collection of options is available to specify which versions should be uninstalled.
+
+> [!NOTE]
+> Currently, the .NET Uninstall Tool doesn't support .NET 8+. For more information about the release schedule of the tool, see [GitHub - dotnet-uninstall-tool Roadmap](https://github.com/dotnet/cli-lab/issues/279).
 
 ::: zone pivot="os-windows"
 


### PR DESCRIPTION
## Summary

- Add note that the uninstall tool doesn't support .NET 8+
- Add link to roadmap of tool
- Remove some information about SDK versioning prior to .NET Core 2.1.

Fixes #39400

@tdykstra 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/additional-tools/uninstall-tool.md](https://github.com/dotnet/docs/blob/c962bb98e5a774f92317d455cd9389045dd07f79/docs/core/additional-tools/uninstall-tool.md) | [.NET uninstall tool](https://review.learn.microsoft.com/en-us/dotnet/core/additional-tools/uninstall-tool?branch=pr-en-us-40055) |
| [docs/core/install/remove-runtime-sdk-versions.md](https://github.com/dotnet/docs/blob/c962bb98e5a774f92317d455cd9389045dd07f79/docs/core/install/remove-runtime-sdk-versions.md) | [How to remove the .NET Runtime and SDK](https://review.learn.microsoft.com/en-us/dotnet/core/install/remove-runtime-sdk-versions?branch=pr-en-us-40055) |

<!-- PREVIEW-TABLE-END -->