### PR TITLE
Fix link

### DIFF
--- a/docs/csharp/advanced-topics/interop/using-type-dynamic.md
+++ b/docs/csharp/advanced-topics/interop/using-type-dynamic.md
@@ -61,6 +61,6 @@ Many COM methods allow for variation in argument types and return type by design
 
 |Title|Description|
 |-----------|-----------------|
-|[dynamic](../../language-reference/builtin-types/reference-types.md)|Describes the usage of the `dynamic` keyword.|
+|[dynamic](../../language-reference/builtin-types/reference-types.md#the-dynamic-type)|Describes the usage of the `dynamic` keyword.|
 |[Dynamic Language Runtime Overview](../../../framework/reflection-and-codedom/dynamic-language-runtime-overview.md)|Provides an overview of the DLR, which is a runtime environment that adds a set of services for dynamic languages to the common language runtime (CLR).|
 |[Walkthrough: Creating and Using Dynamic Objects](walkthrough-creating-and-using-dynamic-objects.md)|Provides step-by-step instructions for creating a custom dynamic object and for creating a project that accesses an `IronPython` library.|


### PR DESCRIPTION
The anchor was missing on the link for `dynamic`


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/advanced-topics/interop/using-type-dynamic.md](https://github.com/dotnet/docs/blob/3719d8593c4f28c28fbc5fbfb573df034b8b4f9c/docs/csharp/advanced-topics/interop/using-type-dynamic.md) | [Using type dynamic](https://review.learn.microsoft.com/en-us/dotnet/csharp/advanced-topics/interop/using-type-dynamic?branch=pr-en-us-41508) |

<!-- PREVIEW-TABLE-END -->