### PR TITLE
Fix: Correct Markdown Formatting for File Name in Dependency Injection Basics Doc

### DIFF
--- a/docs/core/extensions/dependency-injection-basics.md
+++ b/docs/core/extensions/dependency-injection-basics.md
@@ -61,7 +61,7 @@ Next, create an _IGreetingService.cs_ file and add the following C# code:
 
 :::code source="snippets/di/di-basics/IGreetingService.cs":::
 
-Then add a new C# file named DefaultGreetingService.cs_ and add the following code:
+Then add a new C# file named _DefaultGreetingService.cs_ and add the following code:
 
 :::code source="snippets/di/di-basics/DefaultGreetingService.cs":::
 


### PR DESCRIPTION
## Summary

Seems like there is a missing underscore on line 64 in the file name, which breaks the formatting:
```
Then add a new C# file named DefaultGreetingService.cs_ and add the following code:
```
changed to:
```
Then add a new C# file named _DefaultGreetingService.cs_ and add the following code:
``` 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/dependency-injection-basics.md](https://github.com/dotnet/docs/blob/5fdcd6d03190dae102a7376b29fca706a85b8eff/docs/core/extensions/dependency-injection-basics.md) | [docs/core/extensions/dependency-injection-basics](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection-basics?branch=pr-en-us-42610) |

<!-- PREVIEW-TABLE-END -->