### PR TITLE
Remove extra 's' in System.Text.Json support

### DIFF
--- a/docs/standard/datetime/system-text-json-support.md
+++ b/docs/standard/datetime/system-text-json-support.md
@@ -91,7 +91,7 @@ The parameter is useful for handling polymorphic cases and when using generics t
 You can use fast UTF-8-based parsing and formatting methods in your converter logic if your input <xref:System.DateTime> or <xref:System.DateTimeOffset>
 text representations are compliant with one of the "R", "l", "O", or "G"
  [standard date and time format strings](../base-types/standard-date-and-time-format-strings.md),
-or you want to write according to one of these formats. This approach is much faster than using s`DateTime(Offset).Parse` and `DateTime(Offset).ToString`.
+or you want to write according to one of these formats. This approach is much faster than using `DateTime(Offset).Parse` and `DateTime(Offset).ToString`.
 
 The following example shows a custom converter that serializes and deserializes <xref:System.DateTime> values according to
  [the "R" standard format](../base-types/standard-date-and-time-format-strings.md#the-rfc1123-r-r-format-specifier):


### PR DESCRIPTION
## Summary

Remove the extra leading 's' that should not be there.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/datetime/system-text-json-support.md](https://github.com/dotnet/docs/blob/dcf44fce596e05bdac17506269cd8779a79bcff9/docs/standard/datetime/system-text-json-support.md) | [DateTime and DateTimeOffset support in System.Text.Json](https://review.learn.microsoft.com/en-us/dotnet/standard/datetime/system-text-json-support?branch=pr-en-us-41985) |

<!-- PREVIEW-TABLE-END -->