### PR TITLE
Add more clarity on member lookup

### DIFF
--- a/docs/csharp/language-reference/keywords/file.md
+++ b/docs/csharp/language-reference/keywords/file.md
@@ -1,17 +1,17 @@
 ---
-description: "file modifier: Declare types whose scope is the file in which it's declared"
-title: "file keyword"
-ms.date: 09/15/2022
+description: "The file modifier: Declare types whose visibility is the file in which it's declared"
+title: "The file keyword"
+ms.date: 12/10/2024
 f1_keywords: 
   - "file_CSharpKeyword"
 helpviewer_keywords: 
   - "file keyword [C#]"
 ---
-# file (C# Reference)
+# The file modifier
 
 Beginning with C# 11, the `file` contextual keyword is a type modifier.
 
-The `file` modifier restricts a top-level type's scope and visibility to the file in which it's declared. The `file` modifier will generally be applied to types written by a source generator. File-local types provide source generators with a convenient way to avoid name collisions among generated types. The `file` modifier declares a file-local type, as in this example:
+The `file` modifier restricts a top-level type's visibility to the file in which it's declared. The `file` modifier is most often applied to types written by a source generator. File-local types provide source generators with a convenient way to avoid name collisions among generated types. The `file` modifier declares a file-local type, as in this example:
 
 ```csharp
 file class HiddenWidget
@@ -20,11 +20,9 @@ file class HiddenWidget
 }
 ```
 
-Any types nested within a file-local type are also only visible within the file in which it's declared. Other types in an assembly may use the same name as a file-local type. Because the file-local type is visible only in the file where it's declared, these types don't create a naming collision.
+Any types nested within a file-local type are also only visible within the file in which it's declared. Other types in an assembly can use the same name as a file-local type. Because the file-local type is visible only in the file where it's declared, these types don't create a naming collision.
 
-A file-local type can't be the return type or parameter type of any member that is more visible than `file` scope. A file-local type can't be a field member of a type that has greater visibility than `file` scope. However, a more visible type may implicitly implement a file-local interface type. The type can also [explicitly implement](../../programming-guide/interfaces/explicit-interface-implementation.md) a file-local interface but explicit implementations can only be used within the `file` scope.
-
-## Example
+A file-local type can't be the return type or parameter type of any member declared in a non file-local type. A file-local type can't be a field member of a non-file-local. However, a more visible type can implicitly implement a file-local interface type. The type can also [explicitly implement](../../programming-guide/interfaces/explicit-interface-implementation.md) a file-local interface but explicit implementations can only be used within the same file.
 
 The following example shows a public type that uses a file-local type to provide a worker method. In addition, the public type implements a file-local interface implicitly:
 
@@ -33,6 +31,8 @@ The following example shows a public type that uses a file-local type to provide
 In another source file, you can declare types that have the same names as the file-local types. The file-local types aren't visible:
 
 :::code language="csharp" source="./snippets/Program.cs" id="ShadowsFileScopedType":::
+
+Member lookup prefers a file-local type declared in the same file over a non-file-local type declared in a different file. This rule ensures that a source generator can rely on member lookup resolving to a file-local type without ambiguity with other type declarations. In the preceding example, all uses of `HiddenWidget` in *File1.cs* resolve to the file-local type declared in *File1.cs*. The file-local declaration of `HiddenWidget` hides the public declaration in *File2.cs*.
 
 ## C# language specification  
 


### PR DESCRIPTION
Found while updating the feature spec for the feature. This article didn't clearly state that file local types are preferred over other types with the same name in the file where they are declared.

Also, the `file` modifier doesn't actually modify the *scope*, rather, it modifies the *visibility*. Update the language to match the speclet definition.

Finally, quick edit pass.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/file.md](https://github.com/dotnet/docs/blob/9832d206a9c473e93f6cd5aec50209b3b14d866a/docs/csharp/language-reference/keywords/file.md) | [The file modifier](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/file?branch=pr-en-us-43932) |

<!-- PREVIEW-TABLE-END -->