### PR TITLE
Fixed incorrect logic in XmlReader's example (#43799)

### DIFF
--- a/docs/standard/linq/stream-xml-fragments-xmlreader.md
+++ b/docs/standard/linq/stream-xml-fragments-xmlreader.md
@@ -53,14 +53,19 @@ static IEnumerable<XElement> StreamRootChildDoc(StringReader stringReader)
     }
 }
 
-string markup = @"<Root>
-    <Child Key=""01""><GrandChild>aaa</GrandChild>fda</Child>fda<Child Key=""02"">
-    <GrandChild>bbb</GrandChild>
-    </Child>
-    <Child Key=""03"">
-    <GrandChild>ccc</GrandChild>
-    </Child>
-</Root>";
+string markup = """
+                <Root>
+                  <Child Key="01">
+                    <GrandChild>aaa</GrandChild>
+                  </Child>
+                  <Child Key="02">
+                    <GrandChild>bbb</GrandChild>
+                  </Child>
+                  <Child Key="03">
+                    <GrandChild>ccc</GrandChild>
+                  </Child>
+                </Root>
+                """;
 
 IEnumerable<string> grandChildData =
     from el in StreamRootChildDoc(new StringReader(markup))

--- a/docs/standard/linq/stream-xml-fragments-xmlreader.md
+++ b/docs/standard/linq/stream-xml-fragments-xmlreader.md
@@ -27,184 +27,107 @@ The article [How to perform streaming transform of large XML documents](perform-
 This example creates a custom axis method. You can query it by using a LINQ query. The custom axis method `StreamRootChildDoc` can read a document that has a repeating `Child` element.
 
 ```csharp
+using System.Xml;
+using System.Xml.Linq;
+
 static IEnumerable<XElement> StreamRootChildDoc(StringReader stringReader)
 {
-    using (XmlReader reader = XmlReader.Create(stringReader))
+    using XmlReader reader = XmlReader.Create(stringReader);
+
+    reader.MoveToContent();
+
+    // Parse the file and display each of the nodes.
+    while (true)
     {
-        reader.MoveToContent();
-        // Parse the file and display each of the nodes.
-        while (true)
+        // If the current node is an element and named "Child"
+        if (reader.NodeType == XmlNodeType.Element && reader.Name == "Child")
         {
-            switch (reader.NodeType)
-            {
-                case XmlNodeType.Element:
-                    if (reader.Name == "Child") {
-                        XElement? el = XNode.ReadFrom(reader) as XElement;
-                        if (el != null)
-                            yield return el;
-
-                        // Should only call reader.Read(), if XNode.ReadFrom() was NOT called,
-                        // because XNode.ReadFrom() advances the reader to the next element by itself.
-                        continue;
-                    }
-                    break;
-            }
-
-            if (!reader.Read())
-                break;
+            // Get the current node and advance the reader to the next
+            if (XNode.ReadFrom(reader) is XElement el)
+                yield return el;
+            else
+                continue;
         }
+        else if (!reader.Read())
+            break;
     }
 }
 
-static void Main(string[] args)
-{
-    string markup = @"<Root>
-      <Child Key=""01"">
-        <GrandChild>aaa</GrandChild>
-      </Child>
-      <Child Key=""02"">
-        <GrandChild>bbb</GrandChild>
-      </Child>
-      <Child Key=""03"">
-        <GrandChild>ccc</GrandChild>
-      </Child>
-    </Root>";
+string markup = @"<Root>
+    <Child Key=""01""><GrandChild>aaa</GrandChild>fda</Child>fda<Child Key=""02"">
+    <GrandChild>bbb</GrandChild>
+    </Child>
+    <Child Key=""03"">
+    <GrandChild>ccc</GrandChild>
+    </Child>
+</Root>";
 
-    IEnumerable<string> grandChildData =
-        from el in StreamRootChildDoc(new StringReader(markup))
-        where (int)el.Attribute("Key") > 1
-        select (string)el.Element("GrandChild");
+IEnumerable<string> grandChildData =
+    from el in StreamRootChildDoc(new StringReader(markup))
+    where (int)el.Attribute("Key") > 1
+    select (string)el.Element("GrandChild");
 
-    foreach (string str in grandChildData) {
-        Console.WriteLine(str);
-    }
-}
+foreach (string str in grandChildData)
+    Console.WriteLine(str);
 ```
 
 ```vb
+Imports System.Xml
+
 Module Module1
+
+    Public Iterator Function StreamRootChildDoc(stringReader As IO.StringReader) As IEnumerable(Of XElement)
+        Using reader As XmlReader = XmlReader.Create(stringReader)
+            reader.MoveToContent()
+
+            ' Parse the file and display each of the nodes.
+            While True
+
+                ' If the current node is an element and named "Child"
+                If reader.NodeType = XmlNodeType.Element And reader.Name = "Child" Then
+
+                    ' Get the current node and advance the reader to the next
+                    Dim el As XElement = TryCast(XNode.ReadFrom(reader), XElement)
+
+                    If (el IsNot Nothing) Then
+                        Yield el
+                    Else
+                        Continue While
+                    End If
+
+                ElseIf Not reader.Read() Then
+                    Exit While
+                End If
+
+            End While
+        End Using
+    End Function
+
     Sub Main()
-        Dim markup = "<Root>" &
-                     "  <Child Key=""01"">" &
-                     "    <GrandChild>aaa</GrandChild>" &
-                     "  </Child>" &
-                     "  <Child Key=""02"">" &
-                     "    <GrandChild>bbb</GrandChild>" &
-                     "  </Child>" &
-                     "  <Child Key=""03"">" &
-                     "    <GrandChild>ccc</GrandChild>" &
-                     "  </Child>" &
-                     "</Root>"
+
+        Dim markup = "<Root>
+                       <Child Key=""01"">
+                         <GrandChild>aaa</GrandChild>
+                       </Child>
+                       <Child Key=""02"">
+                         <GrandChild>bbb</GrandChild>
+                       </Child>
+                       <Child Key=""03"">
+                         <GrandChild>ccc</GrandChild>
+                       </Child>
+                     </Root>"
 
         Dim grandChildData =
-             From el In New StreamRootChildDoc(New IO.StringReader(markup))
+             From el In StreamRootChildDoc(New IO.StringReader(markup))
              Where CInt(el.@Key) > 1
              Select el.<GrandChild>.Value
 
         For Each s In grandChildData
             Console.WriteLine(s)
         Next
+
     End Sub
 End Module
-
-Public Class StreamRootChildDoc
-    Implements IEnumerable(Of XElement)
-
-    Private _stringReader As IO.StringReader
-
-    Public Sub New(ByVal stringReader As IO.StringReader)
-        _stringReader = stringReader
-    End Sub
-
-    Public Function GetEnumerator() As IEnumerator(Of XElement) Implements IEnumerable(Of XElement).GetEnumerator
-        Return New StreamChildEnumerator(_stringReader)
-    End Function
-
-    Public Function GetEnumerator1() As IEnumerator Implements IEnumerable.GetEnumerator
-        Return Me.GetEnumerator()
-    End Function
-End Class
-
-Public Class StreamChildEnumerator
-    Implements IEnumerator(Of XElement)
-
-    Private _current As XElement
-    Private _reader As Xml.XmlReader
-    Private _stringReader As IO.StringReader
-
-    Public Sub New(ByVal stringReader As IO.StringReader)
-        _stringReader = stringReader
-        _reader = Xml.XmlReader.Create(_stringReader)
-        _reader.MoveToContent()
-    End Sub
-
-    Public ReadOnly Property Current As XElement Implements IEnumerator(Of XElement).Current
-        Get
-            Return _current
-        End Get
-    End Property
-
-    Public ReadOnly Property Current1 As Object Implements IEnumerator.Current
-        Get
-            Return Me.Current
-        End Get
-    End Property
-
-    Public Function MoveNext() As Boolean Implements IEnumerator.MoveNext
-
-        _reader.MoveToContent()
-
-        While True
-            Select Case _reader.NodeType
-                Case Xml.XmlNodeType.Element
-                    If _reader.Name = "Child" Then
-                        Dim el = TryCast(XNode.ReadFrom(_reader), XElement)
-                        If el IsNot Nothing Then
-                            _current = el
-                            Return True
-                        End If
-
-                        ' Should only call _reader.Read(), if XNode.ReadFrom() was NOT called,
-                        ' because XNode.ReadFrom() advances the reader to the next element by itself.
-                        Continue While
-                    End If
-            End Select
-
-            If Not _reader.Read() Then
-                Exit While
-            End If
-
-        End While
-
-        Return False
-    End Function
-
-    Public Sub Reset() Implements IEnumerator.Reset
-        _reader = Xml.XmlReader.Create(_stringReader)
-        _reader.MoveToContent()
-    End Sub
-
-#Region "IDisposable Support"
-
-    Private disposedValue As Boolean ' To detect redundant calls
-
-    ' IDisposable
-    Protected Overridable Sub Dispose(ByVal disposing As Boolean)
-        If Not Me.disposedValue Then
-            If disposing Then
-                _reader.Close()
-            End If
-        End If
-        Me.disposedValue = True
-    End Sub
-
-    Public Sub Dispose() Implements IDisposable.Dispose
-        Dispose(True)
-        GC.SuppressFinalize(Me)
-    End Sub
-#End Region
-
-End Class
 ```
 
 This example produces the following output:

--- a/docs/standard/linq/stream-xml-fragments-xmlreader.md
+++ b/docs/standard/linq/stream-xml-fragments-xmlreader.md
@@ -45,8 +45,7 @@ static IEnumerable<XElement> StreamRootChildDoc(StringReader stringReader)
             // Get the current node and advance the reader to the next
             if (XNode.ReadFrom(reader) is XElement el)
                 yield return el;
-            else
-                continue;
+
         }
         else if (!reader.Read())
             break;
