### PR TITLE
Remove dangling fenced code block start

### DIFF
--- a/docs/fsharp/whats-new/fsharp-9.md
+++ b/docs/fsharp/whats-new/fsharp-9.md
@@ -277,8 +277,6 @@ let round1Order = allPlayers |> List.randomShuffle // [ "Charlie"; "Dave"; "Alic
 
 For arrays, there are also `InPlace` variants that shuffle the items in the existing array instead of creating a new one.
 
-```fsharp
-
 #### Choice
 
 The `Choice` functions return a single random element from the given collection. The random choice is weighted evenly on the size of the collection.


### PR DESCRIPTION
There is currently an unclosed start of a fenced code block. Leading to a problem as shown in the snippet below.

![image](https://github.com/user-attachments/assets/1f611e6f-ed82-4da8-b2b5-a7865ebbce4c)

This PR removes this and fixes the intended fenced code block.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/whats-new/fsharp-9.md](https://github.com/dotnet/docs/blob/680a15b54943b5b2ce8e336409ac669efdbf4abd/docs/fsharp/whats-new/fsharp-9.md) | [docs/fsharp/whats-new/fsharp-9](https://review.learn.microsoft.com/en-us/dotnet/fsharp/whats-new/fsharp-9?branch=pr-en-us-43381) |

<!-- PREVIEW-TABLE-END -->