### PR TITLE
Present the full `ShowConsoleAnimation` method in Top-level statements tutorial

### DIFF
--- a/docs/csharp/tutorials/snippets/top-level-statements/Utilities.cs
+++ b/docs/csharp/tutorials/snippets/top-level-statements/Utilities.cs
@@ -7,19 +7,19 @@ public static class Utilities
 {
     public static async Task ShowConsoleAnimation()
     {
+        // <Animation>
         string[] animations = ["| -", "/ \\", "- |", "\\ /"];
         for (int i = 0; i < 20; i++)
         {
-            // <Animation>
             foreach (string s in animations)
             {
                 Console.Write(s);
                 await Task.Delay(50);
                 Console.Write("\b\b\b");
             }
-            // </Animation>
         }
         Console.WriteLine();
+        // </Animation>
     }
 }
 

--- a/docs/csharp/tutorials/snippets/top-level-statements/Utilities.cs
+++ b/docs/csharp/tutorials/snippets/top-level-statements/Utilities.cs
@@ -5,9 +5,9 @@ namespace MyNamespace;
 
 public static class Utilities
 {
+    // <Animation>
     public static async Task ShowConsoleAnimation()
     {
-        // <Animation>
         string[] animations = ["| -", "/ \\", "- |", "\\ /"];
         for (int i = 0; i < 20; i++)
         {
@@ -19,7 +19,7 @@ public static class Utilities
             }
         }
         Console.WriteLine();
-        // </Animation>
     }
+    // </Animation>
 }
 

--- a/docs/csharp/tutorials/top-level-statements.md
+++ b/docs/csharp/tutorials/top-level-statements.md
@@ -198,7 +198,7 @@ The preceding code creates a local function inside your main method. That's stil
 
 A file that has top-level statements can also contain namespaces and types at the end of the file, after the top-level statements. But for this tutorial you put the animation method in a separate file to make it more readily reusable.
 
-Finally, you can clean the animation code to remove some duplication:
+Finally, you can clean the animation code to remove some duplication, by using `foreach` loop to iterate through set of animations elements defined in `animations` array:
 
 :::code language="csharp" source="snippets/top-level-statements/Utilities.cs" ID="Animation":::
 

--- a/docs/csharp/tutorials/top-level-statements.md
+++ b/docs/csharp/tutorials/top-level-statements.md
@@ -198,7 +198,8 @@ The preceding code creates a local function inside your main method. That's stil
 
 A file that has top-level statements can also contain namespaces and types at the end of the file, after the top-level statements. But for this tutorial you put the animation method in a separate file to make it more readily reusable.
 
-Finally, you can clean the animation code to remove some duplication, by using `foreach` loop to iterate through set of animations elements defined in `animations` array:
+Finally, you can clean the animation code to remove some duplication, by using `foreach` loop to iterate through set of animations elements defined in `animations` array.
+<br/>The full `ShowConsoleAnimation` method after refactor should look similar to the following:
 
 :::code language="csharp" source="snippets/top-level-statements/Utilities.cs" ID="Animation":::
 


### PR DESCRIPTION
This pull request closes #41313 
It changes what is presented in the part of refactoring the utility method of top-level statements tutorial.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/tutorials/top-level-statements.md](https://github.com/dotnet/docs/blob/49b9ce001c5949a20e4b01dba58cc31281c07d05/docs/csharp/tutorials/top-level-statements.md) | [Tutorial: Explore ideas using top-level statements to build code as you learn](https://review.learn.microsoft.com/en-us/dotnet/csharp/tutorials/top-level-statements?branch=pr-en-us-41352) |

<!-- PREVIEW-TABLE-END -->