### PR TITLE
Mention printfn inside parameters and arguments doc.

### DIFF
--- a/docs/fsharp/language-reference/parameters-and-arguments.md
+++ b/docs/fsharp/language-reference/parameters-and-arguments.md
@@ -214,6 +214,8 @@ Occasionally it is necessary to define a function that takes an arbitrary number
 
 In F#, parameter arrays can only be defined in methods. They cannot be used in standalone functions or functions that are defined in modules.
 
+However, functions like `printfn` achieve similar behavior by using format specifiers and type inference to handle multiple arguments dynamically. The `printfn` function does not rely on parameter arrays; instead, it uses F#'s type-safe formatting mechanism to process varying numbers of arguments while ensuring compile-time type checking.
+
 You define a parameter array by using the `ParamArray` attribute. The `ParamArray` attribute can only be applied to the last parameter.
 
 The following code illustrates both calling a .NET method that takes a parameter array and the definition of a type in F# that has a method that takes a parameter array.


### PR DESCRIPTION
## Summary

Mention `printfn` inside parameters and arguments doc.

Fixes #34928 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/parameters-and-arguments.md](https://github.com/dotnet/docs/blob/084b42a169f494100ed8c15431f12f7f346fd1ec/docs/fsharp/language-reference/parameters-and-arguments.md) | [Parameters and Arguments](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/parameters-and-arguments?branch=pr-en-us-44584) |

<!-- PREVIEW-TABLE-END -->