### PR TITLE
Lock auto-merge policy down a bit

### DIFF
--- a/.github/policies/label-prs.yml
+++ b/.github/policies/label-prs.yml
@@ -56,6 +56,8 @@ configuration:
           - payloadType: Pull_Request
           - isActivitySender:
               user: azure-sdk
+          - filesMatchPattern:
+              pattern: docs/azure/includes/*
         then:
           - addLabel:
               label: ":octocat: auto-merge"


### PR DESCRIPTION
Got the idea that a bad actor could impersonate the Azure SDK bot, so why not limit the auto-merge to only those files that we know the Azure SDK updates.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/policies/label-prs.yml](https://github.com/dotnet/docs/blob/8dc63379512f312381f71de28fa2746cd4adcf0a/.github/policies/label-prs.yml) | [.github/policies/label-prs](https://review.learn.microsoft.com/en-us/dotnet/.github/policies/label-prs?branch=pr-en-us-44427) |

<!-- PREVIEW-TABLE-END -->