### PR TITLE
Add examples of a spread element to the "Collection initializers" article

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md
+++ b/docs/csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md
@@ -153,6 +153,10 @@ You can use a spread element to create one list that copies other list or lists.
 
 :::code language="csharp" source="./snippets/object-collection-initializers/BasicObjectInitializers.cs" id="ListInitializerWithSpreadOperator":::
 
+And include additonal elements along with using a spread element.
+
+:::code language="csharp" source="./snippets/object-collection-initializers/BasicObjectInitializers.cs" id="ListInitializerWithSpreadOperatorAndAdditionalElement":::
+
 You can specify indexed elements if the collection supports read / write indexing.
 
 :::code language="csharp" source="./snippets/object-collection-initializers/BasicObjectInitializers.cs" id="DictionaryIndexerInitializer":::

--- a/docs/csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md
+++ b/docs/csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md
@@ -149,6 +149,10 @@ You can specify [null](../../language-reference/keywords/null.md) as an element 
 
 :::code language="csharp" source="./snippets/object-collection-initializers/BasicObjectInitializers.cs" id="ListInitializerWithNull":::
 
+You can use a spread element to create one list that copies other list or lists.
+
+:::code language="csharp" source="./snippets/object-collection-initializers/BasicObjectInitializers.cs" id="ListInitializerWithSpreadOperator":::
+
 You can specify indexed elements if the collection supports read / write indexing.
 
 :::code language="csharp" source="./snippets/object-collection-initializers/BasicObjectInitializers.cs" id="DictionaryIndexerInitializer":::

--- a/docs/csharp/programming-guide/classes-and-structs/snippets/object-collection-initializers/BasicObjectInitializers.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/snippets/object-collection-initializers/BasicObjectInitializers.cs
@@ -1,6 +1,4 @@
 ﻿
-using System.Xml.Linq;
-
 namespace object_collection_initializers;
 
 public class BasicObjectInitializers

--- a/docs/csharp/programming-guide/classes-and-structs/snippets/object-collection-initializers/BasicObjectInitializers.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/snippets/object-collection-initializers/BasicObjectInitializers.cs
@@ -102,6 +102,10 @@ public class BasicObjectInitializers
         List<Cat> allCats = [.. cats, .. moreCats];
         // </SnippetListInitializerWithSpreadOperator>
 
+        // <SnippetListInitializerWithSpreadOperatorAndAdditionalElement>
+        List<Cat> additionalCats = [.. cats, new Cat { Name = "Furrytail", Age = 5 }, .. moreCats];
+        // </SnippetListInitializerWithSpreadOperatorAndAdditionalElement>
+
         // <SnippetDictionaryIndexerInitializer>
         var numbers = new Dictionary<int, string>
         {

--- a/docs/csharp/programming-guide/classes-and-structs/snippets/object-collection-initializers/BasicObjectInitializers.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/snippets/object-collection-initializers/BasicObjectInitializers.cs
@@ -1,4 +1,6 @@
 ﻿
+using System.Xml.Linq;
+
 namespace object_collection_initializers;
 
 public class BasicObjectInitializers
@@ -190,15 +192,10 @@ public class InitializationSample
             null
         };
 
+        List<Cat> allCats = [.. cats, new Cat { Name = "Łapka", Age = 5 }, cat, .. moreCats];
+
         // Display results.
-        System.Console.WriteLine(cat.Name);
-
-        foreach (Cat c in cats)
-        {
-            System.Console.WriteLine(c.Name);
-        }
-
-        foreach (Cat? c in moreCats)
+        foreach (Cat? c in allCats)
         {
             if (c != null)
             {
@@ -211,13 +208,14 @@ public class InitializationSample
         }
     }
     // Output:
-    //Fluffy
-    //Sylvester
-    //Whiskers
-    //Sasha
-    //Furrytail
-    //Peaches
-    //List element has null value.
+    // Sylvester
+    // Whiskers
+    // Sasha
+    // Łapka
+    // Fluffy
+    // Furrytail
+    // Peaches
+    // List element has null value.
 }
 // </SnippetFullExample>
 

--- a/docs/csharp/programming-guide/classes-and-structs/snippets/object-collection-initializers/BasicObjectInitializers.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/snippets/object-collection-initializers/BasicObjectInitializers.cs
@@ -98,6 +98,10 @@ public class BasicObjectInitializers
         };
         // </SnippetListInitializerWithNull>
 
+        // <SnippetListInitializerWithSpreadOperator>
+        List<Cat> allCats = [.. cats, .. moreCats];
+        // </SnippetListInitializerWithSpreadOperator>
+
         // <SnippetDictionaryIndexerInitializer>
         var numbers = new Dictionary<int, string>
         {


### PR DESCRIPTION
This pull request closes #44032 

It presents the spread element examples by:
 * Creating a list out of other lists
 * Creating a list out of other lists and single element in between, to show that those syntax can be mixed
 * Using the spread element syntax to create a full list of all cats that is displayed at the very end of the collection full example

Each example is described with brief intro as other examples in that section.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md](https://github.com/dotnet/docs/blob/62d67da26e2c717e9d982d181fdcf1339d490b3e/docs/csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md) | [Object and Collection Initializers (C# Programming Guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/object-and-collection-initializers?branch=pr-en-us-44045) |


<!-- PREVIEW-TABLE-END -->