### PR TITLE
Fix 42325

### DIFF
--- a/docs/csharp/fundamentals/coding-style/snippets/coding-conventions/program.cs
+++ b/docs/csharp/fundamentals/coding-style/snippets/coding-conventions/program.cs
@@ -112,9 +112,13 @@ namespace Coding_Conventions_Examples
             foreach (char ch in laugh)
             {
                 if (ch == 'h')
+                {
                     Console.Write("H");
+                }
                 else
+                {
                     Console.Write(ch);
+                }
             }
             Console.WriteLine();
             //</snippet12>

--- a/docs/standard/serialization/system-text-json/use-utf8jsonreader.md
+++ b/docs/standard/serialization/system-text-json/use-utf8jsonreader.md
@@ -22,7 +22,7 @@ The following example shows how to use the <xref:System.Text.Json.Utf8JsonReader
 :::code language="csharp" source="snippets/how-to/csharp/Utf8ReaderFromBytes.cs" id="Deserialize":::
 :::code language="vb" source="snippets/how-to/vb/Utf8ReaderFromBytes.vb" id="Deserialize":::
 
-The preceding code assumes that the jsonUtf8Bytes variable is a byte array that contains valid JSON, encoded as UTF-8.
+The preceding code assumes that the `jsonUtf8Bytes` variable is a byte array that contains valid JSON, encoded as UTF-8.
 
 ## Filter data using `Utf8JsonReader`
 

--- a/docs/standard/serialization/system-text-json/use-utf8jsonreader.md
+++ b/docs/standard/serialization/system-text-json/use-utf8jsonreader.md
@@ -22,7 +22,7 @@ The following example shows how to use the <xref:System.Text.Json.Utf8JsonReader
 :::code language="csharp" source="snippets/how-to/csharp/Utf8ReaderFromBytes.cs" id="Deserialize":::
 :::code language="vb" source="snippets/how-to/vb/Utf8ReaderFromBytes.vb" id="Deserialize":::
 
-The preceding code assumes that the `jsonUtf8` variable is a byte array that contains valid JSON, encoded as UTF-8.
+The preceding code assumes that the jsonUtf8Bytes variable is a byte array that contains valid JSON, encoded as UTF-8.
 
 ## Filter data using `Utf8JsonReader`
 


### PR DESCRIPTION
## Summary

Fixes the bracing issue as outlined in the original ticket.

Fixes #42325 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/serialization/system-text-json/use-utf8jsonreader.md](https://github.com/dotnet/docs/blob/00811e99285487675e1ff92cd4da6d020aa78dcb/docs/standard/serialization/system-text-json/use-utf8jsonreader.md) | [docs/standard/serialization/system-text-json/use-utf8jsonreader](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/use-utf8jsonreader?branch=pr-en-us-42345) |

<!-- PREVIEW-TABLE-END -->