### PR TITLE
Fix redundancy in IL naming in documentation

### DIFF
--- a/docs/standard/managed-code.md
+++ b/docs/standard/managed-code.md
@@ -20,7 +20,7 @@ What is "Intermediate Language" (or IL for short)? It is a product of compilatio
 
 Once you produce IL from your high-level code, you will most likely want to run it. This is where the CLR takes over and starts the process of **Just-In-Time** compiling, or **JIT-ing** your code from IL to machine code that can actually be run on a CPU. In this way, the CLR knows exactly what your code is doing and can effectively *manage* it.
 
-Intermediate Language is sometimes also called Common Intermediate Language (CIL) or common intermediate language (CIL).
+Intermediate Language is sometimes also called Common Intermediate Language (CIL).
 
 ## Unmanaged code interoperability
 


### PR DESCRIPTION
## Summary

Fix redundancy in IL naming (CIL) in documentation



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/managed-code.md](https://github.com/dotnet/docs/blob/06c1d4f0ec4bf686cd86fdb44456833dbe6eaec1/docs/standard/managed-code.md) | [What is "managed code"?](https://review.learn.microsoft.com/en-us/dotnet/standard/managed-code?branch=pr-en-us-44207) |

<!-- PREVIEW-TABLE-END -->