### PR TITLE
Fix broken link within new NetDataContractSerializer include file

### DIFF
--- a/includes/netdatacontractserializer-warning.md
+++ b/includes/netdatacontractserializer-warning.md
@@ -1,2 +1,2 @@
 > [!WARNING]
-> Do not confuse <xref:System.Runtime.Serialization.DataContractSerializer> with <xref:System.Runtime.Serialization.NetDataContractSerializer>. <xref:System.Runtime.Serialization.NetDataContractSerializer> is identified as a [dangerous serializer](/dotnet/standard/serialization/binaryformatter-security-guide.md#dangerous-alternatives).
+> Do not confuse <xref:System.Runtime.Serialization.DataContractSerializer> with <xref:System.Runtime.Serialization.NetDataContractSerializer>. <xref:System.Runtime.Serialization.NetDataContractSerializer> is identified as a [dangerous serializer](/dotnet/standard/serialization/binaryformatter-security-guide#dangerous-alternatives).


### PR DESCRIPTION
In #43433, the include file added for the NetDataContractSerializer warning has a broken link where `.md` was left in the path. When that link was part of a docs page directly, it seems to have worked. But (based on the preview site) it looks like the link is going to be broken when the link is moved into an include file.