### PR TITLE
recommend usage of trusted NuGet package sources

### DIFF
--- a/docs/core/tools/dotnet-nuget-add-source.md
+++ b/docs/core/tools/dotnet-nuget-add-source.md
@@ -37,8 +37,8 @@ The `dotnet nuget add source` command adds a new package source to your NuGet co
 
   Path to the package source.
 
-  > [!NOTE]
-  > Use package sources that you trust.
+> [!NOTE]
+> Use package sources that you trust.
 
 ## Options
 

--- a/docs/core/tools/dotnet-nuget-add-source.md
+++ b/docs/core/tools/dotnet-nuget-add-source.md
@@ -36,10 +36,7 @@ The `dotnet nuget add source` command adds a new package source to your NuGet co
 - **`PACKAGE_SOURCE_PATH`**
 
   Path to the package source.
-
-> [!NOTE]
-> Use package sources that you trust.
-
+  
 ## Options
 
 [!INCLUDE [configfile](../../../includes/cli-configfile.md)]

--- a/docs/core/tools/dotnet-nuget-add-source.md
+++ b/docs/core/tools/dotnet-nuget-add-source.md
@@ -11,6 +11,9 @@ ms.date: 03/20/2020
 
 `dotnet nuget add source` - Add a NuGet source.
 
+> [!NOTE]
+> Use package sources that you trust.
+
 ## Synopsis
 
 ```dotnetcli
@@ -33,6 +36,9 @@ The `dotnet nuget add source` command adds a new package source to your NuGet co
 - **`PACKAGE_SOURCE_PATH`**
 
   Path to the package source.
+
+  > [!NOTE]
+  > Use package sources that you trust.
 
 ## Options
 

--- a/docs/core/tools/dotnet-nuget-add-source.md
+++ b/docs/core/tools/dotnet-nuget-add-source.md
@@ -36,7 +36,7 @@ The `dotnet nuget add source` command adds a new package source to your NuGet co
 - **`PACKAGE_SOURCE_PATH`**
 
   Path to the package source.
-  
+
 ## Options
 
 [!INCLUDE [configfile](../../../includes/cli-configfile.md)]

--- a/docs/core/tools/dotnet-nuget-update-source.md
+++ b/docs/core/tools/dotnet-nuget-update-source.md
@@ -11,6 +11,9 @@ ms.date: 03/20/2020
 
 `dotnet nuget update source` - Update a NuGet source.
 
+> [!NOTE]
+> Use package sources that you trust.
+
 ## Synopsis
 
 ```dotnetcli
@@ -46,6 +49,9 @@ The `dotnet nuget update source` command updates an existing source in your NuGe
 - **`-s|--source <SOURCE>`**
 
   Path to the package source.
+
+  > [!NOTE]
+  > Use package sources that you trust.
 
 - **`--store-password-in-clear-text`**
 

--- a/docs/core/tools/dotnet-nuget-update-source.md
+++ b/docs/core/tools/dotnet-nuget-update-source.md
@@ -50,8 +50,8 @@ The `dotnet nuget update source` command updates an existing source in your NuGe
 
   Path to the package source.
 
-  > [!NOTE]
-  > Use package sources that you trust.
+> [!NOTE]
+> Use package sources that you trust.
 
 - **`--store-password-in-clear-text`**
 

--- a/docs/core/tools/dotnet-nuget-update-source.md
+++ b/docs/core/tools/dotnet-nuget-update-source.md
@@ -50,9 +50,6 @@ The `dotnet nuget update source` command updates an existing source in your NuGe
 
   Path to the package source.
 
-> [!NOTE]
-> Use package sources that you trust.
-
 - **`--store-password-in-clear-text`**
 
   Enables storing portable package source credentials by disabling password encryption.


### PR DESCRIPTION
## Summary

Updated dotnet nuget add/update source command docs to recommend usage of trusted package sources.

Fixes https://github.com/NuGet/Client.Engineering/issues/2852


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-nuget-add-source.md](https://github.com/dotnet/docs/blob/59b63986293b4f35309dd0eef3de794087edf23a/docs/core/tools/dotnet-nuget-add-source.md) | [docs/core/tools/dotnet-nuget-add-source](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-add-source?branch=pr-en-us-41922) |
| [docs/core/tools/dotnet-nuget-update-source.md](https://github.com/dotnet/docs/blob/59b63986293b4f35309dd0eef3de794087edf23a/docs/core/tools/dotnet-nuget-update-source.md) | [docs/core/tools/dotnet-nuget-update-source](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-update-source?branch=pr-en-us-41922) |


<!-- PREVIEW-TABLE-END -->