### PR TITLE
fix bug #42677

### DIFF
--- a/docs/standard/serialization/how-to-control-serialization-of-derived-classes.md
+++ b/docs/standard/serialization/how-to-control-serialization-of-derived-classes.md
@@ -43,7 +43,7 @@ Public Class Run
   
         ' Creates an XmlElementAttribute instance to override the
         ' field that returns Book objects. The overridden field  
-        ' returns Expanded objects instead.  
+        ' returns ExpandedBook objects instead.  
         Dim attr As XmlElementAttribute = _  
         New XmlElementAttribute()  
         attr.ElementName = "NewBook"  


### PR DESCRIPTION
## Summary

Change "Expanded objects" to "ExpandedBook objects" in SerializeObject(filename As String) 

Fixes #42677


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/serialization/how-to-control-serialization-of-derived-classes.md](https://github.com/dotnet/docs/blob/c7a680d488000156baa8e776b949f84637bc502b/docs/standard/serialization/how-to-control-serialization-of-derived-classes.md) | [docs/standard/serialization/how-to-control-serialization-of-derived-classes](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/how-to-control-serialization-of-derived-classes?branch=pr-en-us-42718) |

<!-- PREVIEW-TABLE-END -->