### PR TITLE
[.NET 9 rc1] Add docs for configuring .NET install search behaviour in published apphost

### DIFF
--- a/docs/core/deploying/deploy-with-cli.md
+++ b/docs/core/deploying/deploy-with-cli.md
@@ -129,20 +129,20 @@ If you use the [example app](#sample-app), run `dotnet publish -f net6.0 -r win-
 > [!NOTE]
 > You can reduce the total size of your deployment by enabling **globalization invariant mode**. This mode is useful for applications that are not globally aware and that can use the formatting conventions, casing conventions, and string comparison and sort order of the [invariant culture](xref:System.Globalization.CultureInfo.InvariantCulture). For more information about **globalization invariant mode** and how to enable it, see [.NET Globalization Invariant Mode](https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md).
 
-### Configuring .NET install search behavior
+### Configure .NET install search behavior
 
-In .NET 9 RC1 and later versions, how the published executable looks for a .NET install can be configured via the [`AppHostDotNetSearch`](../project-sdk//msbuild-props.md#apphostdotnetsearch) and [`AppHostRelativeDotNet`](../project-sdk//msbuild-props.md#apphostrelativedotnet) properties.
+In .NET 9 and later versions, you can configure the .NET installation search paths of the published executable via the [`AppHostDotNetSearch`](../project-sdk//msbuild-props.md#apphostdotnetsearch) and [`AppHostRelativeDotNet`](../project-sdk//msbuild-props.md#apphostrelativedotnet) properties.
 
-`AppHostDotNetSearch` allows specifying one or more locations the executable will look for a .NET install:
+`AppHostDotNetSearch` allows specifying one or more locations where the executable will look for a .NET installation:
 
 - `AppLocal`: app executable's folder
 - `AppRelative`: path relative to the app executable
 - `EnvironmentVariables`: value of [`DOTNET_ROOT[_<arch>]`](../tools/dotnet-environment-variables.md#dotnet_root-dotnet_rootx86-dotnet_root_x86-dotnet_root_x64) environment variables
-- `Global`: [registered](https://github.com/dotnet/designs/blob/main/accepted/2020/install-locations.md#global-install-to-custom-location) and [default](https://github.com/dotnet/designs/blob/main/accepted/2020/install-locations.md#global-install-to-default-location) or default global locations
+- `Global`: [registered](https://github.com/dotnet/designs/blob/main/accepted/2020/install-locations.md#global-install-to-custom-location) and [default](https://github.com/dotnet/designs/blob/main/accepted/2020/install-locations.md#global-install-to-default-location) global install locations
 
 `AppHostRelativeDotNet` specifies the path relative to the executable that will be searched when `AppHostDotNetSearch` contains `AppRelative`.
 
-For more information, see [`AppHostDotNetSearch`](../project-sdk//msbuild-props.md#apphostdotnetsearch), [`AppHostRelativeDotNet`](../project-sdk//msbuild-props.md#apphostrelativedotnet), and [install location options in apphost](https://github.com/dotnet/designs/blob/main/proposed/apphost-embed-install-location.md).
+For more information, see [`AppHostDotNetSearch`](../project-sdk//msbuild-props.md#apphostdotnetsearch), [`AppHostRelativeDotNet`](../project-sdk//msbuild-props.md#apphostrelativedotnet) and [install location options in apphost](https://github.com/dotnet/designs/blob/main/proposed/apphost-embed-install-location.md).
 
 ## Self-contained deployment
 

--- a/docs/core/deploying/deploy-with-cli.md
+++ b/docs/core/deploying/deploy-with-cli.md
@@ -129,6 +129,21 @@ If you use the [example app](#sample-app), run `dotnet publish -f net6.0 -r win-
 > [!NOTE]
 > You can reduce the total size of your deployment by enabling **globalization invariant mode**. This mode is useful for applications that are not globally aware and that can use the formatting conventions, casing conventions, and string comparison and sort order of the [invariant culture](xref:System.Globalization.CultureInfo.InvariantCulture). For more information about **globalization invariant mode** and how to enable it, see [.NET Globalization Invariant Mode](https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md).
 
+### Configuring .NET install search behavior
+
+In .NET 9 RC1 and later versions, how the published executable looks for a .NET install can be configured via the [`AppHostDotNetSearch`](../project-sdk//msbuild-props.md#apphostdotnetsearch) and [`AppHostRelativeDotNet`](../project-sdk//msbuild-props.md#apphostrelativedotnet) properties.
+
+`AppHostDotNetSearch` allows specifying one or more locations the executable will look for a .NET install:
+
+- `AppLocal`: app executable's folder
+- `AppRelative`: path relative to the app executable
+- `EnvironmentVariables`: value of [`DOTNET_ROOT[_<arch>]`](../tools/dotnet-environment-variables.md#dotnet_root-dotnet_rootx86-dotnet_root_x86-dotnet_root_x64) environment variables
+- `Global`: [registered](https://github.com/dotnet/designs/blob/main/accepted/2020/install-locations.md#global-install-to-custom-location) and [default](https://github.com/dotnet/designs/blob/main/accepted/2020/install-locations.md#global-install-to-default-location) or default global locations
+
+`AppHostRelativeDotNet` specifies the path relative to the executable that will be searched when `AppHostDotNetSearch` contains `AppRelative`.
+
+For more information, see [`AppHostDotNetSearch`](../project-sdk//msbuild-props.md#apphostdotnetsearch), [`AppHostRelativeDotNet`](../project-sdk//msbuild-props.md#apphostrelativedotnet), and [install location options in apphost](https://github.com/dotnet/designs/blob/main/proposed/apphost-embed-install-location.md).
+
 ## Self-contained deployment
 
 When you publish a self-contained deployment (SCD), the .NET SDK creates a platform-specific executable. Publishing an SCD includes all required .NET files to run your app but it doesn't include the native dependencies of .NET (for example, for [.NET 6 on Linux](https://github.com/dotnet/core/blob/main/release-notes/6.0/linux-packages.md) or [.NET 8 on Linux](https://github.com/dotnet/core/blob/main/release-notes/8.0/linux-packages.md)). These dependencies must be present on the system before the app runs.

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -1440,7 +1440,7 @@ The `AppHostDotNetSearch` property configures how [the native executable](../dep
 </PropertyGroup>
 ```
 
-The following table list valid values. Multiple values can be specified, separated by semi-colons.
+The following table lists valid values. You can specify multiple values, separated by semi-colons.
 
 | Value | Meaning |
 | --- | --- |
@@ -1453,7 +1453,7 @@ This property was introduced in .NET 9.
 
 ### AppHostRelativeDotNet
 
-The `AppHostRelativeDotNet` allows specifying a relative path for the app executable to look for the .NET install when it is [configured to do so](#apphostdotnetsearch). Setting the `AppHostRelativeDotNet` property implies that [`AppHostDotNetSearch`](#apphostdotnetsearch) is `AppRelative`. This property only impacts the executable produced on publish, not build.
+The `AppHostRelativeDotNet` property allows specifying a relative path for the app executable to look for the .NET installation when it's [configured to do so](#apphostdotnetsearch). Setting the `AppHostRelativeDotNet` property implies that [`AppHostDotNetSearch`](#apphostdotnetsearch) is `AppRelative`. This property only impacts the executable produced on publish, not build.
 
 ```xml
 <PropertyGroup>

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -1425,8 +1425,43 @@ The `RunWorkingDirectory` property defines the working directory for the applica
 
 The following MSBuild properties are documented in this section:
 
+- [AppHostDotNetSearch](#apphostdotnetsearch)
+- [AppHostRelativeDotNet](#apphostrelativedotnet)
 - [EnableComHosting](#enablecomhosting)
 - [EnableDynamicLoading](#enabledynamicloading)
+
+### AppHostDotNetSearch
+
+The `AppHostDotNetSearch` property configures how [the native executable](../deploying/index.md#produce-an-executable) produced for an application will search for a .NET installation. This property only impacts the executable produced on publish, not build.
+
+```xml
+<PropertyGroup>
+  <AppHostDotNetSearch>Global</AppHostDotNetSearch>
+</PropertyGroup>
+```
+
+The following table list valid values. Multiple values can be specified, separated by semi-colons.
+
+| Value | Meaning |
+| --- | --- |
+| `AppLocal` | App executable's folder |
+| `AppRelative` | Path relative to the app executable as specified by [AppHostRelativeDotNet](#apphostrelativedotnet) |
+| `EnvironmentVariables` | Value of [`DOTNET_ROOT[_<arch>]`](../tools/dotnet-environment-variables.md#dotnet_root-dotnet_rootx86-dotnet_root_x86-dotnet_root_x64) environment variables |
+| `Global` | [Registered](https://github.com/dotnet/designs/blob/main/accepted/2020/install-locations.md#global-install-to-custom-location) and [default](https://github.com/dotnet/designs/blob/main/accepted/2020/install-locations.md#global-install-to-default-location) global install locations |
+
+This property was introduced in .NET 9.
+
+### AppHostRelativeDotNet
+
+The `AppHostRelativeDotNet` allows specifying a relative path for the app executable to look for the .NET install when it is [configured to do so](#apphostdotnetsearch). Setting the `AppHostRelativeDotNet` property implies that [`AppHostDotNetSearch`](#apphostdotnetsearch) is `AppRelative`. This property only impacts the executable produced on publish, not build.
+
+```xml
+<PropertyGroup>
+  <AppHostRelativeDotNet>./relative/path/to/runtime</AppHostRelativeDotNet>
+</PropertyGroup>
+```
+
+This property was introduced in .NET 9.
 
 ### EnableComHosting
 


### PR DESCRIPTION
## Summary

In .NET 9 RC1, we allow publishing an executable with configured .NET install search options. This updates our docs with information about the new properties that can be used.

Design doc: https://github.com/dotnet/designs/blob/main/proposed/apphost-embed-install-location.md
Implementation: https://github.com/dotnet/runtime/pull/104749, https://github.com/dotnet/sdk/pull/42455

cc @dotnet/appmodel @AaronRobinsonMSFT @richlander @vitek-karas 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/deploying/deploy-with-cli.md](https://github.com/dotnet/docs/blob/2781ebeba12441eb16ac0143b7b408de8fb03664/docs/core/deploying/deploy-with-cli.md) | [docs/core/deploying/deploy-with-cli](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/deploy-with-cli?branch=pr-en-us-42397) |
| [docs/core/project-sdk/msbuild-props.md](https://github.com/dotnet/docs/blob/2781ebeba12441eb16ac0143b7b408de8fb03664/docs/core/project-sdk/msbuild-props.md) | [docs/core/project-sdk/msbuild-props](https://review.learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props?branch=pr-en-us-42397) |


<!-- PREVIEW-TABLE-END -->