### PR TITLE
Remove the code mark wrap from the 'using' word in reusable components in Blazor article

### DIFF
--- a/docs/architecture/blazor-for-web-forms-developers/components.md
+++ b/docs/architecture/blazor-for-web-forms-developers/components.md
@@ -269,7 +269,7 @@ public partial class Counter : System.Web.UI.UserControl
 }
 ```
 
-In Blazor, you can register handlers for DOM UI events directly `using` directive attributes of the form `@on{event}`. The `{event}` placeholder represents the name of the event. For example, you can listen for button clicks like this:
+In Blazor, you can register handlers for DOM UI events directly using directive attributes of the form `@on{event}`. The `{event}` placeholder represents the name of the event. For example, you can listen for button clicks like this:
 
 ```razor
 <button @onclick="OnClick">Click me!</button>


### PR DESCRIPTION
This small pull request fixes #41419 
It basically removes the code marks from the "using" word so to make the sentence be correct.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/architecture/blazor-for-web-forms-developers/components.md](https://github.com/dotnet/docs/blob/3563e9ec7dfbcee63fc198d80df24e2537aa5274/docs/architecture/blazor-for-web-forms-developers/components.md) | [Build reusable UI components with Blazor](https://review.learn.microsoft.com/en-us/dotnet/architecture/blazor-for-web-forms-developers/components?branch=pr-en-us-41424) |

<!-- PREVIEW-TABLE-END -->