### PR TITLE
Update the list of BuildChecks in 9.0

### DIFF
--- a/docs/core/tools/buildcheck-rules/index.md
+++ b/docs/core/tools/buildcheck-rules/index.md
@@ -14,7 +14,11 @@ f1_keywords:
 
 The following list includes all build-check warnings that you might get from the .NET SDK.
 
-| Rule                | Message                                                                             |
-|---------------------|-------------------------------------------------------------------------------------|
-| [BC0101](bc0101.md) | Two projects should not share their OutputPath or IntermediateOutputPath locations. |
-| [BC0102](bc0102.md) | Two tasks should not write the same file.                                           |
+| Rule                |  Default Severity | Message                                                                             |
+|---------------------|-------------------|-------------------------------------------------------------------------------------|
+| [BC0101](bc0101.md) | Warning | Two projects should not share their OutputPath or IntermediateOutputPath locations. |
+| [BC0102](bc0102.md) | Warning | Two tasks should not write the same file. |
+| [BC0103](https://github.com/dotnet/msbuild/blob/main/documentation/specs/BuildCheck/Codes.md#bc0103---used-environment-variable) | Suggestion | Environment variables should not be used as a value source for the properties. |
+| [BC0201](https://github.com/dotnet/msbuild/blob/main/documentation/specs/BuildCheck/Codes.md#bc0201---usage-of-undefined-property) | Warning | A property that is accessed should be declared first. |
+| [BC0202](https://github.com/dotnet/msbuild/blob/main/documentation/specs/BuildCheck/Codes.md#bc0202---property-first-declared-after-it-was-used) | Warning | A property should be declared before it is first used. |
+| [BC0203](https://github.com/dotnet/msbuild/blob/main/documentation/specs/BuildCheck/Codes.md#bc0203----property-declared-but-never-used) | None | A property that is not used should not be declared. |


### PR DESCRIPTION
## Summary

The initial list of BuildCheck rules that are going to be shipped with NET 9.0 has a few more rules that what was originaly documented. Adding the missing rules


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/buildcheck-rules/index.md](https://github.com/dotnet/docs/blob/1dbdeeff76dbdc2bb9ee1627dcdcac2223f9854f/docs/core/tools/buildcheck-rules/index.md) | [docs/core/tools/buildcheck-rules/index](https://review.learn.microsoft.com/en-us/dotnet/core/tools/buildcheck-rules/index?branch=pr-en-us-42217) |

<!-- PREVIEW-TABLE-END -->