### PR TITLE
Adjust Uri redaction breaking change docs

### DIFF
--- a/docs/core/compatibility/networking/9.0/query-redaction-events.md
+++ b/docs/core/compatibility/networking/9.0/query-redaction-events.md
@@ -27,7 +27,7 @@ This change is a [behavioral change](../../categories.md#behavioral-change).
 
 ## Reason for change
 
-The primary reason for this change was to enhance privacy by reducing the risk of sensitive information being logged inadvertently. Query strings often contain sensitive data, and redacting them from logs by default helps protect this information. The fragment part is being scrubbed to keep the implementation simple and efficient.
+The primary reason for this change was to enhance privacy by reducing the risk of sensitive information being logged inadvertently. Query strings often contain sensitive data, and redacting them from logs by default helps protect this information. To keep the implementation simple and efficient, the fragment part is also being scrubbed together with the query.
 
 ## Recommended action
 

--- a/docs/core/compatibility/networking/9.0/query-redaction-events.md
+++ b/docs/core/compatibility/networking/9.0/query-redaction-events.md
@@ -5,9 +5,9 @@ ms.date: 11/5/2024
 ai-usage: ai-assisted
 ---
 
-# URI query redaction in HttpClient EventSource events
+# URI query and fragment redaction in HttpClient EventSource events
 
-In .NET 9, the default behavior of <xref:System.Diagnostics.Tracing.EventSource> events emitted by <xref:System.Net.Http.HttpClient> and <xref:System.Net.Http.SocketsHttpHandler> (`EventSource` name: `System.Net.Http`) has been modified to scrub query strings. This change enhances privacy by preventing the logging of potentially sensitive information contained in query strings. If necessary, you can override this behavior.
+In .NET 9, the default behavior of <xref:System.Diagnostics.Tracing.EventSource> events emitted by <xref:System.Net.Http.HttpClient> and <xref:System.Net.Http.SocketsHttpHandler> (`EventSource` name: `System.Net.Http`) has been modified to scrub the query and the fragment part of the Uri. This change enhances privacy by preventing the logging of potentially sensitive information contained in query strings while keeping the performance costs of the redaction minimal. If necessary, you can override this behavior.
 
 ## Version introduced
 
@@ -19,7 +19,7 @@ Previously, events emitted by `HttpClient` and `SocketsHttpHandler` included que
 
 ## New behavior
 
-With the change in [dotnet/runtime#104741](https://github.com/dotnet/runtime/pull/104741), query strings are replaced by a `*` character in `HttpClient` and `SocketsHttpHandler` events, by default. This change affects specific events and parameters such as `pathAndQuery` in `RequestStart` and `redirectUri` in `Redirect`.
+With the change in [dotnet/runtime#104741](https://github.com/dotnet/runtime/pull/104741), the query and the fragment part by a `*` character in `HttpClient` and `SocketsHttpHandler` events, by default. This change affects specific events and parameters such as `pathAndQuery` in `RequestStart` and `redirectUri` in `Redirect`.
 
 ## Type of breaking change
 
@@ -27,7 +27,7 @@ This change is a [behavioral change](../../categories.md#behavioral-change).
 
 ## Reason for change
 
-The primary reason for this change was to enhance privacy by reducing the risk of sensitive information being logged inadvertently. Query strings often contain sensitive data, and redacting them from logs by default helps protect this information.
+The primary reason for this change was to enhance privacy by reducing the risk of sensitive information being logged inadvertently. Query strings often contain sensitive data, and redacting them from logs by default helps protect this information. The fragment part is being scrubbed to keep the implementation simple and efficient.
 
 ## Recommended action
 

--- a/docs/core/compatibility/networking/9.0/query-redaction-logs.md
+++ b/docs/core/compatibility/networking/9.0/query-redaction-logs.md
@@ -5,9 +5,9 @@ ms.date: 11/5/2024
 ai-usage: ai-assisted
 ---
 
-# URI query redaction in IHttpClientFactory logs
+# URI query and fragment redaction in IHttpClientFactory logs
 
-In .NET 9, the default implementation of <xref:System.Net.Http.IHttpClientFactory> has been modified to scrub query strings when logging URI information. This change enhances privacy by preventing the logging of potentially sensitive information contained in query strings. For scenarios where logging query strings is necessary and deemed safe, you can override this behavior.
+In .NET 9, the default implementation of <xref:System.Net.Http.IHttpClientFactory> has been modified to scrub query strings when logging URI information. This change enhances privacy by preventing the logging of potentially sensitive information contained in query strings while keeping the performance costs of the redaction minimal. For scenarios where logging query strings is necessary and deemed safe, you can override this behavior.
 
 ## Version introduced
 
@@ -19,7 +19,7 @@ Previously, the default implementation of `IHttpClientFactory` logging included 
 
 ## New behavior
 
-The messages passed to <xref:Microsoft.Extensions.Logging.ILogger> now have query strings replaced by a `*` character.
+The messages passed to <xref:Microsoft.Extensions.Logging.ILogger> now have the query and the fragment part replaced by a `*` character.
 
 ## Type of breaking change
 
@@ -27,7 +27,7 @@ This change is a [behavioral change](../../categories.md#behavioral-change).
 
 ## Reason for change
 
-The primary reason for this change is to enhance privacy by reducing the risk of sensitive information being logged inadvertently. Query strings often contain sensitive data and excluding them from logs by default helps protect this information.
+The primary reason for this change is to enhance privacy by reducing the risk of sensitive information being logged inadvertently. Query strings often contain sensitive data and excluding them from logs by default helps protect this information. The fragment part is being scrubbed to keep the implementation simple and efficient.
 
 ## Recommended action
 


### PR DESCRIPTION
## Summary

The docs did not document that the fragment part is also being redacted away, which turned out to be problematic, see discussion in https://github.com/dotnet/runtime/issues/109847.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/networking/9.0/query-redaction-events.md](https://github.com/dotnet/docs/blob/e66dd687c52df080c502c4ea84e4a2425b4aa425/docs/core/compatibility/networking/9.0/query-redaction-events.md) | [URI query and fragment redaction in HttpClient EventSource events](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/networking/9.0/query-redaction-events?branch=pr-en-us-43795) |
| [docs/core/compatibility/networking/9.0/query-redaction-logs.md](https://github.com/dotnet/docs/blob/e66dd687c52df080c502c4ea84e4a2425b4aa425/docs/core/compatibility/networking/9.0/query-redaction-logs.md) | ["URI query redaction in IHttpClientFactory logs"](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/networking/9.0/query-redaction-logs?branch=pr-en-us-43795) |

<!-- PREVIEW-TABLE-END -->