### PR TITLE
remove NRT feature spec

### DIFF
--- a/.openpublishing.redirection.csharp.json
+++ b/.openpublishing.redirection.csharp.json
@@ -1391,7 +1391,15 @@
             "redirect_url": "/dotnet/csharp/language-reference/language-specification/types.md#893-nullable-reference-types"
         },
         {
-            "source_path_from_root": "/docs/csharp/language-reference/proposals/nullable-reference-types-specification.md",
+            "source_path_from_root": "/docs/csharp/language-reference/proposals/csharp-9.0/nullable-reference-types-specification.md",
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/types.md#893-nullable-reference-types"
+        },
+        {
+            "source_path_from_root": "/docs/csharp/language-reference/proposals/csharp-9.0/nullable-constructor-analysis.md",
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/types.md#893-nullable-reference-types"
+        },
+        {
+            "source_path_from_root": "/docs/csharp/language-reference/proposals/csharp-9.0/nullable-parameter-default-value-analysis.md",
             "redirect_url": "/dotnet/csharp/language-reference/language-specification/types.md#893-nullable-reference-types"
         },
         {

--- a/.openpublishing.redirection.csharp.json
+++ b/.openpublishing.redirection.csharp.json
@@ -1387,6 +1387,14 @@
             "redirect_url": "/dotnet/csharp/language-reference/language-specification/statements.md#1364-local-function-declarations"
         },
         {
+            "source_path_from_root": "/docs/csharp/language-reference/proposals/csharp-8.0/nullable-reference-types.md",
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/types.md#893-nullable-reference-types"
+        },
+        {
+            "source_path_from_root": "/docs/csharp/language-reference/proposals/nullable-reference-types-specification.md",
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/types.md#893-nullable-reference-types"
+        },
+        {
             "source_path_from_root": "/docs/csharp/language-reference/proposals/csharp-9.0/index.md",
             "redirect_url": "/dotnet/csharp/language-reference/proposals/csharp-9.0/records"
         },

--- a/.openpublishing.redirection.csharp.json
+++ b/.openpublishing.redirection.csharp.json
@@ -109,6 +109,14 @@
             "redirect_url": "/dotnet/csharp/language-reference/language-specification/expressions#121211-tuple-equality-operators"
         },
         {
+            "source_path_from_root": "/redirections/proposals/csharp-8.0/nullable-reference-types.md",
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/types.md#893-nullable-reference-types"
+        },
+        {
+            "source_path_from_root": "/redirections/proposals/csharp-9.0/nullable-reference-types-specification.md",
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/types.md#893-nullable-reference-types"
+        },
+        {
             "source_path_from_root": "/redirections/proposals/csharp-10.0/generic-attributes.md",
             "redirect_url": "/dotnet/csharp/language-reference/proposals/csharp-11.0/generic-attributes"
         },

--- a/docfx.json
+++ b/docfx.json
@@ -71,7 +71,9 @@
                     "csharp-8.0/shadowing-in-nested-functions.md",
                     "csharp-8.0/static-local-functions.md",
                     "csharp-8.0/unconstrained-null-coalescing.md",
