### PR TITLE
Add Triage DumpType description

### DIFF
--- a/docs/core/diagnostics/microsoft-diagnostics-netcore-client.md
+++ b/docs/core/diagnostics/microsoft-diagnostics-netcore-client.md
@@ -343,7 +343,7 @@ Represents the type of dump that can be requested.
 
 * `Normal`: Include just the information necessary to capture stack traces for all existing traces for all existing threads in a process. Limited GC heap memory and information.
 * `WithHeap`: Includes the GC heaps and information necessary to capture stack traces for all existing threads in a process.
-* `Triage`: Include just the information necessary to capture stack traces for all existing traces for all existing threads in a process. Limited GC heap memory and information. Some content that is known to contain potentially sensitive information such as full module paths will be redacted. While this is intended to mitigate some cases of sensitive data exposure, there is no guarantee this redaction feature on its own is sufficient to comply with any particular law or standard regarding data privacy. 
+* `Triage`: Include just the information necessary to capture stack traces for all existing traces for all existing threads in a process. Limited GC heap memory and information. Some content that is known to contain potentially sensitive information such as full module paths will be redacted. While this is intended to mitigate some cases of sensitive data exposure, there is no guarantee this redaction feature on its own is sufficient to comply with any particular law or standard regarding data privacy.
 * `Full`: Include all accessible memory in the process. The raw memory data is included at the end, so that the initial structures can be mapped directly without the raw memory information. This option can result in a very large dump file.
 
 ## Exceptions

--- a/docs/core/diagnostics/microsoft-diagnostics-netcore-client.md
+++ b/docs/core/diagnostics/microsoft-diagnostics-netcore-client.md
@@ -343,7 +343,7 @@ Represents the type of dump that can be requested.
 
 * `Normal`: Include just the information necessary to capture stack traces for all existing traces for all existing threads in a process. Limited GC heap memory and information.
 * `WithHeap`: Includes the GC heaps and information necessary to capture stack traces for all existing threads in a process.
-* `Triage`: Include just the information necessary to capture stack traces for all existing traces for all existing threads in a process. Limited GC heap memory and information.
+* `Triage`: Include just the information necessary to capture stack traces for all existing traces for all existing threads in a process. Limited GC heap memory and information. Some content that is known to contain potentially sensitive information such as full module paths will be redacted. While this is intended to mitigate some cases of sensitive data exposure, there is no guarantee this redaction feature on its own is sufficient to comply with any particular law or standard regarding data privacy. 
 * `Full`: Include all accessible memory in the process. The raw memory data is included at the end, so that the initial structures can be mapped directly without the raw memory information. This option can result in a very large dump file.
 
 ## Exceptions


### PR DESCRIPTION
Triage DumpType was previously identical to Normal. Adding more text describing the redaction behavior that is included when using Triage.

Fixes https://github.com/dotnet/diagnostics/issues/4491


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/microsoft-diagnostics-netcore-client.md](https://github.com/dotnet/docs/blob/8262a8ce507987e723a986206b23b77a4c0d3be6/docs/core/diagnostics/microsoft-diagnostics-netcore-client.md) | [docs/core/diagnostics/microsoft-diagnostics-netcore-client](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/microsoft-diagnostics-netcore-client?branch=pr-en-us-42771) |


<!-- PREVIEW-TABLE-END -->