### PR TITLE
Adding HttpWebRequest to HttpClient Migration Guide

### DIFF
--- a/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
+++ b/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
@@ -79,7 +79,7 @@ using HttpClient client = new();
 using HttpResponseMessage responseMessage = await client.PostAsync(uri, new StringContent("Hello World!"));
 ```
 
-## 1:1 API Mapping Table
+## Migrating ServicePoint(Manager) usage
 
 Developers should be aware that `ServicePointManager` is a static class, meaning that any changes made to its properties will have a global effect on all newly created `ServicePoint` objects within the application. For example, modifying a property like `ConnectionLimit` or `Expect100Continue` will impact every new ServicePoint instance.
 
@@ -95,25 +95,25 @@ Developers should be aware that `ServicePointManager` is a static class, meaning
 | `Expect100Continue` | <xref:System.Net.Http.Headers.HttpRequestHeaders.ExpectContinue> | TODO |
 | `MaxServicePointIdleTime` | <xref:System.Net.Http.SocketsHttpHandler.PooledConnectionIdleTimeout> | TODO |
 | `MaxServicePoints` | No equivalent API | TODO |
-| `ReusePort` | No direct equivalent API | Can be done over <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
+| `ReusePort` | No direct equivalent API | See <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
 | `SecurityProtocol` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.EnabledSslProtocols | TODO |
-| `ServerCertificateValidationCallback` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.RemoteCertificateValidationCallback | Signatures are different need a custom callback |
-| `UseNagleAlgorithm` | No direct equivalent API | Can be done over <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
+| `ServerCertificateValidationCallback` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.RemoteCertificateValidationCallback | Both of them are <xref:System.Net.Security.RemoteCertificateValidationCallback> |
+| `UseNagleAlgorithm` | No direct equivalent API | See <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
 
 ### <xref:System.Net.ServicePointManager> Method Mapping
 
 | <xref:System.Net.ServicePointManager> Old API | New API | Notes |
 |---------|----------------------|-------|
 | `FindServicePoint` | No equivalent API | TODO |
-| `SetTcpKeepAlive` | No direct equivalent API | Can be done over <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
+| `SetTcpKeepAlive` | No direct equivalent API | See <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
 
 ### <xref:System.Net.ServicePoint> Properties Mapping
 
 | <xref:System.Net.ServicePoint> Old API | New API | Notes |
 |---------|----------------------|-------|
-| `Address` | `HttpRequestMessage.RequestUri` | This is request uri, so basically we can get this from `HttpRequestMessage`. |
-| `BindIPEndPointDelegate` | No direct equivalent API | Can be done over <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
-| `Certificate` | No direct equivalent API | We can grab this information during `RemoteCertificateValidationCallback`. |
+| `Address` | `HttpRequestMessage.RequestUri` | This is request uri, this information can be found under `HttpRequestMessage`. |
+| `BindIPEndPointDelegate` | No direct equivalent API | See <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
+| `Certificate` | No direct equivalent API | This information can be fetched from `RemoteCertificateValidationCallback`. TODO: Add example |
 | `ClientCertificate` | No equivalent API | TODO |
 | `ConnectionLeaseTimeout` | `SocketsHttpHandler.PooledConnectionLifetime` | Equivalent setting in <xref:System.Net.Http.HttpClient> |
 | `ConnectionLimit` | <xref:System.Net.Http.SocketsHttpHandler.MaxConnectionsPerServer> | TODO |
@@ -123,14 +123,162 @@ Developers should be aware that `ServicePointManager` is a static class, meaning
 | `IdleSince` | No equivalent API | TODO |
 | `MaxIdleTime` | <xref:System.Net.Http.SocketsHttpHandler.PooledConnectionIdleTimeout> | TODO |
 | `ProtocolVersion` | `HttpRequestMessage.Version` | We can get this from `HttpRequestMessage`. |
-| `ReceiveBufferSize` | No direct equivalent API | Can be done over <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
+| `ReceiveBufferSize` | No direct equivalent API | See <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
 | `SupportsPipelining` | No equivalent API | `HttpClient` doesn't support pipelining. |
-| `UseNagleAlgorithm` | No direct equivalent API | Can be done over <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
+| `UseNagleAlgorithm` | No direct equivalent API | See <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
 
 ### <xref:System.Net.ServicePoint> Method Mapping
 
 | <xref:System.Net.ServicePoint> Old API | New API | Notes |
 |---------|----------------------|-------|
 | `CloseConnectionGroup` | No equivalent | No workaround |
-| `SetTcpKeepAlive` | No direct equivalent API | Can be done over <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
+| `SetTcpKeepAlive` | No direct equivalent API | See <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
 
+### Usage of ConnectCallback
+
+The `ConnectCallback` property in `SocketsHttpHandler` allows developers to customize the process of establishing a TCP connection. This can be useful for scenarios where you need to control DNS resolution or apply specific socket options on the connection. By using `ConnectCallback`, you can intercept and modify the connection process before it is used by `HttpClient`.
+
+#### Example: Binding IP Address to Socket
+
+In the old approach using `HttpWebRequest`, you might have used custom logic to bind a specific IP address to a socket. Here's how you can achieve similar functionality using `HttpClient` and `ConnectCallback`:
+
+**Old Code Using `HttpWebRequest`**:
+
+```csharp
+HttpWebRequest request = (HttpWebRequest)WebRequest.Create(uri);
+request.ServicePoint.BindIPEndPointDelegate = (servicePoint, remoteEndPoint, retryCount) =>
+{
+    // Bind to a specific IP address
+    IPAddress localAddress = IPAddress.Parse("192.168.1.100");
+    return new IPEndPoint(localAddress, 0);
+};
+HttpWebResponse response = (HttpWebResponse)request.GetResponse();
+```
+
+**New Code Using `HttpClient` and `ConnectCallback`**:
+
+```csharp
+var handler = new SocketsHttpHandler
+{
+    ConnectCallback = async (context, cancellationToken) =>
+    {
+        // Bind to a specific IP address
+        IPAddress localAddress = IPAddress.Parse("192.168.1.100");
+        var socket = new Socket(localAddress.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+        socket.Bind(new IPEndPoint(localAddress, 0));
+        await socket.ConnectAsync(context.DnsEndPoint, cancellationToken);
+        return new NetworkStream(socket, ownsSocket: true);
+    }
+};
+var client = new HttpClient(handler);
+var response = await client.GetAsync(uri);
+```
+
+#### Example: Applying Specific Socket Options
+
+If you need to apply specific socket options, such as enabling TCP keep-alive, you can use `ConnectCallback` to configure the socket before it is used by `HttpClient`. In fact, `ConnectCallback` is more flexible to configure socket options.
+
+**Old Code Using `HttpWebRequest`**:
+
+```csharp
+ServicePointManager.ReusePort = true;
+HttpWebRequest request = (HttpWebRequest)WebRequest.Create(uri);
+request.ServicePoint.SetTcpKeepAlive(true, 60000, 1000);
+request.ServicePoint.ReceiveBufferSize = 8192;
+request.ServicePoint.UseNagleAlgorithm = false;
+HttpWebResponse response = (HttpWebResponse)request.GetResponse();
+```
+
+**New Code Using `HttpClient` and `ConnectCallback`**:
+
+```csharp
+var handler = new SocketsHttpHandler
+{
+    ConnectCallback = async (context, cancellationToken) =>
+    {
+        var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+        // Setting TCP Keep Alive
+        socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
+        socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveTime, 60);
+        socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveInterval, 1);
+
+        // Setting ReceiveBufferSize
+        socket.ReceiveBufferSize = 8192;
+
+        // Enabling ReusePort
+        socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseUnicastPort, true);
+
+        // Disabling Nagle Algorithm
+        socket.NoDelay = true;
+
+        await socket.ConnectAsync(context.DnsEndPoint, cancellationToken);
+        return new NetworkStream(socket, ownsSocket: true);
+    }
+};
+var client = new HttpClient(handler);
+var response = await client.GetAsync(uri);
+```
+
+### Usage of Certificate Related Properties in HttpClient
+
+When working with `HttpClient`, you may need to handle client certificates for various purposes, such as custom validation of server certificates or fetching the server certificate. `HttpClient` provides several properties and options to manage certificates effectively.
+
+#### Example: Enabling CRL Check with SocketsHttpHandler
+
+The `CheckCertificateRevocationList` property in `SocketsHttpHandler` allows developers to enable or disable the check for certificate revocation lists (CRL) during SSL/TLS handshake. Enabling this property ensures that the client verifies whether the server's certificate has been revoked, enhancing the security of the connection.
+
+**Old Code Using `HttpWebRequest`**:
+
+```csharp
+ServicePointManager.CheckCertificateRevocationList = true;
+HttpWebRequest request = (HttpWebRequest)WebRequest.Create(uri);
+HttpWebResponse response = (HttpWebResponse)request.GetResponse();
+```
+
+**New Code Using `HttpClient`**:
+
+```csharp
+bool checkCertificateRevocationList = true;
+var handler = new SocketsHttpHandler
+{
+    SslOptions =
+    {
+        CertificateRevocationCheckMode = checkCertificateRevocationList ? X509RevocationMode.Online : X509RevocationMode.NoCheck,
+    }
+};
+var client = new HttpClient(handler);
+var response = await client.GetAsync(uri);
+```
+
+#### Example: Fetch Certificate
+
+To fetch the certificate from the RemoteCertificateValidationCallback in HttpClient, you can use the ServerCertificateCustomValidationCallback property of HttpClientHandler or SocketsHttpHandler. This callback allows you to inspect the server's certificate during the SSL/TLS handshake.
+
+**Old Code Using `HttpWebRequest`**:
+
+```csharp
+HttpWebRequest request = (HttpWebRequest)WebRequest.Create(uri);
+HttpWebResponse response = (HttpWebResponse)request.GetResponse();
+X509Certificate? serverCertificate = request.ServicePoint.Certificate;
+```
+
+**New Code Using `HttpClient`**:
+
+```csharp
+X509Certificate? serverCertificate = null;
+var handler = new SocketsHttpHandler
+{
+    SslOptions = new SslClientAuthenticationOptions
+    {
+        RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) =>
+        {
+            serverCertificate = certificate;
+
+            // Perform custom validation logic
+            return sslPolicyErrors == SslPolicyErrors.None;
+        }
+    }
+};
+var client = new HttpClient(handler);
+var response = await client.GetAsync("https://example.com");
+```

--- a/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
+++ b/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
@@ -79,55 +79,55 @@ using HttpResponseMessage responseMessage = await client.PostAsync(uri, new Stri
 
 | <xref:System.Net.HttpWebRequest> Old API | New API | Notes |
 |---------|----------------------|-------|
-| `Accept` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Accept> | See: `Examples: Set Request Headers`. |
+| `Accept` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Accept> | See: [Example: Set Request Headers](#example-set-request-headers). |
 | `Address` | TODO | TODO |
-| `AllowAutoRedirect` | <xref:System.Net.Http.SocketsHttpHandler.AllowAutoRedirect> | See: `Examples: Setting SocketsHttpHandler properties`. |
-| `AllowReadStreamBuffering` | No direct equivalent API | See: `Example: Read Buffering`. |
-| `AllowWriteStreamBuffering` | No direct equivalent API | See: `Example: Write Buffering`. |
-| `AuthenticationLevel` | No direct equivalent API | See: `Example: Mutual Authentication`. |
-| `AutomaticDecompression` | <xref:System.Net.Http.SocketsHttpHandler.AutomaticDecompression> | See: `Examples: Setting SocketsHttpHandler properties`. |
+| `AllowAutoRedirect` | <xref:System.Net.Http.SocketsHttpHandler.AllowAutoRedirect> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
+| `AllowReadStreamBuffering` | No direct equivalent API | See: [Example: Read Buffering](#example-read-buffering). |
+| `AllowWriteStreamBuffering` | No direct equivalent API | See: [Example: Write Buffering](#example-write-buffering). |
+| `AuthenticationLevel` | No direct equivalent API | See: [Example: Enabling Mutual Authentication](#example-enabling-mutual-authentication). |
+| `AutomaticDecompression` | <xref:System.Net.Http.SocketsHttpHandler.AutomaticDecompression> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
 | `CachePolicy` | No direct equivalent API | See: `Example: Apply CachePolicy Headers`. |
-| `ClientCertificates` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.<xref:System.Net.Security.SslClientAuthenticationOptions.ClientCertificates> | See: `Example: Usage of Certificate Related Properties in HttpClient`. |
-| `Connection` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Connection> | See: `Examples: Set Request Headers`. |
+| `ClientCertificates` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.<xref:System.Net.Security.SslClientAuthenticationOptions.ClientCertificates> | See: [Usage of Certificate Related Properties in HttpClient](#usage-of-certificate-related-properties-in-httpclient). |
+| `Connection` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Connection> | See: [Example: Set Request Headers](#example-set-request-headers). |
 | `ConnectionGroupName` | No equivalent API | TODO |
 | `ContentLength` | <xref:System.Net.Http.Headers.HttpContentHeaders.ContentLength> | TODO |
 | `ContentType` | <xref:System.Net.Http.Headers.HttpContentHeaders.ContentType> | TODO |
 | `ContinueDelegate` | No equivalent API | TODO |
-| `ContinueTimeout` | <xref:System.Net.Http.SocketsHttpHandler.Expect100ContinueTimeout> | See: `Examples: Setting SocketsHttpHandler properties`. |
-| `CookieContainer` | <xref:System.Net.Http.SocketsHttpHandler.CookieContainer> | See: `Examples: Setting SocketsHttpHandler properties`. |
-| `Credentials` | <xref:System.Net.Http.SocketsHttpHandler.Credentials> | See: `Examples: Setting SocketsHttpHandler properties`. |
-| `Date` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Date> | See: `Examples: Set Request Headers`. |
+| `ContinueTimeout` | <xref:System.Net.Http.SocketsHttpHandler.Expect100ContinueTimeout> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
+| `CookieContainer` | <xref:System.Net.Http.SocketsHttpHandler.CookieContainer> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
+| `Credentials` | <xref:System.Net.Http.SocketsHttpHandler.Credentials> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
+| `Date` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Date> | See: [Example: Set Request Headers](#example-set-request-headers). |
 | `DefaultCachePolicy` | No direct equivalent API | See: `Example: Apply CachePolicy Headers`. |
 | `DefaultMaximumErrorResponseLength` | TODO | TODO |
 | `DefaultMaximumResponseHeadersLength` | No equivalent API | <xref:System.Net.Http.SocketsHttpHandler.MaxResponseHeadersLength> can be used instead. |
 | `DefaultWebProxy` | No equivalent API | <xref:System.Net.Http.SocketsHttpHandler.Proxy> can be used instead. |
-| `Expect` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Expect> | See: `Examples: Set Request Headers`. |
+| `Expect` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Expect> | See: [Example: Set Request Headers](#example-set-request-headers). |
 | `HaveResponse` | No equivalent API | TODO |
-| `Headers` | <xref:System.Net.Http.HttpRequestMessage.Headers> | See: `Examples: Set Request Headers`. |
-| `Host` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Host> | See: `Examples: Set Request Headers`. |
-| `IfModifiedSince` | <xref:System.Net.Http.Headers.HttpRequestHeaders.IfModifiedSince> | See: `Examples: Set Request Headers`. |
-| `ImpersonationLevel` | No direct equivalent API | See: `Examples: Change ImpersonationLevel` |
-| `KeepAlive` | No direct equivalent API | See: `Examples: Set Request Headers` |
-| `MaximumAutomaticRedirections` | <xref:System.Net.Http.SocketsHttpHandler.MaxAutomaticRedirections> | See: `Examples: Setting SocketsHttpHandler properties`. |
-| `MaximumResponseHeadersLength` | <xref:System.Net.Http.SocketsHttpHandler.MaxResponseHeadersLength> | See: `Examples: Setting SocketsHttpHandler properties`. |
+| `Headers` | <xref:System.Net.Http.HttpRequestMessage.Headers> | See: [Example: Set Request Headers](#example-set-request-headers). |
+| `Host` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Host> | See: [Example: Set Request Headers](#example-set-request-headers). |
+| `IfModifiedSince` | <xref:System.Net.Http.Headers.HttpRequestHeaders.IfModifiedSince> | See: [Example: Set Request Headers](#example-set-request-headers). |
+| `ImpersonationLevel` | No direct equivalent API | See: [Example: Change ImpersonationLevel](#example-change-impersonationlevel). |
+| `KeepAlive` | No direct equivalent API | See: [Example: Set Request Headers](#example-set-request-headers). |
+| `MaximumAutomaticRedirections` | <xref:System.Net.Http.SocketsHttpHandler.MaxAutomaticRedirections> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
+| `MaximumResponseHeadersLength` | <xref:System.Net.Http.SocketsHttpHandler.MaxResponseHeadersLength> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
 | `MediaType` | TODO | TODO |
-| `Method` | <xref:System.Net.Http.HttpRequestMessage.Method> | See: `Examples: Usage of HttpRequestMessage and properties`. |
+| `Method` | <xref:System.Net.Http.HttpRequestMessage.Method> | See: [Example: Usage of HttpRequestMessage properties](#example-usage-of-httprequestmessage-properties). |
 | `Pipelined` | No equivalent API | `HttpClient` doesn't support pipelining. |
 | `PreAuthenticate` | <xref:System.Net.Http.SocketsHttpHandler.PreAuthenticate> | TODO |
 | `ProtocolVersion` | TODO | TODO |
-| `Proxy` | <xref:System.Net.Http.SocketsHttpHandler.Proxy> | See: `Examples: Setting SocketsHttpHandler properties`. |
+| `Proxy` | <xref:System.Net.Http.SocketsHttpHandler.Proxy> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
 | `ReadWriteTimeout` | No direct equivalent API | See <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
-| `Referer` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Referrer> | See: `Examples: Set Request Headers`. |
-| `RequestUri` | <xref:System.Net.Http.HttpRequestMessage.RequestUri> | See: `Examples: Usage of HttpRequestMessage and properties`. |
-| `SendChunked` | <xref:System.Net.Http.Headers.HttpRequestHeaders.TransferEncodingChunked> | See: `Examples: Set Request Headers`. |
-| `ServerCertificateValidationCallback` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.<xref:System.Net.Security.SslClientAuthenticationOptions.RemoteCertificateValidationCallback> | See: `Examples: Setting SocketsHttpHandler properties`. |
+| `Referer` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Referrer> | See: [Example: Set Request Headers](#example-set-request-headers). |
+| `RequestUri` | <xref:System.Net.Http.HttpRequestMessage.RequestUri> | See: [Example: Usage of HttpRequestMessage properties](#example-usage-of-httprequestmessage-properties). |
+| `SendChunked` | <xref:System.Net.Http.Headers.HttpRequestHeaders.TransferEncodingChunked> | See: [Example: Set Request Headers](#example-set-request-headers). |
+| `ServerCertificateValidationCallback` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.<xref:System.Net.Security.SslClientAuthenticationOptions.RemoteCertificateValidationCallback> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
 | `ServicePoint` | No equivalent API | `ServicePoint` is not part of `HttpClient`. |
-| `SupportsCookieContainer` | No equivalent API | This is always `true`. |
+| `SupportsCookieContainer` | No equivalent API | This is always `true` for `HttpClient`. |
 | `Timeout` | <xref:System.Net.Http.HttpClient.Timeout> |  |
-| `TransferEncoding` | <xref:System.Net.Http.Headers.HttpRequestHeaders.TransferEncoding> | See: `Examples: Set Request Headers`. |
+| `TransferEncoding` | <xref:System.Net.Http.Headers.HttpRequestHeaders.TransferEncoding> | See: [Example: Set Request Headers](#example-set-request-headers). |
 | `UnsafeAuthenticatedConnectionSharing` | No equivalent API | No workaround |
-| `UseDefaultCredentials` | No direct equivalent API | See: `Example: Set Credentials` |
-| `UserAgent` | <xref:System.Net.Http.Headers.HttpRequestHeaders.UserAgent> | See: `Examples: Set Request Headers`. |
+| `UseDefaultCredentials` | No direct equivalent API | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
+| `UserAgent` | <xref:System.Net.Http.Headers.HttpRequestHeaders.UserAgent> | See: [Example: Set Request Headers](#example-set-request-headers). |
 
 ## Migrating ServicePoint(Manager) usage
 
@@ -139,8 +139,8 @@ Developers should be aware that `ServicePointManager` is a static class, meaning
 |---------|----------------------|-------|
 | `CheckCertificateRevocationList` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.<xref:System.Net.Security.SslClientAuthenticationOptions.CertificateRevocationCheckMode> | See: [Example: Enabling CRL Check with SocketsHttpHandler](#example-enabling-crl-check-with-socketshttphandler). |
 | `DefaultConnectionLimit` | <xref:System.Net.Http.SocketsHttpHandler.MaxConnectionsPerServer> | TODO |
-| `DnsRefreshTimeout` | No equivalent API | See: `Example: Enabling Dns Round Robin`. |
-| `EnableDnsRoundRobin` | No equivalent API | See: `Example: Enabling Dns Round Robin`. |
+| `DnsRefreshTimeout` | No equivalent API | See: [Example: Enabling Dns Round Robin](#example-enabling-dns-round-robin). |
+| `EnableDnsRoundRobin` | No equivalent API | See: [Example: Enabling Dns Round Robin](#example-enabling-dns-round-robin). |
 | `EncryptionPolicy` | No equivalent API | TODO |
 | `Expect100Continue` | <xref:System.Net.Http.Headers.HttpRequestHeaders.ExpectContinue> | TODO |
 | `MaxServicePointIdleTime` | <xref:System.Net.Http.SocketsHttpHandler.PooledConnectionIdleTimeout> | TODO |
@@ -184,7 +184,15 @@ Developers should be aware that `ServicePointManager` is a static class, meaning
 | `CloseConnectionGroup` | No equivalent | No workaround |
 | `SetTcpKeepAlive` | No direct equivalent API | See <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
 
-## Usage of ConnectCallback
+## Usage of HttpClient and HttpRequestMessage Properties
+
+TODO:
+
+### Example: Usage of HttpRequestMessage properties
+
+TODO:
+
+## Usage of SocketsHttpHandler and ConnectCallback
 
 The `ConnectCallback` property in `SocketsHttpHandler` allows developers to customize the process of establishing a TCP connection. This can be useful for scenarios where you need to control DNS resolution or apply specific socket options on the connection. By using `ConnectCallback`, you can intercept and modify the connection process before it is used by `HttpClient`.
 
@@ -269,7 +277,97 @@ var client = new HttpClient(handler);
 var response = await client.GetAsync(uri);
 ```
 
