### PR TITLE
Add workaround for Dotnet Runtime Issue 91121

### DIFF
--- a/docs/fundamentals/syslib-diagnostics/syslib1019.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib1019.md
@@ -14,4 +14,15 @@ When a logging method definition doesn't explicitly include a parameter of type 
 
 Ensure the type containing the logging method includes a field of type `ILogger` or include a parameter of type `ILogger` in the logging method signature.
 
+### Primary Constructors
+
+Smallest possible edit to workaround [Dotnet Runtime Issue 91121 - LoggerMessage source generator does not work with logger from primary constructor](https://github.com/dotnet/runtime/issues/91121):
+
+```
+public partial class Foo(ILogger<Foo> logger) {
+    // workaround for https://github.com/dotnet/runtime/issues/91121
+    private readonly ILogger _logger = logger;
+}
+```
+
 [!INCLUDE [suppress-syslib-warning](includes/suppress-source-generator-diagnostics.md)]

--- a/docs/fundamentals/syslib-diagnostics/syslib1019.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib1019.md
@@ -14,14 +14,16 @@ When a logging method definition doesn't explicitly include a parameter of type 
 
 Ensure the type containing the logging method includes a field of type `ILogger` or include a parameter of type `ILogger` in the logging method signature.
 
+<!-- markdownlint-disable MD027 -->
 > [!NOTE]
 > If you get this error but your class uses a [primary constructor that takes an `ILogger`](https://github.com/dotnet/runtime/issues/91121), you can resolve the error by adding an `ILogger` field as follows:
-
-```csharp
-public partial class Foo(ILogger<Foo> logger) {
-    // Workaround for https://github.com/dotnet/runtime/issues/91121.
-    private readonly ILogger _logger = logger;
-}
-```
+>
+> ```csharp
+> public partial class Foo(ILogger<Foo> logger) {
+>     // Workaround for https://github.com/dotnet/runtime/issues/91121.
+>     private readonly ILogger _logger = logger;
+> }
+> ```
+<!-- markdownlint-enable MD027 -->
 
 [!INCLUDE [suppress-syslib-warning](includes/suppress-source-generator-diagnostics.md)]

--- a/docs/fundamentals/syslib-diagnostics/syslib1019.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib1019.md
@@ -14,11 +14,10 @@ When a logging method definition doesn't explicitly include a parameter of type 
 
 Ensure the type containing the logging method includes a field of type `ILogger` or include a parameter of type `ILogger` in the logging method signature.
 
-### Primary Constructors
+> [!NOTE]
+> If you get this error but your class uses a [primary constructor that takes an `ILogger`](https://github.com/dotnet/runtime/issues/91121), you can resolve the error by adding an `ILogger` field as follows:
 
-Smallest possible edit to workaround [Dotnet Runtime Issue 91121 - LoggerMessage source generator does not work with logger from primary constructor](https://github.com/dotnet/runtime/issues/91121):
-
-```
+```csharp
 public partial class Foo(ILogger<Foo> logger) {
     // workaround for https://github.com/dotnet/runtime/issues/91121
     private readonly ILogger _logger = logger;

--- a/docs/fundamentals/syslib-diagnostics/syslib1019.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib1019.md
@@ -19,7 +19,7 @@ Ensure the type containing the logging method includes a field of type `ILogger`
 
 ```csharp
 public partial class Foo(ILogger<Foo> logger) {
-    // workaround for https://github.com/dotnet/runtime/issues/91121
+    // Workaround for https://github.com/dotnet/runtime/issues/91121.
     private readonly ILogger _logger = logger;
 }
 ```


### PR DESCRIPTION
## Summary

Adds workaround from https://github.com/dotnet/runtime/issues/91121

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/syslib-diagnostics/syslib1019.md](https://github.com/dotnet/docs/blob/396e309b52c0467b19aa0fd0c78724b0e4a3838d/docs/fundamentals/syslib-diagnostics/syslib1019.md) | [SYSLIB1019: Couldn't find a field of type `ILogger`](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib1019?branch=pr-en-us-40323) |


<!-- PREVIEW-TABLE-END -->