### PR TITLE
Correct apt-get command

### DIFF
--- a/docs/fundamentals/networking/quic/quic-overview.md
+++ b/docs/fundamentals/networking/quic/quic-overview.md
@@ -59,7 +59,7 @@ Here are some examples of using a package manager to install `libmsquic`:
 - **APT**
 
   ```bash
-  sudo apt-get libmsquic 
+  sudo apt-get install libmsquic 
   ```
 
 - **APK**


### PR DESCRIPTION
## Summary

Correcting the apt-get command to install the libmsquic package. Previously, this caused a syntax error:

$ sudo apt-get libmsquic
E: Invalid operation libmsquic

The command `install` was missing.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/networking/quic/quic-overview.md](https://github.com/dotnet/docs/blob/f66548f8b1b93a8333b25c9725b662342ea1c790/docs/fundamentals/networking/quic/quic-overview.md) | [docs/fundamentals/networking/quic/quic-overview](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/networking/quic/quic-overview?branch=pr-en-us-42641) |

<!-- PREVIEW-TABLE-END -->