### PR TITLE
ServicePointManager obsoletion

### DIFF
--- a/docs/core/compatibility/9.0.md
+++ b/docs/core/compatibility/9.0.md
@@ -82,6 +82,7 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 |-----------------------------------------------------------------------------------|---------------------|--------------------|
 | [HttpClientFactory logging redacts header values by default](networking/9.0/redact-headers.md) | Behavioral change | RC 1    |
 | [HttpListenerRequest.UserAgent is nullable](networking/9.0/useragent-nullable.md) | Source incompatible | Preview 1          |
+| [API obsoletions](core-libraries/9.0/obsolete-apis-with-custom-diagnostics.md)    | Source incompatible | Preview 6          |
 
 ## SDK and MSBuild
 

--- a/docs/core/compatibility/core-libraries/9.0/obsolete-apis-with-custom-diagnostics.md
+++ b/docs/core/compatibility/core-libraries/9.0/obsolete-apis-with-custom-diagnostics.md
@@ -1,8 +1,8 @@
 ---
 title: "Breaking change: .NET 9 obsoletions with custom IDs"
 titleSuffix: ""
-description: Learn about the .NET 9 breaking change in core .NET libraries where some APIs have been marked as obsolete with a custom diagnostic ID.
-ms.date: 08/07/2024
+description: Learn about the APIs that have been marked as obsolete in .NET 9 with a custom diagnostic ID.
+ms.date: 11/06/2024
 ---
 # API obsoletions with non-default diagnostic IDs (.NET 9)
 
@@ -17,6 +17,7 @@ The following table lists the custom diagnostic IDs and their corresponding warn
 | Diagnostic ID | Description | Severity |
 | - | - |
 | [SYSLIB0009](../../../../fundamentals/syslib-diagnostics/syslib0009.md) | <xref:System.Net.AuthenticationManager> is not supported. Methods will no-op or throw <xref:System.PlatformNotSupportedException>. | Warning |
+| [SYSLIB0014: WebRequest, HttpWebRequest, ServicePoint, WebClient are obsolete](../../../../fundamentals/syslib-diagnostics/syslib0014.md) | <xref:System.Net.ServicePointManager> is fully obsolete. Settings on <xref:System.Net.ServicePointManager> don't affect <xref:System.Net.Security.SslStream> or <xref:System.Net.Http.HttpClient> (this behavior hasn't changed since .NET 6). | Warning |
 | [SYSLIB0054](../../../../fundamentals/syslib-diagnostics/syslib0054.md) | <xref:System.Threading.Thread.VolatileRead%2A?displayProperty=nameWithType> and <xref:System.Threading.Thread.VolatileWrite%2A?displayProperty=nameWithType> are obsolete. Use <xref:System.Threading.Volatile.Read%2A?displayProperty=nameWithType> or <xref:System.Threading.Volatile.Write%2A?displayProperty=nameWithType> instead. | Warning |
 | [SYSLIB0055](../../../../fundamentals/syslib-diagnostics/syslib0055.md) | `AdvSimd.ShiftRightLogicalRoundedNarrowingSaturate*` methods with signed parameters are obsolete. Use the unsigned overloads instead. | Warning |
 | [SYSLIB0056](../../../../fundamentals/syslib-diagnostics/syslib0056.md) | `Assembly.LoadFrom` with a custom `AssemblyHashAlgorithm` is obsolete. Use overloads without an `AssemblyHashAlgorithm`. | Warning |
