### PR TITLE
Update line numbers for Azure SDK DI doc

### DIFF
--- a/docs/azure/sdk/dependency-injection.md
+++ b/docs/azure/sdk/dependency-injection.md
@@ -50,7 +50,7 @@ In the *Program.cs* file, invoke the <xref:Microsoft.Extensions.Azure.AzureClien
 
 ### [HostBuilder](#tab/host-builder)
 
-:::code language="csharp" source="snippets/dependency-injection/HostBuilder/Program.cs" id="snippet_HostBuilder" highlight="11-27":::
+:::code language="csharp" source="snippets/dependency-injection/HostBuilder/Program.cs" id="snippet_HostBuilder" highlight="11-26":::
 
 ---
 


### PR DESCRIPTION
Correct the ending line number for the `HostBuilder` code sample.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/azure/sdk/dependency-injection.md](https://github.com/dotnet/docs/blob/14e090b2034a6a96302964f293e5d16132b573ab/docs/azure/sdk/dependency-injection.md) | [Dependency injection with the Azure SDK for .NET](https://review.learn.microsoft.com/en-us/dotnet/azure/sdk/dependency-injection?branch=pr-en-us-41925) |

<!-- PREVIEW-TABLE-END -->