### PR TITLE
Fix markdown lint warnings

### DIFF
--- a/docs/core/compatibility/windows-forms/5.0/invalid-args-cause-argumentoutofrangeexception.md
+++ b/docs/core/compatibility/windows-forms/5.0/invalid-args-cause-argumentoutofrangeexception.md
@@ -27,6 +27,7 @@ Throwing an <xref:System.ArgumentOutOfRangeException> conforms to the behavior o
 The following table lists the affected properties and parameters:
 
 > [!div class="mx-tdBreakAll"]
+>
 > | Property | Parameter name | Version added |
 > |-|-|-|
 > | <xref:System.Windows.Forms.ListBox.IntegerCollection.Item(System.Int32)?displayProperty=nameWithType> | `index` | 5.0 Preview 5 |

--- a/docs/core/compatibility/windows-forms/5.0/null-args-cause-argumentnullexception.md
+++ b/docs/core/compatibility/windows-forms/5.0/null-args-cause-argumentnullexception.md
@@ -26,6 +26,7 @@ If you call any of these methods and your code currently catches a <xref:System.
 The following table lists the affected methods and parameters:
 
 > [!div class="mx-tdBreakAll"]
+>
 > | Method | Parameter name | Version added |
 > |-|-|-|
 > | <xref:System.Windows.Forms.Control.ControlCollection.%23ctor(System.Windows.Forms.Control)> | `owner` | Preview 1 |

--- a/docs/core/compatibility/windows-forms/5.0/null-owner-causes-invalidoperationexception.md
+++ b/docs/core/compatibility/windows-forms/5.0/null-owner-causes-invalidoperationexception.md
@@ -28,6 +28,7 @@ Review your code and, if necessary, update it to prevent constructing the affect
 The following table lists the affected APIs:
 
 > [!div class="mx-tdBreakAll"]
+>
 > | Affected method or property | Validated property | Version added |
 > |-|-|-|
 > | <xref:System.Windows.Forms.DataGridViewButtonCell.DataGridViewButtonCellAccessibleObject.DoDefaultAction?displayProperty=nameWithType> | <xref:System.Windows.Forms.DataGridViewCell.DataGridViewCellAccessibleObject.Owner> | 5.0 |

--- a/docs/framework/whats-new/obsolete-members.md
+++ b/docs/framework/whats-new/obsolete-members.md
@@ -16,6 +16,7 @@ This article doesn't list the members of obsolete types. For a list of obsolete 
 ## mscorlib.dll
 
 > [!div class="mx-tdBreakAll"]
+>
 > |Type|Member|Message|
 > |----------|------------|-------------|
 > |<xref:Microsoft.Win32.Registry?displayProperty=nameWithType>|<xref:Microsoft.Win32.Registry.DynData>|The <xref:Microsoft.Win32.Registry.DynData> registry key only works on Win9x, which is no longer supported by the CLR. On NT-based operating systems, use the  <xref:Microsoft.Win32.Registry.PerformanceData?displayProperty=nameWithType> registry key or the <xref:Microsoft.VisualBasic.MyServices.RegistryProxy.PerformanceData%2A?displayProperty=nameWithType> registry proxy instead.|
@@ -182,6 +183,7 @@ This article doesn't list the members of obsolete types. For a list of obsolete 
 ## PresentationCore.dll
 
 > [!div class="mx-tdBreakAll"]
+>
 > |Type|Member|Message|
 > |----------|------------|-------------|
 > |<xref:System.Windows.UIElement?displayProperty=nameWithType>|<xref:System.Windows.UIElement.BitmapEffect%2A>|Bitmap effects are deprecated and no longer function. Consider using <xref:System.Windows.Media.Effects.Effect?displayProperty=nameWithType> where appropriate instead.|
@@ -222,6 +224,7 @@ This article doesn't list the members of obsolete types. For a list of obsolete 
 ## PresentationFramework.dll
 
 > [!div class="mx-tdBreakAll"]
+>
 > |Type|Member|Message|
 > |----------|------------|-------------|
 > |<xref:System.Windows.Data.BindingListCollectionView?displayProperty=nameWithType>|<xref:System.Windows.Data.CollectionView.OnBeginChangeLogging%2A>|Replaced by <xref:System.Windows.Data.CollectionView.OnAllowsCrossThreadChangesChanged%2A?displayProperty=nameWithType>.|
