### PR TITLE
Add note about System.NET.Http breaking change

### DIFF
--- a/docs/core/project-sdk/overview.md
+++ b/docs/core/project-sdk/overview.md
@@ -144,7 +144,9 @@ You can specify additional implicit `global using` directives by adding `Using` 
     <Using Include="System.IO.Pipes" />
   </ItemGroup>
   ```
-System.Net.Http is [no longer included](https://learn.microsoft.com/dotnet/core/compatibility/sdk/8.0/implicit-global-using-netfx) in Microsoft.NET.Sdk when targeting .NET Framework starting in the .NET 8 SDK
+
+> [!NOTE]
+> Starting with the .NET 8 SDK, <xref:System.Net.Http> is [no longer included](../compatibility/sdk/8.0/implicit-global-using-netfx.md) in `Microsoft.NET.Sdk` when targeting .NET Framework.
 
 ## Implicit package references
 

--- a/docs/core/project-sdk/overview.md
+++ b/docs/core/project-sdk/overview.md
@@ -144,6 +144,7 @@ You can specify additional implicit `global using` directives by adding `Using` 
     <Using Include="System.IO.Pipes" />
   </ItemGroup>
   ```
+System.Net.Http is [no longer included](https://learn.microsoft.com/dotnet/core/compatibility/sdk/8.0/implicit-global-using-netfx) in Microsoft.NET.Sdk when targeting .NET Framework starting in the .NET 8 SDK
 
 ## Implicit package references
 


### PR DESCRIPTION
## Summary

See this customer comment here:
https://developercommunity.visualstudio.com/t/https:learnmicrosoftcomen-usdotnet/10787012
https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/implicit-global-using-netfx

I'm not sure how important it is to include the breaking change in the primary documentation so I'll defer to the doc folks but putting this PR out as a proposal.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/project-sdk/overview.md](https://github.com/dotnet/docs/blob/c798417eb3f6ed577a761da5975daa5bc55fb766/docs/core/project-sdk/overview.md) | [.NET project SDKs](https://review.learn.microsoft.com/en-us/dotnet/core/project-sdk/overview?branch=pr-en-us-43567) |


<!-- PREVIEW-TABLE-END -->