### PR TITLE
Use same severity level for the same warning

### DIFF
--- a/docs/core/extensions/create-resource-files.md
+++ b/docs/core/extensions/create-resource-files.md
@@ -144,7 +144,7 @@ csc greeting.cs -resource:GreetingResources.resources
 </data>
 ```
 
-> [!WARNING]
+> [!CAUTION]
 > Do not use resource files to store passwords, security-sensitive information, or private data.
 
  For resource objects, the **data** tag includes a `type` attribute that indicates the data type of the resource. For objects that consist of binary data, the `data` tag also includes a `mimetype` attribute, which indicates the `base64` type of the binary data.
@@ -183,7 +183,7 @@ You can use the <xref:System.Resources.ResourceWriter?displayProperty=nameWithTy
 
 3. Call the <xref:System.Resources.ResourceWriter.Close%2A?displayProperty=nameWithType> method to write the resources to the file and to close the <xref:System.Resources.ResourceWriter> object.
 
-> [!NOTE]
+> [!CAUTION]
 > Do not use resource files to store passwords, security-sensitive information, or private data.
 
  The following example programmatically creates a .resources file named CarResources.resources that stores six strings, an icon, and two application-defined objects (two `Automobile` objects). The `Automobile` class, which is defined and instantiated in the example, is tagged with the <xref:System.SerializableAttribute> attribute, which allows it to be persisted by the binary serialization formatter.


### PR DESCRIPTION
The same warning for not saving sensitive data in the resource file is displayed as a caution, a warning and an info message. It should be the same for all types of storage.

## Summary

Change the severity level for the same warning message to "!CAUTION" for all cases

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/create-resource-files.md](https://github.com/dotnet/docs/blob/5553159ac68185367f29d1424fa2fc312de65a11/docs/core/extensions/create-resource-files.md) | [docs/core/extensions/create-resource-files](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/create-resource-files?branch=pr-en-us-42019) |

<!-- PREVIEW-TABLE-END -->