### PR TITLE
Fix Incorrect Expected Output in "Partial Classes" Example by Adding Console.WriteLine Statements

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/snippets/partial-classes-and-methods/Program.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/snippets/partial-classes-and-methods/Program.cs
@@ -4,6 +4,7 @@ public partial class Employee
 {
     public void DoWork()
     {
+        Console.WriteLine("Employee is working.");
     }
 }
 
@@ -12,6 +13,7 @@ public partial class Employee
 {
     public void GoToLunch()
     {
+        Console.WriteLine("Employee is at lunch.");
     }
 }
 


### PR DESCRIPTION
## Summary

This PR addresses the issue by:

Adding a `Console.WriteLine` statement to the `DoWork` method in `Employee_Part1.cs` to output: Employee is working.
Adding a `Console.WriteLine` statement to the `GoToLunch` method in `Employee_Part2.cs` to output: Employee is at lunch.

Fixes #43711 
