### PR TITLE
Fix text and formatting in how-to-cancel-a-task-and-its-children.md

### DIFF
--- a/docs/standard/parallel-programming/how-to-cancel-a-task-and-its-children.md
+++ b/docs/standard/parallel-programming/how-to-cancel-a-task-and-its-children.md
@@ -11,27 +11,24 @@ ms.assetid: 08574301-8331-4719-ad50-9cf7f6ff3048
 ---
 # How to: Cancel a Task and Its Children
 
-These examples show how to perform the following tasks:
-  
-1. Create and start a cancelable task.  
-  
-2. Pass a cancellation token to your user delegate and optionally to the task instance.  
-  
-3. Notice and respond to the cancellation request in your user delegate.  
-  
-4. Optionally notice on the calling thread that the task was canceled.  
-  
- The calling thread does not forcibly end the task; it only signals that cancellation is requested. If the task is already running, it is up to the user delegate to notice the request and respond appropriately. If cancellation is requested before the task runs, then the user delegate is never executed and the task object transitions into the Canceled state.  
-  
+This example shows how to perform the following tasks:
+
+1. Create and start a cancelable task.
+2. Pass a cancellation token to your user delegate and optionally to the task instance.
+3. Notice and respond to the cancellation request in your user delegate.
+4. Optionally notice on the calling thread that the task was canceled.
+
+The calling thread does not forcibly end the task; it only signals that cancellation is requested. If the task is already running, it is up to the user delegate to notice the request and respond appropriately. If cancellation is requested before the task runs, then the user delegate is never executed and the task object transitions into the Canceled state.  
+
 ## Example  
 
- This example shows how to terminate a <xref:System.Threading.Tasks.Task> and its children in response to a cancellation request. It also shows that when a user delegate terminates by throwing a <xref:System.Threading.Tasks.TaskCanceledException>, the calling thread can optionally use the <xref:System.Threading.Tasks.Task.Wait%2A> method or <xref:System.Threading.Tasks.Task.WaitAll%2A> method to wait for the tasks to finish. In this case, you must use a `try/catch` block to handle the exceptions on the calling thread.  
-  
- [!code-csharp[TPL_Cancellation#04](../../../samples/snippets/csharp/VS_Snippets_Misc/tpl_cancellation/cs/cancel1.cs#04)]
- [!code-vb[TPL_Cancellation#04](../../../samples/snippets/visualbasic/VS_Snippets_Misc/tpl_cancellation/vb/cancel1.vb#04)]  
-  
- The <xref:System.Threading.Tasks.Task?displayProperty=nameWithType> class is fully integrated with the cancellation model that is based on the <xref:System.Threading.CancellationTokenSource?displayProperty=nameWithType> and <xref:System.Threading.CancellationToken?displayProperty=nameWithType> types. For more information, see [Cancellation in Managed Threads](../threading/cancellation-in-managed-threads.md) and [Task Cancellation](task-cancellation.md).  
-  
+This example shows how to terminate a <xref:System.Threading.Tasks.Task> and its children in response to a cancellation request. It also shows that when a user delegate terminates by throwing a <xref:System.Threading.Tasks.TaskCanceledException>, the calling thread can optionally use the <xref:System.Threading.Tasks.Task.Wait%2A> method or <xref:System.Threading.Tasks.Task.WaitAll%2A> method to wait for the tasks to finish. In this case, you must use a `try/catch` block to handle the exceptions on the calling thread.
+
+[!code-csharp[TPL_Cancellation#04](../../../samples/snippets/csharp/VS_Snippets_Misc/tpl_cancellation/cs/cancel1.cs#04)]
+[!code-vb[TPL_Cancellation#04](../../../samples/snippets/visualbasic/VS_Snippets_Misc/tpl_cancellation/vb/cancel1.vb#04)]
+
+The <xref:System.Threading.Tasks.Task?displayProperty=nameWithType> class is fully integrated with the cancellation model that is based on the <xref:System.Threading.CancellationTokenSource?displayProperty=nameWithType> and <xref:System.Threading.CancellationToken?displayProperty=nameWithType> types. For more information, see [Cancellation in Managed Threads](../threading/cancellation-in-managed-threads.md) and [Task Cancellation](task-cancellation.md).
+
 ## See also
 
 - <xref:System.Threading.CancellationTokenSource?displayProperty=nameWithType>


### PR DESCRIPTION
The page/how-to has only one example for C# and VB respectively. Since the website provides a toggle between the two, it makes more sense to refer to "this example" instead of "these examples" now. The user sees only one example.

* Drop paragraph in each list item
* Drop unnecessary whitespace and unnecessary explicit line breaks


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/parallel-programming/how-to-cancel-a-task-and-its-children.md](https://github.com/dotnet/docs/blob/b02fadc6cf0be42371095d34d61d7d0716ce0f09/docs/standard/parallel-programming/how-to-cancel-a-task-and-its-children.md) | [How to: Cancel a Task and Its Children](https://review.learn.microsoft.com/en-us/dotnet/standard/parallel-programming/how-to-cancel-a-task-and-its-children?branch=pr-en-us-41319) |

<!-- PREVIEW-TABLE-END -->