### PR TITLE
Fixed typo inside networking\overview.md.

### DIFF
--- a/docs/fundamentals/networking/overview.md
+++ b/docs/fundamentals/networking/overview.md
@@ -26,7 +26,7 @@ The <xref:System.Uri?displayProperty=nameWithType> type is used as a representat
 
 :::code language="csharp" source="snippets/misc/Program.Uri.cs" id="canonicaluri":::
 
-The `Uri` class automatically performs validation and canonicalization per [RCF 3986](https://datatracker.ietf.org/doc/html/rfc3986). These validation and canonicalization rules are used to ensure that a URI is well-formed and that the URI is in a canonical form.
+The `Uri` class automatically performs validation and canonicalization per [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986). These validation and canonicalization rules are used to ensure that a URI is well-formed and that the URI is in a canonical form.
 
 ## See also
 


### PR DESCRIPTION
## Summary

Fixed typo inside networking\overview.md.

Fixes #44634 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/networking/overview.md](https://github.com/dotnet/docs/blob/64b11004d3f4934469674273ad69d7c1183808a7/docs/fundamentals/networking/overview.md) | [Network programming in .NET](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/networking/overview?branch=pr-en-us-44639) |

<!-- PREVIEW-TABLE-END -->