### PR TITLE
Add a page for .NET interop abi/platform support.

### DIFF
--- a/docs/navigate/advanced-programming/toc.yml
+++ b/docs/navigate/advanced-programming/toc.yml
@@ -391,7 +391,7 @@ items:
     href: ../../standard/native-interop/preserve-sig.md
   - name: Exceptions
     href: ../../standard/native-interop/exceptions-interoperability.md
-  - name: Native interoperability ABI support
+  - name: ABI support
     href: ../../standard/native-interop/abi-support.md
   - name: Supplemental API remarks
     items:

--- a/docs/navigate/advanced-programming/toc.yml
+++ b/docs/navigate/advanced-programming/toc.yml
@@ -391,6 +391,8 @@ items:
     href: ../../standard/native-interop/preserve-sig.md
   - name: Exceptions
     href: ../../standard/native-interop/exceptions-interoperability.md
+  - name: Target ABI support
+    href: ../../standard/native-interop/abi-support.md
   - name: Supplemental API remarks
     items:
     - name: The ComException class

--- a/docs/navigate/advanced-programming/toc.yml
+++ b/docs/navigate/advanced-programming/toc.yml
@@ -391,7 +391,7 @@ items:
     href: ../../standard/native-interop/preserve-sig.md
   - name: Exceptions
     href: ../../standard/native-interop/exceptions-interoperability.md
-  - name: Target ABI support
+  - name: Native interoperability ABI support
     href: ../../standard/native-interop/abi-support.md
   - name: Supplemental API remarks
     items:

