### PR TITLE
Update limitations on collectible assemblies.

### DIFF
--- a/docs/fundamentals/reflection/collectible-assemblies.md
+++ b/docs/fundamentals/reflection/collectible-assemblies.md
@@ -45,7 +45,9 @@ The following restrictions apply to collectible assemblies:
 
 - **Static references**
 
-  Types in an ordinary dynamic assembly cannot have static references to types that are defined in a collectible assembly. For example, if you define an ordinary type that inherits from a type in a collectible assembly, a <xref:System.NotSupportedException> exception is thrown. A type in a collectible assembly can have static references to a type in another collectible assembly, but this extends the lifetime of the referenced assembly to the lifetime of the referencing assembly.
+   Types in an ordinary dynamic assembly cannot have static references to types that are defined in a collectible assembly. For example, if you define an ordinary type that inherits from a type in a collectible assembly, a <xref:System.NotSupportedException> exception is thrown. A type in a collectible assembly can have static references to a type in another collectible assembly, but this extends the lifetime of the referenced assembly to the lifetime of the referencing assembly.
+
+The following restrictions apply to collectible assemblies in .NET Framework:
 
 - **COM interop**
 
@@ -70,6 +72,12 @@ The following restrictions apply to collectible assemblies:
 - **Thread-static data**
 
    Thread-static variables aren't supported.
+
+The following restrictions apply to collectible assemblies in .NET Framework and .NET versions prior to .NET 9:
+
+- **Static fields with `FixedAddressValueTypeAttribute`**
+
+   Static fields that are defined in collectible assemblies cannot have the <xref:System.Runtime.CompilerServices.FixedAddressValueTypeAttribute> attribute applied.
 
 ## See also
 

--- a/docs/standard/assembly/unloadability.md
+++ b/docs/standard/assembly/unloadability.md
@@ -69,6 +69,13 @@ However, the unload doesn't complete immediately. As previously mentioned, it re
 
 [!code-csharp[Part 6](~/samples/snippets/standard/assembly/unloading/simple_example.cs#7)]
 
+### Limitations
+
+Assemblies loaded in a collectible `AssemblyLoadContext` must abide by the general [restrictions on collectible assemblies](../../fundamentals/reflection/collectible-assemblies.md#restrictions-on-collectible-assemblies). The following limitations additionally apply:
+
+* Assemblies written in C++/CLI are not supported.
+* [ReadyToRun](../../core/deploying/ready-to-run.md) generated code will be ignored.
+
 ### The Unloading event
 
 In some cases, it might be necessary for the code loaded into a custom `AssemblyLoadContext` to perform some cleanup when the unloading is initiated. For example, it might need to stop threads or clean up strong GC handles. The `Unloading` event can be used in such cases. You can hook a handler that performs the necessary cleanup to this event.


### PR DESCRIPTION
## Summary

This PR updates the documents on collectible assemblies and unloadability, to add missing information and keep them up to date with advances on recent frameworks.

Fixes #25517

@janvorli I assume you are the best person to review this?

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/reflection/collectible-assemblies.md](https://github.com/dotnet/docs/blob/6a6bf879d566ce91d01591cb526f26da8786a1ea/docs/fundamentals/reflection/collectible-assemblies.md) | [Collectible assemblies for dynamic type generation](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/reflection/collectible-assemblies?branch=pr-en-us-40745) |
| [docs/standard/assembly/unloadability.md](https://github.com/dotnet/docs/blob/6a6bf879d566ce91d01591cb526f26da8786a1ea/docs/standard/assembly/unloadability.md) | ["How to use and debug assembly unloadability in .NET"](https://review.learn.microsoft.com/en-us/dotnet/standard/assembly/unloadability?branch=pr-en-us-40745) |

<!-- PREVIEW-TABLE-END -->