### PR TITLE
Fix or add more details about some MSTest rules

### DIFF
--- a/docs/core/testing/mstest-analyzers/includes/test-class-rules.md
+++ b/docs/core/testing/mstest-analyzers/includes/test-class-rules.md
@@ -1,0 +1,6 @@
+The type declaring these methods should also respect the following rules:
+
+- The type should be a `class`.
+- The `class` should be `public` or `internal` (if the test project is using the `[DiscoverInternals]` attribute).
+- The `class` shouldn't be `static`.
+- If the `class` is `sealed`, it should be marked with `[TestClass]` (or a derived attribute).

--- a/docs/core/testing/mstest-analyzers/mstest0008.md
+++ b/docs/core/testing/mstest-analyzers/mstest0008.md
@@ -42,10 +42,10 @@ Methods marked with `[TestInitialize]` should follow the following layout to be 
 
 The type declaring these methods should also respect the following rules:
 
-- the type should be a class
-- the class should be `public` or `internal` (if the test project is using the `[DiscoverInternals]` attribute)
-- the class should not be `static`
-- if the class is sealed, it should be marked with `[TestClass]` (or a derived attribute)
+- The type should be a `class`.
+- The `class` should be `public` or `internal` (if the test project is using the `[DiscoverInternals]` attribute).
+- The `class` shouldn't be `static`.
+- If the `class` is `sealed`, it should be marked with `[TestClass]` (or a derived attribute).
 
 ## How to fix violations
 

--- a/docs/core/testing/mstest-analyzers/mstest0008.md
+++ b/docs/core/testing/mstest-analyzers/mstest0008.md
@@ -40,12 +40,7 @@ Methods marked with `[TestInitialize]` should follow the following layout to be 
 - it should not take any parameter
 - return type should be `void`, `Task` or `ValueTask`
 
-The type declaring these methods should also respect the following rules:
-
-- The type should be a `class`.
-- The `class` should be `public` or `internal` (if the test project is using the `[DiscoverInternals]` attribute).
-- The `class` shouldn't be `static`.
-- If the `class` is `sealed`, it should be marked with `[TestClass]` (or a derived attribute).
+[!INCLUDE [test-class-rules](includes/test-class-rules.md)]
 
 ## How to fix violations
 

--- a/docs/core/testing/mstest-analyzers/mstest0008.md
+++ b/docs/core/testing/mstest-analyzers/mstest0008.md
@@ -40,6 +40,13 @@ Methods marked with `[TestInitialize]` should follow the following layout to be 
 - it should not take any parameter
 - return type should be `void`, `Task` or `ValueTask`
 
+The type declaring these methods should also respect the following rules:
+
+- the type should be a class
+- the class should be `public` or `internal` (if the test project is using the `[DiscoverInternals]` attribute)
+- the class should not be `static`
+- if the class is sealed, it should be marked with `[TestClass]` (or a derived attribute)
+
 ## How to fix violations
 
 Ensure that the method matches the layout described above.

--- a/docs/core/testing/mstest-analyzers/mstest0009.md
+++ b/docs/core/testing/mstest-analyzers/mstest0009.md
@@ -40,12 +40,7 @@ Methods marked with `[TestCleanup]` should follow the following layout to be val
 - it should not take any parameter
 - return type should be `void`, `Task` or `ValueTask`
 
-The type declaring these methods should also respect the following rules:
-
-- the type should be a class
-- the class should be `public` or `internal` (if the test project is using the `[DiscoverInternals]` attribute)
-- the class should not be `static`
-- if the class is sealed, it should be marked with `[TestClass]` (or a derived attribute)
+[!INCLUDE [test-class-rules](includes/test-class-rules.md)]
 
 ## How to fix violations
 

--- a/docs/core/testing/mstest-analyzers/mstest0009.md
+++ b/docs/core/testing/mstest-analyzers/mstest0009.md
@@ -40,6 +40,13 @@ Methods marked with `[TestCleanup]` should follow the following layout to be val
 - it should not take any parameter
 - return type should be `void`, `Task` or `ValueTask`
 
+The type declaring these methods should also respect the following rules:
+
+- the type should be a class
+- the class should be `public` or `internal` (if the test project is using the `[DiscoverInternals]` attribute)
+- the class should not be `static`
+- if the class is sealed, it should be marked with `[TestClass]` (or a derived attribute)
+
 ## How to fix violations
 
 Ensure that the method matches the layout described above.

--- a/docs/core/testing/mstest-analyzers/mstest0010.md
+++ b/docs/core/testing/mstest-analyzers/mstest0010.md
@@ -40,6 +40,14 @@ Methods marked with `[ClassInitialize]` should follow the following layout to be
 - it should take one parameter of type `TestContext`
 - return type should be `void`, `Task` or `ValueTask`
 
