### PR TITLE
Note CA1047 is replaced by CS0628 for C#

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1047.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1047.md
@@ -11,6 +11,7 @@ helpviewer_keywords:
 author: gewarren
 ms.author: gewarren
 dev_langs:
+- CSharp
 - VB
 ---
 # CA1047: Do not declare protected members in sealed types

--- a/docs/fundamentals/code-analysis/quality-rules/ca1047.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1047.md
@@ -11,7 +11,6 @@ helpviewer_keywords:
 author: gewarren
 ms.author: gewarren
 dev_langs:
-- CSharp
 - VB
 ---
 # CA1047: Do not declare protected members in sealed types
@@ -32,7 +31,7 @@ A public type is `sealed` (`NotInheritable` in Visual basic) and declares a prot
 
 Types declare protected members so that inheriting types can access or override the member. By definition, you cannot inherit from a sealed type, which means that protected methods on sealed types cannot be called.
 
-The C# compiler issues a warning for this error.
+The C# compiler emits CS0628 for this issue.
 
 ## How to fix violations
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1047.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1047.md
@@ -31,7 +31,7 @@ A public type is `sealed` (`NotInheritable` in Visual basic) and declares a prot
 
 Types declare protected members so that inheriting types can access or override the member. By definition, you cannot inherit from a sealed type, which means that protected methods on sealed types cannot be called.
 
-The C# compiler emits CS0628 for this issue.
+The C# compiler emits warning [CS0628](../../../csharp/misc/cs0628.md) instead of CA1047 for this situation.
 
 ## How to fix violations
 


### PR DESCRIPTION
## Summary

CA1047 is replaced by CS0628 for C#. See dotnet/roslyn-analyzers#3457.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1047.md](https://github.com/dotnet/docs/blob/ca764e09e6a537559056f5d7f523a7e6186e62f1/docs/fundamentals/code-analysis/quality-rules/ca1047.md) | [CA1047: Do not declare protected members in sealed types](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1047?branch=pr-en-us-40503) |


<!-- PREVIEW-TABLE-END -->