### PR TITLE
Fix code highlight in rule index

### DIFF
--- a/docs/core/testing/mstest-analyzers/design-rules.md
+++ b/docs/core/testing/mstest-analyzers/design-rules.md
@@ -15,7 +15,7 @@ Identifier | Name | Description
 [MSTEST0004](mstest0004.md) | PublicTypeShouldBeTestClassAnalyzer | It's considered a good practice to have only test classes marked public in a test project.
 [MSTEST0006](mstest0006.md) | AvoidExpectedExceptionAttributeAnalyzer | Prefer `Assert.ThrowsException` or `Assert.ThrowsExceptionAsync` over `[ExpectedException]` as it ensures that only the expected call throws the expected exception. The assert APIs also provide more flexibility and allow you to assert extra properties of the exception.
 [MSTEST0015](mstest0015.md) | TestMethodShouldNotBeIgnored | Test methods should not be ignored (marked with `[Ignore]`).
-[MSTEST0016](mstest0016.md) | TestClassShouldHaveTestMethod | Test class should have at least one test method or be 'static' with method(s) marked by '[AssemblyInitialization]' and/or '[AssemblyCleanup]'.
+[MSTEST0016](mstest0016.md) | TestClassShouldHaveTestMethod | Test class should have at least one test method or be 'static' with method(s) marked by `[AssemblyInitialization]` and/or `[AssemblyCleanup]`.
 [MSTEST0019](mstest0019.md) | PreferTestInitializeOverConstructorAnalyzer | Prefer TestInitialize methods over constructors
 [MSTEST0020](mstest0020.md) | PreferConstructorOverTestInitializeAnalyzer | Prefer constructors over TestInitialize methods
 [MSTEST0021](mstest0021.md) | PreferDisposeOverTestCleanupAnalyzer | Prefer Dispose over TestCleanup methods


### PR DESCRIPTION
Use `` ` `` (grave accent) to highlight the code, rather than `` ' `` (single quote).


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/mstest-analyzers/design-rules.md](https://github.com/dotnet/docs/blob/7929bda1a3714056d7256beeec7a162b64fcaad2/docs/core/testing/mstest-analyzers/design-rules.md) | [MSTest design rules](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/design-rules?branch=pr-en-us-40981) |

<!-- PREVIEW-TABLE-END -->