### PR TITLE
Add 2 new exit codes for the testing platform

### DIFF
--- a/docs/core/testing/unit-testing-platform-exit-codes.md
+++ b/docs/core/testing/unit-testing-platform-exit-codes.md
@@ -24,6 +24,8 @@ ms.topic: reference
 | `8` | The exit code `8` indicates that the test session ran zero tests. |
 | `9` | The exit code `9` indicates that the minimum execution policy for the executed tests was violated. |
 | `10` | The exit code `10` indicates that the test adapter, Testing.Platform Test Framework, MSTest, NUnit, or xUnit, failed to run tests for an infrastructure reason unrelated to the test's self. An example is failing to create a fixture needed by tests. |
+| `11` | The exit code `11` indicates that the test process will exit if dependent process exits. |
+| `12` | The exit code `12` indicates that the test session was unable to run because the client does not support any of the supported protocol versions. |
 
 To enable verbose logging and troubleshoot issues, see [Microsoft.Testing.Platform Diagnostics extensions](unit-testing-platform-extensions-diagnostics.md#built-in-options).
 


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-platform-exit-codes.md](https://github.com/dotnet/docs/blob/d5e84cdbacedc023576a0ab3dec5ec036683ff28/docs/core/testing/unit-testing-platform-exit-codes.md) | [docs/core/testing/unit-testing-platform-exit-codes](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-platform-exit-codes?branch=pr-en-us-42353) |

<!-- PREVIEW-TABLE-END -->