### PR TITLE
Make it more clear that a positional pattern relies on `Deconstruct`

### DIFF
--- a/docs/csharp/language-reference/operators/patterns.md
+++ b/docs/csharp/language-reference/operators/patterns.md
@@ -198,7 +198,6 @@ You use a *positional pattern* to deconstruct an expression result and match the
 At the preceding example, the type of an expression contains the [Deconstruct](../../fundamentals/functional/deconstruct.md) method, which is used to deconstruct an expression result.
 
 >[!IMPORTANT]
->
 > The order of members in a positional pattern must match the order of parameters in the `Deconstruct` method. That's because the code generated for the positional pattern calls the `Deconstruct` method.
 
 You can also match expressions of [tuple types](../builtin-types/value-tuples.md) against positional patterns. In that way, you can match multiple inputs against various patterns, as the following example shows:

--- a/docs/csharp/language-reference/operators/patterns.md
+++ b/docs/csharp/language-reference/operators/patterns.md
@@ -195,7 +195,13 @@ You use a *positional pattern* to deconstruct an expression result and match the
 
 :::code language="csharp" source="snippets/patterns/PositionalPattern.cs" id="BasicExample":::
 
-At the preceding example, the type of an expression contains the [Deconstruct](../../fundamentals/functional/deconstruct.md) method, which is used to deconstruct an expression result. You can also match expressions of [tuple types](../builtin-types/value-tuples.md) against positional patterns. In that way, you can match multiple inputs against various patterns, as the following example shows:
+At the preceding example, the type of an expression contains the [Deconstruct](../../fundamentals/functional/deconstruct.md) method, which is used to deconstruct an expression result.
+
+>[!IMPORTANT]
+>
+> The order of members in a positional pattern must match the order of parameters in the `Deconstruct` method. That's because the code generated for the positional pattern calls the `Deconstruct` method.
+
+You can also match expressions of [tuple types](../builtin-types/value-tuples.md) against positional patterns. In that way, you can match multiple inputs against various patterns, as the following example shows:
 
 :::code language="csharp" source="snippets/patterns/PositionalPattern.cs" id="MatchTuple":::
 


### PR DESCRIPTION
 Fixes #42307


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/patterns.md](https://github.com/dotnet/docs/blob/9e7c1ef71f716f86c58f3898a9f6f3ae3c2f433f/docs/csharp/language-reference/operators/patterns.md) | [docs/csharp/language-reference/operators/patterns](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/patterns?branch=pr-en-us-42514) |


<!-- PREVIEW-TABLE-END -->