### PR TITLE
Remove connection string, recommend Entra ID and Managed identities for production applications

### DIFF
--- a/docs/fsharp/using-fsharp-on-azure/blob-storage.md
+++ b/docs/fsharp/using-fsharp-on-azure/blob-storage.md
@@ -11,7 +11,7 @@ Azure Blob Storage is a service that stores unstructured data in the cloud as ob
 
 This article shows you how to perform common tasks using Blob storage. The samples are written using F# using the Azure Storage Client Library for .NET. The tasks covered include how to upload, list, download, and delete blobs.
 
-For a conceptual overview of blob storage, see [the .NET guide for blob storage](/azure/storage/blobs/storage-quickstart-blobs-dotnet).
+For a conceptual overview of blob storage, see [the .NET guide for blob storage](/azure/storage/blobs/storage-quickstart-blobs-dotnet). For ease, these tutorials use [connection strings](/azure/storage/storage-configure-connection-string) to authenticate with Azure. For optimal security, you should use Microsoft Entra ID with [managed identities](/entra/identity/managed-identities-azure-resources/).
 
 ## Prerequisites
 

--- a/docs/fsharp/using-fsharp-on-azure/blob-storage.md
+++ b/docs/fsharp/using-fsharp-on-azure/blob-storage.md
@@ -2,7 +2,7 @@
 title: Get started with Azure Blob Storage using F#
 description: Store unstructured data in the cloud with Azure Blob Storage.
 author: sylvanc
-ms.date: 08/26/2021
+ms.date: 09/17/2024
 ms.custom: "devx-track-fsharp"
 ---
 # Get started with Azure Blob Storage using F\#

--- a/docs/fsharp/using-fsharp-on-azure/file-storage.md
+++ b/docs/fsharp/using-fsharp-on-azure/file-storage.md
@@ -9,7 +9,7 @@ ms.custom: "devx-track-fsharp"
 
 Azure Files is a service that offers file shares in the cloud using the standard [Server Message Block (SMB) protocol](/windows/win32/fileio/microsoft-smb-protocol-and-cifs-protocol-overview). Both SMB 2.1 and SMB 3.0 are supported. With Azure Files, you can migrate legacy applications that rely on file shares to Azure quickly and without costly rewrites. Applications running in Azure virtual machines or cloud services or from on-premises clients can mount a file share in the cloud, just as a desktop application mounts a typical SMB share. Any number of application components can then mount and access the file storage share simultaneously.
 
-For a conceptual overview of file storage, see [the .NET guide for file storage](/azure/storage/storage-dotnet-how-to-use-files).
+For a conceptual overview of file storage, see [the .NET guide for file storage](/azure/storage/storage-dotnet-how-to-use-files). For ease, these tutorials use [connection strings](/azure/storage/storage-configure-connection-string) to authenticate with Azure. For optimal security, you should use Microsoft Entra ID with [managed identities](/entra/identity/managed-identities-azure-resources/).
 
 ## Prerequisites
 

--- a/docs/fsharp/using-fsharp-on-azure/file-storage.md
+++ b/docs/fsharp/using-fsharp-on-azure/file-storage.md
@@ -2,7 +2,7 @@
 title: Get started with Azure Files using F#
 description: Store file data in the cloud with Azure Files and mount your cloud file share from an Azure virtual machine (VM) or from an on-premises application running Windows.
 author: sylvanc
-ms.date: 08/26/2021
+ms.date: 09/17/2024
 ms.custom: "devx-track-fsharp"
 ---
 # Get started with Azure Files using F\#

--- a/docs/fsharp/using-fsharp-on-azure/queue-storage.md
+++ b/docs/fsharp/using-fsharp-on-azure/queue-storage.md
@@ -13,7 +13,7 @@ Azure Queue Storage provides cloud messaging between application components. In 
 
 This tutorial shows how to write F# code for some common tasks using Azure Queue Storage. Tasks covered include creating and deleting queues and adding, reading, and deleting queue messages.
 
-For a conceptual overview of queue storage, see [the .NET guide for queue storage](/azure/storage/queues/storage-quickstart-queues-dotnet).
+For a conceptual overview of queue storage, see [the .NET guide for queue storage](/azure/storage/queues/storage-quickstart-queues-dotnet). For ease, these tutorials use [connection strings](/azure/storage/storage-configure-connection-string) to authenticate with Azure. For optimal security, you should use Microsoft Entra ID with [managed identities](/entra/identity/managed-identities-azure-resources/).
 
 ## Prerequisites
 

--- a/docs/fsharp/using-fsharp-on-azure/queue-storage.md
+++ b/docs/fsharp/using-fsharp-on-azure/queue-storage.md
@@ -2,7 +2,7 @@
 title: Get started with Azure Queue Storage using F#
 description: Azure Queues provide reliable, asynchronous messaging between application components. Cloud messaging enables your application components to scale independently.
 author: sylvanc
