### PR TITLE
switch from SQL connection to file access

### DIFF
--- a/docs/visual-basic/programming-guide/language-features/control-flow/how-to-dispose-of-a-system-resource.md
+++ b/docs/visual-basic/programming-guide/language-features/control-flow/how-to-dispose-of-a-system-resource.md
@@ -16,33 +16,32 @@ ms.assetid: 8be2b239-8090-419b-8e7e-bcaa75b0ecc8
 
 You can use a `Using` block to guarantee that the system disposes of a resource when your code exits the block. This is useful if you are using a system resource that consumes a large amount of memory, or that other components also want to use.  
   
-### To dispose of a database connection when your code is finished with it  
+### To dispose of a file stream when your code is finished with it  
   
-1. Make sure you include the appropriate [Imports Statement (.NET Namespace and Type)](../../../language-reference/statements/imports-statement-net-namespace-and-type.md) for the database connection at the beginning of your source file (in this case, <xref:System.Data.SqlClient>).  
+1. Make sure you include the appropriate [Imports Statement (.NET Namespace and Type)](../../../language-reference/statements/imports-statement-net-namespace-and-type.md) for the file stream at the beginning of your source file (in this case, <xref:System.IO>).  
   
-2. Create a `Using` block with the `Using` and `End Using` statements. Inside the block, put the code that deals with the database connection.  
+2. Create a `Using` block with the `Using` and `End Using` statements. Inside the block, put the code that deals with the file stream.  
   
-3. Declare the connection and create an instance of it as part of the `Using` statement.  
+3. Declare the stream and create an instance of it as part of the `Using` statement.  
   
     ```vb  
     ' Insert the following line at the beginning of your source file.  
-    Imports System.Data.SqlClient  
-    Public Sub AccessSql(ByVal s As String)  
-        Using sqc As New System.Data.SqlClient.SqlConnection(s)  
-            MsgBox("Connected with string """ & sqc.ConnectionString & """")  
+    Imports System.IO  
+    Public Sub AccessFile(ByVal s As String)  
+        Using fs As New StreamReader(s)
+            MsgBox("reading file contents """ & fs.ReadToEnd() & """")  
         End Using  
-    End Sub  
+    End Sub
     ```  
   
      The system disposes of the resource no matter how you exit the block, including the case of an unhandled exception.  
   
-     Note that you cannot access `sqc` from outside the `Using` block, because its scope is limited to the block.  
+     Note that you cannot access `fs` from outside the `Using` block, because its scope is limited to the block.  
   
-     You can use this same technique on a system resource such as a file handle or a COM wrapper. You use a `Using` block when you want to be sure to leave the resource available for other components after you have exited the `Using` block.  
+     You can use this same technique on a system resource such as a SQL database connection or a COM wrapper. You use a `Using` block when you want to be sure to leave the resource available for other components after you have exited the `Using` block.  
   
 ## See also
 
-- <xref:System.Data.SqlClient.SqlConnection>
 - [Control Flow](index.md)
 - [Decision Structures](decision-structures.md)
 - [Loop Structures](loop-structures.md)


### PR DESCRIPTION
The file access sample shows the `Using` statement as well,  but doesn't require a connection string.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/visual-basic/programming-guide/language-features/control-flow/how-to-dispose-of-a-system-resource.md](https://github.com/dotnet/docs/blob/a806997b31133393b26fa73535115bddea50ff45/docs/visual-basic/programming-guide/language-features/control-flow/how-to-dispose-of-a-system-resource.md) | [docs/visual-basic/programming-guide/language-features/control-flow/how-to-dispose-of-a-system-resource](https://review.learn.microsoft.com/en-us/dotnet/visual-basic/programming-guide/language-features/control-flow/how-to-dispose-of-a-system-resource?branch=pr-en-us-42453) |

<!-- PREVIEW-TABLE-END -->