### PR TITLE
Using default namespace with System.Xml.Linq.XAttribute explained.

### DIFF
--- a/docs/standard/linq/create-document-namespaces-csharp.md
+++ b/docs/standard/linq/create-document-namespaces-csharp.md
@@ -1,7 +1,7 @@
 ---
 title: How to create a document with namespaces in C# - LINQ to XML
 description: Use the XNamespace object in C# to create documents that have default namespaces or namespaces with a prefix.
-ms.date: 07/20/2015
+ms.date: 01/23/2025
 ms.topic: how-to
 ---
 
@@ -60,6 +60,8 @@ The following example shows the creation of a document that contains two namespa
 
 By including namespace attributes in the root element, the namespaces are serialized so that `http://www.adventure-works.com` is the default namespace, and `www.fourthcoffee.com` is serialized with a prefix of `fc`. To create an attribute that declares a default namespace, you create an attribute with the name `xmlns`, without a namespace. The value of the attribute is the default namespace URI.
 
+If a default namespace declaration is in scope, it applies to child `XElement` objects by prefixing their local names with the corresponding `XNamespace` object. On the other hand, default namespace declarations do not apply directly to attribute names. So, `XAttribute` objects in the default namespace are defined by *not* prefixing their local name with the corresponding `XNamespace` object.
+
 ```csharp
 // The http://www.adventure-works.com namespace is forced to be the default namespace.
 XNamespace aw = "http://www.adventure-works.com";
@@ -70,8 +72,14 @@ XElement root = new XElement(aw + "Root",
     new XElement(fc + "Child",
         new XElement(aw + "DifferentChild", "other content")
     ),
-    new XElement(aw + "Child2", "c2 content"),
-    new XElement(fc + "Child3", "c3 content")
+    new XElement(aw + "Child2", "c2 content",
+        new XAttribute("DefaultNs", "default namespace"),
+        new XAttribute(fc + "PrefixedNs", "prefixed namespace")
+    ),
+    new XElement(fc + "Child3", "c3 content",
+        new XAttribute("DefaultNs", "default namespace"),
+        new XAttribute(fc + "PrefixedNs", "prefixed namespace")
+    )
 );
 Console.WriteLine(root);
 ```
@@ -83,8 +91,9 @@ This example produces the following output:
   <fc:Child>
     <DifferentChild>other content</DifferentChild>
   </fc:Child>
-  <Child2>c2 content</Child2>
-  <fc:Child3>c3 content</fc:Child3>
+  <Child2 DefaultNs="default namespace" fc:PrefixedNs="prefixed namespace">c2 content</Child2>
+  <fc:Child3 DefaultNs="default namespace" fc:PrefixedNs="prefixed namespace">c3 content</fc:Child3>
+
 </Root>
 ```
 


### PR DESCRIPTION
## Summary

The current documentation on "[How to create a document with namespaces in C# (LINQ to XML)](https://learn.microsoft.com/en-us/dotnet/standard/linq/create-document-namespaces-csharp)" doesn't explain how to handle the creation of new [`XAttribute`](https://learn.microsoft.com/en-us/dotnet/api/system.xml.linq.xattribute) objects that are supposed to have the enclosing [`XElement`](https://learn.microsoft.com/en-us/dotnet/api/system.xml.linq.xelement)'s default namespace applied, e.g.:

```xml
<root xmlns="default/namespace">
  <element attribute="value"/>
</root>
```

Without documentation, there are two options that might be hypothetically applicable for creating the correct XML with LINQ to XML in C#:

1. ```xml
   XNamespace ns = new XNamespace("default/namespace");
   ...
   new XElement(ns + "element", new XAttribute(ns + "attribute", "value"))
   ```
3. ```xml
   XNamespace ns = new XNamespace("default/namespace");
   ...
   new XElement(ns + "element", new XAttribute("attribute", "value"))
   ```

This pull request amends one of the examples by including information on how to create `XAttribute` objects applying to a default namespace.

Fixes #44499
and https://github.com/dotnet/runtime/issues/111703


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/linq/create-document-namespaces-csharp.md](https://github.com/dotnet/docs/blob/e239410252f763ec67341882a4f36e7c2ab18cee/docs/standard/linq/create-document-namespaces-csharp.md) | [How to create a document with namespaces in C# (LINQ to XML)](https://review.learn.microsoft.com/en-us/dotnet/standard/linq/create-document-namespaces-csharp?branch=pr-en-us-44501) |

<!-- PREVIEW-TABLE-END -->