### PR TITLE
Fix minor word swap error.

### DIFF
--- a/docs/core/compatibility/sdk/9.0/nugetaudit-transitive-packages.md
+++ b/docs/core/compatibility/sdk/9.0/nugetaudit-transitive-packages.md
@@ -14,7 +14,7 @@ In .NET 8, [NuGetAudit](../8.0/dotnet-restore-audit.md) was introduced to emit w
 ## New behavior
 
 Starting in .NET 9, `NuGetAuditMode` defaults to `all` if it hasn't been explicitly set. This setting means that *transitive packages* (dependencies of packages your project directly references) with known vulnerabilities now cause warnings to be reported.
-If your project treats errors as warnings, this behavior can cause restore failures.
+If your project treats warnings as errors, this behavior can cause restore failures.
 
 ## Version introduced
 


### PR DESCRIPTION

"errors as warnings" -> "warnings as errors"

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/sdk/9.0/nugetaudit-transitive-packages.md](https://github.com/dotnet/docs/blob/7a5b9d3eb019228d6a6661e974a9b208f8befd73/docs/core/compatibility/sdk/9.0/nugetaudit-transitive-packages.md) | ['dotnet restore' audits transitive packages](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/9.0/nugetaudit-transitive-packages?branch=pr-en-us-44405) |

<!-- PREVIEW-TABLE-END -->