### PR TITLE
Update interop.md

### DIFF
--- a/docs/core/deploying/native-aot/interop.md
+++ b/docs/core/deploying/native-aot/interop.md
@@ -57,7 +57,7 @@ Examples:
   <DirectPInvoke Include="Dependency" />
   <!-- Specify library to link against -->
   <NativeLibrary Include="Dependency.lib" Condition="$(RuntimeIdentifier.StartsWith('win'))" />
-  <NativeLibrary Include="Dependency.a" Condition="!$(RuntimeIdentifier.StartsWith('win'))" />
+  <NativeLibrary Include="Dependency.a" Condition="!$(RuntimeIdentifier.StartsWith('linux'))" />
 </ItemGroup>
 ```
 


### PR DESCRIPTION
.a Runtime Identifier should target linux runtime

## Summary
Documentation sample change, .a library should specify Linux runtime identifier

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/deploying/native-aot/interop.md](https://github.com/dotnet/docs/blob/9f88a6c3c4d968a1665e0b74d25f1db8c01ad624/docs/core/deploying/native-aot/interop.md) | [Native code interop with Native AOT](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/interop?branch=pr-en-us-40712) |

<!-- PREVIEW-TABLE-END -->