### PR TITLE
MSTest analyzers: document suppressing warning

### DIFF
--- a/docs/core/testing/mstest-analyzers/mstest0001.md
+++ b/docs/core/testing/mstest-analyzers/mstest0001.md
@@ -44,3 +44,16 @@ To fix a violation of this rule, add `[assembly: Parallelize]` or `[assembly: Do
 ## When to suppress warnings
 
 Do not suppress a warning from this rule. Many libraries can benefit from a massive performance boost when enabling parallelization. When the test application is designed in a way that prevents parallelization, having the attribute explicitly set helps new developers to understand the limitations of the library.
+
+## Suppress a warning
+
+Violations to this rule cannot be suppressed inline.
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0001.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0002.md
+++ b/docs/core/testing/mstest-analyzers/mstest0002.md
@@ -46,3 +46,22 @@ Ensure that the class matches the required layout described above.
 ## When to suppress warnings
 
 Do not suppress a warning from this rule. Ignoring this rule will result in tests being ignored, because MSTest will not consider this class to be a test class.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0002
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0002
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0002.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0003.md
+++ b/docs/core/testing/mstest-analyzers/mstest0003.md
@@ -51,3 +51,22 @@ Ensure that the test method matches the required layout described above.
 ## When to suppress warnings
 
 Do not suppress a warning from this rule. Ignoring this rule will result in tests being ignored, because MSTest will not consider this method to be a test method.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0003
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0003
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0003.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0004.md
+++ b/docs/core/testing/mstest-analyzers/mstest0004.md
@@ -42,3 +42,22 @@ Change the accessibility of the type to not be `public`.
 ## When to suppress warnings
 
 You can suppress instances of this diagnostic if the type should remain `public` for compatibility reason.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0004
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0004
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0004.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0005.md
+++ b/docs/core/testing/mstest-analyzers/mstest0005.md
@@ -48,3 +48,22 @@ Ensure that the `TestContext` property matches the required layout described abo
 ## When to suppress warnings
 
 Do not suppress a warning from this rule. Ignoring this rule will result in the `TestContext` not being injected by MSTest, thus resulting in `NullReferenceException` or inconsistent state when using the property.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0005
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0005
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0005.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0006.md
+++ b/docs/core/testing/mstest-analyzers/mstest0006.md
@@ -98,3 +98,22 @@ public class TestClass
     }
 }
 ```
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0006
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0006
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0006.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0007.md
+++ b/docs/core/testing/mstest-analyzers/mstest0007.md
@@ -48,3 +48,22 @@ To fix a violation of this rule, either convert the method on which you applied 
 ## When to suppress warnings
 
 Do not suppress a warning from this rule. If you ignore this rule, your attributes will be ignored since they are designed for use only in a test context.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0007
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0007
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0007.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0008.md
+++ b/docs/core/testing/mstest-analyzers/mstest0008.md
@@ -50,3 +50,22 @@ Ensure that the method matches the layout described above.
 ## When to suppress warnings
 
 Do not suppress a warning from this rule. If you ignore this rule, flagged instances will be either skipped or result in runtime error.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0008
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0008
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0008.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0009.md
+++ b/docs/core/testing/mstest-analyzers/mstest0009.md
@@ -50,3 +50,22 @@ Ensure that the method matches the layout described above.
 ## When to suppress warnings
 
 Do not suppress a warning from this rule. If you ignore this rule, flagged instances will be either skipped or result in runtime error.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0009
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0009
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0009.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0010.md
+++ b/docs/core/testing/mstest-analyzers/mstest0010.md
@@ -54,3 +54,22 @@ Ensure that the method matches the layout described above.
 ## When to suppress warnings
 
 Do not suppress a warning from this rule. If you ignore this rule, flagged instances will be either skipped or result in runtime error.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0010
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0010
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0010.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0011.md
+++ b/docs/core/testing/mstest-analyzers/mstest0011.md
@@ -54,3 +54,22 @@ Ensure that the method matches the layout described above.
 ## When to suppress warnings
 
 Do not suppress a warning from this rule. If you ignore this rule, flagged instances will be either skipped or result in runtime error.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0011
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0011
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0011.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0012.md
+++ b/docs/core/testing/mstest-analyzers/mstest0012.md
@@ -56,3 +56,22 @@ Ensure that the method matches the layout described above.
 ## When to suppress warnings
 
 Do not suppress a warning from this rule. If you ignore this rule, flagged instances will be either skipped or result in runtime error.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0012
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0012
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0012.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0013.md
+++ b/docs/core/testing/mstest-analyzers/mstest0013.md
@@ -56,3 +56,22 @@ Ensure that the method matches the layout described above.
 ## When to suppress warnings
 
 Do not suppress a warning from this rule. If you ignore this rule, flagged instances will be either skipped or result in runtime error.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0013
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0013
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0013.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0014.md
+++ b/docs/core/testing/mstest-analyzers/mstest0014.md
@@ -43,3 +43,22 @@ Ensure that the `DataRow` instance matches the required layout described above.
 ## When to suppress warnings
 
 Do not suppress a warning from this rule. If you ignore this rule, flagged instances will be either skipped or result in runtime error.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0014
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0014
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0014.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0015.md
+++ b/docs/core/testing/mstest-analyzers/mstest0015.md
@@ -39,3 +39,22 @@ Ensure that the test method isn't ignored.
 ## When to suppress warnings
 
 Do not suppress a warning from this rule. If you ignore this rule, test method will be ignored.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0015
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0015
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0015.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0016.md
+++ b/docs/core/testing/mstest-analyzers/mstest0016.md
@@ -39,3 +39,22 @@ Ensure that the test class has a test method or is `static` and has methods attr
 ## When to suppress warnings
 
 Do not suppress a warning from this rule. If you ignore this rule, test class will be ignored.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0016
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0016
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0016.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0017.md
+++ b/docs/core/testing/mstest-analyzers/mstest0017.md
@@ -46,3 +46,22 @@ Ensure that that `actual` and `expected`/`notExpected` arguments are passed in t
 ## When to suppress warnings
 
 Do not suppress a warning from this rule as it would result to misleading output.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0017
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0017
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0017.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0018.md
+++ b/docs/core/testing/mstest-analyzers/mstest0018.md
@@ -69,3 +69,22 @@ Ensure that the attribute matches the conditions described above.
 ## When to suppress warnings
 
 Do not suppress a warning from this rule. If you ignore this rule, flagged instances will be either skipped or result in runtime error.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0018
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0018
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0018.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0019.md
+++ b/docs/core/testing/mstest-analyzers/mstest0019.md
@@ -39,3 +39,22 @@ Replace the constructor call with a `[TestInitialize]` method.
 ## When to suppress warnings
 
 You usually don't want to suppress warnings from this rule if you decided to opt-in for it.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0019
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0019
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0019.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0020.md
+++ b/docs/core/testing/mstest-analyzers/mstest0020.md
@@ -39,3 +39,22 @@ Replace `[TestInitialize]` returning `void` by constructors.
 ## When to suppress warnings
 
 You usually don't want to suppress warnings from this rule if you decided to opt-in for it.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0020
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0020
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0020.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0021.md
+++ b/docs/core/testing/mstest-analyzers/mstest0021.md
@@ -39,3 +39,22 @@ Replace `[TestCleanup]` method by `Dispose` or `DisposeAsync` pattern.
 ## When to suppress warnings
 
 You usually don't want to suppress warnings from this rule if you decided to opt-in for it.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0021
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0021
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0021.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0022.md
+++ b/docs/core/testing/mstest-analyzers/mstest0022.md
@@ -39,3 +39,22 @@ Replace `Dispose` or `DisposeAsync` methods with `[TestCleanup]`.
 ## When to suppress warnings
 
 You usually don't want to suppress warnings from this rule if you decided to opt-in for it.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0022
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0022
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0022.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0023.md
+++ b/docs/core/testing/mstest-analyzers/mstest0023.md
@@ -40,3 +40,22 @@ When negating argument in a `Assert.IsFalse` call, you should use `Assert.IsTrue
 ## When to suppress warnings
 
 Do not suppress warnings from this rule.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0023
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0023
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0023.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0024.md
+++ b/docs/core/testing/mstest-analyzers/mstest0024.md
@@ -39,3 +39,22 @@ Do not store the `[AssemblyInitialize]` or `[ClassInitialize]` `TestContext` par
 ## When to suppress warnings
 
 You can suppress warnings from this rule if you are sure of the behavior does match what you want to do.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0024
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0024
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0024.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0025.md
+++ b/docs/core/testing/mstest-analyzers/mstest0025.md
@@ -45,3 +45,22 @@ Ensure that calls to `Assert.IsTrue`, `Assert.IsFalse`, `Assert.AreEqual`, `Asse
 ## When to suppress warnings
 
 We do not recommend suppressing warnings from this rule.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0025
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0025
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0025.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0026.md
+++ b/docs/core/testing/mstest-analyzers/mstest0026.md
@@ -73,3 +73,22 @@ StringAssert.Contains(company.Address, "Brazil");
 ## When to suppress warnings
 
 We do not recommend suppressing warnings from this rule.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0026
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0026
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0026.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0027.md
+++ b/docs/core/testing/mstest-analyzers/mstest0027.md
@@ -27,3 +27,14 @@ Suppress the [VSTHRD200: Use Async suffix for async methods](https://github.com/
 ## When to disable suppressor
 
 You can disable this suppressor if you want to follow the `Async` suffix pattern also for your test methods.
+
+## Suppress a warning
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0027.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0027.md
+++ b/docs/core/testing/mstest-analyzers/mstest0027.md
@@ -26,15 +26,4 @@ Suppress the [VSTHRD200: Use Async suffix for async methods](https://github.com/
 
 ## When to disable suppressor
 
-You can disable this suppressor if you want to follow the `Async` suffix pattern also for your test methods.
-
-## Suppress a warning
-
-To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
-
-```ini
-[*.{cs,vb}]
-dotnet_diagnostic.MSTEST0027.severity = none
-```
-
-For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).
+.NET suppressors cannot be disabled.

--- a/docs/core/testing/mstest-analyzers/mstest0028.md
+++ b/docs/core/testing/mstest-analyzers/mstest0028.md
@@ -26,23 +26,4 @@ Suppress the [VSTHRD200: Use Async suffix for async methods](https://github.com/
 
 ## When to disable suppressor
 
-You can disable this suppressor if you want to follow the `Async` suffix pattern also for your test fixture methods.
-
-## Suppress a warning
-
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
-
-```csharp
-#pragma warning disable MSTEST0028
-// The code that's violating the rule is on this line.
-#pragma warning restore MSTEST0028
-```
-
-To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
-
-```ini
-[*.{cs,vb}]
-dotnet_diagnostic.MSTEST0028.severity = none
-```
-
-For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).
+.NET suppressors cannot be disabled.

--- a/docs/core/testing/mstest-analyzers/mstest0028.md
+++ b/docs/core/testing/mstest-analyzers/mstest0028.md
@@ -27,3 +27,22 @@ Suppress the [VSTHRD200: Use Async suffix for async methods](https://github.com/
 ## When to disable suppressor
 
 You can disable this suppressor if you want to follow the `Async` suffix pattern also for your test fixture methods.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0028
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0028
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0028.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0029.md
+++ b/docs/core/testing/mstest-analyzers/mstest0029.md
@@ -39,3 +39,22 @@ Ensure that the public method is a test method (marked with `[TestMethod]`).
 ## When to suppress warnings
 
 Do not suppress a warning from this rule. If you ignore this rule, the public method won't be considered as a test method.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0029
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0029
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0029.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0030.md
+++ b/docs/core/testing/mstest-analyzers/mstest0030.md
@@ -39,3 +39,22 @@ A non-abstract class contains test methods should be marked with '[TestClass]'.
 ## When to suppress warnings
 
 It's safe to suppress the diagnostic if you are sure that your class is being inherited and that the tests declared on this class should only be run in the context of subclasses. Nonetheless, we recommend marking the class as abstract.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0030
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0030
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0030.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0031.md
+++ b/docs/core/testing/mstest-analyzers/mstest0031.md
@@ -39,3 +39,22 @@ Remove or replace `System.ComponentModel.DescriptionAttribute` by `Microsoft.Vis
 ## When to suppress warnings
 
 We don't recommend to suppress the diagnostic as the `System.ComponentModel.DescriptionAttribute` has no effect in the context of tests.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0031
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0031
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0031.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0032.md
+++ b/docs/core/testing/mstest-analyzers/mstest0032.md
@@ -39,3 +39,22 @@ Ensure that calls to `Assert.IsTrue`, `Assert.IsFalse`, `Assert.AreEqual`, `Asse
 ## When to suppress warnings
 
 It's _not_ recommended to suppress warnings from this rule.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0032
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0032
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0032.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0033.md
+++ b/docs/core/testing/mstest-analyzers/mstest0033.md
@@ -27,3 +27,22 @@ Suppress the [CS8618: Non-nullable variable must contain a non-null value when e
 ## When to disable suppressor
 
 It's _not_ recommended to disable this suppressor.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0033
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0033
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0033.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0033.md
+++ b/docs/core/testing/mstest-analyzers/mstest0033.md
@@ -26,23 +26,4 @@ Suppress the [CS8618: Non-nullable variable must contain a non-null value when e
 
 ## When to disable suppressor
 
-It's _not_ recommended to disable this suppressor.
-
-## Suppress a warning
-
-If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
-
-```csharp
-#pragma warning disable MSTEST0033
-// The code that's violating the rule is on this line.
-#pragma warning restore MSTEST0033
-```
-
-To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
-
-```ini
-[*.{cs,vb}]
-dotnet_diagnostic.MSTEST0033.severity = none
-```
-
-For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).
+.NET suppressors cannot be disabled.

--- a/docs/core/testing/mstest-analyzers/mstest0034.md
+++ b/docs/core/testing/mstest-analyzers/mstest0034.md
@@ -39,3 +39,22 @@ Use `ClassCleanupBehavior.EndOfClass` with the `[ClassCleanup]`.
 ## When to suppress warnings
 
 It's _not_ recommended to suppress warnings from this rule as you can use instead `[AssemblyCleanup]`.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0034
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0034
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0034.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0035.md
+++ b/docs/core/testing/mstest-analyzers/mstest0035.md
@@ -39,3 +39,22 @@ Ensure the attribute `[DeploymentItem]` is specified on a test class or a test m
 ## When to suppress warnings
 
 It's _not_ recommended to suppress warnings from this rule as the `[DeploymentItem]` will be ignored.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0035
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0035
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0035.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0036.md
+++ b/docs/core/testing/mstest-analyzers/mstest0036.md
@@ -39,3 +39,22 @@ Delete the shadowing member.
 ## When to suppress warnings
 
 Don't suppress warnings from this rule as it could cause testing issues (such as NRE).
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0036
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0036
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0036.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/mstest0037.md
+++ b/docs/core/testing/mstest-analyzers/mstest0037.md
@@ -57,3 +57,22 @@ Use the better alternative method.
 ## When to suppress warnings
 
 If the assert is intended to verify the behavior of a user-defined operator, you can and should suppress the warning.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0037
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0037
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0037.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).


### PR DESCRIPTION
## Summary

Fixes https://github.com/microsoft/testfx/issues/4615

Based out of documentation https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001#suppress-a-warning

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

<details><summary><strong>Toggle expand/collapse</strong></summary><br/>

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/mstest-analyzers/mstest0002.md](https://github.com/dotnet/docs/blob/5a8544bf8052c87fce8015e5c2676067f3033fb3/docs/core/testing/mstest-analyzers/mstest0002.md) | [MSTEST0002: Test classes should have valid layout](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0002?branch=pr-en-us-44277) |
| [docs/core/testing/mstest-analyzers/mstest0003.md](https://github.com/dotnet/docs/blob/5a8544bf8052c87fce8015e5c2676067f3033fb3/docs/core/testing/mstest-analyzers/mstest0003.md) | ["MSTEST0003: Test methods should have valid layout"](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0003?branch=pr-en-us-44277) |
| [docs/core/testing/mstest-analyzers/mstest0004.md](https://github.com/dotnet/docs/blob/5a8544bf8052c87fce8015e5c2676067f3033fb3/docs/core/testing/mstest-analyzers/mstest0004.md) | [MSTEST0004: Public types should be test classes](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0004?branch=pr-en-us-44277) |
| [docs/core/testing/mstest-analyzers/mstest0005.md](https://github.com/dotnet/docs/blob/5a8544bf8052c87fce8015e5c2676067f3033fb3/docs/core/testing/mstest-analyzers/mstest0005.md) | [docs/core/testing/mstest-analyzers/mstest0005](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0005?branch=pr-en-us-44277) |
| [docs/core/testing/mstest-analyzers/mstest0006.md](https://github.com/dotnet/docs/blob/5a8544bf8052c87fce8015e5c2676067f3033fb3/docs/core/testing/mstest-analyzers/mstest0006.md) | [MSTEST0006: Avoid `[ExpectedException]`](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0006?branch=pr-en-us-44277) |
| [docs/core/testing/mstest-analyzers/mstest0007.md](https://github.com/dotnet/docs/blob/5a8544bf8052c87fce8015e5c2676067f3033fb3/docs/core/testing/mstest-analyzers/mstest0007.md) | ["MSTEST0007: Use test attributes only on test methods"](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0007?branch=pr-en-us-44277) |
| [docs/core/testing/mstest-analyzers/mstest0008.md](https://github.com/dotnet/docs/blob/5a8544bf8052c87fce8015e5c2676067f3033fb3/docs/core/testing/mstest-analyzers/mstest0008.md) | [MSTEST0008: TestInitialize method should have valid layout](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0008?branch=pr-en-us-44277) |
| [docs/core/testing/mstest-analyzers/mstest0009.md](https://github.com/dotnet/docs/blob/5a8544bf8052c87fce8015e5c2676067f3033fb3/docs/core/testing/mstest-analyzers/mstest0009.md) | [docs/core/testing/mstest-analyzers/mstest0009](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0009?branch=pr-en-us-44277) |
| [docs/core/testing/mstest-analyzers/mstest0010.md](https://github.com/dotnet/docs/blob/5a8544bf8052c87fce8015e5c2676067f3033fb3/docs/core/testing/mstest-analyzers/mstest0010.md) | [MSTEST0010: ClassInitialize method should have valid layout](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0010?branch=pr-en-us-44277) |
| [docs/core/testing/mstest-analyzers/mstest0011.md](https://github.com/dotnet/docs/blob/5a8544bf8052c87fce8015e5c2676067f3033fb3/docs/core/testing/mstest-analyzers/mstest0011.md) | ["MSTEST0011: ClassCleanup method should have valid layout"](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0011?branch=pr-en-us-44277) |
| [docs/core/testing/mstest-analyzers/mstest0012.md](https://github.com/dotnet/docs/blob/5a8544bf8052c87fce8015e5c2676067f3033fb3/docs/core/testing/mstest-analyzers/mstest0012.md) | [MSTEST0012: AssemblyInitialize method should have valid layout](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0012?branch=pr-en-us-44277) |
| [docs/core/testing/mstest-analyzers/mstest0013.md](https://github.com/dotnet/docs/blob/5a8544bf8052c87fce8015e5c2676067f3033fb3/docs/core/testing/mstest-analyzers/mstest0013.md) | [docs/core/testing/mstest-analyzers/mstest0013](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0013?branch=pr-en-us-44277) |
| [docs/core/testing/mstest-analyzers/mstest0014.md](https://github.com/dotnet/docs/blob/5a8544bf8052c87fce8015e5c2676067f3033fb3/docs/core/testing/mstest-analyzers/mstest0014.md) | [MSTEST0014: DataRow should be valid](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0014?branch=pr-en-us-44277) |
| [docs/core/testing/mstest-analyzers/mstest0015.md](https://github.com/dotnet/docs/blob/5a8544bf8052c87fce8015e5c2676067f3033fb3/docs/core/testing/mstest-analyzers/mstest0015.md) | ["MSTEST0015: Test method should not be ignored"](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0015?branch=pr-en-us-44277) |
| [docs/core/testing/mstest-analyzers/mstest0016.md](https://github.com/dotnet/docs/blob/5a8544bf8052c87fce8015e5c2676067f3033fb3/docs/core/testing/mstest-analyzers/mstest0016.md) | [MSTEST0016: Test class should have test method](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0016?branch=pr-en-us-44277) |
| [docs/core/testing/mstest-analyzers/mstest0017.md](https://github.com/dotnet/docs/blob/5a8544bf8052c87fce8015e5c2676067f3033fb3/docs/core/testing/mstest-analyzers/mstest0017.md) | [MSTEST0017: Assertion arguments should be passed in the correct order](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0017?branch=pr-en-us-44277) |
| [docs/core/testing/mstest-analyzers/mstest0018.md](https://github.com/dotnet/docs/blob/5a8544bf8052c87fce8015e5c2676067f3033fb3/docs/core/testing/mstest-analyzers/mstest0018.md) | [docs/core/testing/mstest-analyzers/mstest0018](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0018?branch=pr-en-us-44277) |
| [docs/core/testing/mstest-analyzers/mstest0019.md](https://github.com/dotnet/docs/blob/5a8544bf8052c87fce8015e5c2676067f3033fb3/docs/core/testing/mstest-analyzers/mstest0019.md) | [MSTEST0019: Prefer TestInitialize methods over constructors](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0019?branch=pr-en-us-44277) |
| [docs/core/testing/mstest-analyzers/mstest0020.md](https://github.com/dotnet/docs/blob/5a8544bf8052c87fce8015e5c2676067f3033fb3/docs/core/testing/mstest-analyzers/mstest0020.md) | ["MSTEST0020: Prefer constructors over TestInitialize methods"](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0020?branch=pr-en-us-44277) |
| [docs/core/testing/mstest-analyzers/mstest0021.md](https://github.com/dotnet/docs/blob/5a8544bf8052c87fce8015e5c2676067f3033fb3/docs/core/testing/mstest-analyzers/mstest0021.md) | [MSTEST0021: Prefer Dispose over TestCleanup methods](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0021?branch=pr-en-us-44277) |
| [docs/core/testing/mstest-analyzers/mstest0022.md](https://github.com/dotnet/docs/blob/5a8544bf8052c87fce8015e5c2676067f3033fb3/docs/core/testing/mstest-analyzers/mstest0022.md) | [docs/core/testing/mstest-analyzers/mstest0022](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0022?branch=pr-en-us-44277) |
| [docs/core/testing/mstest-analyzers/mstest0023.md](https://github.com/dotnet/docs/blob/5a8544bf8052c87fce8015e5c2676067f3033fb3/docs/core/testing/mstest-analyzers/mstest0023.md) | [MSTEST0023: Do not negate boolean assertions](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0023?branch=pr-en-us-44277) |
| [docs/core/testing/mstest-analyzers/mstest0024.md](https://github.com/dotnet/docs/blob/5a8544bf8052c87fce8015e5c2676067f3033fb3/docs/core/testing/mstest-analyzers/mstest0024.md) | ["MSTEST0024: Do not store TestContext in a static member"](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0024?branch=pr-en-us-44277) |
| [docs/core/testing/mstest-analyzers/mstest0025.md](https://github.com/dotnet/docs/blob/5a8544bf8052c87fce8015e5c2676067f3033fb3/docs/core/testing/mstest-analyzers/mstest0025.md) | [MSTEST0025: Use 'Assert.Fail' instead of an always-failing assert](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0025?branch=pr-en-us-44277) |
| [docs/core/testing/mstest-analyzers/mstest0026.md](https://github.com/dotnet/docs/blob/5a8544bf8052c87fce8015e5c2676067f3033fb3/docs/core/testing/mstest-analyzers/mstest0026.md) | [docs/core/testing/mstest-analyzers/mstest0026](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0026?branch=pr-en-us-44277) |
| [docs/core/testing/mstest-analyzers/mstest0029.md](https://github.com/dotnet/docs/blob/5a8544bf8052c87fce8015e5c2676067f3033fb3/docs/core/testing/mstest-analyzers/mstest0029.md) | [MSTEST0029: Public method should be test method](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0029?branch=pr-en-us-44277) |
| [docs/core/testing/mstest-analyzers/mstest0030.md](https://github.com/dotnet/docs/blob/5a8544bf8052c87fce8015e5c2676067f3033fb3/docs/core/testing/mstest-analyzers/mstest0030.md) | [MSTEST0030: Type containing `[TestMethod]` should be marked with `[TestClass]`](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0030?branch=pr-en-us-44277) |
| [docs/core/testing/mstest-analyzers/mstest0031.md](https://github.com/dotnet/docs/blob/5a8544bf8052c87fce8015e5c2676067f3033fb3/docs/core/testing/mstest-analyzers/mstest0031.md) | ["MSTEST0031: `System.ComponentModel.DescriptionAttribute` has no effect on test methods."](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0031?branch=pr-en-us-44277) |
| [docs/core/testing/mstest-analyzers/mstest0032.md](https://github.com/dotnet/docs/blob/5a8544bf8052c87fce8015e5c2676067f3033fb3/docs/core/testing/mstest-analyzers/mstest0032.md) | [MSTEST0032: Review or remove the assertion as its condition is known to be always true](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0032?branch=pr-en-us-44277) |
| [docs/core/testing/mstest-analyzers/mstest0034.md](https://github.com/dotnet/docs/blob/5a8544bf8052c87fce8015e5c2676067f3033fb3/docs/core/testing/mstest-analyzers/mstest0034.md) | [docs/core/testing/mstest-analyzers/mstest0034](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0034?branch=pr-en-us-44277) |

</details>

> [!NOTE]
> This table shows preview links for the 30 files with the most changes. For preview links for other files in this PR, select <strong>OpenPublishing.Build Details</strong> within [checks](https://github.com/dotnet/docs/pull/44277/checks).


<!-- PREVIEW-TABLE-END -->