### PR TITLE
Fix for 41759

### DIFF
--- a/docs/core/whats-new/dotnet-9/libraries.md
+++ b/docs/core/whats-new/dotnet-9/libraries.md
@@ -397,7 +397,7 @@ The `MyPoco` type is defined as follows:
 
 :::code language="csharp" source="../snippets/dotnet-9/csharp/Serialization.cs" id="Poco":::
 
-You can also enable this setting globally using the `System.Text.Json.JsonSerializerOptions.RespectNullableAnnotations` feature switch in your project file (for example, *.csproj* file):
+You can also enable this setting globally using the `System.Text.Json.JsonSerializerOptions.RespectRequiredConstructorParameters` feature switch in your project file (for example, *.csproj* file):
 
 ```xml
 <ItemGroup>


### PR DESCRIPTION
## Summary

Swap in `RespectRequiredConstructorParameters` for `RespectNullableAnnotations` as noted in the issue.

Fixes #41759


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/whats-new/dotnet-9/libraries.md](https://github.com/dotnet/docs/blob/7b0f6744c0933d715e5d323875046a9e5c1e17da/docs/core/whats-new/dotnet-9/libraries.md) | [What's new in .NET libraries for .NET 9](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-9/libraries?branch=pr-en-us-41778) |


<!-- PREVIEW-TABLE-END -->