### PR TITLE
Fix Typo in default-marshalling-for-arrays.md

### DIFF
--- a/docs/framework/interop/default-marshalling-for-arrays.md
+++ b/docs/framework/interop/default-marshalling-for-arrays.md
@@ -321,12 +321,12 @@ void New(long [][][] ar );
 
 ```vb
 Sub New1( ar As System.Array )
-Sub New2( <MarshalAs(UnmanagedType.Safe array)> ar As System.Array )
+Sub New2( <MarshalAs(UnmanagedType.SafeArray)> ar As System.Array )
 ```
 
 ```csharp
 void New1( System.Array ar );
-void New2( [MarshalAs(UnmanagedType.Safe array)] System.Array ar );
+void New2( [MarshalAs(UnmanagedType.SafeArray)] System.Array ar );
 ```
 
 #### Unmanaged signature


### PR DESCRIPTION
## Summary

Fixes two typos in default-marshalling-for-arrays.md, changing `UnmanagedType.Safe array` to `UnmanagedType.SafeArray`.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/interop/default-marshalling-for-arrays.md](https://github.com/dotnet/docs/blob/b86ead34235a401e52f67a736077ede6215f0e18/docs/framework/interop/default-marshalling-for-arrays.md) | [Default Marshalling for Arrays](https://review.learn.microsoft.com/en-us/dotnet/framework/interop/default-marshalling-for-arrays?branch=pr-en-us-41544) |

<!-- PREVIEW-TABLE-END -->