### PR TITLE
[UUF] Move HTTP example out of main overview page for STJ

### DIFF
--- a/docs/core/whats-new/dotnet-5.md
+++ b/docs/core/whats-new/dotnet-5.md
@@ -134,7 +134,7 @@ For more information on project templates from the .NET CLI, see [`dotnet new`](
 There are new features in and for [System.Text.Json](../../standard/serialization/system-text-json/overview.md):
 
 - [Preserve references and handle circular references](../../standard/serialization/system-text-json/preserve-references.md)
-- [HttpClient and HttpContent extension methods](../../standard/serialization/system-text-json/overview.md#httpclient-and-httpcontent-extension-methods)
+- [Serialization extension methods on HttpClient](../../standard/serialization/system-text-json/httpclient-extensions.md)
 - [Allow or write numbers in quotes](../../standard/serialization/system-text-json/invalid-json.md#allow-or-write-numbers-in-quotes)
 - [Support immutable types and C# 9 Records](../../standard/serialization/system-text-json/immutability.md)
 - [Support non-public property accessors](../../standard/serialization/system-text-json/immutability.md)

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -761,6 +761,8 @@ items:
                     href: ../standard/serialization/system-text-json/preserve-references.md
                   - name: Serialize polymorphic types
                     href: ../standard/serialization/system-text-json/polymorphism.md
+                  - name: Serialize/deserialize network payloads
+                    href: ../standard/serialization/system-text-json/httpclient-extensions.md
                   - name: Read/write JSON without using JsonSerializer
                     items:
                       - name: Use DOM

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -761,7 +761,7 @@ items:
                     href: ../standard/serialization/system-text-json/preserve-references.md
                   - name: Serialize polymorphic types
                     href: ../standard/serialization/system-text-json/polymorphism.md
-                  - name: Serialize/deserialize network payloads
+                  - name: Use extension methods on HttpClient
                     href: ../standard/serialization/system-text-json/httpclient-extensions.md
                   - name: Read/write JSON without using JsonSerializer
                     items:

--- a/docs/standard/serialization/system-text-json/httpclient-extensions.md
+++ b/docs/standard/serialization/system-text-json/httpclient-extensions.md
@@ -1,12 +1,12 @@
 ---
-title: "Serialize and deserialize network payloads"
-description: Learn how to serialize and deserialize JSON payloads from the network in a single line of code using extension methods on HttpClient.
+title: "Serialization extension methods on HttpClient"
+description: Learn how to serialize and deserialize JSON payloads from the network in a single line of code using extension methods on HttpClient and HttpContent.
 ms.date: 01/19/2025
 dev_langs:
   - CSharp
   - VB
 ---
-# Serialize and deserialize network payloads
+# Serialization extension methods on HttpClient
 
 Serializing and deserializing JSON payloads from the network are common operations. Extension methods on [HttpClient](xref:System.Net.Http.Json.HttpClientJsonExtensions) and [HttpContent](xref:System.Net.Http.Json.HttpContentJsonExtensions) let you do these operations in a single line of code. These extension methods use [web defaults for JsonSerializerOptions](configure-options.md#web-defaults-for-jsonserializeroptions).
 

--- a/docs/standard/serialization/system-text-json/httpclient-extensions.md
+++ b/docs/standard/serialization/system-text-json/httpclient-extensions.md
@@ -1,0 +1,16 @@
+---
+title: "Serialize and deserialize network payloads"
+description: Learn how to serialize and deserialize JSON payloads from the network in a single line of code using extension methods on HttpClient.
+ms.date: 01/19/2025
+dev_langs:
+  - CSharp
+  - VB
+---
+# Serialize and deserialize network payloads
+
+Serializing and deserializing JSON payloads from the network are common operations. Extension methods on [HttpClient](xref:System.Net.Http.Json.HttpClientJsonExtensions) and [HttpContent](xref:System.Net.Http.Json.HttpContentJsonExtensions) let you do these operations in a single line of code. These extension methods use [web defaults for JsonSerializerOptions](configure-options.md#web-defaults-for-jsonserializeroptions).
+
+The following example illustrates use of <xref:System.Net.Http.Json.HttpClientJsonExtensions.GetFromJsonAsync%2A?displayProperty=nameWithType> and <xref:System.Net.Http.Json.HttpClientJsonExtensions.PostAsJsonAsync%2A?displayProperty=nameWithType>:
+
+:::code language="csharp" source="snippets/how-to-contd/csharp/HttpClientExtensionMethods.cs" highlight="23,30":::
+:::code language="vb" source="snippets/how-to-contd/vb/HttpClientExtensionMethods.vb":::

--- a/docs/standard/serialization/system-text-json/overview.md
+++ b/docs/standard/serialization/system-text-json/overview.md
@@ -1,7 +1,7 @@
 ---
 title: "Serialize and deserialize JSON using C#"
 description: This overview describes the System.Text.Json namespace functionality for serializing to and deserializing from JSON in .NET.
-ms.date: 10/18/2021
+ms.date: 01/19/2025
 no-loc: [System.Text.Json, Newtonsoft.Json]
 dev_langs:
   - CSharp

--- a/docs/standard/serialization/system-text-json/overview.md
+++ b/docs/standard/serialization/system-text-json/overview.md
@@ -1,5 +1,5 @@
 ---
-title: "Serialize and deserialize JSON using C# - .NET"
+title: "Serialize and deserialize JSON using C#"
 description: This overview describes the System.Text.Json namespace functionality for serializing to and deserializing from JSON in .NET.
 ms.date: 10/18/2021
 no-loc: [System.Text.Json, Newtonsoft.Json]
@@ -13,9 +13,9 @@ helpviewer_keywords:
   - "objects, serializing"
 ---
 
-# JSON serialization and deserialization (marshalling and unmarshalling) in .NET - overview
+# JSON serialization and deserialization in .NET - overview
 
-The <xref:System.Text.Json> namespace provides functionality for serializing to and deserializing from JavaScript Object Notation (JSON). *Serialization* is the process of converting the state of an object, that is, the values of its properties, into a form that can be stored or transmitted. The serialized form doesn't include any information about an object's associated methods. *Deserialization* reconstructs an object from the serialized form.
+The <xref:System.Text.Json> namespace provides functionality for serializing to and deserializing from (or marshalling and unmarshalling) JavaScript Object Notation (JSON). *Serialization* is the process of converting the state of an object, that is, the values of its properties, into a form that can be stored or transmitted. The serialized form doesn't include any information about an object's associated methods. *Deserialization* reconstructs an object from the serialized form.
 
 The `System.Text.Json` library design emphasizes high performance and low memory allocation over an extensive feature set. Built-in UTF-8 support optimizes the process of reading and writing JSON text encoded as UTF-8, which is the most prevalent encoding for data on the web and files on disk.
 
@@ -31,15 +31,13 @@ For framework versions earlier than .NET Core 3.0, install the [System.Text.Json
 
 * .NET Standard 2.0 and later
 * .NET Framework 4.6.2 and later
-* .NET Core 2.1 and later
-* .NET 5 and later
+* .NET 8 and later
 
 ## Namespaces and APIs
 
 * The <xref:System.Text.Json> namespace contains all the entry points and the main types.
 * The <xref:System.Text.Json.Serialization> namespace contains attributes and APIs for advanced scenarios and customization specific to serialization and deserialization.
-
-The code examples shown in this article require `using` directives for one or both of these namespaces.
+* The <xref:System.Net.Http.Json> namespace contains extension methods for [serializing and deserializing JSON payloads from the network](httpclient-extensions.md).
 
 > [!IMPORTANT]
 >
@@ -47,17 +45,6 @@ The code examples shown in this article require `using` directives for one or bo
 >
 > * Attributes from the <xref:System.Runtime.Serialization> namespace.
 > * The <xref:System.SerializableAttribute?displayProperty=fullName> attribute and the <xref:System.Runtime.Serialization.ISerializable> interface. These types are used only for [Binary and XML serialization](/previous-versions/dotnet/fundamentals/serialization/binary/binary-serialization).
-
-### HttpClient and HttpContent extension methods
-
-Serializing and deserializing JSON payloads from the network are common operations. Extension methods on [HttpClient](xref:System.Net.Http.Json.HttpClientJsonExtensions) and [HttpContent](xref:System.Net.Http.Json.HttpContentJsonExtensions) let you do these operations in a single line of code. These extension methods use [web defaults for JsonSerializerOptions](configure-options.md#web-defaults-for-jsonserializeroptions).
-
-The following example illustrates use of <xref:System.Net.Http.Json.HttpClientJsonExtensions.GetFromJsonAsync%2A?displayProperty=nameWithType> and <xref:System.Net.Http.Json.HttpClientJsonExtensions.PostAsJsonAsync%2A?displayProperty=nameWithType>:
-
-:::code language="csharp" source="snippets/how-to-contd/csharp/HttpClientExtensionMethods.cs" highlight="23,30":::
-:::code language="vb" source="snippets/how-to-contd/vb/HttpClientExtensionMethods.vb" :::
-
-There are also extension methods for System.Text.Json on [HttpContent](xref:System.Net.Http.Json.HttpContentJsonExtensions).
 
 ## Reflection vs. source generation
 


### PR DESCRIPTION
In response to UUF feedback: "Title is about dotnet serialization. The only example is with http methods, which is a very particular use case in dotnet. Not helpful if you want to serialize/ deserialize a file for instance. Or in a unit test."

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/whats-new/dotnet-5.md](https://github.com/dotnet/docs/blob/a25b9d74ce28accddeaca0661b96ed45cc395813/docs/core/whats-new/dotnet-5.md) | [What's new in .NET 5](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-5?branch=pr-en-us-44441) |
| [docs/fundamentals/toc.yml](https://github.com/dotnet/docs/blob/a25b9d74ce28accddeaca0661b96ed45cc395813/docs/fundamentals/toc.yml) | [docs/fundamentals/toc](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/toc?branch=pr-en-us-44441) |
| [docs/standard/serialization/system-text-json/httpclient-extensions.md](https://github.com/dotnet/docs/blob/a25b9d74ce28accddeaca0661b96ed45cc395813/docs/standard/serialization/system-text-json/httpclient-extensions.md) | [Serialization extension methods on HttpClient](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/httpclient-extensions?branch=pr-en-us-44441) |
| [docs/standard/serialization/system-text-json/overview.md](https://github.com/dotnet/docs/blob/a25b9d74ce28accddeaca0661b96ed45cc395813/docs/standard/serialization/system-text-json/overview.md) | [JSON serialization and deserialization in .NET - overview](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/overview?branch=pr-en-us-44441) |


<!-- PREVIEW-TABLE-END -->