### PR TITLE
Remove links to the try-samples repo

### DIFF
--- a/docs/csharp/language-reference/operators/lambda-expressions.md
+++ b/docs/csharp/language-reference/operators/lambda-expressions.md
@@ -340,4 +340,3 @@ For more information about these features, see the following feature proposal no
 - [Local functions vs. lambda expressions](../../programming-guide/classes-and-structs/local-functions.md#local-functions-vs-lambda-expressions)
 - [LINQ sample queries](https://github.com/microsoftarchive/msdn-code-gallery-microsoft/tree/master/Visual%20Studio%20Product%20Team/Official%20Visual%20Studio%202008%20C%23%20Samples/%5BC%23%5D-Official%20Visual%20Studio%202008%20C%23%20Samples/LINQ%20-%20Sample%20Queries/C%23)
 - [XQuery sample](https://github.com/microsoftarchive/msdn-code-gallery-microsoft/tree/master/Visual%20Studio%20Product%20Team/Official%20Visual%20Studio%202008%20C%23%20Samples/%5BC%23%5D-Official%20Visual%20Studio%202008%20C%23%20Samples/XQuery/C%23)
-- [101 LINQ samples](/samples/dotnet/try-samples/101-linq-samples/)

--- a/docs/csharp/tour-of-csharp/tutorials/index.md
+++ b/docs/csharp/tour-of-csharp/tutorials/index.md
@@ -23,7 +23,6 @@ You can try these tutorials in different environments. The concepts you'll learn
 
 - [In your browser, on the docs platform](hello-world.yml): This experience embeds a runnable C# code window in docs pages. You write and execute C# code in the browser.
 - [In the Microsoft Learn training experience](/training/paths/csharp-first-steps/). This learning path contains several modules that teach the basics of C#.
-- [In Jupyter on Binder](https://mybinder.org/v2/gh/dotnet/try-samples/main?filepath=hello-csharp%2Fhello-world.ipynb). You can experiment with C# code in a Jupyter notebook on binder.
 - [On your local machine](numbers-in-csharp-local.md). After you've explored online, you can [download the .NET SDK and build programs on your machine](local-environment.md).
 
 All the introductory tutorials following the Hello World lesson are available using
@@ -36,7 +35,7 @@ on your machine.
 ## [Hello world](hello-world.yml)
 
 In the [Hello world](hello-world.yml) tutorial, you'll create the most basic
-C# program. You'll explore the `string` type and how to work with text. You can also use the path on [Microsoft Learn training](/training/paths/csharp-first-steps/) or [Jupyter on Binder](https://mybinder.org/v2/gh/dotnet/try-samples/main?filepath=hello-csharp%2Fhello-world.ipynb).
+C# program. You'll explore the `string` type and how to work with text. You can also use the path on [Microsoft Learn training](/training/paths/csharp-first-steps/).
 
 ## [Numbers in C#](numbers-in-csharp.yml)
 
@@ -66,7 +65,3 @@ a tour of the List collection type that stores sequences of data. You'll learn h
 available [to run locally on your machine](arrays-and-collections.md).
 
 This tutorial assumes that you've finished the lessons listed above.
-
-## [101 Linq Samples](https://github.com/dotnet/try-samples/tree/main/101-linq-samples)
-
-This sample requires the [dotnet-try](https://github.com/dotnet/try/blob/main/README.md#setup) global tool. Once you install the tool, and clone the [try-samples](https://github.com/dotnet/try-samples) repo, you can learn Language Integrated Query (LINQ) through a set of 101 samples you can run interactively. You can explore different ways to query, explore, and transform data sequences.

--- a/docs/standard/linq/index.md
+++ b/docs/standard/linq/index.md
@@ -153,8 +153,6 @@ The answer to this question is **no** if...
 
 ## Essential LINQ
 
-For a truly comprehensive list of LINQ samples, visit [101 LINQ Samples](/samples/dotnet/try-samples/101-linq-samples/).
-
 The following examples are a quick demonstration of some of the essential pieces of LINQ. This is in no way comprehensive, as LINQ provides more functionality than what is showcased here.
 
 ### The bread and butter - `Where`, `Select`, and `Aggregate`
@@ -387,6 +385,5 @@ Parallelizable CPU-bound jobs that can be easily expressed via LINQ (in other wo
 
 ## More resources
 
-* [101 LINQ Samples](/samples/dotnet/try-samples/101-linq-samples/)
 * [Linqpad](https://www.linqpad.net/), a playground environment and Database querying engine for C#/F#/Visual Basic
 * [EduLinq](https://codeblog.jonskeet.uk/2011/02/23/reimplementing-linq-to-objects-part-45-conclusion-and-list-of-posts/), an e-book for learning how LINQ-to-objects is implemented


### PR DESCRIPTION
The try-samples samples aren't widely used.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/lambda-expressions.md](https://github.com/dotnet/docs/blob/9dbbe608ac44f41efce1d7d8e2fecccea794bfad/docs/csharp/language-reference/operators/lambda-expressions.md) | [Lambda expressions and anonymous functions](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/lambda-expressions?branch=pr-en-us-44279) |
| [docs/csharp/tour-of-csharp/tutorials/index.md](https://github.com/dotnet/docs/blob/9dbbe608ac44f41efce1d7d8e2fecccea794bfad/docs/csharp/tour-of-csharp/tutorials/index.md) | [Interactive tutorials](https://review.learn.microsoft.com/en-us/dotnet/csharp/tour-of-csharp/tutorials/index?branch=pr-en-us-44279) |
| [docs/standard/linq/index.md](https://github.com/dotnet/docs/blob/9dbbe608ac44f41efce1d7d8e2fecccea794bfad/docs/standard/linq/index.md) | [LINQ overview](https://review.learn.microsoft.com/en-us/dotnet/standard/linq/index?branch=pr-en-us-44279) |

<!-- PREVIEW-TABLE-END -->