### PR TITLE
Add notes on overload resolution and params

### DIFF
--- a/docs/csharp/language-reference/keywords/method-parameters.md
+++ b/docs/csharp/language-reference/keywords/method-parameters.md
@@ -234,4 +234,6 @@ The following example demonstrates various ways in which arguments can be sent t
 
 :::code language="csharp" source="snippets/ParameterModifiers.cs" id="ParamsModifierExamples":::
 
-- [Argument lists](~/_csharpstandard/standard/expressions.md#1262-argument-lists) in the [C# Language Specification](~/_csharpstandard/standard/README.md). The language specification is the definitive source for C# syntax and usage.
+Overload resolution can cause ambiguity when the argument for a `params` parameter is a collection type. The collection type of the argument must be convertible to the collection type of the parameter. When different overloads provide better conversions for that parameter, that method may be better. However, if the argument to the `params` parameter is either discrete elements or missing, all overloads with different `params` parameter types are equal for that parameter.
+
+For more details, see the section on [Argument lists](~/_csharpstandard/standard/expressions.md#1262-argument-lists) in the [C# Language Specification](~/_csharpstandard/standard/README.md). The language specification is the definitive source for C# syntax and usage.


### PR DESCRIPTION
Fixes #42445

Add a paragraph to describe how overload resolution changes when a `params` argument is a set of discrete elements vs. a collection or a collection expression.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/method-parameters.md](https://github.com/dotnet/docs/blob/23ff942dcc9f15d0af02f0aaee2f0ae209950fe0/docs/csharp/language-reference/keywords/method-parameters.md) | [docs/csharp/language-reference/keywords/method-parameters](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/method-parameters?branch=pr-en-us-43256) |

<!-- PREVIEW-TABLE-END -->