### PR TITLE
Remove username example from compound words

### DIFF
--- a/docs/standard/design-guidelines/capitalization-conventions.md
+++ b/docs/standard/design-guidelines/capitalization-conventions.md
@@ -88,7 +88,6 @@ The guidelines in this chapter lay out a simple method for using case that, when
 |`Placeholder`|`placeholder`|`PlaceHolder`|
 |`SignIn`|`signIn`|`SignOn`|
 |`SignOut`|`signOut`|`SignOff`|
-|`UserName`|`userName`|`Username`|
 |`WhiteSpace`|`whiteSpace`|`Whitespace`|
 |`Writable`|`writable`|`Writeable`|
 


### PR DESCRIPTION
## Summary

This PR removes the `UserName` over `Username` example from the compound words table.

### Reason for Change

Both identifiers are valid in their own way:

- `UserName` refers to the *name* of a user (e.g. `Hazel`).
- `Username` refers to a pseudonym used to identify a user (e.g. `tacosontitan`)

Including these in the compound words table with a focus on preferring `UserName` is misleading to the semantic differences between them.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/design-guidelines/capitalization-conventions.md](https://github.com/dotnet/docs/blob/575b2a8f66401c03211a643e9859f81987217020/docs/standard/design-guidelines/capitalization-conventions.md) | [docs/standard/design-guidelines/capitalization-conventions](https://review.learn.microsoft.com/en-us/dotnet/standard/design-guidelines/capitalization-conventions?branch=pr-en-us-43346) |

<!-- PREVIEW-TABLE-END -->