### PR TITLE
Apply PersistedAssemblyBuilder API changes introduced in preview 3

### DIFF
--- a/docs/core/porting/net-framework-tech-unavailable.md
+++ b/docs/core/porting/net-framework-tech-unavailable.md
@@ -59,7 +59,7 @@ Windows Workflow Foundation (WF) is not supported in .NET 6+. For an alternative
 - <xref:System.Reflection.Emit.AssemblyBuilderAccess.RunAndSave>
 - <xref:System.Reflection.Emit.AssemblyBuilderAccess.Save>
 
-In .NET 9, a persisted `AssemblyBuilder` was implemented and the <xref:System.Reflection.Emit.AssemblyBuilder.Save%2A?displayProperty=nameWithType> method was added back to the reflection emit library. To learn more about how to use this API, see [System.Reflection.Emit.AssemblyBuilder class](../../fundamentals/runtime-libraries/system-reflection-emit-assemblybuilder.md#persistable-dynamic-assemblies-in-net).
+In .NET 9, a `PersistedAssemblyBuilder` was implemented and the <xref:System.Reflection.Emit.AssemblyBuilder.Save%2A?displayProperty=nameWithType> method was added back to the reflection emit library. To learn more about how to use this API, see [System.Reflection.Emit.AssemblyBuilder class](../../fundamentals/runtime-libraries/system-reflection-emit-assemblybuilder.md#persisted-dynamic-assemblies-in-net).
 
 For more information, see [dotnet/runtime issue 15704](https://github.com/dotnet/runtime/issues/15704).
 

--- a/docs/fundamentals/runtime-libraries/system-reflection-emit-assemblybuilder.md
+++ b/docs/fundamentals/runtime-libraries/system-reflection-emit-assemblybuilder.md
@@ -7,7 +7,7 @@ ms.date: 12/31/2023
 
 [!INCLUDE [context](includes/context.md)]
 
-A dynamic assembly is an assembly that is created using the Reflection Emit APIs. A dynamic assembly can reference types defined in another dynamic or static assembly. You can use <xref:System.Reflection.Emit.AssemblyBuilder> to generate dynamic assemblies in memory and execute their code during the same application run. .NET 9 added a fully managed implementation for reflection emit that allows you save the assembly into a file. In .NET Framework, you can do both&mdash;run the dynamic assembly and save it to a file. The dynamic assembly created for saving is called a *persistable* assembly, while the regular memory-only assembly is called *transient*. In .NET Framework, a dynamic assembly can consist of one or more dynamic modules. In .NET Core and .NET 5+, a dynamic assembly can only consist of one dynamic module.
+A dynamic assembly is an assembly that is created using the Reflection Emit APIs. A dynamic assembly can reference types defined in another dynamic or static assembly. You can use <xref:System.Reflection.Emit.AssemblyBuilder> to generate dynamic assemblies in memory and execute their code during the same application run. In .NET 9 we added a new `PersistedAssemblyBuilder` with fully managed implementation of reflection emit that allows you save the assembly into a file. In .NET Framework, you can do both&mdash;run the dynamic assembly and save it to a file. The dynamic assembly created for saving is called a *persisted* assembly, while the regular memory-only assembly is called *transient* or *runnable*. In .NET Framework, a dynamic assembly can consist of one or more dynamic modules. In .NET Core and .NET 5+, a dynamic assembly can only consist of one dynamic module.
 
 The way you create an <xref:System.Reflection.Emit.AssemblyBuilder> instance differs for each implementation, but further steps for defining a module, type, method, or enum, and for writing IL, are quite similar.
 
@@ -49,16 +49,14 @@ public void CreateAndRunAssembly(string assemblyPath)
 }
 ```
 
-## Persistable dynamic assemblies in .NET
+## Persisted dynamic assemblies in .NET
 
-The <xref:System.Reflection.Emit.AssemblyBuilder.Save%2A?displayProperty=nameWithType> API wasn't originally ported to .NET (Core) because the implementation depended heavily on Windows-specific native code that also wasn't ported. However, because you could only *run* a generated assembly and not *save* it, it was difficult to debug these in-memory assemblies. Other advantages of saving a dynamic assembly to a file are:
+The <xref:System.Reflection.Emit.AssemblyBuilder.Save%2A?displayProperty=nameWithType> API wasn't originally ported to .NET (Core) because the implementation depended heavily on Windows-specific native code that also wasn't ported. In .NET 9 we added a fully managed `Reflection.Emit` implementation that supports saving. This implementation has no dependency on the pre-existing, runtime-specific `Reflection.Emit` implementation. That is, now there are two different implementations in .NET, runnable and persisted. To run the persisted assembly, first save it into a memory stream or a file, then load it back. Before `PersistedAssemblyBuilder`, because you could only run a generated assembly and not save it, it was difficult to debug these in-memory assemblies. Advantages of saving a dynamic assembly to a file are:
 
 - You can verify the generated assembly with tools such as ILVerify, or decompile and manually examine it with tools such as ILSpy.
-- The saved assembly can be shared or loaded directly, which can decrease application startup time.
+- The saved assembly can be loaded directly, no need to compile again, which can decrease application startup time.
 
-.NET 9 adds a fully managed `Reflection.Emit` implementation that supports saving. This implementation has no dependency on the pre-existing, runtime-specific `Reflection.Emit` implementation. That is, now there are two different implementations. The assemblies generated with the new managed implementation can be saved. To run the assembly, first save it into a memory stream or a file, then load it back.
-
-To create a persistable `AssemblyBuilder` instance, use the static factory method <xref:System.Reflection.Emit.AssemblyBuilder.DefinePersistedAssembly(System.Reflection.AssemblyName,System.Reflection.Assembly,System.Collections.Generic.IEnumerable{System.Reflection.Emit.CustomAttributeBuilder})?displayProperty=nameWithType>. The `coreAssembly` parameter is used to resolve base runtime types and can be used for resolving reference assembly versioning.
+To create a `PersistedAssemblyBuilder` instance, use the `public PersistedAssemblyBuilder(AssemblyName name, Assembly coreAssembly, IEnumerable<CustomAttributeBuilder>? assemblyAttributes = null)` constructor. The `coreAssembly` parameter is used to resolve base runtime types and can be used for resolving reference assembly versioning:
 
 - If `Reflection.Emit` is used to generate an assembly that targets a specific TFM, open the reference assemblies for the given TFM using `MetadataLoadContext` and use the value of the [MetadataLoadContext.CoreAssembly](xref:System.Reflection.MetadataLoadContext.CoreAssembly) property for `coreAssembly`. This value allows the generator to run on one .NET runtime version and target a different .NET runtime version.
 
@@ -69,7 +67,7 @@ The following example demonstrates how to create and save an assembly to a strea
 ```csharp
 public void CreateSaveAndRunAssembly(string assemblyPath)
 {
-    AssemblyBuilder ab = AssemblyBuilder.DefinePersistedAssembly(new AssemblyName("MyAssembly"), typeof(object).Assembly);
+    PersistedAssemblyBuilder ab = new PersistedAssemblyBuilder(new AssemblyName("MyAssembly"), typeof(object).Assembly);
     ModuleBuilder mob = ab.DefineDynamicModule("MyModule");
     TypeBuilder tb = mob.DefineType("MyType", TypeAttributes.Public | TypeAttributes.Class);
     MethodBuilder meb = tb.DefineMethod("SumMethod", MethodAttributes.Public | MethodAttributes.Static,
@@ -91,6 +89,36 @@ public void CreateSaveAndRunAssembly(string assemblyPath)
 }
 ```
 
+In order to set entry point for an executable and/or set other options for the assembly file you could to call the `public MetadataBuilder GenerateMetadata(out BlobBuilder ilStream, out BlobBuilder mappedFieldData)` method and use the populated metadata for generating the assembly with desired the options, for example:
+
+```csharp
+PersistedAssemblyBuilder ab = new PersistedAssemblyBuilder(new AssemblyName("MyAssembly"), typeof(object).Assembly);
+TypeBuilder tb = ab.DefineDynamicModule("MyModule").DefineType("MyType", TypeAttributes.Public | TypeAttributes.Class);
+// ...
+MethodBuilder entryPoint = tb.DefineMethod("Main", MethodAttributes.HideBySig | MethodAttributes.Public | MethodAttributes.Static);
+ILGenerator il2 = entryPoint.GetILGenerator();
+// ...
+il2.Emit(OpCodes.Ret);
+tb.CreateType();
+
+MetadataBuilder metadataBuilder = ab.GenerateMetadata(out BlobBuilder ilStream, out BlobBuilder fieldData);
+PEHeaderBuilder peHeaderBuilder = new PEHeaderBuilder(imageCharacteristics: Characteristics.ExecutableImage);
+
+ManagedPEBuilder peBuilder = new ManagedPEBuilder(
+                header: peHeaderBuilder,
+                metadataRootBuilder: new MetadataRootBuilder(metadataBuilder),
+                ilStream: ilStream,
+                mappedFieldData: fieldData,
+                entryPoint: MetadataTokens.MethodDefinitionHandle(entryPoint.MetadataToken));
+
+BlobBuilder peBlob = new BlobBuilder();
+peBuilder.Serialize(peBlob);
+
+// in case saving to a file:
+using var fileStream = new FileStream("MyAssembly.exe", FileMode.Create, FileAccess.Write);
+peBlob.WriteContentTo(fileStream); 
+```
+
 > [!NOTE]
 > The metadata tokens for all members are populated on the <xref:System.Reflection.Emit.AssemblyBuilder.Save%2A> operation. Don't use the tokens of a generated type and its members before saving, as they'll have default values or throw exceptions. It's safe to use tokens for types that are referenced, not generated.
 >
@@ -98,7 +126,7 @@ public void CreateSaveAndRunAssembly(string assemblyPath)
 
 For an alternative way to generate assembly files, see <xref:System.Reflection.Metadata.Ecma335.MetadataBuilder>.
 
-## Persistable dynamic assemblies in .NET Framework
+## Persisted dynamic assemblies in .NET Framework
 
 In .NET Framework, dynamic assemblies and modules can be saved to files. To support this feature, the <xref:System.Reflection.Emit.AssemblyBuilderAccess> enumeration declares two additional fields: <xref:System.Reflection.Emit.AssemblyBuilderAccess.Save> and <xref:System.Reflection.Emit.AssemblyBuilderAccess.RunAndSave>.
 


### PR DESCRIPTION
## Summary

We have changed the persisted AssemblyBuilder API shape in preview 3 https://github.com/dotnet/runtime/issues/97015

Apply those updates and add example for setting entry point


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/porting/net-framework-tech-unavailable.md](https://github.com/dotnet/docs/blob/d56504845169fccd1c993cbf0a58de118b0d43b1/docs/core/porting/net-framework-tech-unavailable.md) | [.NET Framework technologies unavailable on .NET](https://review.learn.microsoft.com/en-us/dotnet/core/porting/net-framework-tech-unavailable?branch=pr-en-us-40364) |
| [docs/fundamentals/runtime-libraries/system-reflection-emit-assemblybuilder.md](https://github.com/dotnet/docs/blob/d56504845169fccd1c993cbf0a58de118b0d43b1/docs/fundamentals/runtime-libraries/system-reflection-emit-assemblybuilder.md) | [System.Reflection.Emit.AssemblyBuilder class](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-reflection-emit-assemblybuilder?branch=pr-en-us-40364) |


<!-- PREVIEW-TABLE-END -->