### PR TITLE
Update interfaces.md

### DIFF
--- a/docs/csharp/fundamentals/types/interfaces.md
+++ b/docs/csharp/fundamentals/types/interfaces.md
@@ -18,7 +18,7 @@ You define an interface by using the [`interface`](../../language-reference/keyw
 
 The name of an interface must be a valid C# [identifier name](../coding-style/identifier-names.md). By convention, interface names begin with a capital `I`.
 
-Any class or struct that implements the <xref:System.IEquatable%601> interface must contain a definition for an <xref:System.IEquatable%601.Equals%2A> method that matches the signature that the interface specifies. As a result, you can count on a class that implements `IEquatable<T>` to contain an `Equals` method with which an instance of the class can determine whether it's equal to another instance of the same class.
+Any class or struct that implements the <xref:System.IEquatable%601> interface must contain a definition for an <xref:System.IEquatable%601.Equals%2A> method that matches the signature that the interface specifies. As a result, you can count on a class of type `T` that implements `IEquatable<T>` to contain an `Equals` method with which an instance of this class can determine whether it's equal to another instance of the same class.
 
 The definition of `IEquatable<T>` doesn't provide an implementation for `Equals`. A class or struct can implement multiple interfaces, but a class can only inherit from a single class.
 


### PR DESCRIPTION
This commit makes it more clear the implementing class of the `IEquatable<T>` method must be of type `T ` in order to be able to determine if its equal to other instances of type `T`.

Confusion might arise in certain case. For example, if we have a class of type `MyClass` that implements `IEquatable<MyOtherClass>`, then we can't use `IEquatable`'s method `Equals` to compare an instance of `MyClass` with another instance of `MyClass`

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/fundamentals/types/interfaces.md](https://github.com/dotnet/docs/blob/ef93e33b883b213baaa36af9c87ea10d75ed313a/docs/csharp/fundamentals/types/interfaces.md) | [docs/csharp/fundamentals/types/interfaces](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/types/interfaces?branch=pr-en-us-42657) |

<!-- PREVIEW-TABLE-END -->