### PR TITLE
Rephrase the multi-line comments rule to be more precise regarding localization (translations)

### DIFF
--- a/docs/csharp/fundamentals/coding-style/coding-conventions.md
+++ b/docs/csharp/fundamentals/coding-style/coding-conventions.md
@@ -322,7 +322,7 @@ In general, use the following format for code samples:
 ### Comment style
 
 - Use single-line comments (`//`) for brief explanations.
-- Avoid multi-line comments (`/* */`) for longer explanations. Comments aren't localized. Instead, longer explanations are in the companion article.
+- Avoid multi-line comments (`/* */`) for longer explanations.<br/>Comments in the code samples aren't localized. Which means explanations embedded in the code will not be translated. So longer, explanatory text should be placed in the companion article, so that it can be localized.
 - For describing methods, classes, fields, and all public members use [XML comments](../../language-reference/xmldoc/index.md).
 - Place the comment on a separate line, not at the end of a line of code.
 - Begin comment text with an uppercase letter.

--- a/docs/csharp/fundamentals/coding-style/coding-conventions.md
+++ b/docs/csharp/fundamentals/coding-style/coding-conventions.md
@@ -322,7 +322,7 @@ In general, use the following format for code samples:
 ### Comment style
 
 - Use single-line comments (`//`) for brief explanations.
-- Avoid multi-line comments (`/* */`) for longer explanations.<br/>Comments in the code samples aren't localized. Which means explanations embedded in the code will not be translated. So longer, explanatory text should be placed in the companion article, so that it can be localized.
+- Avoid multi-line comments (`/* */`) for longer explanations.<br/>Comments in the code samples aren't localized. That means explanations embedded in the code will not be translated. Longer, explanatory text should be placed in the companion article, so that it can be localized.
 - For describing methods, classes, fields, and all public members use [XML comments](../../language-reference/xmldoc/index.md).
 - Place the comment on a separate line, not at the end of a line of code.
 - Begin comment text with an uppercase letter.


### PR DESCRIPTION
This pull request fixes #42053 
It rephrases the explanation of the multi-line comments avoidance rule so that it's clear regarding the localization of the page and article versus the embedded comments.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/fundamentals/coding-style/coding-conventions.md](https://github.com/dotnet/docs/blob/c0b10c76607ec4d1a4051a66f7ab8dea23ed5330/docs/csharp/fundamentals/coding-style/coding-conventions.md) | [docs/csharp/fundamentals/coding-style/coding-conventions](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions?branch=pr-en-us-42672) |


<!-- PREVIEW-TABLE-END -->