### PR TITLE
Mention `[]` operator also being able to thrown a runtime exception with indexers

### DIFF
--- a/docs/csharp/nullable-references.md
+++ b/docs/csharp/nullable-references.md
@@ -37,7 +37,7 @@ int length = message.Length; // dereferencing "message"
 
 When you dereference a variable whose value is `null`, the runtime throws a <xref:System.NullReferenceException?displayProperty=nameWithType>.
 
-Similarly warnings can be produced when `[]` notation is used on an indexer whose values were not initialized:
+Similarly warnings can be produced when `[]` notation is used to access a member of an object when the object is `null`:
 
 ```csharp
 using System;

--- a/docs/csharp/nullable-references.md
+++ b/docs/csharp/nullable-references.md
@@ -37,6 +37,28 @@ int length = message.Length; // dereferencing "message"
 
 When you dereference a variable whose value is `null`, the runtime throws a <xref:System.NullReferenceException?displayProperty=nameWithType>.
 
+Similarly warnings can be produced when `[]` notation is used on an indexer whose values were not initialized:
+
+```csharp
+using System;
+
+public class Collection<T>
+{
+    private T[] array = new T[100];
+    public T this[int index]
+    {
+        get => array[index];
+        set => array[index] = value;
+    }
+}
+
+public static void Main()
+{
+    Collection<int> c = default;
+    c[10] = 1;    // CS8602: Possible derefence of null
+}
+```
+
 You'll learn about:
 
 - The compiler's [null-state analysis](#null-state-analysis): how the compiler determines if an expression is not-null, or maybe-null.

--- a/docs/csharp/nullable-references.md
+++ b/docs/csharp/nullable-references.md
@@ -394,3 +394,4 @@ In the preceding example, the declaration of the array shows it holds non-nullab
 - [Unconstrained type parameter annotations](~/_csharplang/proposals/csharp-9.0/unconstrained-type-parameter-annotations.md)
 - [Intro to nullable references tutorial](tutorials/nullable-reference-types.md)
 - [**Nullable** (C# Compiler option)](language-reference/compiler-options/language.md#nullable)
+- [CS8602: Possible dereference of null warning](language-reference/compiler-messages/nullable-warnings.md#possible-dereference-of-null)


### PR DESCRIPTION
This pull request closes #40071
It adds mention of `[]` notation being used on indexer whose values were not initialized.
Also, this addition mentions the exact warning that is received when `#nullable enable` is set.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/nullable-references.md](https://github.com/dotnet/docs/blob/70ff8f1f2ac77853661f6e62caa41104ca04d72c/docs/csharp/nullable-references.md) | [Nullable reference types](https://review.learn.microsoft.com/en-us/dotnet/csharp/nullable-references?branch=pr-en-us-41655) |


<!-- PREVIEW-TABLE-END -->