### PR TITLE
Update MSTEST0026 doc to reflect enabled by default change in 3.8

### DIFF
--- a/docs/core/testing/mstest-analyzers/mstest0026.md
+++ b/docs/core/testing/mstest-analyzers/mstest0026.md
@@ -19,7 +19,7 @@ ms.author: faisalhafeez
 | **Title**                           | Avoid conditional access in assertions                |
 | **Category**                        | Usage                                                 |
 | **Fix is breaking or non-breaking** | Non-breaking                                          |
-| **Enabled by default**              | Yes                                                   |
+| **Enabled by default**              | Yes (from 3.5 to 3.7). No (starting with 3.8)         |
 | **Default severity**                | Info                                                  |
 | **Introduced in version**           | 3.5.0                                                 |
 | **Is there a code fix**             | No                                                    |


### PR DESCRIPTION
Product PR: https://github.com/microsoft/testfx/pull/4816

cc @Evangelink

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/mstest-analyzers/mstest0026.md](https://github.com/dotnet/docs/blob/0e9bb10b4313c6240975be1bea2e92dee45f1b06/docs/core/testing/mstest-analyzers/mstest0026.md) | [MSTEST0026: Avoid conditional access in assertions](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0026?branch=pr-en-us-44585) |

<!-- PREVIEW-TABLE-END -->