### PR TITLE
Fix CA2262 example

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca2262.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2262.md
@@ -40,8 +40,8 @@ HttpClientHandler handler = new()
     // Violation
     MaxResponseHeadersLength = 512
 
-    // Fix
-    MaxResponseHeadersLength = 0.512
+    // Fix (it is not possible to specify a limit lower than 1 KB)
+    MaxResponseHeadersLength = 1
 };
 ```
 
@@ -51,8 +51,8 @@ Dim handler As New HttpClientHandler With {
     ' Violation
     .MaxResponseHeadersLength = 512
 
-    ' Fix
-    .MaxResponseHeadersLength = 0.512
+    ' Fix (it is not possible to specify a limit lower than 1 KB)
+    .MaxResponseHeadersLength = 1
 }
 ```
 


### PR DESCRIPTION
`MaxResponseHeadersLength` is an `int`. It's not possible to set it to a fraction.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca2262.md](https://github.com/dotnet/docs/blob/0d21eca6138b92c3f1f7881f0806c2f977aa56d9/docs/fundamentals/code-analysis/quality-rules/ca2262.md) | [docs/fundamentals/code-analysis/quality-rules/ca2262](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2262?branch=pr-en-us-42818) |

<!-- PREVIEW-TABLE-END -->