### PR TITLE
Add comment about full dumps being supported by single-file and Native AOT app models

### DIFF
--- a/docs/core/diagnostics/collect-dumps-crash.md
+++ b/docs/core/diagnostics/collect-dumps-crash.md
@@ -45,3 +45,5 @@ The following table shows all the values you can use for `DOTNET_DbgMiniDumpType
 |2|`Heap`|A large and relatively comprehensive dump containing module lists, thread lists, all stacks, exception information, handle information, and all memory except for mapped images.|
 |3|`Triage`|Same as `Mini`, but removes personal user information, such as paths and passwords.|
 |4|`Full`|The largest dump containing all memory including the module images.|
+
+Only full dumps are supported by the single-file and Native AOT app models.


### PR DESCRIPTION
Fixes #https://github.com/dotnet/runtime/issues/101957

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/collect-dumps-crash.md](https://github.com/dotnet/docs/blob/3ac0e42a94e13833aced85adce1c2cd9c57b51e4/docs/core/diagnostics/collect-dumps-crash.md) | [Collect dumps on crash](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/collect-dumps-crash?branch=pr-en-us-41314) |

<!-- PREVIEW-TABLE-END -->