### PR TITLE
Remove `Lo` (other letter) surrogate pairs

### DIFF
--- a/docs/csharp/fundamentals/coding-style/identifier-names.md
+++ b/docs/csharp/fundamentals/coding-style/identifier-names.md
@@ -19,7 +19,7 @@ You can declare identifiers that match C# keywords by using the `@` prefix on th
 For a complete definition of valid identifiers, see the [Identifiers article in the C# Language Specification](~/_csharpstandard/standard/lexical-structure.md#643-identifiers).
 
 > [!IMPORTANT]
-> [The C# language specification](~/_csharpstandard/standard/lexical-structure.md#643-identifiers) only allows letter (Lu, Ll, Lt, Lm, Lo or Nl), digit (Nd), connecting (Pc), combining (Mn or Mc), and formatting (Cf) categories. Anything outside that is automatically replaced using `_`. This might impact certain Unicode characters.
+> [The C# language specification](~/_csharpstandard/standard/lexical-structure.md#643-identifiers) only allows letter (Lu, Ll, Lt, Lm, or Nl), digit (Nd), connecting (Pc), combining (Mn or Mc), and formatting (Cf) categories. Anything outside that is automatically replaced using `_`. This might impact certain Unicode characters.
 
 ## Naming conventions
 


### PR DESCRIPTION
See dotnet/csharplang#1742 for details.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/fundamentals/coding-style/identifier-names.md](https://github.com/dotnet/docs/blob/e9c509edf74d013030c89c1c4e8f57127b4f8b7c/docs/csharp/fundamentals/coding-style/identifier-names.md) | [C# identifier naming rules and conventions](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/identifier-names?branch=pr-en-us-43836) |

<!-- PREVIEW-TABLE-END -->