### PR TITLE
RepoMan config update for flagging issues as updated

### DIFF
--- a/.repoman.yml
+++ b/.repoman.yml
@@ -1,4 +1,4 @@
-revision: 3
+revision: 4
 schema-version: 1
 owner-ms-alias: adegeo
 

--- a/.repoman.yml
+++ b/.repoman.yml
@@ -53,6 +53,13 @@ issues:
       pass:
         - labels-add: ["source incompatible"]
 
+    # Temporary label to mark issues as updated for Quest. The label is instantly removed
+    - check:
+      - type: query
+        value: "length(Issue.labels[?name == ':world_map: mapQUEST']) != `0`"
+      pass:
+        - labels-remove: ["world_map: mapQUEST"]
+
   opened:
     # New issue opened, add Not Triaged  
     - labels-add: [":watch: Not Triaged"]


### PR DESCRIPTION
Use this when you're moving an issue to a slipped column and adding it to a new project. This way the issue is marked as updated in GitHub and Sequester can pick it up.
