### PR TITLE
Clarify  restriction on `yield` in `try` blocks.

### DIFF
--- a/docs/csharp/language-reference/statements/yield.md
+++ b/docs/csharp/language-reference/statements/yield.md
@@ -38,7 +38,7 @@ You can't use the `yield` statements in:
 - methods with [in](../keywords/method-parameters.md#in-parameter-modifier), [ref](../keywords/ref.md), or [out](../keywords/method-parameters.md#out-parameter-modifier) parameters
 - [lambda expressions](../operators/lambda-expressions.md) and [anonymous methods](../operators/delegate-operator.md)
 - [unsafe blocks](../keywords/unsafe.md). Before C# 13, `yield` was invalid in any method with an `unsafe` block. Beginning with C# 13, you can use `yield` in methods with `unsafe` blocks, but not in the `unsafe` block.
-- `yield return` and `yield break` can not be used in [try](../statements/exception-handling-statements.md), [catch](../statements/exception-handling-statements.md) and [finally](../statements/exception-handling-statements.md) blocks.
+- `yield return` and `yield break` can not be used in [catch](../statements/exception-handling-statements.md) and [finally](../statements/exception-handling-statements.md) blocks, or in [try](../statements/exception-handling-statements.md) blocks with a corresponding `catch` block. The `yield return` and `yield break` statements can be used in a `try` block with no `catch` blocks, only a `finally` block.
 
 ## Execution of an iterator
 


### PR DESCRIPTION
Fixes anonymous feedback.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/statements/yield.md](https://github.com/dotnet/docs/blob/0a02906a1c0a504ddef7f7fa2363cc97e2a64dfe/docs/csharp/language-reference/statements/yield.md) | [yield statement - provide the next element](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/statements/yield?branch=pr-en-us-43706) |

<!-- PREVIEW-TABLE-END -->