### PR TITLE
Breaking changes (3)

### DIFF
--- a/docs/core/compatibility/9.0.md
+++ b/docs/core/compatibility/9.0.md
@@ -22,6 +22,7 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 | [DefaultKeyResolution.ShouldGenerateNewKey has altered meaning](aspnet-core/9.0/key-resolution.md) | Behavioral change | Preview 3  |
 | [Dev cert export no longer creates folder](aspnet-core/9.0/certificate-export.md)        | Behavioral change   | RC 1               |
 | [HostBuilder enables ValidateOnBuild/ValidateScopes in development environment](aspnet-core/9.0/hostbuilder-validation.md) | Behavioral change | Preview 7  |
+| [Legacy Mono and Emscripten APIs not exported to global namespace](aspnet-core/9.0/legacy-apis.md) | Source incompatible | GA                |
 | [Middleware types with multiple constructors](aspnet-core/9.0/middleware-constructors.md) | Behavioral change  | RC 1               |
 
 ## Containers

--- a/docs/core/compatibility/9.0.md
+++ b/docs/core/compatibility/9.0.md
@@ -28,7 +28,8 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 
 | Title                                                                       | Type of change    | Introduced version |
 |-----------------------------------------------------------------------------|-------------------|--------------------|
-| [.NET 9 container images no longer install zlib](containers/9.0/no-zlib.md) | Behavioral change | Preview 7          |
+| [Container images no longer install zlib](containers/9.0/no-zlib.md) | Behavioral change | Preview 7          |
+| [.NET Monitor images simplified to version-only tags](containers/9.0/monitor-images.md) | Preview 5         |
 
 ## Core .NET libraries
 

--- a/docs/core/compatibility/9.0.md
+++ b/docs/core/compatibility/9.0.md
@@ -29,7 +29,7 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 | Title                                                                       | Type of change    | Introduced version |
 |-----------------------------------------------------------------------------|-------------------|--------------------|
 | [Container images no longer install zlib](containers/9.0/no-zlib.md) | Behavioral change | Preview 7          |
-| [.NET Monitor images simplified to version-only tags](containers/9.0/monitor-images.md) | Preview 5         |
+| [.NET Monitor images simplified to version-only tags](containers/9.0/monitor-images.md) | Behavioral change |Preview 5         |
 
 ## Core .NET libraries
 
@@ -48,6 +48,7 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 | [Inline array struct size limit is enforced](core-libraries/9.0/inlinearray-size.md) | Behavioral change   | Preview 1          |
 | [InMemoryDirectoryInfo prepends rootDir to files](core-libraries/9.0/inmemorydirinfo-prepends-rootdir.md) | Behavioral change   | Preview 1          |
 | [New TimeSpan.From*() overloads that take integers](core-libraries/9.0/timespan-from-overloads.md) | Source incompatible   | Preview 3          |
+| [New version of some OOB packages](core-libraries/9.0/oob-packages.md) | Source incompatible   | Preview 5          |
 | [RuntimeHelpers.GetSubArray returns different type](core-libraries/9.0/getsubarray-return.md) | Behavioral change   | Preview 1          |
 | [String.Trim(params ReadOnlySpan\<char>) overload removed](core-libraries/9.0/string-trim.md) | Source/binary incompatible   | GA          |
 | [Support for empty environment variables](core-libraries/9.0/empty-env-variable.md) | Behavioral change   | Preview 6          |

