### PR TITLE
Indices examples use an array with 10 elements to simplify the tutorial

### DIFF
--- a/docs/csharp/tutorials/ranges-indexes.md
+++ b/docs/csharp/tutorials/ranges-indexes.md
@@ -43,7 +43,7 @@ The following code creates a subrange with the words "second", "third", and "fou
 
 :::code language="csharp" source="snippets/RangesIndexes/IndicesAndRanges.cs" id="SnippetIndicesAndRanges_Range":::
 
-The following code returns the range with "ninth" and "tenth". It includes `words[^2]` and `words[^1]`. The end index `words[^0]` isn't included. 
+The following code returns the range with "ninth" and "tenth". It includes `words[^2]` and `words[^1]`. The end index `words[^0]` isn't included.
 
 :::code language="csharp" source="snippets/RangesIndexes/IndicesAndRanges.cs" id="SnippetIndicesAndRanges_LastRange":::
 

--- a/docs/csharp/tutorials/ranges-indexes.md
+++ b/docs/csharp/tutorials/ranges-indexes.md
@@ -29,22 +29,10 @@ This language support relies on two new types and two new operators:
 - <xref:System.Range?displayProperty=nameWithType> represents a sub range of a sequence.
 - The [range operator `..`](../language-reference/operators/member-access-operators.md#range-operator-), which specifies the start and end of a range as its operands.
 
-Let's start with the rules for indices. Consider an array `sequence`. The `0` index is the same as `sequence[0]`. The `^0` index is the same as `sequence[sequence.Length]`. The expression `sequence[^0]` does throw an exception, just as `sequence[sequence.Length]` does. For any number `n`, the index `^n` is the same as `sequence.Length - n`.
+Let's start with the rules for indices. Consider an array `sequence`. The `0` index is the same as `sequence[0]`. The `^0` index is the same as `sequence[sequence.Length]`. The expression `sequence[^0]` throws an exception, just as `sequence[sequence.Length]` does. For any number `n`, the index `^n` is the same as `sequence.Length - n`.
 
-```csharp
-string[] words = [
-                // index from start    index from end
-    "The",      // 0                   ^9
-    "quick",    // 1                   ^8
-    "brown",    // 2                   ^7
-    "fox",      // 3                   ^6
-    "jumps",    // 4                   ^5
-    "over",     // 5                   ^4
-    "the",      // 6                   ^3
-    "lazy",     // 7                   ^2
-    "dog"       // 8                   ^1
-];              // 9 (or words.Length) ^0
-```
+:::code language="csharp" source="snippets/RangesIndexes/IndicesAndRanges.cs" id="SnippetIndicesAndRanges_Initialization":::
+
 
 You can retrieve the last word with the `^1` index. Add the following code below the initialization:
 
@@ -52,11 +40,11 @@ You can retrieve the last word with the `^1` index. Add the following code below
 
 A range specifies the *start* and *end* of a range. The start of the range is inclusive, but the end of the range is exclusive, meaning the *start* is included in the range but the *end* isn't included in the range. The range `[0..^0]` represents the entire range, just as `[0..sequence.Length]` represents the entire range.
 
-The following code creates a subrange with the words "quick", "brown", and "fox". It includes `words[1]` through `words[3]`. The element `words[4]` isn't in the range.
+The following code creates a subrange with the words "second", "third", and "fourth". It includes `words[1]` through `words[3]`. The element `words[4]` isn't in the range.
 
 :::code language="csharp" source="snippets/RangesIndexes/IndicesAndRanges.cs" id="SnippetIndicesAndRanges_Range":::
 
-The following code returns the range with "lazy" and "dog". It includes `words[^2]` and `words[^1]`. The end index `words[^0]` isn't included. Add the following code as well:
+The following code returns the range with "ninth" and "tenth". It includes `words[^2]` and `words[^1]`. The end index `words[^0]` isn't included. 
 
 :::code language="csharp" source="snippets/RangesIndexes/IndicesAndRanges.cs" id="SnippetIndicesAndRanges_LastRange":::
 

--- a/docs/csharp/tutorials/ranges-indexes.md
+++ b/docs/csharp/tutorials/ranges-indexes.md
@@ -33,7 +33,6 @@ Let's start with the rules for indices. Consider an array `sequence`. The `0` in
 
 :::code language="csharp" source="snippets/RangesIndexes/IndicesAndRanges.cs" id="SnippetIndicesAndRanges_Initialization":::
 
-
 You can retrieve the last word with the `^1` index. Add the following code below the initialization:
 
 :::code language="csharp" source="snippets/RangesIndexes/IndicesAndRanges.cs" id="SnippetIndicesAndRanges_LastIndex":::

--- a/docs/csharp/tutorials/snippets/RangesIndexes/IndicesAndRanges.cs
+++ b/docs/csharp/tutorials/snippets/RangesIndexes/IndicesAndRanges.cs
@@ -4,23 +4,24 @@ class IndicesAndRanges
 {
     // <SnippetIndicesAndRanges_Initialization>
     private string[] words = [
-                    // index from start    index from end
-        "The",      // 0                   ^9
-        "quick",    // 1                   ^8
-        "brown",    // 2                   ^7
-        "fox",      // 3                   ^6
-        "jumped",   // 4                   ^5
-        "over",     // 5                   ^4
-        "the",      // 6                   ^3
-        "lazy",     // 7                   ^2
-        "dog"       // 8                   ^1
-    ];
+                    // index from start     index from end
+        "first",    // 0                    ^10
+        "second",   // 1                    ^9
+        "third",    // 2                    ^8
+        "fourth",   // 3                    ^7
+        "fifth",    // 4                    ^6
+        "sixth",    // 5                    ^5
+        "seventh",  // 6                    ^4
+        "eighth",   // 7                    ^3
+        "ninth",    // 8                    ^2
+        "tenth"     // 9                    ^1
+    ];              // 10 (or words.Length) ^0
     // </SnippetIndicesAndRanges_Initialization>
 
     internal int Syntax_LastIndex()
     {
         // <SnippetIndicesAndRanges_LastIndex>
-        Console.WriteLine($"The last word is {words[^1]}");
+        Console.WriteLine($"The last word is < {words[^1]} >."); // The last worid is < tenth >. 
         // </SnippetIndicesAndRanges_LastIndex>
         return 0;
     }
@@ -28,9 +29,11 @@ class IndicesAndRanges
     internal int Syntax_Range()
     {
         // <SnippetIndicesAndRanges_Range>
-        string[] quickBrownFox = words[1..4];
-        foreach (var word in quickBrownFox)
-            Console.Write($"< {word} >");
+        string[] secondThirdFourth = words[1..4]; // contains "second", "third" and "fourth"
+        
+        // < first >< second >< third >< fourth >
+        foreach (var word in secondThirdFourth)
+            Console.Write($"< {word} >"); 
         Console.WriteLine();
         // </SnippetIndicesAndRanges_Range>
         return 0;
@@ -39,9 +42,11 @@ class IndicesAndRanges
     internal int Syntax_LastRange()
     {
         // <SnippetIndicesAndRanges_LastRange>
-        string[] lazyDog = words[^2..^0];
-        foreach (var word in lazyDog)
-            Console.Write($"< {word} >");
+        string[] lastTwo = words[^2..^0]; // contains "ninth" and "tenth"
+       
+        // < ninth >< tenth >
+        foreach (var word in lastTwo)
+            Console.Write($"< {word} >"); 
         Console.WriteLine();
         // </SnippetIndicesAndRanges_LastRange>
         return 0;
@@ -50,17 +55,23 @@ class IndicesAndRanges
     internal int Syntax_PartialRange()
     {
         // <SnippetIndicesAndRanges_PartialRanges>
-        string[] allWords = words[..]; // contains "The" through "dog".
-        string[] firstPhrase = words[..4]; // contains "The" through "fox"
-        string[] lastPhrase = words[6..]; // contains "the", "lazy" and "dog"
+        string[] allWords = words[..]; // contains "first" through "tenth".
+        string[] firstPhrase = words[..4]; // contains "first" through "fourth"
+        string[] lastPhrase = words[6..]; // contains "seventh", "eight", "ninth" and "tenth"
+
+        // < first >< second >< third >< fourth >< fifth >< sixth >< seventh >< eighth >< ninth >< tenth >
         foreach (var word in allWords)
-            Console.Write($"< {word} >");
+            Console.Write($"< {word} >"); 
         Console.WriteLine();
+
+        // < first >< second >< third >< fourth >
         foreach (var word in firstPhrase)
-            Console.Write($"< {word} >");
+            Console.Write($"< {word} >"); 
         Console.WriteLine();
+
+        // < seventh >< eighth >< ninth >< tenth >
         foreach (var word in lastPhrase)
-            Console.Write($"< {word} >");
+            Console.Write($"< {word} >"); 
         Console.WriteLine();
         // </SnippetIndicesAndRanges_PartialRanges>
         return 0;
@@ -69,12 +80,14 @@ class IndicesAndRanges
     internal int Syntax_IndexRangeType()
     {
         // <SnippetIndicesAndRanges_RangeIndexTypes>
-        Index the = ^3;
-        Console.WriteLine(words[the]);
+        Index thirdFromEnd = ^3;
+        Console.WriteLine($"< {words[thirdFromEnd]} > "); // < eighth > 
         Range phrase = 1..4;
         string[] text = words[phrase];
+        
+        // < second >< third >< fourth >
         foreach (var word in text)
-            Console.Write($"< {word} >");
+            Console.Write($"< {word} >");  
         Console.WriteLine();
         // </SnippetIndicesAndRanges_RangeIndexTypes>
         return 0;


### PR DESCRIPTION
## Summary

Changes to Indices and ranges tutorial only:
1. I used array of 10 elements to simply mental math
2. I used ordinal strings ("first", "second") instead ("The", "quick") to eliminate the need to scroll up to the table declaration to count which index is "fox" etc.
3. I added comments with outputs of `Console.Write[Line]`. Without the comment it seems that the Write[Lines] don't improve to the page and could be removed.
4. I used the existing snippet for table initialisation instead of an inline snipped (i.e. removed duplication). 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/tutorials/ranges-indexes.md](https://github.com/dotnet/docs/blob/fdc46c92a27706683ab8b7962db3a26e7c0df043/docs/csharp/tutorials/ranges-indexes.md) | [Indices and ranges](https://review.learn.microsoft.com/en-us/dotnet/csharp/tutorials/ranges-indexes?branch=pr-en-us-40607) |


<!-- PREVIEW-TABLE-END -->