### PR TITLE
Rephrase the empty string expression in interpolated page

### DIFF
--- a/docs/csharp/language-reference/tokens/interpolated.md
+++ b/docs/csharp/language-reference/tokens/interpolated.md
@@ -36,7 +36,7 @@ Elements in square brackets are optional. The following table describes each ele
 
 | Element | Description |
 |--|--|
-| `interpolationExpression` | The expression that produces a result to be formatted. String representation of `null` is <xref:System.String.Empty?displayProperty=nameWithType>. |
+| `interpolationExpression` | The expression that produces a result to be formatted. When the expression is `null`, the output is the empty string (<xref:System.String.Empty?displayProperty=nameWithType>). |
 | `alignment` | The constant expression whose value defines the minimum number of characters in the string representation of the expression result. If positive, the string representation is right-aligned; if negative, it's left-aligned. For more information, see the [Alignment component](../../../standard/base-types/composite-formatting.md#alignment-component) section of the [Composite formatting](../../../standard/base-types/composite-formatting.md) article. |
 | `formatString` | A format string that is supported by the type of the expression result. For more information, see the [Format string component](../../../standard/base-types/composite-formatting.md#format-string-component) section of the [Composite formatting](../../../standard/base-types/composite-formatting.md) article. |
 


### PR DESCRIPTION
This pull request fixes #41008 
It rephrases the sentence of `interpolationExpression` as per suggestion in the issue,
with the only difference of keeping the link to the `String.Empty` to have a brief mention of what does the "empty string" really mean.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/tokens/interpolated.md](https://github.com/dotnet/docs/blob/8157bb8c3f98630a9aa23cbd3399a6aac8104341/docs/csharp/language-reference/tokens/interpolated.md) | [String interpolation using `$`](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/interpolated?branch=pr-en-us-41016) |

<!-- PREVIEW-TABLE-END -->