### PR TITLE
Update F# documentation for special floating-point infinity values

### DIFF
--- a/docs/fsharp/language-reference/literals.md
+++ b/docs/fsharp/language-reference/literals.md
@@ -1,7 +1,7 @@
 ---
 title: Literals
 description: Learn about the literal types in the F# programming language.
-ms.date: 08/15/2020
+ms.date: 05/28/2024
 ---
 # Literals
 

--- a/docs/fsharp/language-reference/literals.md
+++ b/docs/fsharp/language-reference/literals.md
@@ -23,9 +23,9 @@ The following table shows the literal types in F#. Characters that represent dig
 |unativeint|native pointer as an unsigned natural number|un|`0x00002D3Fun`|
 |int64|signed 64-bit integer|L|`86L`|
 |uint64|unsigned 64-bit natural number|UL|`86UL`|
-|single, float32|32-bit floating point number|F or f|`4.14F` or `4.14f`|
+|single, float32|32-bit floating point number|F or f|`4.14F` or `4.14f` or `infinityf` or `-infinityf`|
 |||lf|`0x00000000lf`|
-|float; double|64-bit floating point number|none|`4.14` or `2.3E+32` or `2.3e+32`|
+|float; double|64-bit floating point number|none|`4.14` or `2.3E+32` or `2.3e+32` or `infinity` or `-infinity`|
 |||LF|`0x0000000000000000LF`|
 |bigint|integer not limited to 64-bit representation|I|`9999999999999999999999999999I`|
 |decimal|fractional number represented as a fixed point or rational number|M or m|`0.7833M` or `0.7833m`|

--- a/docs/fsharp/language-reference/literals.md
+++ b/docs/fsharp/language-reference/literals.md
@@ -109,3 +109,31 @@ let valueAsBits = 0b1101_1110_1010_1101_1011_1110_1110_1111
 
 let exampleSSN = 123_45_6789
 ```
+
+## Special floating-point infinity values
+
+Both the `float` and `single` floating-point numeric types have associated special values representing positive and negative infinity.
+
+| F# value                    | F# type  | Corresponding .NET value              |
+| --------------------------- | -------- | ------------------------------------- |
+| `infinity` or `+infinity`   | `float`  | <xref:System.Double.PositiveInfinity> |
+| `-infinity`                 | `float`  | <xref:System.Double.NegativeInfinity> |
+| `infinityf` or `+infinityf` | `single` | <xref:System.Single.PositiveInfinity> |
+| `-infinityf`                | `single` | <xref:System.Single.NegativeInfinity> |
+
+These values can be used directly or are returned when dividing by a floating-point zero or a number too small to be represented by the given type. For example:
+
+```console
+> 1.0/0.0;;
+val it: float = infinity
+
+> 1.0/(-0.0);;
+val it: float = -infinity
+
+> 1.0/0.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001
+;;
+val it: float = infinity
+```

--- a/docs/fsharp/language-reference/symbol-and-operator-reference/arithmetic-operators.md
+++ b/docs/fsharp/language-reference/symbol-and-operator-reference/arithmetic-operators.md
@@ -1,7 +1,7 @@
 ---
 title: Arithmetic Operators
 description: Learn about the arithmetic operators that are available in the F# programming language.
-ms.date: 04/04/2018
+ms.date: 05/28/2024
 ---
 # Arithmetic Operators
 

--- a/docs/fsharp/language-reference/symbol-and-operator-reference/arithmetic-operators.md
+++ b/docs/fsharp/language-reference/symbol-and-operator-reference/arithmetic-operators.md
@@ -16,7 +16,7 @@ The following table summarizes the binary arithmetic operators that are availabl
 |`+` (addition, plus)|Unchecked. Possible overflow condition when numbers are added together and the sum exceeds the maximum absolute value supported by the type.|
 |`-` (subtraction, minus)|Unchecked. Possible underflow condition when unsigned types are subtracted, or when floating-point values are too small to be represented by the type.|
 |`*` (multiplication, times)|Unchecked. Possible overflow condition when numbers are multiplied and the product exceeds the maximum absolute value supported by the type.|
-|`/` (division, divided by)|Division by zero causes a <xref:System.DivideByZeroException> for integral types. For floating-point types, division by zero gives you the special floating-point values `+Infinity` or `-Infinity`. There is also a possible underflow condition when a floating-point number is too small to be represented by the type.|
+|`/` (division, divided by)|Division by zero causes a <xref:System.DivideByZeroException> for integral types. For floating-point types, division by zero gives you the special floating-point values `infinity` or `-infinity`. There is also a possible underflow condition when a floating-point number is too small to be represented by the type.|
 |`%` (remainder, rem)|Returns the remainder of a division operation. The sign of the result is the same as the sign of the first operand.|
 |`**` (exponentiation, to the power of)|Possible overflow condition when the result exceeds the maximum absolute value for the type.<br /><br />The exponentiation operator works only with floating-point types.|
 


### PR DESCRIPTION
## Summary

I was searching for if F# had infinity values and couldn't find much information. I did find mention of infinity in the [arithmetic operators](https://learn.microsoft.com/en-us/dotnet/fsharp/language-reference/symbol-and-operator-reference/arithmetic-operators) documentation, but the values listed were incorrect, as the actual values are all lowercase. So I started a PR to fix those typos and ended up expanding the pull request to add in a little more detail.

Example of typo issues:

```console
> +Infinity;;

  +Infinity;;
  -^^^^^^^^

stdin(27,2): error FS0039: The value or constructor 'Infinity' is not defined. Maybe you want one of the following:
   infinity
   infinityf

> Infinity;;

  Infinity;;
  ^^^^^^^^

stdin(28,1): error FS0039: The value or constructor 'Infinity' is not defined. Maybe you want one of the following:
   infinity
   infinityf

> infinity;;
val it: float = infinity

> +infinity;;
val it: float = infinity
```

## Changes

In total, the changes are:

1. Fixed typos by changing `+Infinity` and `-Infinity` to `-infinity` and `-infinity`, respectively, in the [F# arithmetic operators documentation](https://learn.microsoft.com/en-us/dotnet/fsharp/language-reference/symbol-and-operator-reference/arithmetic-operators)
2. Added infinity example literals to the [F# literals table](https://learn.microsoft.com/en-us/dotnet/fsharp/language-reference/literals#literal-types)
3. Added a new section in the [F# literals documentation](https://learn.microsoft.com/en-us/dotnet/fsharp/language-reference/literals) describing the literals and their relationships to the corresponding .NET types
4. Updated the dates of the F# arithmetic operators and literals documentation pages that I edited

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/literals.md](https://github.com/dotnet/docs/blob/9513e7534ab2f10de126bb9df7e7ff472f3f4eed/docs/fsharp/language-reference/literals.md) | [Literals](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/literals?branch=pr-en-us-41089) |
| [docs/fsharp/language-reference/symbol-and-operator-reference/arithmetic-operators.md](https://github.com/dotnet/docs/blob/9513e7534ab2f10de126bb9df7e7ff472f3f4eed/docs/fsharp/language-reference/symbol-and-operator-reference/arithmetic-operators.md) | [Arithmetic Operators](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/symbol-and-operator-reference/arithmetic-operators?branch=pr-en-us-41089) |

<!-- PREVIEW-TABLE-END -->