### PR TITLE
Use 'unsafe' modifier explicitly to have it visible in code snippets

### DIFF
--- a/docs/csharp/language-reference/snippets/unsafe-code/FunctionPointers.cs
+++ b/docs/csharp/language-reference/snippets/unsafe-code/FunctionPointers.cs
@@ -1,6 +1,6 @@
 ﻿namespace UnsafeCodePointers;
 
-public unsafe class FunctionPointers
+public class FunctionPointers
 {
     public static void PointerExamples()
     {
@@ -10,35 +10,36 @@ public unsafe class FunctionPointers
         Console.WriteLine();
 
         // <InvokeViaFunctionPointer>
-        static int localMultiply(int x, int y) => x * y;
-        int product = UnsafeCombine(&localMultiply, 3, 4);
+        int product = 0;
+        unsafe
+        {
+            static int localMultiply(int x, int y) => x * y;
+            product = UnsafeCombine(&localMultiply, 3, 4);
+        }
         // </InvokeViaFunctionPointer>
         Console.WriteLine(product);
-
-
     }
 
     // <UseDelegateOrPointer>
     public static T Combine<T>(Func<T, T, T> combinator, T left, T right) => 
         combinator(left, right);
 
-    public static T UnsafeCombine<T>(delegate*<T, T, T> combinator, T left, T right) => 
+    public static unsafe T UnsafeCombine<T>(delegate*<T, T, T> combinator, T left, T right) => 
         combinator(left, right);
     // </UseDelegateOrPointer>
 
     // <UnmanagedFunctionPointers>
-    public static T ManagedCombine<T>(delegate* managed<T, T, T> combinator, T left, T right) =>
+    public static unsafe T ManagedCombine<T>(delegate* managed<T, T, T> combinator, T left, T right) =>
         combinator(left, right);
-    public static T CDeclCombine<T>(delegate* unmanaged[Cdecl]<T, T, T> combinator, T left, T right) =>
+    public static unsafe T CDeclCombine<T>(delegate* unmanaged[Cdecl]<T, T, T> combinator, T left, T right) =>
         combinator(left, right);
-    public static T StdcallCombine<T>(delegate* unmanaged[Stdcall]<T, T, T> combinator, T left, T right) =>
+    public static unsafe T StdcallCombine<T>(delegate* unmanaged[Stdcall]<T, T, T> combinator, T left, T right) =>
         combinator(left, right);
-    public static T FastcallCombine<T>(delegate* unmanaged[Fastcall]<T, T, T> combinator, T left, T right) =>
+    public static unsafe T FastcallCombine<T>(delegate* unmanaged[Fastcall]<T, T, T> combinator, T left, T right) =>
         combinator(left, right);
-    public static T ThiscallCombine<T>(delegate* unmanaged[Thiscall]<T, T, T> combinator, T left, T right) =>
+    public static unsafe T ThiscallCombine<T>(delegate* unmanaged[Thiscall]<T, T, T> combinator, T left, T right) =>
         combinator(left, right);
-    public static T UnmanagedCombine<T>(delegate* unmanaged<T, T, T> combinator, T left, T right) =>
+    public static unsafe T UnmanagedCombine<T>(delegate* unmanaged<T, T, T> combinator, T left, T right) =>
         combinator(left, right);
     // </UnmanagedFunctionPointers>
-
 }


### PR DESCRIPTION
This pull request fixes #42312 

It removes the `unsafe` scope applied to the whole class code, but applies the `unsafe` modifier for each separate statement that requires it, so that every time the `unsafe` is needed, it is clearly visible included in the code snippet presented on the page.

**Note:** For the part with `InvokeViaFunctionPointer`, where I put `product` outside of the `unsafe` scope, is because the `Console.WriteLine` that requires that `product` to be in the same scope of course. But, that `Console.WriteLine` is not included on the page, so **I'm not sure** if this will not be confusing for the reader to have that `product` being put out of `unsafe` because... no reason from the reader perspective.
(Other option, that I considered was to remove the `Console.WriteLine` call)
Let me know, please, what is your opinion, when reviewing 🙏 