### PR TITLE
address nullable reference types warnings in event handler doc

### DIFF
--- a/docs/csharp/programming-guide/events/how-to-publish-events-that-conform-to-net-framework-guidelines.md
+++ b/docs/csharp/programming-guide/events/how-to-publish-events-that-conform-to-net-framework-guidelines.md
@@ -13,7 +13,7 @@ ms.assetid: 9310ae16-8627-44a2-b08c-05e5976202b1
 The following procedure demonstrates how to add events that follow the standard .NET pattern to your classes and structs. All events in the .NET class library are based on the <xref:System.EventHandler> delegate, which is defined as follows:
 
 ```csharp
-public delegate void EventHandler(object sender, EventArgs e);
+public delegate void EventHandler(object? sender, EventArgs e);
 ```
 
 > [!NOTE]
@@ -42,7 +42,7 @@ The name `EventHandler` can lead to a bit of confusion as it doesn't actually ha
 2. (Skip this step if you are using the generic version of <xref:System.EventHandler%601>.) Declare a delegate in your publishing class. Give it a name that ends with `EventHandler`. The second parameter specifies your custom `EventArgs` type.
 
     ```csharp
-    public delegate void CustomEventHandler(object sender, CustomEventArgs args);
+    public delegate void CustomEventHandler(object? sender, CustomEventArgs args);
     ```
 
 3. Declare the event in your publishing class by using one of the following steps.
@@ -50,19 +50,19 @@ The name `EventHandler` can lead to a bit of confusion as it doesn't actually ha
     1. If you have no custom EventArgs class, your Event type will be the non-generic EventHandler delegate. You do not have to declare the delegate because it is already declared in the <xref:System> namespace that is included when you create your C# project. Add the following code to your publisher class.
 
         ```csharp
-        public event EventHandler RaiseCustomEvent;
+        public event EventHandler? RaiseCustomEvent;
         ```
 
     2. If you are using the non-generic version of <xref:System.EventHandler> and you have a custom class derived from <xref:System.EventArgs>, declare your event inside your publishing class and use your delegate from step 2 as the type.
 
         ```csharp
-        public event CustomEventHandler RaiseCustomEvent;
+        public event CustomEventHandler? RaiseCustomEvent;
         ```
 
     3. If you are using the generic version, you do not need a custom delegate. Instead, in your publishing class, you specify your event type as `EventHandler<CustomEventArgs>`, substituting the name of your own class between the angle brackets.
 
         ```csharp
-        public event EventHandler<CustomEventArgs> RaiseCustomEvent;
+        public event EventHandler<CustomEventArgs>? RaiseCustomEvent;
         ```
 
 ## Example

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideEvents/CS/Events.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideEvents/CS/Events.cs
@@ -177,88 +177,89 @@ namespace BaseClassEvents
 //--------------------------------------------------------------------------------------
 
 //<Snippet2>
-namespace DotNetEvents;
-
-// Define a class to hold custom event info
-public class CustomEventArgs : EventArgs
+namespace DotNetEvents
 {
-    public CustomEventArgs(string message)
+    // Define a class to hold custom event info
+    public class CustomEventArgs : EventArgs
     {
-        Message = message;
-    }
-
-    public string Message { get; set; }
-}
-
-// Class that publishes an event
-class Publisher
-{
-    // Declare the event using EventHandler<T>
-    public event EventHandler<CustomEventArgs>? RaiseCustomEvent;
-
-    public void DoSomething()
-    {
-        // Write some code that does something useful here
-        // then raise the event. You can also raise an event
-        // before you execute a block of code.
-        OnRaiseCustomEvent(new CustomEventArgs("Event triggered"));
-    }
-
-    // Wrap event invocations inside a protected virtual method
-    // to allow derived classes to override the event invocation behavior
-    protected virtual void OnRaiseCustomEvent(CustomEventArgs e)
-    {
-        // Make a temporary copy of the event to avoid possibility of
-        // a race condition if the last subscriber unsubscribes
-        // immediately after the null check and before the event is raised.
-        EventHandler<CustomEventArgs>? raiseEvent = RaiseCustomEvent;
-
-        // Event will be null if there are no subscribers
-        if (raiseEvent != null)
+        public CustomEventArgs(string message)
         {
-            // Format the string to send inside the CustomEventArgs parameter
-            e.Message += $" at {DateTime.Now}";
+            Message = message;
+        }
 
-            // Call to raise the event.
-            raiseEvent(this, e);
+        public string Message { get; set; }
+    }
+
+    // Class that publishes an event
+    class Publisher
+    {
+        // Declare the event using EventHandler<T>
+        public event EventHandler<CustomEventArgs>? RaiseCustomEvent;
+
+        public void DoSomething()
+        {
+            // Write some code that does something useful here
+            // then raise the event. You can also raise an event
+            // before you execute a block of code.
+            OnRaiseCustomEvent(new CustomEventArgs("Event triggered"));
+        }
+
+        // Wrap event invocations inside a protected virtual method
+        // to allow derived classes to override the event invocation behavior
+        protected virtual void OnRaiseCustomEvent(CustomEventArgs e)
+        {
+            // Make a temporary copy of the event to avoid possibility of
+            // a race condition if the last subscriber unsubscribes
+            // immediately after the null check and before the event is raised.
+            EventHandler<CustomEventArgs>? raiseEvent = RaiseCustomEvent;
+
+            // Event will be null if there are no subscribers
+            if (raiseEvent != null)
+            {
+                // Format the string to send inside the CustomEventArgs parameter
+                e.Message += $" at {DateTime.Now}";
+
+                // Call to raise the event.
+                raiseEvent(this, e);
+            }
         }
     }
-}
 
