### PR TITLE
use Parameter instead of Param

### DIFF
--- a/docs/csharp/language-reference/attributes/general.md
+++ b/docs/csharp/language-reference/attributes/general.md
@@ -83,7 +83,7 @@ The `AttributeUsage` attribute determines how a custom attribute class can be us
   - Field
   - Event
   - Method
-  - Param
+  - Parameter
   - Property
   - Return
   - Type


### PR DESCRIPTION
## Summary

use `Parameter` instead of `Param`


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/attributes/general.md](https://github.com/dotnet/docs/blob/409494130bea94d1eb02649406e866d91b2a09c5/docs/csharp/language-reference/attributes/general.md) | [docs/csharp/language-reference/attributes/general](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/attributes/general?branch=pr-en-us-43120) |

<!-- PREVIEW-TABLE-END -->