### PR TITLE
Remove 'Attribute' postifx from `WeatherForecastWithPropertyNameAttribute`

### DIFF
--- a/docs/standard/serialization/system-text-json/snippets/how-to/csharp/RoundtripCamelCasePropertyNames.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to/csharp/RoundtripCamelCasePropertyNames.cs
@@ -7,8 +7,8 @@ namespace SystemTextJsonSamples
         public static void Run()
         {
             string jsonString;
-            WeatherForecastWithPropertyNameAttribute weatherForecast =
-                WeatherForecastFactories.CreateWeatherForecastWithPropertyNameAttribute();
+            WeatherForecastWithPropertyName weatherForecast =
+                WeatherForecastFactories.CreateWeatherForecastWithPropertyName();
             weatherForecast.DisplayPropertyValues();
 
             // <Serialize>
@@ -27,7 +27,7 @@ namespace SystemTextJsonSamples
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase
             };
             weatherForecast =
-                JsonSerializer.Deserialize<WeatherForecastWithPropertyNameAttribute>(
+                JsonSerializer.Deserialize<WeatherForecastWithPropertyName>(
                     jsonString, deserializeOptions)!;
             // </Deserialize>
             weatherForecast.DisplayPropertyValues();

--- a/docs/standard/serialization/system-text-json/snippets/how-to/csharp/RoundtripPropertyNamesByAttribute.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to/csharp/RoundtripPropertyNamesByAttribute.cs
@@ -7,8 +7,8 @@ namespace SystemTextJsonSamples
         public static void Run()
         {
             string jsonString;
-            WeatherForecastWithPropertyNameAttribute weatherForecast =
-                WeatherForecastFactories.CreateWeatherForecastWithPropertyNameAttribute();
+            WeatherForecastWithPropertyName weatherForecast =
+                WeatherForecastFactories.CreateWeatherForecastWithPropertyName();
             weatherForecast.DisplayPropertyValues();
 
             // <Serialize>
@@ -21,7 +21,7 @@ namespace SystemTextJsonSamples
             Console.WriteLine($"JSON output:\n{jsonString}\n");
 
             // <Deserialize>
-            weatherForecast = JsonSerializer.Deserialize<WeatherForecastWithPropertyNameAttribute>(jsonString)!;
+            weatherForecast = JsonSerializer.Deserialize<WeatherForecastWithPropertyName>(jsonString)!;
             weatherForecast.DisplayPropertyValues();
             // </Deserialize>
         }

--- a/docs/standard/serialization/system-text-json/snippets/how-to/csharp/WeatherForecast.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to/csharp/WeatherForecast.cs
@@ -111,7 +111,7 @@ namespace SystemTextJsonSamples
     // </WFWithConverterAttribute>
 
     // <WFWithPropertyNameAttribute>
-    public class WeatherForecastWithPropertyNameAttribute
+    public class WeatherForecastWithPropertyName
     {
         public DateTimeOffset Date { get; set; }
         public int TemperatureCelsius { get; set; }
@@ -360,9 +360,9 @@ namespace SystemTextJsonSamples
             return weatherForecast;
         }
 
-        public static WeatherForecastWithPropertyNameAttribute CreateWeatherForecastWithPropertyNameAttribute()
+        public static WeatherForecastWithPropertyName CreateWeatherForecastWithPropertyName()
         {
-            var weatherForecast = new WeatherForecastWithPropertyNameAttribute
+            var weatherForecast = new WeatherForecastWithPropertyName
             {
                 Date = DateTime.Parse("2019-08-01"),
                 TemperatureCelsius = 25,

--- a/docs/standard/serialization/system-text-json/snippets/how-to/vb/RoundtripCamelCasePropertyNames.vb
+++ b/docs/standard/serialization/system-text-json/snippets/how-to/vb/RoundtripCamelCasePropertyNames.vb
@@ -6,7 +6,7 @@ Namespace SystemTextJsonSamples
 
         Public Shared Sub Run()
             Dim jsonString As String
-            Dim weatherForecast As WeatherForecastWithPropertyNameAttribute = WeatherForecastFactories.CreateWeatherForecastWithPropertyNameAttribute()
+            Dim weatherForecast As WeatherForecastWithPropertyName = WeatherForecastFactories.CreateWeatherForecastWithPropertyName()
             weatherForecast.DisplayPropertyValues()
 
             ' <Serialize>
@@ -22,7 +22,7 @@ Namespace SystemTextJsonSamples
             Dim deserializeOptions As JsonSerializerOptions = New JsonSerializerOptions With {
                 .PropertyNamingPolicy = JsonNamingPolicy.CamelCase
             }
-            weatherForecast = JsonSerializer.Deserialize(Of WeatherForecastWithPropertyNameAttribute)(
+            weatherForecast = JsonSerializer.Deserialize(Of WeatherForecastWithPropertyName)(
                     jsonString, deserializeOptions)
             ' </Deserialize>
             weatherForecast.DisplayPropertyValues()

--- a/docs/standard/serialization/system-text-json/snippets/how-to/vb/RoundtripPropertyNamesByAttribute.vb
+++ b/docs/standard/serialization/system-text-json/snippets/how-to/vb/RoundtripPropertyNamesByAttribute.vb
@@ -6,7 +6,7 @@ Namespace SystemTextJsonSamples
 
         Public Shared Sub Run()
             Dim jsonString As String
-            Dim weatherForecast As WeatherForecastWithPropertyNameAttribute = WeatherForecastFactories.CreateWeatherForecastWithPropertyNameAttribute()
+            Dim weatherForecast As WeatherForecastWithPropertyName = WeatherForecastFactories.CreateWeatherForecastWithPropertyName()
             weatherForecast.DisplayPropertyValues()
 
             ' <Serialize>
@@ -18,7 +18,7 @@ Namespace SystemTextJsonSamples
             Console.WriteLine($"JSON output:{jsonString}")
 
             ' <Deserialize>
-            weatherForecast = JsonSerializer.Deserialize(Of WeatherForecastWithPropertyNameAttribute)(jsonString)
+            weatherForecast = JsonSerializer.Deserialize(Of WeatherForecastWithPropertyName)(jsonString)
             weatherForecast.DisplayPropertyValues()
             ' </Deserialize>
         End Sub

--- a/docs/standard/serialization/system-text-json/snippets/how-to/vb/WeatherForecast.vb
+++ b/docs/standard/serialization/system-text-json/snippets/how-to/vb/WeatherForecast.vb
@@ -91,7 +91,7 @@ Namespace SystemTextJsonSamples
     ' </WFWithConverterAttribute>
 
     ' <WFWithPropertyNameAttribute>
-    Public Class WeatherForecastWithPropertyNameAttribute
+    Public Class WeatherForecastWithPropertyName
         Public Property [Date] As DateTimeOffset
         Public Property TemperatureCelsius As Integer
         Public Property Summary As String
@@ -262,7 +262,7 @@ Namespace SystemTextJsonSamples
         End Sub
 
         <Extension()>
-        Public Sub DisplayPropertyValues(wf As WeatherForecastWithPropertyNameAttribute)
+        Public Sub DisplayPropertyValues(wf As WeatherForecastWithPropertyName)
             Utilities.DisplayPropertyValues(wf)
             Console.WriteLine()
         End Sub
@@ -406,8 +406,8 @@ Namespace SystemTextJsonSamples
             Return weatherForecast1
         End Function
 
-        Public Function CreateWeatherForecastWithPropertyNameAttribute() As WeatherForecastWithPropertyNameAttribute
-            Dim weatherForecast1 As WeatherForecastWithPropertyNameAttribute = New WeatherForecastWithPropertyNameAttribute With {
+        Public Function CreateWeatherForecastWithPropertyName() As WeatherForecastWithPropertyName
+            Dim weatherForecast1 As WeatherForecastWithPropertyName = New WeatherForecastWithPropertyName With {
                 .[Date] = Date.Parse("2019-08-01"),
                 .TemperatureCelsius = 25,
                 .Summary = "Hot",


### PR DESCRIPTION
This pull request fixes #41960 
It completely removes the 'Attribute' postfix from the `WeatherForecastWithPropertyNameAttribute` class name (both C# and VB) and from all of it's references in other examples implementations.
