### PR TITLE
Fix for 41486

### DIFF
--- a/docs/csharp/language-reference/xmldoc/recommended-tags.md
+++ b/docs/csharp/language-reference/xmldoc/recommended-tags.md
@@ -256,7 +256,17 @@ The `<para>` tag is for use inside a tag, such as [\<summary>](#summary), [\<rem
 </list>
 ```
 
-The `<listheader>` block is used to define the heading row of either a table or definition list. When defining a table, you only need to supply an entry for `term` in the heading. Each item in the list is specified with an `<item>` block. When creating a definition list, you'll need to specify both `term` and `description`. However, for a table, bulleted list, or numbered list, you only need to supply an entry for `description`. A list or table can have as many `<item>` blocks as needed.
+The `<listheader>` block is used to define the heading row of either a table or definition list. 
+
+When defining a table:
+* You only need to supply an entry for `term` in the heading. 
+* Each item in the list is specified with an `<item>` block. For each `item`, you will only need to supply an entry for `description`.
+
+When creating a definition list:
+* You must supply an entry for `term` in the heading. 
+* Each item in the list is specified with an `<item>` block. Each `item` must contain both a `term` and `description`. 
+
+A list or table can have as many `<item>` blocks as needed.
 
 ### \<c>
 


### PR DESCRIPTION
## Summary

I re-arranged some sentences and added new phrasing based on the context I found in the original.

Fixes #41486 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/xmldoc/recommended-tags.md](https://github.com/dotnet/docs/blob/3d2d8fd1f13322e84f9c45a3b833a9577034287c/docs/csharp/language-reference/xmldoc/recommended-tags.md) | [Recommended XML tags for C# documentation comments](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/recommended-tags?branch=pr-en-us-41861) |

<!-- PREVIEW-TABLE-END -->