### PR TITLE
Add F1 keyword for `using static`

### DIFF
--- a/docs/csharp/language-reference/keywords/using-directive.md
+++ b/docs/csharp/language-reference/keywords/using-directive.md
@@ -1,7 +1,7 @@
 ---
 description: "The `using` directive imports types from a namespace, or creates an alias for a given type. Using directives enable you to use simple names for types instead of the fully qualified type name."
 title: "The using directive: Import types from a namespace"
-ms.date: 11/24/2024
+ms.date: 01/27/2025
 f1_keywords:
   - "using_CSharpKeyword"
   - "using-static_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/using-directive.md
+++ b/docs/csharp/language-reference/keywords/using-directive.md
@@ -4,8 +4,10 @@ title: "The using directive: Import types from a namespace"
 ms.date: 11/24/2024
 f1_keywords:
   - "using_CSharpKeyword"
+  - "using-static_CSharpKeyword"
 helpviewer_keywords:
   - "using directive [C#]"
+  - "using static directive [C#]"
 ---
 # The `using` directive
 


### PR DESCRIPTION
Fixes #43889

The roslyn compiler treats `using static` as a different token than `using`. Make sure both resolve to the correct page.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/using-directive.md](https://github.com/dotnet/docs/blob/beff9ff346d6b84443d5feda3db20bce1a2c4b25/docs/csharp/language-reference/keywords/using-directive.md) | [The `using` directive](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-directive?branch=pr-en-us-44540) |


<!-- PREVIEW-TABLE-END -->