### PR TITLE
Fix typo in arrays.md

### DIFF
--- a/docs/csharp/language-reference/builtin-types/arrays.md
+++ b/docs/csharp/language-reference/builtin-types/arrays.md
@@ -42,7 +42,7 @@ The following example creates single-dimensional, multidimensional, and jagged a
 :::code language="csharp" source="./snippets/shared/Arrays.cs" id="DeclareArrays":::
 
 > [!IMPORTANT]
-> Many of the examples in this article use [collection expressions](../operators/collection-expressions.md) (which use square brackets) to initialize the arrays. Collection expressions were first introduced in C# 12, which shipped with .NET 8. If you can't ugrade to C# 12 yet, use `{` and `}` to initialize the arrays instead.
+> Many of the examples in this article use [collection expressions](../operators/collection-expressions.md) (which use square brackets) to initialize the arrays. Collection expressions were first introduced in C# 12, which shipped with .NET 8. If you can't upgrade to C# 12 yet, use `{` and `}` to initialize the arrays instead.
 >
 > ```csharp
 > // Collection expressions:


### PR DESCRIPTION
## Summary

Fixed typo 'ugrade' --> 'upgrade'



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/builtin-types/arrays.md](https://github.com/dotnet/docs/blob/721cb1eff7015d1bfc74cdba19c41a82000a9a46/docs/csharp/language-reference/builtin-types/arrays.md) | [docs/csharp/language-reference/builtin-types/arrays](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/arrays?branch=pr-en-us-42865) |

<!-- PREVIEW-TABLE-END -->