### PR TITLE
k8s pod permission issue

### DIFF
--- a/docs/orleans/deployment/kubernetes.md
+++ b/docs/orleans/deployment/kubernetes.md
@@ -121,7 +121,7 @@ metadata:
 rules:
 - apiGroups: [ "" ]
   resources: ["pods"]
-  verbs: ["get", "watch", "list", "patch"]
+  verbs: ["get", "watch", "list", "delete", "patch"]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/docs/orleans/deployment/kubernetes.md
+++ b/docs/orleans/deployment/kubernetes.md
@@ -121,7 +121,7 @@ metadata:
 rules:
 - apiGroups: [ "" ]
   resources: ["pods"]
-  verbs: ["get", "watch", "list", "delete"]
+  verbs: ["get", "watch", "list", "patch"]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
the `patch` verb is required for the Kubernetes extension to have access to update pods
Without it, this error is thrown 🙂
```
is forbidden: User \"system:serviceaccount:default:default\" cannot patch resource \"pods\" in API group
```



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/deployment/kubernetes.md](https://github.com/dotnet/docs/blob/6bd3fb6d4aae72ad30eebd73a6e5293fd4442063/docs/orleans/deployment/kubernetes.md) | [docs/orleans/deployment/kubernetes](https://review.learn.microsoft.com/en-us/dotnet/orleans/deployment/kubernetes?branch=pr-en-us-42361) |


<!-- PREVIEW-TABLE-END -->