### PR TITLE
Add two ASP.NET breaking changes

### DIFF
--- a/docs/core/compatibility/9.0.md
+++ b/docs/core/compatibility/9.0.md
@@ -20,7 +20,9 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 | Title                                                                                    | Type of change      | Introduced version |
 |------------------------------------------------------------------------------------------|---------------------|--------------------|
 | [DefaultKeyResolution.ShouldGenerateNewKey has altered meaning](aspnet-core/9.0/key-resolution.md) | Behavioral change | Preview 3  |
+| [Dev cert export no longer creates folder](aspnet-core/9.0/certificate-export.md)        | Behavioral change   | RC 1               |
 | [HostBuilder enables ValidateOnBuild/ValidateScopes in development environment](aspnet-core/9.0/hostbuilder-validation.md) | Behavioral change | Preview 7  |
+| [Middleware types with multiple constructors](aspnet-core/9.0/middleware-constructors.md) | Behavioral change  | RC 1               |
 
 ## Containers
 

--- a/docs/core/compatibility/aspnet-core/9.0/certificate-export.md
+++ b/docs/core/compatibility/aspnet-core/9.0/certificate-export.md
@@ -1,0 +1,45 @@
+---
+title: "Breaking change: Dev cert export no longer creates folder"
+description: Learn about the breaking change in ASP.NET Core 9 where exporting the development certificate no longer creates the target directory if it doesn't exist.
+ms.date: 11/6/2024
+---
+
+# Dev cert export no longer creates folder
+
+When you export the ASP.NET Core development certificate (which is used to enable HTTPS in local development), it no longer creates the directory into which the certificate is being exported if that directory doesn't exist.
+
+This change first appears in .NET 8.0.10 and .NET 9 RC 1.
+
+## Version introduced
+
+.NET 9 RC 1
+
+## Previous behavior
+
+Previously, if the destination directory didn't exist when the `dotnet dev-certs` command was run, it was created (with permissions inherited from the containing directory). For example, *C:\\NonExistent\\* would have been created given the following command:
+
+```dotnetcli
+dotnet dev-certs https -ep C:\NonExistent\cert.pfx
+```
+
+## New behavior
+
+Starting in .NET 9, if target directory doesn't exist, the export fails with a message like:
+
+> There was an error exporting the HTTPS developer certificate to a file.
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+The development certificate is exported with its private key, so unauthorized access can be problematic. It might, nevertheless, be necessary to make it readable to multiple accounts, for example, if the consuming process won't be run as the current user. Rather than attempting to determine (and securely establish) permissions for the target directory, `dotnet dev-certs` requires that it already exist.
+
+## Recommended action
+
+Create the target directory (with appropriate permissions) before invoking `dotnet dev-certs`.
+
+## Affected APIs
+
+N/A

