### PR TITLE
[docs] Add a note on Native AOT diagnostics support on iOS-like platforms

### DIFF
--- a/docs/core/deploying/native-aot/diagnostics.md
+++ b/docs/core/deploying/native-aot/diagnostics.md
@@ -13,7 +13,7 @@ Native AOT shares some, but not all, diagnostics and instrumentation capabilitie
 ## Native AOT diagnostic support
 
 > [!NOTE]
-> Starting from .NET 9, Native AOT supports targeting iOS-like platforms with .NET MAUI for which diagnostics support is described in the following [document](https://github.com/dotnet/docs-maui/blob/7ff3052a0b3535316775bba2583ee09ffdd9befa/docs/deployment/nativeaot.md#native-aot-diagnostic-support-on-ios-like-platforms).
+> Starting from .NET 9, Native AOT supports targeting iOS-like platforms with .NET MAUI for which diagnostics support is described in the following [document](https://learn.microsoft.com/dotnet/maui/deployment/nativeaot?view=net-maui-9.0#native-aot-diagnostic-support-on-ios-and-mac-catalyst).
 
 The following table summarizes diagnostic features supported for Native AOT deployments:
 

--- a/docs/core/deploying/native-aot/diagnostics.md
+++ b/docs/core/deploying/native-aot/diagnostics.md
@@ -8,12 +8,9 @@ ms.date: 08/07/2023
 
 # Diagnostics and instrumentation
 
-Native AOT shares some, but not all, diagnostics and instrumentation capabilities with CoreCLR. Because of CoreCLR's rich selection of diagnostic utilities, it's sometimes appropriate to diagnose and debug problems in CoreCLR. Apps that are [trim-compatible](../trimming/prepare-libraries-for-trimming.md) shouldn't have behavioral differences, so investigations often apply to both runtimes. Nonetheless, some information can only be gathered after publishing, so Native AOT also provides post-publish diagnostic tooling.
+Native AOT shares some, but not all, diagnostics and instrumentation capabilities with the full .NET runtime. Apps that are [trim-compatible](../trimming/prepare-libraries-for-trimming.md) shouldn't have behavioral differences, so investigations often apply to both runtimes and it's sometimes appropriate to diagnose and debug problems in the full .NET runtime, as it has a rich selection of available diagnostic utilities. Nonetheless, some information can only be gathered after publishing, so Native AOT also provides post-publish diagnostic tooling.
 
 ## Native AOT diagnostic support
-
-> [!NOTE]
-> Starting from .NET 9, Native AOT supports targeting iOS-like platforms with .NET MAUI for which diagnostics support is described in the following [document](https://learn.microsoft.com/dotnet/maui/deployment/nativeaot?view=net-maui-9.0&preserve-view=true#native-aot-diagnostic-support-on-ios-and-mac-catalyst).
 
 The following table summarizes diagnostic features supported for Native AOT deployments:
 
@@ -27,7 +24,7 @@ The following table summarizes diagnostic features supported for Native AOT depl
 
 ## Observability and telemetry
 
-As of .NET 8, the Native AOT runtime supports [EventPipe](../../diagnostics/eventpipe.md), which is the base layer used by many logging and tracing libraries. You can interface with EventPipe directly through APIs like `EventSource.WriteEvent` or you can use libraries built on top, like [OpenTelemetry](../../diagnostics/observability-with-otel.md). EventPipe support also allows .NET diagnostic tools like [dotnet-trace](../../diagnostics/dotnet-trace.md), [dotnet-counters](../../diagnostics/dotnet-counters.md), and [dotnet-monitor](../../diagnostics/dotnet-monitor.md) to work seamlessly with Native AOT or CoreCLR applications. EventPipe is an optional component in Native AOT. To include EventPipe support, set the `EventSourceSupport` MSBuild property to `true`.
+As of .NET 8, the Native AOT runtime supports [EventPipe](../../diagnostics/eventpipe.md), which is the base layer used by many logging and tracing libraries. You can interface with EventPipe directly through APIs like `EventSource.WriteEvent` or you can use libraries built on top, like [OpenTelemetry](../../diagnostics/observability-with-otel.md). EventPipe support also allows .NET diagnostic tools like [dotnet-trace](../../diagnostics/dotnet-trace.md), [dotnet-counters](../../diagnostics/dotnet-counters.md), and [dotnet-monitor](../../diagnostics/dotnet-monitor.md) to work seamlessly with Native AOT or full .NET runtime applications. EventPipe is an optional component in Native AOT. To include EventPipe support, set the `EventSourceSupport` MSBuild property to `true`.
 
 ```xml
 <PropertyGroup>
@@ -40,7 +37,7 @@ Native AOT provides partial support for some [well-known event providers](../../
 ## Development-time diagnostics
 
 The .NET CLI tooling (`dotnet` SDK) and Visual Studio offer separate commands for `build` and
-`publish`. `build` (or `Start` in Visual Studio) uses CoreCLR. Only `publish` creates a
+`publish`. `build` (or `Start` in Visual Studio) uses the full .NET runtime. Only `publish` creates a
 Native AOT application.  Publishing your app as Native AOT produces an app that has been
 ahead-of-time (AOT) compiled to native code. As mentioned previously, not all diagnostic
 tools work seamlessly with published Native AOT applications in .NET 8. However, all .NET
@@ -49,7 +46,7 @@ developing, debugging, and testing the applications as usual and publishing the 
 
 ## Native debugging
 
-When you run your app during development, like inside Visual Studio, or with `dotnet run`, `dotnet build`, or `dotnet test`, it runs on CoreCLR by default. However, if `PublishAot` is present in the project file, the behavior should be the same between CoreCLR and Native AOT. This characteristic allows you to use the standard Visual Studio managed debugging engine for development and testing.
+When you run your app during development, like inside Visual Studio, or with `dotnet run`, `dotnet build`, or `dotnet test`, it runs on the full .NET runtime by default. However, if `PublishAot` is present in the project file, the behavior should be the same between the full .NET runtime and Native AOT. This characteristic allows you to use the standard Visual Studio managed debugging engine for development and testing.
 
 After publishing, Native AOT applications are true native binaries. The managed debugger won't work on them. However, the Native AOT compiler generates fully native executable files that native debuggers can debug on your platform of choice (for example, WinDbg or Visual Studio on Windows and gdb or lldb on Unix-like systems).
 
@@ -81,3 +78,7 @@ Platform-specific tools like [PerfView](https://github.com/microsoft/perfview) a
 ## Heap analysis
 
 Managed heap analysis isn't currently supported in Native AOT. Heap analysis tools like [dotnet-gcdump](../../diagnostics/dotnet-gcdump.md), [PerfView](https://github.com/microsoft/perfview), and Visual Studio heap analysis tools don't work in Native AOT in .NET 8.
+
+## See also
+
+- [Native AOT diagnostic support on iOS and Mac Catalyst](https://learn.microsoft.com/dotnet/maui/deployment/nativeaot?view=net-maui-9.0&preserve-view=true#native-aot-diagnostic-support-on-ios-and-mac-catalyst)

--- a/docs/core/deploying/native-aot/diagnostics.md
+++ b/docs/core/deploying/native-aot/diagnostics.md
@@ -8,7 +8,7 @@ ms.date: 08/07/2023
 
 # Diagnostics and instrumentation
 
-Native AOT shares some, but not all, diagnostics and instrumentation capabilities with the full .NET runtime. Apps that are [trim-compatible](../trimming/prepare-libraries-for-trimming.md) shouldn't have behavioral differences, so investigations often apply to both runtimes and it's sometimes appropriate to diagnose and debug problems in the full .NET runtime, as it has a rich selection of available diagnostic utilities. Nonetheless, some information can only be gathered after publishing, so Native AOT also provides post-publish diagnostic tooling.
+Native AOT shares some, but not all, diagnostics and instrumentation capabilities with the full .NET runtime. Apps that are [trim-compatible](../trimming/prepare-libraries-for-trimming.md) shouldn't have behavioral differences, so investigations often apply to both runtimes. As such, it's sometimes appropriate to diagnose and debug problems in the full .NET runtime, as it has a rich selection of available diagnostic utilities. Nonetheless, some information can only be gathered after publishing, so Native AOT also provides post-publish diagnostic tooling.
 
 ## Native AOT diagnostic support
 

--- a/docs/core/deploying/native-aot/diagnostics.md
+++ b/docs/core/deploying/native-aot/diagnostics.md
@@ -81,4 +81,4 @@ Managed heap analysis isn't currently supported in Native AOT. Heap analysis too
 
 ## See also
 
-- [Native AOT diagnostic support on iOS and Mac Catalyst](https://learn.microsoft.com/dotnet/maui/deployment/nativeaot?view=net-maui-9.0&preserve-view=true#native-aot-diagnostic-support-on-ios-and-mac-catalyst)
+- [Native AOT diagnostic support on iOS and Mac Catalyst](/dotnet/maui/deployment/nativeaot#native-aot-diagnostic-support-on-ios-and-mac-catalyst)

--- a/docs/core/deploying/native-aot/diagnostics.md
+++ b/docs/core/deploying/native-aot/diagnostics.md
@@ -10,7 +10,10 @@ ms.date: 08/07/2023
 
 Native AOT shares some, but not all, diagnostics and instrumentation capabilities with CoreCLR. Because of CoreCLR's rich selection of diagnostic utilities, it's sometimes appropriate to diagnose and debug problems in CoreCLR. Apps that are [trim-compatible](../trimming/prepare-libraries-for-trimming.md) shouldn't have behavioral differences, so investigations often apply to both runtimes. Nonetheless, some information can only be gathered after publishing, so Native AOT also provides post-publish diagnostic tooling.
 
-## .NET 8 Native AOT diagnostic support
+## Native AOT diagnostic support
+
+> [!NOTE]
+> Starting from .NET 9, Native AOT supports targeting iOS-like platforms with .NET MAUI for which diagnostics support is described in the following [document](https://github.com/dotnet/docs-maui/blob/7ff3052a0b3535316775bba2583ee09ffdd9befa/docs/deployment/nativeaot.md#native-aot-diagnostic-support-on-ios-like-platforms).
 
 The following table summarizes diagnostic features supported for Native AOT deployments:
 

--- a/docs/core/deploying/native-aot/diagnostics.md
+++ b/docs/core/deploying/native-aot/diagnostics.md
@@ -13,7 +13,7 @@ Native AOT shares some, but not all, diagnostics and instrumentation capabilitie
 ## Native AOT diagnostic support
 
 > [!NOTE]
-> Starting from .NET 9, Native AOT supports targeting iOS-like platforms with .NET MAUI for which diagnostics support is described in the following [document](https://learn.microsoft.com/dotnet/maui/deployment/nativeaot?view=net-maui-9.0#native-aot-diagnostic-support-on-ios-and-mac-catalyst).
+> Starting from .NET 9, Native AOT supports targeting iOS-like platforms with .NET MAUI for which diagnostics support is described in the following [document](https://learn.microsoft.com/dotnet/maui/deployment/nativeaot?view=net-maui-9.0&preserve-view=true#native-aot-diagnostic-support-on-ios-and-mac-catalyst).
 
 The following table summarizes diagnostic features supported for Native AOT deployments:
 


### PR DESCRIPTION
## Summary

This PR adds a note on Native AOT diagnostics support when targeting iOS-like platforms which includes a link to the iOS-specific documentation.

--- 
Contributes to: https://github.com/dotnet/runtime/issues/106799


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/deploying/native-aot/diagnostics.md](https://github.com/dotnet/docs/blob/2986ff3e5d7c5dd1ee5dc427713a1c6ac37eb249/docs/core/deploying/native-aot/diagnostics.md) | [Diagnostics and instrumentation](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/diagnostics?branch=pr-en-us-43399) |


<!-- PREVIEW-TABLE-END -->