### PR TITLE
Update potential-pitfalls-in-data-and-task-parallelism.md - Remove reference to 'cust.Orders' that doesn't apply

### DIFF
--- a/docs/standard/parallel-programming/potential-pitfalls-in-data-and-task-parallelism.md
+++ b/docs/standard/parallel-programming/potential-pitfalls-in-data-and-task-parallelism.md
@@ -31,7 +31,7 @@ In many cases, <xref:System.Threading.Tasks.Parallel.For%2A?displayProperty=name
   
 - You are performing an expensive computation on each order. (The operation shown in the example is not expensive.)  
   
-- The target system is known to have enough processors to handle the number of threads that will be produced by parallelizing the query on `cust.Orders`.  
+- The target system is known to have enough processors to handle the number of threads that will be produced by parallelizing the processing.  
   
  In all cases, the best way to determine the optimum query shape is to test and measure.  
   


### PR DESCRIPTION


## Summary

Removes reference to 'cust.Orders' from pitfalls section, as it appears to have been copied from https://learn.microsoft.com/en-us/dotnet/standard/parallel-programming/potential-pitfalls-with-plinq#avoid-over-parallelization and doesn't apply to this document

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/parallel-programming/potential-pitfalls-in-data-and-task-parallelism.md](https://github.com/dotnet/docs/blob/aefa4463824bd6d85cb71b9e293b62b0b7fa3a3d/docs/standard/parallel-programming/potential-pitfalls-in-data-and-task-parallelism.md) | [Potential Pitfalls in Data and Task Parallelism](https://review.learn.microsoft.com/en-us/dotnet/standard/parallel-programming/potential-pitfalls-in-data-and-task-parallelism?branch=pr-en-us-43669) |

<!-- PREVIEW-TABLE-END -->