### PR TITLE
Random code fix updates

### DIFF
--- a/docs/fundamentals/code-analysis/overview.md
+++ b/docs/fundamentals/code-analysis/overview.md
@@ -25,7 +25,7 @@ If rule violations are found by an analyzer, they're reported as a suggestion, w
 *Code quality analysis* ("CAxxxx") rules inspect your C# or Visual Basic code for security, performance, design and other issues. Analysis is enabled, by default, for projects that target .NET 5 or later. You can enable code analysis on projects that target earlier .NET versions by setting the [EnableNETAnalyzers](../../core/project-sdk/msbuild-props.md#enablenetanalyzers) property to `true`. You can also disable code analysis for your project by setting `EnableNETAnalyzers` to `false`.
 
 > [!TIP]
-> If you're using Visual Studio, many analyzer rules have associated *code fixes* that you can apply to correct the problem. Code fixes are shown in the light bulb icon menu.
+> If you're using Visual Studio, many analyzer rules have associated *code fixes* that you can apply to automatically correct the problem. Code fixes are shown in the light bulb icon menu.
 
 ### Enabled rules
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1865-ca1867.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1865-ca1867.md
@@ -39,11 +39,11 @@ The target methods on `string` for these rules:
 
 The following table summarizes the conditions for each of the related rule IDs.
 
-| Diagnostic ID | Description | Code fix available |
-| - | - | - |
-| CA1865 | Applies when a safe transformation can be performed automatically with a code fix. | Yes |
-| CA1866 | Applies when there's no specified comparison. | No |
-| CA1867 | Applies for any other string comparison not covered by the other two rules. | No |
+| Diagnostic ID | Description                                                                        | Code fix available? |
+|---------------|------------------------------------------------------------------------------------|---------------------|
+| CA1865        | Applies when a safe transformation can be performed automatically with a code fix. | Yes                 |
+| CA1866        | Applies when there's no specified comparison.                                      | No                  |
+| CA1867        | Applies for any other string comparison not covered by the other two rules.        | No                  |
 
 CA1867 is disabled by default.
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1870.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1870.md
@@ -37,7 +37,7 @@ Using a cached <xref:System.Buffers.SearchValues%601> instance is more efficient
 
 Create and cache a <xref:System.Buffers.SearchValues%601> instance in a `static readonly` field, then pass that instance to the `IndexOfAny` or `ContainsAny` call instead.
 
-A code fixer that performs this transformation is available.
+A *code fix* that automatically performs this transformation is available.
 
 ## Example
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0028.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0028.md
@@ -28,10 +28,10 @@ dev_langs:
 
 This style rule concerns the use of [collection initializers](../../../csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md) and, if you're using C# 12 or later, [collection expressions](../../../csharp/language-reference/operators/collection-expressions.md) for collection initialization.
 
