### PR TITLE
Enhance F# Options Documentation: Add Conversion Examples to "Converting to Other Types" Section

### DIFF
--- a/docs/fsharp/language-reference/options.md
+++ b/docs/fsharp/language-reference/options.md
@@ -61,6 +61,21 @@ The option module also includes functions that correspond to the functions that 
 
 Options can be converted to lists or arrays. When an option is converted into either of these data structures, the resulting data structure has zero or one element. To convert an option to an array, use [`Option.toArray`](https://fsharp.github.io/fsharp-core-docs/reference/fsharp-core-optionmodule.html#toArray). To convert an option to a list, use [`Option.toList`](https://fsharp.github.io/fsharp-core-docs/reference/fsharp-core-optionmodule.html#toList).
 
+### Converting Options with Default Values
+
+In addition to converting to lists and arrays, options can be converted to other types by providing default values using the `Option.defaultValue` function. This is particularly useful when you want to ensure that the value is not `None`. For example:
+
+```fsharp
+let optionString = Some("F#")
+let defaultString = optionString |> Option.defaultValue ""
+// defaultString is "F#"
+
+let optionInt = None
+let defaultInt = optionInt |> Option.defaultValue 0
+// defaultInt is 0
+
+The `Option.defaultValue` function allows you to handle both `Some` and `None` cases seamlessly without pattern matching.
+
 ## See also
 
 - [F# Language Reference](index.md)

--- a/docs/fsharp/language-reference/options.md
+++ b/docs/fsharp/language-reference/options.md
@@ -73,6 +73,7 @@ let defaultString = optionString |> Option.defaultValue ""
 let optionInt = None
 let defaultInt = optionInt |> Option.defaultValue 0
 // defaultInt is 0
+```
 
 The `Option.defaultValue` function allows you to handle both `Some` and `None` cases seamlessly without pattern matching.
 


### PR DESCRIPTION
## Summary

This PR enhances the F# Options documentation by providing additional examples and guidance in the "Converting to Other Types" section. The updates include:

- Added examples of using the `Option.defaultValue` function to convert options to default values for `string` and `int` types.
- Highlighted practical scenarios to avoid `None` values and simplify handling with `Option.defaultValue`.
- Improved accessibility for beginners by offering a more comprehensive explanation of converting options without diving directly into pattern matching.

Fixes #40039 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/options.md](https://github.com/dotnet/docs/blob/d3b859931efa0c2d3e32c8d75b0913a27a6691df/docs/fsharp/language-reference/options.md) | [Options](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/options?branch=pr-en-us-44512) |


<!-- PREVIEW-TABLE-END -->