### PR TITLE
MSTEST0031,MSTEST0032: Remove period from title

### DIFF
--- a/docs/core/testing/mstest-analyzers/mstest0031.md
+++ b/docs/core/testing/mstest-analyzers/mstest0031.md
@@ -11,7 +11,7 @@ helpviewer_keywords:
 author: engyebrahim
 ms.author: enjieid
 ---
-# MSTEST0031: `System.ComponentModel.DescriptionAttribute` has no effect on test methods.
+# MSTEST0031: `System.ComponentModel.DescriptionAttribute` has no effect on test methods
 
 | Property                            | Value                                                                       |
 |-------------------------------------|-----------------------------------------------------------------------------|

--- a/docs/core/testing/mstest-analyzers/mstest0032.md
+++ b/docs/core/testing/mstest-analyzers/mstest0032.md
@@ -11,7 +11,7 @@ helpviewer_keywords:
 author: engyebrahim
 ms.author: enjieid
 ---
-# MSTEST0032: Review or remove the assertion as its condition is known to be always true.
+# MSTEST0032: Review or remove the assertion as its condition is known to be always true
 
 | Property                            | Value                                                                       |
 |-------------------------------------|-----------------------------------------------------------------------------|


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/mstest-analyzers/mstest0031.md](https://github.com/dotnet/docs/blob/0fe30d6d28fe65206cf6b97fa4d259c880b3c036/docs/core/testing/mstest-analyzers/mstest0031.md) | [MSTEST0031: `System.ComponentModel.DescriptionAttribute` has no effect on test methods](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0031?branch=pr-en-us-44171) |
| [docs/core/testing/mstest-analyzers/mstest0032.md](https://github.com/dotnet/docs/blob/0fe30d6d28fe65206cf6b97fa4d259c880b3c036/docs/core/testing/mstest-analyzers/mstest0032.md) | ["MSTEST0032: Review or remove the assertion as its condition is known to be always true."](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0032?branch=pr-en-us-44171) |


<!-- PREVIEW-TABLE-END -->