@@ -232,6 +235,7 @@ This article doesn't list the members of obsolete types. For a list of obsolete 
 ## System.Activities.dll
 
 > [!div class="mx-tdBreakAll"]
+>
 > |Type|Member|Message|
 > |----------|------------|-------------|
 > |<xref:System.Activities.Debugger.XamlDebuggerXmlReader?displayProperty=nameWithType>|<xref:System.Activities.Debugger.XamlDebuggerXmlReader.%23ctor%28System.Xaml.XamlReader%2CSystem.Xaml.IXamlLineInfo%2CSystem.IO.TextReader%29>|First deprecated in the .NET Framework 4.5.<br /><br /> Don't use this constructor. Use <xref:System.Activities.Debugger.XamlDebuggerXmlReader.%23ctor%28System.IO.TextReader%29> or <xref:System.Activities.Debugger.XamlDebuggerXmlReader.%23ctor%28System.IO.TextReader%2CSystem.Xaml.XamlSchemaContext%29> instead.|
@@ -240,6 +244,7 @@ This article doesn't list the members of obsolete types. For a list of obsolete 
 ## System.Activities.Presentation.dll
 
 > [!div class="mx-tdBreakAll"]
+>
 > |Type|Member|Message|
 > |----------|------------|-------------|
 > |<xref:System.Activities.Presentation.DragDropHelper?displayProperty=nameWithType>|<xref:System.Activities.Presentation.DragDropHelper.DoDragMove%28System.Activities.Presentation.WorkflowViewElement%2CSystem.Windows.Point%29>|This method doesn't support dragging multiple items.|
@@ -255,6 +260,7 @@ This article doesn't list the members of obsolete types. For a list of obsolete 
 ## System.Core.dll
 
 > [!div class="mx-tdBreakAll"]
+>
 > |Type|Member|Message|
 > |----------|------------|-------------|
 > |<xref:System.Diagnostics.Eventing.Reader.StandardEventKeywords?displayProperty=nameWithType>|<xref:System.Diagnostics.Eventing.Reader.StandardEventKeywords.CorrelationHint>|First deprecated in the .NET Framework 4.5.<br /><br /> Incorrect value; use <xref:System.Diagnostics.Eventing.Reader.StandardEventKeywords.CorrelationHint2> instead.|
@@ -298,6 +304,7 @@ This article doesn't list the members of obsolete types. For a list of obsolete 
 ## System.Data.dll
 
 > [!div class="mx-tdBreakAll"]
+>
 > |Type|Member|Message|
 > |----------|------------|-------------|
 > |<xref:System.Data.DataSysDescriptionAttribute?displayProperty=nameWithType>|<xref:System.Data.DataSysDescriptionAttribute.%23ctor%2A>|<xref:System.Data.DataSysDescriptionAttribute> has been deprecated.|
@@ -320,6 +327,7 @@ This article doesn't list the members of obsolete types. For a list of obsolete 
 ## System.Data.Entity.dll
 
 > [!div class="mx-tdBreakAll"]
+>
 > |Type|Member|Message|
 > |----------|------------|-------------|
 > |<xref:System.Data.Metadata.Edm.AssociationSetEnd?displayProperty=nameWithType>|<xref:System.Data.Metadata.Edm.AssociationSetEnd.Role%2A>|This property is going away, Use the <xref:System.Data.Metadata.Edm.AssociationSetEnd.Name%2A?displayProperty=nameWithType> property instead.|
@@ -330,6 +338,7 @@ This article doesn't list the members of obsolete types. For a list of obsolete 
 ## System.Data.OracleClient.dll
 
 > [!div class="mx-tdBreakAll"]
+>
 > |Type|Member|Message|
 > |----------|------------|-------------|
 > |<xref:System.Data.OracleClient.OracleParameter?displayProperty=nameWithType>|<xref:System.Data.OracleClient.OracleParameter.Precision%2A>|<xref:System.Data.OracleClient.OracleParameter.Precision%2A> has been deprecated. Use the <xref:System.Math?displayProperty=nameWithType> classes to explicitly set the precision of a decimal.|
