### PR TITLE
Document NETSDK1032 and NETSDK1144

### DIFF
--- a/docs/core/tools/sdk-errors/index.md
+++ b/docs/core/tools/sdk-errors/index.md
@@ -29,7 +29,6 @@ f1_keywords:
 - NETSDK1029
 - NETSDK1030
 - NETSDK1031
-- NETSDK1032
 - NETSDK1042
 - NETSDK1043
 - NETSDK1044
@@ -110,7 +109,6 @@ f1_keywords:
 - NETSDK1140
 - NETSDK1142
 - NETSDK1143
-- NETSDK1144
 - NETSDK1146
 - NETSDK1148
 - NETSDK1150
@@ -208,7 +206,7 @@ This list is a complete list of the errors that you might get from the .NET SDK 
 |NETSDK1029|Unable to use '{0}' as application host executable as it does not contain the expected placeholder byte sequence '{1}' that would mark where the application name would be written.|
 |NETSDK1030|Given file name '{0}' is longer than 1024 bytes.|
 |NETSDK1031|It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier. You must either specify a RuntimeIdentifier or set SelfContained to false.|
-|NETSDK1032|The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.|
+|[NETSDK1032](netsdk1032.md)|The RuntimeIdentifier platform '{0}' and the PlatformTarget '{1}' must be compatible.|
 |NETSDK1042|Could not load PlatformManifest from '{0}' because it did not exist.|
 |NETSDK1043|Error parsing PlatformManifest from '{0}' line {1}.  Lines must have the format {2}.|
 |NETSDK1044|Error parsing PlatformManifest from '{0}' line {1}.  {2} '{3}' was invalid.|
@@ -307,7 +305,7 @@ This list is a complete list of the errors that you might get from the .NET SDK 
 |[NETSDK1141](netsdk1141.md)|Unable to resolve the .NET SDK version as specified in the global.json located at {0}.|
 |NETSDK1142|Including symbols in a single file bundle is not supported when publishing for .NET5 or higher.|
 |NETSDK1143|Including all content in a single file bundle also includes native libraries. If IncludeAllContentForSelfExtract is true, IncludeNativeLibrariesForSelfExtract must not be false.|
-|NETSDK1144|Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.|
+|[NETSDK1144](netsdk1144.md)|Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false.|
 |[NETSDK1145](netsdk1145.md)|The {0} pack is not installed and NuGet package restore is not supported. Upgrade Visual Studio, remove global.json if it specifies a certain SDK version, and uninstall the newer SDK. For more options visit <https://aka.ms/targeting-apphost-pack-missing>. Pack Type:{0}, Pack directory: {1}, targetframework: {2}, Pack PackageId: {3}, Pack Package Version: {4}.|
 |NETSDK1146|PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.|
 |[NETSDK1147](netsdk1147.md)|To build this project, the following workloads must be installed: {0}.|

--- a/docs/core/tools/sdk-errors/netsdk1032.md
+++ b/docs/core/tools/sdk-errors/netsdk1032.md
@@ -18,51 +18,43 @@ The RID is specified in the project file or passed into the build process from t
 
 The `PlatformTarget` is specified in the project file or passed into the build process from the command line. If not specified, the default is `AnyCPU`.
 
-With `PlatformTarget` set to `AnyCPU`, the application can run on both 32-bit and 64-bit platforms. The runtime executes the app as 64-bit if the OS is 64-bit, and as 32-bit for a 32-bit OS.
+With `PlatformTarget` set to `AnyCPU`, the application can run on both 32-bit and 64-bit platforms. The runtime executes the app as 64-bit if the OS is 64-bit, and as 32-bit if the OS is 32-bit.
 
 Here's an example of a `.csproj` file with incompatible RID and `PlatformTarget` settings (an x86 RID and an x64 `PlatformTarget`):
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <PlatformTarget>x86</PlatformTarget>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
-
 </Project>
 ```
 
-Fix the error in the preceding `.csproj` file by changing either `PlatformTarget` or `RuntimeIdentifier`. For example:
+Fix the error in the preceding `.csproj` file by changing either `PlatformTarget` or `RuntimeIdentifier`. For example, change the PlatformTarget to match the RID:
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <!-- Change the PlatformTarget to match the RID. -->
     <PlatformTarget>x64</PlatformTarget>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
-
 </Project>
 ```
 
