### PR TITLE
Update internal.md

### DIFF
--- a/docs/csharp/language-reference/keywords/internal.md
+++ b/docs/csharp/language-reference/keywords/internal.md
@@ -15,7 +15,7 @@ The `internal` keyword is an [access modifier](./access-modifiers.md) for types 
   
  > This page covers `internal` access. The `internal` keyword is also part of the [`protected internal`](./protected-internal.md) access modifier.
   
-Internal types or members are accessible only within files in the same assembly, as in this example:  
+Internal types or members are accessible only within files in the same [assembly](../../../standard/assembly/index.md), as in this example:  
   
 ```csharp  
 public class BaseClass
@@ -26,7 +26,9 @@ public class BaseClass
 ```  
 
  For a comparison of `internal` with the other access modifiers, see [Accessibility Levels](./accessibility-levels.md) and [Access Modifiers](../../programming-guide/classes-and-structs/access-modifiers.md).  
-  
+
+ An `assembly` is an executable or dynamic link library (DLL) produced from compiling one or more source files.
+ 
  For more information about assemblies, see [Assemblies in .NET](../../../standard/assembly/index.md).  
   
  A common use of internal access is in component-based development because it enables a group of components to cooperate in a private manner without being exposed to the rest of the application code. For example, a framework for building graphical user interfaces could provide `Control` and `Form` classes that cooperate by using members with internal access. Since these members are internal, they are not exposed to code that is using the framework.  


### PR DESCRIPTION
-Referenced assemblies the first time it was mentioned 

-added an informal definition for an assembly.

## Summary

Fixes #Issue_Number #40066


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/internal.md](https://github.com/dotnet/docs/blob/df4d0faf263c41aa018f63bf2c520090025683fe/docs/csharp/language-reference/keywords/internal.md) | [internal (C# Reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/internal?branch=pr-en-us-40228) |

<!-- PREVIEW-TABLE-END -->