### PR TITLE
Add a note about creating directories before exporting dev certs

### DIFF
--- a/docs/core/tools/dotnet-dev-certs.md
+++ b/docs/core/tools/dotnet-dev-certs.md
@@ -81,7 +81,7 @@ The `dotnet dev-certs` command manages a self-signed certificate to enable HTTPS
 
 - **`-ep|--export-path <PATH>`**
 
-  Exports the certificate to a file so that it can be used by other tools. Specify the full path to the exported certificate file, including the file name. The type of certificate files that are created depends on which options are used with `--export-path`:
+  Exports the certificate to a file so that it can be used by other tools. Specify the full path to the exported certificate file, including the file name. The containing directories must already exist and access to them should be restricted. The type of certificate files that are created depends on which options are used with `--export-path`:
 
   | Options | What is exported |
   |---------|---------|


### PR DESCRIPTION
Required as of https://github.com/aspnet/Announcements/issues/515

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-dev-certs.md](https://github.com/dotnet/docs/blob/ab9385eed53cd61332d1aae8e865b81eb956e8b4/docs/core/tools/dotnet-dev-certs.md) | [docs/core/tools/dotnet-dev-certs](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-dev-certs?branch=pr-en-us-43166) |

<!-- PREVIEW-TABLE-END -->