### PR TITLE
Revert "Add note that exposing COM components in C++/CLI projects is not supported"

### DIFF
--- a/docs/core/native-interop/expose-components-to-com.md
+++ b/docs/core/native-interop/expose-components-to-com.md
@@ -125,6 +125,4 @@ There is a fully functional [COM server sample](https://github.com/dotnet/sample
 
 [Self-contained deployments](../deploying/index.md#publish-self-contained) of COM components are not supported. Only [framework-dependent deployments](../deploying/index.md#publish-framework-dependent) of COM components are supported.
 
-Exposing COM components from [C++/CLI projects](/cpp/dotnet/dotnet-programming-with-cpp-cli-visual-cpp) via the [EnableComHosting property](../project-sdk/msbuild-props.md#enablecomhosting) is not supported.
-
 Additionally, loading both .NET Framework and .NET Core into the same process does have diagnostic limitations. The primary limitation is the debugging of managed components as it is not possible to debug both .NET Framework and .NET Core at the same time. In addition, the two runtime instances don't share managed assemblies. This means that it isn't possible to share actual .NET types across the two runtimes and instead all interactions must be restricted to the exposed COM interface contracts.


### PR DESCRIPTION
Reverts dotnet/docs#43116

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/native-interop/expose-components-to-com.md](https://github.com/dotnet/docs/blob/a84ab15a8a2561260a854f821d3426b8087a2400/docs/core/native-interop/expose-components-to-com.md) | [docs/core/native-interop/expose-components-to-com](https://review.learn.microsoft.com/en-us/dotnet/core/native-interop/expose-components-to-com?branch=pr-en-us-43117) |

<!-- PREVIEW-TABLE-END -->