### PR TITLE
MSTEST0026: Avoid conditional access in assertions

### DIFF
--- a/docs/core/testing/mstest-analyzers/design-rules.md
+++ b/docs/core/testing/mstest-analyzers/design-rules.md
@@ -20,3 +20,4 @@ Identifier | Name | Description
 [MSTEST0020](mstest0020.md) | PreferConstructorOverTestInitializeAnalyzer | Prefer constructors over TestInitialize methods
 [MSTEST0021](mstest0021.md) | PreferDisposeOverTestCleanupAnalyzer | Prefer Dispose over TestCleanup methods
 [MSTEST0022](mstest0022.md) | PreferTestCleanupOverDisposeAnalyzer | Prefer TestCleanup over Dispose methods
+[MSTEST0025](mstest0025.md) | PreferAssertFailOverAlwaysFalseConditionsAnalyzer | Use 'Assert.Fail' instead of an always-failing assert

--- a/docs/core/testing/mstest-analyzers/mstest0026.md
+++ b/docs/core/testing/mstest-analyzers/mstest0026.md
@@ -52,6 +52,10 @@ This rule raises a diagnostic when an argument containing a conditional access i
 
 ## Rule description
 
+## How to fix violations
+
+Ensure that arguments do not contain conditional access when passed to the assertion methods.
+
 ```csharp
 Company? company = GetCompany();
 Assert.AreEqual(company?.Name, "Contoso"); // MSTEST0026
@@ -62,10 +66,6 @@ Assert.IsNotNull(company);
 Assert.AreEqual(company.Name, "Contoso");
 StringAssert.Contains(company.Address, "Brazil");
 ```
-
-## How to fix violations
-
-Ensure that arguments do not contain conditional access when passed to the assertion methods.
 
 ## When to suppress warnings
 

--- a/docs/core/testing/mstest-analyzers/mstest0026.md
+++ b/docs/core/testing/mstest-analyzers/mstest0026.md
@@ -16,8 +16,8 @@ ms.author: faisalhafeez
 | Property                            | Value                                                 |
 |-------------------------------------|-------------------------------------------------------|
 | **Rule ID**                         | MSTEST0026                                            |
-| **Title**                           | Avoid conditional access in assertions |
-| **Category**                        | Usage                                                |
+| **Title**                           | Avoid conditional access in assertions                |
+| **Category**                        | Usage                                                 |
 | **Fix is breaking or non-breaking** | Non-breaking                                          |
 | **Enabled by default**              | Yes                                                   |
 | **Default severity**                | Info                                                  |

--- a/docs/core/testing/mstest-analyzers/mstest0026.md
+++ b/docs/core/testing/mstest-analyzers/mstest0026.md
@@ -25,13 +25,7 @@ ms.author: faisalhafeez
 
 ## Cause
 
-This rule raises a diagnostic when an argument containing a conditional access is passed to the `Assert`, `CollectionAssert` or `StringAssert`  assertion methods.
-
-## Rule description
-
-## How to fix violations
-
-Ensure that arguments do not contain conditional access when passed to the methods below:
+This rule raises a diagnostic when an argument containing a conditional access is passed to the `Assert`, `CollectionAssert` or `StringAssert`  assertion methods below:
 
 - `Assert.IsTrue`
 - `Assert.IsFalse`
@@ -55,6 +49,23 @@ Ensure that arguments do not contain conditional access when passed to the metho
 - `StringAssert.EndsWith`
 - `StringAssert.Matches`
 - `StringAssert.DoesNotMatch`
+
+## Rule description
+
+```csharp
+Company? company = GetCompany();
+Assert.AreEqual(company?.Name, "Contoso"); // MSTEST0026
+StringAssert.Contains(company?.Address, "Brazil"); // MSTEST0026
+
+// Fixed code
+Assert.IsNotNull(company);
+Assert.AreEqual(company.Name, "Contoso");
+StringAssert.Contains(company.Address, "Brazil");
+```
+
+## How to fix violations
+
+Ensure that arguments do not contain conditional access when passed to the assertion methods.
 
 ## When to suppress warnings
 

