### PR TITLE
Add missing comma in MTP dotnet test integration doc

### DIFF
--- a/docs/core/testing/unit-testing-platform-integration-dotnet-test.md
+++ b/docs/core/testing/unit-testing-platform-integration-dotnet-test.md
@@ -132,7 +132,7 @@ Or in project file:
 
 By default, all console output that the underlying test executable writes is captured and hidden from the user. This includes the banner, version information, and formatted test information.
 
-To show this information together with MSBuild output use`<TestingPlatformCaptureOutput>false</TestingPlatformCaptureOutput>`.
+To show this information together with MSBuild output, use `<TestingPlatformCaptureOutput>false</TestingPlatformCaptureOutput>`.
 
 This option doesn't impact how the testing framework captures user output written by `Console.WriteLine` or other similar ways to write to the console.
 


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-platform-integration-dotnet-test.md](https://github.com/dotnet/docs/blob/98529424589acd54762f677c8ab1555b251b03b4/docs/core/testing/unit-testing-platform-integration-dotnet-test.md) | [Use Microsoft.Testing.Platform with `dotnet test`](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-platform-integration-dotnet-test?branch=pr-en-us-44057) |

<!-- PREVIEW-TABLE-END -->