### PR TITLE
Removed warning block as not relevant anymore

### DIFF
--- a/docs/core/whats-new/dotnet-core-3-0.md
+++ b/docs/core/whats-new/dotnet-core-3-0.md
@@ -383,9 +383,6 @@ The GPIO packages include APIs for *GPIO*, *SPI*, *I2C*, and *PWM* devices. The 
 
 When available, .NET Core 3.0 uses **OpenSSL 1.1.1**, **OpenSSL 1.1.0**, or **OpenSSL 1.0.2** on a Linux system. When **OpenSSL 1.1.1** is available, both <xref:System.Net.Security.SslStream?displayProperty=nameWithType> and <xref:System.Net.Http.HttpClient?displayProperty=nameWithType> types will use **TLS 1.3** (assuming both the client and server support **TLS 1.3**).
 
-> [!IMPORTANT]
-> Windows and macOS do not yet support **TLS 1.3**.
-
 The following C# 8.0 example demonstrates .NET Core 3.0 on Ubuntu 18.10 connecting to <https://www.cloudflare.com>:
 
 [!code-csharp[TLSExample](./snippets/dotnet-core-3-0/csharp/TLS.cs#TLS)]


### PR DESCRIPTION
Removed old tls1.3 warning because windows and macos fully support it now.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/whats-new/dotnet-core-3-0.md](https://github.com/dotnet/docs/blob/01154cacf64a70fdcd5e947a131786b414c6c767/docs/core/whats-new/dotnet-core-3-0.md) | [What's new in .NET Core 3.0](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-core-3-0?branch=pr-en-us-40298) |

<!-- PREVIEW-TABLE-END -->