### PR TITLE
Add note that PathMap should not be used in debug builds.

### DIFF
--- a/docs/csharp/language-reference/compiler-options/advanced.md
+++ b/docs/csharp/language-reference/compiler-options/advanced.md
@@ -85,6 +85,9 @@ When you specify [**DebugType**](code-generation.md#debugtype), the compiler cre
 
 ## PathMap
 
+> [!NOTE]
+Specifying **PathMap** may prevent breakpoints from working in local debug builds. **PathMap** should not be specified when building for the purposes of debugging.
+
 The **PathMap** compiler option specifies how to map physical paths to source path names output by the compiler. This option maps each physical path on the machine where the compiler runs to a corresponding path that should be written in the output files. In the following example, `path1` is the full path to the source files in the current environment, and `sourcePath1` is the source path substituted for `path1` in any output files. To specify multiple mapped source paths, separate each with a comma.
 
 ```xml

--- a/docs/csharp/language-reference/compiler-options/advanced.md
+++ b/docs/csharp/language-reference/compiler-options/advanced.md
@@ -86,7 +86,7 @@ When you specify [**DebugType**](code-generation.md#debugtype), the compiler cre
 ## PathMap
 
 > [!NOTE]
-Specifying **PathMap** may prevent breakpoints from working in local debug builds. **PathMap** should not be specified when building for the purposes of debugging.
+Specifying **PathMap** will prevent breakpoints from working in local debug builds. Only set **PathMap** for production or [continuous integration builds](https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#continuousintegrationbuild).
 
 The **PathMap** compiler option specifies how to map physical paths to source path names output by the compiler. This option maps each physical path on the machine where the compiler runs to a corresponding path that should be written in the output files. In the following example, `path1` is the full path to the source files in the current environment, and `sourcePath1` is the source path substituted for `path1` in any output files. To specify multiple mapped source paths, separate each with a comma.
 

--- a/docs/csharp/language-reference/compiler-options/advanced.md
+++ b/docs/csharp/language-reference/compiler-options/advanced.md
@@ -86,7 +86,7 @@ When you specify [**DebugType**](code-generation.md#debugtype), the compiler cre
 ## PathMap
 
 > [!NOTE]
-Specifying **PathMap** will prevent breakpoints from working in local debug builds. Only set **PathMap** for production or [continuous integration builds](https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#continuousintegrationbuild).
+Specifying **PathMap** will prevent breakpoints from working in local debug builds. Only set **PathMap** for production or [continuous integration builds](https://learn.microsoft.com/dotnet/core/project-sdk/msbuild-props#continuousintegrationbuild).
 
 The **PathMap** compiler option specifies how to map physical paths to source path names output by the compiler. This option maps each physical path on the machine where the compiler runs to a corresponding path that should be written in the output files. In the following example, `path1` is the full path to the source files in the current environment, and `sourcePath1` is the source path substituted for `path1` in any output files. To specify multiple mapped source paths, separate each with a comma.
 


### PR DESCRIPTION
## Summary
We have seen several debugger issues with folks specifying this issue. Attempting to update the documentation to try to educate folks about this.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-options/advanced.md](https://github.com/dotnet/docs/blob/a0ae0908623195b3813c95d0bcad61652c04d9a6/docs/csharp/language-reference/compiler-options/advanced.md) | [Advanced C# compiler options](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/advanced?branch=pr-en-us-40219) |


<!-- PREVIEW-TABLE-END -->