### PR TITLE
Remove redundant parenthesis from the "Analyze sentiment using the ML.NET CLI" documentation.

### DIFF
--- a/docs/machine-learning/tutorials/sentiment-analysis-cli.md
+++ b/docs/machine-learning/tutorials/sentiment-analysis-cli.md
@@ -164,7 +164,7 @@ Those enumerated assets are explained in the following steps of the tutorial.
     }
     ```
 
-    - The first lines of code create a *single sample data*, in this case based on the first row of your dataset to be used for the prediction. You can also create your own 'hard-coded' data by updating the code:
+    - The first lines of code create a *single sample data*, in this case, based on the first row of your dataset to be used for the prediction. You can also create your own 'hard-coded' data by updating the code:
 
         ```csharp
         ModelInput sampleData = new ModelInput()
@@ -178,13 +178,13 @@ Those enumerated assets are explained in the following steps of the tutorial.
 
 1. Run the project, either using the original sample data loaded from the first row of the dataset or by providing your own custom hard-coded sample data. You should get a prediction comparable to:
 
-![ML.NET CLI run the app from Visual Studio](./media/mlnet-cli/mlnet-cli-console-app.png))
+![ML.NET CLI run the app from Visual Studio](./media/mlnet-cli/mlnet-cli-console-app.png)
 
-1. Try changing the hard-coded sample data to other sentences with different sentiment and see how the model predicts positive or negative sentiment.
+Try changing the hard-coded sample data to other sentences with different sentiments and see how the model predicts positive or negative sentiment.
 
 ## Infuse your end-user applications with ML model predictions
 
-You can use similar 'ML model scoring code' to run the model in your end-user application and make predictions.
+You can use a similar 'ML model scoring code' to run the model in your end-user application and make predictions.
 
 For instance, you could directly move that code to any Windows desktop application such as **WPF** and **WinForms** and run the model in the same way than it was done in the console app.
 

--- a/docs/machine-learning/tutorials/sentiment-analysis-cli.md
+++ b/docs/machine-learning/tutorials/sentiment-analysis-cli.md
@@ -164,7 +164,7 @@ Those enumerated assets are explained in the following steps of the tutorial.
     }
     ```
 
-    - The first lines of code create a *single sample data*, in this case, based on the first row of your dataset to be used for the prediction. You can also create your own 'hard-coded' data by updating the code:
+    - The first lines of code create a *single sample data*. In this case, the single sample data is based on the first row of the dataset to be used for the prediction. You can also create your own 'hard-coded' data by updating the code:
 
         ```csharp
         ModelInput sampleData = new ModelInput()
@@ -178,13 +178,13 @@ Those enumerated assets are explained in the following steps of the tutorial.
 
 1. Run the project, either using the original sample data loaded from the first row of the dataset or by providing your own custom hard-coded sample data. You should get a prediction comparable to:
 
-![ML.NET CLI run the app from Visual Studio](./media/mlnet-cli/mlnet-cli-console-app.png)
+    ![ML.NET CLI run the app from Visual Studio](./media/mlnet-cli/mlnet-cli-console-app.png)
 
 Try changing the hard-coded sample data to other sentences with different sentiments and see how the model predicts positive or negative sentiment.
 
 ## Infuse your end-user applications with ML model predictions
 
-You can use a similar 'ML model scoring code' to run the model in your end-user application and make predictions.
+You can use similar 'ML model scoring code' to run the model in your end-user application and make predictions.
 
 For instance, you could directly move that code to any Windows desktop application such as **WPF** and **WinForms** and run the model in the same way than it was done in the console app.
 


### PR DESCRIPTION
In the [Analyze sentiment using the ML.NET CLI](https://learn.microsoft.com/en-us/dotnet/machine-learning/tutorials/sentiment-analysis-cli) documentation, there was a redundant closing parenthesis. Within this PR, I removed the redundant parenthesis and made a small enhancement to the content.

![mark](https://github.com/dotnet/docs/assets/43685404/f9fd3dfd-e153-49b9-b0f2-0f2b75657bec)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/machine-learning/tutorials/sentiment-analysis-cli.md](https://github.com/dotnet/docs/blob/19dacd4b9be96187c6eff49b96728643e960ff06/docs/machine-learning/tutorials/sentiment-analysis-cli.md) | [Analyze sentiment using the ML.NET CLI](https://review.learn.microsoft.com/en-us/dotnet/machine-learning/tutorials/sentiment-analysis-cli?branch=pr-en-us-40651) |


<!-- PREVIEW-TABLE-END -->