### PR TITLE
codedom: fix typo in title

### DIFF
--- a/docs/framework/reflection-and-codedom/generating-and-compiling-source-code-from-a-codedom-graph.md
+++ b/docs/framework/reflection-and-codedom/generating-and-compiling-source-code-from-a-codedom-graph.md
@@ -28,7 +28,7 @@ helpviewer_keywords:
   - "CodeDOM, graphs"
 ms.assetid: 6c864c8e-6dd3-4a65-ace0-36879d9a9c42
 ---
-# Generate and compile source code from a CodeDOM fraph
+# Generate and compile source code from a CodeDOM graph
 
 The <xref:System.CodeDom.Compiler> namespace provides interfaces for generating source code from CodeDOM object graphs and for managing compilation with supported compilers. A code provider can produce source code in a particular programming language according to a CodeDOM graph. A class that derives from <xref:System.CodeDom.Compiler.CodeDomProvider> can typically provide methods for generating and compiling code for the language the provider supports.
 


### PR DESCRIPTION
## Summary

fixed typo in CodeDOM document.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/reflection-and-codedom/generating-and-compiling-source-code-from-a-codedom-graph.md](https://github.com/dotnet/docs/blob/bb51aee9ea9dfcd0c46f88ea7188eba8a0bba32f/docs/framework/reflection-and-codedom/generating-and-compiling-source-code-from-a-codedom-graph.md) | [Generate and compile source code from a CodeDOM graph](https://review.learn.microsoft.com/en-us/dotnet/framework/reflection-and-codedom/generating-and-compiling-source-code-from-a-codedom-graph?branch=pr-en-us-41600) |

<!-- PREVIEW-TABLE-END -->