-Or:
+Or change the RID to match the `PlatformTarget`:
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <PlatformTarget>x86</PlatformTarget>
-    <!-- Change the RID to match the PlatformTarget. -->
     <RuntimeIdentifier>win-x86</RuntimeIdentifier>
   </PropertyGroup>
-
 </Project>
 ```

--- a/docs/core/tools/sdk-errors/netsdk1032.md
+++ b/docs/core/tools/sdk-errors/netsdk1032.md
@@ -1,45 +1,66 @@
 ---
-title: "NETSDK1144: Optimizing assemblies for size failed"
-description: How to resolve the optimizing for size failed message.
+title: "NETSDK1032: RuntimeIdentifier and PlatformTarget must be compatible."
+description: How to resolve the NETSDK1032 error 'RuntimeIdentifier and PlatformTarget must be compatible.'
 author: tdykstra
 ms.topic: error-reference
 ms.date: 01/14/2025
+ai-usage: ai-assisted
 f1_keywords:
-- NETSDK1144
+- NETSDK1032
 ---
-# NETSDK1144: Duplicate items were included
+# NETSDK1032: RuntimeIdentifier and PlatformTarget must be compatible
 
-**This article applies to:** ✔️ .NET Core 2.1.100 SDK and later versions
+The error `NETSDK1032` occurs when there is a mismatch between the `RuntimeIdentifier` (RID), such as `win-x64` or `linux-x64`, and the `PlatformTarget`, such as `x64` or `x86`. The full error message is similar to the following example:
 
-## Causes of .NET Build Error Code NETSDK1144
+> The `RuntimeIdentifier` platform '{RID}' and the `PlatformTarget` '{Target}' must be compatible.
 
-One cause of error code `NETSDK1144` is a `UseAppHost` property set to `true` in a project that targets a runtime identifier (RID) that does not support an application host. This typically happens when building a project for a platform that doesn't support generating an executable host.
+The RID is specified in the project file or passed into the build process from the command line. If not specified, the default RID used is `win-x64` for Windows, `linux-x64` for Linux, and `osx-x64` for macOS.
 
-## How to Fix NETSDK1144 Errors
+The `PlatformTarget` is specified in the project file or passed into the build process from the command line. If not specified, the default is `AnyCPU`. With `PlatformTarget` set to `AnyCPU`, the application can run on both 32-bit and 64-bit platforms. The runtime executes the app as 64-bit if the OS is 64-bit, and as 32-bit for a 32-bit OSif the OS is 32-bit.
 
-1. Check the Target Runtime Identifier (RID):
-   - Ensure that the RID specified in your project file is correct and supported for generating an application host.
-   - Some common RIDs are `win-x64`, `linux-x64`, `osx-x64`.
-
-2. Modify the `UseAppHost` Property or remove unsupported RIDs:
-   - If the target RID does not support an application host, set the `UseAppHost` property to `false` in your project file.
-   - If you're targeting multiple RIDs, remove any that don't support generating an application host.
-
-## Example Fix
-
-Here is an example of a `.csproj` file with the `UseAppHost` property set to `false`:
+Here's an example of a `.csproj` file with incompatible RID and `PlatformTarget` settings (x86 and x64):
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
-    <RuntimeIdentifier>linux-arm</RuntimeIdentifier>
-    <UseAppHost>false</UseAppHost>
+    <TargetFramework>net8.0</TargetFramework>
+    <PlatformTarget>x86</PlatformTarget>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
 
 </Project>
 ```
 
-In this example, the `UseAppHost` property is set to `false` because the `linux-arm` RID does not support generating an application host.
+Fix this error by changing either `PlatformTarget` or `RuntimeIdentifier`. For example:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <!-- Change the PlatformTarget to match the RID. -->
+    <PlatformTarget>x64</PlatformTarget>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+  </PropertyGroup>
+
+</Project>
+```
+
+Or:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <PlatformTarget>x86</PlatformTarget>
+    <!-- Change the RID to match the PlatformTarget. -->
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+  </PropertyGroup>
+
+</Project>
+```

