### PR TITLE
Add note about internal representation of .NET runtime types

### DIFF
--- a/docs/standard/native-interop/best-practices.md
+++ b/docs/standard/native-interop/best-practices.md
@@ -400,6 +400,8 @@ Pointers to structs in definitions must either be passed by `ref` or use `unsafe
 
 ✔️ DO use the C# `sizeof()` instead of `Marshal.SizeOf<MyStruct>()` for blittable structures to improve performance.
 
+❌ DON'T depend on internal representation of struct types exposed by .NET runtime libraries unless it is explicitly documented.
+
 ❌ AVOID using classes to express complex native types through inheritance.
 
 ❌ AVOID using `System.Delegate` or `System.MulticastDelegate` fields to represent function pointer fields in structures.


### PR DESCRIPTION
Depending on internal representation is equivalent of private reflection that is not supported for types proviced by .NET runtime.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/native-interop/best-practices.md](https://github.com/dotnet/docs/blob/030a5288bc0c4598cd5e98d3e7e217b454072033/docs/standard/native-interop/best-practices.md) | [Native interoperability best practices](https://review.learn.microsoft.com/en-us/dotnet/standard/native-interop/best-practices?branch=pr-en-us-44672) |

<!-- PREVIEW-TABLE-END -->