### PR TITLE
Add C# 13 small fixes

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -51,7 +51,8 @@
                     "csharp-9.0/*.md",
                     "csharp-10.0/*.md",
                     "csharp-11.0/*.md",
-                    "csharp-12.0/*.md"
+                    "csharp-12.0/*.md",
+                    "method-group-natural-type-improvements.md"
                 ],
                 "src": "_csharplang/proposals",
                 "dest": "csharp/language-reference/proposals",
@@ -479,6 +480,7 @@
                 "_csharplang/proposals/csharp-10.0/*.md": "08/07/2021",
                 "_csharplang/proposals/csharp-11.0/*.md": "09/30/2022",
                 "_csharplang/proposals/csharp-12.0/*.md": "08/15/2023",
+                "_csharplang/proposals/*.md": "03/19/2024",
                 "_roslyn/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md": "11/08/2022",
                 "_roslyn/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 8.md": "09/26/2023",
                 "_vblang/spec/*.md": "07/21/2017"
@@ -645,6 +647,7 @@
                 "_csharplang/proposals/csharp-12.0/collection-expressions.md": "Collection expressions",
                 "_csharplang/proposals/csharp-12.0/experimental-attribute.md": "Experimental attribute",
                 "_csharplang/proposals/csharp-12.0/ref-readonly-parameters.md": "Ref readonly parameters",
+                "_csharplang/proposals/method-group-natural-type-improvements.md": "Method group natural type improvements",
                 "_roslyn/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md": "C# compiler breaking changes since C# 10",
                 "_roslyn/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 8.md": "C# compiler breaking changes since C# 11",
                 "_vblang/spec/introduction.md": "Introduction",
@@ -758,6 +761,7 @@
                 "_csharplang/proposals/csharp-12.0/collection-expressions.md": "Collection expressions provide a concise syntax to initialize collections by defining elements or embedded collections as the source of the new collection's elements.",
                 "_csharplang/proposals/csharp-12.0/experimental-attribute.md": "Use the ExperimentalAttribute attribute to indicate APIs that aren't stable.",
                 "_csharplang/proposals/csharp-12.0/ref-readonly-parameters.md": "Ref readonly parameters enforce that arguments are passed by references, where `in` parameters allow the compiler some flexibiility.",
+                "_csharplang/proposals/method-group-natural-type-improvements.md": "This proposal refines the determination of the natural type of a method group by considering candidates scope-by-scope and pruning at each scope.",
                 "_roslyn/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md": "Learn about any breaking changes since the initial release of C# 10",
                 "_roslyn/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 8.md": "Learn about any breaking changes since the initial release of C# 11",
                 "_vblang/spec/introduction.md": "This chapter provides and introduction to the Visual Basic language.",

