### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs

### DIFF
--- a/docs/core/tools/dotnet-new-sdk-templates.md
+++ b/docs/core/tools/dotnet-new-sdk-templates.md
@@ -251,7 +251,7 @@ The ability to create a project for an earlier TFM depends on having that versio
 
 - **`--tenant-id <ID>`**
 
-  The TenantId ID of the directory to connect to. Use with `SingleOrg` authentication. The default value is `22222222-2222-2222-2222-222222222222`.
+  The TenantId ID of the directory to connect to. Use with `SingleOrg` authentication. The default value is `aaaabbbb-0000-cccc-1111-dddd2222eeee`.
 
 - **`--callback-path <PATH>`**
 
@@ -418,7 +418,7 @@ The ability to create a project for an earlier TFM depends on having that versio
 
 - **`--tenant-id <ID>`**
 
-  The TenantId ID of the directory to connect to. Use with `SingleOrg` authentication. The default value is `22222222-2222-2222-2222-222222222222`.
+  The TenantId ID of the directory to connect to. Use with `SingleOrg` authentication. The default value is `aaaabbbb-0000-cccc-1111-dddd2222eeee`.
 
 - **`-r|--org-read-access`**
 
@@ -555,7 +555,7 @@ The ability to create a project for an earlier TFM depends on having that versio
 
 - **`--tenant-id <ID>`**
 
-  The TenantId ID of the directory to connect to. Use with `SingleOrg` authentication. The default value is `22222222-2222-2222-2222-222222222222`.
+  The TenantId ID of the directory to connect to. Use with `SingleOrg` authentication. The default value is `aaaabbbb-0000-cccc-1111-dddd2222eeee`.
 
 - **`--callback-path <PATH>`**
 
@@ -764,7 +764,7 @@ Creates a web API project with AOT publish enabled. For more information, see [N
 
 - **`--tenant-id <ID>`**
 
-  The TenantId ID of the directory to connect to. Use with `SingleOrg` authentication. The default value is `22222222-2222-2222-2222-222222222222`.
+  The TenantId ID of the directory to connect to. Use with `SingleOrg` authentication. The default value is `aaaabbbb-0000-cccc-1111-dddd2222eeee`.
 
 - **`-r|--org-read-access`**
 


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/dotnet/docs/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-new-sdk-templates.md](https://github.com/dotnet/docs/blob/6001d25834f0bf9036ba99cc7fabfedfd9b95b89/docs/core/tools/dotnet-new-sdk-templates.md) | [docs/core/tools/dotnet-new-sdk-templates](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-new-sdk-templates?branch=pr-en-us-43126) |

<!-- PREVIEW-TABLE-END -->