### PR TITLE
Add example for the more common and confusing IL2111 cases

### DIFF
--- a/docs/core/deploying/trimming/trim-warnings/il2111.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2111.md
@@ -28,7 +28,7 @@ void TestMethod()
 }
 ```
 
-Also, a <xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute> implies reflection access over all of the listed <xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes>. This means that when a type is passed to a parameter, field, generic parameter, or return value annotated with <xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods> .NET tooling assumes that all public methods are accessed via reflection. If a type that contains a method with an annotated parameter or return value is passed to a location annotated with <xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods>, then IL2111 will be raised.
+This warning can also be caused by passing a type to a field, paramter, argument, or return value that is annotated with <xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute>. <xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute> implies reflection access over all of the listed <xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes>. This means that when a type is passed to a parameter, field, generic parameter, or return value annotated with <xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods> .NET tooling assumes that all public methods are accessed via reflection. If a type that contains a method with an annotated parameter or return value is passed to a location annotated with <xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods>, then IL2111 will be raised.
 
 ```csharp
 class TypeWithAnnotatedMethod

--- a/docs/core/deploying/trimming/trim-warnings/il2111.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2111.md
@@ -14,6 +14,8 @@ The trimmer can't guarantee that all requirements of the <xref:System.Diagnostic
 
 ## Example
 
+This warning can be caused by directly accessing a method with a <xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute> on its parameters or return type.
+
 ```csharp
 void MethodWithRequirements([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type type)
 {
@@ -25,3 +27,29 @@ void TestMethod()
     typeof(Test).GetMethod("MethodWithRequirements");
 }
 ```
+
+Also, a <xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute> implies reflection access over all of the listed <xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes>. This means that when a type is passed to a parameter, field, generic parameter, or return value annotated with <xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods> .NET tooling assumes that all public methods are accessed via reflection. If a type that contains a method with an annotated parameter or return value is passed to a location annotated with <xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods>, then IL2111 will be raised.
+
+```csharp
+class TypeWithAnnotatedMethod
+{
+    void MethodWithRequirements([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] Type type)
+    {
+    }
+}
+
+class OtherType
+{
+    void AccessMethodViaReflection([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type type)
+    {
+    }
+
+    void PassTypeToAnnotatedMethod()
+    {
+        // IL2111: Method 'MethodWithRequirements' with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
+        AccessMethodViaReflection(typeof(TypeWithAnnotatedMethod));
+    }
+}
+```
+
+ 

--- a/docs/core/deploying/trimming/trim-warnings/il2111.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2111.md
@@ -51,5 +51,3 @@ class OtherType
     }
 }
 ```
-
- 


### PR DESCRIPTION
## Summary

While going through warnings I saw that this page only describes the trivial case but misses the more confusing case of annotations triggering the warning. I think it would be nice to add a bit more info about it.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/deploying/trimming/trim-warnings/il2111.md](https://github.com/dotnet/docs/blob/0c7b727403016ce7c149e1715bc00ce62df9f33c/docs/core/deploying/trimming/trim-warnings/il2111.md) | [IL2111: Method with parameters or return value with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer cannot guarantee availability of the requirements of the method](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il2111?branch=pr-en-us-40789) |

<!-- PREVIEW-TABLE-END -->