### PR TITLE
Remove suggestion to use .NET Portability analyzer.

### DIFF
--- a/docs/core/porting/index.md
+++ b/docs/core/porting/index.md
@@ -141,14 +141,6 @@ The `try-convert` tool is a .NET global tool that can convert a project or entir
 
 For more information, see the [`try-convert` GitHub repository](https://github.com/dotnet/try-convert).
 
-### .NET Portability Analyzer
-
-The .NET Portability Analyzer is a tool that analyzes assemblies and provides a detailed portability report. It reports .NET APIs that are missing in the applications or libraries to be ported on your specified targeted .NET platforms.
-
-To use the .NET Portability Analyzer in Visual Studio, install the [extension from the marketplace](https://marketplace.visualstudio.com/items?itemName=ConnieYau.NETPortabilityAnalyzer).
-
-For more information, see [The .NET Portability Analyzer](../../standard/analyzers/portability-analyzer.md).
-
 ### Platform compatibility analyzer
 
 The [Platform compatibility analyzer](../../standard/analyzers/platform-compat-analyzer.md) analyzes whether or not you're using an API that throws a <xref:System.PlatformNotSupportedException> at run time. Although finding one of these APIs is unlikely if you're moving from .NET Framework 4.7.2 or higher, it's good to check. For more information about APIs that throw exceptions on .NET, see [APIs that always throw exceptions on .NET Core](../compatibility/unsupported-apis.md).


### PR DESCRIPTION
## Summary

.NET Portability Analyzer has been deprecated since 2022. Removing the suggestion to use it for porting applications.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/porting/index.md](https://github.com/dotnet/docs/blob/0acd795d7d5854e4ec37a4f768411bee7903ec2b/docs/core/porting/index.md) | [Overview of porting from .NET Framework to .NET](https://review.learn.microsoft.com/en-us/dotnet/core/porting/index?branch=pr-en-us-41053) |

<!-- PREVIEW-TABLE-END -->