### PR TITLE
Update method-parameters.md anchor problem

### DIFF
--- a/docs/csharp/language-reference/keywords/method-parameters.md
+++ b/docs/csharp/language-reference/keywords/method-parameters.md
@@ -58,9 +58,9 @@ Informally, you can think of these scopes as the mechanism to ensure your code n
 
 You apply one of the following modifiers to a parameter declaration to pass arguments by reference instead of by value:
 
-- [`ref`](#ref-readonly-modifier): The argument must be initialized before calling the method. The method can assign a new value to the parameter, but isn't required to do so.
+- [`ref`](#ref-parameter-modifier): The argument must be initialized before calling the method. The method can assign a new value to the parameter, but isn't required to do so.
 - [`out`](#out-parameter-modifier): The calling method isn't required to initialize the argument before calling the method. The method must assign a value to the parameter.
-- [`readonly ref`](#ref-parameter-modifier): The argument must be initialized before calling the method. The method can't assign a new value to the parameter.
+- [`readonly ref`](#ref-readonly-modifier): The argument must be initialized before calling the method. The method can't assign a new value to the parameter.
 - [`in`](#in-parameter-modifier): The argument must be initialized before calling the method. The method can't assign a new value to the parameter. The compiler might create a temporary variable to hold a copy of the argument to `in` parameters.
 
 Members of a class can't have signatures that differ only by `ref`, `ref readonly`, `in`, or `out`. A compiler error occurs if the only difference between two members of a type is that one of them has a `ref` parameter and the other has an `out`, `ref readonly`, or `in` parameter. However, methods can be overloaded when one method has a `ref`, `ref readonly`, `in`, or `out` parameter and the other has a parameter that is passed by value, as shown in the following example. In other situations that require signature matching, such as hiding or overriding, `in`, `ref`, `ref readonly`, and `out` are part of the signature and don't match each other.


### PR DESCRIPTION
fix: The anchor's ref-parameter-modifier and ref-readonly-modifier have been swapped.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/method-parameters.md](https://github.com/dotnet/docs/blob/5b86715d275934ca3dfac3614f4f85e664aa944e/docs/csharp/language-reference/keywords/method-parameters.md) | [docs/csharp/language-reference/keywords/method-parameters](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/method-parameters?branch=pr-en-us-43200) |

<!-- PREVIEW-TABLE-END -->