### PR TITLE
Add the section to `CS0809` about methods recognized (or not) as obsolete

### DIFF
--- a/docs/csharp/misc/cs0809.md
+++ b/docs/csharp/misc/cs0809.md
@@ -65,3 +65,8 @@ static class Program
 ```
 
 To fix this add the `Obsolete` attribute to base class as well.
+
+## See also
+
+- [CS0618](../language-reference/compiler-messages/cs0618.md)
+- [CS0672](./cs0672.md)

--- a/docs/csharp/misc/cs0809.md
+++ b/docs/csharp/misc/cs0809.md
@@ -36,3 +36,32 @@ public class C : Base
     }
 }
 ```
+
+## Methods recognized as obsolete
+
+Note that the compiler warning `CS0809` will lead to no [`CS0618`](../language-reference/compiler-messages/cs0618.md) warning when actually calling the obsolete method.
+<br/>In the following example compiler will not warn about the method `Test` being obsolete, because the declaration that is recognized by compiler when calling is in the base class `Base`, not the derived class `Derived`:
+
+```csharp
+class Base
+{
+    public virtual void Test() {}
+}
+
+class Derived : Base
+{
+    [System.Obsolete()]
+    public override void Test() { }
+}
+
+static class Program
+{
+    public static void Main()
+    {
+        Derived derived = new();
+        b.Foo();    // No CS0618
+    }
+}
+```
+
+To fix this add the `Obsolete` attribute to base class as well.


### PR DESCRIPTION
This pull request closes #41621 

It adds the `Methods recognized as obsolete`  section to the article describing the fact that missing `Obsolete` attribute in the class can be a reason to miss the warning about the actually using the obsolete method.

CC: @rhys-vdw

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/misc/cs0809.md](https://github.com/dotnet/docs/blob/e4851058854fafabca55d998a37365a38211ed57/docs/csharp/misc/cs0809.md) | [docs/csharp/misc/cs0809](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/cs0809?branch=pr-en-us-42106) |


<!-- PREVIEW-TABLE-END -->