### PR TITLE
The MMM and MMMM formats may include genitive names.

### DIFF
--- a/docs/fundamentals/runtime-libraries/system-globalization-datetimeformatinfo.md
+++ b/docs/fundamentals/runtime-libraries/system-globalization-datetimeformatinfo.md
@@ -166,7 +166,7 @@ The [standard date and time format strings](../../standard/base-types/standard-d
 |"Y", "y" (year month; standard format string)|<xref:System.Globalization.DateTimeFormatInfo.YearMonthPattern%2A>, to define the overall format of the result string.|
 |"ddd" (custom format specifier)|<xref:System.Globalization.DateTimeFormatInfo.AbbreviatedDayNames%2A>, to include the abbreviated name of the day of the week in the result string.|
 |"g", "gg" (custom format specifier)|Calls the <xref:System.Globalization.DateTimeFormatInfo.GetEraName%2A> method to insert the era name in the result string.|
-|"MMM" (custom format specifier)|<xref:System.Globalization.DateTimeFormatInfo.AbbreviatedMonthNames%2A>, to include the abbreviated month name in the result string.|
+|"MMM" (custom format specifier)|<xref:System.Globalization.DateTimeFormatInfo.AbbreviatedMonthNames%2A> or <xref:System.Globalization.DateTimeFormatInfo.AbbreviatedMonthGenitiveNames%2A>, to include the abbreviated month name in the result string.|
 |"MMMM" (custom format specifier)|<xref:System.Globalization.DateTimeFormatInfo.MonthNames%2A> or <xref:System.Globalization.DateTimeFormatInfo.MonthGenitiveNames%2A>, to include the full month name in the result string.|
 |"t" (custom format specifier)|<xref:System.Globalization.DateTimeFormatInfo.AMDesignator%2A> or <xref:System.Globalization.DateTimeFormatInfo.PMDesignator%2A>, to include the first character of the AM/PM designator in the result string.|
 |"tt" (custom format specifier)|<xref:System.Globalization.DateTimeFormatInfo.AMDesignator%2A> or <xref:System.Globalization.DateTimeFormatInfo.PMDesignator%2A>, to include the full AM/PM designator in the result string.|

--- a/docs/standard/base-types/custom-date-and-time-format-strings.md
+++ b/docs/standard/base-types/custom-date-and-time-format-strings.md
@@ -427,7 +427,7 @@ The following example includes the "MM" custom format specifier in a custom form
 
 ### <a name="MMM_Specifier"></a> The "MMM" custom format specifier
 
-The "MMM" custom format specifier represents the abbreviated name of the month. The localized abbreviated name of the month is retrieved from the <xref:System.Globalization.DateTimeFormatInfo.AbbreviatedMonthNames%2A?displayProperty=nameWithType> property of the current or specified culture.
+The "MMM" custom format specifier represents the abbreviated name of the month. The localized abbreviated name of the month is retrieved from the <xref:System.Globalization.DateTimeFormatInfo.AbbreviatedMonthNames%2A?displayProperty=nameWithType> or <xref:System.Globalization.DateTimeFormatInfo.AbbreviatedMonthGenitiveNames%2A?displayProperty=nameWithType> property of the current or specified culture.
 
 The following example includes the "MMM" custom format specifier in a custom format string.
 
@@ -438,7 +438,7 @@ The following example includes the "MMM" custom format specifier in a custom for
 
 ### <a name="MMMM_Specifier"></a> The "MMMM" custom format specifier
 
-The "MMMM" custom format specifier represents the full name of the month. The localized name of the month is retrieved from the <xref:System.Globalization.DateTimeFormatInfo.MonthNames%2A?displayProperty=nameWithType> property of the current or specified culture.
+The "MMMM" custom format specifier represents the full name of the month. The localized name of the month is retrieved from the <xref:System.Globalization.DateTimeFormatInfo.MonthNames%2A?displayProperty=nameWithType> or <xref:System.Globalization.DateTimeFormatInfo.MonthGenitiveNames%2A?displayProperty=nameWithType> property of the current or specified culture.
 
 The following example includes the "MMMM" custom format specifier in a custom format string.
 

--- a/docs/standard/base-types/custom-date-and-time-format-strings.md
+++ b/docs/standard/base-types/custom-date-and-time-format-strings.md
@@ -427,7 +427,7 @@ The following example includes the "MM" custom format specifier in a custom form
 
 ### <a name="MMM_Specifier"></a> The "MMM" custom format specifier
 
-The "MMM" custom format specifier represents the abbreviated name of the month. The localized abbreviated name of the month is retrieved from the <xref:System.Globalization.DateTimeFormatInfo.AbbreviatedMonthNames%2A?displayProperty=nameWithType> or <xref:System.Globalization.DateTimeFormatInfo.AbbreviatedMonthGenitiveNames%2A?displayProperty=nameWithType> property of the current or specified culture.
+The "MMM" custom format specifier represents the abbreviated name of the month. The localized abbreviated name of the month is retrieved from the <xref:System.Globalization.DateTimeFormatInfo.AbbreviatedMonthNames%2A?displayProperty=nameWithType> property of the current or specified culture. If there is a "d" or "dd" custom format specifier in the custom format string, it is retrieved from the <xref:System.Globalization.DateTimeFormatInfo.AbbreviatedMonthGenitiveNames%2A?displayProperty=nameWithType> property instead.
 
 The following example includes the "MMM" custom format specifier in a custom format string.
 
@@ -438,7 +438,7 @@ The following example includes the "MMM" custom format specifier in a custom for
 
 ### <a name="MMMM_Specifier"></a> The "MMMM" custom format specifier
 
-The "MMMM" custom format specifier represents the full name of the month. The localized name of the month is retrieved from the <xref:System.Globalization.DateTimeFormatInfo.MonthNames%2A?displayProperty=nameWithType> or <xref:System.Globalization.DateTimeFormatInfo.MonthGenitiveNames%2A?displayProperty=nameWithType> property of the current or specified culture.
+The "MMMM" custom format specifier represents the full name of the month. The localized name of the month is retrieved from the <xref:System.Globalization.DateTimeFormatInfo.MonthNames%2A?displayProperty=nameWithType> property of the current or specified culture. If there is a "d" or "dd" custom format specifier in the custom format string, it is retrieved from the <xref:System.Globalization.DateTimeFormatInfo.MonthGenitiveNames%2A?displayProperty=nameWithType> property instead.
 
 The following example includes the "MMMM" custom format specifier in a custom format string.
 


### PR DESCRIPTION
## Summary

According to this question: https://stackoverflow.com/questions/78446297/why-is-the-month-abbreviated-differently-when-the-date-format-includes-a-slot-fo, the `MMM` and `MMMM` formats may retrieve from the genitive names if there is a `d` or `dd` in the format string.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/runtime-libraries/system-globalization-datetimeformatinfo.md](https://github.com/dotnet/docs/blob/02edf1c2c9c9dced394e3eccf7dd2b09f8fef0f0/docs/fundamentals/runtime-libraries/system-globalization-datetimeformatinfo.md) | [docs/fundamentals/runtime-libraries/system-globalization-datetimeformatinfo](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-globalization-datetimeformatinfo?branch=pr-en-us-40823) |
| [docs/standard/base-types/custom-date-and-time-format-strings.md](https://github.com/dotnet/docs/blob/02edf1c2c9c9dced394e3eccf7dd2b09f8fef0f0/docs/standard/base-types/custom-date-and-time-format-strings.md) | [docs/standard/base-types/custom-date-and-time-format-strings](https://review.learn.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings?branch=pr-en-us-40823) |


<!-- PREVIEW-TABLE-END -->