### PR TITLE
Add clarification for partial read breaking change

### DIFF
--- a/docs/core/compatibility/core-libraries/6.0/partial-byte-reads-in-streams.md
+++ b/docs/core/compatibility/core-libraries/6.0/partial-byte-reads-in-streams.md
@@ -5,9 +5,9 @@ ms.date: 03/18/2024
 ---
 # Partial and zero-byte reads in DeflateStream, GZipStream, and CryptoStream
 
-The `Read()` and `ReadAsync()` methods on <xref:System.IO.Compression.DeflateStream>, <xref:System.IO.Compression.GZipStream>, and <xref:System.Security.Cryptography.CryptoStream> might no longer return all the requested bytes.
+The `Read()` and `ReadAsync()` methods on <xref:System.IO.Compression.DeflateStream>, <xref:System.IO.Compression.GZipStream>, and <xref:System.Security.Cryptography.CryptoStream> might no longer return as many bytes as were requested.
 
-<xref:System.IO.Compression.DeflateStream>, <xref:System.IO.Compression.GZipStream>, and <xref:System.Security.Cryptography.CryptoStream> diverged from typical <xref:System.IO.Stream.Read%2A?displayProperty=nameWithType> and <xref:System.IO.Stream.ReadAsync%2A?displayProperty=nameWithType> behavior in two ways:
+Previously, <xref:System.IO.Compression.DeflateStream>, <xref:System.IO.Compression.GZipStream>, and <xref:System.Security.Cryptography.CryptoStream> diverged from typical <xref:System.IO.Stream.Read%2A?displayProperty=nameWithType> and <xref:System.IO.Stream.ReadAsync%2A?displayProperty=nameWithType> behavior in two ways:
 
 - They didn't complete the read operation until either the buffer passed to the read operation was completely filled or the end of the stream was reached.
 - As wrapper streams, they didn't delegate zero-length buffer functionality to the stream they wrap.
@@ -19,7 +19,7 @@ This change addresses both of these issues.
 When `Stream.Read` or `Stream.ReadAsync` was called on one of the affected stream types with a buffer of length `N`, the operation wouldn't complete until:
 
 - `N` bytes had been read from the stream, or
-- The underlying stream they wrap returned 0 from a call to its read, indicating no more data is available.
+- The underlying stream they wrap returned 0 from a call to its read, indicating no more data was available.
 
 Also, when `Stream.Read` or `Stream.ReadAsync` was called with a buffer of length 0, the operation would succeed immediately, sometimes without doing a zero-length read on the stream it wraps.
 
@@ -32,19 +32,50 @@ Starting in .NET 6, when `Stream.Read` or `Stream.ReadAsync` is called on one of
 
 Also, when `Stream.Read` or `Stream.ReadAsync` is called with a buffer of length 0, the operation succeeds once a call with a nonzero buffer would succeed.
 
-For example, the following call to <xref:System.IO.Compression.GZipStream.Read%2A?displayProperty=nameWithType> doesn't read all of the compressed text for very long strings.
+When you call one of the affected `Read` methods, if the read can satisfy at least one byte of the request, regardless of how many were requested, *it returns as many as it can at that moment*.
 
