### PR TITLE
Update VB move example to use my docs instead of c:

### DIFF
--- a/docs/visual-basic/developing-apps/programming/drives-directories-files/how-to-rename-a-file.md
+++ b/docs/visual-basic/developing-apps/programming/drives-directories-files/how-to-rename-a-file.md
@@ -1,51 +1,53 @@
 ---
-description: "Learn more about: How to: Rename a File in Visual Basic"
 title: "How to: Rename a File"
+description: "Learn about how to rename a file with the Visual Basic Runtime Library or the .NET base class library."
 ms.date: 07/20/2015
 helpviewer_keywords: 
-  - "I/O [Visual Basic], renaming files"
-  - "files [Visual Basic], renaming"
+- "I/O [Visual Basic], renaming files"
+- "files [Visual Basic], renaming"
 ms.assetid: 0ea7e0c8-2cb2-4bf5-a00d-7b6e3c08a3bc
 ---
 # How to: Rename a File in Visual Basic
 
-Use the `RenameFile` method of the `My.Computer.FileSystem` object to rename a file by supplying the current location, file name, and the new file name. This method cannot be used to move a file; use the `MoveFile` method to move and rename the file.  
-  
-### To rename a file  
-  
-- Use the `My.Computer.FileSystem.RenameFile` method to rename a file. This example renames the file named `Test.txt` to `SecondTest.txt`.  
-  
-     [!code-vb[VbVbcnMyFileSystem#9](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbcnMyFileSystem/VB/Class1.vb#9)]  
-  
- This code example is also available as an IntelliSense code snippet. In the code snippet picker, the snippet is located in **File system - Processing Drives, Folders, and Files**. For more information, see [Code Snippets](/visualstudio/ide/code-snippets).  
-  
-## Robust Programming  
+In Visual Basic, there are two ways to rename a file. You can use the Visual Basic run-time object `My.Computer.FileSystem` or the .NET provided `System.IO.File` object to rename a file.
 
- The following conditions may cause an exception:  
-  
-- The path is not valid for one of the following reasons: it is a zero-length string, it contains only white space, it contains invalid characters, or it is a device path (starts with \\\\.\\) (<xref:System.ArgumentException>).  
-  
-- `newName` contains path information (<xref:System.ArgumentException>).  
-  
-- The path is not valid because it is `Nothing` (<xref:System.ArgumentNullException>).  
-  
-- `newName` is `Nothing` or an empty string (<xref:System.ArgumentNullException>).  
-  
-- The source file is not valid or does not exist (<xref:System.IO.FileNotFoundException>).  
-  
-- There is an existing file or directory with the name specified in `newName` (<xref:System.IO.IOException>).  
-  
-- The path exceeds the system-defined maximum length (<xref:System.IO.PathTooLongException>).  
-  
-- A file or directory name in the path contains a colon (:) or is in an invalid format (<xref:System.NotSupportedException>).  
-  
-- The user lacks necessary permissions to view the path (<xref:System.Security.SecurityException>).  
-  
-- The user does not have the required permission (<xref:System.UnauthorizedAccessException>).  
-  
+## Rename with .NET
+
+The `System.IO.File` object doesn't contain a method to rename a file, instead, use the `Move` method to "move" the file to the same location but with a different file name. This method can also be used to move the file to a different location with a different name, performing a move and rename together.
+
+The following example renames the file located in the `My Documents` folder from `TextFile.txt` to `NewName.txt`.
+
+:::code language="csharp" source="./snippets/how-to-rename-a-file/Form1.vb" id="BCLRename":::
+
+## Rename with the Visual Basic run-time
+
+Use the `RenameFile` method of the `My.Computer.FileSystem` object to rename a file by supplying the full path to the file and the new file name. This method can't be used to move a file to a different directory. To learn how to move a file, see [How to: Move a File in Visual Basic](how-to-move-a-file.md).
+
+The following example renames the file located in the `My Documents` folder from `TextFile.txt` to `NewName.txt`.
+
+:::code language="csharp" source="./snippets/how-to-rename-a-file/Form1.vb" id="MyRename":::
+
+Visual Studio provides an IntelliSense code snippet that uses `My.Computer.FileSystem.RenameFile`. The snippet is located in **File system - Processing Drives, Folders, and Files**. For more information, see [Code Snippets](/visualstudio/ide/code-snippets).
+
+## Robust Programming
+
+The following conditions might cause an exception:
+
+- The path isn't valid for one of the following reasons: it's a zero-length string, it contains only white space, it contains invalid characters, or it's a device path (starts with \\\\.\\) (<xref:System.ArgumentException>).
+- `newName` contains path information (<xref:System.ArgumentException>).
+- The path isn't valid because it's `Nothing` (<xref:System.ArgumentNullException>).
+- `newName` is `Nothing` or an empty string (<xref:System.ArgumentNullException>).
+- The source file isn't valid or doesn't exist (<xref:System.IO.FileNotFoundException>).
+- There's an existing file or directory with the name specified in `newName` (<xref:System.IO.IOException>).
+- The path exceeds the system-defined maximum length (<xref:System.IO.PathTooLongException>).
+- A file or directory name in the path contains a colon (:) or is in an invalid format (<xref:System.NotSupportedException>).
+- The user lacks necessary permissions to view the path (<xref:System.Security.SecurityException>).
+- The user doesn't have the required permission (<xref:System.UnauthorizedAccessException>).
+
 ## See also
 
 - <xref:Microsoft.VisualBasic.FileIO.FileSystem.RenameFile%2A>
+- <xref:System.IO.File.Move%2A>
 - [How to: Move a File](how-to-move-a-file.md)
 - [Creating, Deleting, and Moving Files and Directories](creating-deleting-and-moving-files-and-directories.md)
 - [How to: Create a Copy of a File in the Same Directory](how-to-create-a-copy-of-a-file-in-the-same-directory.md)

--- a/docs/visual-basic/developing-apps/programming/drives-directories-files/snippets/how-to-rename-a-file/Form1.Designer.vb
+++ b/docs/visual-basic/developing-apps/programming/drives-directories-files/snippets/how-to-rename-a-file/Form1.Designer.vb
@@ -1,0 +1,37 @@
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()>
+Partial Class Form1
+    Inherits System.Windows.Forms.Form
+
+    'Form overrides dispose to clean up the component list.
+    <System.Diagnostics.DebuggerNonUserCode()>
+    Protected Overrides Sub Dispose(ByVal disposing As Boolean)
+        Try
+            If disposing AndAlso components IsNot Nothing Then
+                components.Dispose()
+            End If
+        Finally
+            MyBase.Dispose(disposing)
+        End Try
+    End Sub
+
+    'Required by the Windows Form Designer
+    Private components As System.ComponentModel.IContainer
+
+    'NOTE: The following procedure is required by the Windows Form Designer
+    'It can be modified using the Windows Form Designer.  
+    'Do not modify it using the code editor.
+    <System.Diagnostics.DebuggerStepThrough()>
+    Private Sub InitializeComponent()
+        SuspendLayout()
+        ' 
+        ' Form1
+        ' 
+        AutoScaleDimensions = New SizeF(10.0F, 25.0F)
+        AutoScaleMode = AutoScaleMode.Font
+        ClientSize = New Size(800, 450)
+        Name = "Form1"
+        Text = "Form1"
+        ResumeLayout(False)
+    End Sub
+
+End Class

--- a/docs/visual-basic/developing-apps/programming/drives-directories-files/snippets/how-to-rename-a-file/Form1.resx
+++ b/docs/visual-basic/developing-apps/programming/drives-directories-files/snippets/how-to-rename-a-file/Form1.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema 
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/docs/visual-basic/developing-apps/programming/drives-directories-files/snippets/how-to-rename-a-file/Form1.vb
+++ b/docs/visual-basic/developing-apps/programming/drives-directories-files/snippets/how-to-rename-a-file/Form1.vb
@@ -1,0 +1,26 @@
+﻿Imports System.IO
+
+Public Class Form1
+
+    Sub RenameFileNameMy()
+        '<MyRename>
+        Dim myDocsFolder As String = My.Computer.FileSystem.SpecialDirectories.MyDocuments
+        Dim filePath = System.IO.Path.Combine(myDocsFolder, "TextFile.txt")
+
+        My.Computer.FileSystem.RenameFile(filePath, "NewName.txt")
+        '</MyRename>
+    End Sub
+
+    Sub RenameFileNameBCL()
+
+        '<BCLRename>
+        Dim myDocsFolder As String = My.Computer.FileSystem.SpecialDirectories.MyDocuments
+        Dim filePathSource = System.IO.Path.Combine(myDocsFolder, "TextFile.txt")
+        Dim filePathTarget = System.IO.Path.Combine(myDocsFolder, "NewName.txt")
+
+        System.IO.File.Move(filePathSource, filePathTarget)
+        '</BCLRename>
+
+    End Sub
+
+End Class

--- a/docs/visual-basic/developing-apps/programming/drives-directories-files/snippets/how-to-rename-a-file/Program.vb
+++ b/docs/visual-basic/developing-apps/programming/drives-directories-files/snippets/how-to-rename-a-file/Program.vb
@@ -1,0 +1,11 @@
+﻿Friend Module Program
+
+    <STAThread()>
+    Friend Sub Main(args As String())
+        Application.SetHighDpiMode(HighDpiMode.SystemAware)
+        Application.EnableVisualStyles()
+        Application.SetCompatibleTextRenderingDefault(False)
+        Application.Run(New Form1)
+    End Sub
+
+End Module

--- a/docs/visual-basic/developing-apps/programming/drives-directories-files/snippets/how-to-rename-a-file/how-to-rename-a-file.vbproj
+++ b/docs/visual-basic/developing-apps/programming/drives-directories-files/snippets/how-to-rename-a-file/how-to-rename-a-file.vbproj
@@ -6,7 +6,7 @@
     <RootNamespace>how_to_rename_a_file</RootNamespace>
     <StartupObject>Sub Main</StartupObject>
     <UseWindowsForms>true</UseWindowsForms>
-    <MyType>WindowsForms</MyType>
+    <MyType>WindowsFormsWithCustomSubMain</MyType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/visual-basic/developing-apps/programming/drives-directories-files/snippets/how-to-rename-a-file/how-to-rename-a-file.vbproj
+++ b/docs/visual-basic/developing-apps/programming/drives-directories-files/snippets/how-to-rename-a-file/how-to-rename-a-file.vbproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <RootNamespace>how_to_rename_a_file</RootNamespace>
+    <StartupObject>Sub Main</StartupObject>
+    <UseWindowsForms>true</UseWindowsForms>
+    <MyType>WindowsForms</MyType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Import Include="System.Data" />
+    <Import Include="System.Drawing" />
+    <Import Include="System.Windows.Forms" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

The original example uses C:\ for a file operation, which is blocked when running non-admin. This changes the example to my docs which works under the user account.

- Little fixes to the article.
- Added .NET BCL version of renaming file.
- Updated code with better example.
- Moved code to the ./snippets folder.

Fixes #40319

@BillWagner 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/visual-basic/developing-apps/programming/drives-directories-files/how-to-rename-a-file.md](https://github.com/dotnet/docs/blob/b06ab308e128457223b431ec03500dce5fc04292/docs/visual-basic/developing-apps/programming/drives-directories-files/how-to-rename-a-file.md) | [How to: Rename a File in Visual Basic](https://review.learn.microsoft.com/en-us/dotnet/visual-basic/developing-apps/programming/drives-directories-files/how-to-rename-a-file?branch=pr-en-us-41203) |


<!-- PREVIEW-TABLE-END -->