### PR TITLE
Clarified examples regarding return values

### DIFF
--- a/docs/csharp/methods.md
+++ b/docs/csharp/methods.md
@@ -163,13 +163,15 @@ You can also choose to define your methods with a statement body and a `return` 
 
 :::code language="csharp" source="snippets/methods/return44.cs" id="snippet43":::
 
-To use a value returned from a method, the calling method can use the method call itself anywhere a value of the same type would be sufficient. You can also assign the return value to a variable. For example, the following three code examples accomplish the same goal:
+To use a value returned from a method, the calling method can use the method call itself anywhere a value of the same type would be sufficient, as in the following example:
+
+:::code language="csharp" source="snippets/methods/return44.cs" id="snippet47":::
+
+You can also assign the return value to a variable. For example, the following two code examples accomplish the same goal:
 
 :::code language="csharp" source="snippets/methods/return44.cs" id="snippet45":::
 
 :::code language="csharp" source="snippets/methods/return44.cs" id="snippet46":::
-
-:::code language="csharp" source="snippets/methods/return44.cs" id="snippet47":::
 
 Sometimes, you want your method to return more than a single value. You use *tuple types* and *tuple literals* to return multiple values. The tuple type defines the data types of the tuple's elements. Tuple literals provide the actual values of the returned tuple. In the following example, `(string, string, string, int)` defines the tuple type returned by the `GetPersonalInfo` method. The expression `(per.FirstName, per.MiddleName, per.LastName, per.Age)` is the tuple literal; the method returns the first, middle, and family name, along with the age, of a `PersonInfo` object.
 

--- a/docs/csharp/methods.md
+++ b/docs/csharp/methods.md
@@ -163,11 +163,11 @@ You can also choose to define your methods with a statement body and a `return` 
 
 :::code language="csharp" source="snippets/methods/return44.cs" id="snippet43":::
 
-To use a value returned from a method, the calling method can use the method call itself anywhere a value of the same type would be sufficient, as in the following example:
+To use a value returned from a method, you can assign the return value to a variable:
 
 :::code language="csharp" source="snippets/methods/return44.cs" id="snippet47":::
 
-You can also assign the return value to a variable. For example, the following two code examples accomplish the same goal:
+The calling method can also use the method call itself anywhere a value of the same type would be sufficient. For example, the following two code examples accomplish the same goal:
 
 :::code language="csharp" source="snippets/methods/return44.cs" id="snippet45":::
 

--- a/docs/csharp/snippets/methods/return44.cs
+++ b/docs/csharp/snippets/methods/return44.cs
@@ -19,12 +19,25 @@ class SimpleMath
 }
 //</Snippet44>
 
+static class TestSimpleMathExtension
+{
+    static void Main()
+    {
+        var obj = new SimpleMathExtension();
+        
+        //<Snippet47>
+        int result = obj.DivideTwoNumbers(6,2);
+        // The result is 3.
+        Console.WriteLine(result);
+        //</Snippet47>
+    }
+}
+
 static class TestSimpleMath
 {
     static void Main()
     {
         var obj = new SimpleMath();
-        var obj2 = new SimpleMathExtnsion();
 
         //<Snippet45>
         int result = obj.AddTwoNumbers(1, 2);
@@ -38,11 +51,5 @@ static class TestSimpleMath
         // The result is 9.
         Console.WriteLine(result);
         //</Snippet46>
-
-        //<Snippet47>
-        result = obj2.DivideTwoNumbers(6,2);
-        // The result is 3.
-        Console.WriteLine(result);
-        //</Snippet47>
     }
 }

--- a/docs/csharp/snippets/methods/return44.cs
+++ b/docs/csharp/snippets/methods/return44.cs
@@ -1,5 +1,5 @@
 //<Snippet43>
-class SimpleMathExtnsion
+class SimpleMathExtension
 {
     public int DivideTwoNumbers(int number1, int number2)
     {


### PR DESCRIPTION
## Summary

I broke code snippet 47 into its own class, fixed the type (extnsion -> extension), and moved that snippet below the code where the function is declared rather than being lumped together with two unrelated examples.

Fixes #44734 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/methods.md](https://github.com/dotnet/docs/blob/ed92bb55c41ea8cfd924cf59e7a53cd607a8fcd7/docs/csharp/methods.md) | [Methods in C\#](https://review.learn.microsoft.com/en-us/dotnet/csharp/methods?branch=pr-en-us-44735) |


<!-- PREVIEW-TABLE-END -->