### PR TITLE
Rewrite text for captured primary ctor params

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/instance-constructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/instance-constructors.md
@@ -1,7 +1,7 @@
 ---
 title: "Instance constructors"
 description: Instance constructors in C# create and initialize any instance member variables when you use the new expression to create an instance of a type.
-ms.date: 10/25/2023
+ms.date: 05/29/2024
 helpviewer_keywords:
   - "constructors [C#], instance constructors"
   - "instance constructors [C#]"
@@ -48,9 +48,9 @@ You can add attributes to the synthesized primary constructor method by specifyi
 
 If you don't specify the `method` target, the attribute is placed on the class rather than the method.
 
-In `class` and `struct` types, primary constructor parameters are available anywhere in the body of the type. They can be used as member fields. When a primary constructor parameter is used, the compiler captures the constructor parameter in a private field with a compiler-generated name. If a primary constructor parameter isn't used in the body of the type, no private field is captured. That rule prevents accidentally allocating two copies of a primary constructor parameter that's passed to a base constructor.
+In `class` and `struct` types, primary constructor parameters are available anywhere in the body of the type. The parameter can be implemented as a captured private field. If the only references to a parameter are initializers and constructor calls, that parameter isn't captured in a private field. Uses in other members of the type cause the compiler to capture the parameter in a private field.
 
-If the type includes the `record` modifier, the compiler instead synthesizes a public property with the same name as the primary constructor parameter.  For `record class` types, if a primary constructor parameter uses the same name as a base primary constructor, that property is a public property of the base `record class` type. It isn't duplicated in the derived `record class` type. These properties aren't generated for non-`record` types.
+If the type includes the `record` modifier, the compiler instead synthesizes a public property with the same name as the primary constructor parameter. For `record class` types, if a primary constructor parameter uses the same name as a base primary constructor, that property is a public property of the base `record class` type. It isn't duplicated in the derived `record class` type. These properties aren't generated for non-`record` types.
 
 ## See also
 


### PR DESCRIPTION
Fixes #40656

The original text was confusing.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/classes-and-structs/instance-constructors.md](https://github.com/dotnet/docs/blob/afb065439e8ab6c1e2343aacc778a584fe0cd9cf/docs/csharp/programming-guide/classes-and-structs/instance-constructors.md) | [Instance constructors (C# programming guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/instance-constructors?branch=pr-en-us-41170) |

<!-- PREVIEW-TABLE-END -->