-## Usage of Certificate Related Properties in HttpClient
+### Example: Enabling Dns Round Robin
+
+DNS Round Robin is a technique used to distribute network traffic across multiple servers by rotating through a list of IP addresses associated with a single domain name. This helps in load balancing and improving the availability of services. When using HttpClient, you can implement DNS Round Robin by manually handling the DNS resolution and rotating through the IP addresses using the ConnectCallback property of SocketsHttpHandler.
+
+By enabling DNS Round Robin, you can ensure that your application distributes requests evenly across multiple servers, reducing the load on any single server and improving overall performance and reliability. This approach is particularly useful for high-traffic applications that require efficient load balancing.
+
+To enable DNS Round Robin with HttpClient, you can use the ConnectCallback property to manually resolve the DNS entries and rotate through the IP addresses. Here's an example for `HttpWebRequest` and `HttpClient`:
+
+**Old Code Using `HttpWebRequest`**:
+
+```csharp
+ServicePointManager.DnsRefreshTimeout = 60000;
+ServicePointManager.EnableDnsRoundRobin = true;
+HttpWebRequest request = (HttpWebRequest)WebRequest.Create(uri);
+HttpWebResponse response = (HttpWebResponse)request.GetResponse();
+```
+
+**New Code Using `HttpClient`**:
+
+```csharp
+ConcurrentDictionary<string, DnsCache> dnsCache = new(StringComparer.OrdinalIgnoreCase);
+
+TimeSpan dnsRefreshTimeout = TimeSpan.FromMinutes(1);
+var handler = new SocketsHttpHandler
+{
+    ConnectCallback = async (context, cancellationToken) =>
+    {
+        string host = context.DnsEndPoint.Host;
+        
+        DnsCache? cacheItem;
+        if (!dnsCache.TryGetValue(host, out cacheItem) || DateTime.Now > cacheItem.CacheExpireTime)
+        {
+            dnsCache.TryRemove(host, out _);
+            cacheItem = new DnsCache(await Dns.GetHostAddressesAsync(host, cancellationToken), DateTime.Now.Add(dnsRefreshTimeout), 0);
+            dnsCache.TryAdd(host, cacheItem);
+        }
+
+        IPAddress connectAddress;
+        // If there is only one address, we don't need to do anything special
+        if (cacheItem.Addresses.Length == 1)
+        {
+            connectAddress = cacheItem.Addresses[0];
+        }
+        else
+        {
+            int index = cacheItem.Index;
+            connectAddress = cacheItem.Addresses[index];
+            cacheItem.IncreaseIndex();
+        }
+
+        var socket = new Socket(SocketType.Stream, ProtocolType.Tcp)
+        {
+            NoDelay = true
+        };
+        try
+        {
+            await socket.ConnectAsync(connectAddress, context.DnsEndPoint.Port, cancellationToken);
+            return new NetworkStream(socket, ownsSocket: true);
+        }
+        catch
+        {
+            socket.Dispose();
+            throw;
+        }
+    }
+};
+var client = new HttpClient(handler);
+var response = await client.GetAsync(uri);
+
+class DnsCache(IPAddress[] addresses, DateTime cacheExpireTime, int index)
+{
+    public IPAddress[] Addresses { get; } = addresses;
+    public DateTime CacheExpireTime { get; } = cacheExpireTime;
+    public int Index { get; private set; } = index;
+
+    public void IncreaseIndex()
+    {
+        Index = (Index + 1) % Addresses.Length;
+    }
+}
+```
+
+### Example: Setting SocketsHttpHandler Properties
+
+TODO:
+
+### Example: Change ImpersonationLevel
+
+TODO:
+
+## Usage of Certificate and TLS Related Properties in HttpClient
 
 When working with `HttpClient`, you may need to handle client certificates for various purposes, such as custom validation of server certificates or fetching the server certificate. `HttpClient` provides several properties and options to manage certificates effectively.
 
