### PR TITLE
Fix wrong .NET version mentioned in 'Enabled rules' list description.

### DIFF
--- a/docs/fundamentals/code-analysis/overview.md
+++ b/docs/fundamentals/code-analysis/overview.md
@@ -31,7 +31,7 @@ If rule violations are found by an analyzer, they're reported as a suggestion, w
 
 # [.NET 9](#tab/net-9)
 
-The following rules are enabled, by default, as errors or warnings in .NET 8. Additional rules are enabled as suggestions.
+The following rules are enabled, by default, as errors or warnings in .NET 9. Additional rules are enabled as suggestions.
 
 | Diagnostic ID | Category | Severity | Version added | Description |
 | - | - | - | - | - |


### PR DESCRIPTION
## Summary

Fixes a typo in the 'Enabled rules' list description for .NET 9 (Mentions .NET 8 instead of 9.)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/overview.md](https://github.com/dotnet/docs/blob/d12e2e55fe26cdb06044c2d3404a2db7b15a1fd9/docs/fundamentals/code-analysis/overview.md) | [Overview of .NET source code analysis](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/overview?branch=pr-en-us-43597) |

<!-- PREVIEW-TABLE-END -->