### PR TITLE
`dotnet list package --vulnerable` uses AuditSources

### DIFF
--- a/docs/core/tools/dotnet-list-package.md
+++ b/docs/core/tools/dotnet-list-package.md
@@ -120,7 +120,7 @@ The project or solution file to operate on. If not specified, the command search
 
   Lists packages that have known vulnerabilities. Cannot be combined with `--deprecated` or `--outdated` options. 
   Use the `<AuditSources>` property in your configuration file to specify your source of vulnerabilities. If `<AuditSources>` have not been specified, your `<PackageSources>` will be used for loading vulnerability data. 
-  For more information, see [AuditSources](nuget/concepts/auditing-packages#audit-sources) and [How to Scan NuGet Packages for Security Vulnerabilities](https://devblogs.microsoft.com/nuget/how-to-scan-nuget-packages-for-security-vulnerabilities/).
+  For more information, see [AuditSources](/nuget/concepts/auditing-packages#audit-sources) and [How to Scan NuGet Packages for Security Vulnerabilities](https://devblogs.microsoft.com/nuget/how-to-scan-nuget-packages-for-security-vulnerabilities/).
 
 - **`--format <console|json>`**
 

--- a/docs/core/tools/dotnet-list-package.md
+++ b/docs/core/tools/dotnet-list-package.md
@@ -119,9 +119,9 @@ The project or solution file to operate on. If not specified, the command search
 - **`--vulnerable`**
 
   Lists packages that have known vulnerabilities. Cannot be combined with `--deprecated` or `--outdated` options.
-  Use the `<AuditSources>` property in your configuration file to specify your source of vulnerability data which is acquired from the [VulnerabilityInfo](/nuget/api/vulnerability-info) resource.
-  If `<AuditSources>` have not been specified, your specified `<PackageSources>` will be used for loading vulnerability data.
-  For more information, see [AuditSources](/nuget/concepts/auditing-packages#audit-sources) and [How to Scan NuGet Packages for Security Vulnerabilities](https://devblogs.microsoft.com/nuget/how-to-scan-nuget-packages-for-security-vulnerabilities/).
+  Use the `<AuditSources>` property in your configuration file to specify your source of vulnerability data, which is acquired from the [VulnerabilityInfo](/nuget/api/vulnerability-info) resource.
+  If `<AuditSources>` is not specified, the specified `<PackageSources>` are used to load vulnerability data.
+  For more information, see [Audit sources](/nuget/concepts/auditing-packages#audit-sources) and [How to scan NuGet packages for security vulnerabilities](https://devblogs.microsoft.com/nuget/how-to-scan-nuget-packages-for-security-vulnerabilities/).
 
 - **`--format <console|json>`**
 

--- a/docs/core/tools/dotnet-list-package.md
+++ b/docs/core/tools/dotnet-list-package.md
@@ -119,9 +119,8 @@ The project or solution file to operate on. If not specified, the command search
 - **`--vulnerable`**
 
   Lists packages that have known vulnerabilities. Cannot be combined with `--deprecated` or `--outdated` options.
-  Use the `<AuditSources>` property in your configuration file to specify your source of vulnerabilities.
+  Use the `<AuditSources>` property in your configuration file to specify your source of vulnerability data which is acquired from the [VulnerabilityInfo](/nuget/api/vulnerability-info) resource.
   If `<AuditSources>` have not been specified, your specified `<PackageSources>` will be used for loading vulnerability data.
-  Note: The command uses [VulnerabilityInfo](/nuget/api/vulnerability-info) if you have `<AuditSources>` configured.
   For more information, see [AuditSources](/nuget/concepts/auditing-packages#audit-sources) and [How to Scan NuGet Packages for Security Vulnerabilities](https://devblogs.microsoft.com/nuget/how-to-scan-nuget-packages-for-security-vulnerabilities/).
 
 - **`--format <console|json>`**

--- a/docs/core/tools/dotnet-list-package.md
+++ b/docs/core/tools/dotnet-list-package.md
@@ -118,7 +118,9 @@ The project or solution file to operate on. If not specified, the command search
 
 - **`--vulnerable`**
 
-  Lists packages that have known vulnerabilities. Cannot be combined with `--deprecated` or `--outdated` options. Use the `<AuditSources>` property in your configuration file to specify your source of vulnerabilities. If `<AuditSources>` have not been specified, your `<PackageSources>` will be used for loading vulnerability data. For more information, see [Vulnerabilities](/nuget/api/registration-base-url-resource) and [How to Scan NuGet Packages for Security Vulnerabilities](https://devblogs.microsoft.com/nuget/how-to-scan-nuget-packages-for-security-vulnerabilities/).
+  Lists packages that have known vulnerabilities. Cannot be combined with `--deprecated` or `--outdated` options. 
+  Use the `<AuditSources>` property in your configuration file to specify your source of vulnerabilities. If `<AuditSources>` have not been specified, your `<PackageSources>` will be used for loading vulnerability data. 
+  For more information, see [AuditSources](nuget/concepts/auditing-packages#audit-sources) and [How to Scan NuGet Packages for Security Vulnerabilities](https://devblogs.microsoft.com/nuget/how-to-scan-nuget-packages-for-security-vulnerabilities/).
 
 - **`--format <console|json>`**
 

--- a/docs/core/tools/dotnet-list-package.md
+++ b/docs/core/tools/dotnet-list-package.md
@@ -118,8 +118,9 @@ The project or solution file to operate on. If not specified, the command search
 
 - **`--vulnerable`**
 
-  Lists packages that have known vulnerabilities. Cannot be combined with `--deprecated` or `--outdated` options. 
-  Use the `<AuditSources>` property in your configuration file to specify your source of vulnerabilities. If `<AuditSources>` have not been specified, your `<PackageSources>` will be used for loading vulnerability data.
+  Lists packages that have known vulnerabilities. Cannot be combined with `--deprecated` or `--outdated` options.
+  Use the `<AuditSources>` property in your configuration file to specify your source of vulnerabilities.
+  If `<AuditSources>` have not been specified, your specified `<PackageSources>` will be used for loading vulnerability data.
   Note: The command uses [VulnerabilityInfo](/nuget/api/vulnerability-info) if you have `<AuditSources>` configured.
   For more information, see [AuditSources](/nuget/concepts/auditing-packages#audit-sources) and [How to Scan NuGet Packages for Security Vulnerabilities](https://devblogs.microsoft.com/nuget/how-to-scan-nuget-packages-for-security-vulnerabilities/).
 

--- a/docs/core/tools/dotnet-list-package.md
+++ b/docs/core/tools/dotnet-list-package.md
@@ -119,7 +119,8 @@ The project or solution file to operate on. If not specified, the command search
 - **`--vulnerable`**
 
   Lists packages that have known vulnerabilities. Cannot be combined with `--deprecated` or `--outdated` options. 
-  Use the `<AuditSources>` property in your configuration file to specify your source of vulnerabilities. If `<AuditSources>` have not been specified, your `<PackageSources>` will be used for loading vulnerability data. 
+  Use the `<AuditSources>` property in your configuration file to specify your source of vulnerabilities. If `<AuditSources>` have not been specified, your `<PackageSources>` will be used for loading vulnerability data.
+  Note: The command uses [VulnerabilityInfo](/nuget/api/vulnerability-info) if you have `<AuditSources>` configured.
   For more information, see [AuditSources](/nuget/concepts/auditing-packages#audit-sources) and [How to Scan NuGet Packages for Security Vulnerabilities](https://devblogs.microsoft.com/nuget/how-to-scan-nuget-packages-for-security-vulnerabilities/).
 
 - **`--format <console|json>`**

--- a/docs/core/tools/dotnet-list-package.md
+++ b/docs/core/tools/dotnet-list-package.md
@@ -118,7 +118,7 @@ The project or solution file to operate on. If not specified, the command search
 
 - **`--vulnerable`**
 
-  Lists packages that have known vulnerabilities. Cannot be combined with `--deprecated` or `--outdated` options. Nuget.org is the source of information about vulnerabilities. For more information, see [Vulnerabilities](/nuget/api/registration-base-url-resource) and [How to Scan NuGet Packages for Security Vulnerabilities](https://devblogs.microsoft.com/nuget/how-to-scan-nuget-packages-for-security-vulnerabilities/).
+  Lists packages that have known vulnerabilities. Cannot be combined with `--deprecated` or `--outdated` options. Use the `<AuditSources>` property in your configuration file to specify your source of vulnerabilities. If `<AuditSources>` have not been specified, your `<PackageSources>` will be used for loading vulnerability data. For more information, see [Vulnerabilities](/nuget/api/registration-base-url-resource) and [How to Scan NuGet Packages for Security Vulnerabilities](https://devblogs.microsoft.com/nuget/how-to-scan-nuget-packages-for-security-vulnerabilities/).
 
 - **`--format <console|json>`**
 


### PR DESCRIPTION
## Summary
Update the doc for dotnet list package --vulnerable to mention that <AuditSources> are also used as a source of vulnerability data

Fixes: https://github.com/NuGet/Home/issues/14021


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-list-package.md](https://github.com/dotnet/docs/blob/f4ccd9e3558a20f83cbad02b3f4c088983c4f8a1/docs/core/tools/dotnet-list-package.md) | [dotnet list package](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-list-package?branch=pr-en-us-44722) |


<!-- PREVIEW-TABLE-END -->