### PR TITLE
remove spread operator, use spread element

### DIFF
--- a/docs/csharp/language-reference/operators/member-access-operators.md
+++ b/docs/csharp/language-reference/operators/member-access-operators.md
@@ -232,7 +232,7 @@ The following example demonstrates the effect of using all the ranges presented 
 
 For more information, see [Indices and ranges](../../tutorials/ranges-indexes.md).
 
-The `..` token is also used as the [spread operator](./collection-expressions.md#spread-element) in a collection expression.
+The `..` token is also used for the [spread element](./collection-expressions.md#spread-element) in a collection expression.
 
 ## Operator overloadability
 

--- a/docs/csharp/whats-new/csharp-12.md
+++ b/docs/csharp/whats-new/csharp-12.md
@@ -34,7 +34,7 @@ You can learn more about primary constructors in the tutorial for [exploring pri
 
 ## Collection expressions
 
-Collection expressions introduce a new terse syntax to create common collection values. Inlining other collections into these values is possible using a spread operator `..`.
+Collection expressions introduce a new terse syntax to create common collection values. Inlining other collections into these values is possible using a spread element `..e`.
 
 Several collection-like types can be created without requiring external BCL support.  These types are:
 
@@ -64,7 +64,7 @@ int[] row2 = [7, 8, 9];
 int[][] twoDFromVariables = [row0, row1, row2];
 ```
 
-The *spread operator*, `..` in a collection expression replaces its argument with the elements from that collection. The argument must be a collection type. The following examples show how the spread operator works:
+The *spread element*, `..e` in a collection expression adds all the elements in that expression. The argument must be a collection type. The following examples show how the spread element works:
 
 ```csharp
 int[] row0 = [1, 2, 3];
@@ -79,7 +79,7 @@ foreach (var element in single)
 // 1, 2, 3, 4, 5, 6, 7, 8, 9,
 ```
 
-The operand of a spread operator is an expression that can be enumerated. The spread operator evaluates each element of the enumerations expression.
+The spread element evaluates each element of the enumerations expression. Each element is included in the output collection.
 
 You can use collection expressions anywhere you need a collection of elements. They can specify the initial value for a collection or be passed as arguments to methods that take collection types. You can learn more about collection expressions in the [language reference article on collection expressions](../language-reference/operators/collection-expressions.md) or the [feature specification](~/_csharplang/proposals/csharp-12.0/collection-expressions.md).
 

--- a/docs/csharp/whats-new/csharp-version-history.md
+++ b/docs/csharp/whats-new/csharp-version-history.md
@@ -20,7 +20,7 @@ This article provides a history of each major release of the C# language. The C#
 The following features were added in C# 12:
 
 - [Primary constructors](./csharp-12.md#primary-constructors) - You can create primary constructors in any `class` or `struct` type.
-- [Collection expressions](./csharp-12.md#collection-expressions) - A new syntax to specify collection expressions, including the spread operator, (`..`), to expand any collection.
+- [Collection expressions](./csharp-12.md#collection-expressions) - A new syntax to specify collection expressions, including the spread element, (`..e`), to expand any collection.
 - [Inline arrays](./csharp-12.md#inline-arrays) - Inline arrays enable you to create an array of fixed size in a `struct` type.
 - [Optional parameters in lambda expressions](./csharp-12.md#default-lambda-parameters) - You can define default values for parameters on lambda expressions.
 - [`ref readonly` parameters](./csharp-12.md#ref-readonly-parameters) - `ref readonly` parameters enables more clarity for APIs that might be using `ref` parameters or `in` parameters.


### PR DESCRIPTION
Don't use the term "operator" for the `..` element in a collection expression.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/member-access-operators.md](https://github.com/dotnet/docs/blob/80c43585a72a1f785a5403efc4f0d3ad7dfceacf/docs/csharp/language-reference/operators/member-access-operators.md) | [Member access operators and expressions - the dot, indexer, and invocation operators.](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/member-access-operators?branch=pr-en-us-40877) |
| [docs/csharp/whats-new/csharp-12.md](https://github.com/dotnet/docs/blob/80c43585a72a1f785a5403efc4f0d3ad7dfceacf/docs/csharp/whats-new/csharp-12.md) | [What's new in C# 12 - C# Guide](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-12?branch=pr-en-us-40877) |
| [docs/csharp/whats-new/csharp-version-history.md](https://github.com/dotnet/docs/blob/80c43585a72a1f785a5403efc4f0d3ad7dfceacf/docs/csharp/whats-new/csharp-version-history.md) | [The history of C\#](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-version-history?branch=pr-en-us-40877) |

<!-- PREVIEW-TABLE-END -->