### PR TITLE
Fix unit-testing-mstest-sdk.md

### DIFF
--- a/docs/core/testing/unit-testing-mstest-sdk.md
+++ b/docs/core/testing/unit-testing-mstest-sdk.md
@@ -192,8 +192,6 @@ By setting the property `EnablePlaywright` to `true` you can bring all dependenc
 
 When migrating an existing MSTest test project to MSTest SDK, start by replacing the `Sdk="Microsoft.NET.Sdk"` entry at the top of your test project with `Sdk="MSTest.Sdk/3.3.1"`
 
-`Sdk="MSTest.Sdk/3.3.1"`
-
 ```diff
 - Sdk="Microsoft.NET.Sdk"
 + Sdk="MSTest.Sdk"


### PR DESCRIPTION
Drop wrong code block

The whole section was introduced en-block in ec657dffcbf5b2209c95c99149390aefce3ead70.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-mstest-sdk.md](https://github.com/dotnet/docs/blob/02129b3a7cecc4eacde30faa1f6ae70f0473d196/docs/core/testing/unit-testing-mstest-sdk.md) | [MSTest SDK overview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-sdk?branch=pr-en-us-41316) |

<!-- PREVIEW-TABLE-END -->