### PR TITLE
grammar correction on options-validation-generator.md file

### DIFF
--- a/docs/core/extensions/options-validation-generator.md
+++ b/docs/core/extensions/options-validation-generator.md
@@ -24,7 +24,7 @@ The following class binds to the `"MyCustomSettingsSection"` configuration secti
 
 :::code source="snippets/configuration/console-validation-gen/SettingsOptions.cs":::
 
-In the preceding `SettingsOptions` class, the `ConfigurationSectionName` property contains the name of the configuration section to bind to. In this scenario, the options object provides the name of its configuration section. The use of the following data annotation attributes are used:
+In the preceding `SettingsOptions` class, the `ConfigurationSectionName` property contains the name of the configuration section to bind to. In this scenario, the options object provides the name of its configuration section. The following data annotation attributes are used:
 
 - <xref:System.ComponentModel.DataAnnotations.RequiredAttribute>: Specifies that the property is required.
 - <xref:System.ComponentModel.DataAnnotations.RegularExpressionAttribute>: Specifies that the property value must match the specified regular expression pattern.


### PR DESCRIPTION
"The use of the following data annotation attributes are used" is changed to "The following data annotation attributes are used"

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
#40545

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/options-validation-generator.md](https://github.com/dotnet/docs/blob/1c5e2da9e538c5a72cbb3329df95409130e058bd/docs/core/extensions/options-validation-generator.md) | [Compile-time options validation source generation](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/options-validation-generator?branch=pr-en-us-41097) |

<!-- PREVIEW-TABLE-END -->