### PR TITLE
Correct issues in Quantifier Operations page of `Any` example

### DIFF
--- a/docs/csharp/linq/standard-query-operators/quantifier-operations.md
+++ b/docs/csharp/linq/standard-query-operators/quantifier-operations.md
@@ -26,7 +26,7 @@ The following example uses the `All` to find students that scored above 70 on al
   
 ## Any
 
-The following example uses the `Any` to find students that scored greater than 96 on an exam.
+The following example uses the `Any` to find students that scored greater than 95 on any exam.
 
 :::code language="csharp" source="./snippets/standard-query-operators/QuantifierExamples.cs" id="AnyQuantifier":::
 

--- a/docs/csharp/linq/standard-query-operators/snippets/standard-query-operators/QuantifierExamples.cs
+++ b/docs/csharp/linq/standard-query-operators/snippets/standard-query-operators/QuantifierExamples.cs
@@ -40,7 +40,6 @@ public class QuantifierExamples
     private static void AnyExample()
     {
         // <AnyQuantifier>
-
         IEnumerable<string> names = from student in students
                                     where student.Scores.Any(score => score > 95)
                                     select $"{student.FirstName} {student.LastName}: {student.Scores.Max()}";
@@ -69,7 +68,6 @@ public class QuantifierExamples
     private static void ContainsExample()
     {
         // <ContainsQuantifier>
-
         IEnumerable<string> names = from student in students
                                     where student.Scores.Contains(95)
                                     select $"{student.FirstName} {student.LastName}: {string.Join(", ", student.Scores.Select(s => s.ToString()))}";

--- a/docs/csharp/linq/standard-query-operators/snippets/standard-query-operators/QuantifierExamples.cs
+++ b/docs/csharp/linq/standard-query-operators/snippets/standard-query-operators/QuantifierExamples.cs
@@ -70,7 +70,6 @@ public class QuantifierExamples
     {
         // <ContainsQuantifier>
 
-        // Determine which market contains fruit names equal 'kiwi'
         IEnumerable<string> names = from student in students
                                     where student.Scores.Contains(95)
                                     select $"{student.FirstName} {student.LastName}: {string.Join(", ", student.Scores.Select(s => s.ToString()))}";


### PR DESCRIPTION
This pull request fixes #40293 regarding the issue with the comment being out of place.
Also, as I was modifying the page, I found that the description of `Any` example could be improved by threshold of exam score typo (96 instead of 95) and more specific mention the condition is for 'any' exam which such score was achieved.

Also, this PR removes the empty lines between examples opening XML marks and the first line of code. Initially I thought they meant to be there, but the first example has no such empty line separation and visually it's just fine when checking on the page.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/linq/standard-query-operators/quantifier-operations.md](https://github.com/dotnet/docs/blob/eccb3069d019df7350dfe07864d225f8f1a1b787/docs/csharp/linq/standard-query-operators/quantifier-operations.md) | [Quantifier operations in LINQ (C#)](https://review.learn.microsoft.com/en-us/dotnet/csharp/linq/standard-query-operators/quantifier-operations?branch=pr-en-us-40297) |

<!-- PREVIEW-TABLE-END -->