### PR TITLE
Enhance F# Interactive Documentation: Add Extended #help Directive Details

### DIFF
--- a/docs/fsharp/tools/fsharp-interactive/index.md
+++ b/docs/fsharp/tools/fsharp-interactive/index.md
@@ -240,7 +240,7 @@ The `#r` and `#load` directives seen previously are only available in F# Interac
 |`#r "extname:..."`|Reference a package from `extname` extension[^1] (such as `paket`)|
 |`#r "assembly-name.dll"`|References an assembly on disk|
 |`#load "file-name.fsx"`|Reads a source file, compiles it, and runs it.|
-|`#help`|Displays information about available directives or documentation for specific objects and functions.|
+|`#help`|Displays information about available directives or documentation for specific functions.|
 |`#I`|Specifies an assembly search path in quotation marks.|
 |`#quit`|Terminates an F# Interactive session.|
 |`#time "on"` or `#time "off"`|By itself, `#time` toggles whether to display performance information. When it is `"on"`, F# Interactive measures real time, CPU time, and garbage collection information for each section of code that is interpreted and executed.|

--- a/docs/fsharp/tools/fsharp-interactive/index.md
+++ b/docs/fsharp/tools/fsharp-interactive/index.md
@@ -251,7 +251,7 @@ When you specify files or paths in F# Interactive, a string literal is expected.
 
 ### Extended #help directive
 
-The `#help` directive now supports displaying documentation for specific objects or functions. You can pass the name of the object or function directly (without quotes) to retrieve details.
+The `#help` directive now supports displaying documentation for specific functions. You can pass the name of the function directly (without quotes) to retrieve details.
 
 ```fsharp
 #help List.map;;

--- a/docs/fsharp/tools/fsharp-interactive/index.md
+++ b/docs/fsharp/tools/fsharp-interactive/index.md
@@ -240,7 +240,7 @@ The `#r` and `#load` directives seen previously are only available in F# Interac
 |`#r "extname:..."`|Reference a package from `extname` extension[^1] (such as `paket`)|
 |`#r "assembly-name.dll"`|References an assembly on disk|
 |`#load "file-name.fsx"`|Reads a source file, compiles it, and runs it.|
-|`#help`|Displays information about available directives.|
+|`#help`|Displays information about available directives or documentation for specific objects and functions.|
 |`#I`|Specifies an assembly search path in quotation marks.|
 |`#quit`|Terminates an F# Interactive session.|
 |`#time "on"` or `#time "off"`|By itself, `#time` toggles whether to display performance information. When it is `"on"`, F# Interactive measures real time, CPU time, and garbage collection information for each section of code that is interpreted and executed.|
@@ -248,6 +248,41 @@ The `#r` and `#load` directives seen previously are only available in F# Interac
 [^1]: More about [F# Interactive extensions](https://aka.ms/dotnetdepmanager).
 
 When you specify files or paths in F# Interactive, a string literal is expected. Therefore, files and paths must be in quotation marks, and the usual escape characters apply. You can use the `@` character to cause F# Interactive to interpret a string that contains a path as a verbatim string. This causes F# Interactive to ignore any escape characters.
+
+### Extended #help directive
+
+The `#help` directive now supports displaying documentation for specific objects or functions. You can pass the name of the object or function directly (without quotes) to retrieve details.
+
+```fsharp
+#help List.map;;
+```
+
+The output is as follows:
+```console
+Description:
+Builds a new collection whose elements are the results of applying the given function
+to each of the elements of the collection.
+
+Parameters:
+- mapping: The function to transform elements from the input list.
+- list: The input list.
+
+Returns:
+The list of transformed elements.
+
+Examples:
+let inputs = [ "a"; "bbb"; "cc" ]
+
+inputs |> List.map (fun x -> x.Length)
+// Evaluates to [ 1; 3; 2 ]
+
+Full name: Microsoft.FSharp.Collections.ListModule.map
+Assembly: FSharp.Core.dll
+```
+
+This enhancement makes it easier to explore and understand F# libraries interactively.
+
+For more details, refer to the [official devblog](https://devblogs.microsoft.com/dotnet/enhancing-help-in-fsi/).
 
 ## Interactive and compiled preprocessor directives
 

--- a/docs/fsharp/tools/fsharp-interactive/index.md
+++ b/docs/fsharp/tools/fsharp-interactive/index.md
@@ -258,6 +258,7 @@ The `#help` directive now supports displaying documentation for specific objects
 ```
 
 The output is as follows:
+
 ```console
 Description:
 Builds a new collection whose elements are the results of applying the given function


### PR DESCRIPTION
## Summary

This PR adds a detailed explanation of the enhanced `#help` directive in F# Interactive, which now supports displaying documentation for specific objects or functions.

**Key Updates:**
- Extended the **"F# Interactive directive reference"** section with additional details about `#help`.
- Provided examples showcasing how users can interactively retrieve documentation for specific functions or objects in F# Interactive.
- Included example output to demonstrate the usability of this enhancement.
- Added a reference to the [official development blog](https://devblogs.microsoft.com/dotnet/enhancing-help-in-fsi/) for further details.

These updates aim to improve discoverability and usability for F# developers, making it easier to understand and explore libraries interactively.

Fixes #43704 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/tools/fsharp-interactive/index.md](https://github.com/dotnet/docs/blob/64b1f23f26e23e89b192b3c65f957cf41c63d561/docs/fsharp/tools/fsharp-interactive/index.md) | [Interactive programming with F\#](https://review.learn.microsoft.com/en-us/dotnet/fsharp/tools/fsharp-interactive/index?branch=pr-en-us-43736) |


<!-- PREVIEW-TABLE-END -->