### PR TITLE
Link to .NET 9 MAUI API docs

### DIFF
--- a/api/index.md
+++ b/api/index.md
@@ -4,7 +4,7 @@ layout: ApiBrowserPage
 hide_bc: true
 title: .NET API browser
 quickFilterColumn1: net-9.0,netframework-4.8,netstandard-2.1
-quickFilterColumn2: aspnetcore-9.0,efcore-8.0,net-maui-8.0
+quickFilterColumn2: aspnetcore-9.0,efcore-8.0,net-maui-9.0
 quickFilterColumn3: azure-dotnet,ml-dotnet,spark-dotnet
 ms.topic: landing-page
 ms.custom: "updateeachrelease"


### PR DESCRIPTION
## Summary

Link to .NET 9 MAUI API docs, instead of .NET 8.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [api/index.md](https://github.com/dotnet/docs/blob/7e589d0fc33743945e1374924936042539a6cd5d/api/index.md) | [api/index](https://review.learn.microsoft.com/en-us/dotnet/api/index?branch=pr-en-us-43440) |

<!-- PREVIEW-TABLE-END -->