### PR TITLE
Add default value for csharp_space_between_parentheses

### DIFF
--- a/docs/fundamentals/code-analysis/style-rules/csharp-formatting-options.md
+++ b/docs/fundamentals/code-analysis/style-rules/csharp-formatting-options.md
@@ -1,7 +1,7 @@
 ---
 title: C# formatting options
 description: Learn about the code style options for formatting C# code files.
-ms.date: 12/13/2022
+ms.date: 01/30/2025
 dev_langs:
 - CSharp
 ---
@@ -593,10 +593,10 @@ for(int i;i<x;i++) { ... }
 | **Option values**        | `control_flow_statements`        | Place space between parentheses of control flow statements |
 |                          | `expressions`                    | Place space between parentheses of expressions |
 |                          | `type_casts`                     | Place space between parentheses in type casts |
-|                          | `false` (or any other value)     | Ignore spaces between parentheses |
-| **Default option value** | ``                            |             |
+|                          | `false` (or any other value)     | Prefer no spaces between parentheses† |
+| **Default option value** | `false`†                         |             |
 
-If you omit this rule or use a value other than `control_flow_statements`, `expressions`, or `type_casts`, spaces between parentheses are ignored, meaning new spaces aren't added and existing spaces aren't removed.
+†If you omit this rule or use any value other than `control_flow_statements`, `expressions`, or `type_casts`, spaces between parentheses of control flow statements, expressions, and type casts are removed.
 
 Code examples:
 
@@ -611,6 +611,8 @@ var z = ( x * y ) - ( ( y - x ) * 3 );
 int y = ( int )x;
 
 // csharp_space_between_parentheses = false
