### PR TITLE
Add first level info for migration off of VSTest

### DIFF
--- a/docs/core/testing/unit-testing-platform-vs-vstest.md
+++ b/docs/core/testing/unit-testing-platform-vs-vstest.md
@@ -52,3 +52,79 @@ To disable the use of the new protocol in Test Explorer, you can edit your proje
 ## Executables
 
 VSTest ships multiple executables, notably `vstest.console.exe`, `testhost.exe`, and `datacollector.exe`. However, MSTest is embedded directly into your test project and doesn't ship any other executables. The executable your test project compiles to is used to host all the testing tools and carry out all the tasks needed to run tests.
+
+## Migrating from VSTest
+
+In addition to the steps specific to your test framework, you will need to update your test infrastructure to accommodate to `Microsoft.Testing.Platform`.
+
+### `dotnet test`
+
+Command line options of `dotnet test` are divided into 2 categories: build related arguments and test related ones.
+
+The build related arguments are passed to the `dotnet build` command and as such don't need to be updated for the new platform. Build related arguments are listed below:
+
+- `-a|--arch <ARCHITECTURE>`
+- `--artifacts-path <ARTIFACTS_DIR>`
+- `-c|--configuration <CONFIGURATION>`
+- `-f|--framework <FRAMEWORK>`
+- `-e|--environment <NAME="VALUE">`
+- `--interactive`
+- `--no-build`
+- `--nologo`
+- `--no-restore`
+- `-o|--output <OUTPUT_DIRECTORY>`
+- `--os <OS>`
+- `-r|--runtime <RUNTIME_IDENTIFIER>`
+- `-v|--verbosity <LEVEL>`
+
+The test related arguments are VSTest specific and so need to be transformed to match the new platform. The following table shows the mapping between the VSTest arguments and the new platform:
+
+| VSTest argument | New platform argument |
+|-----------------|-----------------------|
+| `--test-adapter-path <ADAPTER_PATH>` | Not supported |
+| `--blame` | Not supported |
+| `--blame-crash` | `--crashdump` requires [Crash dump extension](./unit-testing-platform-extensions-diagnostics.md#crash-dump) |
+| `--blame-crash-dump-type <DUMP_TYPE>` | `--crashdump-type` requires [Crash dump extension](./unit-testing-platform-extensions-diagnostics.md#crash-dump) |
+| `--blame-crash-collect-always` | Not supported |
+| `--blame-hang` | `--hangdump` requires [Hang dump extension](./unit-testing-platform-extensions-diagnostics.md#hang-dump) |
+| `--blame-hang-dump-type <DUMP_TYPE>` | `--hangdump-type` requires [Hang dump extension](./unit-testing-platform-extensions-diagnostics.md#hang-dump) |
+| `--blame-hang-timeout <TIMESPAN>` | `--hangdump-timeout` requires [Hang dump extension](./unit-testing-platform-extensions-diagnostics.md#hang-dump) |
+| `--collect <DATA_COLLECTOR_NAME>` | Depends on the data collector |
+| `-d\|--diag <LOG_FILE>` | `--diagnostic` |
+| `--filter <EXPRESSION>` | Depends upon the selected test framework |
+| `-l\|--logger <LOGGER>` | Depends on the logger |
+| `--results-directory <RESULTS_DIR>` | `--results-directory <RESULTS_DIR>` |
+| `-s\|--settings <SETTINGS_FILE>` | Depends upon the selected test framework |
+| `-t\|--list-tests` | `--list-tests` |
+| `-- <RunSettings arguments>` | Not supported |
+
+> [!IMPORTANT]
+> Before specifying any `Microsoft.Testing.Platform`, you will need to add `--` to separate the `dotnet test` arguments from the new platform arguments.
+
+### `vstest.console.exe`
+
+If you are using `vstest.console.exe` directly, we recommend replacing it with the `dotnet test` command.
+
+### Test Explorer
+
+When using Visual Studio or Visual Studio Code Test Explorer, you may need to enable the support for the new test platform.
+
+#### Visual Studio
+
+Visual Studio Test Explorer supports the new test platform starting with version 17.14. If you are using an earlier version, you may need to update your Visual Studio to the latest version.
+
+#### Visual Studio Code
+
+Visual Studio Code Test Explorer supports the new test platform starting with version X.
+
+### Azure DevOps
+
+When using Azure DevOps tasks, you may need to update your pipeline to use the new test platform.
+
+#### VSTest task
+
+If you are using the [VSTest task](https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/vstest-v3) in Azure DevOps, you can replace it with the [.NET Core task](https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/dotnet-core-cli-v2).
+
+#### .NET Core task
+
+If you are using the [.NET Core task](https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/dotnet-core-cli-v2), no changes are needed.

--- a/docs/core/testing/unit-testing-platform-vs-vstest.md
+++ b/docs/core/testing/unit-testing-platform-vs-vstest.md
@@ -55,7 +55,7 @@ VSTest ships multiple executables, notably `vstest.console.exe`, `testhost.exe`,
 
 ## Migrating from VSTest
 
-In addition to the steps specific to your test framework, you will need to update your test infrastructure to accommodate to `Microsoft.Testing.Platform`.
+In addition to the steps specific to your test framework, you need to update your test infrastructure to accommodate to `Microsoft.Testing.Platform`.
 
 ### `dotnet test`
 
@@ -99,7 +99,7 @@ The test related arguments are VSTest specific and so need to be transformed to 
 | `-- <RunSettings arguments>` | Not supported |
 
 > [!IMPORTANT]
-> Before specifying any `Microsoft.Testing.Platform`, you will need to add `--` to separate the `dotnet test` arguments from the new platform arguments.
+> Before specifying any `Microsoft.Testing.Platform`, you need to add `--` to separate the `dotnet test` arguments from the new platform arguments.
 
 ### `vstest.console.exe`
 
@@ -107,11 +107,11 @@ If you are using `vstest.console.exe` directly, we recommend replacing it with t
 
 ### Test Explorer
 
-When using Visual Studio or Visual Studio Code Test Explorer, you may need to enable the support for the new test platform.
+When using Visual Studio or Visual Studio Code Test Explorer, you might need to enable the support for the new test platform.
 
 #### Visual Studio
 
-Visual Studio Test Explorer supports the new test platform starting with version 17.14. If you are using an earlier version, you may need to update your Visual Studio to the latest version.
+Visual Studio Test Explorer supports the new test platform starting with version 17.14. If you are using an earlier version, you might need to update your Visual Studio to the latest version.
 
 #### Visual Studio Code
 
@@ -119,7 +119,7 @@ Visual Studio Code Test Explorer supports the new test platform starting with ve
 
 ### Azure DevOps
 
-When using Azure DevOps tasks, you may need to update your pipeline to use the new test platform.
+When using Azure DevOps tasks, you might need to update your pipeline to use the new test platform.
 
 #### VSTest task
 


### PR DESCRIPTION
## Summary

Relates to https://github.com/microsoft/testfx/issues/4801

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-platform-vs-vstest.md](https://github.com/dotnet/docs/blob/a9ca839b6673bfc48fd3791bb4f3702b4a262530/docs/core/testing/unit-testing-platform-vs-vstest.md) | [Microsoft.Testing.Platform and VSTest comparison](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-platform-vs-vstest?branch=pr-en-us-44620) |


<!-- PREVIEW-TABLE-END -->