### PR TITLE
Make command and option order match CLI help

### DIFF
--- a/docs/core/tools/dotnet-format.md
+++ b/docs/core/tools/dotnet-format.md
@@ -14,7 +14,7 @@ ms.date: 07/12/2021
 ## Synopsis
 
 ```dotnetcli
-dotnet format [options] [<PROJECT | SOLUTION>]
+dotnet format [<PROJECT | SOLUTION>] [command] [options]
 
 dotnet format -h|--help
 ```
@@ -85,7 +85,7 @@ None of the options below are required for the `dotnet format` command to succee
 
 #### Description
 
-The `dotnet format whitespace` subcommand will only run formatting rules associated with whitespace formatting. For a complete list of possible formatting options that you can specify in your *.editorconfig* file, see the [C# formatting options](../../fundamentals/code-analysis/style-rules/csharp-formatting-options.md).
+The `dotnet format whitespace` subcommand only runs formatting rules associated with whitespace formatting. For a complete list of possible formatting options that you can specify in your *.editorconfig* file, see the [C# formatting options](../../fundamentals/code-analysis/style-rules/csharp-formatting-options.md).
 
 #### Options
 
@@ -99,7 +99,7 @@ The `dotnet format whitespace` subcommand will only run formatting rules associa
 
 #### Description
 
-The `dotnet format style` subcommand will only run formatting rule associated with code style formatting. For a complete list of formatting options that you can specify in your `editorconfig` file, see [Code style rules](../../fundamentals/code-analysis/style-rules/index.md).
+The `dotnet format style` subcommand only runs formatting rules associated with code style formatting. For a complete list of formatting options that you can specify in your `editorconfig` file, see [Code style rules](../../fundamentals/code-analysis/style-rules/index.md).
 
 #### Options
 
@@ -117,7 +117,7 @@ The `dotnet format style` subcommand will only run formatting rule associated wi
 
 #### Description
 
-The `dotnet format analyzers` subcommand will only run formatting rule associated with analyzers. For a list of analyzer rules that you can specify in your `editorconfig` file, see [Code style rules](../../fundamentals/code-analysis/style-rules/index.md).
+The `dotnet format analyzers` subcommand only runs formatting rules associated with analyzers. For a list of analyzer rules that you can specify in your `editorconfig` file, see [Code style rules](../../fundamentals/code-analysis/style-rules/index.md).
 
 ##### Options
 


### PR DESCRIPTION
Fixes #40208 

Following CLI command help results in inconsistency, as the synopsis has project before command and options, while subcommands detail shows project after the subcommand. Both orders work.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-format.md](https://github.com/dotnet/docs/blob/f7aca7e5dc7e74bf9c0681183a587aa4f4efa252/docs/core/tools/dotnet-format.md) | [dotnet format](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-format?branch=pr-en-us-40619) |

<!-- PREVIEW-TABLE-END -->