### PR TITLE
Add note about unloading Native AOT DLLs

### DIFF
--- a/docs/core/deploying/native-aot/libraries.md
+++ b/docs/core/deploying/native-aot/libraries.md
@@ -11,6 +11,6 @@ ms.date: 04/17/2024
 Publishing .NET class libraries as Native AOT allows creating libraries that can be consumed from non-.NET programming languages. The produced native library is self-contained and doesn't require a .NET runtime to be installed.
 
 > [!NOTE]
-> Only "shared libraries" (also known as DLLs on Windows) are supported. Static libraries are not officially supported and may require compiling Native AOT from source.
+> Only "shared libraries" (also known as DLLs on Windows) are supported. Static libraries are not officially supported and may require compiling Native AOT from source. Unloading Native AOT libraries (via `dlclose` or `FreeLibrary`, for example) is not supported.
 
 Publishing a class library as Native AOT creates a native library that exposes methods of the class library annotated with <xref:System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute> with a non-null `EntryPoint` field. For more information, see the [native library sample](https://github.com/dotnet/samples/tree/main/core/nativeaot/NativeLibrary) available in the dotnet/samples repository on GitHub.


### PR DESCRIPTION
## Summary

Note that unloading Native AOT libraries is not supported.

Fixes https://github.com/dotnet/runtime/issues/103028

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/deploying/native-aot/libraries.md](https://github.com/dotnet/docs/blob/b7b76971cef6161cbf521c4f43fef3e0037b0a97/docs/core/deploying/native-aot/libraries.md) | [Building native libraries](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/libraries?branch=pr-en-us-41303) |

<!-- PREVIEW-TABLE-END -->