### PR TITLE
Fix copy-paste error method-parameters.md

### DIFF
--- a/docs/csharp/language-reference/keywords/method-parameters.md
+++ b/docs/csharp/language-reference/keywords/method-parameters.md
@@ -35,7 +35,7 @@ How an argument is passed, and whether it's a reference type or value type contr
   - If the method assigns the parameter to refer to a different object, those changes **aren't** visible from the caller.
   - If the method modifies the state of the object referred to by the parameter, those changes **are** visible from the caller.
 - When you pass a *value* type *by reference*:
-  - If the method assigns the parameter to refer to a different object, those changes **aren't** visible from the caller.
+  - If the method assigns the parameter to refer to a different object, those changes **are** visible from the caller.
   - If the method modifies the state of the object referred to by the parameter, those changes **are** visible from the caller.
 - When you pass a *reference* type *by reference*:
   - If the method assigns the parameter to refer to a different object, those changes **are** visible from the caller.


### PR DESCRIPTION
When you assign new instance to the value type paramenter by reference, the changes are visible from the caller method
```csharp
var instance = new TestStruct { Property = 0 };
AssignNewInstance(ref instance);
Console.WriteLine(instance.Property);
// 42

void AssignNewInstance(ref TestStruct local)
{
    local = new TestStruct { Property = 42 };
    return;
}
struct TestStruct
{
    public int Property { get; set; }
}
```


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/method-parameters.md](https://github.com/dotnet/docs/blob/3493bb4d51aeec0dcf196248047c3aba4da63968/docs/csharp/language-reference/keywords/method-parameters.md) | [docs/csharp/language-reference/keywords/method-parameters](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/method-parameters?branch=pr-en-us-42676) |

<!-- PREVIEW-TABLE-END -->