### PR TITLE
Update config for semester rollover

### DIFF
--- a/quest-config.json
+++ b/quest-config.json
@@ -8,43 +8,85 @@
     "ImportedLabel": ":pushpin: seQUESTered",
     "ParentNodes": [
         {
+            "Semester": "Selenium",
+            "Label": "okr-freshness",
+            "ParentNodeId": 286034
+        },
+        {
+            "Semester": "Selenium",
+            "Label": "okr-curation",
+            "ParentNodeId": 286038
+        },
+        {
+            "Semester": "Selenium",
+            "Label": "user-feedback",
+            "ParentNodeId": 286039
+        },
+        {
+            "Semester": "Selenium",
+            "Label": "okr-quality",
+            "ParentNodeId": 286038
+        },
+        {
+            "Semester": "Selenium",
+            "Label": "doc-bug",
+            "ParentNodeId": 286039
+        },
+        {
+            "Semester": "Selenium",
+            "ParentNodeId": 286016
+        },
+        {
+            "Semester": "Dilithium",
             "Label": "okr-freshness",
             "ParentNodeId": 237266
         },
         {
+            "Semester": "Dilithium",
             "Label": "okr-curation",
             "ParentNodeId": 237271
         },
         {
+            "Semester": "Dilithium",
             "Label": "user-feedback",
             "ParentNodeId": 233465
         },
         {
+            "Semester": "Dilithium",
             "Label": "okr-quality",
             "ParentNodeId": 237266
         },
         {
+            "Semester": "Dilithium",
             "Label": "doc-bug",
             "ParentNodeId": 233465
         },
         {
+            "Semester": "Dilithium",
             "Label": "dotnet-csharp/svc",
             "ParentNodeId": 227484
         },
         {
+            "Semester": "Dilithium",
             "Label": "sfi-ropc",
             "ParentNodeId": 271716
         },
         {
+            "Semester": "Dilithium",
             "Label": "sfi-admin",
             "ParentNodeId": 271716
         },
         {
+            "Semester": "Dilithium",
             "Label": "sfi-images",
             "ParentNodeId": 286370
+        },
+        {
+            "Semester": "Dilithium",
+            "ParentNodeId": 227485
         }
     ],
-    "DefaultParentNode": 227485,
+    "DefaultParentNode": 286016,
     "WorkItemTags": [
         {
             "Label": ":checkered_flag: Release: .NET 9",


### PR DESCRIPTION
dotnet/docs-tools#413 updated Sequester to handle parents per semester.

This updates the config to respond to those changes.