-ms.date: 08/26/2021
+ms.date: 09/17/2024
 ms.custom: "devx-track-fsharp"
 ---
 # Get started with Azure Queue Storage using F\#

--- a/docs/fsharp/using-fsharp-on-azure/table-storage.md
+++ b/docs/fsharp/using-fsharp-on-azure/table-storage.md
@@ -2,7 +2,7 @@
 title: Get started with Azure Table Storage using F#
 description: Store structured data in the cloud using Azure Table Storage or Azure Cosmos DB.
 author: sylvanc
-ms.date: 07/28/2022
+ms.date: 09/17/2024
 ms.custom: "devx-track-fsharp"
 ---
 # Get started with Azure Table Storage and the Azure Cosmos DB Table api using F\#

--- a/docs/fsharp/using-fsharp-on-azure/table-storage.md
+++ b/docs/fsharp/using-fsharp-on-azure/table-storage.md
@@ -21,7 +21,7 @@ Azure Cosmos DB provides the Table API for applications that are written for Azu
 
 Applications written for Azure Table Storage can migrate to Azure Cosmos DB by using the Table API with no code changes and take advantage of premium capabilities. The Table API has client SDKs available for [.NET](https://www.nuget.org/packages/Azure.Data.Tables/), [Java](https://mvnrepository.com/artifact/com.azure/azure-data-tables), [Python](https://pypi.org/project/azure-data-tables/), and [Node.js](https://www.npmjs.com/package/@azure/data-tables).
 
-For more information, see [Introduction to Azure Cosmos DB Table API](/azure/cosmos-db/table-introduction).
+For more information, see [Introduction to Azure Cosmos DB Table API](/azure/cosmos-db/table-introduction). For ease, these tutorials use [connection strings](/azure/storage/storage-configure-connection-string) to authenticate with Azure. For optimal security, you should use Microsoft Entra ID with [managed identities](/entra/identity/managed-identities-azure-resources/).
 
 ## About this tutorial
 

--- a/samples/snippets/fsharp/azure/table-storage.fsx
+++ b/samples/snippets/fsharp/azure/table-storage.fsx
@@ -12,7 +12,7 @@ open Azure.Data.Tables // Namespace for Table storage types
 // Get your connection string.
 //
 // <connectionString>
-let storageConnString = "UseDevelopmentStorage=true" // fill this in from your storage account
+let storageConnString = "..." // fill this in from your storage account
 // </connectionString>
 
 //


### PR DESCRIPTION
These are "get started" tutorials, so they continue to use connection strings to authenticate with Azure storage services. 

Remove the actual connection string from a tutorial, and add a note that production applications should use Entra ID and Managed Identities.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/using-fsharp-on-azure/blob-storage.md](https://github.com/dotnet/docs/blob/e7a44ba60535e9e7f0da27e854c67fef5698e7e4/docs/fsharp/using-fsharp-on-azure/blob-storage.md) | [docs/fsharp/using-fsharp-on-azure/blob-storage](https://review.learn.microsoft.com/en-us/dotnet/fsharp/using-fsharp-on-azure/blob-storage?branch=pr-en-us-42636) |
| [docs/fsharp/using-fsharp-on-azure/file-storage.md](https://github.com/dotnet/docs/blob/e7a44ba60535e9e7f0da27e854c67fef5698e7e4/docs/fsharp/using-fsharp-on-azure/file-storage.md) | [docs/fsharp/using-fsharp-on-azure/file-storage](https://review.learn.microsoft.com/en-us/dotnet/fsharp/using-fsharp-on-azure/file-storage?branch=pr-en-us-42636) |
| [docs/fsharp/using-fsharp-on-azure/queue-storage.md](https://github.com/dotnet/docs/blob/e7a44ba60535e9e7f0da27e854c67fef5698e7e4/docs/fsharp/using-fsharp-on-azure/queue-storage.md) | [docs/fsharp/using-fsharp-on-azure/queue-storage](https://review.learn.microsoft.com/en-us/dotnet/fsharp/using-fsharp-on-azure/queue-storage?branch=pr-en-us-42636) |
| [docs/fsharp/using-fsharp-on-azure/table-storage.md](https://github.com/dotnet/docs/blob/e7a44ba60535e9e7f0da27e854c67fef5698e7e4/docs/fsharp/using-fsharp-on-azure/table-storage.md) | [docs/fsharp/using-fsharp-on-azure/table-storage](https://review.learn.microsoft.com/en-us/dotnet/fsharp/using-fsharp-on-azure/table-storage?branch=pr-en-us-42636) |


<!-- PREVIEW-TABLE-END -->