### PR TITLE
Update target framework statement for Azure SDK

### DIFF
--- a/docs/azure/sdk/azure-sdk-for-dotnet.md
+++ b/docs/azure/sdk/azure-sdk-for-dotnet.md
@@ -12,7 +12,7 @@ ms.date: 07/26/2024
 
 The **Azure SDK for .NET** is designed to make it easy to use Azure services from your .NET applications. Whether it's uploading and downloading files to Blob Storage, retrieving application secrets from Azure Key Vault, or processing notifications from Azure Event Hubs, the Azure SDK for .NET provides a consistent and familiar interface to access Azure services.  
 
-The Azure SDK for .NET is a collection of NuGet packages that can be used in applications targeting .NET variants that implement [.NET Standard 2.0](/dotnet/standard/net-standard?tabs=net-standard-2-0).
+The Azure SDK for .NET is a collection of NuGet packages that can be used in applications targeting .NET variants that implement [.NET Standard 2.0](/dotnet/standard/net-standard?tabs=net-standard-2-0#select-net-standard-version).
 
 :::image type="content" source="./media/azure-sdk-for-dotnet-overview.png" alt-text="Diagram showing how .NET applications use the Azure SDK to access Azure services.":::
 

--- a/docs/azure/sdk/azure-sdk-for-dotnet.md
+++ b/docs/azure/sdk/azure-sdk-for-dotnet.md
@@ -3,16 +3,16 @@ title: Azure SDK for .NET Overview
 description: Provides an overview of what the Azure SDK for .NET is and the basic steps to use the SDK in a .NET application
 ms.topic: conceptual
 ms.custom: devx-track-dotnet, engagement-fy23
-ms.date: 3/23/2023
+ms.date: 07/26/2024
 ---
 
 # Azure SDK for .NET overview
 
 ## What is the Azure SDK for .NET
 
-The **Azure SDK for .NET** is designed to make it easy to use Azure services from your .NET applications.  Whether it is uploading and downloading files to Blob Storage, retrieving application secrets from Azure Key Vault, or processing notifications from Azure Event Hubs, the Azure SDK for .NET provides a consistent and familiar interface to access Azure services.  
+The **Azure SDK for .NET** is designed to make it easy to use Azure services from your .NET applications. Whether it's uploading and downloading files to Blob Storage, retrieving application secrets from Azure Key Vault, or processing notifications from Azure Event Hubs, the Azure SDK for .NET provides a consistent and familiar interface to access Azure services.  
 
-The Azure SDK for .NET is available as series of NuGet packages that can be used in both .NET Core (2.1 and higher) and .NET Framework (4.7.2 and higher) applications.
+The Azure SDK for .NET is a collection of NuGet packages that can be used in applications targeting .NET variants that implement [.NET Standard 2.0](/dotnet/standard/net-standard?tabs=net-standard-2-0).
 
 :::image type="content" source="./media/azure-sdk-for-dotnet-overview.png" alt-text="Diagram showing how .NET applications use the Azure SDK to access Azure services.":::
 


### PR DESCRIPTION
Correct the statement made about supported .NET implementations. The latest generation of Azure SDK for .NET client libraries target .NET Standard 2.0:

https://github.com/Azure/azure-sdk-for-net/blob/188ef8da939f289e64ae58f8b3652003503c0d91/eng/Directory.Build.Common.props#L135


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/azure/sdk/azure-sdk-for-dotnet.md](https://github.com/dotnet/docs/blob/a3fa4573a4a531cfbe845e91e7ffa976e2794111/docs/azure/sdk/azure-sdk-for-dotnet.md) | [Azure SDK for .NET overview](https://review.learn.microsoft.com/en-us/dotnet/azure/sdk/azure-sdk-for-dotnet?branch=pr-en-us-41917) |


<!-- PREVIEW-TABLE-END -->