### PR TITLE
mention fsproj files as an example of other dotnet reference files

### DIFF
--- a/docs/core/tools/dotnet-add-reference.md
+++ b/docs/core/tools/dotnet-add-reference.md
@@ -29,6 +29,7 @@ The `dotnet add reference` command provides a convenient option to add project r
   <ProjectReference Include="app.csproj" />
   <ProjectReference Include="..\lib2\lib2.csproj" />
   <ProjectReference Include="..\lib1\lib1.csproj" />
+  <ProjectReference Include="..\lib3\lib3.fsproj" />
 </ItemGroup>
 ```
 
@@ -70,6 +71,12 @@ There's no CLI command to add a reference to an assembly that isn't in a project
 
   ```dotnetcli
   dotnet add app/app.csproj reference lib/lib.csproj
+  ```
+
+- Add a compatible .NET language project (e.g. F#) referenc, works in both ways:
+
+  ```dotnetcli
+  dotnet add app/app.csproj reference lib/lib.fsproj
   ```
 
 - Add multiple project references to the project in the current directory:

--- a/docs/core/tools/dotnet-add-reference.md
+++ b/docs/core/tools/dotnet-add-reference.md
@@ -73,7 +73,7 @@ There's no CLI command to add a reference to an assembly that isn't in a project
   dotnet add app/app.csproj reference lib/lib.csproj
   ```
 
-- Add a compatible .NET language project (e.g. F#) referenc, works in both ways:
+- Add a compatible .NET language (for example, F#) project reference, which works in both directions:
 
   ```dotnetcli
   dotnet add app/app.csproj reference lib/lib.fsproj


### PR DESCRIPTION
in .NET ecosystem other supported project formats exist, for example `.vbproj` and `.fsproj` and users are many times confused or not aware of this capability, so it should be made clear is perfectly legit to have solutions with multiple languages. One possible usecase is having test solution in one language, for example .fsproj, referencing an implementation solution in another language, for example .csproj, some languages might have benefits in specific areas or it might be an easier way / lower-friction to introduce a new language to a team, just have it in a small assembly, be it tests or a small module. 

## Summary

Add a mention to the fact that cross language project reference can work within valid .NET project files, for example F#

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-add-reference.md](https://github.com/dotnet/docs/blob/821c5569a25fdbd2f2c5adcc11b4e04fc970b698/docs/core/tools/dotnet-add-reference.md) | [dotnet add reference](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-add-reference?branch=pr-en-us-44031) |


<!-- PREVIEW-TABLE-END -->