### PR TITLE
Clarify top-level access modifiers

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
+++ b/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
@@ -41,7 +41,7 @@ When one declaration of a [partial class or partial method](./partial-classes-an
 
 ## Class and struct accessibility
 
-Classes and structs declared directly within a namespace (aren't nested within other classes or structs) can be either `public` or `internal`. `internal` is the default if no access modifier is specified.
+Classes and structs declared directly within a namespace (aren't nested within other classes or structs) can have `public`, `internal` or `file` access. `internal` is the default if no access modifier is specified.
 
 Struct members, including nested classes and structs, can be declared `public`, `internal`, or `private`. Class members, including nested classes and structs, can be `public`, `protected internal`, `protected`, `internal`, `private protected`, or `private`. Class and struct members,  including nested classes and structs, have `private` access by default.
 


### PR DESCRIPTION
Fixes #41870.

One statement on `file` access stated correctly that `file` access is only allowed on top-level types. Another statement didn't include that note.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/classes-and-structs/access-modifiers.md](https://github.com/dotnet/docs/blob/b3822684b060a3d438d0ec11ad9d429c6a2c0b0e/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md) | [Access Modifiers (C# Programming Guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/access-modifiers?branch=pr-en-us-41871) |

<!-- PREVIEW-TABLE-END -->