### PR TITLE
Fix markdown syntax for pandoc

### DIFF
--- a/docs/core/tools/dotnet-new-sdk-templates.md
+++ b/docs/core/tools/dotnet-new-sdk-templates.md
@@ -13,7 +13,7 @@ When you install the [.NET SDK](https://dotnet.microsoft.com/download), you rece
 dotnet new list
 ```
 
-[!INCLUDE [](../../../includes/templates.md)]
+[!INCLUDE [templates](../../../includes/templates.md)]
 
 ## Template options
 

--- a/docs/core/tools/dotnet-new.md
+++ b/docs/core/tools/dotnet-new.md
@@ -56,7 +56,7 @@ To activate tab completion for the .NET SDK, see [Enable tab completion](enable-
 
   Starting with .NET SDK 5.0.300, the [`search` command](dotnet-new-search.md) should be used to search for templates in NuGet.org.
 
-[!INCLUDE [](../../../includes/templates.md)]
+[!INCLUDE [templates](../../../includes/templates.md)]
 
 ## Options
 


### PR DESCRIPTION
Running the SDK manpage tool (https://github.com/dotnet/sdk/tree/main/documentation/manpages/tool which we run once a year) was complaining about the changes made in https://github.com/dotnet/docs/commit/1de00766422ffb6e01264b17e3eb99e8d5066ef3.
```sh
$ cd sdk/documentation/manpages/tool
$ ./run_docker.sh
...
Working on docs-main/docs/core/tools/dotnet-new-sdk-templates.md
Traceback (most recent call last):
  File "/manpages/tool/remove-metadata-and-embed-includes.py", line 67, in <module>
    sys.exit(main(sys.argv))
  File "/manpages/tool/remove-metadata-and-embed-includes.py", line 59, in main
    lines = read_lines_document_file(filename, original.readlines())
  File "/manpages/tool/remove-metadata-and-embed-includes.py", line 51, in read_lines_document_file
    assert False, 'Unable to parse: ' + line
AssertionError: Unable to parse: [!INCLUDE [](../../../includes/templates.md)]
```

cc @tdykstra
FYI: @jkoritzinsky @marcpopMSFT

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-new-sdk-templates.md](https://github.com/dotnet/docs/blob/6d0e946d04aafe66901048438fbc72b693074d88/docs/core/tools/dotnet-new-sdk-templates.md) | [docs/core/tools/dotnet-new-sdk-templates](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-new-sdk-templates?branch=pr-en-us-42747) |
| [docs/core/tools/dotnet-new.md](https://github.com/dotnet/docs/blob/6d0e946d04aafe66901048438fbc72b693074d88/docs/core/tools/dotnet-new.md) | [docs/core/tools/dotnet-new](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-new?branch=pr-en-us-42747) |

<!-- PREVIEW-TABLE-END -->