### PR TITLE
Update ca1036.md

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1036.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1036.md
@@ -40,18 +40,68 @@ To fix a violation of this rule, override <xref:System.Object.Equals%2A>. If you
 - op_LessThan
 - op_GreaterThan
 
-In C#, the tokens that are used to represent these operators are as follows:
+In C#, implement the following operators:
 
 ```csharp
-==
-!=
-<
->
+    public static bool operator ==(SampleClass? one, SampleClass? other) {
+        throw new NotImplementedException();
+    }
+
+    public static bool operator !=(SampleClass? one, SampleClass? other) {
+        throw new NotImplementedException();
+    }
+
+    public static bool operator <(SampleClass? one, SampleClass? other) {
+        throw new NotImplementedException();
+    }
+
+    public static bool operator >(SampleClass? one, SampleClass? other) {
+        throw new NotImplementedException();
+    }
+
+    //Optionally also implement
+
+    public static bool operator <=(SampleClass? one, SampleClass? other) {
+        throw new NotImplementedException();
+    }
+
+    public static bool operator >=(SampleClass? one, SampleClass? other) {
+        throw new NotImplementedException();
+    }
+```
+
+In VB.NET, implement the following operators:
+```vb
+    Public Shared Operator =(one As SampleClass, other As SampleClass) As Boolean
+        Throw New NotImplementedException()
+    End Operator
+
+    Public Shared Operator <>(one As SampleClass, other As SampleClass) As Boolean
+        Throw New NotImplementedException()
+    End Operator
+
+    Public Shared Operator <(one As SampleClass, other As SampleClass) As Boolean
+        Throw New NotImplementedException()
+    End Operator
+
+    Public Shared Operator >(one As SampleClass, other As SampleClass) As Boolean
+        Throw New NotImplementedException()
+    End Operator
+
+    'Optionally also implement
+
+    Public Shared Operator <=(one As SampleClass, other As SampleClass) As Boolean
+        Throw New NotImplementedException()
+    End Operator
+
+    Public Shared Operator >=(one As SampleClass, other As SampleClass) As Boolean
+        Throw New NotImplementedException()
+    End Operator
 ```
 
 ## When to suppress warnings
 
-It is safe to suppress a warning from rule CA1036 when the violation is caused by missing operators and your programming language does not support operator overloading, as is the case with Visual Basic. If you determine that implementing the operators does not make sense in your app context, it's also safe to suppress a warning from this rule when it fires on equality operators other than op_Equality. However, you should always override op_Equality and the == operator if you override <xref:System.Object.Equals%2A?displayProperty=nameWithType>.
+It is safe to suppress a warning from rule CA1036 when the violation is caused by missing operators and your programming language does not support operator overloading. If you determine that implementing the operators does not make sense in your app context, it's also safe to suppress a warning from this rule when it fires on equality operators other than op_Equality. However, you should always override op_Equality and the == operator if you override <xref:System.Object.Equals%2A?displayProperty=nameWithType>.
 
 ## Suppress a warning
 
