### PR TITLE
Mention the STATestClass and STATestMethod are only in 3.6+

### DIFF
--- a/docs/core/testing/unit-testing-mstest-writing-tests-attributes.md
+++ b/docs/core/testing/unit-testing-mstest-writing-tests-attributes.md
@@ -329,14 +329,14 @@ Starting with MSTest 3.6, it is possible to specify `CooperativeCancellation` pr
 When applied to a test class, the `[STATestClass]` attribute indicates that all test methods (and the `[ClassInitialize]` and `[ClassCleanup]` methods) in the class should be run in a single-threaded apartment (STA). This attribute is useful when the test methods interact with COM objects that require STA.
 
 > [!NOTE]
-> This is only supported on Windows.
+> This is only supported on Windows and in version 3.6 and later.
 
 ### `STATestMethodAttribute`
 
 When applied to a test method, the `[STATestMethod]` attribute indicates that the test method should be run in a single-threaded apartment (STA). This attribute is useful when the test method interacts with COM objects that require STA.
 
 > [!NOTE]
-> This is only supported on Windows.
+> This is only supported on Windows and in version 3.6 and later.
 
 ### `ParallelizeAttribute`
 


### PR DESCRIPTION
## Summary

Address comment on MSTest https://github.com/microsoft/testfx/pull/3286#issuecomment-2309771042

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-mstest-writing-tests-attributes.md](https://github.com/dotnet/docs/blob/dbfdeba15561c84ed0f43b061d8def704d1c650c/docs/core/testing/unit-testing-mstest-writing-tests-attributes.md) | [docs/core/testing/unit-testing-mstest-writing-tests-attributes](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-writing-tests-attributes?branch=pr-en-us-42330) |

<!-- PREVIEW-TABLE-END -->