### PR TITLE
link to microsoft SDKs project github

### DIFF
--- a/docs/core/project-sdk/overview.md
+++ b/docs/core/project-sdk/overview.md
@@ -12,7 +12,7 @@ Modern .NET projects are associated with a project software development kit (SDK
 
 ## Available SDKs
 
-The following SDKs are available:
+The available SDKs include:
 
 | ID                         | Description                                             | Repo                                   |
 |----------------------------|---------------------------------------------------------|----------------------------------------|
@@ -26,11 +26,11 @@ The following SDKs are available:
 
 The .NET SDK is the base SDK for .NET. The other SDKs reference the .NET SDK, and projects that are associated with the other SDKs have all the .NET SDK properties available to them. The Web SDK, for example, depends on both the .NET SDK and the Razor SDK.
 
-You can also author your own SDK that can be distributed via NuGet.
-
 For Windows Forms and Windows Presentation Foundation (WPF) projects, you specify the .NET SDK (`Microsoft.NET.Sdk`) and set some additional properties in the project file. For more information, see [Enable .NET Desktop SDK](msbuild-props-desktop.md#enable-net-desktop-sdk).
 
-Additional Microsoft-provided project SDKs are available at the [Microsoft MSBuild SDKs GitHub](https://github.com/microsoft/MSBuildSdks).
+MSBuild SDKs, which you can use to configure and extend your build, are listed at [MSBuild SDKs](https://github.com/microsoft/MSBuildSdks/blob/main/README.md).
+
+You can also author your own SDK that can be distributed via NuGet.
 
 ## Project files
 

--- a/docs/core/project-sdk/overview.md
+++ b/docs/core/project-sdk/overview.md
@@ -30,6 +30,8 @@ You can also author your own SDK that can be distributed via NuGet.
 
 For Windows Forms and Windows Presentation Foundation (WPF) projects, you specify the .NET SDK (`Microsoft.NET.Sdk`) and set some additional properties in the project file. For more information, see [Enable .NET Desktop SDK](msbuild-props-desktop.md#enable-net-desktop-sdk).
 
+Additional Microsoft-provided project SDKs are available at the [Microsoft MSBuild SDKs GitHub](https://github.com/microsoft/MSBuildSdks).
+
 ## Project files
 
 .NET projects are based on the [MSBuild](/visualstudio/msbuild/msbuild) format. Project files, which have extensions like *.csproj* for C# projects and *.fsproj* for F# projects, are in XML format. The root element of an MSBuild project file is the [Project](/visualstudio/msbuild/project-element-msbuild) element. The `Project` element has an optional `Sdk` attribute that specifies which SDK (and version) to use. To use the .NET tools and build your code, set the `Sdk` attribute to one of the IDs in the [Available SDKs](#available-sdks) table.


### PR DESCRIPTION
The text above implies that this is an exclusive list of MS' official SDKs, which is not the case - there are other Microsoft-provided SDKs available on github, and they should be linked.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/project-sdk/overview.md](https://github.com/dotnet/docs/blob/343be0aeb59e228b1b7417073ee2b03be0531b38/docs/core/project-sdk/overview.md) | [.NET project SDKs](https://review.learn.microsoft.com/en-us/dotnet/core/project-sdk/overview?branch=pr-en-us-43384) |


<!-- PREVIEW-TABLE-END -->