@@ -41,6 +42,10 @@ These obsoletions can affect [source compatibility](../../categories.md#source-c
 ### SYSLIB0009
 
 - <xref:System.Net.AuthenticationManager?displayProperty=fullName>
+
+### SYSLIB0014
+
+- <xref:System.Net.ServicePointManager?displayProperty=fullName>
 
 ### SYSLIB0054
 

--- a/docs/core/compatibility/networking/6.0/webrequest-deprecated.md
+++ b/docs/core/compatibility/networking/6.0/webrequest-deprecated.md
@@ -31,18 +31,6 @@ For FTP, since <xref:System.Net.Http.HttpClient> doesn't support it, we recommen
 - <xref:System.Net.WebClient>
 - <xref:System.Net.ServicePoint>
 
-<!--
+## See also
 
-### Affected APIs
-
-- `T:System.Net.WebRequest`
-- `T:System.Net.HttpWebRequest`
-- `T:System.Net.FtpWebRequest`
-- `T:System.Net.WebClient`
-- `T:System.Net.ServicePoint`
-
-### Category
-
-Networking
-
--->
+- [HttpWebRequest to HttpClient migration guide](../../../../fundamentals/networking/http/httpclient-migrate-from-httpwebrequest.md)

--- a/docs/fundamentals/syslib-diagnostics/syslib0014.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib0014.md
@@ -14,7 +14,8 @@ The following APIs are marked as obsolete, starting in .NET 6. Using them in cod
 - <xref:System.Net.WebRequest.CreateHttp%2A?displayProperty=fullName>
 - <xref:System.Net.WebRequest.CreateDefault(System.Uri)?displayProperty=fullName>
 - <xref:System.Net.HttpWebRequest.%23ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)>
-- <xref:System.Net.ServicePointManager>
+- <xref:System.Net.ServicePointManager> (Starting in .NET 9)
+- <xref:System.Net.ServicePointManager.FindServicePoint%2A?displayProperty=fullName>
 - <xref:System.Net.WebClient.%23ctor>
 
 To reduce the number of analyzer warnings, the <xref:System.Net.ServicePoint> class is not marked as obsolete, but all ways of obtaining its instances are.
@@ -60,3 +61,4 @@ For more information, see [Suppress warnings](obsoletions-overview.md#suppress-w
 ## See also
 
 - [WebRequest, WebClient, and ServicePoint are obsolete](../../core/compatibility/networking/6.0/webrequest-deprecated.md)
+- [HttpWebRequest to HttpClient migration guide](../networking/http/httpclient-migrate-from-httpwebrequest.md)


### PR DESCRIPTION
Fixes #43144 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/9.0.md](https://github.com/dotnet/docs/blob/7d2da9476e0b2e0a6c3941af66cb6fa1090ebc7c/docs/core/compatibility/9.0.md) | [docs/core/compatibility/9.0](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/9.0?branch=pr-en-us-43365) |
| [docs/core/compatibility/core-libraries/9.0/obsolete-apis-with-custom-diagnostics.md](https://github.com/dotnet/docs/blob/7d2da9476e0b2e0a6c3941af66cb6fa1090ebc7c/docs/core/compatibility/core-libraries/9.0/obsolete-apis-with-custom-diagnostics.md) | [docs/core/compatibility/core-libraries/9.0/obsolete-apis-with-custom-diagnostics](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/9.0/obsolete-apis-with-custom-diagnostics?branch=pr-en-us-43365) |
| [docs/core/compatibility/networking/6.0/webrequest-deprecated.md](https://github.com/dotnet/docs/blob/7d2da9476e0b2e0a6c3941af66cb6fa1090ebc7c/docs/core/compatibility/networking/6.0/webrequest-deprecated.md) | [docs/core/compatibility/networking/6.0/webrequest-deprecated](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/networking/6.0/webrequest-deprecated?branch=pr-en-us-43365) |
| [docs/fundamentals/syslib-diagnostics/syslib0014.md](https://github.com/dotnet/docs/blob/7d2da9476e0b2e0a6c3941af66cb6fa1090ebc7c/docs/fundamentals/syslib-diagnostics/syslib0014.md) | [docs/fundamentals/syslib-diagnostics/syslib0014](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib0014?branch=pr-en-us-43365) |

<!-- PREVIEW-TABLE-END -->