### PR TITLE
[Diagnostics] Add EventSource Callback Possible Deadlock Warning

### DIFF
--- a/docs/core/diagnostics/eventsource-collect-and-view-traces.md
+++ b/docs/core/diagnostics/eventsource-collect-and-view-traces.md
@@ -272,3 +272,14 @@ this isn't required. Following is an example `EventListener` implementation that
    3/24/2022 9:23:35 AM RequestStart
    3/24/2022 9:23:35 AM RequestStop
    ```
+
+> [!WARNING]
+> Potential Deadlocks with EventSource Callbacks
+>
+> When implementing EventSources, be cautious with invoking lock-acquiring APIs within EventSource callbacks. EventSource instances are initialized early in the runtime, before some core features are fully initialized. As a result, the re-entrant behavior of EventSource callbacks may cause deadlocks if the callback attempts to acquire locks already held by the thread that triggered the callback.
+>
+> To mitigate this risk, consider the following precautions:
+>
+> - **Avoid Complex Operations**: Refrain from performing complex operations within the callback that might acquire additional locks.
+> - **Minimize Lock Duration**: Ensure that any locks acquired within the callback are not held for extended periods.
+> - **Use Non-blocking APIs**: Prefer using non-blocking APIs within the callback to avoid potential deadlocks.

--- a/docs/core/diagnostics/eventsource-collect-and-view-traces.md
+++ b/docs/core/diagnostics/eventsource-collect-and-view-traces.md
@@ -280,6 +280,6 @@ this isn't required. Following is an example `EventListener` implementation that
 >
 > To mitigate this risk, consider the following precautions:
 >
-> - **Avoid Complex Operations**: Refrain from performing complex operations within the callback that might acquire additional locks.
+> - **Avoid Complex Operations**: Refrain from performing complex operations within the callback that might acquire additional locks. For example, during some event callbacks, attempting to use File or Console APIs may encounter issues. Instead, you can update an in-memory datastructure or add some information about the event to a queue. If more processing is needed it can be done from a separate thread after the callback has already returned.
 > - **Minimize Lock Duration**: Ensure that any locks acquired within the callback are not held for extended periods.
 > - **Use Non-blocking APIs**: Prefer using non-blocking APIs within the callback to avoid potential deadlocks.

--- a/docs/core/diagnostics/eventsource-collect-and-view-traces.md
+++ b/docs/core/diagnostics/eventsource-collect-and-view-traces.md
@@ -283,3 +283,23 @@ this isn't required. Following is an example `EventListener` implementation that
 > - **Avoid Complex Operations**: Refrain from performing complex operations within the callback that might acquire additional locks. For example, during some event callbacks, attempting to use File or Console APIs may encounter issues. Instead, you can update an in-memory datastructure or add some information about the event to a queue. If more processing is needed it can be done from a separate thread after the callback has already returned.
 > - **Minimize Lock Duration**: Ensure that any locks acquired within the callback are not held for extended periods.
 > - **Use Non-blocking APIs**: Prefer using non-blocking APIs within the callback to avoid potential deadlocks.
+> - **Implement Re-entrancy Guard**: Use a re-entrancy guard to prevent infinite recursion. For example:
+>
+>   ```csharp
+>   [ThreadStatic] private static bool t_insideCallback;
+>
+>   public void OnEventWritten(...)
+>   {
+>       if (t_insideCallback) return; // if our callback triggered the event to occur recursively
+>                                     // exit now to avoid infinite recursion
+>       try
+>       {
+>           t_insideCallback = true;
+>           // do callback work
+>       }
+>       finally
+>       {
+>           t_insideCallback = false;
+>       }
+>   }
+>   ```

--- a/docs/core/diagnostics/eventsource-collect-and-view-traces.md
+++ b/docs/core/diagnostics/eventsource-collect-and-view-traces.md
@@ -280,10 +280,10 @@ this isn't required. Following is an example `EventListener` implementation that
 >
 > To mitigate this risk, consider the following precautions:
 >
-> - **Avoid Complex Operations**: Refrain from performing complex operations within the callback that might acquire additional locks. For example, during some event callbacks, attempting to use File or Console APIs may encounter issues. Instead, you can update an in-memory datastructure or add some information about the event to a queue. If more processing is needed it can be done from a separate thread after the callback has already returned.
+> - **Use Queues to Defer Work**: There are a variety of APIs you might want to call in OnEventWritten() that do non-trivial work, for example File IO, Console, or Http. For most events, these APIs work fine, but if you tried to call Console.WriteLine() in an event handler during the initialization of the Console class then it would probably fail. If you don't know whether a given event handler occurs at a time when APIs are safe to call, consider adding some information about the event to an in-memory queue instead. Then, on a separate thread, process items in the queue.
 > - **Minimize Lock Duration**: Ensure that any locks acquired within the callback are not held for extended periods.
 > - **Use Non-blocking APIs**: Prefer using non-blocking APIs within the callback to avoid potential deadlocks.
-> - **Implement Re-entrancy Guard**: Use a re-entrancy guard to prevent infinite recursion. For example:
+> - **Implement a Re-entrancy Guard**: Use a re-entrancy guard to prevent infinite recursion. For example:
 >
 >   ```csharp
 >   [ThreadStatic] private static bool t_insideCallback;

