### PR TITLE
Replace general 'allmost all' with more specific sentence about omitting `finally` block

### DIFF
--- a/docs/csharp/language-reference/statements/exception-handling-statements.md
+++ b/docs/csharp/language-reference/statements/exception-handling-statements.md
@@ -120,7 +120,7 @@ You can also use the `finally` block to clean up allocated resources used in the
 > [!NOTE]
 > When the type of a resource implements the <xref:System.IDisposable> or <xref:System.IAsyncDisposable> interface, consider the [`using` statement](using.md). The `using` statement ensures that acquired resources are disposed when control leaves the `using` statement. The compiler transforms a `using` statement into a `try-finally` statement.
 
-In almost all cases `finally` blocks are executed. The only cases where `finally` blocks aren't executed involve immediate termination of a program. For example, such a termination might happen because of the <xref:System.Environment.FailFast%2A?displayProperty=nameWithType> call or an <xref:System.OverflowException> or <xref:System.InvalidProgramException> exception. Most operating systems perform a reasonable resource clean-up as part of stopping and unloading the process.
+Execution of the `finally` block depends on whether the operating system chooses to trigger an exception unwind operation. The only cases where `finally` blocks aren't executed involve immediate termination of a program. For example, such a termination might happen because of the <xref:System.Environment.FailFast%2A?displayProperty=nameWithType> call or an <xref:System.OverflowException> or <xref:System.InvalidProgramException> exception. Most operating systems perform a reasonable resource clean-up as part of stopping and unloading the process.
 
 ### The `try-catch-finally` statement
 


### PR DESCRIPTION
This pull request closes #42565 
The very general sentence that issue's author reports is now replaced with the exact sentence from referenced article, where, indeed, this is better explained and can act as a good intro sentence to that paragraph.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/statements/exception-handling-statements.md](https://github.com/dotnet/docs/blob/de59ade762093f4ce5f593c369c981e042308f98/docs/csharp/language-reference/statements/exception-handling-statements.md) | [docs/csharp/language-reference/statements/exception-handling-statements](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/statements/exception-handling-statements?branch=pr-en-us-42597) |

<!-- PREVIEW-TABLE-END -->