### PR TITLE
fix: update to latest cli install commands

### DIFF
--- a/docs/core/tools/custom-templates.md
+++ b/docs/core/tools/custom-templates.md
@@ -243,7 +243,7 @@ dotnet new install <NUGET_PACKAGE_ID>
 Provide a custom NuGet source (for example, `https://api.my-custom-nuget.com/v3/index.json`).
 
 ```dotnetcli
-dotnet new --install <NUGET_PACKAGE_ID> --nuget-source <SOURCE>
+dotnet new install <NUGET_PACKAGE_ID> --nuget-source <SOURCE>
 ```
 
 ### To install a template package from a local nupkg file

--- a/docs/core/tools/dotnet-new-install.md
+++ b/docs/core/tools/dotnet-new-install.md
@@ -94,7 +94,7 @@ Starting with .NET SDK 6.0.100, installed template packages are available in lat
 - Install version 2.0 of the SPA templates for ASP.NET Core from a custom NuGet source using interactive mode:
 
   ```dotnetcli
-  dotnet new --install Microsoft.DotNet.Web.Spa.ProjectTemplates::2.0.0 --add-source "https://api.my-custom-nuget.com/v3/index.json" --interactive
+  dotnet new install Microsoft.DotNet.Web.Spa.ProjectTemplates::2.0.0 --add-source "https://api.my-custom-nuget.com/v3/index.json" --interactive
   ```
 
 ## See also


### PR DESCRIPTION
## Summary

The `dotnet new` CLI in version 7.0 changed the way to install templates. This PR updates part of the docs where the old and now deprecated method was used.

```bash
# old and deprecated
dotnet new --install

# new way to install
dotnet new install 
```

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/custom-templates.md](https://github.com/dotnet/docs/blob/70ccb4799499eccebc63ced32c2cb8911c76eb7d/docs/core/tools/custom-templates.md) | [Custom templates for dotnet new](https://review.learn.microsoft.com/en-us/dotnet/core/tools/custom-templates?branch=pr-en-us-43407) |
| [docs/core/tools/dotnet-new-install.md](https://github.com/dotnet/docs/blob/70ccb4799499eccebc63ced32c2cb8911c76eb7d/docs/core/tools/dotnet-new-install.md) | [dotnet new install](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-new-install?branch=pr-en-us-43407) |

<!-- PREVIEW-TABLE-END -->