### PR TITLE
Assembly name attribute breaking change

### DIFF
--- a/docs/core/compatibility/7.0.md
+++ b/docs/core/compatibility/7.0.md
@@ -14,7 +14,7 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 ## ASP.NET Core
 
 | Title | Binary compatible | Source compatible |
-| - | :-: | :-: |
+|-------|:-----------------:|:-----------------:|
 | [API controller actions try to infer parameters from DI](aspnet-core/7.0/api-controller-action-parameters-di.md) | ✔️ | ❌ |
 | [ASPNET-prefixed environment variable precedence](aspnet-core/7.0/environment-variable-precedence.md) | ✔️ | ✔️ |
 | [AuthenticateAsync for remote auth providers](aspnet-core/7.0/authenticateasync-anonymous-request.md) | ✔️ | ❌ |
@@ -34,9 +34,10 @@ If you're migrating an app to .NET 7, the breaking changes listed here might aff
 ## Core .NET libraries
 
 | Title | Binary compatible | Source compatible |
-| - | :-: | :-: |
+|-------|:-----------------:|:-----------------:|
 | [API obsoletions with default diagnostic ID](core-libraries/7.0/obsolete-apis-with-default-diagnostic.md) | ✔️ | ❌ |
 | [API obsoletions with non-default diagnostic IDs](core-libraries/7.0/obsolete-apis-with-custom-diagnostics.md) | ✔️ | ❌ |
+| [Asterisk no longer accepted for assembly name attributes](core-libraries/7.0/assembly-name-wildcard.md) | ✔️ | ✔️ |
 | [BinaryFormatter serialization APIs produce compiler errors](serialization/7.0/binaryformatter-apis-produce-errors.md) | ✔️ | ❌ |
 | [BrotliStream no longer allows undefined CompressionLevel values](core-libraries/7.0/brotlistream-ctor.md) | ❌ | ✔️ |
 | [C++/CLI projects in Visual Studio](core-libraries/7.0/cpluspluscli-compiler-version.md) | ✔️ | ❌ |

--- a/docs/core/compatibility/core-libraries/7.0/assembly-name-wildcard.md
+++ b/docs/core/compatibility/core-libraries/7.0/assembly-name-wildcard.md
@@ -1,0 +1,55 @@
+---
+title: "Breaking change: Asterisk no longer accepted for assembly name attributes"
+description: Learn about the breaking change in core .NET libraries in .NET 7 where assembly names no longer accept '*' as a wildcard attribute value.
+ms.date: 11/25/2024
+ai-usage: ai-assisted
+ms.custom: https://github.com/dotnet/docs/issues/42598
+---
+
+# Asterisk no longer accepted for assembly name attributes
+
+Prior to .NET 7, assembly names allowed specifying `*` as a wildcard value for an attribute value, which was equivalent to not specifying the value at all. This undocumented feature was removed in .NET 7.
+
+## Version introduced
+
+.NET 7
+
+## Previous behavior
+
+Previously, you could specify `*` as a value for assembly name attributes. For example, the following code succeeded:
+
+```csharp
+Assembly.Load("System.Runtime, Version=*, PublicKeyToken=*");
+```
+
+The asterisk had identical behavior to not specifying the attribute value at all:
+
+```csharp
+Assembly.Load("System.Runtime");
+```
+
+## New behavior
+
+Starting in .NET 7, the following code fails with a <xref:System.IO.FileLoadException> with the error message "The given assembly name was invalid".
+
+```csharp
+Assembly.Load("System.Runtime, Version=*, PublicKeyToken=*")
+```
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+The previous behavior was an undocumented feature and it wasn't consistent implemented by all .NET assembly name parsers. The undocumented feature was removed to unify the behavior of assembly name parsing throughout .NET.
+
+## Recommended action
+
+Omit assembly name attributes that have a wildcard value. For example, change `System.Runtime, Version=*` to just `System.Runtime`.
+
+## Affected APIs
+
+- <xref:System.Reflection.Assembly.Load(System.String)?displayProperty=fullName>
+- <xref:System.Type.GetType(System.String)?displayProperty=fullName>
+- <xref:System.Reflection.AssemblyName.#ctor(System.String)?displayProperty=fullName>

--- a/docs/core/compatibility/core-libraries/7.0/assembly-name-wildcard.md
+++ b/docs/core/compatibility/core-libraries/7.0/assembly-name-wildcard.md
@@ -52,4 +52,4 @@ Omit assembly name attributes that have a wildcard value. For example, change `S
 
 - <xref:System.Reflection.Assembly.Load(System.String)?displayProperty=fullName>
 - <xref:System.Type.GetType(System.String)?displayProperty=fullName>
-- <xref:System.Reflection.AssemblyName.#ctor(System.String)?displayProperty=fullName>
+- <xref:System.Reflection.AssemblyName.%23ctor(System.String)?displayProperty=fullName>

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -394,6 +394,8 @@ items:
                 href: core-libraries/7.0/obsolete-apis-with-default-diagnostic.md
               - name: API obsoletions with non-default diagnostic IDs
                 href: core-libraries/7.0/obsolete-apis-with-custom-diagnostics.md
+              - name: Asterisk no longer accepted for assembly name attributes
+                href: core-libraries/7.0/assembly-name-wildcard.md
               - name: BrotliStream no longer allows undefined CompressionLevel values
                 href: core-libraries/7.0/brotlistream-ctor.md
               - name: C++/CLI projects in Visual Studio
@@ -1362,6 +1364,8 @@ items:
                 href: core-libraries/7.0/obsolete-apis-with-default-diagnostic.md
               - name: API obsoletions with non-default diagnostic IDs
                 href: core-libraries/7.0/obsolete-apis-with-custom-diagnostics.md
+              - name: Asterisk no longer accepted for assembly name attributes
+                href: core-libraries/7.0/assembly-name-wildcard.md
               - name: BrotliStream no longer allows undefined CompressionLevel values
                 href: core-libraries/7.0/brotlistream-ctor.md
               - name: C++/CLI projects in Visual Studio


### PR DESCRIPTION
Fixes #42598

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/7.0.md](https://github.com/dotnet/docs/blob/767b0aa4450a0993d66df8db9b89ed6a5d01c932/docs/core/compatibility/7.0.md) | [Breaking changes in .NET 7](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/7.0?branch=pr-en-us-43764) |
| [docs/core/compatibility/core-libraries/7.0/assembly-name-wildcard.md](https://github.com/dotnet/docs/blob/767b0aa4450a0993d66df8db9b89ed6a5d01c932/docs/core/compatibility/core-libraries/7.0/assembly-name-wildcard.md) | [Asterisk no longer accepted for assembly name attributes](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/7.0/assembly-name-wildcard?branch=pr-en-us-43764) |
| [docs/core/compatibility/toc.yml](https://github.com/dotnet/docs/blob/767b0aa4450a0993d66df8db9b89ed6a5d01c932/docs/core/compatibility/toc.yml) | [docs/core/compatibility/toc](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/toc?branch=pr-en-us-43764) |


<!-- PREVIEW-TABLE-END -->