### PR TITLE
.net 9 is probably not what is meant here

### DIFF
--- a/docs/core/compatibility/core-libraries/8.0/drive-current-dir-paths.md
+++ b/docs/core/compatibility/core-libraries/8.0/drive-current-dir-paths.md
@@ -39,7 +39,7 @@ C:\Program.cs
 
 ## New behavior
 
-Running the same code snippet in .NET 9 and later versions produces output without a separator character in each path.
+Running the same code snippet in .NET 8 and later versions produces output without a separator character in each path.
 
 ```output
 Full path of "C:" is C:\Users\myalias\consoleapps\Program.


### PR DESCRIPTION
This is a .net 7 to 8 breaking changes doc, so it seems like it doesn't mean to say 9

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/core-libraries/8.0/drive-current-dir-paths.md](https://github.com/dotnet/docs/blob/a1bf5481874f51896ca5ad07ced95f150dc86eae/docs/core/compatibility/core-libraries/8.0/drive-current-dir-paths.md) | [Drive's current directory path enumeration](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/8.0/drive-current-dir-paths?branch=pr-en-us-41275) |

<!-- PREVIEW-TABLE-END -->