### PR TITLE
Fixed wordings in access-control doc for F#.

### DIFF
--- a/docs/fsharp/language-reference/access-control.md
+++ b/docs/fsharp/language-reference/access-control.md
@@ -22,7 +22,7 @@ In F#, the access control specifiers `public`, `internal`, and `private` can be 
 
 The access specifier is put in front of the name of the entity.
 
-If no access specifier is used, the default is `public`, except for `let` bindings in a type, which are always `private` to the type.
+If no access specifier is used, the default is `public`, except for `let` bindings in a type or a function, which are always `private` to the type.
 
 Signatures in F# provide another mechanism for controlling access to F# program elements. Signatures are not required for access control. For more information, see [Signatures](signature-files.md).
 


### PR DESCRIPTION
## Summary

Fixed wordings in access-control doc for F#.

Fixes #41852 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/access-control.md](https://github.com/dotnet/docs/blob/b86152bae09792b42e5b347d39de1e45c4a46baa/docs/fsharp/language-reference/access-control.md) | [Access Control](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/access-control?branch=pr-en-us-43965) |

<!-- PREVIEW-TABLE-END -->