### PR TITLE
Add missing 2404 to all ubuntu versions

### DIFF
--- a/docs/core/install/linux-ubuntu-install.md
+++ b/docs/core/install/linux-ubuntu-install.md
@@ -357,7 +357,7 @@ You can install a recent version of _libgdiplus_ by [adding the Mono repository 
 ===== All versions
 -->
 
-::: zone pivot="os-linux-ubuntu-2310,os-linux-ubuntu-2204,os-linux-ubuntu-2004,os-linux-ubuntu-1804,os-linux-ubuntu-1604"
+::: zone pivot="os-linux-ubuntu-2404,os-linux-ubuntu-2310,os-linux-ubuntu-2204,os-linux-ubuntu-2004,os-linux-ubuntu-1804,os-linux-ubuntu-1604"
 
 ## Unsupported versions
 


### PR DESCRIPTION
## Summary

Try to fix Ubuntu page duplicating deps. I think it's a publishing problem. However, I did notice that the moniker was missing from the zone that's supposed to list all versions, so I added it. Hopefully republishing will fix the original error.

@BillWagner 

Fixes #41036


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/linux-ubuntu-install.md](https://github.com/dotnet/docs/blob/0d260a5db5969d425ff17bad77df587fc8f83631/docs/core/install/linux-ubuntu-install.md) | [Install .NET SDK or .NET Runtime on Ubuntu](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu-install?branch=pr-en-us-41208) |

<!-- PREVIEW-TABLE-END -->