### PR TITLE
Remove xrefs to fix build warnings

### DIFF
--- a/docs/core/compatibility/jit/9.0/sve-apis.md
+++ b/docs/core/compatibility/jit/9.0/sve-apis.md
@@ -33,15 +33,15 @@ Stop using the removed APIs and instead use the overloads that take 64-bit addre
 
 ## Affected APIs
 
-- <xref:System.Runtime.Intrinsics.Arm.Sve.GatherPrefetch16Bit(System.Numerics.Vector{System.Int16},System.Numerics.Vector{System.UInt32},System.Runtime.Intrinsics.Arm.SvePrefetchType)?displayProperty=fullName>
-- <xref:System.Runtime.Intrinsics.Arm.Sve.GatherPrefetch16Bit(System.Numerics.Vector{System.UInt16},System.Numerics.Vector{System.UInt32},System.Runtime.Intrinsics.Arm.SvePrefetchType)?displayProperty=fullName>
-- <xref:System.Runtime.Intrinsics.Arm.Sve.GatherPrefetch32Bit(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.UInt32},System.Runtime.Intrinsics.Arm.SvePrefetchType)?displayProperty=fullName>
-- <xref:System.Runtime.Intrinsics.Arm.Sve.GatherPrefetch32Bit(System.Numerics.Vector{System.UInt32},System.Numerics.Vector{System.UInt32},System.Runtime.Intrinsics.Arm.SvePrefetchType)?displayProperty=fullName>
-- <xref:System.Runtime.Intrinsics.Arm.Sve.GatherPrefetch64Bit(System.Numerics.Vector{System.UInt64},System.Numerics.Vector{System.UInt32},System.Runtime.Intrinsics.Arm.SvePrefetchType)?displayProperty=fullName>
-- <xref:System.Runtime.Intrinsics.Arm.Sve.GatherPrefetch64Bit(System.Numerics.Vector{System.UInt64},System.Numerics.Vector{System.UInt32},System.Runtime.Intrinsics.Arm.SvePrefetchType)?displayProperty=fullName>
-- <xref:System.Runtime.Intrinsics.Arm.Sve.GatherPrefetch8Bit(System.Numerics.Vector{System.Byte},System.Numerics.Vector{System.UInt32},System.Runtime.Intrinsics.Arm.SvePrefetchType)?displayProperty=fullName>
-- <xref:System.Runtime.Intrinsics.Arm.Sve.GatherPrefetch8Bit(System.Numerics.Vector{System.SByte},System.Numerics.Vector{System.UInt32},System.Runtime.Intrinsics.Arm.SvePrefetchType)?displayProperty=fullName>
-- <xref:System.Runtime.Intrinsics.Arm.Sve.GatherVectorInt16SignExtendFirstFaulting(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.UInt32})?displayProperty=fullName>
-- <xref:System.Runtime.Intrinsics.Arm.Sve.GatherVectorInt16SignExtendFirstFaulting(System.Numerics.Vector{System.UInt32},System.Numerics.Vector{System.UInt32})?displayProperty=fullName>
-- <xref:System.Runtime.Intrinsics.Arm.Sve.GatherVectorSByteSignExtendFirstFaulting(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.UInt32})?displayProperty=fullName>
-- <xref:System.Runtime.Intrinsics.Arm.Sve.GatherVectorSByteSignExtendFirstFaulting(System.Numerics.Vector{System.UInt32},System.Numerics.Vector{System.UInt32})?displayProperty=fullName>
+- System.Runtime.Intrinsics.Arm.Sve.GatherPrefetch16Bit(System.Numerics.Vector{System.Int16},System.Numerics.Vector{System.UInt32},System.Runtime.Intrinsics.Arm.SvePrefetchType)
+- System.Runtime.Intrinsics.Arm.Sve.GatherPrefetch16Bit(System.Numerics.Vector{System.UInt16},System.Numerics.Vector{System.UInt32},System.Runtime.Intrinsics.Arm.SvePrefetchType)
+- System.Runtime.Intrinsics.Arm.Sve.GatherPrefetch32Bit(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.UInt32},System.Runtime.Intrinsics.Arm.SvePrefetchType)
+- System.Runtime.Intrinsics.Arm.Sve.GatherPrefetch32Bit(System.Numerics.Vector{System.UInt32},System.Numerics.Vector{System.UInt32},System.Runtime.Intrinsics.Arm.SvePrefetchType)
+- System.Runtime.Intrinsics.Arm.Sve.GatherPrefetch64Bit(System.Numerics.Vector{System.UInt64},System.Numerics.Vector{System.UInt32},System.Runtime.Intrinsics.Arm.SvePrefetchType)
+- System.Runtime.Intrinsics.Arm.Sve.GatherPrefetch64Bit(System.Numerics.Vector{System.UInt64},System.Numerics.Vector{System.UInt32},System.Runtime.Intrinsics.Arm.SvePrefetchType)
+- System.Runtime.Intrinsics.Arm.Sve.GatherPrefetch8Bit(System.Numerics.Vector{System.Byte},System.Numerics.Vector{System.UInt32},System.Runtime.Intrinsics.Arm.SvePrefetchType)
+- System.Runtime.Intrinsics.Arm.Sve.GatherPrefetch8Bit(System.Numerics.Vector{System.SByte},System.Numerics.Vector{System.UInt32},System.Runtime.Intrinsics.Arm.SvePrefetchType)
+- System.Runtime.Intrinsics.Arm.Sve.GatherVectorInt16SignExtendFirstFaulting(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.UInt32})
+- System.Runtime.Intrinsics.Arm.Sve.GatherVectorInt16SignExtendFirstFaulting(System.Numerics.Vector{System.UInt32},System.Numerics.Vector{System.UInt32})
+- System.Runtime.Intrinsics.Arm.Sve.GatherVectorSByteSignExtendFirstFaulting(System.Numerics.Vector{System.Int32},System.Numerics.Vector{System.UInt32})
+- System.Runtime.Intrinsics.Arm.Sve.GatherVectorSByteSignExtendFirstFaulting(System.Numerics.Vector{System.UInt32},System.Numerics.Vector{System.UInt32})


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/jit/9.0/sve-apis.md](https://github.com/dotnet/docs/blob/f58c2ea5d26464f2cda12bf884062c677da40e50/docs/core/compatibility/jit/9.0/sve-apis.md) | [docs/core/compatibility/jit/9.0/sve-apis](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/jit/9.0/sve-apis?branch=pr-en-us-43014) |

<!-- PREVIEW-TABLE-END -->