### PR TITLE
Update configuration in tutorial (#40594)

### DIFF
--- a/docs/core/tutorials/cli-templates-create-project-template.md
+++ b/docs/core/tutorials/cli-templates-create-project-template.md
@@ -94,7 +94,7 @@ Open the _template.json_ with your favorite text editor and paste in the followi
   "identity": "ExampleTemplate.AsyncProject",
   "name": "Example templates: async project",
   "shortName": "consoleasync",
-  "sourceName":"ExampleTemplate.AsyncProject",
+  "sourceName":"consoleasync",
   "tags": {
     "language": "C#",
     "type": "project"


### PR DESCRIPTION
This change will make that the expected behavior starts working as described

## Summary

Updated the config in json to have the name of the project. This way the `dotnet new consoleasync -n MyProject` starts behaving like expected in the tutorial.

Fixes #40594

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tutorials/cli-templates-create-project-template.md](https://github.com/dotnet/docs/blob/6fafdc5f89c0595ff444b1bc4d31c4c0ce4fc7b6/docs/core/tutorials/cli-templates-create-project-template.md) | [Tutorial: Create a project template](https://review.learn.microsoft.com/en-us/dotnet/core/tutorials/cli-templates-create-project-template?branch=pr-en-us-40595) |

<!-- PREVIEW-TABLE-END -->