### PR TITLE
[Azure SDK] Dependency injection updates

### DIFF
--- a/docs/azure/sdk/dependency-injection.md
+++ b/docs/azure/sdk/dependency-injection.md
@@ -62,7 +62,7 @@ In the preceding code:
 
 ## Use the registered clients
 
-With the clients registered, as described in the [Register clients and subclients](#register-clients-and-subclients) section, you can now use them. In the following example, [constructor injection](../../core/extensions/dependency-injection.md#constructor-injection-behavior) is used to obtain the Blob Storage client in an ASP.NET Core API controller:
+With the clients registered, as described in the [Register clients and subclients](#register-clients-and-subclients) section, you can now use them. In the following example, [constructor injection](../../core/extensions/dependency-injection.md#constructor-injection-behavior) is used to obtain the Blob Storage client and a factory for Service Bus sender subclients in an ASP.NET Core API controller:
 
 ```csharp
 [ApiController]
@@ -70,10 +70,14 @@ With the clients registered, as described in the [Register clients and subclient
 public class MyApiController : ControllerBase
 {
     private readonly BlobServiceClient _blobServiceClient;
+    private readonly ServiceBusSender _serviceBusSender;
   
-    public MyApiController(BlobServiceClient blobServiceClient)
+    public MyApiController(
+        BlobServiceClient blobServiceClient,
+        IAzureClientFactory<ServiceBusSender> senderFactory)
     {
         _blobServiceClient = blobServiceClient;
+        _serviceBusSender = senderFactory.CreateClient("myQueueName");
     }
   
     [HttpGet]


### PR DESCRIPTION
## Summary

The focus of these changes is to extend the example of client usage to include the pattern for injecting subclients that were registered in an earlier example.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/azure/sdk/dependency-injection.md](https://github.com/dotnet/docs/blob/d6ae7f3ce6c50b8cc3723238655b12d868f345af/docs/azure/sdk/dependency-injection.md) | [Dependency injection with the Azure SDK for .NET](https://review.learn.microsoft.com/en-us/dotnet/azure/sdk/dependency-injection?branch=pr-en-us-41192) |

<!-- PREVIEW-TABLE-END -->