### PR TITLE
Improve cancel1.cs how-to example

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_cancellation/cs/cancel1.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_cancellation/cs/cancel1.cs
@@ -61,7 +61,7 @@ public class Example
         char ch = Console.ReadKey().KeyChar;
         if (ch == 'c' || ch == 'C')
         {
-            await tokenSource.CancelAsync();
+            tokenSource.Cancel();
             Console.WriteLine("\nMain: Task cancellation requested.");
 
             // Optional: Observe the change in the Status property on the task.


### PR DESCRIPTION
I attempted to fix #27830, but as per my comment there, I don't think the original raised concern is correct. I did make some improvements though, which are present in this changeset I am submitting.

This snippet is being used in "How to: Cancel a Task and Its Children" https://learn.microsoft.com/en-us/dotnet/standard/parallel-programming/how-to-cancel-a-task-and-its-children

The mixed four-fold goals of the how-to make it a complex mixed bag of an example.

* For distinction, label tasks as cancellable, parent, and child - in output and variable names
* Use output prefixes to indicate in which context the message is logged
* Reduce wait spins (it took infeasibly long on my PC)
* Reduce parent spawn-loop-spin-waits so spawning happens faster than child task execution
* Add "ran to completion" messages so execution can be followed and user cancel can be timed and experimented with at runtime
* ~~Use CancelAsync instead of Cancel on tokenSource~~
