### PR TITLE
Update dotnet test integration doc to point out to use of Directory.Build.props

### DIFF
--- a/docs/core/testing/unit-testing-platform-integration-dotnet-test.md
+++ b/docs/core/testing/unit-testing-platform-integration-dotnet-test.md
@@ -171,4 +171,4 @@ Or in project file:
 ```
 
 > [!IMPORTANT]
-> All examples above add properties like `EnableMSTestRunner`, `TestingPlatformDotnetTestSupport`, and `TestingPlatformCaptureOutput` in csproj file. However, it's highly recommended that you set these properties in `Directory.Build.props`. That way, you don't have to add it to every test project file, and you don't risk introducing a new project that doesn't set these properties and end up with a solution where some projects are VSTest while others are Microsoft.Testing.Platform, which may not work correctly and is unsupported scenario.
+> All examples above add properties like `EnableMSTestRunner`, `TestingPlatformDotnetTestSupport`, and `TestingPlatformCaptureOutput` in the csproj file. However, it's highly recommended that you set these properties in `Directory.Build.props`. That way, you don't have to add it to every test project file, and you don't risk introducing a new project that doesn't set these properties and end up with a solution where some projects are VSTest while others are Microsoft.Testing.Platform, which may not work correctly and is unsupported scenario.

--- a/docs/core/testing/unit-testing-platform-integration-dotnet-test.md
+++ b/docs/core/testing/unit-testing-platform-integration-dotnet-test.md
@@ -169,3 +169,6 @@ Or in project file:
 
 </Project>
 ```
+
+> [!IMPORTANT]
+> All examples above add properties like `EnableMSTestRunner`, `TestingPlatformDotnetTestSupport`, and `TestingPlatformCaptureOutput` in csproj file. However, it's highly recommended that you set these properties in `Directory.Build.props`. That way, you don't have to add it to every test project file, and you don't risk introducing a new project that doesn't set these properties and end up with a solution where some projects are VSTest while others are Microsoft.Testing.Platform, which may not work correctly and is unsupported scenario.


### PR DESCRIPTION
@Evangelink

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-platform-integration-dotnet-test.md](https://github.com/dotnet/docs/blob/b1d723648f37b4eacbdb634644c68c13ac60f231/docs/core/testing/unit-testing-platform-integration-dotnet-test.md) | [Use Microsoft.Testing.Platform with `dotnet test`](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-platform-integration-dotnet-test?branch=pr-en-us-44412) |


<!-- PREVIEW-TABLE-END -->