### PR TITLE
Add default RID breaking change for .NET Framework targets

### DIFF
--- a/docs/core/compatibility/9.0.md
+++ b/docs/core/compatibility/9.0.md
@@ -96,10 +96,10 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 | Title                                                                         | Type of change    | Introduced version |
 |-------------------------------------------------------------------------------|-------------------|--------------------|
 | [`dotnet restore` audits transitive packages](sdk/9.0/nugetaudit-transitive-packages.md) | Behavioral change | Preview 6 |
-| [Default RID used when targeting .NET Framework](sdk/9.0/default-rid.md) | Source incompatible | GA |
 | [`dotnet watch` incompatible with Hot Reload for old frameworks](sdk/9.0/dotnet-watch.md) | Behavioral change | RC 1   |
 | [`dotnet workload` commands output change](sdk/9.0/dotnet-workload-output.md) | Behavioral change | Preview 1          |
 | [`installer` repo version no longer documented](sdk/9.0/productcommits-versions.md) | Behavioral change | Preview 5    |
+| [New default RID used when targeting .NET Framework](sdk/9.0/default-rid.md) | Source incompatible | GA |
 | [Terminal logger is default](sdk/9.0/terminal-logger.md)                      | Behavioral change | Preview 1          |
 | [Version requirements for .NET 9 SDK](sdk/9.0/version-requirements.md)        | Source incompatible | GA               |
 | [Warning emitted for .NET Standard 1.x target](sdk/9.0/netstandard-warning.md) | Source incompatible | Preview 6       |

--- a/docs/core/compatibility/9.0.md
+++ b/docs/core/compatibility/9.0.md
@@ -96,6 +96,7 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 | Title                                                                         | Type of change    | Introduced version |
 |-------------------------------------------------------------------------------|-------------------|--------------------|
 | [`dotnet restore` audits transitive packages](sdk/9.0/nugetaudit-transitive-packages.md) | Behavioral change | Preview 6 |
+| [Default RID used when targeting .NET Framework](sdk/9.0/default-rid.md) | Source incompatible | GA |
 | [`dotnet watch` incompatible with Hot Reload for old frameworks](sdk/9.0/dotnet-watch.md) | Behavioral change | RC 1   |
 | [`dotnet workload` commands output change](sdk/9.0/dotnet-workload-output.md) | Behavioral change | Preview 1          |
 | [`installer` repo version no longer documented](sdk/9.0/productcommits-versions.md) | Behavioral change | Preview 5    |

--- a/docs/core/compatibility/sdk/9.0/default-rid.md
+++ b/docs/core/compatibility/sdk/9.0/default-rid.md
@@ -1,6 +1,6 @@
 ---
 title: "Default RID used when targeting .NET Framework"
-description: "Learn about the breaking change in the .NET 9 SDK where the default RID is used for apps that target .NET Framework."
+description: "Learn about the breaking change in the .NET 9 SDK where a new default RID is used for apps that target .NET Framework."
 ms.date: 12/5/2024
 ai-usage: ai-assisted
 ms.custom: https://github.com/dotnet/docs/issues/43692
