### PR TITLE
Fix Incorrect Field Descriptions in Method Diagnostics Events

### DIFF
--- a/docs/fundamentals/diagnostics/runtime-method-events.md
+++ b/docs/fundamentals/diagnostics/runtime-method-events.md
@@ -234,8 +234,8 @@ The following table shows the event information:
 |`MethodNameSpace`|`win:UnicodeString`|Full namespace name associated with the method.|
 |`MethodName`|`win:UnicodeString`|Full class name associated with the method.|
 |`MethodSignature`|`win:UnicodeString`|Signature of the method (comma-separated list of type names).|
-|`ReJITID`|`win:UInt64`|ReJIT ID of the method.|
 |`ClrInstanceID`|`win:UInt16`|Unique ID for the instance of CoreCLR.|
+|`ReJITID`|`win:UInt64`|ReJIT ID of the method.|
 
 ## MethodJittingStarted_V1 event
 

--- a/docs/fundamentals/diagnostics/runtime-method-events.md
+++ b/docs/fundamentals/diagnostics/runtime-method-events.md
@@ -374,7 +374,7 @@ The following table shows the keyword and level:
 |`MethodID`|`win:UInt64`|Unique identifier of a method.|
 |`ReJITID`|`win:UInt64`|The ReJIT ID of the method.|
 |`MethodExtent`|`win:UInt8`|The extent for the jitted method.|
-|`CountOfMapEntries`|`win:UInt8`|Number of map entries|
+|`CountOfMapEntries`|`win:UInt16`|Number of map entries|
 |`ILOffsets`|`win:UInt32`|The IL offset.|
 |`NativeOffsets`|`win:UInt32`|The native code offset.|
 |`ClrInstanceID`|`win:UInt16`|Unique ID for the instance of CoreCLR.|


### PR DESCRIPTION
## Summary

 - Fix ordering of the fields in `MethodUnloadVerbose_V2` event.
   Source Code: https://github.com/dotnet/runtime/blob/main/src/coreclr/vm/ClrEtwAll.man#L2332
 - Fix data type of `CountOfMapEntries` field in `MethodILToNativeMap` event.
   Source Code: https://github.com/dotnet/runtime/blob/main/src/coreclr/vm/ClrEtwAll.man#L2611


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/diagnostics/runtime-method-events.md](https://github.com/dotnet/docs/blob/ece0ba25f0e1cc98df46e6eb5e5fbf7c35d25be8/docs/fundamentals/diagnostics/runtime-method-events.md) | [.NET runtime method events](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/diagnostics/runtime-method-events?branch=pr-en-us-40261) |

<!-- PREVIEW-TABLE-END -->