### PR TITLE
List Tuple as an unmanaged type

### DIFF
--- a/docs/csharp/language-reference/builtin-types/unmanaged-types.md
+++ b/docs/csharp/language-reference/builtin-types/unmanaged-types.md
@@ -12,6 +12,7 @@ A type is an **unmanaged type** if it's any of the following types:
 - `sbyte`, `byte`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `nint`, `nuint`, `char`, `float`, `double`, `decimal`, or `bool`
 - Any [enum](enum.md) type
 - Any [pointer](../unsafe-code.md#pointer-types) type
+- A [tuple](value-tuples.md) whose members are all of an unmanaged type
 - Any user-defined [struct](struct.md) type that contains fields of unmanaged types only.
 
 You can use the [`unmanaged` constraint](../../programming-guide/generics/constraints-on-type-parameters.md#unmanaged-constraint) to specify that a type parameter is a non-pointer, non-nullable unmanaged type.


### PR DESCRIPTION
This pull request closes #39912 
It adds tuples to the bullet point list of what is considered an unmanaged type.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/builtin-types/unmanaged-types.md](https://github.com/dotnet/docs/blob/3a546e61e59a727d2ee9bf29a5a83a82127a1431/docs/csharp/language-reference/builtin-types/unmanaged-types.md) | [Unmanaged types (C# reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/unmanaged-types?branch=pr-en-us-40282) |

<!-- PREVIEW-TABLE-END -->