### PR TITLE
Use older syntax for Try.NET

### DIFF
--- a/docs/csharp/language-reference/operators/snippets/shared/NameOfOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/NameOfOperator.cs
@@ -10,7 +10,7 @@ public static class NameOfOperator
         Console.WriteLine(nameof(List<int>.Count));  // output: Count
         Console.WriteLine(nameof(List<int>.Add));  // output: Add
 
-        List<int> numbers = new() { 1, 2, 3 };
+        List<int> numbers = new List<int>() { 1, 2, 3 };
         Console.WriteLine(nameof(numbers));  // output: numbers
         Console.WriteLine(nameof(numbers.Count));  // output: Count
         Console.WriteLine(nameof(numbers.Add));  // output: Add


### PR DESCRIPTION
The target typed new operator isn't supported in Try.NET yet.


---
[Associated WorkItem - 241082](https://dev.azure.com/msft-skilling/Content/_workitems/edit/241082)