### PR TITLE
Clarify that NativeLibrary can be used for transitive dependencies

### DIFF
--- a/docs/core/deploying/native-aot/interop.md
+++ b/docs/core/deploying/native-aot/interop.md
@@ -47,7 +47,7 @@ On Windows, Native AOT uses a prepopulated list of direct P/Invoke methods that 
 
 ### Linking
 
-To statically link against an unmanaged library, you need to specify `<NativeLibrary Include="filename" />` pointing to a `.lib` file on Windows and a `.a` file on Unix-like systems.
+To statically link against one or more unmanaged libraries, you need to specify `<NativeLibrary Include="filename" />` pointing to a `.lib` file on Windows and a `.a` file on Unix-like systems for each library.
 
 Examples:
 
@@ -60,6 +60,10 @@ Examples:
   <NativeLibrary Include="Dependency.a" Condition="!$(RuntimeIdentifier.StartsWith('win'))" />
 </ItemGroup>
 ```
+
+If the specified native library has a dependency on other static libraries, then `NativeLibrary` items will need to be added for each of the transitive depenencies as well, otherwise the native linker will fail because of missing symbols.
+
+Platform conventions are followed when it comes to the format of `NativeLibrary` entries. The underlying native linker may search standard library paths or allow rooted file paths.
 
 To specify additional flags to the native linker, use the `<LinkerArg>` item.
 


### PR DESCRIPTION
I have added the following two clarifications:

1. `NativeLibrary` can be used more than once. Originally I thought that it can only be used for the library specified in `DirectPInvoke`, but after some time I realized it can be used for transitive dependencies as well. My change makes this more clear.
2. Added `/path/to` to make it clear that paths are accepted and that the file does not need to be manually moved to the project output directory in order to be found.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/deploying/native-aot/interop.md](https://github.com/dotnet/docs/blob/2a52d5f99ff172f4e5d935caa170150d9d4fae35/docs/core/deploying/native-aot/interop.md) | [Native code interop with Native AOT](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/interop?branch=pr-en-us-42815) |


<!-- PREVIEW-TABLE-END -->