--- a/docs/core/tools/sdk-errors/netsdk1032.md
+++ b/docs/core/tools/sdk-errors/netsdk1032.md
@@ -10,15 +10,17 @@ f1_keywords:
 ---
 # NETSDK1032: RuntimeIdentifier and PlatformTarget must be compatible
 
-The error `NETSDK1032` occurs when there is a mismatch between the `RuntimeIdentifier` (RID), such as `win-x64` or `linux-x64`, and the `PlatformTarget`, such as `x64` or `x86`. The full error message is similar to the following example:
+The error `NETSDK1032` occurs when there's a mismatch between the `RuntimeIdentifier` (RID), such as `win-x64` or `linux-x64`, and the `PlatformTarget`, such as `x64` or `x86`. The full error message is similar to the following example:
 
 > The `RuntimeIdentifier` platform '{RID}' and the `PlatformTarget` '{Target}' must be compatible.
 
 The RID is specified in the project file or passed into the build process from the command line. If not specified, the default RID used is `win-x64` for Windows, `linux-x64` for Linux, and `osx-x64` for macOS.
 
-The `PlatformTarget` is specified in the project file or passed into the build process from the command line. If not specified, the default is `AnyCPU`. With `PlatformTarget` set to `AnyCPU`, the application can run on both 32-bit and 64-bit platforms. The runtime executes the app as 64-bit if the OS is 64-bit, and as 32-bit for a 32-bit OSif the OS is 32-bit.
+The `PlatformTarget` is specified in the project file or passed into the build process from the command line. If not specified, the default is `AnyCPU`.
 
-Here's an example of a `.csproj` file with incompatible RID and `PlatformTarget` settings (x86 and x64):
+With `PlatformTarget` set to `AnyCPU`, the application can run on both 32-bit and 64-bit platforms. The runtime executes the app as 64-bit if the OS is 64-bit, and as 32-bit for a 32-bit OS.
+
+Here's an example of a `.csproj` file with incompatible RID and `PlatformTarget` settings (an x86 RID and an x64 `PlatformTarget`):
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
@@ -33,7 +35,7 @@ Here's an example of a `.csproj` file with incompatible RID and `PlatformTarget`
 </Project>
 ```
 
-Fix this error by changing either `PlatformTarget` or `RuntimeIdentifier`. For example:
+Fix the error in the preceding `.csproj` file by changing either `PlatformTarget` or `RuntimeIdentifier`. For example:
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">

--- a/docs/core/tools/sdk-errors/netsdk1032.md
+++ b/docs/core/tools/sdk-errors/netsdk1032.md
@@ -14,11 +14,9 @@ The error `NETSDK1032` occurs when there's a mismatch between the `RuntimeIdenti
 
 > The `RuntimeIdentifier` platform '{RID}' and the `PlatformTarget` '{Target}' must be compatible.
 
-The RID is specified in the project file or passed into the build process from the command line. If not specified, the default RID used is `win-x64` for Windows, `linux-x64` for Linux, and `osx-x64` for macOS.
+The RID is specified in the project file or the command line. If not specified, the default RID used is `win-x64` for Windows, `linux-x64` for Linux, and `osx-x64` for macOS.
 
-The `PlatformTarget` is specified in the project file or passed into the build process from the command line. If not specified, the default is `AnyCPU`.
-
-With `PlatformTarget` set to `AnyCPU`, the application can run on both 32-bit and 64-bit platforms. The runtime executes the app as 64-bit if the OS is 64-bit, and as 32-bit if the OS is 32-bit.
+The `PlatformTarget` is specified in the project file or the command line. If not specified, the default is `AnyCPU`.
 
 Here's an example of a `.csproj` file with incompatible RID and `PlatformTarget` settings:
 
