### PR TITLE
Update streams-programming-apis.md implicit subscription section to b…

### DIFF
--- a/docs/orleans/streaming/streams-programming-apis.md
+++ b/docs/orleans/streaming/streams-programming-apis.md
@@ -164,7 +164,7 @@ Below are the guidelines on how to write the subscription logic for various case
 
 **Implicit subscriptions:**
 
-For implicit subscriptions, the grain still needs to subscribe to attach the processing logic. This can be done in the consumer grain by implementing the `IStreamSubscriptionObserver` and `IAsyncObserver<T>` interfaces, allowing, for the grain to activate separately from subscribing. To subscribe to the stream, the grain creates a handle and calls `await handle.ResumeAsync(this)` in its `OnSubscribed(...)` method.
+For implicit subscriptions, the grain still needs to subscribe to attach the processing logic. This can be done in the consumer grain by implementing the `IStreamSubscriptionObserver` and `IAsyncObserver<T>` interfaces, allowing the grain to activate separately from subscribing. To subscribe to the stream, the grain creates a handle and calls `await handle.ResumeAsync(this)` in its `OnSubscribed(...)` method.
 
 To process messages, the `IAsyncObserver<T>.OnNextAsync(...)` method is implemented to receive stream data and a sequence token. Alternatively, the `ResumeAsync` method may take a set of delegates representing the methods of the `IAsyncObserver<T>` interface, `onNextAsync`, `onErrorAsync`, and `onCompletedAsync`.
 

--- a/docs/orleans/streaming/streams-programming-apis.md
+++ b/docs/orleans/streaming/streams-programming-apis.md
@@ -164,7 +164,9 @@ Below are the guidelines on how to write the subscription logic for various case
 
 **Implicit subscriptions:**
 
-For implicit subscriptions, the grain still needs to subscribe to attach the processing logic. This should be done in the consumer grain by implementing the `IStreamSubscriptionObserver` and `IAsyncObserver<T>` interfaces. To subscribe to the stream, the grain creates a handle and calls `await handle.ResumeAsync(this)` in its `OnSubscribed(...)` method. To process messages, the `IAsyncObserver<T>.OnNextAsync(...)` method is implemented to receive stream data and a sequence token.
+For implicit subscriptions, the grain still needs to subscribe to attach the processing logic. This can be done in the consumer grain by implementing the `IStreamSubscriptionObserver` and `IAsyncObserver<T>` interfaces, allowing, for the grain to activate separately from subscribing. To subscribe to the stream, the grain creates a handle and calls `await handle.ResumeAsync(this)` in its `OnSubscribed(...)` method.
+
+To process messages, the `IAsyncObserver<T>.OnNextAsync(...)` method is implemented to receive stream data and a sequence token. Alternatively, the `ResumeAsync` method may take a set of delegates representing the methods of the `IAsyncObserver<T>` interface, `onNextAsync`, `onErrorAsync`, and `onCompletedAsync`.
 
 <!-- markdownlint-disable MD044 -->
 :::zone target="docs" pivot="orleans-7-0"


### PR DESCRIPTION
## Summary

The section for Microsoft Orleans Streams Programming is missing information regarding how to implement Implicit Streams using the `IAsyncOberserver` and `IStreamSubscriptionObserver` interfaces. The documentation currently states that an explicit subscription is required, but implicit subscriptions can be supported by implementing two interfaces.

Adds information regarding implementing IAsyncObserver<T> and IStreamSubscriptionObserver for Implicit Streams instead of explicitly subscribing (which ~does not apply~ is not required in the case of an implicit subscription)



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/streaming/streams-programming-apis.md](https://github.com/dotnet/docs/blob/5d69aec7a5e41ba5383444f47933413069e5d4a4/docs/orleans/streaming/streams-programming-apis.md) | [docs/orleans/streaming/streams-programming-apis](https://review.learn.microsoft.com/en-us/dotnet/orleans/streaming/streams-programming-apis?branch=pr-en-us-41988) |


<!-- PREVIEW-TABLE-END -->