### PR TITLE
Fix broken links - March

### DIFF
--- a/docs/breadcrumb/toc.yml
+++ b/docs/breadcrumb/toc.yml
@@ -385,9 +385,6 @@ items:
                   - name: ECMA C# draft specification
                     tocHref: /dotnet/csharp/language-reference/language-specification/
                     topicHref: /dotnet/csharp/language-reference/language-specification/index
-                  - name: Microsoft C# specifications
-                    tocHref: /dotnet/csharp/language-reference/proposals
-                    topicHref: /dotnet/csharp/language-reference/proposals/csharp-12.0/index
           - name: F# guide
             tocHref: /dotnet/fsharp/
             topicHref: /dotnet/fsharp/index

--- a/docs/breadcrumb/toc.yml
+++ b/docs/breadcrumb/toc.yml
@@ -385,6 +385,9 @@ items:
                   - name: ECMA C# draft specification
                     tocHref: /dotnet/csharp/language-reference/language-specification/
                     topicHref: /dotnet/csharp/language-reference/language-specification/index
+                  - name: C# specifications
+                    tocHref: /dotnet/csharp/language-reference/language-specification/proposals/
+                    topicHref: /dotnet/csharp/language-reference/proposals/csharp-10.0/enhanced-line-directives
           - name: F# guide
             tocHref: /dotnet/fsharp/
             topicHref: /dotnet/fsharp/index


### PR DESCRIPTION
@BillWagner LMK if there's a better fix here. "/dotnet/csharp/language-reference/proposals/csharp-12.0/index" was an invalid URL.

Contributes to #39125 
