### PR TITLE
Nits for CA1871 and CA2264

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1871.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1871.md
@@ -36,7 +36,7 @@ Check for null and throw the <xref:System.ArgumentNullException> manually.
 
 ## Example
 
-The following code snippet shows a violations of CA1871:
+The following code snippet shows a violation of CA1871:
 
 ```csharp
 static void Print(int? value)
@@ -46,7 +46,7 @@ static void Print(int? value)
 }
 ```
 
-The following code snippet fixes the violations:
+The following code snippet fixes the violation:
 
 ```csharp
 static void Print(int? value)

--- a/docs/fundamentals/code-analysis/quality-rules/ca2264.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2264.md
@@ -9,6 +9,7 @@ helpviewer_keywords:
 dev_langs:
   - CSharp
 ---
+
 # CA2264: Do not pass a non-nullable value to 'ArgumentNullException.ThrowIfNull'
 
 | Property                            | Value                                                                   |
@@ -35,6 +36,8 @@ Remove the `ArgumentNullException.ThrowIfNull` call.
 
 ## Example
 
+The following code snippet shows a violation of CA2264:
+
 ```csharp
 static void Print(int value)
 {
@@ -43,7 +46,7 @@ static void Print(int value)
 }
 ```
 
-The following code snippet fixes the violations:
+The following code snippet fixes the violation:
 
 ```csharp
 static void Print(int value)


### PR DESCRIPTION
## Summary

Address some minor nits found after viewing #39661.

~~CC @gewarren (since that PR is recently merged)~~ (Edit: apologies for another ping, did not realize this was unnecessary)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1871.md](https://github.com/dotnet/docs/blob/069b179459b125125175731172c343105b388345/docs/fundamentals/code-analysis/quality-rules/ca1871.md) | [CA1871: Do not pass a nullable struct to 'ArgumentNullException.ThrowIfNull'](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1871?branch=pr-en-us-40341) |
| [docs/fundamentals/code-analysis/quality-rules/ca2264.md](https://github.com/dotnet/docs/blob/069b179459b125125175731172c343105b388345/docs/fundamentals/code-analysis/quality-rules/ca2264.md) | ["CA2264: Do not pass a non-nullable value to 'ArgumentNullException.ThrowIfNull'"](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2264?branch=pr-en-us-40341) |

<!-- PREVIEW-TABLE-END -->