@@ -43,7 +43,7 @@ For more information, see [dotnet/sdk issue #35575](https://github.com/dotnet/sd
 If you're affected by this change, choose one of the following actions:
 
 - Update your runtime identifier to a value supported by the portable RID graph. Project file example:
-In the project file
+
    ```xml
    <PropertyGroup>
       <RuntimeIdentifier>win-x64</RuntimeIdentifier>

--- a/docs/core/compatibility/sdk/9.0/default-rid.md
+++ b/docs/core/compatibility/sdk/9.0/default-rid.md
@@ -1,0 +1,65 @@
+---
+title: "Default RID used when targeting .NET Framework"
+description: "Learn about the breaking change in the .NET 9 SDK where the default RID is used for apps that target .NET Framework."
+ms.date: 12/5/2024
+ai-usage: ai-assisted
+ms.custom: https://github.com/dotnet/docs/issues/43692
+---
+
+# Default RID used when targeting .NET Framework
+
+In .NET 8, a change was introduced to [use a smaller runtime identifier (RID) graph](../8.0/rid-graph.md) when targeting `net8.0` and later versions.
+
+However, this broke customers who multi-target .NET and .NET Framework. That's because the restore happens once, but the .NET Framework project tries to use the old RID default and the .NET (Core) project tries to use the new reduced RID graph.
+
+To enable this multi-targeting scenario, a default RID that's compatible with the new RID graph is now used in this scenario.
+
+## Version introduced
+
+.NET 9 GA
+
+## Previous behavior
+
+SDK-style projects that targeted .NET Framework with no RID set defaulted to `win7-x86` or `win7-x64`.
+
+## New behavior
+
+SDK-style projects that target .NET Framework with no RID set default to `win-x86` or `win-x64`.
+
+## Type of breaking change
+
+This change can affect [source compatibility](../../categories.md#source-compatibility).
+
+## Reason for change
+
+.NET Framework applications were getting a default RID that was incompatible with the portable RID graph. That incompatibility resulted in a restore error:
+
+> Sdks\Microsoft.NET.Sdk\targets\Microsoft.PackageDependencyResolution.targets(266,5): error NETSDK1047: Assets file 'D:\1\s\artifacts\obj\MSBuild\project.assets.json' doesn't have a target for 'net472/win7-x64'. Ensure that restore has run and that you have included 'net472' in the TargetFrameworks for your project. You may also need to include 'win7-x64' in your project's RuntimeIdentifiers. \[MSBuild.csproj::TargetFramework=net472]>
+
+For more information, see [dotnet/sdk issue #35575](https://github.com/dotnet/sdk/issues/35575).
+
+## Recommended action
+
+If you're affected by this change, choose one of the following actions:
+
+- Update your runtime identifier to a value supported by the portable RID graph. Project file example:
+In the project file
+   ```xml
+   <PropertyGroup>
+      <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+   </PropertyGroup>
+   ```
+
+  If you specify the RID as a command-line argument, make a similar change. For example, `dotnet publish --runtime win-x64`.
+
+- Switch back to the old RID graph by setting `UseRidGraph` to `true` in the project file:
+
+  ```xml
+  <PropertyGroup>
+    <UseRidGraph>true</UseRidGraph>
+  </PropertyGroup>
+  ```
+
+## Affected APIs
+
+None.

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -98,14 +98,14 @@ items:
             items:
               - name: "`dotnet restore` audits transitive packages"
                 href: sdk/9.0/nugetaudit-transitive-packages.md
-              - name: Default RID used when targeting .NET Framework
-                href: sdk/9.0/default-rid.md
               - name: "`dotnet watch` incompatible with Hot Reload for old frameworks"
                 href: sdk/9.0/dotnet-watch.md
               - name: "`dotnet workload` commands output change"
                 href: sdk/9.0/dotnet-workload-output.md
               - name: "`installer` repo version no longer documented"
                 href: sdk/9.0/productcommits-versions.md
+              - name: New default RID used when targeting .NET Framework
+                href: sdk/9.0/default-rid.md
               - name: Terminal logger is default
                 href: sdk/9.0/terminal-logger.md
               - name: Version requirements
@@ -1790,14 +1790,14 @@ items:
             items:
               - name: "`dotnet restore` audits transitive packages"
                 href: sdk/9.0/nugetaudit-transitive-packages.md
-              - name: Default RID used when targeting .NET Framework
-                href: sdk/9.0/default-rid.md
               - name: "`dotnet watch` incompatible with Hot Reload for old frameworks"
                 href: sdk/9.0/dotnet-watch.md
               - name: "`dotnet workload` commands output change"
                 href: sdk/9.0/dotnet-workload-output.md
               - name: "`installer` repo version no longer documented"
                 href: sdk/9.0/productcommits-versions.md
+              - name: New default RID used when targeting .NET Framework
+                href: sdk/9.0/default-rid.md
               - name: Terminal logger is default
                 href: sdk/9.0/terminal-logger.md
               - name: Version requirements for .NET 9 SDK

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -68,6 +68,8 @@ items:
             items:
               - name: Deprecated desktop Windows/macOS/Linux MonoVM runtime packages
                 href: deployment/9.0/monovm-packages.md
+          - name: Entity Framework Core
+            href: /ef/core/what-is-new/ef-core-9.0/breaking-changes?toc=/dotnet/core/compatibility/toc.json&bc=/dotnet/breadcrumb/toc.json
           - name: Interop
             items:
               - name: CET supported by default
@@ -96,6 +98,8 @@ items:
             items:
               - name: "`dotnet restore` audits transitive packages"
                 href: sdk/9.0/nugetaudit-transitive-packages.md
+              - name: Default RID used when targeting .NET Framework
+                href: sdk/9.0/default-rid.md
               - name: "`dotnet watch` incompatible with Hot Reload for old frameworks"
                 href: sdk/9.0/dotnet-watch.md
               - name: "`dotnet workload` commands output change"
@@ -1584,6 +1588,8 @@ items:
                 href: deployment/7.0/x86-host-path.md
       - name: Entity Framework Core
         items:
+          - name: EF Core 9
+            href: /ef/core/what-is-new/ef-core-9.0/breaking-changes?toc=/dotnet/core/compatibility/toc.json&bc=/dotnet/breadcrumb/toc.json
           - name: EF Core 8
             href: /ef/core/what-is-new/ef-core-8.0/breaking-changes?toc=/dotnet/core/compatibility/toc.json&bc=/dotnet/breadcrumb/toc.json
           - name: EF Core 7
@@ -1784,6 +1790,8 @@ items:
             items:
               - name: "`dotnet restore` audits transitive packages"
                 href: sdk/9.0/nugetaudit-transitive-packages.md
+              - name: Default RID used when targeting .NET Framework
+                href: sdk/9.0/default-rid.md
               - name: "`dotnet watch` incompatible with Hot Reload for old frameworks"
                 href: sdk/9.0/dotnet-watch.md
               - name: "`dotnet workload` commands output change"


### PR DESCRIPTION
Fixes #43692.

Also adds TOC entries for breaking changes in EF Core 9.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/9.0.md](https://github.com/dotnet/docs/blob/1127d0aaa9ce1820aba04c6d6d8171bf53ed53e6/docs/core/compatibility/9.0.md) | [Breaking changes in .NET 9](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/9.0?branch=pr-en-us-43879) |
| [docs/core/compatibility/sdk/9.0/default-rid.md](https://github.com/dotnet/docs/blob/1127d0aaa9ce1820aba04c6d6d8171bf53ed53e6/docs/core/compatibility/sdk/9.0/default-rid.md) | [Default RID used when targeting .NET Framework](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/9.0/default-rid?branch=pr-en-us-43879) |
| [docs/core/compatibility/toc.yml](https://github.com/dotnet/docs/blob/1127d0aaa9ce1820aba04c6d6d8171bf53ed53e6/docs/core/compatibility/toc.yml) | [docs/core/compatibility/toc](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/toc?branch=pr-en-us-43879) |

<!-- PREVIEW-TABLE-END -->