### PR TITLE
Add missing docs for trim warning codes

### DIFF
--- a/docs/core/deploying/trimming/trim-warnings/il2070.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2070.md
@@ -15,14 +15,10 @@ The target location declares some requirements on the type value via its <xref:S
 ## Example
 
 ```csharp
-void GenericWithAnnotation<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] T>()
-{
-}
-
 void TestMethod(Type type)
 {
-    // IL2070 Trim analysis: 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in call to 'System.Reflection.MethodInfo.MakeGenericMethod(Type[])'. The parameter 'type' of method 'TestMethod' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
-    typeof(AnnotatedGenerics).GetMethod(nameof(GenericWithAnnotation)).MakeGenericMethod(type);
+    // IL2070 Trim analysis: 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods' in call to 'System.Type.GetMethod(String)'. The parameter 'type' of method 'TestMethod(Type)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+    type.GetMethod("Method");
 }
 ```
 

--- a/docs/core/deploying/trimming/trim-warnings/il2071.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2071.md
@@ -2,7 +2,7 @@
 title: "IL2071: 'target generic parameter' generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in 'target method or type'. The parameter 'source parameter' of method 'source method' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to."
 description: "Learn about trim warning IL2071: DynamicallyAccessedMembersMismatchParameterTargetsGenericParameter"
 ms.date: 08/23/2024
-author: svbomer
+author: sbomer
 f1_keywords:
   - "IL2071"
 ---

--- a/docs/core/deploying/trimming/trim-warnings/il2071.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2071.md
@@ -1,12 +1,12 @@
 ---
-title: "IL2071: 'target generic parameter' generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in 'target method'. The parameter 'source parameter' of method 'source method' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to."
+title: "IL2071: 'target generic parameter' generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in 'target method or type'. The parameter 'source parameter' of method 'source method' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to."
 description: "Learn about trim warning IL2071: DynamicallyAccessedMembersMismatchParameterTargetsGenericParameter"
 ms.date: 08/23/2024
 author: svbomer
 f1_keywords:
   - "IL2071"
 ---
-# IL2071: 'target generic parameter' generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in 'target method'. The parameter 'source parameter' of method 'source method' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to
+# IL2071: 'target generic parameter' generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in 'target method or type'. The parameter 'source parameter' of method 'source method' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to
 
 ## Cause
 

