### PR TITLE
Fix NIST typo in FIPS changes doc

### DIFF
--- a/docs/framework/release-notes/2024/04-23-april-preview-cumulative-update.md
+++ b/docs/framework/release-notes/2024/04-23-april-preview-cumulative-update.md
@@ -30,7 +30,7 @@ Addresses an issue where `ISymUnmanagedReader::GetMethodsFromDocumentPosition` a
 
 Addresses an issue that can be triggered in the fbx file parser. (*Applies to: .NET Framework 4.8, 4.8.1.*)
 
-Addresses an issue to use MIST-validated implementations of FIPS algorithms. (*Applies to: .NET Framework 4.8, 4.8.1.*)
+Addresses an issue to use NIST-validated implementations of FIPS algorithms. (*Applies to: .NET Framework 4.8, 4.8.1.*)
 
 #### .NET fundamentals
 

--- a/docs/framework/release-notes/2024/05-14-may-security-and-quality-rollup.md
+++ b/docs/framework/release-notes/2024/05-14-may-security-and-quality-rollup.md
@@ -30,7 +30,7 @@ Addresses an issue where `ISymUnmanagedReader::GetMethodsFromDocumentPosition` a
 
 Addresses an issue that can be triggered in the fbx file parser. (*Applies to: .NET Framework 4.8, 4.8.1.*)
 
-Addresses an issue to use MIST-validated implementations of FIPS algorithms. (*Applies to: .NET Framework 4.8, 4.8.1.*)
+Addresses an issue to use NIST-validated implementations of FIPS algorithms. (*Applies to: .NET Framework 4.8, 4.8.1.*)
 
 #### .NET fundamentals
 


### PR DESCRIPTION
A customer noted the typo of "MIST" which should have been "NIST" ([National Institute of Standards and Technology](https://www.nist.gov/)).

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/release-notes/2024/04-23-april-preview-cumulative-update.md](https://github.com/dotnet/docs/blob/a5c1f120d50775a58a82135212ae2a25bf55fda2/docs/framework/release-notes/2024/04-23-april-preview-cumulative-update.md) | [docs/framework/release-notes/2024/04-23-april-preview-cumulative-update](https://review.learn.microsoft.com/en-us/dotnet/framework/release-notes/2024/04-23-april-preview-cumulative-update?branch=pr-en-us-42350) |
| [docs/framework/release-notes/2024/05-14-may-security-and-quality-rollup.md](https://github.com/dotnet/docs/blob/a5c1f120d50775a58a82135212ae2a25bf55fda2/docs/framework/release-notes/2024/05-14-may-security-and-quality-rollup.md) | [docs/framework/release-notes/2024/05-14-may-security-and-quality-rollup](https://review.learn.microsoft.com/en-us/dotnet/framework/release-notes/2024/05-14-may-security-and-quality-rollup?branch=pr-en-us-42350) |

<!-- PREVIEW-TABLE-END -->