### PR TITLE
remove collection expression syntax from try.net sample

### DIFF
--- a/docs/csharp/language-reference/builtin-types/snippets/shared/ValueTuples.cs
+++ b/docs/csharp/language-reference/builtin-types/snippets/shared/ValueTuples.cs
@@ -98,13 +98,13 @@ public static class ValueTuples
     private static void MultipleReturns()
     {
         // <SnippetMultipleReturns>
-        int[] xs = [4, 7, 9];
+        int[] xs = new int[] { 4, 7, 9 };
         var limits = FindMinMax(xs);
         Console.WriteLine($"Limits of [{string.Join(" ", xs)}] are {limits.min} and {limits.max}");
         // Output:
         // Limits of [4 7 9] are 4 and 9
 
-        int[] ys = [-9, 0, 67, 100];
+        int[] ys = new int[] { -9, 0, 67, 100 };
         var (minimum, maximum) = FindMinMax(ys);
         Console.WriteLine($"Limits of [{string.Join(" ", ys)}] are {minimum} and {maximum}");
         // Output:


### PR DESCRIPTION
Fixes #41000

This one sample uses an array, and is run in the try.net syntax.
