### PR TITLE
add PowerShell v7+ into prerequisites

### DIFF
--- a/docs/ai/quickstarts/includes/prerequisites-and-azure-deploy.md
+++ b/docs/ai/quickstarts/includes/prerequisites-and-azure-deploy.md
@@ -1,7 +1,7 @@
 ---
 author: fboucher
 ms.author: frbouche
-ms.date: 03/04/2024
+ms.date: 05/22/2024
 ms.topic: include
 ---
 
@@ -11,6 +11,7 @@ ms.topic: include
 - An Azure subscription - [Create one for free](https://azure.microsoft.com/free)
 - Azure Developer CLI - [Install or update the Azure Developer CLI](/azure/developer/azure-developer-cli/install-azd)
 - Access to [Azure OpenAI service](/azure/ai-services/openai/overview#how-do-i-get-access-to-azure-openai).
+- On Windows, PowerShell `v7+` is required. To validate your version, run `pwsh` in a terminal. It should returns the current version. If it returns an error, execute the following command: `dotnet tool update --global PowerShell`.
 
 ## Deploy the Azure resources
 


### PR DESCRIPTION
## Summary

Add PowerShell v7+ into prerequisites.

If PowerShell v7+ is not present the following error will be throw at the end of `azd up`
>'pwsh' is not recognized as an internal or external command



