### PR TITLE
Remove note that uninstall tool doesn't support .NET 8

### DIFF
--- a/docs/core/install/remove-runtime-sdk-versions.md
+++ b/docs/core/install/remove-runtime-sdk-versions.md
@@ -144,9 +144,6 @@ sudo rm -rf /usr/local/share/dotnet/sdk/6.0.406
 
 The [.NET Uninstall Tool](../additional-tools/uninstall-tool.md) (`dotnet-core-uninstall`) lets you remove .NET SDKs and runtimes from a system. A collection of options is available to specify which versions should be uninstalled.
 
-> [!NOTE]
-> Currently, the .NET Uninstall Tool doesn't support .NET 8+. For more information about the release schedule of the tool, see [GitHub - dotnet-uninstall-tool Roadmap](https://github.com/dotnet/cli-lab/issues/279).
-
 ::: zone pivot="os-windows"
 
 ## Visual Studio dependency on .NET SDK versions


### PR DESCRIPTION
## Summary

Remove note that uninstall tool doesn't support .NET 8

Fixes #41331


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/remove-runtime-sdk-versions.md](https://github.com/dotnet/docs/blob/2467b82f69066bd2dfd61f1d4fbb2751833eb861/docs/core/install/remove-runtime-sdk-versions.md) | [How to remove the .NET Runtime and SDK](https://review.learn.microsoft.com/en-us/dotnet/core/install/remove-runtime-sdk-versions?branch=pr-en-us-41435) |

<!-- PREVIEW-TABLE-END -->