### PR TITLE
fix - Fixed grammatical mistakes in the MSTEST0035 doc

### DIFF
--- a/docs/core/testing/mstest-analyzers/mstest0035.md
+++ b/docs/core/testing/mstest-analyzers/mstest0035.md
@@ -30,7 +30,7 @@ This rule raises a diagnostic when `[DeploymentItem]` isn't set on test class or
 
 ## Rule description
 
-With using  `[DeploymentItem]`, without putting it on test class or test method itwill be ignored.
+By using  `[DeploymentItem]` without putting it on test class or test method, it will be ignored.
 
 ## How to fix violations
 


### PR DESCRIPTION
## Summary

This commit fixes some of the grammatical and typing mistakes found when reading the `MSTEST0035` MSTest analyzer documentation.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/mstest-analyzers/mstest0035.md](https://github.com/dotnet/docs/blob/0e51b382b7fb10c8608ebc242a22642318901799/docs/core/testing/mstest-analyzers/mstest0035.md) | [docs/core/testing/mstest-analyzers/mstest0035](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0035?branch=pr-en-us-42570) |

<!-- PREVIEW-TABLE-END -->