### PR TITLE
fixing an issue in garbage-collection-etw-events.md

### DIFF
--- a/docs/framework/performance/garbage-collection-etw-events.md
+++ b/docs/framework/performance/garbage-collection-etw-events.md
@@ -266,7 +266,7 @@ The following table shows the keyword and level:
 
 |Keyword for raising the event|Level|
 |-----------------------------------|-----------|
-|`GCKeyword` (0x1)|Informational (4)|
+|`GCKeyword` (0x1)|Verbose (5)|
 
 The following table shows the event information:
 
@@ -292,7 +292,7 @@ The following table shows the keyword and level:
 
 |Keyword for raising the event|Level|
 |-----------------------------------|-----------|
-|`GCKeyword` (0x1)|Informational (4)|
+|`GCKeyword` (0x1)|Verbose (5)|
 
 The following table shows the event information:
 


### PR DESCRIPTION
the level for alloctick events is incorrect. should be verbose


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/performance/garbage-collection-etw-events.md](https://github.com/dotnet/docs/blob/96ccee011c30b309bb9998f9d348dc52b0bd249e/docs/framework/performance/garbage-collection-etw-events.md) | [Garbage Collection ETW Events](https://review.learn.microsoft.com/en-us/dotnet/framework/performance/garbage-collection-etw-events?branch=pr-en-us-44424) |

<!-- PREVIEW-TABLE-END -->