### PR TITLE
Fix samples

### DIFF
--- a/docs/csharp/language-reference/keywords/ref.md
+++ b/docs/csharp/language-reference/keywords/ref.md
@@ -1,6 +1,6 @@
 ---
-description: "ref keyword - C# Reference"
-title: "ref keyword"
+description: "Understand the different uses for the `ref` keyword and get more information on those uses"
+title: "The multiple uses of the `ref` keyword"
 ms.date: 09/23/2023
 f1_keywords: 
   - "ref_CSharpKeyword"
@@ -8,43 +8,34 @@ helpviewer_keywords:
   - "parameters [C#], ref"
   - "ref keyword [C#]"
 ---
-# ref (C# reference)
+# The `ref` keyword
 
 You use the `ref` keyword in the following contexts:
 
 - In a method signature and in a method call, to pass an argument to a method [by reference](./method-parameters.md#ref-parameter-modifier).
 
-:::code language="csharp" source="./snippets/PassParameters.cs" id="PassByValueOrReference":::
+:::code language="csharp" source="./snippets/refKeyword.cs" id="PassByReference":::
 
 - In a method signature, to return a value to the caller by reference. For more information, see [`ref return`](../statements/jump-statements.md#ref-returns).
 
-:::code language="csharp" source="../statements/snippets/jump-statements/ReturnStatement.cs" id="RefReturn":::
+:::code language="csharp" source="./snippets/refKeyword.cs" id="ReturnByReference":::
 
 - In a declaration of a local variable, to declare a [reference variable](../statements/declarations.md#reference-variables).
 
-```csharp
-ref int aliasOfvariable = ref variable;
-```
+:::code language="csharp" source="./snippets/refKeyword.cs" id="LocalRef":::
   
 - As the part of a [conditional ref expression](../operators/conditional-operator.md#conditional-ref-expression) or a [ref assignment operator](../operators/assignment-operator.md#ref-assignment).
 
-:::code language="csharp" source="../operators/snippets/shared/AssignmentOperator.cs" id="SnippetRefAssignment":::
+:::code language="csharp" source="./snippets/refKeyword.cs" id="ConditionalRef":::
 
 - In a `struct` declaration, to declare a `ref struct`. For more information, see the [`ref` structure types](../builtin-types/ref-struct.md) article.
 
-:::code language="csharp" source="../builtin-types/snippets/shared/StructType.cs" id="SnippetRefStruct":::
+:::code language="csharp" source="./snippets/refKeyword.cs" id="SnippetRefStruct":::
   
 - In a `ref struct` definition, to declare a `ref` field. For more information, see the [`ref` fields](../builtin-types/ref-struct.md#ref-fields) section of the [`ref` structure types](../builtin-types/ref-struct.md) article.
 
-:::code language="csharp" source="../builtin-types/snippets/shared/StructType.cs" id="SnippetRefField":::
+:::code language="csharp" source="./snippets/refKeyword.cs" id="SnippetRefField":::
 
 - In a generic type declaration to specify that a type parameter [`allows ref struct`](../../programming-guide/generics/constraints-on-type-parameters.md#allows-ref-struct) types.
 
-```csharp
-class SomeClass<T, S>
-    where T : allows ref struct
-    where S : T
-{
-    // etc
-}
-```
+:::code language="csharp" source="./snippets/refKeyword.cs" id="SnippetRefGeneric":::

--- a/docs/csharp/language-reference/keywords/snippets/refkeyword.cs
+++ b/docs/csharp/language-reference/keywords/snippets/refkeyword.cs
@@ -13,7 +13,8 @@ public class RefKeywordExamples
         if (left > right)
         {
             return ref left;
-        } else
+        }
+        else
         {
             return ref right;
         }

--- a/docs/csharp/language-reference/keywords/snippets/refkeyword.cs
+++ b/docs/csharp/language-reference/keywords/snippets/refkeyword.cs
@@ -1,0 +1,61 @@
+public class RefKeywordExamples
+{
+    // <PassByReference>
+    public void M(ref int refParameter)
+    {
+        refParameter += 42;
+    }
+    // </PassByReference>
+
+    // <ReturnByReference>
+    public ref int RefMax(ref int left, ref int right)
+    {
+        if (left > right)
+        {
+            return ref left;
+        } else
+        {
+            return ref right;
+        }
+    }
+    // </ReturnByReference>
+
+    // <LocalRef>
+    public void M2(int variable)
+    {
+        ref int aliasOfvariable = ref variable;
+    }
+    // </LocalRef> 
+
+    // <ConditionalRef>
+    public ref int RefMaxConditions(ref int left, ref int right)
+    {
+        ref int returnValue = left > right ? ref left : ref right;
+        return ref returnValue;
+    }
+    // </ConditionalRef>
+}
+
+// <SnippetRefStruct>
+public ref struct CustomRef
+{
+    public ReadOnlySpan<int> Inputs;
+    public ReadOnlySpan<int> Outputs;
+}
+// </SnippetRefStruct>
+
+// <SnippetRefField>
+public ref struct RefFieldExample
+{
+    private ref int number;
+}
+// </SnippetRefField>
+
+// <SnippetRefGeneric>
+class RefStructGeneric<T, S>
+    where T : allows ref struct
+    where S : T
+{
+    // etc
+}
+// </SnippetRefGeneric>

--- a/docs/csharp/language-reference/keywords/snippets/refkeyword.cs
+++ b/docs/csharp/language-reference/keywords/snippets/refkeyword.cs
@@ -30,7 +30,7 @@ public class RefKeywordExamples
     // <ConditionalRef>
     public ref int RefMaxConditions(ref int left, ref int right)
     {
-        ref int returnValue = left > right ? ref left : ref right;
+        ref int returnValue = ref left > right ? ref left : ref right;
         return ref returnValue;
     }
     // </ConditionalRef>


### PR DESCRIPTION
Over time, the samples used in this article (many of which were also used in other articles) drifted from their original purpose.

Put those samples in this article only, and make them as small as possible to demonstrate the syntax for disambiguation purposes.

Fixes #42499
Fixes #29224


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/ref.md](https://github.com/dotnet/docs/blob/8a207a858820e11c58c98116479bc5914e202a84/docs/csharp/language-reference/keywords/ref.md) | [docs/csharp/language-reference/keywords/ref](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/ref?branch=pr-en-us-42842) |


<!-- PREVIEW-TABLE-END -->