### PR TITLE
Changed the code samples with System.Text.Json Converters (Now readonly property).

### DIFF
--- a/docs/standard/serialization/system-text-json/snippets/how-to/csharp/RegisterConverterWithConvertersCollection.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to/csharp/RegisterConverterWithConvertersCollection.cs
@@ -13,12 +13,9 @@ namespace SystemTextJsonSamples
             // <Serialize>
             var serializeOptions = new JsonSerializerOptions
             {
-                WriteIndented = true,
-                Converters =
-                {
-                    new DateTimeOffsetJsonConverter()
-                }
+                WriteIndented = true
             };
+			serializeOptions.Converters.Add(new DateTimeOffsetJsonConverter());
             
             jsonString = JsonSerializer.Serialize(weatherForecast, serializeOptions);
             // </Serialize>

--- a/docs/standard/serialization/system-text-json/snippets/how-to/csharp/RoundtripStackOfT.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to/csharp/RoundtripStackOfT.cs
@@ -13,10 +13,8 @@ namespace SystemTextJsonSamples
 
             Console.WriteLine("Deserialize JSON string [1, 2, 3] with custom converter, then serialize it back to JSON.");
             // <Register>
-            var options = new JsonSerializerOptions
-            {
-                Converters = { new JsonConverterFactoryForStackOfT() },
-            };
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new JsonConverterFactoryForStackOfT());
             // </Register>
             stack = JsonSerializer.Deserialize<Stack<int>>("[1, 2, 3]", options)!;
             serialized = JsonSerializer.Serialize(stack, options);


### PR DESCRIPTION
## Summary

Changed the code samples with System.Text.Json Converters (Now readonly property).

Fixes https://github.com/dotnet/docs/issues/43178, makes https://github.com/dotnet/docs/pull/43179 obsolete.