@@ -339,6 +348,7 @@ This article doesn't list the members of obsolete types. For a list of obsolete 
 ## System.Design.dll
 
 > [!div class="mx-tdBreakAll"]
+>
 > |Type|Member|Message|
 > |----------|------------|-------------|
 > |<xref:System.ComponentModel.Design.ComponentDesigner?displayProperty=nameWithType>|<xref:System.ComponentModel.Design.ComponentDesigner.InitializeNonDefault%2A>|This method has been deprecated. Use <xref:System.ComponentModel.Design.ComponentDesigner.InitializeExistingComponent%2A?displayProperty=nameWithType> instead.|
@@ -392,6 +402,7 @@ This article doesn't list the members of obsolete types. For a list of obsolete 
 ## System.dll
 
 > [!div class="mx-tdBreakAll"]
+>
 > |Type|Member|Message|
 > |----------|------------|-------------|
 > |<xref:Microsoft.CSharp.CSharpCodeProvider?displayProperty=nameWithType>|<xref:Microsoft.CSharp.CSharpCodeProvider.CreateCompiler%2A>|Callers should not use the <xref:System.CodeDom.Compiler.ICodeCompiler?displayProperty=nameWithType> interface and should instead use the methods directly on the <xref:System.CodeDom.Compiler.CodeDomProvider?displayProperty=nameWithType> class.|
@@ -504,6 +515,7 @@ This article doesn't list the members of obsolete types. For a list of obsolete 
 ## System.Drawing.dll
 
 > [!div class="mx-tdBreakAll"]
+>
 > |Type|Member|Message|
 > |----------|------------|-------------|
 > |<xref:System.Drawing.FontFamily?displayProperty=nameWithType>|<xref:System.Drawing.FontFamily.GetFamilies%2A>|Don't use the <xref:System.Drawing.FontFamily.GetFamilies%2A> method; use the <xref:System.Drawing.FontFamily.Families%2A?displayProperty=nameWithType> property instead.|
@@ -512,6 +524,7 @@ This article doesn't list the members of obsolete types. For a list of obsolete 
 ## System.Messaging.dll
 
 > [!div class="mx-tdBreakAll"]
+>
 > |Type|Member|Message|
 > |----------|------------|-------------|
 > |<xref:System.Messaging.MessageQueue?displayProperty=nameWithType>|<xref:System.Messaging.MessageQueue.GetEnumerator%2A>|This method returns a <xref:System.Messaging.MessageEnumerator?displayProperty=nameWithType> that implements the <xref:System.Messaging.MessageEnumerator.RemoveCurrent%2A?displayProperty=nameWithType> family of methods incorrectly. Use <xref:System.Messaging.MessageQueue.GetMessageEnumerator2%2A?displayProperty=nameWithType> instead.|
@@ -520,6 +533,7 @@ This article doesn't list the members of obsolete types. For a list of obsolete 
 ## System.ServiceModel.dll
 
 > [!div class="mx-tdBreakAll"]
+>
 > |Type|Member|Message|
 > |----------|------------|-------------|
 > |<xref:System.ServiceModel.BasicHttpBinding?displayProperty=nameWithType>|<xref:System.ServiceModel.BasicHttpBinding.EnableHttpCookieContainer%2A>|First deprecated in the .NET Framework 4.5.<br /><br /> This property is obsolete. To enable Http <xref:System.Net.CookieContainer>, use the <xref:System.ServiceModel.HttpBindingBase.AllowCookies%2A?displayProperty=nameWithType> property instead.|
@@ -532,6 +546,7 @@ This article doesn't list the members of obsolete types. For a list of obsolete 
 ## System.ServiceModel.Discovery.dll
 
 > [!div class="mx-tdBreakAll"]
