### PR TITLE
Add note about configuration PATH environment variable in Linux OS to make installed tools globally be executable in shell from any directory.

### DIFF
--- a/docs/core/tools/dotnet-tool-install.md
+++ b/docs/core/tools/dotnet-tool-install.md
@@ -68,6 +68,7 @@ Executables are generated in these folders for each globally installed tool, alt
 > To make the tool executable from any directory, update the `PATH` environment variable.
 > To make the updated `PATH` environment variable permanent in your shell, update your shell settings.
 > For `Bash`, this is the `$HOME/.bashrc` file. 
+
 ### `--tool-path` tools
 
 Tools with explicit tool paths are stored wherever you specified the `--tool-path` parameter to point to. They're stored in the same way as global tools: an executable binary with the actual binaries in a sibling `.store` directory.

--- a/docs/core/tools/dotnet-tool-install.md
+++ b/docs/core/tools/dotnet-tool-install.md
@@ -63,6 +63,15 @@ Global tools are installed in the following directories by default when you spec
 
 Executables are generated in these folders for each globally installed tool, although the actual tool binaries are nested deep into the sibling `.store` directory.
 
+> On Linux OS after installing a command-line tool with `dotnet tool`, the tool may be executed only from the `$HOME/.dotnet/tools` path.
+> To make the tool executable from any directory, you can update the environment variable called `PATH`.
+> To make the updated `PATH` environment variable permanent in your shell, you need to update your shell settings.
+> For `Bash`, this is `$HOME/.bashrc` file. 
+>>```sh
+>> export PATH=$PATH:~/.dotnet/tools
+>> ```
+
+
 ### `--tool-path` tools
 
 Tools with explicit tool paths are stored wherever you specified the `--tool-path` parameter to point to. They're stored in the same way as global tools: an executable binary with the actual binaries in a sibling `.store` directory.

--- a/docs/core/tools/dotnet-tool-install.md
+++ b/docs/core/tools/dotnet-tool-install.md
@@ -65,9 +65,9 @@ Executables are generated in these folders for each globally installed tool, alt
 
 > [!NOTE]
 > On Linux after installing a command-line tool with `dotnet tool`, the tool can be executed only from the `$HOME/.dotnet/tools` path.
-> To make the tool executable from any directory, you can update the environment variable called `PATH`.
-> To make the updated `PATH` environment variable permanent in your shell, you need to update your shell settings.
-> For `Bash`, this is `$HOME/.bashrc` file. 
+> To make the tool executable from any directory, update the `PATH` environment variable.
+> To make the updated `PATH` environment variable permanent in your shell, update your shell settings.
+> For `Bash`, this is the `$HOME/.bashrc` file. 
 >>```sh
 >> export PATH=$PATH:~/.dotnet/tools
 >> ```

--- a/docs/core/tools/dotnet-tool-install.md
+++ b/docs/core/tools/dotnet-tool-install.md
@@ -68,11 +68,6 @@ Executables are generated in these folders for each globally installed tool, alt
 > To make the tool executable from any directory, update the `PATH` environment variable.
 > To make the updated `PATH` environment variable permanent in your shell, update your shell settings.
 > For `Bash`, this is the `$HOME/.bashrc` file. 
->>```sh
->> export PATH=$PATH:~/.dotnet/tools
->> ```
-
-
 ### `--tool-path` tools
 
 Tools with explicit tool paths are stored wherever you specified the `--tool-path` parameter to point to. They're stored in the same way as global tools: an executable binary with the actual binaries in a sibling `.store` directory.

--- a/docs/core/tools/dotnet-tool-install.md
+++ b/docs/core/tools/dotnet-tool-install.md
@@ -67,7 +67,7 @@ Executables are generated in these folders for each globally installed tool, alt
 > On Linux after installing a command-line tool with `dotnet tool`, the tool can be executed only from the `$HOME/.dotnet/tools` path.
 > To make the tool executable from any directory, update the `PATH` environment variable.
 > To make the updated `PATH` environment variable permanent in your shell, update your shell settings.
-> For `Bash`, this is the `$HOME/.bashrc` file. 
+> For `Bash`, this is the `$HOME/.bashrc` file.
 
 ### `--tool-path` tools
 

--- a/docs/core/tools/dotnet-tool-install.md
+++ b/docs/core/tools/dotnet-tool-install.md
@@ -63,7 +63,8 @@ Global tools are installed in the following directories by default when you spec
 
 Executables are generated in these folders for each globally installed tool, although the actual tool binaries are nested deep into the sibling `.store` directory.
 
-> On Linux OS after installing a command-line tool with `dotnet tool`, the tool may be executed only from the `$HOME/.dotnet/tools` path.
+> [!NOTE]
+> On Linux after installing a command-line tool with `dotnet tool`, the tool can be executed only from the `$HOME/.dotnet/tools` path.
 > To make the tool executable from any directory, you can update the environment variable called `PATH`.
 > To make the updated `PATH` environment variable permanent in your shell, you need to update your shell settings.
 > For `Bash`, this is `$HOME/.bashrc` file. 


### PR DESCRIPTION
## Summary

Add note about configuration `PATH` environment variable in Linux OS to make installed tools globally be executable in shell from any directory.




<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-tool-install.md](https://github.com/dotnet/docs/blob/f4a25e3675bdb3245173b61a443d9f0bb28ec70d/docs/core/tools/dotnet-tool-install.md) | [docs/core/tools/dotnet-tool-install](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-install?branch=pr-en-us-42746) |


<!-- PREVIEW-TABLE-END -->