### PR TITLE
Add warning about DAM and add info about DAM on type for IL2075

### DIFF
--- a/docs/core/deploying/trimming/fixing-warnings.md
+++ b/docs/core/deploying/trimming/fixing-warnings.md
@@ -222,6 +222,9 @@ Warnings produced by these extra requirements are automatically suppressed if th
 
 Unlike `RequiresUnreferencedCode`, which simply reports the incompatibility, adding `DynamicallyAccessedMembers` makes the code compatible with trimming.
 
+> [!NOTE]
+> Using `DynamicallyAccessedMembersAttribute` will root all the specified `DynamicallyAccessedMemberTypes` members of the type. This means it will keep the members, as well as any metadata referenced by those members. This can lead to much larger apps than expected. Be careful to use the minimum `DynamicallyAccessedMemberTypes` required.
+
 ### Suppressing trimmer warnings
 
 If you can somehow determine that the call is safe, and all the code that's needed won't be trimmed away, you can also suppress the warning using <xref:System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute>. For example:

--- a/docs/core/deploying/trimming/trim-warnings/il2075.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2075.md
@@ -24,6 +24,56 @@ void TestMethod()
 }
 ```
 
-## Fixing
+To solve this issue, add a `DynamicallyAccessedMembersAttribute` to the return of the method that returns the <xref:System.Type> object that you call an annotated instance method on.
 
-See [Fixing Warnings](../fixing-warnings.md#functionality-with-requirements-on-its-input) for guidance.
+```csharp
+using System.Diagnostics.CodeAnalysis;
+
+[return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+Type GetCustomType() { return typeof(CustomType); }
+
+void TestMethod()
+{
+    // IL2075 Trim analysis: 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to 'GetMethods'. The return value of method 'GetCustomType' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+    GetCustomType().GetMethods(); // Type.GetMethods is annotated with DynamicallyAccessedMemberTypes.PublicMethods
+}
+```
+
+Another common situation is calling reflection APIs on a <xref:System.Type> object returned by <xref:System.Object.GetType>.
+
+```csharp
+void MyMethod(MyType argument)
+{
+    Type t = argument.GetType();
+    // IL2075 Trim analysis: 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to 'GetMethods'. The return value of method 'Object.GetType' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+    t.GetMethods();
+}
+```
+
+In this scenario, the solution is to annotate the definition of `MyType` with `DynamicallyAccessedMembersAttribute`.
+
+```csharp
+using System.Diagnostics.CodeAnalysis;
+
+[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
+class MyType
+{
+    ...
+}
+
+void MyMethod(MyType argument)
+{
+    Type t = argument.GetType();
+    // IL2075 Trim analysis: 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to 'GetMethods'. The return value of method 'Object.GetType' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+    t.GetMethods();
+}
+```
+
+Applying `DynamicallyAccessedMembersAttribute` to a class, interface, or struct, indicates to the linker the members specified may be accessed dynamically on <xref:System.Type> instances returned from calling <xref:System.Object.GetType> on instances of that class, interface, or struct.
+
+> [!NOTE]
+> Applying `DynamicallyAccessedMembersAttribute` to a type definition will "root" all the indicated `DynamicallyAccessedMemberTypes` on the type and all it's derived types (or implementing types when placed on an interface). This means the members will be kept, as well as any metadata referenced by the members. Be careful to use the minimum `DynamicalylAccessedMemberTypes` required, and apply it on the most specific type possible.
+
+## More information
+
+See [Fixing Warnings](../fixing-warnings.md#functionality-with-requirements-on-its-input) for more information.

--- a/docs/core/deploying/trimming/trim-warnings/il2075.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2075.md
@@ -55,7 +55,7 @@ In this scenario, the solution is to annotate the definition of `MyType` with `D
 ```csharp
 using System.Diagnostics.CodeAnalysis;
 
-[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
+[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
 class MyType
 {
     ...


### PR DESCRIPTION
## Summary

Add note about using the least DynamicallyAccessedMemberTypes for DynamicallyAccessedMembersAnnotations.

Add example of Object.GetType causing IL2075 and explain how to solve by adding DAM on the type definition.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/deploying/trimming/fixing-warnings.md](https://github.com/dotnet/docs/blob/d69623d3387de5e71550cd89c0f03a5d3341461b/docs/core/deploying/trimming/fixing-warnings.md) | [docs/core/deploying/trimming/fixing-warnings](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/fixing-warnings?branch=pr-en-us-42306) |
| [docs/core/deploying/trimming/trim-warnings/il2075.md](https://github.com/dotnet/docs/blob/d69623d3387de5e71550cd89c0f03a5d3341461b/docs/core/deploying/trimming/trim-warnings/il2075.md) | [docs/core/deploying/trimming/trim-warnings/il2075](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il2075?branch=pr-en-us-42306) |


<!-- PREVIEW-TABLE-END -->