### PR TITLE
Add "Building native libraries" to TOC

### DIFF
--- a/docs/navigate/devops-testing/toc.yml
+++ b/docs/navigate/devops-testing/toc.yml
@@ -431,6 +431,8 @@ items:
             href: ../../core/deploying/native-aot/diagnostics.md
           - name: Native code interop
             href: ../../core/deploying/native-aot/interop.md
+          - name: Building native libraries
+            href: ../../core/deploying/native-aot/libraries.md
           - name: Cross-compilation
             href: ../../core/deploying/native-aot/cross-compile.md
           - name: Intro to AOT warnings

--- a/docs/navigate/devops-testing/toc.yml
+++ b/docs/navigate/devops-testing/toc.yml
@@ -431,7 +431,7 @@ items:
             href: ../../core/deploying/native-aot/diagnostics.md
           - name: Native code interop
             href: ../../core/deploying/native-aot/interop.md
-          - name: Building native libraries
+          - name: Build native libraries
             href: ../../core/deploying/native-aot/libraries.md
           - name: Cross-compilation
             href: ../../core/deploying/native-aot/cross-compile.md


### PR DESCRIPTION
New page added in #40535 is not in TOC.

Cc @dotnet/ilc-contrib 