### PR TITLE
Document /uninstall and /repair options for .NET

### DIFF
--- a/docs/core/install/windows.md
+++ b/docs/core/install/windows.md
@@ -220,6 +220,8 @@ Suppresses any attempts to restart.
 dotnet-sdk-9.0.100-win-x64.exe /install /quiet /norestart
 ```
 
+You can replace the `/install` option with `/uninstall` or `/repair` to remove or modify an installation.
+
 > [!TIP]
 > The installer returns an exit code of **0** for success and an exit code of **3010** to indicate that a restart is required. Any other value is most likely an error code.
 

--- a/docs/core/install/windows.md
+++ b/docs/core/install/windows.md
@@ -220,8 +220,13 @@ Suppresses any attempts to restart.
 dotnet-sdk-9.0.100-win-x64.exe /install /quiet /norestart
 ```
 
-You can replace the `/install` option with `/uninstall` or `/repair` to remove or modify an installation.
+If you've already installed .NET, use the .NET Installer to manage the installation. Instead of `/install`, use one of the following options:
 
+- `/uninstall`\
+Remove this version of .NET.
+
+- `/repair`\
+Check if the installations key files or components are damaged and restore them.
 > [!TIP]
 > The installer returns an exit code of **0** for success and an exit code of **3010** to indicate that a restart is required. Any other value is most likely an error code.
 

--- a/docs/core/install/windows.md
+++ b/docs/core/install/windows.md
@@ -227,6 +227,7 @@ Remove this version of .NET.
 
 - `/repair`\
 Check if the installations key files or components are damaged and restore them.
+
 > [!TIP]
 > The installer returns an exit code of **0** for success and an exit code of **3010** to indicate that a restart is required. Any other value is most likely an error code.
 


### PR DESCRIPTION
## Summary

Update .NET installer command-line options to include `/uninstall` and `/repair`. There were internal asks for official documentation.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/windows.md](https://github.com/dotnet/docs/blob/a95fdbf2998c0e9e2902b45076f45163ccda9158/docs/core/install/windows.md) | [Install .NET on Windows](https://review.learn.microsoft.com/en-us/dotnet/core/install/windows?branch=pr-en-us-43677) |


<!-- PREVIEW-TABLE-END -->