### PR TITLE
Update fixing-warnings.md

### DIFF
--- a/docs/core/deploying/trimming/fixing-warnings.md
+++ b/docs/core/deploying/trimming/fixing-warnings.md
@@ -87,7 +87,7 @@ If the guidance to the developer becomes too long to be included in a warning me
 For example:
 
 ```csharp
-[RequiresUnreferencedCode("This functionality is not compatible with trimming. Use 'MethodFriendlyToTrimming' instead", Url = "https://site/trimming-and-method)]
+[RequiresUnreferencedCode("This functionality is not compatible with trimming. Use 'MethodFriendlyToTrimming' instead", Url = "https://site/trimming-and-method")]
 void MethodWithAssemblyLoad() { ... }
 ```
 


### PR DESCRIPTION
## Summary

Add missing end quote in trim warning doc fixing-warnings.md that messed up syntax highlighting.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/deploying/trimming/fixing-warnings.md](https://github.com/dotnet/docs/blob/f4a3adb3356cd09f4580eeaf732225c5f2ea8edc/docs/core/deploying/trimming/fixing-warnings.md) | [Introduction to trim warnings](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/fixing-warnings?branch=pr-en-us-40349) |

<!-- PREVIEW-TABLE-END -->