### PR TITLE
Disable MD030

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -14,6 +14,8 @@
         "MD026": false,
         // Cannot be enabled due to sequential Note blocks
         "MD028": false,
+        // Won't allow "1.  Item" to align 4 spaces in with content. According to commonmark
+        "MD030": false,
         "MD033": {
             "allowed_elements": [
                 "a",


### PR DESCRIPTION
Currently this rule doesn't seem to operate correctly. The first item below fails the linter but it should pass:

```markdown
1.  Two spaces after the line item

    Makes it so that this content which is 4 spaces indented, aligns properly

01. This is another option

    That aligns child content to 4 spaces perfectly, but the vscode editor doesn't like this style

1. Content like this with 3 spaces

    And child content with 4 spaces don't align.
```