### PR TITLE
Fix typo on "one or more" instead of "one of more".

### DIFF
--- a/docs/fundamentals/code-analysis/style-rules/language-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/language-rules.md
@@ -11,7 +11,7 @@ helpviewer_keywords:
 
 Code-style language rules affect how various constructs of .NET programming languages, for example, modifiers, and parentheses, are used.
 
-This category also includes rules that identify parts of the code base that are unnecessary and can be refactored or removed. The presence of unnecessary code indicates one of more of the following problems:
+This category also includes rules that identify parts of the code base that are unnecessary and can be refactored or removed. The presence of unnecessary code indicates one or more of the following problems:
 
 - Readability: Code that unnecessarily degrades readability.
 - Maintainability: Code that's no longer used after refactoring and is maintained unnecessarily.


### PR DESCRIPTION
It should be "one or more" instead of "one of more".

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/style-rules/language-rules.md](https://github.com/dotnet/docs/blob/80e82b46884f75e390a0adad07af8b0e576ee1e5/docs/fundamentals/code-analysis/style-rules/language-rules.md) | [Language and unnecessary rules](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/language-rules?branch=pr-en-us-43562) |

<!-- PREVIEW-TABLE-END -->