### PR TITLE
Add events section to Expression-bodied members article

### DIFF
--- a/docs/csharp/programming-guide/statements-expressions-operators/expression-bodied-members.md
+++ b/docs/csharp/programming-guide/statements-expressions-operators/expression-bodied-members.md
@@ -57,6 +57,14 @@ You can use expression body definitions to implement property `get` and `set` ac
 
 For more information about properties, see [Properties (C# Programming Guide)](../classes-and-structs/properties.md).
 
+## Events
+
+Similarly, event `add` and `remove` accessors may be expression-bodied:
+
+[!code-csharp[expression-bodied-event-add-remove](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/ExpressionBodiedMembers/expr-bodied-event.cs#1)]
+
+For more information about events, see [Events (C# Programming Guide)](../events/index.md).
+
 ## Constructors
 
 An expression body definition for a constructor typically consists of a single assignment expression or a method call that handles the constructor's arguments or initializes instance state.

--- a/docs/csharp/programming-guide/statements-expressions-operators/expression-bodied-members.md
+++ b/docs/csharp/programming-guide/statements-expressions-operators/expression-bodied-members.md
@@ -59,7 +59,7 @@ For more information about properties, see [Properties (C# Programming Guide)](.
 
 ## Events
 
-Similarly, event `add` and `remove` accessors may be expression-bodied:
+Similarly, event `add` and `remove` accessors can be expression-bodied:
 
 [!code-csharp[expression-bodied-event-add-remove](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/ExpressionBodiedMembers/expr-bodied-event.cs#1)]
 

--- a/samples/snippets/csharp/programming-guide/classes-and-structs/ExpressionBodiedMembers/expr-bodied-event.cs
+++ b/samples/snippets/csharp/programming-guide/classes-and-structs/ExpressionBodiedMembers/expr-bodied-event.cs
@@ -27,7 +27,7 @@ public class ObservableNum(int _value)
 }
 // </Snippet1>
 
-public class Example
+public class ExpressionExample
 {
    public static void Main()
    {

--- a/samples/snippets/csharp/programming-guide/classes-and-structs/ExpressionBodiedMembers/expr-bodied-event.cs
+++ b/samples/snippets/csharp/programming-guide/classes-and-structs/ExpressionBodiedMembers/expr-bodied-event.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace ExprBodied;
+
+// <Snippet1>
+public class ChangedEventArgs : EventArgs
+{
+   public required int NewValue { get; init; }
+}
+
+public class ObservableNum(int _value)
+{
+   public event EventHandler<ChangedEventArgs> ChangedGeneric = default!;
+
+   public event EventHandler Changed
+   {
+      // Note that, while this is syntactically valid, it won't work as expected because it's creating a new delegate object with each call.
+      add => ChangedGeneric += (sender, args) => value(sender, args);
+      remove => ChangedGeneric -= (sender, args) => value(sender, args);
+   }
+
+   public int Value
+   {
+      get => _value;
+      set => ChangedGeneric?.Invoke(this, new() { NewValue = (_value = value) });
+   }
+}
+// </Snippet1>
+
+public class Example
+{
+   public static void Main()
+   {
+      void PrintingHandler(object? sender, object? args)
+         => Console.WriteLine((args as ChangedEventArgs)?.NewValue);
+      ObservableNum num = new(2);
+      num.Changed += PrintingHandler;
+      num.Value = 3;
+      num.Changed -= PrintingHandler;
+      num.Value = 1; // Still prints!
+   }
+}


### PR DESCRIPTION
## Summary

Adds a sample file and fills in the missing section of the *Expression-bodied members* article re: events.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/statements-expressions-operators/expression-bodied-members.md](https://github.com/dotnet/docs/blob/06447993e48ef802b69ea4aec3ab4fc4a8a2c866/docs/csharp/programming-guide/statements-expressions-operators/expression-bodied-members.md) | [Expression-bodied members (C# programming guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/statements-expressions-operators/expression-bodied-members?branch=pr-en-us-41868) |


<!-- PREVIEW-TABLE-END -->