### PR TITLE
Update supported status of .NET 6

### DIFF
--- a/docs/core/tools/sdk-errors/netsdk1138.md
+++ b/docs/core/tools/sdk-errors/netsdk1138.md
@@ -12,7 +12,7 @@ NETSDK1138 indicates that your project targets a version of the framework that i
 
 > The target framework '\<framework>' is out of support and will not receive security updates in the future. Please refer to <https://aka.ms/dotnet-core-support> for more information about the support policy.
 
-Out-of-support versions include 1.0, 1.1, 2.0, 2.1, 2.2, 3.0, 3.1, 5 and 6.
+Out-of-support versions include 1.0, 1.1, 2.0, 2.1, 2.2, 3.0, 3.1, 5, 6, and 7.
 
 To resolve this error, change your project to target a supported version of .NET.
 

--- a/docs/core/tools/sdk-errors/netsdk1138.md
+++ b/docs/core/tools/sdk-errors/netsdk1138.md
@@ -12,7 +12,7 @@ NETSDK1138 indicates that your project targets a version of the framework that i
 
 > The target framework '\<framework>' is out of support and will not receive security updates in the future. Please refer to <https://aka.ms/dotnet-core-support> for more information about the support policy.
 
-Out-of-support versions include 1.0, 1.1, 2.0, 2.1, 2.2, 3.0, 3.1, and 5.0.
+Out-of-support versions include 1.0, 1.1, 2.0, 2.1, 2.2, 3.0, 3.1, 5 and 6.
 
 To resolve this error, change your project to target a supported version of .NET.
 


### PR DESCRIPTION
Fixes #43896 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/sdk-errors/netsdk1138.md](https://github.com/dotnet/docs/blob/d095dcb4db81cfaead5047c863c2e3ca55db328a/docs/core/tools/sdk-errors/netsdk1138.md) | [NETSDK1138: The target framework is out of support](https://review.learn.microsoft.com/en-us/dotnet/core/tools/sdk-errors/netsdk1138?branch=pr-en-us-44453) |


<!-- PREVIEW-TABLE-END -->