### PR TITLE
Describe .NET 9 logger message generator support for loggers in primary constructor parameters

### DIFF
--- a/docs/core/extensions/logger-message-generator.md
+++ b/docs/core/extensions/logger-message-generator.md
@@ -1,7 +1,7 @@
 ---
 title: Compile-time logging source generation
 description: Learn how to use the LoggerMessageAttribute and compile-time source generation for logging in .NET.
-ms.date: 10/11/2023
+ms.date: 06/21/2024
 ---
 
 # Compile-time logging source generation
@@ -59,6 +59,21 @@ public partial class InstanceLoggingExample
     public partial void CouldNotOpenSocket(string hostName);
 }
 ```
+
+Starting with .NET 9, the logging method can additionally get the logger from an `ILogger` primary constructor parameter in the containing class.
+
+```csharp
+public partial class InstanceLoggingExample(ILogger logger)
+{
+    [LoggerMessage(
+        EventId = 0,
+        Level = LogLevel.Critical,
+        Message = "Could not open socket to `{HostName}`")]
+    public partial void CouldNotOpenSocket(string hostName);
+}
+```
+
+If there is both an `ILogger` field and a primary constructor parameter, the logging method will get the logger from the field.
 
 Sometimes, the log level needs to be dynamic rather than statically built into the code. You can do this by omitting the log level from the attribute and instead requiring it as a parameter to the logging method.
 

--- a/docs/fundamentals/syslib-diagnostics/source-generator-overview.md
+++ b/docs/fundamentals/syslib-diagnostics/source-generator-overview.md
@@ -46,7 +46,7 @@ The following table provides an index to the `SYSLIB1XXX` diagnostics in .NET 6 
 | SYSLIB1024 | Logging method argument uses unsupported `out` parameter modifier |
 | SYSLIB1025 | Multiple logging methods cannot use the same event name within a class |
 | SYSLIB1026 | C# language version not supported by the logging source generator. |
-| SYSLIB1027 | (Reserved for logging.) |
+| SYSLIB1027 | Primary constructor parameter of type Microsoft.Extensions.Logging.ILogger is hidden by a field |
 | SYSLIB1028 | (Reserved for logging.) |
 | SYSLIB1029 | (Reserved for logging.) |
 | [SYSLIB1030][1030] | The `System.Text.Json` source generator did not generate serialization metadata for type |


### PR DESCRIPTION
## Summary
This documents the new logger message generator support for loggers in primary constructor parameters that is being introduced with .NET 9 in https://github.com/dotnet/runtime/pull/101660.

Fixes #41084

We could potentially use a primary constructor parameter in the _Case-insensitive template name support_ example too, since it's shorter and avoids boilerplate, but that may make more sense once .NET 9 is actually out.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/logger-message-generator.md](https://github.com/dotnet/docs/blob/6cba45807e4e855d9515853a9d670dd8da3edfae/docs/core/extensions/logger-message-generator.md) | [Compile-time logging source generation](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/logger-message-generator?branch=pr-en-us-41514) |
| [docs/fundamentals/syslib-diagnostics/source-generator-overview.md](https://github.com/dotnet/docs/blob/6cba45807e4e855d9515853a9d670dd8da3edfae/docs/fundamentals/syslib-diagnostics/source-generator-overview.md) | [Analyzer diagnostics in .NET 6+](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/source-generator-overview?branch=pr-en-us-41514) |

<!-- PREVIEW-TABLE-END -->