### PR TITLE
Unnecessary double allocation in DictionaryTKeyEnumTValueConverter.cs

### DIFF
--- a/docs/standard/serialization/system-text-json/snippets/how-to/csharp/DictionaryTKeyEnumTValueConverter.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to/csharp/DictionaryTKeyEnumTValueConverter.cs
@@ -25,7 +25,7 @@ namespace SystemTextJsonSamples
             Type type,
             JsonSerializerOptions options)
         {
-            Type[] typeArguments = t.GetGenericArguments();
+            Type[] typeArguments = type.GetGenericArguments();
             Type keyType = typeArguments[0];
             Type valueType = typeArguments[1];
 

--- a/docs/standard/serialization/system-text-json/snippets/how-to/csharp/DictionaryTKeyEnumTValueConverter.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to/csharp/DictionaryTKeyEnumTValueConverter.cs
@@ -25,8 +25,9 @@ namespace SystemTextJsonSamples
             Type type,
             JsonSerializerOptions options)
         {
-            Type keyType = type.GetGenericArguments()[0];
-            Type valueType = type.GetGenericArguments()[1];
+            Type[] typeArguments = t.GetGenericArguments();
+            Type keyType = typeArguments[0];
+            Type valueType = typeArguments[1];
 
             JsonConverter converter = (JsonConverter)Activator.CreateInstance(
                 typeof(DictionaryEnumConverterInner<,>).MakeGenericType(


### PR DESCRIPTION
Updated to reflect the GetGenericArguments example ([ref link](https://learn.microsoft.com/en-us/dotnet/api/system.type.getgenericarguments?view=net-8.0))

Fixes #39992