### PR TITLE
Clarify Optional Parameters and Nullable Optional Parameter Behavior in C#.

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/named-and-optional-arguments.md
+++ b/docs/csharp/programming-guide/classes-and-structs/named-and-optional-arguments.md
@@ -70,16 +70,15 @@ The following code implements the examples from this section along with some add
 
 ## Optional arguments
 
-The definition of a method, constructor, indexer, or delegate can specify its parameters are required or optional. Any call must provide arguments for all required parameters, but can omit arguments for optional parameters. Additionally, nullable reference types (`T?`) implicitly have `null` as their default value.
+The definition of a method, constructor, indexer, or delegate can specify its parameters are required or optional. Any call must provide arguments for all required parameters, but can omit arguments for optional parameters. A nullable reference type (`T?`) allows arguments to be explicitly `null` but does not inherently make a parameter optional.
 
 Each optional parameter has a default value as part of its definition. If no argument is sent for that parameter, the default value is used. A default value must be one of the following types of expressions:
-  
+
 - a constant expression;  
 - an expression of the form `new ValType()`, where `ValType` is a value type, such as an [enum](../../language-reference/builtin-types/enum.md) or a [struct](../../language-reference/builtin-types/struct.md);
 - an expression of the form [default(ValType)](../../language-reference/operators/default.md),  where `ValType` is a value type.
-- For nullable value types or nullable reference types (`T?`), the default value is always `null`.
 
-Optional parameters are defined at the end of the parameter list, after any required parameters. If the caller provides an argument for any one of a succession of optional parameters, it must provide arguments for all preceding optional parameters. Comma-separated gaps in the argument list aren't supported. For example, in the following code, instance method `ExampleMethod` is defined with one required and two optional parameters.
+Optional parameters are defined at the end of the parameter list, after any required parameters. The caller must provide arguments for all required parameters and any optional parameters preceding those it specifies. Comma-separated gaps in the argument list aren't supported.For example, in the following code, instance method `ExampleMethod` is defined with one required and two optional parameters.
 
 :::code language="csharp" source="./snippets/NamedAndOptional/optional.cs" id="Snippet15":::
 
@@ -100,15 +99,14 @@ IntelliSense uses brackets to indicate optional parameters, as shown in the foll
 ![Screenshot showing IntelliSense quick info for the ExampleMethod method.](./media/named-and-optional-arguments/optional-examplemethod-parameters.png)
 
 > [!NOTE]
-> You can also declare optional parameters by using the .NET <xref:System.Runtime.InteropServices.OptionalAttribute> class. `OptionalAttribute` parameters do not require a default value. However, if a default value is desired, take a look at <xref:System.Runtime.InteropServices.DefaultParameterValueAttribute> class. Additionally, nullable types (`T?`) implicitly default to `null` without needing to use these attributes.
-
+> You can also declare optional parameters by using the .NET <xref:System.Runtime.InteropServices.OptionalAttribute> class. `OptionalAttribute` parameters do not require a default value. However, if a default value is desired, take a look at <xref:System.Runtime.InteropServices.DefaultParameterValueAttribute> class.
 ### Example
 
 In the following example, the constructor for `ExampleClass` has one parameter, which is optional. Instance method `ExampleMethod` has one required parameter, `required`, and two optional parameters, `optionalstr` and `optionalint`. The code in `Main` shows the different ways in which the constructor and method can be invoked.
 
 :::code language="csharp" source="./snippets/NamedAndOptional/optional.cs" id="Snippet2":::
 
-The preceding code shows a number of examples where optional parameters aren't applied correctly. The first illustrates that an argument must be supplied for the first parameter, which is required.
+The preceding code illustrates several cases where optional parameters are used correctly and incorrectly. Arguments must be supplied for all required parameters. Gaps in optional arguments must be filled with named parameters.
 
 ## Caller information attributes
 

--- a/docs/csharp/programming-guide/classes-and-structs/named-and-optional-arguments.md
+++ b/docs/csharp/programming-guide/classes-and-structs/named-and-optional-arguments.md
@@ -100,6 +100,7 @@ IntelliSense uses brackets to indicate optional parameters, as shown in the foll
 
 > [!NOTE]
 > You can also declare optional parameters by using the .NET <xref:System.Runtime.InteropServices.OptionalAttribute> class. `OptionalAttribute` parameters do not require a default value. However, if a default value is desired, take a look at <xref:System.Runtime.InteropServices.DefaultParameterValueAttribute> class.
+
 ### Example
 
 In the following example, the constructor for `ExampleClass` has one parameter, which is optional. Instance method `ExampleMethod` has one required parameter, `required`, and two optional parameters, `optionalstr` and `optionalint`. The code in `Main` shows the different ways in which the constructor and method can be invoked.

