### PR TITLE
Publish C# 13 breaking changes

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -77,7 +77,8 @@
             {
                 "files": [
                     "Compiler Breaking Changes - DotNet 7.md",
-                    "Compiler Breaking Changes - DotNet 8.md"
+                    "Compiler Breaking Changes - DotNet 8.md",
+                    "Compiler Breaking Changes - DotNet 9.md"
                 ],
                 "src": "_roslyn/docs/compilers/CSharp",
                 "dest": "csharp/whats-new/breaking-changes",

--- a/docfx.json
+++ b/docfx.json
@@ -494,6 +494,7 @@
                 "_csharplang/proposals/*.md": "05/15/2024",
                 "_roslyn/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md": "11/08/2022",
                 "_roslyn/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 8.md": "09/26/2023",
+                "_roslyn/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 9.md": "06/26/2024",
                 "_vblang/spec/*.md": "07/21/2017"
             },
             "ms.subservice": {
@@ -663,6 +664,7 @@
                 "_csharplang/proposals/params-collections.md": "Params collections",
                 "_roslyn/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md": "C# compiler breaking changes since C# 10",
                 "_roslyn/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 8.md": "C# compiler breaking changes since C# 11",
+                "_roslyn/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 9.md": "C# compiler breaking changes since C# 12",
                 "_vblang/spec/introduction.md": "Introduction",
                 "_vblang/spec/lexical-grammar.md": "Lexical grammar",
                 "_vblang/spec/preprocessing-directives.md": "Preprocessing directives",
@@ -778,6 +780,7 @@
                 "_csharplang/proposals/params-collections.md": "Allow the `params` modifier on collection types beyond arrays, including `IEnumerable` types.",
                 "_roslyn/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md": "Learn about any breaking changes since the initial release of C# 10",
                 "_roslyn/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 8.md": "Learn about any breaking changes since the initial release of C# 11",
+                "_roslyn/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 9.md": "Learn about any breaking changes since the initial release of C# 12",
                 "_vblang/spec/introduction.md": "This chapter provides and introduction to the Visual Basic language.",
                 "_vblang/spec/lexical-grammar.md": "This chapter defines the lexical grammar for Visual Basic.",
                 "_vblang/spec/preprocessing-directives.md": "This chapter defines the preprocessing directives allowed in Visual Basic",

--- a/docs/core/compatibility/9.0.md
+++ b/docs/core/compatibility/9.0.md
@@ -64,3 +64,4 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 ## See also
 
 - [What's new in .NET 9](../whats-new/dotnet-9/overview.md)
+- [C# 13 breaking changes](../../_roslyn/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%207.md)

--- a/docs/core/compatibility/9.0.md
+++ b/docs/core/compatibility/9.0.md
@@ -64,4 +64,4 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 ## See also
 
 - [What's new in .NET 9](../whats-new/dotnet-9/overview.md)
-- [C# 13 breaking changes](../../_roslyn/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%207.md)
+- [C# 13 breaking changes](../../../_roslyn/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%207.md)

--- a/docs/core/compatibility/9.0.md
+++ b/docs/core/compatibility/9.0.md
@@ -64,4 +64,4 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 ## See also
 
 - [What's new in .NET 9](../whats-new/dotnet-9/overview.md)
-- [C# 13 breaking changes](../../../_roslyn/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%207.md)
+- [C# 13 breaking changes](../../../_roslyn/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%209.md)

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -149,6 +149,8 @@ items:
   - name: C# 13
     displayName: what's New
     href: whats-new/csharp-13.md
+  - name: Breaking changes in C# 13
+    href: ../../_roslyn/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%209.md
   - name: C# 12
     displayName: what's New
     href: whats-new/csharp-12.md


### PR DESCRIPTION
The C# compiler team has published the C# 13 breaking changes doc. Add it to our docset, and link from the .NET 9 library breaking changes doc.

- [New breaking changes doc](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/breaking-changes/compiler%20breaking%20changes%20-%20dotnet%209?branch=pr-en-us-41541)

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/9.0.md](https://github.com/dotnet/docs/blob/ac7a150ea454f5c9cb9639dfc6f374d5052c463b/docs/core/compatibility/9.0.md) | [Breaking changes in .NET 9](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/9.0?branch=pr-en-us-41541) |


<!-- PREVIEW-TABLE-END -->