### PR TITLE
Update publishing-with-visual-studio-code.md

### DIFF
--- a/docs/core/tutorials/publishing-with-visual-studio-code.md
+++ b/docs/core/tutorials/publishing-with-visual-studio-code.md
@@ -53,7 +53,7 @@ In the following steps, you'll look at the files created by the publish process.
 
 1. Select the **Explorer** in the left navigation bar.
 
-1. Expand *bin/Release/net7.0/publish*.
+1. Expand *bin/Release/net8.0/publish*.
 
    :::image type="content" source="media/publishing-with-visual-studio-code/published-files-output-net8.png" alt-text="Explorer showing published files":::
 


### PR DESCRIPTION
## Summary

Fix path name in net8.0 version

Fixes #40975
<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tutorials/publishing-with-visual-studio-code.md](https://github.com/dotnet/docs/blob/bdec2f7c30fb2c6a133ea4bb51040067c66058bd/docs/core/tutorials/publishing-with-visual-studio-code.md) | [Tutorial: Publish a .NET console application using Visual Studio Code](https://review.learn.microsoft.com/en-us/dotnet/core/tutorials/publishing-with-visual-studio-code?branch=pr-en-us-40973) |

<!-- PREVIEW-TABLE-END -->