### PR TITLE
Removed unused error codes

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/params-arrays.md
+++ b/docs/csharp/language-reference/compiler-messages/params-arrays.md
@@ -12,10 +12,6 @@ f1_keywords:
   - "CS1670"
   - "CS1751"
   - "CS9218"
-  - "CS9219"
-  - "CS9220"
-  - "CS9221"
-  - "CS9222"
   - "CS9223"
   - "CS9224"
   - "CS9225"
@@ -32,10 +28,6 @@ helpviewer_keywords:
   - "CS1670"
   - "CS1751"
   - "CS9218"
-  - "CS9219"
-  - "CS9220"
-  - "CS9221"
-  - "CS9222"
   - "CS9223"
   - "CS9224"
   - "CS9225"
@@ -60,18 +52,11 @@ That's by design. The text closely matches the text of the compiler error / warn
 - [**CS1670**](#method-declaration-rules): *`params` is not valid in this context*
 - [**CS1751**](#method-declaration-rules): *Cannot specify a default value for a parameter array.*
 - [**CS9218**](#parameter-and-argument-type-rules): *The type arguments for method cannot be inferred from the usage because an argument with dynamic type is used and the method has a non-array params collection parameter. Try specifying the type arguments explicitly.*
-- [**CS9219**](#parameter-and-argument-type-rules): *Ambiguity between expanded and normal forms of non-array params collection parameter of, the only corresponding argument has the type `dynamic`. Consider casting the dynamic argument.*
 - [**CS9223**](#other-params-errors): *Creation of params collection results in an infinite chain of invocation of constructor.*
 - [**CS9224**](#other-params-errors): *Method cannot be less visible than the member with params collection.*
 - [**CS9225**](#other-params-errors): *Constructor leaves required member uninitialized.*
 - [**CS9227**](#parameter-and-argument-type-rules): *Type does not contain a definition for a suitable instance `Add` method.*
 - [**CS9228**](#parameter-and-argument-type-rules): *Non-array params collection type must have an applicable constructor that can be called with no arguments.*
-
-In addition, the compiler might produce the following *warning* related to the `params` modifier on method parameters:
-
-- [**CS9220**](#parameter-and-argument-type-rules): *One or more overloads of method having non-array params collection parameter might be applicable only in expanded form which is not supported during dynamic dispatch.*
-- [**CS9221**](#parameter-and-argument-type-rules): *One or more indexer overloads having non-array params collection parameter might be applicable only in expanded form which is not supported during dynamic dispatch.*
-- [**CS9222**](#parameter-and-argument-type-rules): *One or more constructor overloads having non-array params collection parameter might be applicable only in expanded form which is not supported during dynamic dispatch.*
 
 ## Method declaration rules
 
@@ -98,16 +83,9 @@ In versions before C# 12, the `params` modifier can't be used on the parameter o
 The following errors indicate that the type of the parameter used with `params` is invalid:
 
 - **CS9218**: *The type arguments for method cannot be inferred from the usage because an argument with dynamic type is used and the method has a non-array params collection parameter. Try specifying the type arguments explicitly.*
-- **CS9219**: *Ambiguity between expanded and normal forms of non-array params collection parameter of, the only corresponding argument has the type 'dynamic'. Consider casting the dynamic argument.*
 - **CS0225**: *The params parameter must be a single-dimensional array or have a valid collection type*
 - **CS9227**: *Type does not contain a definition for a suitable instance `Add` method.*
 - **CS9228**: *Non-array params collection type must have an applicable constructor that can be called with no arguments.*
-
-The following warnings indicate that the one of the possible overloads might involve dynamic dispatch. The dynamic nature of the argument doesn't participate in overload resolution.
-
-- **CS9220**: *One or more overloads of method having non-array params collection parameter might be applicable only in expanded form which is not supported during dynamic dispatch.*
-- **CS9221**: *One or more indexer overloads having non-array params collection parameter might be applicable only in expanded form which is not supported during dynamic dispatch.*
-- **CS9222**: *One or more constructor overloads having non-array params collection parameter might be applicable only in expanded form which is not supported during dynamic dispatch.*
 
 In versions before C# 13, the `params` modifier is allowed on single-dimensional arrays only. No other types were valid.
 

--- a/docs/csharp/language-reference/toc.yml
+++ b/docs/csharp/language-reference/toc.yml
@@ -467,8 +467,7 @@ items:
   - name: Params modifier
     href: ./compiler-messages/params-arrays.md
     displayName: > 
-      CS0225, CS0231, CS0466, CS0674, CS0758, CS1104, CS1611, CS1670, CS1751, CS9218, CS9219, CS9220, CS9221, CS9222, CS9223,
-      CS9224, CS9225, CS9227, CS9228
+      CS0225, CS0231, CS0466, CS0674, CS0758, CS1104, CS1611, CS1670, CS1751, CS9218, CS9223, CS9224, CS9225, CS9227, CS9228
   - name: Nullable warnings
     href: ./compiler-messages/nullable-warnings.md
     displayName: >


### PR DESCRIPTION
Based on [LDM decision for `params` and `dynamic`](https://github.com/dotnet/csharplang/blob/main/meetings/2024/LDM-2024-06-03.md#params-collections-and-dynamic), these four errors codes have been removed, but may be reused in future updates.

So, remove them from our docs so we don't have duplicates when they are added back.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-messages/params-arrays.md](https://github.com/dotnet/docs/blob/18b80e11a220ca9ace38c7ec67d477621ec872c1/docs/csharp/language-reference/compiler-messages/params-arrays.md) | [Errors and warnings related to the `params` modifier on method parameters](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/params-arrays?branch=pr-en-us-41567) |

<!-- PREVIEW-TABLE-END -->