### PR TITLE
Include lambda shorthand notation in "Lambda Expressions: The fun Keyword" page

### DIFF
--- a/docs/fsharp/language-reference/functions/lambda-expressions-the-fun-keyword.md
+++ b/docs/fsharp/language-reference/functions/lambda-expressions-the-fun-keyword.md
@@ -54,7 +54,7 @@ The *expression* is the body of the function, the last expression of which gener
 
 ## Using Lambda Expressions
 
-Lambda expressions are especially useful when you want to perform operations on a list or other collection and want to avoid the extra work of defining a function. Many F# library functions take function values as arguments, and it can be especially convenient to use a lambda expression in those cases. The following code applies a lambda expression to elements of a list. In this case, the anonymous function checks if an element is a text ending with specified characters.
+Lambda expressions are especially useful when you want to perform operations on a list or other collection and want to avoid the extra work of defining a function. Many F# library functions take function values as arguments, and it can be especially convenient to use a lambda expression in those cases. The following code applies a lambda expression to elements of a list. In this case, the anonymous function checks if an element is text that ends with specified characters.
 
 [!code-fsharp[Main](~/samples/snippets/fsharp/lang-ref-1/snippet302.fs)]
 

--- a/docs/fsharp/language-reference/functions/lambda-expressions-the-fun-keyword.md
+++ b/docs/fsharp/language-reference/functions/lambda-expressions-the-fun-keyword.md
@@ -13,7 +13,7 @@ The `fun` keyword is used to define a lambda expression, that is, an anonymous f
 fun parameter-list -> expression
 ```
 
-or using the _.Property shorthand notation:
+Or using the `_.Property` shorthand notation:
 
 ```fsharp
 _.

--- a/docs/fsharp/language-reference/functions/lambda-expressions-the-fun-keyword.md
+++ b/docs/fsharp/language-reference/functions/lambda-expressions-the-fun-keyword.md
@@ -13,6 +13,14 @@ The `fun` keyword is used to define a lambda expression, that is, an anonymous f
 fun parameter-list -> expression
 ```
 
+or using the _.Property shorthand notation:
+
+```fsharp
+_.
+```
+
+where `fun`, *parameter-list* and lambda arrow (`->`) is omitted and the `_.` is a part of *expression* where `_` replaces the parameter call.
+
 ## Remarks
 
 The *parameter-list* typically consists of names and, optionally, types of parameters. More generally, the *parameter-list* can be composed of any F# patterns. For a full list of possible patterns, see [Pattern Matching](../pattern-matching.md). Lists of valid parameters include the following examples.

--- a/docs/fsharp/language-reference/functions/lambda-expressions-the-fun-keyword.md
+++ b/docs/fsharp/language-reference/functions/lambda-expressions-the-fun-keyword.md
@@ -58,7 +58,7 @@ Lambda expressions are especially useful when you want to perform operations on 
 
 [!code-fsharp[Main](~/samples/snippets/fsharp/lang-ref-1/snippet302.fs)]
 
-The above shows both notations: using the `fun` keyword, and the shorthand `_.Property` notation.
+The previous code snippet shows both notations: using the `fun` keyword, and the shorthand `_.Property` notation.
 
 ## See also
 

--- a/docs/fsharp/language-reference/functions/lambda-expressions-the-fun-keyword.md
+++ b/docs/fsharp/language-reference/functions/lambda-expressions-the-fun-keyword.md
@@ -49,9 +49,11 @@ The *expression* is the body of the function, the last expression of which gener
 
 ## Using Lambda Expressions
 
-Lambda expressions are especially useful when you want to perform operations on a list or other collection and want to avoid the extra work of defining a function. Many F# library functions take function values as arguments, and it can be especially convenient to use a lambda expression in those cases. The following code applies a lambda expression to elements of a list. In this case, the anonymous function adds 1 to every element of a list.
+Lambda expressions are especially useful when you want to perform operations on a list or other collection and want to avoid the extra work of defining a function. Many F# library functions take function values as arguments, and it can be especially convenient to use a lambda expression in those cases. The following code applies a lambda expression to elements of a list. In this case, the anonymous function checks if an element is a text ending with specified characters.
 
 [!code-fsharp[Main](~/samples/snippets/fsharp/lang-ref-1/snippet302.fs)]
+
+The above shows both notations: using the `fun` keyword, and the shorthand `_.Property` notation.
 
 ## See also
 

--- a/docs/fsharp/language-reference/functions/lambda-expressions-the-fun-keyword.md
+++ b/docs/fsharp/language-reference/functions/lambda-expressions-the-fun-keyword.md
@@ -19,7 +19,7 @@ Or using the `_.Property` shorthand notation:
 _.
 ```
 