@@ -332,3 +430,27 @@ var handler = new SocketsHttpHandler
 var client = new HttpClient(handler);
 var response = await client.GetAsync("https://example.com");
 ```
+
+### Example: Enabling Mutual Authentication
+
+TODO:
+
+## Usage of Header Properties
+
+TODO:
+
+### Example: Set Request Headers
+
+TODO:
+
+## Usage of Buffering Properties
+
+TODO:
+
+### Example: Read Buffering
+
+TODO:
+
+### Example: Write Buffering
+
+TODO:

--- a/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
+++ b/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
@@ -1,0 +1,136 @@
+---
+title: Migrate from HttpWebRequest
+description: Guidance document for migrating from HttpWebRequest to HttpClient.
+author: liveans
+ms.author: aaksoy
+ms.date: 07/25/2024
+helpviewer_keywords: 
+  - "protocols, HTTP"
+  - "migration, HTTP"
+  - "HTTP"
+  - "HttpWebRequest class, about HttpWebRequest class"
+  - "application protocols, HTTP"
+  - "HttpClient class, about HttpClient class"
+  - "data requests, HTTP"
+  - "Internet, HTTP"
+---
+
+# HttpWebRequest to HttpClient Migration Guide
+
+This document aims to guide developers through the process of migrating from <xref:System.Net.HttpWebRequest>, <xref:System.Net.ServicePoint>, and <xref:System.Net.ServicePointManager> to <xref:System.Net.Http.HttpClient>. The migration is necessary due to the obsolescence of the older APIs and the numerous benefits offered by <xref:System.Net.Http.HttpClient>, including improved performance, better resource management, and a more modern and flexible API design. By following the steps outlined in this document, developers will be able to transition their codebases smoothly and take full advantage of the features provided by <xref:System.Net.Http.HttpClient>.
+
+## Migration steps
+
+Here is explanation for detailed migration steps.
+
+### Migrating from <xref:System.Net.HttpWebRequest> to <xref:System.Net.Http.HttpClient>
+
+The migration from <xref:System.Net.HttpWebRequest> to <xref:System.Net.Http.HttpClient> is essential due to the modern features and improved performance that <xref:System.Net.Http.HttpClient> offers. <xref:System.Net.Http.HttpClient> provides a more flexible and efficient way to make HTTP requests and handle responses. Here are the key steps and considerations for this migration:
+
+Let's start with some examples:
+
+#### Simple GET Request Using <xref:System.Net.HttpWebRequest>
+
+Here's an example of how the code might look:
+
+```c#
+using System.Net;
+
+HttpWebRequest request = WebRequest.CreateHttp(uri);
+using WebResponse response = await request.GetResponseAsync();
+```
+
+#### Simple GET Request Using <xref:System.Net.Http.HttpClient>
+
+Here's an example of how the code might look:
+
+```c#
+using System.Net.Http;
+
+using HttpClient client = new();
+using HttpResponseMessage message = await client.GetAsync(uri);
+```
+
+#### Simple POST Request Using <xref:System.Net.HttpWebRequest>
+
+Here's an example of how the code might look:
+
+```c#
+using System.Net;
+
+HttpWebRequest request = WebRequest.CreateHttp(uri);
+request.Method = "POST";
+request.ContentType = "text/plain";
+await using Stream stream = await request.GetRequestStreamAsync();
+await stream.WriteAsync("Hello World!"u8.ToArray());
+using WebResponse response = await request.GetResponseAsync();
+Memory<byte> buffer = new byte[1024];
+await using Stream responseStream = response.GetResponseStream();
+```
+
+#### Simple POST Request Using <xref:System.Net.Http.HttpClient>
+
+Here's an example of how the code might look:
+
+```c#
+using System.Net.Http;
+
+using HttpClient client = new();
+using HttpResponseMessage responseMessage = await client.PostAsync(uri, new StringContent("Hello World!"));
+```
+
+## 1:1 API Mapping Table
+
+Developers should be aware that `ServicePointManager` is a static class, meaning that any changes made to its properties will have a global effect on all newly created `ServicePoint` objects within the application. For example, modifying a property like `ConnectionLimit` or `Expect100Continue` will impact every new ServicePoint instance.
+
+### <xref:System.Net.ServicePointManager> Properties Mapping
+
+| <xref:System.Net.ServicePointManager> Old API | New API | Notes |
+|---------|----------------------|-------|
+| `CheckCertificateRevocationList` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.CertificateRevocationCheckMode | See TODO: for usage |
+| `DefaultConnectionLimit` | <xref:System.Net.Http.SocketsHttpHandler.MaxConnectionsPerServer> | TODO |
+| `DnsRefreshTimeout` | No equivalent API | Custom implementation needed |
+| `EnableDnsRoundRobin` | No equivalent API | Custom implementation needed |
+| `EncryptionPolicy` | No equivalent API | TODO |
+| `Expect100Continue` | <xref:System.Net.Http.Headers.HttpRequestHeaders.ExpectContinue> | TODO |
+| `MaxServicePointIdleTime` | <xref:System.Net.Http.SocketsHttpHandler.PooledConnectionIdleTimeout> | TODO |
+| `MaxServicePoints` | No equivalent API | TODO |
+| `ReusePort` | No direct equivalent API | Can be done over <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
+| `SecurityProtocol` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.EnabledSslProtocols | TODO |
+| `ServerCertificateValidationCallback` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.RemoteCertificateValidationCallback | Signatures are different need a custom callback |
+| `UseNagleAlgorithm` | No direct equivalent API | Can be done over <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
+
+### <xref:System.Net.ServicePointManager> Method Mapping
+
+| <xref:System.Net.ServicePointManager> Old API | New API | Notes |
+|---------|----------------------|-------|
+| `FindServicePoint` | No equivalent API | TODO |
+| `SetTcpKeepAlive` | No direct equivalent API | Can be done over <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
+
+### <xref:System.Net.ServicePoint> Properties Mapping
+
+| <xref:System.Net.ServicePoint> Old API | New API | Notes |
+|---------|----------------------|-------|
+| `Address` | `HttpRequestMessage.RequestUri` | This is request uri, so basically we can get this from `HttpRequestMessage`. |
+| `BindIPEndPointDelegate` | No direct equivalent API | Can be done over <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
+| `Certificate` | No direct equivalent API | We can grab this information during `RemoteCertificateValidationCallback`. |
+| `ClientCertificate` | No equivalent API | TODO |
+| `ConnectionLeaseTimeout` | `SocketsHttpHandler.PooledConnectionLifetime` | Equivalent setting in <xref:System.Net.Http.HttpClient> |
+| `ConnectionLimit` | <xref:System.Net.Http.SocketsHttpHandler.MaxConnectionsPerServer> | TODO |
+| `ConnectionName` | No equivalent API | TODO |
+| `CurrentConnections` | No equivalent API | TODO |
+| `Expect100Continue` | <xref:System.Net.Http.Headers.HttpRequestHeaders.ExpectContinue> | TODO |
+| `IdleSince` | No equivalent API | TODO |
+| `MaxIdleTime` | <xref:System.Net.Http.SocketsHttpHandler.PooledConnectionIdleTimeout> | TODO |
+| `ProtocolVersion` | `HttpRequestMessage.Version` | We can get this from `HttpRequestMessage`. |
+| `ReceiveBufferSize` | No direct equivalent API | Can be done over <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
+| `SupportsPipelining` | No equivalent API | `HttpClient` doesn't support pipelining. |
+| `UseNagleAlgorithm` | No direct equivalent API | Can be done over <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
+
+### <xref:System.Net.ServicePoint> Method Mapping
+
+| <xref:System.Net.ServicePoint> Old API | New API | Notes |
+|---------|----------------------|-------|
+| `CloseConnectionGroup` | No equivalent | No workaround |
+| `SetTcpKeepAlive` | No direct equivalent API | Can be done over <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
+

--- a/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
+++ b/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
@@ -86,7 +86,7 @@ using HttpResponseMessage responseMessage = await client.PostAsync(uri, new Stri
 | `AllowWriteStreamBuffering` | No direct equivalent API | See: [Example: Write Buffering](#example-write-buffering). |
 | `AuthenticationLevel` | No direct equivalent API | See: [Example: Enabling Mutual Authentication](#example-enabling-mutual-authentication). |
 | `AutomaticDecompression` | <xref:System.Net.Http.SocketsHttpHandler.AutomaticDecompression> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
-| `CachePolicy` | No direct equivalent API | See: `Example: Apply CachePolicy Headers`. |
+| `CachePolicy` | No direct equivalent API | See: [Example: Apply CachePolicy Headers](#example-apply-cachepolicy-headers). |
 | `ClientCertificates` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.<xref:System.Net.Security.SslClientAuthenticationOptions.ClientCertificates> | See: [Usage of Certificate Related Properties in HttpClient](#usage-of-certificate-related-properties-in-httpclient). |
 | `Connection` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Connection> | See: [Example: Set Request Headers](#example-set-request-headers). |
 | `ConnectionGroupName` | No equivalent API | TODO |
@@ -97,7 +97,7 @@ using HttpResponseMessage responseMessage = await client.PostAsync(uri, new Stri
 | `CookieContainer` | <xref:System.Net.Http.SocketsHttpHandler.CookieContainer> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
 | `Credentials` | <xref:System.Net.Http.SocketsHttpHandler.Credentials> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
 | `Date` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Date> | See: [Example: Set Request Headers](#example-set-request-headers). |
-| `DefaultCachePolicy` | No direct equivalent API | See: `Example: Apply CachePolicy Headers`. |
+| `DefaultCachePolicy` | No direct equivalent API | See: [Example: Apply CachePolicy Headers](#example-apply-cachepolicy-headers). |
 | `DefaultMaximumErrorResponseLength` | TODO | TODO |
 | `DefaultMaximumResponseHeadersLength` | No equivalent API | <xref:System.Net.Http.SocketsHttpHandler.MaxResponseHeadersLength> can be used instead. |
 | `DefaultWebProxy` | No equivalent API | <xref:System.Net.Http.SocketsHttpHandler.Proxy> can be used instead. |
@@ -440,6 +440,10 @@ TODO:
 TODO:
 
 ### Example: Set Request Headers
+
+TODO:
+
+### Example: Apply CachePolicy Headers
 
 TODO:
 

--- a/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
+++ b/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
@@ -19,17 +19,13 @@ helpviewer_keywords:
 
 This document aims to guide developers through the process of migrating from <xref:System.Net.HttpWebRequest>, <xref:System.Net.ServicePoint>, and <xref:System.Net.ServicePointManager> to <xref:System.Net.Http.HttpClient>. The migration is necessary due to the obsolescence of the older APIs and the numerous benefits offered by <xref:System.Net.Http.HttpClient>, including improved performance, better resource management, and a more modern and flexible API design. By following the steps outlined in this document, developers will be able to transition their codebases smoothly and take full advantage of the features provided by <xref:System.Net.Http.HttpClient>.
 
-## Migration steps
-
-Here is explanation for detailed migration steps.
-
-### Migrating from <xref:System.Net.HttpWebRequest> to <xref:System.Net.Http.HttpClient>
+## Migrating from <xref:System.Net.HttpWebRequest> to <xref:System.Net.Http.HttpClient>
 
 The migration from <xref:System.Net.HttpWebRequest> to <xref:System.Net.Http.HttpClient> is essential due to the modern features and improved performance that <xref:System.Net.Http.HttpClient> offers. <xref:System.Net.Http.HttpClient> provides a more flexible and efficient way to make HTTP requests and handle responses. Here are the key steps and considerations for this migration:
 
 Let's start with some examples:
 
-#### Simple GET Request Using <xref:System.Net.HttpWebRequest>
+### Simple GET Request Using <xref:System.Net.HttpWebRequest>
 
 Here's an example of how the code might look:
 
@@ -40,7 +36,7 @@ HttpWebRequest request = WebRequest.CreateHttp(uri);
 using WebResponse response = await request.GetResponseAsync();
 ```
 
-#### Simple GET Request Using <xref:System.Net.Http.HttpClient>
+### Simple GET Request Using <xref:System.Net.Http.HttpClient>
 
 Here's an example of how the code might look:
 
@@ -51,7 +47,7 @@ using HttpClient client = new();
 using HttpResponseMessage message = await client.GetAsync(uri);
 ```
 
-#### Simple POST Request Using <xref:System.Net.HttpWebRequest>
+### Simple POST Request Using <xref:System.Net.HttpWebRequest>
 
 Here's an example of how the code might look:
 
@@ -68,7 +64,7 @@ Memory<byte> buffer = new byte[1024];
 await using Stream responseStream = response.GetResponseStream();
 ```
 
-#### Simple POST Request Using <xref:System.Net.Http.HttpClient>
+### Simple POST Request Using <xref:System.Net.Http.HttpClient>
 
 Here's an example of how the code might look:
 
