### PR TITLE
Fix `global.json` lookup explanation

### DIFF
--- a/docs/core/versions/selection.md
+++ b/docs/core/versions/selection.md
@@ -33,7 +33,7 @@ You can take advantage of the latest SDK features and improvements while targeti
 
 On rare occasions, you may need to use an earlier version of the SDK. You specify that version in a [*global.json* file](../tools/global-json.md). The "use latest" policy means you only use *global.json* to specify a .NET SDK version earlier than the latest installed version.
 
-*global.json* can be placed anywhere in the file hierarchy. The CLI searches upward from the project directory for the first *global.json* it finds. You control which projects a given *global.json* applies to by its place in the file system. The .NET CLI searches for a *global.json* file iteratively navigating the path upward from the current working directory. The first *global.json* file found specifies the version used. If that SDK version is installed, that version is used. If the SDK specified in the *global.json* isn't found, the .NET CLI uses [matching rules](../tools/global-json.md#matching-rules) to select a compatible SDK, or fails if none is found.
+*global.json* can be placed anywhere in the file hierarchy. You control which projects a given *global.json* applies to by its place in the file system. The .NET CLI searches for a *global.json* file iteratively navigating the path upward from the current working directory (which isn't necessarily the same as the project directory). The first *global.json* file found specifies the version used. If that SDK version is installed, that version is used. If the SDK specified in the *global.json* isn't found, the .NET CLI uses [matching rules](../tools/global-json.md#matching-rules) to select a compatible SDK, or fails if none is found.
 
 The following example shows the *global.json* syntax:
 


### PR DESCRIPTION
## Summary

Two sentences were contradicting each other. I simply removed the incorrect one, and brought a small precision from the page about [global.json](https://github.com/dotnet/docs/blob/main/docs/core/tools/global-json.md).

- Fixes #40585


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/versions/selection.md](https://github.com/dotnet/docs/blob/e0d44ee3e5d512917c638d6ca72ee3652952c455/docs/core/versions/selection.md) | [Select the .NET version to use](https://review.learn.microsoft.com/en-us/dotnet/core/versions/selection?branch=pr-en-us-40953) |

<!-- PREVIEW-TABLE-END -->