### PR TITLE
Fix Russian filename typo

### DIFF
--- a/docs/core/extensions/retrieve-resources.md
+++ b/docs/core/extensions/retrieve-resources.md
@@ -51,7 +51,7 @@ The French (France) resource is in a file named Strings.fr-FR.txt:
 TimeHeader=L'heure actuelle est
 ```
 
-The Russian (Russia) resource is in a file named Strings.ru-RU-txt:
+The Russian (Russia) resource is in a file named Strings.ru-RU.txt:
 
 ```text
 TimeHeader=Текущее время —


### PR DESCRIPTION
## Summary

This PR fixes #40281 

The file extension is now `.txt` instead of `-txt`.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/retrieve-resources.md](https://github.com/dotnet/docs/blob/ec9e13df3fd73afd50c36d1d000299e7ae9a14c6/docs/core/extensions/retrieve-resources.md) | [Retrieve resources in .NET apps](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/retrieve-resources?branch=pr-en-us-40291) |

<!-- PREVIEW-TABLE-END -->