### PR TITLE
Fix typo: dotnet-counter -> dotnet-counters

### DIFF
--- a/docs/core/deploying/native-aot/diagnostics.md
+++ b/docs/core/deploying/native-aot/diagnostics.md
@@ -24,7 +24,7 @@ The following table summarizes diagnostic features supported for Native AOT depl
 
 ## Observability and telemetry
 
-As of .NET 8, the Native AOT runtime supports [EventPipe](../../diagnostics/eventpipe.md), which is the base layer used by many logging and tracing libraries. You can interface with EventPipe directly through APIs like `EventSource.WriteEvent` or you can use libraries built on top, like [OpenTelemetry](../../diagnostics/observability-with-otel.md). EventPipe support also allows .NET diagnostic tools like [dotnet-trace](../../diagnostics/dotnet-trace.md), [dotnet-counter](../../diagnostics/dotnet-counters.md), and [dotnet-monitor](../../diagnostics/dotnet-monitor.md) to work seamlessly with Native AOT or CoreCLR applications. EventPipe is an optional component in Native AOT. To include EventPipe support, set the `EventSourceSupport` MSBuild property to `true`.
+As of .NET 8, the Native AOT runtime supports [EventPipe](../../diagnostics/eventpipe.md), which is the base layer used by many logging and tracing libraries. You can interface with EventPipe directly through APIs like `EventSource.WriteEvent` or you can use libraries built on top, like [OpenTelemetry](../../diagnostics/observability-with-otel.md). EventPipe support also allows .NET diagnostic tools like [dotnet-trace](../../diagnostics/dotnet-trace.md), [dotnet-counters](../../diagnostics/dotnet-counters.md), and [dotnet-monitor](../../diagnostics/dotnet-monitor.md) to work seamlessly with Native AOT or CoreCLR applications. EventPipe is an optional component in Native AOT. To include EventPipe support, set the `EventSourceSupport` MSBuild property to `true`.
 
 ```xml
 <PropertyGroup>

--- a/docs/core/diagnostics/event-counters.md
+++ b/docs/core/diagnostics/event-counters.md
@@ -39,7 +39,7 @@ An event listener specifies how long measurement intervals are. At the end of ea
 
 ## Implement an EventSource
 
-The following code implements a sample <xref:System.Diagnostics.Tracing.EventSource> exposed as the named `"Sample.EventCounter.Minimal"` provider. This source contains an <xref:System.Diagnostics.Tracing.EventCounter> representing request-processing time. Such a counter has a name (that is, its unique ID in the source) and a display name, both used by listener tools such as [dotnet-counter](dotnet-counters.md).
+The following code implements a sample <xref:System.Diagnostics.Tracing.EventSource> exposed as the named `"Sample.EventCounter.Minimal"` provider. This source contains an <xref:System.Diagnostics.Tracing.EventCounter> representing request-processing time. Such a counter has a name (that is, its unique ID in the source) and a display name, both used by listener tools such as [dotnet-counters](dotnet-counters.md).
 
 :::code language="csharp" source="snippets/EventCounters/MinimalEventCounterSource.cs":::
 


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/deploying/native-aot/diagnostics.md](https://github.com/dotnet/docs/blob/53af88e3de824d6b86a3e9014c1b577556f877be/docs/core/deploying/native-aot/diagnostics.md) | [Diagnostics and instrumentation](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/diagnostics?branch=pr-en-us-40572) |
| [docs/core/diagnostics/event-counters.md](https://github.com/dotnet/docs/blob/53af88e3de824d6b86a3e9014c1b577556f877be/docs/core/diagnostics/event-counters.md) | [EventCounters in .NET Core](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/event-counters?branch=pr-en-us-40572) |

<!-- PREVIEW-TABLE-END -->