### PR TITLE
Fix typo in processstartinfo-windowstyle.md

### DIFF
--- a/docs/core/compatibility/core-libraries/8.0/processstartinfo-windowstyle.md
+++ b/docs/core/compatibility/core-libraries/8.0/processstartinfo-windowstyle.md
@@ -3,7 +3,7 @@ title: ".NET 8 breaking change: ProcessStartInfo.WindowStyle honored when UseShe
 description: Learn about the .NET 8 breaking change in core .NET libraries where ProcessStartInfo.WindowStyle is now honored even when UseShellExecute is false.
 ms.date: 11/08/2023
 ---
-# ProcessStartInfo.WindowsStyle honored when UseShellExecute is false
+# ProcessStartInfo.WindowStyle honored when UseShellExecute is false
 
 Previously, <xref:System.Diagnostics.ProcessStartInfo.WindowStyle?displayName=nameWithType> was only honored when <xref:System.Diagnostics.ProcessStartInfo.UseShellExecute?displayName=nameWithType> was `true`. This change honors <xref:System.Diagnostics.ProcessStartInfo.WindowStyle> even when <xref:System.Diagnostics.ProcessStartInfo.UseShellExecute> is `false`.
 


### PR DESCRIPTION
## Summary

Fix typo in headline "WindowsStyle" -> "WindowStyle"



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/core-libraries/8.0/processstartinfo-windowstyle.md](https://github.com/dotnet/docs/blob/15914f80f703b511484edccf52626c2a34ea20d7/docs/core/compatibility/core-libraries/8.0/processstartinfo-windowstyle.md) | [docs/core/compatibility/core-libraries/8.0/processstartinfo-windowstyle](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/8.0/processstartinfo-windowstyle?branch=pr-en-us-42817) |

<!-- PREVIEW-TABLE-END -->