--- a/docs/core/compatibility/aspnet-core/9.0/middleware-constructors.md
+++ b/docs/core/compatibility/aspnet-core/9.0/middleware-constructors.md
@@ -21,12 +21,12 @@ public class CookiePolicyMiddleware
 {
     public CookiePolicyMiddleware(RequestDelegate next, IOptions<CookiePolicyOptions> options, ILoggerFactory factory)
     {
-        // Omitted for brevity
+        // ...
     }
 
     public CookiePolicyMiddleware(RequestDelegate next, IOptions<CookiePolicyOptions> options)
     {
-        // Omitted for brevity
+        // ...
     }
 }
 ```

--- a/docs/core/compatibility/aspnet-core/9.0/middleware-constructors.md
+++ b/docs/core/compatibility/aspnet-core/9.0/middleware-constructors.md
@@ -1,0 +1,54 @@
+---
+title: "Breaking change: Middleware types with multiple constructors"
+description: Learn about the breaking change in ASP.NET Core 9 where having multiple constructors in a middleware type can cause an exception at run time.
+ms.date: 11/6/2024
+---
+
+# Middleware types with multiple constructors
+
+Previously, when a middleware type with multiple satisfiable constructors was instantiated from the dependency injection container, the one with the most parameters was used. Now that only happens if the dependency injection container implements <xref:Microsoft.Extensions.DependencyInjection.IServiceProviderIsService>. If it doesn't, an exception is thrown at run time.
+
+## Version introduced
+
+.NET 9 RC 1
+
+## Previous behavior
+
+Previously, the first of the following two constructors was preferred (when both were satisfied) because it has more parameters.
+
+```csharp
+public class CookiePolicyMiddleware
+{
+    public CookiePolicyMiddleware(RequestDelegate next, IOptions<CookiePolicyOptions> options, ILoggerFactory factory)
+    {
+        // Omitted for brevity
+    }
+
+    public CookiePolicyMiddleware(RequestDelegate next, IOptions<CookiePolicyOptions> options)
+    {
+        // Omitted for brevity
+    }
+}
+```
+
+## New behavior
+
+Starting in .NET 9, neither constructor is preferred, and construction fails with an error like:
+
+> System.InvalidOperationException: 'Multiple constructors accepting all given argument types have been found in type 'Microsoft.AspNetCore.CookiePolicy.CookiePolicyMiddleware'. There should only be one applicable constructor.'
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+The activation mechanism was changed to help support keyed dependency injection.
+
+## Recommended action
+
+If this happens and you can't upgrade to a dependency injection container that implements <xref:Microsoft.Extensions.DependencyInjection.IServiceProviderIsService>, you can add the <xref:Microsoft.Extensions.DependencyInjection.ActivatorUtilitiesConstructorAttribute> to the preferred constructor of the affected middleware type.
+
+## Affected APIs
+
+This change is known to cause errors when instantiating <xref:Microsoft.AspNetCore.CookiePolicy.CookiePolicyMiddleware?displayProperty=fullName> with [Autofac.Extensions.DependencyInjection](https://www.nuget.org/packages/Autofac.Extensions.DependencyInjection) 7.x.

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -12,8 +12,12 @@ items:
             items:
               - name: DefaultKeyResolution.ShouldGenerateNewKey has altered meaning
                 href: aspnet-core/9.0/key-resolution.md
+              - name: Dev cert export no longer creates folder
+                href: aspnet-core/9.0/certificate-export.md
               - name: HostBuilder enables ValidateOnBuild/ValidateScopes in development environment
                 href: aspnet-core/9.0/hostbuilder-validation.md
+              - name: Middleware types with multiple constructors
+                href: aspnet-core/9.0/middleware-constructors.md
           - name: Containers
             items:
               - name: .NET 9 container images no longer install zlib
@@ -515,7 +519,7 @@ items:
           - name: WPF
             items:
               - name: Revert behavior with text drag-and-drop operations
-                href: wpf/7.0/drag-and-drop.md  
+                href: wpf/7.0/drag-and-drop.md
       - name: .NET 6
         items:
           - name: Overview
@@ -1018,8 +1022,12 @@ items:
             items:
               - name: DefaultKeyResolution.ShouldGenerateNewKey has altered meaning
                 href: aspnet-core/9.0/key-resolution.md
+              - name: Dev cert export no longer creates folder
+                href: aspnet-core/9.0/certificate-export.md
               - name: HostBuilder enables ValidateOnBuild/ValidateScopes in development environment
                 href: aspnet-core/9.0/hostbuilder-validation.md
+              - name: Middleware types with multiple constructors
+                href: aspnet-core/9.0/middleware-constructors.md
           - name: .NET 8
             items:
               - name: ConcurrencyLimiterMiddleware is obsolete


### PR DESCRIPTION
Fixes #43157.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/9.0.md](https://github.com/dotnet/docs/blob/db5f86d8c086edf9fec920f2b1919a6b0742e5b0/docs/core/compatibility/9.0.md) | [docs/core/compatibility/9.0](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/9.0?branch=pr-en-us-43370) |
| [docs/core/compatibility/aspnet-core/9.0/certificate-export.md](https://github.com/dotnet/docs/blob/db5f86d8c086edf9fec920f2b1919a6b0742e5b0/docs/core/compatibility/aspnet-core/9.0/certificate-export.md) | [docs/core/compatibility/aspnet-core/9.0/certificate-export](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/aspnet-core/9.0/certificate-export?branch=pr-en-us-43370) |
| [docs/core/compatibility/aspnet-core/9.0/middleware-constructors.md](https://github.com/dotnet/docs/blob/db5f86d8c086edf9fec920f2b1919a6b0742e5b0/docs/core/compatibility/aspnet-core/9.0/middleware-constructors.md) | [docs/core/compatibility/aspnet-core/9.0/middleware-constructors](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/aspnet-core/9.0/middleware-constructors?branch=pr-en-us-43370) |

<!-- PREVIEW-TABLE-END -->