-                    "csharp-8.0/nullable-reference-types-specification.md"
+                    "csharp-8.0/nullable-reference-types.md",
+                    "csharp-8.0/nullable-reference-types-specification.md",
+                    "csharp-9.0/nullable-reference-types-specification.md"
                 ]
             },
             {
@@ -599,7 +601,6 @@
                 "_csharpstandard/standard/standard-library.md": "Standard library",
                 "_csharpstandard/standard/documentation-comments.md": "Documentation comments",
                 "_csharpstandard/standard/Bibliography.md": "Bibliography",
-                "_csharplang/proposals/csharp-8.0/nullable-reference-types.md": "Null reference types - proposal",
                 "_csharplang/proposals/csharp-8.0/patterns.md": "Recursive pattern matching",
                 "_csharplang/proposals/csharp-8.0/default-interface-methods.md": "Default interface methods",
                 "_csharplang/proposals/csharp-8.0/async-streams.md": "Async streams",
@@ -617,7 +618,6 @@
                 "_csharplang/proposals/csharp-9.0/local-function-attributes.md": "Attributes on local functions",
                 "_csharplang/proposals/csharp-9.0/module-initializers.md": "Module initializers",
                 "_csharplang/proposals/csharp-9.0/native-integers.md": "Native sized integers",
-                "_csharplang/proposals/csharp-9.0/nullable-reference-types-specification.md": "Nullable reference types - specification",
                 "_csharplang/proposals/csharp-9.0/patterns3.md": "Pattern matching changes",
                 "_csharplang/proposals/csharp-9.0/records.md": "Records",
                 "_csharplang/proposals/csharp-9.0/skip-localsinit.md": "Suppress emitting localsinit flag",
@@ -722,7 +722,6 @@
                 "_csharpstandard/standard/standard-library.md": "This appendix lists requirements of the specification library. The C# language relies on these types for some of its behavior.",
                 "_csharpstandard/standard/documentation-comments.md": "This appendix describes XML comments that are used to document your program.",
                 "_csharpstandard/standard/Bibliography.md": "This appendix lists external standards referenced in this specification.",
-                "_csharplang/proposals/csharp-8.0/nullable-reference-types.md": "This feature specification describes nullable reference types.",
                 "_csharplang/proposals/csharp-8.0/patterns.md": "This feature specification describes recursive pattern matching, where patterns can nest inside other patterns.",
                 "_csharplang/proposals/csharp-8.0/default-interface-methods.md": "This feature specification describe the syntax updates necessary to support default interface methods. This includes declaring bodies in interface declarations, and supporting modifiers on declarations.",
                 "_csharplang/proposals/csharp-8.0/async-streams.md": "This feature specification describes async streams, which return streams of data asynchronously, typically as each element is produced or available.",
@@ -740,7 +739,6 @@
                 "_csharplang/proposals/csharp-9.0/local-function-attributes.md": "This feature specification describes rules to apply attributes on local functions.",
                 "_csharplang/proposals/csharp-9.0/module-initializers.md": "This feature specification describes how to declare module initializers, which are methods called by the runtime when a module, or assembly, is loaded.",
                 "_csharplang/proposals/csharp-9.0/native-integers.md": "This feature specification describes native sized integers, which are integer types that use the processor's natural integral types.",
-                "_csharplang/proposals/csharp-9.0/nullable-reference-types-specification.md": "This feature specification provides a more complete specification for nullable reference types.",
                 "_csharplang/proposals/csharp-9.0/patterns3.md": "This feature specification describes the additional pattern matching syntax added in C# 9.0. This includes relational patterns, 'and' and 'or' patterns, negated patterns and parenthesized patterns.",
                 "_csharplang/proposals/csharp-9.0/records.md": "This feature specification describes records. Records are reference types that provide value based equality semantics.",
                 "_csharplang/proposals/csharp-9.0/skip-localsinit.md": "This feature specification describes a performance enhancement to suppress emitting localsinit flag. This will prevent the runtime from initializing memory to 0 as part of allocating it.",

--- a/docfx.json
+++ b/docfx.json
@@ -73,7 +73,9 @@
                     "csharp-8.0/unconstrained-null-coalescing.md",
                     "csharp-8.0/nullable-reference-types.md",
                     "csharp-8.0/nullable-reference-types-specification.md",
-                    "csharp-9.0/nullable-reference-types-specification.md"
+                    "csharp-9.0/nullable-reference-types-specification.md",
+                    "csharp-9.0/nullable-constructor-analysis.md",
+                    "csharp-9.0/nullable-parameter-default-value-analysis.md"
                 ]
             },
             {

--- a/docs/csharp/nullable-references.md
+++ b/docs/csharp/nullable-references.md
@@ -389,8 +389,7 @@ In the preceding example, the declaration of the array shows it holds non-nullab
 
 ## See also
 
-- [Nullable reference types proposal](~/_csharplang/proposals/csharp-8.0/nullable-reference-types.md)
-- [Draft nullable reference types specification](~/_csharplang/proposals/csharp-9.0/nullable-reference-types-specification.md)
+- [Nullable reference types specification](~/_csharpstandard/standard/types.md#893-nullable-reference-types)
 - [Unconstrained type parameter annotations](~/_csharplang/proposals/csharp-9.0/unconstrained-type-parameter-annotations.md)
 - [Intro to nullable references tutorial](tutorials/nullable-reference-types.md)
 - [**Nullable** (C# Compiler option)](language-reference/compiler-options/language.md#nullable)

--- a/docs/csharp/specification/feature-spec-overview.md
+++ b/docs/csharp/specification/feature-spec-overview.md
@@ -5,7 +5,7 @@ ms.date: 05/08/2024
 ---
 # Feature specifications
 
-Because the [C# standard specification](overview.md) has fallen behind the latest C# implementation, this section contains the [Microsoft specifications](~/_csharplang/proposals/csharp-8.0/nullable-reference-types.md) for those newer features that haven't yet been incorporated into the standard. You can read these specifications to get information on newer features.
+Because the [C# standard specification](overview.md) has fallen behind the latest C# implementation, this section contains the [Microsoft specifications](~/_csharplang/proposals/csharp-10.0/enhanced-line-directives.md) for those newer features that haven't yet been incorporated into the standard. You can read these specifications to get information on newer features.
 
 The feature specifications began as proposals for the design. They include proposed changes to the standard. The C# language design team and compiler team produce these feature specifications. The purpose of the proposals is to guide the design and implementation of the feature. They might include proposed features that haven't yet been implemented. The actual implementation might have modified behavior. Those changes are captured in the language design meeting (LDM) notes. The LDM notes are the minutes of the language design meetings. In most cases, the pertinent LDM notes are linked from the feature specifications.
 

--- a/docs/csharp/specification/toc.yml
+++ b/docs/csharp/specification/toc.yml
@@ -89,10 +89,6 @@ items:
       href: ../../../_csharplang/proposals/csharp-9.0/skip-localsinit.md
   - name: Types
     items:
-    - name: Nullable reference types - proposal
-      href: ../../../_csharplang/proposals/csharp-8.0/nullable-reference-types.md
-    - name: Nullable reference types - specification
-      href: ../../../_csharplang/proposals/csharp-9.0/nullable-reference-types-specification.md
     - name: Records
       href: ../../../_csharplang/proposals/csharp-9.0/records.md
     - name: Record structs


### PR DESCRIPTION
The Nullable Reference Types features have been merged into the draft standard.

Remove the feature specs from our platform, and update any section anchors.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/nullable-references.md](https://github.com/dotnet/docs/blob/e418be4ab3d02b74f037ac0084d5d43601d317ce/docs/csharp/nullable-references.md) | [Nullable reference types](https://review.learn.microsoft.com/en-us/dotnet/csharp/nullable-references?branch=pr-en-us-43686) |
| [docs/csharp/specification/feature-spec-overview.md](https://github.com/dotnet/docs/blob/e418be4ab3d02b74f037ac0084d5d43601d317ce/docs/csharp/specification/feature-spec-overview.md) | ["Feature specifications"](https://review.learn.microsoft.com/en-us/dotnet/csharp/specification/feature-spec-overview?branch=pr-en-us-43686) |
| [docs/csharp/specification/toc.yml](https://github.com/dotnet/docs/blob/e418be4ab3d02b74f037ac0084d5d43601d317ce/docs/csharp/specification/toc.yml) | [docs/csharp/specification/toc](https://review.learn.microsoft.com/en-us/dotnet/csharp/specification/toc?branch=pr-en-us-43686) |


<!-- PREVIEW-TABLE-END -->