### PR TITLE
Document dotnet-watch breaking change

### DIFF
--- a/docs/core/compatibility/9.0.md
+++ b/docs/core/compatibility/9.0.md
@@ -86,6 +86,7 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 
 | Title                                                                         | Type of change    | Introduced version |
 |-------------------------------------------------------------------------------|-------------------|--------------------|
+| [`dotnet watch` incompatible with Hot Reload for old frameworks](sdk/9.0/dotnet-watch.md) | Behavioral change | RC 1          |
 | [`dotnet workload` commands output change](sdk/9.0/dotnet-workload-output.md) | Behavioral change | Preview 1          |
 | [`installer` repo version no longer documented](sdk/9.0/productcommits-versions.md) | Behavioral change | Preview 5    |
 | [Terminal logger is default](sdk/9.0/terminal-logger.md)                      | Behavioral change | Preview 1          |

--- a/docs/core/compatibility/sdk/9.0/dotnet-watch.md
+++ b/docs/core/compatibility/sdk/9.0/dotnet-watch.md
@@ -1,0 +1,37 @@
+---
+title: "Breaking change: dotnet-watch requires disabling Hot Reload mode for projects targeting .NET 5 or older"
+description: Learn about a breaking change in the .NET 9 SDK where dotnet-watch requires disabling Hot Reload for projects targeting .NET 5 or older.
+ms.date: 07/09/2024
+---
+# Error reported for .NET 5 targets or older
+
+## Previous behavior
+
+Previously, `dotnet-watch` automatically disabled Hot Reload when used with projects targeting .NET 5 or older.
+
+## New behavior
+
+An error is reported when dotnet-watch is launched without `--no-hot-reload` on projects targeting .NET 5 or older:
+
+> Hot Reload based watching is only supported in .NET 6.0 or newer apps. 
+
+## Version introduced
+
+.NET 9 RC 1
+
+## Type of breaking change
+
+This change can affect development workflow.
+
+## Reason for change
+
+We have made significant changes in the internal architecture of the tool. Preserving behavior for out of support .NET versions did not warrant increasing complexity of the new implementation.
+
+## Recommended action
+
+Pass `--no-hot-reload` to `dotnet-watch` command line, or update your project to target `net6.0` or higher (`TargetFramework` property).
+
+## Affected APIs
+
+N/A
+

--- a/docs/core/compatibility/sdk/9.0/dotnet-watch.md
+++ b/docs/core/compatibility/sdk/9.0/dotnet-watch.md
@@ -1,19 +1,21 @@
 ---
-title: "Breaking change: dotnet-watch requires disabling Hot Reload mode for projects targeting .NET 5 or older"
-description: Learn about a breaking change in the .NET 9 SDK where dotnet-watch requires disabling Hot Reload for projects targeting .NET 5 or older.
-ms.date: 07/09/2024
+title: "Breaking change: 'dotnet watch' incompatible with Hot Reload for old frameworks"
+description: Learn about a breaking change in the .NET 9 SDK where 'dotnet watch' requires disabling Hot Reload for projects targeting .NET 5 or earlier.
+ms.date: 11/08/2024
 ---
-# Error reported for .NET 5 targets or older
+# 'dotnet watch' incompatible with Hot Reload for old frameworks
+
+.NET 9 introduces a change that requires [`dotnet watch`](../../../tools/dotnet-watch.md) to launched with Hot Reload disabled for projects targeting .NET 5 or earlier versions.
 
 ## Previous behavior
 
-Previously, `dotnet-watch` automatically disabled Hot Reload when used with projects targeting .NET 5 or older.
+Previously, [`dotnet watch`](../../../tools/dotnet-watch.md) automatically disabled Hot Reload when used with projects targeting .NET 5 or earlier.
 
 ## New behavior
 
-An error is reported when dotnet-watch is launched without `--no-hot-reload` on projects targeting .NET 5 or older:
+Starting in .NET 9, an error is reported when [`dotnet watch`](../../../tools/dotnet-watch.md) is launched without `--no-hot-reload` for projects targeting .NET 5 or earlier versions. The error is similar to:
 
-> Hot Reload based watching is only supported in .NET 6.0 or newer apps. 
+> Hot Reload based watching is only supported in .NET 6.0 or newer apps.
 
 ## Version introduced
 
@@ -21,17 +23,16 @@ An error is reported when dotnet-watch is launched without `--no-hot-reload` on 
 
 ## Type of breaking change
 
-This change can affect development workflow.
+This change is a [behavioral change](../../categories.md#behavioral-change).
 
 ## Reason for change
 
-We have made significant changes in the internal architecture of the tool. Preserving behavior for out of support .NET versions did not warrant increasing complexity of the new implementation.
+The internal architecture of the `dotnet watch` tool underwent significant improvements. Preserving behavior for out-of-support .NET versions did not warrant increasing the complexity of the new implementation.
 
 ## Recommended action
 
-Pass `--no-hot-reload` to `dotnet-watch` command line, or update your project to target `net6.0` or higher (`TargetFramework` property).
+Pass `--no-hot-reload` to `dotnet watch` on the command line, or update your project to target `net6.0` or later (using the `TargetFramework` property).
 
 ## Affected APIs
 
 N/A
-

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -78,6 +78,8 @@ items:
                 href: networking/9.0/useragent-nullable.md
           - name: SDK and MSBuild
             items:
+              - name: "`dotnet watch` incompatible with Hot Reload for old frameworks"
+                href: sdk/9.0/dotnet-watch.md
               - name: "'dotnet workload' commands output change"
                 href: sdk/9.0/dotnet-workload-output.md
               - name: "'installer' repo version no longer documented"
@@ -1734,6 +1736,8 @@ items:
         items:
           - name: .NET 9
             items:
+              - name: "`dotnet watch` incompatible with Hot Reload for old frameworks"
+                href: sdk/9.0/dotnet-watch.md
               - name: "'dotnet workload' commands output change"
                 href: sdk/9.0/dotnet-workload-output.md
               - name: "'installer' repo version no longer documented"


### PR DESCRIPTION
Documents breaking change tracked by https://github.com/dotnet/sdk/pull/41324


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/9.0.md](https://github.com/dotnet/docs/blob/f19238c160cade7f002ad5cde7e83ef7b16195c0/docs/core/compatibility/9.0.md) | [Breaking changes in .NET 9](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/9.0?branch=pr-en-us-43214) |
| [docs/core/compatibility/sdk/9.0/dotnet-watch.md](https://github.com/dotnet/docs/blob/f19238c160cade7f002ad5cde7e83ef7b16195c0/docs/core/compatibility/sdk/9.0/dotnet-watch.md) | ['dotnet watch' incompatible with Hot Reload for old frameworks](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/9.0/dotnet-watch?branch=pr-en-us-43214) |
| [docs/core/compatibility/toc.yml](https://github.com/dotnet/docs/blob/f19238c160cade7f002ad5cde7e83ef7b16195c0/docs/core/compatibility/toc.yml) | [docs/core/compatibility/toc](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/toc?branch=pr-en-us-43214) |


<!-- PREVIEW-TABLE-END -->