### PR TITLE
fix typo in srtp doc

### DIFF
--- a/docs/fsharp/language-reference/generics/statically-resolved-type-parameters.md
+++ b/docs/fsharp/language-reference/generics/statically-resolved-type-parameters.md
@@ -73,7 +73,7 @@ let doubleR = double r
 
 Starting with F# 7.0, you can use `'a.Zero()` instead of having to repeat the constraint as in the example below.
 
-Starting with F# 4.1, you can also specify concrete type names in statically resolved type parameter signatures. In previous versions of the language, the type name was inferred by the compiler, but could not be specified in the signature. As of F# 4.1, you may also specify concrete type names in statically resolved type parameter signatures. Here's an example (please not that in this example, `^` must still be used because the simplification to use `'` is not supported):
+Starting with F# 4.1, you can also specify concrete type names in statically resolved type parameter signatures. In previous versions of the language, the type name was inferred by the compiler, but could not be specified in the signature. As of F# 4.1, you may also specify concrete type names in statically resolved type parameter signatures. Here's an example (please note that in this example, `^` must still be used because the simplification to use `'` is not supported):
 
 ```fsharp
 let inline konst x _ = x


### PR DESCRIPTION
## Summary

Fix a typ "not" -> "note"


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/generics/statically-resolved-type-parameters.md](https://github.com/dotnet/docs/blob/64f69b656ed0333c329385d3bce7eb8d844564c0/docs/fsharp/language-reference/generics/statically-resolved-type-parameters.md) | [Statically Resolved Type Parameters](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/generics/statically-resolved-type-parameters?branch=pr-en-us-41603) |


<!-- PREVIEW-TABLE-END -->