### PR TITLE
Remove Serializable attribute from exception example

### DIFF
--- a/docs/standard/exceptions/how-to-create-localized-exception-messages.md
+++ b/docs/standard/exceptions/how-to-create-localized-exception-messages.md
@@ -5,28 +5,26 @@ author: Youssef1313
 dev_langs:
   - csharp
   - vb
-ms.date: 09/13/2019
+ms.date: 07/31/2024
 ---
 # How to create user-defined exceptions with localized exception messages
 
-In this article, you will learn how to create user-defined exceptions that are inherited from the base <xref:System.Exception> class with localized exception messages using satellite assemblies.
+In this article, you learn how to create user-defined exceptions that are inherited from the base <xref:System.Exception> class with localized exception messages using satellite assemblies.
 
 ## Create custom exceptions
 
-.NET contains many different exceptions that you can use. However, in some cases when none of them meets your needs, you can create your own custom exceptions.
+.NET contains many different exceptions that you can use. However, in cases when none of them meets your needs, you can create your own custom exception.
 
 Let's assume you want to create a `StudentNotFoundException` that contains a `StudentName` property.
 To create a custom exception, follow these steps:
 
-1. Create a serializable class that inherits from <xref:System.Exception>. The class name should end in "Exception":
+1. Create a class that inherits from <xref:System.Exception>. The class name should end in "Exception":
 
     ```csharp
-    [Serializable]
     public class StudentNotFoundException : Exception { }
     ```
 
     ```vb
-    <Serializable>
     Public Class StudentNotFoundException
         Inherits Exception
     End Class
@@ -35,7 +33,6 @@ To create a custom exception, follow these steps:
 1. Add the default constructors:
 
     ```csharp
-    [Serializable]
     public class StudentNotFoundException : Exception
     {
         public StudentNotFoundException() { }
@@ -49,7 +46,6 @@ To create a custom exception, follow these steps:
     ```
 
     ```vb
-    <Serializable>
     Public Class StudentNotFoundException
         Inherits Exception
 
@@ -69,7 +65,6 @@ To create a custom exception, follow these steps:
 1. Define any additional properties and constructors:
 
     ```csharp
-    [Serializable]
     public class StudentNotFoundException : Exception
     {
         public string StudentName { get; }
@@ -91,7 +86,6 @@ To create a custom exception, follow these steps:
     ```
 
     ```vb
-    <Serializable>
     Public Class StudentNotFoundException
         Inherits Exception
 
@@ -128,7 +122,7 @@ Throw New StudentNotFoundException("The student cannot be found.", "John")
 ```
 
 The problem with the previous line is that `"The student cannot be found."` is just a constant string. In a localized application, you want to have different messages depending on user culture.
-[Satellite assemblies](../../core/extensions/create-satellite-assemblies.md) are a good way to do that. A satellite assembly is a .dll that contains resources for a specific language. When you ask for a specific resources at run time, the CLR finds that resource depending on user culture. If no satellite assembly is found for that culture, the resources of the default culture are used.
+[Satellite assemblies](../../core/extensions/create-satellite-assemblies.md) are a good way to do that. A satellite assembly is a DLL that contains resources for a specific language. When you ask for a specific resources at run time, the CLR finds that resource depending on user culture. If no satellite assembly is found for that culture, the resources of the default culture are used.
 
 To create the localized exception messages:
 

--- a/docs/standard/exceptions/how-to-create-user-defined-exceptions.md
+++ b/docs/standard/exceptions/how-to-create-user-defined-exceptions.md
@@ -3,11 +3,11 @@ title: "How to: Create User-Defined Exceptions"
 description: Learn how to create user-defined exceptions, which are an alternative to the hierarchy of exception classes derived from the Exception base class in .NET.
 ms.date: "08/10/2022"
 ms.custom: devdivchpfy22
-dev_langs: 
+dev_langs:
   - "csharp"
   - "vb"
   - "cpp"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "user-defined exceptions"
   - "exceptions, examples"
   - "exceptions, user-defined"
@@ -15,13 +15,13 @@ ms.assetid: 25819a5a-f915-4fc8-b924-a76915674e04
 ---
 # How to create user-defined exceptions
 
-.NET provides a hierarchy of exception classes ultimately derived from the <xref:System.Exception> base class. However, if none of the predefined exceptions meet your needs, you can create your own exception classes by deriving from the <xref:System.Exception> class.
+.NET provides a hierarchy of exception classes ultimately derived from the <xref:System.Exception> base class. However, if none of the predefined exceptions meet your needs, you can create your own exception class by deriving from the <xref:System.Exception> class.
 
 When creating your own exceptions, end the class name of the user-defined exception with the word "Exception", and implement the three common constructors, as shown in the following example. The example defines a new exception class named `EmployeeListNotFoundException`. The class is derived from the <xref:System.Exception> base class and includes three constructors.
 
 [!code-cpp[dg_exceptionDesign#14](../../../samples/snippets/cpp/VS_Snippets_CLR/dg_exceptionDesign/cpp/example2.cpp#14)]
 [!code-csharp[dg_exceptionDesign#14](../../../samples/snippets/csharp/VS_Snippets_CLR/dg_exceptionDesign/cs/example2.cs#14)]
-[!code-vb[dg_exceptionDesign#14](../../../samples/snippets/visualbasic/VS_Snippets_CLR/dg_exceptionDesign/vb/example2.vb#14)]  
+[!code-vb[dg_exceptionDesign#14](../../../samples/snippets/visualbasic/VS_Snippets_CLR/dg_exceptionDesign/vb/example2.vb#14)]
 
 > [!NOTE]
 > In situations where you're using remoting, you must ensure that the metadata for any user-defined exceptions is available at the server (callee) and to the client (the proxy object or caller). For more information, see [Best practices for exceptions](best-practices-for-exceptions.md).


### PR DESCRIPTION
Fixes #40333

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/exceptions/how-to-create-localized-exception-messages.md](https://github.com/dotnet/docs/blob/f6d92d6a8cf81bc7bf5d36009269559ea6933880/docs/standard/exceptions/how-to-create-localized-exception-messages.md) | [How to create user-defined exceptions with localized exception messages](https://review.learn.microsoft.com/en-us/dotnet/standard/exceptions/how-to-create-localized-exception-messages?branch=pr-en-us-41971) |
| [docs/standard/exceptions/how-to-create-user-defined-exceptions.md](https://github.com/dotnet/docs/blob/f6d92d6a8cf81bc7bf5d36009269559ea6933880/docs/standard/exceptions/how-to-create-user-defined-exceptions.md) | [How to create user-defined exceptions](https://review.learn.microsoft.com/en-us/dotnet/standard/exceptions/how-to-create-user-defined-exceptions?branch=pr-en-us-41971) |

<!-- PREVIEW-TABLE-END -->