### PR TITLE
fix: prevented early code exit

### DIFF
--- a/docs/orleans/host/client.md
+++ b/docs/orleans/host/client.md
@@ -327,6 +327,8 @@ static async Task RunWatcherAsync()
 
             Console.WriteLine(
                 "Subscribed successfully. Press <Enter> to stop.");
+
+            Console.ReadLine(); 
         }
         catch (Exception e)
         {


### PR DESCRIPTION
## Summary
fix: Added `Console.ReadLine()` to allow clicking on the `Enter` key to stop


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/host/client.md](https://github.com/dotnet/docs/blob/f44dd8cf5ea3a7e431ad9b07e02ee77ffd8a9700/docs/orleans/host/client.md) | [Orleans clients](https://review.learn.microsoft.com/en-us/dotnet/orleans/host/client?branch=pr-en-us-41589) |

<!-- PREVIEW-TABLE-END -->