### PR TITLE
Improvements to the SDK versioning page for .NET 9

### DIFF
--- a/docs/core/porting/versioning-sdk-msbuild-vs.md
+++ b/docs/core/porting/versioning-sdk-msbuild-vs.md
@@ -22,7 +22,7 @@ The support timeframe for the SDK typically matches that of the Visual Studio ve
 
 <!-- markdownlint-disable MD033 -->
 <details>
-<summary>Out of support .NET versions</summary>
+<summary>Expand to see out-of-support .NET versions</summary>
 
 | SDK version | MSBuild/Visual Studio version | Ship date | Lifecycle |
 |-------------|-------------------------------|-----------|-----------|
@@ -41,6 +41,8 @@ The support timeframe for the SDK typically matches that of the Visual Studio ve
 
 </details>
 <!-- markdownlint-enable MD033 -->
+
+### Supported .NET versions
 
 | SDK version | MSBuild/Visual Studio version | Ship date | Lifecycle           |
 |-------------|-------------------------------|-----------|---------------------|

--- a/docs/core/porting/versioning-sdk-msbuild-vs.md
+++ b/docs/core/porting/versioning-sdk-msbuild-vs.md
@@ -19,7 +19,8 @@ For example, version 7.0.203 ships with .NET 7, is the second minor Visual Studi
 ## Lifecycle
 
 The support timeframe for the SDK typically matches that of the Visual Studio version it's included in.
-
+<details>
+<summary>Out of support .NET versions</summary>
 | SDK Version      | MSBuild/Visual Studio version | Ship date    | Lifecycle |
 |------------------|--------------------|--------------|-----------|
 | 2.1.5xx          | 15.9               | Nov '18      | Aug '21   |
@@ -30,18 +31,23 @@ The support timeframe for the SDK typically matches that of the Visual Studio ve
 | 5.0.2xx          | 16.9               | March '21    | May '22   |
 | 5.0.3xx          | 16.10              | May '21      | Aug '21   |
 | 5.0.4xx          | 16.11              | Aug '21      | May '22   |
-| 6.0.1xx          | 17.0               | Nov '21      | Nov '24<sup>1</sup>   |
-| 6.0.2xx          | 17.1               | Feb '22      | May '22   |
-| 6.0.3xx          | 17.2<sup>3</sup>   | May '22      | Oct '23   |
-| 6.0.4xx          | 17.3               | Aug '22      | Nov '24<sup>2</sup>   |
 | 7.0.1xx          | 17.4               | Nov '22      | May '24   |
 | 7.0.2xx          | 17.5<sup>3</sup>   | Feb '23      | May '23   |
 | 7.0.3xx          | 17.6               | May '23      | May '24   |
 | 7.0.4xx          | 17.7               | Aug '23      | May '24   |
-| 8.0.1xx          | 17.8               | Nov '23      | Nov '25<sup>1</sup>    |
+</details>
+
+| SDK Version      | MSBuild/Visual Studio version | Ship date    | Lifecycle |
+|------------------|--------------------|--------------|-----------|
+| 6.0.1xx          | 17.0               | Nov '21      | Nov '24<sup>1</sup>   |
+| 6.0.2xx          | 17.1               | Feb '22      | May '22   |
+| 6.0.3xx          | 17.2<sup>3</sup>   | May '22      | Oct '23   |
+| 6.0.4xx          | 17.3               | Aug '22      | Nov '24<sup>2</sup>   |
+| 8.0.1xx          | 17.8               | Nov '23      | Nov '25<sup>1</sup>   |
 | 8.0.2xx          | 17.9<sup>3</sup>   | Feb '24      | May '24   |
 | 8.0.3xx          | 17.10              | May '24      | TBD       |
-| 8.0.4xx          | 17.11              | Aug '24      | Nov '25<sup>2</sup>       |
+| 8.0.4xx          | 17.11              | Aug '24      | Nov '25<sup>2</sup>   |
+| 9.0.1xx          | 17.12              | Nov '24      | May '26<sup>1</sup>   |
 
 > [!NOTE]
 > Targeting `net6.0` is officially supported in Visual Studio 17.0+ only.
