### PR TITLE
Interpolated string handlers should avoid ref struct

### DIFF
--- a/docs/csharp/advanced-topics/performance/interpolated-string-handler.md
+++ b/docs/csharp/advanced-topics/performance/interpolated-string-handler.md
@@ -93,7 +93,7 @@ Finally, notice that the last warning doesn't invoke the interpolated string han
 
 > [!IMPORTANT]
 >
-> The version of the `Logger` for this section is a `ref struct`. A `ref struct` minimizes allocations because it must be stored on the stack. However, `ref struct` types, in general, can't implement interfaces. This can cause compatibility issues for unit test frameworks and mocking types that use `ref struct` types for implementation.
+> Use `ref struct` for interpolated string handlers only if absolutely necessary. Using `ref struct` will have limitations as they must be stored on the stack. For example, they can't implement interfaces. They also will not work if an interpolated string hole contains an `await` expression because the compiler will need to store the handler in the compiler-generated `IAsyncStateMachine` implementation.
 
 ## Add more capabilities to the handler
 

--- a/docs/csharp/advanced-topics/performance/interpolated-string-handler.md
+++ b/docs/csharp/advanced-topics/performance/interpolated-string-handler.md
@@ -93,7 +93,7 @@ Finally, notice that the last warning doesn't invoke the interpolated string han
 
 > [!IMPORTANT]
 >
-> Use `ref struct` for interpolated string handlers only if absolutely necessary. Using `ref struct` will have limitations as they must be stored on the stack. For example, they can't implement interfaces. They also will not work if an interpolated string hole contains an `await` expression because the compiler will need to store the handler in the compiler-generated `IAsyncStateMachine` implementation.
+> Use `ref struct` for interpolated string handlers only if absolutely necessary. Using `ref struct` will have limitations as they must be stored on the stack. For example, they will not work if an interpolated string hole contains an `await` expression because the compiler will need to store the handler in the compiler-generated `IAsyncStateMachine` implementation.
 
 ## Add more capabilities to the handler
 

--- a/docs/csharp/advanced-topics/performance/snippets/interpolated-string-handler/Logger-v2.cs
+++ b/docs/csharp/advanced-topics/performance/snippets/interpolated-string-handler/Logger-v2.cs
@@ -5,7 +5,7 @@ namespace interpolated_string_handler.Version2
 {
     // <CoreInterpolatedStringHandler>
     [InterpolatedStringHandler]
-    public ref struct LogInterpolatedStringHandler
+    public struct LogInterpolatedStringHandler
     {
         // Storage for the built-up string
         StringBuilder builder;

--- a/docs/csharp/advanced-topics/performance/snippets/interpolated-string-handler/logger-v3.cs
+++ b/docs/csharp/advanced-topics/performance/snippets/interpolated-string-handler/logger-v3.cs
@@ -4,7 +4,7 @@ using System.Text;
 namespace interpolated_string_handler.Version3
 {
     [InterpolatedStringHandler]
-    public ref struct LogInterpolatedStringHandler
+    public struct LogInterpolatedStringHandler
     {
         // Storage for the built-up string
         StringBuilder builder;

--- a/docs/csharp/advanced-topics/performance/snippets/interpolated-string-handler/logger-v4.cs
+++ b/docs/csharp/advanced-topics/performance/snippets/interpolated-string-handler/logger-v4.cs
@@ -4,7 +4,7 @@ using System.Text;
 namespace interpolated_string_handler.Version4
 {
     [InterpolatedStringHandler]
-    public ref struct LogInterpolatedStringHandler
+    public struct LogInterpolatedStringHandler
     {
         // Storage for the built-up string
         StringBuilder builder;


### PR DESCRIPTION
Simplified example:

```csharp
using System.Runtime.CompilerServices;
using System.Threading.Tasks;
public class C {
    
    [InterpolatedStringHandler]
    public ref struct InterpolatedStringHandler
    {
        public InterpolatedStringHandler(int _1, int _2)
        {
        }
        
        public void AppendLiteral(string s) { }
        public void AppendFormatted(string s) { }
    }
    
    private static async Task<string> GetHello()
    {
        await Task.Yield();
        return "Hello";
    }

    public void M(InterpolatedStringHandler s) {
        
    }
    
    public async Task MAsync()
    {
        M($"Hello {await GetHello()}"); // error. Removing ref modifier will work.
    }
}
```

FYI @333fred as we discussed this.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/advanced-topics/performance/interpolated-string-handler.md](https://github.com/dotnet/docs/blob/d51d531912e82950efb76f67638f941b6eb42404/docs/csharp/advanced-topics/performance/interpolated-string-handler.md) | [Tutorial: Write a custom string interpolation handler](https://review.learn.microsoft.com/en-us/dotnet/csharp/advanced-topics/performance/interpolated-string-handler?branch=pr-en-us-44123) |


<!-- PREVIEW-TABLE-END -->