### PR TITLE
Updated the Deployment SDKs with an example of the expected format 

### DIFF
--- a/docs/iot/deployment.md
+++ b/docs/iot/deployment.md
@@ -30,7 +30,7 @@ To deploy your app as a framework-dependent app, complete the following steps:
         ```
 
         > [!NOTE]
-        > This command installs the latest version. If you need a specific version, replace the `--channel STS` parameter with `--version <VERSION>`, where `<VERSION>` is the specific build version, for example `8.0.404`. For a list of versions, see [.NET SDKs for Visual Studio](https://dotnet.microsoft.com/en-us/download/visual-studio-sdks).
+        > This command installs the latest version. If you need a specific version, replace the `--channel STS` parameter with `--version <VERSION>`, where `<VERSION>` is the specific build version, for example `8.0.404`. For a list of versions, see [.NET SDKs for Visual Studio](https://dotnet.microsoft.com/en-us/download/visual-studio-sdks). Refer to "Visual Studio 2022 SDK" column to determine the full build number.
 
     1. To simplify path resolution, add a `DOTNET_ROOT` environment variable and add the *.dotnet* directory to `$PATH` with the following commands:
 

--- a/docs/iot/deployment.md
+++ b/docs/iot/deployment.md
@@ -30,7 +30,7 @@ To deploy your app as a framework-dependent app, complete the following steps:
         ```
 
         > [!NOTE]
-        > This installs the latest version. If you need a specific version, replace the `--channel STS` parameter with `--version <VERSION>`, where `<VERSION>` is the specific build version, for example `8.0.404`. You can view the list of versions on [Visual Studio Sdks](https://dotnet.microsoft.com/en-us/download/visual-studio-sdks) page.
+        > This command installs the latest version. If you need a specific version, replace the `--channel STS` parameter with `--version <VERSION>`, where `<VERSION>` is the specific build version, for example `8.0.404`. For a list of versions, see [.NET SDKs for Visual Studio](https://dotnet.microsoft.com/en-us/download/visual-studio-sdks).
 
     1. To simplify path resolution, add a `DOTNET_ROOT` environment variable and add the *.dotnet* directory to `$PATH` with the following commands:
 

--- a/docs/iot/deployment.md
+++ b/docs/iot/deployment.md
@@ -30,7 +30,7 @@ To deploy your app as a framework-dependent app, complete the following steps:
         ```
 
         > [!NOTE]
-        > This installs the latest version. If you need a specific version, replace the `--channel STS` parameter with `--version <VERSION>`, where `<VERSION>` is the specific build version.
+        > This installs the latest version. If you need a specific version, replace the `--channel STS` parameter with `--version <VERSION>`, where `<VERSION>` is the specific build version, for example `8.0.404`. You can view the list of versions on [Visual Studio Sdks](https://dotnet.microsoft.com/en-us/download/visual-studio-sdks) page.
 
     1. To simplify path resolution, add a `DOTNET_ROOT` environment variable and add the *.dotnet* directory to `$PATH` with the following commands:
 


### PR DESCRIPTION
I am an experienced developer with .Net and was following along with the docs, but when it came to the parameter required for `--version` I did not know what was expected. I figured I could just do the runtime `8`, `8.0`, or `.net8` but of course it makes sense that you want to install a specific version. This required figuring out by a quick google what the versions are. 

I figured it would save time on folks new to the .Net ecosystem that are following along to have an example format and a direct link. 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/iot/deployment.md](https://github.com/dotnet/docs/blob/341fa961d2ac1c52b72fcfc9f446284d5e85fe19/docs/iot/deployment.md) | [Deploy .NET apps on ARM single-board computers](https://review.learn.microsoft.com/en-us/dotnet/iot/deployment?branch=pr-en-us-44192) |


<!-- PREVIEW-TABLE-END -->