### PR TITLE
Replace 'comprised' with 'composed' in CA2253

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca2253.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2253.md
@@ -26,7 +26,7 @@ A message placeholder consists of numeric characters only.
 
 ## Rule description
 
-Named placeholders in the logging message template should not be comprised of only numeric characters.
+Named placeholders in the logging message template should not be composed of only numeric characters.
 
 ## How to fix violations
 


### PR DESCRIPTION
This small PR fixes #44576 
Just like in the linked PR - it updates the statement of the `CA2253` rule description, replacing "comprised" with "composed"


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca2253.md](https://github.com/dotnet/docs/blob/2ae69cd27b41ec295d7ed6ff1c77b0c64385c33a/docs/fundamentals/code-analysis/quality-rules/ca2253.md) | [CA2253: Named placeholders should not be numeric values](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2253?branch=pr-en-us-44612) |

<!-- PREVIEW-TABLE-END -->