### PR TITLE
Fixed links to the attribute reference docs at mstest0001.md

### DIFF
--- a/docs/core/testing/mstest-analyzers/mstest0001.md
+++ b/docs/core/testing/mstest-analyzers/mstest0001.md
@@ -33,7 +33,7 @@ The assembly is not marked with `[assembly: Parallelize]` or `[assembly: DoNotPa
 
 ## Rule description
 
-By default, MSTest runs tests within the same assembly sequentially, which can lead to severe performance limitations. It is recommended to enable assembly attribute [`[assembly: Parallelize]`](/dotnet/docs/blob/main/docs/core/testing/unit-testing-mstest-writing-tests-attributes.md#parallelizeattribute) to run tests in parallel, or if the assembly is known to not be parallelizable, to use explicitly the assembly level attribute [`[assembly: DoNotParallelize]`](/dotnet/api/microsoft.visualstudio.testtools.unittesting.donotparallelizeattribute).
+By default, MSTest runs tests within the same assembly sequentially, which can lead to severe performance limitations. It is recommended to enable assembly attribute [`[assembly: Parallelize]`](/dotnet/docs/blob/main/docs/core/testing/unit-testing-mstest-writing-tests-attributes.md#parallelizeattribute) to run tests in parallel, or if the assembly is known to not be parallelizable, to use explicitly the assembly level attribute [`[assembly: DoNotParallelize]`](/dotnet/docs/blob/main/docs/core/testing/unit-testing-mstest-writing-tests-attributes.md#donotparallelizeattribute).
 
 The default configuration of `[assembly: Parallelize]` is equivalent to `[assembly: Parallelize(Scope = ExecutionScope.ClassLevel)]`, meaning that the parallelization will be set at class level (not method level) and will use as many threads as possible (depending on internal implementation).
 

--- a/docs/core/testing/mstest-analyzers/mstest0001.md
+++ b/docs/core/testing/mstest-analyzers/mstest0001.md
@@ -33,7 +33,7 @@ The assembly is not marked with `[assembly: Parallelize]` or `[assembly: DoNotPa
 
 ## Rule description
 
-By default, MSTest runs tests within the same assembly sequentially, which can lead to severe performance limitations. It is recommended to enable assembly attribute [`[assembly: Parallelize]`](/dotnet/docs/blob/main/docs/core/testing/unit-testing-mstest-writing-tests-attributes.md#parallelizeattribute) to run tests in parallel, or if the assembly is known to not be parallelizable, to use explicitly the assembly level attribute [`[assembly: DoNotParallelize]`](/dotnet/docs/blob/main/docs/core/testing/unit-testing-mstest-writing-tests-attributes.md#donotparallelizeattribute).
+By default, MSTest runs tests within the same assembly sequentially, which can lead to severe performance limitations. It is recommended to enable assembly attribute [`[assembly: Parallelize]`](../unit-testing-mstest-writing-tests-attributes.md#parallelizeattribute) to run tests in parallel, or if the assembly is known to not be parallelizable, to use explicitly the assembly level attribute [`[assembly: DoNotParallelize]`](../unit-testing-mstest-writing-tests-attributes.md#donotparallelizeattribute).
 
 The default configuration of `[assembly: Parallelize]` is equivalent to `[assembly: Parallelize(Scope = ExecutionScope.ClassLevel)]`, meaning that the parallelization will be set at class level (not method level) and will use as many threads as possible (depending on internal implementation).
 

--- a/docs/core/testing/mstest-analyzers/mstest0001.md
+++ b/docs/core/testing/mstest-analyzers/mstest0001.md
@@ -33,7 +33,7 @@ The assembly is not marked with `[assembly: Parallelize]` or `[assembly: DoNotPa
 
 ## Rule description
 
-By default, MSTest runs tests within the same assembly sequentially, which can lead to severe performance limitations. It is recommended to enable assembly attribute [`[assembly: Parallelize]`](/dotnet/api/microsoft.visualstudio.testtools.unittesting.parallelizeattribute) to run tests in parallel, or if the assembly is known to not be parallelizable, to use explicitly the assembly level attribute [`[assembly: DoNotParallelize]`](/dotnet/api/microsoft.visualstudio.testtools.unittesting.donotparallelizeattribute).
+By default, MSTest runs tests within the same assembly sequentially, which can lead to severe performance limitations. It is recommended to enable assembly attribute [`[assembly: Parallelize]`](/dotnet/docs/blob/main/docs/core/testing/unit-testing-mstest-writing-tests-attributes.md#parallelizeattribute) to run tests in parallel, or if the assembly is known to not be parallelizable, to use explicitly the assembly level attribute [`[assembly: DoNotParallelize]`](/dotnet/api/microsoft.visualstudio.testtools.unittesting.donotparallelizeattribute).
 
 The default configuration of `[assembly: Parallelize]` is equivalent to `[assembly: Parallelize(Scope = ExecutionScope.ClassLevel)]`, meaning that the parallelization will be set at class level (not method level) and will use as many threads as possible (depending on internal implementation).
 


### PR DESCRIPTION
## Summary

Fixed broken links.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/mstest-analyzers/mstest0001.md](https://github.com/dotnet/docs/blob/26f34947ad2c9163f6d14934254eeef2a9f80e95/docs/core/testing/mstest-analyzers/mstest0001.md) | [MSTEST0001: Explicitly enable or disable tests parallelization](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0001?branch=pr-en-us-44211) |


<!-- PREVIEW-TABLE-END -->