### PR TITLE
fix(CommandLine): examples

### DIFF
--- a/docs/standard/commandline/get-started-tutorial.md
+++ b/docs/standard/commandline/get-started-tutorial.md
@@ -96,7 +96,7 @@ You can use any of the following ways to test while developing a command-line ap
   dotnet run -- --file bin/Debug/net6.0/scl.runtimeconfig.json
   ```
 
-> The working directory is the csproj folder, so the relative path to `scl.runtimeconfig.json` is from the csproj folder.
+The working directory is the project folder (the folder that has the .csproj  file), so the relative path to `scl.runtimeconfig.json` is from the project folder.
 
   In .NET 7.0.100 SDK Preview, you can use the `commandLineArgs` of a *launchSettings.json* file by running the command `dotnet run --launch-profile <profilename>`.
 

--- a/docs/standard/commandline/get-started-tutorial.md
+++ b/docs/standard/commandline/get-started-tutorial.md
@@ -93,8 +93,10 @@ You can use any of the following ways to test while developing a command-line ap
 * Use `dotnet run` and pass option values to the app instead of to the `run` command by including them after `--`, as in the following example:
 
   ```dotnetcli
-  dotnet run -- --file scl.runtimeconfig.json
+  dotnet run -- --file bin/Debug/net6.0/scl.runtimeconfig.json
   ```
+
+> The working directory is the csproj folder, so the relative path to `scl.runtimeconfig.json` is from the csproj folder.
 
   In .NET 7.0.100 SDK Preview, you can use the `commandLineArgs` of a *launchSettings.json* file by running the command `dotnet run --launch-profile <profilename>`.
 


### PR DESCRIPTION
## Summary

- Modify a example to the `async main` await the main taks.
- Fix a example to run the example program

Fixes #40757 (and its duplicate dotnet/command-line-api#2427)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/commandline/get-started-tutorial.md](https://github.com/dotnet/docs/blob/d30804cc3e78dc9ce59e572fa677ff074052a4cc/docs/standard/commandline/get-started-tutorial.md) | [Tutorial: Get started with System.CommandLine](https://review.learn.microsoft.com/en-us/dotnet/standard/commandline/get-started-tutorial?branch=pr-en-us-41823) |


<!-- PREVIEW-TABLE-END -->