### PR TITLE
Fix xref warnings

### DIFF
--- a/docs/core/extensions/logging-providers.md
+++ b/docs/core/extensions/logging-providers.md
@@ -76,7 +76,7 @@ The `Console` provider logs output to the console.
 
 ### Debug
 
-The `Debug` provider writes log output by using the <xref:System.Diagnostics.Debug?displayProperty=fullName> class, specifically through the <xref:System.Diagnostics.Debug.WriteLine%2A?displayProperty=nameWithType> method and only when the debugger is attached. The <xref:Microsoft.Extensions.Logging.Debug.DebugLoggerProvider> creates <xref:Microsoft.Extensions.Logging.Debug.DebugLogger> instances, which are implementations of the `ILogger` interface.
+The `Debug` provider writes log output by using the <xref:System.Diagnostics.Debug?displayProperty=fullName> class, specifically through the <xref:System.Diagnostics.Debug.WriteLine%2A?displayProperty=nameWithType> method and only when the debugger is attached. The <xref:Microsoft.Extensions.Logging.Debug.DebugLoggerProvider> creates instances of a logger class that implements the `ILogger` interface.
 
 ### Event Source
 

--- a/docs/core/extensions/windows-service.md
+++ b/docs/core/extensions/windows-service.md
@@ -74,7 +74,7 @@ Replace the existing `Worker` from the template with the following C# code, and 
 
 :::code source="snippets/workers/windows-service/WindowsBackgroundService.cs":::
 
-In the preceding code, the `JokeService` is injected along with an `ILogger`. Both are made available to the class as fields. In the `ExecuteAsync` method, the joke service requests a joke and writes it to the logger. In this case, the logger is implemented by the Windows Event Log - <xref:Microsoft.Extensions.Logging.EventLog.EventLogLogger?displayProperty=nameWithType>. Logs are written to, and available for viewing in the **Event Viewer**.
+In the preceding code, the `JokeService` is injected along with an `ILogger`. Both are made available to the class as fields. In the `ExecuteAsync` method, the joke service requests a joke and writes it to the logger. In this case, the logger is implemented by the Windows Event Log - <xref:Microsoft.Extensions.Logging.EventLog.EventLogLoggerProvider?displayProperty=nameWithType>. Logs are written to, and available for viewing in the **Event Viewer**.
 
 > [!NOTE]
 > By default, the *Event Log* severity is <xref:Microsoft.Extensions.Logging.LogLevel.Warning>. This can be configured, but for demonstration purposes the `WindowsBackgroundService` logs with the <xref:Microsoft.Extensions.Logging.LoggerExtensions.LogWarning%2A> extension method. To specifically target the `EventLog` level, add an entry in the **appsettings.{Environment}.json**, or provide an <xref:Microsoft.Extensions.Logging.EventLog.EventLogSettings.Filter?displayProperty=nameWithType> value.

--- a/includes/core-changes/aspnetcore/3.0/logging-debuglogger-to-internal.md
+++ b/includes/core-changes/aspnetcore/3.0/logging-debuglogger-to-internal.md
@@ -23,12 +23,4 @@ ASP.NET Core
 
 #### Affected APIs
 
-<xref:Microsoft.Extensions.Logging.Debug.DebugLogger?displayProperty=nameWithType>
-
-<!--
-
-#### Affected APIs
-
-`T:Microsoft.Extensions.Logging.Debug.DebugLogger`
-
--->
+`Microsoft.Extensions.Logging.Debug.DebugLogger`


### PR DESCRIPTION
These warnings popped up as a result of dotnet/dotnet-api-docs#9905. In the newer API versions, one type was removed and one type was made internal.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/logging-providers.md](https://github.com/dotnet/docs/blob/80e5dc9b3325978605ac7f54b8170592a85f6593/docs/core/extensions/logging-providers.md) | [Logging providers in .NET](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/logging-providers?branch=pr-en-us-40939) |
| [docs/core/extensions/windows-service.md](https://github.com/dotnet/docs/blob/80e5dc9b3325978605ac7f54b8170592a85f6593/docs/core/extensions/windows-service.md) | [Create Windows Service using `BackgroundService`](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/windows-service?branch=pr-en-us-40939) |

<!-- PREVIEW-TABLE-END -->