### PR TITLE
Add Tips section for AOT enabled builds

### DIFF
--- a/docs/core/extensions/options-validation-generator.md
+++ b/docs/core/extensions/options-validation-generator.md
@@ -37,6 +37,9 @@ The following code exemplifies how to bind the configuration section to the opti
 
 :::code source="snippets/configuration/console-validation-gen/Program.cs":::
 
+> [!TIP]
+> When AOT compilation is enabled by including `<PublishAot>true</PublishAot>` in the csproj file, the code may generate warnings such as [IL2025](https://learn.microsoft.com/dotnet/core/deploying/trimming/trim-warnings/il2025) and [IL3050](https://learn.microsoft.com/dotnet/core/deploying/native-aot/warnings/il3050). It's recommended to utilize the configuration source generator to mitigate these warnings. To enable the configuration source generator, add the property `<EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>` to the project file.
+
 By leveraging compile-time source generation for options validation, you can generate performance-optimized validation code and eliminate the need for reflection, resulting in smoother AOT-compatible app building. The following code demonstrates how to use the options validation source generator:
 
 :::code source="snippets/configuration/console-validation-gen/ValidateSettingsOptions.cs":::

--- a/docs/core/extensions/options-validation-generator.md
+++ b/docs/core/extensions/options-validation-generator.md
@@ -38,7 +38,7 @@ The following code exemplifies how to bind the configuration section to the opti
 :::code source="snippets/configuration/console-validation-gen/Program.cs":::
 
 > [!TIP]
-> When AOT compilation is enabled by including `<PublishAot>true</PublishAot>` in the csproj file, the code may generate warnings such as [IL2025](https://learn.microsoft.com/dotnet/core/deploying/trimming/trim-warnings/il2025) and [IL3050](https://learn.microsoft.com/dotnet/core/deploying/native-aot/warnings/il3050). It's recommended to utilize the configuration source generator to mitigate these warnings. To enable the configuration source generator, add the property `<EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>` to the project file.
+> When AOT compilation is enabled by including `<PublishAot>true</PublishAot>` in the csproj file, the code may generate warnings such as [IL2025](../deploying/trimming/trim-warnings/il2025) and [IL3050](../deploying/native-aot/warnings/il3050). It's recommended to utilize the configuration source generator to mitigate these warnings. To enable the configuration source generator, add the property `<EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>` to the project file.
 
 By leveraging compile-time source generation for options validation, you can generate performance-optimized validation code and eliminate the need for reflection, resulting in smoother AOT-compatible app building. The following code demonstrates how to use the options validation source generator:
 

--- a/docs/core/extensions/options-validation-generator.md
+++ b/docs/core/extensions/options-validation-generator.md
@@ -38,7 +38,7 @@ The following code exemplifies how to bind the configuration section to the opti
 :::code source="snippets/configuration/console-validation-gen/Program.cs":::
 
 > [!TIP]
-> When AOT compilation is enabled by including `<PublishAot>true</PublishAot>` in the csproj file, the code may generate warnings such as [IL2025](../deploying/trimming/trim-warnings/il2025) and [IL3050](../deploying/native-aot/warnings/il3050). It's recommended to utilize the configuration source generator to mitigate these warnings. To enable the configuration source generator, add the property `<EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>` to the project file.
+> When AOT compilation is enabled by including `<PublishAot>true</PublishAot>` in the csproj file, the code may generate warnings such as [IL2025](../deploying/trimming/trim-warnings/il2025.md) and [IL3050](../deploying/native-aot/warnings/il3050.md). It's recommended to utilize the configuration source generator to mitigate these warnings. To enable the configuration source generator, add the property `<EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>` to the project file.
 
 By leveraging compile-time source generation for options validation, you can generate performance-optimized validation code and eliminate the need for reflection, resulting in smoother AOT-compatible app building. The following code demonstrates how to use the options validation source generator:
 

--- a/docs/core/extensions/options-validation-generator.md
+++ b/docs/core/extensions/options-validation-generator.md
@@ -38,7 +38,7 @@ The following code exemplifies how to bind the configuration section to the opti
 :::code source="snippets/configuration/console-validation-gen/Program.cs":::
 
 > [!TIP]
-> When AOT compilation is enabled by including `<PublishAot>true</PublishAot>` in the csproj file, the code may generate warnings such as [IL2025](../deploying/trimming/trim-warnings/il2025.md) and [IL3050](../deploying/native-aot/warnings/il3050.md). It's recommended to utilize the configuration source generator to mitigate these warnings. To enable the configuration source generator, add the property `<EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>` to the project file.
+> When AOT compilation is enabled by including `<PublishAot>true</PublishAot>` in the _.csproj_ file, the code may generate warnings such as [IL2025](../deploying/trimming/trim-warnings/il2025.md) and [IL3050](../deploying/native-aot/warnings/il3050.md). It's recommended to utilize the configuration source generator to mitigate these warnings. To enable the configuration source generator, add the property `<EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>` to the project file.
 
 By leveraging compile-time source generation for options validation, you can generate performance-optimized validation code and eliminate the need for reflection, resulting in smoother AOT-compatible app building. The following code demonstrates how to use the options validation source generator:
 

--- a/docs/core/extensions/options-validation-generator.md
+++ b/docs/core/extensions/options-validation-generator.md
@@ -38,7 +38,7 @@ The following code exemplifies how to bind the configuration section to the opti
 :::code source="snippets/configuration/console-validation-gen/Program.cs":::
 
 > [!TIP]
-> When AOT compilation is enabled by including `<PublishAot>true</PublishAot>` in the _.csproj_ file, the code may generate warnings such as [IL2025](../deploying/trimming/trim-warnings/il2025.md) and [IL3050](../deploying/native-aot/warnings/il3050.md). It's recommended to utilize the configuration source generator to mitigate these warnings. To enable the configuration source generator, add the property `<EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>` to the project file.
+> When AOT compilation is enabled by including `<PublishAot>true</PublishAot>` in the _.csproj_ file, the code might generate warnings such as [IL2025](../deploying/trimming/trim-warnings/il2025.md) and [IL3050](../deploying/native-aot/warnings/il3050.md). To mitigate these warnings, it's recommended to use the configuration source generator. To enable the configuration source generator, add the property `<EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>` to the project file.
 
 By leveraging compile-time source generation for options validation, you can generate performance-optimized validation code and eliminate the need for reflection, resulting in smoother AOT-compatible app building. The following code demonstrates how to use the options validation source generator:
 


### PR DESCRIPTION
## Summary

Include a "Tip" section in the Options source generation document to address actions to take when enabling AOT compilation and encountering trimming warnings.

Fixes #40760


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/options-validation-generator.md](https://github.com/dotnet/docs/blob/e190e1cbe5cc1dbc43463d15b1bb378bda11bb43/docs/core/extensions/options-validation-generator.md) | [Compile-time options validation source generation](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/options-validation-generator?branch=pr-en-us-40770) |


<!-- PREVIEW-TABLE-END -->