### PR TITLE
Update toc.yml for consistency

### DIFF
--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -147,27 +147,30 @@ items:
 - name: What's new in C#
   items:
   - name: C# 13
-    displayName: what's New
-    href: whats-new/csharp-13.md
-  - name: Breaking changes since C# 12
-    href: ../../_roslyn/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%209.md
+    items:
+    - name: What's new in C# 13
+      href: whats-new/csharp-13.md
+    - name: Breaking changes since C# 12
+      href: ../../_roslyn/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%209.md
   - name: C# 12
-    displayName: what's New
-    href: whats-new/csharp-12.md
-  - name: Breaking changes since C# 11
-    href: ../../_roslyn/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%208.md
+    items:
+    - name: What's new in C# 12
+      href: whats-new/csharp-12.md
+    - name: Breaking changes since C# 11
+      href: ../../_roslyn/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%208.md
   - name: C# 11
     items:
-    - name: New features
-      displayName: what's new
+    - name: What's new C# 11
       href: whats-new/csharp-11.md
     - name: Breaking changes since C# 10
       href: ../../_roslyn/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%207.md
   - name: C# 10
-    href: whats-new/csharp-10.md
-  - name: Breaking changes in earlier versions
-    href: whats-new/breaking-changes.md
-  - name: C# Version History
+    items:
+    - name: New features in C# 10
+      href: whats-new/csharp-10.md
+    - name: Breaking changes since earlier versions
+      href: whats-new/breaking-changes.md
+  - name: C# version history
     href: whats-new/csharp-version-history.md
   - name: Relationships to .NET library
     href: whats-new/relationships-between-language-and-library.md


### PR DESCRIPTION
## Summary

This PR fixes the inconsistencies in the "What's new in C#" branch of the TOC layout. Specifically:

- The C# 11 section uses superior organization. Let's apply that to C# 10, 12, and 13.
- One of the nodes is not capitalized in [accordance to Microsoft's style guide](https://learn.microsoft.com/en-us/style-guide/capitalization#sentence-style-capitalization-in-titles-and-headings). Let's fix that.

![TOC](https://github.com/user-attachments/assets/11876e4b-91c2-4483-85dc-945b07a9f5b6)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/toc.yml](https://github.com/dotnet/docs/blob/d9e7a5227c8aa4a0366ac86235c2f5f6135c1f25/docs/csharp/toc.yml) | [Taken from https://github.com/dotnet/roslyn/wiki/Samples-and-Walkthroughs](https://review.learn.microsoft.com/en-us/dotnet/csharp/toc?branch=pr-en-us-43586) |

<!-- PREVIEW-TABLE-END -->