--- a/docs/core/diagnostics/eventsource-collect-and-view-traces.md
+++ b/docs/core/diagnostics/eventsource-collect-and-view-traces.md
@@ -274,7 +274,7 @@ this isn't required. Following is an example `EventListener` implementation that
    ```
 
 > [!WARNING]
-> Potential Deadlocks with EventSource Callbacks
+> Potential Pitfalls when implementing EventSource Callbacks via EventListener include deadlocks, infinite recursions, and uninitialized types.
 >
 > When implementing EventSources, be cautious with invoking lock-acquiring APIs within EventSource callbacks. EventSource instances are initialized early in the runtime, before some core features are fully initialized. As a result, the re-entrant behavior of EventSource callbacks may cause deadlocks if the callback attempts to acquire locks already held by the thread that triggered the callback.
 >

--- a/docs/core/diagnostics/eventsource-collect-and-view-traces.md
+++ b/docs/core/diagnostics/eventsource-collect-and-view-traces.md
@@ -276,7 +276,7 @@ this isn't required. Following is an example `EventListener` implementation that
 > [!WARNING]
 > Potential Pitfalls when implementing EventSource Callbacks via EventListener include deadlocks, infinite recursions, and uninitialized types.
 >
-> When implementing EventSources, be cautious with invoking lock-acquiring APIs within EventSource callbacks. EventSource instances are initialized early in the runtime, before some core features are fully initialized. As a result, the re-entrant behavior of EventSource callbacks may cause deadlocks if the callback attempts to acquire locks already held by the thread that triggered the callback.
+> EventSource instances are initialized early in the runtime, before some core features are fully initialized. As a result, acquiring locks inside an EventSource callback like <xref:System.Diagnostics.Tracing.EventListener.OnEventWritten%2A> when the thread normally would not have done so may cause deadlocks.
 >
 > To mitigate this risk, consider the following precautions:
 >

--- a/docs/core/diagnostics/eventsource.md
+++ b/docs/core/diagnostics/eventsource.md
@@ -20,17 +20,6 @@ your own custom events.
 > Many technologies that integrate with EventSource use the terms 'Tracing' and 'Traces' instead of 'Logging' and 'Logs'.
 > The meaning is the same here.
 
-> [!WARNING]
-> Potential Deadlocks with EventSource Callbacks
->
-> When implementing EventSources, be cautious with invoking lock-acquiring APIs within EventSource callbacks. EventSource instances are initialized early in the runtime, before some core features are fully initialized. As a result, the re-entrant behavior of EventSource callbacks may cause deadlocks if the callback attempts to acquire locks already held by the thread that triggered the callback.
->
-> To mitigate this risk, consider the following precautions:
->
-> - **Avoid Complex Operations**: Refrain from performing complex operations within the callback that might acquire additional locks.
-> - **Minimize Lock Duration**: Ensure that any locks acquired within the callback are not held for extended periods.
-> - **Use Non-blocking APIs**: Prefer using non-blocking APIs within the callback to avoid potential deadlocks.
-
 - [Getting started](./eventsource-getting-started.md)
 - [Instrumenting code to create events](./eventsource-instrumentation.md)
 - [Collecting and viewing event traces](./eventsource-collect-and-view-traces.md)

--- a/docs/core/diagnostics/eventsource.md
+++ b/docs/core/diagnostics/eventsource.md
@@ -20,6 +20,17 @@ your own custom events.
 > Many technologies that integrate with EventSource use the terms 'Tracing' and 'Traces' instead of 'Logging' and 'Logs'.
 > The meaning is the same here.
 
+> [!WARNING]
+> Potential Deadlocks with EventSource Callbacks
+>
+> When implementing EventSources, be cautious with invoking lock-acquiring APIs within EventSource callbacks. EventSource instances are initialized early in the runtime, before some core features are fully initialized. As a result, the re-entrant behavior of EventSource callbacks may cause deadlocks if the callback attempts to acquire locks already held by the thread that triggered the callback.
+>
+> To mitigate this risk, consider the following precautions:
+>
+> - **Avoid Complex Operations**: Refrain from performing complex operations within the callback that might acquire additional locks.
+> - **Minimize Lock Duration**: Ensure that any locks acquired within the callback are not held for extended periods.
+> - **Use Non-blocking APIs**: Prefer using non-blocking APIs within the callback to avoid potential deadlocks.
+
 - [Getting started](./eventsource-getting-started.md)
 - [Instrumenting code to create events](./eventsource-instrumentation.md)
 - [Collecting and viewing event traces](./eventsource-collect-and-view-traces.md)


### PR DESCRIPTION
## Summary

This PR aims to improve EventSource documentation by warning users against bad practices when implementing EventSource callbacks.

Fixes https://github.com/dotnet/diagnostics/issues/4825


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/eventsource-collect-and-view-traces.md](https://github.com/dotnet/docs/blob/96fad7bf54224dc638c166eeb5ad9fbf8dd044cf/docs/core/diagnostics/eventsource-collect-and-view-traces.md) | [docs/core/diagnostics/eventsource-collect-and-view-traces](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/eventsource-collect-and-view-traces?branch=pr-en-us-43197) |


<!-- PREVIEW-TABLE-END -->