--- a/docs/standard/native-interop/abi-support.md
+++ b/docs/standard/native-interop/abi-support.md
@@ -7,6 +7,8 @@ ms.date: 10/25/2024
 
 [Application Binary Interface](https://wikipedia.org/wiki/Application_binary_interface) (ABI) is the interface which run times and operating systems express low-level binary details. This can include calling conventions (that is, how parameters are passed and results returned), exception handling, as well as symbol mangling. The below list contains the names of languages, run times and even general technologies since these names tend to represent what users will be working with when looking for guidance on interoperability.
 
+## Support table
+
 |   | Support | APIs |
 |---|---------|----------------|
 | **C**                          | ✔️       | <xref:System.Runtime.InteropServices.LibraryImportAttribute> provides source generated support in .NET 7+. Use <xref:System.Runtime.InteropServices.DllImportAttribute> when targeting earlier .NET versions. |
@@ -17,18 +19,18 @@ ms.date: 10/25/2024
 | **golang**                     | ❌       | [Guidance](#golang) |
 | **ARM64EC**                    | ❌       | [Note](#arm64ec)    |
 
-## <a name="cpp"></a> C++
+### <a name="cpp"></a> C++
 
 The [C++ language](https://isocpp.org/) has no defined ABI across all .NET supported platforms and C++ compiler implementations (that is, MSVC, clang, and GCC). This lack of a stable ABI makes support difficult to provide.
 
 The recommended way to interoperate with C++ is to export functions marked with `extern "C"` and call them as C functions.
 
-## <a name="golang"></a> golang
+### <a name="golang"></a> golang
 
 The Go programming language is not supported for in-process interoperability. The Go runtime [imposes requirements](https://pkg.go.dev/os/signal#hdr-Non_Go_programs_that_call_Go_code) on being hosted in a process with another run time. Specifically, the use of the `SA_ONSTACK` flag on threads that run signal handlers. These requirements are not currently met by .NET and meeting them would impose non-trivial costs.
 
 The recommended way to interoperate with golang is using a golang hosted process and communicate through an inter-process communication mechanism.
 
-## <a name="arm64ec"></a> ARM64EC
+### <a name="arm64ec"></a> ARM64EC
 
 The [ARM64EC](/cpp/build/arm64ec-windows-abi-conventions) ABI is not supported.

--- a/docs/standard/native-interop/abi-support.md
+++ b/docs/standard/native-interop/abi-support.md
@@ -9,21 +9,25 @@ ms.date: 10/25/2024
 
 |   | Support | APIs |
 |---|---------|----------------|
-| **C**                          | ✔️                | <xref:System.Runtime.InteropServices.LibraryImportAttribute> <xref:System.Runtime.InteropServices.DllImportAttribute> |
-| **C++**                        | [Note](#cpp)     |          |
-| **COM and `IUnknown`**         | ✔️                | <xref:System.Runtime.InteropServices.ComWrappers> <xref:System.Runtime.InteropServices.Marshalling.GeneratedComInterfaceAttribute> <xref:System.Runtime.InteropServices.Marshalling.GeneratedComClassAttribute> |
-| **Swift**                      | ✔️                | <xref:System.Runtime.InteropServices.Swift> namespace      |
-| **Objective-C**                | ✔️                | <xref:System.Runtime.InteropServices.ObjectiveC> namespace |
-| **golang**                     | [Note](#golang)  |          |
-| **ARM64EC**                    | [Note](#arm64ec) |          |
+| **C**                          | ✔️       | <xref:System.Runtime.InteropServices.LibraryImportAttribute> <xref:System.Runtime.InteropServices.DllImportAttribute> |
+| **C++**                        | ❌       | [Guidance](#cpp) |
+| **COM and `IUnknown`**         | ✔️       | <xref:System.Runtime.InteropServices.ComWrappers> <xref:System.Runtime.InteropServices.Marshalling.GeneratedComInterfaceAttribute> <xref:System.Runtime.InteropServices.Marshalling.GeneratedComClassAttribute> |
+| **Swift**                      | ✔️       | <xref:System.Runtime.InteropServices.Swift> namespace      |
+| **Objective-C**                | ✔️       | <xref:System.Runtime.InteropServices.ObjectiveC> namespace |
+| **golang**                     | ❌       | [Guidance](#golang) |
+| **ARM64EC**                    | ❌       | [Note](#arm64ec)    |
 
 ## <a name="cpp"></a> C++
 
-The [C++ language](https://isocpp.org/) has no defined ABI across all .NET supported platforms and C++ compiler implementations (that is, MSVC, clang, and GCC). This lack of a stable ABI makes support difficult to provide. The recommended way to interoperate with C++ is to export functions marked with `extern "C"` and then call them as C functions.
+The [C++ language](https://isocpp.org/) has no defined ABI across all .NET supported platforms and C++ compiler implementations (that is, MSVC, clang, and GCC). This lack of a stable ABI makes support difficult to provide.
+
+The recommended way to interoperate with C++ is to export functions marked with `extern "C"` and call them as C functions.
 
 ## <a name="golang"></a> golang
 
 The Go programming language is not supported for in-process interoperability. The Go runtime [imposes requirements](https://pkg.go.dev/os/signal#hdr-Non_Go_programs_that_call_Go_code) on being hosted in a process with another run time. Specifically, the use of the `SA_ONSTACK` flag on threads that run signal handlers. These requirements are not currently met by .NET and meeting them would impose non-trivial costs.
+
+The recommended way to interoperate with golang is using a golang hosted process and communicate through an inter-process communication mechanism.
 
 ## <a name="arm64ec"></a> ARM64EC
 

--- a/docs/standard/native-interop/abi-support.md
+++ b/docs/standard/native-interop/abi-support.md
@@ -20,7 +20,7 @@ Additional links:
 
 ## C++
 
-The [C++ language](https://isocpp.org/) has no defined ABI across all .NET supported platforms and the most popular C++ compiler implementations (that is, MSVC, clang, and GCC). This lack of a consistent ABI makes support difficult to provide.
+The [C++ language](https://isocpp.org/) has no defined ABI across all .NET supported platforms and the most popular C++ compiler implementations (that is, MSVC, clang, and GCC). This lack of a consistent ABI makes it difficult to target directly.
 
 The recommended way to interoperate with C++ is to export functions marked with [`extern "C"`](/cpp/cpp/extern-cpp) and call them as C functions.
 
@@ -70,6 +70,7 @@ The reference implementation of the Python run-time, [CPython](https://github.co
 Additional links:
 
 * [Providing a C API for an Extension Module](https://docs.python.org/3/extending/extending.html#providing-a-c-api-for-an-extension-module)
+* [Python for .NET](https://github.com/pythonnet/pythonnet)
 
 ## golang
 

--- a/docs/standard/native-interop/abi-support.md
+++ b/docs/standard/native-interop/abi-support.md
@@ -15,6 +15,7 @@ In .NET 7+, <xref:System.Runtime.InteropServices.LibraryImportAttribute> provide
 
 Additional links:
 
+* [`LibraryImportAttribute` walkthrough](/dotnet/standard/native-interop/pinvoke-source-generation)
 * [CsWin32](https://github.com/microsoft/CsWin32) is a source generator for accessing the Windows Win32 API surface
 
 ## C++
@@ -33,11 +34,11 @@ The COM and `IUnknown` ABI was defined to align with the C language. It was spec
 
 In .NET 5+, low-level, cross-platform, `IUnknown` lifetime support is provided by <xref:System.Runtime.InteropServices.ComWrappers>. In .NET 8+, <xref:System.Runtime.InteropServices.Marshalling.GeneratedComInterfaceAttribute> and <xref:System.Runtime.InteropServices.Marshalling.GeneratedComClassAttribute> provide source generated C# projections. When targeting versions prior to .NET 5, the [built-in COM interop system](/dotnet/standard/native-interop/cominterop) must be used and is limited to the Windows platforms.
 
-The WinRT platform represents an evolution of the COM and `IUknown` ABI. Support for this is provided by the [CsWinRT toolkit](/windows/apps/develop/platform/csharp-winrt/) and is built upon <xref:System.Runtime.InteropServices.ComWrappers>.
+The WinRT platform represents an evolution of the COM and `IUnknown` ABI. Support for this is provided by the [CsWinRT toolkit](/windows/apps/develop/platform/csharp-winrt/) and is built upon <xref:System.Runtime.InteropServices.ComWrappers>.
 
 Additional links:
 
-* [`ComWrappers` sample](/dotnet/standard/native-interop/tutorial-comwrappers)
+* [`ComWrappers` walkthrough](/dotnet/standard/native-interop/tutorial-comwrappers)
 * [COM source generator sample](/dotnet/standard/native-interop/comwrappers-source-generation)
 * [ClangSharp](https://github.com/dotnet/ClangSharp) binding generator
 
@@ -60,7 +61,7 @@ The Objective-C language follows the C language's ABI and is [supported in .NET]
 Additional links:
 
 * [Objective-Sharpie](/previous-versions/xamarin/cross-platform/macios/binding/)
-* [Objective-C binding sample](/dotnet/maui/migration/ios-binding-projects)
+* [Objective-C binding walkthrough](/dotnet/maui/migration/ios-binding-projects)
 
 ## Python
 

--- a/docs/standard/native-interop/abi-support.md
+++ b/docs/standard/native-interop/abi-support.md
@@ -1,0 +1,43 @@
+---
+title: Native interoperability ABI support - .NET
+description: Defines the current support for interoperability with various ABIs.
+ms.date: 10/25/2024
+---
+# Native interoperability ABI support
+
+Application Binary Interface (ABI) is the interface which run times and operating systems express low-level binary details. This can include calling conventions (that is, how parameters are passed and results returned), exception handling, as well as symbol mangling. The below list contains the names of languages, run times and even general technologies since these names tend to represent what users will be working with when looking for guidance on interoperability.
+
+## C
+
+The C language represents a stable ABI across all platforms where .NET is supported. It is what most .NET interop APIs assume is the target. This is the recommended approach for most interop in .NET.
+
+## C++
+
+The [C++ language](https://isocpp.org/) has no defined ABI across all .NET supported platforms and C++ compiler implementations (that is, MSVC, clang, and GCC). This lack of a stable ABI makes support difficult to provide. The recommended way to interoperate with C++ is to export functions marked with `extern "C"` and then call them as C functions.
+
+## COM and `IUnknown`
+
+The COM and `IUnknown` style ABI was defined to align with the C language. It was specifically to support Object Oriented Programming, similar to C++, but to provide a stable ABI. .NET has a deep history with COM and `IUnknown` and as this ABI was originally designed to align with C, it is supported in all .NET platforms through the <xref:System.Runtime.InteropServices.ComWrappers> API.
+
+## Swift
+
+The Swift programming environment has a well-defined stable ABI that is [supported in .NET](https://github.com/dotnet/designs/blob/main/proposed/swift-interop.md). The specific APIs that support interop with Swift can be found under the <xref:System.Runtime.InteropServices.Swift> namespace.
+
+## Objective-C
+
+The Objective-C language follows the C language's ABI and is [supported in .NET](https://github.com/dotnet/designs/blob/main/accepted/2021/objectivec-interop.md). The specific APIs that support interop with Objective-C can be found under the <xref:System.Runtime.InteropServices.ObjectiveC> namespace.
+
+## Java Virtual Machine (JVM)
+
+The JVM is a virtual machine with managed memory, similar to the .NET runtime. Interoperability with the JVM is limited through tooling like [dotnet/java-interop](https://github.com/dotnet/java-interop) and comes with performance costs. The largest cost of interoperating with the JVM is the coordination between the two virtual machine's Garbage Collectors.
+
+## golang
+
+The Go programming language is not supported for in-process interoperability. The Go runtime [imposes requirements](https://pkg.go.dev/os/signal#hdr-Non_Go_programs_that_call_Go_code) on being hosted in a process with another run time. Specifically, the use of the `SA_ONSTACK` flag on threads that run signal handlers. These requirements are not currently met by .NET and meeting them would impose non-trivial costs.
+
+It is recommended that users with golang dependencies use a cross-process communication technology to interoperate.
+
+## ARM64EC
+
+There are currently no plans to add support for [ARM64EC](https://learn.microsoft.com/cpp/build/arm64ec-windows-abi-conventions) in .NET 5+.
+

--- a/docs/standard/native-interop/abi-support.md
+++ b/docs/standard/native-interop/abi-support.md
@@ -18,11 +18,20 @@ Many virtual machine based languages define a foreign function interface (FFI) i
 * Java Virtual Machine (JVM)
 * CPython
 
+Additional links:
+
+* [CsWin32](https://github.com/microsoft/CsWin32) a source generator for access Windows Win32 API
+* [Java binding generator](https://github.com/dotnet/java-interop)
+
 ## C++
 
 The [C++ language](https://isocpp.org/) has no defined ABI across all .NET supported platforms and the most popular C++ compiler implementations (that is, MSVC, clang, and GCC). This lack of a consistent ABI makes support difficult to provide.
 
 The recommended way to interoperate with C++ is to export functions marked with [`extern "C"`](/cpp/cpp/extern-cpp) and call them as C functions.
+
+Additional links:
+
+* [ClangSharp](https://github.com/dotnet/ClangSharp) binding generator
 
 ## COM and `IUnknown`
 
@@ -32,6 +41,12 @@ In .NET 5+, low-level, cross-platform, `IUnknown` lifetime support is provided b
 
 The WinRT platform represents an evolution of the COM and `IUknown` ABI. Support for this is provided by the [CsWinRT toolkit](/windows/apps/develop/platform/csharp-winrt/) and is built upon <xref:System.Runtime.InteropServices.ComWrappers>.
 
+Additional links:
+
+* [`ComWrappers` sample](/dotnet/standard/native-interop/tutorial-comwrappers)
+* [COM source generator sample](/dotnet/standard/native-interop/comwrappers-source-generation)
+* [ClangSharp](https://github.com/dotnet/ClangSharp) binding generator
+
 ## Swift
 
 The Swift programming environment has a well-defined stable ABI that is [supported in .NET](https://github.com/dotnet/designs/blob/main/proposed/swift-interop.md). In .NET 9+, specific APIs that support interop with Swift can be found under the <xref:System.Runtime.InteropServices.Swift> namespace.
@@ -39,6 +54,11 @@ The Swift programming environment has a well-defined stable ABI that is [support
 ## Objective-C
 
 The Objective-C language follows the C language's ABI and is [supported in .NET](https://github.com/dotnet/designs/blob/main/accepted/2021/objectivec-interop.md). In .NET 8+, specific APIs that support interop with Objective-C can be found under the <xref:System.Runtime.InteropServices.ObjectiveC> namespace.
+
+Additional links:
+
+* [Objective-Sharpie](/previous-versions/xamarin/cross-platform/macios/binding/)
+* [Objective-C binding](/dotnet/maui/migration/ios-binding-projects) sample
 
 ## golang
 

--- a/docs/standard/native-interop/abi-support.md
+++ b/docs/standard/native-interop/abi-support.md
@@ -13,7 +13,10 @@ The C language represents a stable ABI across all platforms where .NET is suppor
 
 <xref:System.Runtime.InteropServices.LibraryImportAttribute> provides source generated support in .NET 7+. Use <xref:System.Runtime.InteropServices.DllImportAttribute> when targeting earlier .NET versions. Refer to [Interop best practices](./best-practices.md) for additional guidance.
 
-Many virtual machine languages define a foreign function interface in C to interoperate with other platforms. The Java Virtual Machine (JVM) and Python runtimes are examples of this.
+Many virtual machine languages define a foreign function interface (FFI) in C to interoperate with other platforms. A list of examples is below.
+
+* Java Virtual Machine (JVM)
+* CPython
 
 ## C++
 

--- a/docs/standard/native-interop/abi-support.md
+++ b/docs/standard/native-interop/abi-support.md
@@ -1,36 +1,48 @@
 ---
 title: Native interoperability ABI support - .NET
 description: Defines the current support for interoperability with various ABIs.
-ms.date: 10/25/2024
+ms.date: 10/27/2024
 ---
 # Native interoperability ABI support
 
 [Application Binary Interface](https://wikipedia.org/wiki/Application_binary_interface) (ABI) is the interface which run times and operating systems express low-level binary details. This can include calling conventions (that is, how parameters are passed and results returned), exception handling, as well as symbol mangling. The below list contains the names of languages, run times and even general technologies since these names tend to represent what users will be working with when looking for guidance on interoperability.
 
-## Support table
+## C
 
-|   | Support | APIs |
-|---|---------|------|
-| **C**                  | ✔️ | <xref:System.Runtime.InteropServices.LibraryImportAttribute> provides source generated support in .NET 7+. Use <xref:System.Runtime.InteropServices.DllImportAttribute> when targeting earlier .NET versions. Refer to [Interop best practices](./best-practices.md) for additional guidance. |
-| **C++**                | ❌ | [Guidance](#cpp) |
-| **COM and `IUnknown`** | ✔️ | In .NET 5+, low-level, cross-platform, `IUnknown` lifetime support is provided by <xref:System.Runtime.InteropServices.ComWrappers>. In .NET 8+, <xref:System.Runtime.InteropServices.Marshalling.GeneratedComInterfaceAttribute> and <xref:System.Runtime.InteropServices.Marshalling.GeneratedComClassAttribute> provide source generated C# projections. The built-in COM interop system is limited to the Windows platforms and required on versions prior to .NET 5. |
-| **Swift**              | ✔️ | For .NET 9+, <xref:System.Runtime.InteropServices.Swift> namespace.      |
-| **Objective-C**        | ✔️ | For .NET 8+, <xref:System.Runtime.InteropServices.ObjectiveC> namespace. |
-| **golang**             | ❌ | [Guidance](#golang) |
-| **ARM64EC**            | ❌ | [Note](#arm64ec)    |
+The C language represents a stable ABI across all platforms where .NET is supported. It is what most .NET interop APIs assume is the target. This is the recommended target language for most interop in .NET.
 
-### <a name="cpp"></a> C++
+<xref:System.Runtime.InteropServices.LibraryImportAttribute> provides source generated support in .NET 7+. Use <xref:System.Runtime.InteropServices.DllImportAttribute> when targeting earlier .NET versions. Refer to [Interop best practices](./best-practices.md) for additional guidance.
+
+Many virtual machine languages define a foreign function interface in C to interoperate with other platforms. The Java Virtual Machine (JVM) and Python runtimes are examples of this.
+
+## C++
 
 The [C++ language](https://isocpp.org/) has no defined ABI across all .NET supported platforms and C++ compiler implementations (that is, MSVC, clang, and GCC). This lack of a stable ABI makes support difficult to provide.
 
 The recommended way to interoperate with C++ is to export functions marked with `extern "C"` and call them as C functions.
 
-### <a name="golang"></a> golang
+## COM and `IUnknown`
 
-The Go programming language is not supported for in-process interoperability. The Go runtime [imposes requirements](https://pkg.go.dev/os/signal#hdr-Non_Go_programs_that_call_Go_code) on being hosted in a process with another run time. Specifically, the use of the `SA_ONSTACK` flag on threads that run signal handlers. These requirements are not currently met by .NET and meeting them would impose non-trivial costs.
+The COM and `IUnknown` style ABI was defined to align with the C language. It was specifically to support Object Oriented Programming, similar to C++, but to provide a stable ABI. .NET has a deep history with COM and `IUnknown` and as this ABI was originally designed to align with C, it is supported on all .NET platforms.
+
+In .NET 5+, low-level, cross-platform, `IUnknown` lifetime support is provided by <xref:System.Runtime.InteropServices.ComWrappers>. In .NET 8+, <xref:System.Runtime.InteropServices.Marshalling.GeneratedComInterfaceAttribute> and <xref:System.Runtime.InteropServices.Marshalling.GeneratedComClassAttribute> provide source generated C# projections. The built-in COM interop system is limited to the Windows platforms and required on versions prior to .NET 5.
+
+The WinRT platform represents an evolution of the COM and `IUknown` ABI. Support for this is provided by the [CsWinRT toolkit](/windows/apps/develop/platform/csharp-winrt/) and is built upon <xref:System.Runtime.InteropServices.ComWrappers>.
+
+## Swift
+
+The Swift programming environment has a well-defined stable ABI that is [supported in .NET](https://github.com/dotnet/designs/blob/main/proposed/swift-interop.md). In .NET 9+, specific APIs that support interop with Swift can be found under the <xref:System.Runtime.InteropServices.Swift> namespace.
+
+## Objective-C
+
+The Objective-C language follows the C language's ABI and is [supported in .NET](https://github.com/dotnet/designs/blob/main/accepted/2021/objectivec-interop.md). In .NET 8+, specific APIs that support interop with Objective-C can be found under the <xref:System.Runtime.InteropServices.ObjectiveC> namespace.
+
+## golang
+
+The Go programming language is not supported for in-process interoperability. The Go runtime [imposes requirements](https://pkg.go.dev/os/signal#hdr-Non_Go_programs_that_call_Go_code) on being hosted in a process with another run time. Specifically, the use of the `SA_ONSTACK` flag on threads that run signal handlers. These requirements are not currently met by .NET.
 
 The recommended way to interoperate with golang is using a golang hosted process and communicate through an inter-process communication mechanism.
 
-### <a name="arm64ec"></a> ARM64EC
+## ARM64EC
 
 The [ARM64EC](/cpp/build/arm64ec-windows-abi-conventions) ABI is not supported.

--- a/docs/standard/native-interop/abi-support.md
+++ b/docs/standard/native-interop/abi-support.md
@@ -5,30 +5,30 @@ ms.date: 10/27/2024
 ---
 # Native interoperability ABI support
 
-[Application Binary Interface](https://wikipedia.org/wiki/Application_binary_interface) (ABI) is the interface which run times and operating systems express low-level binary details. This can include calling conventions (that is, how parameters are passed and results returned), exception handling, as well as symbol mangling. The below list contains the names of languages, run times and even general technologies since these names tend to represent what users will be working with when looking for guidance on interoperability.
+The [Application Binary Interface](https://wikipedia.org/wiki/Application_binary_interface) (ABI) is the interface which run-times and operating systems express low-level binary details. This can include calling conventions (that is, how parameters are passed and results returned), exception handling, as well as symbol mangling. The below list contains the names of languages, run-times and even general technologies since these names tend to represent what users will be working with when looking for guidance on interoperability.
 
 ## C
 
-The C language represents a stable ABI across all platforms where .NET is supported. It is what most .NET interop APIs assume is the target. This is the recommended target language for most interop in .NET.
+The C language represents a stable ABI across all platforms where .NET is supported. It is what most .NET interop APIs assume is the target. This is the recommended target language for most interop scenarios using .NET.
 
-<xref:System.Runtime.InteropServices.LibraryImportAttribute> provides source generated support in .NET 7+. Use <xref:System.Runtime.InteropServices.DllImportAttribute> when targeting earlier .NET versions. Refer to [Interop best practices](./best-practices.md) for additional guidance.
+In .NET 7+, <xref:System.Runtime.InteropServices.LibraryImportAttribute> provides source generated support for calling C functions. When targeting .NET 6 or earlier, use <xref:System.Runtime.InteropServices.DllImportAttribute>. Refer to [Interop best practices](./best-practices.md) for additional guidance.
 
-Many virtual machine languages define a foreign function interface (FFI) in C to interoperate with other platforms. A list of examples is below.
+Many virtual machine based languages define a foreign function interface (FFI) in C to interoperate with other platforms. A list of examples is below.
 
 * Java Virtual Machine (JVM)
 * CPython
 
 ## C++
 
-The [C++ language](https://isocpp.org/) has no defined ABI across all .NET supported platforms and C++ compiler implementations (that is, MSVC, clang, and GCC). This lack of a stable ABI makes support difficult to provide.
+The [C++ language](https://isocpp.org/) has no defined ABI across all .NET supported platforms and the most popular C++ compiler implementations (that is, MSVC, clang, and GCC). This lack of a consistent ABI makes support difficult to provide.
 
-The recommended way to interoperate with C++ is to export functions marked with `extern "C"` and call them as C functions.
+The recommended way to interoperate with C++ is to export functions marked with [`extern "C"`](/cpp/cpp/extern-cpp) and call them as C functions.
 
 ## COM and `IUnknown`
 
-The COM and `IUnknown` style ABI was defined to align with the C language. It was specifically to support Object Oriented Programming, similar to C++, but to provide a stable ABI. .NET has a deep history with COM and `IUnknown` and as this ABI was originally designed to align with C, it is supported on all .NET platforms.
+The COM and `IUnknown` ABI was defined to align with the C language. It was specifically designed to support Object Oriented Programming, similar to C++, but to provide a stable ABI. .NET has a deep history with COM and `IUnknown` and as this ABI was originally designed to align with C, it is supported on all .NET platforms.
 
-In .NET 5+, low-level, cross-platform, `IUnknown` lifetime support is provided by <xref:System.Runtime.InteropServices.ComWrappers>. In .NET 8+, <xref:System.Runtime.InteropServices.Marshalling.GeneratedComInterfaceAttribute> and <xref:System.Runtime.InteropServices.Marshalling.GeneratedComClassAttribute> provide source generated C# projections. The built-in COM interop system is limited to the Windows platforms and required on versions prior to .NET 5.
+In .NET 5+, low-level, cross-platform, `IUnknown` lifetime support is provided by <xref:System.Runtime.InteropServices.ComWrappers>. In .NET 8+, <xref:System.Runtime.InteropServices.Marshalling.GeneratedComInterfaceAttribute> and <xref:System.Runtime.InteropServices.Marshalling.GeneratedComClassAttribute> provide source generated C# projections. When targeting versions prior to .NET 5, the [built-in COM interop system](/dotnet/standard/native-interop/cominterop) must be used and is limited to the Windows platforms.
 
 The WinRT platform represents an evolution of the COM and `IUknown` ABI. Support for this is provided by the [CsWinRT toolkit](/windows/apps/develop/platform/csharp-winrt/) and is built upon <xref:System.Runtime.InteropServices.ComWrappers>.
 
@@ -42,7 +42,7 @@ The Objective-C language follows the C language's ABI and is [supported in .NET]
 
 ## golang
 
-The Go programming language is not supported for in-process interoperability. The Go runtime [imposes requirements](https://pkg.go.dev/os/signal#hdr-Non_Go_programs_that_call_Go_code) on being hosted in a process with another run time. Specifically, the use of the `SA_ONSTACK` flag on threads that run signal handlers. These requirements are not currently met by .NET.
+The Go programming language is not supported for in-process interoperability. The Go runtime [imposes requirements](https://pkg.go.dev/os/signal#hdr-Non_Go_programs_that_call_Go_code) on being hosted in a process with another run-time. Specifically, the use of the `SA_ONSTACK` flag on threads that run signal handlers. These requirements are not currently met by .NET.
 
 The recommended way to interoperate with golang is using a golang hosted process and communicate through an inter-process communication mechanism.
 

--- a/docs/standard/native-interop/abi-support.md
+++ b/docs/standard/native-interop/abi-support.md
@@ -9,22 +9,22 @@ ms.date: 10/25/2024
 
 |   | Support | APIs |
 |---|---------|----------------|
-| **C**                          | ✔️               | <xref:System.Runtime.InteropServices.LibraryImportAttribute> <xref:System.Runtime.InteropServices.DllImportAttribute> |
-| **C++**                        | [Note][cpp]     |          |
-| **COM and `IUnknown`**         | ✔️               | <xref:System.Runtime.InteropServices.ComWrappers> <xref:System.Runtime.InteropServices.Marshalling.GeneratedComInterfaceAttribute> <xref:System.Runtime.InteropServices.Marshalling.GeneratedComClassAttribute> |
-| **Swift**                      | ✔️               | <xref:System.Runtime.InteropServices.Swift> namespace      |
-| **Objective-C**                | ✔️               | <xref:System.Runtime.InteropServices.ObjectiveC> namespace |
-| **golang**                     | [Note][golang]  |          |
-| **ARM64EC**                    | [Note][arm64ec] |          |
+| **C**                          | ✔️                | <xref:System.Runtime.InteropServices.LibraryImportAttribute> <xref:System.Runtime.InteropServices.DllImportAttribute> |
+| **C++**                        | [Note](#cpp)     |          |
+| **COM and `IUnknown`**         | ✔️                | <xref:System.Runtime.InteropServices.ComWrappers> <xref:System.Runtime.InteropServices.Marshalling.GeneratedComInterfaceAttribute> <xref:System.Runtime.InteropServices.Marshalling.GeneratedComClassAttribute> |
+| **Swift**                      | ✔️                | <xref:System.Runtime.InteropServices.Swift> namespace      |
+| **Objective-C**                | ✔️                | <xref:System.Runtime.InteropServices.ObjectiveC> namespace |
+| **golang**                     | [Note](#golang)  |          |
+| **ARM64EC**                    | [Note](#arm64ec) |          |
 
-## C++ <a name="cpp"></a>
+## <a name="cpp"></a> C++
 
 The [C++ language](https://isocpp.org/) has no defined ABI across all .NET supported platforms and C++ compiler implementations (that is, MSVC, clang, and GCC). This lack of a stable ABI makes support difficult to provide. The recommended way to interoperate with C++ is to export functions marked with `extern "C"` and then call them as C functions.
 
-## golang <a name="golang"></a>
+## <a name="golang"></a> golang
 
 The Go programming language is not supported for in-process interoperability. The Go runtime [imposes requirements](https://pkg.go.dev/os/signal#hdr-Non_Go_programs_that_call_Go_code) on being hosted in a process with another run time. Specifically, the use of the `SA_ONSTACK` flag on threads that run signal handlers. These requirements are not currently met by .NET and meeting them would impose non-trivial costs.
 
-## ARM64EC <a name="arm64ec"></a>
+## <a name="arm64ec"></a> ARM64EC
 
 The [ARM64EC](https://learn.microsoft.com/cpp/build/arm64ec-windows-abi-conventions) ABI is not supported.

--- a/docs/standard/native-interop/abi-support.md
+++ b/docs/standard/native-interop/abi-support.md
@@ -10,14 +10,14 @@ ms.date: 10/25/2024
 ## Support table
 
 |   | Support | APIs |
-|---|---------|----------------|
-| **C**                          | ✔️       | <xref:System.Runtime.InteropServices.LibraryImportAttribute> provides source generated support in .NET 7+. Use <xref:System.Runtime.InteropServices.DllImportAttribute> when targeting earlier .NET versions. |
-| **C++**                        | ❌       | [Guidance](#cpp) |
-| **COM and `IUnknown`**         | ✔️       | In .NET 5+, low-level, cross-platform, `IUnknown` lifetime support is provided by <xref:System.Runtime.InteropServices.ComWrappers>. In .NET 8+, <xref:System.Runtime.InteropServices.Marshalling.GeneratedComInterfaceAttribute> and <xref:System.Runtime.InteropServices.Marshalling.GeneratedComClassAttribute> provide source generated C# projections. The built-in COM interop system is limited to the Windows platforms and required on versions prior to .NET 5. |
-| **Swift**                      | ✔️       | For .NET 9+, <xref:System.Runtime.InteropServices.Swift> namespace.      |
-| **Objective-C**                | ✔️       | For .NET 8+, <xref:System.Runtime.InteropServices.ObjectiveC> namespace. |
-| **golang**                     | ❌       | [Guidance](#golang) |
-| **ARM64EC**                    | ❌       | [Note](#arm64ec)    |
+|---|---------|------|
+| **C**                  | ✔️ | <xref:System.Runtime.InteropServices.LibraryImportAttribute> provides source generated support in .NET 7+. Use <xref:System.Runtime.InteropServices.DllImportAttribute> when targeting earlier .NET versions. Refer to [Interop best practices](./best-practices.md) for additional guidance. |
+| **C++**                | ❌ | [Guidance](#cpp) |
+| **COM and `IUnknown`** | ✔️ | In .NET 5+, low-level, cross-platform, `IUnknown` lifetime support is provided by <xref:System.Runtime.InteropServices.ComWrappers>. In .NET 8+, <xref:System.Runtime.InteropServices.Marshalling.GeneratedComInterfaceAttribute> and <xref:System.Runtime.InteropServices.Marshalling.GeneratedComClassAttribute> provide source generated C# projections. The built-in COM interop system is limited to the Windows platforms and required on versions prior to .NET 5. |
+| **Swift**              | ✔️ | For .NET 9+, <xref:System.Runtime.InteropServices.Swift> namespace.      |
+| **Objective-C**        | ✔️ | For .NET 8+, <xref:System.Runtime.InteropServices.ObjectiveC> namespace. |
+| **golang**             | ❌ | [Guidance](#golang) |
+| **ARM64EC**            | ❌ | [Note](#arm64ec)    |
 
 ### <a name="cpp"></a> C++
 

--- a/docs/standard/native-interop/abi-support.md
+++ b/docs/standard/native-interop/abi-support.md
@@ -9,11 +9,11 @@ ms.date: 10/25/2024
 
 |   | Support | APIs |
 |---|---------|----------------|
-| **C**                          | ✔️       | <xref:System.Runtime.InteropServices.LibraryImportAttribute> <xref:System.Runtime.InteropServices.DllImportAttribute> |
+| **C**                          | ✔️       | <xref:System.Runtime.InteropServices.LibraryImportAttribute> provides source generated support in .NET 7+. Use <xref:System.Runtime.InteropServices.DllImportAttribute> when targeting earlier .NET versions. |
 | **C++**                        | ❌       | [Guidance](#cpp) |
-| **COM and `IUnknown`**         | ✔️       | <xref:System.Runtime.InteropServices.ComWrappers> <xref:System.Runtime.InteropServices.Marshalling.GeneratedComInterfaceAttribute> <xref:System.Runtime.InteropServices.Marshalling.GeneratedComClassAttribute> |
-| **Swift**                      | ✔️       | <xref:System.Runtime.InteropServices.Swift> namespace      |
-| **Objective-C**                | ✔️       | <xref:System.Runtime.InteropServices.ObjectiveC> namespace |
+| **COM and `IUnknown`**         | ✔️       | In .NET 5+, low-level, cross-platform, `IUnknown` lifetime support is provided by <xref:System.Runtime.InteropServices.ComWrappers>. In .NET 8+, <xref:System.Runtime.InteropServices.Marshalling.GeneratedComInterfaceAttribute> and <xref:System.Runtime.InteropServices.Marshalling.GeneratedComClassAttribute> provide source generated C# projections. The built-in COM interop system is limited to the Windows platforms and required on versions prior to .NET 5. |
+| **Swift**                      | ✔️       | For .NET 9+, <xref:System.Runtime.InteropServices.Swift> namespace.      |
+| **Objective-C**                | ✔️       | For .NET 8+, <xref:System.Runtime.InteropServices.ObjectiveC> namespace. |
 | **golang**                     | ❌       | [Guidance](#golang) |
 | **ARM64EC**                    | ❌       | [Note](#arm64ec)    |
 

--- a/docs/standard/native-interop/abi-support.md
+++ b/docs/standard/native-interop/abi-support.md
@@ -40,4 +40,3 @@ It is recommended that users with golang dependencies use a cross-process commun
 ## ARM64EC
 
 There are currently no plans to add support for [ARM64EC](https://learn.microsoft.com/cpp/build/arm64ec-windows-abi-conventions) in .NET 5+.
-

--- a/docs/standard/native-interop/abi-support.md
+++ b/docs/standard/native-interop/abi-support.md
@@ -31,4 +31,4 @@ The recommended way to interoperate with golang is using a golang hosted process
 
 ## <a name="arm64ec"></a> ARM64EC
 
-The [ARM64EC](https://learn.microsoft.com/cpp/build/arm64ec-windows-abi-conventions) ABI is not supported.
+The [ARM64EC](/cpp/build/arm64ec-windows-abi-conventions) ABI is not supported.

--- a/docs/standard/native-interop/abi-support.md
+++ b/docs/standard/native-interop/abi-support.md
@@ -5,38 +5,26 @@ ms.date: 10/25/2024
 ---
 # Native interoperability ABI support
 
-Application Binary Interface (ABI) is the interface which run times and operating systems express low-level binary details. This can include calling conventions (that is, how parameters are passed and results returned), exception handling, as well as symbol mangling. The below list contains the names of languages, run times and even general technologies since these names tend to represent what users will be working with when looking for guidance on interoperability.
+[Application Binary Interface](https://wikipedia.org/wiki/Application_binary_interface) (ABI) is the interface which run times and operating systems express low-level binary details. This can include calling conventions (that is, how parameters are passed and results returned), exception handling, as well as symbol mangling. The below list contains the names of languages, run times and even general technologies since these names tend to represent what users will be working with when looking for guidance on interoperability.
 
-## C
+|   | Support | APIs |
+|---|---------|----------------|
+| **C**                          | ✔️               | <xref:System.Runtime.InteropServices.LibraryImportAttribute> <xref:System.Runtime.InteropServices.DllImportAttribute> |
+| **C++**                        | [Note][cpp]     |          |
+| **COM and `IUnknown`**         | ✔️               | <xref:System.Runtime.InteropServices.ComWrappers> <xref:System.Runtime.InteropServices.Marshalling.GeneratedComInterfaceAttribute> <xref:System.Runtime.InteropServices.Marshalling.GeneratedComClassAttribute> |
+| **Swift**                      | ✔️               | <xref:System.Runtime.InteropServices.Swift> namespace      |
+| **Objective-C**                | ✔️               | <xref:System.Runtime.InteropServices.ObjectiveC> namespace |
+| **golang**                     | [Note][golang]  |          |
+| **ARM64EC**                    | [Note][arm64ec] |          |
 
-The C language represents a stable ABI across all platforms where .NET is supported. It is what most .NET interop APIs assume is the target. This is the recommended approach for most interop in .NET.
-
-## C++
+## C++ <a name="cpp"></a>
 
 The [C++ language](https://isocpp.org/) has no defined ABI across all .NET supported platforms and C++ compiler implementations (that is, MSVC, clang, and GCC). This lack of a stable ABI makes support difficult to provide. The recommended way to interoperate with C++ is to export functions marked with `extern "C"` and then call them as C functions.
 
-## COM and `IUnknown`
-
-The COM and `IUnknown` style ABI was defined to align with the C language. It was specifically to support Object Oriented Programming, similar to C++, but to provide a stable ABI. .NET has a deep history with COM and `IUnknown` and as this ABI was originally designed to align with C, it is supported in all .NET platforms through the <xref:System.Runtime.InteropServices.ComWrappers> API.
-
-## Swift
-
-The Swift programming environment has a well-defined stable ABI that is [supported in .NET](https://github.com/dotnet/designs/blob/main/proposed/swift-interop.md). The specific APIs that support interop with Swift can be found under the <xref:System.Runtime.InteropServices.Swift> namespace.
-
-## Objective-C
-
-The Objective-C language follows the C language's ABI and is [supported in .NET](https://github.com/dotnet/designs/blob/main/accepted/2021/objectivec-interop.md). The specific APIs that support interop with Objective-C can be found under the <xref:System.Runtime.InteropServices.ObjectiveC> namespace.
-
-## Java Virtual Machine (JVM)
-
-The JVM is a virtual machine with managed memory, similar to the .NET runtime. Interoperability with the JVM is limited through tooling like [dotnet/java-interop](https://github.com/dotnet/java-interop) and comes with performance costs. The largest cost of interoperating with the JVM is the coordination between the two virtual machine's Garbage Collectors.
-
-## golang
+## golang <a name="golang"></a>
 
 The Go programming language is not supported for in-process interoperability. The Go runtime [imposes requirements](https://pkg.go.dev/os/signal#hdr-Non_Go_programs_that_call_Go_code) on being hosted in a process with another run time. Specifically, the use of the `SA_ONSTACK` flag on threads that run signal handlers. These requirements are not currently met by .NET and meeting them would impose non-trivial costs.
 
-It is recommended that users with golang dependencies use a cross-process communication technology to interoperate.
+## ARM64EC <a name="arm64ec"></a>
 
-## ARM64EC
-
-There are currently no plans to add support for [ARM64EC](https://learn.microsoft.com/cpp/build/arm64ec-windows-abi-conventions) in .NET 5+.
+The [ARM64EC](https://learn.microsoft.com/cpp/build/arm64ec-windows-abi-conventions) ABI is not supported.

--- a/docs/standard/native-interop/abi-support.md
+++ b/docs/standard/native-interop/abi-support.md
@@ -5,17 +5,17 @@ ms.date: 10/28/2024
 ---
 # Native interoperability ABI support
 
-The [Application Binary Interface](https://wikipedia.org/wiki/Application_binary_interface) (ABI) is the interface which run-times and operating systems express low-level binary details. This can include calling conventions (that is, how parameters are passed and results returned), exception handling, as well as symbol mangling. The below list contains the names of languages, run-times and even general technologies since these names tend to represent what users will be working with when looking for guidance on interoperability.
+The [Application Binary Interface](https://wikipedia.org/wiki/Application_binary_interface) (ABI) is the interface that runtimes and operating systems use to express low-level binary details. Those details can include calling conventions (that is, how parameters are passed and results returned), exception handling, and symbol mangling. The list that follows contains the names of languages, runtimes, and even general technologies that you might use when looking for guidance on interoperability.
 
 ## C
 
-The C language represents a stable ABI across all platforms where .NET is supported. It is what most .NET interop APIs assume is the target. This is the recommended target language for most interop scenarios using .NET.
+The C language represents a stable ABI across all platforms where .NET is supported. In general, C is the assumed target for .NET interop APIs and is the recommended target language for most interop scenarios.
 
-In .NET 7+, <xref:System.Runtime.InteropServices.LibraryImportAttribute> provides source generated support for calling C functions. When targeting .NET 6 or earlier, use <xref:System.Runtime.InteropServices.DllImportAttribute>. Refer to [Interop best practices](./best-practices.md) for additional guidance.
+In .NET 7+, <xref:System.Runtime.InteropServices.LibraryImportAttribute> provides source-generated support for calling C functions. If you're targeting .NET 6 or earlier, use <xref:System.Runtime.InteropServices.DllImportAttribute>. For more information, see [Interop best practices](./best-practices.md).
 
 Additional links:
 
-* [`LibraryImportAttribute` walkthrough](/dotnet/standard/native-interop/pinvoke-source-generation)
+* [`LibraryImportAttribute` walkthrough](pinvoke-source-generation.md)
 * [CsWin32](https://github.com/microsoft/CsWin32) is a source generator for accessing the Windows Win32 API surface
 
 ## C++
@@ -30,16 +30,16 @@ Additional links:
 
 ## COM and `IUnknown`
 
-The COM and `IUnknown` ABI was defined to align with the C language. It was specifically designed to support Object Oriented Programming, similar to C++, but to provide a stable ABI. .NET has a deep history with COM and `IUnknown` and as this ABI was originally designed to align with C, it is supported on all .NET platforms.
+The COM and `IUnknown` ABI was defined to align with the C language. It was specifically designed to support object-oriented programming, similar to C++, but to provide a stable ABI. .NET has a deep history with COM and `IUnknown`, and as this ABI was originally designed to align with C, it's supported on all .NET platforms.
 
-In .NET 5+, low-level, cross-platform, `IUnknown` lifetime support is provided by <xref:System.Runtime.InteropServices.ComWrappers>. In .NET 8+, <xref:System.Runtime.InteropServices.Marshalling.GeneratedComInterfaceAttribute> and <xref:System.Runtime.InteropServices.Marshalling.GeneratedComClassAttribute> provide source generated C# projections. When targeting versions prior to .NET 5, the [built-in COM interop system](/dotnet/standard/native-interop/cominterop) must be used and is limited to the Windows platforms.
+In .NET 5+, low-level, cross-platform, `IUnknown` lifetime support is provided by <xref:System.Runtime.InteropServices.ComWrappers>. In .NET 8+, <xref:System.Runtime.InteropServices.Marshalling.GeneratedComInterfaceAttribute> and <xref:System.Runtime.InteropServices.Marshalling.GeneratedComClassAttribute> provide source generated C# projections. If you're targeting versions prior to .NET 5, you must use the [built-in COM interop system](/dotnet/standard/native-interop/cominterop), and this support is limited to Windows.
 
 The WinRT platform represents an evolution of the COM and `IUnknown` ABI. Support for this is provided by the [CsWinRT toolkit](/windows/apps/develop/platform/csharp-winrt/) and is built upon <xref:System.Runtime.InteropServices.ComWrappers>.
 
 Additional links:
 
-* [`ComWrappers` walkthrough](/dotnet/standard/native-interop/tutorial-comwrappers)
-* [COM source generator sample](/dotnet/standard/native-interop/comwrappers-source-generation)
+* [`ComWrappers` walkthrough](tutorial-comwrappers.md)
+* [COM source generator sample](comwrappers-source-generation.md)
 * [ClangSharp](https://github.com/dotnet/ClangSharp) binding generator
 
 ## Java Virtual Machine (JVM) based languages
@@ -74,9 +74,9 @@ Additional links:
 
 ## golang
 
-The Go programming language is not supported for in-process interoperability. The Go runtime [imposes requirements](https://pkg.go.dev/os/signal#hdr-Non_Go_programs_that_call_Go_code) on being hosted in a process with another run-time. Specifically, the use of the `SA_ONSTACK` flag on threads that run signal handlers. These requirements are not currently met by .NET.
+The Go programming language is not supported for in-process interoperability. The Go runtime [imposes requirements](https://pkg.go.dev/os/signal#hdr-Non_Go_programs_that_call_Go_code) on being hosted in a process with another runtime. Specifically, that requirement is the use of the `SA_ONSTACK` flag on threads that run signal handlers. These requirements are not currently met by .NET.
 
-The recommended way to interoperate with golang is using a golang hosted process and communicate through an inter-process communication mechanism.
+The recommended way to interoperate with golang is to use a golang-hosted process and communicate through an inter-process communication mechanism.
 
 ## ARM64EC
 

--- a/docs/standard/native-interop/abi-support.md
+++ b/docs/standard/native-interop/abi-support.md
@@ -1,7 +1,7 @@
 ---
 title: Native interoperability ABI support - .NET
 description: Defines the current support for interoperability with various ABIs.
-ms.date: 10/27/2024
+ms.date: 10/28/2024
 ---
 # Native interoperability ABI support
 
@@ -13,15 +13,9 @@ The C language represents a stable ABI across all platforms where .NET is suppor
 
 In .NET 7+, <xref:System.Runtime.InteropServices.LibraryImportAttribute> provides source generated support for calling C functions. When targeting .NET 6 or earlier, use <xref:System.Runtime.InteropServices.DllImportAttribute>. Refer to [Interop best practices](./best-practices.md) for additional guidance.
 
-Many virtual machine based languages define a foreign function interface (FFI) in C to interoperate with other platforms. A list of examples is below.
-
-* Java Virtual Machine (JVM)
-* CPython
-
 Additional links:
 
-* [CsWin32](https://github.com/microsoft/CsWin32) a source generator for access Windows Win32 API
-* [Java binding generator](https://github.com/dotnet/java-interop)
+* [CsWin32](https://github.com/microsoft/CsWin32) is a source generator for accessing the Windows Win32 API surface
 
 ## C++
 
@@ -47,6 +41,14 @@ Additional links:
 * [COM source generator sample](/dotnet/standard/native-interop/comwrappers-source-generation)
 * [ClangSharp](https://github.com/dotnet/ClangSharp) binding generator
 
+## Java Virtual Machine (JVM) based languages
+
+The Java Virtual Machine (JVM) defines a foreign function interface (FFI) in C to interoperate with other platforms. Interoperability between .NET and Java can be achieved via this interface.
+
+Additional links:
+
+* [Java binding generator](https://github.com/dotnet/java-interop)
+
 ## Swift
 
 The Swift programming environment has a well-defined stable ABI that is [supported in .NET](https://github.com/dotnet/designs/blob/main/proposed/swift-interop.md). In .NET 9+, specific APIs that support interop with Swift can be found under the <xref:System.Runtime.InteropServices.Swift> namespace.
@@ -58,7 +60,15 @@ The Objective-C language follows the C language's ABI and is [supported in .NET]
 Additional links:
 
 * [Objective-Sharpie](/previous-versions/xamarin/cross-platform/macios/binding/)
-* [Objective-C binding](/dotnet/maui/migration/ios-binding-projects) sample
+* [Objective-C binding sample](/dotnet/maui/migration/ios-binding-projects)
+
+## Python
+
+The reference implementation of the Python run-time, [CPython](https://github.com/python/cpython), defines a foreign function interface (FFI) in C to interoperate with other platforms. Interoperability between .NET and Python can be achieved via this interface.
+
+Additional links:
+
+* [Providing a C API for an Extension Module](https://docs.python.org/3/extending/extending.html#providing-a-c-api-for-an-extension-module)
 
 ## golang
 


### PR DESCRIPTION
This is a first pass at a basic description of what is and isn't supported. I tried to avoid calling out specific APIs and complexity of the task. This is merely a starting point since we've got two platforms (golang and ARM64EC) that we can't/won't be able to support in the near term and having a place to point people would be helpful.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/native-interop/abi-support.md](https://github.com/dotnet/docs/blob/e0bead1ac55eacc4f54ca44760970ca1d44ed795/docs/standard/native-interop/abi-support.md) | [docs/standard/native-interop/abi-support](https://review.learn.microsoft.com/en-us/dotnet/standard/native-interop/abi-support?branch=pr-en-us-43210) |


<!-- PREVIEW-TABLE-END -->