### PR TITLE
Fixing the typo as listed in ticket 41628

### DIFF
--- a/docs/csharp/language-reference/keywords/method-parameters.md
+++ b/docs/csharp/language-reference/keywords/method-parameters.md
@@ -35,7 +35,7 @@ How an argument is passed, and whether it's a reference type or value type contr
   - If the method assigns the parameter to refer to a different object, those changes **aren't** visible from the caller.
   - If the method modifies the state of the object referred to by the parameter, those changes **are** visible from the caller.
 - When you pass a *value* type *by reference*:
-  - If the method assigns the parameter to refer to a different object, those changes **aren't** visible from the caller.
+  - If the method assigns the parameter to refer to a different object, those changes **are** visible from the caller.
   - If the method modifies the state of the object referred to by the parameter, those changes **are** visible from the caller.
 - When you pass a *reference* type *by reference*:
   - If the method assigns the parameter to refer to a different object, those changes **are** visible from the caller.


### PR DESCRIPTION
## Summary

I fixed the typo as listed in the ticket.

Fixes #41628

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/method-parameters.md](https://github.com/dotnet/docs/blob/2248199689f1c5b85a5009cad7d27097ebfc28c3/docs/csharp/language-reference/keywords/method-parameters.md) | [Method Parameters](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/method-parameters?branch=pr-en-us-41631) |

<!-- PREVIEW-TABLE-END -->