### PR TITLE
Fix Regex pattern description.

### DIFF
--- a/docs/fundamentals/runtime-libraries/system-text-regularexpressions-regex.md
+++ b/docs/fundamentals/runtime-libraries/system-text-regularexpressions-regex.md
@@ -118,7 +118,7 @@ The next example illustrates the use of a regular expression to check whether a 
 | `\d*`      | Match zero or more decimal digits.                                             |
 | `\.?`      | Match zero or one decimal point symbol.                                        |
 | `(\d{2})?` | Capturing group 1: Match two decimal digits zero or one time.                  |
-| `(\d*\.?(\d{2})?){1}` | Match the pattern of integral and fractional digits separated by a decimal point symbol at least one time. |
+| `(\d*\.?(\d{2})?){1}` | Match the pattern of integral and fractional digits separated by a decimal point symbol exactly once. |
 | `$`        | Match the end of the string.                                                   |
 
 In this case, the regular expression assumes that a valid currency string does not contain group separator symbols, and that it has either no fractional digits or the number of fractional digits defined by the specified culture's <xref:System.Globalization.NumberFormatInfo.CurrencyDecimalDigits> property.


### PR DESCRIPTION
Fixes #42284.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/runtime-libraries/system-text-regularexpressions-regex.md](https://github.com/dotnet/docs/blob/0e582b1e355301791a2f55e2e1818dfabcad5fa8/docs/fundamentals/runtime-libraries/system-text-regularexpressions-regex.md) | [docs/fundamentals/runtime-libraries/system-text-regularexpressions-regex](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-text-regularexpressions-regex?branch=pr-en-us-42283) |

<!-- PREVIEW-TABLE-END -->