### PR TITLE
Reference correct nuget package to align with Orleans 7 or later

### DIFF
--- a/docs/orleans/grains/index.md
+++ b/docs/orleans/grains/index.md
@@ -6,7 +6,7 @@ ms.date: 07/03/2024
 
 # Develop a grain
 
-Before you write code to implement a grain class, create a new Class Library project targeting .NET Standard or .NET Core (preferred) or .NET Framework 4.6.1 or higher (if you cannot use .NET Standard or .NET Core due to dependencies). Grain interfaces and grain classes can be defined in the same Class Library project, or in two different projects for better separation of interfaces from implementation. In either case, the projects need to reference [Microsoft.Orleans.Core.Abstractions](https://www.nuget.org/packages/Microsoft.Orleans.Core.Abstractions) and [Microsoft.Orleans.CodeGenerator.MSBuild](https://www.nuget.org/packages/Microsoft.Orleans.CodeGenerator.MSBuild) NuGet packages.
+Before you write code to implement a grain class, create a new Class Library project targeting .NET Standard or .NET Core (preferred) or .NET Framework 4.6.1 or higher (if you cannot use .NET Standard or .NET Core due to dependencies). Grain interfaces and grain classes can be defined in the same Class Library project, or in two different projects for better separation of interfaces from implementation. In either case, the projects need to reference the [Microsoft.Orleans.Sdk](https://www.nuget.org/packages/Microsoft.Orleans.Sdk) NuGet package.
 
 For more thorough instructions, see the [Project Setup](../tutorials-and-samples/tutorial-1.md#project-setup) section of [Tutorial One – Orleans Basics](../tutorials-and-samples/tutorial-1.md).
 


### PR DESCRIPTION
Reference the correct package needed in a grain class library in a modern Orleans project.

Users reading a "develop a grain" article are unlikely to want to learn about the older Orleans 3 approach. Also, the article that is linked to in the next paragraph covers that if needed.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/grains/index.md](https://github.com/dotnet/docs/blob/38863b5f67b4af8e151719e94b0c61a4bf12e829/docs/orleans/grains/index.md) | [Develop a grain](https://review.learn.microsoft.com/en-us/dotnet/orleans/grains/index?branch=pr-en-us-44433) |

<!-- PREVIEW-TABLE-END -->