--- a/docs/core/testing/mstest-analyzers/mstest0026.md
+++ b/docs/core/testing/mstest-analyzers/mstest0026.md
@@ -1,0 +1,84 @@
+---
+title: "MSTEST0026: Avoid conditional access in assertions"
+description: "Learn about code analysis rule MSTEST0026: Avoid conditional access in assertions"
+ms.date: 05/15/2024
+f1_keywords:
+- MSTEST0026
+- AssertionArgsShouldAvoidConditionalAccessRuleId
+helpviewer_keywords:
+- AssertionArgsShouldAvoidConditionalAccessRuleId
+- MSTEST0026
+author: fhnaseer
+ms.author: faisalhafeez
+---
+# MSTEST0025: Avoid conditional access in assertions
+
+| Property                            | Value                                                 |
+|-------------------------------------|-------------------------------------------------------|
+| **Rule ID**                         | MSTEST0026                                            |
+| **Title**                           | Avoid conditional access in assertions |
+| **Category**                        | Usage                                                |
+| **Fix is breaking or non-breaking** | Non-breaking                                          |
+| **Enabled by default**              | Yes                                                   |
+| **Default severity**                | Info                                                  |
+| **Introduced in version**           | 3.5.0                                                 |
+
+## Cause
+
+This rule raises a diagnostic when an argument contains a conditional access in the assertion methods below:
+
+- `Assert.IsTrue`
+- `Assert.IsFalse`
+- `Assert.AreEqual`
+- `Assert.AreNotEqual`
+- `Assert.AreSame`
+- `Assert.AreNotSame`
+- `CollectionAssert.AreEqual`
+- `CollectionAssert.AreNotEqual`
+- `CollectionAssert.AreEquivalent`
+- `CollectionAssert.AreNotEquivalent`
+- `CollectionAssert.Contains`
+- `CollectionAssert.DoesNotContain`
+- `CollectionAssert.AllItemsAreNotNull`
+- `CollectionAssert.AllItemsAreUnique`
+- `CollectionAssert.AllItemsAreInstancesOfType`
+- `CollectionAssert.IsSubsetOf`
+- `CollectionAssert.IsNotSubsetOf`
+- `StringAssert.Contains`
+- `StringAssert.StartsWith`
+- `StringAssert.EndsWith`
+- `StringAssert.Matches`
+- `StringAssert.DoesNotMatch`
+
+## Rule description
+
+## How to fix violations
+
+Ensure that arguments do not contain conditional access to the methods below:
+
+- `Assert.IsTrue`
+- `Assert.IsFalse`
+- `Assert.AreEqual`
+- `Assert.AreNotEqual`
+- `Assert.AreSame`
+- `Assert.AreNotSame`
+- `CollectionAssert.AreEqual`
+- `CollectionAssert.AreNotEqual`
+- `CollectionAssert.AreEquivalent`
+- `CollectionAssert.AreNotEquivalent`
+- `CollectionAssert.Contains`
+- `CollectionAssert.DoesNotContain`
+- `CollectionAssert.AllItemsAreNotNull`
+- `CollectionAssert.AllItemsAreUnique`
+- `CollectionAssert.AllItemsAreInstancesOfType`
+- `CollectionAssert.IsSubsetOf`
+- `CollectionAssert.IsNotSubsetOf`
+- `StringAssert.Contains`
+- `StringAssert.StartsWith`
+- `StringAssert.EndsWith`
+- `StringAssert.Matches`
+- `StringAssert.DoesNotMatch`
+
+## When to suppress warnings
+
+We do not recommend suppressing warnings from this rule.

--- a/docs/core/testing/mstest-analyzers/mstest0026.md
+++ b/docs/core/testing/mstest-analyzers/mstest0026.md
@@ -25,7 +25,7 @@ ms.author: faisalhafeez
 
 ## Cause
 
-This rule raises a diagnostic when an argument containing a conditional access is passed to the `Assert`, `CollectionAssert` or `StringAssert`  assertion methods below:
+This rule raises a diagnostic when an argument containing a conditional access `(?.)` is passed to the assertion methods below:
 
 - `Assert.IsTrue`
 - `Assert.IsFalse`
@@ -52,9 +52,11 @@ This rule raises a diagnostic when an argument containing a conditional access i
 
 ## Rule description
 
