### PR TITLE
bugfix: Fix typo in tuple equality operators link

### DIFF
--- a/docs/csharp/language-reference/builtin-types/value-tuples.md
+++ b/docs/csharp/language-reference/builtin-types/value-tuples.md
@@ -160,7 +160,7 @@ C# tuples, which are backed by <xref:System.ValueTuple?displayProperty=nameWithT
 For more information, see:
 
 - [Tuple types](/dotnet/csharp/language-reference/language-specification/types#8311-tuple-types)
-- [Tuple equality operators](/dotnet/csharp/language-reference/language-specification/expressions#111211-tuple-equality-operators)
+- [Tuple equality operators](/dotnet/csharp/language-reference/language-specification/expressions#121211-tuple-equality-operators)
 
 ## See also
 


### PR DESCRIPTION
## Summary

Changed the href in the link (from `#111211-tuple-equality-operators` to `#121211-tuple-equality-operators`)

Fixes #42415


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/builtin-types/value-tuples.md](https://github.com/dotnet/docs/blob/5ffefef3ea8c048a3b44d7d3523fb1d2f112d561/docs/csharp/language-reference/builtin-types/value-tuples.md) | [docs/csharp/language-reference/builtin-types/value-tuples](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/value-tuples?branch=pr-en-us-42420) |

<!-- PREVIEW-TABLE-END -->