### PR TITLE
What's new net8 runtime.md - no new properties added to RequiredAttribute

### DIFF
--- a/docs/core/whats-new/dotnet-8/runtime.md
+++ b/docs/core/whats-new/dotnet-8/runtime.md
@@ -561,7 +561,7 @@ Even if you don't explicitly use `Vector512`-specific or `Avx512F`-specific inst
 
 ### Data validation
 
-The <xref:System.ComponentModel.DataAnnotations?displayProperty=fullName> namespace includes new data validation attributes intended for validation scenarios in cloud-native services. While the pre-existing `DataAnnotations` validators are geared towards typical UI data-entry validation, such as fields on a form, the new attributes are designed to validate non-user-entry data, such as [configuration options](../../extensions/options.md#options-validation). In addition to the new attributes, new properties were added to the <xref:System.ComponentModel.DataAnnotations.RangeAttribute> and <xref:System.ComponentModel.DataAnnotations.RequiredAttribute> types.
+The <xref:System.ComponentModel.DataAnnotations?displayProperty=fullName> namespace includes new data validation attributes intended for validation scenarios in cloud-native services. While the pre-existing `DataAnnotations` validators are geared towards typical UI data-entry validation, such as fields on a form, the new attributes are designed to validate non-user-entry data, such as [configuration options](../../extensions/options.md#options-validation). In addition to the new attributes, new properties were added to the <xref:System.ComponentModel.DataAnnotations.RangeAttribute> type.
 
 | New API | Description |
 |--|--|


### PR DESCRIPTION
The addition of the new property was reverted in the end.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/whats-new/dotnet-8/runtime.md](https://github.com/dotnet/docs/blob/0040791c23020ea31e19264f945254c982603655/docs/core/whats-new/dotnet-8/runtime.md) | [What's new in the .NET 8 runtime](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-8/runtime?branch=pr-en-us-41035) |

<!-- PREVIEW-TABLE-END -->