### PR TITLE
Add slight clarification about IsTrimmable metadata

### DIFF
--- a/docs/core/deploying/trimming/trimming-options.md
+++ b/docs/core/deploying/trimming/trimming-options.md
@@ -27,7 +27,7 @@ Place this setting in the project file to ensure that the setting applies during
 
 :::zone pivot="dotnet-8-0,dotnet-7-0"
 
-This setting enables trimming and trims all assemblies by default. In .NET 6, only assemblies that opted-in to trimming via `[AssemblyMetadata("IsTrimmable", "True")]` were trimmed by default. You can return to the previous behavior by using `<TrimMode>partial</TrimMode>`.
+This setting enables trimming and trims all assemblies by default. In .NET 6, only assemblies that opted-in to trimming via `[AssemblyMetadata("IsTrimmable", "True")]` (added in projects that set `<IsTrimmable>true</IsTrimmable>`) were trimmed by default. You can return to the previous behavior by using `<TrimMode>partial</TrimMode>`.
 
 :::zone-end
 


### PR DESCRIPTION
I don't think we want to say much about `[AssemblyMetadata("IsTrimmable", "True")]` since most users should just opt in via the MSBuild options. This adds a minor note to a mention of the assembly metadata to prevent confusion.
Fixes https://github.com/dotnet/docs/issues/30790

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/deploying/trimming/trimming-options.md](https://github.com/dotnet/docs/blob/65d6a634ac2cc91055bf23a796463f2ed3e72b81/docs/core/deploying/trimming/trimming-options.md) | [docs/core/deploying/trimming/trimming-options](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trimming-options?branch=pr-en-us-42317) |

<!-- PREVIEW-TABLE-END -->