### PR TITLE
Add rule on closing newline

### DIFF
--- a/docs/csharp/language-reference/tokens/raw-string.md
+++ b/docs/csharp/language-reference/tokens/raw-string.md
@@ -22,6 +22,7 @@ The following rules govern the interpretation of a multi-line raw string literal
 - Whitespace following the opening quote on the same line is ignored.
 - Whitespace only lines following the opening quote are included in the string literal.
 - If a whitespace precedes the end delimiter on the same line, the exact number and kind of whitespace characters (e.g. spaces vs. tabs) must exist at the beginning of each content line. Specifically, a space does not match a horizontal tab, and vice versa.
+- The newline before the closing quotes isn't included in the literal string.
 
 You may need to create a raw string literal that has three or more consecutive double-quote characters. Raw string literals can start and end with a sequence of at least three double-quote characters. When your string literal contains three consecutive double-quotes, you start and end the raw string literal with four double quote characters:
 


### PR DESCRIPTION
Addresses anonymous feedback. Add a rule that the final newline before the closing quote characters is ignored.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/tokens/raw-string.md](https://github.com/dotnet/docs/blob/e06442791a89c8ab2a33d3541beeb1bd34d0d888/docs/csharp/language-reference/tokens/raw-string.md) | [Raw string literal text - `"""` in string literals](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/raw-string?branch=pr-en-us-44534) |

<!-- PREVIEW-TABLE-END -->