### PR TITLE
add example where a type parameter is used a return type

### DIFF
--- a/docs/csharp/programming-guide/generics/generic-methods.md
+++ b/docs/csharp/programming-guide/generics/generic-methods.md
@@ -50,6 +50,10 @@ class GenericList2<T>
   
  [!code-csharp[csProgGuideGenerics#28](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideGenerics/CS/Generics.cs#28)]  
   
+ You can also use the type parameter as the return type of a method. The following code example shows a method that returns an array of type `T`:  
+  
+ [!code-csharp[csProgGuideGenerics#29](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideGenerics/CS/Generics.cs#29)]
+
 ## C# Language Specification  
 
  For more information, see the [C# Language Specification](~/_csharpstandard/standard/classes.md#156-methods).  

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideGenerics/CS/Generics.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideGenerics/CS/Generics.cs
@@ -392,6 +392,16 @@ namespace CsCsrefProgrammingGenerics
             void DoWork<T, U>() { }
             //</Snippet28>
         }
+
+        class Test3
+        {
+            //<Snippet29>
+            T[] Swap<T>(T a, T b)
+            {
+                return [b, a];
+            }
+            //</Snippet29>
+        }
     }
 
     //---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds an example where a type parameter is used as the return type.

Fixes #40063

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/generics/generic-methods.md](https://github.com/dotnet/docs/blob/4360714a4104176709687d54cdbbeaa5fd6c6ceb/docs/csharp/programming-guide/generics/generic-methods.md) | [Generic methods (C# programming guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/generics/generic-methods?branch=pr-en-us-40188) |

<!-- PREVIEW-TABLE-END -->