### PR TITLE
Update streams-programming-apis.md

### DIFF
--- a/docs/orleans/streaming/streams-programming-apis.md
+++ b/docs/orleans/streaming/streams-programming-apis.md
@@ -217,11 +217,10 @@ public async override Task OnActivateAsync(CancellationToken cancellationToken)
     var stream = streamProvider.GetStream<string>(streamId);
 
     var subscriptionHandles = await stream.GetAllSubscriptionHandles();
-    if (!subscriptionHandles.IsNullOrEmpty())
+    foreach (var handle in subscriptionHandles)
     {
-        subscriptionHandles.ForEach(
-            async x => await x.ResumeAsync(OnNextAsync));
-    }
+       await handle.ResumeAsync(this);
+    } 
 }
 ```
 


### PR DESCRIPTION
## Summary
The `subscriptionHandles` implements the `IList` interface which doesn't expose the ForEach method. So I changed it to use the `foreach` statement


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/streaming/streams-programming-apis.md](https://github.com/dotnet/docs/blob/9717299a186cd0a09e13a485f21c2e2012c9c3f0/docs/orleans/streaming/streams-programming-apis.md) | [Orleans streaming APIs](https://review.learn.microsoft.com/en-us/dotnet/orleans/streaming/streams-programming-apis?branch=pr-en-us-41452) |

<!-- PREVIEW-TABLE-END -->