### PR TITLE
Fix typo in allows ref struct

### DIFF
--- a/docs/csharp/whats-new/csharp-13.md
+++ b/docs/csharp/whats-new/csharp-13.md
@@ -110,7 +110,7 @@ In the same fashion, C# 13 allows `unsafe` contexts in iterator methods. However
 
 Before C# 13, `ref struct` types couldn't be declared as the type argument for a generic type or method. Now, generic type declarations can add an anti-constraint, `allows ref struct`. This anti-constraint declares that the type argument supplied for that type parameter can be a `ref struct` type. The compiler enforces ref safety rules on all instances of that type parameter.
 
-For example, you may declare an interface like the following code:
+For example, you may declare a generic type like the following code:
 
 ```csharp
 public class C<T> where T : allows ref struct


### PR DESCRIPTION
## Summary

Fixed the typo

> For example, you may declare an interface like the following code:

to

> For example, you may declare a generic type like the following code:

Fixes #43098


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/whats-new/csharp-13.md](https://github.com/dotnet/docs/blob/6b18aaabcbf416d88468902e0b06dc390ce09aa0/docs/csharp/whats-new/csharp-13.md) | [docs/csharp/whats-new/csharp-13](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-13?branch=pr-en-us-43106) |

<!-- PREVIEW-TABLE-END -->