### PR TITLE
Update example to be .NET friendly

### DIFF
--- a/docs/standard/io/how-to-add-or-remove-access-control-list-entries.md
+++ b/docs/standard/io/how-to-add-or-remove-access-control-list-entries.md
@@ -37,4 +37,4 @@ To add or remove access control list (ACL) entries from a file or directory, get
 You must specify a valid user or group account to run this example. The example uses a <xref:System.IO.FileInfo> object. Use the same procedure for the <xref:System.IO.DirectoryInfo> class.
 
 [!code-csharp[IO.File.GetAccessControl-SetAccessControl#1](./snippets/add-remove-acls/csharp/sample.cs#1)]
-[!code-vb[IO.File.GetAccessControl-SetAccessControl#1](./snippets/add-remove-acls/csharp/sample.vb#1)]
+[!code-vb[IO.File.GetAccessControl-SetAccessControl#1](./snippets/add-remove-acls/vb/sample.vb#1)]

--- a/docs/standard/io/how-to-add-or-remove-access-control-list-entries.md
+++ b/docs/standard/io/how-to-add-or-remove-access-control-list-entries.md
@@ -1,42 +1,40 @@
 ---
-description: "Learn more about: How to: Add or remove Access Control List entries (.NET Framework only)"
-title: "How to: Add or remove Access Control List entries (.NET Framework only)"
-ms.date: "01/14/2019"
-dev_langs: 
+description: "Learn more about: How to: Add or remove Access Control List entries"
+title: "How to: Add or remove Access Control List entries"
+ms.date: 06/07/2024
+dev_langs:
   - "csharp"
   - "vb"
-  - "cpp"
-helpviewer_keywords: 
-  - "ACEs [.NET Framework]"
-  - "ACLs [.NET Framework]"
-  - "access control entries [.NET Framework]"
-  - "I/O [.NET Framework], access control list entries"
-  - "access control lists [.NET Framework]"
-ms.assetid: 53758b39-bd9b-4640-bb04-cad5ed8d0abf
+helpviewer_keywords:
+  - "ACEs"
+  - "ACLs"
+  - "access control entries"
+  - "I/O, access control list entries"
+  - "access control lists"
 ---
-# How to: Add or remove Access Control List entries (.NET Framework only)
+# How to: Add or remove access control list entries
 
-To add or remove Access Control List (ACL) entries to or from a file or directory, get the <xref:System.Security.AccessControl.FileSecurity> or <xref:System.Security.AccessControl.DirectorySecurity> object from the file or directory. Modify the object, and then apply it back to the file or directory.  
-  
-## Add or remove an ACL entry from a file  
-  
-1. Call the <xref:System.IO.File.GetAccessControl%2A?displayProperty=nameWithType> method to get a <xref:System.Security.AccessControl.FileSecurity> object that contains the current ACL entries of a file.  
-  
-2. Add or remove ACL entries from the <xref:System.Security.AccessControl.FileSecurity> object returned from step 1.  
-  
-3. To apply the changes, pass the <xref:System.Security.AccessControl.FileSecurity> object to the <xref:System.IO.File.SetAccessControl%2A?displayProperty=nameWithType> method.  
-  
-## Add or remove an ACL entry from a directory  
-  
-1. Call the <xref:System.IO.Directory.GetAccessControl%2A?displayProperty=nameWithType> method to get a <xref:System.Security.AccessControl.DirectorySecurity> object that contains the current ACL entries of a directory.  
-  
-2. Add or remove ACL entries from the <xref:System.Security.AccessControl.DirectorySecurity> object returned from step 1.  
-  
-3. To apply the changes, pass the <xref:System.Security.AccessControl.DirectorySecurity> object to the <xref:System.IO.Directory.SetAccessControl%2A?displayProperty=nameWithType> method.  
-  
-## Example  
+To add or remove access control list (ACL) entries from a file or directory, get the <xref:System.Security.AccessControl.FileSecurity> or <xref:System.Security.AccessControl.DirectorySecurity> object from the file or directory. Modify the object, and then apply it back to the file or directory.
 
- You must use a valid user or group account to run this example. The example uses a <xref:System.IO.File> object. Use the same procedure for the <xref:System.IO.FileInfo>, <xref:System.IO.Directory>, and <xref:System.IO.DirectoryInfo> classes.
+## From a file
 
- [!code-csharp[IO.File.GetAccessControl-SetAccessControl#1](../../../samples/snippets/csharp/VS_Snippets_CLR/IO.File.GetAccessControl-SetAccessControl/CS/sample.cs#1)]
- [!code-vb[IO.File.GetAccessControl-SetAccessControl#1](../../../samples/snippets/visualbasic/VS_Snippets_CLR/IO.File.GetAccessControl-SetAccessControl/VB/sample.vb#1)]  
+1. Call the <xref:System.IO.FileSystemAclExtensions.GetAccessControl(System.IO.FileInfo)?displayProperty=nameWithType> (or, for .NET Framework apps, <xref:System.IO.FileInfo.GetAccessControl%2A?displayProperty=nameWithType>) method to get a <xref:System.Security.AccessControl.FileSecurity> object that contains the current ACL entries of a file.
+
+2. Add or remove ACL entries from the <xref:System.Security.AccessControl.FileSecurity> object obtained in step 1.
+
+3. To apply the changes, pass the <xref:System.Security.AccessControl.FileSecurity> object to the <xref:System.IO.FileSystemAclExtensions.SetAccessControl(System.IO.FileInfo,System.Security.AccessControl.FileSecurity)?displayProperty=nameWithType> (or, for .NET Framework apps, <xref:System.IO.FileInfo.SetAccessControl%2A?displayProperty=nameWithType>) method.
+
+## From a directory
+
+1. Call the <xref:System.IO.FileSystemAclExtensions.GetAccessControl(System.IO.DirectoryInfo)?displayProperty=nameWithType> (or, for .NET Framework apps, <xref:System.IO.DirectoryInfo.GetAccessControl%2A?displayProperty=nameWithType>) method to get a <xref:System.Security.AccessControl.DirectorySecurity> object that contains the current ACL entries of a directory.
+
+2. Add or remove ACL entries from the <xref:System.Security.AccessControl.DirectorySecurity> object obtained in step 1.
+
+3. To apply the changes, pass the <xref:System.Security.AccessControl.DirectorySecurity> object to the <xref:System.IO.FileSystemAclExtensions.SetAccessControl(System.IO.DirectoryInfo,System.Security.AccessControl.DirectorySecurity)?displayProperty=nameWithType> (or, for .NET Framework apps, <xref:System.IO.DirectoryInfo.SetAccessControl%2A?displayProperty=nameWithType>) method.
+
+## Example
+
+You must specify a valid user or group account to run this example. The example uses a <xref:System.IO.FileInfo> object. Use the same procedure for the <xref:System.IO.DirectoryInfo> class.
+
+[!code-csharp[IO.File.GetAccessControl-SetAccessControl#1](./snippets/add-remove-acls/csharp/sample.cs#1)]
+[!code-vb[IO.File.GetAccessControl-SetAccessControl#1](./snippets/add-remove-acls/csharp/sample.vb#1)]

--- a/docs/standard/io/snippets/add-remove-acls/csharp/Project.csproj
+++ b/docs/standard/io/snippets/add-remove-acls/csharp/Project.csproj
@@ -1,0 +1,8 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8-windows</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/docs/standard/io/snippets/add-remove-acls/csharp/sample.cs
+++ b/docs/standard/io/snippets/add-remove-acls/csharp/sample.cs
@@ -1,10 +1,8 @@
-﻿//<SNIPPET1>
+﻿//<Snippet1>
 using System;
 using System.IO;
 using System.Security.AccessControl;
 
-namespace FileSystemExample
-{
     class FileExample
     {
         public static void Main()
@@ -13,15 +11,13 @@ namespace FileSystemExample
             {
                 string fileName = "test.xml";
 
-                Console.WriteLine("Adding access control entry for "
-                    + fileName);
+                Console.WriteLine($"Adding access control entry for {fileName}");
 
                 // Add the access control entry to the file.
                 AddFileSecurity(fileName, @"DomainName\AccountName",
                     FileSystemRights.ReadData, AccessControlType.Allow);
 
-                Console.WriteLine("Removing access control entry from "
-                    + fileName);
+                Console.WriteLine($"Removing access control entry from {fileName}");
 
                 // Remove the access control entry from the file.
                 RemoveFileSecurity(fileName, @"DomainName\AccountName",
@@ -39,35 +35,30 @@ namespace FileSystemExample
         public static void AddFileSecurity(string fileName, string account,
             FileSystemRights rights, AccessControlType controlType)
         {
-
-            // Get a FileSecurity object that represents the
-            // current security settings.
-            FileSecurity fSecurity = File.GetAccessControl(fileName);
+            FileInfo fileInfo = new(fileName);
+            FileSecurity fSecurity = fileInfo.GetAccessControl();
 
             // Add the FileSystemAccessRule to the security settings.
             fSecurity.AddAccessRule(new FileSystemAccessRule(account,
                 rights, controlType));
 
             // Set the new access settings.
-            File.SetAccessControl(fileName, fSecurity);
+            fileInfo.SetAccessControl(fSecurity);
         }
 
         // Removes an ACL entry on the specified file for the specified account.
         public static void RemoveFileSecurity(string fileName, string account,
             FileSystemRights rights, AccessControlType controlType)
         {
-
-            // Get a FileSecurity object that represents the
-            // current security settings.
-            FileSecurity fSecurity = File.GetAccessControl(fileName);
+            FileInfo fileInfo = new(fileName);
+            FileSecurity fSecurity = fileInfo.GetAccessControl();
 
             // Remove the FileSystemAccessRule from the security settings.
             fSecurity.RemoveAccessRule(new FileSystemAccessRule(account,
                 rights, controlType));
 
             // Set the new access settings.
-            File.SetAccessControl(fileName, fSecurity);
+            fileInfo.SetAccessControl(fSecurity);
         }
-    }
 }
-//</SNIPPET1>
+//</Snippet1>

--- a/docs/standard/io/snippets/add-remove-acls/vb/Project.vbproj
+++ b/docs/standard/io/snippets/add-remove-acls/vb/Project.vbproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/docs/standard/io/snippets/add-remove-acls/vb/sample.vb
+++ b/docs/standard/io/snippets/add-remove-acls/vb/sample.vb
@@ -1,8 +1,6 @@
-﻿'<SNIPPET1>
+﻿'<Snippet1>
 Imports System.IO
 Imports System.Security.AccessControl
-
-
 
 Module FileExample
 
@@ -13,13 +11,13 @@ Module FileExample
             Console.WriteLine("Adding access control entry for " & fileName)
 
             ' Add the access control entry to the file.
-            AddFileSecurity(fileName, "DomainName\AccountName", _
+            AddFileSecurity(fileName, "DomainName\AccountName",
                 FileSystemRights.ReadData, AccessControlType.Allow)
 
             Console.WriteLine("Removing access control entry from " & fileName)
 
             ' Remove the access control entry from the file.
-            RemoveFileSecurity(fileName, "DomainName\AccountName", _
+            RemoveFileSecurity(fileName, "DomainName\AccountName",
                 FileSystemRights.ReadData, AccessControlType.Allow)
 
             Console.WriteLine("Done.")
@@ -29,42 +27,37 @@ Module FileExample
 
     End Sub
 
-
     ' Adds an ACL entry on the specified file for the specified account.
-    Sub AddFileSecurity(ByVal fileName As String, ByVal account As String, _
+    Sub AddFileSecurity(ByVal fileName As String, ByVal account As String,
         ByVal rights As FileSystemRights, ByVal controlType As AccessControlType)
 
-        ' Get a FileSecurity object that represents the 
-        ' current security settings.
-        Dim fSecurity As FileSecurity = File.GetAccessControl(fileName)
+        Dim fileInfo As New FileInfo(fileName)
+        Dim fSecurity As FileSecurity = fileInfo.GetAccessControl()
 
         ' Add the FileSystemAccessRule to the security settings. 
-        Dim accessRule As FileSystemAccessRule = _
-            New FileSystemAccessRule(account, rights, controlType)
+        Dim accessRule As New FileSystemAccessRule(account, rights, controlType)
 
         fSecurity.AddAccessRule(accessRule)
 
         ' Set the new access settings.
-        File.SetAccessControl(fileName, fSecurity)
+        fileInfo.SetAccessControl(fSecurity)
 
     End Sub
 
-
     ' Removes an ACL entry on the specified file for the specified account.
-    Sub RemoveFileSecurity(ByVal fileName As String, ByVal account As String, _
+    Sub RemoveFileSecurity(ByVal fileName As String, ByVal account As String,
         ByVal rights As FileSystemRights, ByVal controlType As AccessControlType)
 
-        ' Get a FileSecurity object that represents the 
-        ' current security settings.
-        Dim fSecurity As FileSecurity = File.GetAccessControl(fileName)
+        Dim fileInfo As New FileInfo(fileName)
+        Dim fSecurity As FileSecurity = fileInfo.GetAccessControl()
 
         ' Remove the FileSystemAccessRule from the security settings. 
-        fSecurity.RemoveAccessRule(New FileSystemAccessRule(account, _
+        fSecurity.RemoveAccessRule(New FileSystemAccessRule(account,
             rights, controlType))
 
         ' Set the new access settings.
-        File.SetAccessControl(fileName, fSecurity)
+        fileInfo.SetAccessControl(fSecurity)
 
     End Sub
 End Module
-'</SNIPPET1>
+'</Snippet1>


### PR DESCRIPTION
Contributes to dotnet/dotnet-api-docs#9865.
This example should have been updated to be .NET-friendly as part of #10001.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/io/how-to-add-or-remove-access-control-list-entries.md](https://github.com/dotnet/docs/blob/31f066f0168f529b472953bc04c2f27e091266a5/docs/standard/io/how-to-add-or-remove-access-control-list-entries.md) | [How to: Add or remove access control list entries](https://review.learn.microsoft.com/en-us/dotnet/standard/io/how-to-add-or-remove-access-control-list-entries?branch=pr-en-us-41343) |


<!-- PREVIEW-TABLE-END -->