### PR TITLE
Delete mention of null characters from C# string intro

### DIFF
--- a/docs/csharp/programming-guide/strings/index.md
+++ b/docs/csharp/programming-guide/strings/index.md
@@ -9,7 +9,7 @@ ms.assetid: 21580405-cb25-4541-89d5-037846a38b07
 ---
 # Strings and string literals
 
-A string is an object of type <xref:System.String> whose value is text. Internally, the text is stored as a sequential read-only collection of <xref:System.Char> objects. There's no null-terminating character at the end of a C# string; therefore a C# string can contain any number of embedded null characters ('\0'). The <xref:System.String.Length%2A> property of a string represents the number of `Char` objects it contains, not the number of Unicode characters. To access the individual Unicode code points in a string, use the <xref:System.Globalization.StringInfo> object.
+A string is an object of type <xref:System.String> whose value is text. Internally, the text is stored as a sequential read-only collection of <xref:System.Char> objects. The <xref:System.String.Length%2A> property of a string represents the number of `Char` objects it contains, not the number of Unicode characters. To access the individual Unicode code points in a string, use the <xref:System.Globalization.StringInfo> object.
 
 ## string vs. System.String
 


### PR DESCRIPTION
## Summary

Delete mention of null characters from C# string intro. The text is not accurate, and it is too much detail for the intro.

Follow up on https://github.com/dotnet/docs/pull/28470#discussion_r818809549


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/strings/index.md](https://github.com/dotnet/docs/blob/417001b8decb0eb8b4d870fce0ae9d40f05b5037/docs/csharp/programming-guide/strings/index.md) | [docs/csharp/programming-guide/strings/index](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/strings/index?branch=pr-en-us-43097) |

<!-- PREVIEW-TABLE-END -->