### PR TITLE
Update garbage-collection-etw-events.md

### DIFF
--- a/docs/framework/performance/garbage-collection-etw-events.md
+++ b/docs/framework/performance/garbage-collection-etw-events.md
@@ -279,7 +279,7 @@ The following table shows the event data:
 |Field name|Data type|Description|
 |----------------|---------------|-----------------|
 |AllocationAmount|win:UInt32|The allocation size, in bytes. This value is accurate for allocations that are less than the length of a ULONG (4,294,967,295 bytes). If the allocation is greater, this field contains a truncated value. Use `AllocationAmount64` for very large allocations.|
-|AllocationKind|win:UInt32|0x0 - Small object allocation (allocation is in small object heap).<br /><br /> 0x1 - Large object allocation (allocation is in large object heap).|
+|AllocationKind|win:UInt32|0x0 - Small object allocation (allocation is in small object heap).<br /><br /> 0x1 - Large object allocation (allocation is in large object heap).<br /> 0x2 - Pinned object allocation (allocation is in pinned object heap).|
 |ClrInstanceID|win:UInt16|Unique ID for the instance of CLR or CoreCLR.|
 |AllocationAmount64|win:UInt64|The allocation size, in bytes. This value is accurate for very large allocations.|
 |TypeId|win:Pointer|The address of the MethodTable. When there are several types of objects that were allocated during this event, this is the address of the MethodTable that corresponds to the last object allocated (the object that caused the 100 KB threshold to be exceeded).|
@@ -305,7 +305,7 @@ The following table shows the event data:
 |Field name|Data type|Description|
 |----------------|---------------|-----------------|
 |AllocationAmount|win:UInt32|The allocation size, in bytes. This value is accurate for allocations that are less than the length of a ULONG (4,294,967,295 bytes). If the allocation is greater, this field contains a truncated value. Use `AllocationAmount64` for very large allocations.|
-|AllocationKind|win:UInt32|0x0 - Small object allocation (allocation is in small object heap).<br /><br /> 0x1 - Large object allocation (allocation is in large object heap).|
+|AllocationKind|win:UInt32|0x0 - Small object allocation (allocation is in small object heap).<br /><br /> 0x1 - Large object allocation (allocation is in large object heap).<br /> 0x2 - Pinned object allocation (allocation is in pinned object heap).|
 |ClrInstanceID|win:UInt16|Unique ID for the instance of CLR or CoreCLR.|
 |AllocationAmount64|win:UInt64|The allocation size, in bytes. This value is accurate for very large allocations.|
 |TypeId|win:Pointer|The address of the MethodTable. When there are several types of objects that were allocated during this event, this is the address of the MethodTable that corresponds to the last object allocated (the object that caused the 100 KB threshold to be exceeded).|

--- a/docs/framework/performance/garbage-collection-etw-events.md
+++ b/docs/framework/performance/garbage-collection-etw-events.md
@@ -272,7 +272,7 @@ The following table shows the event information:
 
 |Event|Event ID|Raised when|
 |-----------|--------------|-----------------|
-|`GCAllocationTick_V2`|10|Each time approximately 100 KB is allocated.|
+|`GCAllocationTick_V2`|10|Each time approximately 100 KB is allocated per object heap, ie, SOH, LOH and POH accumulate their allocated bytes separately. In Server GC case this is done per heap.|
 
 The following table shows the event data:
 
@@ -298,7 +298,7 @@ The following table shows the event information:
 
 |Event|Event ID|Raised when|
 |-----------|--------------|-----------------|
-|`GCAllocationTick_V3`|10|Each time approximately 100 KB is allocated.|
+|`GCAllocationTick_V2`|10|Each time approximately 100 KB is allocated per object heap, ie, SOH, LOH and POH accumulate their allocated bytes separately. In Server GC case this is done per heap.|
 
 The following table shows the event data:
 

--- a/docs/framework/performance/garbage-collection-etw-events.md
+++ b/docs/framework/performance/garbage-collection-etw-events.md
@@ -298,7 +298,7 @@ The following table shows the event information:
 
 |Event|Event ID|Raised when|
 |-----------|--------------|-----------------|
