### PR TITLE
Drop all preview mentions for .NET Aspire

### DIFF
--- a/docs/breadcrumb/toc.yml
+++ b/docs/breadcrumb/toc.yml
@@ -13,7 +13,7 @@ items:
           - name: Azure
             tocHref: /dotnet/azure/
             topicHref: /dotnet/azure/index
-          - name: .NET Aspire (Preview)
+          - name: .NET Aspire
             tocHref: /dotnet/aspire/
             topicHref: /dotnet/aspire/index
           - name: Orleans

--- a/docs/core/whats-new/dotnet-8/overview.md
+++ b/docs/core/whats-new/dotnet-8/overview.md
@@ -23,7 +23,7 @@ C# 12 shipped with the .NET 8 SDK. For more information, see [What's new in C# 1
 
 ## .NET Aspire
 
-.NET Aspire is an opinionated, cloud-ready stack for building observable, production ready, distributed applications.​ .NET Aspire is delivered through a collection of NuGet packages that handle specific cloud-native concerns, and is available in preview for .NET 8. For more information, see [.NET Aspire (Preview)](/dotnet/aspire).
+.NET Aspire is an opinionated, cloud-ready stack for building observable, production ready, distributed applications.​ .NET Aspire is delivered through a collection of NuGet packages that handle specific cloud-native concerns, and is available in preview for .NET 8. For more information, see [.NET Aspire](/dotnet/aspire).
 
 ## ASP.NET Core
 

--- a/docs/core/whats-new/dotnet-9/overview.md
+++ b/docs/core/whats-new/dotnet-9/overview.md
@@ -29,7 +29,7 @@ The .NET 9 SDK includes improvements to the terminal logger, tool roll-forward, 
 
 ## .NET Aspire
 
-.NET Aspire is an opinionated, cloud-ready stack for building observable, production ready, distributed applications.​ .NET Aspire is delivered through a collection of NuGet packages that handle specific cloud-native concerns, and is available in preview for .NET 9. For more information, see [.NET Aspire (Preview)](/dotnet/aspire).
+.NET Aspire is an opinionated, cloud-ready stack for building observable, production ready, distributed applications.​ .NET Aspire is delivered through a collection of NuGet packages that handle specific cloud-native concerns, and is available in preview for .NET 9. For more information, see [.NET Aspire](/dotnet/aspire).
 
 ## ASP.NET Core
 

--- a/docs/csharp/index.yml
+++ b/docs/csharp/index.yml
@@ -256,7 +256,7 @@ additionalContent:
             - url: ../azure/index.yml
               text: Azure for .NET developers
             - url: /dotnet/aspire
-              text: .NET Aspire (Preview)
+              text: .NET Aspire
             - url: ../azure/migration/app-service.md?preserve-view=true&view=azure-dotnet
               text: Migrate on-premises .NET web apps or services
             - url: ../azure/key-azure-services.md

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -44,7 +44,7 @@ highlightedContent:
       itemType: overview
       url: azure/index.yml
     # Card
-    - title: .NET Aspire (Preview)
+    - title: .NET Aspire
       itemType: overview
       url: /dotnet/aspire
     # Card
@@ -309,7 +309,7 @@ additionalContent:
             - url: azure/index.yml
               text: Azure for .NET developers
             - url: /dotnet/aspire
-              text: .NET Aspire (Preview)
+              text: .NET Aspire
             - url: ./azure/migration/app-service.md?preserve-view=true&view=azure-dotnet
               text: Migrate on-premises .NET web apps or services
             - url: ./azure/key-azure-services.md


### PR DESCRIPTION
## Summary

Drop all preview mentions for .NET Aspire. Needs to be `live` the morning of //build. Approvals and auto-merge will be blocked until the `DO NOT MERGE` label is lifted, please feel free to approve.

Related to https://github.com/dotnet/docs-aspire/issues/896


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/whats-new/dotnet-8/overview.md](https://github.com/dotnet/docs/blob/81184975d13757059459a2208145feb674e4b1d8/docs/core/whats-new/dotnet-8/overview.md) | [What's new in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-8/overview?branch=pr-en-us-40961) |
| [docs/core/whats-new/dotnet-9/overview.md](https://github.com/dotnet/docs/blob/81184975d13757059459a2208145feb674e4b1d8/docs/core/whats-new/dotnet-9/overview.md) | [What's new in .NET 9](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-9/overview?branch=pr-en-us-40961) |

<!-- PREVIEW-TABLE-END -->