### PR TITLE
Remove a link

### DIFF
--- a/docs/csharp/language-reference/keywords/abstract.md
+++ b/docs/csharp/language-reference/keywords/abstract.md
@@ -81,7 +81,6 @@ You will get an error saying that the compiler cannot create an instance of the 
   
 ## See also
 
-- [Modifiers](index.md)
 - [virtual](./virtual.md)
 - [override](./override.md)
 - [C# Keywords](./index.md)


### PR DESCRIPTION
Fixes internal feedback.

This link isn't useful. It's already in the TOC, and doesn't take the reader to any useful additional information.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/abstract.md](https://github.com/dotnet/docs/blob/aab01f360028560f0c5c83f4ddbb87f4399ff76e/docs/csharp/language-reference/keywords/abstract.md) | [docs/csharp/language-reference/keywords/abstract](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/abstract?branch=pr-en-us-42577) |

<!-- PREVIEW-TABLE-END -->