### PR TITLE
Fixed a couple terminology errors

### DIFF
--- a/docs/csharp/nullable-references.md
+++ b/docs/csharp/nullable-references.md
@@ -209,7 +209,7 @@ The **nullable annotation context** determines the compiler's behavior. There ar
   - All new nullable warnings are enabled.
   - You can use the `?` suffix to declare a nullable reference type.
   - Reference type variables without the `?` suffix are non-nullable reference types.
-  - The null forgiving operator suppresses warnings for a possible assignment to `null`.
+  - The null forgiving operator suppresses warnings for a possible dereference of `null`.
 - *warnings*: The compiler performs all null analysis and emits warnings when code might dereference `null`.
   - All new nullable warnings are enabled.
   - Use of the `?` suffix to declare a nullable reference type produces a warning.
@@ -255,7 +255,7 @@ You can also use directives to set these same contexts anywhere in your source c
 - `#nullable restore warnings`: Restores the nullable warning context to the project settings.
 - `#nullable disable annotations`: Set the nullable annotation context to **disable**.
 - `#nullable enable annotations`: Set the nullable annotation context to **enable**.
-- `#nullable restore annotations`: Restores the annotation warning context to the project settings.
+- `#nullable restore annotations`: Restores the nullable annotation context to the project settings.
 
 For any line of code, you can set any of the following combinations:
 


### PR DESCRIPTION
The null forgiving operator warns on dereference, not assignment "Annotation warning context" should be "Nullable annotation context"

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/nullable-references.md](https://github.com/dotnet/docs/blob/21f48f9f22d1aaac7df754ff4f478aa5ff104644/docs/csharp/nullable-references.md) | [Nullable reference types](https://review.learn.microsoft.com/en-us/dotnet/csharp/nullable-references?branch=pr-en-us-41663) |

<!-- PREVIEW-TABLE-END -->