### PR TITLE
Add .NET 9 breaking change about NuGetAuditMode changed default

### DIFF
--- a/docs/core/compatibility/9.0.md
+++ b/docs/core/compatibility/9.0.md
@@ -95,7 +95,7 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 
 | Title                                                                         | Type of change    | Introduced version |
 |-------------------------------------------------------------------------------|-------------------|--------------------|
-| ['dotnet restore' audits transitive packages](sdk/9.0/nugetaudit-transitive-packages.md) | Behavioral change | Preview 6 |
+| [`dotnet restore` audits transitive packages](sdk/9.0/nugetaudit-transitive-packages.md) | Behavioral change | Preview 6 |
 | [`dotnet watch` incompatible with Hot Reload for old frameworks](sdk/9.0/dotnet-watch.md) | Behavioral change | RC 1   |
 | [`dotnet workload` commands output change](sdk/9.0/dotnet-workload-output.md) | Behavioral change | Preview 1          |
 | [`installer` repo version no longer documented](sdk/9.0/productcommits-versions.md) | Behavioral change | Preview 5    |

--- a/docs/core/compatibility/9.0.md
+++ b/docs/core/compatibility/9.0.md
@@ -95,11 +95,12 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 
 | Title                                                                         | Type of change    | Introduced version |
 |-------------------------------------------------------------------------------|-------------------|--------------------|
-| [`dotnet watch` incompatible with Hot Reload for old frameworks](sdk/9.0/dotnet-watch.md) | Behavioral change | RC 1          |
+| ['dotnet restore' audits transitive packages](sdk/9.0/nugetaudit-transitive-packages.md) | Behavioral change | Preview 6 |
+| [`dotnet watch` incompatible with Hot Reload for old frameworks](sdk/9.0/dotnet-watch.md) | Behavioral change | RC 1   |
 | [`dotnet workload` commands output change](sdk/9.0/dotnet-workload-output.md) | Behavioral change | Preview 1          |
 | [`installer` repo version no longer documented](sdk/9.0/productcommits-versions.md) | Behavioral change | Preview 5    |
 | [Terminal logger is default](sdk/9.0/terminal-logger.md)                      | Behavioral change | Preview 1          |
-| [Version requirements for .NET 9 SDK](sdk/9.0/version-requirements.md)        | Source incompatible | GA              |
+| [Version requirements for .NET 9 SDK](sdk/9.0/version-requirements.md)        | Source incompatible | GA               |
 | [Warning emitted for .NET Standard 1.x target](sdk/9.0/netstandard-warning.md) | Source incompatible | Preview 6       |
 | [Warning emitted for .NET 7 target](sdk/9.0/net70-warning.md)                 | Source incompatible | GA               |
 

--- a/docs/core/compatibility/sdk/9.0/nugetaudit-transitive-packages.md
+++ b/docs/core/compatibility/sdk/9.0/nugetaudit-transitive-packages.md
@@ -1,21 +1,20 @@
 ---
-title: "Breaking change: 'dotnet restore' produces security vulnerability warnings for transitive packages"
-description: Learn about a breaking change in the .NET 9 SDK where 'dotnet restore' produces security vulnerability warnings for transitive packages by default.
+title: "Breaking change: 'dotnet restore' audits transitive packages"
+description: Learn about a breaking change in the .NET 9 SDK where 'dotnet restore' also produces security vulnerability warnings for transitive packages by default.
+ms.date: 11/14/2024
 ---
-# 'dotnet restore' produces security vulnerability warnings for transitive packages
+# 'dotnet restore' audits transitive packages
 
 The [`dotnet restore` command](../../../tools/dotnet-restore.md), which restores the dependencies and tools of a project, now produces security vulnerability warnings for transitive packages by default.
 
 ## Previous behavior
 
-In [.NET 8, we introduced NuGetAudit](../8.0/dotnet-restore-audit.md), which emits warnings for packages with known security vulnerabilities.
-It was possible to change the `NuGetAuditMode` property to include all packages, but the default was to report only direct package references.
+In .NET 8, [NuGetAudit](../8.0/dotnet-restore-audit.md) was introduced to emit warnings for packages with known security vulnerabilities. By default, only direct package references were audited, however, it was possible to change the `NuGetAuditMode` property to include all packages.
 
 ## New behavior
 
-`NuGetAuditMode` now defaults to `all`, if it has not been explicitly set.
-This means that transitive packages (dependencies of packages your project directly references) with known vulnerabilities will now cause warnings to be reported.
-If your project treats errors as warnings, this can cause restore failures.
+Starting in .NET 9, `NuGetAuditMode` defaults to `all` if it hasn't been explicitly set. This setting means that *transitive packages* (dependencies of packages your project directly references) with known vulnerabilities now cause warnings to be reported.
+If your project treats errors as warnings, this behavior can cause restore failures.
 
 ## Version introduced
 
