### PR TITLE
Add linux-loongarch64 to rid-catalog.md

### DIFF
--- a/docs/core/rid-catalog.md
+++ b/docs/core/rid-catalog.md
@@ -116,6 +116,7 @@ For more information, see [Install .NET on Windows](install/windows.md#supported
 - `linux-arm` (Linux distributions running on Arm like Raspbian on Raspberry Pi Model 2+)
 - `linux-arm64` (Linux distributions running on 64-bit Arm like Ubuntu Server 64-bit on Raspberry Pi Model 3+)
 - `linux-bionic-arm64` (Distributions using Android's bionic libc, for example, Termux)
+- `linux-loongarch64` (Linux distributions running on LoongArch64)
 
 For more information, see [.NET dependencies and requirements](./install/linux.md).
 


### PR DESCRIPTION


## Summary

What is LoongArch64? See https://github.com/dotnet/runtime/issues/59561


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/rid-catalog.md](https://github.com/dotnet/docs/blob/13941c8ceb3f3044dc94e87a33d630faeefe0d07/docs/core/rid-catalog.md) | [.NET RID Catalog](https://review.learn.microsoft.com/en-us/dotnet/core/rid-catalog?branch=pr-en-us-43441) |


<!-- PREVIEW-TABLE-END -->