### PR TITLE
fix warnings number for f# index notation

### DIFF
--- a/docs/fsharp/language-reference/members/indexed-properties.md
+++ b/docs/fsharp/language-reference/members/indexed-properties.md
@@ -51,7 +51,7 @@ The syntax for accessing a non-default indexed property is to provide the name o
 
 Regardless of which form you use, you should always use the curried form for the set method on an indexed property. For information about curried functions, see [Functions](../functions/index.md).
 
-Prior to F# 6, the syntax `expr.[idx]` was used for indexing. You can activate an optional informational warning (`/warnon:3566` or property `<WarnOn>3566</WarnOn>`) to report uses of the `expr.[idx]` notation.
+Prior to F# 6, the syntax `expr.[idx]` was used for indexing. You can activate an optional informational warning (`/warnon:3366` or property `<WarnOn>3366</WarnOn>`) to report uses of the `expr.[idx]` notation.
 
 ## Example
 

--- a/docs/fsharp/whats-new/fsharp-6.md
+++ b/docs/fsharp/whats-new/fsharp-6.md
@@ -63,7 +63,7 @@ F# 6 allows the syntax `expr[idx]` for indexing and slicing collections.
 
 Up to and including F# 5, F# has used `expr.[idx]` as indexing syntax. Allowing the use of `expr[idx]` is based on repeated feedback from those learning F# or seeing F# for the first time that the use of dot-notation indexing comes across as an unnecessary divergence from standard industry practice.
 
-This is not a breaking change because by default, no warnings are emitted on the use of `expr.[idx]`. However, some informational messages that suggest code clarifications are emitted. You can optionally activate further informational messages as well. For example, you can activate an optional informational warning (`/warnon:3566`) to start reporting uses of the `expr.[idx]` notation. For more information, see [Indexer Notation]( https://aka.ms/fsharp-index-notation).
+This is not a breaking change because by default, no warnings are emitted on the use of `expr.[idx]`. However, some informational messages that suggest code clarifications are emitted. You can optionally activate further informational messages as well. For example, you can activate an optional informational warning (`/warnon:3366`) to start reporting uses of the `expr.[idx]` notation. For more information, see [Indexer Notation]( https://aka.ms/fsharp-index-notation).
 
 In new code, we recommend the systematic use of `expr[idx]` as the indexing syntax.
 


### PR DESCRIPTION
## Summary

Corrects an incorrect warning number for deprecated fsharp index notation.

Fixes #38515


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/members/indexed-properties.md](https://github.com/dotnet/docs/blob/4fdec00068eeb963b89b4af9ad94d3e777542299/docs/fsharp/language-reference/members/indexed-properties.md) | [Indexed Properties](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/members/indexed-properties?branch=pr-en-us-41412) |
| [docs/fsharp/whats-new/fsharp-6.md](https://github.com/dotnet/docs/blob/4fdec00068eeb963b89b4af9ad94d3e777542299/docs/fsharp/whats-new/fsharp-6.md) | [What's new in F# 6 - F# Guide](https://review.learn.microsoft.com/en-us/dotnet/fsharp/whats-new/fsharp-6?branch=pr-en-us-41412) |

<!-- PREVIEW-TABLE-END -->