### PR TITLE
Remove the nested stackalloc proposal

### DIFF
--- a/.openpublishing.redirection.csharp.json
+++ b/.openpublishing.redirection.csharp.json
@@ -113,6 +113,10 @@
             "redirect_url": "/dotnet/csharp/language-reference/language-specification/types.md#893-nullable-reference-types"
         },
         {
+            "source_path_from_root": "/redirections/proposals/csharp-8.0/nested-stackalloc.md",
+            "redirect_url": "/dotnet/csharp/language-reference/language-specification/structs#164127-stackalloc"
+        },
+        {
             "source_path_from_root": "/redirections/proposals/csharp-9.0/nullable-reference-types-specification.md",
             "redirect_url": "/dotnet/csharp/language-reference/language-specification/types.md#893-nullable-reference-types"
         },

--- a/.openpublishing.redirection.csharp.json
+++ b/.openpublishing.redirection.csharp.json
@@ -113,7 +113,7 @@
             "redirect_url": "/dotnet/csharp/language-reference/language-specification/types.md#893-nullable-reference-types"
         },
         {
-            "source_path_from_root": "/redirections/proposals/csharp-8.0/nested-stackalloc.md",
+            "source_path_from_root": "/_csharplang/proposals/csharp-8.0/nested-stackalloc.md",
             "redirect_url": "/dotnet/csharp/language-reference/language-specification/structs#164127-stackalloc"
         },
         {

--- a/docfx.json
+++ b/docfx.json
@@ -73,6 +73,7 @@
                     "csharp-8.0/unconstrained-null-coalescing.md",
                     "csharp-8.0/nullable-reference-types.md",
                     "csharp-8.0/nullable-reference-types-specification.md",
+                    "csharp-8.0/nested-stackalloc.md",
                     "csharp-9.0/nullable-reference-types-specification.md",
                     "csharp-9.0/nullable-constructor-analysis.md",
                     "csharp-9.0/nullable-parameter-default-value-analysis.md"
@@ -613,7 +614,6 @@
                 "_csharplang/proposals/csharp-8.0/using.md": "Pattern based using and using declarations",
                 "_csharplang/proposals/csharp-8.0/null-coalescing-assignment.md": "Null coalescing assignment",
                 "_csharplang/proposals/csharp-8.0/readonly-instance-members.md": "Readonly instance members",
-                "_csharplang/proposals/csharp-8.0/nested-stackalloc.md": "Nested stackalloc expressions",
                 "_csharplang/proposals/csharp-9.0/covariant-returns.md": "Covariant return types",
                 "_csharplang/proposals/csharp-9.0/extending-partial-methods.md": "Extending partial methods",
                 "_csharplang/proposals/csharp-9.0/extension-getenumerator.md": "Extension GetEnumerator support in foreach",
@@ -734,7 +734,6 @@
                 "_csharplang/proposals/csharp-8.0/using.md": "This feature specification supports pattern based using and using declarations to simplify resource cleanup.",
                 "_csharplang/proposals/csharp-8.0/null-coalescing-assignment.md": "This feature specification describes the syntax to support null coalescing assignment expressions using the '??=' operator.",
                 "_csharplang/proposals/csharp-8.0/readonly-instance-members.md": "This feature specification describes the syntax for declaring and using readonly instance members.",
-                "_csharplang/proposals/csharp-8.0/nested-stackalloc.md": "This feature specification describes nested stackalloc expressions, which provides nested arrays of stackalloc storage.",
                 "_csharplang/proposals/csharp-9.0/covariant-returns.md": "This feature specification describes covariant return types, where overriding member declarations can return a type derived from the overridden member declaration.",
                 "_csharplang/proposals/csharp-9.0/extending-partial-methods.md": "This feature specification describes extensions to partial methods. These extensions enable source generators to create or call partial methods.",
                 "_csharplang/proposals/csharp-9.0/extension-getenumerator.md": "This feature specification describes the necessary pattern for an extension method to provide the GetEnumerator support in a foreach loop.",

--- a/docs/csharp/language-reference/operators/stackalloc.md
+++ b/docs/csharp/language-reference/operators/stackalloc.md
@@ -66,7 +66,7 @@ The use of `stackalloc` automatically enables buffer overrun detection features 
 
 ## C# language specification
 
-For more information, see the [Stack allocation](~/_csharpstandard/standard/unsafe-code.md#239-stack-allocation) section of the [C# language specification](~/_csharpstandard/standard/README.md) and the [Permit `stackalloc` in nested contexts](~/_csharplang/proposals/csharp-8.0/nested-stackalloc.md) feature proposal note.
+For more information, see the [Stack allocation](~/_csharpstandard/standard/unsafe-code.md#239-stack-allocation) section of the [C# language specification](~/_csharpstandard/standard/README.md).
 
 ## See also
 

--- a/docs/csharp/specification/toc.yml
+++ b/docs/csharp/specification/toc.yml
@@ -181,8 +181,6 @@ items:
       href: ../../../_csharplang/proposals/csharp-8.0/using.md
     - name: Async streams
       href: ../../../_csharplang/proposals/csharp-8.0/async-streams.md
-    - name: Nested stackalloc
-      href: ../../../_csharplang/proposals/csharp-8.0/nested-stackalloc.md
     - name: Lock object semantics
       href: ../../../_csharplang/proposals/csharp-13.0/lock-object.md
     - name: Allow `ref` and `unsafe`


### PR DESCRIPTION
The official standard language for this feature was merged in the December ECMA committee meeting. It's time to drop the proposal speclet.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/stackalloc.md](https://github.com/dotnet/docs/blob/092e0e36ac7c70f163bf85bc1be78d28f705553b/docs/csharp/language-reference/operators/stackalloc.md) | [stackalloc expression (C# reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/stackalloc?branch=pr-en-us-43986) |
| [docs/csharp/specification/toc.yml](https://github.com/dotnet/docs/blob/092e0e36ac7c70f163bf85bc1be78d28f705553b/docs/csharp/specification/toc.yml) | [docs/csharp/specification/toc](https://review.learn.microsoft.com/en-us/dotnet/csharp/specification/toc?branch=pr-en-us-43986) |


<!-- PREVIEW-TABLE-END -->