### PR TITLE
remove public keyword in interface, sort modifier`s order

### DIFF
--- a/docs/csharp/programming-guide/generics/constraints-on-type-parameters.md
+++ b/docs/csharp/programming-guide/generics/constraints-on-type-parameters.md
@@ -149,11 +149,11 @@ This pattern enables the C# compiler to determine the containing type for the ov
 ```csharp
 public interface IAdditionSubtraction<T> where T : IAdditionSubtraction<T>
 {
-    public abstract static IAdditionSubtraction<T> operator +(
+    abstract static IAdditionSubtraction<T> operator +(
         IAdditionSubtraction<T> left,
         IAdditionSubtraction<T> right);
 
-    public abstract static IAdditionSubtraction<T> operator -(
+    abstract static IAdditionSubtraction<T> operator -(
         IAdditionSubtraction<T> left,
         IAdditionSubtraction<T> right);
 }

--- a/docs/csharp/programming-guide/generics/constraints-on-type-parameters.md
+++ b/docs/csharp/programming-guide/generics/constraints-on-type-parameters.md
@@ -149,11 +149,11 @@ This pattern enables the C# compiler to determine the containing type for the ov
 ```csharp
 public interface IAdditionSubtraction<T> where T : IAdditionSubtraction<T>
 {
-    abstract static IAdditionSubtraction<T> operator +(
+    static abstract IAdditionSubtraction<T> operator +(
         IAdditionSubtraction<T> left,
         IAdditionSubtraction<T> right);
 
-    abstract static IAdditionSubtraction<T> operator -(
+    static abstract IAdditionSubtraction<T> operator -(
         IAdditionSubtraction<T> left,
         IAdditionSubtraction<T> right);
 }

--- a/docs/csharp/programming-guide/generics/snippets/GenericWhereConstraints.cs
+++ b/docs/csharp/programming-guide/generics/snippets/GenericWhereConstraints.cs
@@ -279,8 +279,8 @@ namespace Generics
     // <SelfConstraint>
     public interface IAdditionSubtraction<T> where T : IAdditionSubtraction<T>
     {
-        public abstract static T operator +(T left, T right);
-        public abstract static T operator -(T left, T right);
+        abstract static T operator +(T left, T right);
+        abstract static T operator -(T left, T right);
     }
     // </SelfConstraint>
 }

--- a/docs/csharp/programming-guide/generics/snippets/GenericWhereConstraints.cs
+++ b/docs/csharp/programming-guide/generics/snippets/GenericWhereConstraints.cs
@@ -279,8 +279,8 @@ namespace Generics
     // <SelfConstraint>
     public interface IAdditionSubtraction<T> where T : IAdditionSubtraction<T>
     {
-        abstract static T operator +(T left, T right);
-        abstract static T operator -(T left, T right);
+        static abstract T operator +(T left, T right);
+        static abstract T operator -(T left, T right);
     }
     // </SelfConstraint>
 }


### PR DESCRIPTION
I remove the public keyword inside interface, sort modifiers declaration order.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/generics/constraints-on-type-parameters.md](https://github.com/dotnet/docs/blob/bab98ed5412777a05cb5c41c892b3762ca466d04/docs/csharp/programming-guide/generics/constraints-on-type-parameters.md) | [Constraints on type parameters (C# Programming Guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/generics/constraints-on-type-parameters?branch=pr-en-us-41037) |

<!-- PREVIEW-TABLE-END -->