@@ -79,6 +75,60 @@ using HttpClient client = new();
 using HttpResponseMessage responseMessage = await client.PostAsync(uri, new StringContent("Hello World!"));
 ```
 
+## HttpWebRequest to HttpClient, SocketsHttpHandler Migration Guide
+
+| <xref:System.Net.HttpWebRequest> Old API | New API | Notes |
+|---------|----------------------|-------|
+| `Accept` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Accept> | See: `Examples: Set Request Headers`. |
+| `Address` | TODO | TODO |
+| `AllowAutoRedirect` | <xref:System.Net.Http.SocketsHttpHandler.AllowAutoRedirect> | See: `Examples: Setting SocketsHttpHandler properties`. |
+| `AllowReadStreamBuffering` | No direct equivalent API | See: `Example: Read Buffering`. |
+| `AllowWriteStreamBuffering` | No direct equivalent API | See: `Example: Write Buffering`. |
+| `AuthenticationLevel` | No direct equivalent API | See: `Example: Mutual Authentication`. |
+| `AutomaticDecompression` | <xref:System.Net.Http.SocketsHttpHandler.AutomaticDecompression> | See: `Examples: Setting SocketsHttpHandler properties`. |
+| `CachePolicy` | No direct equivalent API | See: `Example: Apply CachePolicy Headers`. |
+| `ClientCertificates` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.ClientCertificates | See: `Example: Usage of Certificate Related Properties in HttpClient`. |
+| `Connection` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Connection> | See: `Examples: Set Request Headers`. |
+| `ConnectionGroupName` | No equivalent API | TODO |
+| `ContentLength` | <xref:System.Net.Http.Headers.HttpContentHeaders.ContentLength> | TODO |
+| `ContentType` | <xref:System.Net.Http.Headers.HttpContentHeaders.ContentType> | TODO |
+| `ContinueDelegate` | No equivalent API | TODO |
+| `ContinueTimeout` | <xref:System.Net.Http.SocketsHttpHandler.Expect100ContinueTimeout> | See: `Examples: Setting SocketsHttpHandler properties`. |
+| `CookieContainer` | <xref:System.Net.Http.SocketsHttpHandler.CookieContainer> | See: `Examples: Setting SocketsHttpHandler properties`. |
+| `Credentials` | <xref:System.Net.Http.SocketsHttpHandler.Credentials> | See: `Examples: Setting SocketsHttpHandler properties`. |
+| `Date` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Date> | See: `Examples: Set Request Headers`. |
+| `DefaultCachePolicy` | No direct equivalent API | See: `Example: Apply CachePolicy Headers`. |
+| `DefaultMaximumErrorResponseLength` | TODO | TODO |
+| `DefaultMaximumResponseHeadersLength` | No equivalent API | <xref:System.Net.Http.SocketsHttpHandler.MaxResponseHeadersLength> can be used instead. |
+| `DefaultWebProxy` | No equivalent API | <xref:System.Net.Http.SocketsHttpHandler.Proxy> can be used instead. |
+| `Expect` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Expect> | See: `Examples: Set Request Headers`. |
+| `HaveResponse` | No equivalent API | TODO |
+| `Headers` | <xref:System.Net.Http.HttpRequestMessage.Headers> | See: `Examples: Set Request Headers`. |
+| `Host` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Host> | See: `Examples: Set Request Headers`. |
+| `IfModifiedSince` | <xref:System.Net.Http.Headers.HttpRequestHeaders.IfModifiedSince> | See: `Examples: Set Request Headers`. |
+| `ImpersonationLevel` | No direct equivalent API | See: `Examples: Change ImpersonationLevel` |
+| `KeepAlive` | No direct equivalent API | See: `Examples: Set Request Headers` |
+| `MaximumAutomaticRedirections` | <xref:System.Net.Http.SocketsHttpHandler.MaxAutomaticRedirections> | See: `Examples: Setting SocketsHttpHandler properties`. |
+| `MaximumResponseHeadersLength` | <xref:System.Net.Http.SocketsHttpHandler.MaxResponseHeadersLength> | See: `Examples: Setting SocketsHttpHandler properties`. |
+| `MediaType` | TODO | TODO |
+| `Method` | <xref:System.Net.Http.HttpRequestMessage.Method> | See: `Examples: Usage of HttpRequestMessage and properties`. |
+| `Pipelined` | No equivalent API | `HttpClient` doesn't support pipelining. |
+| `PreAuthenticate` | <xref:System.Net.Http.SocketsHttpHandler.PreAuthenticate> | TODO |
+| `ProtocolVersion` | TODO | TODO |
+| `Proxy` | <xref:System.Net.Http.SocketsHttpHandler.Proxy> | See: `Examples: Setting SocketsHttpHandler properties`. |
+| `ReadWriteTimeout` | No direct equivalent API | See <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
+| `Referer` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Referrer> | See: `Examples: Set Request Headers`. |
+| `RequestUri` | <xref:System.Net.Http.HttpRequestMessage.RequestUri> | See: `Examples: Usage of HttpRequestMessage and properties`. |
+| `SendChunked` | <xref:System.Net.Http.Headers.HttpRequestHeaders.TransferEncodingChunked> | See: `Examples: Set Request Headers`. |
+| `ServerCertificateValidationCallback` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.RemoteCertificateValidationCallback | See: `Examples: Setting SocketsHttpHandler properties`. |
+| `ServicePoint` | No equivalent API | `ServicePoint` is not part of `HttpClient`. |
+| `SupportsCookieContainer` | No equivalent API | This is always `true`. |
+| `Timeout` | <xref:System.Net.Http.HttpClient.Timeout> |  |
+| `TransferEncoding` | <xref:System.Net.Http.Headers.HttpRequestHeaders.TransferEncoding> | See: `Examples: Set Request Headers`. |
+| `UnsafeAuthenticatedConnectionSharing` | No equivalent API | No workaround |
+| `UseDefaultCredentials` | No direct equivalent API | See: `Example: Set Credentials` |
+| `UserAgent` | <xref:System.Net.Http.Headers.HttpRequestHeaders.UserAgent> | See: `Examples: Set Request Headers`. |
+
 ## Migrating ServicePoint(Manager) usage
 
 Developers should be aware that `ServicePointManager` is a static class, meaning that any changes made to its properties will have a global effect on all newly created `ServicePoint` objects within the application. For example, modifying a property like `ConnectionLimit` or `Expect100Continue` will impact every new ServicePoint instance.
@@ -87,14 +137,14 @@ Developers should be aware that `ServicePointManager` is a static class, meaning
 
 | <xref:System.Net.ServicePointManager> Old API | New API | Notes |
 |---------|----------------------|-------|
-| `CheckCertificateRevocationList` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.CertificateRevocationCheckMode | See TODO: for usage |
+| `CheckCertificateRevocationList` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.CertificateRevocationCheckMode | See: `Example: Enabling CRL Check with SocketsHttpHandler`. |
 | `DefaultConnectionLimit` | <xref:System.Net.Http.SocketsHttpHandler.MaxConnectionsPerServer> | TODO |
-| `DnsRefreshTimeout` | No equivalent API | Custom implementation needed |
-| `EnableDnsRoundRobin` | No equivalent API | Custom implementation needed |
+| `DnsRefreshTimeout` | No equivalent API | See: `Example: Enabling Dns Round Robin`. |
+| `EnableDnsRoundRobin` | No equivalent API | See: `Example: Enabling Dns Round Robin`. |
 | `EncryptionPolicy` | No equivalent API | TODO |
 | `Expect100Continue` | <xref:System.Net.Http.Headers.HttpRequestHeaders.ExpectContinue> | TODO |
 | `MaxServicePointIdleTime` | <xref:System.Net.Http.SocketsHttpHandler.PooledConnectionIdleTimeout> | TODO |
-| `MaxServicePoints` | No equivalent API | TODO |
+| `MaxServicePoints` | No equivalent API | `ServicePoint` is not part of `HttpClient`. |
 | `ReusePort` | No direct equivalent API | See <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
 | `SecurityProtocol` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.EnabledSslProtocols | TODO |
 | `ServerCertificateValidationCallback` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.RemoteCertificateValidationCallback | Both of them are <xref:System.Net.Security.RemoteCertificateValidationCallback> |

--- a/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
+++ b/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
@@ -137,7 +137,7 @@ Developers should be aware that `ServicePointManager` is a static class, meaning
 
 | <xref:System.Net.ServicePointManager> Old API | New API | Notes |
 |---------|----------------------|-------|
-| `CheckCertificateRevocationList` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.CertificateRevocationCheckMode | See: `Example: Enabling CRL Check with SocketsHttpHandler`. |
+| `CheckCertificateRevocationList` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.CertificateRevocationCheckMode | See: [Example: Enabling CRL Check with SocketsHttpHandler](#example-enabling-crl-check-with-socketshttphandler). |
 | `DefaultConnectionLimit` | <xref:System.Net.Http.SocketsHttpHandler.MaxConnectionsPerServer> | TODO |
 | `DnsRefreshTimeout` | No equivalent API | See: `Example: Enabling Dns Round Robin`. |
 | `EnableDnsRoundRobin` | No equivalent API | See: `Example: Enabling Dns Round Robin`. |

--- a/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
+++ b/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
@@ -87,7 +87,7 @@ using HttpResponseMessage responseMessage = await client.PostAsync(uri, new Stri
 | `AuthenticationLevel` | No direct equivalent API | See: [Example: Enabling Mutual Authentication](#example-enabling-mutual-authentication). |
 | `AutomaticDecompression` | <xref:System.Net.Http.SocketsHttpHandler.AutomaticDecompression> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
 | `CachePolicy` | No direct equivalent API | See: [Example: Apply CachePolicy Headers](#example-apply-cachepolicy-headers). |
-| `ClientCertificates` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.<xref:System.Net.Security.SslClientAuthenticationOptions.ClientCertificates> | See: [Usage of Certificate Related Properties in HttpClient](#usage-of-certificate-related-properties-in-httpclient). |
+| `ClientCertificates` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.<xref:System.Net.Security.SslClientAuthenticationOptions.ClientCertificates> | See: [Usage of Certificate Related Properties in HttpClient](#usage-of-certificate-and-tls-related-properties-in-httpclient). |
 | `Connection` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Connection> | See: [Example: Set Request Headers](#example-set-request-headers). |
 | `ConnectionGroupName` | No equivalent API | TODO |
 | `ContentLength` | <xref:System.Net.Http.Headers.HttpContentHeaders.ContentLength> | TODO |

--- a/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
+++ b/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
@@ -77,7 +77,7 @@ using HttpResponseMessage responseMessage = await client.PostAsync(uri, new Stri
 
 | <xref:System.Net.HttpWebRequest> Old API | New API | Notes |
 |---------|----------------------|-------|
-| `Accept` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Accept> | See: [Example: Set Request Headers](#example-set-request-headers). |
+| `Accept` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Accept> | See: [Example: Set Request Headers](#example-set-common-request-headers). |
 | `Address` | TODO | TODO |
 | `AllowAutoRedirect` | <xref:System.Net.Http.SocketsHttpHandler.AllowAutoRedirect> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
 | `AllowReadStreamBuffering` | No direct equivalent API | See: [Example: Read Buffering](#example-read-buffering). |
@@ -86,7 +86,7 @@ using HttpResponseMessage responseMessage = await client.PostAsync(uri, new Stri
 | `AutomaticDecompression` | <xref:System.Net.Http.SocketsHttpHandler.AutomaticDecompression> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
 | `CachePolicy` | No direct equivalent API | See: [Example: Apply CachePolicy Headers](#example-apply-cachepolicy-headers). |
 | `ClientCertificates` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.<xref:System.Net.Security.SslClientAuthenticationOptions.ClientCertificates> | See: [Usage of Certificate Related Properties in HttpClient](#usage-of-certificate-and-tls-related-properties-in-httpclient). |
-| `Connection` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Connection> | See: [Example: Set Request Headers](#example-set-request-headers). |
+| `Connection` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Connection> | See: [Example: Set Request Headers](#example-set-common-request-headers). |
 | `ConnectionGroupName` | No equivalent API | No workaround |
 | `ContentLength` | <xref:System.Net.Http.Headers.HttpContentHeaders.ContentLength> | See: [Example: Set Content Headers](#example-set-content-headers). |
 | `ContentType` | <xref:System.Net.Http.Headers.HttpContentHeaders.ContentType> | See: [Example: Set Content Headers](#example-set-content-headers). |
@@ -94,18 +94,18 @@ using HttpResponseMessage responseMessage = await client.PostAsync(uri, new Stri
 | `ContinueTimeout` | <xref:System.Net.Http.SocketsHttpHandler.Expect100ContinueTimeout> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
 | `CookieContainer` | <xref:System.Net.Http.SocketsHttpHandler.CookieContainer> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
 | `Credentials` | <xref:System.Net.Http.SocketsHttpHandler.Credentials> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
-| `Date` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Date> | See: [Example: Set Request Headers](#example-set-request-headers). |
+| `Date` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Date> | See: [Example: Set Request Headers](#example-set-common-request-headers). |
 | `DefaultCachePolicy` | No direct equivalent API | See: [Example: Apply CachePolicy Headers](#example-apply-cachepolicy-headers). |
 | `DefaultMaximumErrorResponseLength` | No direct equivalent API | See: [Example: Set MaximumErrorResponseLength in HttpClient](#example-set-maximumerrorresponselength-in-httpclient). |
 | `DefaultMaximumResponseHeadersLength` | No equivalent API | <xref:System.Net.Http.SocketsHttpHandler.MaxResponseHeadersLength> can be used instead. |
 | `DefaultWebProxy` | No equivalent API | <xref:System.Net.Http.SocketsHttpHandler.Proxy> can be used instead. |
-| `Expect` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Expect> | See: [Example: Set Request Headers](#example-set-request-headers). |
+| `Expect` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Expect> | See: [Example: Set Request Headers](#example-set-common-request-headers). |
 | `HaveResponse` | No equivalent API | No workaround |
-| `Headers` | <xref:System.Net.Http.HttpRequestMessage.Headers> | See: [Example: Set Request Headers](#example-set-request-headers). |
-| `Host` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Host> | See: [Example: Set Request Headers](#example-set-request-headers). |
-| `IfModifiedSince` | <xref:System.Net.Http.Headers.HttpRequestHeaders.IfModifiedSince> | See: [Example: Set Request Headers](#example-set-request-headers). |
+| `Headers` | <xref:System.Net.Http.HttpRequestMessage.Headers> | See: [Example: Set Request Headers](#example-set-custom-request-headers). |
+| `Host` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Host> | See: [Example: Set Request Headers](#example-set-common-request-headers). |
+| `IfModifiedSince` | <xref:System.Net.Http.Headers.HttpRequestHeaders.IfModifiedSince> | See: [Example: Set Request Headers](#example-set-common-request-headers). |
 | `ImpersonationLevel` | No direct equivalent API | See: [Example: Change ImpersonationLevel](#example-change-impersonationlevel). |
-| `KeepAlive` | No direct equivalent API | See: [Example: Set Request Headers](#example-set-request-headers). |
+| `KeepAlive` | No direct equivalent API | See: [Example: Set Request Headers](#example-set-custom-request-headers). |
 | `MaximumAutomaticRedirections` | <xref:System.Net.Http.SocketsHttpHandler.MaxAutomaticRedirections> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
 | `MaximumResponseHeadersLength` | <xref:System.Net.Http.SocketsHttpHandler.MaxResponseHeadersLength> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
 | `MediaType` | TODO | TODO |
@@ -115,17 +115,17 @@ using HttpResponseMessage responseMessage = await client.PostAsync(uri, new Stri
 | `ProtocolVersion` | TODO | TODO |
 | `Proxy` | <xref:System.Net.Http.SocketsHttpHandler.Proxy> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
 | `ReadWriteTimeout` | No direct equivalent API | See <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
-| `Referer` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Referrer> | See: [Example: Set Request Headers](#example-set-request-headers). |
+| `Referer` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Referrer> | See: [Example: Set Request Headers](#example-set-common-request-headers). |
 | `RequestUri` | <xref:System.Net.Http.HttpRequestMessage.RequestUri> | See: [Example: Usage of HttpRequestMessage properties](#example-usage-of-httprequestmessage-properties). |
-| `SendChunked` | <xref:System.Net.Http.Headers.HttpRequestHeaders.TransferEncodingChunked> | See: [Example: Set Request Headers](#example-set-request-headers). |
+| `SendChunked` | <xref:System.Net.Http.Headers.HttpRequestHeaders.TransferEncodingChunked> | See: [Example: Set Request Headers](#example-set-common-request-headers). |
 | `ServerCertificateValidationCallback` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.<xref:System.Net.Security.SslClientAuthenticationOptions.RemoteCertificateValidationCallback> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
 | `ServicePoint` | No equivalent API | `ServicePoint` is not part of `HttpClient`. |
 | `SupportsCookieContainer` | No equivalent API | This is always `true` for `HttpClient`. |
 | `Timeout` | <xref:System.Net.Http.HttpClient.Timeout> |  |
-| `TransferEncoding` | <xref:System.Net.Http.Headers.HttpRequestHeaders.TransferEncoding> | See: [Example: Set Request Headers](#example-set-request-headers). |
+| `TransferEncoding` | <xref:System.Net.Http.Headers.HttpRequestHeaders.TransferEncoding> | See: [Example: Set Request Headers](#example-set-common-request-headers). |
 | `UnsafeAuthenticatedConnectionSharing` | No equivalent API | No workaround |
 | `UseDefaultCredentials` | No direct equivalent API | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
-| `UserAgent` | <xref:System.Net.Http.Headers.HttpRequestHeaders.UserAgent> | See: [Example: Set Request Headers](#example-set-request-headers). |
+| `UserAgent` | <xref:System.Net.Http.Headers.HttpRequestHeaders.UserAgent> | See: [Example: Set Request Headers](#example-set-common-request-headers). |
 
 ## Migrating ServicePoint(Manager) usage
 
@@ -138,7 +138,7 @@ Developers should be aware that `ServicePointManager` is a static class, meaning
 
 | <xref:System.Net.ServicePointManager> Old API | New API | Notes |
 |---------|----------------------|-------|
-| `CheckCertificateRevocationList` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.<xref:System.Net.Security.SslClientAuthenticationOptions.CertificateRevocationCheckMode> | See: [Example: Enabling CRL Check with SocketsHttpHandler](#example-enabling-crl-check-with-socketshttphandler). |
+| `CheckCertificateRevocationList` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.<xref:System.Net.Security.SslClientAuthenticationOptions.CertificateRevocationCheckMode> | See: [Example: Enabling CRL Check with SocketsHttpHandler](#example-check-certificate-revocation-list-with-socketshttphandler). |
 | `DefaultConnectionLimit` | <xref:System.Net.Http.SocketsHttpHandler.MaxConnectionsPerServer> | TODO |
 | `DnsRefreshTimeout` | No equivalent API | See: [Example: Enabling Dns Round Robin](#example-enabling-dns-round-robin). |
 | `EnableDnsRoundRobin` | No equivalent API | See: [Example: Enabling Dns Round Robin](#example-enabling-dns-round-robin). |

--- a/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
+++ b/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
@@ -184,11 +184,11 @@ Developers should be aware that `ServicePointManager` is a static class, meaning
 | `CloseConnectionGroup` | No equivalent | No workaround |
 | `SetTcpKeepAlive` | No direct equivalent API | See <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
 
-### Usage of ConnectCallback
+## Usage of ConnectCallback
 
 The `ConnectCallback` property in `SocketsHttpHandler` allows developers to customize the process of establishing a TCP connection. This can be useful for scenarios where you need to control DNS resolution or apply specific socket options on the connection. By using `ConnectCallback`, you can intercept and modify the connection process before it is used by `HttpClient`.
 
-#### Example: Binding IP Address to Socket
+### Example: Binding IP Address to Socket
 
 In the old approach using `HttpWebRequest`, you might have used custom logic to bind a specific IP address to a socket. Here's how you can achieve similar functionality using `HttpClient` and `ConnectCallback`:
 
@@ -224,7 +224,7 @@ var client = new HttpClient(handler);
 var response = await client.GetAsync(uri);
 ```
 
