### PR TITLE
Fixed some outdated usage of quic connection stream handling

### DIFF
--- a/docs/fundamentals/networking/quic/quic-overview.md
+++ b/docs/fundamentals/networking/quic/quic-overview.md
@@ -314,7 +314,7 @@ The sample usage of `QuicStream` in client scenario:
 
 ```csharp
 // Consider connection from the connection example, open a bidirectional stream.
-await using var stream = await connection.OpenStreamAsync(QuicStreamType.Bidirectional, cancellationToken);
+await using var stream = await connection.OpenOutboundStreamAsync(QuicStreamType.Bidirectional, cancellationToken);
 
 // Send some data.
 await stream.WriteAsync(data, cancellationToken);
@@ -338,7 +338,7 @@ And the sample usage of `QuicStream` in server scenario:
 
 ```csharp
 // Consider connection from the connection example, accept a stream.
-await using var stream = await connection.AcceptStreamAsync(cancellationToken);
+await using var stream = await connection.AcceptInboundStreamAsync(cancellationToken);
 
 if (stream.Type != QuicStreamType.Bidirectional)
 {


### PR DESCRIPTION
There were some changes of the QuicConnection's API:
OpenStreamAsync => OpenOutboundStreamAsync
AcceptStreamAsync => AcceptInboundStreamAsync


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/networking/quic/quic-overview.md](https://github.com/dotnet/docs/blob/cb3361f9cea4be44acdff2b81d6a79df58829a7d/docs/fundamentals/networking/quic/quic-overview.md) | [QUIC protocol](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview?branch=pr-en-us-40858) |

<!-- PREVIEW-TABLE-END -->