### PR TITLE
PictureBox breaking change

### DIFF
--- a/docs/core/compatibility/9.0.md
+++ b/docs/core/compatibility/9.0.md
@@ -54,6 +54,7 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 | [ComponentDesigner.Initialize throws ArgumentNullException](windows-forms/9.0/componentdesigner-initialize.md) | Behavioral change | Preview 1          |
 | [DataGridViewRowAccessibleObject.Name starting row index](windows-forms/9.0/datagridviewrowaccessibleobject-name-row.md) | Behavioral change | Preview 1 |
 | [No exception if DataGridView is null](windows-forms/9.0/datagridviewheadercell-nre.md) | Behavioral change   | Preview 1          |
+| [PictureBox raises HttpClient exceptions](windows-forms/9.0/httpclient-exceptions.md)   | Preview 6          |
 
 ## WPF
 

--- a/docs/core/compatibility/9.0.md
+++ b/docs/core/compatibility/9.0.md
@@ -54,7 +54,7 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 | [ComponentDesigner.Initialize throws ArgumentNullException](windows-forms/9.0/componentdesigner-initialize.md) | Behavioral change | Preview 1          |
 | [DataGridViewRowAccessibleObject.Name starting row index](windows-forms/9.0/datagridviewrowaccessibleobject-name-row.md) | Behavioral change | Preview 1 |
 | [No exception if DataGridView is null](windows-forms/9.0/datagridviewheadercell-nre.md) | Behavioral change   | Preview 1          |
-| [PictureBox raises HttpClient exceptions](windows-forms/9.0/httpclient-exceptions.md)   | Preview 6          |
+| [PictureBox raises HttpClient exceptions](windows-forms/9.0/httpclient-exceptions.md)   | Behavioral change   | Preview 6          |
 
 ## WPF
 

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -48,6 +48,8 @@ items:
         href: windows-forms/9.0/datagridviewrowaccessibleobject-name-row.md
       - name: No exception if DataGridView is null
         href: windows-forms/9.0/datagridviewheadercell-nre.md
+      - name: PictureBox raises HttpClient exceptions
+        href: windows-forms/9.0/httpclient-exceptions.md
     - name: WPF
       items:
       - name: "'GetXmlNamespaceMaps' type change"
@@ -1824,6 +1826,8 @@ items:
         href: windows-forms/9.0/datagridviewrowaccessibleobject-name-row.md
       - name: No exception if DataGridView is null
         href: windows-forms/9.0/datagridviewheadercell-nre.md
+      - name: PictureBox raises HttpClient exceptions
+        href: windows-forms/9.0/httpclient-exceptions.md
     - name: .NET 8
       items:
       - name: Anchor layout changes

--- a/docs/core/compatibility/windows-forms/9.0/httpclient-exceptions.md
+++ b/docs/core/compatibility/windows-forms/9.0/httpclient-exceptions.md
@@ -1,0 +1,36 @@
+---
+title: "Breaking change: PictureBox raises HttpClient exceptions"
+description: Learn about the breaking change in .NET 9 for Windows Forms where `PictureBox` raises HttpClient exceptions for network errors when loading an image from a URL.
+ms.date: 07/09/2024
+---
+# PictureBox raises HttpClient exceptions
+
+When <xref:System.Windows.Forms.PictureBox> loads an image from a URL and a network error occurs, it now raises <xref:System.Net.Http.HttpClient> exceptions, such as <xref:System.Net.Http.HttpRequestException> and <xref:System.Threading.Tasks.TaskCanceledException>, instead of <xref:System.Net.WebException>.
+
+## Version introduced
+
+.NET 9 Preview 6
+
+## Previous behavior
+
+Previously, when <xref:System.Windows.Forms.PictureBox> failed to load an image from a URL due to a network error, a <xref:System.Net.WebException> was thrown.
+
+## New behavior
+
+Starting in .NET 9, when <xref:System.Windows.Forms.PictureBox> fails to load an image from a URL due to a network error, <xref:System.Net.Http.HttpRequestException> or <xref:System.Threading.Tasks.TaskCanceledException> is thrown.
+
+## Change category
+
+This change is a [*behavioral change*](../../categories.md#behavioral-change).
+
+## Reason for change
+
+<xref:System.Net.WebClient> is obsolete.
+
+## Recommended action
+
+Update your code to catch <xref:System.Net.Http.HttpRequestException> and <xref:System.Threading.Tasks.TaskCanceledException> instead of <xref:System.Net.WebException>.
+
+## Affected APIs
+
+- <xref:System.Windows.Forms.PictureBox> control


### PR DESCRIPTION
Fixes #41485.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/9.0.md](https://github.com/dotnet/docs/blob/f1d24c8a905f6a707457d84fc3eea375d2ce23dc/docs/core/compatibility/9.0.md) | [Breaking changes in .NET 9](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/9.0?branch=pr-en-us-41695) |
| [docs/core/compatibility/windows-forms/9.0/httpclient-exceptions.md](https://github.com/dotnet/docs/blob/f1d24c8a905f6a707457d84fc3eea375d2ce23dc/docs/core/compatibility/windows-forms/9.0/httpclient-exceptions.md) | [PictureBox raises HttpClient exceptions](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/windows-forms/9.0/httpclient-exceptions?branch=pr-en-us-41695) |


<!-- PREVIEW-TABLE-END -->