### PR TITLE
Update MSTEST0006 docs now that there is a codefix

### DIFF
--- a/docs/core/testing/mstest-analyzers/mstest0006.md
+++ b/docs/core/testing/mstest-analyzers/mstest0006.md
@@ -1,7 +1,7 @@
 ---
 title: "MSTEST0006: Avoid '[ExpectedException]'"
 description: "Learn about code analysis rule MSTEST0006: Avoid '[ExpectedException]'"
-ms.date: 01/03/2024
+ms.date: 11/12/2024
 f1_keywords:
 - MSTEST0006
 - AvoidExpectedExceptionAttributeAnalyzer
@@ -25,7 +25,7 @@ dev_langs:
 | **Enabled by default**              | Yes                                                |
 | **Default severity**                | Info                                               |
 | **Introduced in version**           | 3.2.0                                              |
-| **There is a code fix**             | Yes                                                |
+| **There is a code fix**             | Yes, starting with 3.7.0                           |
 
 ## Cause
 

--- a/docs/core/testing/mstest-analyzers/mstest0006.md
+++ b/docs/core/testing/mstest-analyzers/mstest0006.md
@@ -25,7 +25,7 @@ dev_langs:
 | **Enabled by default**              | Yes                                                |
 | **Default severity**                | Info                                               |
 | **Introduced in version**           | 3.2.0                                              |
-| **There is a code fix**             | No                                                 |
+| **There is a code fix**             | Yes                                                |
 
 ## Cause
 


### PR DESCRIPTION
Product PR: https://github.com/microsoft/testfx/pull/4038

The product PR needs to be merged first

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/mstest-analyzers/mstest0006.md](https://github.com/dotnet/docs/blob/f6c5984d0a5ba6a6fcc0b7e45a947fd07b952ea9/docs/core/testing/mstest-analyzers/mstest0006.md) | [MSTEST0006: Avoid `[ExpectedException]`](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0006?branch=pr-en-us-43403) |


<!-- PREVIEW-TABLE-END -->