### PR TITLE
Fix typo in cross-platform-cryptography.md

### DIFF
--- a/docs/standard/security/cross-platform-cryptography.md
+++ b/docs/standard/security/cross-platform-cryptography.md
@@ -51,7 +51,7 @@ The underlying ciphers and chaining are done by the system libraries.
 
 Authenticated encryption (AE) support is provided for AES-CCM, AES-GCM, and ChaCha20Poly1305 via the <xref:System.Security.Cryptography.AesCcm?displayProperty=fullName>, <xref:System.Security.Cryptography.AesGcm?displayProperty=fullName>, and <xref:System.Security.Cryptography.ChaCha20Poly1305?displayProperty=fullName> classes, respectively.
 
-As authenticated encryption requires newer platform APIs to support the algorithm, support may not be present on all platforms. The `IsSupported` static property on the classes for the algorithm can be used to detect at runtime if the current platform supports the algorithm or not.
+Since authenticated encryption requires newer platform APIs to support the algorithm, support may not be present on all platforms. The `IsSupported` static property on the classes for the algorithm can be used to detect at runtime if the current platform supports the algorithm or not.
 
 | Cipher + Mode     | Windows                 | Linux          | macOS   | iOS, tvOS, MacCatalyst | Android       | Browser |
 |-------------------|-------------------------|----------------|---------|------------------------|---------------|---------|

--- a/docs/standard/security/cross-platform-cryptography.md
+++ b/docs/standard/security/cross-platform-cryptography.md
@@ -51,7 +51,7 @@ The underlying ciphers and chaining are done by the system libraries.
 
 Authenticated encryption (AE) support is provided for AES-CCM, AES-GCM, and ChaCha20Poly1305 via the <xref:System.Security.Cryptography.AesCcm?displayProperty=fullName>, <xref:System.Security.Cryptography.AesGcm?displayProperty=fullName>, and <xref:System.Security.Cryptography.ChaCha20Poly1305?displayProperty=fullName> classes, respectively.
 
-As authentication encryption requires newer platform APIs to support the algorithm, support may not be present on all platforms. The `IsSupported` static property on the classes for the algorithm can be used to detect at runtime if the current platform supports the algorithm or not.
+As authenticated encryption requires newer platform APIs to support the algorithm, support may not be present on all platforms. The `IsSupported` static property on the classes for the algorithm can be used to detect at runtime if the current platform supports the algorithm or not.
 
 | Cipher + Mode     | Windows                 | Linux          | macOS   | iOS, tvOS, MacCatalyst | Android       | Browser |
 |-------------------|-------------------------|----------------|---------|------------------------|---------------|---------|


### PR DESCRIPTION
I believe given the context, the sentence:

> As **authentication** encryption requires ...

Should read:

> As **authenticated** encryption requires ...

It may be worth going further and changing "As" to "Since" so it reads:

> **Since authenticated** encryption requires ...

...but I defer to the PR reviewers on that extra tweak.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/security/cross-platform-cryptography.md](https://github.com/dotnet/docs/blob/1eb93d7e46aae6df662b3c3dd9c87afc426632cf/docs/standard/security/cross-platform-cryptography.md) | [Cross-Platform Cryptography in .NET](https://review.learn.microsoft.com/en-us/dotnet/standard/security/cross-platform-cryptography?branch=pr-en-us-40599) |


<!-- PREVIEW-TABLE-END -->