### PR TITLE
Fix language for TrimMode examples

### DIFF
--- a/docs/core/deploying/trimming/trimming-options.md
+++ b/docs/core/deploying/trimming/trimming-options.md
@@ -45,13 +45,13 @@ This setting also enables the trim-compatibility [Roslyn analyzer](#roslyn-analy
 
 Use the `TrimMode` property to set the trimming granularity to either `partial` or `full`. The default setting for console apps (and, starting in .NET 8, Web SDK apps) is `full`:
 
-```csharp
+```xml
 <TrimMode>full</TrimMode>
 ```
 
 To only trim assemblies that have opted-in to trimming, set the property to `partial`:
 
-```csharp
+```xml
 <TrimMode>partial</TrimMode>
 ```
 


### PR DESCRIPTION
Fix language for `TrimMode` examples.
Fixes https://github.com/dotnet/docs/issues/41469

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/deploying/trimming/trimming-options.md](https://github.com/dotnet/docs/blob/1ac0d4dc7cb7f602c0386c0b9c5c2543dd5243ae/docs/core/deploying/trimming/trimming-options.md) | [Trimming options](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trimming-options?branch=pr-en-us-41470) |

<!-- PREVIEW-TABLE-END -->