### PR TITLE
Update github-actions-overview.md

### DIFF
--- a/docs/devops/github-actions-overview.md
+++ b/docs/devops/github-actions-overview.md
@@ -185,7 +185,7 @@ For more information, see [Events that trigger workflows](https://docs.github.co
 
 The .NET command-line interface (CLI) is a cross-platform toolchain for developing, building, running, and publishing .NET applications. The .NET CLI is used to `run` as part of individual `steps` within a workflow file. Common command include:
 
-- [dotnet workflow install](../core/tools/dotnet-workload-install.md)
+- [dotnet workload install](../core/tools/dotnet-workload-install.md)
 - [dotnet restore](../core/tools/dotnet-restore.md)
 - [dotnet build](../core/tools/dotnet-build.md)
 - [dotnet test](../core/tools/dotnet-test.md)


### PR DESCRIPTION
Fixing typo in .NET CLI command name: `workflow` -> `workload`.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/devops/github-actions-overview.md](https://github.com/dotnet/docs/blob/38544642af9d940b342a2ef0d5d4990422f348f6/docs/devops/github-actions-overview.md) | [docs/devops/github-actions-overview](https://review.learn.microsoft.com/en-us/dotnet/devops/github-actions-overview?branch=pr-en-us-44156) |

<!-- PREVIEW-TABLE-END -->