### PR TITLE
add example for order of execution

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-objects-by-using-an-object-initializer.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-objects-by-using-an-object-initializer.md
@@ -28,7 +28,7 @@ Object initializers can be used to set indexers in an object. The following exam
 
 The next example shows the order of execution of constructor and member initializations using constructor with and without parameter:
 
-[!code-csharp[InitializerIndexerExample](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/object-collection-initializers/HowToIndexInitializer.cs#HowToIndexInitializer)]  
+[!code-csharp[ObjectInitializersExecutionOrder](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/object-collection-initializers/HowToIndexInitializer.cs#ObjectInitializersExecutionOrder)]  
 
 ## See also
 

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-objects-by-using-an-object-initializer.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-objects-by-using-an-object-initializer.md
@@ -26,6 +26,10 @@ Object initializers can be used to set indexers in an object. The following exam
 
 [!code-csharp[InitializerIndexerExample](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/object-collection-initializers/HowToIndexInitializer.cs#HowToIndexInitializer)]  
 
+The next example shows the order of execution of constructor and member initializations using constructor with and without parameter:
+
+[!code-csharp[InitializerIndexerExample](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/object-collection-initializers/HowToIndexInitializer.cs#HowToIndexInitializer)]  
+
 ## See also
 
 - [Object and Collection Initializers](object-and-collection-initializers.md)

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-objects-by-using-an-object-initializer.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-objects-by-using-an-object-initializer.md
@@ -28,7 +28,7 @@ Object initializers can be used to set indexers in an object. The following exam
 
 The next example shows the order of execution of constructor and member initializations using constructor with and without parameter:
 
-[!code-csharp[ObjectInitializersExecutionOrder](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/object-collection-initializers/HowToIndexInitializer.cs#ObjectInitializersExecutionOrder)]  
+[!code-csharp[ExecutionOrderExample](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/object-collection-initializers/HowToIndexInitializer.cs#ObjectInitializersExecutionOrder)]  
 
 ## See also
 

--- a/samples/snippets/csharp/programming-guide/classes-and-structs/object-collection-initializers/ObjectInitializersExecutionOrder.cs
+++ b/samples/snippets/csharp/programming-guide/classes-and-structs/object-collection-initializers/ObjectInitializersExecutionOrder.cs
@@ -1,0 +1,90 @@
+﻿using System;
+
+namespace object_collection_initializers;
+
+// <ObjectInitializersExecutionOrder>
+public class ObjectInitializersExecutionOrder
+{
+    public static void Main()
+    {
+        new Person { FirstName = "Paisley", LastName = "Smith", City = "Dallas" };
+        new Dog(2) { Name = "Mike" };
+    }
+
+    public class Dog
+    {
+        private int age;
+        private string name;
+
+        public Dog(int age)
+        {
+            Console.WriteLine("Hello from Dog's non-parameterless constructor");
+            this.age = age;
+        }
+
+        public required string Name
+        {
+            get { return name; }
+
+            set
+            {
+                Console.WriteLine("Hello from setter of Dog's required property 'Name'");
+                name = value;
+            }
+        }
+    }
+
+    public class Person
+    {
+        private string firstName;
+        private string lastName;
+        private string city;
+
+        public Person()
+        {
+            Console.WriteLine("Hello from Person's parameterless constructor");
+        }
+
+        public required string FirstName
+        {
+            get { return firstName; }
+
+            set
+            {
+                Console.WriteLine("Hello from setter of Person's required property 'FirstName'");
+                firstName = value;
+            }
+        }
+
+        public string LastName
+        {
+            get { return lastName; }
+
+            init
+            {
+                Console.WriteLine("Hello from setter of Person's init property 'LastName'");
+                lastName = value;
+            }
+        }
+
+        public string City
+        {
+            get { return city; }
+
+            set
+            {
+                Console.WriteLine("Hello from setter of Person's property 'City'");
+                city = value;
+            }
+        }
+    }
+
+    // Output:
+    // Hello from Person's parameterless constructor
+    // Hello from setter of Person's required property 'FirstName'
+    // Hello from setter of Person's init property 'LastName'
+    // Hello from setter of Person's property 'City'
+    // Hello from Dog's non-parameterless constructor
+    // Hello from setter of Dog's required property 'Name'
+}
+// </ObjectInitializersExecutionOrder>

--- a/samples/snippets/csharp/programming-guide/classes-and-structs/object-collection-initializers/Program.cs
+++ b/samples/snippets/csharp/programming-guide/classes-and-structs/object-collection-initializers/Program.cs
@@ -10,6 +10,7 @@ namespace object_collection_initializers
             HowToObjectInitializers.Main();
             HowToIndexInitializer.Main();
             HowToDictionaryInitializer.Main();
+            ObjectInitializersExecutionOrder.Main();
         }
     }
 }

--- a/samples/snippets/csharp/programming-guide/classes-and-structs/object-collection-initializers/object-collection-initializers.csproj
+++ b/samples/snippets/csharp/programming-guide/classes-and-structs/object-collection-initializers/object-collection-initializers.csproj
@@ -2,10 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <RootNamespace>object_collection_initializers</RootNamespace>
     <StartupObject>object_collection_initializers.Program</StartupObject>
+    <LangVersion>11</LangVersion>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Added an example for order of execution of constructor and member initializations. 

Fixes #40768


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/classes-and-structs/how-to-initialize-objects-by-using-an-object-initializer.md](https://github.com/dotnet/docs/blob/57c8890dcc692a2de626be1ee5d1a9ef49f9ad94/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-objects-by-using-an-object-initializer.md) | [How to initialize objects by using an object initializer (C# Programming Guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/how-to-initialize-objects-by-using-an-object-initializer?branch=pr-en-us-40844) |


<!-- PREVIEW-TABLE-END -->