--- a/docs/csharp/programming-guide/classes-and-structs/named-and-optional-arguments.md
+++ b/docs/csharp/programming-guide/classes-and-structs/named-and-optional-arguments.md
@@ -70,7 +70,7 @@ The following code implements the examples from this section along with some add
 
 ## Optional arguments
 
-The definition of a method, constructor, indexer, or delegate can specify its parameters as required or optional. Any call must provide arguments for all required parameters, but can omit arguments for optional parameters. Additionally, nullable reference types (`T?`) implicitly have `null` as their default value.
+The definition of a method, constructor, indexer, or delegate can specify its parameters are required or optional. Any call must provide arguments for all required parameters, but can omit arguments for optional parameters. Additionally, nullable reference types (`T?`) implicitly have `null` as their default value.
 
 Each optional parameter has a default value as part of its definition. If no argument is sent for that parameter, the default value is used. A default value must be one of the following types of expressions:
   

--- a/docs/csharp/programming-guide/classes-and-structs/named-and-optional-arguments.md
+++ b/docs/csharp/programming-guide/classes-and-structs/named-and-optional-arguments.md
@@ -70,13 +70,14 @@ The following code implements the examples from this section along with some add
 
 ## Optional arguments
 
-The definition of a method, constructor, indexer, or delegate can specify its parameters are required or optional. Any call must provide arguments for all required parameters, but can omit arguments for optional parameters.
+The definition of a method, constructor, indexer, or delegate can specify its parameters as required or optional. Any call must provide arguments for all required parameters, but can omit arguments for optional parameters. Additionally, nullable reference types (`T?`) implicitly have `null` as their default value.
 
 Each optional parameter has a default value as part of its definition. If no argument is sent for that parameter, the default value is used. A default value must be one of the following types of expressions:
   
 - a constant expression;  
 - an expression of the form `new ValType()`, where `ValType` is a value type, such as an [enum](../../language-reference/builtin-types/enum.md) or a [struct](../../language-reference/builtin-types/struct.md);
 - an expression of the form [default(ValType)](../../language-reference/operators/default.md),  where `ValType` is a value type.
+- For nullable value types or nullable reference types (`T?`), the default value is always `null`.
 
 Optional parameters are defined at the end of the parameter list, after any required parameters. If the caller provides an argument for any one of a succession of optional parameters, it must provide arguments for all preceding optional parameters. Comma-separated gaps in the argument list aren't supported. For example, in the following code, instance method `ExampleMethod` is defined with one required and two optional parameters.
 
@@ -85,7 +86,7 @@ Optional parameters are defined at the end of the parameter list, after any requ
 The following call to `ExampleMethod` causes a compiler error, because an argument is provided for the third parameter but not for the second.
 
 ```csharp
-//anExample.ExampleMethod(3, ,4);
+// anExample.ExampleMethod(3, ,4);
 ```
 
 However, if you know the name of the third parameter, you can use a named argument to accomplish the task.
@@ -99,7 +100,7 @@ IntelliSense uses brackets to indicate optional parameters, as shown in the foll
 ![Screenshot showing IntelliSense quick info for the ExampleMethod method.](./media/named-and-optional-arguments/optional-examplemethod-parameters.png)
 
 > [!NOTE]
-> You can also declare optional parameters by using the .NET <xref:System.Runtime.InteropServices.OptionalAttribute> class. `OptionalAttribute` parameters do not require a default value. However, if a default value is desired, take a look at <xref:System.Runtime.InteropServices.DefaultParameterValueAttribute> class.
+> You can also declare optional parameters by using the .NET <xref:System.Runtime.InteropServices.OptionalAttribute> class. `OptionalAttribute` parameters do not require a default value. However, if a default value is desired, take a look at <xref:System.Runtime.InteropServices.DefaultParameterValueAttribute> class. Additionally, nullable types (`T?`) implicitly default to `null` without needing to use these attributes.
 
 ### Example
 


### PR DESCRIPTION
## Summary

This PR improves the documentation for optional parameters in C# by:

- Clarifying the distinction between nullable (`T?`) parameters and optional parameters with default values.
- Highlighting that parameters can be both nullable and optional (`T? allTheOptionalMeanings = default`).
- Adding examples and notes to address user confusion, ensuring better understanding of the behavior of nullable and optional parameters.
- Maintaining all existing code snippets as they are already accurate and illustrative.

Fixes #44404 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/classes-and-structs/named-and-optional-arguments.md](https://github.com/dotnet/docs/blob/bca56d5d74ce7942900afcc0f87c34777f09a56a/docs/csharp/programming-guide/classes-and-structs/named-and-optional-arguments.md) | [Named and Optional Arguments (C# Programming Guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/named-and-optional-arguments?branch=pr-en-us-44408) |


<!-- PREVIEW-TABLE-END -->