### PR TITLE
Update migrate-from-newtonsoft.md

### DIFF
--- a/docs/standard/serialization/system-text-json/migrate-from-newtonsoft.md
+++ b/docs/standard/serialization/system-text-json/migrate-from-newtonsoft.md
@@ -50,7 +50,7 @@ The following table lists `Newtonsoft.Json` features and `System.Text.Json` equi
 | Allow comments                                        | ✔️ [ReadCommentHandling global setting](#comments) |
 | Allow trailing commas                                 | ✔️ [AllowTrailingCommas global setting](#trailing-commas) |
 | Custom converter registration                         | ✔️ [Order of precedence differs](#converter-registration-precedence) |
-| No maximum depth by default                           | ✔️ [Default maximum depth 64, configurable](#maximum-depth) |
+| Default maximum depth 64, configurable                | ✔️ [Default maximum depth 64, configurable](#maximum-depth) |
 | `PreserveReferencesHandling` global setting           | ✔️ [ReferenceHandling global setting](#preserve-object-references-and-handle-loops) |
 | Serialize or deserialize numbers in quotes            | ✔️ [NumberHandling global setting, [JsonNumberHandling] attribute](#allow-or-write-numbers-in-quotes) |
 | Deserialize to immutable classes and structs          | ✔️ [JsonConstructor, C# 9 Records](#deserialize-to-immutable-classes-and-structs) |
@@ -149,7 +149,7 @@ The following table lists `Newtonsoft.Json` features and `System.Text.Json` equi
 | Allow comments                                        | ✔️ [ReadCommentHandling global setting](#comments) |
 | Allow trailing commas                                 | ✔️ [AllowTrailingCommas global setting](#trailing-commas) |
 | Custom converter registration                         | ✔️ [Order of precedence differs](#converter-registration-precedence) |
-| No maximum depth by default                           | ✔️ [Default maximum depth 64, configurable](#maximum-depth) |
+| Default maximum depth 64, configurable                | ✔️ [Default maximum depth 64, configurable](#maximum-depth) |
 | `PreserveReferencesHandling` global setting           | ✔️ [ReferenceHandling global setting](#preserve-object-references-and-handle-loops) |
 | Serialize or deserialize numbers in quotes            | ✔️ [NumberHandling global setting, [JsonNumberHandling] attribute](#allow-or-write-numbers-in-quotes) |
 | Deserialize to immutable classes and structs          | ✔️ [JsonConstructor, C# 9 Records](#deserialize-to-immutable-classes-and-structs) |

--- a/docs/standard/serialization/system-text-json/migrate-from-newtonsoft.md
+++ b/docs/standard/serialization/system-text-json/migrate-from-newtonsoft.md
@@ -99,7 +99,7 @@ The following table lists `Newtonsoft.Json` features and `System.Text.Json` equi
 | Allow comments                                        | ✔️ [ReadCommentHandling global setting](#comments) |
 | Allow trailing commas                                 | ✔️ [AllowTrailingCommas global setting](#trailing-commas) |
 | Custom converter registration                         | ✔️ [Order of precedence differs](#converter-registration-precedence) |
-| No maximum depth by default                           | ✔️ [Default maximum depth 64, configurable](#maximum-depth) |
+| Default maximum depth 64, configurable                | ✔️ [Default maximum depth 64, configurable](#maximum-depth) |
 | `PreserveReferencesHandling` global setting           | ✔️ [ReferenceHandling global setting](#preserve-object-references-and-handle-loops) |
 | Serialize or deserialize numbers in quotes            | ✔️ [NumberHandling global setting, [JsonNumberHandling] attribute](#allow-or-write-numbers-in-quotes) |
 | Deserialize to immutable classes and structs          | ✔️ [JsonConstructor, C# 9 Records](#deserialize-to-immutable-classes-and-structs) |


### PR DESCRIPTION
[Newtonsoft.Json v13.0.1](https://github.com/JamesNK/Newtonsoft.Json/releases/tag/13.0.1)

> Change - JsonReader and JsonSerializer MaxDepth defaults to 64

## Summary

Updating feature comparison.

From Newtonsoft.Json v13.0.1 (latest is v13.0.3), `JsonReader` and `JsonSerializer` **MaxDepth** defaults to **64**. 

### Preview

| Newtonsoft.Json feature                               | System.Text.Json equivalent |
|-------------------------------------------------------|-----------------------------|
| ... | ... | 
| Default maximum depth 64, configurable                | ✔️ [Default maximum depth 64, configurable](#maximum-depth) |
| ... | ... | 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/serialization/system-text-json/migrate-from-newtonsoft.md](https://github.com/dotnet/docs/blob/4bde26610b5fcdc3db67d9b6760fdbfe12338cdb/docs/standard/serialization/system-text-json/migrate-from-newtonsoft.md) | [Migrate from Newtonsoft.Json to System.Text.Json](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/migrate-from-newtonsoft?branch=pr-en-us-40458) |


<!-- PREVIEW-TABLE-END -->