+>
 > |Type|Member|Message|
 > |----------|------------|-------------|
 > |<xref:System.ServiceModel.Discovery.UdpAnnouncementEndpoint?displayProperty=nameWithType>|<xref:System.ServiceModel.Discovery.UdpAnnouncementEndpoint.TransportSettings%2A>|First deprecated in the .NET Framework 4.5.<br /><br /> The <xref:System.ServiceModel.Discovery.UdpAnnouncementEndpoint.TransportSettings%2A> property is obsolete. Consider using  <xref:System.ServiceModel.Channels.UdpTransportBindingElement?displayProperty=nameWithType> for setting the transport properties.|
@@ -540,6 +555,7 @@ This article doesn't list the members of obsolete types. For a list of obsolete 
 ## System.Web.DataVisualization.dll
 
 > [!div class="mx-tdBreakAll"]
+>
 > |Type|Member|Message|
 > |----------|------------|-------------|
 > |<xref:System.Web.UI.DataVisualization.Charting.Chart?displayProperty=nameWithType>|<xref:System.Web.UI.DataVisualization.Charting.Chart.ViewStateData%2A>|<xref:System.Web.UI.DataVisualization.Charting.Chart.ViewStateData%2A> has been deprecated. Investigate <xref:System.Web.UI.Control.ViewState%2A?displayProperty=nameWithType> instead.|
@@ -547,6 +563,7 @@ This article doesn't list the members of obsolete types. For a list of obsolete 
 ## System.Web.dll
 
 > [!div class="mx-tdBreakAll"]
+>
 > |Type|Member|Message|
 > |----------|------------|-------------|
 > |<xref:System.Web.HttpContext?displayProperty=nameWithType>|<xref:System.Web.HttpContext.GetAppConfig%2A>|The recommended alternative is <xref:System.Web.Configuration.WebConfigurationManager.GetWebApplicationSection%2A?displayProperty=nameWithType> in System.Web.dll.|
@@ -582,6 +599,7 @@ This article doesn't list the members of obsolete types. For a list of obsolete 
 ## System.Web.DynamicData.dll
 
 > [!div class="mx-tdBreakAll"]
+>
 > |Type|Member|Message|
 > |----------|------------|-------------|
 > |<xref:System.Web.DynamicData.DynamicDataExtensions?displayProperty=nameWithType>|<xref:System.Web.DynamicData.DynamicDataExtensions.EnablePersistedSelection%2A>|Use the `EnablePersistedSelection` property on a databound control such as <xref:System.Web.UI.WebControls.GridView?displayProperty=nameWithType> or <xref:System.Web.UI.WebControls.ListView?displayProperty=nameWithType>.|
@@ -589,6 +607,7 @@ This article doesn't list the members of obsolete types. For a list of obsolete 
 ## System.Web.Extensions.dll
 
 > [!div class="mx-tdBreakAll"]
+>
 > |Type|Member|Message|
 > |----------|------------|-------------|
 > |<xref:System.Web.UI.CompositeScriptReference?displayProperty=nameWithType>|<xref:System.Web.UI.CompositeScriptReference.IsFromSystemWebExtensions%2A>|Use <xref:System.Web.UI.CompositeScriptReference.IsAjaxFrameworkScript%2A?displayProperty=nameWithType>.|
@@ -603,6 +622,7 @@ This article doesn't list the members of obsolete types. For a list of obsolete 
 ## System.Web.Services.dll
 
 > [!div class="mx-tdBreakAll"]
+>
 > |Type|Member|Message|
 > |----------|------------|-------------|
 > |<xref:System.Web.Services.Discovery.DiscoveryClientProtocol?displayProperty=nameWithType>|<xref:System.Web.Services.Discovery.DiscoveryClientProtocol.LoadExternals%2A>|This method will be removed from a future version. The method call is no longer required for resource discovery.|
@@ -611,6 +631,7 @@ This article doesn't list the members of obsolete types. For a list of obsolete 
 ## System.Windows.Forms.dll
 
 > [!div class="mx-tdBreakAll"]
+>
 > |Type|Member|Message|
 > |----------|------------|-------------|
 > |<xref:System.Windows.Forms.AccessibleStates?displayProperty=nameWithType>|<xref:System.Windows.Forms.AccessibleStates.Valid>|This enumeration value has been deprecated. There is no replacement.|
@@ -628,6 +649,7 @@ This article doesn't list the members of obsolete types. For a list of obsolete 
 ## System.Xaml.dll
 
 > [!div class="mx-tdBreakAll"]
