### PR TITLE
Fix minor character encoding example bug

### DIFF
--- a/docs/standard/base-types/snippets/character-encoding-introduction/csharp/InsertNewlines.cs
+++ b/docs/standard/base-types/snippets/character-encoding-introduction/csharp/InsertNewlines.cs
@@ -35,7 +35,7 @@ namespace RuneSamples
                 while (enumerator.MoveNext())
                 {
                     builder.Append(enumerator.Current);
-                    if (textElementCount % 10 == 0 && textElementCount > 0)
+                    if (textElementCount % 10 == 0)
                     {
                         builder.AppendLine(); // newline
                     }


### PR DESCRIPTION
## Summary

Remove `if` clause that always triggered.

Fixes #42767
