### PR TITLE
Edit pass on Azure Identity lib docs

### DIFF
--- a/docs/azure/sdk/authentication/credential-chains.md
+++ b/docs/azure/sdk/authentication/credential-chains.md
@@ -76,7 +76,7 @@ In the preceding code sample, `EnvironmentCredential` and `WorkloadIdentityCrede
 :::image type="content" source="../media/mermaidjs/DefaultAzureCredentialExcludes.svg" alt-text="DefaultAzureCredential using Excludes properties":::
 
 > [!NOTE]
-> `InteractiveBrowserCredential` is excluded by default and therefore isn't shown in the preceding diagram. To include `InteractiveBrowserCredential`, either use constructor <xref:Azure.Identity.DefaultAzureCredential.%23ctor%28System.Boolean%29> or set property <xref:Azure.Identity.DefaultAzureCredentialOptions.ExcludeInteractiveBrowserCredential%2A?displayProperty=nameWithType> to `false`.
+> `InteractiveBrowserCredential` is excluded by default and therefore isn't shown in the preceding diagram. To include `InteractiveBrowserCredential`, either pass `true` to constructor <xref:Azure.Identity.DefaultAzureCredential.%23ctor%28System.Boolean%29> or set property <xref:Azure.Identity.DefaultAzureCredentialOptions.ExcludeInteractiveBrowserCredential%2A?displayProperty=nameWithType> to `false`.
 
 As more `Exclude`-prefixed properties are set to `true` (credential exclusions are configured), the advantages of using `DefaultAzureCredential` diminish. In such cases, `ChainedTokenCredential` is a better choice and requires less code. To illustrate, these two code samples behave the same way:
 

--- a/docs/azure/sdk/authentication/credential-chains.md
+++ b/docs/azure/sdk/authentication/credential-chains.md
@@ -2,7 +2,7 @@
 title: 'Credential chains in the Azure Identity library for .NET'
 description: 'This article describes the DefaultAzureCredential and ChainedTokenCredential classes in the Azure Identity library.'
 ms.topic: conceptual
-ms.date: 08/13/2024
+ms.date: 08/15/2024
 ---
 
 # Credential chains in the Azure Identity library for .NET
@@ -76,7 +76,7 @@ In the preceding code sample, `EnvironmentCredential` and `WorkloadIdentityCrede
 :::image type="content" source="../media/mermaidjs/DefaultAzureCredentialExcludes.svg" alt-text="DefaultAzureCredential using Excludes properties":::
 
 > [!NOTE]
-> `InteractiveBrowserCredential` is excluded by default and therefore isn't shown in the preceding diagram. To include `InteractiveBrowserCredential`, use constructor <xref:Azure.Identity.DefaultAzureCredential.%23ctor%28System.Boolean%29>.
+> `InteractiveBrowserCredential` is excluded by default and therefore isn't shown in the preceding diagram. To include `InteractiveBrowserCredential`, either use constructor <xref:Azure.Identity.DefaultAzureCredential.%23ctor%28System.Boolean%29> or set property <xref:Azure.Identity.DefaultAzureCredentialOptions.ExcludeInteractiveBrowserCredential%2A?displayProperty=nameWithType> to `false`.
 
 As more `Exclude`-prefixed properties are set to `true` (credential exclusions are configured), the advantages of using `DefaultAzureCredential` diminish. In such cases, `ChainedTokenCredential` is a better choice and requires less code. To illustrate, these two code samples behave the same way:
 

--- a/docs/azure/sdk/includes/implement-defaultazurecredential.md
+++ b/docs/azure/sdk/includes/implement-defaultazurecredential.md
@@ -1,10 +1,8 @@
 ---
 ms.topic: include
-ms.date: 07/31/2024
+ms.date: 08/15/2024
 ---
-[DefaultAzureCredential](/dotnet/api/azure.identity.defaultazurecredential?view=azure-dotnet&preserve-view=true) is an opinionated, ordered sequence of mechanisms for authenticating to Microsoft Entra. Each authentication mechanism is a class derived from the [TokenCredential](/dotnet/api/azure.core.tokencredential?view=azure-dotnet&preserve-view=true) class and is known as a *credential*. At runtime, `DefaultAzureCredential` attempts to authenticate using the first credential. If that credential fails to acquire an access token, the next credential in the sequence is attempted, and so on, until an access token is successfully obtained. In this way, your app can use different credentials in different environments without writing environment-specific code.
-
-The order and locations in which `DefaultAzureCredential` looks for credentials is found at [DefaultAzureCredential](/dotnet/api/overview/azure/identity-readme?view=azure-dotnet&preserve-view=true#defaultazurecredential).
+[DefaultAzureCredential](../authentication/credential-chains.md#defaultazurecredential-overview) is an opinionated, ordered sequence of mechanisms for authenticating to Microsoft Entra ID. Each authentication mechanism is a class derived from the [TokenCredential](/dotnet/api/azure.core.tokencredential?view=azure-dotnet&preserve-view=true) class and is known as a *credential*. At runtime, `DefaultAzureCredential` attempts to authenticate using the first credential. If that credential fails to acquire an access token, the next credential in the sequence is attempted, and so on, until an access token is successfully obtained. In this way, your app can use different credentials in different environments without writing environment-specific code.
 
 To use `DefaultAzureCredential`, add the [Azure.Identity](/dotnet/api/azure.identity) and optionally the [Microsoft.Extensions.Azure](/dotnet/api/microsoft.extensions.azure) packages to your application:
 


### PR DESCRIPTION
**Summary of changes**
- Direct traffic from the include to the new `DefaultAzureCredential` overview section
- Document a 2nd way to include `InteractiveBrowserCredential` in `DefaultAzureCredential`'s chain

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/azure/sdk/authentication/credential-chains.md](https://github.com/dotnet/docs/blob/74a26a3c5200e2a9caccf728ee241642e1d369f9/docs/azure/sdk/authentication/credential-chains.md) | [docs/azure/sdk/authentication/credential-chains](https://review.learn.microsoft.com/en-us/dotnet/azure/sdk/authentication/credential-chains?branch=pr-en-us-42198) |


<!-- PREVIEW-TABLE-END -->