### PR TITLE
Update INSTALLFOLDER from ProgramFilesFolder to ProgramFiles64Folder

### DIFF
--- a/docs/core/extensions/windows-service-with-installer.md
+++ b/docs/core/extensions/windows-service-with-installer.md
@@ -187,7 +187,7 @@ After the project reference has been added, configure the _Package.wxs_ file. Op
 
         <!-- Define the directory structure -->
         <Directory Id="TARGETDIR" Name="SourceDir">
-            <Directory Id="ProgramFilesFolder">
+            <Directory Id="ProgramFiles64Folder">
 
                 <!-- Create a folder inside program files -->
                 <Directory Id="ROOTDIRECTORY" Name="$(var.Manufacturer)">


### PR DESCRIPTION
- WIX0204	ICE80: This 64BitComponent ServiceExecutable uses 32BitDirectory INSTALLFOLDER
- https://wixtoolset.org/docs/tools/burn/builtin-variables/


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/windows-service-with-installer.md](https://github.com/dotnet/docs/blob/ed8284a4373d4965de583a502938a4f85ecf3a9a/docs/core/extensions/windows-service-with-installer.md) | [Create a Windows Service installer](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/windows-service-with-installer?branch=pr-en-us-40287) |

<!-- PREVIEW-TABLE-END -->