### PR TITLE
Use 'LogWarning' method in examples

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca2254.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2254.md
@@ -36,7 +36,7 @@ var lastName = "Otto";
 
 // This tells the logger that there are FirstName and LastName properties
 // on the log message, and correlates them with the argument values.
-logger.Warning("Person {FirstName} {LastName} encountered an issue", firstName, lastName);
+logger.LogWarning("Person {FirstName} {LastName} encountered an issue", firstName, lastName);
 ```
 
 Not preferred:
@@ -48,10 +48,10 @@ var firstName = "Lorenz";
 var lastName = "Otto";
 
 // Here, the log template itself is changing, and the association between named placeholders and their values is lost.
-logger.Warning("Person " + firstName + " " + lastName + " encountered an issue");
+logger.LogWarning("Person " + firstName + " " + lastName + " encountered an issue");
 
 // String interpolation also loses the association between placeholder names and their values.
-logger.Warning($"Person {firstName} {lastName} encountered an issue");
+logger.LogWarning($"Person {firstName} {lastName} encountered an issue");
 ```
 
 The logging message template should not vary between calls.
@@ -61,7 +61,7 @@ The logging message template should not vary between calls.
 Update the message template to be a constant expression. If you're using values directly in the template, refactor the template to use named placeholders instead.
 
 ```csharp
-logger.Warning("Person {FirstName} {LastName} encountered an issue", firstName, lastName);
+logger.LogWarning("Person {FirstName} {LastName} encountered an issue", firstName, lastName);
 ```
 
 For usage examples, see the <xref:Microsoft.Extensions.Logging.LoggerExtensions.LogInformation%2A?displayProperty=nameWithType> method.


### PR DESCRIPTION
The current method used by examples, `Warning`, does not exist


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca2254.md](https://github.com/dotnet/docs/blob/819b7d7443de2e75953c31e760de369fa236cf83/docs/fundamentals/code-analysis/quality-rules/ca2254.md) | [CA2254: Template should be a static expression](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2254?branch=pr-en-us-44515) |


<!-- PREVIEW-TABLE-END -->