### PR TITLE
Point the manual .NET 1.1 install using tools instead of mentioning vendors being required

### DIFF
--- a/docs/framework/install/run-net-framework-1-1-apps.md
+++ b/docs/framework/install/run-net-framework-1-1-apps.md
@@ -10,7 +10,8 @@ ms.assetid: fb14e195-fea5-4561-b9a8-60a67283edb9
 
 # Run .NET Framework 1.1 apps on Windows 8, Windows 8.1, Windows 10, or Windows 11
 
-.NET Framework 1.1 is not supported on the Windows 8, Windows 8.1, Windows Server 2012, Windows Server 2012 R2, Windows 10, or Windows 11 operating systems. In some cases, .NET Framework 1.1 is required for an app to run. In those cases, contact your independent software vendor (ISV) to have the app upgraded to run on .NET Framework 3.5 SP1 or a later version. For more information, see [Migrating from .NET Framework 1.1](../migration-guide/migrating-from-the-net-framework-1-1.md).
+.NET Framework 1.1 is not supported on the Windows 8, Windows 8.1, Windows Server 2012, Windows Server 2012 R2, Windows 10, or Windows 11 operating systems. In some cases, .NET Framework 1.1 is required for an app to run. In those cases, you can [enable .NET Framework 3.5 through the Add Roles and Features Wizard](./on-windows-11.md#install-net-framework-on-windows-11).  
+For more information, see [Migrating from .NET Framework 1.1](../migration-guide/migrating-from-the-net-framework-1-1.md).
 
 ## Install .NET Framework 1.1 from a CD or download center
 

--- a/docs/framework/install/run-net-framework-1-1-apps.md
+++ b/docs/framework/install/run-net-framework-1-1-apps.md
@@ -10,8 +10,7 @@ ms.assetid: fb14e195-fea5-4561-b9a8-60a67283edb9
 
 # Run .NET Framework 1.1 apps on Windows 8, Windows 8.1, Windows 10, or Windows 11
 
-.NET Framework 1.1 is not supported on the Windows 8, Windows 8.1, Windows Server 2012, Windows Server 2012 R2, Windows 10, or Windows 11 operating systems. In some cases, .NET Framework 1.1 is required for an app to run. In those cases, you can [enable .NET Framework 3.5 through the Add Roles and Features Wizard](./on-windows-11.md#install-net-framework-on-windows-11).  
-For more information, see [Migrating from .NET Framework 1.1](../migration-guide/migrating-from-the-net-framework-1-1.md).
+.NET Framework 1.1 is not supported on the Windows 8, Windows 8.1, Windows Server 2012, Windows Server 2012 R2, Windows 10, or Windows 11 operating systems. In some cases, .NET Framework 1.1 is required for an app to run. In those cases, you can [enable .NET Framework 3.5 through the Add Roles and Features Wizard](./on-windows-11.md#install-net-framework-on-windows-11).
 
 ## Install .NET Framework 1.1 from a CD or download center
 

--- a/docs/framework/install/run-net-framework-1-1-apps.md
+++ b/docs/framework/install/run-net-framework-1-1-apps.md
@@ -10,7 +10,7 @@ ms.assetid: fb14e195-fea5-4561-b9a8-60a67283edb9
 
 # Run .NET Framework 1.1 apps on Windows 8, Windows 8.1, Windows 10, or Windows 11
 
-.NET Framework 1.1 is not supported on the Windows 8, Windows 8.1, Windows Server 2012, Windows Server 2012 R2, Windows 10, or Windows 11 operating systems. In some cases, .NET Framework 1.1 is required for an app to run. In those cases, you can [enable .NET Framework 3.5 through the Add Roles and Features Wizard](./on-windows-11.md#install-net-framework-on-windows-11).
+.NET Framework 1.1 is not supported on the Windows 8, Windows 8.1, Windows Server 2012, Windows Server 2012 R2, Windows 10, or Windows 11 operating systems. In some cases, .NET Framework 1.1 is required for an app to run. In those cases, refer to the [Install .NET Framework 3.5 on Windows article](./dotnet-35-windows.md).
 
 ## Install .NET Framework 1.1 from a CD or download center
 


### PR DESCRIPTION
This pull request fixes #44186 
It replaces the vendors being required sentence with the link to installing the .NET 1.1 as suggested in the issue.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/install/run-net-framework-1-1-apps.md](https://github.com/dotnet/docs/blob/324b087bea5b9789e78187b487c1a7fc6f1cfbf3/docs/framework/install/run-net-framework-1-1-apps.md) | [Run .NET Framework 1.1 apps on Windows 8, Windows 8.1, Windows 10, or Windows 11](https://review.learn.microsoft.com/en-us/dotnet/framework/install/run-net-framework-1-1-apps?branch=pr-en-us-44395) |


<!-- PREVIEW-TABLE-END -->