### PR TITLE
unpin custom actions

### DIFF
--- a/.github/workflows/check-for-build-warnings.yml
+++ b/.github/workflows/check-for-build-warnings.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         egress-policy: audit
 
-    - uses: dotnet/docs-tools/actions/status-checker@5e8bcc78465d45a7544bba56509a1a69922b6a5a # main
+    - uses: dotnet/docs-tools/actions/status-checker@main
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         docs_path: "docs"

--- a/.github/workflows/cleanrepo-orphaned-articles.yml
+++ b/.github/workflows/cleanrepo-orphaned-articles.yml
@@ -26,7 +26,7 @@ jobs:
       # Call clean repo
       - name: Clean repo
         id: clean-repo-step
-        uses: dotnet/docs-tools/cleanrepo@b1ebc174a5bbd18e6904a12069a8fae2c5cc3b6f
+        uses: dotnet/docs-tools/cleanrepo@main
         with:
           function: "FindOrphanedArticles"
           docfx_directory: "."

--- a/.github/workflows/cleanrepo-orphaned-images.yml
+++ b/.github/workflows/cleanrepo-orphaned-images.yml
@@ -26,7 +26,7 @@ jobs:
       # Call clean repo
       - name: Clean repo
         id: clean-repo-step
-        uses: dotnet/docs-tools/cleanrepo@b1ebc174a5bbd18e6904a12069a8fae2c5cc3b6f
+        uses: dotnet/docs-tools/cleanrepo@main
         with:
           function: "FindOrphanedImages"
           docfx_directory: "."

--- a/.github/workflows/cleanrepo-orphaned-includes.yml
+++ b/.github/workflows/cleanrepo-orphaned-includes.yml
@@ -26,7 +26,7 @@ jobs:
       # Call clean repo
       - name: Clean repo
         id: clean-repo-step
-        uses: dotnet/docs-tools/cleanrepo@b1ebc174a5bbd18e6904a12069a8fae2c5cc3b6f
+        uses: dotnet/docs-tools/cleanrepo@main
         with:
           function: "FindOrphanedIncludes"
           docfx_directory: "."

--- a/.github/workflows/cleanrepo-orphaned-snippets.yml
+++ b/.github/workflows/cleanrepo-orphaned-snippets.yml
@@ -26,7 +26,7 @@ jobs:
       # Call clean repo
       - name: Clean repo
         id: clean-repo-step
-        uses: dotnet/docs-tools/cleanrepo@b1ebc174a5bbd18e6904a12069a8fae2c5cc3b6f
+        uses: dotnet/docs-tools/cleanrepo@main
         with:
           function: "FindOrphanedSnippets"
           docfx_directory: "."

--- a/.github/workflows/cleanrepo-redirect-hops.yml
+++ b/.github/workflows/cleanrepo-redirect-hops.yml
@@ -26,7 +26,7 @@ jobs:
       # Call clean repo
       - name: Clean repo
         id: clean-repo-step
-        uses: dotnet/docs-tools/cleanrepo@b1ebc174a5bbd18e6904a12069a8fae2c5cc3b6f
+        uses: dotnet/docs-tools/cleanrepo@main
         with:
           function: "RemoveRedirectHops"
           docfx_directory: "."

--- a/.github/workflows/cleanrepo-relative-links.yml
+++ b/.github/workflows/cleanrepo-relative-links.yml
@@ -26,7 +26,7 @@ jobs:
       # Call clean repo
       - name: Clean repo
         id: clean-repo-step
-        uses: dotnet/docs-tools/cleanrepo@b1ebc174a5bbd18e6904a12069a8fae2c5cc3b6f
+        uses: dotnet/docs-tools/cleanrepo@main
         with:
           function: "ReplaceWithRelativeLinks"
           docfx_directory: "."

--- a/.github/workflows/cleanrepo-replace-redirects.yml
+++ b/.github/workflows/cleanrepo-replace-redirects.yml
@@ -26,7 +26,7 @@ jobs:
       # Call clean repo
       - name: Clean repo
         id: clean-repo-step
-        uses: dotnet/docs-tools/cleanrepo@b1ebc174a5bbd18e6904a12069a8fae2c5cc3b6f
+        uses: dotnet/docs-tools/cleanrepo@main
         with:
           function: "ReplaceRedirectTargets"
           docfx_directory: "."

--- a/.github/workflows/dependabot-bot.yml
+++ b/.github/workflows/dependabot-bot.yml
@@ -44,7 +44,7 @@ jobs:
       # Run the .NET dependabot-bot tool
       - name: dependabot-bot
         id: dependabot-bot
