### PR TITLE
Clarify ReferenceEquals Behavior for Value Types in Docs

### DIFF
--- a/docs/csharp/programming-guide/statements-expressions-operators/how-to-test-for-reference-equality-identity.md
+++ b/docs/csharp/programming-guide/statements-expressions-operators/how-to-test-for-reference-equality-identity.md
@@ -14,7 +14,7 @@ You do not have to implement any custom logic to support reference equality comp
   
  The following example shows how to determine whether two variables have *reference equality*, which means that they refer to the same object in memory.  
   
-The example also shows why <xref:System.Object.ReferenceEquals%2A?displayProperty=nameWithType> always returns `false` for value types. This is due to **boxing**, which creates separate object instances for each value type argument. Additionally, you should not use <xref:System.Object.ReferenceEquals%2A> to determine string equality. 
+The example also shows why <xref:System.Object.ReferenceEquals%2A?displayProperty=nameWithType> always returns `false` for value types. This is due to **boxing**, which creates separate object instances for each value type argument. Additionally, you should not use <xref:System.Object.ReferenceEquals%2A> to determine string equality.
   
 ## Example  
 
@@ -26,7 +26,6 @@ The example also shows why <xref:System.Object.ReferenceEquals%2A?displayPropert
 
 > [!NOTE]
 > `ReferenceEquals` returns `false` for value types due to **boxing**, as each argument is independently boxed into a separate object.
-  
   
 ## See also
 

--- a/docs/csharp/programming-guide/statements-expressions-operators/how-to-test-for-reference-equality-identity.md
+++ b/docs/csharp/programming-guide/statements-expressions-operators/how-to-test-for-reference-equality-identity.md
@@ -14,7 +14,7 @@ You do not have to implement any custom logic to support reference equality comp
   
  The following example shows how to determine whether two variables have *reference equality*, which means that they refer to the same object in memory.  
   
-The example also shows why <xref:System.Object.ReferenceEquals%2A?displayProperty=nameWithType> always returns `false` for value types. This is due to **boxing**, which creates separate object instances for each value type argument, rather than due to copying. Additionally, you should not use <xref:System.Object.ReferenceEquals%2A> to determine string equality. 
+The example also shows why <xref:System.Object.ReferenceEquals%2A?displayProperty=nameWithType> always returns `false` for value types. This is due to **boxing**, which creates separate object instances for each value type argument. Additionally, you should not use <xref:System.Object.ReferenceEquals%2A> to determine string equality. 
   
 ## Example  
 
@@ -25,7 +25,7 @@ The example also shows why <xref:System.Object.ReferenceEquals%2A?displayPropert
  Constant strings within the same assembly are always interned by the runtime. That is, only one instance of each unique literal string is maintained. However, the runtime does not guarantee that strings created at run time are interned, nor does it guarantee that two equal constant strings in different assemblies are interned.
 
 > [!NOTE]
-> `ReferenceEquals` returns `false` for value types due to **boxing**, not copying, as each argument is independently boxed into a separate object.
+> `ReferenceEquals` returns `false` for value types due to **boxing**, as each argument is independently boxed into a separate object.
   
   
 ## See also

--- a/docs/csharp/programming-guide/statements-expressions-operators/how-to-test-for-reference-equality-identity.md
+++ b/docs/csharp/programming-guide/statements-expressions-operators/how-to-test-for-reference-equality-identity.md
@@ -14,7 +14,7 @@ You do not have to implement any custom logic to support reference equality comp
   
  The following example shows how to determine whether two variables have *reference equality*, which means that they refer to the same object in memory.  
   
- The example also shows why <xref:System.Object.ReferenceEquals%2A?displayProperty=nameWithType> always returns `false` for value types and why you should not use  <xref:System.Object.ReferenceEquals%2A> to determine string equality.  
+The example also shows why <xref:System.Object.ReferenceEquals%2A?displayProperty=nameWithType> always returns `false` for value types. This is due to **boxing**, which creates separate object instances for each value type argument, rather than due to copying. Additionally, you should not use <xref:System.Object.ReferenceEquals%2A> to determine string equality. 
   
 ## Example  
 
@@ -22,7 +22,11 @@ You do not have to implement any custom logic to support reference equality comp
   
  The implementation of `Equals` in the <xref:System.Object?displayProperty=nameWithType> universal base class also performs a reference equality check, but it is best not to use this because, if a class happens to override the method, the results might not be what you expect. The same is true for the `==` and `!=` operators. When they are operating on reference types, the default behavior of `==` and `!=` is to perform a reference equality check. However, derived classes can overload the operator to perform a value equality check. To minimize the potential for error, it is best to always use <xref:System.Object.ReferenceEquals%2A> when you have to determine whether two objects have reference equality.  
   
- Constant strings within the same assembly are always interned by the runtime. That is, only one instance of each unique literal string is maintained. However, the runtime does not guarantee that strings created at run time are interned, nor does it guarantee that two equal constant strings in different assemblies are interned.  
+ Constant strings within the same assembly are always interned by the runtime. That is, only one instance of each unique literal string is maintained. However, the runtime does not guarantee that strings created at run time are interned, nor does it guarantee that two equal constant strings in different assemblies are interned.
+
+> [!NOTE]
+> `ReferenceEquals` returns `false` for value types due to **boxing**, not copying, as each argument is independently boxed into a separate object.
+  
   
 ## See also
 

--- a/docs/csharp/programming-guide/statements-expressions-operators/snippets/how-to-test-for-reference-equality-identity/Program.cs
+++ b/docs/csharp/programming-guide/statements-expressions-operators/snippets/how-to-test-for-reference-equality-identity/Program.cs
@@ -52,8 +52,8 @@ namespace TestReferenceEquality
 
             TestStruct tsC = new TestStruct( 1, "TestStruct 1");
 
-            // Value types are copied on assignment. tsD and tsC have
-            // the same values but are not the same object.
+            // Value types are boxed into separate objects when passed to ReferenceEquals.
+            // Even if the same variable is used twice, boxing ensures they are different instances.
             TestStruct tsD = tsC;
             Console.WriteLine("After assignment: ReferenceEquals(tsC, tsD) = {0}",
                                 Object.ReferenceEquals(tsC, tsD)); // false


### PR DESCRIPTION
## Summary

This PR updates the documentation to clarify that `ReferenceEquals` returns `false` for value types due to boxing, not copying. The previous wording could mislead readers into thinking that copying is the primary reason for the false result.

### Changes
- Updated explanation in the "How to test for reference equality (Identity)" article.
- Added a **[!NOTE]** to explicitly state that `ReferenceEquals` returns `false` for value types because each argument is independently boxed.

Fixes #41839 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/statements-expressions-operators/how-to-test-for-reference-equality-identity.md](https://github.com/dotnet/docs/blob/b2e5ac8ccd569d1fad6ccb6f64cc6d9b32733dad/docs/csharp/programming-guide/statements-expressions-operators/how-to-test-for-reference-equality-identity.md) | [How to test for reference equality (Identity) (C# Programming Guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/statements-expressions-operators/how-to-test-for-reference-equality-identity?branch=pr-en-us-44624) |


<!-- PREVIEW-TABLE-END -->