### PR TITLE
Note that `Channel`s are FIFO

### DIFF
--- a/docs/core/extensions/channels.md
+++ b/docs/core/extensions/channels.md
@@ -14,7 +14,7 @@ This library is available in the [System.Threading.Channels](https://www.nuget.o
 
 ## Producer/consumer conceptual programming model
 
-Channels are an implementation of the producer/consumer conceptual programming model. In this programming model, producers asynchronously produce data, and consumers asynchronously consume that data. In other words, this model hands off data from one party to another. Try to think of channels as you would any other common generic collection type, such as a `List<T>`. The primary difference is that this collection manages synchronization and provides various consumption models through factory creation options. These options control the behavior of the channels, such as how many elements they're allowed to store and what happens if that limit is reached, or whether the channel is accessed by multiple producers or multiple consumers concurrently.
+Channels are an implementation of the producer/consumer conceptual programming model. In this programming model, producers asynchronously produce data, and consumers asynchronously consume that data. In other words, this model passes data from one party to another through a first-in first-out ("FIFO") queue. Try to think of channels as you would any other common generic collection type, such as a `List<T>`. The primary difference is that this collection manages synchronization and provides various consumption models through factory creation options. These options control the behavior of the channels, such as how many elements they're allowed to store and what happens if that limit is reached, or whether the channel is accessed by multiple producers or multiple consumers concurrently.
 
 ## Bounding strategies
 


### PR DESCRIPTION
## Summary

As far as I can tell, the docs currently say nowhere that a `Channel` has FIFO semantics. The documentation appears to be in the form of [this comment on a GitHub issue](https://github.com/dotnet/runtime/issues/32700#issuecomment-1127093007).

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/channels.md](https://github.com/dotnet/docs/blob/a73c4139b4d05c66e0e5cc8dd2c603680d3cce48/docs/core/extensions/channels.md) | [docs/core/extensions/channels](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/channels?branch=pr-en-us-42637) |

<!-- PREVIEW-TABLE-END -->