### PR TITLE
Fix typo in trim-self-contained

### DIFF
--- a/docs/core/deploying/trimming/trim-self-contained.md
+++ b/docs/core/deploying/trimming/trim-self-contained.md
@@ -1,6 +1,6 @@
 ---
 title: Trim self-contained applications
-description: Learn how to trim self-contained apps to reduce their size. .NET Core bundles the runtime with an app that is published self-contained and generally includes more of the runtime then is necessary.
+description: Learn how to trim self-contained apps to reduce their size. .NET Core bundles the runtime with an app that is published self-contained and generally includes more of the runtime than is necessary.
 author: jamshedd
 ms.author: jamshedd
 ms.date: 04/03/2020


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/deploying/trimming/trim-self-contained.md](https://github.com/dotnet/docs/blob/27d0979ceaf1f85d427b1ccef8840093cf8dcb73/docs/core/deploying/trimming/trim-self-contained.md) | [docs/core/deploying/trimming/trim-self-contained](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-self-contained?branch=pr-en-us-42488) |

<!-- PREVIEW-TABLE-END -->