### PR TITLE
Update MSTEST0015 doc to reflect enabled by default change in 3.8

### DIFF
--- a/docs/core/testing/mstest-analyzers/mstest0015.md
+++ b/docs/core/testing/mstest-analyzers/mstest0015.md
@@ -19,7 +19,7 @@ ms.author: enjieid
 | **Title**                           | Test method should not be ignored            |
 | **Category**                        | Design                                       |
 | **Fix is breaking or non-breaking** | Non-breaking                                 |
-| **Enabled by default**              | Yes                                          |
+| **Enabled by default**              | Yes (from 3.3 to 3.7). No (starting with 3.8)|
 | **Default severity**                | Info                                         |
 | **Introduced in version**           | 3.3.0                                        |
 | **Is there a code fix**             | No                                           |


### PR DESCRIPTION
Product PR: https://github.com/microsoft/testfx/pull/4784

cc @Evangelink

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/mstest-analyzers/mstest0015.md](https://github.com/dotnet/docs/blob/7aac2ce994c7dd294d31e42b197278f500c42694/docs/core/testing/mstest-analyzers/mstest0015.md) | [MSTEST0015: Test method should not be ignored](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0015?branch=pr-en-us-44525) |

<!-- PREVIEW-TABLE-END -->