### PR TITLE
Remove invalid line from prometheus.yml config file in .NET observability with OpenTelemetry page

### DIFF
--- a/docs/core/diagnostics/observability-with-otel.md
+++ b/docs/core/diagnostics/observability-with-otel.md
@@ -262,7 +262,6 @@ Modify the Prometheus YAML configuration file to specify the port for your HTTP 
   scrape_configs:
   # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
   - job_name: "prometheus"
-    - scrape_interval: 1s # poll very quickly for a more responsive demo
 
     # metrics_path defaults to '/metrics'
     # scheme defaults to 'http'.


### PR DESCRIPTION
## Summary

The example in the second `yaml` from the section [7.1 Install and configure Prometheus
](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/observability-with-otel#71-install-and-configure-prometheus) is invalid, as it contains a list inside a list. The same `scrap_interval` property is listed bellow, so I just removed it.

```yaml
- job_name: "prometheus"
    - scrape_interval: 1s # poll very quickly for a more responsive demo <-- This line is wrong

    # metrics_path defaults to '/metrics'
    # scheme defaults to 'http'.

    scrape_interval: 1s # poll very quickly for a more responsive demo <-- This line is correct
    ...
```


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/observability-with-otel.md](https://github.com/dotnet/docs/blob/47cd52204e56026ee56c45f5c81efba7e7563be7/docs/core/diagnostics/observability-with-otel.md) | [.NET observability with OpenTelemetry](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/observability-with-otel?branch=pr-en-us-41741) |

<!-- PREVIEW-TABLE-END -->