### PR TITLE
Remove the `binary_analysis` link in favor of `upgrade-with-the-cli-tool` section of .NET Upgrade Assistant tool page

### DIFF
--- a/docs/core/porting/third-party-deps.md
+++ b/docs/core/porting/third-party-deps.md
@@ -95,7 +95,7 @@ The .NET Team would like to know which libraries are the most important to suppo
 
 ## Analyze non-NuGet dependencies
 
-You may have a dependency that isn't a NuGet package, such as a DLL in the file system. You can determine the portability of that dependency by using the [binary analysis](https://github.com/dotnet/upgrade-assistant/blob/main/docs/binary_analysis.md) functionality of the [.NET Upgrade Assistant](upgrade-assistant-overview.md).
+You may have a dependency that isn't a NuGet package, such as a DLL in the file system. You can determine the portability of that dependency with the CLI version of the [.NET Upgrade Assistant](upgrade-assistant-overview.md#upgrade-with-the-cli-tool) tool.
 
 ## Next steps
 

--- a/docs/core/porting/third-party-deps.md
+++ b/docs/core/porting/third-party-deps.md
@@ -95,7 +95,7 @@ The .NET Team would like to know which libraries are the most important to suppo
 
 ## Analyze non-NuGet dependencies
 
-You may have a dependency that isn't a NuGet package, such as a DLL in the file system. You can determine the portability of that dependency with the CLI version of the [.NET Upgrade Assistant](upgrade-assistant-overview.md#upgrade-with-the-cli-tool) tool.
+You might have a dependency that isn't a NuGet package, such as a DLL in the file system. You can determine the portability of that dependency with the CLI version of the [.NET Upgrade Assistant](upgrade-assistant-overview.md#upgrade-with-the-cli-tool) tool.
 
 ## Next steps
 


### PR DESCRIPTION
This pull request fixes #41638.
It removes the binary_analysis link due to https://github.com/dotnet/upgrade-assistant/pull/1555#issuecomment-2161405186 and replaces it with more direct link to .NET Upgrade Assistant tool page just like it was done in #41395.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/porting/third-party-deps.md](https://github.com/dotnet/docs/blob/baa2756ec4f834e46771be3a3d6acdb6dd5e6d37/docs/core/porting/third-party-deps.md) | [Analyze your dependencies to port code from .NET Framework to .NET](https://review.learn.microsoft.com/en-us/dotnet/core/porting/third-party-deps?branch=pr-en-us-41674) |


<!-- PREVIEW-TABLE-END -->