### PR TITLE
Use extension method for Placement registration

### DIFF
--- a/docs/orleans/grains/grain-placement.md
+++ b/docs/orleans/grains/grain-placement.md
@@ -154,13 +154,7 @@ private static async Task<ISiloHost> StartSilo()
 
 private static void ConfigureServices(IServiceCollection services)
 {
-    services.AddSingletonNamedService<
-        PlacementStrategy, SamplePlacementStrategy>(
-            nameof(SamplePlacementStrategy));
-
-    services.AddSingletonKeyedService<
-        Type, IPlacementDirector, SamplePlacementStrategyFixedSiloDirector>(
-            typeof(SamplePlacementStrategy));
+    services.AddPlacementDirector<SamplePlacementStrategy, SamplePlacementStrategyFixedSiloDirector>();
 }
 ```
 


### PR DESCRIPTION
## Summary

Registering placement with extension method

The extension method is slightly different than what the old docs showed (`AddSingletonNamedService` -> `Add(ServiceDescriptor.DescribeKeyed(...`) which I think still results in the same thing in the DI container, but users shouldn't need to worry about getting that setup correct or updating it if there's an extension method for it already.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/grains/grain-placement.md](https://github.com/dotnet/docs/blob/808090502cc550ab21ff913b0fc734b82f180f6f/docs/orleans/grains/grain-placement.md) | [Grain placement](https://review.learn.microsoft.com/en-us/dotnet/orleans/grains/grain-placement?branch=pr-en-us-44185) |

<!-- PREVIEW-TABLE-END -->