### PR TITLE
Update relational-vs-nosql-data.md

### DIFF
--- a/docs/architecture/cloud-native/relational-vs-nosql-data.md
+++ b/docs/architecture/cloud-native/relational-vs-nosql-data.md
@@ -46,12 +46,12 @@ The theorem states that distributed data systems will offer a trade-off between 
 
 - *Partition Tolerance.* Guarantees the system continues to operate even if a replicated data node fails or loses connectivity with other replicated data nodes.
 
-CAP theorem explains the tradeoffs associated with managing consistency and availability during a network partition; however tradeoffs with respect to consistency and performance also exist with the absence of a network partition. 
+CAP theorem explains the tradeoffs associated with managing consistency and availability during a network partition; however tradeoffs with respect to consistency and performance also exist with the absence of a network partition.
 
 > [!NOTE]  
 > Even if you choose availability over consistency, in times of network partition, availability will suffer. CAP available system is more available to some of its clients but it's not necessarily "highly available" to all its clients.
 
-CAP theorem is often further extended to [PACELC](http://www.cs.umd.edu/~abadi/papers/abadi-pacelc.pdf) to explain the tradeoffs more comprehensively. The CAP theorem is particularly relevant in intermittently connected environments, such as those related to the Internet of Things (IoT), environmental monitoring, and mobile applications. In these contexts, devices may become partitioned due to challenging physical conditions, such as power outages or when entering confined spaces like elevators. For distributed systems, such as cloud applications, it is more appropriate to use the PACELC theorem, which is more comprehensive and considers trade-offs such as latency and consistency even in the absence of network partitions. 
+CAP theorem is often further extended to [PACELC](http://www.cs.umd.edu/~abadi/papers/abadi-pacelc.pdf) to explain the tradeoffs more comprehensively. The CAP theorem is particularly relevant in intermittently connected environments, such as those related to the Internet of Things (IoT), environmental monitoring, and mobile applications. In these contexts, devices may become partitioned due to challenging physical conditions, such as power outages or when entering confined spaces like elevators. For distributed systems, such as cloud applications, it is more appropriate to use the PACELC theorem, which is more comprehensive and considers trade-offs such as latency and consistency even in the absence of network partitions.
 
 Relational databases typically provide consistency and availability, but not partition tolerance. They're typically provisioned to a single server and scale vertically by adding more resources to the machine.
 

--- a/docs/architecture/cloud-native/relational-vs-nosql-data.md
+++ b/docs/architecture/cloud-native/relational-vs-nosql-data.md
@@ -30,7 +30,7 @@ NoSQL databases include several different models for accessing and managing data
 | Wide-Column Store | Related data is stored as a set of nested-key/value pairs within a single column. |
 | Graph Store | Data is stored in a graph structure as node, edge, and data properties. |
 
-## The CAP theorem
+## CAP and PACELC theorems
 
 As a way to understand the differences between these types of databases, consider the CAP theorem, a set of principles applied to distributed systems that store state. Figure 5-10 shows the three properties of the CAP theorem.
 
@@ -46,10 +46,12 @@ The theorem states that distributed data systems will offer a trade-off between 
 
 - *Partition Tolerance.* Guarantees the system continues to operate even if a replicated data node fails or loses connectivity with other replicated data nodes.
 
-CAP theorem explains the tradeoffs associated with managing consistency and availability during a network partition; however tradeoffs with respect to consistency and performance also exist with the absence of a network partition. CAP theorem is often further extended to [PACELC](http://www.cs.umd.edu/~abadi/papers/abadi-pacelc.pdf) to explain the tradeoffs more comprehensively.
+CAP theorem explains the tradeoffs associated with managing consistency and availability during a network partition; however tradeoffs with respect to consistency and performance also exist with the absence of a network partition. 
 
 > [!NOTE]  
 > Even if you choose availability over consistency, in times of network partition, availability will suffer. CAP available system is more available to some of its clients but it's not necessarily "highly available" to all its clients.
+
+CAP theorem is often further extended to [PACELC](http://www.cs.umd.edu/~abadi/papers/abadi-pacelc.pdf) to explain the tradeoffs more comprehensively. The CAP theorem is particularly relevant in intermittently connected environments, such as those related to the Internet of Things (IoT), environmental monitoring, and mobile applications. In these contexts, devices may become partitioned due to challenging physical conditions, such as power outages or when entering confined spaces like elevators. For distributed systems, such as cloud applications, it is more appropriate to use the PACELC theorem, which is more comprehensive and considers trade-offs such as latency and consistency even in the absence of network partitions. 
 
 Relational databases typically provide consistency and availability, but not partition tolerance. They're typically provisioned to a single server and scale vertically by adding more resources to the machine.
 


### PR DESCRIPTION
## Summary

The page mainly explains CAP theorem and just briefly mentions PACELC theorem and leaves it to reader to pursue it further. I'm afraid that's not how it should be. Marc Brooker is one of thought leaders in database field. In [this blog post](https://brooker.co.za/blog/2024/07/25/cap-again.html), he explains why CAP theorem is outdated a bit, and it's relevant for intermittent environments such as IoT and for distributed environments, PACELC theorem should be considered, instead. I've made an edit.


Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/architecture/cloud-native/relational-vs-nosql-data.md](https://github.com/dotnet/docs/blob/863251981eb5c6057ae52a28e8ff7d85fe27d7ed/docs/architecture/cloud-native/relational-vs-nosql-data.md) | [SQL vs. NoSQL data](https://review.learn.microsoft.com/en-us/dotnet/architecture/cloud-native/relational-vs-nosql-data?branch=pr-en-us-43234) |


<!-- PREVIEW-TABLE-END -->