### PR TITLE
Add CS8002.md to the language reference TOC.

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -500,6 +500,7 @@
                 "_csharplang/proposals/csharp-10.0/*.md": "08/07/2021",
                 "_csharplang/proposals/csharp-11.0/*.md": "09/30/2022",
                 "_csharplang/proposals/csharp-12.0/*.md": "08/15/2023",
+                "_csharplang/proposals/csharp-13.0/*.md": "10/31/2024",
                 "_csharplang/proposals/*.md": "10/31/2024",
                 "_roslyn/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md": "11/08/2022",
                 "_roslyn/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 8.md": "09/26/2023",

--- a/docs/csharp/language-reference/toc.yml
+++ b/docs/csharp/language-reference/toc.yml
@@ -1949,6 +1949,8 @@ items:
       href: ./compiler-messages/cs8422.md
     - name: CS8515
       href: ./compiler-messages/cs8515.md
+    - name: CS8802
+      href: ./compiler-messages/cs8802.md
     - name: CS8803
       href: ./compiler-messages/cs8803.md
     - name: CS8812


### PR DESCRIPTION
This was missed in #43728

Noticed in #43805


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/toc.yml](https://github.com/dotnet/docs/blob/a9a62111411f963ec767b713b09ed6cf9b045ba8/docs/csharp/language-reference/toc.yml) | [docs/csharp/language-reference/toc](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/toc?branch=pr-en-us-43823) |


<!-- PREVIEW-TABLE-END -->