### PR TITLE
Enhance Attribute Retrieval Guide to Include Member-Level Attributes

### DIFF
--- a/docs/standard/attributes/retrieving-information-stored-in-attributes.md
+++ b/docs/standard/attributes/retrieving-information-stored-in-attributes.md
@@ -1,6 +1,6 @@
 ---
 title: "Retrieving Information Stored in Attributes"
-description: Learn to retrieve information stored in attributes, such as for an attribute instance, many instances for the same scope, & many instances for different scopes.
+description: Learn to retrieve information stored in attributes, including for an attribute instance, multiple instances for the same scope, multiple instances for different scopes, and attributes applied to class members.
 ms.date: "08/05/2022"
 ms.custom: devdivchpfy22
 dev_langs: 
@@ -82,7 +82,50 @@ The attribute was not found.
   
  If no instances of the `DeveloperAttribute` are found on the method level or class level, the `GetAttribute` method notifies the user that no attributes were found and displays the name of the method or class that doesn't contain the attribute. If an attribute is found, the console displays the `Name`, `Level`, and `Reviewed` fields.  
   
- You can use the members of the <xref:System.Type> class to get the individual methods and members in the passed class. This example first queries the `Type` object to get attribute information for the class level. Next, it uses <xref:System.Type.GetMethods%2A?displayProperty=nameWithType> to place instances of all methods into an array of <xref:System.Reflection.MemberInfo?displayProperty=nameWithType> objects to retrieve attribute information for the method level. You can also use the <xref:System.Type.GetProperties%2A?displayProperty=nameWithType> method to check for attributes on the property level or <xref:System.Type.GetConstructors%2A?displayProperty=nameWithType> to check for attributes on the constructor level.  
+ You can use the members of the <xref:System.Type> class to get the individual methods and members in the passed class. This example first queries the `Type` object to get attribute information for the class level. Next, it uses <xref:System.Type.GetMethods%2A?displayProperty=nameWithType> to place instances of all methods into an array of <xref:System.Reflection.MemberInfo?displayProperty=nameWithType> objects to retrieve attribute information for the method level. You can also use the <xref:System.Type.GetProperties%2A?displayProperty=nameWithType> method to check for attributes on the property level or <xref:System.Type.GetConstructors%2A?displayProperty=nameWithType> to check for attributes on the constructor level.
+
+## Retrieving Attributes from Class Members  
+
+In addition to retrieving attributes at the class level, attributes can also be applied to individual members such as methods, properties, and fields. The `GetCustomAttribute` and `GetCustomAttributes` methods can be used to retrieve these attributes.
+
+### Example: Retrieving an Attribute from a Method  
+
+The following example demonstrates how to retrieve an attribute applied to a method:
+
+```csharp
+using System;
+using System.Reflection;
+
+[AttributeUsage(AttributeTargets.Method)]
+public class MyAttribute : Attribute
+{
+    public string Description { get; }
+    public MyAttribute(string description) => Description = description;
+}
+
+public class MyClass
+{
+    [MyAttribute("This is a sample method.")]
+    public void MyMethod() { }
+}
+
+class Program
+{
+    static void Main()
+    {
+        MethodInfo methodInfo = typeof(MyClass).GetMethod("MyMethod");
+        MyAttribute? attribute = (MyAttribute?)Attribute.GetCustomAttribute(methodInfo, typeof(MyAttribute));
+
+        if (attribute != null)
+        {
+            Console.WriteLine($"Method Attribute: {attribute.Description}");
+        }
+        else
+        {
+            Console.WriteLine("Attribute not found.");
+        }
+    }
+}
   
 ## See also
 

--- a/docs/standard/attributes/retrieving-information-stored-in-attributes.md
+++ b/docs/standard/attributes/retrieving-information-stored-in-attributes.md
@@ -88,6 +88,8 @@ The attribute was not found.
 
 In addition to retrieving attributes at the class level, attributes can also be applied to individual members such as methods, properties, and fields. The `GetCustomAttribute` and `GetCustomAttributes` methods can be used to retrieve these attributes.
 
+### Example
+
 The following example demonstrates how to retrieve an attribute applied to a method:
 
 [!code-csharp[Conceptual.Attributes.Usage#21](../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.attributes.usage/cs/source4.cs#21)]

--- a/docs/standard/attributes/retrieving-information-stored-in-attributes.md
+++ b/docs/standard/attributes/retrieving-information-stored-in-attributes.md
@@ -126,6 +126,7 @@ class Program
         }
     }
 }
+```
   
 ## See also
 

