### PR TITLE
Adding using statement

### DIFF
--- a/docs/csharp/asynchronous-programming/snippets/access-web/Program.cs
+++ b/docs/csharp/asynchronous-programming/snippets/access-web/Program.cs
@@ -11,7 +11,7 @@ class AccessWeb
     // <ControlFlow>
     public async Task<int> GetUrlContentLengthAsync()
     {
-        var client = new HttpClient();
+        using var client = new HttpClient();
 
         Task<string> getStringTask =
             client.GetStringAsync("https://learn.microsoft.com/dotnet");


### PR DESCRIPTION
## Summary

There`s a bug in the Program.cs code example.
"using" statement is necessary when create a HttpClient

Fixes #Issue_Number (if available)
