### PR TITLE
Add links among TOCs

### DIFF
--- a/docs/csharp/language-reference/toc.yml
+++ b/docs/csharp/language-reference/toc.yml
@@ -2345,3 +2345,7 @@ items:
       href: ./compiler-messages/cs1610.md
     - name: CS1712
       href: ../misc/cs1712.md
+- name: C# conceptual documentation
+  href: ../index.yml
+- name: C# specification
+  href: ../specification/index.yml

--- a/docs/csharp/specification/toc.yml
+++ b/docs/csharp/specification/toc.yml
@@ -220,3 +220,7 @@ items:
         href: ../../../_csharplang/proposals/csharp-11.0/generic-attributes.md
       - name: Experimental attribute
         href: ../../../_csharplang/proposals/csharp-12.0/experimental-attribute.md
+- name: C# conceptual documentation
+  href: ../index.yml
+- name: C# language reference
+  href: ../language-reference/index.yml

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -672,3 +672,7 @@ items:
       href: programming-guide/generics/differences-between-cpp-templates-and-csharp-generics.md
     - name: Generics in the Run Time
       href: programming-guide/generics/generics-in-the-run-time.md
+- name: C# language reference
+  href: ./language-reference/index.yml
+- name: C# specification
+  href: ./specification/index.yml


### PR DESCRIPTION
This enables a single offline book for the entire C# documentation, and provides navigation between the different sections of the C# Guide.