-#### Example: Applying Specific Socket Options
+### Example: Applying Specific Socket Options
 
 If you need to apply specific socket options, such as enabling TCP keep-alive, you can use `ConnectCallback` to configure the socket before it is used by `HttpClient`. In fact, `ConnectCallback` is more flexible to configure socket options.
 
@@ -269,11 +269,11 @@ var client = new HttpClient(handler);
 var response = await client.GetAsync(uri);
 ```
 
-### Usage of Certificate Related Properties in HttpClient
+## Usage of Certificate Related Properties in HttpClient
 
 When working with `HttpClient`, you may need to handle client certificates for various purposes, such as custom validation of server certificates or fetching the server certificate. `HttpClient` provides several properties and options to manage certificates effectively.
 
-#### Example: Enabling CRL Check with SocketsHttpHandler
+### Example: Enabling CRL Check with SocketsHttpHandler
 
 The `CheckCertificateRevocationList` property in `SocketsHttpHandler` allows developers to enable or disable the check for certificate revocation lists (CRL) during SSL/TLS handshake. Enabling this property ensures that the client verifies whether the server's certificate has been revoked, enhancing the security of the connection.
 
@@ -300,7 +300,7 @@ var client = new HttpClient(handler);
 var response = await client.GetAsync(uri);
 ```
 
-#### Example: Fetch Certificate
+### Example: Fetch Certificate
 
 To fetch the certificate from the RemoteCertificateValidationCallback in HttpClient, you can use the ServerCertificateCustomValidationCallback property of HttpClientHandler or SocketsHttpHandler. This callback allows you to inspect the server's certificate during the SSL/TLS handshake.
 

