### PR TITLE
fix markdown lint issues

### DIFF
--- a/docs/csharp/language-reference/xmldoc/recommended-tags.md
+++ b/docs/csharp/language-reference/xmldoc/recommended-tags.md
@@ -259,8 +259,8 @@ The `<para>` tag is for use inside a tag, such as [\<summary>](#summary), [\<rem
 The `<listheader>` block is used to define the heading row of either a table or definition list.
 
 When defining a table:
-* You only need to supply an entry for `term` in the heading.
 
+* You only need to supply an entry for `term` in the heading.
 * Each item in the list is specified with an `<item>` block. For each `item`, you will only need to supply an entry for `description`.
 
 When creating a definition list:

--- a/docs/csharp/language-reference/xmldoc/recommended-tags.md
+++ b/docs/csharp/language-reference/xmldoc/recommended-tags.md
@@ -256,15 +256,17 @@ The `<para>` tag is for use inside a tag, such as [\<summary>](#summary), [\<rem
 </list>
 ```
 
-The `<listheader>` block is used to define the heading row of either a table or definition list. 
+The `<listheader>` block is used to define the heading row of either a table or definition list.
 
 When defining a table:
-* You only need to supply an entry for `term` in the heading. 
+* You only need to supply an entry for `term` in the heading.
+
 * Each item in the list is specified with an `<item>` block. For each `item`, you will only need to supply an entry for `description`.
 
 When creating a definition list:
-* You must supply an entry for `term` in the heading. 
-* Each item in the list is specified with an `<item>` block. Each `item` must contain both a `term` and `description`. 
+
+* You must supply an entry for `term` in the heading.
+* Each item in the list is specified with an `<item>` block. Each `item` must contain both a `term` and `description`.
 
 A list or table can have as many `<item>` blocks as needed.
 


### PR DESCRIPTION
Auto-merge hurt.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/xmldoc/recommended-tags.md](https://github.com/dotnet/docs/blob/ee3272b650b97293eb94b57119bae4073e68684a/docs/csharp/language-reference/xmldoc/recommended-tags.md) | [Recommended XML tags for C# documentation comments](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/recommended-tags?branch=pr-en-us-41888) |


<!-- PREVIEW-TABLE-END -->