### PR TITLE
Add Y2038 related breaking change notices

### DIFF
--- a/docs/core/compatibility/6.0.md
+++ b/docs/core/compatibility/6.0.md
@@ -77,6 +77,7 @@ For information on other breaking changes for containers in .NET 6, see [.NET 6 
 | [System.Security.SecurityContext is marked obsolete](core-libraries/6.0/securitycontext-obsolete.md) | ✔️ | ❌ |
 | [Task.FromResult may return singleton](core-libraries/6.0/task-fromresult-returns-singleton.md) | ❌ | ✔️ |
 | [Unhandled exceptions from a BackgroundService](core-libraries/6.0/hosting-exception-handling.md) | ✔️ | ❌ |
+| [Year 2038 incompatible](core-libraries/6.0/y2038-incompatible.md) | ❌ | ❌ |
 
 ## Cryptography
 

--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -58,7 +58,7 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 | [ProcessStartInfo.WindowStyle honored when UseShellExecute is false](core-libraries/8.0/processstartinfo-windowstyle.md) | Behavioral change    |
 | [RuntimeIdentifier returns platform for which runtime was built](core-libraries/8.0/runtimeidentifier.md) | Behavioral change   |
 | [`Type.GetType` throws exception for all invalid element types](core-libraries/8.0/type-gettype.md) | Behavioral change   |
-| [year 2038 incompatible](core-libraries/8.0/y2038-incompatible.md) | Behavioral change   |
+| [Year 2038 incompatible](core-libraries/8.0/y2038-incompatible.md) | Behavioral change   |
 
 ## Cryptography
 

--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -58,6 +58,7 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 | [ProcessStartInfo.WindowStyle honored when UseShellExecute is false](core-libraries/8.0/processstartinfo-windowstyle.md) | Behavioral change    |
 | [RuntimeIdentifier returns platform for which runtime was built](core-libraries/8.0/runtimeidentifier.md) | Behavioral change   |
 | [`Type.GetType` throws exception for all invalid element types](core-libraries/8.0/type-gettype.md) | Behavioral change   |
+| [year 2038 incompatible](core-libraries/8.0/y2038-incompatible.md) | Behavioral change   |
 
 ## Cryptography
 

--- a/docs/core/compatibility/9.0.md
+++ b/docs/core/compatibility/9.0.md
@@ -25,7 +25,7 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 
 | Title                                                                                    | Type of change      | Introduced version |
 |------------------------------------------------------------------------------------------|---------------------|--------------------|
-| [`9.0-noble` images are 64-bit only"](containers/9.0/noble-arm32-images.md) | Binary incompatible | Preview 4  |
+| [`9.0-noble` images are 64-bit only](containers/9.0/noble-arm32-images.md) | Binary incompatible | Preview 4  |
 
 ## Core .NET libraries
 

--- a/docs/core/compatibility/9.0.md
+++ b/docs/core/compatibility/9.0.md
@@ -21,6 +21,12 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 |------------------------------------------------------------------------------------------|---------------------|--------------------|
 | [DefaultKeyResolution.ShouldGenerateNewKey has altered meaning](aspnet-core/9.0/key-resolution.md) | Behavioral change | Preview 3  |
 
+## Containers
+
+| Title                                                                                    | Type of change      | Introduced version |
+|------------------------------------------------------------------------------------------|---------------------|--------------------|
+| [`9.0-noble` images are 64-bit only"](containers/9.0/noble-arm32-images.md) | Binary incompatible | Preview 4  |
+
 ## Core .NET libraries
 
 | Title                                                                                    | Type of change      | Introduced version |
@@ -30,6 +36,7 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 | [Inline array struct size limit is enforced](core-libraries/9.0/inlinearray-size.md) | Behavioral change   | Preview 1          |
 | [InMemoryDirectoryInfo prepends rootDir to files](core-libraries/9.0/inmemorydirinfo-prepends-rootdir.md) | Behavioral change   | Preview 1          |
 | [RuntimeHelpers.GetSubArray returns different type](core-libraries/9.0/getsubarray-return.md) | Behavioral change   | Preview 1          |
+| [Year 2038 incompatible](core-libraries/9.0/y2038-incompatible.md) | Behavioral change   | Preview 1          |
 
 ## Networking
 

--- a/docs/core/compatibility/containers/9.0/noble-arm32-images.md
+++ b/docs/core/compatibility/containers/9.0/noble-arm32-images.md
@@ -1,0 +1,50 @@
+---
+title: "Breaking change: `9.0-noble` images are 64-bit only"
+description: Learn about the breaking change in Ubuntu 24.04 "noble" container images.
+ms.date: 07/11/2023
+ms.custom: linux-related-content
+---
+# `9.0-noble` images are 64-bit only
+
+.NET 9 container images for Ubuntu 24.04 are provided for Arm64 and x64 only. .NET 9 is not supported on Ubuntu 24.04 Arm32 due to [year 2038 incompatibility](../../core-libraries/9.0/y2038-incompatible.md).
+
+## Previous behavior
+
+Previously, you could reference a tag like `8.0` and be able to retrieve an Arm32 container image.
+
+## New behavior
+
+Starting in .NET 9, the `9.0` tag will only retrieve 64-bit images.
+
+Canonical has signaled that Arm32 is on the path to being deprecated / not supported for Ubuntu. Ubuntu related .NET tags will be 64-bit only going forward.
+
+> From 24.04 (noble), we will no longer be producing 32-bit (armhf) images for the Raspberry Pi.
+
+> While armhf will remain a supported architecture for noble within its lifespan, there will be no support for the armhf architecture after noble. In future releases, armhf images will not be provided, and it will not be an available foreign architecture.
+
+From [Ubuntu 24.04 release notes (No 32-bit (armhf) images)](https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890#no-32-bit-armhf-images-96)
+
+## Version introduced
+
+.NET 9 Preview 4
+
+## Type of change
+
+This change is a [behavioral change](../../categories.md#binary-compatibility).
+
+## Reason for change
+
+This change was made due to .NET 9 year 2038 incompatibility (specific to Arm32).
+
+## Recommended action
+
+Use Debian or Alpine Arm32 images or switch to a 64-bit environment. For example, Raspberry Pi can run both Arm32 and Arm64 Raspberry Pi OS variants.
+
+Example .NET 9 container tags supported for Arm32.
+
+- Debian: `mcr.microsoft.com/dotnet/sdk:9.0`
+- Alpine: `mcr.microsoft.com/dotnet/sdk:9.0-alpine`
+
+## Affected APIs
+
+None.

--- a/docs/core/compatibility/containers/9.0/noble-arm32-images.md
+++ b/docs/core/compatibility/containers/9.0/noble-arm32-images.md
@@ -1,7 +1,7 @@
 ---
 title: "Breaking change: `9.0-noble` images are 64-bit only"
 description: Learn about the breaking change in Ubuntu 24.04 "noble" container images.
-ms.date: 07/11/2023
+ms.date: 04/29/2024
 ms.custom: linux-related-content
 ---
 # `9.0-noble` images are 64-bit only
@@ -14,9 +14,9 @@ Previously, you could reference a tag like `8.0` and be able to retrieve an Arm3
 
 ## New behavior
 
-Starting in .NET 9, the `9.0` tag will only retrieve 64-bit images.
+Starting in .NET 9, the `9.0` tag only retrieves 64-bit images.
 
-Canonical has signaled that Arm32 is on the path to being deprecated / not supported for Ubuntu. Ubuntu related .NET tags will be 64-bit only going forward.
+Canonical has signaled that Arm32 is on the path to being deprecated / not supported for Ubuntu. Ubuntu-related .NET tags are 64-bit only going forward.
 
 > From 24.04 (noble), we will no longer be producing 32-bit (armhf) images for the Raspberry Pi.
 
@@ -40,7 +40,7 @@ This change was made due to .NET 9 year 2038 incompatibility (specific to Arm32)
 
 Use Debian or Alpine Arm32 images or switch to a 64-bit environment. For example, Raspberry Pi can run both Arm32 and Arm64 Raspberry Pi OS variants.
 
-Example .NET 9 container tags supported for Arm32.
+Example .NET 9 container tags supported for Arm32:
 
 - Debian: `mcr.microsoft.com/dotnet/sdk:9.0`
 - Alpine: `mcr.microsoft.com/dotnet/sdk:9.0-alpine`

--- a/docs/core/compatibility/core-libraries/6.0/y2038-incompatible.md
+++ b/docs/core/compatibility/core-libraries/6.0/y2038-incompatible.md
@@ -1,0 +1,51 @@
+---
+title: "Breaking change: .NET 6 is not supported on Year 2038 compatible Linux distros"
+description: Learn about the .NET 6 behavior on Year 2038 compatible Linxu distros.
+ms.date: 05/01/2024
+---
+# .NET 6 is not supported on Year 2038 compatible Arm32 Linux distros
+
+Linux Arm32 distros have used 32-bit integers to represent time. A 32-bit integer is [unable to represent dates after January 18th, 2038](https://en.wikipedia.org/wiki/Unix_time#Range_of_representable_times). Year 2038 (Y2038) compatible distros use a 64-bit integer for time, which resolves the problem. However, this change is breaking for .NET 6.
+
+[.NET 6 is not supported on Y2038-compatible Arm32 distros](https://github.com/dotnet/core/discussions/9285), such as Ubuntu 24.04 and Debian 13. The same is true for earlier .NET versions.
+
+.NET 10 will be supported on Y2038-compatible Arm32 distros.
+
+Arm64, and x64 environments are unaffected.
+
+## Previous behavior
+
+.NET 6 and earlier versions work on Ubuntu 22.04, Debian 12, and other Y2038-incompatible Arm32 distros.
+
+## New behavior
+
+.NET 6 and earlier versions do not work reliably on Ubuntu 24.04, Debian 13, and other Y2038-compatible Arm32 distros.
+
+Y2038-incompatible .NET builds running on Y2038-compatible Arm32 distros may see the following error.
+
+```bash
+The SSL connection could not be established, see inner exception.
+The remote certificate is invalid because of errors in the certificate chain: NotTimeValid
+```
+
+Some scenarios will be unaffected by this problem and work fine. However, running Y2038-incompatible .NET builds on Y2038-compatible Linux distros (and vice versa) is not supported.
+
+## Version introduced
+
+.NET 6
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+.NET needs to respond to Y2038 changes in Linux distros in order to function correctly. It will do so in .NET 10.
+
+## Recommended action
+
+Deploy .NET 6 and earlier versions on Y2038-incompatible Arm32 distros. Deploy .NET 10 and latest on Y2038-compatible distros.
+
+## Affected APIs
+
+Any API that relies on a native API that takes a time value.

--- a/docs/core/compatibility/core-libraries/8.0/y2038-incompatible.md
+++ b/docs/core/compatibility/core-libraries/8.0/y2038-incompatible.md
@@ -1,0 +1,51 @@
+---
+title: "Breaking change: .NET 8 is not supported on Year 2038 compatible Linux distros"
+description: Learn about the .NET 8 behavior on Year 2038 compatible Linxu distros.
+ms.date: 05/01/2024
+---
+# .NET 8 is not supported on Year 2038 compatible Arm32 Linux distros
+
+Linux Arm32 distros have used 32-bit integers to represent time. A 32-bit integer is [unable to represent dates after January 18th, 2038](https://en.wikipedia.org/wiki/Unix_time#Range_of_representable_times). Year 2038 (Y2038) compatible distros use a 64-bit integer for time, which resolves the problem. However, this change is breaking for .NET 8.
+
+[.NET 8 is not supported on Y2038-compatible Arm32 distros](https://github.com/dotnet/core/discussions/9285), such as Ubuntu 24.04 and Debian 13. The same is true for earlier .NET versions.
+
+.NET 10 will be supported on Y2038-compatible Arm32 distros.
+
+Arm64, and x64 environments are unaffected.
+
+## Previous behavior
+
+.NET 8 and earlier versions work on Ubuntu 22.04, Debian 12, and other Y2038-incompatible Arm32 distros.
+
+## New behavior
+
+.NET 8 and earlier versions do not work reliably on Ubuntu 24.04, Debian 13, and other Y2038-compatible Arm32 distros.
+
+Y2038-incompatible .NET builds running on Y2038-compatible Arm32 distros may see the following error.
+
+```bash
+The SSL connection could not be established, see inner exception.
+The remote certificate is invalid because of errors in the certificate chain: NotTimeValid
+```
+
+Some scenarios will be unaffected by this problem and work fine. However, running Y2038-incompatible .NET builds on Y2038-compatible Linux distros (and vice versa) is not supported.
+
+## Version introduced
+
+.NET 8
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+.NET needs to respond to Y2038 changes in Linux distros in order to function correctly. It will do so in .NET 10.
+
+## Recommended action
+
+Deploy .NET 8 and earlier versions on Y2038-incompatible Arm32 distros. Deploy .NET 10 and latest on Y2038-compatible distros.
+
+## Affected APIs
+
+Any API that relies on a native API that takes a time value.

--- a/docs/core/compatibility/core-libraries/9.0/y2038-incompatible.md
+++ b/docs/core/compatibility/core-libraries/9.0/y2038-incompatible.md
@@ -1,0 +1,51 @@
+---
+title: "Breaking change: .NET 9 is not supported on Year 2038 compatible Linux distros"
+description: Learn about the .NET 9 behavior on Year 2038 compatible Linxu distros.
+ms.date: 05/01/2024
+---
+# .NET 9 is not supported on Year 2038 compatible Arm32 Linux distros
+
+Linux Arm32 distros have used 32-bit integers to represent time. A 32-bit integer is [unable to represent dates after January 18th, 2038](https://en.wikipedia.org/wiki/Unix_time#Range_of_representable_times). Year 2038 (Y2038) compatible distros use a 64-bit integer for time, which resolves the problem. However, this change is breaking for .NET 9.
+
+[.NET 9 is not supported on Y2038-compatible Arm32 distros](https://github.com/dotnet/core/discussions/9285), such as Ubuntu 24.04 and Debian 13. The same is true for earlier .NET versions.
+
+.NET 10 will be supported on Y2038-compatible Arm32 distros.
+
+Arm64, and x64 environments are unaffected.
+
+## Previous behavior
+
+.NET 9 and earlier versions work on Ubuntu 22.04, Debian 12, and other Y2038-incompatible Arm32 distros.
+
+## New behavior
+
+.NET 9 and earlier versions do not work reliably on Ubuntu 24.04, Debian 13, and other Y2038-compatible Arm32 distros.
+
+Y2038-incompatible .NET builds running on Y2038-compatible Arm32 distros may see the following error.
+
+```bash
+The SSL connection could not be established, see inner exception.
+The remote certificate is invalid because of errors in the certificate chain: NotTimeValid
+```
+
+Some scenarios will be unaffected by this problem and work fine. However, running Y2038-incompatible .NET builds on Y2038-compatible Linux distros (and vice versa) is not supported.
+
+## Version introduced
+
+.NET 9
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+.NET needs to respond to Y2038 changes in Linux distros in order to function correctly. It will do so in .NET 10.
+
+## Recommended action
+
+Deploy .NET 9 and earlier versions on Y2038-incompatible Arm32 distros. Deploy .NET 10 and latest on Y2038-compatible distros.
+
+## Affected APIs
+
+Any API that relies on a native API that takes a time value.


### PR DESCRIPTION
Related to https://github.com/dotnet/core/discussions/9285

Still waiting on final confirmation of this particular plan.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/6.0.md](https://github.com/dotnet/docs/blob/06965f5d3c40aca01dfcc4d11e63d85ccaf770c3/docs/core/compatibility/6.0.md) | [Breaking changes in .NET 6](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/6.0?branch=pr-en-us-40669) |
| [docs/core/compatibility/8.0.md](https://github.com/dotnet/docs/blob/06965f5d3c40aca01dfcc4d11e63d85ccaf770c3/docs/core/compatibility/8.0.md) | [Breaking changes in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/8.0?branch=pr-en-us-40669) |
| [docs/core/compatibility/9.0.md](https://github.com/dotnet/docs/blob/06965f5d3c40aca01dfcc4d11e63d85ccaf770c3/docs/core/compatibility/9.0.md) | [Breaking changes in .NET 9](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/9.0?branch=pr-en-us-40669) |
| [docs/core/compatibility/containers/9.0/noble-arm32-images.md](https://github.com/dotnet/docs/blob/06965f5d3c40aca01dfcc4d11e63d85ccaf770c3/docs/core/compatibility/containers/9.0/noble-arm32-images.md) | [`9.0-noble` images are 64-bit only](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/containers/9.0/noble-arm32-images?branch=pr-en-us-40669) |
| [docs/core/compatibility/core-libraries/6.0/y2038-incompatible.md](https://github.com/dotnet/docs/blob/06965f5d3c40aca01dfcc4d11e63d85ccaf770c3/docs/core/compatibility/core-libraries/6.0/y2038-incompatible.md) | [docs/core/compatibility/core-libraries/6.0/y2038-incompatible](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/y2038-incompatible?branch=pr-en-us-40669) |
| [docs/core/compatibility/core-libraries/8.0/y2038-incompatible.md](https://github.com/dotnet/docs/blob/06965f5d3c40aca01dfcc4d11e63d85ccaf770c3/docs/core/compatibility/core-libraries/8.0/y2038-incompatible.md) | [.NET 8 is not supported on Year 2038 compatible Arm32 Linux distros](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/8.0/y2038-incompatible?branch=pr-en-us-40669) |
| [docs/core/compatibility/core-libraries/9.0/y2038-incompatible.md](https://github.com/dotnet/docs/blob/06965f5d3c40aca01dfcc4d11e63d85ccaf770c3/docs/core/compatibility/core-libraries/9.0/y2038-incompatible.md) | ["Breaking change: .NET 9 is not supported on Year 2038 compatible Linux distros"](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/9.0/y2038-incompatible?branch=pr-en-us-40669) |


<!-- PREVIEW-TABLE-END -->