### PR TITLE
Update TypeTestingAndConversionOperators.cs

### DIFF
--- a/docs/csharp/language-reference/operators/snippets/shared/TypeTestingAndConversionOperators.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/TypeTestingAndConversionOperators.cs
@@ -77,7 +77,7 @@ public static class TypeTestingAndConversionOperators
     private static void AsOperator()
     {
         // <SnippetAsOperator>
-        IEnumerable<int> numbers = [10, 20, 30];
+        IEnumerable<int> numbers = {10, 20, 30};
         IList<int> indexable = numbers as IList<int>;
         if (indexable != null)
         {

--- a/docs/csharp/language-reference/operators/snippets/shared/TypeTestingAndConversionOperators.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/TypeTestingAndConversionOperators.cs
@@ -77,7 +77,7 @@ public static class TypeTestingAndConversionOperators
     private static void AsOperator()
     {
         // <SnippetAsOperator>
-        IEnumerable<int> numbers = {10, 20, 30};
+        IEnumerable<int> numbers = new List<int>(){10, 20, 30};
         IList<int> indexable = numbers as IList<int>;
         if (indexable != null)
         {


### PR DESCRIPTION
Fixed code snippet for array casting example.
![image](https://github.com/dotnet/docs/assets/59281307/8d8c1bae-b8e0-48ba-aeec-97aed57ec959)

Now it works in browser.
## Summary

Checking the code in the browser raised an error.

I'm happy to help Microsoft!