### PR TITLE
Use uppercase String.Contains

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1847.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1847.md
@@ -1,6 +1,6 @@
 ---
 title: "CA1847: Use char literal for a single character lookup"
-description: "Use string.Contains(char) instead of string.Contains(string) when searching for a single character"
+description: "Use String.Contains(char) instead of String.Contains(string) when searching for a single character"
 ms.date: 03/03/2021
 f1_keywords:
   - "CA1847"
@@ -12,23 +12,23 @@ dev_langs:
 - VB
 ---
 
-# CA1847: Use string.Contains(char) instead of string.Contains(string) with single characters
+# CA1847: Use String.Contains(char) instead of String.Contains(string) with single characters
 
 | Property                            | Value                                                                               |
 |-------------------------------------|-------------------------------------------------------------------------------------|
 | **Rule ID**                         | CA1847                                                                              |
-| **Title**                           | Use string.Contains(char) instead of string.Contains(string) with single characters |
+| **Title**                           | Use String.Contains(char) instead of String.Contains(string) with single characters |
 | **Category**                        | [Performance](performance-warnings.md)                                              |
 | **Fix is breaking or non-breaking** | Non-breaking                                                                        |
 | **Enabled by default in .NET 8**    | As suggestion                                                                       |
 
 ## Cause
 
-`string.Contains(string)` is used when `string.Contains(char)` was available.
+`String.Contains(string)` is used when `String.Contains(char)` is available.
 
 ## Rule description
 
-When searching for a single character, using `string.Contains(char)` offers better performance than `string.Contains(string)`.
+When searching for a single character, `String.Contains(char)` offers better performance than `String.Contains(string)`.
 
 ## How to fix violations
 

--- a/docs/fundamentals/code-analysis/quality-rules/index.md
+++ b/docs/fundamentals/code-analysis/quality-rules/index.md
@@ -147,7 +147,7 @@ The following table lists code quality analysis rules.
 > | [CA1844: Provide memory-based overrides of async methods when subclassing 'Stream'](ca1844.md) | To improve performance, override the memory-based async methods when subclassing 'Stream'. Then implement the array-based methods in terms of the memory-based methods. |
 > | [CA1845: Use span-based 'string.Concat'](ca1845.md) | It is more efficient to use `AsSpan` and `string.Concat`, instead of `Substring` and a concatenation operator. |
 > | [CA1846: Prefer `AsSpan` over `Substring`](ca1846.md) | `AsSpan` is more efficient than `Substring`. `Substring` performs an O(n) string copy, while `AsSpan` does not and has a constant cost. `AsSpan` also does not perform any heap allocations. |
-> | [CA1847: Use char literal for a single character lookup](ca1847.md) | Use `string.Contains(char)` instead of `string.Contains(string)` when searching for a single character. |
+> | [CA1847: Use char literal for a single character lookup](ca1847.md) | Use `String.Contains(char)` instead of `String.Contains(string)` when searching for a single character. |
 > | [CA1848: Use the LoggerMessage delegates](ca1848.md) | For improved performance, use the `LoggerMessage` delegates. |
 > | [CA1849: Call async methods when in an async method](ca1849.md) | In a method which is already asynchronous, calls to other methods should be to their async versions, where they exist. |
 > | [CA1850: Prefer static `HashData` method over `ComputeHash`](ca1850.md) | It's more efficient to use the static `HashData` method over creating and managing a `HashAlgorithm` instance to call `ComputeHash`. |

--- a/docs/fundamentals/code-analysis/quality-rules/performance-warnings.md
+++ b/docs/fundamentals/code-analysis/quality-rules/performance-warnings.md
@@ -56,7 +56,7 @@ Performance rules support high-performance libraries and applications.
 | [CA1844: Provide memory-based overrides of async methods when subclassing 'Stream'](ca1844.md) | To improve performance, override the memory-based async methods when subclassing 'Stream'. Then implement the array-based methods in terms of the memory-based methods. |
 | [CA1845: Use span-based 'string.Concat'](ca1845.md) | It is more efficient to use `AsSpan` and `string.Concat`, instead of `Substring` and a concatenation operator. |
 | [CA1846: Prefer `AsSpan` over `Substring`](ca1846.md) | `AsSpan` is more efficient than `Substring`. `Substring` performs an O(n) string copy, while `AsSpan` does not and has a constant cost. `AsSpan` also does not perform any heap allocations. |
-| [CA1847: Use char literal for a single character lookup](ca1847.md) | Use `string.Contains(char)` instead of `string.Contains(string)` when searching for a single character. |
+| [CA1847: Use char literal for a single character lookup](ca1847.md) | Use `String.Contains(char)` instead of `String.Contains(string)` when searching for a single character. |
 | [CA1848: Use the LoggerMessage delegates](ca1848.md) | For improved performance, use the `LoggerMessage` delegates. |
 | [CA1849: Call async methods when in an async method](ca1849.md) | In a method which is already asynchronous, calls to other methods should be to their async versions, where they exist. |
 | [CA1850: Prefer static `HashData` method over `ComputeHash`](ca1850.md) | It's more efficient to use the static `HashData` method over creating and managing a `HashAlgorithm` instance to call `ComputeHash`. |


### PR DESCRIPTION
Fixes #40586.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1847.md](https://github.com/dotnet/docs/blob/01eb35053fdea823bc885d8da8e7db97436d8be3/docs/fundamentals/code-analysis/quality-rules/ca1847.md) | [CA1847: Use String.Contains(char) instead of String.Contains(string) with single characters](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1847?branch=pr-en-us-41329) |
| [docs/fundamentals/code-analysis/quality-rules/index.md](https://github.com/dotnet/docs/blob/01eb35053fdea823bc885d8da8e7db97436d8be3/docs/fundamentals/code-analysis/quality-rules/index.md) | [Code quality rules overview](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/index?branch=pr-en-us-41329) |
| [docs/fundamentals/code-analysis/quality-rules/performance-warnings.md](https://github.com/dotnet/docs/blob/01eb35053fdea823bc885d8da8e7db97436d8be3/docs/fundamentals/code-analysis/quality-rules/performance-warnings.md) | [Performance rules](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/performance-warnings?branch=pr-en-us-41329) |

<!-- PREVIEW-TABLE-END -->