### PR TITLE
Add Assembly.LoadFrom(string, byte[], AssemblyHashAlgorithm) to unsupported API list

### DIFF
--- a/docs/core/compatibility/unsupported-apis.md
+++ b/docs/core/compatibility/unsupported-apis.md
@@ -166,6 +166,7 @@ This article organizes the affected APIs by namespace.
 | - | - |
 | <xref:System.Reflection.Assembly.CodeBase?displayProperty=nameWithType> | All |
 | <xref:System.Reflection.Assembly.EscapedCodeBase?displayProperty=nameWithType> | All |
+| <xref:System.Reflection.Assembly.LoadFrom(System.String,System.Byte[],System.Configuration.Assemblies.AssemblyHashAlgorithm)?displayProperty=nameWithType> | All |
 | <xref:System.Reflection.Assembly.ReflectionOnlyLoad%2A?displayProperty=nameWithType> | All |
 | <xref:System.Reflection.Assembly.ReflectionOnlyLoadFrom(System.String)?displayProperty=nameWithType> | All |
 | <xref:System.Reflection.AssemblyName.GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)?displayProperty=nameWithType> | All |


### PR DESCRIPTION
## Summary

`Assembly.LoadFrom(string, byte[], AssemblyHashAlgorithm)` always throws `NotSupportedException`. Add it to the list of unsupported APIs for .NET Core and .NET 5+.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/unsupported-apis.md](https://github.com/dotnet/docs/blob/949dfb18c49e02621e3ae098f5f79e1febeca2e9/docs/core/compatibility/unsupported-apis.md) | [APIs that always throw exceptions on .NET Core and .NET 5+](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/unsupported-apis?branch=pr-en-us-40884) |

<!-- PREVIEW-TABLE-END -->