### PR TITLE
un-publish the static local functions speclet

### DIFF
--- a/.openpublishing.redirection.csharp.json
+++ b/.openpublishing.redirection.csharp.json
@@ -109,10 +109,6 @@
             "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions#121211-tuple-equality-operators"
         },
         {
-            "source_path_from_root": "/redirections/proposals/csharp-8.0/static-local-functions.md",
-            "redirect_url": "/dotnet/csharp/language-reference/language-specification/statements.md#1364-local-function-declarations"
-        },
-        {
             "source_path_from_root": "/redirections/proposals/csharp-10.0/generic-attributes.md",
             "redirect_url": "/dotnet/csharp/language-reference/proposals/csharp-11.0/generic-attributes"
         },
@@ -1315,6 +1311,10 @@
         {
             "source_path_from_root": "/docs/csharp/language-reference/proposals/csharp-8.0/index.md",
             "redirect_url": "/dotnet/csharp/language-reference/proposals/csharp-8.0/nullable-reference-types"
+        },
+        {
+            "source_path_from_root": "/docs/csharp/language-reference/proposals/csharp-8.0/static-local-functions.md",
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/statements.md#1364-local-function-declarations"
         },
         {
             "source_path_from_root": "/docs/csharp/language-reference/proposals/csharp-9.0/index.md",

--- a/.openpublishing.redirection.csharp.json
+++ b/.openpublishing.redirection.csharp.json
@@ -10,15 +10,15 @@
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-7.0/local-functions.md",
-            "redirect_url": "/dotnet/csharp/language-reference/language-specification/statements#1264-local-function-declarations"
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/statements#1364-local-function-declarations"
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-7.0/throw-expression.md",
-            "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions#1115-the-throw-expression-operator"
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions#1215-the-throw-expression-operator"
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-7.0/out-var.md",
-            "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions#1117-declaration-expressions"
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions#1217-declaration-expressions"
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-7.0/pattern-matching.md",
@@ -34,7 +34,7 @@
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-7.1/target-typed-default.md",
-            "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions#11719-default-value-expressions"
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions#12719-default-value-expressions"
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-7.1/infer-tuple-names.md",
@@ -50,11 +50,11 @@
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-7.2/non-trailing-named-arguments.md",
-            "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions#11621-general"
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions#12621-general"
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-7.2/private-protected.md",
-            "redirect_url": "/dotnet/csharp/language-reference/language-specification/classes#1436-access-modifiers"
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/classes#1536-access-modifiers"
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-7.2/readonly-ref.md",
@@ -62,7 +62,7 @@
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-7.2/readonly-struct.md",
-            "redirect_url": "/dotnet/csharp/language-reference/language-specification/structs#1524-struct-interfaces"
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/structs#1624-struct-interfaces"
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-7.2/span-safety.md",
@@ -70,23 +70,23 @@
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-7.3/auto-prop-field-attrs.md",
-            "redirect_url": "/dotnet/csharp/language-reference/language-specification/attributes#213-attribute-specification"
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/attributes#223-attribute-specification"
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-7.3/blittable.md",
-            "redirect_url": "/dotnet/csharp/language-reference/language-specification/classes#1425-type-parameter-constraints"
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/classes#1525-type-parameter-constraints"
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-7.3/expression-variables-in-initializers.md",
-            "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions#1117-declaration-expressions"
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions#1217-declaration-expressions"
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-7.3/improved-overload-candidates.md",
-            "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions#11642-applicable-function-member"
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions#12642-applicable-function-member"
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-7.3/indexing-movable-fixed-fields.md",
-            "redirect_url": "/dotnet/csharp/language-reference/language-specification/unsafe-code#2283-fixed-size-buffers-in-expressions"
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/unsafe-code#2383-fixed-size-buffers-in-expressions"
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-7.3/leading-digit-separator.md",
@@ -94,7 +94,7 @@
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-7.3/pattern-based-fixed.md",
-            "redirect_url": "/dotnet/csharp/language-reference/language-specification/unsafe-code#227-the-fixed-statement"
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/unsafe-code#237-the-fixed-statement"
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-7.3/ref-local-reassignment.md",
@@ -106,7 +106,11 @@
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-7.3/tuple-equality.md",
-            "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions#111211-tuple-equality-operators"
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions#121211-tuple-equality-operators"
+        },
+        {
+            "source_path_from_root": "/redirections/proposals/csharp-8.0/static-local-functions.md",
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/statements.md#1364-local-function-declarations"
         },
         {
             "source_path_from_root": "/redirections/proposals/csharp-10.0/generic-attributes.md",

--- a/docfx.json
+++ b/docfx.json
@@ -67,6 +67,7 @@
                     "csharp-8.0/notnull-constraint.md",
                     "csharp-8.0/obsolete-accessor.md",
                     "csharp-8.0/shadowing-in-nested-functions.md",
+                    "csharp-8.0/static-local-functions.md",
                     "csharp-8.0/unconstrained-null-coalescing.md",
                     "csharp-8.0/nullable-reference-types-specification.md"
                 ]
