### PR TITLE
Micro change in parameters-and-arguments.md

### DIFF
--- a/docs/fsharp/language-reference/parameters-and-arguments.md
+++ b/docs/fsharp/language-reference/parameters-and-arguments.md
@@ -124,7 +124,7 @@ Note that those members could perform any arbitrary work, the syntax is effectiv
 
 ## Optional Parameters
 
-You can specify an optional parameter for a method by using a question mark in front of the parameter name. Optional parameters are interpreted as the F# option type, so you can query them in the regular way that option types are queried, by using a `match` expression with `Some` and `None`. Optional parameters are permitted only on members, not on functions created by using `let` bindings.
+You can specify an optional parameter for a method by using a question mark in front of the parameter name. From the callee's perspective, Optional parameters are interpreted as the F# option type, so you can query them in the regular way that option types are queried, by using a `match` expression with `Some` and `None`. Optional parameters are permitted only on members, not on functions created by using `let` bindings.
 
 You can pass existing optional values to method by parameter name, such as `?arg=None` or `?arg=Some(3)` or `?arg=arg`. This can be useful when building a method that passes optional arguments to another method.
 

--- a/docs/fsharp/language-reference/parameters-and-arguments.md
+++ b/docs/fsharp/language-reference/parameters-and-arguments.md
@@ -124,7 +124,7 @@ Note that those members could perform any arbitrary work, the syntax is effectiv
 
 ## Optional Parameters
 
-You can specify an optional parameter for a method by using a question mark in front of the parameter name. From the callee's perspective, Optional parameters are interpreted as the F# option type, so you can query them in the regular way that option types are queried, by using a `match` expression with `Some` and `None`. Optional parameters are permitted only on members, not on functions created by using `let` bindings.
+You can specify an optional parameter for a method by using a question mark in front of the parameter name. From the callee's perspective, optional parameters are interpreted as the F# option type, so you can query them in the regular way that option types are queried, by using a `match` expression with `Some` and `None`. Optional parameters are permitted only on members, not on functions created by using `let` bindings.
 
 You can pass existing optional values to method by parameter name, such as `?arg=None` or `?arg=Some(3)` or `?arg=arg`. This can be useful when building a method that passes optional arguments to another method.
 


### PR DESCRIPTION
## Summary

I found the documentation a little bit confusing when it comes to optional parameters: Even though optional parameters are interpreted as the `option` type in the callee, they aren't for the caller:

```
type Foo(?label: string) = class end

let myLabel = Some "hi"
let foo = Foo(myLabel)
              ^^^^^^^
```
Error:
> This expression was expected to have type `string` but here has type `string option`


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/parameters-and-arguments.md](https://github.com/dotnet/docs/blob/d24d1d2f0a40e94c41b489bf341894f33e14b1de/docs/fsharp/language-reference/parameters-and-arguments.md) | [Parameters and Arguments](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/parameters-and-arguments?branch=pr-en-us-41755) |


<!-- PREVIEW-TABLE-END -->