-//Class that subscribes to an event
-class Subscriber
-{
-    private readonly string _id;
-
-    public Subscriber(string id, Publisher pub)
+    //Class that subscribes to an event
+    class Subscriber
     {
-        _id = id;
+        private readonly string _id;
 
-        // Subscribe to the event
-        pub.RaiseCustomEvent += HandleCustomEvent;
+        public Subscriber(string id, Publisher pub)
+        {
+            _id = id;
+
+            // Subscribe to the event
+            pub.RaiseCustomEvent += HandleCustomEvent;
+        }
+
+        // Define what actions to take when the event is raised.
+        void HandleCustomEvent(object? sender, CustomEventArgs e)
+        {
+            Console.WriteLine($"{_id} received this message: {e.Message}");
+        }
     }
 
-    // Define what actions to take when the event is raised.
-    void HandleCustomEvent(object? sender, CustomEventArgs e)
+    class Program
     {
-        Console.WriteLine($"{_id} received this message: {e.Message}");
-    }
-}
+        static void Main()
+        {
+            var pub = new Publisher();
+            var sub1 = new Subscriber("sub1", pub);
+            var sub2 = new Subscriber("sub2", pub);
 
-class Program
-{
-    static void Main()
-    {
-        var pub = new Publisher();
-        var sub1 = new Subscriber("sub1", pub);
-        var sub2 = new Subscriber("sub2", pub);
+            // Call the method that raises the event.
+            pub.DoSomething();
 
-        // Call the method that raises the event.
-        pub.DoSomething();
-
-        // Keep the console window open
-        Console.WriteLine("Press any key to continue...");
-        Console.ReadLine();
+            // Keep the console window open
+            Console.WriteLine("Press any key to continue...");
+            Console.ReadLine();
+        }
     }
 }
 //</Snippet2>

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideEvents/CS/Events.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideEvents/CS/Events.cs
@@ -196,7 +196,7 @@ namespace DotNetEvents
     class Publisher
     {
         // Declare the event using EventHandler<T>
-        public event EventHandler<CustomEventArgs> RaiseCustomEvent;
+        public event EventHandler<CustomEventArgs>? RaiseCustomEvent;
 
         public void DoSomething()
         {
@@ -213,7 +213,7 @@ namespace DotNetEvents
             // Make a temporary copy of the event to avoid possibility of
             // a race condition if the last subscriber unsubscribes
             // immediately after the null check and before the event is raised.
-            EventHandler<CustomEventArgs> raiseEvent = RaiseCustomEvent;
+            EventHandler<CustomEventArgs>? raiseEvent = RaiseCustomEvent;
 
             // Event will be null if there are no subscribers
             if (raiseEvent != null)
@@ -241,7 +241,7 @@ namespace DotNetEvents
         }
 
         // Define what actions to take when the event is raised.
-        void HandleCustomEvent(object sender, CustomEventArgs e)
+        void HandleCustomEvent(object? sender, CustomEventArgs e)
         {
             Console.WriteLine($"{_id} received this message: {e.Message}");
         }

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideEvents/CS/Events.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideEvents/CS/Events.cs
@@ -177,91 +177,88 @@ namespace BaseClassEvents
 //--------------------------------------------------------------------------------------
 
 //<Snippet2>
-using System;
+namespace DotNetEvents;
 
-namespace DotNetEvents
+// Define a class to hold custom event info
+public class CustomEventArgs : EventArgs
 {
-    // Define a class to hold custom event info
-    public class CustomEventArgs : EventArgs
+    public CustomEventArgs(string message)
     {
-        public CustomEventArgs(string message)
-        {
-            Message = message;
-        }
-
-        public string Message { get; set; }
+        Message = message;
     }
 
-    // Class that publishes an event
-    class Publisher
+    public string Message { get; set; }
+}
+
+// Class that publishes an event
+class Publisher
+{
+    // Declare the event using EventHandler<T>
+    public event EventHandler<CustomEventArgs>? RaiseCustomEvent;
+
+    public void DoSomething()
     {
-        // Declare the event using EventHandler<T>
-        public event EventHandler<CustomEventArgs>? RaiseCustomEvent;
-
-        public void DoSomething()
-        {
-            // Write some code that does something useful here
-            // then raise the event. You can also raise an event
-            // before you execute a block of code.
-            OnRaiseCustomEvent(new CustomEventArgs("Event triggered"));
-        }
-
-        // Wrap event invocations inside a protected virtual method
-        // to allow derived classes to override the event invocation behavior
-        protected virtual void OnRaiseCustomEvent(CustomEventArgs e)
-        {
-            // Make a temporary copy of the event to avoid possibility of
-            // a race condition if the last subscriber unsubscribes
-            // immediately after the null check and before the event is raised.
-            EventHandler<CustomEventArgs>? raiseEvent = RaiseCustomEvent;
-
-            // Event will be null if there are no subscribers
-            if (raiseEvent != null)
-            {
-                // Format the string to send inside the CustomEventArgs parameter
-                e.Message += $" at {DateTime.Now}";
-
-                // Call to raise the event.
-                raiseEvent(this, e);
-            }
-        }
+        // Write some code that does something useful here
+        // then raise the event. You can also raise an event
+        // before you execute a block of code.
+        OnRaiseCustomEvent(new CustomEventArgs("Event triggered"));
     }
 
-    //Class that subscribes to an event
-    class Subscriber
+    // Wrap event invocations inside a protected virtual method
+    // to allow derived classes to override the event invocation behavior
+    protected virtual void OnRaiseCustomEvent(CustomEventArgs e)
     {
-        private readonly string _id;
+        // Make a temporary copy of the event to avoid possibility of
+        // a race condition if the last subscriber unsubscribes
+        // immediately after the null check and before the event is raised.
+        EventHandler<CustomEventArgs>? raiseEvent = RaiseCustomEvent;
 
-        public Subscriber(string id, Publisher pub)
+        // Event will be null if there are no subscribers
+        if (raiseEvent != null)
         {
-            _id = id;
+            // Format the string to send inside the CustomEventArgs parameter
+            e.Message += $" at {DateTime.Now}";
 
-            // Subscribe to the event
-            pub.RaiseCustomEvent += HandleCustomEvent;
-        }
-
-        // Define what actions to take when the event is raised.
-        void HandleCustomEvent(object? sender, CustomEventArgs e)
-        {
-            Console.WriteLine($"{_id} received this message: {e.Message}");
+            // Call to raise the event.
+            raiseEvent(this, e);
         }
     }
+}
 
-    class Program
+//Class that subscribes to an event
+class Subscriber
+{
+    private readonly string _id;
+
+    public Subscriber(string id, Publisher pub)
     {
-        static void Main()
-        {
-            var pub = new Publisher();
-            var sub1 = new Subscriber("sub1", pub);
-            var sub2 = new Subscriber("sub2", pub);
+        _id = id;
 
-            // Call the method that raises the event.
-            pub.DoSomething();
+        // Subscribe to the event
+        pub.RaiseCustomEvent += HandleCustomEvent;
+    }
 
-            // Keep the console window open
-            Console.WriteLine("Press any key to continue...");
-            Console.ReadLine();
-        }
+    // Define what actions to take when the event is raised.
+    void HandleCustomEvent(object? sender, CustomEventArgs e)
+    {
+        Console.WriteLine($"{_id} received this message: {e.Message}");
+    }
+}
+
+class Program
+{
+    static void Main()
+    {
+        var pub = new Publisher();
+        var sub1 = new Subscriber("sub1", pub);
+        var sub2 = new Subscriber("sub2", pub);
+
+        // Call the method that raises the event.
+        pub.DoSomething();
+
+        // Keep the console window open
+        Console.WriteLine("Press any key to continue...");
+        Console.ReadLine();
     }
 }
 //</Snippet2>

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideEvents/CS/Events.csproj
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideEvents/CS/Events.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWindowsForms>true</UseWindowsForms>
+    <StartupObject>Events.Program</StartupObject>
+  </PropertyGroup>
+
+</Project>

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideEvents/CS/Program.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideEvents/CS/Program.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Events
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Updated snippet and docs to address nullable reference types warnings.
I also updated the sample to use a file-scoped namespace, I can revert this if needed.

Fixes #39991 (if available)


![image](https://github.com/dotnet/docs/assets/28659384/7d1b745a-5c46-40bc-964f-e8b3dc2e5ed6)

Note: the referenced API docs also has a similar snippet that needs to be updated at https://learn.microsoft.com/en-us/dotnet/api/system.eventhandler-1?view=net-8.0 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/events/how-to-publish-events-that-conform-to-net-framework-guidelines.md](https://github.com/dotnet/docs/blob/3f0873180125bc941681d45b2e670231d00844a7/docs/csharp/programming-guide/events/how-to-publish-events-that-conform-to-net-framework-guidelines.md) | [How to publish events that conform to .NET Guidelines (C# Programming Guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/events/how-to-publish-events-that-conform-to-net-framework-guidelines?branch=pr-en-us-40469) |


<!-- PREVIEW-TABLE-END -->