### PR TITLE
Extract comments from code samples of "Program structure" article to get them translated

### DIFF
--- a/docs/csharp/fundamentals/program-structure/index.md
+++ b/docs/csharp/fundamentals/program-structure/index.md
@@ -12,9 +12,12 @@ C# programs consist of one or more files. Each file contains zero or more namesp
 
 :::code language="csharp" source="snippets/toplevel-structure/Program.cs":::
 
-The preceding example uses [*top-level statements*](top-level-statements.md) for the program's entry point. Only one file can have top-level statements. The program's entry point is the first line of program text in that file. You can also create a static method named [`Main`](main-command-line.md) as the program's entry point, as shown in the following example:
+The preceding example uses [*top-level statements*](top-level-statements.md) for the program's entry point. Only one file can have top-level statements. The program's entry point is the first line of program text in that file. In this case, it's the `Console.WriteLine("Hello world!");`.
+You can also create a static method named [`Main`](main-command-line.md) as the program's entry point, as shown in the following example:
 
 :::code language="csharp" source="snippets/structure/Program.cs":::
+
+In that case the program will start in the first line of `Main` method, which is `Console.WriteLine("Hello world!");`
 
 ## Related Sections
 

--- a/docs/csharp/fundamentals/program-structure/main-command-line.md
+++ b/docs/csharp/fundamentals/program-structure/main-command-line.md
@@ -17,12 +17,14 @@ helpviewer_keywords:
 The `Main` method is the entry point of a C# application. When the application is started, the `Main` method is the first method that is invoked.
 
 There can only be one entry point in a C# program. If you have more than one class that has a `Main` method, you must compile your program with the **StartupObject** compiler option to specify which `Main` method to use as the entry point. For more information, see [**StartupObject** (C# Compiler Options)](../../language-reference/compiler-options/advanced.md#mainentrypoint-or-startupobject).
+<br/>Below is the example which first line executed will display the number of command line arguments:
 
 :::code language="csharp" source="snippets/main-command-line/TestClass.cs":::
 
 You can also use Top-level statements in one file as the entry point for your application.
 Just as the `Main` method, top-level statements can also [return values](#main-return-values) and access [command-line arguments](#command-line-arguments).
 For more information, see [Top-level statements](top-level-statements.md).
+<br/>The following example uses `foreach` loop to display the command line arguments using the args variable, and at the end of the program returns a success code (`0`):
 
 :::code language="csharp" source="snippets/top-level-statements-1/Program.cs":::
 
@@ -84,6 +86,8 @@ Create a new application by running `dotnet new console`. Modify the `Main` meth
 
 :::code language="csharp" source="snippets/main-command-line/MainReturnValTest.cs":::
 
+Remember to save this program as *MainReturnValTest.cs*.
+
 When a program is executed in Windows, any value returned from the `Main` function is stored in an environment variable. This environment variable can be retrieved using `ERRORLEVEL` from a batch file, or `$LastExitCode` from PowerShell.
 
 You can build the application using the [dotnet CLI](../../../core/tools/dotnet.md) `dotnet build` command.
@@ -122,7 +126,6 @@ class AsyncMainReturnValTest
 
     private static async Task<int> AsyncConsoleWork()
     {
-        // Main body here
         return 0;
     }
 }
@@ -131,6 +134,8 @@ class AsyncMainReturnValTest
 This boilerplate code can be replaced by:
 
 :::code language="csharp" source="snippets/main-arguments/Program.cs" id="AsyncMain":::
+
+In both examples main body of the program is within the body of `AsyncConsoleWork()` method.
 
 An advantage of declaring `Main` as `async` is that the compiler always generates the correct code.
 
@@ -205,6 +210,10 @@ To compile and run the application from a command prompt, follow these steps:
 
     :::code language="csharp" source="./snippets/main-command-line/Factorial.cs":::
 
+At the beginning of the `Main` method the program tests if input arguments were not supplied comparing length of `args` argument to `0` and displays the help if no argument are found.
+<br/>If arguments are provided (`args.Length` is greater than 0) program tries to convert the input arguments to numbers. This will throw an exception if the argument is not a number.
+<br/>After factorial is calculated (stored in `result` variable of type `long`) the verbose result is printed depending on the `result` variable.
+
 2. From the **Start** screen or **Start** menu, open a Visual Studio **Developer Command Prompt** window, and then navigate to the folder that contains the file that you created.
 
 3. Enter the following command to compile the application.
