### PR TITLE
Updated messaging references in docs

### DIFF
--- a/docs/architecture/maui/communicating-between-components.md
+++ b/docs/architecture/maui/communicating-between-components.md
@@ -21,9 +21,6 @@ The MVVM Toolkit `IMessenger` interface describes the publish-subscribe pattern,
 > [!NOTE]
 > The MVVM Toolkit Messenger is part of the `CommunityToolkit.Mvvm` package. For information on how to add the package to your project, see [Introduction to the MVVM Toolkit](/dotnet/communitytoolkit/mvvm/) on the Microsoft Developer Center.
 
-> [!WARNING]
-> .NET MAUI contains a built-in `MessagingCenter` class which is no longer recommended for use and should be transitioned to the MVVM Toolkit Messenger.
-
 The `IMessenger` interface allows for multicast publish-subscribe functionality. This means that there can be multiple publishers that publish a single message, and there can be multiple subscribers listening to the same message. The image below illustrates this relationship:
 
 ![Multicast publish-subscribe functionality.](./media/messaging-center.png)


### PR DESCRIPTION
Removed warning about deprecated MessagingCenter class and updated references to use WeakReferenceMessenger instead. Adjusted unit testing examples to reflect this change, demonstrating how to test message-based communication with the new messenger class.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/architecture/maui/communicating-between-components.md](https://github.com/dotnet/docs/blob/30392060e60cd255173ac0f2e8287d3e2ae649cb/docs/architecture/maui/communicating-between-components.md) | [Communicating between loosely coupled components](https://review.learn.microsoft.com/en-us/dotnet/architecture/maui/communicating-between-components?branch=pr-en-us-41183) |
| [docs/architecture/maui/unit-testing.md](https://github.com/dotnet/docs/blob/30392060e60cd255173ac0f2e8287d3e2ae649cb/docs/architecture/maui/unit-testing.md) | [Unit Testing](https://review.learn.microsoft.com/en-us/dotnet/architecture/maui/unit-testing?branch=pr-en-us-41183) |

<!-- PREVIEW-TABLE-END -->