### PR TITLE
Don't imply partial members are optional

### DIFF
--- a/docs/csharp/language-reference/keywords/partial-member.md
+++ b/docs/csharp/language-reference/keywords/partial-member.md
@@ -9,7 +9,7 @@ helpviewer_keywords:
 ---
 # Partial member (C# Reference)
 
-A partial member has one *declaring declaration* and often one *implementing declaration*. The *declaring declaration* doesn't include a body. The *implementing declaration* provides the body of the member. Partial members enable class designers to provide member hooks, similar to event handlers, that developers can decide to implement or not. Partial types and members provide a way for human developers to write part of a type while tools write other parts of the type. If the developer doesn't supply an optional implementing declaration, the compiler can remove the declaring declaration at compile time. The following conditions apply to partial members:
+A partial member has one *declaring declaration* and often one *implementing declaration*. The *declaring declaration* doesn't include a body. The *implementing declaration* provides the body of the member. Partial members enable class designers to provide member hooks that can be implemented by tooling such as source generators. Partial types and members provide a way for human developers to write part of a type while tools write other parts of the type. If the developer doesn't supply an optional implementing declaration, the compiler can remove the declaring declaration at compile time. The following conditions apply to partial members:
 
 - Declarations must begin with the contextual keyword [partial](../../language-reference/keywords/partial-type.md).
 - Signatures in both parts of the partial type must match.


### PR DESCRIPTION
Fixes #42442

Only a small subset of partial members are optional. Don't imply that they are.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/partial-member.md](https://github.com/dotnet/docs/blob/8c9244d09601ac7868ca7956df088019042aaba3/docs/csharp/language-reference/keywords/partial-member.md) | [docs/csharp/language-reference/keywords/partial-member](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/partial-member?branch=pr-en-us-42823) |

<!-- PREVIEW-TABLE-END -->