### PR TITLE
Update Kerberos breaking change

### DIFF
--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -27,9 +27,10 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 
 | Title                                                                   | Type of change    |
 | ----------------------------------------------------------------------- | ----------------- |
-| ['ca-certificates' and 'krb5-libs' packages removed from Alpine images](containers/8.0/krb5-libs-package.md) | Binary incompatible |
+| ['ca-certificates' package removed from Alpine images](containers/8.0/ca-certificates-package.md) | Binary incompatible |
 | [Debian container images upgraded to Debian 12](containers/8.0/debian-version.md) | Binary incompatible/behavioral change |
 | [Default ASP.NET Core port changed to 8080](containers/8.0/aspnet-port.md) | Behavioral change |
+| [Kerberos package removed from Alpine and Debian images](containers/8.0/krb5-libs-package.md) | Binary incompatible |
 | ['libintl' package removed from Alpine images](containers/8.0/libintl-package.md) | Behavioral change |
 | [Multi-platform container tags are Linux-only](containers/8.0/multi-platform-tags.md) | Behavioral change |
 | [New 'app' user in Linux images](containers/8.0/app-user.md) | Behavioral change |

--- a/docs/core/compatibility/containers/8.0/ca-certificates-package.md
+++ b/docs/core/compatibility/containers/8.0/ca-certificates-package.md
@@ -11,7 +11,6 @@ The `ca-certificates` package is no longer installed in .NET Alpine container im
 
 Prior to .NET 8, the `ca-certificates` package was included in .NET's Alpine container images.
 
-
 ## New behavior
 
 .NET no longer includes the `ca-certificates` package in its Alpine container images.
