### PR TITLE
Update dotnet nuget why docs with assets file info

### DIFF
--- a/docs/core/tools/dotnet-nuget-why.md
+++ b/docs/core/tools/dotnet-nuget-why.md
@@ -24,6 +24,11 @@ dotnet nuget why -h|--help
 
 The `dotnet nuget why` command shows the dependency graph for a particular package for a given project or solution.
 
+Starting from the .NET 9 SDK, it's possible to pass a NuGet assets file in place of the project file, in order to use the command with projects that can't be restored with the .NET SDK.
+First, restore the project in Visual Studio, or `msbuild.exe`.
+By default the assets file is in the project's `obj\` directory, but you can find the location with `msbuild.exe path\to\project.proj -getProperty:ProjectAssetsFile`.
+Finally, run `dotnet nuget why path\to\project.assets.json SomePackage`.
+
 ## Arguments
 
 - **`PROJECT|SOLUTION`**


### PR DESCRIPTION
## Summary

`dotnet nuget why` is a useful tool to understand the project's package graph. This is particularly true when dealing with transitive packages with known vulnerabilities, as described in this blog post: https://devblogs.microsoft.com/nuget/nugetaudit-2-0-elevating-security-and-trust-in-package-management/

Fixes: https://github.com/NuGet/Home/issues/13623


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-nuget-why.md](https://github.com/dotnet/docs/blob/a23148249271792dcbab9e798887d4217cb8fb58/docs/core/tools/dotnet-nuget-why.md) | [docs/core/tools/dotnet-nuget-why](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-why?branch=pr-en-us-42101) |

<!-- PREVIEW-TABLE-END -->