### PR TITLE
Remove the shift operand type requirement statement

### DIFF
--- a/docs/csharp/language-reference/operators/bitwise-and-shift-operators.md
+++ b/docs/csharp/language-reference/operators/bitwise-and-shift-operators.md
@@ -165,8 +165,6 @@ For the complete list of C# operators ordered by precedence level, see the [Oper
 
 ## Shift count of the shift operators
 
-For the built-in shift operators `<<`, `>>`, and `>>>`, the type of the right-hand operand must be `int` or a type that has a [predefined implicit numeric conversion](../builtin-types/numeric-conversions.md#implicit-numeric-conversions) to `int`.
-
 For the `x << count`, `x >> count`, and `x >>> count` expressions, the actual shift count depends on the type of `x` as follows:
 
 - If the type of `x` is `int` or `uint`, the shift count is defined by the low-order *five* bits of the right-hand operand. That is, the shift count is computed from `count & 0x1F` (or `count & 0b_1_1111`).


### PR DESCRIPTION
This pull request fixes #42311 
It simply removes the outdated statement, as the further reading is correct regarding the latest standard.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/bitwise-and-shift-operators.md](https://github.com/dotnet/docs/blob/37512ade10e9f68e77571b09aa281fab680f829b/docs/csharp/language-reference/operators/bitwise-and-shift-operators.md) | [docs/csharp/language-reference/operators/bitwise-and-shift-operators](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/bitwise-and-shift-operators?branch=pr-en-us-42416) |

<!-- PREVIEW-TABLE-END -->