### PR TITLE
Corrected the generic host configuration sample based on feedback.

### DIFF
--- a/docs/core/extensions/generic-host.md
+++ b/docs/core/extensions/generic-host.md
@@ -196,7 +196,7 @@ Host configuration is used to configure properties of the [IHostEnvironment](#ih
 
 # [IHostApplicationBuilder](#tab/appbuilder)
 
-The host configuration is available in <xref:Microsoft.Extensions.Hosting.IHostApplicationBuilder.Configuration?displayProperty=nameWithType> property and the environment implementation is available in <xref:Microsoft.Extensions.Hosting.IHostApplicationBuilder.Environment?displayProperty=nameWithType> property. To configure the host, access the `Configuration` property and call any of the available extension methods.
+The host configuration is available in <xref:Microsoft.Extensions.Hosting.HostApplicationBuilderSettings.Configuration?displayProperty=nameWithType> property and the environment implementation is available in <xref:Microsoft.Extensions.Hosting.IHostApplicationBuilder.Environment?displayProperty=nameWithType> property. To configure the host, access the `Configuration` property and call any of the available extension methods.
 
 To add host configuration, consider the following example:
 

--- a/docs/core/extensions/generic-host.md
+++ b/docs/core/extensions/generic-host.md
@@ -3,7 +3,7 @@ title: .NET Generic Host
 author: IEvangelist
 description: Learn about the .NET Generic Host, which is responsible for app startup and lifetime management.
 ms.author: dapine
-ms.date: 05/22/2024
+ms.date: 09/11/2024
 ---
 
 # .NET Generic Host
@@ -200,7 +200,7 @@ The host configuration is available in <xref:Microsoft.Extensions.Hosting.HostAp
 
 To add host configuration, consider the following example:
 
-:::code language="csharp" source="snippets/configuration/console-host/Program.cs" highlight="6-9":::
+:::code language="csharp" source="snippets/configuration/console-host/Program.cs" highlight="6-8":::
 
 The preceding code:
 

--- a/docs/core/extensions/snippets/configuration/console-host/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-host/Program.cs
@@ -1,12 +1,18 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
-HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
+HostApplicationBuilderSettings settings = new HostApplicationBuilderSettings()
+{
+    Args = args,
+    Configuration = new ConfigurationManager(),
+    ContentRootPath = Directory.GetCurrentDirectory(),
+};
 
-builder.Environment.ContentRootPath = Directory.GetCurrentDirectory();
-builder.Configuration.AddJsonFile("hostsettings.json", optional: true);
-builder.Configuration.AddEnvironmentVariables(prefix: "PREFIX_");
-builder.Configuration.AddCommandLine(args);
+settings.Configuration.AddJsonFile("hostsettings.json", optional: true);
+settings.Configuration.AddEnvironmentVariables(prefix: "PREFIX_");
+settings.Configuration.AddCommandLine(args);
+
+HostApplicationBuilder builder = Host.CreateApplicationBuilder(settings);
 
 using IHost host = builder.Build();
 

--- a/docs/core/extensions/snippets/configuration/console-host/Program.cs
+++ b/docs/core/extensions/snippets/configuration/console-host/Program.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
-HostApplicationBuilderSettings settings = new HostApplicationBuilderSettings()
+HostApplicationBuilderSettings settings = new()
 {
     Args = args,
     Configuration = new ConfigurationManager(),


### PR DESCRIPTION
## Summary

The sample for applying host configuration was wrong. The configuration needs to be applied to the `HostApplicationBuilderSettings` instead of the `HostApplicationBuilder`.

Fixes dotnet/runtime#97930


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/generic-host.md](https://github.com/dotnet/docs/blob/36b093c637747c63de97379d46c0a3411935e839/docs/core/extensions/generic-host.md) | [docs/core/extensions/generic-host](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/generic-host?branch=pr-en-us-42582) |


<!-- PREVIEW-TABLE-END -->