### PR TITLE
Remove paths from markdownlint.yml

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -9,12 +9,6 @@ on:
       - ".markdownlint-cli2.jsonc"
       - ".github/workflows/markdownlint.yml"
       - ".github/workflows/markdownlint-problem-matcher.json"
-  pull_request:
-    paths:
-      - "**/*.md"
-      - ".markdownlint-cli2.jsonc"
-      - ".github/workflows/markdownlint.yml"
-      - ".github/workflows/markdownlint-problem-matcher.json"
 
 permissions:
   contents: read

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -9,6 +9,7 @@ on:
       - ".markdownlint-cli2.jsonc"
       - ".github/workflows/markdownlint.yml"
       - ".github/workflows/markdownlint-problem-matcher.json"
+  pull_request:
 
 permissions:
   contents: read


### PR DESCRIPTION
Otherwise the lint status check hangs if no .md files are touched in a PR.