### PR TITLE
Add example of `{ }` pattern

### DIFF
--- a/docs/csharp/fundamentals/functional/pattern-matching.md
+++ b/docs/csharp/fundamentals/functional/pattern-matching.md
@@ -1,7 +1,7 @@
 ---
 title: Pattern matching overview
 description: "Learn about pattern matching expressions in C#"
-ms.date: 03/13/2024
+ms.date: 01/27/2025
 ---
 
 # Pattern matching overview
@@ -77,6 +77,14 @@ The first two arms examine two properties of the `Order`. The third examines onl
 :::code language="csharp" source="snippets/patterns/OrderProcessor.cs" ID="DeconstructPattern":::
 
 The preceding code demonstrates the [*positional pattern*](../../language-reference/operators/patterns.md#positional-pattern) where the properties are deconstructed for the expression.
+
+You can also match a property against `{ }`, which matches any non-null value. Consider the following declaration, which stores measurements with an optional annotation:
+
+:::code language="csharp" source="snippets/patterns/Program.cs" ID="Observation":::
+
+You can test if a given observation has a non-null annotation using the following pattern matching expression:
+
+:::code language="csharp" source="snippets/patterns/Program.cs" ID="NotNullPropertyPattern":::
 
 ## List patterns
 

--- a/docs/csharp/fundamentals/functional/snippets/patterns/Program.cs
+++ b/docs/csharp/fundamentals/functional/snippets/patterns/Program.cs
@@ -8,11 +8,13 @@ class Program
 
         NullReferenceCheck();
 
-        var sequence = new List<int> {1,2,3,4,5,6,7};
+        var sequence = new List<int> { 1, 2, 3, 4, 5, 6, 7 };
         var middle = MidPoint(sequence);
         Console.WriteLine(middle);
 
         ListPattern.Example();
+
+        NotNullProperty(new Observation(42, "C", "Temperature"));
     }
 
     // <MidPoint>
@@ -65,4 +67,21 @@ class Program
         }
         // </NullableCheck>
     }
+
+    private static void NotNullProperty(Observation observation)
+    {
+        // <NotNullPropertyPattern>
+        if (observation.Annotation is { })
+        {
+            Console.WriteLine($"Observation description: {observation.Annotation}");
+        }
+        // <NotNullPropertyPattern>
+    }
+
+    // <Observation>
+    public record class Observation(int Value, string Units, string Name)
+    {
+        public string? Annotation { get; set; }
+    }
+    // </Observation>
 }

--- a/docs/csharp/fundamentals/functional/snippets/patterns/Program.cs
+++ b/docs/csharp/fundamentals/functional/snippets/patterns/Program.cs
@@ -75,7 +75,7 @@ class Program
         {
             Console.WriteLine($"Observation description: {observation.Annotation}");
         }
-        // <NotNullPropertyPattern>
+        // </NotNullPropertyPattern>
     }
 
     // <Observation>

--- a/docs/csharp/fundamentals/functional/snippets/patterns/patterns.csproj
+++ b/docs/csharp/fundamentals/functional/snippets/patterns/patterns.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>


### PR DESCRIPTION
Fixes #43926

You can match a property against the `{ }` pattern to match any non-null property. Add an example of that construct.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/fundamentals/functional/pattern-matching.md](https://github.com/dotnet/docs/blob/632c804c838277324b2d2eb05c79f65d748f66bf/docs/csharp/fundamentals/functional/pattern-matching.md) | [Pattern matching overview](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/functional/pattern-matching?branch=pr-en-us-44544) |


<!-- PREVIEW-TABLE-END -->