### PR TITLE
Changed mentioned callback name from 'Del' to 'MultiplyCallback'

### DIFF
--- a/docs/csharp/programming-guide/delegates/delegates-with-named-vs-anonymous-methods.md
+++ b/docs/csharp/programming-guide/delegates/delegates-with-named-vs-anonymous-methods.md
@@ -29,7 +29,7 @@ var write = Console.Write; // ERROR: Multiple overloads, can't choose
 
 ## Examples
 
-The following is a simple example of declaring and using a delegate. Notice that both the delegate, `Del`, and the associated method, `MultiplyNumbers`, have the same signature
+The following is a simple example of declaring and using a delegate. Notice that both the delegate, `MultiplyCallback`, and the associated method, `MultiplyNumbers`, have the same signature
 
 [!code-csharp[csProgGuideDelegates#2](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideDelegates/CS/Delegates.cs#2)]
 


### PR DESCRIPTION
The confusion between documentation and code snippet comes from this change https://github.com/dotnet/docs/pull/36350/files#diff-13fe97ecde4425c747d57bfb229d53f1ce38b3bed0377809dbcb7db8dfb4e402L196-R196

In mentioned PR code snippet was updated (`Del` renamed to `MultiplyCallback`), but the docs were not updated.

Let's fix this https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/delegates/delegates-with-named-vs-anonymous-methods#examples
![image](https://github.com/user-attachments/assets/b31a5a91-e8bb-4901-88d3-bfc50e7cdd69)



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/delegates/delegates-with-named-vs-anonymous-methods.md](https://github.com/dotnet/docs/blob/56e3812e5036edc3a29bc934ca245139083315f4/docs/csharp/programming-guide/delegates/delegates-with-named-vs-anonymous-methods.md) | [docs/csharp/programming-guide/delegates/delegates-with-named-vs-anonymous-methods](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/delegates/delegates-with-named-vs-anonymous-methods?branch=pr-en-us-43036) |

<!-- PREVIEW-TABLE-END -->