### PR TITLE
F# , add chapter on opening with global specifier

### DIFF
--- a/docs/fsharp/language-reference/import-declarations-the-open-keyword.md
+++ b/docs/fsharp/language-reference/import-declarations-the-open-keyword.md
@@ -62,7 +62,7 @@ open type M.DU
 
 printfn "%A" A
 ```
-## Open from root path only with `global` keyword
+## Open from root path only with `global` specifier
 Nested modules like 
 ```fsharp
 module A =
@@ -74,7 +74,7 @@ can be opend via
 open A // opens A
 open B // opens A.B
 ```
-To open **only** fully qualified modules or namspaces prefix them with the `global` keyword:
+To open **only** fully qualified modules or namspaces prefix them with the `global` specifier:
 ```fsharp
 open global.A   // works
 open global.B   // this now fails

--- a/docs/fsharp/language-reference/import-declarations-the-open-keyword.md
+++ b/docs/fsharp/language-reference/import-declarations-the-open-keyword.md
@@ -62,6 +62,25 @@ open type M.DU
 
 printfn "%A" A
 ```
+## Open from root path only with `global` keyword
+Nested modules like 
+```fsharp
+module M =
+    module A =
+        ...
+```
+can be opend via
+```fsharp
+open M
+open A // opens M.A
+```
+if want to open only fully qualified modules or namspaces prefix them with `global`:
+```fsharp
+open global.M
+open global.A // this now fails
+open global.M.A // works
+```
+
 
 ## Namespaces That Are Open by Default
 

--- a/docs/fsharp/language-reference/import-declarations-the-open-keyword.md
+++ b/docs/fsharp/language-reference/import-declarations-the-open-keyword.md
@@ -65,20 +65,20 @@ printfn "%A" A
 ## Open from root path only with `global` keyword
 Nested modules like 
 ```fsharp
-module M =
-    module A =
+module A =
+    module B =
         ...
 ```
 can be opend via
 ```fsharp
-open M
-open A // opens M.A
+open A // opens A
+open B // opens A.B
 ```
-if want to open only fully qualified modules or namspaces prefix them with `global`:
+To open **only** fully qualified modules or namspaces prefix them with the `global` keyword:
 ```fsharp
-open global.M
-open global.A // this now fails
-open global.M.A // works
+open global.A   // works
+open global.B   // this now fails
+open global.A.B // works
 ```
 
 

--- a/docs/fsharp/language-reference/import-declarations-the-open-keyword.md
+++ b/docs/fsharp/language-reference/import-declarations-the-open-keyword.md
@@ -69,7 +69,7 @@ module A =
     module B =
         ...
 ```
-can be opend via
+can be opened via
 ```fsharp
 open A // opens A
 open B // opens A.B

--- a/docs/fsharp/language-reference/import-declarations-the-open-keyword.md
+++ b/docs/fsharp/language-reference/import-declarations-the-open-keyword.md
@@ -74,7 +74,7 @@ can be opened via
 open A // opens A
 open B // opens A.B
 ```
-To open **only** fully qualified modules or namspaces prefix them with the `global` specifier:
+To open **only** fully qualified modules or namespaces prefix them with the `global` specifier:
 ```fsharp
 open global.A   // works
 open global.B   // this now fails

--- a/docs/fsharp/language-reference/import-declarations-the-open-keyword.md
+++ b/docs/fsharp/language-reference/import-declarations-the-open-keyword.md
@@ -62,25 +62,31 @@ open type M.DU
 
 printfn "%A" A
 ```
+
 ## Open from root path only with `global` specifier
-Nested modules like 
+
+Nested modules like
+
 ```fsharp
 module A =
     module B =
         ...
 ```
+
 can be opened via
+
 ```fsharp
 open A // opens A
 open B // opens A.B
 ```
+
 To open **only** fully qualified modules or namespaces prefix them with the `global` specifier:
+
 ```fsharp
 open global.A   // works
 open global.B   // this now fails
 open global.A.B // works
 ```
-
 
 ## Namespaces That Are Open by Default
 


### PR DESCRIPTION
Add chapter on `global` specifier in `open` statements.
Please reword if required.

To address https://github.com/dotnet/fsharp/issues/17124



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/import-declarations-the-open-keyword.md](https://github.com/dotnet/docs/blob/5f52125df8105fe2d0e00f66b2f0e58b77ab65ce/docs/fsharp/language-reference/import-declarations-the-open-keyword.md) | [Import declarations: The `open` keyword](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/import-declarations-the-open-keyword?branch=pr-en-us-40809) |


<!-- PREVIEW-TABLE-END -->