### PR TITLE
Correct EventPipe comparison info

### DIFF
--- a/docs/core/diagnostics/eventpipe.md
+++ b/docs/core/diagnostics/eventpipe.md
@@ -1,13 +1,13 @@
 ---
 title: EventPipe Overview
 description: Learn about EventPipe and how to use it for tracing your .NET applications to diagnose performance issues.
-ms.date: 11/09/2020
+ms.date: 09/03/2024
 ms.topic: overview
 ---
 
 # EventPipe
 
-EventPipe is a runtime component that can be used to collect tracing data, similar to ETW or LTTng. The goal of EventPipe is to allow .NET developers to easily trace their .NET applications without having to rely on platform-specific OS-native components such as ETW or LTTng.
+EventPipe is a runtime component that can be used to collect tracing data, similar to [ETW](/windows/win32/etw/event-tracing-portal) or [perf_events](https://wikipedia.org/wiki/Perf_%28Linux%29). The goal of EventPipe is to allow .NET developers to easily trace their .NET applications without having to rely on platform-specific high-privilege components such as ETW or perf_events.
 
 EventPipe is the mechanism behind many of the diagnostic tools and can be used for consuming events emitted by the runtime as well as custom events written with [EventSource](xref:System.Diagnostics.Tracing.EventSource).
 
@@ -21,17 +21,17 @@ The events are then serialized in the `.nettrace` file format and can be written
 
 To learn more about the EventPipe serialization format, refer to the [EventPipe format documentation](https://github.com/microsoft/perfview/blob/main/src/TraceEvent/EventPipe/EventPipeFormat.md).
 
-## EventPipe vs. ETW/LTTng
+## EventPipe vs. ETW/perf_events
 
-EventPipe is part of the .NET runtime (CoreCLR) and is designed to work the same way across all the platforms .NET Core supports. This allows tracing tools based on EventPipe, such as `dotnet-counters`, `dotnet-gcdump`, and `dotnet-trace`, to work seamlessly across platforms.
+EventPipe is part of the .NET runtime and is designed to work the same way across all the platforms .NET Core supports. This allows tracing tools based on EventPipe, such as `dotnet-counters`, `dotnet-gcdump`, and `dotnet-trace`, to work seamlessly across platforms.
 
-However, because EventPipe is a runtime built-in component, its scope is limited to managed code and the runtime itself. EventPipe cannot be used for tracking some lower-level events, such as resolving native code stack or getting various kernel events. If you use C/C++ interop in your app or you want to trace the runtime itself (which is written in C++), or want deeper diagnostics into the behavior of the app that requires kernel events (that is, native-thread context-switching events) you should use ETW or [perf/LTTng](./trace-perfcollect-lttng.md).
+However, because EventPipe is a runtime built-in component, its scope is limited to managed code and the runtime itself. EventPipe events include stacktraces with managed code frame information only. If you want events generated from other unmanaged user-mode libraries, CPU sampling for native code, or kernel events you should use OS-specific tracing tools such as ETW or perf_events. On Linux the [perfcollect tool](./trace-perfcollect-lttng.md) helps automate using perf_events and [LTTng](https://en.wikipedia.org/wiki/LTTng).
 
-Another major difference between EventPipe and ETW/LTTng is admin/root privilege requirement. To trace an application using ETW or LTTng you need to be an admin/root. Using EventPipe, you can trace applications as long as the tracer (for example, `dotnet-trace`) is run as the same user as the user that launched the application.
+Another major difference between EventPipe and ETW/perf_events is admin/root privilege requirement. To trace an application using ETW or perf_events you need to be an admin/root. Using EventPipe, you can trace applications as long as the tracer (for example, `dotnet-trace`) is run as the same user as the user that launched the application.
 
-The following table is a summary of the differences between EventPipe and ETW/LTTng.
+The following table is a summary of the differences between EventPipe and ETW/perf_events.
 
-|Feature|EventPipe|ETW|LTTng|
+|Feature|EventPipe|ETW|perf_events|
 |-------|---------|---|-----------|
 |Cross-platform|Yes|No (only on Windows)|No (only on supported Linux distros)|
 |Require admin/root privilege|No|Yes|Yes|


### PR DESCRIPTION
The EventPipe docs were saying things about LTTng that were either incorrect or misleading. I think changing the comparison to use perf_events makes it more effective.

- LTTng does support tracing kernel events, but as written users are likely to get the wrong idea. Perfcollect, the tool we recommend to when using LTTng with .NET, uses perf_events rather than LTTng to perform the kernel tracing. Perfcollect only uses lttng for its user-mode tracing capability.
- LTTng doesn't support native callstacks as far as I am aware.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/eventpipe.md](https://github.com/dotnet/docs/blob/bd04aba9e36c9af1ae29678084cfc71507b924f6/docs/core/diagnostics/eventpipe.md) | [docs/core/diagnostics/eventpipe](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/eventpipe?branch=pr-en-us-42456) |

<!-- PREVIEW-TABLE-END -->