### PR TITLE
Fix typo: "release keys" to "release values" (#42219)

### DIFF
--- a/docs/framework/migration-guide/how-to-determine-which-versions-are-installed.md
+++ b/docs/framework/migration-guide/how-to-determine-which-versions-are-installed.md
@@ -181,7 +181,7 @@ if ($version) {
 
 This example follows the recommended practice for version checking:
 
-- It checks whether the value of the **Release** entry is *greater than or equal to* the value of the known release keys.
+- It checks whether the value of the **Release** entry is *greater than or equal to* the value of the known release values.
 - It checks in order from most recent version to earliest version.
 
 ### .NET Framework 1.0-4.0


### PR DESCRIPTION
## Summary

This pull request fixes a typo in the documentation. The term "release keys" was incorrect and has been changed to "release values" to accurately reflect the content.

### Changes
- Updated the text from "greater than or equal to the value of the known release keys" to "greater than or equal to the value of the known release values".

### Verification
Please review the changes to ensure accuracy.

Fixes #42219 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/migration-guide/how-to-determine-which-versions-are-installed.md](https://github.com/dotnet/docs/blob/a4dabec620f07f19bd219cc10c296c09e77f4337/docs/framework/migration-guide/how-to-determine-which-versions-are-installed.md) | [docs/framework/migration-guide/how-to-determine-which-versions-are-installed](https://review.learn.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed?branch=pr-en-us-42369) |

<!-- PREVIEW-TABLE-END -->