@@ -28,17 +27,29 @@ This change is a [behavioral change](../../categories.md#behavioral-change).
 ## Reason for change
 
 Packages with known vulnerabilities might cause your app to be exploitable, even if your project does not directly reference or use the vulnerable package.
-New features in .NET 9 also make it easier to investigate the package graph, and suppress advisories that are not relevant to how your app uses the vulnerable package.
+New features in .NET 9 also make it easier to investigate the package graph and to suppress advisories that aren't relevant to how your app uses the vulnerable package.
 
 ## Recommended action
 
-- To explicitly reduce the probability of this breaking your build due to warnings, you can consider your usage of `<TreatWarningsAsErrors>` and use `<WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>` to ensure known security vulnerabilities are still allowed in your environment.
+- To explicitly reduce the probability of this change breaking your build due to warnings, you can consider your usage of `<TreatWarningsAsErrors>` and use `<WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>` to ensure known security vulnerabilities are still allowed in your environment.
 
-- Use tools, such as `dotnet nuget why`, to find the top-level package that caused the transitive package with the known vulnerability to be included, and try to upgrade it to see if the transitive vulnerability goes away. If not, promote the transitive package to a top-level package by adding a `PackageReference` for it, and upgrade it to a newer version.
+- Use tools such as `dotnet nuget why` to find the top-level package that caused the transitive package with the known vulnerability to be included, and try to upgrade it to see if the transitive vulnerability goes away. If not, promote the transitive package to a top-level package by adding a `PackageReference` for it, and upgrade it to a newer version.
 
-- If you want to suppress a specific advisory, you can add `<NuGetAuditSuppress Include="url" />` within an `<ItemGroup>`, where `url` is the URL reported in NuGet's warning message.
+- If you want to suppress a specific advisory, you can add `<NuGetAuditSuppress Include="url" />` item to your project file, where `url` is the URL reported in NuGet's warning message.
 
-- If you want to only be warned of direct package references with known vulnerabilities, you can set `<NuGetAuditMode>` to `direct`.
+  ```xml
+  <ItemGroup>
+      <NuGetAuditSuppress Include="url" />
+  </ItemGroup>
+  ```
+
+- If you want to only be warned of direct package references with known vulnerabilities, you can set `<NuGetAuditMode>` to `direct` in your project file.
+
+  ```xml
+  <PropertyGroup>
+    <NuGetAuditMode>direct</NuGetAuditMode>
+  </PropertyGroup>
+  ```
 
 ## See also
 

--- a/docs/core/compatibility/sdk/9.0/nugetaudit-transitive-packages.md
+++ b/docs/core/compatibility/sdk/9.0/nugetaudit-transitive-packages.md
@@ -1,0 +1,47 @@
+---
+title: "Breaking change: 'dotnet restore' produces security vulnerability warnings for transitive packages"
+description: Learn about a breaking change in the .NET 9 SDK where 'dotnet restore' produces security vulnerability warnings for transitive packages by default.
+---
+# 'dotnet restore' produces security vulnerability warnings for transitive packages
+
+The [`dotnet restore` command](../../../tools/dotnet-restore.md), which restores the dependencies and tools of a project, now produces security vulnerability warnings for transitive packages by default.
+
+## Previous behavior
+
+In [.NET 8, we introduced NuGetAudit](../8.0/dotnet-restore-audit.md), which emits warnings for packages with known security vulnerabilities.
+It was possible to change the `NuGetAuditMode` property to include all packages, but the default was to report only direct package references.
+
+## New behavior
+
+`NuGetAuditMode` now defaults to `all`, if it has not been explicitly set.
+This means that transitive packages (dependencies of packages your project directly references) with known vulnerabilities will now cause warnings to be reported.
+If your project treats errors as warnings, this can cause restore failures.
+
+## Version introduced
+
+.NET 9 Preview 6
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+Packages with known vulnerabilities might cause your app to be exploitable, even if your project does not directly reference or use the vulnerable package.
+New features in .NET 9 also make it easier to investigate the package graph, and suppress advisories that are not relevant to how your app uses the vulnerable package.
+
+## Recommended action
+
+- To explicitly reduce the probability of this breaking your build due to warnings, you can consider your usage of `<TreatWarningsAsErrors>` and use `<WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>` to ensure known security vulnerabilities are still allowed in your environment.
+
+- Use tools, such as `dotnet nuget why`, to find the top-level package that caused the transitive package with the known vulnerability to be included, and try to upgrade it to see if the transitive vulnerability goes away. If not, promote the transitive package to a top-level package by adding a `PackageReference` for it, and upgrade it to a newer version.
+
+- If you want to suppress a specific advisory, you can add `<NuGetAuditSuppress Include="url" />` within an `<ItemGroup>`, where `url` is the URL reported in NuGet's warning message.
+
+- If you want to only be warned of direct package references with known vulnerabilities, you can set `<NuGetAuditMode>` to `direct`.
+
+## See also
+
+- [Audit for security vulnerabilities (`dotnet restore`)](../../../tools/dotnet-restore.md#audit-for-security-vulnerabilities)
+- [Auditing package dependencies for security vulnerabilities](/nuget/concepts/auditing-packages)
+- [NuGetAudit 2.0: Elevating Security and Trust in Package Management](https://devblogs.microsoft.com/nuget/nugetaudit-2-0-elevating-security-and-trust-in-package-management/)

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -94,13 +94,13 @@ items:
                 href: networking/9.0/query-redaction-logs.md
           - name: SDK and MSBuild
             items:
-              - name: 'dotnet restore' audits transitive packages
+              - name: "`dotnet restore` audits transitive packages"
                 href: sdk/9.0/nugetaudit-transitive-packages.md
               - name: "`dotnet watch` incompatible with Hot Reload for old frameworks"
                 href: sdk/9.0/dotnet-watch.md
-              - name: "'dotnet workload' commands output change"
+              - name: "`dotnet workload` commands output change"
                 href: sdk/9.0/dotnet-workload-output.md
-              - name: "'installer' repo version no longer documented"
+              - name: "`installer` repo version no longer documented"
                 href: sdk/9.0/productcommits-versions.md
               - name: Terminal logger is default
                 href: sdk/9.0/terminal-logger.md
@@ -1778,13 +1778,13 @@ items:
         items:
           - name: .NET 9
             items:
-              - name: 'dotnet restore' audits transitive packages
+              - name: "`dotnet restore` audits transitive packages"
                 href: sdk/9.0/nugetaudit-transitive-packages.md
               - name: "`dotnet watch` incompatible with Hot Reload for old frameworks"
                 href: sdk/9.0/dotnet-watch.md
-              - name: "'dotnet workload' commands output change"
+              - name: "`dotnet workload` commands output change"
                 href: sdk/9.0/dotnet-workload-output.md
-              - name: "'installer' repo version no longer documented"
+              - name: "`installer` repo version no longer documented"
                 href: sdk/9.0/productcommits-versions.md
               - name: Terminal logger is default
                 href: sdk/9.0/terminal-logger.md

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -94,6 +94,8 @@ items:
                 href: networking/9.0/query-redaction-logs.md
           - name: SDK and MSBuild
             items:
+              - name: 'dotnet restore' audits transitive packages
+                href: sdk/9.0/nugetaudit-transitive-packages.md
               - name: "`dotnet watch` incompatible with Hot Reload for old frameworks"
                 href: sdk/9.0/dotnet-watch.md
               - name: "'dotnet workload' commands output change"
@@ -1776,6 +1778,8 @@ items:
         items:
           - name: .NET 9
             items:
+              - name: 'dotnet restore' audits transitive packages
+                href: sdk/9.0/nugetaudit-transitive-packages.md
               - name: "`dotnet watch` incompatible with Hot Reload for old frameworks"
                 href: sdk/9.0/dotnet-watch.md
               - name: "'dotnet workload' commands output change"


### PR DESCRIPTION
## Summary

As the article describes, NuGet changed a default so will now emit warnings when .NET 8 would not. This means that projects that treat all warnings as errors might fail unexpectedly.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/9.0.md](https://github.com/dotnet/docs/blob/e40f32f9dbcb65233b92ead43d8098f8a15877ec/docs/core/compatibility/9.0.md) | [Breaking changes in .NET 9](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/9.0?branch=pr-en-us-43569) |
| [docs/core/compatibility/sdk/9.0/nugetaudit-transitive-packages.md](https://github.com/dotnet/docs/blob/e40f32f9dbcb65233b92ead43d8098f8a15877ec/docs/core/compatibility/sdk/9.0/nugetaudit-transitive-packages.md) | ['dotnet restore' audits transitive packages](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/9.0/nugetaudit-transitive-packages?branch=pr-en-us-43569) |
| [docs/core/compatibility/toc.yml](https://github.com/dotnet/docs/blob/e40f32f9dbcb65233b92ead43d8098f8a15877ec/docs/core/compatibility/toc.yml) | [docs/core/compatibility/toc](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/toc?branch=pr-en-us-43569) |


<!-- PREVIEW-TABLE-END -->