@@ -217,7 +226,7 @@ To compile and run the application from a command prompt, follow these steps:
   
      `dotnet run -- 3`  
   
-5. The command produces this output: `The factorial of 3 is 6.`
+5. If 3 is entered on command line as the program's argument, the output reads: `The factorial of 3 is 6.`
 
 > [!NOTE]
 > When running an application in Visual Studio, you can specify command-line arguments in the [Debug Page, Project Designer](/visualstudio/ide/reference/debug-page-project-designer).

--- a/docs/csharp/fundamentals/program-structure/main-command-line.md
+++ b/docs/csharp/fundamentals/program-structure/main-command-line.md
@@ -17,14 +17,14 @@ helpviewer_keywords:
 The `Main` method is the entry point of a C# application. When the application is started, the `Main` method is the first method that is invoked.
 
 There can only be one entry point in a C# program. If you have more than one class that has a `Main` method, you must compile your program with the **StartupObject** compiler option to specify which `Main` method to use as the entry point. For more information, see [**StartupObject** (C# Compiler Options)](../../language-reference/compiler-options/advanced.md#mainentrypoint-or-startupobject).
-<br/>Below is the example which first line executed will display the number of command line arguments:
+<br/>Below is the example where the first line executed will display the number of command line arguments:
 
 :::code language="csharp" source="snippets/main-command-line/TestClass.cs":::
 
 You can also use Top-level statements in one file as the entry point for your application.
 Just as the `Main` method, top-level statements can also [return values](#main-return-values) and access [command-line arguments](#command-line-arguments).
 For more information, see [Top-level statements](top-level-statements.md).
-<br/>The following example uses `foreach` loop to display the command line arguments using the args variable, and at the end of the program returns a success code (`0`):
+<br/>The following example uses a `foreach` loop to display the command line arguments using the `args` variable, and at the end of the program returns a success code (`0`):
 
 :::code language="csharp" source="snippets/top-level-statements-1/Program.cs":::
 

--- a/docs/csharp/fundamentals/program-structure/main-command-line.md
+++ b/docs/csharp/fundamentals/program-structure/main-command-line.md
@@ -210,9 +210,9 @@ To compile and run the application from a command prompt, follow these steps:
 
     :::code language="csharp" source="./snippets/main-command-line/Factorial.cs":::
 
-At the beginning of the `Main` method the program tests if input arguments were not supplied comparing length of `args` argument to `0` and displays the help if no argument are found.
-<br/>If arguments are provided (`args.Length` is greater than 0) program tries to convert the input arguments to numbers. This will throw an exception if the argument is not a number.
-<br/>After factorial is calculated (stored in `result` variable of type `long`) the verbose result is printed depending on the `result` variable.
+    At the beginning of the `Main` method the program tests if input arguments were not supplied comparing length of `args` argument to `0` and displays the help if no argument are found.<br/>
+    If arguments are provided (`args.Length` is greater than 0) program tries to convert the input arguments to numbers. This will throw an exception if the argument is not a number.<br/>
+    After factorial is calculated (stored in `result` variable of type `long`) the verbose result is printed depending on the `result` variable.
 
 2. From the **Start** screen or **Start** menu, open a Visual Studio **Developer Command Prompt** window, and then navigate to the folder that contains the file that you created.
 

--- a/docs/csharp/fundamentals/program-structure/snippets/main-arguments/Program.cs
+++ b/docs/csharp/fundamentals/program-structure/snippets/main-arguments/Program.cs
@@ -10,7 +10,6 @@ class Program
 
     private static async Task<int> AsyncConsoleWork()
     {
-        // main body here 
         return 0;
     }
 }

