### PR TITLE
Typo in What's New in C#13

### DIFF
--- a/docs/csharp/whats-new/csharp-13.md
+++ b/docs/csharp/whats-new/csharp-13.md
@@ -46,7 +46,7 @@ You can use `\e` as a [character literal](~/_csharpstandard/standard/lexical-str
 
 ## Method group natural type
 
-This feature makes small optimizations to overload resolution involving method groups. A *method groups* is a method and all overloads with the same name. The previous behavior was for the compiler to construct the full set of candidate methods for a method group. If a natural type was needed, the natural type was determined from the full set of candidate methods.
+This feature makes small optimizations to overload resolution involving method groups. A *method group* is a method and all overloads with the same name. The previous behavior was for the compiler to construct the full set of candidate methods for a method group. If a natural type was needed, the natural type was determined from the full set of candidate methods.
 
 The new behavior is to prune the set of candidate methods at each scope, removing those candidate methods that aren't applicable. Typically, the removed methods are generic methods with the wrong arity, or constraints that aren't satisfied. The process continues to the next outer scope only if no candidate methods are found. This process more closely follows the general algorithm for overload resolution. If all candidate methods found at a given scope don't match, the method group doesn't have a natural type.
 


### PR DESCRIPTION
## Summary

A small typo

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/whats-new/csharp-13.md](https://github.com/dotnet/docs/blob/31376f999fa36e0475bd3ced5e5e0b093d4f268c/docs/csharp/whats-new/csharp-13.md) | [docs/csharp/whats-new/csharp-13](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-13?branch=pr-en-us-42458) |

<!-- PREVIEW-TABLE-END -->