### PR TITLE
Fix links for docs verifier

### DIFF
--- a/docs/core/compatibility/9.0.md
+++ b/docs/core/compatibility/9.0.md
@@ -64,4 +64,4 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 ## See also
 
 - [What's new in .NET 9](../whats-new/dotnet-9/overview.md)
-- [C# 13 breaking changes](../../../_roslyn/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%209.md)
+- [C# 13 breaking changes](~/_roslyn/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%209.md)

--- a/docs/csharp/whats-new/csharp-13.md
+++ b/docs/csharp/whats-new/csharp-13.md
@@ -20,6 +20,8 @@ You can download the latest .NET 9 preview SDK from the [.NET downloads page](ht
 
 New features are added to the "What's new in C#" page when they're available in public preview releases. The [working set](https://github.com/dotnet/roslyn/blob/main/docs/Language%20Feature%20Status.md#working-set) section of the [roslyn feature status page](https://github.com/dotnet/roslyn/blob/main/docs/Language%20Feature%20Status.md) tracks when upcoming features are merged into the main branch.
 
+You can find any breaking changes introduced in C# 13 in our article on [breaking changes](~/_roslyn/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%209.md).
+
 [!INCLUDE [released-version-feedback](./includes/released-feedback.md)]
 
 ## `params` collections


### PR DESCRIPTION
The links worked, but the verifier was issuing a false positive.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/9.0.md](https://github.com/dotnet/docs/blob/062859e342b011bee1b805eaed3d34e8d196424e/docs/core/compatibility/9.0.md) | [Breaking changes in .NET 9](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/9.0?branch=pr-en-us-41562) |
| [docs/csharp/whats-new/csharp-13.md](https://github.com/dotnet/docs/blob/062859e342b011bee1b805eaed3d34e8d196424e/docs/csharp/whats-new/csharp-13.md) | [What's new in C# 13](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-13?branch=pr-en-us-41562) |

<!-- PREVIEW-TABLE-END -->