### PR TITLE
Update Fedora install docs for Fedora 40

### DIFF
--- a/docs/core/install/linux-fedora.md
+++ b/docs/core/install/linux-fedora.md
@@ -24,15 +24,13 @@ The following table is a list of currently supported .NET releases and the versi
 
 | Fedora | .NET      |
 |--------|-----------|
+| 40     | 8, 6   |
 | 39     | 8, 7, 6   |
 | 38     | 8, 7, 6   |
-| 37     | 8, 7, 6   |
 
 [!INCLUDE [versions-not-supported](includes/versions-not-supported.md)]
 
 ## Install .NET 8
-
-[!INCLUDE [linux-release-wait](includes/linux-release-wait.md)]
 
 [!INCLUDE [linux-dnf-install-80](includes/linux-install-80-dnf.md)]
 


### PR DESCRIPTION
## Summary

Fedora 40 is now available. Fedora 40 dropped .NET 7 because of the upcoming .NET 7 EOL.

Also, .NET 8 is now available via package manager for all versions of Fedora.

Fixes https://github.com/dotnet/docs/issues/39413

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/linux-fedora.md](https://github.com/dotnet/docs/blob/d0b5f7a173bbeec9959002d1de40cb08f720259e/docs/core/install/linux-fedora.md) | [Install the .NET SDK or the .NET Runtime on Fedora](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-fedora?branch=pr-en-us-40659) |


<!-- PREVIEW-TABLE-END -->