### PR TITLE
DebugSymbols breaking change

### DIFF
--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -138,6 +138,7 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 | [--arch option doesn't imply self-contained](sdk/8.0/arch-option.md)                           | Behavioral change                                |
 | ['dotnet restore' produces security vulnerability warnings](sdk/8.0/dotnet-restore-audit.md)   | Behavioral change                                |
 | [SDK uses a smaller RID graph](sdk/8.0/rid-graph.md)                                           | Behavioral change/Source incompatible            |
+| [Setting DebugSymbols to false disables PDB generation](sdk/8.0/debugsymbols.md)               | Behavioral change                                |
 | [Source Link included in the .NET SDK](sdk/8.0/source-link.md)                                 | Source incompatible                              |
 | [Trimming may not be used with .NET Standard or .NET Framework](sdk/8.0/trimming-unsupported-targetframework.md) | Behavioral change                                |
 | [Unlisted packages not installed by default for .NET tools](sdk/8.0/unlisted-versions.md)                         | Behavioral change                                |

--- a/docs/core/compatibility/sdk/8.0/debugsymbols.md
+++ b/docs/core/compatibility/sdk/8.0/debugsymbols.md
@@ -8,7 +8,7 @@ ms.date: 07/30/2024
 
 The existing [MSBuild documentation](/visualstudio/msbuild/common-msbuild-project-properties) says that specifying `DebugSymbols=false` on the command line means that program database (*.pdb*) files aren't generated. However, that wasn't true before .NET 8. The behavior has been updated such that setting `DebugSymbols` to `false` now suppresses PDB generation by changing `DebugType` to `None`.
 
-If you currently have a script that includes `-p:DebugSymbols=false`, you might expect PDBs to be created. If you upgrade to .NET 8 or a later version, that behavior will change.
+If you currently have a script where you expect PDBs to be created, and the behavior changes when you upgrade to .NET 8 or a later version, check if the script includes `-p:DebugSymbols=false`.
 
 ## Previous behavior
 

--- a/docs/core/compatibility/sdk/8.0/debugsymbols.md
+++ b/docs/core/compatibility/sdk/8.0/debugsymbols.md
@@ -1,0 +1,39 @@
+---
+title: "Breaking change: Setting DebugSymbols to false disables PDB generation"
+description: Learn about the breaking change in the .NET SDK where setting DebugSymbols to false disables PDB generation.
+no-loc: [DebugSymbols]
+ms.date: 07/30/2024
+---
+# Setting DebugSymbols to false disables PDB generation
+
+The existing [MSBuild documentation](/visualstudio/msbuild/common-msbuild-project-properties) says that specifying `DebugSymbols=false` on the command line means that program database (*.pdb*) files aren't generated. However, that wasn't true before .NET 8. The behavior has been updated such that setting `DebugSymbols` to `false` now suppresses PDB generation by changing `DebugType` to `None`.
+
+If you currently have a script that includes `-p:DebugSymbols=false`, you might expect PDBs to be created. If you upgrade to .NET 8 or a later version, that behavior will change.
+
+## Previous behavior
+
+`-p:DebugSymbols=false` did not suppress PDB generation.
+
+## New behavior
+
+`-p:DebugSymbols=false` suppresses PDB generation.
+
+## Version introduced
+
+.NET 8
+
+## Type of change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+This change aligns with the existing documentation and user expectations. The previous behavior often led to confusion.
+
+## Recommended action
+
+If you want to generate PDBs, don't specify `-p:DebugSymbols=false` on the command line. Simply remove that property and the PDB files will be generated again.
+
+## Affected APIs
+
+N/A

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -228,6 +228,8 @@ items:
         href: sdk/8.0/arch-option.md
       - name: SDK uses a smaller RID graph
         href: sdk/8.0/rid-graph.md
+      - name: Setting DebugSymbols to false disables PDB generation
+        href: sdk/8.0/debugsymbols.md
       - name: Source Link included in the .NET SDK
         href: sdk/8.0/source-link.md
       - name: Trimming can't be used with .NET Standard or .NET Framework
@@ -1664,6 +1666,8 @@ items:
         href: sdk/8.0/arch-option.md
       - name: SDK uses a smaller RID graph
         href: sdk/8.0/rid-graph.md
+      - name: Setting DebugSymbols to false disables PDB generation
+        href: sdk/8.0/debugsymbols.md
       - name: Source Link included in the .NET SDK
         href: sdk/8.0/source-link.md
       - name: Trimming can't be used with .NET Standard or .NET Framework


### PR DESCRIPTION
Fixes #41400 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/8.0.md](https://github.com/dotnet/docs/blob/0b06107fe8a827da31b7f61304f752d5c3ce582b/docs/core/compatibility/8.0.md) | [Breaking changes in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/8.0?branch=pr-en-us-41957) |
| [docs/core/compatibility/sdk/8.0/debugsymbols.md](https://github.com/dotnet/docs/blob/0b06107fe8a827da31b7f61304f752d5c3ce582b/docs/core/compatibility/sdk/8.0/debugsymbols.md) | [Setting DebugSymbols to false disables PDB generation](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/debugsymbols?branch=pr-en-us-41957) |

<!-- PREVIEW-TABLE-END -->