### PR TITLE
Enhance Documentation: Add Nested Record Copy-and-Update Feature Details.

### DIFF
--- a/docs/fsharp/language-reference/copy-and-update-record-expressions.md
+++ b/docs/fsharp/language-reference/copy-and-update-record-expressions.md
@@ -32,6 +32,32 @@ To update only two fields in that record you can use the *copy and update record
 
 [!code-fsharp[Main](~/samples/snippets/fsharp/lang-ref-1/snippet1906.fs)]
 
+## Nested Record Copy and Update
+
+In F# 7.0 and later, the *copy and update expression* has been enhanced to support updates on nested record fields. This feature allows for more concise syntax when working with deeply nested records.
+
+Consider the following example:
+
+### Before
+
+[!code-fsharp[Main](~/samples/snippets/fsharp/lang-ref-1/snippet19061.fs)]
+
+### After
+
+With the new feature, you can use dot-notation to reach nested fields and update them directly:
+
+[!code-fsharp[Main](~/samples/snippets/fsharp/lang-ref-1/snippet19062.fs)]
+
+This syntax eliminates the need for multiple `with` expressions. Instead, it allows for specifying updates on nested fields directly, while still allowing multiple fields (even at different levels of nesting) to be updated in the same expression.
+
+### Anonymous Records
+
+The same syntax extension works for anonymous records as well. Additionally, you can use this syntax to copy and update regular records into anonymous ones, adding new fields in the process:
+
+[!code-fsharp[Main](~/samples/snippets/fsharp/lang-ref-1/snippet19063.fs)]
+
+This flexibility ensures that the same concise syntax applies whether you're working with regular or anonymous records.
+
 ## See also
 
 - [Records](records.md)

--- a/samples/snippets/fsharp/lang-ref-1/snippet19061.fs
+++ b/samples/snippets/fsharp/lang-ref-1/snippet19061.fs
@@ -1,0 +1,10 @@
+type SteeringWheel = { Type: string }
+type CarInterior = { Steering: SteeringWheel; Seats: int }
+type Car = { Interior: CarInterior; ExteriorColor: string option }
+
+let beforeThisFeature x =
+    { x with Interior = { x.Interior with
+                            Steering = {x.Interior.Steering with Type = "yoke"}
+                            Seats = 5
+                        }
+    }

--- a/samples/snippets/fsharp/lang-ref-1/snippet19062.fs
+++ b/samples/snippets/fsharp/lang-ref-1/snippet19062.fs
@@ -1,0 +1,2 @@
+let withTheFeature x =
+    { x with Interior.Steering.Type = "yoke"; Interior.Seats = 5 }

--- a/samples/snippets/fsharp/lang-ref-1/snippet19063.fs
+++ b/samples/snippets/fsharp/lang-ref-1/snippet19063.fs
@@ -1,0 +1,4 @@
+let updatedRecord =
+    {| originalRecord with
+        Interior.Seats = 4;
+        Price = 35000 |}


### PR DESCRIPTION
## Summary

**Motivation and Context**

This PR addresses outdated information in the [Copy and Update Record Expressions](https://learn.microsoft.com/en-ca/dotnet/fsharp/language-reference/copy-and-update-record-expressions) article. It incorporates details from the F# announcement regarding the new feature for nested record field copy-and-update.

The addition of this feature greatly simplifies working with nested records, reducing verbosity and enhancing code readability. Including this in the documentation ensures users are informed about the latest capabilities in F#.

The existing article lacks information on the nested record field copy-and-update feature. This enhancement ensures users can fully leverage F#'s latest functionality.

**Description**

- Added a new section to highlight the nested record field copy-and-update feature with before-and-after examples for clarity.
- Provided usage examples for both regular and anonymous records.
- Updated the syntax and example sections to align with the new feature.
- Linked related documentation for easy navigation.

Fixes #43608 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/copy-and-update-record-expressions.md](https://github.com/dotnet/docs/blob/ffd602b5c345419a2fa1b207329e2230707f2a5f/docs/fsharp/language-reference/copy-and-update-record-expressions.md) | [Copy and Update Record Expressions](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/copy-and-update-record-expressions?branch=pr-en-us-43667) |

<!-- PREVIEW-TABLE-END -->