### PR TITLE
Move metrics-collection.md to .NET 6

### DIFF
--- a/docs/core/diagnostics/metrics-collection.md
+++ b/docs/core/diagnostics/metrics-collection.md
@@ -7,7 +7,7 @@ ms.date: 10/27/2021
 
 # Collect metrics
 
-**This article applies to: ✔️** .NET Core 3.1 and later **✔️** .NET Framework 4.6.1 and later
+**This article applies to: ✔️** .NET 6.0 and later **✔️** .NET Framework 4.6.1 and later
 
 Instrumented code can record numeric measurements, but the measurements usually need to be aggregated, transmitted, and stored to create useful metrics for monitoring. The process of aggregating, transmitting, and storing data is called collection. This tutorial shows several examples of collecting metrics:
 
@@ -19,7 +19,7 @@ For more information on custom metric instrumentation and options, see [Compare 
 
 ## Prerequisites
 
-- [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download/dotnet) or a later
+- [.NET 6.0 SDK](https://dotnet.microsoft.com/download/dotnet) or a later
 
 ## Create an example app
 


### PR DESCRIPTION
Changes in dotnet-counters have made it incompatible with .NET Core 3.1. Given 3.1 is already out of support I am updating the docs to include .NET 6 as the lowest version.

Fixes https://github.com/dotnet/diagnostics/issues/4522


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/metrics-collection.md](https://github.com/dotnet/docs/blob/848edd12d3686a9a2e0823e829eb03b06de22d2a/docs/core/diagnostics/metrics-collection.md) | [docs/core/diagnostics/metrics-collection](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/metrics-collection?branch=pr-en-us-42770) |

<!-- PREVIEW-TABLE-END -->