### PR TITLE
Add credential builder context

### DIFF
--- a/docs/azure/sdk/authentication/credential-chains.md
+++ b/docs/azure/sdk/authentication/credential-chains.md
@@ -72,7 +72,7 @@ In its simplest form, you can use the parameterless version of `DefaultAzureCred
 
 To remove a credential from `DefaultAzureCredential`, use the corresponding `Exclude`-prefixed property in [DefaultAzureCredentialOptions](/dotnet/api/azure.identity.defaultazurecredentialoptions?view=azure-dotnet&preserve-view=true#properties). For example:
 
-:::code language="csharp" source="../snippets/authentication/credential-chains/Program.cs" id="snippet_DacExcludes" highlight="6-7":::
+:::code language="csharp" source="../snippets/authentication/credential-chains/Program.cs" id="snippet_DacExcludes" highlight="9-10":::
 
 In the preceding code sample, `EnvironmentCredential` and `WorkloadIdentityCredential` are removed from the credential chain. As a result, the first credential to be attempted is `ManagedIdentityCredential`. The modified chain looks like this:
 

--- a/docs/azure/sdk/authentication/credential-chains.md
+++ b/docs/azure/sdk/authentication/credential-chains.md
@@ -63,7 +63,7 @@ The order in which `DefaultAzureCredential` attempts credentials follows.
 
 In its simplest form, you can use the parameterless version of `DefaultAzureCredential` as follows:
 
-:::code language="csharp" source="../snippets/authentication/credential-chains/Program.cs" id="snippet_Dac" highlight="1":::
+:::code language="csharp" source="../snippets/authentication/credential-chains/Program.cs" id="snippet_Dac" highlight="6":::
 
 > [!TIP]
 > The `UseCredential` method in the preceding code snippet is recommended for use in ASP.NET Core apps. For more information, see [Use the Azure SDK for .NET in ASP.NET Core apps](../aspnetcore-guidance.md#authenticate-using-microsoft-entra-id).
@@ -72,7 +72,7 @@ In its simplest form, you can use the parameterless version of `DefaultAzureCred
 
 To remove a credential from `DefaultAzureCredential`, use the corresponding `Exclude`-prefixed property in [DefaultAzureCredentialOptions](/dotnet/api/azure.identity.defaultazurecredentialoptions?view=azure-dotnet&preserve-view=true#properties). For example:
 
-:::code language="csharp" source="../snippets/authentication/credential-chains/Program.cs" id="snippet_DacExcludes" highlight="4-5":::
+:::code language="csharp" source="../snippets/authentication/credential-chains/Program.cs" id="snippet_DacExcludes" highlight="6-7":::
 
 In the preceding code sample, `EnvironmentCredential` and `WorkloadIdentityCredential` are removed from the credential chain. As a result, the first credential to be attempted is `ManagedIdentityCredential`. The modified chain looks like this:
 

--- a/docs/azure/sdk/authentication/credential-chains.md
+++ b/docs/azure/sdk/authentication/credential-chains.md
@@ -97,7 +97,7 @@ As more `Exclude`-prefixed properties are set to `true` (credential exclusions a
 
 [ChainedTokenCredential](/dotnet/api/azure.identity.chainedtokencredential?view=azure-dotnet&preserve-view=true) is an empty chain to which you add credentials to suit your app's needs. For example:
 
-:::code language="csharp" source="../snippets/authentication/credential-chains/Program.cs" id="snippet_Ctc" highlight="6-9" :::
+:::code language="csharp" source="../snippets/authentication/credential-chains/Program.cs" id="snippet_Ctc" highlight="6-8" :::
 
 The preceding code sample creates a tailored credential chain comprised of two credentials. The user-assigned managed identity variant of `ManagedIdentityCredential` is attempted first, followed by `VisualStudioCredential`, if necessary. In graphical form, the chain looks like this:
 

--- a/docs/azure/sdk/authentication/credential-chains.md
+++ b/docs/azure/sdk/authentication/credential-chains.md
@@ -97,7 +97,7 @@ As more `Exclude`-prefixed properties are set to `true` (credential exclusions a
 
 [ChainedTokenCredential](/dotnet/api/azure.identity.chainedtokencredential?view=azure-dotnet&preserve-view=true) is an empty chain to which you add credentials to suit your app's needs. For example:
 
-:::code language="csharp" source="../snippets/authentication/credential-chains/Program.cs" id="snippet_Ctc":::
+:::code language="csharp" source="../snippets/authentication/credential-chains/Program.cs" id="snippet_Ctc" highlight="6-9" :::
 
 The preceding code sample creates a tailored credential chain comprised of two credentials. The user-assigned managed identity variant of `ManagedIdentityCredential` is attempted first, followed by `VisualStudioCredential`, if necessary. In graphical form, the chain looks like this:
 

--- a/docs/azure/sdk/snippets/authentication/credential-chains/Program.cs
+++ b/docs/azure/sdk/snippets/authentication/credential-chains/Program.cs
@@ -31,6 +31,9 @@ builder.Services.AddAzureClients(clientBuilder =>
 #region snippet_DacExcludes
 builder.Services.AddAzureClients(clientBuilder =>
 {
+    clientBuilder.AddBlobServiceClient(
+        new Uri("https://<account-name>.blob.core.windows.net"));
+
     clientBuilder.UseCredential(new DefaultAzureCredential(
         new DefaultAzureCredentialOptions
         {
@@ -44,6 +47,9 @@ builder.Services.AddAzureClients(clientBuilder =>
 #region snippet_Ctc
 builder.Services.AddAzureClients(clientBuilder =>
 {
+    clientBuilder.AddBlobServiceClient(
+        new Uri("https://<account-name>.blob.core.windows.net"));
+
     clientBuilder.UseCredential(new ChainedTokenCredential(
         new ManagedIdentityCredential(clientId: userAssignedClientId),
         new VisualStudioCredential()));

--- a/docs/azure/sdk/snippets/authentication/credential-chains/Program.cs
+++ b/docs/azure/sdk/snippets/authentication/credential-chains/Program.cs
@@ -17,16 +17,20 @@ using AzureEventSourceListener listener = new((args, message) =>
 }, EventLevel.LogAlways);
 #endregion snippet_FilteredLogging
 
+#region snippet_Dac
 builder.Services.AddAzureClients(clientBuilder =>
 {
     clientBuilder.AddBlobServiceClient(
         new Uri("https://<account-name>.blob.core.windows.net"));
-    #region snippet_Dac
+
     DefaultAzureCredential credential = new();
     clientBuilder.UseCredential(credential);
-    #endregion snippet_Dac
+});
+#endregion snippet_Dac
 
-    #region snippet_DacExcludes
+#region snippet_DacExcludes
+builder.Services.AddAzureClients(clientBuilder =>
+{
     clientBuilder.UseCredential(new DefaultAzureCredential(
         new DefaultAzureCredentialOptions
         {
@@ -34,14 +38,18 @@ builder.Services.AddAzureClients(clientBuilder =>
             ExcludeWorkloadIdentityCredential = true,
             ManagedIdentityClientId = userAssignedClientId,
         }));
-    #endregion snippet_DacExcludes
+});
+#endregion snippet_DacExcludes
 
-    #region snippet_Ctc
+#region snippet_Ctc
+builder.Services.AddAzureClients(clientBuilder =>
+{
     clientBuilder.UseCredential(new ChainedTokenCredential(
         new ManagedIdentityCredential(clientId: userAssignedClientId),
         new VisualStudioCredential()));
-    #endregion snippet_Ctc
 });
+#endregion snippet_Ctc
+
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();


### PR DESCRIPTION
## Summary

This PR is to address feedback we received that showing clientBuilder on its own without wider context is confusing. Restructures the code examples to add AddAzureClients context to show where the clientBuilder originates from. 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/azure/sdk/authentication/credential-chains.md](https://github.com/dotnet/docs/blob/0c9ea5e07f5ed0558bcd75600f0905837ed45bf4/docs/azure/sdk/authentication/credential-chains.md) | [Credential chains in the Azure Identity library for .NET](https://review.learn.microsoft.com/en-us/dotnet/azure/sdk/authentication/credential-chains?branch=pr-en-us-43708) |


<!-- PREVIEW-TABLE-END -->