### PR TITLE
Add entries for dependent repos

### DIFF
--- a/.openpublishing.redirection.csharp.json
+++ b/.openpublishing.redirection.csharp.json
@@ -3984,7 +3984,7 @@
         },
         {
             "source_path_from_root": "/docs/csharp/whats-new.md",
-            "redirect_url": "/dotnet/csharp/whats-new/csharp-12",
+            "redirect_url": "/dotnet/csharp/whats-new/csharp-13",
             "redirect_document_id": true
         },
         {
@@ -4017,7 +4017,7 @@
         },
         {
             "source_path_from_root": "/docs/csharp/whats-new/index.md",
-            "redirect_url": "/dotnet/csharp/whats-new/csharp-12",
+            "redirect_url": "/dotnet/csharp/whats-new/csharp-13",
             "ms.custom": "updateeachrelease"
         },
         {

--- a/docfx.json
+++ b/docfx.json
@@ -168,7 +168,9 @@
         },
         "fileMetadata": {
             "uhfHeaderId": {
-                "docs/csharp/**/**.*": "MSDocsHeader-DotNetCSharp"
+                "docs/csharp/**/**.*": "MSDocsHeader-DotNetCSharp",
+                "_csharplang/**.*": "MSDocsHeader-DotNetCSharp",
+                "_csharpstandard/standard/*.md": "MSDocsHeader-DotNetCSharp"
             },
             "feedback_system": {
                 "docs/standard/design-guidelines/**/**.md": "None",


### PR DESCRIPTION
Update the default location for "What's new" in C# to C# 13. We have preview features now.

The C# L2 header wasn't displayed for the C# specification, or the feature specifications.

I suspect that's because the docfx setting for this uses the source folder, not the destination folder.

