### PR TITLE
Exclude dependabot PRs from policy

### DIFF
--- a/.github/policies/policy-edits.yml
+++ b/.github/policies/policy-edits.yml
@@ -29,6 +29,8 @@ configuration:
                     user: dependabot
                 - isActivitySender:
                     user: dependabot[bot]
+                - isActivitySender:
+                    user: dotnet-policy-service[bot]
         then:
           - addReply:
               reply: >-

--- a/.github/policies/policy-edits.yml
+++ b/.github/policies/policy-edits.yml
@@ -25,6 +25,10 @@ configuration:
                     permission: admin
                 - activitySenderHasPermission:
                     permission: write
+                - isActivitySender:
+                    user: dependabot
+                - isActivitySender:
+                    user: dependabot[bot]
         then:
           - addReply:
               reply: >-


### PR DESCRIPTION
For reason, see https://github.com/dotnet/docs/pull/43059.