### PR TITLE
Use latest packages in unit-testing-with-mstest.md

### DIFF
--- a/docs/core/testing/unit-testing-with-mstest.md
+++ b/docs/core/testing/unit-testing-with-mstest.md
@@ -65,14 +65,12 @@ Make the *PrimeService.Tests* directory the current directory and create a new p
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-  <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
-  <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
-  <PackageReference Include="coverlet.collector" Version="1.3.0" />
+  <PackageReference Include="MSTest" Version="3.2.0" />
+  <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.10.1" />
 </ItemGroup>
 ```
 
-The test project requires other packages to create and run unit tests. `dotnet new` in the previous step added the MSTest SDK, the MSTest test framework, the MSTest runner, and coverlet for code coverage reporting.
+The test project requires other packages to create and run unit tests. `dotnet new` in the previous step added the necessary MSTest packages and tools for code coverage reporting.
 
 Add the `PrimeService` class library as another dependency to the project. Use the [`dotnet add reference`](../tools/dotnet-add-reference.md) command:
 


### PR DESCRIPTION
## Summary

The basic MSTest instructions are showing very old package versions that don't match what's used in the `mstest` dotnet template.

Update to the versions uses in the template to reduce confusion.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-with-mstest.md](https://github.com/dotnet/docs/blob/750693e7fe3837ca72a1fb7bdedbdb5f0d883fb8/docs/core/testing/unit-testing-with-mstest.md) | [Unit testing C# with MSTest and .NET](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-with-mstest?branch=pr-en-us-40996) |

<!-- PREVIEW-TABLE-END -->