### PR TITLE
Update globalization-icu.md to detail differences in string equality and sorting

### DIFF
--- a/docs/core/extensions/globalization-icu.md
+++ b/docs/core/extensions/globalization-icu.md
@@ -50,16 +50,16 @@ The following table shows which versions of .NET are capable of loading the ICU 
 
 ### Behavioral differences
 
-If you upgrade your app to target .NET 5 or later, you might see changes in your app even if you don't realize you're using globalization facilities. This section lists several behavioral changes you might see, but there are others too.
+If you upgrade your app to target .NET 5 or later, you might see changes in your app even if you don't realize you're using globalization facilities. The following section lists some behavioral changes you might experience.
 
-#### String Sorting and System.Globalization.CompareOptions
+#### String sorting and `System.Globalization.CompareOptions`
 
 `CompareOptions` is the options enumeration which can be passed to `String.Compare` to influence how two strings are compared.
 
 Comparing strings for equality and determining their sort order differs between NLS and ICU. In particular:
 
-- The default string sort order is different, so this will be apparent even if you do not use `CompareOptions` directly. When using ICU, the `None` default option performs the same as `StringSort`. `StringSort` sorts non-alphanumeric characters before alphanumeric ones (so "bill's" sorts before "bills", for example). To restore the previous `None` functionality, you must use the NLS-based implementation.
-- The default handling of ligature characters differs. Under NLS, ligatures and their non-ligature counterparts (for example, "oeuf" and "œuf") are considered equal, but this is not the case with ICU under .NET. This is because of a different collation strength between the two implementations. To restore the NLS behaviour when using ICU, you can use the `IgnoreNonSpace` `CompareOptions` value.
+- The default string sort order is different, so this will be apparent even if you don't use `CompareOptions` directly. When using ICU, the `None` default option performs the same as `StringSort`. `StringSort` sorts non-alphanumeric characters before alphanumeric ones (so "bill's" sorts before "bills", for example). To restore the previous `None` functionality, you must use the NLS-based implementation.
+- The default handling of ligature characters differs. Under NLS, ligatures and their non-ligature counterparts (for example, "oeuf" and "œuf") are considered equal, but this isn't the case with ICU in .NET. This is because of a different collation strength between the two implementations. To restore the NLS behavior when using ICU, use the `CompareOptions.IgnoreNonSpace` value.
 
 #### String.IndexOf
 

--- a/docs/core/extensions/globalization-icu.md
+++ b/docs/core/extensions/globalization-icu.md
@@ -50,7 +50,16 @@ The following table shows which versions of .NET are capable of loading the ICU 
 
 ### Behavioral differences
 
-If you upgrade your app to target .NET 5 or later, you might see changes in your app even if you don't realize you're using globalization facilities. This section lists one of the behavioral changes you might see, but there are others too.
+If you upgrade your app to target .NET 5 or later, you might see changes in your app even if you don't realize you're using globalization facilities. This section lists several behavioral changes you might see, but there are others too.
+
+#### String Sorting and System.Globalization.CompareOptions
+
+`CompareOptions` is the options enumeration which can be passed to `String.Compare` to influence how two strings are compared.
+
+Comparing strings for equality and determining their sort order differs between NLS and ICU. In particular:
+
+- The default string sort order is different, so this will be apparent even if you do not use `CompareOptions` directly. When using ICU, the `None` default option performs the same as `StringSort`. `StringSort` sorts non-alphanumeric characters before alphanumeric ones (so "bill's" sorts before "bills", for example). To restore the previous `None` functionality, you must use the NLS-based implementation.
+- The default handling of ligature characters differs. Under NLS, ligatures and their non-ligature counterparts (for example, "oeuf" and "œuf") are considered equal, but this is not the case with ICU under .NET. This is because of a different collation strength between the two implementations. To restore the NLS behaviour when using ICU, you can use the `IgnoreNonSpace` `CompareOptions` value.
 
 #### String.IndexOf
 


### PR DESCRIPTION
## Summary

(Part of a documentation fix for `CompareOptions` API issue #41052 )

An update to detail the differences between NLS and ICU implementations for string equality and sorting:

- Ligatures are not regarded as equal to their expanded forms under ICU by default (`CompareOptions.IgnoreNonSpace` must be used to override this). This is because of the different collation strength between NLS and ICU.
- The default sort order for strings has changed under ICU, effectively removing the previous `None` functionality and making `StringSort` the default. The only way to restore previous `None` ordering is to switch back to NLS.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/globalization-icu.md](https://github.com/dotnet/docs/blob/1a7799f6f47b72afc1c69d08a31d01a2afba0312/docs/core/extensions/globalization-icu.md) | [.NET globalization and ICU](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/globalization-icu?branch=pr-en-us-41661) |


<!-- PREVIEW-TABLE-END -->