### PR TITLE
Fix typo in dotnet-nuget-config-set.md

### DIFF
--- a/docs/core/tools/dotnet-nuget-config-set.md
+++ b/docs/core/tools/dotnet-nuget-config-set.md
@@ -53,7 +53,7 @@ The `dotnet nuget config set` sets the values for NuGet configuration settings t
 * Sets the `repositoryPath` configuration value `c:\installed_packages` to the specified configuration file:
 
   ```dotnetcli
-  dotnet nuget config set repositoryPath "c:\installed_packages" --configfile "C:/nugte.config"
+  dotnet nuget config set repositoryPath "c:\installed_packages" --configfile "c:\nuget.config"
   ```
 
 ## See also


### PR DESCRIPTION
## Summary

Fix a typo in the command line example.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-nuget-config-set.md](https://github.com/dotnet/docs/blob/3a305d5306338d654529cc0cf479b1c514f47c64/docs/core/tools/dotnet-nuget-config-set.md) | [docs/core/tools/dotnet-nuget-config-set](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-config-set?branch=pr-en-us-42669) |

<!-- PREVIEW-TABLE-END -->