@@ -91,6 +141,171 @@ The following code contains a type that correctly implements <xref:System.ICompa
 The following application code tests the behavior of the <xref:System.IComparable> implementation that was shown earlier.
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1036.cs" id="snippet2":::
+
+@Reviewer: Please convert to snipped (I am editing this file in the browser and do not have the repo checked out, sorry)
+(VB.NET example of a good implementation)
+```vb
+Public Class SampleClass
+    Implements IComparable
+    Implements IComparable(Of SampleClass)
+
+    Public Sub New(value As Int32)
+        Me.Value = value
+    End Sub
+
+    Public ReadOnly Property Value As Int32
+
+    Public Function CompareTo(obj As Object) As Integer Implements IComparable.CompareTo
+        If (obj Is Nothing) Then Return 1
+        If (TypeOf obj IsNot SampleClass) Then Return 0
+        Dim other As SampleClass = DirectCast(obj, SampleClass)
+        Return CompareTo(other)
+    End Function
+
+    Public Function CompareTo(other As SampleClass) As Integer Implements IComparable(Of SampleClass).CompareTo
+        If (other Is Nothing) Then Return 1
+        Return Comparer.DefaultInvariant.Compare(Value, other.Value)
+    End Function
+
+    Public Shared Operator =(one As SampleClass, other As SampleClass) As Boolean
+        If (one Is Nothing) Then Return (other Is Nothing)
+        If (other Is Nothing) Then Return False
+        Return (one.Value = other.Value)
+    End Operator
+
+    Public Shared Operator <>(one As SampleClass, other As SampleClass) As Boolean
+        If (one Is Nothing) Then Return (other IsNot Nothing)
+        If (other Is Nothing) Then Return True
+        Return (one.Value <> other.Value)
+    End Operator
+
+    Public Shared Operator <(one As SampleClass, other As SampleClass) As Boolean
+        If (one Is Nothing) Then Return (other IsNot Nothing)
+        If (other Is Nothing) Then Return False
+        Return (one.Value < other.Value)
+    End Operator
+
+    Public Shared Operator >(one As SampleClass, other As SampleClass) As Boolean
+        If (one Is Nothing) Then Return False
+        If (other Is Nothing) Then Return True
+        Return (one.Value > other.Value)
+    End Operator
+
+    Public Shared Operator <=(one As SampleClass, other As SampleClass) As Boolean
+        If (one Is Nothing) Then Return True
+        If (other Is Nothing) Then Return False
+        Return (one.Value <= other.Value)
+    End Operator
+
+    Public Shared Operator >=(one As SampleClass, other As SampleClass) As Boolean
+        If (one Is Nothing) Then Return (other Is Nothing)
+        If (other Is Nothing) Then Return True
+        Return (one.Value >= other.Value)
+    End Operator
+
+End Class
+```
+
+(Unit test of the example above)
+```vb
+Imports Microsoft.VisualStudio.TestTools.UnitTesting
+
+<TestClass>
+Public Class UnitTest
+
+    <TestMethod>
+    Public Sub UseCase_A_eq_B()
+        Dim a As New SampleClass(42)
+        Dim b As New SampleClass(42)
+        Assert.AreEqual(0, a.CompareTo(b))
+        Assert.IsTrue(a = b)
+        Assert.IsFalse(a <> b)
+        Assert.IsFalse(a < b)
+        Assert.IsFalse(a > b)
+        Assert.IsTrue(a <= b)
+        Assert.IsTrue(a >= b)
+    End Sub
+
+    <TestMethod>
+    Public Sub UseCase_A_lt_B()
+        Dim a As New SampleClass(42)
+        Dim b As New SampleClass(43)
+        Assert.AreEqual(-1, a.CompareTo(b))
+        Assert.IsFalse(a = b)
+        Assert.IsTrue(a <> b)
+        Assert.IsTrue(a < b)
+        Assert.IsFalse(a > b)
+        Assert.IsTrue(a <= b)
+        Assert.IsFalse(a >= b)
+    End Sub
+
+    <TestMethod>
+    Public Sub UseCase_A_gt_B()
+        Dim a As New SampleClass(43)
+        Dim b As New SampleClass(42)
+        Assert.AreEqual(1, a.CompareTo(b))
+        Assert.IsFalse(a = b)
+        Assert.IsTrue(a <> b)
+        Assert.IsFalse(a < b)
+        Assert.IsTrue(a > b)
+        Assert.IsFalse(a <= b)
+        Assert.IsTrue(a >= b)
+    End Sub
+
+    <TestMethod>
+    Public Sub UseCase_Nothing_NotNothing()
+        Dim a As SampleClass = Nothing
+        Dim b As New SampleClass(42)
+        Assert.IsFalse(a = b)
+        Assert.IsTrue(a <> b)
+        Assert.IsTrue(a < b)
+        Assert.IsFalse(a > b)
+        Assert.IsTrue(a <= b)
+        Assert.IsFalse(a >= b)
+    End Sub
+
+    <TestMethod>
+    Public Sub UseCase_NotNothing_Nothing()
+        Dim a As New SampleClass(42)
+        Dim b As SampleClass = Nothing
+        Assert.AreEqual(1, a.CompareTo(b))
+        Assert.IsFalse(a = b)
+        Assert.IsTrue(a <> b)
+        Assert.IsFalse(a < b)
+        Assert.IsTrue(a > b)
+        Assert.IsFalse(a <= b)
+        Assert.IsTrue(a >= b)
+    End Sub
+
+    <TestMethod>
+    Public Sub UseCase_Nothing_Nothing()
+        Dim a As SampleClass = Nothing
+        Dim b As SampleClass = Nothing
+        Assert.IsTrue(a = b)
+        Assert.IsFalse(a <> b)
+        Assert.IsFalse(a < b)
+        Assert.IsFalse(a > b)
+        Assert.IsTrue(a <= b)
+        Assert.IsTrue(a >= b)
+    End Sub
+
+    <TestMethod>
+    Public Sub UseCase_A_Rogue()
+        Dim a As New SampleClass(42)
+        Dim rogue As String = "Something else"
+        Assert.AreEqual(0, a.CompareTo(rogue))
+    End Sub
+
+    <TestMethod>
+    Public Sub UseCase_A_RogueNothing()
+        Dim a As New SampleClass(42)
+        Dim rogue As String = Nothing
+        Assert.AreEqual(1, a.CompareTo(rogue))
+    End Sub
+
+End Class
+```
+@Reviewer: End of snippets
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1036.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1036.md
@@ -10,6 +10,9 @@ helpviewer_keywords:
 - CA1036
 author: gewarren
 ms.author: gewarren
