### PR TITLE
Document CorHandleWeakWinRT

### DIFF
--- a/docs/framework/unmanaged-api/debugging/corgcreferencetype-enumeration.md
+++ b/docs/framework/unmanaged-api/debugging/corgcreferencetype-enumeration.md
@@ -32,9 +32,10 @@ typedef enum {
     CorHandleStrongDependent = 64,
     CorHandleStrongAsyncPinned = 128,
     CorHandleStrongSizedByref = 256,
+    CorHandleWeakWinRT = 512,
 
     CorReferenceStack = 0x80000001,
-    CorReferenceFinalizer = 0x80000002,
+    CorReferenceFinalizer = 80000002,  // Note the constant is decimal, not hexadecimal
 
     CorHandleStrongOnly = 0x1E3,
     CorHandleWeakOnly = 0xC,
@@ -54,6 +55,7 @@ typedef enum {
 |`CorHandleStrongDependent`|A handle to a dependent object from the object handle table.|
 |`CorHandleStrongAsyncPinned`|An asynchronous pinned object from the object handle table.|
 |`CorHandleStrongSizedByref`|A strong handle that keeps an approximate size of the collective closure of all objects and object roots at garbage collection time.|
+|`CorHandleWeakWinRT`|A weak handle to a RCW (Runtime Callable Wrapper). An RCW is a managed object that proxies calls to an underlying COM object.|
 |`CorReferenceStack`|A reference from the managed stack.|
 |`CorReferenceFinalizer`|A reference from the finalizer queue.|
 |CorHandleStrongOnly|Return only strong references from the handle table. This value is used by the [ICorDebugProcess5::EnumerateHandles](icordebugprocess5-enumeratehandles-method.md) method only.|


### PR DESCRIPTION
- Add docs for that enumeration value in the .NET debugging APIs.
- Also updates the CorReferenceFinalizer value. 80000002 in decimal is the correct value in the shipping code. Probably some earlier developer intended it to be hexadecimal in the product but made a mistake. Since it has already shipped it won't be changed.

Fixes https://github.com/dotnet/diagnostics/issues/4171


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/unmanaged-api/debugging/corgcreferencetype-enumeration.md](https://github.com/dotnet/docs/blob/f4208cb9e271b532d184a085b2940711d8df1764/docs/framework/unmanaged-api/debugging/corgcreferencetype-enumeration.md) | [docs/framework/unmanaged-api/debugging/corgcreferencetype-enumeration](https://review.learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/corgcreferencetype-enumeration?branch=pr-en-us-42659) |


<!-- PREVIEW-TABLE-END -->