### PR TITLE
Add section about putting DynamicallyAccessedMemberson a type

### DIFF
--- a/docs/core/deploying/trimming/fixing-warnings.md
+++ b/docs/core/deploying/trimming/fixing-warnings.md
@@ -245,7 +245,7 @@ class MyClass
 }
 ```
 
-This will inform the trimmer that code in the application might reflect over `MyClass`. The trimmer will keep all the `DynamicallyAccessedMemberTypes` declared on `MyClass` (in this case public methods), as well as all `DynamicallyAccessedMemberTypes` on all accessible members on base classes, but not on derived classes.
+This will inform the trimmer that code in the application might reflect over `MyClass`. The trimmer will keep all the `DynamicallyAccessedMemberTypes` declared on `MyClass` (in this case public methods) and on any derived classes.
 
 #### Considerations when using DynamicallyAccessedMembersAttribute
 


### PR DESCRIPTION
## Summary

Adds documentation describing the motivation and effects of adding `DynamicallyAccessedMembers` on a type definition.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/deploying/trimming/fixing-warnings.md](https://github.com/dotnet/docs/blob/5e6949aad5e2a961fd45a2bbf735ffc2a9da650c/docs/core/deploying/trimming/fixing-warnings.md) | [docs/core/deploying/trimming/fixing-warnings](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/fixing-warnings?branch=pr-en-us-42285) |


<!-- PREVIEW-TABLE-END -->