--- a/docs/core/compatibility/aspnet-core/9.0/legacy-apis.md
+++ b/docs/core/compatibility/aspnet-core/9.0/legacy-apis.md
@@ -1,0 +1,41 @@
+---
+title: "Legacy Mono and Emscripten JavaScript APIs not exported to global namespace in Blazor WebAssembly apps"
+description: Learn about the breaking change in ASP.NET Core 9 where legacy Mono and Emscripten APIs are now accessible through the Blazor.runtime object instead of the global namespace.
+ms.date: 12/4/2024
+ai-usage: ai-assisted
+ms.custom: https://github.com/aspnet/Announcements/issues/516
+---
+
+# Legacy Mono and Emscripten JavaScript APIs not exported to global namespace
+
+Blazor WebAssembly no longer exports legacy Mono and Emscripten APIs to the global namespace. These APIs are now accessible through the `Blazor.runtime` object.
+
+## Version introduced
+
+.NET 9 GA
+
+## Previous behavior
+
+Legacy Mono APIs (`MONO` and `BINDING`) and the Emscripten `Module` object were exported to the global `window` object. For example, `window.Module.FS` returned the Emscripten virtual filesystem.
+
+## New behavior
+
+The Emscripten `Module` object is now exported to the `Blazor.runtime` object. For example, `Blazor.runtime.Module.FS` returns the Emscripten virtual filesystem. The legacy Mono API for interop (`MONO` and `BINDING`) is removed completely and replaced with `JSImport`/`JSExport`.
+
+## Type of breaking change
+
+This change can affect [source compatibility](../categories.md#source-incompatible).
+
+## Reason for change
+
+This change was made to avoid polluting the global namespace and keep all the APIs accessible from a single Blazor object.
+
+## Recommended action
+
+Instead of accessing Emscripten APIs from the `window` object, access them from the `Blazor.runtime` object.
+
+## Affected APIs
+
+- `window.MONO.*`
+- `window.BINDING.*`
+- `window.Module.*`

--- a/docs/core/compatibility/aspnet-core/9.0/legacy-apis.md
+++ b/docs/core/compatibility/aspnet-core/9.0/legacy-apis.md
@@ -24,7 +24,7 @@ The Emscripten `Module` object is now exported to the `Blazor.runtime` object. F
 
 ## Type of breaking change
 
-This change can affect [source compatibility](../../categories.md#source-incompatible).
+This change can affect [source compatibility](../../categories.md#source-compatibility).
 
 ## Reason for change
 

--- a/docs/core/compatibility/aspnet-core/9.0/legacy-apis.md
+++ b/docs/core/compatibility/aspnet-core/9.0/legacy-apis.md
@@ -24,7 +24,7 @@ The Emscripten `Module` object is now exported to the `Blazor.runtime` object. F
 
 ## Type of breaking change
 
-This change can affect [source compatibility](../categories.md#source-incompatible).
+This change can affect [source compatibility](../../categories.md#source-incompatible).
 
 ## Reason for change
 

--- a/docs/core/compatibility/containers/9.0/monitor-images.md
+++ b/docs/core/compatibility/containers/9.0/monitor-images.md
@@ -1,0 +1,85 @@
+---
+title: ".NET Monitor images simplified to version-only tags"
+description: Learn about the breaking change in containers where the .NET Monitor 9 image offering has been simplified to only provide Azure Linux distroless images.
+ms.date: 12/4/2024
+ai-usage: ai-assisted
+ms.custom: https://github.com/dotnet/docs/issues/43379
+---
+
+# .NET Monitor images simplified to version-only tags
+
+The .NET Monitor 9 image offering has been simplified to only provide Azure Linux distroless images. As part of this change, the Ubuntu Chiseled and CBL-Mariner tags have been superseded by version-only tags.
+
+## Version introduced
+
+.NET Monitor 9
+
+## Previous behavior
+
+.NET Monitor 8 offered the following types of images:
+
+- Ubuntu Chiseled Arm64 and x64
+- CBL-Mariner Distroless Arm64 and x64
+
+## New behavior
+
+.NET Monitor 9 offers the following types of images and their tags:
+
+- Azure Linux distroless Arm64 and x64: `9`, `9.0`, and `9.0.0`
+
+The following tag patterns from .NET Monitor 8 don't have an equivalent in the .NET Monitor 9 offering:
+
+- Ubuntu Chiseled Arm64 and x64:
+  - `*-ubuntu-chiseled`
+  - `*-ubuntu-chiseled-amd64`
+  - `*-ubuntu-chiseled-arm64v8`
+- CBL-Mariner distroless Arm64 and x64:
+  - `*-cbl-mariner-distroless`
+  - `*-cbl-mariner-distroless-amd64`
+  - `*-cbl-mariner-distroless-arm64v8`
+
+The .NET Monitor 9 images have version-only tags. There are no OS tags due to only producing images based on a single distro.
+
+The `latest` tag has been updated from the Ubuntu Chiseled images to Azure Linux images.
+
+## Type of breaking change
+
+This change is a [behavioral change](../categories.md#behavioral-change).
+
+## Reason for change
+
+During the .NET Monitor 8.0 development cycle, only the .NET Ubuntu Chiseled images were publicly available for customers to use. Later in the development cycle, the .NET CBL-Mariner distroless images became publicly available for customers to use. At that time, it was decided to keep producing .NET Monitor images based on both distros so that current usage wasn't disrupted.
+
+From the perspective of the .NET Monitor tool, both distros provided a similar capability set, footprint, and security posture. The .NET Monitor images are intended to be used as appliance images. These images aren't intended to be used as base images for derivation and are only intended to be used "as-is". With the public availability of the .NET CBL-Mariner images last year, and subsequent change to Azure Linux, the .NET Monitor image offering has been simplified to only produce images based on the Azure Linux distro. The tagging scheme has been simplified to reflect this change.
+
+## Recommended action
+
+Updated your tag usage to indicate which image from the .NET Monitor 9 image offering you want to use. The following examples show some recommended migrations:
+
+- `8-cbl-mariner-distroless` -> `9`
+- `8.0-cbl-mariner-distroless` -> `9.0`
+- `8-ubuntu-chiseled` -> `9`
+- `8.0-ubuntu-chiseled` -> `9.0`
+
+The following table shows the recommended .NET Monitor 9 tags.
+
+| Tag   | Recommended use                                                     |
+|-------|---------------------------------------------------------------------|
+| `9`   | To stay on the latest .NET Monitor 9 *release and servicing* update |
+| `9.0` | To stay on the latest .NET Monitor 9.0 *servicing* update           |
+
+A full list of all supported tags can be found on .NET Monitor's [README](https://github.com/dotnet/dotnet-docker/blob/main/README.monitor.md#full-tag-listing) in the `dotnet/dotnet-docker` GitHub repository.
+
+Starting in .NET Monitor 8, the image offering was changed from using full distro images to using distroless images. If you're migrating from .NET Monitor 7 or earlier, the notable changes when migrating from a full distro image to a distroless image are:
+
+- The use of a non-root user
+- The lack of a package manager
+- The lack of a shell
+
+If you were using full distro images (for example, Alpine), you might need to adjust the running user of the .NET Monitor image in your deployments when migrating to .NET Monitor 8 or later. You can find guidance for changing the running user in the .NET Monitor 8.0 [compatibility documentation](https://github.com/dotnet/dotnet-monitor/blob/main/documentation/compatibility/8.0/README.md).
+
+For changes from .NET Monitor 8 to .NET Monitor 9, see the .NET Monitor 9.0 [compatibility documentation](https://github.com/dotnet/dotnet-monitor/blob/main/documentation/compatibility/9.0/README.md).
+
+## Affected APIs
+
+N/A

--- a/docs/core/compatibility/containers/9.0/monitor-images.md
+++ b/docs/core/compatibility/containers/9.0/monitor-images.md
@@ -54,7 +54,7 @@ From the perspective of the .NET Monitor tool, both distros provided a similar c
 
 ## Recommended action
 
-Updated your tag usage to indicate which image from the .NET Monitor 9 image offering you want to use. The following examples show some recommended migrations:
+Update your tag usage to indicate which image from the .NET Monitor 9 image offering you want to use. The following examples show some recommended migrations:
 
 - `8-cbl-mariner-distroless` -> `9`
 - `8.0-cbl-mariner-distroless` -> `9.0`

--- a/docs/core/compatibility/containers/9.0/monitor-images.md
+++ b/docs/core/compatibility/containers/9.0/monitor-images.md
@@ -44,7 +44,7 @@ The `latest` tag has been updated from the Ubuntu Chiseled images to Azure Linux
 
 ## Type of breaking change
 
-This change is a [behavioral change](../categories.md#behavioral-change).
+This change is a [behavioral change](../../categories.md#behavioral-change).
 
 ## Reason for change
 

--- a/docs/core/compatibility/core-libraries/9.0/oob-packages.md
+++ b/docs/core/compatibility/core-libraries/9.0/oob-packages.md
@@ -1,0 +1,60 @@
+---
+title: "New version of some OOB packages"
+description: Learn about the breaking change in core .NET libraries where updates were made to TFMs and package versions for several OOB packages.
+ms.date: 12/4/2024
+ai-usage: ai-assisted
+ms.custom: https://github.com/dotnet/docs/issues/43564
+---
+
+# New version of some OOB packages
+
+New versions of some out-of-band (OOB) packages were generated. The following changes were made that can be considered breaking:
+
+- The supported target framework monikers (TFMs) were updated.
+- The package version minor number was updated.
+- In some cases, some TFMs are no longer supported.
+
+Additionally, the source code of these packages was migrated from their old location, which was a branch of .NET that is no longer in support, to the <https://github.com/dotnet/maintenance-packages> repo.
+
+| Package                                 | Old source code location   | New package version |
+|-----------------------------------------|----------------------------|---------------------|
+| Microsoft.Bcl.HashCode                  | dotnet/corefx, 3.1 branch  | 6.0.0               |
+| Microsoft.IO.Redist                     | dotnet/runtime, 6.0 branch | 6.1.0               |
+| System.Buffers                          | dotnet/corefx, 2.1 branch  | 4.6.0               |
+| System.Data.SqlClient                   | dotnet/corefx, 3.1 branch  | 4.9.0               |
+| System.Json                             | dotnet/corefx, 3.1 branch  | 4.8.0               |
+| System.Memory                           | dotnet/corefx, 2.1 branch  | 4.6.0               |
+| System.Net.WebSockets.WebSocketProtocol | dotnet/runtime, 5.0 branch | 5.1.0               |
+| System.Numerics.Vectors                 | dotnet/corefx, 2.1 branch  | 4.6.0               |
+| System.Reflection.DispatchProxy         | dotnet/corefx, 3.1 branch  | 4.8.0               |
+| System.Runtime.CompilerServices.Unsafe  | dotnet/runtime, 6.0 branch | 6.1.0               |
+| System.Threading.Tasks.Extensions       | dotnet/corefx, 2.1 branch  | 4.6.0               |
+| System.Xml.XPath.XmlDocument            | dotnet/corefx, 1.1 branch  | 4.7.0               |
+
+## Version introduced
+
+.NET 9
+
+## Previous behavior
+
+The old packages targeted some TFMs that became out-of-support.
+
+## New behavior
+
+Some TFMs that were previously supported are no longer supported. However, there are no source code changes.
+
+## Type of breaking change
+
+This change can affect [source compatibility](../categories.md#source-incompatible).
+
+## Reason for change
+
+The source code of these packages was moved from their old branch, which was already out of support, to a repository that is actively maintained.
+
+## Recommended action
+
+Depending on the package, different recommended actions are provided. For more information, see the [package support policy](https://github.com/dotnet/maintenance-packages/tree/main/package-support-policy.md).
+
+## Affected APIs
+
+All APIs contained in the affected packages.

--- a/docs/core/compatibility/core-libraries/9.0/oob-packages.md
+++ b/docs/core/compatibility/core-libraries/9.0/oob-packages.md
@@ -16,20 +16,20 @@ New versions of some out-of-band (OOB) packages were generated. The following ch
 
 Additionally, the source code of these packages was migrated from their old location, which was a branch of .NET that is no longer in support, to the <https://github.com/dotnet/maintenance-packages> repo.
 
-| Package                                 | Old source code location   | New package version |
-|-----------------------------------------|----------------------------|---------------------|
-| Microsoft.Bcl.HashCode                  | dotnet/corefx, 3.1 branch  | 6.0.0               |
-| Microsoft.IO.Redist                     | dotnet/runtime, 6.0 branch | 6.1.0               |
-| System.Buffers                          | dotnet/corefx, 2.1 branch  | 4.6.0               |
-| System.Data.SqlClient                   | dotnet/corefx, 3.1 branch  | 4.9.0               |
-| System.Json                             | dotnet/corefx, 3.1 branch  | 4.8.0               |
-| System.Memory                           | dotnet/corefx, 2.1 branch  | 4.6.0               |
-| System.Net.WebSockets.WebSocketProtocol | dotnet/runtime, 5.0 branch | 5.1.0               |
-| System.Numerics.Vectors                 | dotnet/corefx, 2.1 branch  | 4.6.0               |
-| System.Reflection.DispatchProxy         | dotnet/corefx, 3.1 branch  | 4.8.0               |
-| System.Runtime.CompilerServices.Unsafe  | dotnet/runtime, 6.0 branch | 6.1.0               |
-| System.Threading.Tasks.Extensions       | dotnet/corefx, 2.1 branch  | 4.6.0               |
-| System.Xml.XPath.XmlDocument            | dotnet/corefx, 1.1 branch  | 4.7.0               |
+| Package                                 | Old source code location                                        | New package version |
+|-----------------------------------------|-----------------------------------------------------------------|---------------------|
+| Microsoft.Bcl.HashCode                  | [dotnet/corefx](https://github.com/dotnet/corefx), 3.1 branch   | 6.0.0               |
+| Microsoft.IO.Redist                     | [dotnet/runtime](https://github.com/dotnet/runtime), 6.0 branch | 6.1.0               |
+| System.Buffers                          | [dotnet/corefx](https://github.com/dotnet/corefx), 2.1 branch   | 4.6.0               |
+| System.Data.SqlClient                   | [dotnet/corefx](https://github.com/dotnet/corefx), 3.1 branch   | 4.9.0               |
+| System.Json                             | [dotnet/corefx](https://github.com/dotnet/corefx), 3.1 branch   | 4.8.0               |
+| System.Memory                           | [dotnet/corefx](https://github.com/dotnet/corefx), 2.1 branch   | 4.6.0               |
+| System.Net.WebSockets.WebSocketProtocol | [dotnet/runtime](https://github.com/dotnet/runtime), 5.0 branch | 5.1.0               |
+| System.Numerics.Vectors                 | [dotnet/corefx](https://github.com/dotnet/corefx), 2.1 branch   | 4.6.0               |
+| System.Reflection.DispatchProxy         | [dotnet/corefx](https://github.com/dotnet/corefx), 3.1 branch   | 4.8.0               |
+| System.Runtime.CompilerServices.Unsafe  | [dotnet/runtime](https://github.com/dotnet/runtime), 6.0 branch | 6.1.0               |
+| System.Threading.Tasks.Extensions       | [dotnet/corefx](https://github.com/dotnet/corefx), 2.1 branch   | 4.6.0               |
+| System.Xml.XPath.XmlDocument            | [dotnet/corefx](https://github.com/dotnet/corefx), 1.1 branch   | 4.7.0               |
 
 ## Version introduced
 
@@ -45,7 +45,7 @@ Some TFMs that were previously supported are no longer supported. However, there
 
 ## Type of breaking change
 
-This change can affect [source compatibility](../categories.md#source-incompatible).
+This change can affect [source compatibility](../../categories.md#source-incompatible).
 
 ## Reason for change
 

--- a/docs/core/compatibility/core-libraries/9.0/oob-packages.md
+++ b/docs/core/compatibility/core-libraries/9.0/oob-packages.md
@@ -45,7 +45,7 @@ Some TFMs that were previously supported are no longer supported. However, there
 
 ## Type of breaking change
 
-This change can affect [source compatibility](../../categories.md#source-incompatible).
+This change can affect [source compatibility](../../categories.md#source-compatibility).
 
 ## Reason for change
 

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -16,6 +16,8 @@ items:
                 href: aspnet-core/9.0/certificate-export.md
               - name: HostBuilder enables ValidateOnBuild/ValidateScopes in development environment
                 href: aspnet-core/9.0/hostbuilder-validation.md
+              - name: Legacy Mono and Emscripten APIs not exported to global namespace
+                href: aspnet-core/9.0/legacy-apis.md
               - name: Middleware types with multiple constructors
                 href: aspnet-core/9.0/middleware-constructors.md
           - name: Containers
@@ -1050,6 +1052,8 @@ items:
                 href: aspnet-core/9.0/certificate-export.md
               - name: HostBuilder enables ValidateOnBuild/ValidateScopes in development environment
                 href: aspnet-core/9.0/hostbuilder-validation.md
+              - name: Legacy Mono and Emscripten APIs not exported to global namespace
+                href: aspnet-core/9.0/legacy-apis.md
               - name: Middleware types with multiple constructors
                 href: aspnet-core/9.0/middleware-constructors.md
           - name: .NET 8

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -20,8 +20,10 @@ items:
                 href: aspnet-core/9.0/middleware-constructors.md
           - name: Containers
             items:
-              - name: .NET 9 container images no longer install zlib
+              - name: Container images no longer install zlib
                 href: containers/9.0/no-zlib.md
+              - name: .NET Monitor images simplified to version-only tags
+                href: containers/9.0/monitor-images.md
           - name: Core .NET libraries
             items:
               - name: Adding a ZipArchiveEntry sets header general-purpose bit flags
@@ -1254,8 +1256,10 @@ items:
         items:
           - name: .NET 9
             items:
-              - name: .NET 9 container images no longer install zlib
+              - name: Container images no longer install zlib
                 href: containers/9.0/no-zlib.md
+              - name: .NET Monitor images simplified to version-only tags
+                href: containers/9.0/monitor-images.md
           - name: .NET 8
             items:
               - name: "'ca-certificates' removed from Alpine images"

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -50,6 +50,8 @@ items:
                 href: core-libraries/9.0/inmemorydirinfo-prepends-rootdir.md
               - name: New TimeSpan.From*() overloads that take integers
                 href: core-libraries/9.0/timespan-from-overloads.md
+              - name: New version of some OOB packages
+                href: core-libraries/9.0/oob-packages.md
               - name: RuntimeHelpers.GetSubArray returns different type
                 href: core-libraries/9.0/getsubarray-return.md
               - name: String.Trim(params ReadOnlySpan<char>) overload removed
@@ -1312,6 +1314,8 @@ items:
                 href: core-libraries/9.0/inmemorydirinfo-prepends-rootdir.md
               - name: New TimeSpan.From*() overloads that take integers
                 href: core-libraries/9.0/timespan-from-overloads.md
+              - name: New version of some OOB packages
+                href: core-libraries/9.0/oob-packages.md
               - name: RuntimeHelpers.GetSubArray returns different type
                 href: core-libraries/9.0/getsubarray-return.md
               - name: String.Trim(params ReadOnlySpan<char>) overload removed


### PR DESCRIPTION
Fixes #43635 
Fixes #43379 
Fixes #43564

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/9.0.md](https://github.com/dotnet/docs/blob/0bc9dbf1dc2502ef1b20f1c558f45a3e11cdad63/docs/core/compatibility/9.0.md) | [Breaking changes in .NET 9](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/9.0?branch=pr-en-us-43874) |
| [docs/core/compatibility/aspnet-core/9.0/legacy-apis.md](https://github.com/dotnet/docs/blob/0bc9dbf1dc2502ef1b20f1c558f45a3e11cdad63/docs/core/compatibility/aspnet-core/9.0/legacy-apis.md) | [Legacy Mono and Emscripten JavaScript APIs not exported to global namespace](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/aspnet-core/9.0/legacy-apis?branch=pr-en-us-43874) |
| [docs/core/compatibility/containers/9.0/monitor-images.md](https://github.com/dotnet/docs/blob/0bc9dbf1dc2502ef1b20f1c558f45a3e11cdad63/docs/core/compatibility/containers/9.0/monitor-images.md) | [".NET Monitor images simplified to version-only tags"](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/containers/9.0/monitor-images?branch=pr-en-us-43874) |
| [docs/core/compatibility/core-libraries/9.0/oob-packages.md](https://github.com/dotnet/docs/blob/0bc9dbf1dc2502ef1b20f1c558f45a3e11cdad63/docs/core/compatibility/core-libraries/9.0/oob-packages.md) | [New version of some OOB packages](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/9.0/oob-packages?branch=pr-en-us-43874) |
| [docs/core/compatibility/toc.yml](https://github.com/dotnet/docs/blob/0bc9dbf1dc2502ef1b20f1c558f45a3e11cdad63/docs/core/compatibility/toc.yml) | [docs/core/compatibility/toc](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/toc?branch=pr-en-us-43874) |


<!-- PREVIEW-TABLE-END -->