### PR TITLE
Add named and typed httpclient example to the IHttpClientFactory with .NET page

### DIFF
--- a/docs/core/extensions/httpclient-factory.md
+++ b/docs/core/extensions/httpclient-factory.md
@@ -38,6 +38,7 @@ There are several ways `IHttpClientFactory` can be used in an app:
 * [Basic usage](#basic-usage)
 * [Named clients](#named-clients)
 * [Typed clients](#typed-clients)
+* [Named and typed clients](#named-and-typed-clients)
 * [Generated clients](#generated-clients)
 
 The best approach depends upon the app's requirements.
@@ -126,6 +127,48 @@ The typed client is registered as transient with DI. In the preceding code, `Add
 
 > [!NOTE]
 > When registering a typed client with the `AddHttpClient<TClient>` method, the `TClient` type must have a constructor that accepts an `HttpClient` parameter. Additionally, the `TClient` type shouldn't be registered with the DI container separately.
+
+### Named and typed clients
+
+Named clients and typed clients have their own strengths and weaknesses. There is a way to combine these two client types to get the best both worlds.
+
+The primary use case is the following: Use the same typed client but against different domains. For example you have a primary and a secondary service and they expose the exact same functionality. That means you can use the same typed client to wrap the `HttpClient` usage to issue requests, process responses, and handle errors. The exact same code will be used but with different configurations (different base address, timeout, credentials, etc.).
+
+The following example uses the same `TodoService` typed client which was shown under the [typed clients](#typed-clients) section.
+
+First register the named and typed clients.
+
+:::code source="snippets/http/nameandtyped/Program.cs" range="1-25" highlight="9,14-15,19,23-24":::
+
+In the preceding code:
+
+- The first `AddHttpClient` call registers a `TodoService` typed client under the `primary` name. The underlying `HttpClient` points to the primary service and has a short timeout.
+- The second `AddHttpClient` call registers a `TodoService` typed client under the `secondary` name. The underlying `HttpClient` points to the secondary service and has a longer timeout.
+
+:::code source="snippets/http/nameandtyped/Program.cs" range="27-39" highlight="34-35,38-39":::
+
+In the preceding code:
+
+- An `IHttpClientFactory` instance is retrieved from the DI container to be able to create named clients via its `CreateClient` method.
+- An `ITypedHttpClientFactory<TodoService>` instance is retrieved from the DI container to be able to create typed clients via its `CreateClient` method.
+  - This `CreateClient` overload received a named `HttpClient` (with the proper configuration) as its parameter.
+  - The created `todoService` is configured to use the primary service.
+
+> [!NOTE]
+> The `IHttpClientFactory` type resides inside the `System.Net.Http` namespaces whereas the `ITypedHttpClientFactory` type inside the `Microsoft.Extensions.Http`.
+
+> [!IMPORTANT]
+> Use the implementation class (in the preceding example the `TodoService`) as the type parameter for the `ITypedHttpClientFactory`.
+> Even if you have an abstraction (like `ITodoService` interface) as well, you still have to use the implementation.
+> If you accidentally use the abstraction (`ITodoService`) then when you call its `CreateClient` it will throw an `InvalidOperationException`.
+
+:::code source="snippets/http/nameandtyped/Program.cs" range="41-55" highlight="45,50-51,54":::
+
+In the preceding code:
+
+- It tries to issue a request against the primary service.
+- If the request times out (takes longer than 3 seconds) then it throws a `TaskCanceledException` with a `TimeoutException` inner.
+- In case of timeout a new client is created and used which is now targeting the secondary service.
 
 ### Generated clients
 

--- a/docs/core/extensions/httpclient-factory.md
+++ b/docs/core/extensions/httpclient-factory.md
@@ -130,15 +130,15 @@ The typed client is registered as transient with DI. In the preceding code, `Add
 
 ### Named and typed clients
 
-Named clients and typed clients have their own strengths and weaknesses. There is a way to combine these two client types to get the best both worlds.
+Named clients and typed clients have their own strengths and weaknesses. There is a way to combine these two client types to get the best of both worlds.
 
-The primary use case is the following: Use the same typed client but against different domains. For example you have a primary and a secondary service and they expose the exact same functionality. That means you can use the same typed client to wrap the `HttpClient` usage to issue requests, process responses, and handle errors. The exact same code will be used but with different configurations (different base address, timeout, credentials, etc.).
+The primary use case is the following: Use the same typed client but against different domains. For example you have a primary and a secondary service and they expose the exact same functionality. That means you can use the same typed client to wrap the `HttpClient` usage to issue requests, process responses, and handle errors. The exact same code will be used but with different configurations (different base address, timeout, and credentials for example).
 
 The following example uses the same `TodoService` typed client which was shown under the [typed clients](#typed-clients) section.
 
 First register the named and typed clients.
 
-:::code source="snippets/http/namedandtyped/Program.cs" range="1-25" highlight="9,14-15,19,23-24":::
+:::code source="snippets/http/namedandtyped/Program.cs" range="1-25" highlight="10,14-15,19,23-24":::
 
 In the preceding code:
 
@@ -158,9 +158,7 @@ In the preceding code:
 > The `IHttpClientFactory` type resides inside the `System.Net.Http` namespaces whereas the `ITypedHttpClientFactory` type inside the `Microsoft.Extensions.Http`.
 
 > [!IMPORTANT]
-> Use the implementation class (in the preceding example the `TodoService`) as the type parameter for the `ITypedHttpClientFactory`.
-> Even if you have an abstraction (like `ITodoService` interface) as well, you still have to use the implementation.
-> If you accidentally use the abstraction (`ITodoService`) then when you call its `CreateClient` it will throw an `InvalidOperationException`.
+> Use the implementation class (in the preceding example the `TodoService`) as the type parameter for the `ITypedHttpClientFactory`. Even if you have an abstraction (like `ITodoService` interface) as well, you still have to use the implementation. If you accidentally use the abstraction (`ITodoService`) then when you call its `CreateClient` it will throw an `InvalidOperationException`.
 
 :::code source="snippets/http/namedandtyped/Program.cs" range="41-55" highlight="45,50-51,54":::
 

--- a/docs/core/extensions/httpclient-factory.md
+++ b/docs/core/extensions/httpclient-factory.md
@@ -145,7 +145,7 @@ In the preceding code:
 - The first `AddHttpClient` call registers a `TodoService` typed client under the `primary` name. The underlying `HttpClient` points to the primary service and has a short timeout.
 - The second `AddHttpClient` call registers a `TodoService` typed client under the `secondary` name. The underlying `HttpClient` points to the secondary service and has a longer timeout.
 
-:::code source="snippets/http/namedandtyped/Program.cs" range="27-39" highlight="34-35,38-39":::
+:::code source="snippets/http/namedandtyped/Program.cs" range="27-39" highlight="8-9,12-13":::
 
 In the preceding code:
 
@@ -160,7 +160,7 @@ In the preceding code:
 > [!IMPORTANT]
 > Use the implementation class (in the preceding example the `TodoService`) as the type parameter for the `ITypedHttpClientFactory`. Even if you have an abstraction (like `ITodoService` interface) as well, you still have to use the implementation. If you accidentally use the abstraction (`ITodoService`) then when you call its `CreateClient` it will throw an `InvalidOperationException`.
 
-:::code source="snippets/http/namedandtyped/Program.cs" range="41-55" highlight="45,50-51,54":::
+:::code source="snippets/http/namedandtyped/Program.cs" range="41-55" highlight="5,10-11":::
 
 In the preceding code:
 

--- a/docs/core/extensions/httpclient-factory.md
+++ b/docs/core/extensions/httpclient-factory.md
@@ -138,14 +138,14 @@ The following example uses the same `TodoService` typed client which was shown u
 
 First register the named and typed clients.
 
-:::code source="snippets/http/nameandtyped/Program.cs" range="1-25" highlight="9,14-15,19,23-24":::
+:::code source="snippets/http/namedandtyped/Program.cs" range="1-25" highlight="9,14-15,19,23-24":::
 
 In the preceding code:
 
 - The first `AddHttpClient` call registers a `TodoService` typed client under the `primary` name. The underlying `HttpClient` points to the primary service and has a short timeout.
 - The second `AddHttpClient` call registers a `TodoService` typed client under the `secondary` name. The underlying `HttpClient` points to the secondary service and has a longer timeout.
 
-:::code source="snippets/http/nameandtyped/Program.cs" range="27-39" highlight="34-35,38-39":::
+:::code source="snippets/http/namedandtyped/Program.cs" range="27-39" highlight="34-35,38-39":::
 
 In the preceding code:
 
@@ -162,7 +162,7 @@ In the preceding code:
 > Even if you have an abstraction (like `ITodoService` interface) as well, you still have to use the implementation.
 > If you accidentally use the abstraction (`ITodoService`) then when you call its `CreateClient` it will throw an `InvalidOperationException`.
 
-:::code source="snippets/http/nameandtyped/Program.cs" range="41-55" highlight="45,50-51,54":::
+:::code source="snippets/http/namedandtyped/Program.cs" range="41-55" highlight="45,50-51,54":::
 
 In the preceding code:
 

--- a/docs/core/extensions/snippets/http/namedandtyped/Program.cs
+++ b/docs/core/extensions/snippets/http/namedandtyped/Program.cs
@@ -1,0 +1,57 @@
+using Shared;
+using TypedHttp.Example;
+using Microsoft.Extensions.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
+
+builder.Services.AddHttpClient<TodoService>("primary"
+    client =>
+    {
+        // Configure the primary typed client
+        client.BaseAddress = new Uri("https://primary-host-address.com/");
+        client.Timeout = TimeSpan.FromSeconds(3);
+    });
+
+// Register the same typed client but with different settings
+builder.Services.AddHttpClient<TodoService>("secondary"
+    client =>
+    {
+        // Configure the secondary typed client
+        client.BaseAddress = new Uri("https://secondary-host-address.com/");
+        client.Timeout = TimeSpan.FromSeconds(10);
+    });
+
+using IHost host = builder.Build();
+
+// Fetch an IHttpClientFactory instance to create a named client
+IHttpClientFactory namedClientFactory =
+    host.Services.GetRequiredService<IHttpClientFactory>();
+
+// Fetch an ITypedHttpClientFactory<TodoService> instance to create a named and typed client
+ITypedHttpClientFactory<TodoService> typedClientFactory  =
+    host.Services.GetRequiredService<ITypedHttpClientFactory<TodoService>>();
+
+// Create a TodoService instance against the primary host
+var primaryClient = namedClientFactory.CreateClient("primary");
+var todoService = typedClientFactory.CreateClient(primaryClient);
+
+try
+{
+    Todo[] todos = await todoService.GetUserTodosAsync(4);
+}
+catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException)
+{
+    // The request timed out against the primary host
+
+    // Create a TodoService instance against the secondary host
+    var fallbackClient = namedClientFactory.CreateClient("secondary");
+    var todoFallbackService = typedClientFactory.CreateClient(fallbackClient);
+
+    // Issue request against the secondary host
+    Todo[] todos = await todoFallbackService.GetUserTodosAsync(4);
+}
+
+await host.RunAsync();

--- a/docs/core/extensions/snippets/http/namedandtyped/TodoService.cs
+++ b/docs/core/extensions/snippets/http/namedandtyped/TodoService.cs
@@ -1,0 +1,31 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Shared;
+
+namespace TypedHttp.Example;
+
+public sealed class TodoService(
+    HttpClient httpClient,
+    ILogger<TodoService> logger) : IDisposable
+{
+    public async Task<Todo[]> GetUserTodosAsync(int userId)
+    {
+        try
+        {
+            // Make HTTP GET request
+            // Parse JSON response deserialize into Todo type
+            Todo[]? todos = await httpClient.GetFromJsonAsync<Todo[]>(
+                $"todos?userId={userId}",
+                new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+            return todos ?? [];
+        }
+        catch (Exception ex)
+        {
+            logger.LogError("Error getting something fun to say: {Error}", ex);
+        }
+
+        return [];
+    }
+}

--- a/docs/core/extensions/snippets/http/namedandtyped/namedandtyped.csproj
+++ b/docs/core/extensions/snippets/http/namedandtyped/namedandtyped.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+    <RootNamespace>TypedHttp.Example</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\shared\shared.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

The [Use the IHttpClientFactory / IHttpClientFactory with .NET](https://learn.microsoft.com/en-us/dotnet/core/extensions/httpclient-factory) page shows how to use named or typed `HttpClient`s. 

But it does not even mention **named and typed** client.

The main aim of this pull request is to show how to register and use named and typed clients.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/httpclient-factory.md](https://github.com/dotnet/docs/blob/669bc221bbcaf2186137e622034120d1346e0245/docs/core/extensions/httpclient-factory.md) | [IHttpClientFactory with .NET](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/httpclient-factory?branch=pr-en-us-40359) |


<!-- PREVIEW-TABLE-END -->