### PR TITLE
Mention character literals as source of CS1009 error

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs1009.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1009.md
@@ -22,10 +22,18 @@ class MyClass
 {  
    static void Main()  
    {  
-      // The following line causes CS1009.  
+      // The following escape sequence causes CS1009:  
       string a = "\m";
       // Try the following line instead.  
       // string a = "\t";  
+
+      // The following character literals causes CS1009:
+      // CS1009; a lowercase \u-style Unicode escape sequence must have exactly 4 hex digits
+      string unicodeEscapeSequence = '\u061';
+      // CS1009; a hex escape sequence must start with lowercase \x
+      string hexEscapeSequence = '\X061';
+      // CS1009; an uppercase \U-style Unicode escape sequence *must* have *exactly* 8 hex digits
+      string uppercaseUnicodeEscape = '\U0061';
    }  
 }  
 ```  

--- a/docs/csharp/language-reference/compiler-messages/cs1009.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1009.md
@@ -12,7 +12,7 @@ ms.assetid: 348f500c-0e4f-44d7-95a8-e215ac49940a
 
 Unrecognized escape sequence  
   
- An unexpected character follows a backslash (\\) in a [string](../builtin-types/reference-types.md#the-string-type). The compiler expects one of the valid escape characters. For more information, see [Character Escapes](../../../standard/base-types/character-escapes-in-regular-expressions.md).  
+ An unexpected character follows a backslash (\\) in a [string](../builtin-types/reference-types.md#the-string-type) of an [escape sequence](../../programming-guide/strings/index.md#string-escape-sequences) or character literal. The compiler expects one of the valid escape characters. For more information, see [Character Escapes](../../../standard/base-types/character-escapes-in-regular-expressions.md).  
   
  The following sample generates CS1009.  
   

--- a/docs/csharp/language-reference/compiler-messages/cs1009.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1009.md
@@ -32,7 +32,7 @@ class MyClass
       string unicodeEscapeSequence = '\u061';
       // CS1009; a hex escape sequence must start with lowercase \x
       string hexEscapeSequence = '\X061';
-      // CS1009; an uppercase \U-style Unicode escape sequence *must* have *exactly* 8 hex digits
+      // CS1009; an uppercase \U-style Unicode escape sequence must have exactly 8 hex digits
       string uppercaseUnicodeEscape = '\U0061';
    }  
 }  


### PR DESCRIPTION
This pull request closes #39301 
It adds character literals along with escape sequences to the description of `CS1009` error.
Also, some examples taken directly from the original issue are added to the failing code to illustrate the mistakes in formatting the character literals.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-messages/cs1009.md](https://github.com/dotnet/docs/blob/c40b2178d71cdabe70986f05cb32f923ee3b3185/docs/csharp/language-reference/compiler-messages/cs1009.md) | [Compiler Error CS1009](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs1009?branch=pr-en-us-40056) |


<!-- PREVIEW-TABLE-END -->