### PR TITLE
Add version 13 to version table

### DIFF
--- a/docs/csharp/language-reference/configure-language-version.md
+++ b/docs/csharp/language-reference/configure-language-version.md
@@ -2,7 +2,7 @@
 title: Configure language version
 description: Learn how to override the default C# language version manually.
 ms.custom: "updateeachrelease"
-ms.date: 10/30/2023
+ms.date: 08/02/2024
 ---
 
 # Configure C# language version
@@ -42,4 +42,10 @@ To configure multiple projects, you can create a *Directory.Build.props* file, t
 </Project>
 ```
 
+## C# language version reference
+
 Builds in all subdirectories of the directory containing that file now use the preview C# version. For more information, see [Customize your build](/visualstudio/msbuild/customize-your-build).
+
+The following table shows all current C# language versions. Older compilers might not understand every value. If you install the latest .NET SDK, you have access to everything listed.
+
+[!INCLUDE [langversion-table](includes/langversion-table.md)]

--- a/docs/csharp/language-reference/includes/default-langversion-table.md
+++ b/docs/csharp/language-reference/includes/default-langversion-table.md
@@ -4,6 +4,7 @@ ms.custom: "updateeachrelease"
 
 | Target           | Version | C# language version default |
 |------------------|---------|-----------------------------|
+| .NET             | 9.x     | C# 13                       |
 | .NET             | 8.x     | C# 12                       |
 | .NET             | 7.x     | C# 11                       |
 | .NET             | 6.x     | C# 10                       |

--- a/docs/csharp/language-reference/includes/langversion-table.md
+++ b/docs/csharp/language-reference/includes/langversion-table.md
@@ -7,6 +7,7 @@ ms.custom: "updateeachrelease"
 | `preview`                     | The compiler accepts all valid language syntax from the latest preview version.                         |
 | `latest`                      | The compiler accepts syntax from the latest released version of the compiler (including minor version). |
 | `latestMajor`<br>or `default` | The compiler accepts syntax from the latest released major version of the compiler.                     |
+| `13.0`                        | The compiler accepts only syntax that is included in C# 13 or lower.                                    |
 | `12.0`                        | The compiler accepts only syntax that is included in C# 12 or lower.                                    |
 | `11.0`                        | The compiler accepts only syntax that is included in C# 11 or lower.                                    |
 | `10.0`                        | The compiler accepts only syntax that is included in C# 10 or lower.                                    |

--- a/docs/csharp/language-reference/language-versioning.md
+++ b/docs/csharp/language-reference/language-versioning.md
@@ -2,7 +2,7 @@
 title: Language versioning
 description: Learn about how the C# language version is determined based on your project and the reasons behind that choice.
 ms.custom: "updateeachrelease"
-ms.date: 10/30/2023
+ms.date: 08/02/2024
 ---
 
 # C# language versioning


### PR DESCRIPTION
C# 13 is coming. It's time to add it to the default and all version tables.

Also, include the table on the article about configuring the version based on anonymous feedback.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/configure-language-version.md](https://github.com/dotnet/docs/blob/00587195cd8475f176f3f3e7bc2fbf4d5f7ffa33/docs/csharp/language-reference/configure-language-version.md) | [docs/csharp/language-reference/configure-language-version](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version?branch=pr-en-us-42011) |
| [docs/csharp/language-reference/language-versioning.md](https://github.com/dotnet/docs/blob/00587195cd8475f176f3f3e7bc2fbf4d5f7ffa33/docs/csharp/language-reference/language-versioning.md) | [docs/csharp/language-reference/language-versioning](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-versioning?branch=pr-en-us-42011) |

<!-- PREVIEW-TABLE-END -->