### PR TITLE
Fix Compile Error due to Nullability

### DIFF
--- a/samples/snippets/standard/data/sqlite/DapperSample/Program.cs
+++ b/samples/snippets/standard/data/sqlite/DapperSample/Program.cs
@@ -9,7 +9,7 @@ namespace DapperSample
     abstract class SqliteTypeHandler<T> : SqlMapper.TypeHandler<T>
     {
         // Parameters are converted by Microsoft.Data.Sqlite
-        public override void SetValue(IDbDataParameter parameter, T value)
+        public override void SetValue(IDbDataParameter parameter, T? value)
             => parameter.Value = value;
     }
 


### PR DESCRIPTION
Current version yields this:
Nullability of type of parameter 'value' does not match overridden member.

See:
![image](https://github.com/user-attachments/assets/010f3424-7206-45fc-8f26-661d29674854)

After:
![image](https://github.com/user-attachments/assets/d1e82076-ce8f-42fe-9b58-c169c3c778d6)


## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
