### PR TITLE
bugfix: Fix typos in keyword links

### DIFF
--- a/docs/core/compatibility/library-change-rules.md
+++ b/docs/core/compatibility/library-change-rules.md
@@ -314,7 +314,7 @@ Changes in this category modify the public surface area of a type. Most of the c
 
 - ❌ **DISALLOWED: Changing a [struct](../../csharp/language-reference/builtin-types/struct.md) to a [class](../../csharp/language-reference/keywords/class.md) and vice versa**
 
-- ❌ **DISALLOWED: Adding the [checked](../../csharp/language-reference/statements/checked-and-unchecked.md) keyword to a code block**
+- ❌ **DISALLOWED: Adding the [checked](../../csharp/language-reference/statements/checked-and-unchecked.md) statement to a code block**
 
    This change may cause code that previously executed to throw an <xref:System.OverflowException> and is unacceptable.
 

--- a/docs/core/compatibility/library-change-rules.md
+++ b/docs/core/compatibility/library-change-rules.md
@@ -86,7 +86,7 @@ Changes in this category modify the public surface area of a type. Most of the c
 
 ### Members
 
-- ✔️ **ALLOWED: Expanding the visibility of a member that is not [virtual](../../csharp/language-reference/keywords/sealed.md)**
+- ✔️ **ALLOWED: Expanding the visibility of a member that is not [virtual](../../csharp/language-reference/keywords/virtual.md)**
 
 - ✔️ **ALLOWED: Adding an abstract member to a public type that has no *accessible* (public or protected) constructors, or the type is [sealed](../../csharp/language-reference/keywords/sealed.md)**
 
@@ -314,7 +314,7 @@ Changes in this category modify the public surface area of a type. Most of the c
 
 - ❌ **DISALLOWED: Changing a [struct](../../csharp/language-reference/builtin-types/struct.md) to a [class](../../csharp/language-reference/keywords/class.md) and vice versa**
 
-- ❌ **DISALLOWED: Adding the [checked](../../csharp/language-reference/keywords/virtual.md) keyword to a code block**
+- ❌ **DISALLOWED: Adding the [checked](../../csharp/language-reference/statements/checked-and-unchecked.md) keyword to a code block**
 
    This change may cause code that previously executed to throw an <xref:System.OverflowException> and is unacceptable.
 

--- a/docs/core/compatibility/library-change-rules.md
+++ b/docs/core/compatibility/library-change-rules.md
@@ -316,7 +316,7 @@ Changes in this category modify the public surface area of a type. Most of the c
 
 - ❌ **DISALLOWED: Adding the [checked](../../csharp/language-reference/statements/checked-and-unchecked.md) statement to a code block**
 
-   This change may cause code that previously executed to throw an <xref:System.OverflowException> and is unacceptable.
+   This change might cause code that previously executed to throw an <xref:System.OverflowException> and is unacceptable.
 
 - ❌ **DISALLOWED: Removing [params](../../csharp/language-reference/keywords/method-parameters.md#params-modifier) from a parameter**
 


### PR DESCRIPTION
## Summary

Fixed the links for 'virtual' keyword in "Members" section and 'checked' keyword in "Code Changes" section.

Fixes #42213


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/library-change-rules.md](https://github.com/dotnet/docs/blob/3e267e26ca0ba3fda2f84568adedc6bcbb7e8812/docs/core/compatibility/library-change-rules.md) | [docs/core/compatibility/library-change-rules](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/library-change-rules?branch=pr-en-us-42244) |


<!-- PREVIEW-TABLE-END -->