### PR TITLE
Add docs for --maximum-failed-tests

### DIFF
--- a/docs/core/testing/unit-testing-platform-exit-codes.md
+++ b/docs/core/testing/unit-testing-platform-exit-codes.md
@@ -26,6 +26,7 @@ ms.topic: reference
 | `10` | The exit code `10` indicates that the test adapter, Testing.Platform Test Framework, MSTest, NUnit, or xUnit, failed to run tests for an infrastructure reason unrelated to the test's self. An example is failing to create a fixture needed by tests. |
 | `11` | The exit code `11` indicates that the test process will exit if dependent process exits. |
 | `12` | The exit code `12` indicates that the test session was unable to run because the client does not support any of the supported protocol versions. |
+| `13` | The exit code `13` indicates that the test session was stopped due to reaching the specified number of maximum failed tests using `--maximum-failed-tests` command-line option. For more information, see [the Options section in Microsoft.Testing.Platform overview](unit-testing-platform-intro.md#options) |
 
 To enable verbose logging and troubleshoot issues, see [Microsoft.Testing.Platform Diagnostics extensions](unit-testing-platform-extensions-diagnostics.md#built-in-options).
 

--- a/docs/core/testing/unit-testing-platform-intro.md
+++ b/docs/core/testing/unit-testing-platform-intro.md
@@ -261,6 +261,13 @@ The list below described only the platform options. To see the specific options 
 
   List available tests. Tests will not be executed.
 
+- **`--maximum-failed-tests`**
+
+  Specifies the maximum number of tests failures that, when reached, will stop the test run. Support for this switch requires framework authors to implement the `IGracefulStopTestExecutionCapability` capability. The exit code when reaching that amount of test failures is 13. For more information, see [Microsoft.Testing.Platform exit codes](unit-testing-platform-exit-codes.md).
+
+  > [!NOTE]
+  > This feature is available in Microsoft.Testing.Platform starting with version 1.5.
+
 - **`--minimum-expected-tests`**
 
   Specifies the minimum number of tests that are expected to run. By default, at least one test is expected to run.


### PR DESCRIPTION
cc @Evangelink

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-platform-exit-codes.md](https://github.com/dotnet/docs/blob/cd04cc79fd8a72b5cb4df3f00e57764dad232a96/docs/core/testing/unit-testing-platform-exit-codes.md) | [Microsoft.Testing.Platform exit codes](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-platform-exit-codes?branch=pr-en-us-43939) |
| [docs/core/testing/unit-testing-platform-intro.md](https://github.com/dotnet/docs/blob/cd04cc79fd8a72b5cb4df3f00e57764dad232a96/docs/core/testing/unit-testing-platform-intro.md) | [Microsoft.Testing.Platform overview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-platform-intro?branch=pr-en-us-43939) |

<!-- PREVIEW-TABLE-END -->