### PR TITLE
Complex.ToString and BigInteger breaking changes

### DIFF
--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -45,6 +45,7 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 | [Backslash mapping in Unix file paths](core-libraries/8.0/file-path-backslash.md)                         | Behavioral change   |
 | [Base64.DecodeFromUtf8 methods ignore whitespace](core-libraries/8.0/decodefromutf8-whitespace.md)        | Behavioral change   |
 | [Boolean-backed enum type support removed](core-libraries/8.0/bool-backed-enum.md)                        | Behavioral change   |
+| [Complex.ToString format changed to `<a; b>`](core-libraries/8.0/complex-format.md)              | Behavioral change   |
 | [Drive's current directory path enumeration](core-libraries/8.0/drive-current-dir-paths.md)              | Behavioral change   |
 | [Enumerable.Sum throws new OverflowException for some inputs](core-libraries/8.0/enumerable-sum.md)       | Behavioral change   |
 | [FileStream writes when pipe is closed](core-libraries/8.0/filestream-disposed-pipe.md)                   | Behavioral change   |

--- a/docs/core/compatibility/9.0.md
+++ b/docs/core/compatibility/9.0.md
@@ -28,7 +28,8 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 |------------------------------------------------------------------------------------------|---------------------|--------------------|
 | [Adding a ZipArchiveEntry with CompressionLevel sets ZIP central directory header general-purpose bit flags](core-libraries/9.0/compressionlevel-bits.md) | Behavioral change | Preview 5 |
 | [Altered UnsafeAccessor support for non-open generics](core-libraries/9.0/unsafeaccessor-generics.md) | Behavioral change   | Preview 6          |
-| [API obsoletions with custom diagnostic IDs](core-libraries/9.0/obsolete-apis-with-custom-diagnostics.md) | Source incompatible | Preview 1  |
+| [BigInteger maximum length](core-libraries/9.0/biginteger-limit.md) | Source incompatible | Preview 1  |
+| [API obsoletions with custom diagnostic IDs](core-libraries/9.0/obsolete-apis-with-custom-diagnostics.md) | Source incompatible | Preview 16 |
 | [Creating type of array of System.Void not allowed](core-libraries/9.0/type-instance.md) | Behavioral change   | Preview 1          |
 | [Default `Equals()` and `GetHashCode()` throw for types marked with `InlineArrayAttribute`](core-libraries/9.0/inlinearrayattribute.md) | Behavioral change   | Preview 6          |
 | [Inline array struct size limit is enforced](core-libraries/9.0/inlinearray-size.md) | Behavioral change   | Preview 1          |

--- a/docs/core/compatibility/9.0.md
+++ b/docs/core/compatibility/9.0.md
@@ -28,8 +28,8 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 |------------------------------------------------------------------------------------------|---------------------|--------------------|
 | [Adding a ZipArchiveEntry with CompressionLevel sets ZIP central directory header general-purpose bit flags](core-libraries/9.0/compressionlevel-bits.md) | Behavioral change | Preview 5 |
 | [Altered UnsafeAccessor support for non-open generics](core-libraries/9.0/unsafeaccessor-generics.md) | Behavioral change   | Preview 6          |
-| [BigInteger maximum length](core-libraries/9.0/biginteger-limit.md) | Source incompatible | Preview 1  |
 | [API obsoletions with custom diagnostic IDs](core-libraries/9.0/obsolete-apis-with-custom-diagnostics.md) | Source incompatible | Preview 16 |
+| [BigInteger maximum length](core-libraries/9.0/biginteger-limit.md) | Source incompatible | Preview 1  |
 | [Creating type of array of System.Void not allowed](core-libraries/9.0/type-instance.md) | Behavioral change   | Preview 1          |
 | [Default `Equals()` and `GetHashCode()` throw for types marked with `InlineArrayAttribute`](core-libraries/9.0/inlinearrayattribute.md) | Behavioral change   | Preview 6          |
 | [Inline array struct size limit is enforced](core-libraries/9.0/inlinearray-size.md) | Behavioral change   | Preview 1          |

--- a/docs/core/compatibility/core-libraries/8.0/complex-format.md
+++ b/docs/core/compatibility/core-libraries/8.0/complex-format.md
@@ -1,0 +1,38 @@
+---
+title: ".NET 8 breaking change: Complex.ToString format changed to `<a; b>`"
+description: Learn about the .NET 8 breaking change in core .NET libraries where the Complex.ToString() format changed from `(a, b)` to `<a; b>`.
+ms.date: 08/06/2024
+---
+# Complex.ToString format changed to `<a; b>`
+
+To better support formatting values with culture-specific information, the default string representation of complex numbers was changed to avoid using characters that can be used in formatted numeric values. This change affects <xref:System.Numerics.Complex.ToString%2A?displayProperty=nameWithType>, where the value is now formatted as `<a; b>` instead of `(a, b)`. Both *a* and *b* are formatted using the general format specifier ("G") and the conventions of the culture defined by provider&mdash;this hasn't changed.
+
+## Previous behavior
+
+Previously, the string representation of the complex number returned by <xref:System.Numerics.Complex.ToString%2A?displayProperty=nameWithType> displayed the number using its Cartesian coordinates in the form `(a, b)`, where *a* was the real part of the complex number, and *b* was its imaginary part.
+
+## New behavior
+
+Starting in .NET 8, the string representation of the complex number returned by <xref:System.Numerics.Complex.ToString%2A?displayProperty=nameWithType> displays the number using its Cartesian coordinates in the form `<a; b>`, where *a* is the real part of the complex number, and *b* is its imaginary part.
+
+## Version introduced
+
+.NET 8
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+The change to use a semicolon enables support of formatting with culture-specific information. It also enables the corresponding need to be able to parse results back out given that it implements <xref:System.Numerics.INumberBase%601>.
+
+The change from parentheses (`( )`) to angle brackets avoids potential collision with numeric formats where negative numbers are formatted as `(x)`. The new behavior is also consistent with the behavior of the `Vector*` types.
+
+## Recommended action
+
+If you need the previous format, you can use a custom string formatting mechanism such as `$"({complex.Real}, {complex.Imaginary})"` to produce a string in that format.
+
+## Affected APIs
+
+- <xref:System.Numerics.Complex.ToString%2A?displayProperty=fullName>

--- a/docs/core/compatibility/core-libraries/9.0/biginteger-limit.md
+++ b/docs/core/compatibility/core-libraries/9.0/biginteger-limit.md
@@ -9,7 +9,10 @@ ms.date: 08/06/2024
 
 ## Previous behavior
 
-Previously, you could assign a value with any length to a <xref:System.Numerics.BigInteger> variable.
+Previously, you could assign a value with a length up to `Array.MaxLength * 32` bits to a <xref:System.Numerics.BigInteger> variable.
+
+> [!NOTE]
+> Typical machines would hit an <xref:System.OutOfMemoryException> far before this limit could ever be reached.
 
 ## New behavior
 

--- a/docs/core/compatibility/core-libraries/9.0/biginteger-limit.md
+++ b/docs/core/compatibility/core-libraries/9.0/biginteger-limit.md
@@ -1,0 +1,40 @@
+---
+title: "Breaking change: BigInteger maximum length"
+description: Learn about the .NET 9 breaking change in core .NET libraries where a maximum length for BigInteger is enforced.
+ms.date: 08/06/2024
+---
+# BigInteger maximum length
+
+.NET 9 enforces a maximum length of <xref:System.Numerics.BigInteger>, which is that it can contain no more than `(2^31) - 1` (approximately 2.14 billion) bits. Such a number represents an almost 256 MB allocation and contains approximately 646.5 million digits. This new limit ensures that all APIs exposed are well behaved and consistent while still allowing numbers that are far beyond most usage scenarios.
+
+## Previous behavior
+
+Previously, you could assign a value with any length to a <xref:System.Numerics.BigInteger> variable.
+
+## New behavior
+
+Starting in .NET 9, <xref:System.Numerics.BigInteger> has a maximum length of `(2^31) - 1` (approximately 2.14 billion) bits. If you attempt to assign a larger value, an <xref:System.OverflowException> is thrown at run time. For example, the following code throws an exception:
+
+```csharp
+BigInteger bigInt = new BigInteger(-1) << int.MaxValue;
+```
+
+## Version introduced
+
+.NET 9 Preview 6
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+<xref:System.Numerics.BigInteger> supports representing integer values of essentially arbitrary length. However, in practice, the length is constrained by limits of the underlying computer, such as available memory or how long it would take to compute a given expression. Additionally, there exist some APIs that fail given inputs that result in a value that's too large. For these reasons, a maximum length is now enforced.
+
+## Recommended action
+
+If your code is affected, decrease the length of value you're assigning to <xref:System.Numerics.BigInteger> or add a length check.
+
+## Affected APIs
+
+- <xref:System.Numerics.BigInteger>

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -22,6 +22,8 @@ items:
         href: core-libraries/9.0/unsafeaccessor-generics.md
       - name: API obsoletions with custom diagnostic IDs
         href: core-libraries/9.0/obsolete-apis-with-custom-diagnostics.md
+      - name: BigInteger maximum length
+        href: core-libraries/9.0/biginteger-limit.md
       - name: Creating type of array of System.Void not allowed
         href: core-libraries/9.0/type-instance.md
       - name: "`Equals`/`GetHashCode` throw for `InlineArrayAttribute` types"
@@ -122,6 +124,8 @@ items:
         href: core-libraries/8.0/decodefromutf8-whitespace.md
       - name: Boolean-backed enum type support removed
         href: core-libraries/8.0/bool-backed-enum.md
+      - name: Complex.ToString format changed to `<a; b>`
+        href: core-libraries/8.0/complex-format.md
       - name: Drive's current directory path enumeration
         href: core-libraries/8.0/drive-current-dir-paths.md
       - name: Enumerable.Sum throws new OverflowException for some inputs
@@ -1204,6 +1208,8 @@ items:
         href: core-libraries/9.0/unsafeaccessor-generics.md
       - name: API obsoletions with custom diagnostic IDs
         href: core-libraries/9.0/obsolete-apis-with-custom-diagnostics.md
+      - name: BigInteger maximum length
+        href: core-libraries/9.0/biginteger-limit.md
       - name: Creating type of array of System.Void not allowed
         href: core-libraries/9.0/type-instance.md
       - name: "`Equals`/`GetHashCode` throw for `InlineArrayAttribute` types"
@@ -1230,6 +1236,8 @@ items:
         href: core-libraries/8.0/decodefromutf8-whitespace.md
       - name: Boolean-backed enum type support removed
         href: core-libraries/8.0/bool-backed-enum.md
+      - name: Complex.ToString format changed to `<a; b>`
+        href: core-libraries/8.0/complex-format.md
       - name: Drive's current directory path enumeration
         href: core-libraries/8.0/drive-current-dir-paths.md
       - name: Enumerable.Sum throws new OverflowException for some inputs


### PR DESCRIPTION
Fixes #41752 
Fixes #41835

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/8.0.md](https://github.com/dotnet/docs/blob/8d6bf71c9c5939003b254d9db9d83b52a2f8a8db/docs/core/compatibility/8.0.md) | [docs/core/compatibility/8.0](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/8.0?branch=pr-en-us-42052) |
| [docs/core/compatibility/9.0.md](https://github.com/dotnet/docs/blob/8d6bf71c9c5939003b254d9db9d83b52a2f8a8db/docs/core/compatibility/9.0.md) | [docs/core/compatibility/9.0](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/9.0?branch=pr-en-us-42052) |
| [docs/core/compatibility/core-libraries/8.0/complex-format.md](https://github.com/dotnet/docs/blob/8d6bf71c9c5939003b254d9db9d83b52a2f8a8db/docs/core/compatibility/core-libraries/8.0/complex-format.md) | [docs/core/compatibility/core-libraries/8.0/complex-format](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/8.0/complex-format?branch=pr-en-us-42052) |
| [docs/core/compatibility/core-libraries/9.0/biginteger-limit.md](https://github.com/dotnet/docs/blob/8d6bf71c9c5939003b254d9db9d83b52a2f8a8db/docs/core/compatibility/core-libraries/9.0/biginteger-limit.md) | [docs/core/compatibility/core-libraries/9.0/biginteger-limit](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/9.0/biginteger-limit?branch=pr-en-us-42052) |


<!-- PREVIEW-TABLE-END -->