### PR TITLE
Add more warnings about BinaryFormatter and NetDataContractSerializer

### DIFF
--- a/docs/orleans/host/configuration-guide/serialization.md
+++ b/docs/orleans/host/configuration-guide/serialization.md
@@ -389,7 +389,7 @@ Alternatively, the fallback serialization provider can be specified in XML confi
 
 The <xref:Orleans.Serialization.BinaryFormatterSerializer> is the default fallback serializer.
 
-[!INCLUDE [binary-serialization-warning](../../../../binary-serialization-warning.md)]
+[!INCLUDE [binary-serialization-warning](../../../../includes/binary-serialization-warning.md)]
 
 ## Exception serialization
 

--- a/docs/orleans/host/configuration-guide/serialization.md
+++ b/docs/orleans/host/configuration-guide/serialization.md
@@ -389,6 +389,8 @@ Alternatively, the fallback serialization provider can be specified in XML confi
 
 The <xref:Orleans.Serialization.BinaryFormatterSerializer> is the default fallback serializer.
 
+[!INCLUDE [binary-serialization-warning](../../../../binary-serialization-warning.md)]
+
 ## Exception serialization
 
 Exceptions are serialized using the [fallback serializer](serialization.md#fallback-serialization). Using the default configuration, `BinaryFormatter` is the fallback serializer and so the [ISerializable pattern](/previous-versions/dotnet/fundamentals/serialization/binary/custom-serialization) must be followed in order to ensure correct serialization of all properties in an exception type.

--- a/docs/standard/design-guidelines/serialization.md
+++ b/docs/standard/design-guidelines/serialization.md
@@ -32,6 +32,10 @@ Serialization is the process of converting an object into a format that can be r
 
  ❌ AVOID supporting Runtime Serialization or XML Serialization just for general persistence reasons. Prefer Data Contract Serialization instead.
 
+[!INCLUDE [binary-serialization-warning](../../../binary-serialization-warning.md)]
+
+[!INCLUDE [netdatacontractserializer-warning](../../../netdatacontractserializer-warning.md)]
+
 ## Supporting Data Contract Serialization
 
  Types can support Data Contract Serialization by applying the <xref:System.Runtime.Serialization.DataContractAttribute> to the type and the <xref:System.Runtime.Serialization.DataMemberAttribute> to the members (fields and properties) of the type.

--- a/docs/standard/design-guidelines/serialization.md
+++ b/docs/standard/design-guidelines/serialization.md
@@ -32,10 +32,6 @@ Serialization is the process of converting an object into a format that can be r
 
  ❌ AVOID supporting Runtime Serialization or XML Serialization just for general persistence reasons. Prefer Data Contract Serialization instead.
 
-[!INCLUDE [binary-serialization-warning](../../../binary-serialization-warning.md)]
-
-[!INCLUDE [netdatacontractserializer-warning](../../../netdatacontractserializer-warning.md)]
-
 ## Supporting Data Contract Serialization
 
  Types can support Data Contract Serialization by applying the <xref:System.Runtime.Serialization.DataContractAttribute> to the type and the <xref:System.Runtime.Serialization.DataMemberAttribute> to the members (fields and properties) of the type.

--- a/docs/standard/serialization/binaryformatter-migration-guide/choose-a-serializer.md
+++ b/docs/standard/serialization/binaryformatter-migration-guide/choose-a-serializer.md
@@ -58,8 +58,7 @@ While `DataContractSerializer` carries those functional benefits when migrating 
 
 [Migrate to DataContractSerializer (XML)](./migrate-to-datacontractserializer.md).
 
-> [!NOTE]
-> Do not confuse <xref:System.Runtime.Serialization.DataContractSerializer> with <xref:System.Runtime.Serialization.NetDataContractSerializer>. <xref:System.Runtime.Serialization.NetDataContractSerializer> is also identified as a [dangerous serializer](../binaryformatter-security-guide.md#dangerous-alternatives).
+[!INCLUDE [netdatacontractserializer-warning](../../../../netdatacontractserializer-warning.md)]
 
 ## Binary using MessagePack
 

--- a/docs/standard/serialization/binaryformatter-migration-guide/choose-a-serializer.md
+++ b/docs/standard/serialization/binaryformatter-migration-guide/choose-a-serializer.md
@@ -58,7 +58,7 @@ While `DataContractSerializer` carries those functional benefits when migrating 
 
 [Migrate to DataContractSerializer (XML)](./migrate-to-datacontractserializer.md).
 
-[!INCLUDE [netdatacontractserializer-warning](../../../../netdatacontractserializer-warning.md)]
+[!INCLUDE [netdatacontractserializer-warning](../../../../includes/netdatacontractserializer-warning.md)]
 
 ## Binary using MessagePack
 

--- a/includes/migration-guide/runtime/serialization/soapformatter-cannot-deserialize-hashtable-similar-ordered-collection.md
+++ b/includes/migration-guide/runtime/serialization/soapformatter-cannot-deserialize-hashtable-similar-ordered-collection.md
@@ -6,9 +6,11 @@ The <xref:System.Runtime.Serialization.Formatters.Soap.SoapFormatter?displayProp
 
 #### Suggestion
 
-<xref:System.Runtime.Serialization.Formatters.Soap.SoapFormatter?displayProperty=fullName> serialization should be replaced with <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter?displayProperty=fullName> serialization or <xref:System.Runtime.Serialization.NetDataContractSerializer?displayProperty=fullName> to be resilient to .NET Framework changes.
+<xref:System.Runtime.Serialization.Formatters.Soap.SoapFormatter?displayProperty=fullName> serialization should be replaced with a serializer that is resilient to .NET Framework changes. Examples include [System.Text.Json](/dotnet/standard/serialization/system-text-json/overview) and <xref:System.Runtime.Serialization.DataContractSerializer?displayProperty=fullName>.
 
 [!INCLUDE [binary-serialization-warning](../../../binary-serialization-warning.md)]
+
+[!INCLUDE [netdatacontractserializer-warning](../../../netdatacontractserializer-warning.md)]
 
 | Name    | Value   |
 | :------ | :------ |

--- a/includes/netdatacontractserializer-warning.md
+++ b/includes/netdatacontractserializer-warning.md
@@ -1,0 +1,2 @@
+> [!WARNING]
+> Do not confuse <xref:System.Runtime.Serialization.DataContractSerializer> with <xref:System.Runtime.Serialization.NetDataContractSerializer>. <xref:System.Runtime.Serialization.NetDataContractSerializer> is identified as a [dangerous serializer](/dotnet/standard/serialization/binaryformatter-security-guide.md#dangerous-alternatives).


### PR DESCRIPTION
I searched through all references to BinaryFormatter and found a few places where we could use more warnings about its dangers. There were also a couple places where warnings about `NetDataContractSerializer` seemed prudent.

For the Orleans doc change, please note it's in the 3.x pivot on the page and not visible on the 7.0 pivot.

This was prompted by [Don't recommend BinaryFormatter (dotnet/docs-desktop#1551)](https://github.com/dotnet/docs-desktop/issues/1551).

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/host/configuration-guide/serialization.md](https://github.com/dotnet/docs/blob/d8f52d162f0b85b943b20576e14ea2cf33dd1beb/docs/orleans/host/configuration-guide/serialization.md) | [Serialization in Orleans](https://review.learn.microsoft.com/en-us/dotnet/orleans/host/configuration-guide/serialization?branch=pr-en-us-43433) |
| [docs/standard/serialization/binaryformatter-migration-guide/choose-a-serializer.md](https://github.com/dotnet/docs/blob/d8f52d162f0b85b943b20576e14ea2cf33dd1beb/docs/standard/serialization/binaryformatter-migration-guide/choose-a-serializer.md) | [Choose a serializer](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/binaryformatter-migration-guide/choose-a-serializer?branch=pr-en-us-43433) |


<!-- PREVIEW-TABLE-END -->