### PR TITLE
Fix job name in action

### DIFF
--- a/.github/workflows/live-protection.yml
+++ b/.github/workflows/live-protection.yml
@@ -6,7 +6,7 @@ permissions:
 
 jobs:
   live_protection_job:
-    name: Create comment
+    name: Check base branch
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
It no longer comments, it fails the job.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/workflows/live-protection.yml](https://github.com/dotnet/docs/blob/98cfdd8e06684d46e9af697d2563a0565224c996/.github/workflows/live-protection.yml) | [.github/workflows/live-protection](https://review.learn.microsoft.com/en-us/dotnet/.github/workflows/live-protection?branch=pr-en-us-44557) |

<!-- PREVIEW-TABLE-END -->