### PR TITLE
Automatically close code-of-conduct issues

### DIFF
--- a/.github/policies/close-issues.yml
+++ b/.github/policies/close-issues.yml
@@ -19,3 +19,12 @@ configuration:
               - addReply:
                   reply: This issue has been automatically closed due to no response from the original author. Feel free to reopen it if you have more information that can help us investigate the issue further.
               - closeIssue
+
+        eventResponderTasks:
+            - description: Close issues labeled 'code-of-conduct'
+              if:
+                - payloadType: Issues
+                - hasLabel:
+                    label: code-of-conduct
+              then:
+                - closeIssue


### PR DESCRIPTION
If someone adds the code-of-conduct label, automatically close the issue.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/policies/close-issues.yml](https://github.com/dotnet/docs/blob/459ed514b5901a2a21831aa09c10d66d5bf8ae03/.github/policies/close-issues.yml) | [.github/policies/close-issues](https://review.learn.microsoft.com/en-us/dotnet/.github/policies/close-issues?branch=pr-en-us-43763) |

<!-- PREVIEW-TABLE-END -->