@@ -80,6 +86,7 @@ Starting with .NET SDK 7.0.100 and .NET SDK 6.0.300, a policy has been put into 
 | 8.0.200 | 17.9 | 17.8 | Net8.0 | Net8.0 |
 | 8.0.300 | 17.10 | 17.8 | Net8.0 | Net8.0 |
 | 8.0.400 | 17.11 | 17.8 | Net8.0 | Net8.0 |
+| 9.0.100 | 17.12 | 17.11 | Net8.0 | Net9.0 |
 
 > [!NOTE]
 > The table depicts how these versioning rules will be applied going forward, starting with .NET SDK 7.0.100 and .NET SDK 6.0.300. It also depicts how the policy would have applied to previously shipped versions of the .NET SDK, had it been in place then. However, the requirements for previous versions of the SDK don't change&mdash;that is, the minimum required version of Visual Studio for .NET SDK 6.0.100 or 6.0.200 remains 16.10.
@@ -100,6 +107,9 @@ Major versions of the .NET SDK are typically released within a few days of a Vis
 | 9.0.100 Preview 4 | 17.11 Preview 1 |
 | 9.0.100 Preview 5 | 17.11 Preview 2 |
 | 9.0.100 Preview 6 | 17.11 Preview 3 |
+| 9.0.100 Preview 7 | 17.12 Preview 1 |
+| 9.0.100 RC 1 | 17.12 Preview 2 |
+| 9.0.100 RC 2 | 17.12 Preview 3 |
 
 ## Reference
 

--- a/docs/core/porting/versioning-sdk-msbuild-vs.md
+++ b/docs/core/porting/versioning-sdk-msbuild-vs.md
@@ -19,35 +19,40 @@ For example, version 7.0.203 ships with .NET 7, is the second minor Visual Studi
 ## Lifecycle
 
 The support timeframe for the SDK typically matches that of the Visual Studio version it's included in.
+
+<!-- markdownlint-disable MD033 -->
 <details>
 <summary>Out of support .NET versions</summary>
-| SDK Version      | MSBuild/Visual Studio version | Ship date    | Lifecycle |
-|------------------|--------------------|--------------|-----------|
-| 2.1.5xx          | 15.9               | Nov '18      | Aug '21   |
-| 2.1.8xx          | 16.2 (No VS)       | July '19     | Aug '21   |
-| 3.1.1xx          | 16.4               | Dec '19      | Oct '21   |
-| 3.1.4xx          | 16.7               | Aug '20      | Dec '22   |
-| 5.0.1xx          | 16.8               | Nov '20      | Mar '21   |
-| 5.0.2xx          | 16.9               | March '21    | May '22   |
-| 5.0.3xx          | 16.10              | May '21      | Aug '21   |
-| 5.0.4xx          | 16.11              | Aug '21      | May '22   |
-| 7.0.1xx          | 17.4               | Nov '22      | May '24   |
-| 7.0.2xx          | 17.5<sup>3</sup>   | Feb '23      | May '23   |
-| 7.0.3xx          | 17.6               | May '23      | May '24   |
-| 7.0.4xx          | 17.7               | Aug '23      | May '24   |
-</details>
 
