### PR TITLE
Add other C# 13 features to the C# list

### DIFF
--- a/docs/core/whats-new/dotnet-9/overview.md
+++ b/docs/core/whats-new/dotnet-9/overview.md
@@ -82,6 +82,11 @@ C# 13 ships with the .NET 9 SDK and includes the following new features:
 - New escape sequence - `\e`
 - Method group natural type improvements
 - Implicit indexer access in object initializers
+- Enable `ref` locals and `unsafe` contexts in iterators and async methods
+- Enable `ref struct` types to implement interfaces
+- Allow ref struct types as arguments for type parameters in generics.
+- Partial properties and indexers are now allowed in `partial` types.
+- Overload resolution priority allows library authors to designate one overload as better than others.
 
 For more information, see [What's new in C# 13](../../../csharp/whats-new/csharp-13.md).
 


### PR DESCRIPTION
I missed adding these to the list when I made the new features. This short list matches the list in the "What's new in C# 13" article.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/whats-new/dotnet-9/overview.md](https://github.com/dotnet/docs/blob/9fcb3a4d87b82265da2de1887d616351f5bf2a15/docs/core/whats-new/dotnet-9/overview.md) | [docs/core/whats-new/dotnet-9/overview](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-9/overview?branch=pr-en-us-43053) |

<!-- PREVIEW-TABLE-END -->