### PR TITLE
update description to match code snippet

### DIFF
--- a/docs/csharp/linq/standard-query-operators/index.md
+++ b/docs/csharp/linq/standard-query-operators/index.md
@@ -33,11 +33,11 @@ The standard query operators differ in the timing of their execution, depending 
 
 ## Query operators
 
-In a LINQ query, the first step is to specify the data source. In a LINQ query, the `from` clause comes first in order to introduce the data source (`customers`) and the *range variable* (`cust`).
+In a LINQ query, the first step is to specify the data source. In a LINQ query, the `from` clause comes first in order to introduce the data source (`students`) and the *range variable* (`student`).
 
 :::code language="csharp" source="./snippets/standard-query-operators/IndexExamples.cs" id="ObtainDataSource":::
 
-The range variable is like the iteration variable in a `foreach` loop except that no actual iteration occurs in a query expression. When the query is executed, the range variable serves as a reference to each successive element in `customers`. Because the compiler can infer the type of `cust`, you don't have to specify it explicitly. You can introduce more range variables in a `let` clause. For more information, see [let clause](../../language-reference/keywords/let-clause.md).
+The range variable is like the iteration variable in a `foreach` loop except that no actual iteration occurs in a query expression. When the query is executed, the range variable serves as a reference to each successive element in `students`. Because the compiler can infer the type of `student`, you don't have to specify it explicitly. You can introduce more range variables in a `let` clause. For more information, see [let clause](../../language-reference/keywords/let-clause.md).
 
 > [!NOTE]
 > For non-generic data sources such as <xref:System.Collections.ArrayList>, the range variable must be explicitly typed. For more information, see [How to query an ArrayList with LINQ (C#)](../how-to-query-collections.md) and [from clause](../../language-reference/keywords/from-clause.md).


### PR DESCRIPTION
## Summary

This PR updates the description to match the code snippet.

Fixes #42855

Before:

![image](https://github.com/user-attachments/assets/60ccabc8-e6c6-4bcd-9786-9300d86d6e02)


After:

![image](https://github.com/user-attachments/assets/315b7aeb-a185-49b1-9841-6f1e138e3508)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/linq/standard-query-operators/index.md](https://github.com/dotnet/docs/blob/d02dbe50cdfe4c1af881b2bc24d0714a2db965d8/docs/csharp/linq/standard-query-operators/index.md) | [docs/csharp/linq/standard-query-operators/index](https://review.learn.microsoft.com/en-us/dotnet/csharp/linq/standard-query-operators/index?branch=pr-en-us-42856) |

<!-- PREVIEW-TABLE-END -->