### PR TITLE
Update attributes-that-control-xml-serialization.md

### DIFF
--- a/docs/standard/serialization/attributes-that-control-xml-serialization.md
+++ b/docs/standard/serialization/attributes-that-control-xml-serialization.md
@@ -29,11 +29,11 @@ You can apply the attributes in the following table to classes and class members
 |<xref:System.Xml.Serialization.XmlElementAttribute>|Public field, property, parameter, or return value.|The field or property will be serialized as an XML element.|
 |<xref:System.Xml.Serialization.XmlEnumAttribute>|Public field that is an enumeration identifier.|The element name of an enumeration member.|
 |<xref:System.Xml.Serialization.XmlIgnoreAttribute>|Public properties and fields.|The property or field should be ignored when the containing class is serialized.|
-|<xref:System.ObsoleteAttribute>|Public properties and fields.|The property or field will be ignored when the containing class is serialized.|
 |<xref:System.Xml.Serialization.XmlIncludeAttribute>|Public derived class declarations, and return values of public methods for Web Services Description Language (WSDL) documents.|The class should be included when generating schemas (to be recognized when serialized).|
 |<xref:System.Xml.Serialization.XmlRootAttribute>|Public class declarations.|Controls XML serialization of the attribute target as an XML root element. Use the attribute to further specify the namespace and element name.|
 |<xref:System.Xml.Serialization.XmlTextAttribute>|Public properties and fields.|The property or field should be serialized as XML text.|
 |<xref:System.Xml.Serialization.XmlTypeAttribute>|Public class declarations.|The name and namespace of the XML type.|
+|<xref:System.ObsoleteAttribute>|Public properties and fields.|The property or field will be ignored when the containing class is serialized.|
 
  In addition to these attributes, which are all found in the <xref:System.Xml.Serialization> namespace, you can also apply the <xref:System.ComponentModel.DefaultValueAttribute> attribute to a field. The **DefaultValueAttribute** sets the value that will be automatically assigned to the member if no value is specified.
 

--- a/docs/standard/serialization/attributes-that-control-xml-serialization.md
+++ b/docs/standard/serialization/attributes-that-control-xml-serialization.md
@@ -29,6 +29,7 @@ You can apply the attributes in the following table to classes and class members
 |<xref:System.Xml.Serialization.XmlElementAttribute>|Public field, property, parameter, or return value.|The field or property will be serialized as an XML element.|
 |<xref:System.Xml.Serialization.XmlEnumAttribute>|Public field that is an enumeration identifier.|The element name of an enumeration member.|
 |<xref:System.Xml.Serialization.XmlIgnoreAttribute>|Public properties and fields.|The property or field should be ignored when the containing class is serialized.|
+|<xref:System.ObsoleteAttribute>|Public properties and fields.|The property or field will be ignored when the containing class is serialized.|
 |<xref:System.Xml.Serialization.XmlIncludeAttribute>|Public derived class declarations, and return values of public methods for Web Services Description Language (WSDL) documents.|The class should be included when generating schemas (to be recognized when serialized).|
 |<xref:System.Xml.Serialization.XmlRootAttribute>|Public class declarations.|Controls XML serialization of the attribute target as an XML root element. Use the attribute to further specify the namespace and element name.|
 |<xref:System.Xml.Serialization.XmlTextAttribute>|Public properties and fields.|The property or field should be serialized as XML text.|


### PR DESCRIPTION
## Summary

The System.Obsolete attribute has prevented serialization in the XMLSerializer since .NET 3.5. This PR adds an entry to include the Obsolete attribute.

Fixes #40232


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/serialization/attributes-that-control-xml-serialization.md](https://github.com/dotnet/docs/blob/96e9d299e653d8147df32b2193d3da2de4daa9ce/docs/standard/serialization/attributes-that-control-xml-serialization.md) | [Attributes That Control XML Serialization](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/attributes-that-control-xml-serialization?branch=pr-en-us-40263) |


<!-- PREVIEW-TABLE-END -->