### PR TITLE
Add documentation for dotnet nuget config commands

### DIFF
--- a/docs/core/tools/dotnet-nuget-config-get.md
+++ b/docs/core/tools/dotnet-nuget-config-get.md
@@ -1,0 +1,65 @@
+---
+title: dotnet nuget config get command
+description: The dotnet-nuget-config command helps manage nuget configuration files.
+author: martinrrm
+ms.date: 05/14/2024
+---
+# dotnet nuget config get
+
+**This article applies to:** ✔️ .NET 8.0.2xx SDK and later versions
+
+## Name
+
+`dotnet nuget config get` - Gets the NuGet configuration settings that will be applied.
+
+## Synopsis
+
+```dotnetcli
+dotnet nuget config get <ALL | CONFIG_KEY> [--show-path] [--working-directory <DIRECTORY>]
+
+dotnet nuget config get -h|--help
+```
+
+## Description
+
+The `dotnet nuget config get` Gets the NuGet configuration settings that will be applied from the config section.
+
+## Arguments
+
+- **`ALL`**
+
+  Get all merged NuGet configuration settings from multiple NuGet configuration files that will be applied, when invoking NuGet command from the working directory path.
+
+- **`CONFIG_KEY`**
+  
+  Get the effective value of the specified configuration settings of the config section.
+
+## Options
+
+* **`--show-path`**
+ 
+Indicate that the NuGet configuration file path will be shown beside the configuration settings.
+
+* **`--working-directory <DIRECTORY>`**
+
+Specifies the directory to start from when listing configuration files. If not specified, the current directory is used.
+
+[!INCLUDE [help](../../../includes/cli-help.md)]
+
+## Examples
+
+* Lists all the Nuget configuration settings being applied to the current directory:
+
+  ```dotnetcli
+  dotnet nuget config get all
+  ```
+
+* Lists the `repositoryPath` value from the config section being applied to the specified directory:
+
+  ```dotnetcli
+  dotnet nuget config get repositoryPath --working-directory "C:/working-directory"
+  ```
+
+## See also
+
+- [nuGet.config reference](/nuget/reference/nuget-config-file)

--- a/docs/core/tools/dotnet-nuget-config-get.md
+++ b/docs/core/tools/dotnet-nuget-config-get.md
@@ -36,13 +36,13 @@ The `dotnet nuget config get` Gets the NuGet configuration settings that will be
 
 ## Options
 
-* **`--show-path`**
- 
-Indicate that the NuGet configuration file path will be shown beside the configuration settings.
+* **`--show-path`** 
+
+  Indicate that the NuGet configuration file path will be shown beside the configuration settings.
 
 * **`--working-directory <DIRECTORY>`**
-
-Specifies the directory to start from when listing configuration files. If not specified, the current directory is used.
+ 
+  Specifies the directory to start from when listing configuration files. If not specified, the current directory is used.
 
 [!INCLUDE [help](../../../includes/cli-help.md)]
 

--- a/docs/core/tools/dotnet-nuget-config-get.md
+++ b/docs/core/tools/dotnet-nuget-config-get.md
@@ -36,12 +36,12 @@ The `dotnet nuget config get` Gets the NuGet configuration settings that will be
 
 ## Options
 
-* **`--show-path`** 
+* **`--show-path`**
 
   Indicate that the NuGet configuration file path will be shown beside the configuration settings.
 
 * **`--working-directory <DIRECTORY>`**
- 
+
   Specifies the directory to start from when listing configuration files. If not specified, the current directory is used.
 
 [!INCLUDE [help](../../../includes/cli-help.md)]

--- a/docs/core/tools/dotnet-nuget-config-paths.md
+++ b/docs/core/tools/dotnet-nuget-config-paths.md
@@ -1,0 +1,52 @@
+---
+title: dotnet nuget config paths command
+description: The dotnet-nuget-config command helps list nuget configuration files.
+author: martinrrm
+ms.date: 05/14/2024
+---
+# dotnet nuget config paths
+
+**This article applies to:** ✔️ .NET 8.0.2xx SDK and later versions
+
+## Name
+
+`dotnet nuget config paths` - Lists nuget configuration files currently being appplied to directory.
+
+## Synopsis
+
+```dotnetcli
+dotnet nuget config paths [--working-directory <DIRECTORY>]
+
+dotnet nuget config paths -h|--help
+```
+
+## Description
+
+The `dotnet nuget config paths` Lists the paths to all NuGet configuration files that will be applied when invoking NuGet command in a specific directory.
+
+
+## Options
+
+* **`--working-directory <DIRECTORY>`**
+
+Specifies the directory to start from when listing configuration files. If not specified, the current directory is used.
+
+[!INCLUDE [help](../../../includes/cli-help.md)]
+
+## Examples
+
+* Lists Nuget configuration files being applied to the current directory:
+
+  ```dotnetcli
+  dotnet nuget config paths
+  ```
+
+* Lists Nuget configuration files being applied to the specified directory:
+
+  ```dotnetcli
+  dotnet nuget config paths --working-directory "C:/working-directory"
+  ```
+
+## See also
+
+- [nuGet.config reference](/nuget/reference/nuget-config-file)

