### PR TITLE
Fixed the typo by removing `\` from `System.Nullable\<T>` in the title and description.

### DIFF
--- a/docs/fundamentals/runtime-libraries/system-nullable{t}.md
+++ b/docs/fundamentals/runtime-libraries/system-nullable{t}.md
@@ -1,7 +1,7 @@
 ---
-title: System.Nullable\<T> structure
-description: Learn about the System.Nullable\<T> structure.
-ms.date: 12/31/2023
+title: System.Nullable<T> structure
+description: Learn about the System.Nullable<T> structure.
+ms.date: 10/31/2024
 ---
 # System.Nullable\<T> structure
 


### PR DESCRIPTION
## Summary

Fixed the typo by removing `\` from `System.Nullable\<T>` in the title and description.

page URL: https://learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-nullable%7Bt%7D

![image](https://github.com/user-attachments/assets/1072c43f-effa-4c84-a660-4bb84e7fd757)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/runtime-libraries/system-nullable{t}.md](https://github.com/dotnet/docs/blob/3acd52e9831e3a31dc45aa31719f58a9571e9441/docs/fundamentals/runtime-libraries/system-nullable{t}.md) | [docs/fundamentals/runtime-libraries/system-nullable{t}](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-nullable{t}?branch=pr-en-us-43262) |

<!-- PREVIEW-TABLE-END -->