### PR TITLE
Rename 'alias' variable to 'aliansOfa' in declaration page

### DIFF
--- a/docs/csharp/language-reference/statements/declarations.md
+++ b/docs/csharp/language-reference/statements/declarations.md
@@ -67,7 +67,7 @@ In pattern matching, the `var` keyword is used in a [`var` pattern](../operators
 When you declare a local variable and add the `ref` keyword before the variable's type, you declare a *reference variable*, or a `ref` local:
 
 ```csharp
-ref int alias = ref variable;
+ref int aliasOfvariable = ref variable;
 ```
 
 A reference variable is a variable that refers to another variable, which is called the *referent*. That is, a reference variable is an *alias* to its referent. When you assign a value to a reference variable, that value is assigned to the referent. When you read the value of a reference variable, the referent's value is returned. The following example demonstrates that behavior:

--- a/docs/csharp/language-reference/statements/snippets/declarations/ReferenceVariables.cs
+++ b/docs/csharp/language-reference/statements/snippets/declarations/ReferenceVariables.cs
@@ -11,14 +11,14 @@
     {
         // <AliasToLocalVariable>
         int a = 1;
-        ref int alias = ref a;
-        Console.WriteLine($"(a, alias) is ({a}, {alias})");  // output: (a, alias) is (1, 1)
+        ref int aliasOfa = ref a;
+        Console.WriteLine($"(a, aliasOfa) is ({a}, {aliasOfa})");  // output: (a, aliasOfa) is (1, 1)
 
         a = 2;
-        Console.WriteLine($"(a, alias) is ({a}, {alias})");  // output: (a, alias) is (2, 2)
+        Console.WriteLine($"(a, aliasOfa) is ({a}, {aliasOfa})");  // output: (a, aliasOfa) is (2, 2)
 
-        alias = 3;
-        Console.WriteLine($"(a, alias) is ({a}, {alias})");  // output: (a, alias) is (3, 3)
+        aliasOfa = 3;
+        Console.WriteLine($"(a, aliasOfa) is ({a}, {aliasOfa})");  // output: (a, aliasOfa) is (3, 3)
         // </AliasToLocalVariable>
     }
 


### PR DESCRIPTION
This pull request fixes #40304 
It renames `alias` variable to `aliansOfa` to prevent syntax coloring considering it a keyword.

I decided to go with lowercase for `a` in the name to indicate the `a` referent even more, as I was finding it still readable even when going away from camel case.

I went through the article and saw one more case of such, also renamed it to fix the same issue.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/statements/declarations.md](https://github.com/dotnet/docs/blob/0b522d3c3ffd8e57cf52d2fdba04b3c265c69f01/docs/csharp/language-reference/statements/declarations.md) | [Declaration statements](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/statements/declarations?branch=pr-en-us-40573) |

<!-- PREVIEW-TABLE-END -->