### PR TITLE
Add tag / label mapping

### DIFF
--- a/quest-config.json
+++ b/quest-config.json
@@ -32,5 +32,11 @@
             "ParentNodeId": 227484
         }
     ],
-    "DefaultParentNode": 227485
+    "DefaultParentNode": 227485,
+    "WorkItemTags": [
+        {
+            "Label": ":checkered_flag: Release: .NET 9",
+            "Tag": "new-feature"
+        }
+    ]
 }


### PR DESCRIPTION
Relies on dotnet/docs-tools#358

This adds an initial set map for GitHub issue labels that should populate Azure DevOps Work item tags.
