### PR TITLE
Add anchor for built-in reference types.

### DIFF
--- a/docs/csharp/language-reference/keywords/reference-types.md
+++ b/docs/csharp/language-reference/keywords/reference-types.md
@@ -23,9 +23,9 @@ There are two kinds of types in C#: reference types and value types. Variables o
 
  C# also provides the following built-in reference types:
 
-- [dynamic](../builtin-types/reference-types.md)
-- [object](../builtin-types/reference-types.md)
-- [string](../builtin-types/reference-types.md)
+- [dynamic](../builtin-types/reference-types.md#the-dynamic-type)
+- [object](../builtin-types/reference-types.md#the-object-type)
+- [string](../builtin-types/reference-types.md#the-string-type)
 
 ## See also
 


### PR DESCRIPTION
## Summary

The link went to the correct page, but without the necessary anchor for navigation.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/reference-types.md](https://github.com/dotnet/docs/blob/1cc6d2f482eacb031d5e5af84369aa1425297696/docs/csharp/language-reference/keywords/reference-types.md) | [Reference types (C# reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/reference-types?branch=pr-en-us-40581) |

<!-- PREVIEW-TABLE-END -->