### PR TITLE
Add a link to Visual Studio docs on registering a C# COM assembly

### DIFF
--- a/docs/csharp/advanced-topics/interop/index.md
+++ b/docs/csharp/advanced-topics/interop/index.md
@@ -58,3 +58,4 @@ COM clients can consume C# types that have been correctly exposed. The basic ste
 - [Introduction to COM Interop in Visual Basic](../../../visual-basic/programming-guide/com-interop/introduction-to-com-interop.md)
 - [Marshaling between Managed and Unmanaged Code](../../../framework/interop/interop-marshalling.md)
 - [Interoperating with Unmanaged Code](../../../framework/interop/index.md)
+- [Registering Assemblies with COM](../../../framework/interop/registering-assemblies-with-com.md)


### PR DESCRIPTION
Fixes #40065


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/advanced-topics/interop/index.md](https://github.com/dotnet/docs/blob/f5293d6b5706f937cc23ec4039493258b0ccadd3/docs/csharp/advanced-topics/interop/index.md) | [Interoperability Overview](https://review.learn.microsoft.com/en-us/dotnet/csharp/advanced-topics/interop/index?branch=pr-en-us-40191) |

<!-- PREVIEW-TABLE-END -->