### PR TITLE
Update sealed.md with sealing methods from Object class

### DIFF
--- a/docs/csharp/language-reference/keywords/sealed.md
+++ b/docs/csharp/language-reference/keywords/sealed.md
@@ -27,8 +27,7 @@ In the following example, `Z` inherits from `Y` but `Z` cannot override the virt
 [!code-csharp[csrefKeywordsModifiers#16](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs#16)]
 
 When you define new methods or properties in a class, you can prevent deriving classes from overriding them by not declaring them as [virtual](virtual.md).
-When you override method inherited from <xref:System.Object?displayProperty=nameWithType> class, which are already virtual, you can prevent deriving classes from overriding them by using sealed keyword as in example:
-(feature [introduced with C# 10](../../whats-new/csharp-version-history.md))
+When you override a `virtual` member declared in a base type, you can prevent deriving types from overriding them by using sealed keyword as in the following example:
 
 ```
 public sealed override string ToString() => Value;

--- a/docs/csharp/language-reference/keywords/sealed.md
+++ b/docs/csharp/language-reference/keywords/sealed.md
@@ -28,7 +28,7 @@ In the following example, `Z` inherits from `Y` but `Z` cannot override the virt
 
 When you define new methods or properties in a class, you can prevent deriving classes from overriding them by not declaring them as [virtual](virtual.md).
 When you override method inherited from <xref:System.Object?displayProperty=nameWithType> class, which are already virtual, you can prevent deriving classes from overriding them by using sealed keyword as in example:
-(feature [introduced with C# 10](../../csharp/whats-new/csharp-version-history.md))
+(feature [introduced with C# 10](../../whats-new/csharp-version-history.md))
 
 ```
 public sealed override string ToString() => Value;

--- a/docs/csharp/language-reference/keywords/sealed.md
+++ b/docs/csharp/language-reference/keywords/sealed.md
@@ -27,6 +27,11 @@ In the following example, `Z` inherits from `Y` but `Z` cannot override the virt
 [!code-csharp[csrefKeywordsModifiers#16](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs#16)]
 
 When you define new methods or properties in a class, you can prevent deriving classes from overriding them by not declaring them as [virtual](virtual.md).
+When you override method inherited from [Object](https://github.com/dotnet/runtime/blob/1d1bf92fcf43aa6981804dc53c5174445069c9e4/src/libraries/System.Private.CoreLib/src/System/Object.cs) class, which are already virtual, you can prevent deriving classes from overriding them by using sealed keyword as in example: ( [introduced with C# 10](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-version-history#c-version-10) )
+
+```
+public sealed override string ToString() => Value;
+```
 
 It is an error to use the [abstract](abstract.md) modifier with a sealed class, because an abstract class must be inherited by a class that provides an implementation of the abstract methods or properties.
 

--- a/docs/csharp/language-reference/keywords/sealed.md
+++ b/docs/csharp/language-reference/keywords/sealed.md
@@ -27,7 +27,8 @@ In the following example, `Z` inherits from `Y` but `Z` cannot override the virt
 [!code-csharp[csrefKeywordsModifiers#16](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs#16)]
 
 When you define new methods or properties in a class, you can prevent deriving classes from overriding them by not declaring them as [virtual](virtual.md).
-When you override method inherited from <xref:System.Object?displayProperty=nameWithType> class, which are already virtual, you can prevent deriving classes from overriding them by using sealed keyword as in example: ( feature [introduced with C# 10](../../csharp/whats-new/csharp-version-history.md#c-version-10) )
+When you override method inherited from <xref:System.Object?displayProperty=nameWithType> class, which are already virtual, you can prevent deriving classes from overriding them by using sealed keyword as in example:
+(feature [introduced with C# 10](../../csharp/whats-new/csharp-version-history.md))
 
 ```
 public sealed override string ToString() => Value;

--- a/docs/csharp/language-reference/keywords/sealed.md
+++ b/docs/csharp/language-reference/keywords/sealed.md
@@ -27,7 +27,7 @@ In the following example, `Z` inherits from `Y` but `Z` cannot override the virt
 [!code-csharp[csrefKeywordsModifiers#16](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs#16)]
 
 When you define new methods or properties in a class, you can prevent deriving classes from overriding them by not declaring them as [virtual](virtual.md).
-When you override method inherited from [Object](https://github.com/dotnet/runtime/blob/1d1bf92fcf43aa6981804dc53c5174445069c9e4/src/libraries/System.Private.CoreLib/src/System/Object.cs) class, which are already virtual, you can prevent deriving classes from overriding them by using sealed keyword as in example: ( [introduced with C# 10](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-version-history#c-version-10) )
+When you override method inherited from <xref:System.Object?displayProperty=nameWithType> class, which are already virtual, you can prevent deriving classes from overriding them by using sealed keyword as in example: ( feature [introduced with C# 10](../../csharp/whats-new/csharp-version-history.md#c-version-10) )
 
 ```
 public sealed override string ToString() => Value;


### PR DESCRIPTION
It was introduced in C# 10. There is possibility to prevent overriding of ToString() and the rest of Object's virtual methods

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/sealed.md](https://github.com/dotnet/docs/blob/0847ee6a616f79b2b76328737f26ea554cdd9901/docs/csharp/language-reference/keywords/sealed.md) | [sealed (C# Reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/sealed?branch=pr-en-us-44196) |


<!-- PREVIEW-TABLE-END -->