### PR TITLE
Mention the `decimal` simple type in Built-in types section

### DIFF
--- a/docs/csharp/language-reference/builtin-types/value-types.md
+++ b/docs/csharp/language-reference/builtin-types/value-types.md
@@ -47,9 +47,12 @@ C# provides the following built-in value types, also known as *simple types*:
 
 All simple types are structure types and differ from other structure types in that they permit certain additional operations:
 
-- You can use literals to provide a value of a simple type. For example, `'A'` is a literal of the type `char` and `2001` is a literal of the type `int`.
+- You can use literals to provide a value of a simple type.
+<br/>For example, `'A'` is a literal of the type `char`, `2001` is a literal of the type `int` and `12.34m` is a literal of the type `decimal`.
 
-- You can declare constants of the simple types with the [const](../keywords/const.md) keyword. It's not possible to have constants of other structure types.
+- You can declare constants of the simple types with the [const](../keywords/const.md) keyword.
+<br/>For example, you can define `const decimal = 12.34m`.
+<br/>It's not possible to have constants of other structure types.
 
 - Constant expressions, whose operands are all constants of the simple types, are evaluated at compile time.
 


### PR DESCRIPTION
This pull request adds `decimal` to the section of "Built-in value types" to mention it's literal and the possibility of having it's constant value just like it's possible for other simple types.
I decided not to create a separate section or even a paragraph for the decimal only, because in the page of "Floating-point numeric types" the decimal is already described and I didn't want to create redundant content.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/builtin-types/value-types.md](https://github.com/dotnet/docs/blob/fdf41dff0c8d594bbce67e3e24fb483b788e5745/docs/csharp/language-reference/builtin-types/value-types.md) | [docs/csharp/language-reference/builtin-types/value-types](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/value-types?branch=pr-en-us-43186) |

<!-- PREVIEW-TABLE-END -->