-|`GCAllocationTick_V2`|10|Each time approximately 100 KB is allocated per object heap, ie, SOH, LOH and POH accumulate their allocated bytes separately. In Server GC case this is done per heap.|
+|`GCAllocationTick_V2`|10|Each time approximately 100 KB is allocated per object heap. That is, SOH, LOH, and POH accumulate their allocated bytes separately. In Server GC, this is done per heap.|
 
 The following table shows the event data:
 

--- a/docs/framework/performance/garbage-collection-etw-events.md
+++ b/docs/framework/performance/garbage-collection-etw-events.md
@@ -279,7 +279,7 @@ The following table shows the event data:
 |Field name|Data type|Description|
 |----------------|---------------|-----------------|
 |AllocationAmount|win:UInt32|The allocation size, in bytes. This value is accurate for allocations that are less than the length of a ULONG (4,294,967,295 bytes). If the allocation is greater, this field contains a truncated value. Use `AllocationAmount64` for very large allocations.|
-|AllocationKind|win:UInt32|0x0 - Small object allocation (allocation is in small object heap).<br /><br /> 0x1 - Large object allocation (allocation is in large object heap).<br /> 0x2 - Pinned object allocation (allocation is in pinned object heap).|
+|AllocationKind|win:UInt32|0x0 - Small object allocation (allocation is in small object heap).<br /> 0x1 - Large object allocation (allocation is in large object heap).<br /> 0x2 - Pinned object allocation (allocation is in pinned object heap).|
 |ClrInstanceID|win:UInt16|Unique ID for the instance of CLR or CoreCLR.|
 |AllocationAmount64|win:UInt64|The allocation size, in bytes. This value is accurate for very large allocations.|
 |TypeId|win:Pointer|The address of the MethodTable. When there are several types of objects that were allocated during this event, this is the address of the MethodTable that corresponds to the last object allocated (the object that caused the 100 KB threshold to be exceeded).|
@@ -305,7 +305,7 @@ The following table shows the event data:
 |Field name|Data type|Description|
 |----------------|---------------|-----------------|
 |AllocationAmount|win:UInt32|The allocation size, in bytes. This value is accurate for allocations that are less than the length of a ULONG (4,294,967,295 bytes). If the allocation is greater, this field contains a truncated value. Use `AllocationAmount64` for very large allocations.|
-|AllocationKind|win:UInt32|0x0 - Small object allocation (allocation is in small object heap).<br /><br /> 0x1 - Large object allocation (allocation is in large object heap).<br /> 0x2 - Pinned object allocation (allocation is in pinned object heap).|
+|AllocationKind|win:UInt32|0x0 - Small object allocation (allocation is in small object heap).<br /> 0x1 - Large object allocation (allocation is in large object heap).<br /> 0x2 - Pinned object allocation (allocation is in pinned object heap).|
 |ClrInstanceID|win:UInt16|Unique ID for the instance of CLR or CoreCLR.|
 |AllocationAmount64|win:UInt64|The allocation size, in bytes. This value is accurate for very large allocations.|
 |TypeId|win:Pointer|The address of the MethodTable. When there are several types of objects that were allocated during this event, this is the address of the MethodTable that corresponds to the last object allocated (the object that caused the 100 KB threshold to be exceeded).|

--- a/docs/framework/performance/garbage-collection-etw-events.md
+++ b/docs/framework/performance/garbage-collection-etw-events.md
@@ -272,7 +272,7 @@ The following table shows the event information:
 
 |Event|Event ID|Raised when|
 |-----------|--------------|-----------------|
-|`GCAllocationTick_V2`|10|Each time approximately 100 KB is allocated per object heap, ie, SOH, LOH and POH accumulate their allocated bytes separately. In Server GC case this is done per heap.|
+|`GCAllocationTick_V2`|10|Each time approximately 100 KB is allocated per object heap. That is, SOH, LOH, and POH accumulate their allocated bytes separately. In Server GC, this is done per heap.|
 
 The following table shows the event data:
 


### PR DESCRIPTION
the description for alloctick event should mention how this 100kb is accumulated.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/performance/garbage-collection-etw-events.md](https://github.com/dotnet/docs/blob/66437499e3a2ad8ccfc9a1c34cc4fb0ca45879a3/docs/framework/performance/garbage-collection-etw-events.md) | [Garbage Collection ETW Events](https://review.learn.microsoft.com/en-us/dotnet/framework/performance/garbage-collection-etw-events?branch=pr-en-us-40366) |


<!-- PREVIEW-TABLE-END -->