### PR TITLE
Change References to .NET 9 SDK

### DIFF
--- a/docs/core/tutorials/library-with-visual-studio-code.md
+++ b/docs/core/tutorials/library-with-visual-studio-code.md
@@ -10,7 +10,7 @@ zone_pivot_groups: dotnet-version
 
 In this tutorial, you create a simple utility library that contains a single string-handling method.
 
-A *class library* defines types and methods that are called by an application. If the library targets .NET Standard 2.0, it can be called by any .NET implementation (including .NET Framework) that supports .NET Standard 2.0. If the library targets .NET 8, it can be called by any application that targets .NET 8. This tutorial shows how to target .NET 8.
+A *class library* defines types and methods that are called by an application. If the library targets .NET Standard 2.0, it can be called by any .NET implementation (including .NET Framework) that supports .NET Standard 2.0. If the library targets .NET 9, it can be called by any application that targets .NET 9. This tutorial shows how to target .NET 9.
 
 When you create a class library, you can distribute it as a third-party component or as a bundled component with one or more applications.
 
@@ -20,7 +20,7 @@ When you create a class library, you can distribute it as a third-party componen
 
   For information about how to install extensions on Visual Studio Code, see [VS Code Extension Marketplace](https://code.visualstudio.com/docs/editor/extension-gallery).
 
-* The [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0).
+* The [.NET 9 SDK](https://dotnet.microsoft.com/download/dotnet/9.0).
 
 ## Create a class library project
 
@@ -36,21 +36,21 @@ Start by creating a .NET class library project named "StringLibrary" and an asso
 
 1. Then select the location where you would like the new project to be created: Create a folder named `ClassLibraryProjects` and select it.
 
-1. Name the project **StringLibrary**, select **Show all template options**, select **.NET 8** and select **Create Project**.
+1. Name the project **StringLibrary**, select **Show all template options**, select **.NET 9** and select **Create Project**.
 
 1. Name the project **StringLibrary** and select **Create Project**.
 
 1. Press Enter at the prompt **Project will be created in \<path>**.
 
-1. Check to make sure that the library targets .NET 8. In **Explorer**, open *StringLibrary/StringLibrary.csproj*.
+1. Check to make sure that the library targets .NET 9. In **Explorer**, open *StringLibrary/StringLibrary.csproj*.
 
-   The `TargetFramework` element shows that the project targets .NET 8.0.
+   The `TargetFramework` element shows that the project targets .NET 9.0.
 
    ```xml
    <Project Sdk="Microsoft.NET.Sdk">
 
      <PropertyGroup>
-       <TargetFramework>net8.0</TargetFramework>
+       <TargetFramework>net9.0</TargetFramework>
      </PropertyGroup>
 
    </Project>
@@ -77,7 +77,7 @@ Start by creating a .NET class library project named "StringLibrary" and an asso
    Copyright (C) Microsoft Corporation. All rights reserved.
      Determining projects to restore...
      All projects are up-to-date for restore.
-     StringLibrary -> C:\Projects\ClassLibraryProjects\StringLibrary\bin\Debug\net8.0\StringLibrary.dll
+     StringLibrary -> C:\Projects\ClassLibraryProjects\StringLibrary\bin\Debug\net9.0\StringLibrary.dll
    Build succeeded.
        0 Warning(s)
        0 Error(s)


### PR DESCRIPTION
Includes hyperlink to .NET 9 SDK download page

## Summary

Just a quick change to version numbers mentioned within the documentation and the download hyperlink 



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tutorials/library-with-visual-studio-code.md](https://github.com/dotnet/docs/blob/c25eee7bcfd9d3f5ea833b2ff66f07c7d206b7de/docs/core/tutorials/library-with-visual-studio-code.md) | [Tutorial: Create a .NET class library using Visual Studio Code](https://review.learn.microsoft.com/en-us/dotnet/core/tutorials/library-with-visual-studio-code?branch=pr-en-us-43770) |

<!-- PREVIEW-TABLE-END -->