### PR TITLE
Terminal logger is enabled by default

### DIFF
--- a/docs/core/compatibility/sdk/9.0/terminal-logger.md
+++ b/docs/core/compatibility/sdk/9.0/terminal-logger.md
@@ -9,7 +9,7 @@ The terminal logger is now enabled by default for all "interactive" terminal ses
 
 ## Previous behavior
 
-`dotnet build` and other build-related CLI commands used the 'minimal' verbosity console logger by default for user-driven builds.
+`dotnet build` and other build-related CLI commands used the 'minimal' verbosity MSBuild console logger by default for user-driven builds.
 
 ## New behavior
 
@@ -31,8 +31,8 @@ The terminal logger output about the progress of a build is more information den
 
 If you need to revert to the console logger, you can disable the terminal logger can be disabled in the following ways:
 
-- To disable terminal logger for a single build, specify `--tl:off` on the command line or via an MSBuild response file.
-- To disable terminal logger for all builds, set the `MSBUILDTERMINALLOGGER` environment variable to `off` to accomplish this.
+- To disable terminal logger for a specific command, specify `--tl:off` on the command line or via an MSBuild response file.
+- To disable terminal logger for all commands, set the `MSBUILDTERMINALLOGGER` environment variable to `off`.
 
 ## Affected APIs
 
@@ -41,3 +41,4 @@ N/A
 ## See also
 
 - ['dotnet build' options](../../../tools/dotnet-build.md#options)
+- [Terminal logger](../../../whats-new/dotnet-9/sdk.md#terminal-logger)

--- a/docs/core/whats-new/dotnet-9/sdk.md
+++ b/docs/core/whats-new/dotnet-9/sdk.md
@@ -53,7 +53,7 @@ The set of commands that uses terminal logger by default is:
 - `pack`
 - `publish`
 - `restore`
-- te`st
+- `test`
 
 ### Usability
 

--- a/docs/core/whats-new/dotnet-9/sdk.md
+++ b/docs/core/whats-new/dotnet-9/sdk.md
@@ -29,7 +29,33 @@ For more information about the terminal logger, see [dotnet build options](../..
 
 A new option for [`dotnet tool install`](../../tools/dotnet-tool-install.md) lets *users* decide how .NET tools should be run. When you install a tool via `dotnet tool install`, or when you run tool via [`dotnet tool run <toolname>`](../../tools/dotnet-tool-run.md), you can specify a new flag called `--allow-roll-forward`. This option configures the tool with roll-forward mode `Major`. This mode allows the tool to run on a newer major version of .NET if the matching .NET version is not available. This feature helps early adopters use .NET tools without tool authors having to change any code.
 
-## Terminal logger usability
+## Terminal logger
+
+The terminal logger is now [enabled by default](#enabled-by-default) and also has [improved usability](#usability).
+
+### Enabled by default
+
+Starting in .NET 9, the default experience for all .NET CLI commands that use MSBuild is terminal logger, the enhanced logging experience that was released in .NET 8. This new output uses the capabilities of modern terminals to provide functionality like:
+
+- Clickable links
+- Duration timers for MSBuild tasks
+- Color coding of warning and error messages
+
+The output is more condensed and usable than the existing MSBuild console logger.
+
+The new logger attempts to auto-detect if it can be used, but you can also manually control whether terminal logger is used. Specify the `--tl:off` command-line option to disable terminal logger for a specific command. Or, to disable terminal logger more broadly, set the `MSBUILDTERMINALLOGGER` environment variable to `off`.
+
+The set of commands that uses terminal logger by default is:
+
+- `build`
+- `clean`
+- `msbuild`
+- `pack`
+- `publish`
+- `restore`
+- te`st
+
+### Usability
 
 The terminal logger now summarizes the total count of failures and warnings at the end of a build. It also shows errors that contain newlines. (For more information about the terminal logger, see ['dotnet build' options](../../tools/dotnet-build.md#options), specifically the `--tl` option.)
 


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/sdk/9.0/terminal-logger.md](https://github.com/dotnet/docs/blob/d5cc74e129f2d7f4ce36c0b2688927eb701896d4/docs/core/compatibility/sdk/9.0/terminal-logger.md) | [Terminal logger is default](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/9.0/terminal-logger?branch=pr-en-us-40720) |
| [docs/core/whats-new/dotnet-9/sdk.md](https://github.com/dotnet/docs/blob/d5cc74e129f2d7f4ce36c0b2688927eb701896d4/docs/core/whats-new/dotnet-9/sdk.md) | [What's new in the SDK for .NET 9](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-9/sdk?branch=pr-en-us-40720) |

<!-- PREVIEW-TABLE-END -->