### PR TITLE
Part of ROPC

### DIFF
--- a/docs/framework/whats-new/index.md
+++ b/docs/framework/whats-new/index.md
@@ -707,24 +707,6 @@ ASP.NET processes requests in a predefined pipeline that includes 23 events. ASP
 
 .NET Framework 4.7.1 includes a new method, <xref:System.Web.HttpCookie.TryParse%2A?displayProperty=nameWithType>, that provides a standardized way to create an <xref:System.Web.HttpCookie> object from a string and accurately assign cookie values such as expiration date and path. For more information, see "ASP.NET HttpCookie parsing" in the [.NET Framework 4.7.1 ASP.NET and Configuration Features](https://devblogs.microsoft.com/dotnet/net-framework-4-7-1-asp-net-and-configuration-features/) blog post.
 
-**SHA-2 hash options for ASP.NET forms authentication credentials**
-
-In .NET Framework 4.7 and earlier versions, ASP.NET allowed developers to store user credentials with hashed passwords in configuration files using either MD5 or SHA1. Starting with .NET Framework 4.7.1, ASP.NET also supports new secure SHA-2 hash options such as SHA256, SHA384, and SHA512. SHA1 remains the default, and a non-default hash algorithm can be defined in the web configuration file. For example:
-
-```xml
-<system.web>
-    <authentication mode="Forms">
-        <forms loginUrl="~/login.aspx">
-          <credentials passwordFormat="SHA512">
-            <user name="jdoe" password="6D003E98EA1C7F04ABF8FCB375388907B7F3EE06F278DB966BE960E7CBBD103DF30CA6D61F7E7FD981B2E4E3A64D43C836A4BEDCA165C33B163E6BCDC538A664" />
-          </credentials>
-        </forms>
-    </authentication>
-</system.web>
-```
-
-[!INCLUDE [managed-identities](../includes/managed-identities.md)]
-
 ## What's new in .NET Framework 4.7
 
 .NET Framework 4.7 includes new features in the following areas:

--- a/docs/framework/whats-new/index.md
+++ b/docs/framework/whats-new/index.md
@@ -667,12 +667,6 @@ Configuration builders allow developers to inject and build configuration settin
 
 To create a custom configuration builder, you derive your builder from the abstract <xref:System.Configuration.ConfigurationBuilder> class and override its <xref:System.Configuration.ConfigurationBuilder.ProcessConfigurationSection%2A?displayProperty=nameWithType> and <xref:System.Configuration.ConfigurationBuilder.ProcessRawXml%2A?displayProperty=nameWithType>. You also define your builders in your .config file. For more information, see the "Configuration Builders" section in the [.NET Framework 4.7.1 ASP.NET and Configuration Features](https://devblogs.microsoft.com/dotnet/net-framework-4-7-1-asp-net-and-configuration-features/) blog post.
 
-**SHA-2 hash options for ASP.NET forms authentication credentials**
-
-In .NET Framework 4.7 and earlier versions, ASP.NET allowed developers to store user credentials with hashed passwords in configuration files using either MD5 or SHA1. Starting with .NET Framework 4.7.1, ASP.NET also supports new secure SHA-2 hash options such as SHA256, SHA384, and SHA512. SHA1 remains the default, and a non-default hash algorithm can be defined in the web configuration file. For example:
-
-[!INCLUDE [managed-identities](../includes/managed-identities.md)]
-
 **Run-time feature detection**
 
 The <xref:System.Runtime.CompilerServices.RuntimeFeature?displayProperty=nameWithType> class provides a mechanism for determine whether a predefined feature is supported on a given .NET implementation at compile time or run time. At compile time, a compiler can check whether a specified field exists to determine whether the feature is supported; if so, it can emit code that takes advantage of that feature. At run time, an application can call the <xref:System.Runtime.CompilerServices.RuntimeFeature.IsSupported%2A?displayProperty=nameWithType> method before emitting code at run time. For more information, see [Add helper method to describe features supported by the runtime](https://github.com/dotnet/corefx/issues/17116).
@@ -712,6 +706,12 @@ ASP.NET processes requests in a predefined pipeline that includes 23 events. ASP
 **ASP.NET HttpCookie parsing**
 
 .NET Framework 4.7.1 includes a new method, <xref:System.Web.HttpCookie.TryParse%2A?displayProperty=nameWithType>, that provides a standardized way to create an <xref:System.Web.HttpCookie> object from a string and accurately assign cookie values such as expiration date and path. For more information, see "ASP.NET HttpCookie parsing" in the [.NET Framework 4.7.1 ASP.NET and Configuration Features](https://devblogs.microsoft.com/dotnet/net-framework-4-7-1-asp-net-and-configuration-features/) blog post.
+
+**SHA-2 hash options for ASP.NET forms authentication credentials**
+
+In .NET Framework 4.7 and earlier versions, ASP.NET allowed developers to store user credentials with hashed passwords in configuration files using either MD5 or SHA1. Starting with .NET Framework 4.7.1, ASP.NET also supports new secure SHA-2 hash options such as SHA256, SHA384, and SHA512. SHA1 remains the default, and a non-default hash algorithm can be defined in the web configuration file.
+
+[!INCLUDE [managed-identities](../includes/managed-identities.md)]
 
 ## What's new in .NET Framework 4.7
 

--- a/docs/framework/whats-new/index.md
+++ b/docs/framework/whats-new/index.md
@@ -667,6 +667,12 @@ Configuration builders allow developers to inject and build configuration settin
 
 To create a custom configuration builder, you derive your builder from the abstract <xref:System.Configuration.ConfigurationBuilder> class and override its <xref:System.Configuration.ConfigurationBuilder.ProcessConfigurationSection%2A?displayProperty=nameWithType> and <xref:System.Configuration.ConfigurationBuilder.ProcessRawXml%2A?displayProperty=nameWithType>. You also define your builders in your .config file. For more information, see the "Configuration Builders" section in the [.NET Framework 4.7.1 ASP.NET and Configuration Features](https://devblogs.microsoft.com/dotnet/net-framework-4-7-1-asp-net-and-configuration-features/) blog post.
 
+**SHA-2 hash options for ASP.NET forms authentication credentials**
+
+In .NET Framework 4.7 and earlier versions, ASP.NET allowed developers to store user credentials with hashed passwords in configuration files using either MD5 or SHA1. Starting with .NET Framework 4.7.1, ASP.NET also supports new secure SHA-2 hash options such as SHA256, SHA384, and SHA512. SHA1 remains the default, and a non-default hash algorithm can be defined in the web configuration file. For example:
+
+[!INCLUDE [managed-identities](../includes/managed-identities.md)]
+
 **Run-time feature detection**
 
 The <xref:System.Runtime.CompilerServices.RuntimeFeature?displayProperty=nameWithType> class provides a mechanism for determine whether a predefined feature is supported on a given .NET implementation at compile time or run time. At compile time, a compiler can check whether a specified field exists to determine whether the feature is supported; if so, it can emit code that takes advantage of that feature. At run time, an application can call the <xref:System.Runtime.CompilerServices.RuntimeFeature.IsSupported%2A?displayProperty=nameWithType> method before emitting code at run time. For more information, see [Add helper method to describe features supported by the runtime](https://github.com/dotnet/corefx/issues/17116).


### PR DESCRIPTION
Per CoPilot:
Storing passwords in a web config file using SHA-2 hash options like SHA256, SHA384, and SHA512 is not considered a security best practice. While SHA-2 is a strong cryptographic hash function, it is not designed specifically for password storage. Instead, it is better suited for data integrity and digital signatures.

## Summary

***Why show them something that's insecure***

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/whats-new/index.md](https://github.com/dotnet/docs/blob/d1be6883d423fe503c67ab6a24b45203b82b4b90/docs/framework/whats-new/index.md) | [docs/framework/whats-new/index](https://review.learn.microsoft.com/en-us/dotnet/framework/whats-new/index?branch=pr-en-us-42469) |


<!-- PREVIEW-TABLE-END -->