### PR TITLE
Fail job instead of leaving comment

### DIFF
--- a/.github/workflows/live-protection.yml
+++ b/.github/workflows/live-protection.yml
@@ -8,8 +8,6 @@ jobs:
   live_protection_job:
     name: Create comment
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
 
     steps:
       - name: Harden Runner
@@ -19,14 +17,9 @@ jobs:
 
       - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         env:
-          SHOULD_COMMENT: ${{ github.base_ref == 'live' && github.head_ref != 'main' }}
+          LIVE_BASE: ${{ github.base_ref == 'live' && github.head_ref != 'main' }}
         with:
           script: |
-            if (process.env.SHOULD_COMMENT == 'true') {
-              github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: 'It looks like this pull request was opened on the live branch by mistake. In general, PRs should target main.'
-              })
+            if (process.env.LIVE_BASE == 'true') {
+              core.setFailed('PR targets live branch and base isn't main branch')
             }

--- a/.github/workflows/live-protection.yml
+++ b/.github/workflows/live-protection.yml
@@ -21,5 +21,5 @@ jobs:
         with:
           script: |
             if (process.env.LIVE_BASE == 'true') {
-              core.setFailed('PR targets live branch and base isn't main branch')
+              core.setFailed('PR targets live branch')
             }


### PR DESCRIPTION
If auto-merge was enabled, just leaving a comment wouldn't prevent the merge. This will if we make it a required check.

Contributes to #44553.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/workflows/live-protection.yml](https://github.com/dotnet/docs/blob/2e154254e335015ccbbd5f0d842cad048b00583f/.github/workflows/live-protection.yml) | [.github/workflows/live-protection](https://review.learn.microsoft.com/en-us/dotnet/.github/workflows/live-protection?branch=pr-en-us-44554) |


<!-- PREVIEW-TABLE-END -->