### PR TITLE
Update ServicePointManager obsoletion docs

### DIFF
--- a/docs/fundamentals/syslib-diagnostics/syslib0014.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib0014.md
@@ -14,8 +14,12 @@ The following APIs are marked as obsolete, starting in .NET 6. Using them in cod
 - <xref:System.Net.WebRequest.CreateHttp%2A?displayProperty=fullName>
 - <xref:System.Net.WebRequest.CreateDefault(System.Uri)?displayProperty=fullName>
 - <xref:System.Net.HttpWebRequest.%23ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)>
-- <xref:System.Net.ServicePointManager.FindServicePoint%2A?displayProperty=fullName>
+- <xref:System.Net.ServicePointManager>
 - <xref:System.Net.WebClient.%23ctor>
+
+To reduce the number of analyzer warnings, the <xref:System.Net.ServicePoint> class is not marked as obsolete, but all ways of obtaining its instances are.
+
+Settings on <xref:System.Net.ServicePointManager> and <xref:System.Net.ServicePoint> no longer affect <xref:System.Net.Security.SslStream> or <xref:System.Net.Http.HttpClient>.
 
 ## Workarounds
 

--- a/docs/fundamentals/syslib-diagnostics/syslib0014.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib0014.md
@@ -25,6 +25,8 @@ Settings on <xref:System.Net.ServicePointManager> and <xref:System.Net.ServicePo
 
 Use <xref:System.Net.Http.HttpClient> instead.
 
+See the [HttpWebRequest to HttpClient migration guide](https://learn.microsoft.com/dotnet/fundamentals/networking/http/httpclient-migrate-from-httpwebrequest) for more info.
+
 ## Suppress a warning
 
 If you must use the obsolete APIs, you can suppress the warning in code or in your project file.


### PR DESCRIPTION
Add the note about `ServicePointManager` being obsolete, and that its settings have no effect on `SslStream`/`HttpClient`.

Followup to https://github.com/dotnet/runtime/pull/103456, https://github.com/dotnet/sdk/issues/43621

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/syslib-diagnostics/syslib0014.md](https://github.com/dotnet/docs/blob/797aead2c5c3cab55dc69157e9a9603f75669c74/docs/fundamentals/syslib-diagnostics/syslib0014.md) | [docs/fundamentals/syslib-diagnostics/syslib0014](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib0014?branch=pr-en-us-43143) |


<!-- PREVIEW-TABLE-END -->