### PR TITLE
Add .NET NativeAOT dependencies for Fedora/RHEL

### DIFF
--- a/docs/core/deploying/native-aot/index.md
+++ b/docs/core/deploying/native-aot/index.md
@@ -32,15 +32,6 @@ AOT support in .NET 8 is more comprehensive than in .NET 7. However, there are s
 
 [Visual Studio 2022](https://visualstudio.microsoft.com/vs/), including the **Desktop development with C++** workload with all default components.
 
-# [Ubuntu](#tab/linux-ubuntu)
-
-- The compiler toolchain and developer packages for libraries that the .NET runtime depends on.
-- Ubuntu (18.04+)
-
-  ```sh
-  sudo apt-get install clang zlib1g-dev
-  ```
-
 # [Alpine](#tab/linux-alpine)
 
 - The compiler toolchain and developer packages for libraries that the .NET runtime depends on.
@@ -48,6 +39,33 @@ AOT support in .NET 8 is more comprehensive than in .NET 7. However, there are s
 
   ```sh
   sudo apk add clang build-base zlib-dev
+  ```
+
+# [Fedora](#tab/linux-fedora)
+
+- The compiler toolchain and developer packages for libraries that the .NET runtime depends on.
+- Fedora (39+)
+
+  ```sh
+  sudo dnf install clang zlib-devel
+  ```
+
+# [RHEL](#tab/linux-rhel)
+
+- The compiler toolchain and developer packages for libraries that the .NET runtime depends on.
+- RHEL (8+)
+
+  ```sh
+  sudo dnf install clang zlib-devel
+  ```
+
+# [Ubuntu](#tab/linux-ubuntu)
+
+- The compiler toolchain and developer packages for libraries that the .NET runtime depends on.
+- Ubuntu (18.04+)
+
+  ```sh
+  sudo apt-get install clang zlib1g-dev
   ```
 
 # [macOS](#tab/macOS)


### PR DESCRIPTION
## Summary

Add NativeAOT dependencies for Fedora/RHEL.

I also sorted all the Linux entries alphabetically.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/deploying/native-aot/index.md](https://github.com/dotnet/docs/blob/6383b6d84ca3f76b91e18abe36dccab778b26015/docs/core/deploying/native-aot/index.md) | [Native AOT deployment](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/index?branch=pr-en-us-41893) |

<!-- PREVIEW-TABLE-END -->