### PR TITLE
Add a remark about `IEqualityComparer` not being supported in 'group' syntax

### DIFF
--- a/docs/csharp/language-reference/keywords/group-clause.md
+++ b/docs/csharp/language-reference/keywords/group-clause.md
@@ -80,6 +80,8 @@ This example shows how to perform additional logic on the groups after you have 
 
 At compile time, `group` clauses are translated into calls to the <xref:System.Linq.Enumerable.GroupBy%2A> method.
 
+Custom equality comparer is not supported in the syntax of `group` clause query. Use <xref:System.Linq.Enumerable.GroupBy%2A> method explicitly if you want to utilize <xref:System.Collections.IEqualityComparer> in your query.
+
 ## See also
 
 - <xref:System.Linq.IGrouping%602>


### PR DESCRIPTION
This pull request closes #41353 
It adds a remark to the "Remarks" section about the need to use `GroupBy` explicitly for having custom equality comparer.

The issue mentions examples not including that information, however, I didn't find any example suitable for adding that remark or the code, so I didn't want to include it being out of the context, hence putting it in remarks.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/group-clause.md](https://github.com/dotnet/docs/blob/66f626d56b9aa990693ab209ad2b8d8a463e0257/docs/csharp/language-reference/keywords/group-clause.md) | [group clause (C# Reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/group-clause?branch=pr-en-us-41449) |

<!-- PREVIEW-TABLE-END -->