### PR TITLE
deprecate SHA-1 usage in dotnet nuget sign command

### DIFF
--- a/docs/core/tools/dotnet-nuget-sign.md
+++ b/docs/core/tools/dotnet-nuget-sign.md
@@ -73,7 +73,7 @@ The `dotnet nuget sign` command signs all the packages matching the first argume
 
   Specifies the fingerprint of the certificate used to search a local certificate store for the certificate.
 
-  Starting with `.NET 9`, this option can be used to specify the SHA-1, SHA-256, SHA-384, or SHA-512 fingerprint of the certificate.
+  Starting with .NET 9, this option can be used to specify the SHA-1, SHA-256, SHA-384, or SHA-512 fingerprint of the certificate.
   However, a `NU3043` warning is raised when a SHA-1 certificate fingerprint is used because it is no longer considered secure.
 
   All the previous versions of the .NET SDK continue to accept only SHA-1 certificate fingerprint.

--- a/docs/core/tools/dotnet-nuget-sign.md
+++ b/docs/core/tools/dotnet-nuget-sign.md
@@ -76,7 +76,7 @@ The `dotnet nuget sign` command signs all the packages matching the first argume
   Starting with `.NET 9`, this option can be used to specify the SHA-1, SHA-256, SHA-384, or SHA-512 fingerprint of the certificate.
   However, a `NU3043` warning is raised when a SHA-1 certificate fingerprint is used because it is no longer considered secure.
 
-  All previous versions of the .NET SDK continue to accept only SHA-1 fingerprint.
+  All previous versions of the .NET SDK continue to accept only SHA-1 certificate fingerprint.
 
 - **`--certificate-password <PASSWORD>`**
 

--- a/docs/core/tools/dotnet-nuget-sign.md
+++ b/docs/core/tools/dotnet-nuget-sign.md
@@ -71,7 +71,12 @@ The `dotnet nuget sign` command signs all the packages matching the first argume
 
 - **`--certificate-fingerprint <FINGERPRINT>`**
 
-   SHA-1 fingerprint of the certificate used to search a local certificate store for the certificate.
+   Specifies the fingerprint of the certificate used to search a local certificate store for the certificate.
+
+  > [!NOTE]
+  > Starting with `.NET 9 Preview 7`, a `NU3043` warning is raised when a SHA-1 certificate fingerprint is passed.
+  > SHA-1 is considered insecure and should no longer be used.
+  > The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).
 
 - **`--certificate-password <PASSWORD>`**
 

--- a/docs/core/tools/dotnet-nuget-sign.md
+++ b/docs/core/tools/dotnet-nuget-sign.md
@@ -71,12 +71,12 @@ The `dotnet nuget sign` command signs all the packages matching the first argume
 
 - **`--certificate-fingerprint <FINGERPRINT>`**
 
-   Specifies the fingerprint of the certificate used to search a local certificate store for the certificate.
+  Specifies the fingerprint of the certificate used to search a local certificate store for the certificate.
 
-  > [!NOTE]
-  > Starting with `.NET 9 Preview 7`, a `NU3043` warning is raised when a SHA-1 certificate fingerprint is passed.
-  > SHA-1 is considered insecure and should no longer be used.
-  > The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).
+  Starting with `.NET 9`, this option can be used to specify the SHA-1, SHA-256, SHA-384, or SHA-512 fingerprint of the certificate.
+  However, a `NU3043` warning is raised when a SHA-1 certificate fingerprint is used because it is no longer considered secure.
+
+  All previous versions of the .NET SDK continue to accept only SHA-1 fingerprint.
 
 - **`--certificate-password <PASSWORD>`**
 

--- a/docs/core/tools/dotnet-nuget-sign.md
+++ b/docs/core/tools/dotnet-nuget-sign.md
@@ -76,7 +76,7 @@ The `dotnet nuget sign` command signs all the packages matching the first argume
   Starting with `.NET 9`, this option can be used to specify the SHA-1, SHA-256, SHA-384, or SHA-512 fingerprint of the certificate.
   However, a `NU3043` warning is raised when a SHA-1 certificate fingerprint is used because it is no longer considered secure.
 
-  All previous versions of the .NET SDK continue to accept only SHA-1 certificate fingerprint.
+  All the previous versions of the .NET SDK continue to accept only SHA-1 certificate fingerprint.
 
 - **`--certificate-password <PASSWORD>`**
 


### PR DESCRIPTION
## Summary
Deprecate SHA-1 usage in dotnet nuget sign command

Starting with .NET 9 Preview 7, dotnet nuget sign command will raise a NU3043 warning if an invalid value or SHA-1 hash is passed for the certificate fingerprint option. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-nuget-sign.md](https://github.com/dotnet/docs/blob/5c045483ec482e444d12e115004d9283e19e1474/docs/core/tools/dotnet-nuget-sign.md) | [docs/core/tools/dotnet-nuget-sign](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-sign?branch=pr-en-us-42697) |


<!-- PREVIEW-TABLE-END -->