+The purpose of assertions in unit tests is to verify that certain conditions are met. When a conditional access is used in an assertion, it introduces an additional condition that may or may not be met, depending on the state of the object being accessed. This can lead to inconsistent test results and make test less clear.
+
 ## How to fix violations
 
-Ensure that arguments do not contain conditional access when passed to the assertion methods.
+Ensure that arguments do not contain conditional access `(?.)` when passed to the assertion methods. Instead, perform null checks before making the assertion.
 
 ```csharp
 Company? company = GetCompany();

--- a/docs/core/testing/mstest-analyzers/mstest0026.md
+++ b/docs/core/testing/mstest-analyzers/mstest0026.md
@@ -25,30 +25,7 @@ ms.author: faisalhafeez
 
 ## Cause
 
-This rule raises a diagnostic when an argument containing a conditional access is passed to the assertion methods below:
-
-- `Assert.IsTrue`
-- `Assert.IsFalse`
-- `Assert.AreEqual`
-- `Assert.AreNotEqual`
-- `Assert.AreSame`
-- `Assert.AreNotSame`
-- `CollectionAssert.AreEqual`
-- `CollectionAssert.AreNotEqual`
-- `CollectionAssert.AreEquivalent`
-- `CollectionAssert.AreNotEquivalent`
-- `CollectionAssert.Contains`
-- `CollectionAssert.DoesNotContain`
-- `CollectionAssert.AllItemsAreNotNull`
-- `CollectionAssert.AllItemsAreUnique`
-- `CollectionAssert.AllItemsAreInstancesOfType`
-- `CollectionAssert.IsSubsetOf`
-- `CollectionAssert.IsNotSubsetOf`
-- `StringAssert.Contains`
-- `StringAssert.StartsWith`
-- `StringAssert.EndsWith`
-- `StringAssert.Matches`
-- `StringAssert.DoesNotMatch`
+This rule raises a diagnostic when an argument containing a conditional access is passed to the `Assert`, `CollectionAssert` or `StringAssert`  assertion methods.
 
 ## Rule description
 

--- a/docs/core/testing/mstest-analyzers/mstest0026.md
+++ b/docs/core/testing/mstest-analyzers/mstest0026.md
@@ -25,7 +25,7 @@ ms.author: faisalhafeez
 
 ## Cause
 
-This rule raises a diagnostic when an argument containing a [conditional access](../../../csharp/language-reference/operators/member-access-operators.md#null-conditional-operators--and-) `(?.)` or `?[]` is passed to the assertion methods below:
+This rule raises a diagnostic when an argument containing a [null conditional operator](../../../csharp/language-reference/operators/member-access-operators.md#null-conditional-operators--and-) `(?.)` or `?[]` is passed to the assertion methods below:
 
 - `Assert.IsTrue`
 - `Assert.IsFalse`
@@ -50,15 +50,13 @@ This rule raises a diagnostic when an argument containing a [conditional access]
 - `StringAssert.Matches`
 - `StringAssert.DoesNotMatch`
 
-
-
 ## Rule description
 
-The purpose of assertions in unit tests is to verify that certain conditions are met. When a conditional access is used in an assertion, it introduces an additional condition that may or may not be met, depending on the state of the object being accessed. This can lead to inconsistent test results and make test less clear.
+The purpose of assertions in unit tests is to verify that certain conditions are met. When a conditional access operator is used in an assertion, it introduces an additional condition that may or may not be met, depending on the state of the object being accessed. This can lead to inconsistent test results and make test less clear.
 
 ## How to fix violations
 
-Ensure that arguments do not contain conditional access `(?.)` or `?[]` when passed to the assertion methods. Instead, perform null checks before making the assertion.
+Ensure that arguments do not contain `(?.)` or `?[]` when passed to the assertion methods. Instead, perform null checks before making the assertion.
 
 ```csharp
 Company? company = GetCompany();

--- a/docs/core/testing/mstest-analyzers/mstest0026.md
+++ b/docs/core/testing/mstest-analyzers/mstest0026.md
@@ -25,7 +25,7 @@ ms.author: faisalhafeez
 
 ## Cause
 
