### PR TITLE
Update ca1872.md

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1872.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1872.md
@@ -90,12 +90,12 @@ class HelloWorldEncoder
 
     public string Encode()
     {
-        return Convert.ToHexString(data);
+        return Convert.ToHexString(_data);
     }
 
     public string EncodeToLower()
     {
-        return Convert.ToHexStringLower(data);
+        return Convert.ToHexStringLower(_data);
     }
 }
 ```
@@ -108,11 +108,11 @@ Class HelloWorldEncoder
     Private ReadOnly _data As Byte() = Encoding.ASCII.GetBytes("Hello World")
 
     Public Function Encode() As String
-        Return Convert.ToHexString(data)
+        Return Convert.ToHexString(_data)
     End Function
 
     Public Function EncodeToLower() As String
-        Return Convert.ToHexStringLower(data)
+        Return Convert.ToHexStringLower(_data)
     End Function
 End Class
 ```


### PR DESCRIPTION
## Summary

Fix typo in code snippet.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1872.md](https://github.com/dotnet/docs/blob/b7002169b9f31756f45e9063b62aff01bdecdd53/docs/fundamentals/code-analysis/quality-rules/ca1872.md) | [CA1872: Prefer 'Convert.ToHexString' and 'Convert.ToHexStringLower' over call chains based on 'BitConverter.ToString'](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1872?branch=pr-en-us-43739) |

<!-- PREVIEW-TABLE-END -->