--- a/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
+++ b/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
@@ -87,7 +87,7 @@ using HttpResponseMessage responseMessage = await client.PostAsync(uri, new Stri
 | `AuthenticationLevel` | No direct equivalent API | See: `Example: Mutual Authentication`. |
 | `AutomaticDecompression` | <xref:System.Net.Http.SocketsHttpHandler.AutomaticDecompression> | See: `Examples: Setting SocketsHttpHandler properties`. |
 | `CachePolicy` | No direct equivalent API | See: `Example: Apply CachePolicy Headers`. |
-| `ClientCertificates` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.ClientCertificates | See: `Example: Usage of Certificate Related Properties in HttpClient`. |
+| `ClientCertificates` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.<xref:System.Net.Security.SslClientAuthenticationOptions.ClientCertificates> | See: `Example: Usage of Certificate Related Properties in HttpClient`. |
 | `Connection` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Connection> | See: `Examples: Set Request Headers`. |
 | `ConnectionGroupName` | No equivalent API | TODO |
 | `ContentLength` | <xref:System.Net.Http.Headers.HttpContentHeaders.ContentLength> | TODO |
@@ -120,7 +120,7 @@ using HttpResponseMessage responseMessage = await client.PostAsync(uri, new Stri
 | `Referer` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Referrer> | See: `Examples: Set Request Headers`. |
 | `RequestUri` | <xref:System.Net.Http.HttpRequestMessage.RequestUri> | See: `Examples: Usage of HttpRequestMessage and properties`. |
 | `SendChunked` | <xref:System.Net.Http.Headers.HttpRequestHeaders.TransferEncodingChunked> | See: `Examples: Set Request Headers`. |
-| `ServerCertificateValidationCallback` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.RemoteCertificateValidationCallback | See: `Examples: Setting SocketsHttpHandler properties`. |
+| `ServerCertificateValidationCallback` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.<xref:System.Net.Security.SslClientAuthenticationOptions.RemoteCertificateValidationCallback> | See: `Examples: Setting SocketsHttpHandler properties`. |
 | `ServicePoint` | No equivalent API | `ServicePoint` is not part of `HttpClient`. |
 | `SupportsCookieContainer` | No equivalent API | This is always `true`. |
 | `Timeout` | <xref:System.Net.Http.HttpClient.Timeout> |  |
@@ -137,7 +137,7 @@ Developers should be aware that `ServicePointManager` is a static class, meaning
 
 | <xref:System.Net.ServicePointManager> Old API | New API | Notes |
 |---------|----------------------|-------|
-| `CheckCertificateRevocationList` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.CertificateRevocationCheckMode | See: [Example: Enabling CRL Check with SocketsHttpHandler](#example-enabling-crl-check-with-socketshttphandler). |
+| `CheckCertificateRevocationList` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.<xref:System.Net.Security.SslClientAuthenticationOptions.CertificateRevocationCheckMode> | See: [Example: Enabling CRL Check with SocketsHttpHandler](#example-enabling-crl-check-with-socketshttphandler). |
 | `DefaultConnectionLimit` | <xref:System.Net.Http.SocketsHttpHandler.MaxConnectionsPerServer> | TODO |
 | `DnsRefreshTimeout` | No equivalent API | See: `Example: Enabling Dns Round Robin`. |
 | `EnableDnsRoundRobin` | No equivalent API | See: `Example: Enabling Dns Round Robin`. |
@@ -146,8 +146,8 @@ Developers should be aware that `ServicePointManager` is a static class, meaning
 | `MaxServicePointIdleTime` | <xref:System.Net.Http.SocketsHttpHandler.PooledConnectionIdleTimeout> | TODO |
 | `MaxServicePoints` | No equivalent API | `ServicePoint` is not part of `HttpClient`. |
 | `ReusePort` | No direct equivalent API | See <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
-| `SecurityProtocol` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.EnabledSslProtocols | TODO |
-| `ServerCertificateValidationCallback` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.RemoteCertificateValidationCallback | Both of them are <xref:System.Net.Security.RemoteCertificateValidationCallback> |
+| `SecurityProtocol` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.<xref:System.Net.Security.SslClientAuthenticationOptions.EnabledSslProtocols> | TODO |
+| `ServerCertificateValidationCallback` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.<xref:System.Net.Security.SslClientAuthenticationOptions.RemoteCertificateValidationCallback> | Both of them are <xref:System.Net.Security.RemoteCertificateValidationCallback> |
 | `UseNagleAlgorithm` | No direct equivalent API | See <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
 
 ### <xref:System.Net.ServicePointManager> Method Mapping

--- a/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
+++ b/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
@@ -89,20 +89,20 @@ using HttpResponseMessage responseMessage = await client.PostAsync(uri, new Stri
 | `CachePolicy` | No direct equivalent API | See: [Example: Apply CachePolicy Headers](#example-apply-cachepolicy-headers). |
 | `ClientCertificates` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.<xref:System.Net.Security.SslClientAuthenticationOptions.ClientCertificates> | See: [Usage of Certificate Related Properties in HttpClient](#usage-of-certificate-and-tls-related-properties-in-httpclient). |
 | `Connection` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Connection> | See: [Example: Set Request Headers](#example-set-request-headers). |
-| `ConnectionGroupName` | No equivalent API | TODO |
-| `ContentLength` | <xref:System.Net.Http.Headers.HttpContentHeaders.ContentLength> | TODO |
-| `ContentType` | <xref:System.Net.Http.Headers.HttpContentHeaders.ContentType> | TODO |
-| `ContinueDelegate` | No equivalent API | TODO |
+| `ConnectionGroupName` | No equivalent API | No workaround |
+| `ContentLength` | <xref:System.Net.Http.Headers.HttpContentHeaders.ContentLength> | See: [Example: Set Content Headers](#example-set-content-headers). |
+| `ContentType` | <xref:System.Net.Http.Headers.HttpContentHeaders.ContentType> | See: [Example: Set Content Headers](#example-set-content-headers). |
+| `ContinueDelegate` | No equivalent API | TODO: There might be workaround for it. |
 | `ContinueTimeout` | <xref:System.Net.Http.SocketsHttpHandler.Expect100ContinueTimeout> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
 | `CookieContainer` | <xref:System.Net.Http.SocketsHttpHandler.CookieContainer> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
 | `Credentials` | <xref:System.Net.Http.SocketsHttpHandler.Credentials> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
 | `Date` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Date> | See: [Example: Set Request Headers](#example-set-request-headers). |
 | `DefaultCachePolicy` | No direct equivalent API | See: [Example: Apply CachePolicy Headers](#example-apply-cachepolicy-headers). |
-| `DefaultMaximumErrorResponseLength` | TODO | TODO |
+| `DefaultMaximumErrorResponseLength` | No direct equivalent API | See: [Example: Set MaximumErrorResponseLength in HttpClient](#example-set-maximumerrorresponselength-in-httpclient). |
 | `DefaultMaximumResponseHeadersLength` | No equivalent API | <xref:System.Net.Http.SocketsHttpHandler.MaxResponseHeadersLength> can be used instead. |
 | `DefaultWebProxy` | No equivalent API | <xref:System.Net.Http.SocketsHttpHandler.Proxy> can be used instead. |
 | `Expect` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Expect> | See: [Example: Set Request Headers](#example-set-request-headers). |
-| `HaveResponse` | No equivalent API | TODO |
+| `HaveResponse` | No equivalent API | No workaround |
 | `Headers` | <xref:System.Net.Http.HttpRequestMessage.Headers> | See: [Example: Set Request Headers](#example-set-request-headers). |
 | `Host` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Host> | See: [Example: Set Request Headers](#example-set-request-headers). |
 | `IfModifiedSince` | <xref:System.Net.Http.Headers.HttpRequestHeaders.IfModifiedSince> | See: [Example: Set Request Headers](#example-set-request-headers). |
@@ -113,7 +113,7 @@ using HttpResponseMessage responseMessage = await client.PostAsync(uri, new Stri
 | `MediaType` | TODO | TODO |
 | `Method` | <xref:System.Net.Http.HttpRequestMessage.Method> | See: [Example: Usage of HttpRequestMessage properties](#example-usage-of-httprequestmessage-properties). |
 | `Pipelined` | No equivalent API | `HttpClient` doesn't support pipelining. |
-| `PreAuthenticate` | <xref:System.Net.Http.SocketsHttpHandler.PreAuthenticate> | TODO |
+| `PreAuthenticate` | <xref:System.Net.Http.SocketsHttpHandler.PreAuthenticate> | |
 | `ProtocolVersion` | TODO | TODO |
 | `Proxy` | <xref:System.Net.Http.SocketsHttpHandler.Proxy> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
 | `ReadWriteTimeout` | No direct equivalent API | See <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
@@ -440,6 +440,14 @@ TODO:
 TODO:
 
 ### Example: Set Request Headers
+
+TODO:
+
+### Example: Set Content Headers
+
+TODO:
+
+### Example: Set MaximumErrorResponseLength in HttpClient
 
 TODO:
 

--- a/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
+++ b/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
@@ -80,8 +80,8 @@ using HttpResponseMessage responseMessage = await client.PostAsync(uri, new Stri
 | `Accept` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Accept> | See: [Example: Set Request Headers](#example-set-common-request-headers). |
 | `Address` | TODO | TODO |
 | `AllowAutoRedirect` | <xref:System.Net.Http.SocketsHttpHandler.AllowAutoRedirect> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
-| `AllowReadStreamBuffering` | No direct equivalent API | See: [Example: Read Buffering](#example-read-buffering). |
-| `AllowWriteStreamBuffering` | No direct equivalent API | See: [Example: Write Buffering](#example-write-buffering). |
+| `AllowReadStreamBuffering` | No direct equivalent API | See: [Usage of Buffering Properties](#usage-of-buffering-properties). |
+| `AllowWriteStreamBuffering` | No direct equivalent API | See: [Usage of Buffering Properties](#usage-of-buffering-properties). |
 | `AuthenticationLevel` | No direct equivalent API | See: [Example: Enabling Mutual Authentication](#example-enabling-mutual-authentication). |
 | `AutomaticDecompression` | <xref:System.Net.Http.SocketsHttpHandler.AutomaticDecompression> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
 | `CachePolicy` | No direct equivalent API | See: [Example: Apply CachePolicy Headers](#example-apply-cachepolicy-headers). |

--- a/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
+++ b/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
@@ -160,8 +160,8 @@ Developers should be aware that `ServicePointManager` is a static class, meaning
 |---------|----------------------|-------|
 | `Address` | `HttpRequestMessage.RequestUri` | This is request uri, this information can be found under `HttpRequestMessage`. |
 | `BindIPEndPointDelegate` | No direct equivalent API | See: [Usage of SocketsHttpHandler and ConnectCallback](#usage-of-socketshttphandler-and-connectcallback). |
-| `Certificate` | No direct equivalent API | This information can be fetched from `RemoteCertificateValidationCallback`. See: [Example: Fetch Certificate](#example-fetch-certificate) |
-| `ClientCertificate` | No equivalent API | No workaround |
+| `Certificate` | No direct equivalent API | This information can be fetched from `RemoteCertificateValidationCallback`. See: [Example: Fetch Certificate](#example-fetch-certificate). |
+| `ClientCertificate` | No equivalent API | See: [Example: Enabling Mutual Authentication](#example-enabling-mutual-authentication). |
 | `ConnectionLeaseTimeout` | `SocketsHttpHandler.PooledConnectionLifetime` | Equivalent setting in <xref:System.Net.Http.HttpClient> |
 | `ConnectionLimit` | <xref:System.Net.Http.SocketsHttpHandler.MaxConnectionsPerServer> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
 | `ConnectionName` | No equivalent API | No workaround |
@@ -597,13 +597,14 @@ request.AllowWriteStreamBuffering = false; // Default is `true`.
 
 In `HttpClient`, there are no direct equivalents to the `AllowWriteStreamBuffering` and `AllowReadStreamBuffering` properties.
 
-However, you can achieve similar outcome of `disable write buffering` behavior by using the `StreamContent` class for streaming data. Here's an example:
+HttpClient does not buffer request bodies on its own, instead delegating the responsibility to the `HttpContent` used. Contents like `StringContent` or `ByteArrayContent` are logically already buffered in memory, while using `StreamContent` will not incur any buffering by default. To force the content to be buffered, you may call `HttpContent.LoadIntoBufferAsync` before sending the request. Here's an example:
 
 ```csharp
 HttpClient client = new HttpClient();
 
 HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, uri);
 request.Content = new StreamContent(yourStream);
+await request.Content.LoadIntoBufferAsync();
 
 HttpResponseMessage response = await client.SendAsync(request);
 ```

--- a/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
+++ b/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
@@ -556,6 +556,9 @@ And usage example of `TruncatedReadStream`:
 
 ### Example: Apply CachePolicy Headers
 
+> [!WARNING]
+> HttpClient does not have built-in logic to cache responses. There is no workaround other than implementing all the caching yourself. Simply setting the headers will not achieve caching.
+
 When migrating from `HttpWebRequest` to `HttpClient`, it's important to correctly handle cache-related headers such as `pragma` and `cache-control`. These headers control how responses are cached and retrieved, ensuring that your application behaves as expected in terms of performance and data freshness.
 
 In `HttpWebRequest`, you might have used the `CachePolicy` property to set these headers. However, in `HttpClient`, you need to manually set these headers on the request.

--- a/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
+++ b/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
@@ -78,7 +78,7 @@ using HttpResponseMessage responseMessage = await client.PostAsync(uri, new Stri
 | <xref:System.Net.HttpWebRequest> Old API | New API | Notes |
 |---------|----------------------|-------|
 | `Accept` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Accept> | See: [Example: Set Request Headers](#example-set-common-request-headers). |
-| `Address` | TODO | TODO |
+| `Address` | <xref:System.Net.Http.HttpRequestMessage.RequestUri> | See: [Example: Fetch Redirected URI](#example-fetch-redirected-uri). |
 | `AllowAutoRedirect` | <xref:System.Net.Http.SocketsHttpHandler.AllowAutoRedirect> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
 | `AllowReadStreamBuffering` | No direct equivalent API | See: [Usage of Buffering Properties](#usage-of-buffering-properties). |
 | `AllowWriteStreamBuffering` | No direct equivalent API | See: [Usage of Buffering Properties](#usage-of-buffering-properties). |
@@ -108,13 +108,13 @@ using HttpResponseMessage responseMessage = await client.PostAsync(uri, new Stri
 | `KeepAlive` | No direct equivalent API | See: [Example: Set Request Headers](#example-set-custom-request-headers). |
 | `MaximumAutomaticRedirections` | <xref:System.Net.Http.SocketsHttpHandler.MaxAutomaticRedirections> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
 | `MaximumResponseHeadersLength` | <xref:System.Net.Http.SocketsHttpHandler.MaxResponseHeadersLength> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
-| `MediaType` | TODO | TODO |
+| `MediaType` | No direct equivalent API | See: [Example: Set Content Headers](#example-set-content-headers). |
 | `Method` | <xref:System.Net.Http.HttpRequestMessage.Method> | See: [Example: Usage of HttpRequestMessage properties](#example-usage-of-httprequestmessage-properties). |
 | `Pipelined` | No equivalent API | `HttpClient` doesn't support pipelining. |
 | `PreAuthenticate` | <xref:System.Net.Http.SocketsHttpHandler.PreAuthenticate> | |
-| `ProtocolVersion` | TODO | TODO |
+| `ProtocolVersion` | `HttpRequestMessage.Version` | See: [Example: Usage of HttpRequestMessage properties](#example-usage-of-httprequestmessage-properties). |
 | `Proxy` | <xref:System.Net.Http.SocketsHttpHandler.Proxy> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
-| `ReadWriteTimeout` | No direct equivalent API | See <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
+| `ReadWriteTimeout` | No direct equivalent API | See: [Usage of SocketsHttpHandler and ConnectCallback](#usage-of-socketshttphandler-and-connectcallback). |
 | `Referer` | <xref:System.Net.Http.Headers.HttpRequestHeaders.Referrer> | See: [Example: Set Request Headers](#example-set-common-request-headers). |
 | `RequestUri` | <xref:System.Net.Http.HttpRequestMessage.RequestUri> | See: [Example: Usage of HttpRequestMessage properties](#example-usage-of-httprequestmessage-properties). |
 | `SendChunked` | <xref:System.Net.Http.Headers.HttpRequestHeaders.TransferEncodingChunked> | See: [Example: Set Request Headers](#example-set-common-request-headers). |
@@ -139,17 +139,17 @@ Developers should be aware that `ServicePointManager` is a static class, meaning
 | <xref:System.Net.ServicePointManager> Old API | New API | Notes |
 |---------|----------------------|-------|
 | `CheckCertificateRevocationList` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.<xref:System.Net.Security.SslClientAuthenticationOptions.CertificateRevocationCheckMode> | See: [Example: Enabling CRL Check with SocketsHttpHandler](#example-check-certificate-revocation-list-with-socketshttphandler). |
-| `DefaultConnectionLimit` | <xref:System.Net.Http.SocketsHttpHandler.MaxConnectionsPerServer> | TODO |
+| `DefaultConnectionLimit` | <xref:System.Net.Http.SocketsHttpHandler.MaxConnectionsPerServer> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
 | `DnsRefreshTimeout` | No equivalent API | See: [Example: Enabling Dns Round Robin](#example-enabling-dns-round-robin). |
 | `EnableDnsRoundRobin` | No equivalent API | See: [Example: Enabling Dns Round Robin](#example-enabling-dns-round-robin). |
-| `EncryptionPolicy` | No equivalent API | TODO |
-| `Expect100Continue` | <xref:System.Net.Http.Headers.HttpRequestHeaders.ExpectContinue> | TODO |
-| `MaxServicePointIdleTime` | <xref:System.Net.Http.SocketsHttpHandler.PooledConnectionIdleTimeout> | TODO |
+| `EncryptionPolicy` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.<xref:System.Net.Security.SslClientAuthenticationOptions.EncryptionPolicy> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
+| `Expect100Continue` | <xref:System.Net.Http.Headers.HttpRequestHeaders.ExpectContinue> | See: [Example: Set Request Headers](#example-set-common-request-headers). |
+| `MaxServicePointIdleTime` | <xref:System.Net.Http.SocketsHttpHandler.PooledConnectionIdleTimeout> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
 | `MaxServicePoints` | No equivalent API | `ServicePoint` is not part of `HttpClient`. |
-| `ReusePort` | No direct equivalent API | See <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
-| `SecurityProtocol` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.<xref:System.Net.Security.SslClientAuthenticationOptions.EnabledSslProtocols> | TODO |
+| `ReusePort` | No direct equivalent API | See: [Usage of SocketsHttpHandler and ConnectCallback](#usage-of-socketshttphandler-and-connectcallback). |
+| `SecurityProtocol` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.<xref:System.Net.Security.SslClientAuthenticationOptions.EnabledSslProtocols> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
 | `ServerCertificateValidationCallback` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.<xref:System.Net.Security.SslClientAuthenticationOptions.RemoteCertificateValidationCallback> | Both of them are <xref:System.Net.Security.RemoteCertificateValidationCallback> |
-| `UseNagleAlgorithm` | No direct equivalent API | See <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
+| `UseNagleAlgorithm` | No direct equivalent API | See: [Usage of SocketsHttpHandler and ConnectCallback](#usage-of-socketshttphandler-and-connectcallback). |
 
 > ![WARNING]
 > In modern .NET, the default values for the `UseNagleAlgorithm` and `Expect100Continue` properties are set to `false`. These values were `true` by default in .NET Framework.
@@ -158,35 +158,35 @@ Developers should be aware that `ServicePointManager` is a static class, meaning
 
 | <xref:System.Net.ServicePointManager> Old API | New API | Notes |
 |---------|----------------------|-------|
-| `FindServicePoint` | No equivalent API | TODO |
-| `SetTcpKeepAlive` | No direct equivalent API | See <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
+| `FindServicePoint` | No equivalent API | No workaround |
+| `SetTcpKeepAlive` | No direct equivalent API | See: [Usage of SocketsHttpHandler and ConnectCallback](#usage-of-socketshttphandler-and-connectcallback). |
 
 ### <xref:System.Net.ServicePoint> Properties Mapping
 
 | <xref:System.Net.ServicePoint> Old API | New API | Notes |
 |---------|----------------------|-------|
 | `Address` | `HttpRequestMessage.RequestUri` | This is request uri, this information can be found under `HttpRequestMessage`. |
-| `BindIPEndPointDelegate` | No direct equivalent API | See <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
+| `BindIPEndPointDelegate` | No direct equivalent API | See: [Usage of SocketsHttpHandler and ConnectCallback](#usage-of-socketshttphandler-and-connectcallback). |
 | `Certificate` | No direct equivalent API | This information can be fetched from `RemoteCertificateValidationCallback`. See: [Example: Fetch Certificate](#example-fetch-certificate) |
-| `ClientCertificate` | No equivalent API | TODO |
+| `ClientCertificate` | No equivalent API | No workaround |
 | `ConnectionLeaseTimeout` | `SocketsHttpHandler.PooledConnectionLifetime` | Equivalent setting in <xref:System.Net.Http.HttpClient> |
-| `ConnectionLimit` | <xref:System.Net.Http.SocketsHttpHandler.MaxConnectionsPerServer> | TODO |
-| `ConnectionName` | No equivalent API | TODO |
-| `CurrentConnections` | No equivalent API | TODO |
-| `Expect100Continue` | <xref:System.Net.Http.Headers.HttpRequestHeaders.ExpectContinue> | TODO |
-| `IdleSince` | No equivalent API | TODO |
-| `MaxIdleTime` | <xref:System.Net.Http.SocketsHttpHandler.PooledConnectionIdleTimeout> | TODO |
-| `ProtocolVersion` | `HttpRequestMessage.Version` | We can get this from `HttpRequestMessage`. |
-| `ReceiveBufferSize` | No direct equivalent API | See <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
+| `ConnectionLimit` | <xref:System.Net.Http.SocketsHttpHandler.MaxConnectionsPerServer> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
+| `ConnectionName` | No equivalent API | No workaround |
+| `CurrentConnections` | No equivalent API | No workaround |
+| `Expect100Continue` | <xref:System.Net.Http.Headers.HttpRequestHeaders.ExpectContinue> | See: [Example: Set Request Headers](#example-set-common-request-headers). |
+| `IdleSince` | No equivalent API | No workaround |
+| `MaxIdleTime` | <xref:System.Net.Http.SocketsHttpHandler.PooledConnectionIdleTimeout> | See: [Example: Setting SocketsHttpHandler Properties](#example-setting-socketshttphandler-properties). |
+| `ProtocolVersion` | `HttpRequestMessage.Version` | See: [Example: Usage of HttpRequestMessage properties](#example-usage-of-httprequestmessage-properties). |
+| `ReceiveBufferSize` | No direct equivalent API | See: [Usage of SocketsHttpHandler and ConnectCallback](#usage-of-socketshttphandler-and-connectcallback). |
 | `SupportsPipelining` | No equivalent API | `HttpClient` doesn't support pipelining. |
-| `UseNagleAlgorithm` | No direct equivalent API | See <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
+| `UseNagleAlgorithm` | No direct equivalent API | See: [Usage of SocketsHttpHandler and ConnectCallback](#usage-of-socketshttphandler-and-connectcallback). |
 
 ### <xref:System.Net.ServicePoint> Method Mapping
 
 | <xref:System.Net.ServicePoint> Old API | New API | Notes |
 |---------|----------------------|-------|
 | `CloseConnectionGroup` | No equivalent | No workaround |
-| `SetTcpKeepAlive` | No direct equivalent API | See <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback>. |
+| `SetTcpKeepAlive` | No direct equivalent API | See: [Usage of SocketsHttpHandler and ConnectCallback](#usage-of-socketshttphandler-and-connectcallback). |
 
 ## Usage of HttpClient and HttpRequestMessage Properties
 
@@ -209,6 +209,17 @@ request.Headers.Add("Custom-Header", "value");
 request.Content = new StringContent("somestring");
 
 using var response = await client.SendAsync(request);
+var protocolVersion = response.RequestMessage.Version; // Fetch `ProtocolVersion`.
+```
+
+### Example: Fetch Redirected URI
+
+Here's an example of how to fetch redirected URI (Same as `HttpWebRequest.Address`):
+
+```csharp
+var client = new HttpClient();
+using var response = await client.GetAsync(uri);
+var redirectedUri = response.RequestMessage.RequestUri;
 ```
 
 ## Usage of SocketsHttpHandler and ConnectCallback
@@ -351,7 +362,8 @@ var handler = new SocketsHttpHandler
         {
             // Custom validation logic
             return sslPolicyErrors == SslPolicyErrors.None;
-        }
+        },
+        EncryptionPolicy = EncryptionPolicy.RequireEncryption,
     },
 };
 
@@ -521,6 +533,7 @@ var request = new HttpRequestMessage(HttpMethod.Post, uri);
 // Create the content and set the content headers
 var jsonData = "{\"key\":\"value\"}";
 var content = new StringContent(jsonData, Encoding.UTF8, "application/json");
+// This is also corresponding example to set `MediaType` in `HttpWebRequest`.
 content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
 content.Headers.ContentEncoding.Add("utf-8");
 // WARNING: This is not needed in most of the cases, because most `HttpContent` implementations will calculate this field automatically.

--- a/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
+++ b/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
@@ -317,6 +317,8 @@ In the older `HttpWebRequest` API, enabling DNS Round Robin was straightforward 
 
 **New Code Using `HttpClient`**:
 
+:::code source="../snippets/httpclient/DnsRoundRobin.cs" id="DnsRoundRobinConnector":::
+
 You can find implementation of `DnsRoundRobinConnector` [here](../snippets/httpclient/DnsRoundRobin.cs).
 
 `DnsRoundRobinConnector` Usage:

--- a/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
+++ b/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
@@ -19,6 +19,9 @@ helpviewer_keywords:
 
 This document aims to guide developers through the process of migrating from <xref:System.Net.HttpWebRequest>, <xref:System.Net.ServicePoint>, and <xref:System.Net.ServicePointManager> to <xref:System.Net.Http.HttpClient>. The migration is necessary due to the obsolescence of the older APIs and the numerous benefits offered by <xref:System.Net.Http.HttpClient>, including improved performance, better resource management, and a more modern and flexible API design. By following the steps outlined in this document, developers will be able to transition their codebases smoothly and take full advantage of the features provided by <xref:System.Net.Http.HttpClient>.
 
+> ![WARNING]
+> Migrating from `HttpWebRequest`, `ServicePoint`, and `ServicePointManager` to `HttpClient` is not just a "nice to have" performance improvement. It's crucial to understand that the existing `WebRequest` logic's performance is likely to degrade significantly once you move to .NET Core. This is because `WebRequest` is maintained as a minimal compatibility layer, which means it lacks many optimizations, such as connection reuse in numerous cases. Therefore, transitioning to `HttpClient` is essential to ensure your application's performance and resource management are up to modern standards.
+
 ## Migrating from <xref:System.Net.HttpWebRequest> to <xref:System.Net.Http.HttpClient>
 
 Let's start with some examples:

--- a/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
+++ b/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
@@ -337,7 +337,7 @@ In the older `HttpWebRequest` API, enabling DNS Round Robin was straightforward 
 
 :::code source="../snippets/httpclient/DnsRoundRobin.cs" id="DnsRoundRobinConnector":::
 
-You can find implementation of `DnsRoundRobinConnector` [here](https://github.com/dotnet/docs/blob/main/docs/fundamentals/networking/snippets/httpclient/DnsRoundRobin.cs).
+You can find implementation of `DnsRoundRobinConnector` [here](https://raw.githubusercontent.com/dotnet/docs/refs/heads/main/docs/fundamentals/networking/snippets/httpclient/DnsRoundRobin.cs).
 
 `DnsRoundRobinConnector` Usage:
 :::code source="../snippets/httpclient/Program.DnsRoundRobin.cs" id="DnsRoundRobinConnect":::
@@ -577,7 +577,7 @@ In the older `HttpWebRequest` API, applying `CachePolicy` was straightforward du
 
 :::code source="../snippets/httpclient/AddCacheControlHeaders.cs" id="CachePolicy":::
 
-You can find implementation of `AddCacheControlHeaders` [here](https://github.com/dotnet/docs/blob/main/docs/fundamentals/networking/snippets/httpclient/AddCacheControlHeaders.cs).
+You can find implementation of `AddCacheControlHeaders` [here](https://raw.githubusercontent.com/dotnet/docs/refs/heads/main/docs/fundamentals/networking/snippets/httpclient/AddCacheControlHeaders.cs).
 
 `AddCacheControlHeaders` Usage:
 :::code source="../snippets/httpclient/Program.CacheControlHeaders.cs" id="CacheControlProgram":::

--- a/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
+++ b/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
@@ -256,8 +256,16 @@ var handler = new SocketsHttpHandler
         // Bind to a specific IP address
         IPAddress localAddress = IPAddress.Parse("192.168.1.100");
         var socket = new Socket(localAddress.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-        socket.Bind(new IPEndPoint(localAddress, 0));
-        await socket.ConnectAsync(context.DnsEndPoint, cancellationToken);
+        try
+        {
+            socket.Bind(new IPEndPoint(localAddress, 0));
+            await socket.ConnectAsync(context.DnsEndPoint, cancellationToken);
+        }
+        catch
+        {
+            socket.Dispose();
+            throw;
+        }
         return new NetworkStream(socket, ownsSocket: true);
     }
 };
@@ -288,21 +296,29 @@ var handler = new SocketsHttpHandler
     ConnectCallback = async (context, cancellationToken) =>
     {
         var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-        // Setting TCP Keep Alive
-        socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
-        socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveTime, 60);
-        socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveInterval, 1);
+        try
+        {
+            // Setting TCP Keep Alive
+            socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
+            socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveTime, 60);
+            socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveInterval, 1);
 
-        // Setting ReceiveBufferSize
-        socket.ReceiveBufferSize = 8192;
+            // Setting ReceiveBufferSize
+            socket.ReceiveBufferSize = 8192;
 
-        // Enabling ReusePort
-        socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseUnicastPort, true);
+            // Enabling ReusePort
+            socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseUnicastPort, true);
 
-        // Disabling Nagle Algorithm
-        socket.NoDelay = true;
+            // Disabling Nagle Algorithm
+            socket.NoDelay = true;
 
-        await socket.ConnectAsync(context.DnsEndPoint, cancellationToken);
+            await socket.ConnectAsync(context.DnsEndPoint, cancellationToken);
+        }
+        catch
+        {
+            socket.Dispose();
+            throw;
+        }
         return new NetworkStream(socket, ownsSocket: true);
     }
 };

--- a/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
+++ b/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
@@ -337,7 +337,7 @@ In the older `HttpWebRequest` API, enabling DNS Round Robin was straightforward 
 
 :::code source="../snippets/httpclient/DnsRoundRobin.cs" id="DnsRoundRobinConnector":::
 
-You can find implementation of `DnsRoundRobinConnector` [here](../snippets/httpclient/DnsRoundRobin.cs).
+You can find implementation of `DnsRoundRobinConnector` [here](https://github.com/dotnet/docs/blob/main/docs/fundamentals/networking/snippets/httpclient/DnsRoundRobin.cs).
 
 `DnsRoundRobinConnector` Usage:
 :::code source="../snippets/httpclient/Program.DnsRoundRobin.cs" id="DnsRoundRobinConnect":::
@@ -577,7 +577,7 @@ In the older `HttpWebRequest` API, applying `CachePolicy` was straightforward du
 
 :::code source="../snippets/httpclient/AddCacheControlHeaders.cs" id="CachePolicy":::
 
-You can find implementation of `AddCacheControlHeaders` [here](../snippets/httpclient/AddCacheControlHeaders.cs).
+You can find implementation of `AddCacheControlHeaders` [here](https://github.com/dotnet/docs/blob/main/docs/fundamentals/networking/snippets/httpclient/AddCacheControlHeaders.cs).
 
 `AddCacheControlHeaders` Usage:
 :::code source="../snippets/httpclient/Program.CacheControlHeaders.cs" id="CacheControlProgram":::

--- a/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
+++ b/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md
@@ -19,7 +19,7 @@ helpviewer_keywords:
 
 This document aims to guide developers through the process of migrating from <xref:System.Net.HttpWebRequest>, <xref:System.Net.ServicePoint>, and <xref:System.Net.ServicePointManager> to <xref:System.Net.Http.HttpClient>. The migration is necessary due to the obsolescence of the older APIs and the numerous benefits offered by <xref:System.Net.Http.HttpClient>, including improved performance, better resource management, and a more modern and flexible API design. By following the steps outlined in this document, developers will be able to transition their codebases smoothly and take full advantage of the features provided by <xref:System.Net.Http.HttpClient>.
 
-> ![WARNING]
+> [!WARNING]
 > Migrating from `HttpWebRequest`, `ServicePoint`, and `ServicePointManager` to `HttpClient` is not just a "nice to have" performance improvement. It's crucial to understand that the existing `WebRequest` logic's performance is likely to degrade significantly once you move to .NET Core. This is because `WebRequest` is maintained as a minimal compatibility layer, which means it lacks many optimizations, such as connection reuse in numerous cases. Therefore, transitioning to `HttpClient` is essential to ensure your application's performance and resource management are up to modern standards.
 
 ## Migrating from <xref:System.Net.HttpWebRequest> to <xref:System.Net.Http.HttpClient>
@@ -154,7 +154,7 @@ Developers should be aware that `ServicePointManager` is a static class, meaning
 | `ServerCertificateValidationCallback` | <xref:System.Net.Http.SocketsHttpHandler.SslOptions>.<xref:System.Net.Security.SslClientAuthenticationOptions.RemoteCertificateValidationCallback> | Both of them are <xref:System.Net.Security.RemoteCertificateValidationCallback> |
 | `UseNagleAlgorithm` | No direct equivalent API | See: [Usage of SocketsHttpHandler and ConnectCallback](#usage-of-socketshttphandler-and-connectcallback). |
 
-> ![WARNING]
+> [!WARNING]
 > In modern .NET, the default values for the `UseNagleAlgorithm` and `Expect100Continue` properties are set to `false`. These values were `true` by default in .NET Framework.
 
 ### <xref:System.Net.ServicePointManager> Method Mapping

--- a/docs/fundamentals/networking/snippets/httpclient/AddCacheControlHeaders.cs
+++ b/docs/fundamentals/networking/snippets/httpclient/AddCacheControlHeaders.cs
@@ -1,0 +1,105 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Cache;
+using System.Net.Http.Headers;
+using System.Net.Sockets;
+
+// <CachePolicy>
+public static class CachePolicy
+{
+    public static void AddCacheControlHeaders(HttpRequestMessage request, RequestCachePolicy policy)
+// </CachePolicy>
+    {
+        if (policy != null && policy.Level != RequestCacheLevel.BypassCache)
+        {
+            CacheControlHeaderValue? cacheControl = null;
+            HttpHeaderValueCollection<NameValueHeaderValue> pragmaHeaders = request.Headers.Pragma;
+
+            if (policy is HttpRequestCachePolicy httpRequestCachePolicy)
+            {
+                switch (httpRequestCachePolicy.Level)
+                {
+                    case HttpRequestCacheLevel.NoCacheNoStore:
+                        cacheControl = new CacheControlHeaderValue
+                        {
+                            NoCache = true,
+                            NoStore = true
+                        };
+                        pragmaHeaders.Add(new NameValueHeaderValue("no-cache"));
+                        break;
+                    case HttpRequestCacheLevel.Reload:
+                        cacheControl = new CacheControlHeaderValue
+                        {
+                            NoCache = true
+                        };
+                        pragmaHeaders.Add(new NameValueHeaderValue("no-cache"));
+                        break;
+                    case HttpRequestCacheLevel.CacheOnly:
+                        throw new WebException("CacheOnly is not supported!");
+                    case HttpRequestCacheLevel.CacheOrNextCacheOnly:
+                        cacheControl = new CacheControlHeaderValue
+                        {
+                            OnlyIfCached = true
+                        };
+                        break;
+                    case HttpRequestCacheLevel.Default:
+                        cacheControl = new CacheControlHeaderValue();
+
+                        if (httpRequestCachePolicy.MinFresh > TimeSpan.Zero)
+                        {
+                            cacheControl.MinFresh = httpRequestCachePolicy.MinFresh;
+                        }
+
+                        if (httpRequestCachePolicy.MaxAge != TimeSpan.MaxValue)
+                        {
+                            cacheControl.MaxAge = httpRequestCachePolicy.MaxAge;
+                        }
+
+                        if (httpRequestCachePolicy.MaxStale > TimeSpan.Zero)
+                        {
+                            cacheControl.MaxStale = true;
+                            cacheControl.MaxStaleLimit = httpRequestCachePolicy.MaxStale;
+                        }
+
+                        break;
+                    case HttpRequestCacheLevel.Refresh:
+                        cacheControl = new CacheControlHeaderValue
+                        {
+                            MaxAge = TimeSpan.Zero
+                        };
+                        pragmaHeaders.Add(new NameValueHeaderValue("no-cache"));
+                        break;
+                }
+            }
+            else
+            {
+                switch (policy.Level)
+                {
+                    case RequestCacheLevel.NoCacheNoStore:
+                        cacheControl = new CacheControlHeaderValue
+                        {
+                            NoCache = true,
+                            NoStore = true
+                        };
+                        pragmaHeaders.Add(new NameValueHeaderValue("no-cache"));
+                        break;
+                    case RequestCacheLevel.Reload:
+                        cacheControl = new CacheControlHeaderValue
+                        {
+                            NoCache = true
+                        };
+                        pragmaHeaders.Add(new NameValueHeaderValue("no-cache"));
+                        break;
+                    case RequestCacheLevel.CacheOnly:
+                        throw new Exception("CacheOnly is not supported!");
+                }
+            }
+
+            if (cacheControl != null)
+            {
+                request.Headers.CacheControl = cacheControl;
+            }
+        }
+    }
+}

--- a/docs/fundamentals/networking/snippets/httpclient/DnsRoundRobin.cs
+++ b/docs/fundamentals/networking/snippets/httpclient/DnsRoundRobin.cs
@@ -3,7 +3,9 @@ using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
 
+// <DnsRoundRobinConnector>
 public sealed class DnsRoundRobinConnector : IDisposable
+// </DnsRoundRobinConnector>
 {
     private const int DefaultDnsRefreshIntervalSeconds = 2 * 60;
     private const int MaxCleanupIntervalSeconds = 60;

--- a/docs/fundamentals/networking/snippets/httpclient/DnsRoundRobin.cs
+++ b/docs/fundamentals/networking/snippets/httpclient/DnsRoundRobin.cs
@@ -4,6 +4,8 @@ using System.Net;
 using System.Net.Sockets;
 
 // <DnsRoundRobinConnector>
+// This is available as NuGet Package: https://www.nuget.org/packages/DnsRoundRobin/
+// The original source code can be found also here: https://github.com/MihaZupan/DnsRoundRobin
 public sealed class DnsRoundRobinConnector : IDisposable
 // </DnsRoundRobinConnector>
 {

--- a/docs/fundamentals/networking/snippets/httpclient/DnsRoundRobin.cs
+++ b/docs/fundamentals/networking/snippets/httpclient/DnsRoundRobin.cs
@@ -1,0 +1,268 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+
+public sealed class DnsRoundRobinConnector : IDisposable
+{
+    private const int DefaultDnsRefreshIntervalSeconds = 2 * 60;
+    private const int MaxCleanupIntervalSeconds = 60;
+
+    public static DnsRoundRobinConnector Shared { get; } = new();
+
+    private readonly ConcurrentDictionary<string, HostRoundRobinState> _states = new(StringComparer.Ordinal);
+    private readonly Timer _cleanupTimer;
+    private readonly TimeSpan _cleanupInterval;
+    private readonly long _cleanupIntervalTicks;
+    private readonly long _dnsRefreshTimeoutTicks;
+    private readonly TimeSpan _endpointConnectTimeout;
+
+    /// <summary>
+    /// Creates a new <see cref="DnsRoundRobinConnector"/>.
+    /// </summary>
+    /// <param name="dnsRefreshInterval">Maximum amount of time a Dns resolution is cached for. Default to 2 minutes.</param>
+    /// <param name="endpointConnectTimeout">Maximum amount of time allowed for a connection attempt to any individual endpoint. Defaults to infinite.</param>
+    public DnsRoundRobinConnector(TimeSpan? dnsRefreshInterval = null, TimeSpan? endpointConnectTimeout = null)
+    {
+        dnsRefreshInterval = TimeSpan.FromSeconds(Math.Max(1, dnsRefreshInterval?.TotalSeconds ?? DefaultDnsRefreshIntervalSeconds));
+        _cleanupInterval = TimeSpan.FromSeconds(Math.Clamp(dnsRefreshInterval.Value.TotalSeconds / 2, 1, MaxCleanupIntervalSeconds));
+        _cleanupIntervalTicks = (long)(_cleanupInterval.TotalSeconds * Stopwatch.Frequency);
+        _dnsRefreshTimeoutTicks = (long)(dnsRefreshInterval.Value.TotalSeconds * Stopwatch.Frequency);
+        _endpointConnectTimeout = endpointConnectTimeout is null || endpointConnectTimeout.Value.Ticks < 1 ? Timeout.InfiniteTimeSpan : endpointConnectTimeout.Value;
+
+        bool restoreFlow = false;
+        try
+        {
+            // Don't capture the current ExecutionContext and its AsyncLocals onto the timer causing them to live forever
+            if (!ExecutionContext.IsFlowSuppressed())
+            {
+                ExecutionContext.SuppressFlow();
+                restoreFlow = true;
+            }
+
+            // Ensure the Timer has a weak reference to the connector; otherwise, it
+            // can introduce a cycle that keeps the connector rooted by the Timer
+            _cleanupTimer = new Timer(static state =>
+            {
+                var thisWeakRef = (WeakReference<DnsRoundRobinConnector>)state!;
+                if (thisWeakRef.TryGetTarget(out DnsRoundRobinConnector? thisRef))
+                {
+                    thisRef.Cleanup();
+                    thisRef._cleanupTimer.Change(thisRef._cleanupInterval, Timeout.InfiniteTimeSpan);
+                }
+            }, new WeakReference<DnsRoundRobinConnector>(this), Timeout.Infinite, Timeout.Infinite);
+
+            _cleanupTimer.Change(_cleanupInterval, Timeout.InfiniteTimeSpan);
+        }
+        finally
+        {
+            if (restoreFlow)
+            {
+                ExecutionContext.RestoreFlow();
+            }
+        }
+    }
+
+    private void Cleanup()
+    {
+        long minTimestamp = Stopwatch.GetTimestamp() - _cleanupIntervalTicks;
+
+        foreach (KeyValuePair<string, HostRoundRobinState> state in _states)
+        {
+            if (state.Value.LastAccessTimestamp < minTimestamp)
+            {
+                _states.TryRemove(state);
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        _states.Clear();
+    }
+
+    public Task<Socket> ConnectAsync(DnsEndPoint endPoint, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<Socket>(cancellationToken);
+        }
+
+        if (IPAddress.TryParse(endPoint.Host, out IPAddress? address))
+        {
+            // Avoid the overhead of HostRoundRobinState if we're dealing with a single endpoint
+            return ConnectToIPAddressAsync(address, endPoint.Port, cancellationToken);
+        }
+
+        HostRoundRobinState state = _states.GetOrAdd(
+            endPoint.Host,
+            static (_, thisRef) => new HostRoundRobinState(thisRef._dnsRefreshTimeoutTicks, thisRef._endpointConnectTimeout),
+            this);
+
+        return state.ConnectAsync(endPoint, cancellationToken);
+    }
+
+    private static async Task<Socket> ConnectToIPAddressAsync(IPAddress address, int port, CancellationToken cancellationToken)
+    {
+        var socket = new Socket(SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+        try
+        {
+            await socket.ConnectAsync(address, port, cancellationToken);
+            return socket;
+        }
+        catch
+        {
+            socket.Dispose();
+            throw;
+        }
+    }
+
+    private sealed class HostRoundRobinState
+    {
+        private readonly long _dnsRefreshTimeoutTicks;
+        private readonly TimeSpan _endpointConnectTimeout;
+        private long _lastAccessTimestamp;
+        private long _lastDnsTimestamp;
+        private IPAddress[]? _addresses;
+        private uint _roundRobinIndex;
+
+        public long LastAccessTimestamp => Volatile.Read(ref _lastAccessTimestamp);
+
+        private bool AddressesAreStale => Stopwatch.GetTimestamp() - Volatile.Read(ref _lastDnsTimestamp) > _dnsRefreshTimeoutTicks;
+
+        public HostRoundRobinState(long dnsRefreshTimeoutTicks, TimeSpan endpointConnectTimeout)
+        {
+            _dnsRefreshTimeoutTicks = dnsRefreshTimeoutTicks;
+            _endpointConnectTimeout = endpointConnectTimeout;
+
+            _roundRobinIndex--; // Offset the first Increment to ensure we start with the first address in the list
+
+            RefreshLastAccessTimestamp();
+        }
+
+        private void RefreshLastAccessTimestamp() => Volatile.Write(ref _lastAccessTimestamp, Stopwatch.GetTimestamp());
+
+        public async Task<Socket> ConnectAsync(DnsEndPoint endPoint, CancellationToken cancellationToken)
+        {
+            RefreshLastAccessTimestamp();
+
+            uint sharedIndex = Interlocked.Increment(ref _roundRobinIndex);
+            IPAddress[]? attemptedAddresses = null;
+            IPAddress[]? addresses = null;
+            Exception? lastException = null;
+
+            while (attemptedAddresses is null)
+            {
+                if (addresses is null)
+                {
+                    addresses = _addresses;
+                }
+                else
+                {
+                    attemptedAddresses = addresses;
+
+                    // Give each connection attempt a chance to do its own Dns call.
+                    addresses = null;
+                }
+
+                if (addresses is null || AddressesAreStale)
+                {
+                    // It's possible that multiple connection attempts are resolving the same host concurrently - that's okay.
+                    _addresses = addresses = await Dns.GetHostAddressesAsync(endPoint.Host, cancellationToken);
+                    Volatile.Write(ref _lastDnsTimestamp, Stopwatch.GetTimestamp());
+
+                    if (attemptedAddresses is not null && AddressListsAreEquivalent(attemptedAddresses, addresses))
+                    {
+                        // We've already tried to connect to every address in the list, and a new Dns resolution returned the same list.
+                        // Instead of attempting every address again, give up early.
+                        break;
+                    }
+                }
+
+                for (int i = 0; i < addresses.Length; i++)
+                {
+                    Socket? attemptSocket = null;
+                    CancellationTokenSource? endpointConnectTimeoutCts = null;
+                    try
+                    {
+                        IPAddress address = addresses[(int)((sharedIndex + i) % addresses.Length)];
+
+                        if (Socket.OSSupportsIPv6 && address.AddressFamily == AddressFamily.InterNetworkV6)
+                        {
+                            attemptSocket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
+                            if (address.IsIPv4MappedToIPv6)
+                            {
+                                attemptSocket.DualMode = true;
+                            }
+                        }
+                        else if (Socket.OSSupportsIPv4 && address.AddressFamily == AddressFamily.InterNetwork)
+                        {
+                            attemptSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+                        }
+
+                        if (attemptSocket is not null)
+                        {
+                            attemptSocket.NoDelay = true;
+
+                            if (_endpointConnectTimeout != Timeout.InfiniteTimeSpan)
+                            {
+                                endpointConnectTimeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                                endpointConnectTimeoutCts.CancelAfter(_endpointConnectTimeout);
+                            }
+
+                            await attemptSocket.ConnectAsync(address, endPoint.Port, endpointConnectTimeoutCts?.Token ?? cancellationToken);
+
+                            RefreshLastAccessTimestamp();
+                            return attemptSocket;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        attemptSocket?.Dispose();
+
+                        if (cancellationToken.IsCancellationRequested)
+                        {
+                            throw;
+                        }
+
+                        if (endpointConnectTimeoutCts?.IsCancellationRequested == true)
+                        {
+                            ex = new TimeoutException($"Failed to connect to any endpoint within the specified endpoint connect timeout of {_endpointConnectTimeout.TotalSeconds:N2} seconds.", ex);
+                        }
+
+                        lastException = ex;
+                    }
+                    finally
+                    {
+                        endpointConnectTimeoutCts?.Dispose();
+                    }
+                }
+            }
+
+            throw lastException ?? new SocketException((int)SocketError.NoData);
+        }
+
+        private static bool AddressListsAreEquivalent(IPAddress[] left, IPAddress[] right)
+        {
+            if (ReferenceEquals(left, right))
+            {
+                return true;
+            }
+
+            if (left.Length != right.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < left.Length; i++)
+            {
+                if (!left[i].Equals(right[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/docs/fundamentals/networking/snippets/httpclient/Program.CacheControlHeaders.cs
+++ b/docs/fundamentals/networking/snippets/httpclient/Program.CacheControlHeaders.cs
@@ -1,0 +1,17 @@
+using System.Net;
+using System.Net.Cache;
+using System.Net.Http;
+using System.Net.Sockets;
+
+static partial class Program
+{
+    // <CacheControlProgram>
+    static async Task AddCacheControlHeaders()
+    {
+        HttpClient client = new HttpClient();
+        HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Get, Uri);
+        CachePolicy.AddCacheControlHeaders(requestMessage, new HttpRequestCachePolicy(HttpRequestCacheLevel.NoCacheNoStore));
+        HttpResponseMessage response = await client.SendAsync(requestMessage);
+    }
+    // </CacheControlProgram>
+}

--- a/docs/fundamentals/networking/snippets/httpclient/Program.DnsRoundRobin.cs
+++ b/docs/fundamentals/networking/snippets/httpclient/Program.DnsRoundRobin.cs
@@ -1,0 +1,28 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+
+static partial class Program
+{
+    const string uri = "http://example.com";
+    // <DnsRoundRobinConnect>
+    private static readonly DnsRoundRobinConnector s_roundRobinConnector = new(
+            dnsRefreshInterval: TimeSpan.FromSeconds(10),
+            endpointConnectTimeout: TimeSpan.FromSeconds(5));
+    static async Task DnsRoundRobinConnectAsync()
+    {
+        var handler = new SocketsHttpHandler
+        {
+            ConnectCallback = async (context, cancellation) =>
+            {
+                Socket socket = await DnsRoundRobinConnector.Shared.ConnectAsync(context.DnsEndPoint, cancellation);
+                // Or you can create and use your custom DnsRoundRobinConnector instance
+                // Socket socket = await s_roundRobinConnector.ConnectAsync(context.DnsEndPoint, cancellation);
+                return new NetworkStream(socket, ownsSocket: true);
+            }
+        };
+        var client = new HttpClient(handler);
+        HttpResponseMessage response = await client.GetAsync(uri);
+    }
+    // </DnsRoundRobinConnect>
+}

--- a/docs/fundamentals/networking/snippets/httpclient/Program.DnsRoundRobin.cs
+++ b/docs/fundamentals/networking/snippets/httpclient/Program.DnsRoundRobin.cs
@@ -4,7 +4,7 @@ using System.Net.Sockets;
 
 static partial class Program
 {
-    const string uri = "http://example.com";
+    const string Uri = "http://example.com";
     // <DnsRoundRobinConnect>
     private static readonly DnsRoundRobinConnector s_roundRobinConnector = new(
             dnsRefreshInterval: TimeSpan.FromSeconds(10),
@@ -22,7 +22,7 @@ static partial class Program
             }
         };
         var client = new HttpClient(handler);
-        HttpResponseMessage response = await client.GetAsync(uri);
+        HttpResponseMessage response = await client.GetAsync(Uri);
     }
     // </DnsRoundRobinConnect>
 }

--- a/docs/fundamentals/networking/snippets/httpclient/Program.TruncatedReadStream.cs
+++ b/docs/fundamentals/networking/snippets/httpclient/Program.TruncatedReadStream.cs
@@ -10,7 +10,7 @@
 
         if (response.Content is not null)
         {
-            Stream responseReadStream = response.Content.ReadAsStream();
+            Stream responseReadStream = await response.Content.ReadAsStreamAsync();
             // If MaxErrorResponseLength is set and the response status code is an error code, then wrap the response stream in a TruncatedReadStream
             if (maxErrorResponseLength >= 0 && !response.IsSuccessStatusCode)
             {

--- a/docs/fundamentals/networking/snippets/httpclient/Program.TruncatedReadStream.cs
+++ b/docs/fundamentals/networking/snippets/httpclient/Program.TruncatedReadStream.cs
@@ -1,0 +1,79 @@
+﻿static partial class Program
+{
+    static async Task TruncatedReadStream()
+    {
+        // <TruncatedReadStreamUsage>
+        int maxErrorResponseLength = 1 * 1024; // 1 KB
+
+        HttpClient client = new HttpClient();
+        using HttpResponseMessage response = await client.GetAsync(Uri);
+
+        if (response.Content is not null)
+        {
+            Stream responseReadStream = response.Content.ReadAsStream();
+            // If MaxErrorResponseLength is set and the response status code is an error code, then wrap the response stream in a TruncatedReadStream
+            if (maxErrorResponseLength >= 0 && !response.IsSuccessStatusCode)
+            {
+                responseReadStream = new TruncatedReadStream(responseReadStream, maxErrorResponseLength);
+            }
+            // Read the response stream
+            Memory<byte> buffer = new byte[1024];
+            int readValue = await responseReadStream.ReadAsync(buffer);
+        }
+        // </TruncatedReadStreamUsage>
+    }
+}
+
+// <TruncatedReadStream>
+internal sealed class TruncatedReadStream(Stream innerStream, long maxSize) : Stream
+{
+    private long _maxRemainingLength = maxSize;
+    public override bool CanRead => true;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+
+    public override long Length => throw new NotSupportedException();
+    public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+    public override void Flush() => throw new NotSupportedException();
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        return Read(new Span<byte>(buffer, offset, count));
+    }
+
+    public override int Read(Span<byte> buffer)
+    {
+        int readBytes = innerStream.Read(buffer.Slice(0, (int)Math.Min(buffer.Length, _maxRemainingLength)));
+        _maxRemainingLength -= readBytes;
+        return readBytes;
+    }
+
+    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        return ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
+    }
+
+    public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        int readBytes = await innerStream.ReadAsync(buffer.Slice(0, (int)Math.Min(buffer.Length, _maxRemainingLength)), cancellationToken)
+            .ConfigureAwait(false);
+        _maxRemainingLength -= readBytes;
+        return readBytes;
+    }
+
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    public override ValueTask DisposeAsync() => innerStream.DisposeAsync();
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            innerStream.Dispose();
+        }
+    }
+}
+// </TruncatedReadStream>

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -1095,6 +1095,9 @@ items:
               - name: HTTP client guidelines
                 href: networking/http/httpclient-guidelines.md
                 displayName: networking, httpclient
+              - name: Migration from HttpWebRequest to HttpClient
+                href: networking/http/httpclient-migrate-from-httpwebrequest.md
+                displayName: networking,http,httpclient,migrate,httpwebrequest
               - name: Make HTTP requests
                 href: networking/http/httpclient.md
                 displayName: networking,http,web services,client


### PR DESCRIPTION
## Summary

Fixes dotnet/runtime#92690

/cc @dotnet/ncl 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md](https://github.com/dotnet/docs/blob/068e9daa1d1aefd8b711d721be5aa34d8da6f754/docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md) | [docs/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest?branch=pr-en-us-42242) |


<!-- PREVIEW-TABLE-END -->