### PR TITLE
HttpClientFactory Keyed DI docs

### DIFF
--- a/docs/core/extensions/httpclient-factory-keyed-di.md
+++ b/docs/core/extensions/httpclient-factory-keyed-di.md
@@ -37,7 +37,7 @@ Endpoint response:
 
 In the example, the configured `HttpClient` is injected into the request handler through the standard Keyed DI infrastructure, which is integrated into ASP.NET Core parameter binding. For more information on Keyed Services in ASP.NET Core, see [Dependency injection in ASP.NET Core](/aspnet/core/fundamentals/dependency-injection#keyed-services).
 
-## Approach comparison
+## Comparison of Keyed, Named, and Typed approaches
 
 Consider only the `IHttpClientFactory`-related code from the [Basic Usage](#basic-usage) example:
 
@@ -131,7 +131,7 @@ If you call `AddAsKeyed()` within a Typed client registration, only the underlyi
 ### Avoid transient HttpClient memory leak
 
 > [!IMPORTANT]
-> `HttpClient` is `IDisposable`, so we strongly recommend _avoiding_ Transient lifetime for Keyed `HttpClient`s.
+> `HttpClient` is `IDisposable`, so we strongly recommend _avoiding_ Transient lifetime for Keyed `HttpClient` instances.
 >
 > Registering the client as a Keyed Transient service leads to the `HttpClient` and `HttpMessageHandler` instances being _captured by DI container_, as both implement `IDisposable`. This can result in _memory leaks_ if the client is resolved multiple times within Singleton services.
 
@@ -215,7 +215,7 @@ Technically, the example "unwraps" the Typed client, so that the previously "hid
 
 ## How to: Opt in to Keyed DI by default
 
-You don't have to call `AddAsKeyed` for every single client&mdash;you can easily opt in "globally" (for any client name) via <xref:Microsoft.Extensions.DependencyInjection.HttpClientFactoryServiceCollectionExtensions.ConfigureHttpClientDefaults%2A>. From Keyed Services perspective, it results in the <xref:Microsoft.Extensions.DependencyInjection.KeyedService.AnyKey?displayProperty=nameWithType> registration.
+You don't have to call <xref:Microsoft.Extensions.DependencyInjection.HttpClientBuilderExtensions.AddAsKeyed%2A> for every single client&mdash;you can easily opt in "globally" (for any client name) via <xref:Microsoft.Extensions.DependencyInjection.HttpClientFactoryServiceCollectionExtensions.ConfigureHttpClientDefaults%2A>. From Keyed Services perspective, it results in the <xref:Microsoft.Extensions.DependencyInjection.KeyedService.AnyKey?displayProperty=nameWithType> registration.
 
 ```csharp
 services.ConfigureHttpClientDefaults(b => b.AddAsKeyed());

--- a/docs/core/extensions/httpclient-factory-keyed-di.md
+++ b/docs/core/extensions/httpclient-factory-keyed-di.md
@@ -16,7 +16,7 @@ For an overview on how to use `IHttpClientFactory` in your .NET application, see
 
 ## Background
 
-`IHttpClientFactory` and Named `HttpClient` instances, unsurprisingly, align well with the Keyed Services idea. Among other things, `IHttpClientFactory` was a way to overcome this long-missing DI feature. But plain Named clients require you to obtain, store and query the `IHttpClientFactory` instance &mdash; instead of injecting a configured `HttpClient` &mdash; which might be inconvenient. While Typed clients attempt to simplify that part, it comes with a catch: Typed clients are quite easy to [misconfigure](httpclient-factory-troubleshooting.md#typed-client-has-the-wrong-httpclient-injected) and [misuse](httpclient-factory.md#avoid-typed-clients-in-singleton-services), and the supporting infra can also be a tangible overhead in certain scenarios (for example, om mobile platforms).
+`IHttpClientFactory` and Named `HttpClient` instances, unsurprisingly, align well with the Keyed Services idea. Among other things, `IHttpClientFactory` historically was a way to overcome this long-missing DI feature. But plain Named clients require you to obtain, store and query the `IHttpClientFactory` instance &mdash; instead of injecting a configured `HttpClient` &mdash; which might be inconvenient. While Typed clients attempt to simplify that part, it comes with a catch: Typed clients are quite easy to [misconfigure](httpclient-factory-troubleshooting.md#typed-client-has-the-wrong-httpclient-injected) and [misuse](httpclient-factory.md#avoid-typed-clients-in-singleton-services), and the supporting infra can also be a tangible overhead in certain scenarios (for example, om mobile platforms).
 
 Starting from .NET 9 (package-provided), `IHttpClientFactory` can leverage Keyed DI directly, introducing a new "Keyed DI approach" (as opposed to "Named" and "Typed" approaches). "Keyed DI approach" pairs the convenient, highly configurable `HttpClient` registrations with the straightforward injection of the specific configured `HttpClient` instances.
 
@@ -26,7 +26,7 @@ As of .NET 9 (package-provided), you need to _opt in_ to the feature by calling 
 
 Below is a full runnable example of the integration between `HttpClientFactory`, Keyed DI and ASP.NET Core 9.0 Minimal APIs:
 
-:::code source="snippets/http/keyedservices/Program.cs" highlight="9,14":::
+:::code source="snippets/http/keyedservices/Program.cs" highlight="4,10,16":::
 
 Endpoint response:
 
@@ -37,7 +37,7 @@ Endpoint response:
 
 In the example above, the configured `HttpClient` is directly injected into the request handler via the Keyed DI infra and ASP.NET Core parameter binding. For more information on Keyed Services in ASP.NET Core, see [Dependency injection in ASP.NET Core](/aspnet/core/fundamentals/dependency-injection#keyed-services)
 
-## Approach comparison
+## Approach Comparison
 
 Stripping away the code unrelated to `IHttpClientFactory`, you can compare the _Keyed DI approach_
 
@@ -79,57 +79,9 @@ public class GitHubClient(HttpClient httpClient)          // (2)
 
 Out of the three, the Keyed DI approach offers the most succinct way to achieve the same behavior.
 
-## Keyed Message Handler Chain
+## Built-In DI Container Validation
 
-For some advanced scenarios, you might want to access `HttpMessageHandler` chain directly, instead of an `HttpClient` object. `HttpClientFactory` provides `IHttpMessageHandlerFactory` interface for that; and if you enable Keyed DI, then not only `HttpClient`, but also the respective `HttpMessageHandler` chain will be registered as a Keyed service:
-
-```csharp
-services.AddHttpClient("foo").AddAsKeyed();
-
-var handler = provider.GetRequiredKeyedService<HttpMessageHandler>("foo");
-var invoker = new HttpMessageInvoker(handler, disposeHandler: false);
-```
-
-
-## HOW-TO: Switch from Typed approach to Keyed DI
-
-> [!NOTE]
-> We currently recommend using Keyed DI approach instead of Typed clients.
-
-A minimal-change switch from an existing Typed client to a Keyed dependency can look as follows:
-
-```diff
-- services.AddHttpClient<Foo>(        // (1) Typed client
-+ services.AddHttpClient(nameof(Foo), // (1) Named client
-      c => { /* ... */ }              // HttpClient configuration
-  //).Configure....
-- );
-+ ).AddAsKeyed();                     // (1) Keyed DI opt-in
-+
-+ services.AddTransient<Foo>();       // (1) Plain Transient service
-
-  public class Foo(
--                                      // (2) Implicit ("hidden" Named) dependency
-+     [FromKeyedServices(nameof(Foo))] // (2) Explicit Keyed dependency
-      HttpClient httpClient) // { ...
-```
-
-In the example above:
-1. The registration of the Typed client `Foo` is split into:
-    - A registration of a Named client `nameof(Foo)`
-        - retaining the `HttpClient` configuration, and
-        - opting in to Keyed DI;
-    - Plain Transient service `Foo`.
-2. `HttpClient` dependency in `Foo`'s constructor is explicitly bound to a Keyed Service with a key `nameof(Foo)`.
-
-The name doesn't have to be `nameof(Foo)`, but the example aimed to minimize semantic change as well: Typed clients use Named clients "under the hood", and by default, such "hidden" Named clients go by the linked Typed client's type name; in this case it is `nameof(Foo)`.
-
-Technically, the example "unwraps" the Typed client, so that the previously "hidden" Named client becomes "exposed", and the dependency is satisfied via the Keyed DI infra instead of the Typed client infra.
-
-
-## Leverage DI Container Validation
-
-If you enabled the Keyed registration for a specific Named client, you can access it with any existing Keyed DI APIs, but if you try to use a name which was not enabled yet, you will get the standard Keyed DI exception:
+If you enabled the Keyed registration for a specific Named client, you can access it with any existing Keyed DI APIs. But if you erroneously try to use a name which was not enabled yet, you will get the standard Keyed DI exception:
 
 ```c#
 services.AddHttpClient("keyed").AddAsKeyed();
@@ -141,7 +93,7 @@ provider.GetRequiredKeyedService<HttpClient>("keyed"); // OK
 provider.GetRequiredKeyedService<HttpClient>("not-keyed");
 ```
 
-Additionaly, the Scoped lifetime of the clients can help to catch cases of captive dependencies:
+Additionaly, the Scoped lifetime of the clients can help catching cases of captive dependencies:
 
 ```csharp
 services.AddHttpClient("scoped").AddAsKeyed();
@@ -158,6 +110,96 @@ public class CapturingSingleton([FromKeyedServices("scoped")] HttpClient httpCli
 //{ ...
 ```
 
+## Service Lifetime Selection
+
+By default, `AddAsKeyed()` registers `HttpClient` as a Keyed _Scoped_ service. You can also explicitly specify the lifetime by passing the `ServiceLifetime` parameter to the `AddAsKeyed()` method:
+
+```csharp
+services.AddHttpClient("explicit-scoped")
+    .AddAsKeyed(ServiceLifetime.Scoped);
+
+services.AddHttpClient("singleton")
+    .AddAsKeyed(ServiceLifetime.Singleton);
+```
+
+### ⚠️ Avoid Transient HttpClient Memory Leak ⚠️
+
+We strongly recommend _avoiding_ Transient lifetime for Keyed `HttpClient`s.
+
+Registering the client as a Keyed Transient service will lead to the `HttpClient` and `HttpMessageHandler` instances being _captured by DI container_, as both implement `IDisposable`. This can result in _memory leaks_ if the client is resolved multiple times within Singleton services.
+
+### ⚠️ Avoid Captive Dependency ⚠️
+
+If `HttpClient` is registered either:
+  - as a Keyed _Singleton_, -OR-
+  - as a Keyed _Scoped_ or _Transient_, and injected within a _long-running_ (longer than `HandlerLifetime`) application Scope, -OR-
+  - as a Keyed _Transient_, and injected into a _Singleton_ service,
+
+the `HttpClient` instance will become _captive_, and will most possibly outlive way beyond its expected `HandlerLifetime`. `HttpClientFactory` has no control over captive clients, they are NOT able to participate in the handler rotation, and this can result in [the loss of DNS changes](httpclient-factory-troubleshooting.md#httpclient-doesnt-respect-dns-changes). A similar issue [already exists](httpclient-factory.md#avoid-typed-clients-in-singleton-services) for Typed clients, which are registered as Transient services.
+
+In cases when client's longevity cannot be avoided &mdash; or if it is concsiously desired, e.g. for a Keyed Singleton &mdash; it is advised to [leverage `SocketsHttpHandler`](httpclient-factory.md#using-ihttpclientfactory-together-with-socketshttphandler) by setting `PooledConnectionLifetime` to a reasonable value.
+
+```csharp
+services.AddHttpClient("shared")
+    .AddAsKeyed(ServiceLifetime.Singleton) // explicit singleton
+    .UseSocketsHttpHandler((h, _) => h.PooledConnectionLifetime = TimeSpan.FromMinutes(2))
+    .SetHandlerLifetime(Timeout.InfiniteTimeSpan); // disable rotation
+services.AddSingleton<MySingleton>();
+
+public class MySingleton([FromKeyedServices("shared")] HttpClient shared) // { ...
+```
+
+### ⚠️ Beware Of Scope Mismatch ⚠️
+
+While Scoped lifetime is much less problematic for the Named `HttpClient`s (compared to Singleton and Transient pitfalls), it has its own catch. 
+
+Keyed Scoped lifetime of a specific `HttpClient` instance will be bound &mdash; as expected &mdash; to the "ordinary" application scope (e.g. incoming request scope) where it was resolved from. However, it does NOT apply to the underlying message handler chain, which is still managed by the `HttpClientFactory`, in the same way it is for the Named clients created directly from factory. `HttpClient`s with the _same_ name, but resolved (within a `HandlerLifetime` timeframe) in two different scopes (e.g. two concurrent requests to the same endpoint), can reuse the _same_ `HttpMessageHandler` instance. Which in turn will have it's own separate scope, as illustrated in the [docs](httpclient-factory.md#message-handler-scopes-in-ihttpclientfactory).
+
+The [Scope Mismatch](httpclient-factory-troubleshooting.md#httpclient-doesnt-respect-scoped-lifetime) problem is nasty and long-existing one, and as of .NET 9 (package-provided) is still remains [unsolved](https://github.com/dotnet/runtime/issues/47091). From a service injected through the regular DI infra, you would expect all the dependencies to be satisfied from the same scope &mdash; but be aware that for the Keyed Scoped `HttpClient`s it is, unfortunately, not the case.
+
+## Keyed Message Handler Chain
+
+For some advanced scenarios, you might want to access `HttpMessageHandler` chain directly, instead of an `HttpClient` object. `HttpClientFactory` provides `IHttpMessageHandlerFactory` interface for that; and if you enable Keyed DI, then not only `HttpClient`, but also the respective `HttpMessageHandler` chain will be registered as a Keyed service:
+
+```csharp
+services.AddHttpClient("foo").AddAsKeyed();
+
+var handler = provider.GetRequiredKeyedService<HttpMessageHandler>("foo");
+var invoker = new HttpMessageInvoker(handler, disposeHandler: false);
+```
+
+## HOW-TO: Switch from Typed approach to Keyed DI
+
+> [!NOTE]
+> We currently recommend using Keyed DI approach instead of Typed clients.
+
+A minimal-change switch from an existing Typed client to a Keyed dependency can look as follows:
+
+```diff
+- services.AddHttpClient<Foo>(        // (1) Typed client
++ services.AddHttpClient(nameof(Foo), // (1) Named client
+      c => { /* ... */ }              // HttpClient configuration
+  //).Configure....
+- );
++ ).AddAsKeyed();                     // (1) + Keyed DI opt-in
+
++ services.AddTransient<Foo>();       // (1) Plain Transient service
+
+  public class Foo(
+-                                      // (2) Implicit ("hidden" Named) dependency
++     [FromKeyedServices(nameof(Foo))] // (2) Explicit Keyed Service dependency
+      HttpClient httpClient) // { ...
+```
+
+In the example above:
+1. The registration of the Typed client `Foo` is split into:
+    - A registration of a Named client `nameof(Foo)` with the same `HttpClient` configuration, and opt-in to Keyed DI; and
+    - Plain Transient service `Foo`.
+2. `HttpClient` dependency in `Foo` is explicitly bound to a Keyed Service with a key `nameof(Foo)`.
+
+The name doesn't have to be `nameof(Foo)`, but the example aimed to minimize the behavioral changes. Typed clients use Named clients "under the hood", and by default, such "hidden" Named clients go by the linked Typed client's type name. In this case, the "hidden" name was `nameof(Foo)`, so the example preserved it.
+
+Technically, the example "unwraps" the Typed client, so that the previously "hidden" Named client becomes "exposed", and the dependency is satisfied via the Keyed DI infra instead of the Typed client infra.
 
 ## HOW-TO: Opt-In To Keyed DI By Default
 
@@ -177,13 +219,17 @@ public class FooBarBazController(
 //{ ...
 ```
 
-## ⚠️ Beware Of "Unknown" Clients ⚠️
+### ⚠️ Beware Of "Unknown" Clients ⚠️
 
-One thing to be aware of with `KeyedService.AnyKey` registrations, is that a mistake in the key _silently_ leads to a wrong instance being injected. In case of Keyed `HttpClient`s, a mistake in the client name can result even in erroneously injecting an "unknown" client &mdash; meaning, a client which name was never registered.
+`KeyedService.AnyKey` registrations define a mapping from _any_ key value to some service instance. However, as a result, the Container validation will not apply, and an _erroneous_ key value will _silently_ lead to a _wrong instance_ being injected.
 
-Actually, in the first place, same is true for the plain Named clients: `HttpClientFactory` doesn't require the client name to be explicitly registered (aligning with the way the [Options pattern](options.md) work). The factory will give you an unconfigured &mdash; or, more precisely, default-configured &mdash; `HttpClient` for any unknown name.
+> [!IMPORTANT]
+> In case of Keyed `HttpClient`s, a mistake in the client name can result in erroneously injecting an "unknown" client &mdash; meaning, a client which name was never registered.
 
-Therefore, it is important to keep in mind: the "Keyed by default" approach covers not only all _registered_ `HttpClient`s, but all the clients that `HttpClientFactory` is _able to create_.
+Actually, in the first place, same is true for the plain Named clients: `IHttpClientFactory` doesn't require the client name to be explicitly registered (aligning with the way the [Options pattern](options.md) work). The factory will give you an unconfigured &mdash; or, more precisely, default-configured &mdash; `HttpClient` for any unknown name.
+
+> [!NOTE]
+> Therefore, it is important to keep in mind: the "Keyed by default" approach covers not only all _registered_ `HttpClient`s, but all the clients that `HttpClientFactory` is _able to create_.
 
 ```csharp
 services.ConfigureHttpClientDefaults(b => b.AddAsKeyed());
@@ -193,7 +239,7 @@ provider.GetRequiredKeyedService<HttpClient>("known");   // OK
 provider.GetRequiredKeyedService<HttpClient>("unknown"); // OK (unconfigured instance)
 ```
 
-## "Opt-In" Strategy Considerations
+### "Opt-In" Strategy Considerations
 
 Even though the "global" opt-in is a one-liner, it is unfortunate that the feature still requires it, instead of just working "out of the box". For full context and reasoning on that decision, see [dotnet/runtime#89755](https://github.com/dotnet/runtime/issues/89755) and [dotnet/runtime#104943](https://github.com/dotnet/runtime/pull/104943). In short, the main blocker for "on by default" is the `ServiceLifetime` "controversy": for the current (`9.0.0`) state of the DI and `HttpClientFactory` implementations, there is no single `ServiceLifetime` that would be reasonably safe for all `HttpClient`s in all possible situations. There is an intention, however, to address the caveats in the upcoming releases, and switch the strategy from "opt-in" to "opt-out".
 
@@ -223,54 +269,8 @@ provider.GetRequiredKeyedService<HttpClient>("not-keyed"); // Throws: No service
 provider.GetRequiredKeyedService<HttpClient>("unknown");   // Throws: No service for type 'System.Net.Http.HttpClient' has been registered.
 ```
 
-## Service Lifetime Selection
 
-By default, `AddAsKeyed()` registers `HttpClient` as a Keyed _Scoped_ service. You can also explicitly specify the lifetime by passing the `ServiceLifetime` parameter to the `AddAsKeyed()` method:
-
-```csharp
-services.AddHttpClient("explicit-scoped")
-    .AddAsKeyed(ServiceLifetime.Scoped);
-
-services.AddHttpClient("singleton")
-    .AddAsKeyed(ServiceLifetime.Singleton);
-```
-
-## ⚠️ Avoid Transient HttpClient Memory Leak ⚠️
-
-We strongly recommend _avoiding_ Transient lifetime for Keyed `HttpClient`s.
-
-Registering the client as a Keyed Transient service will lead to the `HttpClient` and `HttpMessageHandler` instances being _captured by DI container_, as both implement `IDisposable`. This can result in _memory leaks_ if the client is resolved multiple times within Singleton services.
-
-## ⚠️ Avoid Captive Dependency ⚠️
-
-If `HttpClient` is registered either:
-  - as a Keyed _Singleton_, -OR-
-  - as a Keyed _Scoped_ or _Transient_, and injected within a _long-running_ (longer than `HandlerLifetime`) application Scope, -OR-
-  - as a Keyed _Transient_, and injected into a _Singleton_ service,
-
-the `HttpClient` instance will become _captive_, and will most possibly outlive way beyond its expected `HandlerLifetime`. `HttpClientFactory` has no control over captive clients, they are NOT able to participate in the handler rotation, and this can result in [the loss of DNS changes](httpclient-factory-troubleshooting.md#httpclient-doesnt-respect-dns-changes). A similar issue [already exists](httpclient-factory.md#avoid-typed-clients-in-singleton-services) for Typed clients, which are registered as Transient services.
-
-In cases when client's longevity cannot be avoided &mdash; or if it is concsiously desired, e.g. for a Keyed Singleton &mdash; it is advised to [leverage `SocketsHttpHandler`](httpclient-factory.md#using-ihttpclientfactory-together-with-socketshttphandler) by setting `PooledConnectionLifetime` to a reasonable value.
-
-```csharp
-services.AddHttpClient("shared")
-    .AddAsKeyed(ServiceLifetime.Singleton) // explicit singleton
-    .UseSocketsHttpHandler((h, _) => h.PooledConnectionLifetime = TimeSpan.FromMinutes(2))
-    .SetHandlerLifetime(Timeout.InfiniteTimeSpan); // disable rotation
-services.AddSingleton<MySingleton>();
-
-public class MySingleton([FromKeyedServices("shared")] HttpClient shared) // { ...
-```
-
-## ⚠️ Beware Of Scope Mismatch ⚠️
-
-While Scoped lifetime is much less problematic for the Named `HttpClient`s (compared to Singleton and Transient pitfalls), it has its own catch. 
-
-Keyed Scoped lifetime of a specific `HttpClient` instance will be bound &mdash; as expected &mdash; to the "ordinary" application scope (e.g. incoming request scope) where it was resolved from. However, it does NOT apply to the underlying message handler chain, which is still managed by the `HttpClientFactory`, in the same way it is for the Named clients created directly from factory. `HttpClient`s with the _same_ name, but resolved (within a `HandlerLifetime` timeframe) in two different scopes (e.g. two concurrent requests to the same endpoint), can reuse the _same_ `HttpMessageHandler` instance. Which in turn will have it's own separate scope, as illustrated in the [docs](httpclient-factory.md#message-handler-scopes-in-ihttpclientfactory).
-
-The [Scope Mismatch](httpclient-factory-troubleshooting.md#httpclient-doesnt-respect-scoped-lifetime) problem is nasty and long-existing one, and as of .NET 9 is still remains [unsolved](https://github.com/dotnet/runtime/issues/47091). From a service injected through the regular DI infra, you would expect all the dependencies to be satisfied from the same scope &mdash; but be aware that for the Keyed Scoped `HttpClient`s it is, unfortunately, not the case.
-
-## Precedence
+## Order Of Precedence
 
 If called together or any of them more then once, `AddAsKeyed()` and `RemoveAsKeyed()` generally follow the rules of `HttpClientFactory` configs and DI registrations:
 
@@ -283,57 +283,10 @@ Note that if `AddAsKeyed()` is called within a Typed client registration, only t
 ## See also
 
 - [IHttpClientFactory with .NET][hcf]
+- [Common `IHttpClientFactory` usage issues][hcf-troubleshooting]
 - <xref:System.Net.Http.IHttpClientFactory>
 
 [hcf]: httpclient-factory.md
+[hcf-troubleshooting]: httpclient-factory-troubleshooting.md
 [httpclient]: ../../fundamentals/networking/http/httpclient.md
-
------------------
-
-# Default Primary Handler Change
-
-One of the most common problems `HttpClientFactory` users run into is when a Named or a Typed client erroneously gets [captured in a Singleton service](httpclient-factory.md#avoid-typed-clients-in-singleton-services), or, in general, stored somewhere for a period of time that's longer than the specified `HandlerLifetime`. Because `HttpClientFactory` can't rotate such handlers, they might end up [not respecting DNS changes](httpclient-factory-troubleshooting.md#httpclient-doesnt-respect-dns-changes). It is, unfortunately, very easy and seemingly "intuitive" to inject a Typed client into a singleton, but very hard to have any kind of check/analyzer to make sure `HttpClient` is not captured when it was not supposed to. It might be even harder to troubleshoot the resulting issues.
-
-On the other hand, the problem can be [mitigated](httpclient-factory.md#using-ihttpclientfactory-together-with-socketshttphandler) by using `SocketsHttpHandler`, which has an option to control `PooledConnectionLifetime`. Similarly to `HandlerLifetime`, it allows regularly recreating connections to pick up the DNS changes, but on a lower level. A client with `PooledConnectionLifetime` set up can be safely used as a Singleton.
-
-Therefore, to minimize the potential impact of the erroneous usage patterns, .NET 9 makes the default Primary handler to be a `SocketsHttpHandler` (on platforms that support it; other platforms, e.g. .NET Framework, continue to use `HttpClientHandler`). And most importantly, `SocketsHttpHandler` will also have the `PooledConnectionLifetime` property _pre-set_ to match the `HandlerLifetime` value (it will reflect the latest value, if you configured `HandlerLifetime` one or more times).
-
-Note that the change will only affect cases when the client was _not_ configured to have a custom Primary handler (via e.g. `ConfigurePrimaryHttpMessageHandler<T>()`).
-
-While the default Primary handler is an implementation detail, as it is never specified in the docs, it is still considered a breaking change. There are cases in which you might have depended on it, for example, casting the Primary handler to `HttpClientHandler` to set properties like `ClientCertificates`, `UseCookies`, `UseProxy` etc. If you need to use such properties, it is suggected to check for both `HttpClientHandler` and `SocketsHttpHandler` in the configuration action:
-
-```csharp
-services.AddHttpClient("test")
-    .ConfigurePrimaryHttpMessageHandler((h, _) =>
-    {
-        if (h is HttpClientHandler hch)
-        {
-            hch.UseCookies = false;
-        }
-
-        if (h is SocketsHttpHandler shh)
-        {
-            shh.UseCookies = false;
-        }
-    });
-```
-
-Alternatively, you can explicitly specify a Primary handler for each of your clients:
-
-```csharp
-services.AddHttpClient("test")
-    .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler() { UseCookies = false });
-```
-
-Or, configure the default Primary handler for all clients using `ConfigureHttpClientDefaults`:
-
-```csharp
-services.ConfigureHttpClientDefaults(b =>
-    b.ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler() { UseCookies = false }));
-```
-
-
-
-
-
 

--- a/docs/core/extensions/httpclient-factory-keyed-di.md
+++ b/docs/core/extensions/httpclient-factory-keyed-di.md
@@ -160,7 +160,7 @@ public class MySingleton([FromKeyedServices("shared")] HttpClient shared) // { .
 
 ### Beware Of Scope Mismatch
 
-While Scoped lifetime is much less problematic for the Named `HttpClient`s (compared to Singleton and Transient pitfalls), it has its own catch. 
+While Scoped lifetime is much less problematic for the Named `HttpClient`s (compared to Singleton and Transient pitfalls), it has its own catch.
 
 > [!IMPORTANT]
 > Keyed Scoped lifetime of a specific `HttpClient` instance is bound&mdash;as expected&mdash;to the "ordinary" application scope (for example, incoming request scope) where it was resolved from. However, it does NOT apply to the underlying message handler chain, which is still managed by the `HttpClientFactory`, in the same way it is for the Named clients created directly from factory. `HttpClient`s with the _same_ name, but resolved (within a `HandlerLifetime` timeframe) in two different scopes (for example, two concurrent requests to the same endpoint), can reuse the _same_ `HttpMessageHandler` instance. Which in turn has its own separate scope, as illustrated in the [docs](httpclient-factory.md#message-handler-scopes-in-ihttpclientfactory).
@@ -258,7 +258,7 @@ Even though the "global" opt-in is a one-liner, it's unfortunate that the featur
 
 ## HOW-TO: Opt-Out From Keyed Registration
 
-You can explicitly opt out from Keyed DI for `HttpClient`s by calling the <xref:Microsoft.Extensions.DependencyInjection.httpclientbuilderextensions.RemoveAsKeyed%2A> extension method, either per client name: 
+You can explicitly opt out from Keyed DI for `HttpClient`s by calling the <xref:Microsoft.Extensions.DependencyInjection.httpclientbuilderextensions.RemoveAsKeyed%2A> extension method, either per client name:
 
 ```csharp
 services.ConfigureHttpClientDefaults(b => b.AddAsKeyed());      // opt IN by default

--- a/docs/core/extensions/httpclient-factory-keyed-di.md
+++ b/docs/core/extensions/httpclient-factory-keyed-di.md
@@ -213,7 +213,7 @@ The name doesn't have to be `nameof(Foo)`, but the example aimed to minimize the
 
 Technically, the example "unwraps" the Typed client, so that the previously "hidden" Named client becomes "exposed," and the dependency is satisfied via the Keyed DI infra instead of the Typed client infra.
 
-## HOW-TO: Opt-In To Keyed DI By Default
+## HOW-TO: Opt In To Keyed DI By Default
 
 You don't have to call `AddAsKeyed` for every single client&mdash;you can easily opt in "globally" (for any client name) via `ConfigureHttpClientDefaults`. From Keyed Services perspective, it results in the <xref:Microsoft.Extensions.DependencyInjection.KeyedService.AnyKey?displayProperty=nameWithType> registration.
 
@@ -256,9 +256,9 @@ provider.GetRequiredKeyedService<HttpClient>("unknown"); // OK (unconfigured ins
 
 Even though the "global" opt-in is a one-liner, it's unfortunate that the feature still requires it, instead of just working "out of the box." For full context and reasoning on that decision, see [dotnet/runtime#89755](https://github.com/dotnet/runtime/issues/89755) and [dotnet/runtime#104943](https://github.com/dotnet/runtime/pull/104943). In short, the main blocker for "on by default" is the `ServiceLifetime` "controversy": for the current (`9.0.0`) state of the DI and `HttpClientFactory` implementations, there's no single `ServiceLifetime` that would be reasonably safe for all `HttpClient`s in all possible situations. There's an intention, however, to address the caveats in the upcoming releases, and switch the strategy from "opt-in" to "opt-out".
 
-## HOW-TO: Opt-Out From Keyed Registration
+## HOW-TO: Opt Out From Keyed Registration
 
-You can explicitly opt out from Keyed DI for `HttpClient`s by calling the <xref:Microsoft.Extensions.DependencyInjection.httpclientbuilderextensions.RemoveAsKeyed%2A> extension method, either per client name:
+You can explicitly opt out from Keyed DI for `HttpClient`s by calling the <xref:Microsoft.Extensions.DependencyInjection.HttpClientBuilderExtensions.RemoveAsKeyed%2A> extension method, either per client name:
 
 ```csharp
 services.ConfigureHttpClientDefaults(b => b.AddAsKeyed());      // opt IN by default

--- a/docs/core/extensions/httpclient-factory-keyed-di.md
+++ b/docs/core/extensions/httpclient-factory-keyed-di.md
@@ -1,0 +1,339 @@
+---
+title: Keyed DI Support in IHttpClientFactory
+description: Learn how to integrate IHttpClientFactory with Keyed Services.
+author: CarnaViire
+ms.author: knatalia
+ms.date: 01/03/2025
+---
+
+# Keyed DI Support in `IHttpClientFactory`
+
+In this article, you'll learn how to integrate `IHttpClientFactory` with Keyed Services.
+
+[_Keyed Services_](dependency-injection.md#keyed-services) (also called _Keyed DI_) is a DI feature that allows you to conveniently operate with multiple implementations of a single service. Upon registration, you can assign different _service keys_ to the implementations. In runtime, this key is used in lookup in combination with a service type, which means you can retrieve a specific implementation by passing the matching key. For more information on Keyed Services, and DI in general, see [.NET dependency injection](dependency-injection.md).
+
+For an overview on how to use `IHttpClientFactory` in your .NET application, see [IHttpClientFactory with .NET](httpclient-factory.md).
+
+## Background
+
+`IHttpClientFactory` and Named `HttpClient` instances, unsurprisingly, align well with the Keyed Services idea. Among other things, `IHttpClientFactory` was a way to overcome this long-missing DI feature. But plain Named clients require you to obtain, store and query the `IHttpClientFactory` instance &mdash; instead of injecting a configured `HttpClient` &mdash; which might be inconvenient. While Typed clients attempt to simplify that part, it comes with a catch: Typed clients are quite easy to [misconfigure](httpclient-factory-troubleshooting.md#typed-client-has-the-wrong-httpclient-injected) and [misuse](httpclient-factory.md#avoid-typed-clients-in-singleton-services), and the supporting infra can also be a tangible overhead in certain scenarios (for example, om mobile platforms).
+
+Starting from .NET 9 (package-provided), `IHttpClientFactory` can leverage Keyed DI directly, introducing a new "Keyed DI approach" (as opposed to "Named" and "Typed" approaches). "Keyed DI approach" pairs the convenient, highly configurable `HttpClient` registrations with the straightforward injection of the specific configured `HttpClient` instances.
+
+## Basic Usage
+
+As of .NET 9 (package-provided), you need to _opt in_ to the feature by calling the [`AddAsKeyed()`](https://learn.microsoft.com/dotnet/api/microsoft.extensions.dependencyinjection.httpclientbuilderextensions.addaskeyed) extension method. This will register a Named `HttpClient` as a Keyed service, using the client's name as a service key &mdash; and enable you to leverage the Keyed Services APIs (e.g. [`[FromKeyedServices(...)]`](https://learn.microsoft.com/dotnet/api/microsoft.extensions.dependencyinjection.fromkeyedservicesattribute)) to obtain the required `HttpClient` instances. By default, the clients are registered with Scoped lifetime.
+
+Below is a full runnable example of the integration between `HttpClientFactory`, Keyed DI and ASP.NET Core 9.0 Minimal APIs:
+
+:::code source="snippets/http/keyedservices/Program.cs" highlight="9,14":::
+
+Endpoint response:
+
+```sh
+> ~  curl http://localhost:5000/
+{"name":"runtime","url":"https://api.github.com/repos/dotnet/runtime"}
+```
+
+In the example above, the configured `HttpClient` is directly injected into the request handler via the Keyed DI infra and ASP.NET Core parameter binding. For more information on Keyed Services in ASP.NET Core, see [Dependency injection in ASP.NET Core](/aspnet/core/fundamentals/dependency-injection#keyed-services)
+
+## Approach comparison
+
+Stripping away the code unrelated to `IHttpClientFactory`, you can compare the _Keyed DI approach_
+
+```csharp
+services.AddHttpClient("github", /* ... */).AddAsKeyed();                // (1)
+
+app.MapGet("/", ([FromKeyedServices("github")] HttpClient httpClient) => // (2)
+    //httpClient.Get....                                                 // (3)
+```
+
+with how the same is achieved the two "older" ones: first with the _Named approach_
+
+```csharp
+services.AddHttpClient("github", /* ... */);                          // (1)
+
+app.MapGet("/github", (IHttpClientFactory httpClientFactory) =>
+{
+    HttpClient httpClient = httpClientFactory.CreateClient("github"); // (2)
+    //return httpClient.Get....                                       // (3)
+});
+```
+
+and second, the _Typed approach_.
+
+```csharp
+services.AddHttpClient<GitHubClient>(/* ... */);          // (1)
+
+app.MapGet("/github", (GitHubClient gitHubClient) =>
+    gitHubClient.GetRepoAsync());
+
+public class GitHubClient(HttpClient httpClient)          // (2)
+{
+    private readonly HttpClient _httpClient = httpClient;
+
+    public Task<Repo> GetRepoAsync() =>
+        //_httpClient.Get....                             // (3)
+}
+```
+
+Out of the three, the Keyed DI approach offers the most succinct way to achieve the same behavior.
+
+## Keyed Message Handler Chain
+
+For some advanced scenarios, you might want to access `HttpMessageHandler` chain directly, instead of an `HttpClient` object. `HttpClientFactory` provides `IHttpMessageHandlerFactory` interface for that; and if you enable Keyed DI, then not only `HttpClient`, but also the respective `HttpMessageHandler` chain will be registered as a Keyed service:
+
+```csharp
+services.AddHttpClient("foo").AddAsKeyed();
+
+var handler = provider.GetRequiredKeyedService<HttpMessageHandler>("foo");
+var invoker = new HttpMessageInvoker(handler, disposeHandler: false);
+```
+
+
+## HOW-TO: Switch from Typed approach to Keyed DI
+
+> [!NOTE]
+> We currently recommend using Keyed DI approach instead of Typed clients.
+
+A minimal-change switch from an existing Typed client to a Keyed dependency can look as follows:
+
+```diff
+- services.AddHttpClient<Foo>(        // (1) Typed client
++ services.AddHttpClient(nameof(Foo), // (1) Named client
+      c => { /* ... */ }              // HttpClient configuration
+  //).Configure....
+- );
++ ).AddAsKeyed();                     // (1) Keyed DI opt-in
++
++ services.AddTransient<Foo>();       // (1) Plain Transient service
+
+  public class Foo(
+-                                      // (2) Implicit ("hidden" Named) dependency
++     [FromKeyedServices(nameof(Foo))] // (2) Explicit Keyed dependency
+      HttpClient httpClient) // { ...
+```
+
+In the example above:
+1. The registration of the Typed client `Foo` is split into:
+    - A registration of a Named client `nameof(Foo)`
+        - retaining the `HttpClient` configuration, and
+        - opting in to Keyed DI;
+    - Plain Transient service `Foo`.
+2. `HttpClient` dependency in `Foo`'s constructor is explicitly bound to a Keyed Service with a key `nameof(Foo)`.
+
+The name doesn't have to be `nameof(Foo)`, but the example aimed to minimize semantic change as well: Typed clients use Named clients "under the hood", and by default, such "hidden" Named clients go by the linked Typed client's type name; in this case it is `nameof(Foo)`.
+
+Technically, the example "unwraps" the Typed client, so that the previously "hidden" Named client becomes "exposed", and the dependency is satisfied via the Keyed DI infra instead of the Typed client infra.
+
+
+## Leverage DI Container Validation
+
+If you enabled the Keyed registration for a specific Named client, you can access it with any existing Keyed DI APIs, but if you try to use a name which was not enabled yet, you will get the standard Keyed DI exception:
+
+```c#
+services.AddHttpClient("keyed").AddAsKeyed();
+services.AddHttpClient("not-keyed");
+
+provider.GetRequiredKeyedService<HttpClient>("keyed"); // OK
+
+// Throws: No service for type 'System.Net.Http.HttpClient' has been registered.
+provider.GetRequiredKeyedService<HttpClient>("not-keyed");
+```
+
+Additionaly, the Scoped lifetime of the clients can help to catch cases of captive dependencies:
+
+```csharp
+services.AddHttpClient("scoped").AddAsKeyed();
+services.AddSingleton<CapturingSingleton>();
+
+// Throws: Cannot resolve scoped service 'System.Net.Http.HttpClient' from root provider.
+rootProvider.GetRequiredKeyedService<HttpClient>("scoped");
+
+using var scope = provider.CreateScope();
+scope.ServiceProvider.GetRequiredKeyedService<HttpClient>("scoped"); // OK
+
+// Throws: Cannot consume scoped service 'System.Net.Http.HttpClient' from singleton 'CapturingSingleton'.
+public class CapturingSingleton([FromKeyedServices("scoped")] HttpClient httpClient)
+//{ ...
+```
+
+
+## HOW-TO: Opt-In To Keyed DI By Default
+
+You don't have to call `AddAsKeyed` for every single client &mdash; you can easily opt in "globally" (for any client name) via `ConfigureHttpClientDefaults`. From Keyed Services perspective, it will result in the [`KeyedService.AnyKey`](https://learn.microsoft.com/dotnet/api/microsoft.extensions.dependencyinjection.keyedservice.anykey) registration.
+
+```csharp
+services.ConfigureHttpClientDefaults(b => b.AddAsKeyed());
+
+services.AddHttpClient("foo", /* ... */);
+services.AddHttpClient("bar", /* ... */);
+services.AddHttpClient("baz", /* ... */);
+
+public class FooBarBazController(
+    [FromKeyedServices("foo")] HttpClient foo,
+    [FromKeyedServices("bar")] HttpClient bar,
+    [FromKeyedServices("baz")] HttpClient baz)
+//{ ...
+```
+
+## ⚠️ Beware Of "Unknown" Clients ⚠️
+
+One thing to be aware of with `KeyedService.AnyKey` registrations, is that a mistake in the key _silently_ leads to a wrong instance being injected. In case of Keyed `HttpClient`s, a mistake in the client name can result even in erroneously injecting an "unknown" client &mdash; meaning, a client which name was never registered.
+
+Actually, in the first place, same is true for the plain Named clients: `HttpClientFactory` doesn't require the client name to be explicitly registered (aligning with the way the [Options pattern](options.md) work). The factory will give you an unconfigured &mdash; or, more precisely, default-configured &mdash; `HttpClient` for any unknown name.
+
+Therefore, it is important to keep in mind: the "Keyed by default" approach covers not only all _registered_ `HttpClient`s, but all the clients that `HttpClientFactory` is _able to create_.
+
+```csharp
+services.ConfigureHttpClientDefaults(b => b.AddAsKeyed());
+services.AddHttpClient("known", /* ... */);
+
+provider.GetRequiredKeyedService<HttpClient>("known");   // OK
+provider.GetRequiredKeyedService<HttpClient>("unknown"); // OK (unconfigured instance)
+```
+
+## "Opt-In" Strategy Considerations
+
+Even though the "global" opt-in is a one-liner, it is unfortunate that the feature still requires it, instead of just working "out of the box". For full context and reasoning on that decision, see [dotnet/runtime#89755](https://github.com/dotnet/runtime/issues/89755) and [dotnet/runtime#104943](https://github.com/dotnet/runtime/pull/104943). In short, the main blocker for "on by default" is the `ServiceLifetime` "controversy": for the current (`9.0.0`) state of the DI and `HttpClientFactory` implementations, there is no single `ServiceLifetime` that would be reasonably safe for all `HttpClient`s in all possible situations. There is an intention, however, to address the caveats in the upcoming releases, and switch the strategy from "opt-in" to "opt-out".
+
+## HOW-TO: Opt-Out From Keyed Registration
+
+You can explicitly opt out from Keyed DI for `HttpClient`s by calling [`RemoveAsKeyed()`](https://learn.microsoft.com/dotnet/api/microsoft.extensions.dependencyinjection.httpclientbuilderextensions.removeaskeyed), either per client name: 
+
+```csharp
+services.ConfigureHttpClientDefaults(b => b.AddAsKeyed());      // opt IN by default
+services.AddHttpClient("keyed", /* ... */);
+services.AddHttpClient("not-keyed", /* ... */).RemoveAsKeyed(); // opt OUT per name
+
+provider.GetRequiredKeyedService<HttpClient>("keyed");     // OK
+provider.GetRequiredKeyedService<HttpClient>("not-keyed"); // Throws: No service for type 'System.Net.Http.HttpClient' has been registered.
+provider.GetRequiredKeyedService<HttpClient>("unknown");   // OK (unconfigured instance)
+```
+
+or "globally" with `ConfigureHttpClientDefaults`:
+
+```csharp
+services.ConfigureHttpClientDefaults(b => b.RemoveAsKeyed()); // opt OUT by default
+services.AddHttpClient("keyed", /* ... */).AddAsKeyed();      // opt IN per name
+services.AddHttpClient("not-keyed", /* ... */);
+
+provider.GetRequiredKeyedService<HttpClient>("keyed");     // OK
+provider.GetRequiredKeyedService<HttpClient>("not-keyed"); // Throws: No service for type 'System.Net.Http.HttpClient' has been registered.
+provider.GetRequiredKeyedService<HttpClient>("unknown");   // Throws: No service for type 'System.Net.Http.HttpClient' has been registered.
+```
+
+## Service Lifetime Selection
+
+By default, `AddAsKeyed()` registers `HttpClient` as a Keyed _Scoped_ service. You can also explicitly specify the lifetime by passing the `ServiceLifetime` parameter to the `AddAsKeyed()` method:
+
+```csharp
+services.AddHttpClient("explicit-scoped")
+    .AddAsKeyed(ServiceLifetime.Scoped);
+
+services.AddHttpClient("singleton")
+    .AddAsKeyed(ServiceLifetime.Singleton);
+```
+
+## ⚠️ Avoid Transient HttpClient Memory Leak ⚠️
+
+We strongly recommend _avoiding_ Transient lifetime for Keyed `HttpClient`s.
+
+Registering the client as a Keyed Transient service will lead to the `HttpClient` and `HttpMessageHandler` instances being _captured by DI container_, as both implement `IDisposable`. This can result in _memory leaks_ if the client is resolved multiple times within Singleton services.
+
+## ⚠️ Avoid Captive Dependency ⚠️
+
+If `HttpClient` is registered either:
+  - as a Keyed _Singleton_, -OR-
+  - as a Keyed _Scoped_ or _Transient_, and injected within a _long-running_ (longer than `HandlerLifetime`) application Scope, -OR-
+  - as a Keyed _Transient_, and injected into a _Singleton_ service,
+
+the `HttpClient` instance will become _captive_, and will most possibly outlive way beyond its expected `HandlerLifetime`. `HttpClientFactory` has no control over captive clients, they are NOT able to participate in the handler rotation, and this can result in [the loss of DNS changes](httpclient-factory-troubleshooting.md#httpclient-doesnt-respect-dns-changes). A similar issue [already exists](httpclient-factory.md#avoid-typed-clients-in-singleton-services) for Typed clients, which are registered as Transient services.
+
+In cases when client's longevity cannot be avoided &mdash; or if it is concsiously desired, e.g. for a Keyed Singleton &mdash; it is advised to [leverage `SocketsHttpHandler`](httpclient-factory.md#using-ihttpclientfactory-together-with-socketshttphandler) by setting `PooledConnectionLifetime` to a reasonable value.
+
+```csharp
+services.AddHttpClient("shared")
+    .AddAsKeyed(ServiceLifetime.Singleton) // explicit singleton
+    .UseSocketsHttpHandler((h, _) => h.PooledConnectionLifetime = TimeSpan.FromMinutes(2))
+    .SetHandlerLifetime(Timeout.InfiniteTimeSpan); // disable rotation
+services.AddSingleton<MySingleton>();
+
+public class MySingleton([FromKeyedServices("shared")] HttpClient shared) // { ...
+```
+
+## ⚠️ Beware Of Scope Mismatch ⚠️
+
+While Scoped lifetime is much less problematic for the Named `HttpClient`s (compared to Singleton and Transient pitfalls), it has its own catch. 
+
+Keyed Scoped lifetime of a specific `HttpClient` instance will be bound &mdash; as expected &mdash; to the "ordinary" application scope (e.g. incoming request scope) where it was resolved from. However, it does NOT apply to the underlying message handler chain, which is still managed by the `HttpClientFactory`, in the same way it is for the Named clients created directly from factory. `HttpClient`s with the _same_ name, but resolved (within a `HandlerLifetime` timeframe) in two different scopes (e.g. two concurrent requests to the same endpoint), can reuse the _same_ `HttpMessageHandler` instance. Which in turn will have it's own separate scope, as illustrated in the [docs](httpclient-factory.md#message-handler-scopes-in-ihttpclientfactory).
+
+The [Scope Mismatch](httpclient-factory-troubleshooting.md#httpclient-doesnt-respect-scoped-lifetime) problem is nasty and long-existing one, and as of .NET 9 is still remains [unsolved](https://github.com/dotnet/runtime/issues/47091). From a service injected through the regular DI infra, you would expect all the dependencies to be satisfied from the same scope &mdash; but be aware that for the Keyed Scoped `HttpClient`s it is, unfortunately, not the case.
+
+## Precedence
+
+If called together or any of them more then once, `AddAsKeyed()` and `RemoveAsKeyed()` generally follow the rules of `HttpClientFactory` configs and DI registrations:
+
+1. If called for the same name, the last one wins: the lifetime from the last `AddAsKeyed()` is used to create the Keyed registration (unless `RemoveAsKeyed()` was called last, in which case the name is excluded).
+2. If used only within `ConfigureHttpClientDefaults`, the last one wins.
+3. If both `ConfigureHttpClientDefaults` and specific client name were used, all defaults are considered to "happen" before all per-name ones. Thus, defaults can be disregarded, and the last of the per-name ones wins.
+
+Note that if `AddAsKeyed()` is called within a Typed client registration, only the underlying Named client  will be registered as Keyed. The Typed client itself will continue to be registered as a plain Transient service.
+
+## See also
+
+- [IHttpClientFactory with .NET][hcf]
+- <xref:System.Net.Http.IHttpClientFactory>
+
+[hcf]: httpclient-factory.md
+[httpclient]: ../../fundamentals/networking/http/httpclient.md
+
+-----------------
+
+# Default Primary Handler Change
+
+One of the most common problems `HttpClientFactory` users run into is when a Named or a Typed client erroneously gets [captured in a Singleton service](httpclient-factory.md#avoid-typed-clients-in-singleton-services), or, in general, stored somewhere for a period of time that's longer than the specified `HandlerLifetime`. Because `HttpClientFactory` can't rotate such handlers, they might end up [not respecting DNS changes](httpclient-factory-troubleshooting.md#httpclient-doesnt-respect-dns-changes). It is, unfortunately, very easy and seemingly "intuitive" to inject a Typed client into a singleton, but very hard to have any kind of check/analyzer to make sure `HttpClient` is not captured when it was not supposed to. It might be even harder to troubleshoot the resulting issues.
+
+On the other hand, the problem can be [mitigated](httpclient-factory.md#using-ihttpclientfactory-together-with-socketshttphandler) by using `SocketsHttpHandler`, which has an option to control `PooledConnectionLifetime`. Similarly to `HandlerLifetime`, it allows regularly recreating connections to pick up the DNS changes, but on a lower level. A client with `PooledConnectionLifetime` set up can be safely used as a Singleton.
+
+Therefore, to minimize the potential impact of the erroneous usage patterns, .NET 9 makes the default Primary handler to be a `SocketsHttpHandler` (on platforms that support it; other platforms, e.g. .NET Framework, continue to use `HttpClientHandler`). And most importantly, `SocketsHttpHandler` will also have the `PooledConnectionLifetime` property _pre-set_ to match the `HandlerLifetime` value (it will reflect the latest value, if you configured `HandlerLifetime` one or more times).
+
+Note that the change will only affect cases when the client was _not_ configured to have a custom Primary handler (via e.g. `ConfigurePrimaryHttpMessageHandler<T>()`).
+
+While the default Primary handler is an implementation detail, as it is never specified in the docs, it is still considered a breaking change. There are cases in which you might have depended on it, for example, casting the Primary handler to `HttpClientHandler` to set properties like `ClientCertificates`, `UseCookies`, `UseProxy` etc. If you need to use such properties, it is suggected to check for both `HttpClientHandler` and `SocketsHttpHandler` in the configuration action:
+
+```csharp
+services.AddHttpClient("test")
+    .ConfigurePrimaryHttpMessageHandler((h, _) =>
+    {
+        if (h is HttpClientHandler hch)
+        {
+            hch.UseCookies = false;
+        }
+
+        if (h is SocketsHttpHandler shh)
+        {
+            shh.UseCookies = false;
+        }
+    });
+```
+
+Alternatively, you can explicitly specify a Primary handler for each of your clients:
+
+```csharp
+services.AddHttpClient("test")
+    .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler() { UseCookies = false });
+```
+
+Or, configure the default Primary handler for all clients using `ConfigureHttpClientDefaults`:
+
+```csharp
+services.ConfigureHttpClientDefaults(b =>
+    b.ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler() { UseCookies = false }));
+```
+
+
+
+
+
+

--- a/docs/core/extensions/httpclient-factory-keyed-di.md
+++ b/docs/core/extensions/httpclient-factory-keyed-di.md
@@ -8,7 +8,7 @@ ms.date: 01/27/2025
 
 # Keyed DI Support in `IHttpClientFactory`
 
-In this article, you'll learn how to integrate `IHttpClientFactory` with Keyed Services.
+In this article, you learn how to integrate `IHttpClientFactory` with Keyed Services.
 
 [_Keyed Services_](dependency-injection.md#keyed-services) (also called _Keyed DI_) is a DI feature that allows you to conveniently operate with multiple implementations of a single service. Upon registration, you can associate different _service keys_ with the specific implementations. In runtime, this key is used in lookup in combination with a service type, which means you can retrieve a specific implementation by passing the matching key. For more information on Keyed Services, and DI in general, see [.NET dependency injection][di].
 
@@ -16,15 +16,15 @@ For an overview on how to use `IHttpClientFactory` in your .NET application, see
 
 ## Background
 
-`IHttpClientFactory` and Named `HttpClient` instances, unsurprisingly, align well with the Keyed Services idea. Historically, among other things, `IHttpClientFactory` was a way to overcome this long-missing DI feature. But plain Named clients require you to obtain, store and query the `IHttpClientFactory` instance &mdash; instead of injecting a configured `HttpClient` &mdash; which might be inconvenient. While Typed clients attempt to simplify that part, it comes with a catch: Typed clients are quite easy to [misconfigure](httpclient-factory-troubleshooting.md#typed-client-has-the-wrong-httpclient-injected) and [misuse](httpclient-factory.md#avoid-typed-clients-in-singleton-services), and the supporting infra can also be a tangible overhead in certain scenarios (for example, om mobile platforms).
+`IHttpClientFactory` and Named `HttpClient` instances, unsurprisingly, align well with the Keyed Services idea. Historically, among other things, `IHttpClientFactory` was a way to overcome this long-missing DI feature. But plain Named clients require you to obtain, store and query the `IHttpClientFactory` instance&mdash;instead of injecting a configured `HttpClient`&mdash;which might be inconvenient. While Typed clients attempt to simplify that part, it comes with a catch: Typed clients are easy to [misconfigure](httpclient-factory-troubleshooting.md#typed-client-has-the-wrong-httpclient-injected) and [misuse](httpclient-factory.md#avoid-typed-clients-in-singleton-services), and the supporting infra can also be a tangible overhead in certain scenarios (for example, on mobile platforms).
 
 Starting from .NET 9 (`Microsoft.Extensions.Http` and `Microsoft.Extensions.DependencyInjection` packages version `9.0.0+`), `IHttpClientFactory` can leverage Keyed DI directly, introducing a new "Keyed DI approach" (as opposed to "Named" and "Typed" approaches). "Keyed DI approach" pairs the convenient, highly configurable `HttpClient` registrations with the straightforward injection of the specific configured `HttpClient` instances.
 
 ## Basic Usage
 
-As of .NET 9, you need to _opt in_ to the feature by calling the <xref:Microsoft.Extensions.DependencyInjection.HttpClientBuilderExtensions.AddAsKeyed> extension method. If opted in, the Named client applying the configuraion is added to the DI container as a Keyed `HttpClient` service, using the client's name as a service key. With that, you can use the standard Keyed Services APIs (e.g. <xref:Microsoft.Extensions.DependencyInjection.FromKeyedServicesAttribute>) to obtain the desired Named `HttpClient` instances (created and configured by `IHttpClientFactory`). By default, the clients are registered with _Scoped_ lifetime.
+As of .NET 9, you need to _opt in_ to the feature by calling the <xref:Microsoft.Extensions.DependencyInjection.HttpClientBuilderExtensions.AddAsKeyed%2A> extension method. If opted in, the Named client applying the configuration is added to the DI container as a Keyed `HttpClient` service, using the client's name as a service key, so you can use the standard Keyed Services APIs (for example, <xref:Microsoft.Extensions.DependencyInjection.FromKeyedServicesAttribute>) to obtain the desired Named `HttpClient` instances (created and configured by `IHttpClientFactory`). By default, the clients are registered with _Scoped_ lifetime.
 
-The code below illustrates the integration between `HttpClientFactory`, Keyed DI and ASP.NET Core 9.0 Minimal APIs:
+The following code illustrates the integration between `HttpClientFactory`, Keyed DI and ASP.NET Core 9.0 Minimal APIs:
 
 :::code source="snippets/http/keyedservices/Program.cs" highlight="4,10,16":::
 
@@ -35,7 +35,7 @@ Endpoint response:
 {"name":"runtime","url":"https://api.github.com/repos/dotnet/runtime"}
 ```
 
-In the example above, the configured `HttpClient` is injected into the request handler through the standard Keyed DI infra, integrated into ASP.NET Core parameter binding. For more information on Keyed Services in ASP.NET Core, see [Dependency injection in ASP.NET Core](/aspnet/core/fundamentals/dependency-injection#keyed-services).
+In the example, the configured `HttpClient` is injected into the request handler through the standard Keyed DI infra, integrated into ASP.NET Core parameter binding. For more information on Keyed Services in ASP.NET Core, see [Dependency injection in ASP.NET Core](/aspnet/core/fundamentals/dependency-injection#keyed-services).
 
 ## Approach Comparison
 
@@ -48,7 +48,7 @@ app.MapGet("/", ([FromKeyedServices("github")] HttpClient httpClient) => // (2)
     //httpClient.Get....                                                 // (3)
 ```
 
-The code snippet above is illustrating how the registration `(1)`, obtaining the configured `HttpClient` instance `(2)`, and using the obtained client instance as needed `(3)` can look like in the _Keyed DI approach_.
+&mdash;the code snippet is illustrating how the registration `(1)`, obtaining the configured `HttpClient` instance `(2)`, and using the obtained client instance as needed `(3)` can look like in the _Keyed DI approach_.
 
 Now we can compare how the same steps are achieved with the two "older" approaches.
 
@@ -64,7 +64,7 @@ app.MapGet("/github", (IHttpClientFactory httpClientFactory) =>
 });
 ```
 
-And second, with the _Typed approach_:
+&mdash;and second, with the _Typed approach_:
 
 ```csharp
 services.AddHttpClient<GitHubClient>(/* ... */);          // (1)
@@ -85,7 +85,7 @@ Out of the three, the Keyed DI approach offers the most succinct way to achieve 
 
 ## Built-In DI Container Validation
 
-If you enabled the Keyed registration for a specific Named client, you can access it with any existing Keyed DI APIs. But if you erroneously try to use a name which was not enabled yet, you will get the standard Keyed DI exception:
+If you enabled the Keyed registration for a specific Named client, you can access it with any existing Keyed DI APIs. But if you erroneously try to use a name which wasn't enabled yet, you get the standard Keyed DI exception:
 
 ```c#
 services.AddHttpClient("keyed").AddAsKeyed();
@@ -97,7 +97,7 @@ provider.GetRequiredKeyedService<HttpClient>("keyed"); // OK
 provider.GetRequiredKeyedService<HttpClient>("not-keyed");
 ```
 
-Additionaly, the Scoped lifetime of the clients can help catching cases of captive dependencies:
+Additionally, the Scoped lifetime of the clients can help catching cases of captive dependencies:
 
 ```csharp
 services.AddHttpClient("scoped").AddAsKeyed();
@@ -126,25 +126,27 @@ services.AddHttpClient("singleton")
     .AddAsKeyed(ServiceLifetime.Singleton);
 ```
 
+If you call `AddAsKeyed()` within a Typed client registration, only the underlying Named client is registered as Keyed. The Typed client itself continues to be registered as a plain Transient service.
+
 ### Avoid Transient HttpClient Memory Leak
 
 > [!IMPORTANT]
-> We strongly recommend _avoiding_ Transient lifetime for Keyed `HttpClient`s.
+> `HttpClient` is `IDisposable`, so we strongly recommend _avoiding_ Transient lifetime for Keyed `HttpClient`s.
 >
-> Registering the client as a Keyed Transient service will lead to the `HttpClient` and `HttpMessageHandler` instances being _captured by DI container_, as both implement `IDisposable`. This can result in _memory leaks_ if the client is resolved multiple times within Singleton services.
+> Registering the client as a Keyed Transient service leads to the `HttpClient` and `HttpMessageHandler` instances being _captured by DI container_, as both implement `IDisposable`. This can result in _memory leaks_ if the client is resolved multiple times within Singleton services.
 
 ### Avoid Captive Dependency
 
 > [!IMPORTANT]
 > If `HttpClient` is registered either:
 >
->  - as a Keyed _Singleton_, -OR-
->  - as a Keyed _Scoped_ or _Transient_, and injected within a _long-running_ (longer than `HandlerLifetime`) application Scope, -OR-
->  - as a Keyed _Transient_, and injected into a _Singleton_ service,
+> - as a Keyed _Singleton_, -OR-
+> - as a Keyed _Scoped_ or _Transient_, and injected within a _long-running_ (longer than `HandlerLifetime`) application Scope, -OR-
+> - as a Keyed _Transient_, and injected into a _Singleton_ service,
 >
-> the `HttpClient` instance will become _captive_, and will most possibly outlive way beyond its expected `HandlerLifetime`. `HttpClientFactory` has no control over captive clients, they are NOT able to participate in the handler rotation, and this can result in [the loss of DNS changes](httpclient-factory-troubleshooting.md#httpclient-doesnt-respect-dns-changes). A similar issue [already exists](httpclient-factory.md#avoid-typed-clients-in-singleton-services) for Typed clients, which are registered as Transient services.
+> &mdash;the `HttpClient` instance becomes _captive_, and will most possibly outlive way beyond its expected `HandlerLifetime`. `HttpClientFactory` has no control over captive clients, they're NOT able to participate in the handler rotation, and it can result in [the loss of DNS changes](httpclient-factory-troubleshooting.md#httpclient-doesnt-respect-dns-changes). A similar issue [already exists](httpclient-factory.md#avoid-typed-clients-in-singleton-services) for Typed clients, which are registered as Transient services.
 
-In cases when client's longevity cannot be avoided &mdash; or if it is concsiously desired, e.g. for a Keyed Singleton &mdash; it is advised to [leverage `SocketsHttpHandler`](httpclient-factory.md#using-ihttpclientfactory-together-with-socketshttphandler) by setting `PooledConnectionLifetime` to a reasonable value.
+In cases when client's longevity can't be avoided&mdash;or if it's consciously desired, for example, for a Keyed Singleton&mdash;it's advised to [leverage `SocketsHttpHandler`](httpclient-factory.md#using-ihttpclientfactory-together-with-socketshttphandler) by setting `PooledConnectionLifetime` to a reasonable value.
 
 ```csharp
 services.AddHttpClient("shared")
@@ -161,14 +163,14 @@ public class MySingleton([FromKeyedServices("shared")] HttpClient shared) // { .
 While Scoped lifetime is much less problematic for the Named `HttpClient`s (compared to Singleton and Transient pitfalls), it has its own catch. 
 
 > [!IMPORTANT]
-> Keyed Scoped lifetime of a specific `HttpClient` instance will be bound &mdash; as expected &mdash; to the "ordinary" application scope (e.g. incoming request scope) where it was resolved from. However, it does NOT apply to the underlying message handler chain, which is still managed by the `HttpClientFactory`, in the same way it is for the Named clients created directly from factory. `HttpClient`s with the _same_ name, but resolved (within a `HandlerLifetime` timeframe) in two different scopes (e.g. two concurrent requests to the same endpoint), can reuse the _same_ `HttpMessageHandler` instance. Which in turn will have it's own separate scope, as illustrated in the [docs](httpclient-factory.md#message-handler-scopes-in-ihttpclientfactory).
+> Keyed Scoped lifetime of a specific `HttpClient` instance is bound&mdash;as expected&mdash;to the "ordinary" application scope (for example, incoming request scope) where it was resolved from. However, it does NOT apply to the underlying message handler chain, which is still managed by the `HttpClientFactory`, in the same way it is for the Named clients created directly from factory. `HttpClient`s with the _same_ name, but resolved (within a `HandlerLifetime` timeframe) in two different scopes (for example, two concurrent requests to the same endpoint), can reuse the _same_ `HttpMessageHandler` instance. Which in turn has its own separate scope, as illustrated in the [docs](httpclient-factory.md#message-handler-scopes-in-ihttpclientfactory).
 
 > [!NOTE]
-> The [Scope Mismatch](httpclient-factory-troubleshooting.md#httpclient-doesnt-respect-scoped-lifetime) problem is nasty and long-existing one, and as of .NET 9 is still remains [unsolved](https://github.com/dotnet/runtime/issues/47091). From a service injected through the regular DI infra, you would expect all the dependencies to be satisfied from the same scope &mdash; but be aware that for the Keyed Scoped `HttpClient`s it is, unfortunately, not the case.
+> The [Scope Mismatch](httpclient-factory-troubleshooting.md#httpclient-doesnt-respect-scoped-lifetime) problem is nasty and long-existing one, and as of .NET 9 still remains [unsolved](https://github.com/dotnet/runtime/issues/47091). From a service injected through the regular DI infra, you would expect all the dependencies to be satisfied from the same scope&mdash;but for the Keyed Scoped `HttpClient`s it is, unfortunately, not the case.
 
 ## Keyed Message Handler Chain
 
-For some advanced scenarios, you might want to access `HttpMessageHandler` chain directly, instead of an `HttpClient` object. `HttpClientFactory` provides `IHttpMessageHandlerFactory` interface for that; and if you enable Keyed DI, then not only `HttpClient`, but also the respective `HttpMessageHandler` chain will be registered as a Keyed service:
+For some advanced scenarios, you might want to access `HttpMessageHandler` chain directly, instead of an `HttpClient` object. `HttpClientFactory` provides `IHttpMessageHandlerFactory` interface to create the handlers; and if you enable Keyed DI, then not only `HttpClient`, but also the respective `HttpMessageHandler` chain is registered as a Keyed service:
 
 ```csharp
 services.AddHttpClient("foo").AddAsKeyed();
@@ -200,19 +202,20 @@ A minimal-change switch from an existing Typed client to a Keyed dependency can 
       HttpClient httpClient) // { ...
 ```
 
-In the example above:
+In the example:
+
 1. The registration of the Typed client `Foo` is split into:
-    - A registration of a Named client `nameof(Foo)` with the same `HttpClient` configuration, and opt-in to Keyed DI; and
+    - A registration of a Named client `nameof(Foo)` with the same `HttpClient` configuration, and an opt-in to Keyed DI; and
     - Plain Transient service `Foo`.
 2. `HttpClient` dependency in `Foo` is explicitly bound to a Keyed Service with a key `nameof(Foo)`.
 
-The name doesn't have to be `nameof(Foo)`, but the example aimed to minimize the behavioral changes. Typed clients use Named clients "under the hood", and by default, such "hidden" Named clients go by the linked Typed client's type name. In this case, the "hidden" name was `nameof(Foo)`, so the example preserved it.
+The name doesn't have to be `nameof(Foo)`, but the example aimed to minimize the behavioral changes. Typed clients use Named clients "under the hood," and by default, such "hidden" Named clients go by the linked Typed client's type name. In this case, the "hidden" name was `nameof(Foo)`, so the example preserved it.
 
-Technically, the example "unwraps" the Typed client, so that the previously "hidden" Named client becomes "exposed", and the dependency is satisfied via the Keyed DI infra instead of the Typed client infra.
+Technically, the example "unwraps" the Typed client, so that the previously "hidden" Named client becomes "exposed," and the dependency is satisfied via the Keyed DI infra instead of the Typed client infra.
 
 ## HOW-TO: Opt-In To Keyed DI By Default
 
-You don't have to call `AddAsKeyed` for every single client &mdash; you can easily opt in "globally" (for any client name) via `ConfigureHttpClientDefaults`. From Keyed Services perspective, it will result in the <xref:Microsoft.Extensions.DependencyInjection.KeyedService.AnyKey?displayProperty=nameWithType> registration.
+You don't have to call `AddAsKeyed` for every single client&mdash;you can easily opt in "globally" (for any client name) via `ConfigureHttpClientDefaults`. From Keyed Services perspective, it results in the <xref:Microsoft.Extensions.DependencyInjection.KeyedService.AnyKey?displayProperty=nameWithType> registration.
 
 ```csharp
 services.ConfigureHttpClientDefaults(b => b.AddAsKeyed());
@@ -231,15 +234,15 @@ public class FooBarBazController(
 ### Beware Of "Unknown" Clients
 
 > [!NOTE]
-> `KeyedService.AnyKey` registrations define a mapping from _any_ key value to some service instance. However, as a result, the Container validation will not apply, and an _erroneous_ key value will _silently_ lead to a _wrong instance_ being injected.
+> `KeyedService.AnyKey` registrations define a mapping from _any_ key value to some service instance. However, as a result, the Container validation doesn't apply, and an _erroneous_ key value _silently_ leads to a _wrong instance_ being injected.
 
 > [!IMPORTANT]
-> In case of Keyed `HttpClient`s, a mistake in the client name can result in erroneously injecting an "unknown" client &mdash; meaning, a client which name was never registered.
+> For Keyed `HttpClient`s, a mistake in the client name can result in erroneously injecting an "unknown" client&mdash;meaning, a client which name was never registered.
 
-Actually, in the first place, same is true for the plain Named clients: `IHttpClientFactory` doesn't require the client name to be explicitly registered (aligning with the way the [Options pattern](options.md) work). The factory will give you an unconfigured &mdash; or, more precisely, default-configured &mdash; `HttpClient` for any unknown name.
+Actually, in the first place, same is true for the plain Named clients: `IHttpClientFactory` doesn't require the client name to be explicitly registered (aligning with the way the [Options pattern](options.md) work). The factory gives you an unconfigured&mdash;or, more precisely, default-configured&mdash;`HttpClient` for any unknown name.
 
 > [!NOTE]
-> Therefore, it is important to keep in mind: the "Keyed by default" approach covers not only all _registered_ `HttpClient`s, but all the clients that `HttpClientFactory` is _able to create_.
+> Therefore, it's important to keep in mind: the "Keyed by default" approach covers not only all _registered_ `HttpClient`s, but all the clients that `HttpClientFactory` is _able to create_.
 
 ```csharp
 services.ConfigureHttpClientDefaults(b => b.AddAsKeyed());
@@ -251,11 +254,11 @@ provider.GetRequiredKeyedService<HttpClient>("unknown"); // OK (unconfigured ins
 
 ### "Opt-In" Strategy Considerations
 
-Even though the "global" opt-in is a one-liner, it is unfortunate that the feature still requires it, instead of just working "out of the box". For full context and reasoning on that decision, see [dotnet/runtime#89755](https://github.com/dotnet/runtime/issues/89755) and [dotnet/runtime#104943](https://github.com/dotnet/runtime/pull/104943). In short, the main blocker for "on by default" is the `ServiceLifetime` "controversy": for the current (`9.0.0`) state of the DI and `HttpClientFactory` implementations, there is no single `ServiceLifetime` that would be reasonably safe for all `HttpClient`s in all possible situations. There is an intention, however, to address the caveats in the upcoming releases, and switch the strategy from "opt-in" to "opt-out".
+Even though the "global" opt-in is a one-liner, it's unfortunate that the feature still requires it, instead of just working "out of the box." For full context and reasoning on that decision, see [dotnet/runtime#89755](https://github.com/dotnet/runtime/issues/89755) and [dotnet/runtime#104943](https://github.com/dotnet/runtime/pull/104943). In short, the main blocker for "on by default" is the `ServiceLifetime` "controversy": for the current (`9.0.0`) state of the DI and `HttpClientFactory` implementations, there's no single `ServiceLifetime` that would be reasonably safe for all `HttpClient`s in all possible situations. There's an intention, however, to address the caveats in the upcoming releases, and switch the strategy from "opt-in" to "opt-out".
 
 ## HOW-TO: Opt-Out From Keyed Registration
 
-You can explicitly opt out from Keyed DI for `HttpClient`s by calling the <xref:Microsoft.Extensions.DependencyInjection.httpclientbuilderextensions.RemoveAsKeyed> extension method, either per client name: 
+You can explicitly opt out from Keyed DI for `HttpClient`s by calling the <xref:Microsoft.Extensions.DependencyInjection.httpclientbuilderextensions.RemoveAsKeyed%2A> extension method, either per client name: 
 
 ```csharp
 services.ConfigureHttpClientDefaults(b => b.AddAsKeyed());      // opt IN by default
@@ -267,7 +270,7 @@ provider.GetRequiredKeyedService<HttpClient>("not-keyed"); // Throws: No service
 provider.GetRequiredKeyedService<HttpClient>("unknown");   // OK (unconfigured instance)
 ```
 
-or "globally" with `ConfigureHttpClientDefaults`:
+&mdash;or "globally" with `ConfigureHttpClientDefaults`:
 
 ```csharp
 services.ConfigureHttpClientDefaults(b => b.RemoveAsKeyed()); // opt OUT by default
@@ -279,16 +282,13 @@ provider.GetRequiredKeyedService<HttpClient>("not-keyed"); // Throws: No service
 provider.GetRequiredKeyedService<HttpClient>("unknown");   // Throws: No service for type 'System.Net.Http.HttpClient' has been registered.
 ```
 
-
 ## Order Of Precedence
 
-If called together or any of them more then once, `AddAsKeyed()` and `RemoveAsKeyed()` generally follow the rules of `HttpClientFactory` configs and DI registrations:
+If called together or any of them more than once, `AddAsKeyed()` and `RemoveAsKeyed()` generally follow the rules of `HttpClientFactory` configs and DI registrations:
 
-1. If called for the same name, the last one wins: the lifetime from the last `AddAsKeyed()` is used to create the Keyed registration (unless `RemoveAsKeyed()` was called last, in which case the name is excluded).
-2. If used only within `ConfigureHttpClientDefaults`, the last one wins.
-3. If both `ConfigureHttpClientDefaults` and specific client name were used, all defaults are considered to "happen" before all per-name ones. Thus, defaults can be disregarded, and the last of the per-name ones wins.
-
-Note that if `AddAsKeyed()` is called within a Typed client registration, only the underlying Named client  will be registered as Keyed. The Typed client itself will continue to be registered as a plain Transient service.
+1. If called for the same name, the last setting wins: the lifetime from the last `AddAsKeyed()` is used to create the Keyed registration (unless `RemoveAsKeyed()` was called last, in which case the name is excluded).
+2. If used only within `ConfigureHttpClientDefaults`, the last setting wins.
+3. If both `ConfigureHttpClientDefaults` and specific client name were used, all defaults are considered to "happen" before all per-name settings. Thus, defaults can be disregarded, and the last of the per-name settings wins.
 
 ## See also
 
@@ -300,4 +300,3 @@ Note that if `AddAsKeyed()` is called within a Typed client registration, only t
 [hcf]: httpclient-factory.md
 [di]: dependency-injection.md
 [hcf-troubleshooting]: httpclient-factory-troubleshooting.md
-

--- a/docs/core/extensions/httpclient-factory.md
+++ b/docs/core/extensions/httpclient-factory.md
@@ -303,7 +303,7 @@ In this section, the term _"factory-default" Primary Handler_ refers to the Prim
 
 There are cases in which you need to know the specific type of a Primary Handler, especially if working on a class library. While preserving the end user's configuration, you might want to update, for example, `HttpClientHandler`-specific properties like `ClientCertificates`, `UseCookies`, and `UseProxy`. It might be tempting to cast the Primary handler to `HttpClientHandler`, which _happened to_ work while `HttpClientHandler` was used as the "factory-default" Primary Handler. But as any code depending on implementation details, such a workaround is _fragile_ and bound to break.
 
-Instead, you can use `ConfigureHttpClientDefaults` to set up an "app-level" default Primary Handler instance instead of relying on the "factory-default" one:
+Instead of relying on the "factory-default" Primary Handler, you can use `ConfigureHttpClientDefaults` to set up an "app-level" default Primary Handler instance:
 
 ```csharp
 // Contract with the end-user: Only HttpClientHandler is supported.

--- a/docs/core/extensions/httpclient-factory.md
+++ b/docs/core/extensions/httpclient-factory.md
@@ -295,17 +295,15 @@ For more information, see the [full example](https://github.com/dotnet/docs/tree
 
 ## Avoid depending on "factory-default" Primary Handler
 
-In this section, we use the term _"factory-default" Primary Handler_, by which we mean the Primary Handler that the default `IHttpClientFactory` implementation (or more precisely, the default `HttpMessageHandlerBuilder` implementation) will assign if _not configured in any way_ whatsoever.
+In this section, we use the term _"factory-default" Primary Handler_, by which we mean the Primary Handler that the default `IHttpClientFactory` implementation (or more precisely, the default `HttpMessageHandlerBuilder` implementation) assigns if _not configured in any way_ whatsoever.
 
 > [!NOTE]
 > The "factory-default" Primary Handler is an _implementation detail_ and subject to change.
-> It is strongly advised to AVOID depending on a specific implementation being used as a "factory-default" (e.g. `HttpClientHandler`).
+> ❌ AVOID depending on a specific implementation being used as a "factory-default" (for example, `HttpClientHandler`).
 
-There are cases in which you need to depended on the specific type of a Primary Handler, especially if working on a class library. While preserving the end-user's configuration, you might want to update, for example, `HttpClientHandler`-specific properies like `ClientCertificates`, `UseCookies`, `UseProxy`, etc.
+There are cases in which you need to know the specific type of a Primary Handler, especially if working on a class library. While preserving the end-user's configuration, you might want to update, for example, `HttpClientHandler`-specific properties like `ClientCertificates`, `UseCookies`, `UseProxy`, etc. It might be tempting to cast the Primary handler to `HttpClientHandler`, which _happened to_ work while `HttpClientHandler` was used as the "factory-default" Primary Handler. But as any code depending on implementation details, such a workaround is _fragile_ and bound to break.
 
-It might be tempting to simply cast the Primary handler to `HttpClientHandler`, which _happened to_ work while `HttpClientHandler` was used as the "factory-default" Primary Handler. But as any code depending on implementation details, such a workaround is _fragile_ and bound to break.
-
-It is advised to leverage `ConfigureHttpClientDefaults` to set up an "app-level" default Primary Handler instance instead of relying on the "factory-default" one:
+Instead, you can use `ConfigureHttpClientDefaults` to set up an "app-level" default Primary Handler instance instead of relying on the "factory-default" one:
 
 ```csharp
 // Contract with the end-user: Only HttpClientHandler is supported.

--- a/docs/core/extensions/httpclient-factory.md
+++ b/docs/core/extensions/httpclient-factory.md
@@ -295,13 +295,13 @@ For more information, see the [full example](https://github.com/dotnet/docs/tree
 
 ## Avoid depending on "factory-default" Primary Handler
 
-In this section, we use the term _"factory-default" Primary Handler_, by which we mean the Primary Handler that the default `IHttpClientFactory` implementation (or more precisely, the default `HttpMessageHandlerBuilder` implementation) assigns if _not configured in any way_ whatsoever.
+In this section, the term _"factory-default" Primary Handler_ refers to the Primary Handler that the default `IHttpClientFactory` implementation (or more precisely, the default `HttpMessageHandlerBuilder` implementation) assigns if _not configured in any way_ whatsoever.
 
 > [!NOTE]
 > The "factory-default" Primary Handler is an _implementation detail_ and subject to change.
 > ❌ AVOID depending on a specific implementation being used as a "factory-default" (for example, `HttpClientHandler`).
 
-There are cases in which you need to know the specific type of a Primary Handler, especially if working on a class library. While preserving the end-user's configuration, you might want to update, for example, `HttpClientHandler`-specific properties like `ClientCertificates`, `UseCookies`, `UseProxy`, etc. It might be tempting to cast the Primary handler to `HttpClientHandler`, which _happened to_ work while `HttpClientHandler` was used as the "factory-default" Primary Handler. But as any code depending on implementation details, such a workaround is _fragile_ and bound to break.
+There are cases in which you need to know the specific type of a Primary Handler, especially if working on a class library. While preserving the end user's configuration, you might want to update, for example, `HttpClientHandler`-specific properties like `ClientCertificates`, `UseCookies`, and `UseProxy`. It might be tempting to cast the Primary handler to `HttpClientHandler`, which _happened to_ work while `HttpClientHandler` was used as the "factory-default" Primary Handler. But as any code depending on implementation details, such a workaround is _fragile_ and bound to break.
 
 Instead, you can use `ConfigureHttpClientDefaults` to set up an "app-level" default Primary Handler instance instead of relying on the "factory-default" one:
 

--- a/docs/core/extensions/snippets/http/keyedservices/Program.cs
+++ b/docs/core/extensions/snippets/http/keyedservices/Program.cs
@@ -1,0 +1,22 @@
+﻿var builder = WebApplication.CreateBuilder(args);
+
+// --- (1) Registration ---
+builder.Services.AddHttpClient("github", c =>
+    {
+        c.BaseAddress = new Uri("https://api.github.com/");
+        c.DefaultRequestHeaders.Add("Accept", "application/vnd.github.v3+json");
+        c.DefaultRequestHeaders.Add("User-Agent", "dotnet");
+    })
+    .AddAsKeyed(); // Add HttpClient as a Keyed Scoped service for key="github"
+
+var app = builder.Build();
+
+// --- (2) Obtaining HttpClient instance ---
+// Directly inject the Keyed HttpClient by its name
+app.MapGet("/", ([FromKeyedServices("github")] HttpClient httpClient) =>
+    // --- (3) Using HttpClient instance ---
+    httpClient.GetFromJsonAsync<Repo>("/repos/dotnet/runtime"));
+
+app.Run();
+
+record Repo(string Name, string Url);

--- a/docs/core/extensions/snippets/http/keyedservices/keyedservices.csproj
+++ b/docs/core/extensions/snippets/http/keyedservices/keyedservices.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>KeyedServices</RootNamespace>
+  </PropertyGroup>
+
+</Project>

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -1098,6 +1098,9 @@ items:
               - name: HTTP client factory troubleshooting
                 href: ../core/extensions/httpclient-factory-troubleshooting.md
                 displayName: httpclient,http,client,factory,named client,named httpclient,typed client,typed httpclient
+              - name: Keyed DI Support in HTTP client factory
+                href: ../core/extensions/httpclient-factory-keyed-di.md
+                displayName: httpclient,http,client,factory,dependency injection,keyed,keyed di,keyed services
               - name: Build resilient HTTP apps
                 href: ../core/resilience/http-resilience.md
                 displayName: resilience,transient fault handling,http,httpclient,recovery,polly

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -1098,7 +1098,7 @@ items:
               - name: HTTP client factory troubleshooting
                 href: ../core/extensions/httpclient-factory-troubleshooting.md
                 displayName: httpclient,http,client,factory,named client,named httpclient,typed client,typed httpclient
-              - name: Keyed DI Support in HTTP client factory
+              - name: Keyed DI support in HTTP client factory
                 href: ../core/extensions/httpclient-factory-keyed-di.md
                 displayName: httpclient,http,client,factory,dependency injection,keyed,keyed di,keyed services
               - name: Build resilient HTTP apps


### PR DESCRIPTION
Moving all the details from the blogpost to the dedicated conceptual doc.

cc @dotnet/ncl @ManickaP 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/httpclient-factory-keyed-di.md](https://github.com/dotnet/docs/blob/973c4af7605354991543de4d49ba3a815a54ac26/docs/core/extensions/httpclient-factory-keyed-di.md) | [Keyed DI support in `IHttpClientFactory`](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/httpclient-factory-keyed-di?branch=pr-en-us-44533) |
| [docs/core/extensions/httpclient-factory.md](https://github.com/dotnet/docs/blob/973c4af7605354991543de4d49ba3a815a54ac26/docs/core/extensions/httpclient-factory.md) | [IHttpClientFactory with .NET](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/httpclient-factory?branch=pr-en-us-44533) |
| [docs/fundamentals/toc.yml](https://github.com/dotnet/docs/blob/973c4af7605354991543de4d49ba3a815a54ac26/docs/fundamentals/toc.yml) | [docs/fundamentals/toc](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/toc?branch=pr-en-us-44533) |


<!-- PREVIEW-TABLE-END -->