### PR TITLE
Remove extraneous note

### DIFF
--- a/docs/csharp/language-reference/attributes/nullable-analysis.md
+++ b/docs/csharp/language-reference/attributes/nullable-analysis.md
@@ -139,9 +139,6 @@ That informs the compiler that any code where the return value is `false` doesn'
 
 :::code language="csharp" source="snippets/NullableAttributes.cs" ID="NullCheckExample" :::
 
-> [!NOTE]
-> The preceding example is only valid in C# 11 and later. Starting with C# 11, the [`nameof` expression](../operators/nameof.md) can reference parameter and type parameter names when used in an attribute applied to a method. In C# 10 and earlier, you need to use a string literal instead of the `nameof` expression.
-
 The <xref:System.String.IsNullOrEmpty(System.String)?DisplayProperty=nameWithType> method will be annotated as shown above for .NET Core 3.0. You may have similar methods in your codebase that check the state of objects for null values. The compiler won't recognize custom null check methods, and you'll need to add the annotations yourself. When you add the attribute, the compiler's static analysis knows when the tested variable has been null checked.
 
 Another use for these attributes is the `Try*` pattern. The postconditions for `ref` and `out` arguments are communicated through the return value. Consider this method shown earlier (in a nullable disabled context):


### PR DESCRIPTION
Remove the note on `nameof`. It's in the wrong location, and the sample that uses `nameof` already has text noting that it's a C# 11 feature.

Responding to anonymous feedback.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/attributes/nullable-analysis.md](https://github.com/dotnet/docs/blob/d5044a64d0da6dde51eea202172c83dfe57522e2/docs/csharp/language-reference/attributes/nullable-analysis.md) | [Attributes for null-state static analysis interpreted by the C# compiler](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/attributes/nullable-analysis?branch=pr-en-us-41536) |

<!-- PREVIEW-TABLE-END -->