### PR TITLE
Update Resource utilization health checks doc page

### DIFF
--- a/docs/core/diagnostics/diagnostic-health-checks.md
+++ b/docs/core/diagnostics/diagnostic-health-checks.md
@@ -25,15 +25,11 @@ To perform health checks on the resource utilization of your .NET apps, add a pa
 The preceding code:
 
 - Creates a new <xref:Microsoft.Extensions.Hosting.HostApplicationBuilder> instance.
-- Adds resource monitoring by calling <xref:Microsoft.Extensions.DependencyInjection.ResourceMonitoringServiceCollectionExtensions.AddResourceMonitoring%2A>.
 - Adds a health check for resource utilization by chaining a call from the <xref:Microsoft.Extensions.DependencyInjection.HealthCheckServiceCollectionExtensions.AddHealthChecks%2A> call to the <xref:Microsoft.Extensions.DependencyInjection.ResourceUtilizationHealthCheckExtensions.AddResourceUtilizationHealthCheck%2A> extension method.
 - Builds the <xref:Microsoft.Extensions.Hosting.IHost> instance as the `app` variable.
 - Gets an instance of the <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckService> class from the service provider.
 - Performs a health check and displays the result.
 - Runs the application.
-
-> [!NOTE]
-> The `Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilization` library assumes that the consumer will register the dependent call to <xref:Microsoft.Extensions.DependencyInjection.ResourceMonitoringServiceCollectionExtensions.AddResourceMonitoring%2A>. If you don't register this, when resolving the `HealthCheckService` an exception is thrown.
 
 ## Application lifetime health checks
 

--- a/docs/core/diagnostics/snippets/health-checks/Program.cs
+++ b/docs/core/diagnostics/snippets/health-checks/Program.cs
@@ -1,11 +1,8 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Microsoft.Extensions.Diagnostics.ResourceMonitoring;
 using Microsoft.Extensions.Hosting;
 
 var builder = Host.CreateApplicationBuilder(args);
-
-builder.Services.AddResourceMonitoring();
 
 builder.Services.AddHealthChecks()
     .AddResourceUtilizationHealthCheck();


### PR DESCRIPTION
Resource utilization health checks does not require registering Resource Monitoring any more. The issue was https://github.com/dotnet/extensions/issues/4560 and resolved by https://github.com/dotnet/extensions/pull/5413. Now, updating the docs accordingly.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/diagnostic-health-checks.md](https://github.com/dotnet/docs/blob/c4b9f1f1edcc2a68e13d7afaa793c8db9320149c/docs/core/diagnostics/diagnostic-health-checks.md) | [docs/core/diagnostics/diagnostic-health-checks](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/diagnostic-health-checks?branch=pr-en-us-42626) |


<!-- PREVIEW-TABLE-END -->