--- a/docs/core/tools/dotnet-nuget-config-paths.md
+++ b/docs/core/tools/dotnet-nuget-config-paths.md
@@ -22,14 +22,13 @@ dotnet nuget config paths -h|--help
 
 ## Description
 
-The `dotnet nuget config paths` Lists the paths to all NuGet configuration files that will be applied when invoking NuGet command in a specific directory.
-
+The `dotnet nuget config paths` Lists the paths to all NuGet configuration files that will be applied when invoking NuGet commands in a specific directory.
 
 ## Options
 
 * **`--working-directory <DIRECTORY>`**
 
-Specifies the directory to start from when listing configuration files. If not specified, the current directory is used.
+  Specifies the directory to start from when listing configuration files. If not specified, the current directory is used.
 
 [!INCLUDE [help](../../../includes/cli-help.md)]
 

--- a/docs/core/tools/dotnet-nuget-config-paths.md
+++ b/docs/core/tools/dotnet-nuget-config-paths.md
@@ -10,7 +10,7 @@ ms.date: 05/14/2024
 
 ## Name
 
-`dotnet nuget config paths` - Lists nuget configuration files currently being appplied to directory.
+`dotnet nuget config paths` - Lists nuget configuration files currently being appplied to a directory.
 
 ## Synopsis
 

--- a/docs/core/tools/dotnet-nuget-config-set.md
+++ b/docs/core/tools/dotnet-nuget-config-set.md
@@ -1,0 +1,61 @@
+---
+title: dotnet nuget config set command
+description: The dotnet-nuget-config command helps manage nuget configuration files.
+author: martinrrm
+ms.date: 05/14/2024
+---
+# dotnet nuget config set
+
+**This article applies to:** ✔️ .NET 8.0.2xx SDK and later versions
+
+## Name
+
+`dotnet nuget config set` - Set the value of a specified NuGet configuration setting.
+
+## Synopsis
+
+```dotnetcli
+dotnet nuget config set <CONFIG-KEY> <CONFIG-VALUE> [--configfile <FILE>]
+
+dotnet nuget config set -h|--help
+```
+
+## Description
+
+The `dotnet nuget config set` 
+
+## Arguments
+
+- **`CONFIG_KEY`**
+  
+  The key of the settings that are to be set.
+
+- **`CONFIG-VALUE`**
+
+  The value of the settings that are to be set.
+
+## Options
+
+- **`--configfile <FILE>`**
+
+  The NuGet configuration file (*nuget.config*) to use. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see [Common NuGet Configurations](/nuget/consume-packages/configuring-nuget-behavior).
+
+[!INCLUDE [help](../../../includes/cli-help.md)]
+
+## Examples
+
+* Set's the `repositoryPath` configuration value `c:\installed_packages` to the current directory:
+
+  ```dotnetcli
+  dotnet nuget config set repositoryPath "c:\installed_packages"
+  ```
+
+* Set's the `repositoryPath` configuration value `c:\installed_packages` to the specified configuration file:
+
+  ```dotnetcli
+  dotnet nuget config set repositoryPath "c:\installed_packages" --configfile "C:/nugte.config"
+  ```
+
+## See also
+
+- [nuGet.config reference](/nuget/reference/nuget-config-file)

--- a/docs/core/tools/dotnet-nuget-config-set.md
+++ b/docs/core/tools/dotnet-nuget-config-set.md
@@ -22,7 +22,7 @@ dotnet nuget config set -h|--help
 
 ## Description
 
-The `dotnet nuget config set` 
+The `dotnet nuget config set` sets the values for NuGet configuration settings that will be applied from the config section.
 
 ## Arguments
 
@@ -44,13 +44,13 @@ The `dotnet nuget config set`
 
 ## Examples
 
-* Set's the `repositoryPath` configuration value `c:\installed_packages` to the current directory:
+* Sets the `repositoryPath` configuration value `c:\installed_packages` to the current directory:
 
   ```dotnetcli
   dotnet nuget config set repositoryPath "c:\installed_packages"
   ```
 
