### PR TITLE
Fix debian dependencies

### DIFF
--- a/docs/core/install/linux-debian.md
+++ b/docs/core/install/linux-debian.md
@@ -114,15 +114,33 @@ If you're using a Debian version prior to 12, try the following commands:
 
 When you install with a package manager, these libraries are installed for you. But, if you manually install .NET or you publish a self-contained app, you'll need to make sure these libraries are installed:
 
+### 10.x
+
 - libc6
-- libgcc1 (for 10.x)
-- libgcc-s1 (for 11.x and 12.x)
+- libgcc1
 - libgssapi-krb5-2
-- libicu63 (for 10.x)
-- libicu67 (for 11.x)
-- libicu72 (for 12.x)
-- libssl1.1 (for 10.x and 11.x)
-- libssl3 (for 12.x)
+- libicu63
+- libssl1.1
+- libstdc++6
+- zlib1g
+
+### 11.x
+
+- libc6
+- libgcc-s1
+- libgssapi-krb5-2
+- libicu67
+- libssl1.1
+- libstdc++6
+- zlib1g
+
+### 12.x
+
+- libc6
+- libgcc-s1
+- libgssapi-krb5-2
+- libicu72
+- libssl3
 - libstdc++6
 - zlib1g
 

--- a/docs/core/install/linux-debian.md
+++ b/docs/core/install/linux-debian.md
@@ -121,7 +121,8 @@ When you install with a package manager, these libraries are installed for you. 
 - libicu63 (for 10.x)
 - libicu67 (for 11.x)
 - libicu72 (for 12.x)
-- libssl1.1
+- libssl1.1 (for 10.x and 11.x)
+- libssl3 (for 12.x)
 - libstdc++6
 - zlib1g
 


### PR DESCRIPTION
## Summary
- This fixes the dependency (OpenSSL) about Linux Debian 12.
  - It replaces libssl1.1 with libssl3. 
    - Debian 10(buster): https://packages.debian.org/buster/openssl
    - Debian 11(bullseye): https://packages.debian.org/bullseye/openssl
    - Debian 12(bookworm): https://packages.debian.org/bookworm/openssl
- It separates to sections by versions
  - Update to a format similar to [the Alpine document](docs/core/install/linux-alpine.md).

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/linux-debian.md](https://github.com/dotnet/docs/blob/b6d896c7e2ddb69317aceaab609fa57cf81bb415/docs/core/install/linux-debian.md) | [Install the .NET SDK or the .NET Runtime on Debian](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-debian?branch=pr-en-us-41076) |

<!-- PREVIEW-TABLE-END -->