--- a/docs/standard/attributes/retrieving-information-stored-in-attributes.md
+++ b/docs/standard/attributes/retrieving-information-stored-in-attributes.md
@@ -84,49 +84,13 @@ The attribute was not found.
   
  You can use the members of the <xref:System.Type> class to get the individual methods and members in the passed class. This example first queries the `Type` object to get attribute information for the class level. Next, it uses <xref:System.Type.GetMethods%2A?displayProperty=nameWithType> to place instances of all methods into an array of <xref:System.Reflection.MemberInfo?displayProperty=nameWithType> objects to retrieve attribute information for the method level. You can also use the <xref:System.Type.GetProperties%2A?displayProperty=nameWithType> method to check for attributes on the property level or <xref:System.Type.GetConstructors%2A?displayProperty=nameWithType> to check for attributes on the constructor level.
 
-## Retrieving attributes from class members  
+## Retrieving Attributes from Class Members  
 
 In addition to retrieving attributes at the class level, attributes can also be applied to individual members such as methods, properties, and fields. The `GetCustomAttribute` and `GetCustomAttributes` methods can be used to retrieve these attributes.
 
-### Example
-
 The following example demonstrates how to retrieve an attribute applied to a method:
 
-```csharp
-using System;
-using System.Reflection;
-
-[AttributeUsage(AttributeTargets.Method)]
-public class MyAttribute : Attribute
-{
-    public string Description { get; }
-    public MyAttribute(string description) => Description = description;
-}
-
-public class MyClass
-{
-    [MyAttribute("This is a sample method.")]
-    public void MyMethod() { }
-}
-
-class Program
-{
-    static void Main()
-    {
-        MethodInfo methodInfo = typeof(MyClass).GetMethod("MyMethod");
-        MyAttribute? attribute = (MyAttribute?)Attribute.GetCustomAttribute(methodInfo, typeof(MyAttribute));
-
-        if (attribute != null)
-        {
-            Console.WriteLine($"Method Attribute: {attribute.Description}");
-        }
-        else
-        {
-            Console.WriteLine("Attribute not found.");
-        }
-    }
-}
-```
+[!code-csharp[Conceptual.Attributes.Usage#21](../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.attributes.usage/cs/source4.cs#21)]
   
 ## See also
 

--- a/docs/standard/attributes/retrieving-information-stored-in-attributes.md
+++ b/docs/standard/attributes/retrieving-information-stored-in-attributes.md
@@ -88,7 +88,7 @@ The attribute was not found.
 
 In addition to retrieving attributes at the class level, attributes can also be applied to individual members such as methods, properties, and fields. The `GetCustomAttribute` and `GetCustomAttributes` methods can be used to retrieve these attributes.
 
-### Example: Retrieving an Attribute from a Method  
+### Example
 
 The following example demonstrates how to retrieve an attribute applied to a method:
 

--- a/docs/standard/attributes/retrieving-information-stored-in-attributes.md
+++ b/docs/standard/attributes/retrieving-information-stored-in-attributes.md
@@ -84,7 +84,7 @@ The attribute was not found.
   
  You can use the members of the <xref:System.Type> class to get the individual methods and members in the passed class. This example first queries the `Type` object to get attribute information for the class level. Next, it uses <xref:System.Type.GetMethods%2A?displayProperty=nameWithType> to place instances of all methods into an array of <xref:System.Reflection.MemberInfo?displayProperty=nameWithType> objects to retrieve attribute information for the method level. You can also use the <xref:System.Type.GetProperties%2A?displayProperty=nameWithType> method to check for attributes on the property level or <xref:System.Type.GetConstructors%2A?displayProperty=nameWithType> to check for attributes on the constructor level.
 
-## Retrieving Attributes from Class Members  
+## Retrieving attributes from class members  
 
 In addition to retrieving attributes at the class level, attributes can also be applied to individual members such as methods, properties, and fields. The `GetCustomAttribute` and `GetCustomAttributes` methods can be used to retrieve these attributes.
 

--- a/samples/snippets/cpp/VS_Snippets_CLR/conceptual.attributes.usage/cpp/source3.cpp
+++ b/samples/snippets/cpp/VS_Snippets_CLR/conceptual.attributes.usage/cpp/source3.cpp
@@ -118,50 +118,7 @@ public:
     //</snippet20>
 };
 
-//<snippet21>
-// This snippet demonstrates retrieving attributes from class members such as methods.
-
-using namespace System;
-using namespace System::Reflection;
-
-[AttributeUsage(AttributeTargets::Method)]
-public ref class MyAttribute : Attribute
-{
-public:
-    String^ Description;
-    MyAttribute(String^ description) { Description = description; }
-};
-
-public ref class MyClass
-{
-public:
-    [MyAttribute("This is a sample method.")]
-    void MyMethod() { }
-};
-
-ref class AttributeRetrieval
-{
-public:
-    static void Main()
-    {
-        MethodInfo^ methodInfo = MyClass::typeid->GetMethod("MyMethod");
-        MyAttribute^ attribute = (MyAttribute^)Attribute::GetCustomAttribute(methodInfo, MyAttribute::typeid);
-
-        if (attribute != nullptr)
-        {
-            Console::WriteLine("Method Attribute: {0}", attribute->Description);
-        }
-        else
-        {
-            Console::WriteLine("Attribute not found.");
-        }
-    }
-};
-
-//</snippet21>
-
 int main()
 {
     MainApp::Main();
-    AttributeRetrieval::Main();
 }

--- a/samples/snippets/cpp/VS_Snippets_CLR/conceptual.attributes.usage/cpp/source3.cpp
+++ b/samples/snippets/cpp/VS_Snippets_CLR/conceptual.attributes.usage/cpp/source3.cpp
@@ -118,7 +118,50 @@ public:
     //</snippet20>
 };
 
