### PR TITLE
Clarify Language Version Selection in Visual Studio Documentation.

### DIFF
--- a/docs/csharp/language-reference/configure-language-version.md
+++ b/docs/csharp/language-reference/configure-language-version.md
@@ -22,9 +22,9 @@ If you must specify your C# version explicitly, you can do so in several ways:
 >
 > To know what language version you're currently using, put `#error version` (case sensitive) in your code. This makes the compiler report a compiler error, CS8304, with a message containing the compiler version being used and the current selected language version. See [#error (C# Reference)](preprocessor-directives.md#error-and-warning-information) for more information.
 
-## Why can't I select a different C# version?
+## Why you can't select a different C# version in Visual Studio
 
-In Visual Studio, the option to change the language version through the UI may be disabled because the default version is aligned with the project's target framework (`TFM`). This default configuration ensures compatibility between language features and runtime support.
+In Visual Studio, the option to change the language version through the UI might be disabled because the default version is aligned with the project's target framework (`TFM`). This default configuration ensures compatibility between language features and runtime support.
 
 For example, changing the target `TFM` (e.g., from [.NET 6](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) to [.NET 9](https://dotnet.microsoft.com/en-us/download/dotnet/9.0)) will update the language version accordingly, from C# 10 to C# 13. This approach prevents issues with runtime compatibility and minimizes unexpected build errors due to unsupported language features.
 

--- a/docs/csharp/language-reference/configure-language-version.md
+++ b/docs/csharp/language-reference/configure-language-version.md
@@ -22,6 +22,14 @@ If you must specify your C# version explicitly, you can do so in several ways:
 >
 > To know what language version you're currently using, put `#error version` (case sensitive) in your code. This makes the compiler report a compiler error, CS8304, with a message containing the compiler version being used and the current selected language version. See [#error (C# Reference)](preprocessor-directives.md#error-and-warning-information) for more information.
 
+## Why can't I select a different C# version?
+
+In Visual Studio, the option to change the language version through the UI may be disabled because the default version is aligned with the project's target framework (`TFM`). This default configuration ensures compatibility between language features and runtime support.
+
+For example, changing the target `TFM` (e.g., from [.NET 6](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) to [.NET 9](https://dotnet.microsoft.com/en-us/download/dotnet/9.0)) will update the language version accordingly, from C# 10 to C# 13. This approach prevents issues with runtime compatibility and minimizes unexpected build errors due to unsupported language features.
+
+If you need a specific language version that differs from the one automatically selected, refer to the methods below to override the default settings directly in the project file.
+
 ## Edit the project file
 
 You can set the language version in your project file. For example, if you explicitly want access to preview features, add an element like this:


### PR DESCRIPTION
## Summary

Added a new section, **"Why can't I select a different C# version?"**, explaining that Visual Studio links the language version to the target framework to ensure compatibility. The section:

- Clarifies that the language version aligns with the TFM to maintain runtime support and prevent build issues.
- Provides a practical example: changing the target TFM, such as from .NET 6 to .NET 9, automatically updates the language version, such as from C# 10 to C# 13.
- Guides users on how to set the language version manually if required, referencing the relevant Edit the project file and Configure multiple projects sections.

Fixes #43428 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/configure-language-version.md](https://github.com/dotnet/docs/blob/c4890432186dd3f1a5298aa225e4eef5353c31bc/docs/csharp/language-reference/configure-language-version.md) | [Configure C# language version](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version?branch=pr-en-us-43565) |


<!-- PREVIEW-TABLE-END -->