### PR TITLE
Add missing dependencies in linux-alpine.md

### DIFF
--- a/docs/core/install/linux-alpine.md
+++ b/docs/core/install/linux-alpine.md
@@ -76,7 +76,7 @@ When you install with a package manager, these libraries are installed for you. 
 - libssl3
 - libstdc++
 - zlib
-- icu-libs and icu-data-full (unless the .NET app is running in [globalization-invariant mode](../runtime-config/globalization#invariant-mode)
+- icu-libs and icu-data-full (unless the .NET app is running in [globalization-invariant mode](../runtime-config/globalization.md#invariant-mode)
 - libgdiplus (if the .NET app requires the *System.Drawing.Common* assembly)
 
 Use the `apk add` command to install the dependencies.

--- a/docs/core/install/linux-alpine.md
+++ b/docs/core/install/linux-alpine.md
@@ -76,6 +76,7 @@ When you install with a package manager, these libraries are installed for you. 
 - libssl3
 - libstdc++
 - zlib
+- icu-libs and icu-data-full (unless the .NET app is running in [globalization-invariant mode](../runtime-config/globalization#invariant-mode)
 - libgdiplus (if the .NET app requires the *System.Drawing.Common* assembly)
 
 Use the `apk add` command to install the dependencies.


### PR DESCRIPTION
## Summary

This commit adds icu-libs and icu-data-full to the list of required dependencies on Alpine. There are required unless the app is running in globalization-invariant mode.

See https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.16.0#ICU_data_split for more information about why both those packages need to be mentioned.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/linux-alpine.md](https://github.com/dotnet/docs/blob/ad5dcfd3710ec1d5a9beea29174415e0de96d57b/docs/core/install/linux-alpine.md) | [Install the .NET SDK or the .NET Runtime on Alpine](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-alpine?branch=pr-en-us-44113) |


<!-- PREVIEW-TABLE-END -->