### PR TITLE
Refine Documentation on Verbatim Identifiers: Clarify @ Character Usage to Avoid Misinterpretation

### DIFF
--- a/docs/csharp/language-reference/operators/nameof.md
+++ b/docs/csharp/language-reference/operators/nameof.md
@@ -26,7 +26,7 @@ Beginning with C# 11, you can use a `nameof` expression with a method parameter 
 
 A `nameof` expression with a parameter is useful when you use the [nullable analysis attributes](../attributes/nullable-analysis.md) or the [CallerArgumentExpression attribute](../attributes/caller-information.md#argument-expressions).
 
-When the operand is a [verbatim identifier](../tokens/verbatim.md), the `@` character isn't the part of a name, as the following example shows:
+When the operand is a [verbatim identifier](../tokens/verbatim.md), the `@` character isn't part of the name, as the following example shows:
 
 [!code-csharp-interactive[nameof verbatim](snippets/shared/NameOfOperator.cs#Verbatim)]
 


### PR DESCRIPTION
## Summary

**Updated Wording:** Revised "isn't the part of a name" to "isn't part of the name," clarifying that `@` is a syntactic marker, not included in the identifier name.

**Contextual Clarity:** By updating the phrasing, we help readers better understand the behavior of the `@` character in verbatim identifiers, which is essential for accurate comprehension of the `nameof` operator.

Fixes #43400

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/nameof.md](https://github.com/dotnet/docs/blob/2568ae1499c144475b3e35939051d1337e98fd10/docs/csharp/language-reference/operators/nameof.md) | [nameof expression (C# reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/nameof?branch=pr-en-us-43406) |

<!-- PREVIEW-TABLE-END -->