### PR TITLE
Clarify postfix notation usage for seq in F# style guide

### DIFF
--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -2103,13 +2103,14 @@ This section discusses formatting types and type annotations. This includes form
 
 F# allows both postfix style of writing generic types (for example, `int list`) and the prefix style (for example, `list<int>`).
 Postfix style can only be used with a single type argument.
-Always prefer the .NET style, except for five specific types:
+Always prefer the .NET style, except for six specific types:
 
 1. For F# Lists, use the postfix form: `int list` rather than `list<int>`.
 2. For F# Options, use the postfix form: `int option` rather than `option<int>`.
 3. For F# Value Options, use the postfix form: `int voption` rather than `voption<int>`.
 4. For F# arrays, use the postfix form: `int array` rather than `array<int>` or `int[]`.
 5. For Reference Cells, use `int ref` rather than `ref<int>` or `Ref<int>`.
+6. For F# Sequences, use the postfix form: `int seq` rather than `seq<int>`.  
 
 For all other types, use the prefix form.
 


### PR DESCRIPTION
## Summary

### PR Description  
  
The current F# style guide lacks explicit mention of the `seq` type in the exceptions list for postfix notation usage. This creates ambiguity since `seq` is consistently used in postfix notation across FSharp.Core functions and the `seq { }` computation expression.  

This PR:  
- Updates the F# style guide section on "prefer prefix syntax for generics" to include `seq` as an exception, using the postfix form (`int seq`).  
- Maintains alignment with existing practices in F# and the style of similar aliases like `list` and `option`.  

Fixes #40681 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/style-guide/formatting.md](https://github.com/dotnet/docs/blob/64d010b4f1bdca6507726db4a6198a9e063b95f3/docs/fsharp/style-guide/formatting.md) | [F# code formatting guidelines](https://review.learn.microsoft.com/en-us/dotnet/fsharp/style-guide/formatting?branch=pr-en-us-44226) |


<!-- PREVIEW-TABLE-END -->