### PR TITLE
[diagnostics] Add InstrumentAdvice details to instrumentation doc

### DIFF
--- a/docs/core/diagnostics/metrics-instrumentation.md
+++ b/docs/core/diagnostics/metrics-instrumentation.md
@@ -568,15 +568,22 @@ OpenTelemetry is: `[ 0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000,
 The default values may not lead to the best granularity for every Histogram. For
 example, sub-second request durations would all fall into the `0` bucket.
 
-To solve this problem the `9.0.0` version of the
+The tool or library collecting the Histogram data may offer mechanism(s) to
+allow users to customize the bucket configuration. For example, OpenTelemetry
+defines a [View
+API](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#view).
+This however requires end user action and makes it the user's responsibility to
+understand the data distribution well enough to choose correct buckets.
+
+To improve the experience the `9.0.0` version of the
 `System.Diagnostics.DiagnosticSource` package introduced the
 (<xref:System.Diagnostics.Metrics.InstrumentAdvice%2A>) API.
 
 The `InstrumentAdvice` API may be used by instrumentation authors to specify the
 set of recommended default bucket boundaries for a given Histogram. The tool or
 library collecting the Histogram data can then choose to use those values when
-configuring aggregation. This is supported in the OpenTelemetry .NET SDK as of
-version `1.10.0`.
+configuring aggregation leading to a more seamless onboarding experience for
+users. This is supported in the OpenTelemetry .NET SDK as of version `1.10.0`.
 
 > [!IMPORTANT]
 > In general more buckets will lead to more precise data for a given Histogram

--- a/docs/core/diagnostics/metrics-instrumentation.md
+++ b/docs/core/diagnostics/metrics-instrumentation.md
@@ -580,10 +580,11 @@ version `1.10.0`.
 
 > [!IMPORTANT]
 > In general more buckets will lead to more precise data for a given Histogram
-> but each bucket requires memory to store the aggregated details. It is
-> important to understand this tradeoff between precision and memory consumption
-> when choosing the number of buckets to recommend via the `InstrumentAdvice`
-> API.
+> but each bucket requires memory to store the aggregated details and there is
+> CPU cost to find the correct bucket when processing a measurement. It is
+> important to understand the tradeoffs between precision and CPU/memory
+> consumption when choosing the number of buckets to recommend via the
+> `InstrumentAdvice` API.
 
 The following code shows an example using the `InstrumentAdvice` API to set
 recommended default buckets.

--- a/docs/core/diagnostics/metrics-instrumentation.md
+++ b/docs/core/diagnostics/metrics-instrumentation.md
@@ -577,7 +577,7 @@ understand the data distribution well enough to choose correct buckets.
 
 To improve the experience the `9.0.0` version of the
 `System.Diagnostics.DiagnosticSource` package introduced the
-(<xref:System.Diagnostics.Metrics.InstrumentAdvice%2A>) API.
+(<xref:System.Diagnostics.Metrics.InstrumentAdvice`1>) API.
 
 The `InstrumentAdvice` API may be used by instrumentation authors to specify the
 set of recommended default bucket boundaries for a given Histogram. The tool or

--- a/docs/core/diagnostics/metrics-instrumentation.md
+++ b/docs/core/diagnostics/metrics-instrumentation.md
@@ -583,7 +583,8 @@ The `InstrumentAdvice` API may be used by instrumentation authors to specify the
 set of recommended default bucket boundaries for a given Histogram. The tool or
 library collecting the Histogram data can then choose to use those values when
 configuring aggregation leading to a more seamless onboarding experience for
-users. This is supported in the OpenTelemetry .NET SDK as of version `1.10.0`.
+users. This is supported in the [OpenTelemetry .NET SDK as of version
+1.10.0](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/docs/metrics/customizing-the-sdk#configuring-the-aggregation-of-a-histogram).
 
 > [!IMPORTANT]
 > In general more buckets will lead to more precise data for a given Histogram


### PR DESCRIPTION
## Summary

Add content + example showing the System.Diagnostics.DiagnosticSource v9.0.0 InstrumentAdvice API.

The goal is to link to this from the OTel .NET docs: https://github.com/open-telemetry/opentelemetry-dotnet/blob/e3665c95c21082f5675cb4d5863051201f640397/docs/metrics/customizing-the-sdk/README.md?plain=1#L244-L252

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/metrics-instrumentation.md](https://github.com/dotnet/docs/blob/9161132fe49fb94a83600a3945d4c859de9a1144/docs/core/diagnostics/metrics-instrumentation.md) | [Creating metrics](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/metrics-instrumentation?branch=pr-en-us-43640) |


<!-- PREVIEW-TABLE-END -->