### PR TITLE
Fix for 41767

### DIFF
--- a/docs/csharp/language-reference/tokens/raw-string.md
+++ b/docs/csharp/language-reference/tokens/raw-string.md
@@ -17,7 +17,7 @@ Raw string literals can span multiple lines:
 
 The following rules govern the interpretation of a multi-line raw string literal:
 
-- Both opening and closing quote characters must be on their own line.
+- The opening quotes must be the last non-comment token on its respective line, and the closing quote must be the first non-comment token on its respective line.
 - Any whitespace to the left of the closing quotes is removed from all lines of the raw string literal.
 - Whitespace following the opening quote on the same line is ignored.
 - Whitespace only lines following the opening quote are included in the string literal.


### PR DESCRIPTION
## Summary

Added @BillWagner's suggestion, and included language for "respective lines" to reinforce the requirement that the opening/closing quotes will be located on different lines from one another.

Fixes #41767 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/tokens/raw-string.md](https://github.com/dotnet/docs/blob/1793e446b733d25dfbe24e08e4708149cea41bdb/docs/csharp/language-reference/tokens/raw-string.md) | [Raw string literal text - `"""` in string literals](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/raw-string?branch=pr-en-us-41812) |

<!-- PREVIEW-TABLE-END -->