### PR TITLE
Fix mention of MSTest ordering tests

### DIFF
--- a/docs/core/testing/order-unit-tests.md
+++ b/docs/core/testing/order-unit-tests.md
@@ -20,7 +20,7 @@ If you prefer to browse the source code, see the [order .NET Core unit tests](/s
 
 ## Order alphabetically
 
-MSTest discovers tests in the same order in which they are defined in the test class. 
+MSTest discovers tests in the same order in which they are defined in the test class.
 
 When running through Test Explorer (in Visual Studio, or in Visual Studio Code), the tests are ordered in alphabetical order based on their test name.
 

--- a/docs/core/testing/order-unit-tests.md
+++ b/docs/core/testing/order-unit-tests.md
@@ -20,7 +20,11 @@ If you prefer to browse the source code, see the [order .NET Core unit tests](/s
 
 ## Order alphabetically
 
-With MSTest, tests are automatically ordered by their test name under Test Explorer (Visual Studio or Visual Studio Code). No special ordering is applied when running tests outside of Test Explorer.
+MSTest discovers tests in the same order in which they are defined in the test class. 
+
+When running through Test Explorer (in Visual Studio, or in Visual Studio Code), the tests are ordered in alphabetical order based on their test name.
+
+When running outside of Test Explorer, tests are executed in the order in which they are defined in the test class.
 
 > [!NOTE]
 > A test named `Test14` will run before `Test2` even though the number  `2` is less than `14`. This is because test name ordering uses the text name of the test.

--- a/docs/core/testing/order-unit-tests.md
+++ b/docs/core/testing/order-unit-tests.md
@@ -20,7 +20,7 @@ If you prefer to browse the source code, see the [order .NET Core unit tests](/s
 
 ## Order alphabetically
 
-With MSTest, tests are automatically ordered by their test name.
+With MSTest, tests are automatically ordered by their test name under Test Explorer (Visual Studio or Visual Studio Code). No special ordering is applied when running tests outside of Test Explorer.
 
 > [!NOTE]
 > A test named `Test14` will run before `Test2` even though the number  `2` is less than `14`. This is because test name ordering uses the text name of the test.


### PR DESCRIPTION
## Summary

Relates to https://developercommunity.visualstudio.com/t/MSTests-no-longer-run-in-alphabetical-or/10722873

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/order-unit-tests.md](https://github.com/dotnet/docs/blob/7ffc6adb2fab4cb49f7c328ddda16e1834c64b1d/docs/core/testing/order-unit-tests.md) | [docs/core/testing/order-unit-tests](https://review.learn.microsoft.com/en-us/dotnet/core/testing/order-unit-tests?branch=pr-en-us-42297) |


<!-- PREVIEW-TABLE-END -->