### PR TITLE
Fix compilation error.

### DIFF
--- a/docs/architecture/maui/configuration-management.md
+++ b/docs/architecture/maui/configuration-management.md
@@ -51,7 +51,7 @@ Our application will use the `Preferences` class need to implement the `ISetting
 public sealed class SettingsService : ISettingsService
 {
     private const string AccessToken = "access_token";
-    private const string AccessTokenDefault = string.Empty;
+    private const string AccessTokenDefault = "";
 
     private const string IdUseMocks = "use_mocks";
     private const bool UseMocksDefault = true;


### PR DESCRIPTION
## Summary

`private const string AccessTokenDefault = string.Empty;` doesn't compile.

This should also be updated in the Word doc source.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/architecture/maui/configuration-management.md](https://github.com/dotnet/docs/blob/46c8bf482d7c9c3ab3436f2cff96f0fc44542af8/docs/architecture/maui/configuration-management.md) | [Configuration management](https://review.learn.microsoft.com/en-us/dotnet/architecture/maui/configuration-management?branch=pr-en-us-41218) |

<!-- PREVIEW-TABLE-END -->