### PR TITLE
Add collection expressions to the list of disallowed features

### DIFF
--- a/docs/csharp/advanced-topics/expression-trees/index.md
+++ b/docs/csharp/advanced-topics/expression-trees/index.md
@@ -54,6 +54,7 @@ Expression trees won't support new expression node types. It would be a breaking
 - [`dynamic` operations](../../language-reference/builtin-types/reference-types.md#the-dynamic-type)
 - [Coalescing operators with `null` or `default` literal left side, null coalescing assignment](../../language-reference/operators/assignment-operator.md#null-coalescing-assignment), and the [null propagating operator (`?.`)](../../language-reference/operators/null-coalescing-operator.md)
 - [Multi-dimensional array initializers](../../language-reference/builtin-types/arrays.md#multidimensional-arrays), [indexed properties, and dictionary initializers](../../programming-guide/classes-and-structs/object-and-collection-initializers.md#collection-initializers)
+- [Collection expressions](../../language-reference/operators/collection-expressions.md)
 - [`throw` expressions](../../language-reference/statements/exception-handling-statements.md#the-throw-expression)
 - Accessing [`static virtual` or `abstract` interface members](../../language-reference/keywords/interface.md#static-abstract-and-virtual-members)
 - Lambda expressions that have [attributes](../../language-reference/operators/lambda-expressions.md#attributes)


### PR DESCRIPTION
Collection expressions aren't allowed in expression trees. I missed adding this in the updates on collection expressions.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/advanced-topics/expression-trees/index.md](https://github.com/dotnet/docs/blob/2fa2d035550a94bbc2c280a56b36487ec3d90e64/docs/csharp/advanced-topics/expression-trees/index.md) | [Expression Trees](https://review.learn.microsoft.com/en-us/dotnet/csharp/advanced-topics/expression-trees/index?branch=pr-en-us-41496) |

<!-- PREVIEW-TABLE-END -->