### PR TITLE
Add missing space in IHostApplicationBuilder description

### DIFF
--- a/docs/core/extensions/generic-host.md
+++ b/docs/core/extensions/generic-host.md
@@ -225,7 +225,7 @@ To add host configuration, call <xref:Microsoft.Extensions.Hosting.HostBuilder.C
 
 # [IHostApplicationBuilder](#tab/appbuilder)
 
-App configuration is created by calling <xref:Microsoft.Extensions.Hosting.HostBuilder.ConfigureAppConfiguration%2A> on an <xref:Microsoft.Extensions.Hosting.IHostApplicationBuilder>. The public<xref:Microsoft.Extensions.Hosting.IHostApplicationBuilder.Configuration?displayProperty=nameWithType> property allows consumers to read from or make changes to the existing configuration using available extension methods.
+App configuration is created by calling <xref:Microsoft.Extensions.Hosting.HostBuilder.ConfigureAppConfiguration%2A> on an <xref:Microsoft.Extensions.Hosting.IHostApplicationBuilder>. The public <xref:Microsoft.Extensions.Hosting.IHostApplicationBuilder.Configuration?displayProperty=nameWithType> property allows consumers to read from or make changes to the existing configuration using available extension methods.
 
 # [IHostBuilder](#tab/hostbuilder)
 


### PR DESCRIPTION
This simple pull request fixes #43918 by adding missing space in the `IHostApplicationBuilder` section.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/generic-host.md](https://github.com/dotnet/docs/blob/f52a73004bfda28a1096c229af2109b509f74594/docs/core/extensions/generic-host.md) | [.NET Generic Host](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/generic-host?branch=pr-en-us-43934) |

<!-- PREVIEW-TABLE-END -->