### PR TITLE
Fix code sample for "The init keyword" docs

### DIFF
--- a/docs/csharp/language-reference/keywords/snippets/InitExample5.cs
+++ b/docs/csharp/language-reference/keywords/snippets/InitExample5.cs
@@ -5,7 +5,7 @@
         get;
         init
         {
-            field = (YearOfBirth <= DateTime.Now.Year)
+            field = (value <= DateTime.Now.Year)
                 ? value
                 : throw new ArgumentOutOfRangeException(nameof(value), "Year of birth can't be in the future");
         }


### PR DESCRIPTION
## Summary

The validation logic now checks the actual new value instead of old stored property value.