@@ -33,7 +31,7 @@ Here's an example of a `.csproj` file with incompatible RID and `PlatformTarget`
 </Project>
 ```
 
-Fix the error in the preceding `.csproj` file by changing either `PlatformTarget` or `RuntimeIdentifier`. For example, change the PlatformTarget to match the RID:
+Fix the preceding `.csproj` file by changing either `PlatformTarget` or `RuntimeIdentifier`. For example, change `PlatformTarget` to match the RID:
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">

--- a/docs/core/tools/sdk-errors/netsdk1032.md
+++ b/docs/core/tools/sdk-errors/netsdk1032.md
@@ -1,0 +1,45 @@
+---
+title: "NETSDK1144: Optimizing assemblies for size failed"
+description: How to resolve the optimizing for size failed message.
+author: tdykstra
+ms.topic: error-reference
+ms.date: 01/14/2025
+f1_keywords:
+- NETSDK1144
+---
+# NETSDK1144: Duplicate items were included
+
+**This article applies to:** ✔️ .NET Core 2.1.100 SDK and later versions
+
+## Causes of .NET Build Error Code NETSDK1144
+
+One cause of error code `NETSDK1144` is a `UseAppHost` property set to `true` in a project that targets a runtime identifier (RID) that does not support an application host. This typically happens when building a project for a platform that doesn't support generating an executable host.
+
+## How to Fix NETSDK1144 Errors
+
+1. Check the Target Runtime Identifier (RID):
+   - Ensure that the RID specified in your project file is correct and supported for generating an application host.
+   - Some common RIDs are `win-x64`, `linux-x64`, `osx-x64`.
+
+2. Modify the `UseAppHost` Property or remove unsupported RIDs:
+   - If the target RID does not support an application host, set the `UseAppHost` property to `false` in your project file.
+   - If you're targeting multiple RIDs, remove any that don't support generating an application host.
+
+## Example Fix
+
+Here is an example of a `.csproj` file with the `UseAppHost` property set to `false`:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <RuntimeIdentifier>linux-arm</RuntimeIdentifier>
+    <UseAppHost>false</UseAppHost>
+  </PropertyGroup>
+
+</Project>
+```
+
+In this example, the `UseAppHost` property is set to `false` because the `linux-arm` RID does not support generating an application host.

--- a/docs/core/tools/sdk-errors/netsdk1032.md
+++ b/docs/core/tools/sdk-errors/netsdk1032.md
@@ -20,7 +20,7 @@ The `PlatformTarget` is specified in the project file or passed into the build p
 
 With `PlatformTarget` set to `AnyCPU`, the application can run on both 32-bit and 64-bit platforms. The runtime executes the app as 64-bit if the OS is 64-bit, and as 32-bit if the OS is 32-bit.
 
-Here's an example of a `.csproj` file with incompatible RID and `PlatformTarget` settings (an x86 RID and an x64 `PlatformTarget`):
+Here's an example of a `.csproj` file with incompatible RID and `PlatformTarget` settings:
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">

--- a/docs/core/tools/sdk-errors/netsdk1144.md
+++ b/docs/core/tools/sdk-errors/netsdk1144.md
@@ -1,0 +1,44 @@
+---
+title: "NETSDK1144: Optimizing assemblies for size failed"
+description: How to resolve the 'optimizing for size failed' message.
+author: tdykstra
+ms.topic: error-reference
+ms.date: 01/14/2025
+ai-usage: ai-assisted
+f1_keywords:
+- NETSDK1144
+---
+# NETSDK1144: Optimizing assemblies for size failed
+
+## Error Message
+
+The error `NETSDK1144` is reported when an error occurs in the trimming process. The full error message is similar to the following example:
+
+> Optimizing assemblies for size failed. Optimization can be disabled by setting the `PublishTrimmed` property to false.
+
+Set the `PublishTrimmed` property to `false` in the project file or the command line:
+
+   ```xml
+   <PropertyGroup>
+     <PublishTrimmed>false</PublishTrimmed>
+   </PropertyGroup>
+   ```
+
+   ```dotnetcli
+   dotnet publish /p:PublishTrimmed=false
+   ```
+
+Here's an example of a `.csproj` file with trimming disabled:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeIdentifier>linux-arm</RuntimeIdentifier>
+    <PublishTrimmed>false</PublishTrimmed>
+  </PropertyGroup>
+
+</Project>
+```

--- a/docs/core/tools/sdk-errors/netsdk1144.md
+++ b/docs/core/tools/sdk-errors/netsdk1144.md
@@ -16,7 +16,7 @@ The error `NETSDK1144` is reported when an error occurs in the trimming process.
 
 > Optimizing assemblies for size failed. Optimization can be disabled by setting the `PublishTrimmed` property to false.
 
-Set the `PublishTrimmed` property to `false` in the project file or the command line:
+To disable trimming, set the `PublishTrimmed` property to `false` in the project file or the command line:
 
    ```xml
    <PropertyGroup>
