### PR TITLE
Add new Resource Monitoring metrics

### DIFF
--- a/docs/core/diagnostics/built-in-metrics-diagnostics.md
+++ b/docs/core/diagnostics/built-in-metrics-diagnostics.md
@@ -65,7 +65,7 @@ Available starting in: .NET 8.0.
 The `Microsoft.Extensions.Diagnostics.ResourceMonitoring` metrics report resource information from [resource monitoring](diagnostic-resource-monitoring.md):
 
 - [`container.cpu.limit.utilization`](#metric-containercpulimitutilization)
-- [`container.cpu.request.utilization`](#metric-containercpurequesttutilization)
+- [`container.cpu.request.utilization`](#metric-containercpurequestutilization)
 - [`container.memory.limit.utilization`](#metric-containermemorylimitutilization)
 - [`process.cpu.utilization`](#metric-processcpuutilization)
 - [`dotnet.process.memory.virtual.utilization`](#metric-dotnetprocessmemoryvirtualutilization)

--- a/docs/core/diagnostics/built-in-metrics-diagnostics.md
+++ b/docs/core/diagnostics/built-in-metrics-diagnostics.md
@@ -64,6 +64,9 @@ Available starting in: .NET 8.0.
 
 The `Microsoft.Extensions.Diagnostics.ResourceMonitoring` metrics report resource information from [resource monitoring](diagnostic-resource-monitoring.md):
 
+- [`container.cpu.limit.utilization`](#metric-containercpulimitutilization)
+- [`container.cpu.request.utilization`](#metric-containercpurequesttutilization)
+- [`container.memory.limit.utilization`](#metric-containermemorylimitutilization)
 - [`process.cpu.utilization`](#metric-processcpuutilization)
 - [`dotnet.process.memory.virtual.utilization`](#metric-dotnetprocessmemoryvirtualutilization)
 - [`system.network.connections`](#metric-systemnetworkconnections)
@@ -71,9 +74,37 @@ The `Microsoft.Extensions.Diagnostics.ResourceMonitoring` metrics report resourc
 > [!NOTE]
 > Metrics emitted by the `Microsoft.Extensions.Diagnostics.ResourceMonitoring` meter are in experimental stage. This means that there could be breaking changes to them.
 
-##### Metric: `process.cpu.utilization`
+##### Metric: `container.cpu.limit.utilization`
 
-The instrument is available only on Linux.
+The instrument is only available on a system running on containers both on Windows and Linux.
+
+| Name | Instrument Type | Unit (UCUM) | Description |
+| ---- | --------------- | ----------- | ----------- |
+| `container.cpu.limit.utilization` | ObservableGauge | `1` | The CPU consumption of the running containerized application relative to resource limit in range `[0, 1]`. |
+
+Available starting in: .NET 8.8.0.
+
+##### Metric: `container.cpu.request.utilization`
+
+The instrument is only available on a system running on containers on Linux.
+
+| Name | Instrument Type | Unit (UCUM) | Description |
+| ---- | --------------- | ----------- | ----------- |
+| `container.cpu.request.utilization` | ObservableGauge | `1` | The CPU consumption of the running containerized application relative to resource request in range `[0, 1]`. |
+
+Available starting in: .NET 8.8.0.
+
+##### Metric: `container.memory.limit.utilization`
+
+The instrument is only available on a system running on containers both on Windows and Linux.
+
+| Name | Instrument Type | Unit (UCUM) | Description |
+| ---- | --------------- | ----------- | ----------- |
+| `container.memory.limit.utilization` | ObservableGauge | `1` | The memory consumption of the running containerized application relative to resource limit in range `[0, 1]`. |
+
+Available starting in: .NET 8.8.0.
+
+##### Metric: `process.cpu.utilization`
 
 | Name | Instrument Type | Unit (UCUM) | Description |
 | ---- | --------------- | ----------- | ----------- |
@@ -83,8 +114,6 @@ Available starting in: .NET 8.0.
 
 ##### Metric: `dotnet.process.memory.virtual.utilization`
 
-The instrument is available only on Linux.
-
 | Name | Instrument Type | Unit (UCUM) | Description |
 | ---- | --------------- | ----------- | ----------- |
 | `dotnet.process.memory.virtual.utilization` | ObservableGauge | `1` | The memory consumption of the running application in range `[0, 1]`. |
@@ -92,8 +121,6 @@ The instrument is available only on Linux.
 Available starting in: .NET 8.0.
 
 ##### Metric: `system.network.connections`
-
-The instrument is available only on Windows.
 
 | Name | Instrument Type | Unit (UCUM) | Description |
 | ---- | --------------- | ----------- | ----------- |


### PR DESCRIPTION
Following PRs related to metrics were recently merged in the dotnet/extensions repo:
1. https://github.com/dotnet/extensions/pull/5290
2. https://github.com/dotnet/extensions/pull/5341
3. https://github.com/dotnet/extensions/pull/5367

which, shortly, include these changes:
- Completely new `container.*` metrics were added.
- Already existing metrics became available on both Linux and Windows.

So, in this PR, I make respective changes in the docs.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/built-in-metrics-diagnostics.md](https://github.com/dotnet/docs/blob/fc68f4beb40699ce576741617662f0394622ee6d/docs/core/diagnostics/built-in-metrics-diagnostics.md) | [docs/core/diagnostics/built-in-metrics-diagnostics](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/built-in-metrics-diagnostics?branch=pr-en-us-42366) |


<!-- PREVIEW-TABLE-END -->