### PR TITLE
Add link to trimming options

### DIFF
--- a/docs/core/compatibility/serialization/8.0/publishtrimmed.md
+++ b/docs/core/compatibility/serialization/8.0/publishtrimmed.md
@@ -49,3 +49,7 @@ However, if you must use reflection, you can revert to the original behavior by 
 ## Affected APIs
 
 N/A
+
+## See also
+
+- [Trimming options: Enable trimming](../../../deploying/trimming/trimming-options.md#enable-trimming)


### PR DESCRIPTION
Fixes #43697.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/serialization/8.0/publishtrimmed.md](https://github.com/dotnet/docs/blob/7905b24987212c16bd71ccf0816070659814e88b/docs/core/compatibility/serialization/8.0/publishtrimmed.md) | [PublishedTrimmed projects fail reflection-based serialization](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/serialization/8.0/publishtrimmed?branch=pr-en-us-44099) |

<!-- PREVIEW-TABLE-END -->