### PR TITLE
Add Example for Mutually Recursive Discriminated Unions in F#

### DIFF
--- a/docs/fsharp/language-reference/discriminated-unions.md
+++ b/docs/fsharp/language-reference/discriminated-unions.md
@@ -159,6 +159,22 @@ Discriminated unions work well if the nodes in the tree are heterogeneous. In th
 
 When this code is executed, the value of `result` is 5.
 
+## Mutually Recursive Discriminated Unions
+
+Discriminated unions in F# can be mutually recursive, meaning that multiple union types can reference each other in a recursive manner. This is useful when modeling hierarchical or interconnected structures. To define mutually recursive discriminated unions, use the `and` keyword.
+
+For example, consider an abstract syntax tree (AST) representation where expressions can include statements, and statements can contain expressions:
+
+```fsharp
+type Expression =
+    | Literal of int
+    | Variable of string
+    | Operation of string * Expression * Expression
+and Statement =
+    | Assign of string * Expression
+    | Sequence of Statement list
+    | IfElse of Expression * Statement * Statement
+
 ## Members
 
 It is possible to define members on discriminated unions. The following example shows how to define a property and implement an interface:

--- a/docs/fsharp/language-reference/discriminated-unions.md
+++ b/docs/fsharp/language-reference/discriminated-unions.md
@@ -174,6 +174,7 @@ and Statement =
     | Assign of string * Expression
     | Sequence of Statement list
     | IfElse of Expression * Statement * Statement
+```
 
 ## Members
 


### PR DESCRIPTION
## Summary

This PR enhances the **Discriminated** Unions documentation by adding an example of **mutually recursive discriminated** unions using the `and` keyword. While the F# language reference mentions this feature, an explicit example in the guide improves clarity for readers.

### Changes:
- Introduced a new section **"Mutually Recursive Discriminated Unions"**
- Added a practical example demonstrating recursion between `Expression` and `Statement` types
- Explained use cases and relevance in AST modeling and hierarchical data structures

This update improves comprehension for developers working with recursive types in F#. 

Fixes #31809 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/discriminated-unions.md](https://github.com/dotnet/docs/blob/e2a8843e7487a5dbab5ec2660b8ac0e3f9d25275/docs/fsharp/language-reference/discriminated-unions.md) | [Discriminated Unions](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/discriminated-unions?branch=pr-en-us-44610) |


<!-- PREVIEW-TABLE-END -->