### PR TITLE
fix System.IO.IOException error

### DIFF
--- a/samples/snippets/standard/data/sqlite/HelloWorldSample/Program.cs
+++ b/samples/snippets/standard/data/sqlite/HelloWorldSample/Program.cs
@@ -79,6 +79,7 @@ namespace HelloWorldSample
             #endregion
 
             // Clean up
+            SqliteConnection.ClearAllPools();
             File.Delete("hello.db");
         }
     }


### PR DESCRIPTION
previous version throwing error:
System.IO.IOException: 'The process cannot access the file because it is being used by another process.' 

on line 82:
  File.Delete("hello.db");

with SQLite version 3.47.0 and dotnet version 8.0.401

adding 
SqliteConnection.ClearAllPools(); 
in the line before deleting the file seems to close background connections and release the file to be deleted.
