### PR TITLE
chore: Fix capitalization

### DIFF
--- a/docs/architecture/maui/unit-testing.md
+++ b/docs/architecture/maui/unit-testing.md
@@ -10,7 +10,7 @@ ms.date: 05/30/2024
 
 [!INCLUDE [download-alert](includes/download-alert.md)]
 
-multi-platform apps experience problems similar to both desktop and web-based applications. Mobile users will differ by their devices, network connectivity, availability of services, and various other factors. Therefore, multi-platform apps should be tested as they would be used in the real world to improve their quality, reliability, and performance. Many types of testing should be performed on an app, including unit testing, integration testing, and user interface testing. Unit testing is the most common form and essential to building high-quality applications.
+Multi-platform apps experience problems similar to both desktop and web-based applications. Mobile users will differ by their devices, network connectivity, availability of services, and various other factors. Therefore, multi-platform apps should be tested as they would be used in the real world to improve their quality, reliability, and performance. Many types of testing should be performed on an app, including unit testing, integration testing, and user interface testing. Unit testing is the most common form and essential to building high-quality applications.
 
 A unit test takes a small unit of the app, typically a method, isolates it from the remainder of the code, and verifies that it behaves as expected. Its goal is to check that each unit of functionality performs as expected, so errors don't propagate throughout the app. Detecting a bug where it occurs is more efficient that observing the effect of a bug indirectly at a secondary point of failure.
 


### PR DESCRIPTION
## Fixed capitalization error in Unit Testing docs.

multi-platform was in all small-case letters made the first letter capital.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/architecture/maui/unit-testing.md](https://github.com/dotnet/docs/blob/49da1cb90e4d7209e92110fffd20bc2f29a8c8cd/docs/architecture/maui/unit-testing.md) | [docs/architecture/maui/unit-testing](https://review.learn.microsoft.com/en-us/dotnet/architecture/maui/unit-testing?branch=pr-en-us-42996) |


<!-- PREVIEW-TABLE-END -->