### PR TITLE
Fix link in CA5374: Do not use XslTransform

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca5374.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5374.md
@@ -30,7 +30,7 @@ Instantiating an <xref:System.Xml.Xsl.XslTransform?displayProperty=nameWithType>
 
 ## How to fix violations
 
-Replace <xref:System.Xml.Xsl.XslTransform> with <xref:System.Xml.Xsl.XslCompiledTransform?displayProperty=nameWithType>. For more guidance, see [/dotnet/standard/data/xml/migrating-from-the-xsltransform-class].
+Replace <xref:System.Xml.Xsl.XslTransform> with <xref:System.Xml.Xsl.XslCompiledTransform?displayProperty=nameWithType>. For more guidance, see [Migrating From the XslTransform Class](/dotnet/standard/data/xml/migrating-from-the-xsltransform-class).
 
 ## When to suppress warnings
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5374.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5374.md
@@ -30,7 +30,7 @@ Instantiating an <xref:System.Xml.Xsl.XslTransform?displayProperty=nameWithType>
 
 ## How to fix violations
 
-Replace <xref:System.Xml.Xsl.XslTransform> with <xref:System.Xml.Xsl.XslCompiledTransform?displayProperty=nameWithType>. For more guidance, see [Migrating From the XslTransform Class](/dotnet/standard/data/xml/migrating-from-the-xsltransform-class).
+Replace <xref:System.Xml.Xsl.XslTransform> with <xref:System.Xml.Xsl.XslCompiledTransform?displayProperty=nameWithType>. For more guidance, see [Migrating from the XslTransform class](../../../standard/data/xml/migrating-from-the-xsltransform-class.md).
 
 ## When to suppress warnings
 


### PR DESCRIPTION
## Summary

Fix link to [Migrating From the XslTransform Class](https://learn.microsoft.com/en-us//dotnet/standard/data/xml/migrating-from-the-xsltransform-class)

Fixes #42310


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca5374.md](https://github.com/dotnet/docs/blob/3308b2b7aeec5df85ee1c80dcb56cb79db349613/docs/fundamentals/code-analysis/quality-rules/ca5374.md) | [docs/fundamentals/code-analysis/quality-rules/ca5374](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca5374?branch=pr-en-us-43136) |


<!-- PREVIEW-TABLE-END -->