+for (int i = 0; i < 10; i++) { }
+var z = (x * y) - ((y - x) * 3);
 int y = (int)x;
 ```
 

--- a/docs/fundamentals/code-analysis/style-rules/csharp-formatting-options.md
+++ b/docs/fundamentals/code-analysis/style-rules/csharp-formatting-options.md
@@ -39,15 +39,15 @@ csharp_new_line_between_query_expression_clauses = true
 
 This option concerns whether an open brace `{` should be placed on the same line as the preceding code, or on a new line. For this rule, you specify **all**, **none**, or one or more code elements such as **methods** or **properties**, to define when this rule should be applied. To specify multiple code elements, separate them with a comma (,).
 
-| Property                 | Value                             | Description                                                              |
-|--------------------------|-----------------------------------|--------------------------------------------------------------------------|
-| **Option name**          | csharp_new_line_before_open_brace |                                                                          |
-| **Applicable languages** | C#                                |                                                                          |
-| **Introduced version**   | Visual Studio 2017                |                                                                          |
+| Property                 | Value                             | Description |
+|--------------------------|-----------------------------------|-------------|
+| **Option name**          | csharp_new_line_before_open_brace |             |
+| **Applicable languages** | C#                                |             |
+| **Introduced version**   | Visual Studio 2017                |             |
 | **Option values**        | `all`                             | Require braces to be on a new line for all expressions ("Allman" style). |
-|                          | `none`                            | Require braces to be on the same line for all expressions ("K&R").       |
+|                          | `none`                            | Require braces to be on the same line for all expressions ("K&R"). |
 |                          | `accessors`, `anonymous_methods`, `anonymous_types`, `control_blocks`, `events`, `indexers`,</br>`lambdas`, `local_functions`, `methods`, `object_collection_array_initializers`, `properties`, `types` | Require braces to be on a new line for the specified code element ("Allman" style). |
-| **Default option value** | `all`                             |                                                                          |
+| **Default option value** | `all`                             |              |
 
 Code examples:
 
@@ -101,14 +101,14 @@ if (...) {
 
 ### csharp_new_line_before_catch
 
-| Property                 | Value                           | Description                                |
-| ------------------------ | ------------------------------- | ------------------------------------------ |
-| **Option name**          | csharp_new_line_before_catch    |                                            |
-| **Applicable languages** | C#                              |                                            |
-| **Introduced version**   | Visual Studio 2017 |                                            |
-| **Option values**        | `true`                          | Place `catch` statements on a new line.    |
-|                          | `false`                         | Place `catch` statements on the same line. |
-| **Default option value** | `true`                          |                                            |
+| Property                 | Value                        | Description                                |
+|--------------------------|------------------------------|--------------------------------------------|
+| **Option name**          | csharp_new_line_before_catch |                                            |
+| **Applicable languages** | C#                           |                                            |
+| **Introduced version**   | Visual Studio 2017           |                                            |
+| **Option values**        | `true`                       | Place `catch` statements on a new line.    |
+|                          | `false`                      | Place `catch` statements on the same line. |
+| **Default option value** | `true`                       |                                            |
 
 Code examples:
 
@@ -131,14 +131,14 @@ try {
 
 ### csharp_new_line_before_finally
 
-| Property                 | Value                           | Description                                                               |
-| ------------------------ | ------------------------------- | ------------------------------------------------------------------------- |
-| **Option name**          | csharp_new_line_before_finally  |                                                                           |
-| **Applicable languages** | C#                              |                                                                           |
-| **Introduced version**   | Visual Studio 2017 |                                                                           |
-| **Option values**        | `true`                          | Require `finally` statements to be on a new line after the closing brace. |
-|                          | `false`                         | Require `finally` statements to be on the same line as the closing brace. |
-| **Default option value** | `true`                          |                                                                           |
+| Property                 | Value                          | Description |
+|--------------------------|--------------------------------|-------------|
+| **Option name**          | csharp_new_line_before_finally |             |
+| **Applicable languages** | C#                             |             |
+| **Introduced version**   | Visual Studio 2017             |             |
+| **Option values**        | `true`                         | Require `finally` statements to be on a new line after the closing brace. |
+|                          | `false`                        | Require `finally` statements to be on the same line as the closing brace. |
+| **Default option value** | `true`                         |             |
 
 Code examples:
 
@@ -166,14 +166,14 @@ try {
 
 ### csharp_new_line_before_members_in_object_initializers
 
-| Property                 | Value                                                 | Description                                                    |
-| ------------------------ | ----------------------------------------------------- | -------------------------------------------------------------- |
-| **Option name**          | csharp_new_line_before_members_in_object_initializers |                                                                |
-| **Applicable languages** | C#                                                    |                                                                |
-| **Introduced version**   | Visual Studio 2017                                    |                                                                |
+| Property                 | Value                                                 | Description |
+|--------------------------|-------------------------------------------------------|-------------|
+| **Option name**          | csharp_new_line_before_members_in_object_initializers |             |
+| **Applicable languages** | C#                                                    |             |
+| **Introduced version**   | Visual Studio 2017                                    |             |
 | **Option values**        | `true`                                                | Require members of object initializers to be on separate lines |
-|                          | `false`                                               | Require members of object initializers to be on the same line  |
-| **Default option value** | `true`                                                |                                                                |
+|                          | `false`                                               | Require members of object initializers to be on the same line |
+| **Default option value** | `true`                                                |             |
 
 Code examples:
 
@@ -194,14 +194,14 @@ var z = new B()
 
 ### csharp_new_line_before_members_in_anonymous_types
 
-| Property                 | Value                                             | Description                                                |
-| ------------------------ | ------------------------------------------------- | ---------------------------------------------------------- |
-| **Option name**          | csharp_new_line_before_members_in_anonymous_types |                                                            |
-| **Applicable languages** | C#                                                |                                                            |
-| **Introduced version**   | Visual Studio 2017                                |                                                            |
+| Property                 | Value                                             | Description |
+|--------------------------|---------------------------------------------------|-------------|
+| **Option name**          | csharp_new_line_before_members_in_anonymous_types |             |
+| **Applicable languages** | C#                                                |             |
+| **Introduced version**   | Visual Studio 2017                                |             |
 | **Option values**        | `true`                                            | Require members of anonymous types to be on separate lines |
 |                          | `false`                                           | Require members of anonymous types to be on the same line  |
-| **Default option value** | `true`                                            |                                                            |
+| **Default option value** | `true`                                            |             |
 
 Code examples:
 
@@ -222,14 +222,14 @@ var z = new
 
 ### csharp_new_line_between_query_expression_clauses
 
-| Property                 | Value                                            | Description                                                          |
-| ------------------------ | ------------------------------------------------ | -------------------------------------------------------------------- |
-| **Option name**          | csharp_new_line_between_query_expression_clauses |                                                                      |
-| **Applicable languages** | C#                                               |                                                                      |
-| **Introduced version**   | Visual Studio 2017                               |                                                                      |
+| Property                 | Value                                            | Description |
+|--------------------------|--------------------------------------------------|-------------|
+| **Option name**          | csharp_new_line_between_query_expression_clauses |             |
+| **Applicable languages** | C#                                               |             |
+| **Introduced version**   | Visual Studio 2017                               |             |
 | **Option values**        | `true`                                           | Require elements of query expression clauses to be on separate lines |
 |                          | `false`                                          | Require elements of query expression clauses to be on the same line  |
-| **Default option value** | `true`                                           |                                                                      |
+| **Default option value** | `true`                                           |             |
 
 Code examples:
 
@@ -270,14 +270,14 @@ csharp_indent_case_contents_when_block = true
 
 ### csharp_indent_case_contents
 
-| Property                 | Value                           | Description                          |
-| ------------------------ | ------------------------------- | ------------------------------------ |
-| **Option name**          | csharp_indent_case_contents     |                                      |
-| **Applicable languages** | C#                              |                                      |
-| **Introduced version**   | Visual Studio 2017              |                                      |
-| **Option values**        | `true`                          | Indent `switch` case contents        |
-|                          | `false`                         | Do not indent `switch` case contents |
-| **Default option value** | `true`                          |                                      |
+| Property                 | Value                       | Description |
+|--------------------------|-----------------------------|-------------|
+| **Option name**          | csharp_indent_case_contents |             |
+| **Applicable languages** | C#                          |             |
+| **Introduced version**   | Visual Studio 2017          |             |
+| **Option values**        | `true`                      | Indent `switch` case contents |
+|                          | `false`                     | Do not indent `switch` case contents |
+| **Default option value** | `true`                      |             |
 
 Code examples:
 
@@ -352,15 +352,15 @@ default:
 
 ### csharp_indent_labels
 
-| Property                 | Value                           | Description                                                 |
-| ------------------------ | ------------------------------- | ----------------------------------------------------------- |
-| **Option name**          | csharp_indent_labels            |                                                             |
-| **Applicable languages** | C#                              |                                                             |
-| **Introduced version**   | Visual Studio 2017              |                                                             |
-| **Option values**        | `flush_left`                    | Labels are placed at the leftmost column                    |
-|                          | `one_less_than_current`         | Labels are placed at one less indent to the current context |
-|                          | `no_change`                     | Labels are placed at the same indent as the current context |
-| **Default option value** | `one_less_than_current`         |                                                             |
+| Property                 | Value                | Description |
+|--------------------------|----------------------|-------------|
+| **Option name**          | csharp_indent_labels |             |
+| **Applicable languages** | C#                   |             |
+| **Introduced version**   | Visual Studio 2017   |             |
+| **Option values**        | `flush_left`         | Labels are placed at the leftmost column                    |
+|                          | `one_less_than_current` | Labels are placed at one less indent to the current context |
+|                          | `no_change`          | Labels are placed at the same indent as the current context |
+| **Default option value** | `one_less_than_current` |            |
 
 Code examples:
 
@@ -459,13 +459,13 @@ static void Hello()
 
 ### csharp_indent_case_contents_when_block
 
-| Property                 | Value                                  | Description                                                                                           |
-| ------------------------ | -------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| **Option name**          | csharp_indent_case_contents_when_block |                                                                                                       |
-| **Applicable languages** | C#                                     |                                                                                                       |
-| **Option values**        | `true`                                 | When it's a block, indent the statement list and curly braces for a case in a switch statement.       |
+| Property                 | Value                                  | Description |
+|--------------------------|----------------------------------------|-------------|
+| **Option name**          | csharp_indent_case_contents_when_block |             |
+| **Applicable languages** | C#                                     |             |
+| **Option values**        | `true`                                 | When it's a block, indent the statement list and curly braces for a case in a switch statement. |
 |                          | `false`                                | When it's a block, don't indent the statement list and curly braces for a case in a switch statement. |
-| **Default option value** | `true`                                 |                                                                                                       |
+| **Default option value** | `true`                                 |             |
 
 Code examples:
 
@@ -543,14 +543,14 @@ csharp_space_between_square_brackets = false
 
 ### csharp_space_after_cast
 
-| Property                 | Value                           | Description                                          |
-| ------------------------ | ------------------------------- | ---------------------------------------------------- |
-| **Option name**          | csharp_space_after_cast         |                                                      |
-| **Applicable languages** | C#                              |                                                      |
-| **Introduced version**   | Visual Studio 2017              |                                                      |
-| **Option values**        | `true`                          | Place a space character between a cast and the value |
-|                          | `false`                         | Remove space between the cast and the value          |
-| **Default option value** | `false`                         |                                                      |
+| Property                 | Value                   | Description |
+|--------------------------|-------------------------|-------------|
+| **Option name**          | csharp_space_after_cast |             |
+| **Applicable languages** | C#                      |             |
+| **Introduced version**   | Visual Studio 2017      |             |
+| **Option values**        | `true`                  | Place a space character between a cast and the value |
+|                          | `false`                 | Remove space between the cast and the value |
+| **Default option value** | `false`                 |             |
 
 Code examples:
 
@@ -564,14 +564,14 @@ int y = (int)x;
 
 ### csharp_space_after_keywords_in_control_flow_statements
 
-| Property                 | Value                                                  | Description                                                                              |
-| ------------------------ | ------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
-| **Option name**          | csharp_space_after_keywords_in_control_flow_statements |                                                                                          |
-| **Applicable languages** | C#                                                     |                                                                                          |
-| **Introduced version**   | Visual Studio 2017                                     |                                                                                          |
+| Property                 | Value              | Description |
+|--------------------------|--------------------|-------------|
+| **Option name**          | csharp_space_after_keywords_in_control_flow_statements |         |
+| **Applicable languages** | C#                 |             |
+| **Introduced version**   | Visual Studio 2017 |             |
 | **Option values**        | `true`                                                 | Place a space character after a keyword in a control flow statement such as a `for` loop |
-|                          | `false`                                                | Remove space after a keyword in a control flow statement such as a `for` loop            |
-| **Default option value** | `true`                                                 |                                                                                          |
+|                          | `false`                                                | Remove space after a keyword in a control flow statement such as a `for` loop |
+| **Default option value** | `true`             |             |
 
 Code examples:
 
@@ -585,17 +585,18 @@ for(int i;i<x;i++) { ... }
 
 ### csharp_space_between_parentheses
 
-| Property                 | Value                            | Description                                                |
-| ------------------------ | -------------------------------- | ---------------------------------------------------------- |
-| **Option name**          | csharp_space_between_parentheses |                                                            |
-| **Applicable languages** | C#                               |                                                            |
-| **Introduced version**   | Visual Studio 2017               |                                                            |
+| Property                 | Value                            | Description |
+|--------------------------|----------------------------------|-------------|
+| **Option name**          | csharp_space_between_parentheses |             |
+| **Applicable languages** | C#                               |             |
+| **Introduced version**   | Visual Studio 2017               |             |
 | **Option values**        | `control_flow_statements`        | Place space between parentheses of control flow statements |
-|                          | `expressions`                    | Place space between parentheses of expressions             |
-|                          | `type_casts`                     | Place space between parentheses in type casts              |
-|                          | `false` (or any other value)     | Never add spaces between parentheses                       |
+|                          | `expressions`                    | Place space between parentheses of expressions |
+|                          | `type_casts`                     | Place space between parentheses in type casts |
+|                          | `false` (or any other value)     | Ignore spaces between parentheses |
+| **Default option value** | ``                            |             |
 
-If you omit this rule or use a value other than `control_flow_statements`, `expressions`, or `type_casts`, the setting is not applied.
+If you omit this rule or use a value other than `control_flow_statements`, `expressions`, or `type_casts`, spaces between parentheses are ignored, meaning new spaces aren't added and existing spaces aren't removed.
 
 Code examples:
 
@@ -615,14 +616,14 @@ int y = (int)x;
 
 ### csharp_space_before_colon_in_inheritance_clause
 
-| Property                 | Value                                           | Description                                                                            |
-| ------------------------ | ----------------------------------------------- | -------------------------------------------------------------------------------------- |
-| **Option name**          | csharp_space_before_colon_in_inheritance_clause |                                                                                        |
-| **Applicable languages** | C#                                              |                                                                                        |
-| **Introduced version**   | Visual Studio 2017                              |                                                                                        |
+| Property                 | Value                                           | Description |
+|--------------------------|-------------------------------------------------|-------------|
+| **Option name**          | csharp_space_before_colon_in_inheritance_clause |             |
+| **Applicable languages** | C#                                              |             |
+| **Introduced version**   | Visual Studio 2017                              |             |
 | **Option values**        | `true`                                          | Place a space character before the colon for bases or interfaces in a type declaration |
-|                          | `false`                                         | Remove space before the colon for bases or interfaces in a type declaration            |
-| **Default option value** | `true`                                          |                                                                                        |
+|                          | `false`                                         | Remove space before the colon for bases or interfaces in a type declaration |
+| **Default option value** | `true`                                          |             |
 
 Code examples:
 
@@ -652,14 +653,14 @@ class C: I
 
 ### csharp_space_after_colon_in_inheritance_clause
 
-| Property                 | Value                                          | Description                                                                           |
-| ------------------------ | ---------------------------------------------- | ------------------------------------------------------------------------------------- |
-| **Option name**          | csharp_space_after_colon_in_inheritance_clause |                                                                                       |
-| **Applicable languages** | C#                                             |                                                                                       |
-| **Introduced version**   | Visual Studio 2017                             |                                                                                       |
+| Property                 | Value                                          | Description |
+|--------------------------|------------------------------------------------|-------------|
+| **Option name**          | csharp_space_after_colon_in_inheritance_clause |             |
+| **Applicable languages** | C#                                             |             |
+| **Introduced version**   | Visual Studio 2017                             |             |
 | **Option values**        | `true`                                         | Place a space character after the colon for bases or interfaces in a type declaration |
-|                          | `false`                                        | Remove space after the colon for bases or interfaces in a type declaration            |
-| **Default option value** | `true`                                         |                                                                                       |
+|                          | `false`                                        | Remove space after the colon for bases or interfaces in a type declaration |
+| **Default option value** | `true`                                         |             |
 
 Code examples:
 
@@ -689,15 +690,15 @@ class C :I
 
 ### csharp_space_around_binary_operators
 
-| Property                 | Value                                | Description                                        |
-| ------------------------ | ------------------------------------ | -------------------------------------------------- |
-| **Option name**          | csharp_space_around_binary_operators |                                                    |
-| **Applicable languages** | C#                                   |                                                    |
-| **Introduced version**   | Visual Studio 2017                   |                                                    |
+| Property                 | Value                                | Description |
+|--------------------------|--------------------------------------|-------------|
+| **Option name**          | csharp_space_around_binary_operators |             |
+| **Applicable languages** | C#                                   |             |
+| **Introduced version**   | Visual Studio 2017                   |             |
 | **Option values**        | `before_and_after`                   | Insert space before and after the binary operator  |
 |                          | `none`                               | Remove spaces before and after the binary operator |
 |                          | `ignore`                             | Ignore spaces around binary operators              |
-| **Default option value** | `before_and_after`                   |                                                    |
+| **Default option value** | `before_and_after`                   |             |
 
 Code examples:
 
@@ -714,14 +715,14 @@ return x  *  (x-y);
 
 ### csharp_space_between_method_declaration_parameter_list_parentheses
 
-| Property                 | Value                                                              | Description |
-|--------------------------|--------------------------------------------------------------------|-------------|
-| **Option name**          | csharp_space_between_method_declaration_parameter_list_parentheses |             |
-| **Applicable languages** | C#                                                                 |             |
-| **Introduced version**   | Visual Studio 2017                                                 |             |
+| Property                 | Value              | Description |
+|--------------------------|--------------------|-------------|
+| **Option name**          | csharp_space_between_method_declaration_parameter_list_parentheses | |
+| **Applicable languages** | C#                 |             |
+| **Introduced version**   | Visual Studio 2017 |             |
 | **Option values**        | `true` | Place a space character after the opening parenthesis and before the closing parenthesis of a method declaration parameter list |
 |                          | `false` | Remove space characters after the opening parenthesis and before the closing parenthesis of a method declaration parameter list |
-| **Default option value** | `false`                                                            |             |
+| **Default option value** | `false`            |             |
 
 Code examples:
 
@@ -735,14 +736,14 @@ void Bark(int x) { ... }
 
 ### csharp_space_between_method_declaration_empty_parameter_list_parentheses
 
-| Property                 | Value                                                                    | Description  |
-|--------------------------|--------------------------------------------------------------------------|--------------|
-| **Option name**          | csharp_space_between_method_declaration_empty_parameter_list_parentheses |              |
-| **Applicable languages** | C#                                                                       |              |
-| **Introduced version**   | Visual Studio 2017                                                       |              |
+| Property                 | Value              | Description |
+|--------------------------|--------------------|-------------|
+| **Option name**          | csharp_space_between_method_declaration_empty_parameter_list_parentheses | |
+| **Applicable languages** | C#                 |             |
+| **Introduced version**   | Visual Studio 2017 |             |
 | **Option values**        | `true` | Insert space within empty parameter list parentheses for a method declaration  |
 |                          | `false` | Remove space within empty parameter list parentheses for a method declaration |
-| **Default option value** | `false`                                                                  |              |
+| **Default option value** | `false`            |             |
 
 Code examples:
 
@@ -772,13 +773,13 @@ void Goo(int x)
 
 ### csharp_space_between_method_declaration_name_and_open_parenthesis
 
-| Property                 | Value                                                             | Description |
-|--------------------------|-------------------------------------------------------------------|-------------|
-| **Option name**          | csharp_space_between_method_declaration_name_and_open_parenthesis |             |
-| **Applicable languages** | C#                                                                |             |
-| **Option values**        | `true` | Place a space character between the method name and opening parenthesis in the method declaration |
+| Property                 | Value   | Description |
+|--------------------------|---------|-------------|
+| **Option name**          | csharp_space_between_method_declaration_name_and_open_parenthesis | |
+| **Applicable languages** | C#      |             |
+| **Option values**        | `true`  | Place a space character between the method name and opening parenthesis in the method declaration |
 |                          | `false` | Remove space characters between the method name and opening parenthesis in the method declaration |
-| **Default option value** | `false` |                                                                                                   |
+| **Default option value** | `false` |           |
 
 Code examples:
 
@@ -792,14 +793,14 @@ void M() { }
 
 ### csharp_space_between_method_call_parameter_list_parentheses
 
-| Property                 | Value                                                       | Description |
-|--------------------------|-------------------------------------------------------------|-------------|
-| **Option name**          | csharp_space_between_method_call_parameter_list_parentheses |             |
-| **Applicable languages** | C#                                                          |             |
-| **Introduced version**   | Visual Studio 2017                                          |             |
-| **Option values**        | `true` | Place a space character after the opening parenthesis and before the closing parenthesis of a method call |
-|                          | `false` | Remove space characters after the opening parenthesis and before the closing parenthesis of a method call |
-| **Default option value** | `false` |                                                                                                           |
+| Property                 | Value              | Description |
+|--------------------------|--------------------|-------------|
+| **Option name**          | csharp_space_between_method_call_parameter_list_parentheses | |
+| **Applicable languages** | C#                 |             |
+| **Introduced version**   | Visual Studio 2017 |             |
+| **Option values**        | `true`             | Place a space character after the opening parenthesis and before the closing parenthesis of a method call |
+|                          | `false`            | Remove space characters after the opening parenthesis and before the closing parenthesis of a method call |
+| **Default option value** | `false`            |             |
 
 Code examples:
 
@@ -813,14 +814,14 @@ MyMethod(argument);
 
 ### csharp_space_between_method_call_empty_parameter_list_parentheses
 
-| Property                 | Value                                                             | Description                                         |
-| ------------------------ | ----------------------------------------------------------------- | --------------------------------------------------- |
-| **Option name**          | csharp_space_between_method_call_empty_parameter_list_parentheses |                                                     |
-| **Applicable languages** | C#                                                                |                                                     |
-| **Introduced version**   | Visual Studio 2017                                                |                                                     |
-| **Option values**        | `true`                                                            | Insert space within empty argument list parentheses |
-|                          | `false`                                                           | Remove space within empty argument list parentheses |
-| **Default option value** | `false`                                                           |                                                     |
+| Property                 | Value              | Description |
+|--------------------------|--------------------|-------------|
+| **Option name**          | csharp_space_between_method_call_empty_parameter_list_parentheses | |
+| **Applicable languages** | C#                 |             |
+| **Introduced version**   | Visual Studio 2017 |             |
+| **Option values**        | `true`             | Insert space within empty argument list parentheses |
+|                          | `false`            | Remove space within empty argument list parentheses |
+| **Default option value** | `false`            |             |
 
 Code examples:
 
@@ -850,14 +851,14 @@ void Goo(int x)
 
 ### csharp_space_between_method_call_name_and_opening_parenthesis
 
-| Property                 | Value                                                         | Description                                                   |
-| ------------------------ | ------------------------------------------------------------- | ------------------------------------------------------------- |
-| **Option name**          | csharp_space_between_method_call_name_and_opening_parenthesis |                                                               |
-| **Applicable languages** | C#                                                            |                                                               |
-| **Introduced version**   | Visual Studio 2017                                            |                                                               |
-| **Option values**        | `true`                                                        | Insert space between method call name and opening parenthesis |
-|                          | `false`                                                       | Remove space between method call name and opening parenthesis |
-| **Default option value** | `false`                                                       |                                                               |
+| Property                 | Value              | Description |
+|--------------------------|--------------------|-------------|
+| **Option name**          | csharp_space_between_method_call_name_and_opening_parenthesis | |
+| **Applicable languages** | C#                 |             |
+| **Introduced version**   | Visual Studio 2017 |             |
+| **Option values**        | `true`             | Insert space between method call name and opening parenthesis |
+|                          | `false`            | Remove space between method call name and opening parenthesis |
+| **Default option value** | `false`            |              |
 
 Code examples:
 
@@ -967,13 +968,13 @@ this.Goo();
 
 ### csharp_space_after_semicolon_in_for_statement
 
-| Property                 | Value                                         | Description                                            |
-| ------------------------ | --------------------------------------------- | ------------------------------------------------------ |
-| **Option name**          | csharp_space_after_semicolon_in_for_statement |                                                        |
-| **Applicable languages** | C#                                            |                                                        |
+| Property                 | Value                                         | Description |
+|--------------------------|-----------------------------------------------|-------------|
+| **Option name**          | csharp_space_after_semicolon_in_for_statement |             |
+| **Applicable languages** | C#                                            |             |
 | **Option values**        | `true`                                        | Insert space after each semicolon in a `for` statement |
 |                          | `false`                                       | Remove space after each semicolon in a `for` statement |
-| **Default option value** | `true`                                        |                                                        |
+| **Default option value** | `true`                                        |             |
 
 Code examples:
 
@@ -987,13 +988,13 @@ for (int i = 0;i < x.Length;i++)
 
 ### csharp_space_before_semicolon_in_for_statement
 
-| Property                 | Value                                          | Description                                             |
-| ------------------------ | ---------------------------------------------- | ------------------------------------------------------- |
-| **Option name**          | csharp_space_before_semicolon_in_for_statement |                                                         |
-| **Applicable languages** | C#                                             |                                                         |
+| Property                 | Value                                          | Description |
+|--------------------------|------------------------------------------------|-------------|
+| **Option name**          | csharp_space_before_semicolon_in_for_statement |             |
+| **Applicable languages** | C#                                             |             |
 | **Option values**        | `true`                                         | Insert space before each semicolon in a `for` statement |
 |                          | `false`                                        | Remove space before each semicolon in a `for` statement |
-| **Default option value** | `false`                                        |                                                         |
+| **Default option value** | `false`                                        |             |
 
 Code examples:
 
@@ -1007,13 +1008,13 @@ for (int i = 0; i < x.Length; i++)
 
 ### csharp_space_around_declaration_statements
 
-| Property                 | Value                                      | Description                                                   |
-| ------------------------ | ------------------------------------------ | ------------------------------------------------------------- |
-| **Option name**          | csharp_space_around_declaration_statements |                                                               |
-| **Applicable languages** | C#                                         |                                                               |
+| Property                 | Value                                      | Description |
+|--------------------------|--------------------------------------------|-------------|
+| **Option name**          | csharp_space_around_declaration_statements |             |
+| **Applicable languages** | C#                                         |             |
 | **Option values**        | `ignore`                                   | Don't remove extra space characters in declaration statements |
-|                          | `false`                                    | Remove extra space characters in declaration statements       |
-| **Default option value** | `false`                                    |                                                               |
+|                          | `false`                                    | Remove extra space characters in declaration statements |
+| **Default option value** | `false`                                    |             |
 
 Code examples:
 
@@ -1027,13 +1028,13 @@ int x = 0;
 
 ### csharp_space_before_open_square_brackets
 
-| Property                 | Value                                    | Description                                     |
-| ------------------------ | ---------------------------------------- | ----------------------------------------------- |
-| **Option name**          | csharp_space_before_open_square_brackets |                                                 |
-| **Applicable languages** | C#                                       |                                                 |
+| Property                 | Value                                    | Description |
+|--------------------------|------------------------------------------|-------------|
+| **Option name**          | csharp_space_before_open_square_brackets |             |
+| **Applicable languages** | C#                                       |             |
 | **Option values**        | `true`                                   | Insert space before opening square brackets `[` |
 |                          | `false`                                  | Remove space before opening square brackets `[` |
-| **Default option value** | `false`                                  |                                                 |
+| **Default option value** | `false`                                  |             |
 
 Code examples:
 
@@ -1047,13 +1048,13 @@ int[] numbers = new int[] { 1, 2, 3, 4, 5 };
 
 ### csharp_space_between_empty_square_brackets
 
-| Property                 | Value                                      | Description                                      |
-| ------------------------ | ------------------------------------------ | ------------------------------------------------ |
-| **Option name**          | csharp_space_between_empty_square_brackets |                                                  |
-| **Applicable languages** | C#                                         |                                                  |
+| Property                 | Value                                      | Description |
+|--------------------------|--------------------------------------------|-------------|
+| **Option name**          | csharp_space_between_empty_square_brackets |             |
+| **Applicable languages** | C#                                         |             |
 | **Option values**        | `true`                                     | Insert space between empty square brackets `[ ]` |
 |                          | `false`                                    | Remove space between empty square brackets `[]`  |
-| **Default option value** | `false`                                    |                                                  |
+| **Default option value** | `false`                                    |             |
 
 Code examples:
 
@@ -1067,13 +1068,13 @@ int[] numbers = new int[] { 1, 2, 3, 4, 5 };
 
 ### csharp_space_between_square_brackets
 
-| Property                 | Value                                | Description                                                  |
-| ------------------------ | ------------------------------------ | ------------------------------------------------------------ |
-| **Option name**          | csharp_space_between_square_brackets |                                                              |
-| **Applicable languages** | C#                                   |                                                              |
+| Property                 | Value                                | Description |
+|--------------------------|--------------------------------------|-------------|
+| **Option name**          | csharp_space_between_square_brackets |             |
+| **Applicable languages** | C#                                   |             |
 | **Option values**        | `true`                               | Insert space characters in non-empty square brackets `[ 0 ]` |
-|                          | `false`                              | Remove space characters in non-empty square brackets `[0]`   |
-| **Default option value** | `false`                              |                                                              |
+|                          | `false`                              | Remove space characters in non-empty square brackets `[0]` |
+| **Default option value** | `false`                              |             |
 
 Code examples:
 
@@ -1103,14 +1104,14 @@ csharp_preserve_single_line_blocks = true
 
 ### csharp_preserve_single_line_statements
 
-| Property                 | Value                                  | Description                                                 |
-| ------------------------ | -------------------------------------- | ----------------------------------------------------------- |
-| **Option name**          | csharp_preserve_single_line_statements |                                                             |
-| **Applicable languages** | C#                                     |                                                             |
-| **Introduced version**   | Visual Studio 2017                     |                                                             |
-| **Option values**        | `true`                                 | Leave statements and member declarations on the same line   |
+| Property                 | Value                                  | Description |
+|--------------------------|----------------------------------------|-------------|
+| **Option name**          | csharp_preserve_single_line_statements |             |
+| **Applicable languages** | C#                                     |             |
+| **Introduced version**   | Visual Studio 2017                     |             |
+| **Option values**        | `true`                                 | Leave statements and member declarations on the same line |
 |                          | `false`                                | Leave statements and member declarations on different lines |
-| **Default option value** | `true`                                 |                                                             |
+| **Default option value** | `true`                                 |             |
 
 Code examples:
 
@@ -1125,14 +1126,14 @@ string name = "John";
 
 ### csharp_preserve_single_line_blocks
 
-| Property                 | Value                              | Description                        |
-| ------------------------ | ---------------------------------- | ---------------------------------- |
-| **Option name**          | csharp_preserve_single_line_blocks |                                    |
-| **Applicable languages** | C#                                 |                                    |
-| **Introduced version**   | Visual Studio 2017                 |                                    |
-| **Option values**        | `true`                             | Leave code block on single line    |
+| Property                 | Value                              | Description |
+|--------------------------|------------------------------------|-------------|
+| **Option name**          | csharp_preserve_single_line_blocks |             |
+| **Applicable languages** | C#                                 |             |
+| **Introduced version**   | Visual Studio 2017                 |             |
+| **Option values**        | `true`                             | Leave code block on single line |
 |                          | `false`                            | Leave code block on separate lines |
-| **Default option value** | `true`                             |                                    |
+| **Default option value** | `true`                             |             |
 
 Code examples:
 


### PR DESCRIPTION
Fixes #37130 

- Add default value for csharp_space_between_parentheses, and clarify `false` value
- Also formats other tables in doc (so [hide whitespace changes](https://github.com/dotnet/docs/pull/44623/files?diff=unified&w=1))

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/style-rules/csharp-formatting-options.md](https://github.com/dotnet/docs/blob/d38b964959f3c8006d9f24706ebfd6d6fdfca726/docs/fundamentals/code-analysis/style-rules/csharp-formatting-options.md) | [C# formatting options](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/csharp-formatting-options?branch=pr-en-us-44623) |

<!-- PREVIEW-TABLE-END -->