### PR TITLE
Remove the ordinal comment

### DIFF
--- a/docs/csharp/language-reference/keywords/access-modifiers.md
+++ b/docs/csharp/language-reference/keywords/access-modifiers.md
@@ -27,7 +27,7 @@ Access modifiers are keywords used to specify the declared accessibility of a me
 
  This section also introduces the following concepts:
 
-- [Accessibility Levels](./accessibility-levels.md): Using the four access modifiers to declare six levels of accessibility.
+- [Accessibility Levels](./accessibility-levels.md): Using the access modifiers to declare levels of accessibility.
 - [Accessibility Domain](./accessibility-domain.md): Specifies where, in the program sections, a member can be referenced.
 - [Restrictions on Using Accessibility Levels](./restrictions-on-using-accessibility-levels.md): A summary of the restrictions on using declared accessibility levels.
 


### PR DESCRIPTION
This is out of date with the number of access modifiers. Just remove the number(s).

Fixes anonymous feedback.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/access-modifiers.md](https://github.com/dotnet/docs/blob/c39a6125df8a8725b2ed88d7e010bd3d2bbe64e6/docs/csharp/language-reference/keywords/access-modifiers.md) | [docs/csharp/language-reference/keywords/access-modifiers](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/access-modifiers?branch=pr-en-us-43140) |

<!-- PREVIEW-TABLE-END -->