### PR TITLE
Constant definition update for issue 41677

### DIFF
--- a/docs/csharp/language-reference/preprocessor-directives.md
+++ b/docs/csharp/language-reference/preprocessor-directives.md
@@ -184,7 +184,7 @@ You use `#define` to define a symbol. When you use the symbol as the expression 
  ```
 
 > [!NOTE]
-> In C#, primitive constants should be defined using the `const` keyword. The `#define` directive cannot be used to declare constant values as is typically done in C and C++. You can also define constants in C# as static members of a class or struct, but be aware that static members are resolved at runtime, and thus not necessarily read-only. If you have several such constants, consider creating a separate "Constants" class to hold them.
+> In C#, primitive constants should be defined using the [`const`](keywords/const.md) keyword. A `const` declaration creates a `static` member that can't be modified at runtime. The `#define` directive can't be used to declare constant values as is typically done in C and C++. If you have several such constants, consider creating a separate "Constants" class to hold them.
 
 Symbols can be used to specify conditions for compilation. You can test for the symbol with either `#if` or `#elif`. You can also use the <xref:System.Diagnostics.ConditionalAttribute> to perform conditional compilation. You can define a symbol, but you can't assign a value to a symbol. The `#define` directive must appear in the file before you use any instructions that aren't also preprocessor directives. You can also define a symbol with the [**DefineConstants**](compiler-options/language.md#defineconstants) compiler option. You can undefine a symbol with `#undef`.
 

--- a/docs/csharp/language-reference/preprocessor-directives.md
+++ b/docs/csharp/language-reference/preprocessor-directives.md
@@ -184,7 +184,7 @@ You use `#define` to define a symbol. When you use the symbol as the expression 
  ```
 
 > [!NOTE]
-> The `#define` directive cannot be used to declare constant values as is typically done in C and C++. Constants in C# are best defined as static members of a class or struct. If you have several such constants, consider creating a separate "Constants" class to hold them.
+> In C#, primitive constants should be defined using the `const` keyword. The `#define` directive cannot be used to declare constant values as is typically done in C and C++. You can also define constants in C# as static members of a class or struct, but be aware that static members are resolved at runtime, and thus not necessarily read-only. If you have several such constants, consider creating a separate "Constants" class to hold them.
 
 Symbols can be used to specify conditions for compilation. You can test for the symbol with either `#if` or `#elif`. You can also use the <xref:System.Diagnostics.ConditionalAttribute> to perform conditional compilation. You can define a symbol, but you can't assign a value to a symbol. The `#define` directive must appear in the file before you use any instructions that aren't also preprocessor directives. You can also define a symbol with the [**DefineConstants**](compiler-options/language.md#defineconstants) compiler option. You can undefine a symbol with `#undef`.
 

--- a/docs/csharp/language-reference/xmldoc/recommended-tags.md
+++ b/docs/csharp/language-reference/xmldoc/recommended-tags.md
@@ -212,7 +212,7 @@ The `<paramref>` tag gives you a way to indicate that a word in the code comment
 <exception cref="member">description</exception>
 ```
 
-- cref = "`member`": A reference to an exception that is available from the current compilation environment. The compiler checks that the given exception exists and translates `member` to the canonical element name in the output XML. `member` must appear within double quotation marks (" ").
+- cref = "`member`": A reference to an exception that is available from the current compilation environment. The compiler checks that the given exception exists and translates `member` to the canonical element name in the output XML. `member` must appear within quotation marks (").
 
 The `<exception>` tag lets you specify which exceptions can be thrown. This tag can be applied to definitions for methods, properties, events, and indexers.
 
@@ -315,7 +315,7 @@ Add your XML comments in base classes or interfaces and let inheritdoc copy the 
 - `filename`: The name of the XML file containing the documentation. The file name can be qualified with a path relative to the source code file. Enclose `filename` in single quotation marks (' ').
 - `tagpath`: The path of the tags in `filename` that leads to the tag `name`. Enclose the path in single quotation marks (' ').
 - `name`: The name specifier in the tag that precedes the comments; `name` will have an `id`.
-- `id`: The ID for the tag that precedes the comments. Enclose the ID in double quotation marks (" ").
+- `id`: The ID for the tag that precedes the comments. Enclose the ID in quotation marks (").
 
 The `<include>` tag lets you refer to comments in another file that describe the types and members in your source code. Including an external file is an alternative to placing documentation comments directly in your source code file. By putting the documentation in a separate file, you can apply source control to the documentation separately from the source code. One person can have the source code file checked out and someone else can have the documentation file checked out. The `<include>` tag uses the XML XPath syntax. Refer to XPath documentation for ways to customize your `<include>` use.
 
@@ -355,7 +355,7 @@ The XML output for this method is shown in the following example:
 <see langword="keyword"/>
 ```
 
-- `cref="member"`: A reference to a member or field that is available to be called from the current compilation environment. The compiler checks that the given code element exists and passes `member` to the element name in the output XML. Place *member* within double quotation marks (" "). You can provide different link text for a "cref", by using a separate closing tag.
+- `cref="member"`: A reference to a member or field that is available to be called from the current compilation environment. The compiler checks that the given code element exists and passes `member` to the element name in the output XML. Place *member* within quotation marks ("). You can provide different link text for a "cref", by using a separate closing tag.
 - `href="link"`: A clickable link to a given URL. For example, `<see href="https://github.com">GitHub</see>` produces a clickable link with text :::no-loc text="GitHub"::: that links to `https://github.com`.
 - `langword="keyword"`: A language keyword, such as `true` or one of the other valid [keywords](../keywords/index.md).
 
@@ -369,7 +369,7 @@ The `<see>` tag lets you specify a link from within text. Use [\<seealso>](#seea
 <seealso href="link">Link Text</seealso>
 ```
 
-- `cref="member"`: A reference to a member or field that is available to be called from the current compilation environment. The compiler checks that the given code element exists and passes `member` to the element name in the output XML. `member` must appear within double quotation marks (" ").
+- `cref="member"`: A reference to a member or field that is available to be called from the current compilation environment. The compiler checks that the given code element exists and passes `member` to the element name in the output XML. `member` must appear within quotation marks (").
 - `href="link"`: A clickable link to a given URL. For example, `<seealso href="https://github.com">GitHub</seealso>` produces a clickable link with text :::no-loc text="GitHub"::: that links to `https://github.com`.
 
 The `<seealso>` tag lets you specify the text that you might want to appear in a **See Also** section. Use [\<see>](#see) to specify a link from within text. You cannot nest the `seealso` tag inside the `summary` tag.

--- a/docs/csharp/language-reference/xmldoc/recommended-tags.md
+++ b/docs/csharp/language-reference/xmldoc/recommended-tags.md
@@ -192,7 +192,7 @@ The `<returns>` tag should be used in the comment for a method declaration to de
 <param name="name">description</param>
 ```
 
-- `name`: The name of a method parameter. Enclose the name in double quotation marks (" "). The names for parameters must match the API signature. If one or more parameter aren't covered, the compiler issues a warning. The compiler also issues a warning if the value of `name` doesn't match a formal parameter in the method declaration.
+- `name`: The name of a method parameter. Enclose the name in quotation marks ("). The names for parameters must match the API signature. If one or more parameter aren't covered, the compiler issues a warning. The compiler also issues a warning if the value of `name` doesn't match a formal parameter in the method declaration.
 
 The `<param>` tag should be used in the comment for a method declaration to describe one of the parameters for the method. To document multiple parameters, use multiple `<param>` tags. The text for the `<param>` tag is displayed in IntelliSense, the Object Browser, and the Code Comment Web Report.
 
@@ -202,7 +202,7 @@ The `<param>` tag should be used in the comment for a method declaration to desc
 <paramref name="name"/>
 ```
 
-- `name`: The name of the parameter to refer to. Enclose the name in double quotation marks (" ").
+- `name`: The name of the parameter to refer to. Enclose the name in quotation marks (").
 
 The `<paramref>` tag gives you a way to indicate that a word in the code comments, for example in a `<summary>` or `<remarks>` block refers to a parameter. The XML file can be processed to format this word in some distinct way, such as with a bold or italic font.
 
@@ -390,7 +390,7 @@ The `href` attribute means a reference to a web page. You can use it to directly
 <typeparam name="TResult">The type returned from this method</typeparam>
 ```
 
-- `TResult`: The name of the type parameter. Enclose the name in double quotation marks (" ").
+- `TResult`: The name of the type parameter. Enclose the name in quotation marks (").
 
 The `<typeparam>` tag should be used in the comment for a generic type or method declaration to describe a type parameter. Add a tag for each type parameter of the generic type or method. The text for the `<typeparam>` tag will be displayed in IntelliSense.
 
@@ -400,7 +400,7 @@ The `<typeparam>` tag should be used in the comment for a generic type or method
 <typeparamref name="TKey"/>
 ```
 
-- `TKey`: The name of the type parameter. Enclose the name in double quotation marks (" ").
+- `TKey`: The name of the type parameter. Enclose the name in quotation marks (").
 
 Use this tag to enable consumers of the documentation file to format the word in some distinct way, for example in italics.
 


### PR DESCRIPTION
## Summary

I rewrote the note, based on the comment from @kevinfoley in the linked issue. 

(hopefully) Fixes #41677 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/preprocessor-directives.md](https://github.com/dotnet/docs/blob/82cbe58701055f97308d0b15b462712e72ea37b3/docs/csharp/language-reference/preprocessor-directives.md) | [C# preprocessor directives](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/preprocessor-directives?branch=pr-en-us-41726) |
| [docs/csharp/language-reference/xmldoc/recommended-tags.md](https://github.com/dotnet/docs/blob/82cbe58701055f97308d0b15b462712e72ea37b3/docs/csharp/language-reference/xmldoc/recommended-tags.md) | [Recommended XML tags for C# documentation comments](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/recommended-tags?branch=pr-en-us-41726) |


<!-- PREVIEW-TABLE-END -->