### PR TITLE
Add an Experimental APIs overview page

### DIFF
--- a/docs/core/whats-new/dotnet-9/libraries.md
+++ b/docs/core/whats-new/dotnet-9/libraries.md
@@ -757,7 +757,7 @@ The following codes shows some of the APIs included with the new `Tensor<T>` typ
 :::code language="csharp" source="../snippets/dotnet-9/csharp/Tensors.cs" id="Tensor":::
 
 > [!NOTE]
-> This API is marked as [experimental](../../../fundamentals/apicompat/preview-apis.md#experimentalattribute) for .NET 9.
+> This API is marked as [experimental](../../../fundamentals/syslib-diagnostics/experimental-overview) for .NET 9.
 
 ### TensorPrimitives
 

--- a/docs/core/whats-new/dotnet-9/libraries.md
+++ b/docs/core/whats-new/dotnet-9/libraries.md
@@ -757,7 +757,7 @@ The following codes shows some of the APIs included with the new `Tensor<T>` typ
 :::code language="csharp" source="../snippets/dotnet-9/csharp/Tensors.cs" id="Tensor":::
 
 > [!NOTE]
-> This API is marked as [experimental](../../../fundamentals/syslib-diagnostics/experimental-overview) for .NET 9.
+> This API is marked as [experimental](../../../fundamentals/syslib-diagnostics/experimental-overview.md) for .NET 9.
 
 ### TensorPrimitives
 

--- a/docs/fundamentals/apicompat/preview-apis.md
+++ b/docs/fundamentals/apicompat/preview-apis.md
@@ -54,6 +54,8 @@ When building against an experimental API, the compiler will produce an error. E
 
 Since each experimental feature has a separate ID, consenting to using one experimental feature doesn't consent to using another.
 
+For more information, see [Experimental features][experimental-overview].
+
 ## Choose between the options
 
 Library developers should only use prerelease NuGet packages or mark APIs with `[Experimental]`:
@@ -67,3 +69,4 @@ The `[RequiresPreviewFeatures]` attribute is only meant for components of the .N
 The exception to this rule is if you're building a stable library and want to expose certain features that in turn depend on runtime or language preview behaviors. In that case you should use `[RequiresPreviewFeatures]` for the entry points of that feature. However, you need to consider that users of such APIs have to turn on preview features too, which exposes them to all runtime, library, and language preview behaviors.
 
 [choosing-diagnostic-ids]: ../../csharp/roslyn-sdk/choosing-diagnostic-ids.md
+[experimental-overview]: ../syslib-diagnostics/experimental-overview.md

--- a/docs/fundamentals/syslib-diagnostics/experimental-overview.md
+++ b/docs/fundamentals/syslib-diagnostics/experimental-overview.md
@@ -25,7 +25,6 @@ The following table provides an index to the `SYSLIB5XXX` experimental APIs in .
 | SYSLIB5004 | .NET 9 | <xref:System.Runtime.Intrinsics.X86.X86Base.DivRem(System.UInt32,System.Int32,System.Int32)> is experimental since performance is not as optimized as `T.DivRem` |
 | SYSLIB5005 | .NET 9 | <xref:System.Formats.Nrbf> is experimental |
 
-
 ## Suppress warnings
 
 Using an experimental feature offers the opportunity to submit feedback on the API shape and functionality before the feature is marked as stable and fully supported, but using the feature will produce a warning from the compiler. Suppressing the warning acknowledges that the API shape or functionality might change in the next major release. The warning can be suppressed through a `#pragma` directive in code or a `<NoWarn>` project setting.
@@ -62,4 +61,4 @@ To suppress the warnings in a project file:
 
 ## See also
 
-- [Preview APIs](../../../fundamentals/apicompat/preview-apis.md)
+- [Preview APIs](../apicompat/preview-apis.md)

--- a/docs/fundamentals/syslib-diagnostics/experimental-overview.md
+++ b/docs/fundamentals/syslib-diagnostics/experimental-overview.md
@@ -1,0 +1,65 @@
+---
+title: Experimental features in .NET 9+
+titleSuffix: ""
+description: Learn about APIs that are marked as experimental in .NET 9 and later versions that produce SYSLIB compiler warnings.
+ms.date: 10/21/2024
+---
+
+# Experimental features in .NET 9+
+
+Starting in .NET 9, some features make use of the <xref:System.Diagnostics.CodeAnalysis.ExperimentalAttribute> to indicate that the API shape or functionality is included in the release but not yet officially supported. Experimental features offer the opportunity to collect feedback on the API shape and functionality with the intent of refining the APIs and removing the `[Experimental]` attribute in the next major release.
+
+When an experimental API is referenced, the compiler will produce an error. Each feature that is marked as experimental has a unique diagnostic ID. To express consent to using them, you suppress the specific diagnostic. You can do that via any of the means for suppressing diagnostics, but the recommended way is to add the diagnostic to the project's `<NoWarn>` property. For more information, see [Suppress warnings](#suppress-warnings).
+
+Since each experimental feature has a separate ID, consenting to using one experimental feature doesn't consent to using another.
+
+## Reference
+
+The following table provides an index to the `SYSLIB5XXX` experimental APIs in .NET 9+.
+
+| Diagnostic ID | Experimental Versions | Description |
+| - | - | - |
+| SYSLIB5001 | .NET 9 | <xref:System.Numerics.Tensors.Tensor%601> and related APIs in <xref:System.Numerics.Tensors> are experimental |
+| SYSLIB5002 | .NET 9 | <xref:System.Drawing.SystemColors> alternate colors are experimental |
+| SYSLIB5003 | .NET 9 | <xref:System.Runtime.Intrinsics.Arm.Sve> is experimental |
+| SYSLIB5004 | .NET 9 | <xref:System.Runtime.Intrinsics.X86.X86Base.DivRem> is experimental since performance is not as optimized as `T.DivRem` |
+| SYSLIB5005 | .NET 9 | <xref:System.Formats.Nrbf> is experimental |
+
+
+## Suppress warnings
+
+Using an experimental feature offers the opportunity to submit feedback on the API shape and functionality before the feature is marked as stable and fully supported, but using the feature will produce a warning from the compiler. Suppressing the warning acknowledges that the API shape or functionality might change in the next major release. The warning can be suppressed through a `#pragma` directive in code or a `<NoWarn>` project setting.
+
+To suppress the warnings in code:
+
+```csharp
+// Disable the warning.
+#pragma warning disable SYSLIB5001
+
+// Code that uses an experimental API that produces the diagnostic SYSLIB5001
+//...
+
+// Re-enable the warning.
+#pragma warning restore SYSLIB5001
+```
+
+To suppress the warnings in a project file:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+   <TargetFramework>net9.0</TargetFramework>
+   <!-- NoWarn below suppresses SYSLIB5001 project-wide -->
+   <NoWarn>$(NoWarn);SYSLIB5001</NoWarn>
+   <!-- To suppress multiple warnings, you can use multiple NoWarn elements -->
+   <NoWarn>$(NoWarn);SYSLIB5002</NoWarn>
+   <NoWarn>$(NoWarn);SYSLIB5003</NoWarn>
+   <!-- Alternatively, you can suppress multiple warnings by using a semicolon-delimited list -->
+   <NoWarn>$(NoWarn);SYSLIB5001;SYSLIB5002;SYSLIB5003</NoWarn>
+  </PropertyGroup>
+</Project>
+```
+
+## See also
+
+- [Preview APIs](../../../fundamentals/apicompat/preview-apis.md)

--- a/docs/fundamentals/syslib-diagnostics/experimental-overview.md
+++ b/docs/fundamentals/syslib-diagnostics/experimental-overview.md
@@ -7,9 +7,9 @@ ms.date: 10/21/2024
 
 # Experimental features in .NET 9+
 
-Starting in .NET 9, some features make use of the <xref:System.Diagnostics.CodeAnalysis.ExperimentalAttribute> to indicate that the API shape or functionality is included in the release but not yet officially supported. Experimental features offer the opportunity to collect feedback on the API shape and functionality with the intent of refining the APIs and removing the `[Experimental]` attribute in the next major release.
+Starting in .NET 9, some features make use of the <xref:System.Diagnostics.CodeAnalysis.ExperimentalAttribute> to indicate that the API shape or functionality is included in the release but not yet officially supported. Experimental features let the .NET team collect feedback on an API's shape and functionality with the intent of refining the API and removing the `[Experimental]` attribute in the next major release.
 
-When an experimental API is referenced, the compiler will produce an error. Each feature that is marked as experimental has a unique diagnostic ID. To express consent to using them, you suppress the specific diagnostic. You can do that via any of the means for suppressing diagnostics, but the recommended way is to add the diagnostic to the project's `<NoWarn>` property. For more information, see [Suppress warnings](#suppress-warnings).
+When your code references an experimental API, the compiler produces an error with an ID like `SYSLIB5XXX`. Each feature that's marked as experimental has a unique diagnostic ID. To express consent to using an experimental feature, you suppress the specific diagnostic. You can do that via any of the means for suppressing diagnostics, but the recommended way is to add the diagnostic to the project's `<NoWarn>` property. For more information, see [Suppress warnings](#suppress-warnings).
 
 Since each experimental feature has a separate ID, consenting to using one experimental feature doesn't consent to using another.
 
@@ -17,7 +17,7 @@ Since each experimental feature has a separate ID, consenting to using one exper
 
 The following table provides an index to the `SYSLIB5XXX` experimental APIs in .NET 9+.
 
-| Diagnostic ID | Experimental Versions | Description |
+| Diagnostic ID | Experimental version | Description |
 | - | - | - |
 | SYSLIB5001 | .NET 9 | <xref:System.Numerics.Tensors.Tensor%601> and related APIs in <xref:System.Numerics.Tensors> are experimental |
 | SYSLIB5002 | .NET 9 | <xref:System.Drawing.SystemColors> alternate colors are experimental |
@@ -27,7 +27,7 @@ The following table provides an index to the `SYSLIB5XXX` experimental APIs in .
 
 ## Suppress warnings
 
-Using an experimental feature offers the opportunity to submit feedback on the API shape and functionality before the feature is marked as stable and fully supported, but using the feature will produce a warning from the compiler. Suppressing the warning acknowledges that the API shape or functionality might change in the next major release. The warning can be suppressed through a `#pragma` directive in code or a `<NoWarn>` project setting.
+Using an experimental feature gives you the opportunity to submit feedback on the API shape and functionality before the feature is marked as stable and fully supported. But using the feature produces a warning from the compiler. When you suppress the warning, you acknowledge that the API shape or functionality might change in the next major release. The API might even be removed. You can suppress the warning through a `#pragma` directive in code or a `<NoWarn>` project setting.
 
 To suppress the warnings in code:
 

--- a/docs/fundamentals/syslib-diagnostics/experimental-overview.md
+++ b/docs/fundamentals/syslib-diagnostics/experimental-overview.md
@@ -29,19 +29,6 @@ The following table provides an index to the `SYSLIB5XXX` experimental APIs in .
 
 Using an experimental feature gives you the opportunity to submit feedback on the API shape and functionality before the feature is marked as stable and fully supported. But using the feature produces a warning from the compiler. When you suppress the warning, you acknowledge that the API shape or functionality might change in the next major release. The API might even be removed. You can suppress the warning through a `#pragma` directive in code or a `<NoWarn>` project setting.
 
-To suppress the warnings in code:
-
-```csharp
-// Disable the warning.
-#pragma warning disable SYSLIB5001
-
-// Code that uses an experimental API that produces the diagnostic SYSLIB5001
-//...
-
-// Re-enable the warning.
-#pragma warning restore SYSLIB5001
-```
-
 To suppress the warnings in a project file:
 
 ```xml
@@ -57,6 +44,19 @@ To suppress the warnings in a project file:
    <NoWarn>$(NoWarn);SYSLIB5001;SYSLIB5002;SYSLIB5003</NoWarn>
   </PropertyGroup>
 </Project>
+```
+
+To suppress the warnings in code:
+
+```csharp
+// Disable the warning.
+#pragma warning disable SYSLIB5001
+
+// Code that uses an experimental API that produces the diagnostic SYSLIB5001
+//...
+
+// Re-enable the warning.
+#pragma warning restore SYSLIB5001
 ```
 
 ## See also

--- a/docs/fundamentals/syslib-diagnostics/experimental-overview.md
+++ b/docs/fundamentals/syslib-diagnostics/experimental-overview.md
@@ -22,7 +22,7 @@ The following table provides an index to the `SYSLIB5XXX` experimental APIs in .
 | SYSLIB5001 | .NET 9 | <xref:System.Numerics.Tensors.Tensor%601> and related APIs in <xref:System.Numerics.Tensors> are experimental |
 | SYSLIB5002 | .NET 9 | <xref:System.Drawing.SystemColors> alternate colors are experimental |
 | SYSLIB5003 | .NET 9 | <xref:System.Runtime.Intrinsics.Arm.Sve> is experimental |
-| SYSLIB5004 | .NET 9 | <xref:System.Runtime.Intrinsics.X86.X86Base.DivRem> is experimental since performance is not as optimized as `T.DivRem` |
+| SYSLIB5004 | .NET 9 | <xref:System.Runtime.Intrinsics.X86.X86Base.DivRem(System.UInt32,System.Int32,System.Int32)> is experimental since performance is not as optimized as `T.DivRem` |
 | SYSLIB5005 | .NET 9 | <xref:System.Formats.Nrbf> is experimental |
 
 

--- a/docs/fundamentals/syslib-diagnostics/experimental-overview.md
+++ b/docs/fundamentals/syslib-diagnostics/experimental-overview.md
@@ -27,7 +27,7 @@ The following table provides an index to the `SYSLIB5XXX` experimental APIs in .
 
 ## Suppress warnings
 
-Using an experimental feature gives you the opportunity to submit feedback on the API shape and functionality before the feature is marked as stable and fully supported. But using the feature produces a warning from the compiler. When you suppress the warning, you acknowledge that the API shape or functionality might change in the next major release. The API might even be removed. You can suppress the warning through a `#pragma` directive in code or a `<NoWarn>` project setting.
+Using an experimental feature gives you the opportunity to submit feedback on the API shape and functionality before the feature is marked as stable and fully supported. But using the feature produces a warning from the compiler. When you suppress the warning, you acknowledge that the API shape or functionality might change in the next major release. The API might even be removed. You can suppress the warning through a `<NoWarn>` project setting (recommended) or a `#pragma` directive in code.
 
 To suppress the warnings in a project file:
 

--- a/docs/navigate/tools-diagnostics/toc.yml
+++ b/docs/navigate/tools-diagnostics/toc.yml
@@ -1800,6 +1800,11 @@ items:
             href: ../../fundamentals/syslib-diagnostics/syslib0056.md
           - name: SYSLIB0057
             href: ../../fundamentals/syslib-diagnostics/syslib0057.md
+      - name: Experimental features
+        items:
+          - name: Overview
+            displayName: syslib, experimental
+            href: ../../fundamentals/syslib-diagnostics/experimental-overview.md
       - name: Source-generated code
         items:
           - name: Overview


### PR DESCRIPTION
Contributes to #42812, adding the overview page for experimental APIs

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/whats-new/dotnet-9/libraries.md](https://github.com/dotnet/docs/blob/e7f73d54dec1d94e6ebcc22dd09ef2eb44002130/docs/core/whats-new/dotnet-9/libraries.md) | [docs/core/whats-new/dotnet-9/libraries](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-9/libraries?branch=pr-en-us-43119) |
| [docs/fundamentals/apicompat/preview-apis.md](https://github.com/dotnet/docs/blob/e7f73d54dec1d94e6ebcc22dd09ef2eb44002130/docs/fundamentals/apicompat/preview-apis.md) | [docs/fundamentals/apicompat/preview-apis](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/preview-apis?branch=pr-en-us-43119) |
| [docs/fundamentals/syslib-diagnostics/experimental-overview.md](https://github.com/dotnet/docs/blob/e7f73d54dec1d94e6ebcc22dd09ef2eb44002130/docs/fundamentals/syslib-diagnostics/experimental-overview.md) | [docs/fundamentals/syslib-diagnostics/experimental-overview](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/experimental-overview?branch=pr-en-us-43119) |


<!-- PREVIEW-TABLE-END -->