### PR TITLE
Add alias any type devblog link

### DIFF
--- a/docs/csharp/whats-new/csharp-12.md
+++ b/docs/csharp/whats-new/csharp-12.md
@@ -103,7 +103,7 @@ You can learn more about default parameters on lambda expressions in the article
 
 ## Alias any type
 
-You can use the `using` alias directive to alias any type, not just named types. That means you can create semantic aliases for tuple types, array types, pointer types, or other unsafe types. For more information, see the [feature specification](~/_csharplang/proposals/csharp-12.0/using-alias-types.md).
+You can use the `using` alias directive to alias any type, not just named types. That means you can create semantic aliases for tuple types, array types, pointer types, or other unsafe types. For more information, see the [feature specification](~/_csharplang/proposals/csharp-12.0/using-alias-types.md). For an example refactoring walkthrough, see [Refactor your code using alias any type on the .NET blog](https://devblogs.microsoft.com/dotnet/refactor-your-code-using-alias-any-type/).
 
 ## Inline arrays
 


### PR DESCRIPTION
The description is abstract-descriptive.
The specification is very technical.

Given how verbose the devblog is with a full walkthrough on an example project, I put the reference after, in a separate sentence.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/whats-new/csharp-12.md](https://github.com/dotnet/docs/blob/f2e2b32d7fbe984d8c19f6a60ff1e84e2b0635ea/docs/csharp/whats-new/csharp-12.md) | [What's new in C# 12](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-12?branch=pr-en-us-41293) |

<!-- PREVIEW-TABLE-END -->