-This rule raises a diagnostic when an argument containing a conditional access `(?.)` is passed to the assertion methods below:
+This rule raises a diagnostic when an argument containing a [conditional access](../../../csharp/language-reference/operators/member-access-operators.md#null-conditional-operators--and-) `(?.)` or `?[]` is passed to the assertion methods below:
 
 - `Assert.IsTrue`
 - `Assert.IsFalse`
@@ -50,13 +50,15 @@ This rule raises a diagnostic when an argument containing a conditional access `
 - `StringAssert.Matches`
 - `StringAssert.DoesNotMatch`
 
+
+
 ## Rule description
 
 The purpose of assertions in unit tests is to verify that certain conditions are met. When a conditional access is used in an assertion, it introduces an additional condition that may or may not be met, depending on the state of the object being accessed. This can lead to inconsistent test results and make test less clear.
 
 ## How to fix violations
 
-Ensure that arguments do not contain conditional access `(?.)` when passed to the assertion methods. Instead, perform null checks before making the assertion.
+Ensure that arguments do not contain conditional access `(?.)` or `?[]` when passed to the assertion methods. Instead, perform null checks before making the assertion.
 
 ```csharp
 Company? company = GetCompany();

--- a/docs/core/testing/mstest-analyzers/mstest0026.md
+++ b/docs/core/testing/mstest-analyzers/mstest0026.md
@@ -11,7 +11,7 @@ helpviewer_keywords:
 author: fhnaseer
 ms.author: faisalhafeez
 ---
-# MSTEST0025: Avoid conditional access in assertions
+# MSTEST0026: Avoid conditional access in assertions
 
 | Property                            | Value                                                 |
 |-------------------------------------|-------------------------------------------------------|
@@ -25,7 +25,7 @@ ms.author: faisalhafeez
 
 ## Cause
 
-This rule raises a diagnostic when an argument contains a conditional access in the assertion methods below:
+This rule raises a diagnostic when an argument containing a conditional access is passed to the assertion methods below:
 
 - `Assert.IsTrue`
 - `Assert.IsFalse`
@@ -54,7 +54,7 @@ This rule raises a diagnostic when an argument contains a conditional access in 
 
 ## How to fix violations
 
-Ensure that arguments do not contain conditional access to the methods below:
+Ensure that arguments do not contain conditional access when passed to the methods below:
 
 - `Assert.IsTrue`
 - `Assert.IsFalse`

--- a/docs/core/testing/mstest-analyzers/usage-rules.md
+++ b/docs/core/testing/mstest-analyzers/usage-rules.md
@@ -26,3 +26,4 @@ Identifier | Name | Description
 [MSTEST0017](mstest0017.md) | AssertionArgsShouldBePassedInCorrectOrder | Assertion arguments should be passed in the correct order
 [MSTEST0023](mstest0023.md) | DoNotNegateBooleanAssertionAnalyzer | Do not negate boolean assertions
 [MSTEST0024](mstest0024.md) | DoNotStoreStaticTestContextAnalyzer | Do not store TestContext in a static member
+[MSTEST0026](mstest0026.md) | AssertionArgsShouldAvoidConditionalAccessRuleId | Avoid conditional access in assertions


### PR DESCRIPTION
Fixes https://github.com/microsoft/testfx/issues/2854 and follows https://github.com/microsoft/testfx/issues/2751

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/mstest-analyzers/design-rules.md](https://github.com/dotnet/docs/blob/8dc6acffecf5fbc57444a38064a0d11fa06d0136/docs/core/testing/mstest-analyzers/design-rules.md) | [MSTest design rules](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/design-rules?branch=pr-en-us-40895) |
| [docs/core/testing/mstest-analyzers/mstest0026.md](https://github.com/dotnet/docs/blob/8dc6acffecf5fbc57444a38064a0d11fa06d0136/docs/core/testing/mstest-analyzers/mstest0026.md) | [MSTEST0026: Avoid conditional access in assertions](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0026?branch=pr-en-us-40895) |
| [docs/core/testing/mstest-analyzers/usage-rules.md](https://github.com/dotnet/docs/blob/8dc6acffecf5fbc57444a38064a0d11fa06d0136/docs/core/testing/mstest-analyzers/usage-rules.md) | [MSTest Usage rules (code analysis)](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/usage-rules?branch=pr-en-us-40895) |


<!-- PREVIEW-TABLE-END -->