### PR TITLE
typo fixed typo-in-parameter-name-of-a-method #41750

### DIFF
--- a/docs/csharp/language-reference/xmldoc/snippets/xmldoc/idstrings.cs
+++ b/docs/csharp/language-reference/xmldoc/snippets/xmldoc/idstrings.cs
@@ -46,7 +46,7 @@ public unsafe class MyClass
     /// <param name="num">Describe parameter.</param>
     /// <param name="ptr">Describe parameter.</param>
     /// <returns>Describe return value.</returns>
-    public int SomeMethod(string str, ref int nm, void* ptr) { return 1; }
+    public int SomeMethod(string str, ref int num, void* ptr) { return 1; }
 
     /// <summary>
     /// Enter description for method AnotherMethod.


### PR DESCRIPTION
## Summary

Describe your changes here.
-> Fixed the typo "public int SomeMethod(string str, ref int nm, void* ptr) { return 1; }" 
-> New line of code  "public int SomeMethod(string str, ref int num, void* ptr) { return 1; }" 

![image](https://github.com/user-attachments/assets/ec89ee5e-9ca3-4975-88f1-ad9759edee0d)



Fixes #41750 
