### PR TITLE
Updated list of types removed in NET3.1 

### DIFF
--- a/includes/core-changes/windowsforms/3.1/remove-controls-3.1.md
+++ b/includes/core-changes/windowsforms/3.1/remove-controls-3.1.md
@@ -15,6 +15,7 @@ The following types are no longer available:
 - <xref:System.Windows.Forms.DataGridCell>
 - <xref:System.Windows.Forms.DataGridColumnStyle>
 - <xref:System.Windows.Forms.DataGridColumnStyle.DataGridColumnHeaderAccessibleObject>
+- <xref:System.Windows.Forms.DataGridColumnStyle.CompModSwitches>
 - <xref:System.Windows.Forms.DataGridLineStyle>
 - <xref:System.Windows.Forms.DataGridParentRowsLabelStyle>
 - <xref:System.Windows.Forms.DataGridPreferredColumnWidthTypeConverter>


### PR DESCRIPTION
We didn't document a removed class - https://learn.microsoft.com/dotnet/api/system.windows.forms.datagridcolumnstyle.compmodswitches?view=netframework-4.8.1&viewFallbackFrom=net-5.0
Adding it to the list.
