### PR TITLE
Updated ranges for code snippets in High-performance logging

### DIFF
--- a/docs/core/extensions/high-performance-logging.md
+++ b/docs/core/extensions/high-performance-logging.md
@@ -52,7 +52,7 @@ Structured logging stores may use the event name when it's supplied with the eve
 
 The <xref:System.Action> is invoked through a strongly typed extension method. The `PriorityItemProcessed` method logs a message every time a work item is processed. `FailedToProcessWorkItem` is called if and when an exception occurs:
 
-:::code language="csharp" source="snippets/logging/worker-service-options/Worker.cs" range="13-34" highlight="15-18":::
+:::code language="csharp" source="snippets/logging/worker-service-options/Worker.cs" range="9-30" highlight="15-18":::
 
 Inspect the app's console output:
 
@@ -78,7 +78,7 @@ The static extension method for logging that a work item is being processed, `Pr
 
 In the worker service's `ExecuteAsync` method, `PriorityItemProcessed` is called to log the message:
 
-:::code language="csharp" source="snippets/logging/worker-service-options/Worker.cs" range="13-34" highlight="12":::
+:::code language="csharp" source="snippets/logging/worker-service-options/Worker.cs" range="9-30" highlight="12":::
 
 Inspect the app's console output:
 
@@ -111,7 +111,7 @@ Provide a static extension method for the log message. Include any type paramete
 
 The scope wraps the logging extension calls in a [using](../../csharp/language-reference/statements/using.md) block:
 
-:::code language="csharp" source="snippets/logging/worker-service-options/Worker.cs" range="13-349" highlight="4":::
+:::code language="csharp" source="snippets/logging/worker-service-options/Worker.cs" range="9-30" highlight="4":::
 
 Inspect the log messages in the app's console output. The following result shows priority ordering of log messages with the log scope message included:
 


### PR DESCRIPTION
## Summary

The range indexes in [the article](https://learn.microsoft.com/en-us/dotnet/core/extensions/high-performance-logging) no longer reflect the actual code snippet after [this change](https://github.com/dotnet/docs/commit/114b8f9e63ea6be3a2aa7ddfae18fc32d169e762#diff-757d56c99a006f335f185fe56d9f73bf81f76a8b6292620f35accff33401c06f). 

Fixes #40035


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/high-performance-logging.md](https://github.com/dotnet/docs/blob/1a7511bd2c4587eaa7ec51a7538b90729c4dea33/docs/core/extensions/high-performance-logging.md) | [High-performance logging in .NET](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/high-performance-logging?branch=pr-en-us-40073) |

<!-- PREVIEW-TABLE-END -->