### PR TITLE
Remove sentence about 'extra configuration file' next to the single-file app

### DIFF
--- a/docs/core/deploying/single-file/overview.md
+++ b/docs/core/deploying/single-file/overview.md
@@ -42,7 +42,7 @@ These properties have the following functions:
 
 Single file apps are always OS and architecture specific. You need to publish for each configuration, such as Linux x64, Linux Arm64, Windows x64, and so forth.
 
-Runtime configuration files, such as _\*.runtimeconfig.json_ and _\*.deps.json_, are included in the single file. If an extra, non-runtime configuration file is needed separate from the single file executable, you can [exclude it from being embedded](#exclude-files-from-being-embedded) such that it will be placed beside the single file.
+Runtime configuration files, such as _\*.runtimeconfig.json_ and _\*.deps.json_, are included in the single file.
 
 ## Publish a single-file app
 

--- a/docs/core/deploying/single-file/overview.md
+++ b/docs/core/deploying/single-file/overview.md
@@ -42,7 +42,7 @@ These properties have the following functions:
 
 Single file apps are always OS and architecture specific. You need to publish for each configuration, such as Linux x64, Linux Arm64, Windows x64, and so forth.
 
-Runtime configuration files, such as _\*.runtimeconfig.json_ and _\*.deps.json_, are included in the single file. If an extra configuration file is needed, you can place it beside the single file.
+Runtime configuration files, such as _\*.runtimeconfig.json_ and _\*.deps.json_, are included in the single file. If an extra, non-runtime configuration file is needed separate from the single file executable, you can [exclude it from being embedded](#exclude-files-from-being-embedded) such that it will be placed beside the single file.
 
 ## Publish a single-file app
 


### PR DESCRIPTION
## Summary

As is, the sentence can be read as stating that extra runtime configuration files (for example, a second *.runtimeconfig.json) can be placed next to the single-file app and be respected at runtime - https://github.com/dotnet/runtime/issues/108814. This is not the case - when a single-file app finds the runtime configuration files embedded in itself, it will not look next to it for loose runtime configuration files.

cc @agocke @VSadov 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/deploying/single-file/overview.md](https://github.com/dotnet/docs/blob/015cb809787dadab5119c63c054a426585db594e/docs/core/deploying/single-file/overview.md) | [docs/core/deploying/single-file/overview](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/single-file/overview?branch=pr-en-us-43042) |


<!-- PREVIEW-TABLE-END -->