### PR TITLE
Describe compatibility issue of Http.Resilience with App Insights

### DIFF
--- a/docs/core/resilience/http-resilience.md
+++ b/docs/core/resilience/http-resilience.md
@@ -264,3 +264,23 @@ There's a build time check that verifies if you're using `Grpc.Net.ClientFactory
   <SuppressCheckGrpcNetClientFactoryVersion>true</SuppressCheckGrpcNetClientFactoryVersion>
 </PropertyGroup>
 ```
+
+### Compatibility with .NET Application Insights
+
+If you're using .NET Application Insights, then enabling resilience functionality in your application could cause all Application Insights telemetry to be missing. The issue occurs when resilience functionality is registered before Application Insights services. Consider the following sample causing the issue:
+
+```csharp
+// At first, we register resilience functionality.
+services.AddHttpClient().AddStandardResilienceHandler();
+
+// And then we register Application Insights. As a result, Application Insights doesn't work.
+services.AddApplicationInsightsTelemetry();
+```
+
+The issue is caused by the following [bug](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2879) in Application Insights and can be fixed by registering Application Insights services before resilience functionality, as shown below:
+
+```csharp
+// We register Application Insights first, and now it will be working correctly.
+services.AddApplicationInsightsTelemetry();
+services.AddHttpClient().AddStandardResilienceHandler();
+```


### PR DESCRIPTION
The PR adds description of a compatibility issue of Microsoft.Extensions.Http.Resilience library with .NET Application Insights.

The issue was already reported two times https://github.com/dotnet/extensions/issues/5222, https://github.com/dotnet/extensions/issues/5421, therefore we decided to document it.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/extensions/pull/5444)

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/resilience/http-resilience.md](https://github.com/dotnet/docs/blob/6467e9a079df2e2f5e69f9c65b5f7dab88d757f7/docs/core/resilience/http-resilience.md) | [docs/core/resilience/http-resilience](https://review.learn.microsoft.com/en-us/dotnet/core/resilience/http-resilience?branch=pr-en-us-42728) |

<!-- PREVIEW-TABLE-END -->