-        uses: dotnet/docs-tools/actions/dependabot-bot@5e8bcc78465d45a7544bba56509a1a69922b6a5a # main
+        uses: dotnet/docs-tools/actions/dependabot-bot@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/quest-bulk.yml
+++ b/.github/workflows/quest-bulk.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Azure OpenID Connect
         id: azure-oidc-auth
-        uses: dotnet/docs-tools/.github/actions/oidc-auth-flow@5e8bcc78465d45a7544bba56509a1a69922b6a5a # main
+        uses: dotnet/docs-tools/.github/actions/oidc-auth-flow@main
         with:
           client-id: ${{ secrets.CLIENT_ID }}
           tenant-id: ${{ secrets.TENANT_ID }}
@@ -45,7 +45,7 @@ jobs:
      
       - name: bulk-sequester
         id: bulk-sequester
-        uses: dotnet/docs-tools/actions/sequester@5e8bcc78465d45a7544bba56509a1a69922b6a5a # main
+        uses: dotnet/docs-tools/actions/sequester@main
         env:
           ImportOptions__ApiKeys__GitHubToken: ${{ secrets.GITHUB_TOKEN }}
           ImportOptions__ApiKeys__QuestKey: ${{ secrets.QUEST_KEY }}

--- a/.github/workflows/quest.yml
+++ b/.github/workflows/quest.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Azure OpenID Connect
         id: azure-oidc-auth
-        uses: dotnet/docs-tools/.github/actions/oidc-auth-flow@5e8bcc78465d45a7544bba56509a1a69922b6a5a # main
+        uses: dotnet/docs-tools/.github/actions/oidc-auth-flow@main
         with:
           client-id: ${{ secrets.CLIENT_ID }}
           tenant-id: ${{ secrets.TENANT_ID }}
@@ -51,7 +51,7 @@ jobs:
       - name: manual-sequester
         if: ${{ github.event_name == 'workflow_dispatch' }}
         id: manual-sequester
-        uses: dotnet/docs-tools/actions/sequester@5e8bcc78465d45a7544bba56509a1a69922b6a5a # main
+        uses: dotnet/docs-tools/actions/sequester@main
         env:
           ImportOptions__ApiKeys__GitHubToken: ${{ secrets.GITHUB_TOKEN }}
           ImportOptions__ApiKeys__AzureAccessToken: ${{ steps.azure-oidc-auth.outputs.access-token }}
@@ -67,7 +67,7 @@ jobs:
       - name: auto-sequester
         if: ${{ github.event_name != 'workflow_dispatch' }}
         id: auto-sequester
-        uses: dotnet/docs-tools/actions/sequester@5e8bcc78465d45a7544bba56509a1a69922b6a5a # main
+        uses: dotnet/docs-tools/actions/sequester@main
         env:
           ImportOptions__ApiKeys__GitHubToken: ${{ secrets.GITHUB_TOKEN }}
           ImportOptions__ApiKeys__AzureAccessToken: ${{ steps.azure-oidc-auth.outputs.access-token }}

--- a/.github/workflows/version-sweep.yml
+++ b/.github/workflows/version-sweep.yml
@@ -40,7 +40,7 @@ jobs:
 
             - name: .NET version updater
               id: dotnet-version-updater
-              uses: dotnet/docs-tools/actions/dotnet-version-updater@5e8bcc78465d45a7544bba56509a1a69922b6a5a # main
+              uses: dotnet/docs-tools/actions/dotnet-version-updater@main
               with:
                   support: ${{ github.event.inputs.support }}
                   token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/whats-new.yml
+++ b/.github/workflows/whats-new.yml
@@ -36,13 +36,13 @@ jobs:
 
       - name: Azure OpenID Connect
         id: azure-oidc-auth
-        uses: dotnet/docs-tools/.github/actions/oidc-auth-flow@5e8bcc78465d45a7544bba56509a1a69922b6a5a # main
+        uses: dotnet/docs-tools/.github/actions/oidc-auth-flow@main
         with:
           client-id: ${{ secrets.CLIENT_ID }}
           tenant-id: ${{ secrets.TENANT_ID }}
           audience: ${{ secrets.OSMP_API_AUDIENCE }}
      
-      - uses: dotnet/docs-tools/WhatsNew.Cli@5e8bcc78465d45a7544bba56509a1a69922b6a5a # main
+      - uses: dotnet/docs-tools/WhatsNew.Cli@main
         env:
           GitHubKey: ${{ secrets.GITHUB_TOKEN }}
           AZURE_ACCESS_TOKEN: ${{ steps.azure-oidc-auth.outputs.access-token }}


### PR DESCRIPTION
Dependabot won't update commit hashes for custom actions. They are in one of our repos so we can use the main branch.