-| SDK Version      | MSBuild/Visual Studio version | Ship date    | Lifecycle |
-|------------------|--------------------|--------------|-----------|
-| 6.0.1xx          | 17.0               | Nov '21      | Nov '24<sup>1</sup>   |
-| 6.0.2xx          | 17.1               | Feb '22      | May '22   |
-| 6.0.3xx          | 17.2<sup>3</sup>   | May '22      | Oct '23   |
-| 6.0.4xx          | 17.3               | Aug '22      | Nov '24<sup>2</sup>   |
-| 8.0.1xx          | 17.8               | Nov '23      | Nov '25<sup>1</sup>   |
-| 8.0.2xx          | 17.9<sup>3</sup>   | Feb '24      | May '24   |
-| 8.0.3xx          | 17.10              | May '24      | TBD       |
-| 8.0.4xx          | 17.11              | Aug '24      | Nov '25<sup>2</sup>   |
-| 9.0.1xx          | 17.12              | Nov '24      | May '26<sup>1</sup>   |
+| SDK version | MSBuild/Visual Studio version | Ship date | Lifecycle |
+|-------------|-------------------------------|-----------|-----------|
+| 2.1.5xx     | 15.9                          | Nov '18   | Aug '21   |
+| 2.1.8xx     | 16.2 (No VS)                  | July '19  | Aug '21   |
+| 3.1.1xx     | 16.4                          | Dec '19   | Oct '21   |
+| 3.1.4xx     | 16.7                          | Aug '20   | Dec '22   |
+| 5.0.1xx     | 16.8                          | Nov '20   | Mar '21   |
+| 5.0.2xx     | 16.9                          | March '21 | May '22   |
+| 5.0.3xx     | 16.10                         | May '21   | Aug '21   |
+| 5.0.4xx     | 16.11                         | Aug '21   | May '22   |
+| 7.0.1xx     | 17.4                          | Nov '22   | May '24   |
+| 7.0.2xx     | 17.5<sup>3</sup>              | Feb '23   | May '23   |
+| 7.0.3xx     | 17.6                          | May '23   | May '24   |
+| 7.0.4xx     | 17.7                          | Aug '23   | May '24   |
+
+</details>
+<!-- markdownlint-enable MD033 -->
+
+| SDK version | MSBuild/Visual Studio version | Ship date | Lifecycle           |
+|-------------|-------------------------------|-----------|---------------------|
+| 6.0.1xx     | 17.0                          | Nov '21   | Nov '24<sup>1</sup> |
+| 6.0.2xx     | 17.1                          | Feb '22   | May '22             |
+| 6.0.3xx     | 17.2<sup>3</sup>              | May '22   | Oct '23             |
+| 6.0.4xx     | 17.3                          | Aug '22   | Nov '24<sup>2</sup> |
+| 8.0.1xx     | 17.8                          | Nov '23   | Nov '25<sup>1</sup> |
+| 8.0.2xx     | 17.9<sup>3</sup>              | Feb '24   | May '24             |
+| 8.0.3xx     | 17.10                         | May '24   | TBD                 |
+| 8.0.4xx     | 17.11                         | Aug '24   | Nov '25<sup>2</sup> |
+| 9.0.1xx     | 17.12                         | Nov '24   | May '26<sup>1</sup> |
 
 > [!NOTE]
 > Targeting `net6.0` is officially supported in Visual Studio 17.0+ only.
@@ -73,20 +78,19 @@ Starting with .NET SDK 7.0.100 and .NET SDK 6.0.300, a policy has been put into 
 - The first version of a new .NET SDK that supports a new TargetFramework can still be used with the prior version of Visual Studio to allow one quarter for tooling and infrastructure (for example, actions and pipelines) to migrate.
 
 | SDK | Visual Studio version<br/>the SDK ships with | Minimum Visual Studio version | Max TargetFramework in<br/>minimum Visual Studio version | Max TargetFramework in `dotnet` |
