### PR TITLE
Document MSBuild support for 'IfDifferent' for 'CopyToOutputDirectory'

### DIFF
--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -1783,7 +1783,16 @@ In addition to the standard [MSBuild item attributes](/visualstudio/msbuild/item
 
 ### CopyToPublishDirectory
 
-The `CopyToPublishDirectory` metadata on an MSBuild item controls when the item is copied to the publish directory. Allowable values are `PreserveNewest`, which only copies the item if it has changed in the source location, `IfDifferent`, which only copies the item if it has changed either in the source or target location (helpful for situations where we need to reset changs occuring after the publishing), `Always`, which always copies the item, and `Never`, which never copies the item. From a performance standpoint, `PreserveNewest` is preferable because it enables an incremental build. `Always` should be avoided - as any scenarios requiring it should be achievable with more effective `IfDifferent`.
+The `CopyToPublishDirectory` metadata on an MSBuild item controls when the item is copied to the publish directory. The following table shows the allowable values.
+
+| Value | Description |
+| ------ | ------------ |
+| `PreserveNewest` | Only copies the item if it has changed in the source location. |
+| `IfDifferent` | Only copies the item if it has changed either in the source or target location. This setting is helpful for situations where you need to reset changes that occur after publishing. |
+| `Always` | Always copies the item. |
+| `Never` | Never copies the item. |
+
+From a performance standpoint, `PreserveNewest` is preferable because it enables an incremental build. Avoid using `Always` and use `IfDifferent` instead, which is more effective.
 
 ```xml
 <ItemGroup>

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -1783,7 +1783,7 @@ In addition to the standard [MSBuild item attributes](/visualstudio/msbuild/item
 
 ### CopyToPublishDirectory
 
-The `CopyToPublishDirectory` metadata on an MSBuild item controls when the item is copied to the publish directory. Allowable values are `PreserveNewest`, which only copies the item if it has changed, `Always`, which always copies the item, and `Never`, which never copies the item. From a performance standpoint, `PreserveNewest` is preferable because it enables an incremental build.
+The `CopyToPublishDirectory` metadata on an MSBuild item controls when the item is copied to the publish directory. Allowable values are `PreserveNewest`, which only copies the item if it has changed in the source location, `IfDifferent`, which only copies the item if it has changed either in the source or target location (helpful for situations where we need to reset changs occuring after the publishing), `Always`, which always copies the item, and `Never`, which never copies the item. From a performance standpoint, `PreserveNewest` is preferable because it enables an incremental build. `Always` should be avoided - as any scenarios requiring it should be achievable with more effective `IfDifferent`.
 
 ```xml
 <ItemGroup>

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -1792,7 +1792,7 @@ The `CopyToPublishDirectory` metadata on an MSBuild item controls when the item 
 | `Always` | Always copies the item. |
 | `Never` | Never copies the item. |
 
-From a performance standpoint, `PreserveNewest` is preferable because it enables an incremental build. Avoid using `Always` and use `IfDifferent` instead, which is more effective.
+From a performance standpoint, `PreserveNewest` is preferable because it enables an incremental build. Avoid using `Always` and use `IfDifferent` instead, which avoids I/O writes with no effect.
 
 ```xml
 <ItemGroup>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/docs/issues/44059

### Context

Adding documentation for a new option added in VS 17.13 / .NET SDK 9.0.2xx
More details in the linked bug

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/project-sdk/msbuild-props.md](https://github.com/dotnet/docs/blob/e0eb66aef97abb2f0f6fd333be0d8dec8a601727/docs/core/project-sdk/msbuild-props.md) | [MSBuild reference for .NET SDK projects](https://review.learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props?branch=pr-en-us-44060) |


<!-- PREVIEW-TABLE-END -->