### PR TITLE
MSBuild CustomBuildEventArgs deprecation - Update information about Visual Studio

### DIFF
--- a/docs/core/compatibility/sdk/8.0/custombuildeventargs.md
+++ b/docs/core/compatibility/sdk/8.0/custombuildeventargs.md
@@ -17,7 +17,7 @@ Starting in .NET 8, a build error is issued if your code uses any type derived f
 
 > Usage of unsecure BinaryFormatter during serialization of custom event type 'MyCustomBuildEventArgs'. This will be deprecated soon. Please use Extended*EventArgs instead. More info: <https://aka.ms/msbuild/eventargs>
 
-If you build from Visual Studio, there's no change in behavior unless you opt in by setting the `MSBUILDCUSTOMBUILDEVENTWARNING` environment variable to 1 (available in Visual Studio version 17.8 and later).
+Starting from Visual Studio 17.10 same behavior applies to builds in Visual Studio.
 
 ## Version introduced
 

--- a/docs/core/compatibility/sdk/8.0/custombuildeventargs.md
+++ b/docs/core/compatibility/sdk/8.0/custombuildeventargs.md
@@ -29,7 +29,7 @@ This change is a [behavioral change](../../categories.md#behavioral-change).
 
 ## Reason for change
 
-<xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter> serialization is obsolete in .NET 8 and later versions. Any use of <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter> throws an exception at run time. Since MSBuild custom derived build events use <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter>, your build would crash if you use these events in your build. The new build error provides a more graceful failure.
+<xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter> serialization is obsolete in .NET 8 and later versions. Any use of <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter> is deamed unsecure and throws an exception at run time. Since MSBuild custom derived build events use <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter>, your build would crash if you use these events in your build. The new build error provides a more graceful failure.
 
 ## Recommended action
 

--- a/docs/core/compatibility/sdk/8.0/custombuildeventargs.md
+++ b/docs/core/compatibility/sdk/8.0/custombuildeventargs.md
@@ -17,7 +17,7 @@ Starting in .NET 8, a build error is issued if your code uses any type derived f
 
 > Usage of unsecure BinaryFormatter during serialization of custom event type 'MyCustomBuildEventArgs'. This will be deprecated soon. Please use Extended*EventArgs instead. More info: <https://aka.ms/msbuild/eventargs>
 
-Starting from Visual Studio 17.10 same behavior applies to builds in Visual Studio.
+Starting from Visual Studio version 17.10, the same behavior applies to builds in Visual Studio.
 
 ## Version introduced
 


### PR DESCRIPTION
## Summary

The described behavior flipped from opt-in to opt-out from VS version 17.10 and up


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/sdk/8.0/custombuildeventargs.md](https://github.com/dotnet/docs/blob/05ceb9ad4c0bff6ef88e4178f1d32ddd394e516d/docs/core/compatibility/sdk/8.0/custombuildeventargs.md) | [docs/core/compatibility/sdk/8.0/custombuildeventargs](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/custombuildeventargs?branch=pr-en-us-42202) |


<!-- PREVIEW-TABLE-END -->