-|-|-|-|-|-|
-| 6.0.100 | 17.0 | 16.11 | Net5.0 | Net6.0 |
-| 6.0.200 | 17.1 | 17.0 | Net6.0 | Net6.0 |
-| 6.0.300 | 17.2 | 17.0 | Net6.0 | Net6.0 |
-| 6.0.400 | 17.3 | 17.0 | Net6.0 | Net6.0 |
-| 7.0.100 | 17.4 | 17.3 | Net6.0 | Net7.0 |
-| 7.0.200 | 17.5 | 17.4 | Net7.0 | Net7.0 |
-| 7.0.300 | 17.6 | 17.4<sup>1</sup>  | Net7.0 | Net7.0 |
-| 7.0.400 | 17.7 | 17.4 | Net7.0 | Net7.0 |
-| 8.0.100 | 17.8 | 17.7 | Net7.0 | Net8.0 |
-| 8.0.200 | 17.9 | 17.8 | Net8.0 | Net8.0 |
-| 8.0.300 | 17.10 | 17.8 | Net8.0 | Net8.0 |
-| 8.0.400 | 17.11 | 17.8 | Net8.0 | Net8.0 |
-| 9.0.100 | 17.12 | 17.11 | Net8.0 | Net9.0 |
+|---------|-------|------------------|--------|--------|
+| 6.0.200 | 17.1  | 17.0             | Net6.0 | Net6.0 |
+| 6.0.300 | 17.2  | 17.0             | Net6.0 | Net6.0 |
+| 6.0.400 | 17.3  | 17.0             | Net6.0 | Net6.0 |
+| 7.0.100 | 17.4  | 17.3             | Net6.0 | Net7.0 |
+| 7.0.200 | 17.5  | 17.4             | Net7.0 | Net7.0 |
+| 7.0.300 | 17.6  | 17.4<sup>1</sup> | Net7.0 | Net7.0 |
+| 7.0.400 | 17.7  | 17.4             | Net7.0 | Net7.0 |
+| 8.0.100 | 17.8  | 17.7             | Net7.0 | Net8.0 |
+| 8.0.200 | 17.9  | 17.8             | Net8.0 | Net8.0 |
+| 8.0.300 | 17.10 | 17.8             | Net8.0 | Net8.0 |
+| 8.0.400 | 17.11 | 17.8             | Net8.0 | Net8.0 |
+| 9.0.100 | 17.12 | 17.11            | Net8.0 | Net9.0 |
 
 > [!NOTE]
 > The table depicts how these versioning rules will be applied going forward, starting with .NET SDK 7.0.100 and .NET SDK 6.0.300. It also depicts how the policy would have applied to previously shipped versions of the .NET SDK, had it been in place then. However, the requirements for previous versions of the SDK don't change&mdash;that is, the minimum required version of Visual Studio for .NET SDK 6.0.100 or 6.0.200 remains 16.10.
@@ -100,16 +104,16 @@ To ensure consistent tooling, you should use `dotnet build` rather than `msbuild
 Major versions of the .NET SDK are typically released within a few days of a Visual Studio preview version. While there may be other combinations that work, only the latest preview released is tested and officially supported. The following table shows which version of Visual Studio each .NET preview version was tested with prior to release.
 
 | SDK preview version | Visual Studio version |
-|-|-|
-| 9.0.100 Preview 1 | 17.10 Preview 1 |
-| 9.0.100 Preview 2 | 17.10 Preview 2 |
-| 9.0.100 Preview 3 | 17.10 Preview 3 |
-| 9.0.100 Preview 4 | 17.11 Preview 1 |
-| 9.0.100 Preview 5 | 17.11 Preview 2 |
-| 9.0.100 Preview 6 | 17.11 Preview 3 |
-| 9.0.100 Preview 7 | 17.12 Preview 1 |
-| 9.0.100 RC 1 | 17.12 Preview 2 |
-| 9.0.100 RC 2 | 17.12 Preview 3 |
+|---------------------|-----------------------|
+| 9.0.100 Preview 1   | 17.10 Preview 1       |
+| 9.0.100 Preview 2   | 17.10 Preview 2       |
+| 9.0.100 Preview 3   | 17.10 Preview 3       |
+| 9.0.100 Preview 4   | 17.11 Preview 1       |
+| 9.0.100 Preview 5   | 17.11 Preview 2       |
+| 9.0.100 Preview 6   | 17.11 Preview 3       |
+| 9.0.100 Preview 7   | 17.12 Preview 1       |
+| 9.0.100 RC 1        | 17.12 Preview 2       |
+| 9.0.100 RC 2        | 17.12 Preview 3       |
 
 ## Reference
 


### PR DESCRIPTION
Add 9.0.100 to the various tables
Also break the top table into an out of support table and an active table to simplify it some



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/porting/versioning-sdk-msbuild-vs.md](https://github.com/dotnet/docs/blob/e2b6794735c1799902afd48aaa53577ea59e0c86/docs/core/porting/versioning-sdk-msbuild-vs.md) | [.NET SDK, MSBuild, and Visual Studio versioning](https://review.learn.microsoft.com/en-us/dotnet/core/porting/versioning-sdk-msbuild-vs?branch=pr-en-us-41768) |


<!-- PREVIEW-TABLE-END -->