### PR TITLE
fix typo in .NET 9 link

### DIFF
--- a/docs/csharp/whats-new/csharp-13.md
+++ b/docs/csharp/whats-new/csharp-13.md
@@ -58,4 +58,4 @@ In versions prior to C# 13, the `^` operator can't be used in an object initiali
 
 ## See also
 
-- [What's new in .NET 9](../../core/whats-new/dotnet-8/overview.md)
+- [What's new in .NET 9](../../core/whats-new/dotnet-9/overview.md)


### PR DESCRIPTION
## Summary

Fix the typo leading to the wrong link for .NET changes for C# 13. (It leads to .NET 8 while it should lead to .NET 9)

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/whats-new/csharp-13.md](https://github.com/dotnet/docs/blob/8e9ae7c717f34456c94c66eadc1e6111bd8b96a1/docs/csharp/whats-new/csharp-13.md) | [What's new in C# 13](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-13?branch=pr-en-us-40158) |

<!-- PREVIEW-TABLE-END -->