### PR TITLE
Update fixing-warnings.md

### DIFF
--- a/docs/core/deploying/trimming/fixing-warnings.md
+++ b/docs/core/deploying/trimming/fixing-warnings.md
@@ -9,7 +9,7 @@ ms.date: 10/30/2023
 
 Conceptually, [trimming](trim-self-contained.md) is simple: when you publish an application, the .NET SDK analyzes the entire application and removes all unused code. However, it can be difficult to determine what is unused, or more precisely, what is used.
 
-To prevent changes in behavior when trimming applications, the .NET SDK provides static analysis of trim compatibility through **trim warnings**. The trimmer produces trim warnings when it finds code that might not be compatible with trimming. Code that's not trim-compatible can produce behavioral changes, or even crashes, in an application after it has been trimmed.  All applications that use trimming shouldn't produce any trim warnings. If there are any trim warnings, the app should be thoroughly tested after trimming to ensure that there are no behavior changes.
+To prevent changes in behavior when trimming applications, the .NET SDK provides static analysis of trim compatibility through **trim warnings**. The trimmer produces trim warnings when it finds code that might not be compatible with trimming. Code that's not trim-compatible can produce behavioral changes, or even crashes, in an application after it has been trimmed. An app that uses trimming shouldn't produce any trim warnings. If there are any trim warnings, the app should be thoroughly tested after trimming to ensure that there are no behavior changes.
 
 This article helps you understand why some patterns produce trim warnings, and how these warnings can be addressed.
 

--- a/docs/core/deploying/trimming/fixing-warnings.md
+++ b/docs/core/deploying/trimming/fixing-warnings.md
@@ -9,7 +9,7 @@ ms.date: 10/30/2023
 
 Conceptually, [trimming](trim-self-contained.md) is simple: when you publish an application, the .NET SDK analyzes the entire application and removes all unused code. However, it can be difficult to determine what is unused, or more precisely, what is used.
 
-To prevent changes in behavior when trimming applications, the .NET SDK provides static analysis of trim compatibility through **trim warnings**. The trimmer produces trim warnings when it finds code that might not be compatible with trimming. Code that's not trim-compatible can produce behavioral changes, or even crashes, in an application after it has been trimmed.  Ideally, all applications that use trimming shouldn't produce any trim warnings. If there are any trim warnings, the app should be thoroughly tested after trimming to ensure that there are no behavior changes.
+To prevent changes in behavior when trimming applications, the .NET SDK provides static analysis of trim compatibility through **trim warnings**. The trimmer produces trim warnings when it finds code that might not be compatible with trimming. Code that's not trim-compatible can produce behavioral changes, or even crashes, in an application after it has been trimmed.  All applications that use trimming shouldn't produce any trim warnings. If there are any trim warnings, the app should be thoroughly tested after trimming to ensure that there are no behavior changes.
 
 This article helps you understand why some patterns produce trim warnings, and how these warnings can be addressed.
 


### PR DESCRIPTION
Use more forceful language on removing trim warnings

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/deploying/trimming/fixing-warnings.md](https://github.com/dotnet/docs/blob/802041bda0911a6a62949176eaa8a606f9419a04/docs/core/deploying/trimming/fixing-warnings.md) | [Introduction to trim warnings](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/trimming/fixing-warnings?branch=pr-en-us-43634) |


<!-- PREVIEW-TABLE-END -->