### PR TITLE
Update the BuildCheck opt-in info

### DIFF
--- a/docs/core/whats-new/dotnet-9/sdk.md
+++ b/docs/core/whats-new/dotnet-9/sdk.md
@@ -116,12 +116,9 @@ Starting in .NET 8, `dotnet restore` [audits NuGet package references for known 
 
 ## MSBuild script analyzers ("BuildChecks")
 
-.NET 9 introduces a feature that helps guard against defects and regressions in your build scripts. To run the build-checks, add the `/check` flag to any command that invokes MSBuild. For example, `dotnet build myapp.sln /check` builds the `myapp` solution and runs all configured build checks.
+.NET 9 introduces a feature that helps guard against defects and regressions in your build scripts. To run the build checks, add the `/check` flag to any command that invokes MSBuild. For example, `dotnet build myapp.sln /check` builds the `myapp` solution and runs all configured build checks.
 
-Small number of initial checks are added inbox with .NET SDK 9.0 (see [BuildCheck codes](https://github.com/dotnet/msbuild/blob/main/documentation/specs/BuildCheck/Codes.md)). For example:
-
-- [BC0101](../../tools/buildcheck-rules/bc0101.md)
-- [BC0102](../../tools/buildcheck-rules/bc0102.md)
+The .NET 9 SDK includes a small number of initial checks, for example, [BC0101](../../tools/buildcheck-rules/bc0101.md) and [BC0102](../../tools/buildcheck-rules/bc0102.md). For a complete list, see [BuildCheck codes](https://github.com/dotnet/msbuild/blob/main/documentation/specs/BuildCheck/Codes.md).
 
 When a problem is detected, a diagnostic is produced in the build output for the project that contains the issue.
 

--- a/docs/core/whats-new/dotnet-9/sdk.md
+++ b/docs/core/whats-new/dotnet-9/sdk.md
@@ -116,9 +116,9 @@ Starting in .NET 8, `dotnet restore` [audits NuGet package references for known 
 
 ## MSBuild script analyzers ("BuildChecks")
 
-.NET 9 introduces a feature that helps guard against defects and regressions in your build scripts. To run the build-check analyzers, add the `/analyze` flag to any command that invokes MSBuild. For example, `dotnet build myapp.sln /analyze` builds the `myapp` solution and runs all configured build checks.
+.NET 9 introduces a feature that helps guard against defects and regressions in your build scripts. To run the build-checks, add the `/check` flag to any command that invokes MSBuild. For example, `dotnet build myapp.sln /check` builds the `myapp` solution and runs all configured build checks.
 
-The following two BuildCheck rules are run:
+Small number of initial checks are added inbox with .NET SDK 9.0 (see [BuildCheck codes](https://github.com/dotnet/msbuild/blob/main/documentation/specs/BuildCheck/Codes.md)). For example:
 
 - [BC0101](../../tools/buildcheck-rules/bc0101.md)
 - [BC0102](../../tools/buildcheck-rules/bc0102.md)


### PR DESCRIPTION
## Summary

The MSBuild BuildCheck opt-in was changed from `/analyze` to `/check` - so updating the doc accordingly.
Also I added a reference to the full list of rules shipped inbox


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/whats-new/dotnet-9/sdk.md](https://github.com/dotnet/docs/blob/0f99d17cbbaf1156fa142b79c5bba80ad23de8de/docs/core/whats-new/dotnet-9/sdk.md) | [docs/core/whats-new/dotnet-9/sdk](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-9/sdk?branch=pr-en-us-42218) |


<!-- PREVIEW-TABLE-END -->