### PR TITLE
docs: fix command spelling

### DIFF
--- a/docs/core/extensions/artificial-intelligence.md
+++ b/docs/core/extensions/artificial-intelligence.md
@@ -18,7 +18,7 @@ To install the [📦 Microsoft.Extensions.AI](https://www.nuget.org/packages/Mic
 ### [.NET CLI](#tab/dotnet-cli)
 
 ```dotnetcli
-dotnet add package Microsoft.Extensions.AI --prelease
+dotnet add package Microsoft.Extensions.AI --prerelease
 ```
 
 ### [PackageReference](#tab/package-reference)


### PR DESCRIPTION
## Summary

Previously was giving an error due to the typod:

```
$ dotnet add package Microsoft.Extensions.AI --prelease
Unrecognized command or argument '--prelease'.

Description:
  Add a NuGet package reference to the project.
```


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/artificial-intelligence.md](https://github.com/dotnet/docs/blob/0c41dce7d3c32e6c3645e6c1942992068fad9bbb/docs/core/extensions/artificial-intelligence.md) | [Artificial intelligence in .NET (Preview)](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/artificial-intelligence?branch=pr-en-us-44673) |

<!-- PREVIEW-TABLE-END -->