### PR TITLE
Fix "nullable to primitive type" snippets in nullable-value-types.md

### DIFF
--- a/docs/fsharp/language-reference/nullable-value-types.md
+++ b/docs/fsharp/language-reference/nullable-value-types.md
@@ -108,10 +108,10 @@ You can also use an appropriate non-nullable operator to convert to a primitive 
 open System
 open FSharp.Linq
 
-let nullableInt = Nullable 10
-let nullableFloat = Nullable.float nullableInt
+let nullableFloat = Nullable 10.0
+let standardFloat = float nullableFloat
 
-printfn $"value is %f{float nullableFloat}"
+printfn $"value is %f{float standardFloat}"
 ```
 
 You can also use nullable operators as a short-hand for checking `HasValue` and `Value`:


### PR DESCRIPTION
## Summary

Hello,

when reading the documentation for F# nullable I found the second snippet equivalent to the one above.

![CleanShot 2025-01-22 at 10 19 28](https://github.com/user-attachments/assets/91b670f8-2504-46b8-8cd0-1f3f329710f4)

This seems suspicious to me, so I am mostly opening this PR to trigger a discussion with the F# team to check if this is expected or not.

After experimenting with the code, I think the intended snippet is something like proposed in this PR:

```fs
open System
open FSharp.Linq

let nullableFloat = Nullable 10.0
let standardFloat = float nullableFloat

printfn $"value is %f{float standardFloat}"
```

Can someone from the F# team confirm or invalidate my suspicions?




<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/nullable-value-types.md](https://github.com/dotnet/docs/blob/42cfe1851f642c044b5e017164973a0b15813923/docs/fsharp/language-reference/nullable-value-types.md) | [docs/fsharp/language-reference/nullable-value-types](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/nullable-value-types?branch=pr-en-us-44456) |

<!-- PREVIEW-TABLE-END -->