### PR TITLE
Fix markdown block not terminated properly.

### DIFF
--- a/docs/core/docker/publish-as-container.md
+++ b/docs/core/docker/publish-as-container.md
@@ -127,6 +127,7 @@ Determining projects to restore...
   DotNet.ContainerImage -> .\Worker\bin\Release\net8.0\linux-x64\publish\
   Building image 'dotnet-worker-image' with tags latest on top of base image mcr.microsoft.com/dotnet/aspnet:8.0
   Pushed container 'dotnet-worker-image:latest' to Docker daemon
+```
 
 This command compiles your worker app to the *publish* folder and pushes the container to your local docker registry.
 


### PR DESCRIPTION


## Summary

The output is confusing because the next paragraph is still in code block,  due to markdown block no terminated properly.
Added markdown end quotes to complete the code block in the correct place.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/docker/publish-as-container.md](https://github.com/dotnet/docs/blob/2532b6f0a08d921a22a9d39304439b43ac18b25c/docs/core/docker/publish-as-container.md) | [Containerize a .NET app with dotnet publish](https://review.learn.microsoft.com/en-us/dotnet/core/docker/publish-as-container?branch=pr-en-us-43421) |

<!-- PREVIEW-TABLE-END -->