### PR TITLE
Test filter: Add example of escaping double quotes

### DIFF
--- a/docs/core/testing/selective-unit-tests.md
+++ b/docs/core/testing/selective-unit-tests.md
@@ -56,6 +56,12 @@ For `FullyQualifiedName` values that include a comma for generic type parameters
 dotnet test --filter "FullyQualifiedName=MyNamespace.MyTestsClass<ParameterType1%2CParameterType2>.MyTestMethod"
 ```
 
+For `Name` or `DisplayName`, use the URL encoding for the special characters. For example, to run a test with the name `MyTestMethod` and a string value `"text"`, use the following filter:
+
+```dotnetcli
+dotnet test --filter "Name=MyTestMethod \(%22text%22\)"
+```
+
 :::zone pivot="mstest"
 
 ## MSTest examples


### PR DESCRIPTION
## Summary

Relates to https://github.com/microsoft/testfx/issues/4519

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/selective-unit-tests.md](https://github.com/dotnet/docs/blob/19f47ab2e01df9cac6020e2d5ad2ab01d182e4ac/docs/core/testing/selective-unit-tests.md) | [Run selected unit tests](https://review.learn.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests?branch=pr-en-us-44158) |

<!-- PREVIEW-TABLE-END -->