@@ -591,7 +592,6 @@
                 "_csharplang/proposals/csharp-8.0/using.md": "Pattern based using and using declarations",
                 "_csharplang/proposals/csharp-8.0/null-coalescing-assignment.md": "Null coalescing assignment",
                 "_csharplang/proposals/csharp-8.0/readonly-instance-members.md": "Readonly instance members",
-                "_csharplang/proposals/csharp-8.0/static-local-functions.md": "Static local functions",
                 "_csharplang/proposals/csharp-8.0/nested-stackalloc.md": "Nested stackalloc expressions",
                 "_csharplang/proposals/csharp-9.0/covariant-returns.md": "Covariant return types",
                 "_csharplang/proposals/csharp-9.0/extending-partial-methods.md": "Extending partial methods",
@@ -705,7 +705,6 @@
                 "_csharplang/proposals/csharp-8.0/using.md": "This feature specification supports pattern based using and using declarations to simplify resource cleanup.",
                 "_csharplang/proposals/csharp-8.0/null-coalescing-assignment.md": "This feature specification describes the syntax to support null coalescing assignment expressions using the '??=' operator.",
                 "_csharplang/proposals/csharp-8.0/readonly-instance-members.md": "This feature specification describes the syntax for declaring and using readonly instance members.",
-                "_csharplang/proposals/csharp-8.0/static-local-functions.md": "This feature specification describes static local functions, which are local functions that cannot access variables in the enclosing scope.",
                 "_csharplang/proposals/csharp-8.0/nested-stackalloc.md": "This feature specification describes nested stackalloc expressions, which provides nested arrays of stackalloc storage.",
                 "_csharplang/proposals/csharp-9.0/covariant-returns.md": "This feature specification describes covariant return types, where overriding member declarations can return a type derived from the overridden member declaration.",
                 "_csharplang/proposals/csharp-9.0/extending-partial-methods.md": "This feature specification describes extensions to partial methods. These extensions enable source generators to create or call partial methods.",

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -1324,8 +1324,6 @@ items:
         href: ../../_csharplang/proposals/csharp-10.0/GlobalUsingDirective.md
       - name: Alias any type
         href: ../../_csharplang/proposals/csharp-12.0/using-alias-types.md
-      - name: Static local functions
-        href: ../../_csharplang/proposals/csharp-8.0/static-local-functions.md
       - name: Attributes on local functions
         href: ../../_csharplang/proposals/csharp-9.0/local-function-attributes.md
       - name: Pattern based using and using declarations


### PR DESCRIPTION
The ECMA committee has merged the first C# 8.0 feature into the draft spec. Un-publish the related feature spec.

Also, fix some of the anchors that had drifted in the redirection file.
