### PR TITLE
include a link to the data set within LINQ examples

### DIFF
--- a/docs/csharp/linq/includes/data-sources-definition.md
+++ b/docs/csharp/linq/includes/data-sources-definition.md
@@ -5,10 +5,9 @@ ms.topic: include
 ms.date: 10/04/2024
 ---
 
-The following examples in this article use the common data sources for this area:
+> [!NOTE]
+> The following examples in this article use the common data sources for this area.  
+> Each `Student` has a grade level, a primary department, and a series of scores. A `Teacher` also has a `City` property that identifies the campus where the teacher holds classes. A `Department` has a name, and a reference to a `Teacher` who serves as the department head.  
+> You can find the example data set in the [source repo](https://github.com/dotnet/docs/blob/main/docs/csharp/linq/standard-query-operators/snippets/standard-query-operators/DataSources.cs#L41).
 
 :::code language="csharp" source="../standard-query-operators/snippets/standard-query-operators/DataSources.cs" id="QueryDataSource":::
-
-Each `Student` has a grade level, a primary department, and a series of scores. A `Teacher` also has a `City` property that identifies the campus where the teacher holds classes. A `Department` has a name, and a reference to a `Teacher` who serves as the department head.
-
-You can find the data set in the [source repo](https://github.com/dotnet/docs/blob/main/docs/csharp/linq/standard-query-operators/snippets/standard-query-operators/DataSources.cs#L41).

--- a/docs/csharp/linq/includes/data-sources-definition.md
+++ b/docs/csharp/linq/includes/data-sources-definition.md
@@ -1,0 +1,14 @@
+---
+author: BillWagner
+ms.author: wiwagn
+ms.topic: include
+ms.date: 10/04/2024
+---
+
+The following examples in this article use the common data sources for this area:
+
+:::code language="csharp" source="../standard-query-operators/snippets/standard-query-operators/DataSources.cs" id="QueryDataSource":::
+
+Each `Student` has a grade level, a primary department, and a series of scores. A `Teacher` also has a `City` property that identifies the campus where the teacher holds classes. A `Department` has a name, and a reference to a `Teacher` who serves as the department head.
+
+You can find the data set in the [source repo](https://github.com/dotnet/docs/blob/main/docs/csharp/linq/standard-query-operators/snippets/standard-query-operators/DataSources.cs#L41).

--- a/docs/csharp/linq/standard-query-operators/converting-data-types.md
+++ b/docs/csharp/linq/standard-query-operators/converting-data-types.md
@@ -32,11 +32,7 @@ The conversion methods in this table whose names start with "As" change the stat
 |ToList|Converts a collection to a <xref:System.Collections.Generic.List%601>. This method forces query execution.|Not applicable.|<xref:System.Linq.Enumerable.ToList%2A?displayProperty=nameWithType>|
 |ToLookup|Puts elements into a <xref:System.Linq.Lookup%602> (a one-to-many dictionary) based on a key selector function. This method forces query execution.|Not applicable.|<xref:System.Linq.Enumerable.ToLookup%2A?displayProperty=nameWithType>|
 
-The following examples in this article use the common data sources for this area:
-
-:::code language="csharp" source="./snippets/standard-query-operators/DataSources.cs" id="QueryDataSource":::
-
-Each `Student` has a grade level, a primary department, and a series of scores. A `Teacher` also has a `City` property that identifies the campus where the teacher holds classes. A `Department` has a name, and a reference to a `Teacher` who serves as the department head.
+[!INCLUDE [Datasources](../includes/data-sources-definition.md)]
 
 ## Query Expression Syntax Example
 

--- a/docs/csharp/linq/standard-query-operators/grouping-data.md
+++ b/docs/csharp/linq/standard-query-operators/grouping-data.md
@@ -26,11 +26,7 @@ The equivalent query using method syntax is shown in the following code:
 
 :::code language="csharp" source="./snippets/standard-query-operators/GroupOverview.cs" id="OverviewSampleMethodSyntax":::
 
-The following examples in this article use the common data sources for this area:
-
-:::code language="csharp" source="./snippets/standard-query-operators/DataSources.cs" id="QueryDataSource":::
-
-Each `Student` has a grade level, a primary department, and a series of scores. A `Teacher` also has a `City` property that identifies the campus where the teacher holds classes. A `Department` has a name, and a reference to a `Teacher` who serves as the department head.
+[!INCLUDE [Datasources](../includes/data-sources-definition.md)]
 
 ## Group query results
 

--- a/docs/csharp/linq/standard-query-operators/index.md
+++ b/docs/csharp/linq/standard-query-operators/index.md
@@ -27,6 +27,8 @@ Where possible, the queries in this section use a sequence of words or numbers a
 
 Each `Student` has a grade level, a primary department, and a series of scores. A `Teacher` also has a `City` property that identifies the campus where the teacher holds classes. A `Department` has a name, and a reference to a `Teacher` who serves as the department head.
 
+You can find the data set in the [source repo](https://github.com/dotnet/docs/blob/main/docs/csharp/linq/standard-query-operators/snippets/standard-query-operators/DataSources.cs#L41).
+
 ## Types of query operators
 
 The standard query operators differ in the timing of their execution, depending on whether they return a singleton value or a sequence of values. Those methods that return a singleton value (such as <xref:System.Linq.Enumerable.Average%2A> and <xref:System.Linq.Enumerable.Sum%2A>) execute immediately. Methods that return a sequence defer the query execution and return an enumerable object. You can use the output sequence of one query as the input sequence to another query. Calls to query methods can be chained together in one query, which enables queries to become arbitrarily complex.

--- a/docs/csharp/linq/standard-query-operators/join-operations.md
+++ b/docs/csharp/linq/standard-query-operators/join-operations.md
@@ -25,11 +25,7 @@ The following illustration shows a conceptual view of two sets and the elements 
 |Join|Joins two sequences based on key selector functions and extracts pairs of values.|`join … in … on … equals …`|<xref:System.Linq.Enumerable.Join%2A?displayProperty=nameWithType><br /><br /> <xref:System.Linq.Queryable.Join%2A?displayProperty=nameWithType>|
 |GroupJoin|Joins two sequences based on key selector functions and groups the resulting matches for each element.|`join … in … on … equals … into …`|<xref:System.Linq.Enumerable.GroupJoin%2A?displayProperty=nameWithType><br /><br /> <xref:System.Linq.Queryable.GroupJoin%2A?displayProperty=nameWithType>|
 
-The following examples in this article use the common data sources for this area:
-
-:::code language="csharp" source="./snippets/standard-query-operators/DataSources.cs" id="QueryDataSource":::
-
-Each `Student` has a grade level, a primary department, and a series of scores. A `Teacher` also has a `City` property that identifies the campus where the teacher holds classes. A `Department` has a name, and a reference to a `Teacher` who serves as the department head.
+[!INCLUDE [Datasources](../includes/data-sources-definition.md)]
 
 The following example uses the `join … in … on … equals …` clause to join two sequences based on specific value:
 

--- a/docs/csharp/linq/standard-query-operators/set-operations.md
+++ b/docs/csharp/linq/standard-query-operators/set-operations.md
@@ -34,11 +34,7 @@ The following example depicts the behavior of <xref:System.Linq.Enumerable.Excep
 
 :::image type="content" source="./media/set-operations/except-behavior-graphic.png" alt-text="Graphic showing the action of Except()":::
 
-The following examples in this article use the common data sources for this area:
-
-:::code language="csharp" source="./snippets/standard-query-operators/DataSources.cs" id="QueryDataSource":::
-
-Each `Student` has a grade level, a primary department, and a series of scores. A `Teacher` also has a `City` property that identifies the campus where the teacher holds classes. A `Department` has a name, and a reference to a `Teacher` who serves as the department head.
+[!INCLUDE [Datasources](../includes/data-sources-definition.md)]
 
 :::code language="csharp" source="./snippets/standard-query-operators/SetOperations.cs" id="Except":::
 

--- a/docs/csharp/linq/standard-query-operators/snippets/standard-query-operators/DataSources.cs
+++ b/docs/csharp/linq/standard-query-operators/snippets/standard-query-operators/DataSources.cs
@@ -28,6 +28,7 @@ public class Teacher
     public required int ID { get; init; }
     public required string City { get; init; }
 }
+
 public class Department
 {
     public required string Name { get; init; }

--- a/docs/csharp/linq/standard-query-operators/sorting-data.md
+++ b/docs/csharp/linq/standard-query-operators/sorting-data.md
@@ -25,11 +25,7 @@ The standard query operator methods that sort data are listed in the following s
 |ThenByDescending|Performs a secondary sort in descending order.|`orderby …, … descending`|<xref:System.Linq.Enumerable.ThenByDescending%2A?displayProperty=nameWithType><br /><br /> <xref:System.Linq.Queryable.ThenByDescending%2A?displayProperty=nameWithType>|
 |Reverse|Reverses the order of the elements in a collection.|Not applicable.|<xref:System.Linq.Enumerable.Reverse%2A?displayProperty=nameWithType><br /><br /> <xref:System.Linq.Queryable.Reverse%2A?displayProperty=nameWithType>|
 
-The following examples in this article use the common data sources for this area:
-
-:::code language="csharp" source="./snippets/standard-query-operators/DataSources.cs" id="QueryDataSource":::
-
-Each `Student` has a grade level, a primary department, and a series of scores. A `Teacher` also has a `City` property that identifies the campus where the teacher holds classes. A `Department` has a name, and a reference to a `Teacher` who serves as the department head.
+[!INCLUDE [Datasources](../includes/data-sources-definition.md)]
 
 ## Primary Ascending Sort
 


### PR DESCRIPTION
## Summary

Describe your changes here.

Fixes #42599

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/linq/standard-query-operators/converting-data-types.md](https://github.com/dotnet/docs/blob/0095e97f3d7450990f77e8f5dbf95d0c27c59eed/docs/csharp/linq/standard-query-operators/converting-data-types.md) | [docs/csharp/linq/standard-query-operators/converting-data-types](https://review.learn.microsoft.com/en-us/dotnet/csharp/linq/standard-query-operators/converting-data-types?branch=pr-en-us-42844) |
| [docs/csharp/linq/standard-query-operators/grouping-data.md](https://github.com/dotnet/docs/blob/0095e97f3d7450990f77e8f5dbf95d0c27c59eed/docs/csharp/linq/standard-query-operators/grouping-data.md) | [docs/csharp/linq/standard-query-operators/grouping-data](https://review.learn.microsoft.com/en-us/dotnet/csharp/linq/standard-query-operators/grouping-data?branch=pr-en-us-42844) |
| [docs/csharp/linq/standard-query-operators/index.md](https://github.com/dotnet/docs/blob/0095e97f3d7450990f77e8f5dbf95d0c27c59eed/docs/csharp/linq/standard-query-operators/index.md) | [docs/csharp/linq/standard-query-operators/index](https://review.learn.microsoft.com/en-us/dotnet/csharp/linq/standard-query-operators/index?branch=pr-en-us-42844) |
| [docs/csharp/linq/standard-query-operators/join-operations.md](https://github.com/dotnet/docs/blob/0095e97f3d7450990f77e8f5dbf95d0c27c59eed/docs/csharp/linq/standard-query-operators/join-operations.md) | [docs/csharp/linq/standard-query-operators/join-operations](https://review.learn.microsoft.com/en-us/dotnet/csharp/linq/standard-query-operators/join-operations?branch=pr-en-us-42844) |
| [docs/csharp/linq/standard-query-operators/set-operations.md](https://github.com/dotnet/docs/blob/0095e97f3d7450990f77e8f5dbf95d0c27c59eed/docs/csharp/linq/standard-query-operators/set-operations.md) | [docs/csharp/linq/standard-query-operators/set-operations](https://review.learn.microsoft.com/en-us/dotnet/csharp/linq/standard-query-operators/set-operations?branch=pr-en-us-42844) |
| [docs/csharp/linq/standard-query-operators/sorting-data.md](https://github.com/dotnet/docs/blob/0095e97f3d7450990f77e8f5dbf95d0c27c59eed/docs/csharp/linq/standard-query-operators/sorting-data.md) | [docs/csharp/linq/standard-query-operators/sorting-data](https://review.learn.microsoft.com/en-us/dotnet/csharp/linq/standard-query-operators/sorting-data?branch=pr-en-us-42844) |


<!-- PREVIEW-TABLE-END -->