### PR TITLE
Clarify Event Raising in Structures and Add Code Example for Triggering Events

### DIFF
--- a/docs/visual-basic/programming-guide/language-features/data-types/how-to-declare-a-structure.md
+++ b/docs/visual-basic/programming-guide/language-features/data-types/how-to-declare-a-structure.md
@@ -44,11 +44,24 @@ You begin a structure declaration with the [Structure Statement](../../../langua
             salary *= raise  
         End Sub  
         Public Event salaryReviewTime()  
+
+        ' Method to raise the event
+        Public Sub TriggerSalaryReview()
+            RaiseEvent salaryReviewTime()
+        End Sub
     End Structure  
     ```  
   
-     The `salary` field in the preceding example is `Private`, which means it is inaccessible outside the structure, even from the containing class. However, the `giveRaise` procedure is `Public`, so it can be called from outside the structure. Similarly, you can raise the `salaryReviewTime` event from outside the structure.  
-  
+     The `salary` field in the preceding example is `Private`, which means it is inaccessible outside the structure, even from the containing class. However, the `giveRaise` procedure is `Public`, so it can be called from outside the structure. Similarly, you can raise the `salaryReviewTime` event indirectly by calling a method within the structure that raises it. For example:  
+
+     ```vb
+     Public Sub TriggerSalaryReview()
+         RaiseEvent salaryReviewTime()
+     End Sub
+     ```  
+
+     This allows you to control how and when the event is raised while keeping the event inaccessible directly from outside the structure.
+
      In addition to variables, `Sub` procedures, and events, you can also define constants, `Function` procedures, and properties in a structure. You can designate at most one property as the *default property*, provided it takes at least one argument. You can handle an event with a [Shared](../../../language-reference/modifiers/shared.md)`Sub` procedure. For more information, see [How to: Declare and Call a Default Property in Visual Basic](../procedures/how-to-declare-and-call-a-default-property.md).  
   
 ## See also


### PR DESCRIPTION
## Summary

This update resolves confusion regarding event raising in structures by addressing the statement:
"Similarly, you can raise the `salaryReviewTime` event from outside the structure."

### Key changes:
- Explained that events cannot be raised directly from outside the structure.
- Introduced a public method `TriggerSalaryReview` within the structure to raise the `salaryReviewTime` event.
- Added a code example demonstrating how to trigger the event through this method.

These changes ensure accurate guidance, improve clarity, and enhance developer understanding of event handling in Visual Basic structures.

Fixes #36231 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/visual-basic/programming-guide/language-features/data-types/how-to-declare-a-structure.md](https://github.com/dotnet/docs/blob/6bf832cceec1eb4a2dde98bec8137e912aa9163f/docs/visual-basic/programming-guide/language-features/data-types/how-to-declare-a-structure.md) | [How to: Declare a Structure (Visual Basic)](https://review.learn.microsoft.com/en-us/dotnet/visual-basic/programming-guide/language-features/data-types/how-to-declare-a-structure?branch=pr-en-us-44556) |

<!-- PREVIEW-TABLE-END -->