### PR TITLE
fix example with an invalid preprocessor expression

### DIFF
--- a/docs/csharp/language-reference/preprocessor-directives.md
+++ b/docs/csharp/language-reference/preprocessor-directives.md
@@ -88,12 +88,12 @@ The following code is compiled when `MYTEST` is **not** defined:
 
 You can use the operators [`==` (equality)](operators/equality-operators.md#equality-operator-) and [`!=` (inequality)](operators/equality-operators.md#inequality-operator-) to test for the [`bool`](builtin-types/bool.md) values `true` or `false`. `true` means the symbol is defined. The statement `#if DEBUG` has the same meaning as `#if (DEBUG == true)`. You can use the [`&&` (and)](operators/boolean-logical-operators.md#conditional-logical-and-operator-), [`||` (or)](operators/boolean-logical-operators.md#conditional-logical-or-operator-), and [`!` (not)](operators/boolean-logical-operators.md#logical-negation-operator-) operators to evaluate whether multiple symbols have been defined. You can also group symbols and operators with parentheses.
 
-The following is a complex directive that allows your code to take advantage of newer .NET features while remaining backward compatible.  For example, imagine that you're using a NuGet package in your code, but the package only supports .NET 6 and up, as well as .NET Standard 2.0 and up:
+The following is a complex directive that allows your code to take advantage of newer .NET features while remaining backward compatible. For example, imagine that you're using a NuGet package in your code, but the package only supports .NET 6 and up, as well as .NET Standard 2.0 and up:
 
 ```csharp
 #if (NET6_0_OR_GREATER || NETSTANDARD2_0_OR_GREATER)
     Console.WriteLine("Using .NET 6+ or .NET Standard 2+ code.");
-#elif
+#else
     Console.WriteLine("Using older code that doesn't support the above .NET versions.");
 #endif
 ```


### PR DESCRIPTION
## Summary

An example of the _C# preprocessor directives_ page is using an `#elif` directive without a condition, which is an error.
Changing this to the expected `#else` directive, preceding the code that showcases backward compatibility.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/preprocessor-directives.md](https://github.com/dotnet/docs/blob/76bdbc9efd9f134dbf1d8bfb7a70cce26b4b54c1/docs/csharp/language-reference/preprocessor-directives.md) | [C# preprocessor directives](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/preprocessor-directives?branch=pr-en-us-40857) |

<!-- PREVIEW-TABLE-END -->