### PR TITLE
Update SettingsOptions.cs

### DIFF
--- a/docs/core/extensions/snippets/configuration/console-validation-gen/SettingsOptions.cs
+++ b/docs/core/extensions/snippets/configuration/console-validation-gen/SettingsOptions.cs
@@ -7,7 +7,7 @@ public sealed class SettingsOptions
     public const string ConfigurationSectionName = "MyCustomSettingsSection";
 
     [Required]
-    [RegularExpression(@"^[a-zA-Z''-'\s]{1,40}$")]
+    [RegularExpression(@"^[a-zA-Z''!'\s]{1,40}$")]
     public required string SiteTitle { get; set; }
 
     [Required]


### PR DESCRIPTION
## Summary

Changed the Regular Expression to allow an exclamation mark which is used in the sample code.  The existing Regular Expression allowed a dash which was not used in the sample.  I replaced the dash with the exclamation mark. The sample code will now run as is, instead of throwing an exception.  I have tested the updated Regular Expression, and it is working as expected.

[Fixes 44198](https://github.com/dotnet/docs/issues/44198)