### PR TITLE
Update blog post link on fsharp-9.md

### DIFF
--- a/docs/fsharp/whats-new/fsharp-9.md
+++ b/docs/fsharp/whats-new/fsharp-9.md
@@ -15,7 +15,7 @@ F# 9 is available in .NET 9. You can download the latest .NET SDK from the [.NET
 
 Although F# is designed to avoid `null`, it can creep in when interfacing with .NET libraries written in C#. F# now provides a type-safe way to deal with reference types that can have `null` as a valid value.
 
-For more details, watch out for an [upcoming blog post about this feature](https://devblogs.microsoft.com/dotnet/tag/f/).
+For more details, see the [Nullable Reference Types in F# 9](https://devblogs.microsoft.com/dotnet/nullable-reference-types-in-fsharp-9/) blog post.
 
 Here are some examples:
 


### PR DESCRIPTION
## Summary

The change updates a hyperlink to point to the correct blog post about Nullable Reference Types in F# 9.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/whats-new/fsharp-9.md](https://github.com/dotnet/docs/blob/b66553221c238073acf98d868decadac57f20e7d/docs/fsharp/whats-new/fsharp-9.md) | [What's new in F# 9](https://review.learn.microsoft.com/en-us/dotnet/fsharp/whats-new/fsharp-9?branch=pr-en-us-44024) |

<!-- PREVIEW-TABLE-END -->