+>
 > |Type|Member|Message|
 > |----------|------------|-------------|
 > |<xref:System.Windows.Markup.MarkupExtensionReturnTypeAttribute?displayProperty=nameWithType>|<xref:System.Windows.Markup.MarkupExtensionReturnTypeAttribute.ExpressionType%2A>|This isn't used by the XAML parser. See <xref:System.Windows.Markup.XamlSetMarkupExtensionAttribute?displayProperty=nameWithType>.|
@@ -636,6 +658,7 @@ This article doesn't list the members of obsolete types. For a list of obsolete 
 ## System.Xml.dll
 
 > [!div class="mx-tdBreakAll"]
+>
 > |Type|Member|Message|
 > |----------|------------|-------------|
 > |<xref:System.Xml.ValidationType?displayProperty=nameWithType>|<xref:System.Xml.ValidationType.Auto>|Validation type should be specified as <xref:System.Xml.ValidationType.DTD?displayProperty=nameWithType> or <xref:System.Xml.ValidationType.Schema?displayProperty=nameWithType>.|
@@ -662,6 +685,7 @@ The IEHost.dll and IEExec.exe assemblies have been removed from .NET Framework. 
 ## ISymWrapper.dll
 
 > [!div class="mx-tdBreakAll"]
+>
 > |Type|Member|Message|
 > |----------|------------|-------------|
 > |<xref:System.Diagnostics.SymbolStore.SymBinder?displayProperty=nameWithType>|<xref:System.Diagnostics.SymbolStore.SymBinder.GetReader%28System.Int32%2CSystem.String%2CSystem.String%29>|The recommended alternative is <xref:System.Diagnostics.SymbolStore.SymBinder.GetReader%28System.IntPtr%2CSystem.String%2CSystem.String%29?displayProperty=nameWithType>. <xref:System.Diagnostics.SymbolStore.ISymbolBinder1.GetReader%2A?displayProperty=nameWithType> takes the importer interface pointer as an <xref:System.IntPtr?displayProperty=nameWithType> instead of an <xref:System.Int32?displayProperty=nameWithType>, and thus works on both 32-bit and 64-bit architectures.|
@@ -669,6 +693,7 @@ The IEHost.dll and IEExec.exe assemblies have been removed from .NET Framework. 
 ## Microsoft.Build.Conversion.v4.0.dll
 
 > [!div class="mx-tdBreakAll"]
+>
 > |Type|Member|Message|
 > |----------|------------|-------------|
 > |<xref:Microsoft.Build.Conversion.ProjectFileConverter?displayProperty=nameWithType>|<xref:Microsoft.Build.Conversion.ProjectFileConverter.Convert%28Microsoft.Build.BuildEngine.ProjectLoadSettings%29>|Use parameterless <xref:Microsoft.Build.Conversion.ProjectFileConverter.Convert> overload instead.|
@@ -679,6 +704,7 @@ The IEHost.dll and IEExec.exe assemblies have been removed from .NET Framework. 
 ## Microsoft.Build.Engine.dll
 
 > [!div class="mx-tdBreakAll"]
+>
 > |Type|Member|Message|
 > |----------|------------|-------------|
 > |<xref:Microsoft.Build.BuildEngine.Engine?displayProperty=nameWithType>|<xref:Microsoft.Build.BuildEngine.Engine.BinPath%2A>|Avoid setting <xref:Microsoft.Build.BuildEngine.Engine.BinPath%2A>. If you were simply passing in the .NET Framework location as the <xref:Microsoft.Build.BuildEngine.Engine.BinPath%2A>, no other action is necessary. Otherwise, define Toolsets instead in the registry or config file, or by adding elements to the Engine's <xref:Microsoft.Build.BuildEngine.ToolsetCollection?displayProperty=nameWithType>, to use a custom <xref:Microsoft.Build.BuildEngine.Engine.BinPath%2A>.|
@@ -687,6 +713,7 @@ The IEHost.dll and IEExec.exe assemblies have been removed from .NET Framework. 
 ## Microsoft.Build.Framework.dll
 
 > [!div class="mx-tdBreakAll"]
