### PR TITLE
Correct Typo in the Releases and support for .NET article

### DIFF
--- a/docs/core/releases-and-support.md
+++ b/docs/core/releases-and-support.md
@@ -59,7 +59,7 @@ There are two support tracks for releases:
 
 * *Standard Term Support* (STS) releases
 
-  These versions are supported until 6 months after the next major or minor release ships.
+  These versions are supported until 18 months after the next major or minor release ships.
 
   Example:
 


### PR DESCRIPTION
Corrected a typo in the list featured in the Releases and support for .NET article

Fixes #42753



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/releases-and-support.md](https://github.com/dotnet/docs/blob/80cd0a932993c3ab8101f2b5d194950022a2bf6d/docs/core/releases-and-support.md) | [docs/core/releases-and-support](https://review.learn.microsoft.com/en-us/dotnet/core/releases-and-support?branch=pr-en-us-42754) |

<!-- PREVIEW-TABLE-END -->