### PR TITLE
Document .NET 8 changes to `dotnet watch`

### DIFF
--- a/docs/core/tools/dotnet-watch.md
+++ b/docs/core/tools/dotnet-watch.md
@@ -1,7 +1,7 @@
 ---
 title: dotnet watch command
 description: The dotnet watch command is a file watcher that runs a dotnet command when changes in source code are detected.
-ms.date: 11/09/2022
+ms.date: 06/03/2024
 ---
 # dotnet watch
 
@@ -50,13 +50,17 @@ As an alternative to disabling response compression, manually add the browser re
 
 ## Arguments
 
-- **`command`**
+- **`<command>`**
 
-  `dotnet watch` can run any command that is dispatched via the `dotnet` executable, such as built-in CLI commands and global tools. If you can run `dotnet <command>`, you can run `dotnet watch <command>`. If the child command isn't specified, the default is `run` for `dotnet run`.
+  In .NET 7 SDK and earlier, `dotnet watch` can run any command that is dispatched via the `dotnet` executable, such as built-in CLI commands and global tools. If you can run `dotnet <command>`, you can run `dotnet watch <command>`.
 
-- **`forwarded arguments`**
+  In .NET 8 SDK and later, `dotnet watch` can run `dotnet run`, `dotnet build`, or `dotnet test`. Specify `run`, `build`, or `test` for `<command>`.
 
-  Arguments provided after a double dash (` -- `) are passed to the child `dotnet` process. If you're running `dotnet watch run`, these arguments are options for [dotnet run](dotnet-run.md). If you're running `dotnet watch test`, these arguments are options for [dotnet test](dotnet-test.md).
+  If the child command isn't specified, the default is `run` for `dotnet run`.
+
+- **`<forwarded arguments>`**
+
+  Arguments provided after a double dash (` -- `) are passed to the child `dotnet` process. If you're running `dotnet watch run`, these a`rguments are options for [dotnet run](dotnet-run.md). If you're running `dotnet watch test`, these arguments are options for [dotnet test](dotnet-test.md).
 
 ## Options
 

--- a/docs/core/tools/dotnet-watch.md
+++ b/docs/core/tools/dotnet-watch.md
@@ -60,7 +60,7 @@ As an alternative to disabling response compression, manually add the browser re
 
 - **`<forwarded arguments>`**
 
-  Arguments provided after a double dash (` -- `) are passed to the child `dotnet` process. If you're running `dotnet watch run`, these a`rguments are options for [dotnet run](dotnet-run.md). If you're running `dotnet watch test`, these arguments are options for [dotnet test](dotnet-test.md).
+  Arguments provided after a double dash (` -- `) are passed to the child `dotnet` process. If you're running `dotnet watch run`, these arguments are options for [dotnet run](dotnet-run.md). If you're running `dotnet watch test`, these arguments are options for [dotnet test](dotnet-test.md).
 
 ## Options
 


### PR DESCRIPTION
Fixes #41274 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-watch.md](https://github.com/dotnet/docs/blob/bbaca820de64d213cf3bfdae4a63ef4c3801a971/docs/core/tools/dotnet-watch.md) | [dotnet watch](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-watch?branch=pr-en-us-41276) |


<!-- PREVIEW-TABLE-END -->