### PR TITLE
Clarify ref struct interface impl

### DIFF
--- a/docs/csharp/language-reference/builtin-types/ref-struct.md
+++ b/docs/csharp/language-reference/builtin-types/ref-struct.md
@@ -1,7 +1,7 @@
 ---
 title: "ref struct types"
 description: Learn about the ref struct type in C#
-ms.date: 07/26/2024
+ms.date: 01/27/2025
 ---
 # `ref` structure types (C# reference)
 
@@ -66,15 +66,15 @@ Beginning with C# 13, you can also implement the <xref:System.IDisposable?displa
 
 These restrictions ensure that a `ref struct` type that implements an interface obeys the necessary [ref safety](~/_csharpstandard/standard/structs.md#1623-ref-modifier) rules.
 
-- A `ref struct` can't be converted to an instance of an interface it implements. This restriction includes the implicit conversion when you use a `ref struct` type as an argument when the parameter is an interface type. The conversion results in a boxing conversion, which violates ref safety.
-- A `ref struct` that implements an interface *must* implement all interface members. The `ref struct` must implement members where the interface includes a default implementation.
+- A `ref struct` can't be converted to an instance of an interface it implements. This restriction includes the implicit conversion when you use a `ref struct` type as an argument when the parameter is an interface type. The conversion results in a boxing conversion, which violates ref safety. A `ref struct` can declare methods as explicit interface declarations. However, those methods can be accessed only from generic methods where the type parameter [`allows ref struct`](../../programming-guide/generics/constraints-on-type-parameters.md#allows-ref-struct) types.
+- A `ref struct` that implements an interface *must* implement all instance interface members. The `ref struct` must implement instance members even when the interface includes a default implementation.
 
-The compiler enforces these restrictions. If you write `ref struct` types that implement interfaces, each new update might include new [default interface members](../keywords/interface.md#default-interface-members). Until you provide an implementation for these new methods, your application won't compile.
+The compiler enforces these restrictions. If you write `ref struct` types that implement interfaces, each new update might include new [default interface members](../keywords/interface.md#default-interface-members). Until you provide an implementation for any new instance methods, your application won't compile. You can't provide a specific implementation for a `static` interface method with a default implementation.
 
 > [!IMPORTANT]
 > A `ref struct` that implements an interface includes the potential for later source-breaking and binary-breaking changes. The break occurs if a `ref struct` implements an interface defined in another assembly, and that assembly provides an update which adds default members to that interface.
 >
-> The source-break happens when you recompile the `ref struct`: It must implement the new member, even though there is a default implementation.
+> The source-break happens when you recompile the `ref struct`: It must implement the new member, even though there's a default implementation.
 >
 > The binary-break happens if you upgrade the external assembly without recompiling the `ref struct` type *and* the updated code calls the default implementation of the new method. The runtime throws an exception when the default member is accessed.
 

--- a/docs/csharp/whats-new/csharp-13.md
+++ b/docs/csharp/whats-new/csharp-13.md
@@ -1,7 +1,7 @@
 ---
 title: What's new in C# 13
 description: Get an overview of the new features in C# 13.
-ms.date: 09/30/2024
+ms.date: 01/27/2025
 ms.topic: whats-new
 ---
 # What's new in C# 13
@@ -136,9 +136,9 @@ This enables types such as <xref:System.Span%601?displayProperty=nameWithType> a
 
 ## `ref struct` interfaces
 
-Before C# 13, `ref struct` types weren't allowed to implement interfaces. Beginning with C# 13, they can. You can declare that a `ref struct` type implements an interface. However, to ensure ref safety rules, a `ref struct` type can't be converted to an interface type. That conversion is a boxing conversion, and could violate ref safety. From that rule, `ref struct` types can't declare methods that explicitly implement an interface method. Also, `ref struct` types must implement all methods declared in an interface, including those methods with a default implementation.
+Before C# 13, `ref struct` types weren't allowed to implement interfaces. Beginning with C# 13, they can. You can declare that a `ref struct` type implements an interface. However, to ensure ref safety rules, a `ref struct` type can't be converted to an interface type. That conversion is a boxing conversion, and could violate ref safety. Explicit interface method declarations in a `ref struct` can be accessed only through a type parameter where that type parameter [`allows ref struct`](../programming-guide/generics/constraints-on-type-parameters.md#allows-ref-struct). Also, `ref struct` types must implement all methods declared in an interface, including those methods with a default implementation.
 
-Learn more in the updates on [`ref struct` types](../language-reference/builtin-types/ref-struct.md#restrictions-for-ref-struct-types-that-implement-an-interface).
+Learn more in the updates on [`ref struct` types](../language-reference/builtin-types/ref-struct.md#restrictions-for-ref-struct-types-that-implement-an-interface) and the addition of the [`allows ref struct`](../programming-guide/generics/constraints-on-type-parameters.md#allows-ref-struct) generic constraint.
 
 ## More partial members
 
@@ -175,7 +175,7 @@ This feature is intended for library authors to avoid ambiguity when adding new 
 
 The [`field`](../language-reference/keywords/field.md) contextual keyword is in C# 13 as a preview feature. The token `field` accesses the compiler synthesized backing field in a property accessor. It enables you to write an accessor body without declaring an explicit backing field in your type declaration. You can declare a body for one or both accessors for a field backed property.
 
-The `field` feature is released as a preview feature. We want to learn from your experiences using it. There's a potential a breaking change or confusion reading code in types that also include a field named `field`.  You can use `@field` or `this.field` to disambiguate between the `field` keyword and the identifier.
+The `field` feature is released as a preview feature. We want to learn from your experiences using it. There's a potential breaking change or confusion reading code in types that also include a field named `field`. You can use `@field` or `this.field` to disambiguate between the `field` keyword and the identifier.
 
 [!INCLUDE[field-preview](../includes/field-preview.md)]
 


### PR DESCRIPTION
Fixes #44003: Ref structs can explicitly implement an interface. However, those methods are only callable from a generic method that allows ref structs on a type parameter. Otherwise, they require a boxing conversion, which violates ref safety.

Fixes #44508: Ref struct types don't need to, and in fact can't provide a specific implementation of a static method with a default implementation declared in an interface.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/builtin-types/ref-struct.md](https://github.com/dotnet/docs/blob/fac972d117b7a56c6f9b3a26b50546ce700ecdbe/docs/csharp/language-reference/builtin-types/ref-struct.md) | [`ref` structure types (C# reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/ref-struct?branch=pr-en-us-44545) |
| [docs/csharp/whats-new/csharp-13.md](https://github.com/dotnet/docs/blob/fac972d117b7a56c6f9b3a26b50546ce700ecdbe/docs/csharp/whats-new/csharp-13.md) | [What's new in C# 13](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-13?branch=pr-en-us-44545) |

<!-- PREVIEW-TABLE-END -->