### PR TITLE
Update System.IO.Pipelines title

### DIFF
--- a/docs/standard/io/pipelines.md
+++ b/docs/standard/io/pipelines.md
@@ -1,5 +1,5 @@
 ---
-title: I/O pipelines - .NET
+title: System.IO.Pipelines - .NET
 description: Learn how to efficiently use I/O pipelines in .NET and avoid problems in your code.
 ms.date: 05/09/2022
 helpviewer_keywords:


### PR DESCRIPTION
I was surprised that the search link to the System.IO.Pipelines doc was "I/O Pipelines". While, they are I/O related, we don't call it that anywhere else. The best title is the namespace.

![image](https://github.com/user-attachments/assets/5ae0ae29-e6e4-4297-be48-6ed75d2be636)



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/io/pipelines.md](https://github.com/dotnet/docs/blob/60765edc3f89a625657ad528b09f4d94b400cf54/docs/standard/io/pipelines.md) | [docs/standard/io/pipelines](https://review.learn.microsoft.com/en-us/dotnet/standard/io/pipelines?branch=pr-en-us-42556) |

<!-- PREVIEW-TABLE-END -->