### PR TITLE
Update using-udp-services.md

### DIFF
--- a/docs/framework/network-programming/using-udp-services.md
+++ b/docs/framework/network-programming/using-udp-services.md
@@ -121,6 +121,7 @@ Imports System.Text
 Public Class Program
     Public Shared Sub Main(args() As [String])
       Dim s As New Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp)
+      s.EnableBroadcast = True
       Dim broadcast As IPAddress = IPAddress.Parse("192.168.1.255")
       Dim sendbuf As Byte() = Encoding.ASCII.GetBytes(args(0))
       Dim ep As New IPEndPoint(broadcast, 11000)

--- a/docs/framework/network-programming/using-udp-services.md
+++ b/docs/framework/network-programming/using-udp-services.md
@@ -141,6 +141,7 @@ class Program
     static void Main(string[] args)
     {
         Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        s.EnableBroadcast = true;
 
         IPAddress broadcast = IPAddress.Parse("192.168.1.255");
 


### PR DESCRIPTION
## Summary

Set s.EnableBroadcast to true to avoid exception
System.Net.Sockets.SocketException (13): Permission denied

Describe your changes here.

Added the line 
`s.EnableBroadcast = true;`
 following the creation of the socket object to avoid encountering a permission denied socket exception.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/network-programming/using-udp-services.md](https://github.com/dotnet/docs/blob/9c52105c053c58b29ad7d6b4f851cfba541b709a/docs/framework/network-programming/using-udp-services.md) | [Use UDP services](https://review.learn.microsoft.com/en-us/dotnet/framework/network-programming/using-udp-services?branch=pr-en-us-43738) |


<!-- PREVIEW-TABLE-END -->