### PR TITLE
DateTimePicker.Text breaking change

### DIFF
--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -158,6 +158,7 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 | -------------------------------------------------------------------------------------------------------- | ------------------- |
 | [Anchor layout changes](windows-forms/8.0/anchor-layout.md)                                              | Behavioral change   |
 | [Certs checked before loading remote images in PictureBox](windows-forms/8.0/picturebox-remote-image.md) | Behavioral change   |
+| [DateTimePicker.Text is empty string](windows-forms/8.0/datetimepicker-text.md)                          | Behavioral change   |
 | [DefaultValueAttribute removed from some properties](windows-forms/8.0/defaultvalueattribute-removal.md) | Behavioral change   |
 | [ExceptionCollection ctor throws ArgumentException](windows-forms/8.0/exceptioncollection.md)            | Behavioral change   |
 | [Forms scale according to AutoScaleMode](windows-forms/8.0/top-level-window-scaling.md)                  | Behavioral change   |

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -242,6 +242,8 @@ items:
         href: windows-forms/8.0/anchor-layout.md
       - name: Certs checked before loading remote images in PictureBox
         href: windows-forms/8.0/picturebox-remote-image.md
+      - name: DateTimePicker.Text is empty string
+        href: windows-forms/8.0/datetimepicker-text.md
       - name: DefaultValueAttribute removed from some properties
         href: windows-forms/8.0/defaultvalueattribute-removal.md
       - name: ExceptionCollection ctor throws ArgumentException
@@ -1828,6 +1830,8 @@ items:
         href: windows-forms/8.0/anchor-layout.md
       - name: Certs checked before loading remote images in PictureBox
         href: windows-forms/8.0/picturebox-remote-image.md
+      - name: DateTimePicker.Text is empty string
+        href: windows-forms/8.0/datetimepicker-text.md
       - name: DefaultValueAttribute removed from some properties
         href: windows-forms/8.0/defaultvalueattribute-removal.md
       - name: ExceptionCollection ctor throws ArgumentException

--- a/docs/core/compatibility/windows-forms/8.0/datetimepicker-text.md
+++ b/docs/core/compatibility/windows-forms/8.0/datetimepicker-text.md
@@ -1,0 +1,52 @@
+---
+title: "Breaking change: DateTimePicker.Text is empty string"
+description: Learn about the breaking change in .NET 8 for Windows Forms where the DateTimePicker.Text property is the empty string until a handle to the control is created.
+ms.date: 06/06/2024
+---
+# DateTimePicker.Text is empty string
+
+The <xref:System.Windows.Forms.DateTimePicker.Text> property of the <xref:System.Windows.Forms.DateTimePicker> control is now set to the empty string until a handle to the control is created.
+
+## Version introduced
+
+.NET 8
+
+## Previous behavior
+
+Previously, the <xref:System.Windows.Forms.DateTimePicker.Text?displayProperty=nameWithType> property was available as soon as the <xref:System.Windows.Forms.DateTimePicker> was constructed.
+
+## New behavior
+
+Starting in .NET 8, the <xref:System.Windows.Forms.DateTimePicker.Text?displayProperty=nameWithType> property is the empty string until a handle is created. Once the handle is created, <xref:System.Windows.Forms.DateTimePicker.Text> is set to the date that's currently displayed in the control.
+
+## Change category
+
+This change is a [*behavioral change*](../../categories.md#behavioral-change).
+
+## Reason for change
+
+This change was introduced so that what the narrator (screen reader) announces matches the displayed text.
+
+## Recommended action
+
+If your code is affected by this change, access the `Text` property later on, as shown in the following code snippet.
+
+```csharp
+public partial class Form1 : Form
+{
+    public Form1()
+    {
+        InitializeComponent();
+        Shown += DateTimePicker_Shown;
+    }
+
+    private void DateTimePicker_Shown(object sender, EventArgs e)
+    {
+        string date = this.dateTimePicker1.Text;
+    }
+}
+```
+
+## Affected APIs
+
+- <xref:System.Windows.Forms.DateTimePicker.Text?displayProperty=fullName>


### PR DESCRIPTION
Fixes #41073 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/8.0.md](https://github.com/dotnet/docs/blob/82f86f1e5269df57889175c4d4340d743f85dc1d/docs/core/compatibility/8.0.md) | [Breaking changes in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/8.0?branch=pr-en-us-41328) |
| [docs/core/compatibility/windows-forms/8.0/datetimepicker-text.md](https://github.com/dotnet/docs/blob/82f86f1e5269df57889175c4d4340d743f85dc1d/docs/core/compatibility/windows-forms/8.0/datetimepicker-text.md) | [DateTimePicker.Text is empty string](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/windows-forms/8.0/datetimepicker-text?branch=pr-en-us-41328) |

<!-- PREVIEW-TABLE-END -->