### PR TITLE
Fix MSTEST0012/MSTEST0013 documentation about test class being static

### DIFF
--- a/docs/core/testing/mstest-analyzers/mstest0012.md
+++ b/docs/core/testing/mstest-analyzers/mstest0012.md
@@ -32,12 +32,12 @@ A method marked with `[AssemblyInitialize]` should have valid layout.
 
 Methods marked with `[AssemblyInitialize]` should follow the following layout to be valid:
 
-- it can't be declared on a generic class
 - it should be `public`
 - it should be `static`
 - it should not be `async void`
 - it should not be a special method (finalizer, operator...).
 - it should not be generic
+- it should not be abstract
 - it should take one parameter of type `TestContext`
 - return type should be `void`, `Task` or `ValueTask`
 
@@ -45,7 +45,6 @@ The type declaring these methods should also respect the following rules:
 
 - The type should be a class.
 - The class should be public or internal (if the test project is using the [DiscoverInternals] attribute).
-- The class shouldn't be static.
 - The class should be marked with [TestClass] (or a derived attribute)
 - the class should not be generic
 

--- a/docs/core/testing/mstest-analyzers/mstest0013.md
+++ b/docs/core/testing/mstest-analyzers/mstest0013.md
@@ -32,12 +32,12 @@ A method marked with `[AssemblyCleanup]` should have valid layout.
 
 Methods marked with `[AssemblyCleanup]` should follow the following layout to be valid:
 
-- it can't be declared on a generic class
 - it should be `public`
 - it should be `static`
 - it should not be `async void`
 - it should not be a special method (finalizer, operator...).
 - it should not be generic
+- it should not be abstract
 - it should not take any parameter, or starting with MSTest 3.8, it can have a single `TestContext` parameter
 - return type should be `void`, `Task` or `ValueTask`
 
@@ -45,7 +45,6 @@ The type declaring these methods should also respect the following rules:
 
 - The type should be a class.
 - The class should be public or internal (if the test project is using the [DiscoverInternals] attribute).
-- The class shouldn't be static.
 - The class should be marked with [TestClass] (or a derived attribute)
 - the class should not be generic
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/testfx/issues/3818

cc @Evangelink

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/mstest-analyzers/mstest0012.md](https://github.com/dotnet/docs/blob/479427ddcc832163fa356da322adfe6465422ece/docs/core/testing/mstest-analyzers/mstest0012.md) | [MSTEST0012: AssemblyInitialize method should have valid layout](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0012?branch=pr-en-us-44431) |
| [docs/core/testing/mstest-analyzers/mstest0013.md](https://github.com/dotnet/docs/blob/479427ddcc832163fa356da322adfe6465422ece/docs/core/testing/mstest-analyzers/mstest0013.md) | ["MSTEST0013: AssemblyCleanup method should have valid layout"](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0013?branch=pr-en-us-44431) |

<!-- PREVIEW-TABLE-END -->