### PR TITLE
Clarify "unbound" generic types

### DIFF
--- a/docs/csharp/advanced-topics/reflection-and-attributes/generics-and-attributes.md
+++ b/docs/csharp/advanced-topics/reflection-and-attributes/generics-and-attributes.md
@@ -8,13 +8,13 @@ helpviewer_keywords:
 ---
 # Generics and Attributes
 
-Attributes can be applied to generic types in the same way as nongeneric types. However, you can apply attributes only on *open generic types* and *closed constructed generic types*, not on *partially constructed generic types*. An *open generic type* is one where none of the type arguments are specified, such as `Dictionary<TKey, TValue>` A *closed constructed generic type* specifies all type arguments, such as `Dictionary<string, object>`. A *partially constructed generic type* specifies some, but not all, type arguments. An example is `Dictionary<string, TValue>`.
+Attributes can be applied to generic types in the same way as nongeneric types. However, you can apply attributes only on *open generic types* and *closed constructed generic types*, not on *partially constructed generic types*. An *open generic type* is one where none of the type arguments are specified, such as `Dictionary<TKey, TValue>` A *closed constructed generic type* specifies all type arguments, such as `Dictionary<string, object>`. A *partially constructed generic type* specifies some, but not all, type arguments. An example is `Dictionary<string, TValue>`. An *unbound generic type* is one where type arguments are omitted, such as `Dictionary<,>`.
 
 The following examples use this custom attribute:
 
 :::code language="csharp" source="./snippets/conceptual/GenericsAndAttributes.cs" id="CustomAttribute":::
 
-An attribute can reference an open generic type:
+An attribute can reference an unbound generic type:
 
 :::code language="csharp" source="./snippets/conceptual/GenericsAndAttributes.cs" id="GenericClassAsAttribute":::
 


### PR DESCRIPTION
With C# adding `nameof` support for unbound generic types, it'd be good to explain what _unbound_ means in this doc.

cc @CyrusNajmabadi 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/advanced-topics/reflection-and-attributes/generics-and-attributes.md](https://github.com/dotnet/docs/blob/396574d244f10e5223b64eff84058aa15283d08e/docs/csharp/advanced-topics/reflection-and-attributes/generics-and-attributes.md) | [Generics and Attributes](https://review.learn.microsoft.com/en-us/dotnet/csharp/advanced-topics/reflection-and-attributes/generics-and-attributes?branch=pr-en-us-43644) |

<!-- PREVIEW-TABLE-END -->