### PR TITLE
Update testing platform documentation

### DIFF
--- a/docs/core/testing/unit-testing-platform-extensions-vstest-bridge.md
+++ b/docs/core/testing/unit-testing-platform-extensions-vstest-bridge.md
@@ -10,9 +10,6 @@ ms.date: 04/10/2024
 
 This extension provides a compatibility layer with VSTest allowing the test frameworks depending on it to continue supporting running in VSTest mode (`vstest.console.exe`, usual `dotnet test`, `VSTest task` on AzDo, Test Explorers of Visual Studio and Visual Studio Code...). This extension is shipped as part of [Microsoft.Testing.Extensions.VSTestBridge](https://www.nuget.org/packages/Microsoft.Testing.Extensions.VSTestBridge) package.
 
-> [!IMPORTANT]
-> The package is shipped with Microsoft .NET library closed-source free to use licensing model.
-
 ## Compatibility with VSTest
 
 The main purpose of this extension is to offer an easy and smooth upgrade experience for VSTest users by allowing a dual mode where the new platform is enabled and in parallel a compatibility mode is offered to allow the usual workflows to continue working.

--- a/docs/core/testing/unit-testing-platform-intro.md
+++ b/docs/core/testing/unit-testing-platform-intro.md
@@ -17,6 +17,7 @@ Microsoft.Testing.Platform is a lightweight and portable alternative to [VSTest]
 * MSTest. In MSTest, the support of `Microsoft.Testing.Platform` is done via [MSTest runner](unit-testing-mstest-runner-intro.md).
 * NUnit. In NUnit, the support of `Microsoft.Testing.Platform` is done via [NUnit runner](unit-testing-nunit-runner-intro.md).
 * xUnit: work in progress, for more information, see [Microsoft Testing Platform for xUnit](https://github.com/xunit/visualstudio.xunit/issues/402).
+* TUnit: entirely constructed on top of the `Microsoft.Testing.Platform`, for more information, see [TUnit documentation](https://thomhurst.github.io/TUnit/)
 
 ## Run and debug tests
 

--- a/docs/core/testing/unit-testing-platform-vs-vstest.md
+++ b/docs/core/testing/unit-testing-platform-vs-vstest.md
@@ -36,10 +36,10 @@ VSTest is extensible and common types are placed in [Microsoft.TestPlatform.Obje
 
 Microsoft.Testing.Platform is based on [Microsoft.Testing.Platform](https://www.nuget.org/packages/Microsoft.Testing.Platform) NuGet package and other libraries in the `Microsoft.Testing.*` namespace. Like VSTest, the `Microsoft.Testing.Platform` is open-source and has a [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Platform) GitHub repository.
 
-## Communication protocol
+## Communication protocol (preview)
 
 > [!NOTE]
-> The Visual Studio Test Explorer supports the Microsoft.Testing.Platform protocol from version 17.10 onward. If you run/debug your tests using earlier versions of Visual Studio, Test Explorer will use `vstest.console.exe` and the old protocol to run these tests.
+> The Visual Studio Test Explorer supports the Microsoft.Testing.Platform protocol in the **preview** versions since 17.10 onward. If you run/debug your tests using earlier versions of Visual Studio, Test Explorer will use `vstest.console.exe` and the old protocol to run these tests.
 
 Microsoft.Testing.Platform uses a JSON-RPC based protocol to communicate between Visual Studio and the test runner process. The protocol is documented in the [MSTest GitHub repository](https://github.com/microsoft/testfx/tree/main/docs/mstest-runner-protocol).
 


### PR DESCRIPTION
This pull request includes several documentation updates to improve clarity and add new information about testing platforms. The most important changes include the removal of a licensing note, the addition of a new supported testing framework, and updates to the communication protocol section.

### Documentation Updates:

* [`docs/core/testing/unit-testing-platform-extensions-vstest-bridge.md`](diffhunk://#diff-ef6a25872537e53d8a9f9fd9b07c99123e26a5f09542be79d10a9f113afabb9aL13-L15): Removed the note about the licensing model for the `Microsoft.Testing.Extensions.VSTestBridge` package.
* [`docs/core/testing/unit-testing-platform-intro.md`](diffhunk://#diff-cebcb8fad917430e33a5b650a92e1219c1b759d702b27462e0bc2998c94a90b9R20): Added `TUnit` as a new testing framework supported by `Microsoft.Testing.Platform`.
* [`docs/core/testing/unit-testing-platform-vs-vstest.md`](diffhunk://#diff-9c59a3dad0ea17591701d1383366268a5c1ff0dc61cf049b8918c4cb85551d5dL39-R42): Updated the communication protocol section to specify that the `Microsoft.Testing.Platform` protocol is supported in preview versions of Visual Studio Test Explorer from version 17.10 onward.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-platform-extensions-vstest-bridge.md](https://github.com/dotnet/docs/blob/5a3b5f59356e0267b06223960b445ee401a52179/docs/core/testing/unit-testing-platform-extensions-vstest-bridge.md) | [docs/core/testing/unit-testing-platform-extensions-vstest-bridge](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-platform-extensions-vstest-bridge?branch=pr-en-us-42490) |
| [docs/core/testing/unit-testing-platform-intro.md](https://github.com/dotnet/docs/blob/5a3b5f59356e0267b06223960b445ee401a52179/docs/core/testing/unit-testing-platform-intro.md) | [docs/core/testing/unit-testing-platform-intro](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-platform-intro?branch=pr-en-us-42490) |
| [docs/core/testing/unit-testing-platform-vs-vstest.md](https://github.com/dotnet/docs/blob/5a3b5f59356e0267b06223960b445ee401a52179/docs/core/testing/unit-testing-platform-vs-vstest.md) | [docs/core/testing/unit-testing-platform-vs-vstest](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-platform-vs-vstest?branch=pr-en-us-42490) |

<!-- PREVIEW-TABLE-END -->