### PR TITLE
Remove note about HTTP extensions

### DIFF
--- a/docs/core/extensions/httpclient-factory.md
+++ b/docs/core/extensions/httpclient-factory.md
@@ -8,7 +8,7 @@ ms.date: 05/19/2023
 
 # IHttpClientFactory with .NET
 
-In this article, you'll learn how to use the `IHttpClientFactory` to create `HttpClient` types with various .NET fundamentals, such as dependency injection (DI), logging, and configuration. The <xref:System.Net.Http.HttpClient> type was introduced in .NET Framework 4.5, which was released in 2012. In other words, it's been around for a while. `HttpClient` is used for making HTTP requests and handling HTTP responses from web resources identified by a <xref:System.Uri>. The HTTP protocol makes up the vast majority of all internet traffic.
+In this article, you'll learn how to use the `IHttpClientFactory` interface to create `HttpClient` types with various .NET fundamentals, such as dependency injection (DI), logging, and configuration. The <xref:System.Net.Http.HttpClient> type was introduced in .NET Framework 4.5, which was released in 2012. In other words, it's been around for a while. `HttpClient` is used for making HTTP requests and handling HTTP responses from web resources identified by a <xref:System.Uri>. The HTTP protocol makes up the vast majority of all internet traffic.
 
 With modern application development principles driving best practices, the <xref:System.Net.Http.IHttpClientFactory> serves as a factory abstraction that can create `HttpClient` instances with custom configurations. <xref:System.Net.Http.IHttpClientFactory> was introduced in .NET Core 2.1. Common HTTP-based .NET workloads can take advantage of resilient and transient-fault-handling third-party middleware with ease.
 

--- a/docs/standard/runtime-libraries-overview.md
+++ b/docs/standard/runtime-libraries-overview.md
@@ -1,33 +1,33 @@
 ---
 title: Runtime libraries overview
 description: Learn what is included in the Runtime libraries section of the table of contents.
-ms.date: 08/24/2021
+ms.date: 05/30/2024
 ---
 # Runtime libraries overview
 
-The [.NET runtime](../core/introduction.md) has an expansive standard set of class libraries, known as [runtime libraries](glossary.md#runtime), [framework libraries](glossary.md#framework-libraries), or the [base class library (BCL)](glossary.md#bcl). In addition, there are extensions to the runtime libraries, provided in NuGet packages.
+The [.NET runtime](../core/introduction.md) has an expansive standard set of class libraries, known as [runtime libraries](glossary.md#runtime), [framework libraries](glossary.md#framework-libraries), or the [base class library (BCL)](glossary.md#bcl). In addition, there are extensions to the runtime libraries, which are provided in NuGet packages.
 
 These libraries provide implementations for many general and app-specific types, algorithms, and utility functionality.
 
 ## Runtime libraries
 
-These libraries provide the foundational types and utility functionality and are the base of all other .NET class libraries. An example is the <xref:System.String?displayProperty=nameWithType> class, which provides APIs for working with strings. Another example is the [serialization libraries](serialization/index.md).
+The runtime libraries provide the foundational types and utility functionality and are the base of all other .NET class libraries. An example is the <xref:System.String?displayProperty=nameWithType> class, which provides APIs for working with strings. Another example is the [serialization libraries](serialization/index.md).
 
 ## Extensions to the runtime libraries
 
-Some libraries are provided in NuGet packages rather than included in the runtime's [shared framework](glossary.md#shared-framework). For example:
+Some libraries are provided in NuGet packages rather than as part of the runtime's [shared framework](glossary.md#shared-framework). These libraries are often made available to apps that target downlevel .NET versions, such as .NET Framework, as well.
 
-| Conceptual content                                                 | NuGet package                                         |
-|--------------------------------------------------------------------|-------------------------------------------------------|
-| [Configuration](../core/extensions/configuration.md)               | [`Microsoft.Extensions.Configuration`][configuration] |
-| [Dependency injection](../core/extensions/dependency-injection.md) | [`Microsoft.Extensions.DependencyInjection`][di]      |
-| [File globbing](../core/extensions/file-globbing.md)               | [`Microsoft.Extensions.FileSystemGlobbing`][fsg]      |
-| [Generic Host](../core/extensions/generic-host.md)                 | [`Microsoft.Extensions.Hosting`][host]                |
-| [HTTP](../core/extensions/httpclient-factory.md)                   | <sup>†</sup> [`Microsoft.Extensions.Http`][http]      |
-| [Localization](../core/extensions/localization.md)                 | [`Microsoft.Extensions.Localization`][loc]            |
-| [Logging](../core/extensions/logging.md)                           | [`Microsoft.Extensions.Logging`][log]                 |
+The following table shows some examples of package-provided libraries.
 
-<sup>†</sup> For some target frameworks, including `net6.0`, these libraries are part of the shared framework and don't need to be installed separately.
+| NuGet package                                         | Conceptual content                                                 |
+|-------------------------------------------------------|--------------------------------------------------------------------|
+| [`Microsoft.Extensions.Configuration`][configuration] | [Configuration](../core/extensions/configuration.md)               |
+| [`Microsoft.Extensions.DependencyInjection`][di]      | [Dependency injection](../core/extensions/dependency-injection.md) |
+| [`Microsoft.Extensions.FileSystemGlobbing`][fsg]      | [File globbing](../core/extensions/file-globbing.md)               |
+| [`Microsoft.Extensions.Hosting`][host]                | [Generic Host](../core/extensions/generic-host.md)                 |
+| [`Microsoft.Extensions.Http`][http]                   | [HTTP](../core/extensions/httpclient-factory.md)                   |
+| [`Microsoft.Extensions.Localization`][loc]            | [Localization](../core/extensions/localization.md)                 |
+| [`Microsoft.Extensions.Logging`][log]                 | [Logging](../core/extensions/logging.md)                           |
 
 [configuration]: https://www.nuget.org/packages/Microsoft.Extensions.Configuration
 [di]: https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection


### PR DESCRIPTION
Fixes #37405

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/httpclient-factory.md](https://github.com/dotnet/docs/blob/bd0f3ac942fe213f539f29c3e15fc61a2059188e/docs/core/extensions/httpclient-factory.md) | [IHttpClientFactory with .NET](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/httpclient-factory?branch=pr-en-us-41197) |
| [docs/standard/runtime-libraries-overview.md](https://github.com/dotnet/docs/blob/bd0f3ac942fe213f539f29c3e15fc61a2059188e/docs/standard/runtime-libraries-overview.md) | [Runtime libraries overview](https://review.learn.microsoft.com/en-us/dotnet/standard/runtime-libraries-overview?branch=pr-en-us-41197) |

<!-- PREVIEW-TABLE-END -->