### PR TITLE
Take training out of IoT TOC and Index

### DIFF
--- a/docs/iot/index.yml
+++ b/docs/iot/index.yml
@@ -51,10 +51,6 @@ landingContent:
 
   - title: Build devices
     linkLists:
-      - linkListType: learn
-        links:
-          - text: Construct Internet of Things devices using the .NET IoT Libraries
-            url: /training/modules/create-iot-device-dotnet/
       - linkListType: tutorial
         links:
           - text: Blink an LED

--- a/docs/iot/toc.yml
+++ b/docs/iot/toc.yml
@@ -4,11 +4,6 @@
   href: intro.md
 - name: Quickstart (Sense HAT)
   href: quickstarts/sensehat.md
-- name: Training
-  expanded: true
-  items:
-  - name: Construct Internet of Things devices using the .NET IoT Libraries
-    href: /training/modules/create-iot-device-dotnet/
 - name: Tutorials
   expanded: true
   items:


### PR DESCRIPTION
## Summary

Removes IoT training links. See #41841
