### PR TITLE
Update broadcast-channel.md adding information on AddBroadcastChannel.

### DIFF
--- a/docs/orleans/streaming/broadcast-channel.md
+++ b/docs/orleans/streaming/broadcast-channel.md
@@ -8,6 +8,12 @@ ms.date: 07/03/2024
 
 Broadcast channels are a special type of broadcasting mechanism that can be used to send messages to all subscribers. Unlike [streaming providers](stream-providers.md), broadcast channels are not persistent and don't store messages, and they're not a replacement for persistent streams. With broadcast channels, grains are implicitly subscribed to the broadcast channel and receive broadcast messages from a producer. This decouples the sender and receiver of the message, which is useful for scenarios where the sender and receiver are not known in advance.
 
+To use broadcast channel you should configure Orleans Streams and then enable broadcast on your channel using the [`AddBroadcastChannel`](https://learn.microsoft.com/en-us/dotnet/api/orleans.hosting.channelhostingextensions.addbroadcastchannel?view=orleans-7.0) during silo configuration.
+
+```csharp
+siloBuilder.AddBroadcastChannel(OrleansBroadcastChannelNames.ReadmodelChanges);
+```
+
 ## Example scenario
 
 Consider a scenario where you have a grain that needs to receive stock price updates from a stock price provider. The stock price provider is a background service that publishes stock price updates to a broadcast channel. Grains are implicitly subscribed to the broadcast channel and receive updated stock prices. The following diagram shows the scenario:

--- a/docs/orleans/streaming/broadcast-channel.md
+++ b/docs/orleans/streaming/broadcast-channel.md
@@ -8,7 +8,7 @@ ms.date: 07/03/2024
 
 Broadcast channels are a special type of broadcasting mechanism that can be used to send messages to all subscribers. Unlike [streaming providers](stream-providers.md), broadcast channels are not persistent and don't store messages, and they're not a replacement for persistent streams. With broadcast channels, grains are implicitly subscribed to the broadcast channel and receive broadcast messages from a producer. This decouples the sender and receiver of the message, which is useful for scenarios where the sender and receiver are not known in advance.
 
-To use broadcast channel you should configure Orleans Streams and then enable broadcast on your channel using the [`AddBroadcastChannel`](https://learn.microsoft.com/en-us/dotnet/api/orleans.hosting.channelhostingextensions.addbroadcastchannel?view=orleans-7.0) during silo configuration.
+To use broadcast channel you should configure Orleans Streams and then enable broadcast on your channel using the [`AddBroadcastChannel`](/dotnet/api/orleans.hosting.channelhostingextensions.addbroadcastchannel) during silo configuration.
 
 ```csharp
 siloBuilder.AddBroadcastChannel(OrleansBroadcastChannelNames.ReadmodelChanges);


### PR DESCRIPTION
Added the AddBroadcastChannel configuration, without that configuration I was not able to use Broadcast Channels.

## Summary

Actually following the instruction on this documentation page I was not able to have Broadcast Channel works until I call the AddBroadcastChannel call during silo configuration. 

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/streaming/broadcast-channel.md](https://github.com/dotnet/docs/blob/9b9efcdccfa2b553bc8aeddc70041907cfcf095f/docs/orleans/streaming/broadcast-channel.md) | [Broadcast channels in Orleans](https://review.learn.microsoft.com/en-us/dotnet/orleans/streaming/broadcast-channel?branch=pr-en-us-41774) |


<!-- PREVIEW-TABLE-END -->