### PR TITLE
Document new .NET 8 runtime counters

### DIFF
--- a/docs/core/diagnostics/available-counters.md
+++ b/docs/core/diagnostics/available-counters.md
@@ -40,6 +40,8 @@ The following counters are published as part of .NET runtime (CoreCLR) and are m
 | :::no-loc text="IL Bytes Jitted"::: (`il-bytes-jitted`) | The total size of ILs that are JIT-compiled, in bytes | .NET 5 |
 | :::no-loc text="Methods Jitted Count"::: (`methods-jitted-count`) | The number of methods that are JIT-compiled | .NET 5 |
 | :::no-loc text="GC Committed Bytes"::: (`gc-committed`) | The number of bytes committed by the GC | .NET 6 |
+| :::no-loc text="Time paused by GC"::: (`total-pause-time-by-gc`) | The total amount of time program execution was paused by the GC | .NET 8 |
+| :::no-loc text="Gen 0 GC Budget"::: (`gen-0-gc-budget`) | The Gen 0 memory budget | .NET 8 |
 
 ## Microsoft.AspNetCore.Hosting counters
 


### PR DESCRIPTION
## Summary

 Document new .NET 8 runtime counters
* `total-pause-time-by-gc`  - The total amount of time program execution was paused by the GC 
* `gen-0-gc-budget` - The Gen 0 memory budget 



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/available-counters.md](https://github.com/dotnet/docs/blob/d3bf5eb5e75297fb5e6a304961f49b3dd69a27f9/docs/core/diagnostics/available-counters.md) | [docs/core/diagnostics/available-counters](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/available-counters?branch=pr-en-us-43017) |

<!-- PREVIEW-TABLE-END -->