### PR TITLE
Clarify record equality

### DIFF
--- a/docs/csharp/fundamentals/types/records.md
+++ b/docs/csharp/fundamentals/types/records.md
@@ -19,7 +19,7 @@ Consider using a record in place of a class or struct in the following scenarios
 
 ### Value equality
 
-For records, value equality means that two variables of a record type are equal if the types match and all property and field values match. For other reference types such as classes, equality means [reference equality](../../programming-guide/statements-expressions-operators/equality-comparisons.md#reference-equality). That is, two variables of a class type are equal if they refer to the same object. Methods and operators that determine equality of two record instances use value equality.
+For records, value equality means that two variables of a record type are equal if the types match and all property and field values compare equal. For other reference types such as classes, equality means [reference equality](../../programming-guide/statements-expressions-operators/equality-comparisons.md#reference-equality) by default, unless [value equality](../../programming-guide/statements-expressions-operators/how-to-define-value-equality-for-a-type.md) was implemented. That is, two variables of a class type are equal if they refer to the same object. Methods and operators that determine equality of two record instances use value equality.
 
 Not all data models work well with value equality. For example, [Entity Framework Core](/ef/core/) depends on reference equality to ensure that it uses only one instance of an entity type for what is conceptually one entity. For this reason, record types aren't appropriate for use as entity types in Entity Framework Core.
 


### PR DESCRIPTION
Records do not specifically use reference equality on reference types, they compare members using `EqualityComparer<T>.Default.Equals` which means that overriden Equality is respected

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/fundamentals/types/records.md](https://github.com/dotnet/docs/blob/76c16f38641b9caf3267f497a628783e49fa8c43/docs/csharp/fundamentals/types/records.md) | [Introduction to record types in C\#](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/types/records?branch=pr-en-us-40986) |

<!-- PREVIEW-TABLE-END -->