### PR TITLE
What's new in .NET9 - AlternateLookup snippet - unused code removal

### DIFF
--- a/docs/core/whats-new/snippets/dotnet-9/csharp/Collections.cs
+++ b/docs/core/whats-new/snippets/dotnet-9/csharp/Collections.cs
@@ -58,8 +58,6 @@ internal partial class ReadOnlyCollections
     // </ReadOnlySet>
 
     // <AlternateLookup>
-    private readonly Dictionary<string, int> _wordCounts = new(StringComparer.OrdinalIgnoreCase);
-
     private static Dictionary<string, int> CountWords(ReadOnlySpan<char> input)
     {
         Dictionary<string, int> wordCounts = new(StringComparer.OrdinalIgnoreCase);


### PR DESCRIPTION
the `_wordCounts` field does not make sense in this snippet
