### PR TITLE
Update: the usage instructions for parameter <ConsiderFixturesAsSpecialTests>

### DIFF
--- a/docs/core/testing/unit-testing-mstest-configure.md
+++ b/docs/core/testing/unit-testing-mstest-configure.md
@@ -43,7 +43,7 @@ The following runsettings entries let you configure how MSTest behaves.
 |**TestTimeout**|0|Gets specified global test case timeout.|
 |**TreatClassAndAssemblyCleanupWarningsAsErrors**|false|To see your failures in class cleanups as errors, set this value to **true**.|
 |**TreatDiscoveryWarningsAsErrors**|false|To report test discovery warnings as errors, set this value to **true**.|
-|**ConsiderFixturesAsSpecialTests**|false|To display `AssemblyInitialize`, `AssemblyCleanup`, `ClassInitialize`, `ClassCleanup` as individual entries in Visual Studio and Visual Studio Code `Test Explorer` and `.trx` log, set this value to **true**|
+|**ConsiderFixturesAsSpecialTests**|false|To display `AssemblyInitialize`, `AssemblyCleanup`, `ClassInitialize`, `ClassCleanup` as individual entries in Visual Studio and Visual Studio Code `Test Explorer` and _.trx_ log, set this value to **true**|
 
 ### `TestRunParameter` element
 

--- a/docs/core/testing/unit-testing-mstest-configure.md
+++ b/docs/core/testing/unit-testing-mstest-configure.md
@@ -43,7 +43,7 @@ The following runsettings entries let you configure how MSTest behaves.
 |**TestTimeout**|0|Gets specified global test case timeout.|
 |**TreatClassAndAssemblyCleanupWarningsAsErrors**|false|To see your failures in class cleanups as errors, set this value to **true**.|
 |**TreatDiscoveryWarningsAsErrors**|false|To report test discovery warnings as errors, set this value to **true**.|
-|**ConsiderFixturesAsSpecialTests**|false|To display `AssemblyInitialize`, `AssemblyCleanup`, `ClassInitialize`, `ClassCleanup` as individual entries in Visual Studio `Test Explorer` and `.trx` log, set this value to **true**|
+|**ConsiderFixturesAsSpecialTests**|false|To display `AssemblyInitialize`, `AssemblyCleanup`, `ClassInitialize`, `ClassCleanup` as individual entries in Visual Studio and Visual Studio Code `Test Explorer` and `.trx` log, set this value to **true**|
 
 ### `TestRunParameter` element
 

--- a/docs/core/testing/unit-testing-mstest-configure.md
+++ b/docs/core/testing/unit-testing-mstest-configure.md
@@ -43,6 +43,7 @@ The following runsettings entries let you configure how MSTest behaves.
 |**TestTimeout**|0|Gets specified global test case timeout.|
 |**TreatClassAndAssemblyCleanupWarningsAsErrors**|false|To see your failures in class cleanups as errors, set this value to **true**.|
 |**TreatDiscoveryWarningsAsErrors**|false|To report test discovery warnings as errors, set this value to **true**.|
+|**ConsiderFixturesAsSpecialTests**|false|To display `AssemblyInitialize`, `AssemblyCleanup`, `ClassInitialize`, `ClassCleanup` as individual entries in Visual Studio `Test Explorer` and `.trx` log, set this value to **true**|
 
 ### `TestRunParameter` element
 
@@ -90,6 +91,7 @@ Each element of the file is optional because it has a default value.
     <CaptureTraceOutput>false</CaptureTraceOutput>
     <DeleteDeploymentDirectoryAfterTestRunIsComplete>False</DeleteDeploymentDirectoryAfterTestRunIsComplete>
     <DeploymentEnabled>False</DeploymentEnabled>
+    <ConsiderFixturesAsSpecialTests>False</ConsiderFixturesAsSpecialTests>
     <AssemblyResolution>
       <Directory path="D:\myfolder\bin\" includeSubDirectories="false"/>
     </AssemblyResolution>


### PR DESCRIPTION
## Summary

### Describe your changes here.
Hi @Evangelink @IEvangelist

Add `ConsiderFixturesAsSpecialTests` usage based on discussion: https://github.com/microsoft/testfx/issues/3785

### Fixes #Issue_Number (if available)
No issue number.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-mstest-configure.md](https://github.com/dotnet/docs/blob/44ac49da33574dc5a1b70bbeeb65ac6123525987/docs/core/testing/unit-testing-mstest-configure.md) | [docs/core/testing/unit-testing-mstest-configure](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-configure?branch=pr-en-us-42567) |


<!-- PREVIEW-TABLE-END -->