### PR TITLE
Fix text to match sample

### DIFF
--- a/docs/csharp/language-reference/keywords/value.md
+++ b/docs/csharp/language-reference/keywords/value.md
@@ -9,7 +9,7 @@ helpviewer_keywords:
 ---
 # The `value` implicit parameter
 
-The implicit parameter `value` is used in the `set` accessor in [property](../../programming-guide/classes-and-structs/properties.md) and [indexer](../../programming-guide/indexers/index.md) declarations. It's an input parameter of a method. The word `value` references the value that client code is attempting to assign to the property or indexer. In the following example, `MyDerivedClass` has a property called `Name` that uses the `value` parameter to assign a new string to the backing field `name`. From the point of view of client code, the operation is written as a simple assignment.
+The implicit parameter `value` is used in the `set` accessor in [property](../../programming-guide/classes-and-structs/properties.md) and [indexer](../../programming-guide/indexers/index.md) declarations. It's an input parameter of a method. The word `value` references the value that client code is attempting to assign to the property or indexer. In the following example, `TimePeriod2` has a property called `Name` that uses the `value` parameter to assign a new string to the backing field `name`. From the point of view of client code, the operation is written as a simple assignment.
 
 :::code language="csharp" source="./snippets/PropertyAccessors.cs" id="GetSetExpressions":::
 


### PR DESCRIPTION
Reported by anonymous feedback.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/value.md](https://github.com/dotnet/docs/blob/bd9e5a9e63dc6dabaf2356c7452ccdff51968b7c/docs/csharp/language-reference/keywords/value.md) | [The `value` implicit parameter](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/value?branch=pr-en-us-43592) |

<!-- PREVIEW-TABLE-END -->