### PR TITLE
Apple .NET TFMs aren't compatible with Xamarin TFMs.

### DIFF
--- a/docs/standard/frameworks.md
+++ b/docs/standard/frameworks.md
@@ -65,10 +65,10 @@ The following table shows the compatibility of the .NET 5+ TFMs.
 | net5.0-windows     | netcoreapp1..3.1 (plus everything else inherited from `net5.0`)                                                         |
 | net6.0             | (Subsequent version of `net5.0`)                                                                                        |
 | net6.0-android     | `xamarin.android` (plus everything else inherited from `net6.0`)                                                            |
-| net6.0-ios         | `xamarin.ios` (plus everything else inherited from `net6.0`)                                                                |
-| net6.0-maccatalyst | `xamarin.ios` (plus everything else inherited from `net6.0`)                                                                |
-| net6.0-macos       | `xamarin.mac` (plus everything else inherited from `net6.0`)                                                                |
-| net6.0-tvos        | `xamarin.tvos` (plus everything else inherited from `net6.0`)                                                               |
+| net6.0-ios         | Everything inherited from `net6.0`                                                                                      |
+| net6.0-maccatalyst | Everything inherited from `net6.0`                                                                                      |
+| net6.0-macos       | Everything inherited from `net6.0`                                                                                      |
+| net6.0-tvos        | Everything inherited from `net6.0`                                                                                      |
 | net6.0-windows     | (Subsequent version of `net5.0-windows`)                                                                                |
 | net7.0             | (Subsequent version of `net6.0`)                                                                                        |
 | net7.0-android     | (Subsequent version of `net6.0-android`)                                                                                |


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/frameworks.md](https://github.com/dotnet/docs/blob/18f9705c41734729d9ca7ba775e8e19a4f59f391/docs/standard/frameworks.md) | [docs/standard/frameworks](https://review.learn.microsoft.com/en-us/dotnet/standard/frameworks?branch=pr-en-us-43088) |

<!-- PREVIEW-TABLE-END -->