### PR TITLE
Move AI for .NET up in the list

### DIFF
--- a/.whatsnew.json
+++ b/.whatsnew.json
@@ -23,6 +23,10 @@
             "heading": ".NET breaking changes"
         },
         {
+            "names": [ "ai" ],
+            "heading": "AI in .NET"
+        },
+        {
             "names": [ "core", "fundamentals", "standard" ],
             "heading": ".NET fundamentals"
         },
@@ -74,10 +78,6 @@
                        "standard/garbage-collection"
                      ],
             "heading": "Advanced .NET programming"
-        },
-        {
-            "names": [ "ai" ],
-            "heading": "AI in .NET"
         },
         {
             "names": [ "azure" ],

--- a/.whatsnew.json
+++ b/.whatsnew.json
@@ -27,6 +27,10 @@
             "heading": "AI in .NET"
         },
         {
+            "names": [ "machine-learning" ],
+            "heading": "ML.NET"
+        },
+        {
             "names": [ "core", "fundamentals", "standard" ],
             "heading": ".NET fundamentals"
         },
@@ -94,10 +98,6 @@
         {
             "names": [ "iot" ],
             "heading": ".NET IoT libraries"
-        },
-        {
-            "names": [ "machine-learning" ],
-            "heading": "ML.NET"
         },
         {
             "names": [ "orleans", "dotnet-orleans" ],

--- a/docs/whats-new/dotnet-docs-mod0.md
+++ b/docs/whats-new/dotnet-docs-mod0.md
@@ -20,6 +20,12 @@ Welcome to what's new in the .NET docs for December 2024. This article lists som
 - [Nullable JsonDocument properties deserialize to JsonValueKind.Null](../core/compatibility/serialization/9.0/jsondocument-props.md)
 - [System.Windows.Forms.StatusStrip uses a different default renderer](../core/compatibility/windows-forms/9.0/statusstrip-renderer.md)
 
+## AI in .NET
+
+### Updated articles
+
+- [Build a .NET AI vector search app](../ai/quickstarts/quickstart-ai-chat-with-data.md) - New vector search quickstart
+
 ## .NET fundamentals
 
 ### New articles
@@ -52,12 +58,6 @@ Welcome to what's new in the .NET docs for December 2024. This article lists som
 ### Updated articles
 
 - [Attributes (F#)](../fsharp/language-reference/attributes.md) - F# 9 doc updates
-
-## AI in .NET
-
-### Updated articles
-
-- [Build a .NET AI vector search app](../ai/quickstarts/quickstart-ai-chat-with-data.md) - New vector search quickstart
 
 ## ML.NET
 

--- a/docs/whats-new/dotnet-docs-mod0.md
+++ b/docs/whats-new/dotnet-docs-mod0.md
@@ -26,6 +26,12 @@ Welcome to what's new in the .NET docs for December 2024. This article lists som
 
 - [Build a .NET AI vector search app](../ai/quickstarts/quickstart-ai-chat-with-data.md) - New vector search quickstart
 
+## ML.NET
+
+### Updated articles
+
+- [Machine learning tasks in ML.NET](../machine-learning/resources/tasks.md) - Add text classification and sentence similarity to ML tasks
+
 ## .NET fundamentals
 
 ### New articles
@@ -58,12 +64,6 @@ Welcome to what's new in the .NET docs for December 2024. This article lists som
 ### Updated articles
 
 - [Attributes (F#)](../fsharp/language-reference/attributes.md) - F# 9 doc updates
-
-## ML.NET
-
-### Updated articles
-
-- [Machine learning tasks in ML.NET](../machine-learning/resources/tasks.md) - Add text classification and sentence similarity to ML tasks
 
 ## .NET Framework
 

--- a/docs/whats-new/dotnet-docs-mod1.md
+++ b/docs/whats-new/dotnet-docs-mod1.md
@@ -27,6 +27,12 @@ Welcome to what's new in the .NET docs for January 2025. This article lists some
 - [TreeView checkbox image truncation](../core/compatibility/windows-forms/10.0/treeview-text-location.md)
 - [X500DistinguishedName validation is stricter](../core/compatibility/cryptography/10.0/x500distinguishedname-validation.md)
 
+## AI in .NET
+
+### New articles
+
+- [Create a minimal AI assistant using .NET](../ai/quickstarts/quickstart-assistants.md)
+
 ## .NET fundamentals
 
 ### New articles
@@ -66,12 +72,6 @@ Welcome to what's new in the .NET docs for January 2025. This article lists some
 ### Updated articles
 
 - [Generic types in Visual Basic (Visual Basic)](../visual-basic/programming-guide/language-features/data-types/generic-types.md) - Add VB new features
-
-## AI in .NET
-
-### New articles
-
-- [Create a minimal AI assistant using .NET](../ai/quickstarts/quickstart-assistants.md)
 
 ## Azure SDK for .NET
 

--- a/docs/whats-new/dotnet-docs-mod2.md
+++ b/docs/whats-new/dotnet-docs-mod2.md
@@ -29,6 +29,12 @@ Welcome to what's new in the .NET docs for November 2024. This article lists som
 - [Version requirements for .NET 9 SDK](../core/compatibility/sdk/9.0/version-requirements.md)
 - [Warning emitted when targeting net7.0](../core/compatibility/sdk/9.0/net70-warning.md)
 
+## AI in .NET
+
+### New articles
+
+- [Unified AI building blocks for .NET using Microsoft.Extensions.AI](../ai/ai-extensions.md)
+
 ## .NET fundamentals
 
 ### New articles
@@ -58,12 +64,6 @@ Welcome to what's new in the .NET docs for November 2024. This article lists som
 ### New articles
 
 - [What's new in F# 9](../fsharp/whats-new/fsharp-9.md)
-
-## AI in .NET
-
-### New articles
-
-- [Unified AI building blocks for .NET using Microsoft.Extensions.AI](../ai/ai-extensions.md)
 
 ## Azure SDK for .NET
 


### PR DESCRIPTION
The AI for .NET docs should appear higher in the What's new pages for .NET


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/whats-new/dotnet-docs-mod0.md](https://github.com/dotnet/docs/blob/418faea635672b223c7c9e3cdcb0dfc8899641a6/docs/whats-new/dotnet-docs-mod0.md) | [.NET docs: What's new for December 2024](https://review.learn.microsoft.com/en-us/dotnet/whats-new/dotnet-docs-mod0?branch=pr-en-us-44677) |
| [docs/whats-new/dotnet-docs-mod1.md](https://github.com/dotnet/docs/blob/418faea635672b223c7c9e3cdcb0dfc8899641a6/docs/whats-new/dotnet-docs-mod1.md) | [".NET docs: What's new for January 2025"](https://review.learn.microsoft.com/en-us/dotnet/whats-new/dotnet-docs-mod1?branch=pr-en-us-44677) |
| [docs/whats-new/dotnet-docs-mod2.md](https://github.com/dotnet/docs/blob/418faea635672b223c7c9e3cdcb0dfc8899641a6/docs/whats-new/dotnet-docs-mod2.md) | [.NET docs: What's new for November 2024](https://review.learn.microsoft.com/en-us/dotnet/whats-new/dotnet-docs-mod2?branch=pr-en-us-44677) |


<!-- PREVIEW-TABLE-END -->