@@ -96,8 +95,6 @@ Module Module1
 
                     If (el IsNot Nothing) Then
                         Yield el
-                    Else
-                        Continue While
                     End If
 
                 ElseIf Not reader.Read() Then


### PR DESCRIPTION
(#43799 is now 3 weeks old without even being triaged, so fixing it myself)

[The code sample for XmlReader](https://learn.microsoft.com/en-us/dotnet/standard/linq/stream-xml-fragments-xmlreader?source=docs#example-create-a-custom-axis-method) is incorrect. It relies on the fact that the input XML has some formatting in it. Without formatting the code returns wrong results.

In more details, the issue happens because `XElement.ReadFrom()` reads the current element and _positions the reader at the next element_. When the XML has formatting, that next element will be of type `Whitespace` or smth - and everything works. But without formatting that next element will be the next `Child` element. Then the `reader.Read()` happens, which moves the reader to yet another next element. Hence the `<Child Key=""02"">` tag simply gets skipped.

Here is the code to address the issue.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/linq/stream-xml-fragments-xmlreader.md](https://github.com/dotnet/docs/blob/e1815642db9eb36cb8e3730d8d8102364be582ba/docs/standard/linq/stream-xml-fragments-xmlreader.md) | [How to stream XML fragments from an XmlReader (LINQ to XML)](https://review.learn.microsoft.com/en-us/dotnet/standard/linq/stream-xml-fragments-xmlreader?branch=pr-en-us-44054) |


<!-- PREVIEW-TABLE-END -->