### PR TITLE
Update fsharp-9.md minor formatting issue

### DIFF
--- a/docs/fsharp/whats-new/fsharp-9.md
+++ b/docs/fsharp/whats-new/fsharp-9.md
@@ -120,9 +120,9 @@ Example:
 type Foo() =
     member val X : int = 0 with get, set
 
-[&ltExtension>]
+[<Extension>]
 type FooExt =
-    [&ltExtension>]
+    [<Extension>]
     static member X (f: Foo, i: int) = f.X <- i; f
 
 let f = Foo()


### PR DESCRIPTION
Update fsharp-9.md minor formatting issue:
https://learn.microsoft.com/en-us/dotnet/fsharp/whats-new/fsharp-9#prefer-extension-methods-to-intrinsic-properties-when-arguments-are-provided
![image](https://github.com/user-attachments/assets/27104ec3-a41a-4f98-8ea1-fc03b25a8e91)

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/whats-new/fsharp-9.md](https://github.com/dotnet/docs/blob/6771209fae8736a47c85dcfcd9e2bf73aaa6d08d/docs/fsharp/whats-new/fsharp-9.md) | [docs/fsharp/whats-new/fsharp-9](https://review.learn.microsoft.com/en-us/dotnet/fsharp/whats-new/fsharp-9?branch=pr-en-us-43361) |

<!-- PREVIEW-TABLE-END -->