+//<snippet21>
+// This snippet demonstrates retrieving attributes from class members such as methods.
+
+using namespace System;
+using namespace System::Reflection;
+
+[AttributeUsage(AttributeTargets::Method)]
+public ref class MyAttribute : Attribute
+{
+public:
+    String^ Description;
+    MyAttribute(String^ description) { Description = description; }
+};
+
+public ref class MyClass
+{
+public:
+    [MyAttribute("This is a sample method.")]
+    void MyMethod() { }
+};
+
+ref class AttributeRetrieval
+{
+public:
+    static void Main()
+    {
+        MethodInfo^ methodInfo = MyClass::typeid->GetMethod("MyMethod");
+        MyAttribute^ attribute = (MyAttribute^)Attribute::GetCustomAttribute(methodInfo, MyAttribute::typeid);
+
+        if (attribute != nullptr)
+        {
+            Console::WriteLine("Method Attribute: {0}", attribute->Description);
+        }
+        else
+        {
+            Console::WriteLine("Attribute not found.");
+        }
+    }
+};
+
+//</snippet21>
+
 int main()
 {
     MainApp::Main();
+    AttributeRetrieval::Main();
 }

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.attributes.usage/conceptualAttrUsage.csproj
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.attributes.usage/conceptualAttrUsage.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <StartupObject>AttributeRetrieval</StartupObject>
+  </PropertyGroup>
+
+</Project>

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.attributes.usage/conceptualAttrUsage.csproj
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.attributes.usage/conceptualAttrUsage.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <StartupObject>AttributeRetrieval</StartupObject>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
 </Project>

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.attributes.usage/cs/makefile
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.attributes.usage/cs/makefile
@@ -1,4 +1,4 @@
-all: source1.exe source2.dll source3.exe
+all: source1.exe source2.dll source3.exe source4.exe
 
 source1.exe: source1.cs
     csc source1.cs
@@ -8,4 +8,8 @@ source2.dll: source2.cs
 
 source3.exe: source2.dll source3.cs
     csc /r:source2.dll source3.cs
+
+source4.exe: source4.cs
+    csc source4.cs
+
 

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.attributes.usage/cs/makefile
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.attributes.usage/cs/makefile
@@ -11,5 +11,3 @@ source3.exe: source2.dll source3.cs
 
 source4.exe: source4.cs
     csc source4.cs
-
-

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.attributes.usage/cs/source4.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.attributes.usage/cs/source4.cs
@@ -1,0 +1,40 @@
+﻿//<snippet21>
+using System;
+using System.Reflection;
+
+[AttributeUsage(AttributeTargets.Method)]
+public class MyAttribute : Attribute
+{
+    public string Description { get; }
+    public MyAttribute(string description) { Description = description; }
+}
+
+public class MyClass
+{
+    [MyAttribute("This is a sample method.")]
+    public void MyMethod() { }
+}
+
+class AttributeRetrieval
+{
+    public static void Main()
+    {
+        // Create an instance of MyClass
+        MyClass myClass = new MyClass();
+
+        // Retrieve the method information for MyMethod
+        MethodInfo methodInfo = typeof(MyClass).GetMethod("MyMethod");
+        MyAttribute attribute = (MyAttribute)Attribute.GetCustomAttribute(methodInfo, typeof(MyAttribute));
+
+        if (attribute != null)
+        {
+            // Print the description of the method attribute
+            Console.WriteLine("Method Attribute: {0}", attribute.Description);
+        }
+        else
+        {
+            Console.WriteLine("Attribute not found.");
+        }
+    }
+}
+//</snippet21>


### PR DESCRIPTION
## Summary

Updated the documentation on retrieving information stored in attributes to include details on reading attributes applied to class members.

- Expanded explanations to cover member-level attribute retrieval.
- Clarified usage of `GetCustomAttribute` and `GetCustomAttributes` for different scopes.
- Ensured consistency in terminology and improved readability.

Fixes #40174 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/attributes/retrieving-information-stored-in-attributes.md](https://github.com/dotnet/docs/blob/d3569cb5fe889616bf26e74573df17689982ef8c/docs/standard/attributes/retrieving-information-stored-in-attributes.md) | [Retrieving Information Stored in Attributes](https://review.learn.microsoft.com/en-us/dotnet/standard/attributes/retrieving-information-stored-in-attributes?branch=pr-en-us-44665) |


<!-- PREVIEW-TABLE-END -->