### PR TITLE
Update trimming-options.md

### DIFF
--- a/docs/core/deploying/trimming/trimming-options.md
+++ b/docs/core/deploying/trimming/trimming-options.md
@@ -3,7 +3,7 @@ title: Trimming options
 description: Learn how to control trimming of self-contained apps.
 author: sbomer
 ms.author: svbomer
-ms.date: 08/10/2023
+ms.date: 06/26/2024
 ms.topic: reference
 zone_pivot_groups: dotnet-version
 ---
@@ -45,13 +45,13 @@ This setting also enables the trim-compatibility [Roslyn analyzer](#roslyn-analy
 
 Use the `TrimMode` property to set the trimming granularity to either `partial` or `full`. The default setting for console apps (and, starting in .NET 8, Web SDK apps) is `full`:
 
-```csharp
+```xml
 <TrimMode>full</TrimMode>
 ```
 
 To only trim assemblies that have opted-in to trimming, set the property to `partial`:
 
-```csharp
+```xml
 <TrimMode>partial</TrimMode>
 ```
 


### PR DESCRIPTION
Noticed while watching @shanselman's talk from NDC Australia that the trimming docs had the incorrect language identifier. He also used my code, yay!

https://youtu.be/KqhhaMgbGhU?t=590

![image](https://github.com/dotnet/docs/assets/7679720/978dbe5c-3472-4dd4-829d-3ac17e49f59b)

https://learn.microsoft.com/en-us/dotnet/core/docker/build-container?tabs=windows&pivots=dotnet-8-0#create-net-app

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/deploying/trimming/trimming-options.md](https://github.com/dotnet/docs/blob/869091375c8f30935ddb500aed71af8bdec2e572/docs/core/deploying/trimming/trimming-options.md) | [Trimming options](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trimming-options?branch=pr-en-us-41568) |

<!-- PREVIEW-TABLE-END -->