### PR TITLE
Update event.md - the description is hard to understand

### DIFF
--- a/docs/csharp/language-reference/keywords/event.md
+++ b/docs/csharp/language-reference/keywords/event.md
@@ -13,7 +13,9 @@ ms.assetid: 7858fd85-153b-4259-85d0-6aa13c35f174
 ---
 # event (C# reference)
 
-The `event` keyword is used to declare an event in a publisher class.
+The `event` keyword changes the regular variable into an event variable. Referring to the language semantics the variable must be of a delegate type (it is a set of pointers to methods compliant with a predefined signature). The "event" keyword changes the visibility of selected operations we can execute against the event variable despite the access modifier of the variable. For example, we cannot invoke pointed methods outside the class where the event variable is declared even if the variable is public. Hence, this class is called publisher. All these operations are only private. In other words, the "event" keyword is an access modifier replacement for selected operations of the delegate type.
+
+The level of abstraction means that we don't know the methods, we only know that all are compliant with the predefined signature. Consequently, signaling an event means that we are calling methods pointed by the set held by the event variable. The event variable may be used in the methods invocation statement and expressions like a regular method.
 
 ## Example
 

--- a/docs/csharp/language-reference/keywords/event.md
+++ b/docs/csharp/language-reference/keywords/event.md
@@ -13,9 +13,7 @@ ms.assetid: 7858fd85-153b-4259-85d0-6aa13c35f174
 ---
 # event (C# reference)
 
-The `event` keyword changes the regular variable into an event variable. Referring to the language semantics the variable must be of a delegate type (it is a set of pointers to methods compliant with a predefined signature). The "event" keyword changes the visibility of selected operations we can execute against the event variable despite the access modifier of the variable. For example, we cannot invoke pointed methods outside the class where the event variable is declared even if the variable is public. Hence, this class is called publisher. All these operations are only private. In other words, the "event" keyword is an access modifier replacement for selected operations of the delegate type.
-
-The level of abstraction means that we don't know the methods, we only know that all are compliant with the predefined signature. Consequently, signaling an event means that we are calling methods pointed by the set held by the event variable. The event variable may be used in the methods invocation statement and expressions like a regular method.
+An ***event*** is a member that enables an object or class to provide notifications. Clients can attach executable code for events by supplying ***event handlers***. The `event` keyword declares an ***event***. An instance of an event is a delegate type. An object raises the event by invoking event handlers. Event handlers are delegate instances added to the event instance. Clients can add or remove their event handlers from an event.
 
 ## Example
 


### PR DESCRIPTION
The description is hard to understand. It uses circular references to the word event and refers to an undefined term, namely `pub;lisher class".

## Summary

Describe your changes here.

I propose a new description of the `event` keyword without referring to the meaningless event word.
The `publisher class` must be defined as a placeholder of the event variable but must not be defined referring to the event term.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/event.md](https://github.com/dotnet/docs/blob/7082df02d7368e9710b47118180e99fad0af4dc9/docs/csharp/language-reference/keywords/event.md) | [docs/csharp/language-reference/keywords/event](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/event?branch=pr-en-us-42509) |


<!-- PREVIEW-TABLE-END -->