### PR TITLE
.NET Aspire 9 - GA

### DIFF
--- a/docs/core/project-sdk/overview.md
+++ b/docs/core/project-sdk/overview.md
@@ -14,15 +14,15 @@ Modern .NET projects are associated with a project software development kit (SDK
 
 The following SDKs are available:
 
-| ID                         | Description                                             | Repo                                   |
-|----------------------------|---------------------------------------------------------|----------------------------------------|
-| `Microsoft.NET.Sdk`        | The .NET SDK                                            | <https://github.com/dotnet/sdk>        |
-| `Microsoft.NET.Sdk.Web`    | The .NET [Web SDK](/aspnet/core/razor-pages/web-sdk)    | <https://github.com/dotnet/sdk>        |
-| `Microsoft.NET.Sdk.Razor`  | The .NET [Razor SDK](/aspnet/core/razor-pages/sdk)      | <https://github.com/dotnet/aspnetcore> |
+| ID                         | Description                                                                          | Repo                                   |
+|----------------------------|--------------------------------------------------------------------------------------|----------------------------------------|
+| `Microsoft.NET.Sdk`        | The .NET SDK                                                                         | <https://github.com/dotnet/sdk>        |
+| `Microsoft.NET.Sdk.Web`    | The .NET [Web SDK](/aspnet/core/razor-pages/web-sdk)                                 | <https://github.com/dotnet/sdk>        |
+| `Microsoft.NET.Sdk.Razor`  | The .NET [Razor SDK](/aspnet/core/razor-pages/sdk)                                   | <https://github.com/dotnet/aspnetcore> |
 | `Microsoft.NET.Sdk.BlazorWebAssembly` | The .NET [Blazor WebAssembly SDK](/aspnet/core/blazor#blazor-webassembly) | <https://github.com/dotnet/aspnetcore> |
-| `Microsoft.NET.Sdk.Worker` | The .NET [Worker Service](../extensions/workers.md) SDK |                                        |
-| `Aspire.AppHost.Sdk`       | The .NET Aspire SDK                                     | <https://github.com/dotnet/aspire>     |
-| `MSTest.Sdk`               | The [MSTest SDK](../testing/unit-testing-mstest-sdk.md) | <https://github.com/microsoft/testfx>  |
+| `Microsoft.NET.Sdk.Worker` | The .NET [Worker Service SDK](../extensions/workers.md)                              | <https://github.com/dotnet/aspnetcore> |
+| `Aspire.AppHost.Sdk`       | The .NET [Aspire SDK](/dotnet/aspire/fundamentals/dotnet-aspire-sdk)                 | <https://github.com/dotnet/aspire>     |
+| `MSTest.Sdk`               | The [MSTest SDK](../testing/unit-testing-mstest-sdk.md)                              | <https://github.com/microsoft/testfx>  |
 
 The .NET SDK is the base SDK for .NET. The other SDKs reference the .NET SDK, and projects that are associated with the other SDKs have all the .NET SDK properties available to them. The Web SDK, for example, depends on both the .NET SDK and the Razor SDK.
 
@@ -36,22 +36,22 @@ For Windows Forms and Windows Presentation Foundation (WPF) projects, you specif
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
-  ...
+    <!-- Omitted for brevity... -->
 </Project>
 ```
 
-Starting with .NET Aspire 9, the preceding example could instead use the .NET Aspire SDK.
+The `Project/Sdk` attribute and `Sdk` element enable additive SDKs. Consider the following example, where the .NET Aspire SDK (`Aspire.AppHost.Sdk`) is added to the project atop the `Microsoft.NET.Sdk`:
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <Sdk Name="Aspire.AppHost.Sdk" Version="9.0.0-rc.1.24511.1" />
+    <Sdk Name="Aspire.AppHost.Sdk" Version="9.0.0" />
     <!-- Omitted for brevity... -->
 
 </Project>
 ```
 
-For more information, see [.NET Aspire tooling and setup](/dotnet/aspire/fundamentals/setup-tooling).
+In the preceding project file, both SDKs are used to resolve dependencies in an additive nature. For more information, see [.NET Aspire SDK](/dotnet/aspire/fundamentals/dotnet-aspire-sdk)
 
 To specify an SDK that comes from NuGet, include the version at the end of the name, or specify the name and version in the *global.json* file.
 


### PR DESCRIPTION
## Summary

- Add links to .NET Aspire SDK
- Correct phrasing about additive nature of `Sdk`

Related to https://github.com/dotnet/docs-aspire/issues/1888 and https://github.com/dotnet/docs-aspire/pull/1867.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/project-sdk/overview.md](https://github.com/dotnet/docs/blob/f33ab2b6f1c5f62e27503275f224ee9ac7a8218e/docs/core/project-sdk/overview.md) | [docs/core/project-sdk/overview](https://review.learn.microsoft.com/en-us/dotnet/core/project-sdk/overview?branch=pr-en-us-43203) |

<!-- PREVIEW-TABLE-END -->