### PR TITLE
Fix: Improve F# Recursive Module Example for Banana Type Logic

### DIFF
--- a/docs/fsharp/language-reference/modules.md
+++ b/docs/fsharp/language-reference/modules.md
@@ -107,7 +107,7 @@ module rec RecursiveModule =
             raise (DontSqueezeTheBananaException self)
 
     module BananaHelpers =
-        let peel (b: Banana) =
+        let peel (banana: Banana) =
             let flip (banana: Banana) =
                 match banana.Orientation with
                 | Up ->

--- a/docs/fsharp/language-reference/modules.md
+++ b/docs/fsharp/language-reference/modules.md
@@ -93,12 +93,18 @@ module rec RecursiveModule =
     exception DontSqueezeTheBananaException of Banana
 
     type Banana(orientation : Orientation) =
-        member val IsPeeled = false with get, set
         member val Orientation = orientation with get, set
-        member val Sides: PeelState list = [ Unpeeled; Unpeeled; Unpeeled; Unpeeled] with get, set
+        member val Sides: PeelState list = [ Unpeeled; Unpeeled; Unpeeled; Unpeeled ] with get, set
 
-        member self.Peel() = BananaHelpers.peel self // Note the dependency on the BananaHelpers module.
-        member self.SqueezeJuiceOut() = raise (DontSqueezeTheBananaException self) // This member depends on the exception above.
+        member self.IsPeeled =
+            self.Sides |> List.forall ((=) Peeled)
+
+        member self.Peel() =
+            BananaHelpers.peel self
+            |> fun peeledSides -> self.Sides <- peeledSides
+
+        member self.SqueezeJuiceOut() =
+            raise (DontSqueezeTheBananaException self)
 
     module BananaHelpers =
         let peel (b: Banana) =
@@ -115,9 +121,7 @@ module rec RecursiveModule =
                              | Unpeeled -> Peeled
                              | Peeled -> Peeled)
 
-            match b.Orientation with
-            | Up ->   b |> flip |> peelSides
-            | Down -> b |> peelSides
+            banana |> flip |> peelSides
 ```
 
 Note that the exception `DontSqueezeTheBananaException` and the class `Banana` both refer to each other.  Additionally, the module `BananaHelpers` and the class `Banana` also refer to each other.  This would not be possible to express in F# if you removed the `rec` keyword from the `RecursiveModule` module.


### PR DESCRIPTION
## Summary

This PR refines the F# recursive module example by addressing issues in the `Banana` type logic:

1. **Updated** `IsPeeled`: Changed logic to accurately determine if all sides are peeled.
2. **Enhanced** `Peel` Method: Modified to mutate `Sides` after peeling using `BananaHelpers`.
3. **Streamlined** `BananaHelpers.peel`: Simplified peeling logic for clarity and removed redundant pattern matching.

Partially addresses #41533 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/modules.md](https://github.com/dotnet/docs/blob/56e61684383198f5f742cac0e8687de2362df159/docs/fsharp/language-reference/modules.md) | [Modules](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/modules?branch=pr-en-us-44181) |


<!-- PREVIEW-TABLE-END -->