### PR TITLE
Clean up superfluous semicolons

### DIFF
--- a/docs/architecture/maui/navigation.md
+++ b/docs/architecture/maui/navigation.md
@@ -59,7 +59,7 @@ This interface specifies that an implementing class must provide the following m
 The `MauiNavigationService` class, which implements the `INavigationService` interface, is registered as a singleton with the dependency injection container in the `MauiProgram.CreateMauiApp()` method, as demonstrated in the following code example:
 
 ```csharp
-mauiAppBuilder.Services.AddSingleton<INavigationService, MauiNavigationService>();;
+mauiAppBuilder.Services.AddSingleton<INavigationService, MauiNavigationService>();
 ```
 
 The `INavigationService` interface can then be resolved by adding it to the constructor of our views and view-models, as demonstrated in the following code example:

--- a/docs/orleans/host/configuration-guide/local-development-configuration.md
+++ b/docs/orleans/host/configuration-guide/local-development-configuration.md
@@ -26,7 +26,7 @@ using Microsoft.Extensions.Hosting;
 await Host.CreateDefaultBuilder(args)
     .UseOrleans(siloBuilder =>
     {
-        siloBuilder.UseLocalhostClustering();;
+        siloBuilder.UseLocalhostClustering();
     })
     .RunConsoleAsync();
 ```


### PR DESCRIPTION
## Summary

Remove superfluous semicolons in 2 C# snippets.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/architecture/maui/navigation.md](https://github.com/dotnet/docs/blob/cd411432e1ee4c35b316a23ee805b7d54291fa23/docs/architecture/maui/navigation.md) | [Navigation](https://review.learn.microsoft.com/en-us/dotnet/architecture/maui/navigation?branch=pr-en-us-44179) |
| [docs/orleans/host/configuration-guide/local-development-configuration.md](https://github.com/dotnet/docs/blob/cd411432e1ee4c35b316a23ee805b7d54291fa23/docs/orleans/host/configuration-guide/local-development-configuration.md) | [Local development configuration](https://review.learn.microsoft.com/en-us/dotnet/orleans/host/configuration-guide/local-development-configuration?branch=pr-en-us-44179) |

<!-- PREVIEW-TABLE-END -->