### PR TITLE
Provide xsd tool example with `/classes` option

### DIFF
--- a/docs/standard/serialization/xml-schema-def-tool-gen.md
+++ b/docs/standard/serialization/xml-schema-def-tool-gen.md
@@ -23,10 +23,10 @@ _C:\\Program Files (x86)\\Microsoft SDKs\\Windows\\{version}\\bin\\NETFX {versio
 2. Pass the XML Schema as an argument to the XML Schema Definition tool, which creates a set of classes that are precisely matched to the XML Schema, for example:  
   
     ```console  
-    xsd mySchema.xsd  
+    xsd mySchema.xsd /classes
     ```  
-  
-     The tool can only process schemas that reference the World Wide Web Consortium XML specification of March 16, 2001. In other words, the XML Schema namespace must be `"http://www.w3.org/2001/XMLSchema"`, as shown in the following example.  
+    (The `/classes` option used in the above is to generate classes for the `mySchema` schema.)
+    <br/>The tool can only process schemas that reference the World Wide Web Consortium XML specification of March 16, 2001. In other words, the XML Schema namespace must be `"http://www.w3.org/2001/XMLSchema"`, as shown in the following example.  
   
     ```xml  
     <?xml version="1.0" encoding="utf-8"?>  

--- a/docs/standard/serialization/xml-schema-def-tool-gen.md
+++ b/docs/standard/serialization/xml-schema-def-tool-gen.md
@@ -25,8 +25,8 @@ _C:\\Program Files (x86)\\Microsoft SDKs\\Windows\\{version}\\bin\\NETFX {versio
     ```console  
     xsd mySchema.xsd /classes
     ```  
+
     (The `/classes` option in this command is used to generate classes for the `mySchema` schema.)
-    
     The tool can only process schemas that reference the World Wide Web Consortium XML specification of March 16, 2001. In other words, the XML Schema namespace must be `"http://www.w3.org/2001/XMLSchema"`, as shown in the following example.  
   
     ```xml  

--- a/docs/standard/serialization/xml-schema-def-tool-gen.md
+++ b/docs/standard/serialization/xml-schema-def-tool-gen.md
@@ -25,9 +25,9 @@ _C:\\Program Files (x86)\\Microsoft SDKs\\Windows\\{version}\\bin\\NETFX {versio
     ```console  
     xsd mySchema.xsd /classes
     ```  
+    (The `/classes` option in this command is used to generate classes for the `mySchema` schema.)
     
-    (The `/classes` option used in the above is to generate classes for the `mySchema` schema.)
-    <br/>The tool can only process schemas that reference the World Wide Web Consortium XML specification of March 16, 2001. In other words, the XML Schema namespace must be `"http://www.w3.org/2001/XMLSchema"`, as shown in the following example.  
+    The tool can only process schemas that reference the World Wide Web Consortium XML specification of March 16, 2001. In other words, the XML Schema namespace must be `"http://www.w3.org/2001/XMLSchema"`, as shown in the following example.  
   
     ```xml  
     <?xml version="1.0" encoding="utf-8"?>  

--- a/docs/standard/serialization/xml-schema-def-tool-gen.md
+++ b/docs/standard/serialization/xml-schema-def-tool-gen.md
@@ -25,6 +25,7 @@ _C:\\Program Files (x86)\\Microsoft SDKs\\Windows\\{version}\\bin\\NETFX {versio
     ```console  
     xsd mySchema.xsd /classes
     ```  
+    
     (The `/classes` option used in the above is to generate classes for the `mySchema` schema.)
     <br/>The tool can only process schemas that reference the World Wide Web Consortium XML specification of March 16, 2001. In other words, the XML Schema namespace must be `"http://www.w3.org/2001/XMLSchema"`, as shown in the following example.  
   


### PR DESCRIPTION
This pull request fixes #42634 
It adds the `/classes` option to the xsd tool description.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/serialization/xml-schema-def-tool-gen.md](https://github.com/dotnet/docs/blob/a14f8908e925de8d5df266e9fa9df373ed82c1a8/docs/standard/serialization/xml-schema-def-tool-gen.md) | [docs/standard/serialization/xml-schema-def-tool-gen](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/xml-schema-def-tool-gen?branch=pr-en-us-42685) |


<!-- PREVIEW-TABLE-END -->