--- a/docs/csharp/fundamentals/program-structure/snippets/main-command-line/Factorial.cs
+++ b/docs/csharp/fundamentals/program-structure/snippets/main-command-line/Factorial.cs
@@ -22,7 +22,6 @@ class MainClass
 {
     static int Main(string[] args)
     {
-        // Test if input arguments were supplied.
         if (args.Length == 0)
         {
             Console.WriteLine("Please enter a numeric argument.");
@@ -30,9 +29,6 @@ class MainClass
             return 1;
         }
 
-        // Try to convert the input arguments to numbers. This will throw
-        // an exception if the argument is not a number.
-        // num = int.Parse(args[0]);
         int num;
         bool test = int.TryParse(args[0], out num);
         if (!test)
@@ -42,10 +38,8 @@ class MainClass
             return 1;
         }
 
-        // Calculate factorial.
         long result = Functions.Factorial(num);
 
-        // Print result.
         if (result == -1)
             Console.WriteLine("Input must be >= 0 and <= 20.");
         else
@@ -54,6 +48,3 @@ class MainClass
         return 0;
     }
 }
-// If 3 is entered on command line, the
-// output reads: The factorial of 3 is 6.
-

--- a/docs/csharp/fundamentals/program-structure/snippets/main-command-line/MainReturnValTest.cs
+++ b/docs/csharp/fundamentals/program-structure/snippets/main-command-line/MainReturnValTest.cs
@@ -1,4 +1,3 @@
-// Save this program as MainReturnValTest.cs.
 class MainReturnValTest
 {
     static int Main()

--- a/docs/csharp/fundamentals/program-structure/snippets/main-command-line/TestClass.cs
+++ b/docs/csharp/fundamentals/program-structure/snippets/main-command-line/TestClass.cs
@@ -2,7 +2,6 @@
 {
     static void Main(string[] args)
     {
-        // Display the number of command line arguments.
         Console.WriteLine(args.Length);
     }
 }

--- a/docs/csharp/fundamentals/program-structure/snippets/structure/Program.cs
+++ b/docs/csharp/fundamentals/program-structure/snippets/structure/Program.cs
@@ -31,7 +31,6 @@ namespace YourNamespace
     {
         static void Main(string[] args)
         {
-            //Your program starts here...
             Console.WriteLine("Hello world!");
         }
     }

--- a/docs/csharp/fundamentals/program-structure/snippets/top-level-statements-1/Program.cs
+++ b/docs/csharp/fundamentals/program-structure/snippets/top-level-statements-1/Program.cs
@@ -3,7 +3,6 @@
 StringBuilder builder = new();
 builder.AppendLine("The following arguments are passed:");
 
-// Display the command line arguments using the args variable.
 foreach (var arg in args)
 {
     builder.AppendLine($"Argument={arg}");
@@ -11,5 +10,4 @@ foreach (var arg in args)
 
 Console.WriteLine(builder.ToString());
 
-// Return a success code.
 return 0;

--- a/docs/csharp/fundamentals/program-structure/snippets/toplevel-structure/Program.cs
+++ b/docs/csharp/fundamentals/program-structure/snippets/toplevel-structure/Program.cs
@@ -1,7 +1,5 @@
-﻿// A skeleton of a C# program
-using System;
+﻿using System;
 
-// Your program starts here:
 Console.WriteLine("Hello world!");
 
 namespace YourNamespace


### PR DESCRIPTION
This pull request closes #43924 

For all three pages of "Program structure" article this PR goes through all code snippets and moves comments from the code to the text (embedding them or explaining if needed, so they are not left out of context).

Only the last page "Top-level statements - programs without Main methods" does not contain code that would have comments requiring translations.
The only code snippet, in the `## using directives` section, was already moved in the previous page and the translated text does not relate to it.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/fundamentals/program-structure/index.md](https://github.com/dotnet/docs/blob/24f02b76198af231fa6d8c65729aee6dcaa9cd14/docs/csharp/fundamentals/program-structure/index.md) | [General Structure of a C# Program](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/program-structure/index?branch=pr-en-us-44422) |
| [docs/csharp/fundamentals/program-structure/main-command-line.md](https://github.com/dotnet/docs/blob/24f02b76198af231fa6d8c65729aee6dcaa9cd14/docs/csharp/fundamentals/program-structure/main-command-line.md) | [Main() and command-line arguments](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/program-structure/main-command-line?branch=pr-en-us-44422) |


<!-- PREVIEW-TABLE-END -->