### PR TITLE
Fixed wrong comment in code snippet Indices And Ranges

### DIFF
--- a/docs/csharp/tutorials/snippets/RangesIndexes/IndicesAndRanges.cs
+++ b/docs/csharp/tutorials/snippets/RangesIndexes/IndicesAndRanges.cs
@@ -31,7 +31,7 @@ class IndicesAndRanges
         // <SnippetIndicesAndRanges_Range>
         string[] secondThirdFourth = words[1..4]; // contains "second", "third" and "fourth"
         
-        // < first >< second >< third >< fourth >
+        // < second >< third >< fourth >
         foreach (var word in secondThirdFourth)
             Console.Write($"< {word} >"); 
         Console.WriteLine();


### PR DESCRIPTION
## Summary
Fixed wrong code comment introduced by #40607 in one of the snippets for Indices And Ranges. 

```
dotnet run
==========          Starting Index and Range Samples.          ==========
          ==========          Last Index.            ==========
The last word is < tenth >.
          ==========          Range.                 ==========
< second >< third >< fourth >                                                                   <---- fixed this comment
          ==========          Last Range.            ==========
< ninth >< tenth >
          ==========          Partial Range.         ==========
< first >< second >< third >< fourth >< fifth >< sixth >< seventh >< eighth >< ninth >< tenth >
< first >< second >< third >< fourth >
< seventh >< eighth >< ninth >< tenth >
          ==========          Index and Range types. ==========
< eighth >
< second >< third >< fourth >
```