### PR TITLE
Fix code example output on roundtrip decimal

### DIFF
--- a/docs/standard/base-types/standard-numeric-format-strings.md
+++ b/docs/standard/base-types/standard-numeric-format-strings.md
@@ -1,7 +1,7 @@
 ---
 title: Standard numeric format strings
 description: In this article, learn to use standard numeric format strings to format common numeric types into text representations in .NET.
-ms.date: 04/08/2021
+ms.date: 10/22/2024
 ms.topic: reference
 dev_langs:
   - "csharp"

--- a/samples/snippets/csharp/VS_Snippets_CLR_System/system.Double.ToString/cs/roundtripex1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR_System/system.Double.ToString/cs/roundtripex1.cs
@@ -26,7 +26,10 @@ public class Example
       // If compiled to an application that targets anycpu or x64 and run on an x64 system,
       // the example displays the following output:
       //       Attempting to round-trip a Double with 'R':
+      //       .NET Framework:
       //       0.6822871999174 = 0.68228719991740006: False
+      //       .NET:
+      //       0.6822871999174 = 0.6822871999174: True
       //
       //       Attempting to round-trip a Double with 'G17':
       //       0.6822871999174 = 0.6822871999174: True

--- a/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Double.ToString/vb/roundtripex1.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Double.ToString/vb/roundtripex1.vb
@@ -28,7 +28,10 @@ End Module
 ' If compiled to an application that targets anycpu or x64 and run on an x64 system,
 ' the example displays the following output:
 '       Attempting to round-trip a Double with 'R':
+'       .NET Framework:
 '       0.6822871999174 = 0.68228719991740006: False
+'       .NET:
+'       0.6822871999174 = 0.6822871999174: True
 '
 '       Attempting to round-trip a Double with 'G17':
 '       0.6822871999174 = 0.6822871999174: True


### PR DESCRIPTION
## Summary

- Wrote some code to test locally.
- Adjusted the captured output text to differentiate .NET and .NET Framework.

Fixes #41766 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/base-types/standard-numeric-format-strings.md](https://github.com/dotnet/docs/blob/93aeb9ea6763572896351b5bb50cc21e02d63529/docs/standard/base-types/standard-numeric-format-strings.md) | [docs/standard/base-types/standard-numeric-format-strings](https://review.learn.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings?branch=pr-en-us-43162) |

<!-- PREVIEW-TABLE-END -->