-In .NET 8 (C# 12) and later versions, if you have the `dotnet_style_prefer_collection_expression` option set to `true`, the code fixer in Visual Studio converts your collection initialization code to use a collection expression (`List<int> list = [1, 2, 3];`). In Visual Basic and in .NET 7 (C# 11) and earlier versions, the code fixer converts your code to use a collection initializer (`List<int> list = new List<int> { 1, 2, 3 };`).
+In .NET 8 (C# 12) and later versions, if you have the `dotnet_style_prefer_collection_expression` option set to `true`, the *code fix* in Visual Studio converts your collection initialization code to use a collection expression (`List<int> list = [1, 2, 3];`). In Visual Basic and in .NET 7 (C# 11) and earlier versions, the *code fix* converts your code to use a collection initializer (`List<int> list = new List<int> { 1, 2, 3 };`).
 
 > [!NOTE]
-> If you use the code fixer in Visual Studio, the change it offers might have different semantics in some cases. For example, `int[] x = new int[] { }` is replaced with `int[] x = [];`, which has slightly different semantics&mdash;the compiler uses a singleton for `x` instead of creating a new instance.
+> If you use the *code fix* in Visual Studio, the change it offers might have different semantics in some cases. For example, `int[] x = new int[] { }` is replaced with `int[] x = [];`, which has slightly different semantics&mdash;the compiler uses a singleton for `x` instead of creating a new instance.
 
 ## Options
 

--- a/docs/fundamentals/code-analysis/style-rules/ide0058.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide0058.md
@@ -62,13 +62,13 @@ For information about configuring options, see [Option format](language-rules.md
 
 ### csharp_style_unused_value_expression_statement_preference
 
-| Property                 | Value                                                     | Description                                                                 |
-| ------------------------ | --------------------------------------------------------- | --------------------------------------------------------------------------- |
-| **Option name**          | csharp_style_unused_value_expression_statement_preference |                                                                             |
-| **Applicable languages** | C#                                                        |                                                                             |
-| **Option values**        | `discard_variable`                                        | Prefer to assign an unused expression to a discard                          |
+| Property                 | Value                                                     | Description |
+|--------------------------|-----------------------------------------------------------|-------------|
+| **Option name**          | csharp_style_unused_value_expression_statement_preference |             |
+| **Applicable languages** | C#                                                        |             |
+| **Option values**        | `discard_variable`                                        | Prefer to assign an unused expression to a discard |
 |                          | `unused_local_variable`                                   | Prefer to assign an unused expression to a local variable that's never used |
-| **Default option value** | `discard_variable`                                        |                                                                             |
+| **Default option value** | `discard_variable`                                        |             |
 
 ```csharp
 // Original code:
@@ -85,12 +85,12 @@ var unused = Convert.ToInt32("35");
 
 ### visual_basic_style_unused_value_expression_statement_preference
 
-| Property                 | Value                                                           | Description                                                                 |
-| ------------------------ | --------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| **Option name**          | visual_basic_style_unused_value_expression_statement_preference |                                                                             |
-| **Applicable languages** | Visual Basic                                                    |                                                                             |
+| Property                 | Value                                                           | Description |
+|--------------------------|-----------------------------------------------------------------|-------------|
+| **Option name**          | visual_basic_style_unused_value_expression_statement_preference |             |
+| **Applicable languages** | Visual Basic                                                    |             |
 | **Option values**        | `unused_local_variable`                                         | Prefer to assign an unused expression to a local variable that's never used |
-| **Default option value** | `unused_local_variable`                                         |                                                                             |
+| **Default option value** | `unused_local_variable`                                         |             |
 
 ```vb
 ' visual_basic_style_unused_value_expression_statement_preference = unused_local_variable


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/overview.md](https://github.com/dotnet/docs/blob/bf647ffe6bcac13446453aa86c154efee3d2a901/docs/fundamentals/code-analysis/overview.md) | [Overview of .NET source code analysis](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/overview?branch=pr-en-us-43826) |
| [docs/fundamentals/code-analysis/quality-rules/ca1865-ca1867.md](https://github.com/dotnet/docs/blob/bf647ffe6bcac13446453aa86c154efee3d2a901/docs/fundamentals/code-analysis/quality-rules/ca1865-ca1867.md) | [CA1865-CA1867: Use 'string.Method(char)' instead of 'string.Method(string)' for string with single char](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1865-ca1867?branch=pr-en-us-43826) |
| [docs/fundamentals/code-analysis/quality-rules/ca1870.md](https://github.com/dotnet/docs/blob/bf647ffe6bcac13446453aa86c154efee3d2a901/docs/fundamentals/code-analysis/quality-rules/ca1870.md) | ["CA1870: Use a cached 'SearchValues' instance"](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1870?branch=pr-en-us-43826) |
| [docs/fundamentals/code-analysis/style-rules/ide0028.md](https://github.com/dotnet/docs/blob/bf647ffe6bcac13446453aa86c154efee3d2a901/docs/fundamentals/code-analysis/style-rules/ide0028.md) | [Use collection initializers or expressions (IDE0028)](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0028?branch=pr-en-us-43826) |
| [docs/fundamentals/code-analysis/style-rules/ide0058.md](https://github.com/dotnet/docs/blob/bf647ffe6bcac13446453aa86c154efee3d2a901/docs/fundamentals/code-analysis/style-rules/ide0058.md) | [Remove unnecessary expression value (IDE0058)](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0058?branch=pr-en-us-43826) |

<!-- PREVIEW-TABLE-END -->