### PR TITLE
Update MSTEST0003 to reflect that generic test methods are supported in 3.8+

### DIFF
--- a/docs/core/testing/mstest-analyzers/mstest0003.md
+++ b/docs/core/testing/mstest-analyzers/mstest0003.md
@@ -37,7 +37,7 @@ Test methods (methods marked with the `[TestMethod]` attribute) should follow th
 
 - they should be `public` (or `internal` if `[assembly: DiscoverInternals]` attribute is set)
 - they should not be `static`
-- they should not be generic
+- they should not be generic if using MSTest 3.7 or earlier
 - they should not be `abstract`
 - they should return `void` or `Task`
 - they should not be `async void`


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/mstest-analyzers/mstest0003.md](https://github.com/dotnet/docs/blob/3da456e639617d965e6bb04914e91c434298c584/docs/core/testing/mstest-analyzers/mstest0003.md) | [MSTEST0003: Test methods should have valid layout](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0003?branch=pr-en-us-44451) |

<!-- PREVIEW-TABLE-END -->