### PR TITLE
Clarify the need for SG to target `netstandard2.0`

### DIFF
--- a/docs/csharp/roslyn-sdk/source-generators-overview.md
+++ b/docs/csharp/roslyn-sdk/source-generators-overview.md
@@ -71,9 +71,7 @@ In this guide, you'll explore the creation of a source generator using the <xref
     :::code language="xml" source="snippets/source-generators/SourceGenerator/SourceGenerator.csproj":::
 
     > [!TIP]
-    > The source generator project needs to target the `netstandard2.0` TFM, otherwise it will not work.
-    > The source generator can be hosted under .NET Framework environment (in Visual Studio IDE or MSBuild CLI), or .NET 7.0+ environment (`dotnet` CLI, VS Code, or VS out-of-process).
-    > So, to support all the possible environments where a source generator can run in, it should be `netstandard2.0`.
+    > The source generator project should typically target the `netstandard2.0` TFM, as to support their consumption within .NET Framework environments including the Visual Studio IDE and MSBuild CLI.
 
 1. Create a new C# file named _HelloSourceGenerator.cs_ that specifies your own Source Generator like so:
 

--- a/docs/csharp/roslyn-sdk/source-generators-overview.md
+++ b/docs/csharp/roslyn-sdk/source-generators-overview.md
@@ -72,6 +72,8 @@ In this guide, you'll explore the creation of a source generator using the <xref
 
     > [!TIP]
     > The source generator project needs to target the `netstandard2.0` TFM, otherwise it will not work.
+    > The source generator can be hosted under .NET Framework environment (in Visual Studio IDE or MSBuild CLI), or .NET 7.0+ environment (`dotnet` CLI, VS Code, or VS out-of-process).
+    > So, to support all the possible environments where a source generator can run in, it should be `netstandard2.0`.
 
 1. Create a new C# file named _HelloSourceGenerator.cs_ that specifies your own Source Generator like so:
 


### PR DESCRIPTION
Fixes #40603


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/roslyn-sdk/source-generators-overview.md](https://github.com/dotnet/docs/blob/623a151fc007ab3c050576b017cc7d212b6a97fd/docs/csharp/roslyn-sdk/source-generators-overview.md) | [Source Generators](https://review.learn.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/source-generators-overview?branch=pr-en-us-40644) |


<!-- PREVIEW-TABLE-END -->