### PR TITLE
Clarify XML Documentation Comments Processing in F#.

### DIFF
--- a/docs/fsharp/language-reference/xml-documentation.md
+++ b/docs/fsharp/language-reference/xml-documentation.md
@@ -14,7 +14,7 @@ The compiler-generated XML file can be distributed alongside your .NET assembly 
 show quick information about types or members. Additionally, the XML file can be run through tools
 like [fsdocs](http://fsprojects.github.io/FSharp.Formatting/) to generate API reference websites.
 
-XML documentation comments are not ignored by the compiler; they are processed to generate XML documentation files if the appropriate settings are enabled. Additionally, the compiler can check the validity and completeness of these comments at compile time when specific options are configured.
+By default, XML documentation comments are ignored by the compiler. To change this, set `--warnon:3390`. The compiler will then verify the syntax of the XML and the parameters referred to in <param> and <paramref> tags.
 
 You can generate the XML file at compile time by doing one of the following:
 

--- a/docs/fsharp/language-reference/xml-documentation.md
+++ b/docs/fsharp/language-reference/xml-documentation.md
@@ -14,8 +14,7 @@ The compiler-generated XML file can be distributed alongside your .NET assembly 
 show quick information about types or members. Additionally, the XML file can be run through tools
 like [fsdocs](http://fsprojects.github.io/FSharp.Formatting/) to generate API reference websites.
 
-XML documentation comments, like all other comments, are ignored by the compiler, unless the options described below are enabled to check the validity and
-completeness of comments at compile time.
+XML documentation comments are not ignored by the compiler; they are processed to generate XML documentation files if the appropriate settings are enabled. Additionally, the compiler can check the validity and completeness of these comments at compile time when specific options are configured.
 
 You can generate the XML file at compile time by doing one of the following:
 

--- a/docs/fsharp/language-reference/xml-documentation.md
+++ b/docs/fsharp/language-reference/xml-documentation.md
@@ -14,7 +14,7 @@ The compiler-generated XML file can be distributed alongside your .NET assembly 
 show quick information about types or members. Additionally, the XML file can be run through tools
 like [fsdocs](http://fsprojects.github.io/FSharp.Formatting/) to generate API reference websites.
 
-By default, XML documentation comments are ignored by the compiler. To change this, set `--warnon:3390`. The compiler will then verify the syntax of the XML and the parameters referred to in <param> and <paramref> tags.
+By default, XML documentation comments are ignored by the compiler. To change this, set `--warnon:3390`. The compiler will then verify the syntax of the XML and the parameters referred to in `<param>` and `<paramref>` tags.
 
 You can generate the XML file at compile time by doing one of the following:
 


### PR DESCRIPTION
## Summary

### PR Description

**Motivation and Context**
This PR rewords a potentially confusing statement in the XML Documentation page for F#. Previously, the text suggested that XML documentation comments are ignored by the compiler, which could be misleading. In reality, the compiler processes these comments to generate XML documentation files and can validate their completeness if configured.

**Changes Made**
Updated the phrasing of the sentence to clarify that XML documentation comments are processed by the compiler for generating XML files and validating their content when the appropriate settings are enabled.

### Why This Matters

- Provides clear and accurate information to help developers better understand the role of XML documentation comments.
- Prevents misunderstandings about how the compiler interacts with these comments.
- Related Page - [XML Documentation (F#)](https://learn.microsoft.com/en-us/dotnet/fsharp/language-reference/xml-documentation)

This PR improves clarity without altering the technical content or overall meaning.

Fixes #41853 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/xml-documentation.md](https://github.com/dotnet/docs/blob/20159bea76421b02142b2c4f53227d12bfaeda57/docs/fsharp/language-reference/xml-documentation.md) | [Document your code with XML comments](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/xml-documentation?branch=pr-en-us-43960) |


<!-- PREVIEW-TABLE-END -->