### PR TITLE
Remove distributed tracing TIP

### DIFF
--- a/docs/fundamentals/networking/telemetry/overview.md
+++ b/docs/fundamentals/networking/telemetry/overview.md
@@ -14,6 +14,3 @@ The .NET networking stack is instrumented at various layers. .NET gives you the 
 - **[Distributed tracing](tracing.md)**: `HttpClient` is instrumented to emit [distributed tracing](../../../core/diagnostics/distributed-tracing.md) activities (also known as spans).
 - **[Networking events](events.md)**: Events provide debug and trace information with accurate timestamps.
 - **[Networking event counters](event-counters.md)**: All networking components are instrumented to publish real-time performance metrics using the EventCounters API.
-
-> [!TIP]
-> If you're looking for information on tracking HTTP operations across different services, see the [distributed tracing documentation](../../../core/diagnostics/distributed-tracing.md).


### PR DESCRIPTION
Fix an overlook from #44063. Since we added added a Distributed tracing bulletpoint in the overview, this tip is confusing and no longer needed.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/networking/telemetry/overview.md](https://github.com/dotnet/docs/blob/b3e9b56027d70f0ded415e9ad0579521664f8e33/docs/fundamentals/networking/telemetry/overview.md) | [Networking telemetry in .NET](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/networking/telemetry/overview?branch=pr-en-us-44633) |

<!-- PREVIEW-TABLE-END -->