### PR TITLE
Add link to .NET Aspire API ref

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -372,9 +372,9 @@ additionalContent:
           summary: API reference documentation for ML.NET
           url: ../api/index.md?view=ml-dotnet&preserve-view=true
         # Card
-        - title: ".NET Package-provided API reference"
-          summary: Reference documentation for package-provided .NET APIs
-          url: ../api/index.md?view=dotnet-9.0-pp&preserve-view=true
+        - title: ".NET Aspire API reference"
+          summary: Reference documentation for .NET Aspire
+          url: ../api/index.md?view=dotnet-aspire-9.0&preserve-view=true
         # Card
         - title: "C# language reference"
           summary: C# language reference and specification


### PR DESCRIPTION
The platform extensions monikers don't exist anymore, so needed to replace that card with something else.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/index.yml](https://github.com/dotnet/docs/blob/1b92c93fe432900a7ad7b9a037b6c85cbd493ed0/docs/index.yml) | [highlightedContent section (optional)](https://review.learn.microsoft.com/en-us/dotnet/index?branch=pr-en-us-44488) |

<!-- PREVIEW-TABLE-END -->