### PR TITLE
Use `Task.CurrentId` instead of hard-coded values.

### DIFF
--- a/docs/standard/parallel-programming/how-to-cancel-a-task-and-its-children.md
+++ b/docs/standard/parallel-programming/how-to-cancel-a-task-and-its-children.md
@@ -1,7 +1,7 @@
 ---
 title: "How to: Cancel a Task and Its Children"
 description: See examples of how to cancel a task and its children in .NET. The examples cover steps from cancelable task creation, to the notice that the task was canceled.
-ms.date: "03/30/2017"
+ms.date: 04/09/2024
 dev_langs: 
   - "csharp"
   - "vb"
@@ -11,7 +11,7 @@ ms.assetid: 08574301-8331-4719-ad50-9cf7f6ff3048
 ---
 # How to: Cancel a Task and Its Children
 
-These examples show how to perform the following tasks:  
+These examples show how to perform the following tasks:
   
 1. Create and start a cancelable task.  
   

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_cancellation/cs/cancel1.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_cancellation/cs/cancel1.cs
@@ -24,7 +24,7 @@ public class Example
         // Request cancellation of a single task when the token source is canceled.
         // Pass the token to the user delegate, and also to the task so it can
         // handle the exception correctly.
-        t = Task.Run(() => DoSomeWork(1, token), token);
+        t = Task.Run(() => DoSomeWork(token), token);
         Console.WriteLine("Task {0} executing", t.Id);
         tasks.Add(t);
 
@@ -39,12 +39,12 @@ public class Example
             {
                 // For each child task, pass the same token
                 // to each user delegate and to Task.Run.
-                tc = Task.Run(() => DoSomeWork(i, token), token);
+                tc = Task.Run(() => DoSomeWork(token), token);
                 Console.WriteLine("Task {0} executing", tc.Id);
                 tasks.Add(tc);
                 // Pass the same token again to do work on the parent task.
                 // All will be signaled by the call to tokenSource.Cancel below.
-                DoSomeWork(2, token);
+                DoSomeWork(token);
             }
         }, token);
 
@@ -84,13 +84,13 @@ public class Example
             Console.WriteLine("Task {0} status is now {1}", task.Id, task.Status);
     }
 
-    static void DoSomeWork(int taskNum, CancellationToken ct)
+    static void DoSomeWork(CancellationToken ct)
     {
         // Was cancellation already requested?
         if (ct.IsCancellationRequested)
         {
             Console.WriteLine("Task {0} was cancelled before it got started.",
-                              taskNum);
+                              Task.CurrentId);
             ct.ThrowIfCancellationRequested();
         }
 
@@ -110,7 +110,7 @@ public class Example
 
             if (ct.IsCancellationRequested)
             {
-                Console.WriteLine("Task {0} cancelled", taskNum);
+                Console.WriteLine("Task {0} cancelled", Task.CurrentId);
                 ct.ThrowIfCancellationRequested();
             }
         }

--- a/samples/snippets/visualbasic/VS_Snippets_Misc/tpl_cancellation/vb/cancel1.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_Misc/tpl_cancellation/vb/cancel1.vb
@@ -21,7 +21,7 @@ Module Example
         ' Request cancellation of a single task when the token source is canceled.
         ' Pass the token to the user delegate, and also to the task so it can
         ' handle the exception correctly.
-        t = Task.Factory.StartNew(Sub() DoSomeWork(1, token), token)
+        t = Task.Factory.StartNew(Sub() DoSomeWork(token), token)
         Console.WriteLine("Task {0} executing", t.Id)
         tasks.Add(t)
 
@@ -34,12 +34,12 @@ Module Example
                                       For i As Integer = 3 To 10
                                           ' For each child task, pass the same token
                                           ' to each user delegate and to StartNew.
-                                          tc = Task.Factory.StartNew(Sub(iteration) DoSomeWork(iteration, token), i, token)
+                                          tc = Task.Factory.StartNew(Sub(iteration) DoSomeWork(token), i, token)
                                           Console.WriteLine("Task {0} executing", tc.Id)
                                           tasks.Add(tc)
                                           ' Pass the same token again to do work on the parent task.
                                           ' All will be signaled by the call to tokenSource.Cancel below.
-                                          DoSomeWork(2, token)
+                                          DoSomeWork(token)
                                       Next
                                   End Sub,
                                   token)
@@ -85,11 +85,11 @@ Module Example
         Next
     End Sub
 
-    Sub DoSomeWork(ByVal taskNum As Integer, ByVal ct As CancellationToken)
+    Sub DoSomeWork(ByVal ct As CancellationToken)
         ' Was cancellation already requested?
         If ct.IsCancellationRequested = True Then
             Console.WriteLine("Task {0} was cancelled before it got started.",
-                              taskNum)
+                              Task.CurrentId)
             ct.ThrowIfCancellationRequested()
         End If
 
@@ -107,7 +107,7 @@ Module Example
                 sw.SpinOnce()
             Next
             If ct.IsCancellationRequested Then
-                Console.WriteLine("Task {0} cancelled", taskNum)
+                Console.WriteLine("Task {0} cancelled", Task.CurrentId)
                 ct.ThrowIfCancellationRequested()
             End If
         Next


### PR DESCRIPTION
## Summary

Use `Task.CurrentId` instead of hard-coded values.

Fixes #37135


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/parallel-programming/how-to-cancel-a-task-and-its-children.md](https://github.com/dotnet/docs/blob/a151852a081001873582bfc1368fd1951b8aa3bc/docs/standard/parallel-programming/how-to-cancel-a-task-and-its-children.md) | [How to: Cancel a Task and Its Children](https://review.learn.microsoft.com/en-us/dotnet/standard/parallel-programming/how-to-cancel-a-task-and-its-children?branch=pr-en-us-40431) |

<!-- PREVIEW-TABLE-END -->