### PR TITLE
Moving code highligth to expected lines

### DIFF
--- a/docs/standard/serialization/system-text-json/deserialization.md
+++ b/docs/standard/serialization/system-text-json/deserialization.md
@@ -23,7 +23,7 @@ Any JSON properties that aren't represented in your class are ignored [by defaul
 
 The following example shows how to deserialize a JSON string:
 
-:::code language="csharp" source="snippets/how-to/csharp/DeserializeExtra.cs" highlight="53-54":::
+:::code language="csharp" source="snippets/how-to/csharp/DeserializeExtra.cs" highlight="54-55":::
 :::code language="vb" source="snippets/how-to/vb/RoundtripToString.vb" id="Deserialize":::
 
 To deserialize from a file by using synchronous code, read the file into a string, as shown in the following example:


### PR DESCRIPTION
In file deserialization.md, highlight of snippet points to empty line.

![image](https://github.com/dotnet/docs/assets/43842809/084981b2-56d5-4c18-9e88-7501ddef049f)



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/serialization/system-text-json/deserialization.md](https://github.com/dotnet/docs/blob/2799db03ef9697d7b2f0f43d20bf024cd4a53590/docs/standard/serialization/system-text-json/deserialization.md) | [How to read JSON as .NET objects (deserialize)](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/deserialization?branch=pr-en-us-40783) |


<!-- PREVIEW-TABLE-END -->