### PR TITLE
Fix important alert in single file deployment

### DIFF
--- a/docs/core/deploying/single-file/overview.md
+++ b/docs/core/deploying/single-file/overview.md
@@ -13,7 +13,7 @@ Bundling all application-dependent files into a single binary provides an applic
 
 The size of the single file in a self-contained application is large since it includes the runtime and the framework libraries. In .NET 6, you can [publish trimmed](../trimming/trim-self-contained.md) to reduce the total size of trim-compatible applications. The single file deployment option can be combined with [ReadyToRun](../ready-to-run.md) and [Trim](../trimming/trim-self-contained.md) publish options.
 
-> [IMPORTANT]
+> [!IMPORTANT]
 > To run a single file app on Windows 7, you must use .NET Runtime 6.0.3 or later.
 
 ## Sample project file


### PR DESCRIPTION
## Summary

The important alert is missing the bang (`!`), causing it to be rendered as a regular blockquote. Added the bang.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/deploying/single-file/overview.md](https://github.com/dotnet/docs/blob/538c8defe80973f297a645fe0ef939659611c99f/docs/core/deploying/single-file/overview.md) | [Single-file deployment](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/single-file/overview?branch=pr-en-us-40160) |

<!-- PREVIEW-TABLE-END -->