### PR TITLE
Fix the meaning of ISA to be Instruction Set Architecture

### DIFF
--- a/docs/core/compatibility/core-libraries/5.0/hardware-instrinsics-issupported-checks.md
+++ b/docs/core/compatibility/core-libraries/5.0/hardware-instrinsics-issupported-checks.md
@@ -8,7 +8,7 @@ ms.date: 11/01/2020
 Checking `<Isa>.X64.IsSupported`, where `<Isa>` refers to the classes in the <xref:System.Runtime.Intrinsics.X86?displayProperty=nameWithType> namespace, may now produce a different result to previous versions of .NET.
 
 > [!TIP]
-> *ISA* stands for industry standard architecture.
+> *ISA* stands for Instruction Set Architecture.
 
 ## Version introduced
 

--- a/docs/core/compatibility/core-libraries/5.0/sse-comparegreaterthan-intrinsics.md
+++ b/docs/core/compatibility/core-libraries/5.0/sse-comparegreaterthan-intrinsics.md
@@ -22,7 +22,7 @@ Previously, `NaN` inputs to the listed <xref:System.Runtime.Intrinsics.X86.Sse> 
 
 Starting in .NET 5, these methods correctly handle `NaN` inputs and return the same results as the corresponding methods in the <xref:System.Runtime.Intrinsics.X86.Avx> class.
 
-The Streaming SIMD Extensions (SSE) and Streaming SIMD Extensions 2 (SSE2) industry standard architectures (ISAs) don't provide direct hardware support for these comparison methods, so they're implemented in software. Previously, the methods were improperly implemented, and they incorrectly handled `NaN` inputs. For code ported from native, the incorrect behavior may introduce bugs. For a 256-bit code path, the methods can also produce different results to the equivalent methods in the <xref:System.Runtime.Intrinsics.X86.Avx> class.
+The Streaming SIMD Extensions (SSE) and Streaming SIMD Extensions 2 (SSE2) Industry Set Architectures (ISAs) don't provide direct hardware support for these comparison methods, so they're implemented in software. Previously, the methods were improperly implemented, and they incorrectly handled `NaN` inputs. For code ported from native, the incorrect behavior may introduce bugs. For a 256-bit code path, the methods can also produce different results to the equivalent methods in the <xref:System.Runtime.Intrinsics.X86.Avx> class.
 
 As an example of how the methods were previously incorrect, you can implement `CompareNotGreaterThan(x,y)` as `CompareLessThanOrEqual(x,y)` for regular integers. However, for `NaN` inputs, that logic computes the wrong result. Instead, using `CompareNotLessThan(y,x)` compares the numbers correctly *and* takes `NaN` inputs into consideration.
 

--- a/docs/core/compatibility/core-libraries/5.0/sse-comparegreaterthan-intrinsics.md
+++ b/docs/core/compatibility/core-libraries/5.0/sse-comparegreaterthan-intrinsics.md
@@ -22,7 +22,7 @@ Previously, `NaN` inputs to the listed <xref:System.Runtime.Intrinsics.X86.Sse> 
 
 Starting in .NET 5, these methods correctly handle `NaN` inputs and return the same results as the corresponding methods in the <xref:System.Runtime.Intrinsics.X86.Avx> class.
 
-The Streaming SIMD Extensions (SSE) and Streaming SIMD Extensions 2 (SSE2) Industry Set Architectures (ISAs) don't provide direct hardware support for these comparison methods, so they're implemented in software. Previously, the methods were improperly implemented, and they incorrectly handled `NaN` inputs. For code ported from native, the incorrect behavior may introduce bugs. For a 256-bit code path, the methods can also produce different results to the equivalent methods in the <xref:System.Runtime.Intrinsics.X86.Avx> class.
+The Streaming SIMD Extensions (SSE) and Streaming SIMD Extensions 2 (SSE2) Instruction Set Architectures (ISAs) don't provide direct hardware support for these comparison methods, so they're implemented in software. Previously, the methods were improperly implemented, and they incorrectly handled `NaN` inputs. For code ported from native, the incorrect behavior may introduce bugs. For a 256-bit code path, the methods can also produce different results to the equivalent methods in the <xref:System.Runtime.Intrinsics.X86.Avx> class.
 
 As an example of how the methods were previously incorrect, you can implement `CompareNotGreaterThan(x,y)` as `CompareLessThanOrEqual(x,y)` for regular integers. However, for `NaN` inputs, that logic computes the wrong result. Instead, using `CompareNotLessThan(y,x)` compares the numbers correctly *and* takes `NaN` inputs into consideration.
 


### PR DESCRIPTION
## Summary

The definition of the abbreviation was incorrect.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/core-libraries/5.0/hardware-instrinsics-issupported-checks.md](https://github.com/dotnet/docs/blob/ab7046812004d074f5e887add16d371fb6229b34/docs/core/compatibility/core-libraries/5.0/hardware-instrinsics-issupported-checks.md) | [Hardware intrinsic IsSupported checks may differ for nested types](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/5.0/hardware-instrinsics-issupported-checks?branch=pr-en-us-44180) |
| [docs/core/compatibility/core-libraries/5.0/sse-comparegreaterthan-intrinsics.md](https://github.com/dotnet/docs/blob/ab7046812004d074f5e887add16d371fb6229b34/docs/core/compatibility/core-libraries/5.0/sse-comparegreaterthan-intrinsics.md) | ["Breaking change: SSE and SSE2 CompareGreaterThan methods properly handle NaN inputs"](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/5.0/sse-comparegreaterthan-intrinsics?branch=pr-en-us-44180) |


<!-- PREVIEW-TABLE-END -->