### PR TITLE
Clarify the unitialized nature of stackalloc memory.

### DIFF
--- a/docs/csharp/language-reference/operators/stackalloc.md
+++ b/docs/csharp/language-reference/operators/stackalloc.md
@@ -52,7 +52,7 @@ The amount of memory available on the stack is limited. If you allocate too much
 The content of the newly allocated memory is undefined. You should initialize it, either with a `stackalloc` initializer, or a method like <xref:System.Span%601.Clear%2A?displayProperty=nameWithType> before the use.
 
 > [!IMPORTANT]
-> Not initializing memory allocated by `stackalloc` is an important difference from the `new` operator. Memory allocated using the `new` operator is initialized to 0.
+> Not initializing memory allocated by `stackalloc` is an important difference from the `new` operator. Memory allocated using the `new` operator is initialized to the 0 bit pattern.
 
 You can use array initializer syntax to define the content of the newly allocated memory. The following example demonstrates various ways to do that:
 

--- a/docs/csharp/language-reference/operators/stackalloc.md
+++ b/docs/csharp/language-reference/operators/stackalloc.md
@@ -52,7 +52,7 @@ The amount of memory available on the stack is limited. If you allocate too much
 The content of the newly allocated memory is undefined. You should initialize it, either with a `stackalloc` initializer, or a method like <xref:System.Span%601.Clear%2A?displayProperty=nameWithType> before the use.
 
 > [!IMPORTANT]
-> Not initializing memory allocated by `stackalloc` is an important difference from the `new `operator. Memory allocated using the `new` operator is initialized to 0. 
+> Not initializing memory allocated by `stackalloc` is an important difference from the `new `operator. Memory allocated using the `new` operator is initialized to 0.
 
 You can use array initializer syntax to define the content of the newly allocated memory. The following example demonstrates various ways to do that:
 

--- a/docs/csharp/language-reference/operators/stackalloc.md
+++ b/docs/csharp/language-reference/operators/stackalloc.md
@@ -52,7 +52,7 @@ The amount of memory available on the stack is limited. If you allocate too much
 The content of the newly allocated memory is undefined. You should initialize it, either with a `stackalloc` initializer, or a method like <xref:System.Span%601.Clear%2A?displayProperty=nameWithType> before the use.
 
 > [!IMPORTANT]
-> Not initializing memory allocated by `stackalloc` is an important difference from the `new `operator. Memory allocated using the `new` operator is initialized to 0.
+> Not initializing memory allocated by `stackalloc` is an important difference from the `new` operator. Memory allocated using the `new` operator is initialized to 0.
 
 You can use array initializer syntax to define the content of the newly allocated memory. The following example demonstrates various ways to do that:
 

--- a/docs/csharp/language-reference/operators/stackalloc.md
+++ b/docs/csharp/language-reference/operators/stackalloc.md
@@ -49,7 +49,10 @@ The amount of memory available on the stack is limited. If you allocate too much
 
 - Avoid using `stackalloc` inside loops. Allocate the memory block outside a loop and reuse it inside the loop.
 
-The content of the newly allocated memory is undefined. You should initialize it before the use. For example, you can use the <xref:System.Span%601.Clear%2A?displayProperty=nameWithType> method that sets all the items to the default value of type `T`.
+The content of the newly allocated memory is undefined. You should initialize it, either with a `stackalloc` initializer, or a method like <xref:System.Span%601.Clear%2A?displayProperty=nameWithType> before the use.
+
+> [!IMPORTANT]
+> Not initializing memory allocated by `stackalloc` is an important difference from the `new `operator. Memory allocated using the `new` operator is initialized to 0. 
 
 You can use array initializer syntax to define the content of the newly allocated memory. The following example demonstrates various ways to do that:
 

--- a/docs/csharp/language-reference/operators/stackalloc.md
+++ b/docs/csharp/language-reference/operators/stackalloc.md
@@ -49,7 +49,7 @@ The amount of memory available on the stack is limited. If you allocate too much
 
 - Avoid using `stackalloc` inside loops. Allocate the memory block outside a loop and reuse it inside the loop.
 
-The content of the newly allocated memory is undefined. You should initialize it, either with a `stackalloc` initializer, or a method like <xref:System.Span%601.Clear%2A?displayProperty=nameWithType> before the use.
+The content of the newly allocated memory is undefined. You should initialize it, either with a `stackalloc` initializer, or a method like <xref:System.Span%601.Clear%2A?displayProperty=nameWithType> before it's used.
 
 > [!IMPORTANT]
 > Not initializing memory allocated by `stackalloc` is an important difference from the `new` operator. Memory allocated using the `new` operator is initialized to the 0 bit pattern.


### PR DESCRIPTION
Responding to anonymous feedback. The OP expressed confusion with the statement that `stackalloc` memory is unitialized.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/stackalloc.md](https://github.com/dotnet/docs/blob/5ee8cf8f60fa9311a8a8c3a3902e11c73727d653/docs/csharp/language-reference/operators/stackalloc.md) | [stackalloc expression (C# reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/stackalloc?branch=pr-en-us-41630) |


<!-- PREVIEW-TABLE-END -->