+>
 > |Type|Member|Message|
 > |----------|------------|-------------|
 > |<xref:Microsoft.Build.Framework.XamlTypes.ContentType?displayProperty=nameWithType>|<xref:Microsoft.Build.Framework.XamlTypes.ContentType.ItemGroupName%2A>|First deprecated in the .NET Framework 4.5.<br /><br /> Use of this member generates a compiler error.<br /><br /> Use the <xref:Microsoft.Build.Framework.XamlTypes.ContentType.ItemType%2A?displayProperty=nameWithType> property instead.|
@@ -694,6 +721,7 @@ The IEHost.dll and IEExec.exe assemblies have been removed from .NET Framework. 
 ## Microsoft.Build.Utilities.v4.0.dll
 
 > [!div class="mx-tdBreakAll"]
+>
 > |Type|Member|Message|
 > |----------|------------|-------------|
 > |<xref:Microsoft.Build.Utilities.ToolTask?displayProperty=nameWithType>|<xref:Microsoft.Build.Utilities.ToolTask.EnvironmentOverride%2A>|Use the <xref:Microsoft.Build.Utilities.ToolTask.EnvironmentVariables%2A?displayProperty=nameWithType> property.|
@@ -701,6 +729,7 @@ The IEHost.dll and IEExec.exe assemblies have been removed from .NET Framework. 
 ## Microsoft.Data.Entity.Build.Tasks.dll
 
 > [!div class="mx-tdBreakAll"]
+>
 > |Type|Member|Message|
 > |----------|------------|-------------|
 > |`Microsoft.Data.Entity.Build.Tasks.EntityDeploy`|`EntityDataModelEmbeddedResources`|First deprecated in the .NET Framework 4.5.<br /><br /> Used only for version 3.5 backward compatibility.|
@@ -708,6 +737,7 @@ The IEHost.dll and IEExec.exe assemblies have been removed from .NET Framework. 
 ## Microsoft.VisualBasic.dll
 
 > [!div class="mx-tdBreakAll"]
+>
 > |Type|Member|Message|
 > |----------|------------|-------------|
 > |<xref:Microsoft.VisualBasic.FileSystem?displayProperty=nameWithType>|<xref:Microsoft.VisualBasic.FileSystem.FilePut%28System.Object%2CSystem.Object%2CSystem.Object%29>|This member has been deprecated. Use <xref:Microsoft.VisualBasic.FileSystem.FilePutObject%2A?displayProperty=nameWithType> to write <xref:System.Object> types, or coerce `FileNumber` and `RecordNumber` to <xref:System.Int32> for writing non-object types.|

--- a/docs/fundamentals/code-analysis/quality-rules/index.md
+++ b/docs/fundamentals/code-analysis/quality-rules/index.md
@@ -12,6 +12,7 @@ ms.date: 01/31/2024
 The following table lists code quality analysis rules.
 
 > [!div class="mx-tdCol2BreakAll"]
+>
 > | Rule ID and warning | Description |
 > | ------------------- | ----------- |
 > | [CA1000: Do not declare static members on generic types](ca1000.md) | When a static member of a generic type is called, the type argument must be specified for the type. When a generic instance member that does not support inference is called, the type argument must be specified for the member. In these two cases, the syntax for specifying the type argument is different and easily confused. |

--- a/docs/fundamentals/code-analysis/style-rules/index.md
+++ b/docs/fundamentals/code-analysis/style-rules/index.md
@@ -32,6 +32,7 @@ The code-style rules are organized into the following subcategories:
 The following table list all the code-style rules by ID and [options](../code-style-rule-options.md), if any.
 
 > [!div class="mx-tdCol3BreakAll"]
+>
 > | Rule ID | Title | Option |
 > | - | - | - |
 > | [IDE0001](ide0001.md) | Simplify name | |

--- a/docs/standard/base-types/regular-expressions.md
+++ b/docs/standard/base-types/regular-expressions.md
@@ -88,6 +88,7 @@ The <xref:System.String> class includes string search and replacement methods th
  The regular expression pattern `\b(\w+?)\s\1\b` can be interpreted as follows:  
   
 > [!div class="mx-tdCol2BreakAll"]
