### PR TITLE
Fix missing return type for method

### DIFF
--- a/docs/core/whats-new/dotnet-9/runtime.md
+++ b/docs/core/whats-new/dotnet-9/runtime.md
@@ -24,7 +24,7 @@ Two new attributes make it possible to define [feature switches](https://github.
       [FeatureSwitchDefinition("Feature.IsSupported")]
       internal static bool IsSupported => AppContext.TryGetSwitch("Feature.IsSupported", out bool isEnabled) ? isEnabled : true;
 
-      internal static Implementation() => ...;
+      internal static void Implementation() => ...;
   }
   ```
 
@@ -48,7 +48,7 @@ Two new attributes make it possible to define [feature switches](https://github.
       internal static bool IsSupported => RuntimeFeature.IsDynamicCodeSupported;
 
       [RequiresDynamicCode("Feature requires dynamic code support.")]
-      internal static Implementation() => ...; // Uses dynamic code
+      internal static void Implementation() => ...; // Uses dynamic code
   }
   ```
 


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/whats-new/dotnet-9/runtime.md](https://github.com/dotnet/docs/blob/f3cbaa8dfe30579ed2f4d1b8ad5494499b80ae1a/docs/core/whats-new/dotnet-9/runtime.md) | [What's new in the .NET 9 runtime](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-9/runtime?branch=pr-en-us-44232) |


<!-- PREVIEW-TABLE-END -->