### PR TITLE
Fix typo in keyboard shortcut formatting

### DIFF
--- a/docs/visual-basic/programming-guide/language-features/early-late-binding/walkthrough-creating-and-using-dynamic-objects.md
+++ b/docs/visual-basic/programming-guide/language-features/early-late-binding/walkthrough-creating-and-using-dynamic-objects.md
@@ -119,7 +119,7 @@ The first walkthrough defines a custom dynamic object that searches the contents
 
      [!code-vb[VbDynamicWalkthrough#8](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/vbdynamicwalkthrough/vb/Program.vb#8)]
 
-3. Save the file and press <kbd>Ctrl</kdb>+<kbd>F5</kbd> to build and run the application.
+3. Save the file and press <kbd>Ctrl</kbd>+<kbd>F5</kbd> to build and run the application.
 
 ## Call a dynamic language library
 
@@ -153,7 +153,7 @@ The following walkthrough creates a project that accesses a library that is writ
 
      [!code-vb[VbDynamicWalkthroughIronPython#3](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/vbdynamicwalkthroughironpython/vb/Program.vb#3)]
 
-1. Save the file and press <kbd>Ctrl</kdb>+<kbd>F5</kbd> to build and run the application.
+1. Save the file and press <kbd>Ctrl</kbd>+<kbd>F5</kbd> to build and run the application.
 
 ## See also
 


### PR DESCRIPTION
Corrected the keyboard shortcut formatting from `<kbd>Ctrl</kdb>+<kbd>F5</kbd>` to `<kbd>Ctrl</kbd>+<kbd>F5</kbd>` to fix a typo in the HTML rendering of the shortcuts.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/visual-basic/programming-guide/language-features/early-late-binding/walkthrough-creating-and-using-dynamic-objects.md](https://github.com/dotnet/docs/blob/4e632545725c257112bfae1d2c46d89febbfae5a/docs/visual-basic/programming-guide/language-features/early-late-binding/walkthrough-creating-and-using-dynamic-objects.md) | [docs/visual-basic/programming-guide/language-features/early-late-binding/walkthrough-creating-and-using-dynamic-objects](https://review.learn.microsoft.com/en-us/dotnet/visual-basic/programming-guide/language-features/early-late-binding/walkthrough-creating-and-using-dynamic-objects?branch=pr-en-us-42603) |

<!-- PREVIEW-TABLE-END -->