### PR TITLE
Document MSTest 3.8 TestContext support for ClassCleanup/AssemblyCleanup

### DIFF
--- a/docs/core/testing/mstest-analyzers/mstest0011.md
+++ b/docs/core/testing/mstest-analyzers/mstest0011.md
@@ -38,7 +38,7 @@ Methods marked with `[ClassCleanup]` should follow the following layout to be va
 - it should not be `async void`
 - it should not be a special method (finalizer, operator...).
 - it should not be generic
-- it should not take any parameter
+- it should not take any parameter, or starting with MSTest 3.8, it can have a single `TestContext` parameter
 - return type should be `void`, `Task` or `ValueTask`
 - `InheritanceBehavior.BeforeEachDerivedClass` attribute parameter should be specified if the class is `abstract`.
 - `InheritanceBehavior.BeforeEachDerivedClass` attribute parameter should not be specified if the class is `sealed`.

--- a/docs/core/testing/mstest-analyzers/mstest0013.md
+++ b/docs/core/testing/mstest-analyzers/mstest0013.md
@@ -38,7 +38,7 @@ Methods marked with `[AssemblyCleanup]` should follow the following layout to be
 - it should not be `async void`
 - it should not be a special method (finalizer, operator...).
 - it should not be generic
-- it should not take any parameter
+- it should not take any parameter, or starting with MSTest 3.8, it can have a single `TestContext` parameter
 - return type should be `void`, `Task` or `ValueTask`
 
 The type declaring these methods should also respect the following rules:

--- a/docs/core/testing/unit-testing-mstest-writing-tests-attributes.md
+++ b/docs/core/testing/unit-testing-mstest-writing-tests-attributes.md
@@ -189,7 +189,7 @@ Setup and cleanup that is common to multiple tests can be extracted to a separat
 
 [AssemblyInitialize](<xref:Microsoft.VisualStudio.TestTools.UnitTesting.AssemblyInitializeAttribute>) is called right after your assembly is loaded and [AssemblyCleanup](<xref:Microsoft.VisualStudio.TestTools.UnitTesting.AssemblyCleanupAttribute>) is called right before your assembly is unloaded.
 
-The methods marked with these attributes should be defined as `static void`, `static Task` or `static ValueTask` (starting with MSTest v3.3), in a `TestClass`, and appear only once. The initialize part requires one argument of type [TestContext](xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestContext) and the cleanup no argument.
+The methods marked with these attributes should be defined as `static void`, `static Task` or `static ValueTask` (starting with MSTest v3.3), in a `TestClass`, and appear only once. The initialize part requires one parameter of type [TestContext](xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestContext) and the cleanup either no parameters, or starting with MSTest 3.8 can have one parameter of type [TestContext](xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestContext).
 
 ```csharp
 [TestClass]
@@ -201,23 +201,7 @@ public class MyTestClass
     }
 
     [AssemblyCleanup]
-    public static void AssemblyCleanup()
-    {
-    }
-}
-```
-
-```csharp
-[TestClass]
-public class MyOtherTestClass
-{
-    [AssemblyInitialize]
-    public static async Task AssemblyInitialize(TestContext testContext)
-    {
-    }
-
-    [AssemblyCleanup]
-    public static async Task AssemblyCleanup()
+    public static void AssemblyCleanup() // Starting with MSTest 3.8, it can be AssemblyCleanup(TestContext testContext)
     {
     }
 }
@@ -231,7 +215,7 @@ It's possible to control the inheritance behavior: only for current class using 
 
 It's also possible to configure whether the class cleanup should be run at the end of the class or at the end of the assembly.
 
-The methods marked with these attributes should be defined as `static void`, `static Task` or `static ValueTask` (starting with MSTest v3.3), in a `TestClass`, and appear only once. The initialize part requires one argument of type [TestContext](xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestContext) and the cleanup no argument.
+The methods marked with these attributes should be defined as `static void`, `static Task` or `static ValueTask` (starting with MSTest v3.3), in a `TestClass`, and appear only once. The initialize part requires one parameter of type [TestContext](xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestContext) and the cleanup either no parameters, or starting with MSTest 3.8 can have one parameter of type [TestContext](xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestContext).
 
 ```csharp
 [TestClass]
@@ -243,7 +227,7 @@ public class MyTestClass
     }
 
     [ClassCleanup]
-    public static void ClassCleanup()
+    public static void ClassCleanup() // Starting with MSTest 3.8, it can be ClassCleanup(TestContext testContext)
     {
     }
 }
@@ -259,7 +243,7 @@ public class MyOtherTestClass
     }
 
     [ClassCleanup]
-    public static async Task ClassCleanup()
+    public static async Task ClassCleanup() // Starting with MSTest 3.8, it can be ClassCleanup(TestContext testContext)
     {
     }
 }

--- a/docs/core/testing/unit-testing-mstest-writing-tests-attributes.md
+++ b/docs/core/testing/unit-testing-mstest-writing-tests-attributes.md
@@ -207,6 +207,22 @@ public class MyTestClass
 }
 ```
 
+```csharp
+[TestClass]
+public class MyOtherTestClass
+{
+    [AssemblyInitialize]
+    public static async Task AssemblyInitialize(TestContext testContext)
+    {
+    }
+
+    [AssemblyCleanup]
+    public static async Task AssemblyCleanup() // Starting with MSTest 3.8, it can be AssemblyCleanup(TestContext testContext)
+    {
+    }
+}
+```
+
 ### Class level
 
 [ClassInitialize](<xref:Microsoft.VisualStudio.TestTools.UnitTesting.ClassInitializeAttribute>) is called right before your class is loaded (but after static constructor) and [ClassCleanup](<xref:Microsoft.VisualStudio.TestTools.UnitTesting.ClassCleanupAttribute>) is called right after your class is unloaded.


### PR DESCRIPTION
Fixes https://github.com/microsoft/testfx/issues/4391

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/mstest-analyzers/mstest0011.md](https://github.com/dotnet/docs/blob/11f6cdbfc1030aa5d450561269a7f80236c9bbc9/docs/core/testing/mstest-analyzers/mstest0011.md) | [MSTEST0011: ClassCleanup method should have valid layout](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0011?branch=pr-en-us-44140) |
| [docs/core/testing/mstest-analyzers/mstest0013.md](https://github.com/dotnet/docs/blob/11f6cdbfc1030aa5d450561269a7f80236c9bbc9/docs/core/testing/mstest-analyzers/mstest0013.md) | ["MSTEST0013: AssemblyCleanup method should have valid layout"](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0013?branch=pr-en-us-44140) |
| [docs/core/testing/unit-testing-mstest-writing-tests-attributes.md](https://github.com/dotnet/docs/blob/11f6cdbfc1030aa5d450561269a7f80236c9bbc9/docs/core/testing/unit-testing-mstest-writing-tests-attributes.md) | [MSTest attributes](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-writing-tests-attributes?branch=pr-en-us-44140) |


<!-- PREVIEW-TABLE-END -->