--- a/docs/csharp/language-reference/operators/member-access-operators.md
+++ b/docs/csharp/language-reference/operators/member-access-operators.md
@@ -192,6 +192,8 @@ As the preceding example shows, expression `^e` is of the <xref:System.Index?dis
 
 You can also use the `^` operator with the [range operator](#range-operator-) to create a range of indices. For more information, see [Indices and ranges](../../tutorials/ranges-indexes.md).
 
+Beginning with C# 13, the Index from the end operator can be used in an object initializer.
+
 ## Range operator `..`
 
 The `..` operator specifies the start and end of a range of indices as its operands. The left-hand operand is an *inclusive* start of a range. The right-hand operand is an *exclusive* end of a range. Either of the operands can be an index from the start or from the end of a sequence, as the following example shows:

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1301,6 +1301,8 @@ items:
         href: ../../_csharplang/proposals/csharp-9.0/function-pointers.md
       - name: Lambda improvements
         href: ../../_csharplang/proposals/csharp-10.0/lambda-improvements.md
+      - name: Method group natural type conversion
+        href: ../../_csharplang/proposoals/method-group-natural-type-improvements.md
       - name: Optional Lambda expression parameters
         href: ../../_csharplang/proposals/csharp-12.0/lambda-method-group-defaults.md
       - name: Checked user-defined operators

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1302,7 +1302,7 @@ items:
       - name: Lambda improvements
         href: ../../_csharplang/proposals/csharp-10.0/lambda-improvements.md
       - name: Method group natural type conversion
-        href: ../../_csharplang/proposoals/method-group-natural-type-improvements.md
+        href: ../../_csharplang/proposals/method-group-natural-type-improvements.md
       - name: Optional Lambda expression parameters
         href: ../../_csharplang/proposals/csharp-12.0/lambda-method-group-defaults.md
       - name: Checked user-defined operators

--- a/docs/csharp/whats-new/csharp-12.md
+++ b/docs/csharp/whats-new/csharp-12.md
@@ -1,7 +1,7 @@
 ---
 title: What's new in C# 12 - C# Guide
 description: Get an overview of the new features in C# 12.
-ms.date: 10/26/2023
+ms.date: 03/19/2024
 ---
 # What's new in C# 12
 
@@ -16,6 +16,12 @@ C# 12 includes the following new features. You can try these features using the 
 - [Experimental attribute](#experimental-attribute) - Introduced in Visual Studio 2022 version 17.7 Preview 3.
 
 - [Interceptors](#interceptors) - *Preview feature* Introduced in Visual Studio 2022 version 17.7 Preview 3.
+
+C# 12 is supported on **.NET 8**. For more information, see [C# language versioning](../language-reference/configure-language-version.md).
+
+You can download the latest .NET 8 SDK from the [.NET downloads page](https://dotnet.microsoft.com/download). You can also download [Visual Studio 2022](https://visualstudio.microsoft.com/vs/), which includes the .NET 8 SDK.
+
+[!INCLUDE [released-version-feedback](./includes/released-feedback.md)]
 
 ## Primary constructors
 

--- a/docs/csharp/whats-new/csharp-13.md
+++ b/docs/csharp/whats-new/csharp-13.md
@@ -19,7 +19,7 @@ New features are added to the "What's new in C#" page when they are available in
 
 [!INCLUDE [released-version-feedback](./includes/released-feedback.md)]
 
-# New escape sequence
+## New escape sequence
 
 You can use `\e` as a [character literal](~/_csharpstandard/standard/lexical-structure.md#6455-character-literals) escape sequence for the `ESCAPE` character, Unicode `U+001B`. Previously, you used `\u001b` or `\x1b`. Using `\x1b` wasn't recommended because if the next characters following `1b` were valid hexadecimal digits, those characters became part of the escape sequence.
 

--- a/docs/csharp/whats-new/csharp-13.md
+++ b/docs/csharp/whats-new/csharp-13.md
@@ -1,0 +1,61 @@
+---
+title: What's new in C# 13 - C# Guide
+description: Get an overview of the new features in C# 13. Follow the release of new preview features as .NET 9 and C# 13 previews are released.
+ms.date: 03/19/2024
+---
+# What's new in C# 13
+
+C# 13 includes the following new features. You can try these features using the latest [Visual Studio 2022](https://visualstudio.microsoft.com/vs/preview/) version or the [.NET 9 preview SDK](https://dotnet.microsoft.com/download/dotnet).
+
+- [New escape sequence - `\e`](#new-escape-sequence).
+- [Method group natural type improvements](#method-group-natural-type)
+- [Implicit indexer access in object initializers](#implicit-index-access)
+
+C# 13 is supported on **.NET 9**. For more information, see [C# language versioning](../language-reference/configure-language-version.md).
+
+You can download the latest .NET 9 preview SDK from the [.NET downloads page](https://dotnet.microsoft.com/download). You can also download [Visual Studio 2022 - preview](https://visualstudio.microsoft.com/vs/), which includes the .NET 9 preview SDK.
+
+New features are added to the "What's new in C#" page when they are available in public preview releases. The [working set](https://github.com/dotnet/roslyn/blob/main/docs/Language%20Feature%20Status.md#working-set) section of the [roslyn feature status page](https://github.com/dotnet/roslyn/blob/main/docs/Language%20Feature%20Status.md) tracks when upcoming features are merged into the main branch.
+
+[!INCLUDE [released-version-feedback](./includes/released-feedback.md)]
+
+# New escape sequence
+
+You can use `\e` as a [character literal](~/_csharpstandard/standard/lexical-structure.md#6455-character-literals) escape sequence for the `ESCAPE` character, Unicode `U+001B`. Previously, you used `\u001b` or `\x1b`. Using `\x1b` wasn't recommended because if the next characters following `1b` were valid hexadecimal digits, those characters became part of the escape sequence.
+
+## Method group natural type
+
+This feature makes small optimizations to overload resolution involving method groups. The previous behavior was for the compiler to construct the full set of candidate methods for a method group. If a natural type is needed, the natural type was determined from the full set of candidate methods.
+
+The new behavior is to prune the set of candidate methods at each scope, removing those candidate methods that aren't applicable. Typically, these are generic methods with the wrong arity, or constraints that aren't satisfied. The process continues to the next outer scope only if no candidate methods have been found. This process more closely follows the general algorithm for overload resolution. If all candidate methods found at a given scope don't match, the method group doesn't have a natural type.
+
+You can read the details of the changes in the [proposal specification](~/_csharplang/proposals/method-group-natural-type-improvements.md).
+
+## Implicit index access
+
+The implicit "from the end" index operator, `^`, is now allowed in an object initializer expression. For example, you can now initialize an array in an object initializer as shown in the following code:
+
+```csharp
+var v = new S() 
+{ 
+    buffer = 
+    { 
+        [^1] = 0,
+        [^2] = 1,
+        [^3] = 2,
+        [^4] = 3,
+        [^5] = 4,
+        [^6] = 5,
+        [^7] = 6,
+        [^8] = 7,
+        [^9] = 8,
+        [^10] = 9
+    } 
+};
+```
+
+Before C# 13, the `^` operator can't be used in an object initializer. You'd need to index the elements from the front.
+
+## See also
+
+- [What's new in .NET 9](../../core/whats-new/dotnet-8/overview.md)

--- a/docs/csharp/whats-new/csharp-13.md
+++ b/docs/csharp/whats-new/csharp-13.md
@@ -5,7 +5,7 @@ ms.date: 03/19/2024
 ---
 # What's new in C# 13
 
-C# 13 includes the following new features. You can try these features using the latest [Visual Studio 2022](https://visualstudio.microsoft.com/vs/preview/) version or the [.NET 9 preview SDK](https://dotnet.microsoft.com/download/dotnet).
+C# 13 includes the following new features. You can try these features using the latest [Visual Studio 2022](https://visualstudio.microsoft.com/vs/preview/) version or the [.NET 9 Preview SDK](https://dotnet.microsoft.com/download/dotnet).
 
 - [New escape sequence - `\e`](#new-escape-sequence).
 - [Method group natural type improvements](#method-group-natural-type)
@@ -13,7 +13,7 @@ C# 13 includes the following new features. You can try these features using the 
 
 C# 13 is supported on **.NET 9**. For more information, see [C# language versioning](../language-reference/configure-language-version.md).
 
-You can download the latest .NET 9 preview SDK from the [.NET downloads page](https://dotnet.microsoft.com/download). You can also download [Visual Studio 2022 - preview](https://visualstudio.microsoft.com/vs/), which includes the .NET 9 preview SDK.
+You can download the latest .NET 9 preview SDK from the [.NET downloads page](https://dotnet.microsoft.com/download). You can also download [Visual Studio 2022 - preview](https://visualstudio.microsoft.com/vs/), which includes the .NET 9 Preview SDK.
 
 New features are added to the "What's new in C#" page when they are available in public preview releases. The [working set](https://github.com/dotnet/roslyn/blob/main/docs/Language%20Feature%20Status.md#working-set) section of the [roslyn feature status page](https://github.com/dotnet/roslyn/blob/main/docs/Language%20Feature%20Status.md) tracks when upcoming features are merged into the main branch.
 
@@ -25,7 +25,7 @@ You can use `\e` as a [character literal](~/_csharpstandard/standard/lexical-str
 
 ## Method group natural type
 
-This feature makes small optimizations to overload resolution involving method groups. The previous behavior was for the compiler to construct the full set of candidate methods for a method group. If a natural type is needed, the natural type was determined from the full set of candidate methods.
+This feature makes small optimizations to overload resolution involving method groups. The previous behavior was for the compiler to construct the full set of candidate methods for a method group. If a natural type was needed, the natural type was determined from the full set of candidate methods.
 
 The new behavior is to prune the set of candidate methods at each scope, removing those candidate methods that aren't applicable. Typically, these are generic methods with the wrong arity, or constraints that aren't satisfied. The process continues to the next outer scope only if no candidate methods have been found. This process more closely follows the general algorithm for overload resolution. If all candidate methods found at a given scope don't match, the method group doesn't have a natural type.
 
@@ -54,7 +54,7 @@ var v = new S()
 };
 ```
 
-Before C# 13, the `^` operator can't be used in an object initializer. You'd need to index the elements from the front.
+In versions prior to C# 13, the `^` operator can't be used in an object initializer. You need to index the elements from the front.
 
 ## See also
 


### PR DESCRIPTION
Fixes #39816

These three small fixes / features were added in .NET 9 preview 1.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/member-access-operators.md](https://github.com/dotnet/docs/blob/edbaf44f50cd9523705774e42c0d05612e7ad1d6/docs/csharp/language-reference/operators/member-access-operators.md) | [Member access operators and expressions - the dot, indexer, and invocation operators.](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/member-access-operators?branch=pr-en-us-40077) |
| [docs/csharp/whats-new/csharp-12.md](https://github.com/dotnet/docs/blob/edbaf44f50cd9523705774e42c0d05612e7ad1d6/docs/csharp/whats-new/csharp-12.md) | [What's new in C# 12 - C# Guide](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-12?branch=pr-en-us-40077) |
| [docs/csharp/whats-new/csharp-13.md](https://github.com/dotnet/docs/blob/edbaf44f50cd9523705774e42c0d05612e7ad1d6/docs/csharp/whats-new/csharp-13.md) | [What's new in C# 13](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-13?branch=pr-en-us-40077) |


<!-- PREVIEW-TABLE-END -->