### PR TITLE
Correction to a 3.1 breaking change

### DIFF
--- a/includes/core-changes/windowsforms/3.1/remove-controls-3.1.md
+++ b/includes/core-changes/windowsforms/3.1/remove-controls-3.1.md
@@ -14,6 +14,7 @@ The following types are no longer available:
 - <xref:System.Windows.Forms.DataGridBoolColumn>
 - <xref:System.Windows.Forms.DataGridCell>
 - <xref:System.Windows.Forms.DataGridColumnStyle>
+- <xref:System.Windows.Forms.DataGridColumnStyle.DataGridColumnHeaderAccessibleObject>
 - <xref:System.Windows.Forms.DataGridLineStyle>
 - <xref:System.Windows.Forms.DataGridParentRowsLabelStyle>
 - <xref:System.Windows.Forms.DataGridPreferredColumnWidthTypeConverter>


### PR DESCRIPTION
This announcement missed one removed class - https://learn.microsoft.com/en-us/dotnet/api/system.windows.forms.datagridcolumnstyle.datagridcolumnheaderaccessibleobject?view=netframework-4.8.1 removed by https://github.com/dotnet/winforms/pull/2157/files#diff-6c923d581c0a5dd37789e43626a7fb0ddccdc332b14ae314bb03dda06167ffec

