### PR TITLE
[QUIC] fix name of parameter

### DIFF
--- a/docs/fundamentals/networking/quic/quic-overview.md
+++ b/docs/fundamentals/networking/quic/quic-overview.md
@@ -321,7 +321,7 @@ await stream.WriteAsync(data, cancellationToken);
 await stream.WriteAsync(data, cancellationToken);
 
 // End the writing-side together with the last data.
-await stream.WriteAsync(data, endStream: true, cancellationToken);
+await stream.WriteAsync(data, completeWrites: true, cancellationToken);
 // Or separately.
 stream.CompleteWrites();
 


### PR DESCRIPTION
Fixed old name of parameter to the current one: https://learn.microsoft.com/en-us/dotnet/api/system.net.quic.quicstream.writeasync?view=net-8.0#system-net-quic-quicstream-writeasync(system-readonlymemory((system-byte))-system-boolean-system-threading-cancellationtoken) @dotnet/ncl



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/networking/quic/quic-overview.md](https://github.com/dotnet/docs/blob/fcebbde9161b0f3b07097ef9987ac20429a7f35e/docs/fundamentals/networking/quic/quic-overview.md) | [QUIC protocol](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview?branch=pr-en-us-41189) |

<!-- PREVIEW-TABLE-END -->