@@ -26,7 +25,7 @@ This change can affect [binary compatibility](../../categories.md#binary-compati
 
 ## Reason for change
 
-The package was removed to reduce the image size. The removal of this package reduces .NET 8 Alpine images by 0.6MB.
+The package was removed to reduce the image size. The removal of this package reduces .NET 8 Alpine images by 0.6 MB.
 
 ## Recommended action
 

--- a/docs/core/compatibility/containers/8.0/ca-certificates-package.md
+++ b/docs/core/compatibility/containers/8.0/ca-certificates-package.md
@@ -9,7 +9,8 @@ The `ca-certificates` package is no longer installed in .NET Alpine container im
 
 ## Previous behavior
 
-Prior to .NET 8, the `ca-certificates` packages was included in .NET's Alpine container images.
+Prior to .NET 8, the `ca-certificates` package was included in .NET's Alpine container images.
+
 
 ## New behavior
 

--- a/docs/core/compatibility/containers/8.0/ca-certificates-package.md
+++ b/docs/core/compatibility/containers/8.0/ca-certificates-package.md
@@ -1,0 +1,40 @@
+---
+title: "Breaking change: 'ca-certificates' package removed from Alpine images"
+description: Learn about the breaking change in containers where the 'ca-certificates' package was removed from Alpine container images.
+ms.date: 08/01/2023
+---
+# 'ca-certificates' package removed from Alpine images
+
+The `ca-certificates` package is no longer installed in .NET Alpine container images. The Alpine base image includes the `ca-certificates-bundle` package, which provides the same baseline content that's needed for most .NET apps. It's expected that very few .NET apps will be affected by this change.
+
+## Previous behavior
+
+Prior to .NET 8, the `ca-certificates` packages was included in .NET's Alpine container images.
+
+## New behavior
+
+.NET no longer includes the `ca-certificates` package in its Alpine container images.
+
+## Version introduced
+
+.NET 8 Preview 7
+
+## Type of change
+
+This change can affect [binary compatibility](../../categories.md#binary-compatibility).
+
+## Reason for change
+
+The package was removed to reduce the image size. The removal of this package reduces .NET 8 Alpine images by 0.6MB.
+
+## Recommended action
+
+If you require the affected package for your scenario, install it manually using the following Dockerfile instruction.
+
+```dockerfile
+RUN apk add --upgrade ca-certificates
+```
+
+## Affected APIs
+
+- <xref:System.Net.Http.HttpClient?displayProperty=fullName>

--- a/docs/core/compatibility/containers/8.0/krb5-libs-package.md
+++ b/docs/core/compatibility/containers/8.0/krb5-libs-package.md
@@ -1,6 +1,6 @@
 ---
-title: "Breaking change: 'krb5-libs' packages removed from .NET container images"
-description: Learn about the breaking change in containers where the 'krb5-libs' packages was removed from .NET container images.
+title: "Breaking change: 'krb5-libs' package removed from .NET container images"
+description: Learn about the breaking change in containers where the 'krb5-libs' package was removed from .NET container images.
 ms.date: 08/01/2023
 ---
 # Kerberos package removed from .NET container images
@@ -21,7 +21,7 @@ Prior to .NET 8, the Kerberos package was explicitly installed in all .NET conta
 
 ## New behavior
 
-.NET no longer installs the Kerberos packages in its container images.
+.NET no longer installs the Kerberos package in its container images.
 
 ## Version introduced
 

--- a/docs/core/compatibility/containers/8.0/krb5-libs-package.md
+++ b/docs/core/compatibility/containers/8.0/krb5-libs-package.md
@@ -1,21 +1,27 @@
 ---
-title: "Breaking change: 'ca-certificates' and 'krb5-libs' packages removed from Alpine images"
-description: Learn about the breaking change in containers where the 'ca-certificates' and 'krb5-libs' packages were removed from Alpine container images.
+title: "Breaking change: 'krb5-libs' packages removed from .NET container images"
+description: Learn about the breaking change in containers where the 'krb5-libs' packages was removed from .NET container images.
 ms.date: 08/01/2023
 ---
-# 'ca-certificates' and 'krb5-libs' packages removed from Alpine images
+# Kerberos package removed from .NET container images
 
-The `krb5-libs` package is no longer installed in .NET Alpine container images. This package enables Kerberos secure networking. Kerberos is installed by default in Debian and Ubuntu, so .NET Debian and Ubuntu images aren't affected by this change.
+Kerberos is no longer installed in .NET Alpine and Debian container images. Kerberos provides secure networking using the Kerberos protocol.
 
-In addition, the `ca-certificates` package is no longer installed in .NET Alpine container images. The Alpine base image includes the `ca-certificates-bundle` package, which provides the same baseline content that's needed for most .NET apps. It's expected that very few (if any) .NET apps will be affected by this change.
+Kerberos is installed by default in Ubuntu, so .NET Ubuntu images aren't affected by this change. However, Kerberos is not present in .NET Chiseled images.
+
+Kerberos packages:
+
+- Alpine: `krb5-libs`
+- Debian: `libkrb5-3`
+- Ubuntu: `libkrb5-3`
 
 ## Previous behavior
 
-Prior to .NET 8, the `ca-certificates` and `krb5-libs` packages were included in .NET's Alpine container images.
+Prior to .NET 8, the Kerberos package was explicitly installed in all .NET container images.
 
 ## New behavior
 
-.NET no longer includes the `ca-certificates` and `krb5-libs` packages in its Alpine container images.
+.NET no longer installs the Kerberos packages in its container images.
 
 ## Version introduced
 
@@ -27,21 +33,26 @@ This change can affect [binary compatibility](../../categories.md#binary-compati
 
 ## Reason for change
 
-The packages were removed to reduce the image size.
-
-- For `krb5-libs`, the Kerberos secure networking scenario was considered not popular enough to warrant installing this package by default. The removal of this package reduces .NET 8 Alpine images by ~2.7 MB.
-- For `ca-certificates`, the removal of this package reduces .NET 8 Alpine images by 0.6MB.
+The packages were removed to reduce the image size. The Kerberos secure networking scenario was considered not popular enough to warrant installing this package by default. The removal of this package reduces .NET 8 images by ~2.7 MB.
 
 ## Recommended action
 
-If you require the affected packages for your scenario, install them yourself using the following Dockerfile instruction.
+If you require the affected package for your scenario, install it manually using the following Dockerfile instruction.
+
+For Alpine:
 
 ```dockerfile
 RUN apk add --upgrade krb5-libs
-RUN apk add --upgrade ca-certificates
 ```
+
+For Debian:
+
+```dockerfile
+RUN apt update && apt -y upgrade libkrb5-3
+```
+
+For Ubuntu Chiseled, follow [pattern to install additional slices](https://github.com/ubuntu-rocks/dotnet/issues/21).
 
 ## Affected APIs
 
 - <xref:System.DirectoryServices.Protocols?displayProperty=fullName>
-- <xref:System.Net.Http.HttpClient?displayProperty=fullName>

--- a/docs/core/compatibility/containers/8.0/krb5-libs-package.md
+++ b/docs/core/compatibility/containers/8.0/krb5-libs-package.md
@@ -3,7 +3,7 @@ title: "Kerberos package removed from Alpine and Debian images"
 description: Learn about the breaking change in containers where the 'krb5-libs' package was removed from .NET container images.
 ms.date: 08/01/2023
 ---
-# Kerberos package removed from .NET container images
+# Kerberos package removed from Alpine and Debian images
 
 Kerberos is no longer installed in .NET Alpine and Debian container images. Kerberos provides secure networking using the Kerberos protocol.
 

--- a/docs/core/compatibility/containers/8.0/krb5-libs-package.md
+++ b/docs/core/compatibility/containers/8.0/krb5-libs-package.md
@@ -1,5 +1,5 @@
 ---
-title: "Breaking change: 'krb5-libs' package removed from .NET container images"
+title: "Kerberos package removed from Alpine and Debian images"
 description: Learn about the breaking change in containers where the 'krb5-libs' package was removed from .NET container images.
 ms.date: 08/01/2023
 ---

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -73,7 +73,7 @@ items:
     - name: Containers
       items:
       - name: "'ca-certificates' removed from Alpine images"
-        href: containers/8.0/krb5-libs-package.md
+        href: containers/8.0/ca-certificates-package.md
       - name: Container images upgraded to Debian 12
         href: containers/8.0/debian-version.md
       - name: Default ASP.NET Core port changed to 8080

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -72,12 +72,14 @@ items:
         href: aspnet-core/8.0/trimmode-full.md
     - name: Containers
       items:
-      - name: "'ca-certificates' and 'krb5-libs' removed from Alpine images"
+      - name: "'ca-certificates'removed from Alpine images"
         href: containers/8.0/krb5-libs-package.md
       - name: Container images upgraded to Debian 12
         href: containers/8.0/debian-version.md
       - name: Default ASP.NET Core port changed to 8080
         href: containers/8.0/aspnet-port.md
+      - name: Kerberos package removed from Alpine and Debian images
+        href: containers/8.0/krb5-libs-package.md
       - name: libintl package removed from Alpine images
         href: containers/8.0/libintl-package.md
       - name: Multi-platform container tags are Linux-only

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -1152,12 +1152,14 @@ items:
         href: https://github.com/dotnet/dotnet-docker/discussions/3699
     - name: .NET 8
       items:
-      - name: "'ca-certificates' and 'krb5-libs' removed from Alpine images"
-        href: containers/8.0/krb5-libs-package.md
+      - name: "'ca-certificates' removed from Alpine images"
+        href: containers/8.0/ca-certificates-package.md
       - name: Container images upgraded to Debian 12
         href: containers/8.0/debian-version.md
       - name: Default ASP.NET Core port changed to 8080
         href: containers/8.0/aspnet-port.md
+      - name: Kerberos package removed from Alpine and Debian images
+        href: containers/8.0/krb5-libs-package.md        
       - name: libintl package removed from Alpine images
         href: containers/8.0/libintl-package.md
       - name: Multi-platform container tags are Linux-only

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -72,7 +72,7 @@ items:
         href: aspnet-core/8.0/trimmode-full.md
     - name: Containers
       items:
-      - name: "'ca-certificates'removed from Alpine images"
+      - name: "'ca-certificates' removed from Alpine images"
         href: containers/8.0/krb5-libs-package.md
       - name: Container images upgraded to Debian 12
         href: containers/8.0/debian-version.md


### PR DESCRIPTION
Fixed #40441

@gewarren 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/8.0.md](https://github.com/dotnet/docs/blob/2d6c3e8f13605edde2a8ec0bde124e285696e390/docs/core/compatibility/8.0.md) | [Breaking changes in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/8.0?branch=pr-en-us-40456) |
| [docs/core/compatibility/containers/8.0/ca-certificates-package.md](https://github.com/dotnet/docs/blob/2d6c3e8f13605edde2a8ec0bde124e285696e390/docs/core/compatibility/containers/8.0/ca-certificates-package.md) | ['ca-certificates' package removed from Alpine images](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/containers/8.0/ca-certificates-package?branch=pr-en-us-40456) |
| [docs/core/compatibility/containers/8.0/krb5-libs-package.md](https://github.com/dotnet/docs/blob/2d6c3e8f13605edde2a8ec0bde124e285696e390/docs/core/compatibility/containers/8.0/krb5-libs-package.md) | ["Kerberos package removed from Alpine and Debian images"](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/containers/8.0/krb5-libs-package?branch=pr-en-us-40456) |


<!-- PREVIEW-TABLE-END -->