### PR TITLE
Fix number formatting

### DIFF
--- a/docs/machine-learning/tutorials/snippets/predict-prices/csharp/Program.cs
+++ b/docs/machine-learning/tutorials/snippets/predict-prices/csharp/Program.cs
@@ -82,7 +82,7 @@ void Evaluate(MLContext mlContext, ITransformer model)
     Console.WriteLine($"*       RSquared Score:      {metrics.RSquared:0.##}");
     // </Snippet18>
     // <Snippet19>
-    Console.WriteLine($"*       Root Mean Squared Error:      {metrics.RootMeanSquaredError:#.##}");
+    Console.WriteLine($"*       Root Mean Squared Error:      {metrics.RootMeanSquaredError:0.##}");
     // </Snippet19>
     Console.WriteLine($"*************************************************");
 }


### PR DESCRIPTION
## Summary

Currently when `metrics.RootMeanSquaredError = 0` it'll not print that value

