### PR TITLE
Clarify local function description

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/local-functions.md
+++ b/docs/csharp/programming-guide/classes-and-structs/local-functions.md
@@ -123,7 +123,7 @@ int M()
 
 The compiler can determine that `LocalFunction` definitely assigns `y` when called. Because `LocalFunction` is called before the `return` statement, `y` is definitely assigned at the `return` statement.
 
-Note that when a local function captures variables in the enclosing scope, the local function is implemented as a delegate type.
+Note that when a local function captures variables in the enclosing scope, the local function is implemented using a closure, like delegate types are.
 
 ### Heap allocations
 


### PR DESCRIPTION
The description of variable capture was a bit confusing; the local function won't be emitted as a delegate type here. However, it will use a closure, just like delegate types do, so I've updated the wording to reflect that. @BillWagner for review.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/classes-and-structs/local-functions.md](https://github.com/dotnet/docs/blob/e1eb66ab2c834b85bd3c5b4e0f87588b5571793e/docs/csharp/programming-guide/classes-and-structs/local-functions.md) | [Local functions (C# Programming Guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/local-functions?branch=pr-en-us-40820) |

<!-- PREVIEW-TABLE-END -->