### PR TITLE
Correct typo in regular-expression-source-generators.md - Issue #41176

### DIFF
--- a/docs/standard/base-types/regular-expression-source-generators.md
+++ b/docs/standard/base-types/regular-expression-source-generators.md
@@ -2,7 +2,7 @@
 title: ".NET regular expression source generators"
 description: Learn how to use regular expression source generators to optimize the performance of matching algorithms in .NET.
 ms.topic: conceptual
-ms.date: 04/19/2024
+ms.date: 05/29/2024
 author: IEvangelist
 ms.author: dapine
 zone_pivot_groups: dotnet-version-7-8
@@ -78,7 +78,7 @@ You can set breakpoints in it, you can step through it, and you can use it as a 
 
 ## Inside the source-generated files
 
-With .NET 7, both the source generator and `RegexCompiler` were almost entirely rewritten, fundamentally changing the structure of the generated code. This approach has been extended to handle all constructs (with one caveat), and both `RegexCompiler` and the source generator still map mostly 1:1 with each other, following the new approach. Consider the source generator output for one of the primary functions from the `(a|bc)d` expression:
+With .NET 7, both the source generator and `RegexCompiler` were almost entirely rewritten, fundamentally changing the structure of the generated code. This approach has been extended to handle all constructs (with one caveat), and both `RegexCompiler` and the source generator still map mostly 1:1 with each other, following the new approach. Consider the source generator output for one of the primary functions from the `abc|def` expression:
 
 :::zone pivot="dotnet-8-0"
 


### PR DESCRIPTION
## Summary

Correct the typo in regular-expression-source-generators.md so the described regex pattern matches the example generated code section below it.

Fixes #41176 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/base-types/regular-expression-source-generators.md](https://github.com/dotnet/docs/blob/da9b4970caed312414dd501763f5f373a9f76d71/docs/standard/base-types/regular-expression-source-generators.md) | [.NET regular expression source generators](https://review.learn.microsoft.com/en-us/dotnet/standard/base-types/regular-expression-source-generators?branch=pr-en-us-41181) |

<!-- PREVIEW-TABLE-END -->