### PR TITLE
Update linux-scripted-manual with latest info

### DIFF
--- a/docs/core/install/linux-scripted-manual.md
+++ b/docs/core/install/linux-scripted-manual.md
@@ -21,9 +21,10 @@ The following table lists the support status of each version of .NET (and .NET C
 
 | ✔️ Supported | ❌ Unsupported |
 |-------------|---------------|
-| 8 (LTS)     | 5             |
-| 7 (STS)     | 3.1           |
-| 6 (LTS)     | 3.0           |
+| 8 (LTS)     | 7             |
+| 6 (LTS)     | 5             |
+|             | 3.1           |
+|             | 3.0           |
 |             | 2.2           |
 |             | 2.1           |
 |             | 2.0           |
@@ -51,8 +52,6 @@ If your distribution wasn't previously listed, and is RPM-based, you may need th
 - libicu
 - openssl-libs
 
-If the target runtime environment's OpenSSL version is 1.1 or newer, install `compat-openssl10`.
-
 ### DEB dependencies
 
 If your distribution wasn't previously listed, and is debian-based, you may need the following dependencies:
@@ -60,8 +59,8 @@ If your distribution wasn't previously listed, and is debian-based, you may need
 - libc6
 - libgcc1
 - libgssapi-krb5-2
-- libicu67
-- libssl1.1
+- libicu70
+- libssl3
 - libstdc++6
 - zlib1g
 


### PR DESCRIPTION
## Summary

This fixes a couple of minor issues on the `linux-scripted-manual` page.

1. Move 7.0 out of the "Supported" column and in to the "Unsupported" column.
2. Fix dependencies for a few different distributions.
    1. RPM-based does not need an OpenSSL 1.0 compatibility package.
    2. Debian was recommending installing OpenSSL 1.1, which is no longer supported. Since all supported versions of .NET support OpenSSL 3, recommend OpenSSL 3.
    3. libicu67 is not present on latest distributions like Ubuntu Jammy. libicu70 is.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/linux-scripted-manual.md](https://github.com/dotnet/docs/blob/ef05f8fa76c3a8b4ba1b3bc48f75d583d1372856/docs/core/install/linux-scripted-manual.md) | [docs/core/install/linux-scripted-manual](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-scripted-manual?branch=pr-en-us-42595) |

<!-- PREVIEW-TABLE-END -->