### PR TITLE
Fix path in template pack command

### DIFF
--- a/docs/core/tutorials/cli-templates-create-template-package.md
+++ b/docs/core/tutorials/cli-templates-create-template-package.md
@@ -232,7 +232,7 @@ working
 
 The _content_ folder has two folders: _extensions_ and _consoleasync_.
 
-In your terminal, from the _working_ folder, run the `dotnet pack` command. This command builds the project and creates a NuGet package in the _working\bin\Debug_ folder, as indicated by the following output:
+In your terminal, from the _working_ folder, run the `dotnet pack` command. This command builds the project and creates a NuGet package in the _working\bin\Release_ folder, as indicated by the following output:
 
 ```output
 MSBuild version 17.8.0-preview-23367-03+0ff2a83e9 for .NET


### PR DESCRIPTION
## Summary

- Change the path to Release

Fixes #42117 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tutorials/cli-templates-create-template-package.md](https://github.com/dotnet/docs/blob/9b5c20608dbaf7cb6d8109a901e9ec911670c2f4/docs/core/tutorials/cli-templates-create-template-package.md) | [docs/core/tutorials/cli-templates-create-template-package](https://review.learn.microsoft.com/en-us/dotnet/core/tutorials/cli-templates-create-template-package?branch=pr-en-us-42189) |

<!-- PREVIEW-TABLE-END -->