### PR TITLE
MSTest SDK - remove incorrect mention of net9

### DIFF
--- a/docs/core/testing/unit-testing-mstest-sdk.md
+++ b/docs/core/testing/unit-testing-mstest-sdk.md
@@ -8,7 +8,7 @@ ms.date: 02/13/2024
 
 # MSTest SDK overview
 
-Introduced in .NET 9, [MSTest.Sdk](https://www.nuget.org/packages/MSTest.Sdk) is a [MSBuild project SDK](/visualstudio/msbuild/how-to-use-project-sdk) for building MSTest apps. It's possible to build a MSTest app without this SDK, however, the MSTest SDK is:
+[MSTest.Sdk](https://www.nuget.org/packages/MSTest.Sdk) is a [MSBuild project SDK](/visualstudio/msbuild/how-to-use-project-sdk) for building MSTest apps. It's possible to build a MSTest app without this SDK, however, the MSTest SDK is:
 
 * Tailored towards providing a first-class experience for testing with MSTest.
 * The recommended target for most users.


### PR DESCRIPTION
## Summary

@gewarren I am removing the .NET 9 mention you added that is incorrect in this case. Our SDK is a simple NuGet package not inserted in .NET SDK.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-mstest-sdk.md](https://github.com/dotnet/docs/blob/8ca5e6083896333fddc0cdbb9170fd92ae31a1be/docs/core/testing/unit-testing-mstest-sdk.md) | [MSTest SDK overview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-sdk?branch=pr-en-us-43716) |

<!-- PREVIEW-TABLE-END -->