+>
 > |Pattern|Interpretation|  
 > |-|-|
 > |`\b`|Start at a word boundary.|  
@@ -110,6 +111,7 @@ The <xref:System.String> class includes string search and replacement methods th
  On a computer whose current culture is English - United States (en-US), the example dynamically builds the regular expression `\$\s*[-+]?([0-9]{0,3}(,[0-9]{3})*(\.[0-9]+)?)`. This regular expression pattern can be interpreted as follows:  
 
 > [!div class="mx-tdCol2BreakAll"]
+>
 > |Pattern|Interpretation|  
 > |-|-|  
 > |`\$`|Look for a single occurrence of the dollar symbol (`$`) in the input string. The regular expression pattern string includes a backslash to indicate that the dollar symbol is to be interpreted literally rather than as a regular expression anchor. The `$` symbol alone would indicate that the regular expression engine should try to begin its match at the end of a string. To ensure that the current culture's currency symbol isn't misinterpreted as a regular expression symbol, the example calls the <xref:System.Text.RegularExpressions.Regex.Escape%2A?displayProperty=nameWithType> method to escape the character.|  


### PR DESCRIPTION
These are new warnings that will be introduced in #43611

Pre-emptively fix them.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/windows-forms/5.0/invalid-args-cause-argumentoutofrangeexception.md](https://github.com/dotnet/docs/blob/c1bd9d45d5702db1cadb19c3f02e98daa79f2928/docs/core/compatibility/windows-forms/5.0/invalid-args-cause-argumentoutofrangeexception.md) | [WinForms properties now throw ArgumentOutOfRangeException](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/windows-forms/5.0/invalid-args-cause-argumentoutofrangeexception?branch=pr-en-us-43625) |
| [docs/core/compatibility/windows-forms/5.0/null-args-cause-argumentnullexception.md](https://github.com/dotnet/docs/blob/c1bd9d45d5702db1cadb19c3f02e98daa79f2928/docs/core/compatibility/windows-forms/5.0/null-args-cause-argumentnullexception.md) | ["Breaking change: WinForms methods now throw ArgumentNullException"](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/windows-forms/5.0/null-args-cause-argumentnullexception?branch=pr-en-us-43625) |
| [docs/core/compatibility/windows-forms/5.0/null-owner-causes-invalidoperationexception.md](https://github.com/dotnet/docs/blob/c1bd9d45d5702db1cadb19c3f02e98daa79f2928/docs/core/compatibility/windows-forms/5.0/null-owner-causes-invalidoperationexception.md) | [DataGridView-related APIs throw InvalidOperationException](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/windows-forms/5.0/null-owner-causes-invalidoperationexception?branch=pr-en-us-43625) |
| [docs/framework/whats-new/obsolete-members.md](https://github.com/dotnet/docs/blob/c1bd9d45d5702db1cadb19c3f02e98daa79f2928/docs/framework/whats-new/obsolete-members.md) | [docs/framework/whats-new/obsolete-members](https://review.learn.microsoft.com/en-us/dotnet/framework/whats-new/obsolete-members?branch=pr-en-us-43625) |
| [docs/fundamentals/code-analysis/quality-rules/index.md](https://github.com/dotnet/docs/blob/c1bd9d45d5702db1cadb19c3f02e98daa79f2928/docs/fundamentals/code-analysis/quality-rules/index.md) | [Code quality rules](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/index?branch=pr-en-us-43625) |
| [docs/fundamentals/code-analysis/style-rules/index.md](https://github.com/dotnet/docs/blob/c1bd9d45d5702db1cadb19c3f02e98daa79f2928/docs/fundamentals/code-analysis/style-rules/index.md) | [Code-style rules](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/index?branch=pr-en-us-43625) |
| [docs/standard/base-types/regular-expressions.md](https://github.com/dotnet/docs/blob/c1bd9d45d5702db1cadb19c3f02e98daa79f2928/docs/standard/base-types/regular-expressions.md) | [.NET regular expressions](https://review.learn.microsoft.com/en-us/dotnet/standard/base-types/regular-expressions?branch=pr-en-us-43625) |

<!-- PREVIEW-TABLE-END -->