### PR TITLE
remove repeated statement

### DIFF
--- a/docs/csharp/linq/standard-query-operators/index.md
+++ b/docs/csharp/linq/standard-query-operators/index.md
@@ -13,7 +13,7 @@ Most of these methods operate on sequences, where a sequence is an object whose 
 
 The distinction between <xref:System.Collections.Generic.IEnumerable%601> and <xref:System.Linq.IQueryable%601> sequences determines how the query is executed at runtime.
 
-For `IEnumerable<T>`, the returned enumerable object captures the arguments that were passed to the method. The returned enumerable object captures the arguments that were passed to the method. When that object is enumerated, the logic of the query operator is employed and the query results are returned.
+For `IEnumerable<T>`, the returned enumerable object captures the arguments that were passed to the method. When that object is enumerated, the logic of the query operator is employed and the query results are returned.
 
 For `IQueryable<T>`, the query is translated into an [expression tree](../../advanced-topics/expression-trees/index.md). The expression tree can be translated to a native query when the data source can optimize the query. Libraries such as [Entity Framework](/ef/core/) translate LINQ queries into native SQL queries that execute at the database.
 


### PR DESCRIPTION
## Summary

remove the duplicated "the returned enumerable object captures the arguments that were passed to the method"


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/linq/standard-query-operators/index.md](https://github.com/dotnet/docs/blob/b1c5037b8c8846c72140edf88198b0a0768ce865/docs/csharp/linq/standard-query-operators/index.md) | [Standard Query Operators Overview](https://review.learn.microsoft.com/en-us/dotnet/csharp/linq/standard-query-operators/index?branch=pr-en-us-41367) |

<!-- PREVIEW-TABLE-END -->