### PR TITLE
Fix compression level docs

### DIFF
--- a/docs/core/compatibility/core-libraries/9.0/compressionlevel-bits.md
+++ b/docs/core/compatibility/core-libraries/9.0/compressionlevel-bits.md
@@ -22,7 +22,7 @@ Starting in .NET 9, the <xref:System.IO.Compression.CompressionLevel> parameter 
 | `CompressionLevel` | Bit 1 | Bit 2 |
 |--------------------|-------|-------|
 | `NoCompression`    | 0     | 0     |
-| `Optimal`          | 0     | 0     |
+| `Optimal`          | 0     | 1     |
 | `SmallestSize`     | 1     | 0     |
 | `Fastest`          | 1     | 1     |
 


### PR DESCRIPTION
## Summary

Fix the compression level bits documentation.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/core-libraries/9.0/compressionlevel-bits.md](https://github.com/dotnet/docs/blob/4dbc52b720c9b83ac54d5528b803a059f62c54a1/docs/core/compatibility/core-libraries/9.0/compressionlevel-bits.md) | [Adding a ZipArchiveEntry with CompressionLevel sets ZIP central directory header general-purpose bit flags](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/9.0/compressionlevel-bits?branch=pr-en-us-43700) |

<!-- PREVIEW-TABLE-END -->