### PR TITLE
Add link to MSBuild information about setting assembly-level attributes

### DIFF
--- a/docs/standard/assembly/set-attributes-project-file.md
+++ b/docs/standard/assembly/set-attributes-project-file.md
@@ -69,6 +69,8 @@ This item tells the .NET SDK to emit the following C# (or equivalent F# or Visua
 
 (The actual date string would be whatever you provided at the time of the build.)
 
+If the attribute takes types other than `System.String`, you can specify the type, or provide the literal text by using a particular pattern of XML elements supported by the MSBuild `WriteCodeFragment` task. See [WriteCodeFragment task - Generate assembly-level attributes](/visualstudio/msbuild/writecodefragment-task#generate-assembly-level-attributes).
+
 ## Migrate from .NET Framework
 
 If you migrate your .NET Framework project to .NET 6 or later, you might encounter an error related to duplicate assembly info files. That's because .NET Framework project templates create a code file with assembly info attributes set. The file is typically located at *.\Properties\AssemblyInfo.cs* or *.\Properties\AssemblyInfo.vb*. However, SDK-style projects also *generate* this file for you based on the project settings.

--- a/docs/standard/assembly/set-attributes-project-file.md
+++ b/docs/standard/assembly/set-attributes-project-file.md
@@ -69,7 +69,7 @@ This item tells the .NET SDK to emit the following C# (or equivalent F# or Visua
 
 (The actual date string would be whatever you provided at the time of the build.)
 
-If the attribute takes types other than `System.String`, you can specify the type, or provide the literal text by using a particular pattern of XML elements supported by the MSBuild `WriteCodeFragment` task. See [WriteCodeFragment task - Generate assembly-level attributes](/visualstudio/msbuild/writecodefragment-task#generate-assembly-level-attributes).
+If the attribute has parameter types other than `System.String`, you can specify the type, or provide the literal text by using a particular pattern of XML elements supported by the MSBuild `WriteCodeFragment` task. See [WriteCodeFragment task - Generate assembly-level attributes](/visualstudio/msbuild/writecodefragment-task#generate-assembly-level-attributes).
 
 ## Migrate from .NET Framework
 

--- a/docs/standard/assembly/set-attributes-project-file.md
+++ b/docs/standard/assembly/set-attributes-project-file.md
@@ -69,7 +69,7 @@ This item tells the .NET SDK to emit the following C# (or equivalent F# or Visua
 
 (The actual date string would be whatever you provided at the time of the build.)
 
-If the attribute has parameter types other than `System.String`, you can specify the type, or provide the literal text by using a particular pattern of XML elements supported by the MSBuild `WriteCodeFragment` task. See [WriteCodeFragment task - Generate assembly-level attributes](/visualstudio/msbuild/writecodefragment-task#generate-assembly-level-attributes).
+If the attribute has parameter types other than `System.String`, you can specify the parameters by using a particular pattern of XML elements supported by the MSBuild `WriteCodeFragment` task. See [WriteCodeFragment task - Generate assembly-level attributes](/visualstudio/msbuild/writecodefragment-task#generate-assembly-level-attributes).
 
 ## Migrate from .NET Framework
 


### PR DESCRIPTION
## Summary

Reference updates in MSBuild 17.7 to support non-string parameters in the WriteCodeFragment task that can be used to set assembly-level attributes.

See comments in MSBuild issue 6285:
https://github.com/dotnet/msbuild/pull/6285#issuecomment-2103104105

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/assembly/set-attributes-project-file.md](https://github.com/dotnet/docs/blob/cfab2198c9beee360f0636b51511376768e0c958/docs/standard/assembly/set-attributes-project-file.md) | [Set assembly attributes in a project file](https://review.learn.microsoft.com/en-us/dotnet/standard/assembly/set-attributes-project-file?branch=pr-en-us-40830) |


<!-- PREVIEW-TABLE-END -->