### PR TITLE
Fix warning.

### DIFF
--- a/docs/csharp/language-reference/keywords/using.md
+++ b/docs/csharp/language-reference/keywords/using.md
@@ -14,12 +14,12 @@ The `using` keyword has two major uses:
 
 - The [using statement](../statements/using.md) defines a scope at the end of which an object is disposed:
 
- :::code language="csharp" source="./snippets/UsingKeywordExample.cs" id="UsingStatement":::
- 
+:::code language="csharp" source="./snippets/UsingKeywordExample.cs" id="UsingStatement":::
+
 - The [using directive](using-directive.md) creates an alias for a namespace or imports types defined in other namespaces:
 
- :::code language="csharp" source="./snippets/UsingKeywordExample.cs" id="UsingDirective":::
- 
+:::code language="csharp" source="./snippets/UsingKeywordExample.cs" id="UsingDirective":::
+
 ## See also
 
 - [C# keywords](index.md)


### PR DESCRIPTION
Whitespace only changes because of markdown lint errors.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/using.md](https://github.com/dotnet/docs/blob/5d86e8f9bafe7c4883185ac6642308c84fbcd635/docs/csharp/language-reference/keywords/using.md) | [using (C# reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using?branch=pr-en-us-41030) |

<!-- PREVIEW-TABLE-END -->