### PR TITLE
Document MSTEST0038: Don't use 'Assert.AreSame' with value types

### DIFF
--- a/docs/core/testing/mstest-analyzers/mstest0038.md
+++ b/docs/core/testing/mstest-analyzers/mstest0038.md
@@ -32,9 +32,11 @@ The use of <xref:Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreSame%2A?
 
 The way <xref:Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreSame%2A?displayProperty=nameWithType> works is by comparing the *reference* of the given expected and actual arguments via `ReferenceEquals`. Hence, when you pass a value type, it will be [boxed](../../../csharp/programming-guide/types/boxing-and-unboxing.md#boxing). So, the assert will always fail.
 
+The only case where this assert will pass is if both arguments are nullable value types whose values are both null. In this case, it's clearer to have two separate `Assert.IsNull` calls.
+
 ## How to fix violations
 
-Use `Assert.AreEqual` instead of `Assert.AreSame`.
+If both arguments are nullable value types whose values are expected to be null, then use two separate `Assert.IsNull` calls. Otherwise, use `Assert.AreEqual` instead of `Assert.AreSame`.
 
 ## When to suppress warnings
 

--- a/docs/core/testing/mstest-analyzers/mstest0038.md
+++ b/docs/core/testing/mstest-analyzers/mstest0038.md
@@ -1,0 +1,41 @@
+---
+title: "Don't use 'Assert.AreSame' with value types"
+description: "Learn about code analysis rule MSTEST0038: Don't use 'Assert.AreSame' with value types"
+ms.date: 01/06/2025
+f1_keywords:
+- MSTEST0038
+- AvoidAssertAreSameWithValueTypesAnalyzer
+helpviewer_keywords:
+- AvoidAssertAreSameWithValueTypesAnalyzer
+- MSTEST0038
+author: Youssef1313
+ms.author: ygerges
+---
+# MSTEST0038: Don't use 'Assert.AreSame' with value types
+
+| Property                            | Value                                                                  |
+|-------------------------------------|------------------------------------------------------------------------|
+| **Rule ID**                         | MSTEST0038                                                             |
+| **Title**                           | Don't use 'Assert.AreSame' with value types                            |
+| **Category**                        | Usage                                                                  |
+| **Fix is breaking or non-breaking** | Non-breaking                                                           |
+| **Enabled by default**              | Yes                                                                    |
+| **Default severity**                | Warning                                                                |
+| **Introduced in version**           | 3.8.0                                                                  |
+| **Is there a code fix**             | Yes                                                                    |
+
+## Cause
+
+The use of <xref:Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreSame%2A?displayProperty=nameWithType> with one or both arguments being a value type.
+
+## Rule description
+
+The way <xref:Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreSame%2A?displayProperty=nameWithType> works is by comparing the *reference* of the given expected and actual arguments via `ReferenceEquals`. Hence, when you pass a value type, it will be [boxed](../../../csharp/programming-guide/types/boxing-and-unboxing.md#boxing). So, the assert will always fail.
+
+## How to fix violations
+
+Use `Assert.AreEqual` instead of `Assert.AreSame`.
+
+## When to suppress warnings
+
+Do not suppress a warning from this rule. Ignoring this rule will result in an assertion that will fail.

--- a/docs/core/testing/mstest-analyzers/mstest0038.md
+++ b/docs/core/testing/mstest-analyzers/mstest0038.md
@@ -26,20 +26,20 @@ ms.author: ygerges
 
 ## Cause
 
-The use of <xref:Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreSame%2A?displayProperty=nameWithType> or <xref:Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreNotSame%2A?displayProperty=nameWithType> with one or both arguments being a value type.
+The use of <xref:Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreSame%2A?displayProperty=nameWithType> or <xref:Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreNotSame*?displayProperty=nameWithType> with one or both arguments being a value type.
 
 ## Rule description
 
-The way <xref:Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreSame%2A?displayProperty=nameWithType> and <xref:Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreNotSame%2A?displayProperty=nameWithType> work is by comparing the *reference* of the given expected/notExpected and actual arguments via `ReferenceEquals`. Hence, when you pass a value type, it will be [boxed](../../../csharp/programming-guide/types/boxing-and-unboxing.md#boxing).
+<xref:Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreSame%2A?displayProperty=nameWithType> and <xref:Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreNotSame%2A?displayProperty=nameWithType> work by comparing the *reference* of the given `expected`/`notExpected` and actual arguments via `ReferenceEquals`. Hence, when you pass a value type, it is [boxed](../../../csharp/programming-guide/types/boxing-and-unboxing.md#boxing).
 
 If using `AreSame`, the assert will always fail. If using `AreNotSame`, the assert will always pass.
 
-The only case for `AreSame` when this assert will pass is if both arguments are nullable value types whose values are both null. In this case, it's clearer to have two separate `Assert.IsNull` calls.
+For `AreSame`, the only case when the assert passes is if both arguments are nullable value types whose values are both null. In this case, it's clearer to have two separate `Assert.IsNull` calls.
 
 ## How to fix violations
 
 Use `Assert.AreEqual` and `Assert.AreNotEqual` instead of `Assert.AreSame` and `Assert.AreNotSame`.
-If using `Assert.AreSame` and both arguments are nullable value types whose values are expected to be null, then two separate `Assert.IsNull` calls may be a better fit than `AreEqual`, depending on the intent of the test.
+If using `Assert.AreSame` and both arguments are nullable value types whose values are expected to be null, then two separate `Assert.IsNull` calls might be a better fit than `AreEqual`, depending on the intent of the test.
 
 ## When to suppress warnings
 

--- a/docs/core/testing/mstest-analyzers/mstest0038.md
+++ b/docs/core/testing/mstest-analyzers/mstest0038.md
@@ -32,7 +32,7 @@ The use of <xref:Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreSame%2A?
 
 The way <xref:Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreSame%2A?displayProperty=nameWithType> and <xref:Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreNotSame%2A?displayProperty=nameWithType> work is by comparing the *reference* of the given expected/notExpected and actual arguments via `ReferenceEquals`. Hence, when you pass a value type, it will be [boxed](../../../csharp/programming-guide/types/boxing-and-unboxing.md#boxing).
 
-If using `AreSame`, the assert will always fail. If using `AreNotSame`, the assert will always pass. 
+If using `AreSame`, the assert will always fail. If using `AreNotSame`, the assert will always pass.
 
 The only case for `AreSame` when this assert will pass is if both arguments are nullable value types whose values are both null. In this case, it's clearer to have two separate `Assert.IsNull` calls.
 

--- a/docs/core/testing/mstest-analyzers/mstest0038.md
+++ b/docs/core/testing/mstest-analyzers/mstest0038.md
@@ -1,6 +1,6 @@
 ---
-title: "Don't use 'Assert.AreSame' with value types"
-description: "Learn about code analysis rule MSTEST0038: Don't use 'Assert.AreSame' with value types"
+title: "Don't use 'Assert.AreSame' or 'Assert.AreNotSame' with value types"
+description: "Learn about code analysis rule MSTEST0038: Don't use 'Assert.AreSame' or 'Assert.AreNotSame' with value types"
 ms.date: 01/06/2025
 f1_keywords:
 - MSTEST0038
@@ -11,33 +11,36 @@ helpviewer_keywords:
 author: Youssef1313
 ms.author: ygerges
 ---
-# MSTEST0038: Don't use 'Assert.AreSame' with value types
+# MSTEST0038: Don't use 'Assert.AreSame' or 'Assert.AreNotSame' with value types
 
 | Property                            | Value                                                                  |
 |-------------------------------------|------------------------------------------------------------------------|
 | **Rule ID**                         | MSTEST0038                                                             |
-| **Title**                           | Don't use 'Assert.AreSame' with value types                            |
+| **Title**                           | Don't use 'Assert.AreSame' or 'Assert.AreNotSame' with value types     |
 | **Category**                        | Usage                                                                  |
 | **Fix is breaking or non-breaking** | Non-breaking                                                           |
 | **Enabled by default**              | Yes                                                                    |
 | **Default severity**                | Warning                                                                |
 | **Introduced in version**           | 3.8.0                                                                  |
-| **Is there a code fix**             | Yes                                                                    |
+| **Is there a code fix**             | No                                                                     |
 
 ## Cause
 
-The use of <xref:Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreSame%2A?displayProperty=nameWithType> with one or both arguments being a value type.
+The use of <xref:Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreSame%2A?displayProperty=nameWithType> or <xref:Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreNotSame%2A?displayProperty=nameWithType> with one or both arguments being a value type.
 
 ## Rule description
 
-The way <xref:Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreSame%2A?displayProperty=nameWithType> works is by comparing the *reference* of the given expected and actual arguments via `ReferenceEquals`. Hence, when you pass a value type, it will be [boxed](../../../csharp/programming-guide/types/boxing-and-unboxing.md#boxing). So, the assert will always fail.
+The way <xref:Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreSame%2A?displayProperty=nameWithType> and <xref:Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreNotSame%2A?displayProperty=nameWithType> work is by comparing the *reference* of the given expected/notExpected and actual arguments via `ReferenceEquals`. Hence, when you pass a value type, it will be [boxed](../../../csharp/programming-guide/types/boxing-and-unboxing.md#boxing).
 
-The only case where this assert will pass is if both arguments are nullable value types whose values are both null. In this case, it's clearer to have two separate `Assert.IsNull` calls.
+If using `AreSame`, the assert will always fail. If using `AreNotSame`, the assert will always pass. 
+
+The only case for `AreSame` when this assert will pass is if both arguments are nullable value types whose values are both null. In this case, it's clearer to have two separate `Assert.IsNull` calls.
 
 ## How to fix violations
 
-If both arguments are nullable value types whose values are expected to be null, then use two separate `Assert.IsNull` calls. Otherwise, use `Assert.AreEqual` instead of `Assert.AreSame`.
+Use `Assert.AreEqual` and `Assert.AreNotEqual` instead of `Assert.AreSame` and `Assert.AreNotSame`.
+If using `Assert.AreSame` and both arguments are nullable value types whose values are expected to be null, then two separate `Assert.IsNull` calls may be a better fit than `AreEqual`, depending on the intent of the test.
 
 ## When to suppress warnings
 
-Do not suppress a warning from this rule. Ignoring this rule will result in an assertion that will fail.
+Do not suppress a warning from this rule. Ignoring this rule will result in an assertion that will always fail or always pass.

--- a/docs/core/testing/mstest-analyzers/usage-rules.md
+++ b/docs/core/testing/mstest-analyzers/usage-rules.md
@@ -28,3 +28,4 @@ Identifier | Name | Description
 [MSTEST0024](mstest0024.md) | DoNotStoreStaticTestContextAnalyzer | Do not store TestContext in a static member
 [MSTEST0026](mstest0026.md) | AssertionArgsShouldAvoidConditionalAccessRuleId | Avoid conditional access in assertions
 [MSTEST0037](mstest0037.md) | UseProperAssertMethodsAnalyzer | Use proper `Assert` methods
+[MSTEST0038](mstest0038.md) | AvoidAssertAreSameWithValueTypesAnalyzer | Don't use 'Assert.AreSame' with value types

--- a/docs/core/testing/mstest-analyzers/usage-rules.md
+++ b/docs/core/testing/mstest-analyzers/usage-rules.md
@@ -28,4 +28,4 @@ Identifier | Name | Description
 [MSTEST0024](mstest0024.md) | DoNotStoreStaticTestContextAnalyzer | Do not store TestContext in a static member
 [MSTEST0026](mstest0026.md) | AssertionArgsShouldAvoidConditionalAccessRuleId | Avoid conditional access in assertions
 [MSTEST0037](mstest0037.md) | UseProperAssertMethodsAnalyzer | Use proper `Assert` methods
-[MSTEST0038](mstest0038.md) | AvoidAssertAreSameWithValueTypesAnalyzer | Don't use 'Assert.AreSame' or 'Assert.AreNotSame' with value types
+[MSTEST0038](mstest0038.md) | AvoidAssertAreSameWithValueTypesAnalyzer | Don't use `Assert.AreSame` or `Assert.AreNotSame` with value types

--- a/docs/core/testing/mstest-analyzers/usage-rules.md
+++ b/docs/core/testing/mstest-analyzers/usage-rules.md
@@ -28,4 +28,4 @@ Identifier | Name | Description
 [MSTEST0024](mstest0024.md) | DoNotStoreStaticTestContextAnalyzer | Do not store TestContext in a static member
 [MSTEST0026](mstest0026.md) | AssertionArgsShouldAvoidConditionalAccessRuleId | Avoid conditional access in assertions
 [MSTEST0037](mstest0037.md) | UseProperAssertMethodsAnalyzer | Use proper `Assert` methods
-[MSTEST0038](mstest0038.md) | AvoidAssertAreSameWithValueTypesAnalyzer | Don't use 'Assert.AreSame' with value types
+[MSTEST0038](mstest0038.md) | AvoidAssertAreSameWithValueTypesAnalyzer | Don't use 'Assert.AreSame' or 'Assert.AreNotSame' with value types


### PR DESCRIPTION
Fixes https://github.com/microsoft/testfx/issues/4515

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/mstest-analyzers/mstest0038.md](https://github.com/dotnet/docs/blob/3efde8e2dacaa8a4b4aa0c373505b9bb4147deef/docs/core/testing/mstest-analyzers/mstest0038.md) | [MSTEST0038: Don't use 'Assert.AreSame' or 'Assert.AreNotSame' with value types](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0038?branch=pr-en-us-44157) |
| [docs/core/testing/mstest-analyzers/usage-rules.md](https://github.com/dotnet/docs/blob/3efde8e2dacaa8a4b4aa0c373505b9bb4147deef/docs/core/testing/mstest-analyzers/usage-rules.md) | [MSTest Usage rules (code analysis)](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/usage-rules?branch=pr-en-us-44157) |


<!-- PREVIEW-TABLE-END -->