### PR TITLE
Update Visual Basic Build Commands to Use dotnet build Instead of VBC

### DIFF
--- a/docs/visual-basic/reference/command-line-compiler/index.md
+++ b/docs/visual-basic/reference/command-line-compiler/index.md
@@ -12,17 +12,17 @@ ms.assetid: 6b57c444-50c7-4b88-8f59-ed65cff5e05c
 ---
 # Visual Basic command-line compiler
 
-The Visual Basic command-line compiler provides an alternative to compiling programs from within the Visual Studio integrated development environment (IDE). This section contains descriptions for the Visual Basic compiler options.
+The `dotnet build` command now replaces the Visual Basic command-line compiler (`VBC`) as the primary tool for compiling programs outside the Visual Studio integrated development environment (IDE). This section contains descriptions for the Visual Basic compiler options.
 
 [!INCLUDE[compiler-options](~/includes/compiler-options.md)]
   
 ## In this section
 
 [Building from the Command Line](building-from-the-command-line.md)  
-Describes the Visual Basic command-line compiler, which is provided as an alternative to compiling programs from within the Visual Studio IDE.
+Describes how to use `dotnet build` to compile Visual Basic applications, which replaces the legacy Visual Basic command-line compiler (`VBC`) as an alternative to compiling programs from within the Visual Studio IDE.
 
 [Visual Basic Compiler Options Listed Alphabetically](compiler-options-listed-alphabetically.md)  
-Lists compiler options in an alphabetical table
+Lists compiler options in an alphabetical table.
 
 [Visual Basic Compiler Options Listed by Category](compiler-options-listed-by-category.md)  
 Presents compiler options in functional groups.


### PR DESCRIPTION
## Summary

This PR updates the documentation to reflect the use of the modern `dotnet build` command for compiling Visual Basic applications, replacing references to the legacy Visual Basic command-line compiler (`VBC`).

### Key Changes:
- Replaced mentions of `VBC` with `dotnet build` to align with current .NET build practices.
- Updated the description and the "Building from the Command Line" section to clarify that `dotnet build` is now the primary build tool for Visual Basic programs outside the Visual Studio IDE.
- Ensured all references are consistent with the modern .NET ecosystem.

Fixes #40060 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/visual-basic/reference/command-line-compiler/index.md](https://github.com/dotnet/docs/blob/ebf9113677ffcc1158459e1f737e97cf497cb678/docs/visual-basic/reference/command-line-compiler/index.md) | [Visual Basic command-line compiler](https://review.learn.microsoft.com/en-us/dotnet/visual-basic/reference/command-line-compiler/index?branch=pr-en-us-44511) |

<!-- PREVIEW-TABLE-END -->