### PR TITLE
Slightly inaccurate verbiage

### DIFF
--- a/docs/core/docker/publish-as-container.md
+++ b/docs/core/docker/publish-as-container.md
@@ -111,7 +111,7 @@ The preceding .NET CLI command publishes the app as a container:
 - Specifying an x64 architecture (`--arch x64`).
 
 > [!IMPORTANT]
-> To build the container locally, you must have the Docker daemon running. If it isn't running when you attempt to publish the app as a container, you'll experience an error similar to the following:
+> To publish the container locally, you must have the Docker daemon running. If it isn't running when you attempt to publish the app as a container, you'll experience an error similar to the following:
 >
 > ```console
 > ..\build\Microsoft.NET.Build.Containers.targets(66,9): error MSB4018:


### PR DESCRIPTION
Slightly inaccurate verbiage. It is not the build that requires the daemon. It is the publish.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/docker/publish-as-container.md](https://github.com/dotnet/docs/blob/2ba4fcba0d112e8955452b907aa10ebb7fed229b/docs/core/docker/publish-as-container.md) | [Containerize a .NET app with dotnet publish](https://review.learn.microsoft.com/en-us/dotnet/core/docker/publish-as-container?branch=pr-en-us-44143) |

<!-- PREVIEW-TABLE-END -->