### PR TITLE
Make "Built in Metrics for Runtime" doc accurate for memory metrics

### DIFF
--- a/docs/core/diagnostics/built-in-metrics-runtime.md
+++ b/docs/core/diagnostics/built-in-metrics-runtime.md
@@ -83,7 +83,7 @@ Available starting in: .NET 9.0.
 
 | Attribute | Type | Description | Examples | Presence |
 |---|---|---|---|---|
-| `gc.heap.generation` | string | Name of the garbage collector managed heap generation. | `gen0`; `gen1`; `gen2`;`loh`;`poh` | Always |
+| `gc.heap.generation` | string | Name of the garbage collector managed heap generation. | `gen0`; `gen1`; `gen2`; `loh`; `poh` | Always |
 
 The .NET GC divides the heap into generations. In addition to the standard numbered generations, the GC also puts some objects into two special generations:
 
@@ -102,7 +102,7 @@ Available starting in: .NET 9.0.
 
 | Attribute | Type | Description | Examples | Presence |
 |---|---|---|---|---|
-| `gc.heap.generation` | string | Name of the garbage collector managed heap generation. | `gen0`; `gen1`; `gen2`;`loh`;`poh` | Always |
+| `gc.heap.generation` | string | Name of the garbage collector managed heap generation. | `gen0`; `gen1`; `gen2`; `loh`; `poh` | Always |
 
 This metric reports the same values as calling <xref:System.GCGenerationInfo.FragmentationAfterBytes?displayProperty=nameWithType>.
 

--- a/docs/core/diagnostics/built-in-metrics-runtime.md
+++ b/docs/core/diagnostics/built-in-metrics-runtime.md
@@ -100,6 +100,10 @@ Available starting in: .NET 9.0.
 | -------- | --------------- | ----------- | -------------- |
 | `dotnet.gc.last_collection.heap.fragmentation.size` | UpDownCounter | `By` | The heap fragmentation, as observed during the latest garbage collection. |
 
+| Attribute | Type | Description | Examples | Presence |
+|---|---|---|---|---|
+| `gc.heap.generation` | string | Name of the garbage collector managed heap generation. | `gen0`; `gen1`; `gen2`;`loh`;`poh` | Always |
+
 This metric reports the same values as calling <xref:System.GCGenerationInfo.FragmentationAfterBytes?displayProperty=nameWithType>.
 
 When .NET objects are allocated, initially they tend to be laid out contiguously in memory. However, if some of those objects are later collected by the GC, this creates gaps of unused memory between the live objects that remain. These gaps represent the portion of the GC heap that's not currently being used to store objects, often called "fragmentation."  The GC can reuse the fragmentation bytes in the future for new object allocations if the object size is small enough to fit in one of the gaps. The GC can also perform a special compacting garbage collection that moves remaining live objects next to each other as long as the objects haven't been pinned in place.

--- a/docs/core/diagnostics/built-in-metrics-runtime.md
+++ b/docs/core/diagnostics/built-in-metrics-runtime.md
@@ -49,7 +49,7 @@ Available starting in: .NET 9.0.
 
 | Attribute | Type | Description | Examples | Presence |
 |---|---|---|---|---|
-| `dotnet.gc.heap.generation` | string | Name of the maximum managed heap generation being collected. | `gen0`; `gen1`; `gen2` | Always |
+| `gc.heap.generation` | string | Name of the maximum managed heap generation being collected. | `gen0`; `gen1`; `gen2` | Always |
 
 The .NET GC is a generational garbage collector. Each time the garbage collector runs, it uses heuristics to select a maximum generation and then collects objects in all generations up to the selected maximum. For example, a `gen1` collection collects all objects in generations 0 and 1. A `gen2` collection collects all objects in generations 0, 1, and 2. For more information about the .NET GC and generational garbage collection, see the [.NET garbage collection guide](../../standard/garbage-collection/fundamentals.md#generations).
 
@@ -83,7 +83,7 @@ Available starting in: .NET 9.0.
 
 | Attribute | Type | Description | Examples | Presence |
 |---|---|---|---|---|
-| `dotnet.gc.heap.generation` | string | Name of the garbage collector managed heap generation. | `gen0`; `gen1`; `gen2`;`loh`;`poh` | Always |
+| `gc.heap.generation` | string | Name of the garbage collector managed heap generation. | `gen0`; `gen1`; `gen2`;`loh`;`poh` | Always |
 
 The .NET GC divides the heap into generations. In addition to the standard numbered generations, the GC also puts some objects into two special generations:
 


### PR DESCRIPTION
## Summary
I was looking at https://learn.microsoft.com/en-us/dotnet/core/diagnostics/built-in-metrics-runtime and spotted a couple of things which don't seem to align with reality, so I've tried to fix them with this PR. 

Firstly, the metrics `dotnet.gc.last_collection.heap.size` and `dotnet.gc.collections` list `dotnet.gc.heap.generation` as an attribute to mark the generation they are referring to. But when I checked the [source code](https://github.com/dotnet/runtime/blob/adf123c23ee42262515c36562b09fa0b19959599/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/RuntimeMetrics.cs#L191C110-L191C128), the attribute is called  `gc.heap.generation`. This is also what I have experienced while using this new meter.

Secondly, the metric`dotnet.gc.last_collection.heap.fragmentation.size` has no attributes listed. But when I checked the [source code](https://github.com/dotnet/runtime/blob/adf123c23ee42262515c36562b09fa0b19959599/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/RuntimeMetrics.cs#L195-L203) it had an attribute similarly called `gc.heap.generation`. This has been my experience with the library as well. To address that I have copied the table from the `dotnet.gc.last_collection.heap.size` metric because it is exactly the same concept.

Hopefully this format of submission is okay, I'm still pretty new to open source submissions!

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/built-in-metrics-runtime.md](https://github.com/dotnet/docs/blob/c10f703033f9e51fb57e650c33f49c56b66e80e8/docs/core/diagnostics/built-in-metrics-runtime.md) | [.NET Runtime metrics](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/built-in-metrics-runtime?branch=pr-en-us-44616) |


<!-- PREVIEW-TABLE-END -->