### PR TITLE
docs: update --no-openapi description

### DIFF
--- a/docs/core/tools/dotnet-new-sdk-templates.md
+++ b/docs/core/tools/dotnet-new-sdk-templates.md
@@ -842,7 +842,7 @@ Creates a web API project with AOT publish enabled. For more information, see [N
 
 - **`--no-openapi`**
 
-  Turns off OpenAPI (Swagger) support. `AddSwaggerGen`, `UseSwagger`, and `UseSwaggerUI` aren't called.
+  Turns off OpenAPI (Swagger) support. `AddOpenApi` and `MapOpenApi` aren't called.
 
 - **`--no-https`**
 


### PR DESCRIPTION
## Summary

This small PR updates the `--no-openapi` description, by replacing the Swagger extension methods with OpenAPI methods.

Attached is a screenshot between a `dotnet new webapi` and `dotnet new webapi --no-openapi` commands.

![image](https://github.com/user-attachments/assets/d50f83ad-b91e-4f33-a2a4-dacbd93734ed)



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-new-sdk-templates.md](https://github.com/dotnet/docs/blob/534931faf6714e6e2d91069019bedc2f9ec1b4a9/docs/core/tools/dotnet-new-sdk-templates.md) | [docs/core/tools/dotnet-new-sdk-templates](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-new-sdk-templates?branch=pr-en-us-43995) |

<!-- PREVIEW-TABLE-END -->