### PR TITLE
Clarify Introduction of Wildcard Pattern in F# Pattern Matching Documentation

### DIFF
--- a/docs/fsharp/tour.md
+++ b/docs/fsharp/tour.md
@@ -120,7 +120,7 @@ Because DUs allow you to represent the recursive structure of the tree in the da
 
 [!code-fsharp[PatternMatching](~/samples/snippets/fsharp/tour.fs#L717-L743)]
 
-Something you may have noticed is the use of the `_` pattern.  This is known as the [Wildcard Pattern](language-reference/pattern-matching.md#wildcard-pattern), which is a way of saying "I don't care what something is".  Although convenient, you can accidentally bypass Exhaustive Pattern Matching and no longer benefit from compile-time enforcements if you aren't careful in using `_`.  It is best used when you don't care about certain pieces of a decomposed type when pattern matching, or the final clause when you have enumerated all meaningful cases in a pattern matching expression.
+Something you may have noticed is that the `_` pattern is introduced in the following example. This is known as the [Wildcard Pattern](language-reference/pattern-matching.md#wildcard-pattern), which is a way of saying "I don't care what something is". Although convenient, you can accidentally bypass Exhaustive Pattern Matching and no longer benefit from compile-time enforcements if you aren't careful in using `_`. It is best used when you don't care about certain pieces of a decomposed type when pattern matching, or the final clause when you have enumerated all meaningful cases in a pattern matching expression.
 
 In the following example, the `_` case is used when a parse operation fails.
 

--- a/docs/fsharp/tour.md
+++ b/docs/fsharp/tour.md
@@ -120,7 +120,7 @@ Because DUs allow you to represent the recursive structure of the tree in the da
 
 [!code-fsharp[PatternMatching](~/samples/snippets/fsharp/tour.fs#L717-L743)]
 
-Something you may have noticed is that the `_` pattern is introduced in the following example. This is known as the [Wildcard Pattern](language-reference/pattern-matching.md#wildcard-pattern), which is a way of saying "I don't care what something is". Although convenient, you can accidentally bypass Exhaustive Pattern Matching and no longer benefit from compile-time enforcements if you aren't careful in using `_`. It is best used when you don't care about certain pieces of a decomposed type when pattern matching, or the final clause when you have enumerated all meaningful cases in a pattern matching expression.
+The following sample introduces the `_` pattern, which you might have noticed before. This is known as the [Wildcard Pattern](language-reference/pattern-matching.md#wildcard-pattern), which is a way of saying "I don't care what something is". Although convenient, you can accidentally bypass Exhaustive Pattern Matching and no longer benefit from compile-time enforcements if you aren't careful in using `_`. It is best used when you don't care about certain pieces of a decomposed type when pattern matching, or the final clause when you have enumerated all meaningful cases in a pattern matching expression.
 
 In the following example, the `_` case is used when a parse operation fails.
 


### PR DESCRIPTION
## Summary

This PR updates the F# Pattern Matching documentation to clarify the introduction of the `_` (Wildcard Pattern). The original text implied its use in the preceding example, but it is actually introduced in the following example. The updated wording ensures accuracy while retaining the original intent and style.

Changes include:

Adjusted text to specify that the `_` pattern is introduced in the following example.
Retained original wordings where not necessary to change.
This improves the clarity and accuracy of the documentation for users.

Fixes #37053 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/tour.md](https://github.com/dotnet/docs/blob/ab4449c0ee160546f2701357f100a98e057b0a14/docs/fsharp/tour.md) | [Tour of F\#](https://review.learn.microsoft.com/en-us/dotnet/fsharp/tour?branch=pr-en-us-44154) |


<!-- PREVIEW-TABLE-END -->