### PR TITLE
Update how-to-determine-which-versions-are-installed.md

### DIFF
--- a/docs/framework/migration-guide/how-to-determine-which-versions-are-installed.md
+++ b/docs/framework/migration-guide/how-to-determine-which-versions-are-installed.md
@@ -266,9 +266,9 @@ ForEach-Object {
         $parentName = $_.PSChildName
         Get-ChildItem -LiteralPath $_.PSPath |
         Where-Object {
-            if ($_.Property -contains 'Version') { $name = Get-ItemPropertyValue -Path $_.PSPath -Name Version }
-            if ($name -and ($_.Property -contains 'SP')) { $sp = Get-ItemPropertyValue -Path $_.PSPath -Name SP }
-            if ($_.Property -contains 'Install') { $install = Get-ItemPropertyValue -Path $_.PSPath -Name Install }
+            if ($_.Property -contains 'Version') { $name = $((Get-ItemProperty -Path "Registry::$_").Version) }
+            if ($name -and ($_.Property -contains 'SP')) { $sp = $((Get-ItemProperty -Path "Registry::$_").SP) }
+            if ($_.Property -contains 'Install') { $install = $((Get-ItemProperty -Path "Registry::$_").Install) }
             if (-not $install) {
                 Write-Host -Object "  $($parentName)  $($name)"
             }


### PR DESCRIPTION
If you're checking for old versions of .NET Framework, there's a good chance the machine is old enough to be stuck on PowerShell 2. This makes the .NET Framework version detection script compatible with PowerShell 2 and above.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/migration-guide/how-to-determine-which-versions-are-installed.md](https://github.com/dotnet/docs/blob/7498674bed46c8ab547d34bf6fb941d791b8efbf/docs/framework/migration-guide/how-to-determine-which-versions-are-installed.md) | [docs/framework/migration-guide/how-to-determine-which-versions-are-installed](https://review.learn.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed?branch=pr-en-us-43947) |

<!-- PREVIEW-TABLE-END -->