### PR TITLE
addition to top-level statements

### DIFF
--- a/docs/csharp/fundamentals/program-structure/main-command-line.md
+++ b/docs/csharp/fundamentals/program-structure/main-command-line.md
@@ -20,7 +20,9 @@ There can only be one entry point in a C# program. If you have more than one cla
 
 :::code language="csharp" source="snippets/main-command-line/TestClass.cs":::
 
-You can also use [Top-level statements](top-level-statements.md) in one file as the entry point for your application:
+You can also use Top-level statements in one file as the entry point for your application.
+Just as the `Main` method, top-level statements can also [return values](#main-return-values) and access [command-line arguments](#command-line-arguments).
+For more information, see [Top-level statements](top-level-statements.md).
 
 :::code language="csharp" source="snippets/top-level-statements-1/Program.cs":::
 

--- a/docs/csharp/fundamentals/program-structure/snippets/top-level-statements-1/Program.cs
+++ b/docs/csharp/fundamentals/program-structure/snippets/top-level-statements-1/Program.cs
@@ -1,16 +1,15 @@
 ﻿using System.Text;
 
 StringBuilder builder = new();
-builder.AppendLine("Hello,");
 builder.AppendLine("The following arguments are passed:");
-
-Console.WriteLine(builder.ToString());
 
 // Display the command line arguments using the args variable.
 foreach (var arg in args)
 {
-    Console.WriteLine($"Argument={arg}");
+    builder.AppendLine($"Argument={arg}");
 }
+
+Console.WriteLine(builder.ToString());
 
 // Return a success code.
 return 0;

--- a/docs/csharp/fundamentals/program-structure/snippets/top-level-statements-1/Program.cs
+++ b/docs/csharp/fundamentals/program-structure/snippets/top-level-statements-1/Program.cs
@@ -1,7 +1,16 @@
 ﻿using System.Text;
 
 StringBuilder builder = new();
-builder.AppendLine("Hello");
-builder.AppendLine("World!");
+builder.AppendLine("Hello,");
+builder.AppendLine("The following arguments are passed:");
 
 Console.WriteLine(builder.ToString());
+
+// Display the command line arguments using the args variable.
+foreach (var arg in args)
+{
+    Console.WriteLine($"Argument={arg}");
+}
+
+// Return a success code.
+return 0;


### PR DESCRIPTION
## Summary

This PR adds a mention of return values and command line arguments to the main command line example of top-level statements.
It also updates the example to show an example.

I didn't add more information because I was afraid that it would just be a repetition of the referenced article about top level statements.

Should both articles reference each other add the bottom of the page in a "See also" section?

Fixes #40064

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/fundamentals/program-structure/main-command-line.md](https://github.com/dotnet/docs/blob/e449f0e7de66fd53828d9897d74da6007c53a29e/docs/csharp/fundamentals/program-structure/main-command-line.md) | [Main() and command-line arguments](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/program-structure/main-command-line?branch=pr-en-us-40230) |


<!-- PREVIEW-TABLE-END -->