+The type declaring these methods should also respect the following rules:
+
+- the type should be a class
+- the class should be `public` or `internal` (if the test project is using the `[DiscoverInternals]` attribute)
+- the class should not be `static`
+- the class should not be generic
+- if the class is sealed, it should be marked with `[TestClass]` (or a derived attribute)
+
 ## How to fix violations
 
 Ensure that the method matches the layout described above.

--- a/docs/core/testing/mstest-analyzers/mstest0010.md
+++ b/docs/core/testing/mstest-analyzers/mstest0010.md
@@ -40,13 +40,9 @@ Methods marked with `[ClassInitialize]` should follow the following layout to be
 - it should take one parameter of type `TestContext`
 - return type should be `void`, `Task` or `ValueTask`
 
-The type declaring these methods should also respect the following rules:
+[!INCLUDE [test-class-rules](includes/test-class-rules.md)]
 
-- the type should be a class
-- the class should be `public` or `internal` (if the test project is using the `[DiscoverInternals]` attribute)
-- the class should not be `static`
 - the class should not be generic
-- if the class is sealed, it should be marked with `[TestClass]` (or a derived attribute)
 
 ## How to fix violations
 

--- a/docs/core/testing/mstest-analyzers/mstest0011.md
+++ b/docs/core/testing/mstest-analyzers/mstest0011.md
@@ -40,13 +40,9 @@ Methods marked with `[ClassCleanup]` should follow the following layout to be va
 - it should not take any parameter
 - return type should be `void`, `Task` or `ValueTask`
 
-The type declaring these methods should also respect the following rules:
+[!INCLUDE [test-class-rules](includes/test-class-rules.md)]
 
-- the type should be a class
-- the class should be `public` or `internal` (if the test project is using the `[DiscoverInternals]` attribute)
-- the class should not be `static`
 - the class should not be generic
-- if the class is sealed, it should be marked with `[TestClass]` (or a derived attribute)
 
 ## How to fix violations
 

--- a/docs/core/testing/mstest-analyzers/mstest0011.md
+++ b/docs/core/testing/mstest-analyzers/mstest0011.md
@@ -40,6 +40,14 @@ Methods marked with `[ClassCleanup]` should follow the following layout to be va
 - it should not take any parameter
 - return type should be `void`, `Task` or `ValueTask`
 
+The type declaring these methods should also respect the following rules:
+
+- the type should be a class
+- the class should be `public` or `internal` (if the test project is using the `[DiscoverInternals]` attribute)
+- the class should not be `static`
+- the class should not be generic
+- if the class is sealed, it should be marked with `[TestClass]` (or a derived attribute)
+
 ## How to fix violations
 
 Ensure that the method matches the layout described above.

--- a/docs/core/testing/mstest-analyzers/mstest0012.md
+++ b/docs/core/testing/mstest-analyzers/mstest0012.md
@@ -40,6 +40,14 @@ Methods marked with `[AssemblyInitialize]` should follow the following layout to
 - it should take one parameter of type `TestContext`
 - return type should be `void`, `Task` or `ValueTask`
 
+The type declaring these methods should also respect the following rules:
+
+- the type should be a class
+- the class should be `public` or `internal` (if the test project is using the `[DiscoverInternals]` attribute)
+- the class should not be `static`
+- the class should not be generic
+- if the class is sealed, it should be marked with `[TestClass]` (or a derived attribute)
+
 ## How to fix violations
 
 Ensure that the method matches the layout described above.

--- a/docs/core/testing/mstest-analyzers/mstest0012.md
+++ b/docs/core/testing/mstest-analyzers/mstest0012.md
@@ -40,13 +40,9 @@ Methods marked with `[AssemblyInitialize]` should follow the following layout to
 - it should take one parameter of type `TestContext`
 - return type should be `void`, `Task` or `ValueTask`
 
-The type declaring these methods should also respect the following rules:
+[!INCLUDE [test-class-rules](includes/test-class-rules.md)]
 
-- the type should be a class
-- the class should be `public` or `internal` (if the test project is using the `[DiscoverInternals]` attribute)
-- the class should not be `static`
 - the class should not be generic
-- if the class is sealed, it should be marked with `[TestClass]` (or a derived attribute)
 
 ## How to fix violations
 

--- a/docs/core/testing/mstest-analyzers/mstest0013.md
+++ b/docs/core/testing/mstest-analyzers/mstest0013.md
@@ -40,13 +40,9 @@ Methods marked with `[AssemblyCleanup]` should follow the following layout to be
 - it should not take any parameter
 - return type should be `void`, `Task` or `ValueTask`
 
-The type declaring these methods should also respect the following rules:
+[!INCLUDE [test-class-rules](includes/test-class-rules.md)]
 
-- the type should be a class
-- the class should be `public` or `internal` (if the test project is using the `[DiscoverInternals]` attribute)
-- the class should not be `static`
 - the class should not be generic
