### PR TITLE
Mention more android/ios RIDs in rid-catalog.md

### DIFF
--- a/docs/core/rid-catalog.md
+++ b/docs/core/rid-catalog.md
@@ -132,10 +132,15 @@ For more information, see [.NET dependencies and requirements](./install/macos.m
 ### iOS RIDs
 
 - `ios-arm64`
+- `iossimulator-arm64`
+- `iossimulator-x64`
 
 ### Android RIDs
 
 - `android-arm64`
+- `android-arm`
+- `android-x64`
+- `android-x86`
 
 ## See also
 


### PR DESCRIPTION
## Summary
A couple customers got confused about "missing" RIDs for ios/android. While the full list is available in the linked PortableRuntimeIdentifierGraph.json let's mention the most important ones to prevent confusion.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/rid-catalog.md](https://github.com/dotnet/docs/blob/5894a627976e595c89e44f2870890a2c123d0db7/docs/core/rid-catalog.md) | [docs/core/rid-catalog](https://review.learn.microsoft.com/en-us/dotnet/core/rid-catalog?branch=pr-en-us-43812) |

<!-- PREVIEW-TABLE-END -->