### PR TITLE
Repeated link

### DIFF
--- a/docs/csharp/language-reference/keywords/ref.md
+++ b/docs/csharp/language-reference/keywords/ref.md
@@ -14,7 +14,7 @@ You use the `ref` keyword in the following contexts:
 
 - In a method signature and in a method call, to pass an argument to a method [by reference](./method-parameters.md#ref-parameter-modifier).
 - In a method signature, to return a value to the caller by reference. For more information, see [`ref return`](../statements/jump-statements.md#ref-returns).
-- In a declaration of a local variable, to declare a [reference variable](../statements/declarations.md#reference-variables) section of the [Declaration statements](../statements/declarations.md) article.
+- In a declaration of a local variable, to declare a [reference variable](../statements/declarations.md#reference-variables).
 - As the part of a [conditional ref expression](../operators/conditional-operator.md#conditional-ref-expression) or a [ref assignment operator](../operators/assignment-operator.md#ref-assignment).
 - In a `struct` declaration, to declare a `ref struct`. For more information, see the [`ref` structure types](../builtin-types/ref-struct.md) article.
 - In a `ref struct` definition, to declare a `ref` field. For more information, see the [`ref` fields](../builtin-types/ref-struct.md#ref-fields) section of the [`ref` structure types](../builtin-types/ref-struct.md) article.


### PR DESCRIPTION
## Summary

Removed repetitive link in what seems like two sentences that were jumbled together.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/ref.md](https://github.com/dotnet/docs/blob/eb602e1c469fe1a10b8e0454cb38829c8013c850/docs/csharp/language-reference/keywords/ref.md) | [ref (C# reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/ref?branch=pr-en-us-41056) |

<!-- PREVIEW-TABLE-END -->