--- a/docs/core/deploying/trimming/trim-warnings/il2071.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2071.md
@@ -1,0 +1,31 @@
+---
+title: "IL2071: 'target generic parameter' generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in 'target method'. The parameter 'source parameter' of method 'source method' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to."
+description: "Learn about trim warning IL2071: DynamicallyAccessedMembersMismatchParameterTargetsGenericParameter"
+ms.date: 08/23/2024
+author: svbomer
+f1_keywords:
+  - "IL2071"
+---
+# IL2071: 'target generic parameter' generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in 'target method'. The parameter 'source parameter' of method 'source method' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to
+
+## Cause
+
+The target location declares some requirements on the type value via its <xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute>. Those requirements must be met by those declared on the source value also via the <xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute>. The source value can declare more requirements than the target, if necessary.
+
+## Example
+
+```csharp
+public void GenericWithAnnotation<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] T>()
+{
+}
+
+void TestMethod(Type type)
+{
+    // IL2071 Trim Analysis: 'T' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in 'GenericWithAnnotation<T>()'. The parameter 'type' of method 'TestMethod(Type)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+    typeof(AnnotatedGenerics).GetMethod(nameof(GenericWithAnnotation)).MakeGenericMethod(type);
+}
+```
+
+## Fixing
+
+See [Fixing Warnings](../fixing-warnings.md#functionality-with-requirements-on-its-input) for guidance.

--- a/docs/core/deploying/trimming/trim-warnings/il2076.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2076.md
@@ -1,0 +1,33 @@
+---
+title: "IL2076: 'target generic parameter' generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in 'target method'. The return value of method 'source method' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+description: "Learn about trim warning IL2076: DynamicallyAccessedMembersMismatchMethodReturnTypeTargetsGenericParameter"
+ms.date: 08/23/2024
+author: svbomer
+f1_keywords:
+  - "IL2076"
+---
+# IL2076: 'target generic parameter' generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in 'target method'. The return value of method 'source method' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to
+
+## Cause
+
+The target location declares some requirements on the type value via its <xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute>. Those requirements must be met by those declared on the source value also via the <xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute>. The source value can declare more requirements than the target, if necessary.
+
+## Example
+
+```csharp
+public void GenericWithAnnotation<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] T>()
+{
+}
+
+Type GetType() => typeof(int);
+
+void TestMethod()
+{
+    // IL2076 Trim Analysis: AnnotatedGenerics.TestMethod(Type): 'T' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in 'GenericWithAnnotation<T>()'. The return value of method 'GetType()' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to
+    typeof(AnnotatedGenerics).GetMethod(nameof(GenericWithAnnotation)).MakeGenericMethod(GetType());
+}
+```
+
+## Fixing
+
+See [Fixing Warnings](../fixing-warnings.md#functionality-with-requirements-on-its-input) for guidance.

--- a/docs/core/deploying/trimming/trim-warnings/il2076.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2076.md
@@ -1,12 +1,12 @@
 ---
-title: "IL2076: 'target generic parameter' generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in 'target method'. The return value of method 'source method' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+title: "IL2076: 'target generic parameter' generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in 'target method or type'. The return value of method 'source method' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
 description: "Learn about trim warning IL2076: DynamicallyAccessedMembersMismatchMethodReturnTypeTargetsGenericParameter"
 ms.date: 08/23/2024
 author: svbomer
 f1_keywords:
   - "IL2076"
 ---
-# IL2076: 'target generic parameter' generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in 'target method'. The return value of method 'source method' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to
+# IL2076: 'target generic parameter' generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in 'target method or type'. The return value of method 'source method' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to
 
 ## Cause
 

--- a/docs/core/deploying/trimming/trim-warnings/il2076.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2076.md
@@ -1,8 +1,8 @@
 ---
-title: "IL2076: 'target generic parameter' generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in 'target method or type'. The return value of method 'source method' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+title: "IL2076: 'target generic parameter' generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in 'target method or type'. The return value of method 'source method' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to."
 description: "Learn about trim warning IL2076: DynamicallyAccessedMembersMismatchMethodReturnTypeTargetsGenericParameter"
 ms.date: 08/23/2024
-author: svbomer
+author: sbomer
 f1_keywords:
   - "IL2076"
 ---

--- a/docs/core/deploying/trimming/trim-warnings/il2081.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2081.md
@@ -1,8 +1,8 @@
 ---
-title: "IL2081: 'target generic parameter' generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in 'target method or type'. The field 'source field' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+title: "IL2081: 'target generic parameter' generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in 'target method or type'. The field 'source field' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to."
 description: "Learn about trim warning IL2081: DynamicallyAccessedMembersMismatchFieldTargetsGenericParameter"
 ms.date: 08/23/2024
-author: svbomer
+author: sbomer
 f1_keywords:
   - "IL2081"
 ---

--- a/docs/core/deploying/trimming/trim-warnings/il2081.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2081.md
@@ -1,12 +1,12 @@
 ---
-title: "IL2081: 'target generic parameter' generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in 'target method'. The field 'source field' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+title: "IL2081: 'target generic parameter' generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in 'target method or type'. The field 'source field' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
 description: "Learn about trim warning IL2081: DynamicallyAccessedMembersMismatchFieldTargetsGenericParameter"
 ms.date: 08/23/2024
 author: svbomer
 f1_keywords:
   - "IL2081"
 ---
-# IL2081: 'target generic parameter' generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in 'target method'. The field 'source field' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to
+# IL2081: 'target generic parameter' generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in 'target method or type'. The field 'source field' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to
 
 ## Cause
 

--- a/docs/core/deploying/trimming/trim-warnings/il2081.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2081.md
@@ -1,0 +1,33 @@
+---
+title: "IL2081: 'target generic parameter' generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in 'target method'. The field 'source field' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+description: "Learn about trim warning IL2081: DynamicallyAccessedMembersMismatchFieldTargetsGenericParameter"
+ms.date: 08/23/2024
+author: svbomer
+f1_keywords:
+  - "IL2081"
+---
+# IL2081: 'target generic parameter' generic argument does not satisfy 'DynamicallyAccessedMembersAttribute' in 'target method'. The field 'source field' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to
+
+## Cause
+
+The target location declares some requirements on the type value via its <xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute>. Those requirements must be met by those declared on the source value also via the <xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute>. The source value can declare more requirements than the target, if necessary.
+
+## Example
+
+```csharp
+public void GenericWithAnnotation<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] T>()
+{
+}
+
+Type typeField;
+
+void TestMethod()
+{
+    // IL2081 Trim Analysis: 'T' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in 'GenericWithAnnotation<T>()'. The field 'typeField' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
+    typeof(AnnotatedGenerics).GetMethod(nameof(GenericWithAnnotation)).MakeGenericMethod(typeField);
+}
+```
+
+## Fixing
+
+See [Fixing Warnings](../fixing-warnings.md#functionality-with-requirements-on-its-input) for guidance.

--- a/docs/core/deploying/trimming/trim-warnings/il2122.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2122.md
@@ -1,8 +1,8 @@
 ---
 title: "IL2122: Type 'type' is not assembly qualified. Type name strings used for dynamically accessing a type should be assembly qualified."
 description: "Learn about trim warning IL2122: TypeNameIsNotAssemblyQualified"
-ms.date: 08/23/24
-author: svbomer
+ms.date: 08/23/2024
+author: sbomer
 f1_keywords:
   - "IL2122"
 ---

--- a/docs/core/deploying/trimming/trim-warnings/il2122.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2122.md
@@ -29,6 +29,7 @@ void ForwardTypeNameToAnotherMethod(
     MyTypeFromAnotherAssembly.GetType(typeName);
 }
 ```
+
 ```csharp
 // In Assembly 2
 public class MyTypeFromAnotherAssembly
@@ -50,6 +51,7 @@ class MyType
 In a non-trimmed app, at runtime the `Type.GetType` call will discover `MyType` in Assembly 2. However, trimming will remove `MyType` because the trimming tools don't have enough information to determine where the type will be found at runtime.
 
 To fix this, consider using a fully-qualified type name instead:
+
 ```csharp
 RequirePublicMethodsOnAType("MyType,Assembly2");
 ```

--- a/docs/core/deploying/trimming/trim-warnings/il2122.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2122.md
@@ -15,16 +15,56 @@ Type name strings representing dynamically accessed types must be assembly quali
 ## Example
 
 ```csharp
+// In Assembly 1
 void TestInvalidTypeName()
 {
-    // IL2122: Type 'UnqualifiedTypeName' is not assembly qualified. Type name strings used for dynamically accessing a type should be assembly qualified.
-    RequirePublicMethodOnAType("UnqualifiedTypeName");
+    // IL2122: Type 'MyType' is not assembly qualified. Type name strings used for dynamically accessing a type should be assembly qualified.
+    RequirePublicMethodOnAType("MyType");
 }
 
-void RequirePublicMethodOnAType(
+void ForwardTypeNameToAnotherMethod(
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
     string typeName)
 {
-    Type.GetType(typeName);
+    MyTypeFromAnotherAssembly.GetType(typeName);
 }
 ```
+```csharp
+// In Assembly 2
+public class MyTypeFromAnotherAssembly
+{
+    void GetTypeAndSearchThroughMethods(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+        string typeName)
+    {
+        Type.GetType(typeName).GetMethods();
+    }
+}
+
+class MyType
+{
+    // ...
+}
+```
+
+In a non-trimmed app, at runtime the `Type.GetType` call will discover `MyType` in Assembly 2. However, trimming will remove `MyType` because the trimming tools don't have enough information to determine where the type will be found at runtime.
+
+To fix this, consider using a fully-qualified type name instead:
+```csharp
+RequirePublicMethodsOnAType("MyType,Assembly2");
+```
+
+Another option is to pass the unqualified type name string directly to `Type.GetType`, and avoid annotations on `string`:
+
+```csharp
+var type = Type.GetType("MyType");
+
+void SearchThroughMethods(
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+    Type type)
+{
+    type.GetMethods();
+}
+```
+
+This gives the trimming tools enough information to look up the type using the same semantics that <xref:System.Type.GetType(System.String)> has at runtime, causing the type (and public methods in this example) to be preserved.

--- a/docs/core/deploying/trimming/trim-warnings/il2122.md
+++ b/docs/core/deploying/trimming/trim-warnings/il2122.md
@@ -1,0 +1,30 @@
+---
+title: "IL2122: Type 'type' is not assembly qualified. Type name strings used for dynamically accessing a type should be assembly qualified."
+description: "Learn about trim warning IL2122: TypeNameIsNotAssemblyQualified"
+ms.date: 08/23/24
+author: svbomer
+f1_keywords:
+  - "IL2122"
+---
+# IL2122: Type 'type' is not assembly qualified. Type name strings used for dynamically accessing a type should be assembly qualified
+
+## Cause
+
+Type name strings representing dynamically accessed types must be assembly qualified. Otherwise, the lookup semantics of `Type.GetType` will search the assembly with the `Type.GetType` callsite and the core library. The assembly with the `Type.GetType` callsite may be different than the assembly which passes the type name string to a location with `DynamicallyAccessedMembersAttribute`, so the tooling cannot determine which assemblies to search.
+
+## Example
+
+```csharp
+void TestInvalidTypeName()
+{
+    // IL2122: Type 'UnqualifiedTypeName' is not assembly qualified. Type name strings used for dynamically accessing a type should be assembly qualified.
+    RequirePublicMethodOnAType("UnqualifiedTypeName");
+}
+
+void RequirePublicMethodOnAType(
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+    string typeName)
+{
+    Type.GetType(typeName);
+}
+```

--- a/docs/navigate/devops-testing/toc.yml
+++ b/docs/navigate/devops-testing/toc.yml
@@ -381,6 +381,8 @@ items:
                 href: ../../core/deploying/trimming/trim-warnings/il2069.md
               - name: IL2070
                 href: ../../core/deploying/trimming/trim-warnings/il2070.md
+              - name: IL2071
+                href: ../../core/deploying/trimming/trim-warnings/il2071.md
               - name: IL2072
                 href: ../../core/deploying/trimming/trim-warnings/il2072.md
               - name: IL2073
@@ -389,6 +391,8 @@ items:
                 href: ../../core/deploying/trimming/trim-warnings/il2074.md
               - name: IL2075
                 href: ../../core/deploying/trimming/trim-warnings/il2075.md
+              - name: IL2076
+                href: ../../core/deploying/trimming/trim-warnings/il2076.md
               - name: IL2077
                 href: ../../core/deploying/trimming/trim-warnings/il2077.md
               - name: IL2078
@@ -397,6 +401,8 @@ items:
                 href: ../../core/deploying/trimming/trim-warnings/il2079.md
               - name: IL2080
                 href: ../../core/deploying/trimming/trim-warnings/il2080.md
+              - name: IL2081
+                href: ../../core/deploying/trimming/trim-warnings/il2081.md
               - name: IL2082
                 href: ../../core/deploying/trimming/trim-warnings/il2082.md
               - name: IL2083
@@ -467,6 +473,8 @@ items:
                 href: ../../core/deploying/trimming/trim-warnings/il2116.md
               - name: IL2117
                 href: ../../core/deploying/trimming/trim-warnings/il2117.md
+              - name: IL2122
+                href: ../../core/deploying/trimming/trim-warnings/il2122.md
       - name: Native AOT deployment model
         items:
           - name: Overview


### PR DESCRIPTION
Fixes https://github.com/dotnet/docs/issues/30487

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/deploying/trimming/trim-warnings/il2070.md](https://github.com/dotnet/docs/blob/bfc1ac0ccc0706b174336873045f75a4023af757/docs/core/deploying/trimming/trim-warnings/il2070.md) | [docs/core/deploying/trimming/trim-warnings/il2070](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il2070?branch=pr-en-us-42315) |
| [docs/core/deploying/trimming/trim-warnings/il2071.md](https://github.com/dotnet/docs/blob/bfc1ac0ccc0706b174336873045f75a4023af757/docs/core/deploying/trimming/trim-warnings/il2071.md) | [docs/core/deploying/trimming/trim-warnings/il2071](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il2071?branch=pr-en-us-42315) |
| [docs/core/deploying/trimming/trim-warnings/il2076.md](https://github.com/dotnet/docs/blob/bfc1ac0ccc0706b174336873045f75a4023af757/docs/core/deploying/trimming/trim-warnings/il2076.md) | [docs/core/deploying/trimming/trim-warnings/il2076](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il2076?branch=pr-en-us-42315) |
| [docs/core/deploying/trimming/trim-warnings/il2081.md](https://github.com/dotnet/docs/blob/bfc1ac0ccc0706b174336873045f75a4023af757/docs/core/deploying/trimming/trim-warnings/il2081.md) | [docs/core/deploying/trimming/trim-warnings/il2081](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il2081?branch=pr-en-us-42315) |
| [docs/core/deploying/trimming/trim-warnings/il2122.md](https://github.com/dotnet/docs/blob/bfc1ac0ccc0706b174336873045f75a4023af757/docs/core/deploying/trimming/trim-warnings/il2122.md) | [docs/core/deploying/trimming/trim-warnings/il2122](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il2122?branch=pr-en-us-42315) |


<!-- PREVIEW-TABLE-END -->