### PR TITLE
add 'return' keyword in sample code

### DIFF
--- a/docs/orleans/grains/grain-identity.md
+++ b/docs/orleans/grains/grain-identity.md
@@ -152,7 +152,7 @@ public class ExampleGrain : Orleans.Grain, IExampleGrain
         long primaryKey = this.GetPrimaryKeyLong(out string keyExtension);
         Console.WriteLine($"Hello from {keyExtension}");
 
-        Task.CompletedTask;
+        return Task.CompletedTask;
     }
 }
 ```


### PR DESCRIPTION
## Summary
In this page [https://learn.microsoft.com/en-us/dotnet/orleans/grains/grain-identity](https://learn.microsoft.com/en-us/dotnet/orleans/grains/grain-identity) ,the sample code lack the 'return' keyword 
![image](https://github.com/user-attachments/assets/6b348e9e-fb54-4ae5-88fb-6605a86921bd)



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/grains/grain-identity.md](https://github.com/dotnet/docs/blob/53bc19de61ff7a61d4b2e64e6354536e160c583d/docs/orleans/grains/grain-identity.md) | [Grain identity](https://review.learn.microsoft.com/en-us/dotnet/orleans/grains/grain-identity?branch=pr-en-us-44506) |

<!-- PREVIEW-TABLE-END -->