### PR TITLE
Update dotnet-nuget-why.md to include RID specific packages

### DIFF
--- a/docs/core/tools/dotnet-nuget-why.md
+++ b/docs/core/tools/dotnet-nuget-why.md
@@ -29,8 +29,8 @@ First, restore the project in Visual Studio, or `msbuild.exe`.
 By default the assets file is in the project's `obj\` directory, but you can find the location with `msbuild.exe path\to\project.proj -getProperty:ProjectAssetsFile`.
 Finally, run `dotnet nuget why path\to\project.assets.json SomePackage`.
 
-Starting with version 9.0.200, the command introduces support for RID-specific (Runtime identifier) packages by generating separate dependency trees for each Runtime Identifier (RID) and framework combination.
-For example, if a project targets the net9.0 framework with the win-x64 RID, it will generate trees for: `net9.0/win-x64` and `net9.0`.
+Starting with version 9.0.200, the command introduces support for runtime identifier (RID) specific packages by generating separate dependency trees for each RID and framework combination.
+For example, if a project targets `net9.0` with the `win-x64` RID, the command generates trees for `net9.0/win-x64` and `net9.0`.
 
 ## Arguments
 

--- a/docs/core/tools/dotnet-nuget-why.md
+++ b/docs/core/tools/dotnet-nuget-why.md
@@ -29,6 +29,9 @@ First, restore the project in Visual Studio, or `msbuild.exe`.
 By default the assets file is in the project's `obj\` directory, but you can find the location with `msbuild.exe path\to\project.proj -getProperty:ProjectAssetsFile`.
 Finally, run `dotnet nuget why path\to\project.assets.json SomePackage`.
 
+Starting with version 9.0.200, the command introduces support for RID-specific (Runtime identifier) packages by generating separate dependency trees for each Runtime Identifier (RID) and framework combination.
+For example, if a project targets the net9.0 framework with the win-x64 RID, it will generate trees for: `net9.0/win-x64` and `net9.0`.
+
 ## Arguments
 
 - **`PROJECT|SOLUTION`**


### PR DESCRIPTION
## Summary

Describe your changes here.
documents changes made https://github.com/NuGet/NuGet.Client/pull/6154 which allows `dotnet nuget why` to build trees for RID specific packages.

Fixes https://github.com/NuGet/Home/issues/13944


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-nuget-why.md](https://github.com/dotnet/docs/blob/d3954613d19bacbd0e127827bcc5aaaebe1fef9b/docs/core/tools/dotnet-nuget-why.md) | [docs/core/tools/dotnet-nuget-why](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-why?branch=pr-en-us-43672) |


<!-- PREVIEW-TABLE-END -->