### PR TITLE
Change `master` to `main` for GitHub links

### DIFF
--- a/docs/framework/reflection-and-codedom/dynamic-language-runtime-overview.md
+++ b/docs/framework/reflection-and-codedom/dynamic-language-runtime-overview.md
@@ -7,7 +7,6 @@ helpviewer_keywords:
   - "IronPython"
   - "DLR"
   - "IronRuby"
-ms.assetid: f769a271-8aff-4bea-bfab-6160217ce23d
 ---
 # Dynamic language runtime overview
 
@@ -77,7 +76,7 @@ The DLR uses binders in call sites to communicate not only with .NET, but with o
 
 ## DLR documentation
 
-For more information about how to use the open source version of the DLR to add dynamic behavior to a language, or about how to enable the use of a dynamic language with .NET, see the documentation on the [IronLanguages/dlr](https://github.com/IronLanguages/dlr/tree/master/Docs) repo on GitHub.
+For more information about how to use the open source version of the DLR to add dynamic behavior to a language, or about how to enable the use of a dynamic language with .NET, see the documentation on the [IronLanguages/dlr](https://github.com/IronLanguages/dlr/tree/main/Docs) repo on GitHub.
 
 ## See also
 

--- a/docs/framework/whats-new/index.md
+++ b/docs/framework/whats-new/index.md
@@ -847,7 +847,7 @@ WPF's printing APIs in the <xref:System.Printing.PrintQueue?displayProperty=name
 
 - [Debugging improvements](#Debug462)
 
-For a list of new APIs added to .NET Framework 4.6.2, see [.NET Framework 4.6.2 API Changes](https://github.com/Microsoft/dotnet/blob/master/releases/net462/dotnet462-api-changes.md) on GitHub. For a list of feature improvements and bug fixes in .NET Framework 4.6.2, see [.NET Framework 4.6.2 List of Changes](https://github.com/Microsoft/dotnet/blob/master/releases/net462/dotnet462-changes.md) on GitHub. For more information, see [Announcing .NET Framework 4.6.2](https://devblogs.microsoft.com/dotnet/announcing-net-framework-4-6-2/) in the .NET blog.
+For a list of new APIs added to .NET Framework 4.6.2, see [.NET Framework 4.6.2 API Changes](https://github.com/Microsoft/dotnet/blob/main/releases/net462/dotnet462-api-changes.md) on GitHub. For a list of feature improvements and bug fixes in .NET Framework 4.6.2, see [.NET Framework 4.6.2 List of Changes](https://github.com/Microsoft/dotnet/blob/main/releases/net462/dotnet462-changes.md) on GitHub. For more information, see [Announcing .NET Framework 4.6.2](https://devblogs.microsoft.com/dotnet/announcing-net-framework-4-6-2/) in the .NET blog.
 
 <a name="ASPNET462"></a>
 

--- a/includes/core-changes/windowsforms/3.0/deprecate-uselegacyimages.md
+++ b/includes/core-changes/windowsforms/3.0/deprecate-uselegacyimages.md
@@ -4,7 +4,7 @@ The `Switch.System.Windows.Forms.UseLegacyImages` compatibility switch, which wa
 
 #### Change description
 
-Starting with .NET Framework 4.8, the `Switch.System.Windows.Forms.UseLegacyImages` compatibility switch addressed possible image scaling issues in ClickOnce scenarios in high DPI environments. When set to `true`, the switch allows the user to restore legacy image scaling on high DPI displays whose scale is set to greater than 100%. For more information, see [.NET Framework 4.8 Release Notes](https://github.com/microsoft/dotnet/blob/master/releases/net48/dotnet48-changes.md#clickonce) on GitHub.
+Starting with .NET Framework 4.8, the `Switch.System.Windows.Forms.UseLegacyImages` compatibility switch addressed possible image scaling issues in ClickOnce scenarios in high DPI environments. When set to `true`, the switch allows the user to restore legacy image scaling on high DPI displays whose scale is set to greater than 100%. For more information, see [.NET Framework 4.8 Release Notes](https://github.com/microsoft/dotnet/blob/main/releases/net48/dotnet48-changes.md#clickonce) on GitHub.
 
 In .NET Core and .NET 5.0 and later, the `Switch.System.Windows.Forms.UseLegacyImages` switch is not supported.
 

--- a/includes/migration-guide/retargeting/wpf/add-selectiontextbrush-public-property-textboxpasswordbox-non-adorner.md
+++ b/includes/migration-guide/retargeting/wpf/add-selectiontextbrush-public-property-textboxpasswordbox-non-adorner.md
@@ -2,7 +2,7 @@
 
 #### Details
 
-In WPF applications using [non-adorner based text selection](https://github.com/Microsoft/dotnet/blob/master/Documentation/compatibility/wpf-TextBox-PasswordBox-text-selection-does-not-follow-system-colors.md) for <xref:System.Windows.Controls.TextBox> and <xref:System.Windows.Controls.PasswordBox>, developers may now set the newly added SelectionTextBrush property in order to alter the rendering of the selected text.  By default, this color changes with <xref:System.Windows.SystemColors.HighlightTextBrushKey>.  If non-adorner based text selection is not enabled, this property does nothing.
+In WPF applications using [non-adorner based text selection](https://github.com/Microsoft/dotnet/blob/main/Documentation/compatibility/wpf-TextBox-PasswordBox-text-selection-does-not-follow-system-colors.md) for <xref:System.Windows.Controls.TextBox> and <xref:System.Windows.Controls.PasswordBox>, developers may now set the newly added SelectionTextBrush property in order to alter the rendering of the selected text.  By default, this color changes with <xref:System.Windows.SystemColors.HighlightTextBrushKey>.  If non-adorner based text selection is not enabled, this property does nothing.
 
 #### Suggestion
 

--- a/includes/migration-guide/runtime/wpf/improvements-grid-star-rows-space-allocating-algorithm.md
+++ b/includes/migration-guide/runtime/wpf/improvements-grid-star-rows-space-allocating-algorithm.md
@@ -2,7 +2,7 @@
 
 #### Details
 
-Fixed a bug in the [algorithm for allocating sizes to](https://github.com/Microsoft/dotnet/blob/master/Documentation/compatibility/wpf-grid-allocation-of-space-to-star-columns.md)) in a <xref:System.Windows.Controls.Grid> introduced in .NET Framework 4.7.  In some cases, such as a Grid with `Height=&quot;Auto&quot;` containing empty rows, rows were arranged at the wrong position, possibly outside the Grid altogether.
+Fixed a bug in the [algorithm for allocating sizes to](https://github.com/Microsoft/dotnet/blob/main/Documentation/compatibility/wpf-grid-allocation-of-space-to-star-columns.md)) in a <xref:System.Windows.Controls.Grid> introduced in .NET Framework 4.7.  In some cases, such as a Grid with `Height=&quot;Auto&quot;` containing empty rows, rows were arranged at the wrong position, possibly outside the Grid altogether.
 
 #### Suggestion
 


### PR DESCRIPTION
## Summary

Update GitHub links with old `master` branch to `main`, so as to prevent branch not found redirects.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/reflection-and-codedom/dynamic-language-runtime-overview.md](https://github.com/dotnet/docs/blob/0be627e852bbfc048a068d689356288139052e7c/docs/framework/reflection-and-codedom/dynamic-language-runtime-overview.md) | [Dynamic language runtime overview](https://review.learn.microsoft.com/en-us/dotnet/framework/reflection-and-codedom/dynamic-language-runtime-overview?branch=pr-en-us-43913) |
| [docs/framework/whats-new/index.md](https://github.com/dotnet/docs/blob/0be627e852bbfc048a068d689356288139052e7c/docs/framework/whats-new/index.md) | ["What's new in .NET Framework"](https://review.learn.microsoft.com/en-us/dotnet/framework/whats-new/index?branch=pr-en-us-43913) |

<!-- PREVIEW-TABLE-END -->