-```csharp
-var gZipBuffer = Convert.FromBase64String(compressedText);
-using var memoryStream = new MemoryStream();
-int dataLength = BitConverter.ToInt32(gZipBuffer, 0);
-memoryStream.Write(gZipBuffer, 4, gZipBuffer.Length - 4);
-var buffer = new byte[dataLength];
-memoryStream.Position = 0;
-using (var stream = new GZipStream(memoryStream, CompressionMode.Decompress))
-{
-    stream.Read(buffer, 0, buffer.Length);
-}
+Consider this example that creates and compresses 150 random bytes. It then sends the compressed data one byte at a time from the client to the server, and the server decompresses the data by calling `Read` and requesting all 150 bytes.
+
+:::code language="csharp" source="./snippets/ReadStream.cs":::
+
+In previous versions of .NET and .NET Framework, this code would output the following output. Even though data is available for `GZipStream` to return, `Read` is forced to wait until the requested number of bytes is available, and so it's only called once.
+
+```output
+Read: 150 bytes
+Total received: 150 bytes
+```
+
+In .NET 6 and later versions, the output is similar to the following output, which shows that `Read` was called multiple times until *all* the requested data was received. Even though the call to `Read` requests 150 bytes, each call to `Read` was able to successfully decompress *some* bytes (that is, all of the bytes that had been received at that time) to return, and it did:
+
+```output
+Read: 1 bytes
+Read: 101 bytes
+Read: 4 bytes
+Read: 4 bytes
+Read: 2 bytes
+Read: 2 bytes
+Read: 2 bytes
+Read: 2 bytes
+Read: 3 bytes
+Read: 2 bytes
+Read: 3 bytes
+Read: 2 bytes
+Read: 2 bytes
+Read: 2 bytes
+Read: 2 bytes
+Read: 1 bytes
+Read: 2 bytes
+Read: 1 bytes
+Read: 1 bytes
+Read: 1 bytes
+Read: 2 bytes
+Read: 1 bytes
+Read: 1 bytes
+Read: 2 bytes
+Read: 1 bytes
+Read: 1 bytes
+Read: 2 bytes
+Total received: 150 bytes
 ```
 
 ## Version introduced
@@ -67,7 +98,7 @@ In general, code should:
   int totalRead = 0;
   while (totalRead < buffer.Length)
   {
-      int bytesRead = stream.Read(buffer, totalRead, buffer.Length - totalRead);
+      int bytesRead = stream.Read(buffer.AsSpan(totalRead));
       if (bytesRead == 0) break;
       totalRead += bytesRead;
   }

--- a/docs/core/compatibility/core-libraries/6.0/partial-byte-reads-in-streams.md
+++ b/docs/core/compatibility/core-libraries/6.0/partial-byte-reads-in-streams.md
@@ -16,7 +16,7 @@ This change addresses both of these issues.
 
 ## Old behavior
 
-When `Stream.Read` or `Stream.ReadAsync` was called on one of the affected stream types with a buffer of length `N`, the operation would not complete until:
+When `Stream.Read` or `Stream.ReadAsync` was called on one of the affected stream types with a buffer of length `N`, the operation wouldn't complete until:
 
 - `N` bytes had been read from the stream, or
 - The underlying stream they wrap returned 0 from a call to its read, indicating no more data is available.
@@ -27,12 +27,12 @@ Also, when `Stream.Read` or `Stream.ReadAsync` was called with a buffer of lengt
 
 Starting in .NET 6, when `Stream.Read` or `Stream.ReadAsync` is called on one of the affected stream types with a buffer of length `N`, the operation completes when:
 
-- At least one byte has been read from the stream, or
+- At least 1 byte has been read from the stream, or
 - The underlying stream they wrap returns 0 from a call to its read, indicating no more data is available.
 
-Also, when `Stream.Read` or `Stream.ReadAsync` is called with a buffer of length 0, the operation succeeds once a call with a non-zero buffer would succeed.
+Also, when `Stream.Read` or `Stream.ReadAsync` is called with a buffer of length 0, the operation succeeds once a call with a nonzero buffer would succeed.
 
-For example, the following call to <xref:System.IO.Compression.GZipStream.Read%2A?displayProperty=nameWithType> does not read all of the compressed text for very long strings.
+For example, the following call to <xref:System.IO.Compression.GZipStream.Read%2A?displayProperty=nameWithType> doesn't read all of the compressed text for very long strings.
 
 ```csharp
 var gZipBuffer = Convert.FromBase64String(compressedText);
@@ -53,7 +53,7 @@ using (var stream = new GZipStream(memoryStream, CompressionMode.Decompress))
 
 ## Reason for change
 
-The streams might not have returned from a read operation even if data had been successfully read. This meant they couldn't readily be used in any bidirectional communication situation where messages smaller than the buffer size were being used. This could lead to deadlocks: the application is unable to read the data from the stream that's necessary to continue the operation. It could also lead to arbitrary slowdowns, with the consumer unable to process available data while waiting for additional data to arrive.
+The streams might not have returned from a read operation even if data had been successfully read. This meant they couldn't readily be used in any bidirectional communication situation where messages smaller than the buffer size were being used. This could lead to deadlocks: the application is unable to read the data from the stream that's necessary to continue the operation. It could also lead to arbitrary slowdowns, with the consumer unable to process available data while waiting for more data to arrive.
 
 Also, in highly scalable applications, it's common to use zero-byte reads as a way of delaying buffer allocation until a buffer is needed. An application can issue a read with an empty buffer, and when that read completes, data should soon be available to consume. The application can then issue the read again, this time with a buffer to receive the data. By delegating to the wrapped stream if no already decompressed or transformed data is available, these streams now inherit any such behavior of the streams they wrap.
 
