### PR TITLE
Add clarity to UseCredential call

### DIFF
--- a/docs/azure/sdk/authentication/credential-chains.md
+++ b/docs/azure/sdk/authentication/credential-chains.md
@@ -2,7 +2,7 @@
 title: 'Credential chains in the Azure Identity library for .NET'
 description: 'This article describes the DefaultAzureCredential and ChainedTokenCredential classes in the Azure Identity library.'
 ms.topic: conceptual
-ms.date: 11/12/2024
+ms.date: 11/15/2024
 ---
 
 # Credential chains in the Azure Identity library for .NET
@@ -63,7 +63,10 @@ The order in which `DefaultAzureCredential` attempts credentials follows.
 
 In its simplest form, you can use the parameterless version of `DefaultAzureCredential` as follows:
 
-:::code language="csharp" source="../snippets/authentication/credential-chains/Program.cs" id="snippet_Dac":::
+:::code language="csharp" source="../snippets/authentication/credential-chains/Program.cs" id="snippet_Dac" highlight="1":::
+
+> [!TIP]
+> The `UseCredential` method in the preceding code snippet is recommended for use in ASP.NET Core apps. For more information, see [Use the Azure SDK for .NET in ASP.NET Core apps](../aspnetcore-guidance.md#authenticate-using-microsoft-entra-id).
 
 ### How to customize DefaultAzureCredential
 

--- a/docs/azure/sdk/snippets/authentication/Directory.Packages.props
+++ b/docs/azure/sdk/snippets/authentication/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Azure SDK packages -->
-    <PackageVersion Include="Azure.Identity" Version="1.12.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.13.1" />
     <PackageVersion Include="Azure.Identity.Broker" Version="1.1.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.21.2" />
     <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.7.5" />

--- a/docs/azure/sdk/snippets/authentication/additional-auth/interactive/InteractiveBrokeredAuth.csproj
+++ b/docs/azure/sdk/snippets/authentication/additional-auth/interactive/InteractiveBrokeredAuth.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/docs/azure/sdk/snippets/authentication/credential-chains/Program.cs
+++ b/docs/azure/sdk/snippets/authentication/credential-chains/Program.cs
@@ -22,7 +22,8 @@ builder.Services.AddAzureClients(clientBuilder =>
     clientBuilder.AddBlobServiceClient(
         new Uri("https://<account-name>.blob.core.windows.net"));
     #region snippet_Dac
-    clientBuilder.UseCredential(new DefaultAzureCredential());
+    DefaultAzureCredential credential = new();
+    clientBuilder.UseCredential(credential);
     #endregion snippet_Dac
 
     #region snippet_DacExcludes


### PR DESCRIPTION
**Summary of changes**
- React to customer verbatim expressing confusion about `UseCredential`. Delegate the explaining to the new ASP.NET Core best practices doc.
- Update Azure.Identity package to latest stable version.
- Update project to .NET 9.0.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/azure/sdk/authentication/credential-chains.md](https://github.com/dotnet/docs/blob/177b90a1de5a8762d8c13b058157503c8279b789/docs/azure/sdk/authentication/credential-chains.md) | [docs/azure/sdk/authentication/credential-chains](https://review.learn.microsoft.com/en-us/dotnet/azure/sdk/authentication/credential-chains?branch=pr-en-us-43591) |

<!-- PREVIEW-TABLE-END -->