### PR TITLE
Improve CA1802 Documentation with Warnings About Potential Risks of Using const

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1802.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1802.md
@@ -50,7 +50,7 @@ To fix a violation of this rule, replace the `static` and `readonly` modifiers w
 It is safe to suppress a warning from this rule, or disable the rule, if performance is not of concern.
 
 > [!WARNING]
-> For public or externally visible members, changing `static readonly` to `const` can lead to issues. `const` values are embedded in dependent assemblies at compile time, so changes in the library's value may not propagate, potentially causing errors. Suppress this rule if the value might change in the future.
+> For public or externally visible members, changing `static readonly` to `const` can lead to issues. `const` values are embedded in dependent assemblies at compile time, so changes in the library's value might not propagate, potentially causing errors. If the value of your member might change in the future, suppress this rule.
 
 > [!NOTE]
 > Using `const` is safe for `private` members and generally safe for `internal` members unless exposed via `InternalsVisibleTo` or deployed separately.

--- a/docs/fundamentals/code-analysis/quality-rules/ca1802.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1802.md
@@ -49,6 +49,12 @@ To fix a violation of this rule, replace the `static` and `readonly` modifiers w
 
 It is safe to suppress a warning from this rule, or disable the rule, if performance is not of concern.
 
+> [!WARNING]
+> For public or externally visible members, changing `static readonly` to `const` can lead to issues. `const` values are embedded in dependent assemblies at compile time, so changes in the library's value may not propagate, potentially causing errors. Suppress this rule if the value might change in the future.
+
+> [!NOTE]
+> Using `const` is safe for `private` members and generally safe for `internal` members unless exposed via `InternalsVisibleTo` or deployed separately.
+
 ## Suppress a warning
 
 If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.


### PR DESCRIPTION
## Summary

This update enhances the documentation for CA1802 by:

- Adding a **warning** about the risks of replacing `static readonly` with `const` for public and externally visible members.
- Clarifying that `const` is safe for `private` members and generally safe for `internal` members unless exposed via `InternalsVisibleTo` or deployed separately.

Fixes #40827 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1802.md](https://github.com/dotnet/docs/blob/b1ae77b383ae67c4d842e5923e801fc0ad0ecc4c/docs/fundamentals/code-analysis/quality-rules/ca1802.md) | [CA1802: Use Literals Where Appropriate](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1802?branch=pr-en-us-44169) |


<!-- PREVIEW-TABLE-END -->