### PR TITLE
Fix and Clarify Bash Command for Microsoft Package Repository in Linux Installation Docs.

### DIFF
--- a/docs/core/install/linux-ubuntu.md
+++ b/docs/core/install/linux-ubuntu.md
@@ -211,7 +211,7 @@ sudo apt update
 > [!TIP]  
 > The previous script was written for Ubuntu and might not work if you're using a derived distribution, such as Linux Mint. It's likely that the `$ID` and `$VERSION_ID` variables won't be assigned the correct values, making the URI for the `wget` command invalid. The `$ID` corresponds to the distribution (e.g., `ubuntu`), while `$VERSION_ID` maps to the specific version of Ubuntu you want to get packages for, such as 22.04 or 23.10.
 >
-> For example, on Ubuntu 22.04, `$ID` would be `ubuntu`, and `$VERSION_ID` would be `22.04`, so the resulting URL would look like:  
+> For example, on Ubuntu 22.04 `$ID` would be `ubuntu` and `$VERSION_ID` would be `22.04`. The URL would look like:  
 > `https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb`.  
 >
 > You can use a web browser and navigate to <https://packages.microsoft.com/config/ubuntu/> to see which versions of Ubuntu are available to use as the `$repo_version` value.

--- a/docs/core/install/linux-ubuntu.md
+++ b/docs/core/install/linux-ubuntu.md
@@ -208,8 +208,11 @@ rm packages-microsoft-prod.deb
 sudo apt update
 ```
 
-> [!TIP]
-> The previous script was written for Ubuntu and it might not work if you're using a derived distribution, such as Linux Mint. It's likely that the `$repo_version` variable won't be assigned the correct value, making the URI for the `wget` command invalid. This variable maps to the specific Ubuntu version you want to get packages for, such as 22.04 or 23.10.
+> [!TIP]  
+> The previous script was written for Ubuntu and might not work if you're using a derived distribution, such as Linux Mint. It's likely that the `$ID` and `$VERSION_ID` variables won't be assigned the correct values, making the URI for the `wget` command invalid. The `$ID` corresponds to the distribution (e.g., `ubuntu`), while `$VERSION_ID` maps to the specific version of Ubuntu you want to get packages for, such as 22.04 or 23.10.
+>
+> For example, on Ubuntu 22.04, `$ID` would be `ubuntu`, and `$VERSION_ID` would be `22.04`, so the resulting URL would look like:  
+> `https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb`.  
 >
 > You can use a web browser and navigate to <https://packages.microsoft.com/config/ubuntu/> to see which versions of Ubuntu are available to use as the `$repo_version` value.
 


### PR DESCRIPTION
## Summary

### PR Description:
This PR addresses a typo and clarifies the instructions under the "Register the Microsoft package repository" section in the .NET documentation for Linux installation for `linux-ubuntu.md` page (Path: https://learn.microsoft.com/en-gb/dotnet/core/install/linux-ubuntu).
- **Issue:** The "Tip" mentions $repo_version, which does not exist in the Bash code block above. The confusion stems from whether $ID or $VERSION_ID (or both) should be replaced in the command:
`wget https://packages.microsoft.com/config/$ID/$VERSION_ID/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
`
- **Fix:** I have updated the documentation to clarify that $ID refers to the distribution and $VERSION_ID to its version. For example, on Linux Mint 22.0 (based on Ubuntu 24.04), the user would replace these variables with ubuntu/24.04.

Fixes #42755 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/linux-ubuntu.md](https://github.com/dotnet/docs/blob/fa222c7c28d97b33c07bd5a6753b62a56d94443d/docs/core/install/linux-ubuntu.md) | [docs/core/install/linux-ubuntu](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu?branch=pr-en-us-43046) |


<!-- PREVIEW-TABLE-END -->