### PR TITLE
Replace 'a' with 'the' for grammar in list

### DIFF
--- a/docs/csharp/language-reference/keywords/init.md
+++ b/docs/csharp/language-reference/keywords/init.md
@@ -44,7 +44,7 @@ The `init` accessor can also be used in autoimplemented properties, as the follo
 
 :::code language="csharp" source="snippets/InitExample2.cs":::
 
-The following example shows the distinction between a `private set`, read only, and `init` properties. Both the private set version and the read only version require callers to use the added constructor to set the name property. The `private set` version allows a person to change their name after the instance is constructed. The `init` version doesn't require a constructor. Callers can initialize the properties using an object initializer:
+The following example shows the distinction between the `private set`, read only, and `init` properties. Both the private set version and the read only version require callers to use the added constructor to set the name property. The `private set` version allows a person to change their name after the instance is constructed. The `init` version doesn't require a constructor. Callers can initialize the properties using an object initializer:
 
 :::code language="csharp" source="snippets/InitExample4.cs" id="SnippetClassDefinitions":::
 

--- a/docs/csharp/language-reference/keywords/init.md
+++ b/docs/csharp/language-reference/keywords/init.md
@@ -44,7 +44,7 @@ The `init` accessor can also be used in autoimplemented properties, as the follo
 
 :::code language="csharp" source="snippets/InitExample2.cs":::
 
-The following example shows the distinction between the `private set`, read only, and `init` properties. Both the private set version and the read only version require callers to use the added constructor to set the name property. The `private set` version allows a person to change their name after the instance is constructed. The `init` version doesn't require a constructor. Callers can initialize the properties using an object initializer:
+The following example shows the distinction between a `private set`, read only, and `init` property. Both the private set version and the read only version require callers to use the added constructor to set the name property. The `private set` version allows a person to change their name after the instance is constructed. The `init` version doesn't require a constructor. Callers can initialize the properties using an object initializer:
 
 :::code language="csharp" source="snippets/InitExample4.cs" id="SnippetClassDefinitions":::
 


### PR DESCRIPTION
This small pull request fixes #40278 
It replaces `a` with `the` word for the list as per suggestion in issue.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/init.md](https://github.com/dotnet/docs/blob/a490bb1188cf8e37d6d918f76ea4d7ee3db18bd9/docs/csharp/language-reference/keywords/init.md) | [init (C# Reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/init?branch=pr-en-us-40283) |


<!-- PREVIEW-TABLE-END -->