### PR TITLE
Add information about when health check metrics are emitted

### DIFF
--- a/docs/core/diagnostics/built-in-metrics-diagnostics.md
+++ b/docs/core/diagnostics/built-in-metrics-diagnostics.md
@@ -17,7 +17,7 @@ The `Microsoft.Extensions.Diagnostics.HealthChecks` metrics report health check 
 - [`dotnet.health_check.reports`](#metric-dotnethealth_checkreports)
 - [`dotnet.health_check.unhealthy_checks`](#metric-dotnethealth_checkunhealthy_checks)
 
-These metrics can be enabled by calling the `AddTelemetryHealthCheckPublisher` extension method. These metrics can only be enabled for push-based metrics, and are not available for pull-based metrics.
+You can enable these metrics by calling the <xref:Microsoft.Extensions.DependencyInjection.CommonHealthChecksExtensions.AddTelemetryHealthCheckPublisher%2A> extension method. These metrics can only be enabled for push-based metrics and aren't available for pull-based metrics.
 
 ##### Metric: `dotnet.health_check.reports`
 

--- a/docs/core/diagnostics/built-in-metrics-diagnostics.md
+++ b/docs/core/diagnostics/built-in-metrics-diagnostics.md
@@ -17,6 +17,8 @@ The `Microsoft.Extensions.Diagnostics.HealthChecks` metrics report health check 
 - [`dotnet.health_check.reports`](#metric-dotnethealth_checkreports)
 - [`dotnet.health_check.unhealthy_checks`](#metric-dotnethealth_checkunhealthy_checks)
 
+These metrics can be enabled by calling the `AddTelemetryHealthCheckPublisher` extension method. These metrics can only be enabled for push-based metrics, and are not available for pull-based metrics.
+
 ##### Metric: `dotnet.health_check.reports`
 
 | Name | Instrument Type | Unit (UCUM) | Description |


### PR DESCRIPTION
Add information about when `Microsoft.Extensions.Diagnostics.HealthChecks` metrics are emitted

## Summary

The page currently reads as if the health check metrics are available automatically. I spent two days reverse engineering to figure out that you have to call an undocumented method to enable these metrics, and that this method did not work for the way I use health checks. It would have saved me a lot of time if this information was available in the documentation.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/built-in-metrics-diagnostics.md](https://github.com/dotnet/docs/blob/2799e996a9c43dca381d359bf7bee606aa2f1ba7/docs/core/diagnostics/built-in-metrics-diagnostics.md) | [.NET extensions metrics](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/built-in-metrics-diagnostics?branch=pr-en-us-40426) |


<!-- PREVIEW-TABLE-END -->