+dev_langs:
+- CSharp
+- VB
 ---
 # CA1036: Override methods on comparable types
 
@@ -35,23 +38,22 @@ Types that define a custom sort order implement the <xref:System.IComparable> in
 
 To fix a violation of this rule, override <xref:System.Object.Equals%2A>. If your programming language supports operator overloading, supply the following operators:
 
-- op_Equality
-- op_Inequality
-- op_LessThan
-- op_GreaterThan
-
-In C#, implement the following operators:
+- `op_Equality`
+- `op_Inequality`
+- `op_LessThan`
+- `op_GreaterThan`
 
 ```csharp
+// In C#, implement these operators.
 public static bool operator ==(SampleClass? one, SampleClass? other) { }
 public static bool operator !=(SampleClass? one, SampleClass? other) { }
 public static bool operator <(SampleClass? one, SampleClass? other) { }
 public static bool operator >(SampleClass? one, SampleClass? other) { }
 ```
 
-In Visual Basic, implement the following operators:
-
 ```vb
+' In Visual Basic, implement these operators.
+
 Public Shared Operator =(one As SampleClass, other As SampleClass) As Boolean
     ...
 End Operator

--- a/docs/fundamentals/code-analysis/quality-rules/ca1036.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1036.md
@@ -43,65 +43,35 @@ To fix a violation of this rule, override <xref:System.Object.Equals%2A>. If you
 In C#, implement the following operators:
 
 ```csharp
-    public static bool operator ==(SampleClass? one, SampleClass? other) {
-        throw new NotImplementedException();
-    }
-
-    public static bool operator !=(SampleClass? one, SampleClass? other) {
-        throw new NotImplementedException();
-    }
-
-    public static bool operator <(SampleClass? one, SampleClass? other) {
-        throw new NotImplementedException();
-    }
-
-    public static bool operator >(SampleClass? one, SampleClass? other) {
-        throw new NotImplementedException();
-    }
-
-    //Optionally also implement
-
-    public static bool operator <=(SampleClass? one, SampleClass? other) {
-        throw new NotImplementedException();
-    }
-
-    public static bool operator >=(SampleClass? one, SampleClass? other) {
-        throw new NotImplementedException();
-    }
+public static bool operator ==(SampleClass? one, SampleClass? other) { }
+public static bool operator !=(SampleClass? one, SampleClass? other) { }
+public static bool operator <(SampleClass? one, SampleClass? other) { }
+public static bool operator >(SampleClass? one, SampleClass? other) { }
 ```
 
-In VB.NET, implement the following operators:
+In Visual Basic, implement the following operators:
+
 ```vb
-    Public Shared Operator =(one As SampleClass, other As SampleClass) As Boolean
-        Throw New NotImplementedException()
-    End Operator
+Public Shared Operator =(one As SampleClass, other As SampleClass) As Boolean
+    ...
+End Operator
 
-    Public Shared Operator <>(one As SampleClass, other As SampleClass) As Boolean
-        Throw New NotImplementedException()
-    End Operator
+Public Shared Operator <>(one As SampleClass, other As SampleClass) As Boolean
+    ...
+End Operator
 
-    Public Shared Operator <(one As SampleClass, other As SampleClass) As Boolean
-        Throw New NotImplementedException()
-    End Operator
+Public Shared Operator <(one As SampleClass, other As SampleClass) As Boolean
+    ...
+End Operator
 