-where `fun`, *parameter-list* and lambda arrow (`->`) is omitted and the `_.` is a part of *expression* where `_` replaces the parameter symbol.
+`fun`, *parameter-list*, and lambda arrow (`->`) are omitted, and the `_.` is a part of *expression* where `_` replaces the parameter symbol.
 
 The following snippets are equivalent:
 

--- a/docs/fsharp/language-reference/functions/lambda-expressions-the-fun-keyword.md
+++ b/docs/fsharp/language-reference/functions/lambda-expressions-the-fun-keyword.md
@@ -19,7 +19,12 @@ or using the _.Property shorthand notation:
 _.
 ```
 
-where `fun`, *parameter-list* and lambda arrow (`->`) is omitted and the `_.` is a part of *expression* where `_` replaces the parameter call.
+where `fun`, *parameter-list* and lambda arrow (`->`) is omitted and the `_.` is a part of *expression* where `_` replaces the parameter symbol.
+
+The following snippets are equivalent:
+`(fun x -> x.Property)`
+`_.Property`
+
 
 ## Remarks
 

--- a/docs/fsharp/language-reference/functions/lambda-expressions-the-fun-keyword.md
+++ b/docs/fsharp/language-reference/functions/lambda-expressions-the-fun-keyword.md
@@ -22,9 +22,9 @@ _.
 where `fun`, *parameter-list* and lambda arrow (`->`) is omitted and the `_.` is a part of *expression* where `_` replaces the parameter symbol.
 
 The following snippets are equivalent:
+
 `(fun x -> x.Property)`
 `_.Property`
-
 
 ## Remarks
 

--- a/samples/snippets/fsharp/lang-ref-1/snippet302.fs
+++ b/samples/snippets/fsharp/lang-ref-1/snippet302.fs
@@ -1,2 +1,5 @@
-let list = List.map (fun i -> i + 1) [ 1; 2; 3 ]
-printfn "%A" list
+let fullNotation = [ "a"; "ab"; "abc" ] |> List.find ( fun text -> text.EndsWith("c") )
+printfn "%A" fullNotation         // Output: "abc"
+
+let shorthandNotation = [ "a"; "ab"; "abc" ] |> List.find ( _.EndsWith("b") )
+printfn "%A" shorthandNotation    // Output: "ab"


### PR DESCRIPTION
This pull request closes #41858 

It adds the mention of the alternate, shorthand notation just below the "standard" one in the syntax section,
and also shows both notations in action in "Using Lambda Expressions" section.

**Note:** as the shorthand notation can only be used for property access, method calls and indexing, I couldn't use the existing implementation and had to refactor it to present something that will use the property accessing, but won't be more complicated.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/functions/lambda-expressions-the-fun-keyword.md](https://github.com/dotnet/docs/blob/8df533a8366e7aae35987df0460a683331a51a3d/docs/fsharp/language-reference/functions/lambda-expressions-the-fun-keyword.md) | [Lambda Expressions: The fun Keyword (F#)](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/functions/lambda-expressions-the-fun-keyword?branch=pr-en-us-43675) |


<!-- PREVIEW-TABLE-END -->