### PR TITLE
Fix missing apostrophe in sample

### DIFF
--- a/samples/snippets/visualbasic/VS_Snippets_CLR/Conceptual.Threading.Resuming/vb/Sleep1.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/Conceptual.Threading.Resuming/vb/Sleep1.vb
@@ -37,7 +37,7 @@ Module Example
             Console.WriteLine("Thread '{0}' executing finally block.",
                               Thread.CurrentThread.Name)
         End Try
-        Console.WriteLine("Thread '{0} finishing normal execution.",
+        Console.WriteLine("Thread '{0}' finishing normal execution.",
                           Thread.CurrentThread.Name)
         Console.WriteLine()
     End Sub


### PR DESCRIPTION
## Summary

Fixed a missing apostrophe in: \samples\snippets\visualbasic\VS_Snippets_CLR\Conceptual.Threading.Resuming\vb\Sleep1
