### PR TITLE
Link EF Core metrics documentation

### DIFF
--- a/docs/core/diagnostics/built-in-metrics.md
+++ b/docs/core/diagnostics/built-in-metrics.md
@@ -14,4 +14,4 @@ see the [EventCounters reference](available-counters.md) and [Windows Performanc
 - [.NET extensions metrics](built-in-metrics-diagnostics.md)
 - [ASP.NET Core Metrics](built-in-metrics-aspnetcore.md)
 - [System.Net Metrics](built-in-metrics-system-net.md)
-- [Entity Framework Core Metrics](../../../ef/core/logging-events-diagnostics/metrics)
+- [Entity Framework Core Metrics](/ef/core/logging-events-diagnostics/metrics)

--- a/docs/core/diagnostics/built-in-metrics.md
+++ b/docs/core/diagnostics/built-in-metrics.md
@@ -14,3 +14,4 @@ see the [EventCounters reference](available-counters.md) and [Windows Performanc
 - [.NET extensions metrics](built-in-metrics-diagnostics.md)
 - [ASP.NET Core Metrics](built-in-metrics-aspnetcore.md)
 - [System.Net Metrics](built-in-metrics-system-net.md)
+- [Entity Framework Core Metrics](../../../ef/core/logging-events-diagnostics/metrics)


### PR DESCRIPTION
After https://github.com/dotnet/EntityFramework.Docs/pull/4743 is merged, this can be merged.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/built-in-metrics.md](https://github.com/dotnet/docs/blob/031010d558deefe1f6a6287580e395bae5f1632e/docs/core/diagnostics/built-in-metrics.md) | [Built-in metrics in .NET](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/built-in-metrics?branch=pr-en-us-41361) |


<!-- PREVIEW-TABLE-END -->