-* Set's the `repositoryPath` configuration value `c:\installed_packages` to the specified configuration file:
+* Sets the `repositoryPath` configuration value `c:\installed_packages` to the specified configuration file:
 
   ```dotnetcli
   dotnet nuget config set repositoryPath "c:\installed_packages" --configfile "C:/nugte.config"

--- a/docs/core/tools/dotnet-nuget-config-unset.md
+++ b/docs/core/tools/dotnet-nuget-config-unset.md
@@ -22,7 +22,7 @@ dotnet nuget config unset -h|--help
 
 ## Description
 
-The `dotnet nuget config unset` 
+The `dotnet nuget config unset` unsets the values for NuGet configuration settings that will be applied from the config section.
 
 ## Arguments
 
@@ -40,12 +40,6 @@ The `dotnet nuget config unset`
 [!INCLUDE [help](../../../includes/cli-help.md)]
 
 ## Examples
-
-* Removes's the `repositoryPath` config value from the current directory:
-
-  ```dotnetcli
-  dotnet nuget config unset repositoryPath
-  ```
 
 * Removes's the `repositoryPath` config value from the specified configuration file:
 

--- a/docs/core/tools/dotnet-nuget-config-unset.md
+++ b/docs/core/tools/dotnet-nuget-config-unset.md
@@ -1,0 +1,58 @@
+---
+title: dotnet nuget config unset command
+description: The dotnet-nuget-config command helps manage nuget configuration files.
+author: martinrrm
+ms.date: 05/14/2024
+---
+# dotnet nuget config unset
+
+**This article applies to:** ✔️ .NET 8.0.2xx SDK and later versions
+
+## Name
+
+`dotnet nuget config unset` - Removes the key-value pair from a specified NuGet configuration setting.
+
+## Synopsis
+
+```dotnetcli
+dotnet nuget config unset <CONFIG-KEY> [--configfile <FILE>]
+
+dotnet nuget config unset -h|--help
+```
+
+## Description
+
+The `dotnet nuget config unset` 
+
+## Arguments
+
+- **`CONFIG_KEY`**
+  
+  The key of the settings that are to be removed.
+
+
+## Options
+
+- **`--configfile <FILE>`**
+
+  The NuGet configuration file (*nuget.config*) to use. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see [Common NuGet Configurations](/nuget/consume-packages/configuring-nuget-behavior).
+
+[!INCLUDE [help](../../../includes/cli-help.md)]
+
+## Examples
+
+* Removes's the `repositoryPath` config value from the current directory:
+
+  ```dotnetcli
+  dotnet nuget config unset repositoryPath
+  ```
+
+* Removes's the `repositoryPath` config value from the specified configuration file:
+
+  ```dotnetcli
+  dotnet nuget config unset repositoryPath --configfile "C:/nugte.config"
+  ```
+
+## See also
+
+- [nuGet.config reference](/nuget/reference/nuget-config-file)

--- a/docs/core/tools/dotnet-nuget-config-unset.md
+++ b/docs/core/tools/dotnet-nuget-config-unset.md
@@ -30,7 +30,6 @@ The `dotnet nuget config unset` unsets the values for NuGet configuration settin
   
   The key of the settings that are to be removed.
 
-
 ## Options
 
 - **`--configfile <FILE>`**


### PR DESCRIPTION
## Summary

Add documentation for `dotnet nuget config` commands.
Implementation: https://github.com/NuGet/NuGet.Client/pull/5549


Fixes https://github.com/NuGet/Home/issues/13398


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-nuget-config-get.md](https://github.com/dotnet/docs/blob/cba033dc2f6705418ab16bb47f6cce532ec2be3f/docs/core/tools/dotnet-nuget-config-get.md) | [dotnet nuget config get](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-config-get?branch=pr-en-us-41019) |
| [docs/core/tools/dotnet-nuget-config-paths.md](https://github.com/dotnet/docs/blob/cba033dc2f6705418ab16bb47f6cce532ec2be3f/docs/core/tools/dotnet-nuget-config-paths.md) | [dotnet nuget config paths command](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-config-paths?branch=pr-en-us-41019) |
| [docs/core/tools/dotnet-nuget-config-set.md](https://github.com/dotnet/docs/blob/cba033dc2f6705418ab16bb47f6cce532ec2be3f/docs/core/tools/dotnet-nuget-config-set.md) | [dotnet nuget config set](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-config-set?branch=pr-en-us-41019) |
| [docs/core/tools/dotnet-nuget-config-unset.md](https://github.com/dotnet/docs/blob/cba033dc2f6705418ab16bb47f6cce532ec2be3f/docs/core/tools/dotnet-nuget-config-unset.md) | [docs/core/tools/dotnet-nuget-config-unset](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-config-unset?branch=pr-en-us-41019) |


<!-- PREVIEW-TABLE-END -->