### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs

### DIFF
--- a/docs/framework/wcf/diagnostics/tracing/propagation.md
+++ b/docs/framework/wcf/diagnostics/tracing/propagation.md
@@ -49,7 +49,7 @@ This topic describes activity propagation in the Windows Communication Foundatio
       </a:Action>  
       <a:MessageID>urn:uuid:f0091eae-d339-4c7e-9408-ece34602f1ce  
       </a:MessageID>  
-      <ActivityId CorrelationId="f94c6af1-7d5d-4295-b693-4670a8a0ce34"
+      <ActivityId CorrelationId="aaaa0000-bb11-2222-33cc-444444dddddd"
                xmlns="http://schemas.microsoft.com/2004/09/ServiceModel/Diagnostics">  
         17f59a29-b435-4a15-bf7b-642ffc40eac8  
       </ActivityId>  

--- a/docs/framework/wcf/diagnostics/tracing/using-service-trace-viewer-for-viewing-correlated-traces-and-troubleshooting.md
+++ b/docs/framework/wcf/diagnostics/tracing/using-service-trace-viewer-for-viewing-correlated-traces-and-troubleshooting.md
@@ -66,7 +66,7 @@ If you examine the "Sent a message over a channel" trace, you may see the follow
       <Level>8</Level>
       <TimeCreated SystemTime="2006-08-04T18:45:30.8491051Z" />
       <Source Name="System.ServiceModel" />
-       <Correlation ActivityID="{27c6331d-8998-43aa-a382-03239013a6bd}"/>
+       <Correlation ActivityID="{bbbb1111-cc22-3333-44dd-555555eeeeee}"/>
        <Execution ProcessName="client" ProcessID="1808" ThreadID="1" />
        <Channel />
        <Computer>TEST1</Computer>
@@ -87,7 +87,7 @@ If you examine the "Sent a message over a channel" trace, you may see the follow
                   <MessageHeaders>
                      <Action d4p1:mustUnderstand="1" xmlns:d4p1="http://www.w3.org/2003/05/soap-envelope" xmlns="http://www.w3.org/2005/08/addressing">http://Microsoft.ServiceModel.Samples/ICalculator/Multiply</Action>
                      <MessageID xmlns="http://www.w3.org/2005/08/addressing">urn:uuid:7c6670d8-4c9c-496e-b6a0-2ceb6db35338</MessageID>
-                     <ActivityId CorrelationId="b02e2189-0816-4387-980c-dd8e306440f5" xmlns="http://schemas.microsoft.com/2004/09/ServiceModel/Diagnostics">27c6331d-8998-43aa-a382-03239013a6bd</ActivityId>
+                     <ActivityId CorrelationId="aaaa0000-bb11-2222-33cc-444444dddddd" xmlns="http://schemas.microsoft.com/2004/09/ServiceModel/Diagnostics">bbbb1111-cc22-3333-44dd-555555eeeeee</ActivityId>
                      <ReplyTo xmlns="http://www.w3.org/2005/08/addressing">
                         <Address>http://www.w3.org/2005/08/addressing/anonymous</Address>
                     </ReplyTo>

--- a/docs/framework/wcf/feature-details/how-to-configure-a-port-with-an-ssl-certificate.md
+++ b/docs/framework/wcf/feature-details/how-to-configure-a-port-with-an-ssl-certificate.md
@@ -63,7 +63,7 @@ When creating a self-hosted Windows Communication Foundation (WCF) service with 
 2. In Windows Vista, use the Netsh.exe tool, as shown in the following example.  
   
     ```console  
-    netsh http add sslcert ipport=0.0.0.0:8000 certhash=0000000000003ed9cd0c315bbb6dc1c08da5e6 appid={00112233-4455-6677-8899-AABBCCDDEEFF}
+    netsh http add sslcert ipport=0.0.0.0:8000 certhash=0000000000003ed9cd0c315bbb6dc1c08da5e6 appid={00001111-aaaa-2222-bbbb-3333cccc4444}
     ```  
   
     - The **certhash** parameter specifies the thumbprint of the certificate.  
@@ -85,7 +85,7 @@ When creating a self-hosted Windows Communication Foundation (WCF) service with 
 2. In Windows Vista, to support clients that authenticate with X.509 certificates at the transport layer, follow the preceding procedure, but with an additional parameter, as shown in the following example.  
   
     ```console  
-    netsh http add sslcert ipport=0.0.0.0:8000 certhash=0000000000003ed9cd0c315bbb6dc1c08da5e6 appid={00112233-4455-6677-8899-AABBCCDDEEFF} clientcertnegotiation=enable  
+    netsh http add sslcert ipport=0.0.0.0:8000 certhash=0000000000003ed9cd0c315bbb6dc1c08da5e6 appid={00001111-aaaa-2222-bbbb-3333cccc4444} clientcertnegotiation=enable  
     ```  
   
 ## Delete an SSL certificate from a port number  


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/dotnet/docs/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/wcf/diagnostics/tracing/propagation.md](https://github.com/dotnet/docs/blob/7c3fb07ba67c619423a66a4b8346f7ac6b044899/docs/framework/wcf/diagnostics/tracing/propagation.md) | [docs/framework/wcf/diagnostics/tracing/propagation](https://review.learn.microsoft.com/en-us/dotnet/framework/wcf/diagnostics/tracing/propagation?branch=pr-en-us-43128) |
| [docs/framework/wcf/diagnostics/tracing/using-service-trace-viewer-for-viewing-correlated-traces-and-troubleshooting.md](https://github.com/dotnet/docs/blob/7c3fb07ba67c619423a66a4b8346f7ac6b044899/docs/framework/wcf/diagnostics/tracing/using-service-trace-viewer-for-viewing-correlated-traces-and-troubleshooting.md) | [docs/framework/wcf/diagnostics/tracing/using-service-trace-viewer-for-viewing-correlated-traces-and-troubleshooting](https://review.learn.microsoft.com/en-us/dotnet/framework/wcf/diagnostics/tracing/using-service-trace-viewer-for-viewing-correlated-traces-and-troubleshooting?branch=pr-en-us-43128) |
| [docs/framework/wcf/feature-details/how-to-configure-a-port-with-an-ssl-certificate.md](https://github.com/dotnet/docs/blob/7c3fb07ba67c619423a66a4b8346f7ac6b044899/docs/framework/wcf/feature-details/how-to-configure-a-port-with-an-ssl-certificate.md) | [docs/framework/wcf/feature-details/how-to-configure-a-port-with-an-ssl-certificate](https://review.learn.microsoft.com/en-us/dotnet/framework/wcf/feature-details/how-to-configure-a-port-with-an-ssl-certificate?branch=pr-en-us-43128) |

<!-- PREVIEW-TABLE-END -->