### PR TITLE
Configure parent workitem(s) in quest.config

### DIFF
--- a/quest-config.json
+++ b/quest-config.json
@@ -12,9 +12,17 @@
             "ParentNodeId": 237266
         },
         {
+            "Label": "user-feedback",
+            "ParentNodeId": 233465
+        },
+        {
+            "Label": "doc-bug",
+            "ParentNodeId": 233465
+        },
+        {
             "Label": "dotnet-csharp/svc",
             "ParentNodeId": 227484
         }
     ],
-    "DefaultParentNode": 228485
+    "DefaultParentNode": 227485
 }

--- a/quest-config.json
+++ b/quest-config.json
@@ -5,5 +5,16 @@
         "AreaPath": "Production\\Digital and App Innovation\\DotNet and more\\dotnet"
     },
     "ImportTriggerLabel": ":world_map: reQUEST",
-    "ImportedLabel": ":pushpin: seQUESTered"
+    "ImportedLabel": ":pushpin: seQUESTered",
+    "ParentNodes": [
+        {
+            "Label": "okr-health",
+            "ParentNodeId": 199082
+        },
+        {
+            "Label": "dotnet-csharp/svc",
+            "ParentNodeId": 227484
+        }
+    ],
+    "DefaultParentNode": 228485
 }

--- a/quest-config.json
+++ b/quest-config.json
@@ -9,7 +9,7 @@
     "ParentNodes": [
         {
             "Label": "okr-health",
-            "ParentNodeId": 199082
+            "ParentNodeId": 237266
         },
         {
             "Label": "dotnet-csharp/svc",

--- a/quest-config.json
+++ b/quest-config.json
@@ -8,8 +8,16 @@
     "ImportedLabel": ":pushpin: seQUESTered",
     "ParentNodes": [
         {
-            "Label": "okr-health",
+            "Label": "okr-freshness",
             "ParentNodeId": 237266
+        },
+        {
+            "Label": "okr-curation",
+            "ParentNodeId": 237271
+        },
+        {
+            "Label": "okr-health",
+            "ParentNodeId": 237267
         },
         {
             "Label": "user-feedback",


### PR DESCRIPTION
Updates required for parenting work items once dotnet/docs-tools#317 is merged.

This adds the necessary config items for work items from this repo to be parented correctly.