### PR TITLE
Fixed confusing lowercase letters

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca2254.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2254.md
@@ -36,7 +36,7 @@ var lastName = "Otto";
 
 // This tells the logger that there are FirstName and LastName properties
 // on the log message, and correlates them with the argument values.
-logger.Warning("Person {FirstName} {LastName} encountered an issue", firstName, lastName);
+logger.Warning("Person {firstName} {lastName} encountered an issue", firstName, lastName);
 ```
 
 Not preferred:
@@ -61,7 +61,7 @@ The logging message template should not vary between calls.
 Update the message template to be a constant expression. If you're using values directly in the template, refactor the template to use named placeholders instead.
 
 ```csharp
-logger.Warning("Person {FirstName} {LastName} encountered an issue", firstName, lastName);
+logger.Warning("Person {firstName} {lastName} encountered an issue", firstName, lastName);
 ```
 
 ## When to suppress errors


### PR DESCRIPTION
A new developer might think there is a meaning to the words being uppercase when it is not needed

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca2254.md](https://github.com/dotnet/docs/blob/f5e3e5ecd3a09b88b7bbf6779fac01ab4787fa85/docs/fundamentals/code-analysis/quality-rules/ca2254.md) | [CA2254: Template should be a static expression](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2254?branch=pr-en-us-41088) |

<!-- PREVIEW-TABLE-END -->