### PR TITLE
Remove extraneous trailing colons

### DIFF
--- a/docs/framework/windows-workflow-foundation/samples/suspended-instance-management.md
+++ b/docs/framework/windows-workflow-foundation/samples/suspended-instance-management.md
@@ -1,8 +1,7 @@
 ---
-description: "Learn more about: Suspended Instance Management"
 title: "Suspended Instance Management"
+description: "Learn more about: Suspended Instance Management"
 ms.date: "03/30/2017"
-ms.assetid: f5ca3faa-ba1f-4857-b92c-d927e4b29598
 ---
 # Suspended Instance Management
 
@@ -58,7 +57,7 @@ The [SuspendedInstanceManagement sample](https://github.com/dotnet/samples/tree/
 
     1. In Visual Studio, run the SampleWorkflowApp project again without debugging by pressing <kbd>Ctrl</kbd>+<kbd>F5</kbd>. Two endpoint addresses will be printed in the console window: one for the application endpoint and then other from the <xref:System.ServiceModel.Activities.WorkflowControlEndpoint>. A workflow instance is then created, and tracking records for that instance will appear in the console window. The workflow instance will throw an exception causing the instance to be suspended and aborted.
 
-    2. The command-line utility can then be used to take further action on any of these instances. The syntax for command line arguments is as follows::
+    2. The command-line utility can then be used to take further action on any of these instances. The syntax for command line arguments is as follows:
 
          `SuspendedInstanceManagement -Command:[CommandName] -Server:[ServerName] -Database:[DatabaseName] -InstanceId:[InstanceId]`
 

--- a/docs/standard/linq/find-element-specific-attribute.md
+++ b/docs/standard/linq/find-element-specific-attribute.md
@@ -84,7 +84,7 @@ Module Module1
 End Module
 ```
 
-This example produces the following output::
+This example produces the following output:
 
 ```xml
 <aw:Address aw:Type="Billing" xmlns:aw="http://www.adventure-works.com">

--- a/docs/standard/linq/valid-content-xelement-xdocument-objects.md
+++ b/docs/standard/linq/valid-content-xelement-xdocument-objects.md
@@ -2,7 +2,6 @@
 title: Valid content of XElement and XDocument objects - LINQ to XML
 description: The XElement and XDocument constructors accept many argument types, including collections returned from queries. There are other constructors and functions for adding XML content.
 ms.date: 07/20/2015
-ms.assetid: 0d253586-2b97-459f-b1a7-f30f38f3ed9f
 ---
 
 # Valid content of XElement and XDocument objects (LINQ to XML)
@@ -13,7 +12,7 @@ This article describes the valid arguments that can be passed to constructors, a
 
 Queries often evaluate to <xref:System.Collections.Generic.IEnumerable%601> of <xref:System.Xml.Linq.XElement> or <xref:System.Collections.Generic.IEnumerable%601> of <xref:System.Xml.Linq.XAttribute>. You can pass collections of <xref:System.Xml.Linq.XElement> or <xref:System.Xml.Linq.XAttribute> objects to the <xref:System.Xml.Linq.XElement> constructor. That's why it's convenient to pass the results of a query as content into methods and constructors that you use to populate XML trees.
 
-When adding simple content, various types can be passed to this method, including::
+When adding simple content, various types can be passed to this method, including:
 
 - <xref:System.String>
 - <xref:System.Double>

--- a/includes/migration-guide/retargeting/core/allow-unicode-bidirectional-control-characters-uris.md
+++ b/includes/migration-guide/retargeting/core/allow-unicode-bidirectional-control-characters-uris.md
@@ -14,7 +14,7 @@ For applications that target versions of .NET Framework starting with 4.7.2, sup
 </runtime>
 ```
 
-For applications that target earlier versions of the .NET Framework but are running under versions starting with .NET Framework 4.7.2, support for Unicode bidirectional characters is disabled by default. You can enable it by adding the following [AppContextSwitchOverrides](~/docs/framework/configure-apps/file-schema/runtime/appcontextswitchoverrides-element.md) switch to the `<runtime>` section of the application configuration file::
+For applications that target earlier versions of the .NET Framework but are running under versions starting with .NET Framework 4.7.2, support for Unicode bidirectional characters is disabled by default. You can enable it by adding the following [AppContextSwitchOverrides](~/docs/framework/configure-apps/file-schema/runtime/appcontextswitchoverrides-element.md) switch to the `<runtime>` section of the application configuration file:
 
 ```xml
 <runtime>


### PR DESCRIPTION
## Summary

Elide extraneous colons and some metadata updates.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/windows-workflow-foundation/samples/suspended-instance-management.md](https://github.com/dotnet/docs/blob/ee035d9d563d23a3a66d9b85b7fa66b1ec5d3c0c/docs/framework/windows-workflow-foundation/samples/suspended-instance-management.md) | [Suspended Instance Management](https://review.learn.microsoft.com/en-us/dotnet/framework/windows-workflow-foundation/samples/suspended-instance-management?branch=pr-en-us-44153) |
| [docs/standard/linq/find-element-specific-attribute.md](https://github.com/dotnet/docs/blob/ee035d9d563d23a3a66d9b85b7fa66b1ec5d3c0c/docs/standard/linq/find-element-specific-attribute.md) | [How to find an element with a specific attribute (LINQ to XML)](https://review.learn.microsoft.com/en-us/dotnet/standard/linq/find-element-specific-attribute?branch=pr-en-us-44153) |
| [docs/standard/linq/valid-content-xelement-xdocument-objects.md](https://github.com/dotnet/docs/blob/ee035d9d563d23a3a66d9b85b7fa66b1ec5d3c0c/docs/standard/linq/valid-content-xelement-xdocument-objects.md) | [Valid content of XElement and XDocument objects - LINQ to XML](https://review.learn.microsoft.com/en-us/dotnet/standard/linq/valid-content-xelement-xdocument-objects?branch=pr-en-us-44153) |

<!-- PREVIEW-TABLE-END -->