### PR TITLE
Remove superfluous backticks

### DIFF
--- a/docs/csharp/linq/get-started/write-linq-queries.md
+++ b/docs/csharp/linq/get-started/write-linq-queries.md
@@ -64,7 +64,7 @@ If the method has <xref:System.Action?displayProperty=fullName> or <xref:System.
 
 In the previous queries, only Query #4 executes immediately, because it returns a single value, and not a generic <xref:System.Collections.Generic.IEnumerable%601> collection. The method itself uses `foreach` or similar code in order to compute its value.
 
-Each of the previous queries can be written by using implicit typing with [`var``](../../language-reference/statements/declarations.md#implicitly-typed-local-variables), as shown in the following example:
+Each of the previous queries can be written by using implicit typing with [`var`](../../language-reference/statements/declarations.md#implicitly-typed-local-variables), as shown in the following example:
 
 :::code language="csharp" source="./snippets/SnippetApp/WriteLinqQueries.cs" id="write_linq_queries_4":::
 

--- a/includes/core-changes/corefx/openssl-dependencies-macos.md
+++ b/includes/core-changes/corefx/openssl-dependencies-macos.md
@@ -50,7 +50,7 @@ Core .NET libraries
 
 #### Affected APIs
 
-- `T:System.Security.Cryptography.AesCcm``
+- `T:System.Security.Cryptography.AesCcm`
 - `T:System.Security.Cryptography.AesGcm`
 - `T:System.Security.Cryptography.DSAOpenSsl`
 - `T:System.Security.Cryptography.ECDiffieHellmanOpenSsl`


### PR DESCRIPTION
## Summary

Address 2 instances of excess backticks.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/linq/get-started/write-linq-queries.md](https://github.com/dotnet/docs/blob/cc63b7b33a20deaec2cfebff8e83fcfd30350922/docs/csharp/linq/get-started/write-linq-queries.md) | [docs/csharp/linq/get-started/write-linq-queries](https://review.learn.microsoft.com/en-us/dotnet/csharp/linq/get-started/write-linq-queries?branch=pr-en-us-42309) |

<!-- PREVIEW-TABLE-END -->