### PR TITLE
Fix code snippet for security token events breaking change in .NET 8

### DIFF
--- a/docs/core/compatibility/aspnet-core/8.0/securitytoken-events.md
+++ b/docs/core/compatibility/aspnet-core/8.0/securitytoken-events.md
@@ -45,7 +45,7 @@ However, if you were down-casting one of the affected `SecurityToken` properties
 
   ```csharp
   service.Configure<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme, options => {
-      options.Events.TokenValidated = (context) => {
+      options.Events.OnTokenValidated = (context) => {
           // Replace your cast to JwtSecurityToken.
           JsonWebToken token = context.SecurityToken as JsonWebToken;
           // Do something ...
@@ -58,7 +58,7 @@ However, if you were down-casting one of the affected `SecurityToken` properties
   ```csharp
   service.Configure<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme,  options => {
       options.UseSecurityTokenValidators = true;
-      options.Events.TokenValidated = (context) => {
+      options.Events.OnTokenValidated = (context) => {
           // As you were doing before
           JwtSecurityToken token = context.SecurityToken as JwtSecurityToken;
           // Do something ...


### PR DESCRIPTION
## Summary

Correctly invoke the OnTokenValidated property instead of TokenValidated method in sample

Fixes #40021


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/aspnet-core/8.0/securitytoken-events.md](https://github.com/dotnet/docs/blob/cfbf853dbabe835caf6c6ce6168c9fe1f638a546/docs/core/compatibility/aspnet-core/8.0/securitytoken-events.md) | [Security token events return a JsonWebToken](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/aspnet-core/8.0/securitytoken-events?branch=pr-en-us-40062) |

<!-- PREVIEW-TABLE-END -->