### PR TITLE
Correct Typo in the .NET Implementations article

### DIFF
--- a/docs/fundamentals/implementations.md
+++ b/docs/fundamentals/implementations.md
@@ -17,7 +17,7 @@ Each implementation of .NET includes the following components:
 
 There are four .NET implementations that Microsoft supports:
 
-- .NET 6 and later versions
+- .NET 5 and later versions
 - .NET Framework
 - Mono
 - UWP


### PR DESCRIPTION
Corrected a typo in the list featured in the .NET Implementations article

Fixes #42750


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/implementations.md](https://github.com/dotnet/docs/blob/76cb284cfd3a0ef578977e09be3e34c638ab0fa6/docs/fundamentals/implementations.md) | [docs/fundamentals/implementations](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/implementations?branch=pr-en-us-42751) |


<!-- PREVIEW-TABLE-END -->