### PR TITLE
Use the C# L2 header

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -165,6 +165,9 @@
             }
         },
         "fileMetadata": {
+            "uhfHeaderId": {
+                "docs/csharp/**/**.*": "MSDocsHeader-DotNetCSharp"
+            },
             "feedback_system": {
                 "docs/standard/design-guidelines/**/**.md": "None",
                 "docs/framework/data/adonet/**/**.md": "None",


### PR DESCRIPTION
Use the updated C# L2 header.

[Internal review site - C# home page](https://review.learn.microsoft.com/en-us/dotnet/csharp/?branch=pr-en-us-40451)

To review, check the L2 header in both the C# area, and a few pages in other areas to make sure the scope of the change is correct.
