### PR TITLE
Add System.Diagnostics.DiagnosticSource netstandard guidance

### DIFF
--- a/docs/core/diagnostics/distributed-tracing-instrumentation-walkthroughs.md
+++ b/docs/core/diagnostics/distributed-tracing-instrumentation-walkthroughs.md
@@ -29,7 +29,7 @@ dotnet new console
 
 Applications that target .NET 5 and later already have the necessary distributed tracing APIs included. For apps targeting older
 .NET versions, add the [System.Diagnostics.DiagnosticSource NuGet package](https://www.nuget.org/packages/System.Diagnostics.DiagnosticSource/)
-version 5 or greater.
+version 5 or greater. For libraries targetting netstandard, we recommend referencing the latest version of NuGet package.
 
 ```dotnetcli
 dotnet add package System.Diagnostics.DiagnosticSource

--- a/docs/core/diagnostics/distributed-tracing-instrumentation-walkthroughs.md
+++ b/docs/core/diagnostics/distributed-tracing-instrumentation-walkthroughs.md
@@ -29,7 +29,7 @@ dotnet new console
 
 Applications that target .NET 5 and later already have the necessary distributed tracing APIs included. For apps targeting older
 .NET versions, add the [System.Diagnostics.DiagnosticSource NuGet package](https://www.nuget.org/packages/System.Diagnostics.DiagnosticSource/)
-version 5 or greater. For libraries targetting netstandard, we recommend referencing the oldest version of the package which is still supported and contains the APIs your library needs.
+version 5 or greater. For libraries targeting netstandard, we recommend referencing the oldest version of the package which is still supported and contains the APIs your library needs.
 
 ```dotnetcli
 dotnet add package System.Diagnostics.DiagnosticSource

--- a/docs/core/diagnostics/distributed-tracing-instrumentation-walkthroughs.md
+++ b/docs/core/diagnostics/distributed-tracing-instrumentation-walkthroughs.md
@@ -29,7 +29,7 @@ dotnet new console
 
 Applications that target .NET 5 and later already have the necessary distributed tracing APIs included. For apps targeting older
 .NET versions, add the [System.Diagnostics.DiagnosticSource NuGet package](https://www.nuget.org/packages/System.Diagnostics.DiagnosticSource/)
-version 5 or greater. For libraries targetting netstandard, we recommend referencing the latest version of the NuGet package.
+version 5 or greater. For libraries targetting netstandard, we recommend referencing the oldest version of the package which is still supported and contains the APIs your library needs.
 
 ```dotnetcli
 dotnet add package System.Diagnostics.DiagnosticSource

--- a/docs/core/diagnostics/distributed-tracing-instrumentation-walkthroughs.md
+++ b/docs/core/diagnostics/distributed-tracing-instrumentation-walkthroughs.md
@@ -29,7 +29,7 @@ dotnet new console
 
 Applications that target .NET 5 and later already have the necessary distributed tracing APIs included. For apps targeting older
 .NET versions, add the [System.Diagnostics.DiagnosticSource NuGet package](https://www.nuget.org/packages/System.Diagnostics.DiagnosticSource/)
-version 5 or greater. For libraries targetting netstandard, we recommend referencing the latest version of NuGet package.
+version 5 or greater. For libraries targetting netstandard, we recommend referencing the latest version of the NuGet package.
 
 ```dotnetcli
 dotnet add package System.Diagnostics.DiagnosticSource


### PR DESCRIPTION
Updating the guidance to clarify that this is also relevant for authors of netstandard libraries.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/distributed-tracing-instrumentation-walkthroughs.md](https://github.com/dotnet/docs/blob/a4bca80431d1dc21dff0c0d6e086982565c299d6/docs/core/diagnostics/distributed-tracing-instrumentation-walkthroughs.md) | [docs/core/diagnostics/distributed-tracing-instrumentation-walkthroughs](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/distributed-tracing-instrumentation-walkthroughs?branch=pr-en-us-43269) |


<!-- PREVIEW-TABLE-END -->