-- if the class is sealed, it should be marked with `[TestClass]` (or a derived attribute)
 
 ## How to fix violations
 

--- a/docs/core/testing/mstest-analyzers/mstest0013.md
+++ b/docs/core/testing/mstest-analyzers/mstest0013.md
@@ -40,6 +40,14 @@ Methods marked with `[AssemblyCleanup]` should follow the following layout to be
 - it should not take any parameter
 - return type should be `void`, `Task` or `ValueTask`
 
+The type declaring these methods should also respect the following rules:
+
+- the type should be a class
+- the class should be `public` or `internal` (if the test project is using the `[DiscoverInternals]` attribute)
+- the class should not be `static`
+- the class should not be generic
+- if the class is sealed, it should be marked with `[TestClass]` (or a derived attribute)
+
 ## How to fix violations
 
 Ensure that the method matches the layout described above.

--- a/docs/core/testing/mstest-analyzers/mstest0029.md
+++ b/docs/core/testing/mstest-analyzers/mstest0029.md
@@ -25,11 +25,11 @@ ms.author: enjieid
 
 ## Cause
 
-A Public method should be a test method.
+A `public` method should be a test method.
 
 ## Rule description
 
-A Public method should be a test method (marked with `[TestMethod]`).
+A `public` method of a class marked with `[TestClass]` should be a test method (marked with `[TestMethod]`). The rule ignores methods that are marked with `[TestInitialize]`, or `[TestCleanup]` attributes.
 
 ## How to fix violations
 

--- a/docs/core/testing/mstest-analyzers/mstest0030.md
+++ b/docs/core/testing/mstest-analyzers/mstest0030.md
@@ -25,7 +25,7 @@ ms.author: enjieid
 
 ## Cause
 
-Type contaning `[TestMethod]` should be marked with `[TestClass]`, otherwise the test method will be silently ignored.
+Type containing `[TestMethod]` should be marked with `[TestClass]`, otherwise the test method will be silently ignored.
 
 ## Rule description
 


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/mstest-analyzers/mstest0008.md](https://github.com/dotnet/docs/blob/8bc8e4a4595dea292a2772703ce4f017fe84732c/docs/core/testing/mstest-analyzers/mstest0008.md) | [MSTEST0008: TestInitialize method should have valid layout](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0008?branch=pr-en-us-41885) |
| [docs/core/testing/mstest-analyzers/mstest0009.md](https://github.com/dotnet/docs/blob/8bc8e4a4595dea292a2772703ce4f017fe84732c/docs/core/testing/mstest-analyzers/mstest0009.md) | ["MSTEST0009: TestCleanup method should have valid layout"](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0009?branch=pr-en-us-41885) |
| [docs/core/testing/mstest-analyzers/mstest0010.md](https://github.com/dotnet/docs/blob/8bc8e4a4595dea292a2772703ce4f017fe84732c/docs/core/testing/mstest-analyzers/mstest0010.md) | [MSTEST0010: ClassInitialize method should have valid layout](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0010?branch=pr-en-us-41885) |
| [docs/core/testing/mstest-analyzers/mstest0011.md](https://github.com/dotnet/docs/blob/8bc8e4a4595dea292a2772703ce4f017fe84732c/docs/core/testing/mstest-analyzers/mstest0011.md) | [docs/core/testing/mstest-analyzers/mstest0011](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0011?branch=pr-en-us-41885) |
| [docs/core/testing/mstest-analyzers/mstest0012.md](https://github.com/dotnet/docs/blob/8bc8e4a4595dea292a2772703ce4f017fe84732c/docs/core/testing/mstest-analyzers/mstest0012.md) | [MSTEST0012: AssemblyInitialize method should have valid layout](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0012?branch=pr-en-us-41885) |
| [docs/core/testing/mstest-analyzers/mstest0013.md](https://github.com/dotnet/docs/blob/8bc8e4a4595dea292a2772703ce4f017fe84732c/docs/core/testing/mstest-analyzers/mstest0013.md) | ["MSTEST0013: AssemblyCleanup method should have valid layout"](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0013?branch=pr-en-us-41885) |
| [docs/core/testing/mstest-analyzers/mstest0029.md](https://github.com/dotnet/docs/blob/8bc8e4a4595dea292a2772703ce4f017fe84732c/docs/core/testing/mstest-analyzers/mstest0029.md) | [MSTEST0029: Public method should be test method](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0029?branch=pr-en-us-41885) |
| [docs/core/testing/mstest-analyzers/mstest0030.md](https://github.com/dotnet/docs/blob/8bc8e4a4595dea292a2772703ce4f017fe84732c/docs/core/testing/mstest-analyzers/mstest0030.md) | [MSTEST0030: Type containing `[TestMethod]` should be marked with `[TestClass]`](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0030?branch=pr-en-us-41885) |


<!-- PREVIEW-TABLE-END -->