### PR TITLE
Provide "Inline arrays" article with explanation examples

### DIFF
--- a/docs/csharp/language-reference/builtin-types/snippets/shared/StructType.cs
+++ b/docs/csharp/language-reference/builtin-types/snippets/shared/StructType.cs
@@ -269,5 +269,21 @@
             private char _firstElement;
         }
         // </DeclareInlineArray>
+
+        // <DeclareInlineArrayWithPointer>
+        [System.Runtime.CompilerServices.InlineArray(10)]
+        public struct CharBufferWithPointer
+        {
+            private unsafe char* _pointerElement;    // CS9184
+        }
+        // </DeclareInlineArrayWithPointer>
+
+        // <DeclareInlineArrayWithReferenceType>
+        [System.Runtime.CompilerServices.InlineArray(10)]
+        public struct CharBufferWithReferenceType
+        {
+            private string _referenceElement;
+        }
+        // </DeclareInlineArrayWithReferenceType>
     }
 }

--- a/docs/csharp/language-reference/builtin-types/struct.md
+++ b/docs/csharp/language-reference/builtin-types/struct.md
@@ -100,7 +100,15 @@ In addition, the compiler validates the <xref:System.Runtime.CompilerServices.In
 
 In most cases, an inline array can be accessed like an array, both to read and write values. In addition, you can use the [range](../operators/member-access-operators.md#range-operator-) and [index](../operators/member-access-operators.md#indexer-access) operators.
 
-There are minimal restrictions on the type of the single field of an inline array. It can't be a pointer type, but it can be any reference type, or any value type. You can use inline arrays with almost any C# data structure.
+There are minimal restrictions on the type of the single field of an inline array. It can't be a pointer type:
+
+:::code language="csharp" source="snippets/shared/StructType.cs" id="DeclareInlineArrayWithPointer":::
+
+but it can be any reference type, or any value type:
+
+:::code language="csharp" source="snippets/shared/StructType.cs" id="DeclareInlineArrayWithReferenceType":::
+
+You can use inline arrays with almost any C# data structure.
 
 Inline arrays are an advanced language feature. They're intended for high-performance scenarios where an inline, contiguous block of elements is faster than other alternative data structures. You can learn more about inline arrays from the [feature speclet](~/_csharplang/proposals/csharp-12.0/inline-arrays.md)
 

--- a/docs/csharp/language-reference/builtin-types/struct.md
+++ b/docs/csharp/language-reference/builtin-types/struct.md
@@ -100,7 +100,7 @@ In addition, the compiler validates the <xref:System.Runtime.CompilerServices.In
 
 In most cases, an inline array can be accessed like an array, both to read and write values. In addition, you can use the [range](../operators/member-access-operators.md#range-operator-) and [index](../operators/member-access-operators.md#indexer-access) operators.
 
-There are minimal restrictions on the type of the single field. It can't be a pointer type, but it can be any reference type, or any value type. You can use inline arrays with almost any C# data structure.
+There are minimal restrictions on the type of the single field of an inline array. It can't be a pointer type, but it can be any reference type, or any value type. You can use inline arrays with almost any C# data structure.
 
 Inline arrays are an advanced language feature. They're intended for high-performance scenarios where an inline, contiguous block of elements is faster than other alternative data structures. You can learn more about inline arrays from the [feature speclet](~/_csharplang/proposals/csharp-12.0/inline-arrays.md)
 

--- a/docs/csharp/language-reference/builtin-types/struct.md
+++ b/docs/csharp/language-reference/builtin-types/struct.md
@@ -184,3 +184,4 @@ For more information about `struct` features, see the following feature proposal
 - [The C# type system](../../fundamentals/types/index.md)
 - [Design guidelines - Choosing between class and struct](../../../standard/design-guidelines/choosing-between-class-and-struct.md)
 - [Design guidelines - Struct design](../../../standard/design-guidelines/struct.md)
+- [Resolve errors and warnings with inline array declarations](../../language-reference/compiler-messages/inline-array-errors.md)


### PR DESCRIPTION
This pull request fixes #42329 

It adds the examples presenting the cases of having non-acceptable types of inline struct fields, as well as the reference type used for it.
I didn't include the value type as that most simple scenario was already presented when showing the inline array declaration general example.
This PR also enhances the sentence mentioning the restrictions so that it is more clear and readable that those restrictions are for fields.
Moreover, the "See also" section has been provided with the link to compiler errors (messages) regarding this new feature of inline arrays.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/builtin-types/struct.md](https://github.com/dotnet/docs/blob/4d1ea6af9afe3fccecbc7defaea720447e293fba/docs/csharp/language-reference/builtin-types/struct.md) | [docs/csharp/language-reference/builtin-types/struct](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/struct?branch=pr-en-us-42349) |

<!-- PREVIEW-TABLE-END -->