### PR TITLE
Assign BC issues to Cam

### DIFF
--- a/.github/ISSUE_TEMPLATE/02-breaking-change.yml
+++ b/.github/ISSUE_TEMPLATE/02-breaking-change.yml
@@ -6,7 +6,7 @@ labels:
   - Pri1
   - doc-idea
 assignees:
- - gewarren
+ - camsoper
 body:
   - type: textarea
     id: description
@@ -21,15 +21,14 @@ body:
       label: Version
       description: What version of .NET introduced the breaking change?
       options:
-        - .NET 8 GA
-        - .NET 9 Preview 7
-        - .NET 9 RC 1
-        - .NET 9 RC 2
-        - .NET 9 GA
+        - .NET 8
+        - .NET 9
         - .NET 10 Preview 1
         - .NET 10 Preview 2
         - .NET 10 Preview 3
         - .NET 10 Preview 4
+        - .NET 10 Preview 5
+        - .NET 10 Preview 6
         - Other (please put exact version in description textbox)
     validations:
       required: true


### PR DESCRIPTION
Cam is taking over the breaking change docs.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/ISSUE_TEMPLATE/02-breaking-change.yml](https://github.com/dotnet/docs/blob/28d5c1e5d74c21d1524dfdc9949cc920bddbe5c6/.github/ISSUE_TEMPLATE/02-breaking-change.yml) | ["[Breaking change]: "](https://review.learn.microsoft.com/en-us/dotnet/.github/ISSUE_TEMPLATE/02-breaking-change?branch=pr-en-us-43878) |

<!-- PREVIEW-TABLE-END -->