### PR TITLE
Fix Syntax for Output Samples

### DIFF
--- a/docs/csharp/language-reference/attributes/caller-information.md
+++ b/docs/csharp/language-reference/attributes/caller-information.md
@@ -54,7 +54,7 @@ You would invoke it as shown in the following example:
 
 The expression used for `condition` is injected by the compiler into the `message` argument. When a developer calls `Operation` with a `null` argument, the following message is stored in the `ArgumentException`:
 
-```dotnetcli
+```text
 Argument failed validation: <func is not null>
 ```
 
@@ -68,7 +68,7 @@ The previous example uses the [`nameof`](../operators/nameof.md) operator for th
 
 The preceding example would throw an <xref:System.ArgumentException> whose message is the following text:
 
-```dotnetcli
+```text
 Expression doesn't have enough elements: Enumerable.Range(0, 10) (Parameter 'sequence')
 ```
 


### PR DESCRIPTION
## Summary

Sets the output sample's code type to `text` to avoid CLI type syntax coloring (shown below):

![image](https://github.com/user-attachments/assets/23bab038-430e-4bc9-ac02-82ccce7f477f)




<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/attributes/caller-information.md](https://github.com/dotnet/docs/blob/33c1381039c86e554301ae37dabbc8495e6450f8/docs/csharp/language-reference/attributes/caller-information.md) | [docs/csharp/language-reference/attributes/caller-information](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/attributes/caller-information?branch=pr-en-us-42462) |

<!-- PREVIEW-TABLE-END -->