@@ -32,13 +32,11 @@ Here's an example of a `.csproj` file with trimming disabled:
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <RuntimeIdentifier>linux-arm</RuntimeIdentifier>
     <PublishTrimmed>false</PublishTrimmed>
   </PropertyGroup>
-
 </Project>
 ```

--- a/docs/navigate/tools-diagnostics/toc.yml
+++ b/docs/navigate/tools-diagnostics/toc.yml
@@ -33,6 +33,8 @@ items:
                 href: ../../core/tools/sdk-errors/netsdk1013.md
               - name: NETSDK1022
                 href: ../../core/tools/sdk-errors/netsdk1022.md
+              - name: NETSDK1032
+                href: ../../core/tools/sdk-errors/netsdk1032.md
               - name: NETSDK1045
                 href: ../../core/tools/sdk-errors/netsdk1045.md
               - name: NETSDK1059
@@ -67,6 +69,8 @@ items:
                 href: ../../core/tools/sdk-errors/netsdk1138.md
               - name: NETSDK1141
                 href: ../../core/tools/sdk-errors/netsdk1141.md
+              - name: NETSDK1144
+                href: ../../core/tools/sdk-errors/netsdk1144.md
               - name: NETSDK1145
                 href: ../../core/tools/sdk-errors/netsdk1145.md
               - name: NETSDK1147


### PR DESCRIPTION
Fixes #44285 
Fixes #44286 

@keylime-unicorn This PR addresses the documentation gap you noted for NETSDK errors 1032 and 1144 in your 1/9/25 email. The work is tracked in the two issues noted above as fixed.

@marcpopMSFT Please review or suggest a reviewer..

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/sdk-errors/index.md](https://github.com/dotnet/docs/blob/411d52e3108d3fc74840f31ae7666e22def4b9d5/docs/core/tools/sdk-errors/index.md) | [.NET SDK error list](https://review.learn.microsoft.com/en-us/dotnet/core/tools/sdk-errors/index?branch=pr-en-us-44452) |
| [docs/core/tools/sdk-errors/netsdk1032.md](https://github.com/dotnet/docs/blob/411d52e3108d3fc74840f31ae7666e22def4b9d5/docs/core/tools/sdk-errors/netsdk1032.md) | ["NETSDK1032: RuntimeIdentifier and PlatformTarget must be compatible."](https://review.learn.microsoft.com/en-us/dotnet/core/tools/sdk-errors/netsdk1032?branch=pr-en-us-44452) |
| [docs/core/tools/sdk-errors/netsdk1144.md](https://github.com/dotnet/docs/blob/411d52e3108d3fc74840f31ae7666e22def4b9d5/docs/core/tools/sdk-errors/netsdk1144.md) | [NETSDK1144: Optimizing assemblies for size failed](https://review.learn.microsoft.com/en-us/dotnet/core/tools/sdk-errors/netsdk1144?branch=pr-en-us-44452) |
| [docs/navigate/tools-diagnostics/toc.yml](https://github.com/dotnet/docs/blob/411d52e3108d3fc74840f31ae7666e22def4b9d5/docs/navigate/tools-diagnostics/toc.yml) | [docs/navigate/tools-diagnostics/toc](https://review.learn.microsoft.com/en-us/dotnet/navigate/tools-diagnostics/toc?branch=pr-en-us-44452) |


<!-- PREVIEW-TABLE-END -->