### PR TITLE
Update Troubleshoot section with a Win error submitted by a Student Ambassador

### DIFF
--- a/docs/ai/quickstarts/includes/prerequisites-and-azure-deploy.md
+++ b/docs/ai/quickstarts/includes/prerequisites-and-azure-deploy.md
@@ -29,7 +29,7 @@ Ensure that you follow the [Prerequisites](#prerequisites) to have access to Azu
 
 ## Troubleshoot
 
-On Windows, you might get the following errosr message after running `azd up`:
+On Windows, you might get the following error messages after running `azd up`:
 
 > *postprovision.ps1 is not digitally signed. The script will not execute on the system*
 

--- a/docs/ai/quickstarts/includes/prerequisites-and-azure-deploy.md
+++ b/docs/ai/quickstarts/includes/prerequisites-and-azure-deploy.md
@@ -29,7 +29,8 @@ Ensure that you follow the [Prerequisites](#prerequisites) to have access to Azu
 
 ## Troubleshoot
 
-On Windows, you might get the following error message after running `azd up`:
+On Windows, you might get the following errosr message after running `azd up`:
+
 > *postprovision.ps1 is not digitally signed. The script will not execute on the system*
 
 The script **postprovision.ps1** is executed to set the .NET user secrets used in the application. To avoid this error, run the following PowerShell command:
@@ -39,3 +40,18 @@ Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
 ```
 
 Then re-run the `azd up` command.
+
+Another possible error:
+
+> 'pwsh' is not recognized as an internal or external command,
+> operable program or batch file.
+> WARNING: 'postprovision' hook failed with exit code: '1', Path: '.\infra\post-script\postprovision.ps1'. : exit code: 1
+> Execution will continue since ContinueOnError has been set to true.
+
+The script **postprovision.ps1** is executed to set the .NET user secrets used in the application. To avoid this error, manually run the script using the following PowerShell command:
+
+```powershell
+.\infra\post-script\postprovision.ps1
+```
+
+The .NET AI apps now have the user-secrets configured and they can be tested.


### PR DESCRIPTION
## Summary

Added a new error scenario in the Troubleshoot section, based on feedback from a Student Ambasador. Solution was to manually run the provision powershell script to set the user secrets.

Fixes #Issue_Number (if available)
