### PR TITLE
Add new SDK versions and clean up out of support versions

### DIFF
--- a/docs/core/porting/versioning-sdk-msbuild-vs.md
+++ b/docs/core/porting/versioning-sdk-msbuild-vs.md
@@ -63,7 +63,6 @@ The support timeframe for the SDK typically matches that of the Visual Studio ve
 | 9.0.2xx     | 17.13                         | Feb '25   | May '26             |
 | 9.0.3xx     | 17.14                         | May '25   | May '26             |
 
-
 > [!NOTE]
 > <sup>1</sup> .1xx .NET SDK feature bands are supported throughout the lifecycle of major .NET versions. During the extended support period, support is limited to security fixes and minimal high-priority non-security fixes for Linux only. To learn more about the reasoning for this extended support, see [Source-build support](https://github.com/dotnet/source-build#support).
 >
@@ -93,11 +92,10 @@ A the following policy dictates which versions of MSBuild and Visual Studio a gi
 
 > [!NOTE]
 > The table depicts how these versioning rules are applied, starting with .NET SDK 7.0.100 and .NET SDK 6.0.300. It also depicts how the policy would have applied to previously shipped versions of the .NET SDK, had it been in place then. However, the requirements for previous versions of the SDK don't change&mdash;that is, the minimum required version of Visual Studio for .NET SDK 6.0.100 or 6.0.200 remains 16.10.
-> 
-> Targeting `net8.0` is officially supported in Visual Studio 17.8+ only.
-> 
-> Targeting `net9.0` is officially supported in Visual Studio 17.12+ only.
 >
+> Targeting `net8.0` is officially supported in Visual Studio 17.8+ only.
+>
+> Targeting `net9.0` is officially supported in Visual Studio 17.12+ only.
 
 To ensure consistent tooling, you should use `dotnet build` rather than `msbuild` to build your application when possible.
 

--- a/docs/core/porting/versioning-sdk-msbuild-vs.md
+++ b/docs/core/porting/versioning-sdk-msbuild-vs.md
@@ -56,21 +56,18 @@ The support timeframe for the SDK typically matches that of the Visual Studio ve
 | SDK version | MSBuild/Visual Studio version | Ship date | Lifecycle           |
 |-------------|-------------------------------|-----------|---------------------|
 | 8.0.1xx     | 17.8                          | Nov '23   | Nov '25<sup>1</sup> |
-| 8.0.2xx     | 17.9<sup>3</sup>              | Feb '24   | May '24<sup>3</sup> |
+| 8.0.2xx     | 17.9                          | Feb '24   | May '24             |
 | 8.0.3xx     | 17.10                         | May '24   | TBD                 |
 | 8.0.4xx     | 17.11                         | Aug '24   | Nov '25<sup>2</sup> |
-| 9.0.1xx     | 17.12                         | Nov '24   | May '26<sup>1</sup> |
+| 9.0.1xx     | 17.12                         | Nov '24   | May '26             |
+| 9.0.2xx     | 17.13                         | Feb '25   | May '26             |
+| 9.0.3xx     | 17.14                         | May '25   | May '26             |
+
 
 > [!NOTE]
-> Targeting `net6.0` is officially supported in Visual Studio 17.0+ only.
-> Targeting `net7.0` is officially supported in Visual Studio 17.4+ only.
-> Targeting `net8.0` is officially supported in Visual Studio 17.8+ only.
->
 > <sup>1</sup> .1xx .NET SDK feature bands are supported throughout the lifecycle of major .NET versions. During the extended support period, support is limited to security fixes and minimal high-priority non-security fixes for Linux only. To learn more about the reasoning for this extended support, see [Source-build support](https://github.com/dotnet/source-build#support).
 >
 > <sup>2</sup> .4xx .NET SDK feature bands are supported for the life of the matching runtime as stand-alone installs.
->
-> <sup>3</sup> 8.0.200 requires a newer Visual Studio version. For more information, see the [support rules](#targeting-and-support-rules).
 >
 > [Visual Studio 2019 Lifecycle](/lifecycle/products/visual-studio-2019)
 >
@@ -86,23 +83,21 @@ A the following policy dictates which versions of MSBuild and Visual Studio a gi
 
 | SDK | Visual Studio version<br/>the SDK ships with | Minimum Visual Studio version | Max TargetFramework in<br/>minimum Visual Studio version | Max TargetFramework in `dotnet` |
 |---------|-------|------------------|--------|--------|
-| 6.0.200 | 17.1  | 17.0             | Net6.0 | Net6.0 |
-| 6.0.300 | 17.2  | 17.0             | Net6.0 | Net6.0 |
-| 6.0.400 | 17.3  | 17.0             | Net6.0 | Net6.0 |
-| 7.0.100 | 17.4  | 17.3             | Net6.0 | Net7.0 |
-| 7.0.200 | 17.5  | 17.4             | Net7.0 | Net7.0 |
-| 7.0.300 | 17.6  | 17.4<sup>1</sup> | Net7.0 | Net7.0 |
-| 7.0.400 | 17.7  | 17.4             | Net7.0 | Net7.0 |
 | 8.0.100 | 17.8  | 17.7             | Net7.0 | Net8.0 |
 | 8.0.200 | 17.9  | 17.8             | Net8.0 | Net8.0 |
 | 8.0.300 | 17.10 | 17.8             | Net8.0 | Net8.0 |
 | 8.0.400 | 17.11 | 17.8             | Net8.0 | Net8.0 |
 | 9.0.100 | 17.12 | 17.11            | Net8.0 | Net9.0 |
+| 9.0.200 | 17.13 | 17.12            | Net9.0 | Net9.0 |
+| 9.0.300 | 17.14 | 17.12            | Net9.0 | Net9.0 |
 
 > [!NOTE]
 > The table depicts how these versioning rules are applied, starting with .NET SDK 7.0.100 and .NET SDK 6.0.300. It also depicts how the policy would have applied to previously shipped versions of the .NET SDK, had it been in place then. However, the requirements for previous versions of the SDK don't change&mdash;that is, the minimum required version of Visual Studio for .NET SDK 6.0.100 or 6.0.200 remains 16.10.
-
-> <sup>1</sup> A breaking change in 7.0.300 for Blazor and Razor development requires Visual Studio version 17.6 or newer. For more information, see [dotnet/razor issue 8718](https://github.com/dotnet/razor/issues/8718).
+> 
+> Targeting `net8.0` is officially supported in Visual Studio 17.8+ only.
+> 
+> Targeting `net9.0` is officially supported in Visual Studio 17.12+ only.
+>
 
 To ensure consistent tooling, you should use `dotnet build` rather than `msbuild` to build your application when possible.
 
@@ -112,16 +107,10 @@ Major versions of the .NET SDK are typically released within a few days of a Vis
 
 | SDK preview version | Visual Studio version |
 |---------------------|-----------------------|
-| 9.0.100 Preview 1   | 17.10 Preview 1       |
-| 9.0.100 Preview 2   | 17.10 Preview 2       |
-| 9.0.100 Preview 3   | 17.10 Preview 3       |
-| 9.0.100 Preview 4   | 17.11 Preview 1       |
-| 9.0.100 Preview 5   | 17.11 Preview 2       |
-| 9.0.100 Preview 6   | 17.11 Preview 3       |
-| 9.0.100 Preview 7   | 17.12 Preview 1       |
 | 9.0.100 RC 1        | 17.12 Preview 2       |
 | 9.0.100 RC 2        | 17.12 Preview 3       |
 | 9.0.100 GA          | 17.12 GA              |
+| 10.0.100 Preview 1  | 17.14 Preview 1       |
 
 ## Reference
 


### PR DESCRIPTION
Added 9.0.2xx and 9.0.3xx bands
Added 10.0.100 preview 1
Moved the targeting information to the targeting section Removed some unnecessary notes
Remove the out of support versions from the target table


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/porting/versioning-sdk-msbuild-vs.md](https://github.com/dotnet/docs/blob/886fa7c4945c394f97f021fe6329cbb8de3df529/docs/core/porting/versioning-sdk-msbuild-vs.md) | [docs/core/porting/versioning-sdk-msbuild-vs](https://review.learn.microsoft.com/en-us/dotnet/core/porting/versioning-sdk-msbuild-vs?branch=pr-en-us-44418) |


<!-- PREVIEW-TABLE-END -->