### PR TITLE
#42677 suspected typo how to control serialization of derived classes

### DIFF
--- a/docs/standard/serialization/how-to-control-serialization-of-derived-classes.md
+++ b/docs/standard/serialization/how-to-control-serialization-of-derived-classes.md
@@ -89,7 +89,7 @@ Public Class Run
   
         ' Creates an XmlElementAttribute to override the
         ' field that returns Book objects. The overridden field  
-        ' returns Expanded objects instead.
+        ' returns ExpandedBook objects instead.
         Dim attr As XmlElementAttribute = _  
         New XmlElementAttribute()  
         attr.ElementName = "NewBook"  

--- a/docs/standard/serialization/how-to-control-serialization-of-derived-classes.md
+++ b/docs/standard/serialization/how-to-control-serialization-of-derived-classes.md
@@ -89,7 +89,7 @@ Public Class Run
   
         ' Creates an XmlElementAttribute to override the
         ' field that returns Book objects. The overridden field  
-        ' returns Expanded objects instead.
+        ' returns ExpandedBook objects instead.
         Dim attr As XmlElementAttribute = _  
         New XmlElementAttribute()  
         attr.ElementName = "NewBook"  
@@ -149,7 +149,7 @@ public class Run
   
         // Creates an XmlElementAttribute instance to override the
         // field that returns Book objects. The overridden field  
-        // returns Expanded objects instead.  
+        // returns ExpandedBook objects instead.  
         XmlElementAttribute attr = new XmlElementAttribute();  
         attr.ElementName = "NewBook";  
         attr.Type = typeof(ExpandedBook);  
@@ -194,7 +194,7 @@ public class Run
   
         // Creates an XmlElementAttribute to override the
         // field that returns Book objects. The overridden field  
-        // returns Expanded objects instead.  
+        // returns ExpandedBook objects instead.  
         XmlElementAttribute attr = new XmlElementAttribute();  
         attr.ElementName = "NewBook";  
         attr.Type = typeof(ExpandedBook);  

--- a/docs/standard/serialization/how-to-control-serialization-of-derived-classes.md
+++ b/docs/standard/serialization/how-to-control-serialization-of-derived-classes.md
@@ -43,7 +43,7 @@ Public Class Run
   
         ' Creates an XmlElementAttribute instance to override the
         ' field that returns Book objects. The overridden field  
-        ' returns Expanded objects instead.  
+        ' returns ExpandedBook objects instead.  
         Dim attr As XmlElementAttribute = _  
         New XmlElementAttribute()  
         attr.ElementName = "NewBook"  


### PR DESCRIPTION
## Summary

Suspected typo how to control serialization of derived classes, correct typ from Expanded objects to ExpandedBook objects in:
VB
SerializeObject(filename As String)
DeserializeObject(filename As String)

C#
SerializeObject(string filename)
DeserializeObject(string filename)


Fixes #42677


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/serialization/how-to-control-serialization-of-derived-classes.md](https://github.com/dotnet/docs/blob/2a47b3af40721703b79e34656a13c20239c4346d/docs/standard/serialization/how-to-control-serialization-of-derived-classes.md) | [docs/standard/serialization/how-to-control-serialization-of-derived-classes](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/how-to-control-serialization-of-derived-classes?branch=pr-en-us-42720) |

<!-- PREVIEW-TABLE-END -->