### PR TITLE
Update netsdk1045.md added more details about where to look for the g…

### DIFF
--- a/docs/core/tools/sdk-errors/netsdk1045.md
+++ b/docs/core/tools/sdk-errors/netsdk1045.md
@@ -58,7 +58,7 @@ Check the MSBuildSDKPath environment variable. This optional environment variabl
 
 ## global.json file
 
-Check for a *global.json* file in the root folder in your project and up the directory chain to the root of the volume, since it can be anywhere in the folder structure. If it contains an SDK version, delete the `sdk` node and all its children, or update it to the desired newer .NET Core version.
+Check for a *global.json* file in the root folder in your project and in your solution, and up the directory chain to the root of the volume, since it can be anywhere in the folder structure. If it contains an SDK version, delete the `sdk` node and all its children, or update it to the desired newer .NET Core version.
 
 ```json
 {


### PR DESCRIPTION
…lobal.json

The name project can be misleading, instead the user must look also inside the Solution root folder.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/sdk-errors/netsdk1045.md](https://github.com/dotnet/docs/blob/0ff60434bd51d5cd2f2266dcd48383d0a4a0a7a4/docs/core/tools/sdk-errors/netsdk1045.md) | [docs/core/tools/sdk-errors/netsdk1045](https://review.learn.microsoft.com/en-us/dotnet/core/tools/sdk-errors/netsdk1045?branch=pr-en-us-43204) |

<!-- PREVIEW-TABLE-END -->