### PR TITLE
#42112 Updated yield.md

### DIFF
--- a/docs/csharp/language-reference/statements/yield.md
+++ b/docs/csharp/language-reference/statements/yield.md
@@ -38,6 +38,7 @@ You can't use the `yield` statements in:
 - methods with [in](../keywords/method-parameters.md#in-parameter-modifier), [ref](../keywords/ref.md), or [out](../keywords/method-parameters.md#out-parameter-modifier) parameters
 - [lambda expressions](../operators/lambda-expressions.md) and [anonymous methods](../operators/delegate-operator.md)
 - [unsafe blocks](../keywords/unsafe.md). Before C# 13, `yield` was invalid in any method with an `unsafe` block. Beginning with C# 13, you can use `yield` in methods with `unsafe` blocks, but not in the `unsafe` block.
+- `yield return` and `yield break` can not be used in [try](../statements/exception-handling-statements.md), [catch](../statements/exception-handling-statements.md) and [finally](../statements/exception-handling-statements.md) blocks.
 
 ## Execution of an iterator
 


### PR DESCRIPTION
#42112 updated yield.md document to mention its not allowed inside try, catch and finally blocks

https://github.com/dotnet/docs/issues/42112

Fixes #42112 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/statements/yield.md](https://github.com/dotnet/docs/blob/493d53928951a5fc41fae1e44f58774832621ce5/docs/csharp/language-reference/statements/yield.md) | [docs/csharp/language-reference/statements/yield](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/statements/yield?branch=pr-en-us-42560) |

<!-- PREVIEW-TABLE-END -->