### PR TITLE
Added clarification for match expression multiline case

### DIFF
--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -1092,14 +1092,22 @@ match l with
     | [] -> failwith "Couldn't find David"
 ```
 
-If the expression on the right of the pattern matching arrow is too large, move it to the following line, indented one step from the `match`/`|`.
+If one of the expressions on the right of the pattern matching arrow is too large, move it to the following line, indented one step from the `match`/`|`. Move all the other expressions to the next line as well for consistency.
 
 ```fsharp
 // ✔️ OK
 match lam with
-| Var v -> 1
+| Var v ->
+    1
 | Abs(x, body) ->
     1 + sizeLambda body
+| App(lam1, lam2) ->
+    sizeLambda lam1 + sizeLambda lam2
+
+// ❌ Not OK, see above for preferred formatting
+match lam with
+| Var v -> 1
+| Abs(x, body) -> 1 + sizeLambda body
 | App(lam1, lam2) ->
     sizeLambda lam1 + sizeLambda lam2
 ```


### PR DESCRIPTION
Discussed and approved in https://github.com/fsharp/fslang-design/issues/650

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/style-guide/formatting.md](https://github.com/dotnet/docs/blob/f0bf252ec90be87e767f06608fe0ee3ed8ef2569/docs/fsharp/style-guide/formatting.md) | [F# code formatting guidelines](https://review.learn.microsoft.com/en-us/dotnet/fsharp/style-guide/formatting?branch=pr-en-us-40762) |

<!-- PREVIEW-TABLE-END -->