-    Public Shared Operator >(one As SampleClass, other As SampleClass) As Boolean
-        Throw New NotImplementedException()
-    End Operator
-
-    'Optionally also implement
-
-    Public Shared Operator <=(one As SampleClass, other As SampleClass) As Boolean
-        Throw New NotImplementedException()
-    End Operator
-
-    Public Shared Operator >=(one As SampleClass, other As SampleClass) As Boolean
-        Throw New NotImplementedException()
-    End Operator
+Public Shared Operator >(one As SampleClass, other As SampleClass) As Boolean
+    ...
+End Operator
 ```
 
 ## When to suppress warnings
 
-It is safe to suppress a warning from rule CA1036 when the violation is caused by missing operators and your programming language does not support operator overloading. If you determine that implementing the operators does not make sense in your app context, it's also safe to suppress a warning from this rule when it fires on equality operators other than op_Equality. However, you should always override op_Equality and the == operator if you override <xref:System.Object.Equals%2A?displayProperty=nameWithType>.
+It's safe to suppress a warning from rule CA1036 when the violation is caused by missing operators and your programming language does not support operator overloading. If you determine that implementing the operators does not make sense in your app context, it's also safe to suppress a warning from this rule when it fires on equality operators other than `op_Equality`. However, you should always override `op_Equality` and the `==` operator if you override <xref:System.Object.Equals%2A?displayProperty=nameWithType>.
 
 ## Suppress a warning
 
@@ -137,175 +107,12 @@ You can configure this option for just this rule, for all rules it applies to, o
 The following code contains a type that correctly implements <xref:System.IComparable>. Code comments identify the methods that satisfy various rules that are related to <xref:System.Object.Equals%2A> and the <xref:System.IComparable> interface.
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1036.cs" id="snippet1":::
+:::code language="vb" source="snippets/vb/all-rules/ca1036.vb" id="snippet1":::
 
 The following application code tests the behavior of the <xref:System.IComparable> implementation that was shown earlier.
 
 :::code language="csharp" source="snippets/csharp/all-rules/ca1036.cs" id="snippet2":::
-
-@Reviewer: Please convert to snipped (I am editing this file in the browser and do not have the repo checked out, sorry)
-(VB.NET example of a good implementation)
-```vb
-Public Class SampleClass
-    Implements IComparable
-    Implements IComparable(Of SampleClass)
-
-    Public Sub New(value As Int32)
-        Me.Value = value
-    End Sub
-
-    Public ReadOnly Property Value As Int32
-
-    Public Function CompareTo(obj As Object) As Integer Implements IComparable.CompareTo
-        If (obj Is Nothing) Then Return 1
-        If (TypeOf obj IsNot SampleClass) Then Return 0
-        Dim other As SampleClass = DirectCast(obj, SampleClass)
-        Return CompareTo(other)
-    End Function
-
-    Public Function CompareTo(other As SampleClass) As Integer Implements IComparable(Of SampleClass).CompareTo
-        If (other Is Nothing) Then Return 1
-        Return Comparer.DefaultInvariant.Compare(Value, other.Value)
-    End Function
-
-    Public Shared Operator =(one As SampleClass, other As SampleClass) As Boolean
-        If (one Is Nothing) Then Return (other Is Nothing)
-        If (other Is Nothing) Then Return False
-        Return (one.Value = other.Value)
-    End Operator
-
-    Public Shared Operator <>(one As SampleClass, other As SampleClass) As Boolean
-        If (one Is Nothing) Then Return (other IsNot Nothing)
-        If (other Is Nothing) Then Return True
-        Return (one.Value <> other.Value)
-    End Operator
-
-    Public Shared Operator <(one As SampleClass, other As SampleClass) As Boolean
-        If (one Is Nothing) Then Return (other IsNot Nothing)
-        If (other Is Nothing) Then Return False
-        Return (one.Value < other.Value)
-    End Operator
-
-    Public Shared Operator >(one As SampleClass, other As SampleClass) As Boolean
-        If (one Is Nothing) Then Return False
-        If (other Is Nothing) Then Return True
-        Return (one.Value > other.Value)
-    End Operator
-
-    Public Shared Operator <=(one As SampleClass, other As SampleClass) As Boolean
-        If (one Is Nothing) Then Return True
-        If (other Is Nothing) Then Return False
-        Return (one.Value <= other.Value)
-    End Operator
-
-    Public Shared Operator >=(one As SampleClass, other As SampleClass) As Boolean
-        If (one Is Nothing) Then Return (other Is Nothing)
-        If (other Is Nothing) Then Return True
-        Return (one.Value >= other.Value)
-    End Operator
-
-End Class
-```
-
-(Unit test of the example above)
-```vb
-Imports Microsoft.VisualStudio.TestTools.UnitTesting
-
-<TestClass>
-Public Class UnitTest
-
-    <TestMethod>
-    Public Sub UseCase_A_eq_B()
-        Dim a As New SampleClass(42)
-        Dim b As New SampleClass(42)
-        Assert.AreEqual(0, a.CompareTo(b))
-        Assert.IsTrue(a = b)
-        Assert.IsFalse(a <> b)
-        Assert.IsFalse(a < b)
-        Assert.IsFalse(a > b)
-        Assert.IsTrue(a <= b)
-        Assert.IsTrue(a >= b)
-    End Sub
-
-    <TestMethod>
-    Public Sub UseCase_A_lt_B()
-        Dim a As New SampleClass(42)
-        Dim b As New SampleClass(43)
-        Assert.AreEqual(-1, a.CompareTo(b))
-        Assert.IsFalse(a = b)
-        Assert.IsTrue(a <> b)
-        Assert.IsTrue(a < b)
-        Assert.IsFalse(a > b)
-        Assert.IsTrue(a <= b)
-        Assert.IsFalse(a >= b)
-    End Sub
-
-    <TestMethod>
-    Public Sub UseCase_A_gt_B()
-        Dim a As New SampleClass(43)
-        Dim b As New SampleClass(42)
-        Assert.AreEqual(1, a.CompareTo(b))
-        Assert.IsFalse(a = b)
-        Assert.IsTrue(a <> b)
-        Assert.IsFalse(a < b)
-        Assert.IsTrue(a > b)
-        Assert.IsFalse(a <= b)
-        Assert.IsTrue(a >= b)
-    End Sub
-
-    <TestMethod>
-    Public Sub UseCase_Nothing_NotNothing()
-        Dim a As SampleClass = Nothing
-        Dim b As New SampleClass(42)
-        Assert.IsFalse(a = b)
-        Assert.IsTrue(a <> b)
-        Assert.IsTrue(a < b)
-        Assert.IsFalse(a > b)
-        Assert.IsTrue(a <= b)
-        Assert.IsFalse(a >= b)
-    End Sub
-
-    <TestMethod>
-    Public Sub UseCase_NotNothing_Nothing()
-        Dim a As New SampleClass(42)
-        Dim b As SampleClass = Nothing
-        Assert.AreEqual(1, a.CompareTo(b))
-        Assert.IsFalse(a = b)
-        Assert.IsTrue(a <> b)
-        Assert.IsFalse(a < b)
-        Assert.IsTrue(a > b)
-        Assert.IsFalse(a <= b)
-        Assert.IsTrue(a >= b)
-    End Sub
-
-    <TestMethod>
-    Public Sub UseCase_Nothing_Nothing()
-        Dim a As SampleClass = Nothing
-        Dim b As SampleClass = Nothing
-        Assert.IsTrue(a = b)
-        Assert.IsFalse(a <> b)
-        Assert.IsFalse(a < b)
-        Assert.IsFalse(a > b)
-        Assert.IsTrue(a <= b)
-        Assert.IsTrue(a >= b)
-    End Sub
-
-    <TestMethod>
-    Public Sub UseCase_A_Rogue()
-        Dim a As New SampleClass(42)
-        Dim rogue As String = "Something else"
-        Assert.AreEqual(0, a.CompareTo(rogue))
-    End Sub
-
-    <TestMethod>
-    Public Sub UseCase_A_RogueNothing()
-        Dim a As New SampleClass(42)
-        Dim rogue As String = Nothing
-        Assert.AreEqual(1, a.CompareTo(rogue))
-    End Sub
-
-End Class
-```
-@Reviewer: End of snippets
+:::code language="vb" source="snippets/vb/all-rules/ca1036.vb" id="snippet2":::
 
 ## See also
 

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/Program.cs
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/Program.cs
@@ -1,0 +1,1 @@
+﻿TestCompare.Main1036("A", "B");

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/all-rules.csproj
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/all-rules.csproj
@@ -7,6 +7,14 @@
     <RootNamespace>all_rules</RootNamespace>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;31049</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <NoWarn>1701;1702;31049</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageReference Include="System.Security.Permissions" Version="8.0.0" />

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/all-rules.csproj
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/all-rules.csproj
@@ -7,14 +7,6 @@
     <RootNamespace>all_rules</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <NoWarn>1701;1702;31049</NoWarn>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <NoWarn>1701;1702;31049</NoWarn>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageReference Include="System.Security.Permissions" Version="8.0.0" />

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1036.cs
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1036.cs
@@ -1,143 +1,134 @@
 ﻿using System;
 using System.Globalization;
 
-namespace ca1036
+//<snippet1>
+// Valid ratings are between A and C.
+// A is the highest rating; it is greater than any other valid rating.
+// C is the lowest rating; it is less than any other valid rating.
+
+public class RatingInformation : IComparable, IComparable<RatingInformation>
 {
-    //<snippet1>
-    // Valid ratings are between A and C.
-    // A is the highest rating; it is greater than any other valid rating.
-    // C is the lowest rating; it is less than any other valid rating.
+    public string Rating { get; private set; }
 
-    public class RatingInformation : IComparable, IComparable<RatingInformation>
+    public RatingInformation(string rating)
     {
-        public string Rating
+        ArgumentNullException.ThrowIfNull(rating);
+
+        string v = rating.ToUpper(CultureInfo.InvariantCulture);
+        if (v.Length != 1 ||
+            string.Compare(v, "C", StringComparison.Ordinal) > 0 ||
+            string.Compare(v, "A", StringComparison.Ordinal) < 0)
         {
-            get;
-            private set;
+            throw new ArgumentException("Invalid rating value was specified.", nameof(rating));
         }
 
-        public RatingInformation(string rating)
-        {
-            if (rating == null)
-            {
-                throw new ArgumentNullException("rating");
-            }
-
-            string v = rating.ToUpper(CultureInfo.InvariantCulture);
-            if (v.Length != 1 || string.Compare(v, "C", StringComparison.Ordinal) > 0 || string.Compare(v, "A", StringComparison.Ordinal) < 0)
-            {
-                throw new ArgumentException("Invalid rating value was specified.", "rating");
-            }
-
-            Rating = v;
-        }
-
-        public int CompareTo(object? obj)
-        {
-            if (obj == null)
-            {
-                return 1;
-            }
-
-            if (obj is RatingInformation other)
-            {
-                return CompareTo(other);
-            }
-
-            throw new ArgumentException("A RatingInformation object is required for comparison.", "obj");
-        }
-
-        public int CompareTo(RatingInformation? other)
-        {
-            if (other is null)
-            {
-                return 1;
-            }
-
-            // Ratings compare opposite to normal string order, 
-            // so reverse the value returned by String.CompareTo.
-            return -string.Compare(this.Rating, other.Rating, StringComparison.OrdinalIgnoreCase);
-        }
-
-        public static int Compare(RatingInformation left, RatingInformation right)
-        {
-            if (object.ReferenceEquals(left, right))
-            {
-                return 0;
-            }
-            if (left is null)
-            {
-                return -1;
-            }
-            return left.CompareTo(right);
-        }
-
-        // Omitting Equals violates rule: OverrideMethodsOnComparableTypes.
-        public override bool Equals(object? obj)
-        {
-            if (obj is RatingInformation other)
-            {
-                return this.CompareTo(other) == 0;
-            }
-
-            return false;
-        }
-
-        // Omitting getHashCode violates rule: OverrideGetHashCodeOnOverridingEquals.
-        public override int GetHashCode()
-        {
-            char[] c = this.Rating.ToCharArray();
-            return (int)c[0];
-        }
-
-        // Omitting any of the following operator overloads 
-        // violates rule: OverrideMethodsOnComparableTypes.
-        public static bool operator ==(RatingInformation left, RatingInformation right)
-        {
-            if (left is null)
-            {
-                return right is null;
-            }
-            return left.Equals(right);
-        }
-        public static bool operator !=(RatingInformation left, RatingInformation right)
-        {
-            return !(left == right);
-        }
-        public static bool operator <(RatingInformation left, RatingInformation right)
-        {
-            return (Compare(left, right) < 0);
-        }
-        public static bool operator >(RatingInformation left, RatingInformation right)
-        {
-            return (Compare(left, right) > 0);
-        }
+        Rating = v;
     }
-    //</snippet1>
 
-    //<snippet2>
-    public class Test
+    public int CompareTo(object? obj)
     {
-        public static void Main1036(string[] args)
+        if (obj == null)
         {
-            if (args.Length < 2)
-            {
-                Console.WriteLine("usage - TestRatings  string 1 string2");
-                return;
-            }
-            RatingInformation r1 = new RatingInformation(args[0]);
-            RatingInformation r2 = new RatingInformation(args[1]);
-            string answer;
-
-            if (r1.CompareTo(r2) > 0)
-                answer = "greater than";
-            else if (r1.CompareTo(r2) < 0)
-                answer = "less than";
-            else
-                answer = "equal to";
-
-            Console.WriteLine("{0} is {1} {2}", r1.Rating, answer, r2.Rating);
+            return 1;
         }
+
+        if (obj is RatingInformation other)
+        {
+            return CompareTo(other);
+        }
+
+        throw new ArgumentException("A RatingInformation object is required for comparison.", nameof(obj));
     }
-    //</snippet2>
+
+    public int CompareTo(RatingInformation? other)
+    {
+        if (other is null)
+        {
+            return 1;
+        }
+
+        // Ratings compare opposite to normal string order,
+        // so reverse the value returned by String.CompareTo.
+        return -string.Compare(Rating, other.Rating, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static int Compare(RatingInformation left, RatingInformation right)
+    {
+        if (object.ReferenceEquals(left, right))
+        {
+            return 0;
+        }
+        if (left is null)
+        {
+            return -1;
+        }
+        return left.CompareTo(right);
+    }
+
+    // Omitting Equals violates rule: OverrideMethodsOnComparableTypes.
+    public override bool Equals(object? obj)
+    {
+        if (obj is RatingInformation other)
+        {
+            return CompareTo(other) == 0;
+        }
+
+        return false;
+    }
+
+    // Omitting getHashCode violates rule: OverrideGetHashCodeOnOverridingEquals.
+    public override int GetHashCode()
+    {
+        char[] c = Rating.ToCharArray();
+        return (int)c[0];
+    }
+
+    // Omitting any of the following operator overloads
+    // violates rule: OverrideMethodsOnComparableTypes.
+    public static bool operator ==(RatingInformation left, RatingInformation right)
+    {
+        if (left is null)
+        {
+            return right is null;
+        }
+        return left.Equals(right);
+    }
+    public static bool operator !=(RatingInformation left, RatingInformation right)
+    {
+        return !(left == right);
+    }
+    public static bool operator <(RatingInformation left, RatingInformation right)
+    {
+        return (Compare(left, right) < 0);
+    }
+    public static bool operator >(RatingInformation left, RatingInformation right)
+    {
+        return (Compare(left, right) > 0);
+    }
 }
+//</snippet1>
+
+//<snippet2>
+public class TestCompare
+{
+    public static void Main1036(params string[] args)
+    {
+        if (args.Length < 2)
+        {
+            return;
+        }
+        RatingInformation r1 = new(args[0]);
+        RatingInformation r2 = new(args[1]);
+        string answer;
+
+        if (r1.CompareTo(r2) > 0)
+            answer = "greater than";
+        else if (r1.CompareTo(r2) < 0)
+            answer = "less than";
+        else
+            answer = "equal to";
+
+        Console.WriteLine("{0} is {1} {2}", r1.Rating, answer, r2.Rating);
+    }
+}
+//</snippet2>

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/vb/all-rules/Program.vb
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/vb/all-rules/Program.vb
@@ -1,5 +1,5 @@
 ﻿Public Class Program
     Public Shared Sub Main()
-        TestCompare.Main(New String() {"A", "B"})
+        TestCompare.Main1036(New String() {"C", "B"})
     End Sub
 End Class

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/vb/all-rules/Program.vb
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/vb/all-rules/Program.vb
@@ -1,0 +1,5 @@
+﻿Public Class Program
+    Public Shared Sub Main()
+        TestCompare.Main(New String() {"A", "B"})
+    End Sub
+End Class

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/vb/all-rules/all-rules.vbproj
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/vb/all-rules/all-rules.vbproj
@@ -4,11 +4,8 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>all_rules</RootNamespace>
     <TargetFramework>net8.0</TargetFramework>
+    <NoWarn>$(NoWarn);BC30149</NoWarn>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Compile Remove="Program.vb" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/vb/all-rules/all-rules.vbproj
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/vb/all-rules/all-rules.vbproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>all_rules</RootNamespace>
     <TargetFramework>net8.0</TargetFramework>
-    <NoWarn>$(NoWarn);BC30149</NoWarn>
+    <NoWarn>$(NoWarn);SYSLIB0050</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/vb/all-rules/ca1003-use-generic-event-handler-instances_1.vb
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/vb/all-rules/ca1003-use-generic-event-handler-instances_1.vb
@@ -42,7 +42,7 @@ Namespace ca1003
 
     Class Test
 
-        Shared Sub Main()
+        Shared Sub Main1003()
 
             Dim eventRaiser As New ClassThatRaisesEvent()
             Dim eventHandler As New ClassThatHandlesEvent(eventRaiser)

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/vb/all-rules/ca1036.vb
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/vb/all-rules/ca1036.vb
@@ -16,7 +16,7 @@ Public Class RatingInformation
             Throw New ArgumentException("Invalid rating value was specified.", NameOf(rating))
         End If
 
-        rating = v
+        Me.Rating = v
     End Sub
 
     Public ReadOnly Property Rating As String
@@ -30,7 +30,9 @@ Public Class RatingInformation
 
     Public Function CompareTo(other As RatingInformation) As Integer Implements IComparable(Of RatingInformation).CompareTo
         If (other Is Nothing) Then Return 1
-        Return Comparer.DefaultInvariant.Compare(Rating, other.Rating)
+        ' Ratings compare opposite To normal String order,
+        ' so reverse the value returned by String.CompareTo.
+        Return -String.Compare(Rating, other.Rating, StringComparison.OrdinalIgnoreCase)
     End Function
 
     Public Shared Operator =(one As RatingInformation, other As RatingInformation) As Boolean
@@ -77,7 +79,7 @@ End Class
 
 ' <Snippet2>
 Public Class TestCompare
-    Public Shared Sub Main(ByVal args As String())
+    Public Shared Sub Main1036(ByVal args As String())
         If (args.Length < 2) Then
             Return
         End If

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/vb/all-rules/ca1036.vb
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/vb/all-rules/ca1036.vb
@@ -1,0 +1,99 @@
+﻿
+' <Snippet1>
+Imports System.Globalization
+
+Public Class RatingInformation
+    Implements IComparable
+    Implements IComparable(Of RatingInformation)
+
+    Public Sub New(rating As String)
+        ArgumentNullException.ThrowIfNull(rating)
+
+        Dim v As String = rating.ToUpper(CultureInfo.InvariantCulture)
+        If (v.Length <> 1 Or
+            String.Compare(v, "C", StringComparison.Ordinal) > 0 Or
+            String.Compare(v, "A", StringComparison.Ordinal) < 0) Then
+            Throw New ArgumentException("Invalid rating value was specified.", NameOf(rating))
+        End If
+
+        rating = v
+    End Sub
+
+    Public ReadOnly Property Rating As String
+
+    Public Function CompareTo(obj As Object) As Integer Implements IComparable.CompareTo
+        If (obj Is Nothing) Then Return 1
+        If (TypeOf obj IsNot RatingInformation) Then Return 0
+        Dim other As RatingInformation = DirectCast(obj, RatingInformation)
+        Return CompareTo(other)
+    End Function
+
+    Public Function CompareTo(other As RatingInformation) As Integer Implements IComparable(Of RatingInformation).CompareTo
+        If (other Is Nothing) Then Return 1
+        Return Comparer.DefaultInvariant.Compare(Rating, other.Rating)
+    End Function
+
+    Public Shared Operator =(one As RatingInformation, other As RatingInformation) As Boolean
+        If (one Is Nothing) Then Return (other Is Nothing)
+        If (other Is Nothing) Then Return False
+        Return (one.Rating = other.Rating)
+    End Operator
+
+    Public Shared Operator <>(one As RatingInformation, other As RatingInformation) As Boolean
+        If (one Is Nothing) Then Return (other IsNot Nothing)
+        If (other Is Nothing) Then Return True
+        Return (one.Rating <> other.Rating)
+    End Operator
+
+    Public Shared Operator <(one As RatingInformation, other As RatingInformation) As Boolean
+        If (one Is Nothing) Then Return (other IsNot Nothing)
+        If (other Is Nothing) Then Return False
+        Return (one.Rating < other.Rating)
+    End Operator
+
+    Public Shared Operator >(one As RatingInformation, other As RatingInformation) As Boolean
+        If (one Is Nothing) Then Return False
+        If (other Is Nothing) Then Return True
+        Return (one.Rating > other.Rating)
+    End Operator
+
+    Public Overrides Function Equals(obj As Object) As Boolean
+        If ReferenceEquals(Me, obj) Then
+            Return True
+        End If
+
+        If obj Is Nothing Then
+            Return False
+        End If
+
+        Throw New NotImplementedException()
+    End Function
+
+    Public Overrides Function GetHashCode() As Integer
+        Throw New NotImplementedException()
+    End Function
+End Class
+' </Snippet1>
+
+' <Snippet2>
+Public Class TestCompare
+    Public Shared Sub Main(ByVal args As String())
+        If (args.Length < 2) Then
+            Return
+        End If
+        Dim r1 As New RatingInformation(args(0))
+        Dim r2 As New RatingInformation(args(1))
+        Dim answer As String
+
+        If (r1.CompareTo(r2) > 0) Then
+            answer = "greater than"
+        ElseIf (r1.CompareTo(r2) < 0) Then
+            answer = "less than"
+        Else
+            answer = "equal to"
+        End If
+
+        Console.WriteLine("{0} is {1} {2}", r1.Rating, answer, r2.Rating)
+    End Sub
+End Class
+' </Snippet2>

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/vb/all-rules/ca2237-mark-iserializable-types-with-serializableattribute_1.vb
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/vb/all-rules/ca2237-mark-iserializable-types-with-serializableattribute_1.vb
@@ -20,14 +20,10 @@ Namespace ca2237
         End Sub
 
         Overridable Sub GetObjectData(
-         info As SerializationInfo, context As StreamingContext)
+         info As SerializationInfo, context As StreamingContext) Implements ISerializable.GetObjectData
 
             info.AddValue("baseValue", baseValue)
 
-        End Sub
-
-        Private Sub ISerializable_GetObjectData(info As SerializationInfo, context As StreamingContext)
-            Throw New NotImplementedException()
         End Sub
     End Class
 

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/vb/all-rules/ca2237-mark-iserializable-types-with-serializableattribute_1.vb
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/vb/all-rules/ca2237-mark-iserializable-types-with-serializableattribute_1.vb
@@ -1,6 +1,4 @@
-﻿Imports System
-Imports System.Runtime.Serialization
-Imports System.Security.Permissions
+﻿Imports System.Runtime.Serialization
 
 Namespace ca2237
 
@@ -22,13 +20,15 @@ Namespace ca2237
         End Sub
 
         Overridable Sub GetObjectData(
-         info As SerializationInfo, context As StreamingContext) _
-         Implements ISerializable.GetObjectData
+         info As SerializationInfo, context As StreamingContext)
 
             info.AddValue("baseValue", baseValue)
 
         End Sub
 
+        Private Sub ISerializable_GetObjectData(info As SerializationInfo, context As StreamingContext)
+            Throw New NotImplementedException()
+        End Sub
     End Class
 
 End Namespace


### PR DESCRIPTION
## Summary

Incorrect statement that VB.NET does not support operator overloading corrected and sample operators provided for C# and VB.NET, sample VB.NET snipped provided (inline).


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1036.md](https://github.com/dotnet/docs/blob/d8406043130bba5ac91ce01a9c05525e04738b2c/docs/fundamentals/code-analysis/quality-rules/ca1036.md) | [docs/fundamentals/code-analysis/quality-rules/ca1036](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1036?branch=pr-en-us-42739) |


<!-- PREVIEW-TABLE-END -->