@@ -61,7 +61,7 @@ Also, in highly scalable applications, it's common to use zero-byte reads as a w
 
 In general, code should:
 
-- Not make any assumptions about a stream `Read` or `ReadAsync` operation reading as much as was requested. The call returns the number of bytes read, which may be less than what was requested. If an application depends on the buffer being completely filled before progressing, it can perform the read in a loop to regain the behavior.
+- Not make any assumptions about a stream `Read` or `ReadAsync` operation reading as much as was requested. The call returns the number of bytes read, which might be less than what was requested. If an application depends on the buffer being completely filled before progressing, it can perform the read in a loop to regain the behavior.
 
   ```csharp
   int totalRead = 0;

--- a/docs/core/compatibility/core-libraries/6.0/partial-byte-reads-in-streams.md
+++ b/docs/core/compatibility/core-libraries/6.0/partial-byte-reads-in-streams.md
@@ -67,7 +67,7 @@ In general, code should:
   int totalRead = 0;
   while (totalRead < buffer.Length)
   {
-      int bytesRead = stream.Read(buffer.Slice(totalRead));
+      int bytesRead = stream.Read(buffer, totalRead, buffer.Length - totalRead);
       if (bytesRead == 0) break;
       totalRead += bytesRead;
   }

--- a/docs/core/compatibility/core-libraries/6.0/snippets/ReadStream.cs
+++ b/docs/core/compatibility/core-libraries/6.0/snippets/ReadStream.cs
@@ -1,0 +1,58 @@
+﻿using System.IO.Compression;
+using System.Net;
+using System.Net.Sockets;
+
+internal class Program
+{
+    private static async Task Main()
+    {
+        // Connect two sockets and wrap a stream around each.
+        using (Socket listener = new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+        using (Socket client = new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+        {
+            listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            listener.Listen(int.MaxValue);
+            client.Connect(listener.LocalEndPoint!);
+            using (Socket server = listener.Accept())
+            {
+                var clientStream = new NetworkStream(client, ownsSocket: true);
+                var serverStream = new NetworkStream(server, ownsSocket: true);
+
+                // Create some compressed data.
+                var compressedData = new MemoryStream();
+                using (var gz = new GZipStream(compressedData, CompressionLevel.Fastest, leaveOpen: true))
+                {
+                    byte[] bytes = new byte[150];
+                    new Random().NextBytes(bytes);
+                    gz.Write(bytes, 0, bytes.Length);
+                }
+
+                // Trickle it from the client stream to the server.
+                Task sendTask = Task.Run(() =>
+                {
+                    foreach (byte b in compressedData.ToArray())
+                    {
+                        clientStream.WriteByte(b);
+                    }
+                    clientStream.Dispose();
+                });
+
+                // Read and decompress all the sent bytes.
+                byte[] buffer = new byte[150];
+                int total = 0;
+                using (var gz = new GZipStream(serverStream, CompressionMode.Decompress))
+                {
+                    int numRead = 0;
+                    while ((numRead = gz.Read(buffer.AsSpan(numRead))) > 0)
+                    {
+                        total += numRead;
+                        Console.WriteLine($"Read: {numRead} bytes");
+                    }
+                }
+                Console.WriteLine($"Total received: {total} bytes");
+
+                await sendTask;
+            }
+        }
+    }
+}

--- a/docs/core/compatibility/core-libraries/6.0/snippets/project.csproj
+++ b/docs/core/compatibility/core-libraries/6.0/snippets/project.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Contributes to #40081.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/core-libraries/6.0/partial-byte-reads-in-streams.md](https://github.com/dotnet/docs/blob/a35a233188f9535bb1a74aeaca1f62f92dd3758f/docs/core/compatibility/core-libraries/6.0/partial-byte-reads-in-streams.md) | [Partial and zero-byte reads in DeflateStream, GZipStream, and CryptoStream](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/partial-byte-reads-in-streams?branch=pr-en-us-40057) |


<!-- PREVIEW-TABLE-END -->