### PR TITLE
Fix activity sender for auto-merge policy

### DIFF
--- a/.github/policies/auto-merge.yml
+++ b/.github/policies/auto-merge.yml
@@ -18,11 +18,7 @@ configuration:
             branch: main
         - or:
             - isActivitySender:
-                user: azure-sdk
-            - isActivitySender:
-                user: dependabot
-            - isActivitySender:
-                user: dependabot[bot]
+                user: dotnet-policy-service[bot]
       then:
         - enableAutoMerge:
             mergeMethod: Squash


### PR DESCRIPTION
Activity sender appears to be the user that triggered the event, not the user that created the PR. PRs such as [this](https://github.com/dotnet/docs/pull/43093) weren't getting enabled for auto-merge by the bot.