### PR TITLE
Update comwrappers-source-generation.md

### DIFF
--- a/docs/standard/native-interop/comwrappers-source-generation.md
+++ b/docs/standard/native-interop/comwrappers-source-generation.md
@@ -20,10 +20,10 @@ interface IFoo
 }
 
 [DllImport("MyComObjectProvider.dll")]
-static nint GetPointerToComInterface();
+static nint GetPointerToComInterface(); // C definition - IUnknown* GetPointerToComInterface();
 
 [DllImport("MyComObjectProvider.dll")]
-static void GivePointerToComInterface(nint comObject);
+static void GivePointerToComInterface(nint comObject); // C definition - void GivePointerToComInterface(IUnknown* pUnk);
 
 // Use the system to create a Runtime Callable Wrapper to use in managed code
 nint ptr = GetPointerToComInterface();
@@ -68,10 +68,10 @@ At compile time, the generator creates an implementation of the ComWrappers API,
 
 ```csharp
 [LibraryImport("MyComObjectProvider.dll")]
-static nint GetPointerToComInterface();
+static nint GetPointerToComInterface();  // C definition - IUnknown* GetPointerToComInterface();
 
 [LibraryImport("MyComObjectProvider.dll")]
-static void GivePointerToComInterface(nint comObject);
+static void GivePointerToComInterface(nint comObject); // C definition - void GivePointerToComInterface(IUnknown* pUnk);
 
 // Use the ComWrappers API to create a Runtime Callable Wrapper to use in managed code
 ComWrappers cw = new StrategyBasedComWrappers();

--- a/docs/standard/native-interop/comwrappers-source-generation.md
+++ b/docs/standard/native-interop/comwrappers-source-generation.md
@@ -19,10 +19,10 @@ interface IFoo
     void Method(int i);
 }
 
-[DllImport("MyComObjectProvider.dll")]
+[DllImport("MyComObjectProvider")]
 static nint GetPointerToComInterface(); // C definition - IUnknown* GetPointerToComInterface();
 
-[DllImport("MyComObjectProvider.dll")]
+[DllImport("MyComObjectProvider")]
 static void GivePointerToComInterface(nint comObject); // C definition - void GivePointerToComInterface(IUnknown* pUnk);
 
 // Use the system to create a Runtime Callable Wrapper to use in managed code
@@ -67,22 +67,22 @@ internal partial class Foo : IFoo
 At compile time, the generator creates an implementation of the ComWrappers API, and you can use the <xref:System.Runtime.InteropServices.Marshalling.StrategyBasedComWrappers> type or a custom derived type to consume or expose the COM interface.
 
 ```csharp
-[LibraryImport("MyComObjectProvider.dll")]
-static nint GetPointerToComInterface();  // C definition - IUnknown* GetPointerToComInterface();
+[LibraryImport("MyComObjectProvider")]
+private static partial nint GetPointerToComInterface(); // C definition - IUnknown* GetPointerToComInterface();
 
-[LibraryImport("MyComObjectProvider.dll")]
-static void GivePointerToComInterface(nint comObject); // C definition - void GivePointerToComInterface(IUnknown* pUnk);
+[LibraryImport("MyComObjectProvider")]
+private static partial void GivePointerToComInterface(nint comObject); // C definition - void GivePointerToComInterface(IUnknown* pUnk);
 
 // Use the ComWrappers API to create a Runtime Callable Wrapper to use in managed code
 ComWrappers cw = new StrategyBasedComWrappers();
 nint ptr = GetPointerToComInterface();
-IFoo foo = (IFoo)cw.GetOrCreateObjectForComInterface(ptr);
+IFoo foo = (IFoo)cw.GetOrCreateObjectForComInstance(ptr, CreateObjectFlags.None);
 foo.Method(0);
 ...
 // Use the system to create a COM Callable Wrapper to pass to unmanaged code
 ComWrappers cw = new StrategyBasedComWrappers();
 Foo foo = new();
-nint ptr = cw.GetOrCreateComInterfaceForObject(foo);
+nint ptr = cw.GetOrCreateComInterfaceForObject(foo, CreateComInterfaceFlags.None);
 GivePointerToComInterface(ptr);
 ```
 


### PR DESCRIPTION
Add clarifying comment about the native API being called.

See https://github.com/dotnet/runtime/issues/106978#issuecomment-2310804737

Fixes https://github.com/dotnet/runtime/issues/106978


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/native-interop/comwrappers-source-generation.md](https://github.com/dotnet/docs/blob/013c1d59185b0fc414275ebead5683e7b89b58e3/docs/standard/native-interop/comwrappers-source-generation.md) | [docs/standard/native-interop/comwrappers-source-generation](https://review.learn.microsoft.com/en-us/dotnet/standard/native-interop/comwrappers-source-generation?branch=pr-en-us-42347) |


<!-- PREVIEW-TABLE-END -->