### PR TITLE
Clarify location of headers and libraries

### DIFF
--- a/docs/core/tutorials/netcore-hosting.md
+++ b/docs/core/tutorials/netcore-hosting.md
@@ -54,11 +54,13 @@ The sample uses the following includes:
 ```
 
 These files can be found at the following locations:
+
 * <https://github.com/dotnet/runtime/blob/main/src/native/corehost/nethost/nethost.h>
 * <https://github.com/dotnet/runtime/blob/main/src/native/corehost/coreclr_delegates.h>
 * <https://github.com/dotnet/runtime/blob/main/src/native/corehost/hostfxr.h>
 
 Or, if you have for example installed the .Net 8 SDK on Windows:
+
 * `C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Host.win-x64\8.0.4\runtimes\win-x64\native`
 
 ### Step 2 - Initialize and start the .NET runtime

--- a/docs/core/tutorials/netcore-hosting.md
+++ b/docs/core/tutorials/netcore-hosting.md
@@ -17,7 +17,7 @@ This article gives an overview of the steps necessary to start the .NET runtime 
 
 Because hosts are native applications, this tutorial covers constructing a C++ application to host .NET. You will need a C++ development environment (such as that provided by [Visual Studio](https://aka.ms/vsdownload?utm_source=mscom&utm_campaign=msdocs)).
 
-You will also need to build a .NET component to test the host with, so you should install the [.NET SDK](https://dotnet.microsoft.com/download).
+You will also need to build a .NET component to test the host with, so you should install the [.NET SDK](https://dotnet.microsoft.com/download). It includes the necessary headers and libraries to link with. As an example, on Windows with the .Net 8 SDK the files can be found in `C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Host.win-x64\8.0.4\runtimes\win-x64\native`.
 
 ## Hosting APIs
 
@@ -31,7 +31,7 @@ A [sample host](https://github.com/dotnet/samples/tree/main/core/hosting) demons
 
 Keep in mind that the sample host is meant to be used for learning purposes, so it is light on error checking and designed to emphasize readability over efficiency.
 
-The following steps detail how to use the `nethost` and `hostfxr` libraries to start the .NET runtime in a native application and call into a managed static method. The [sample](https://github.com/dotnet/samples/tree/main/core/hosting/src) uses the `nethost` header and library installed with the .NET SDK and copies of the [`coreclr_delegates.h`](https://github.com/dotnet/runtime/blob/main/src/native/corehost/coreclr_delegates.h) and [`hostfxr.h`](https://github.com/dotnet/runtime/blob/main/src/native/corehost/hostfxr.h) files from the [dotnet/runtime](https://github.com/dotnet/runtime) repository.
+The following steps detail how to use the `nethost` and `hostfxr` libraries to start the .NET runtime in a native application and call into a managed static method. The [sample](https://github.com/dotnet/samples/tree/main/core/hosting/src) uses the `nethost` headers and library and the `coreclr_delegates.h` and `hostfxr.h` headers installed with the .NET SDK.
 
 ### Step 1 - Load `hostfxr` and get exported hosting functions
 
@@ -54,10 +54,12 @@ The sample uses the following includes:
 ```
 
 These files can be found at the following locations:
-
 * <https://github.com/dotnet/runtime/blob/main/src/native/corehost/nethost/nethost.h>
 * <https://github.com/dotnet/runtime/blob/main/src/native/corehost/coreclr_delegates.h>
 * <https://github.com/dotnet/runtime/blob/main/src/native/corehost/hostfxr.h>
+
+Or, if you have for example installed the .Net 8 SDK on Windows:
+* `C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Host.win-x64\8.0.4\runtimes\win-x64\native`
 
 ### Step 2 - Initialize and start the .NET runtime
 

--- a/docs/core/tutorials/netcore-hosting.md
+++ b/docs/core/tutorials/netcore-hosting.md
@@ -17,7 +17,7 @@ This article gives an overview of the steps necessary to start the .NET runtime 
 
 Because hosts are native applications, this tutorial covers constructing a C++ application to host .NET. You will need a C++ development environment (such as that provided by [Visual Studio](https://aka.ms/vsdownload?utm_source=mscom&utm_campaign=msdocs)).
 
-You will also need to build a .NET component to test the host with, so you should install the [.NET SDK](https://dotnet.microsoft.com/download). It includes the necessary headers and libraries to link with. As an example, on Windows with the .Net 8 SDK the files can be found in `C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Host.win-x64\8.0.4\runtimes\win-x64\native`.
+You will also need to build a .NET component to test the host with, so you should install the [.NET SDK](https://dotnet.microsoft.com/download). It includes the necessary headers and libraries to link with. As an example, on Windows with the .NET 8 SDK the files can be found in `C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Host.win-x64\8.0.4\runtimes\win-x64\native`.
 
 ## Hosting APIs
 
@@ -59,7 +59,7 @@ These files can be found at the following locations:
 * <https://github.com/dotnet/runtime/blob/main/src/native/corehost/coreclr_delegates.h>
 * <https://github.com/dotnet/runtime/blob/main/src/native/corehost/hostfxr.h>
 
-Or, if you have for example installed the .Net 8 SDK on Windows:
+Or, if you have installed the .NET 8 SDK on Windows:
 
 * `C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Host.win-x64\8.0.4\runtimes\win-x64\native`
 


### PR DESCRIPTION
## Summary

I tried hosting .NET in a native app, but from the tutorial it wasn't clear to me at all where I should get all the required files.
After googling a bit and finding issue #37143, I managed to get it working. I updated the tutorial to make it clearer where to find the headers and libraries.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tutorials/netcore-hosting.md](https://github.com/dotnet/docs/blob/3129c80ec2c611f9a0be1b920d9b74b681fda68b/docs/core/tutorials/netcore-hosting.md) | [Write a custom .NET host to control the .NET runtime from your native code](https://review.learn.microsoft.com/en-us/dotnet/core/tutorials/netcore-hosting?branch=pr-en-us-40859) |


<!-- PREVIEW-TABLE-END -->