### PR TITLE
Fix for 42212

### DIFF
--- a/docs/csharp/language-reference/operators/member-access-operators.md
+++ b/docs/csharp/language-reference/operators/member-access-operators.md
@@ -101,6 +101,13 @@ You also use square brackets to specify [attributes](/dotnet/csharp/advanced-top
 void TraceMethod() {}
 ```
 
+Additionally, square brackets can be used to designate [list patterns](../../fundamentals/functional/pattern-matching.md) for use in pattern matching or testing.
+
+```csharp
+arr is ([1, 2, ..])
+//Specifies that an array starts with (1, 2)
+```
+
 ## Null-conditional operators `?.` and `?[]`
 
 A null-conditional operator applies a [member access](#member-access-expression-) (`?.`) or [element access](#indexer-operator-) (`?[]`) operation to its operand only if that operand evaluates to non-null; otherwise, it returns `null`. In other words:


### PR DESCRIPTION
## Summary

Adds code example from issue, links to list pattern docs as well.

Fixes #42212 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/member-access-operators.md](https://github.com/dotnet/docs/blob/679c73ce67ea5a3748820261e7c92109e120c356/docs/csharp/language-reference/operators/member-access-operators.md) | [docs/csharp/language-reference/operators/member-access-operators](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/member-access-operators?branch=pr-en-us-42243) |

<!-- PREVIEW-TABLE-END -->