### PR TITLE
Add documentation to the new dotnet test

### DIFF
--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -11,7 +11,7 @@ ms.date: 03/27/2024
 
 ## Description
 
-The `dotnet test` command builds the solution and runs the tests either with VSTest or with Microsoft Testing Platform (MTP). In order to enable MTP, you need to add a config file named `dotnet.config` using TOML format located at the root of the solution or repository.
+The `dotnet test` command builds the solution and runs the tests either with VSTest or with Microsoft Testing Platform (MTP). In order to enable MTP, you need to add a config file named `dotnet.config` with TOML format located at the root of the solution or repository.
 
 Some examples of the `dotnet.config` file:
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -540,6 +540,9 @@ With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest.
 
   Specifies extra arguments to pass to the test application(s). Use a space to separate multiple arguments. For more information and examples on what to pass, see [Microsoft Testing Platform](../../../docs/core/testing/unit-testing-platform-intro.md) and [Microsoft.Testing.Platform extensions](../../../docs/core/testing/unit-testing-platform-extensions.md).
 
+> [!NOTE]
+> To enable trace logging to a file, please use the environment variable `DOTNET_CLI_TESTING_PLATFORM_TRACEFILE` where you provide the path to the trace file.
+
 #### Examples
 
 - Run the tests in the project in the current directory:

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -11,7 +11,7 @@ ms.date: 03/27/2024
 
 ## Description
 
-The `dotnet test` command builds the solution and runs the tests either with VSTest or with Microsoft Testing Platform (MTP). In order to enable MTP, you need to add a config file named `dotnet.config` with TOML format located at the root of the solution or repository.
+The `dotnet test` command builds the solution and runs the tests with either VSTest or Microsoft Testing Platform (MTP). To enable MTP, you need to add a config file named `dotnet.config` with TOML format located at the root of the solution or repository.
 
 Some examples of the `dotnet.config` file:
 
@@ -439,10 +439,10 @@ dotnet test -h|--help
 
 #### Description
 
-With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest. The test related arguments are no longer fixed as they are tied to the registered extensions in the test project(s). Moreover, it supports globbing filter when running tests. For more information, see [Microsoft.Testing.Platform](../testing/unit-testing-platform-intro.md).
+With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest. The test-related arguments are no longer fixed, as they are tied to the registered extensions in the test project(s). Moreover, MTP supports a globbing filter when running tests. For more information, see [Microsoft.Testing.Platform](../testing/unit-testing-platform-intro.md).
 
 > [!WARNING]
-> `dotnet test` doesn't run in an environment where we have test projects using VSTest and Microsoft Testing Platform in the same solution, as the two platforms are mutually incompatible.
+> `dotnet test` doesn't run in environments that have test projects using both VSTest and Microsoft Testing Platform in the same solution, as the two platforms are mutually incompatible.
 
 #### Implicit restore
 
@@ -463,7 +463,7 @@ With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest.
   Specifies the path to a directory that contains a project or a solution.
 
 > [!NOTE]
-> You can use only one of the following options at a time: `--project`, `--solution`, or `--directory`. These options cannot be combined.
+> You can use only one of the following options at a time: `--project`, `--solution`, or `--directory`. These options can't be combined.
 
 - **`--test-modules <EXPRESSION>`**
 
@@ -479,7 +479,7 @@ With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest.
 
 - **`--max-parallel-test-modules <NUMBER>`**
 
-  Specifies the max number of test modules that can run in parallel.
+  Specifies the maximum number of test modules that can run in parallel.
 
 [!INCLUDE [arch-no-a](../../../includes/cli-arch-no-a.md)]
 
@@ -499,15 +499,15 @@ With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest.
 
 - **`-v|--verbosity <LEVEL>`**
   
-  Sets the MSBuild verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]. For more information, see <xref:Microsoft.Build.Framework.LoggerVerbosity>.
+  Sets the MSBuild verbosity level. Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`. For more information, see <xref:Microsoft.Build.Framework.LoggerVerbosity>.
 
 - **`--no-build`**
 
-  Doesn't build the test project before running it. It also implicitly sets the `--no-restore` flag.
+  Specifies that the test project isn't built before being run. It also implicitly sets the `--no-restore` flag.
 
 - **`--no-restore`**
 
-  Doesn't execute an implicit restore when running the command.
+  Specifies that an implicit restore isn't executed when running the command.
 
 - **`--no-ansi`**
 
@@ -519,7 +519,7 @@ With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest.
 
 - **`--output <VERBOSITY_LEVEL>`**
 
-  Specifies the output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.
+  Specifies the output verbosity when reporting tests. Valid values are `Normal` and `Detailed`. The default is `Normal`.
 
 - **`--property:<NAME>=<VALUE>`**
 
@@ -534,14 +534,14 @@ With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest.
 
 - **`-h|--help`**
 
-  Prints out a description of how to use the command. The options will be dynamic and they may differ from one test application to another as they will be based on the registered extensions in the test project.
+  Prints out a description of how to use the command. The options are dynamic and might differ from one test application to another, as they are based on the registered extensions in the test project.
 
 - **`args`**
 
   Specifies extra arguments to pass to the test application(s). Use a space to separate multiple arguments. For more information and examples on what to pass, see [Microsoft Testing Platform](../../../docs/core/testing/unit-testing-platform-intro.md) and [Microsoft.Testing.Platform extensions](../../../docs/core/testing/unit-testing-platform-extensions.md).
 
 > [!NOTE]
-> To enable trace logging to a file, please use the environment variable `DOTNET_CLI_TEST_TRACEFILE` where you provide the path to the trace file.
+> To enable trace logging to a file, use the environment variable `DOTNET_CLI_TEST_TRACEFILE` to provide the path to the trace file.
 
 #### Examples
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -472,7 +472,7 @@ With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest.
 
   Specifies the root directory of the `--test-modules` option. It can only be used with the `--test-modules` option.
 
-- **`-t|--list-tests`**
+- **`--list-tests`**
 
   Lists the discovered tests instead of running the tests.
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -497,7 +497,7 @@ With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest.
 
   Short form `-r` available starting in .NET SDK 7.
 
-  [!INCLUDE [verbosity](../../../includes/cli-verbosity-minimal.md)]
+[!INCLUDE [verbosity](../../../includes/cli-verbosity-minimal.md)]
 
 - **`--no-build`**
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -497,7 +497,9 @@ With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest.
 
   Short form `-r` available starting in .NET SDK 7.
 
-[!INCLUDE [verbosity](../../../includes/cli-verbosity-minimal.md)]
+- **`-v|--verbosity <LEVEL>`**
+  
+  Sets the MSBuild verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]. For more information, see <xref:Microsoft.Build.Framework.LoggerVerbosity>.
 
 - **`--no-build`**
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -541,7 +541,7 @@ With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest.
   Specifies extra arguments to pass to the test application(s). Use a space to separate multiple arguments. For more information and examples on what to pass, see [Microsoft Testing Platform](../../../docs/core/testing/unit-testing-platform-intro.md) and [Microsoft.Testing.Platform extensions](../../../docs/core/testing/unit-testing-platform-extensions.md).
 
 > [!NOTE]
-> To enable trace logging to a file, please use the environment variable `DOTNET_CLI_TESTING_PLATFORM_TRACEFILE` where you provide the path to the trace file.
+> To enable trace logging to a file, please use the environment variable `DOTNET_CLI_TEST_TRACEFILE` where you provide the path to the trace file.
 
 #### Examples
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -426,6 +426,7 @@ dotnet test
     [-f|--framework <FRAMEWORK>]
     [--os <OS>]
     [-r|--runtime <RUNTIME_IDENTIFIER>]
+    [-v|--verbosity <LEVEL>]
     [--no-build]
     [--no-restore]
     [--no-ansi]
@@ -495,6 +496,8 @@ With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest.
   The target runtime to test for.
 
   Short form `-r` available starting in .NET SDK 7.
+
+  [!INCLUDE [verbosity](../../../includes/cli-verbosity-minimal.md)]
 
 - **`--no-build`**
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -414,18 +414,19 @@ For more information and examples on how to use selective unit test filtering, s
 
 ```dotnetcli
 dotnet test
-    [-a|--arch <ARCHITECTURE>]
-    [-c|--configuration <CONFIGURATION>]
-    [--directory <DIRECTORY_PATH>]
-    [-mptm|--max-parallel-test-modules <NUMBER>]
-    [--no-build]
-    [--no-restore]
     [--project <PROJECT_PATH>]
     [--solution <SOLUTION_PATH>]
+    [--directory <DIRECTORY_PATH>]
+    [--test-modules <EXPRESSION>] 
+    [--root-directory <ROOT_PATH>]
+    [-a|--arch <ARCHITECTURE>]
+    [-c|--configuration <CONFIGURATION>]
     [-t|--list-tests]
-    [--test-modules <EXPRESSION>] [--root-directory <ROOT_PATH>]
+    [--max-parallel-test-modules <NUMBER>]
     [--no-ansi]
+    [--no-build]
     [--no-progress]
+    [--no-restore]
     [--output <VERBOSITY_LEVEL>]
     [<args>...]
 
@@ -437,35 +438,13 @@ dotnet test -h|--help
 With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest. The test related arguments are no longer fixed as they are tied to the registered extensions in the test project(s). Moreover, it supports globbing filter when running tests. For more information, see [Microsoft.Testing.Platform](../testing/unit-testing-platform-intro.md).
 
 > [!WARNING]
-> `dotnet test` doesn't run in an environment where we have test projects using VSTest and Microsoft Testing Platform in the same solution, as the two platforms have different command line options and different features.
+> `dotnet test` doesn't run in an environment where we have test projects using VSTest and Microsoft Testing Platform in the same solution, as the two platforms are mutually incompatible.
 
 #### Implicit restore
 
 [!INCLUDE[dotnet restore note](~/includes/dotnet-restore-note.md)]
 
 #### Options
-
-- **`--arch <ARCHITECTURE>`**
-
-  Specifies the target architecture. This is a shorthand syntax for setting the [Runtime Identifier (RID)](../../../docs/core/rid-catalog.md), where the provided value is combined with the default RID. For example, on a `win-x64` machine, specifying `--arch x86` sets the RID to `win-x86`.
-
-[!INCLUDE [configuration](../../../includes/cli-configuration.md)]
-
-- **`--directory <DIRECTORY_PATH>`**
-
-  Specifies the path to a directory that contains a project or a solution.
-
-- **`--max-parallel-test-modules <NUMBER>`**
-
-  Specifies the max number of test modules that can run in parallel.
-
-- **`--no-build`**
-
-  Doesn't build the test project before running it. It also implicitly sets the `--no-restore` flag.
-
-- **`--no-restore`**
-
-  Doesn't execute an implicit restore when running the command.
 
 - **`--project <PROJECT_PATH>`**
 
@@ -475,9 +454,12 @@ With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest.
 
   Specifies the path to the solution.
 
-- **`-t|--list-tests`**
+- **`--directory <DIRECTORY_PATH>`**
 
-  Lists the discovered tests instead of running the tests.
+  Specifies the path to a directory that contains a project or a solution.
+
+> [!NOTE]
+> > You can use only one of the following options at a time: `--project`, `--solution`, or `--directory`. These options cannot be combined.
 
 - **`--test-modules <EXPRESSION>`**
 
@@ -487,13 +469,35 @@ With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest.
 
   Specifies the root directory of the `--test-modules` option. It can only be used with the `--test-modules` option.
 
+- **`--arch <ARCHITECTURE>`**
+
+  Specifies the target architecture. This is a shorthand syntax for setting the [Runtime Identifier (RID)](../../../docs/core/rid-catalog.md), where the provided value is combined with the default RID. For example, on a `win-x64` machine, specifying `--arch x86` sets the RID to `win-x86`.
+
+[!INCLUDE [configuration](../../../includes/cli-configuration.md)]
+
+- **`-t|--list-tests`**
+
+  Lists the discovered tests instead of running the tests.
+
+- **`--max-parallel-test-modules <NUMBER>`**
+
+  Specifies the max number of test modules that can run in parallel.
+
 - **`--no-ansi`**
 
   Disables outputting ANSI escape characters to screen.
 
+- **`--no-build`**
+
+  Doesn't build the test project before running it. It also implicitly sets the `--no-restore` flag.
+
 - **`--no-progress`**
 
   Disables reporting progress to screen.
+
+- **`--no-restore`**
+
+  Doesn't execute an implicit restore when running the command.
 
 - **`--output <VERBOSITY_LEVEL>`**
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -25,11 +25,13 @@ Some examples of the `dotnet.config` file
   name= "VSTest"
   ```
 
-## [dotnet test with VSTest](#tab/dotnet-test-with-vstest)
+## VSTest and Microsoft Testing Platform (MTP)
+
+### [dotnet test with VSTest](#tab/dotnet-test-with-vstest)
 
 **This article applies to:** ✔️ .NET Core 3.1 SDK and later versions
 
-### Synopsis
+#### Synopsis
 
 ```dotnetcli
 dotnet test [<PROJECT> | <SOLUTION> | <DIRECTORY> | <DLL> | <EXE>]
@@ -67,7 +69,7 @@ dotnet test [<PROJECT> | <SOLUTION> | <DIRECTORY> | <DLL> | <EXE>]
 dotnet test -h|--help
 ```
 
-### Description
+#### Description
 
 The `dotnet test` command is used to execute unit tests in a given solution. The `dotnet test` command builds the solution and runs a test host application for each test project in the solution using `VSTest`. The test host executes tests in the given project using a test framework, for example: MSTest, NUnit, or xUnit, and reports the success or failure of each test. If all tests are successful, the test runner returns 0 as an exit code; otherwise if any test fails, it returns 1.
 
@@ -82,13 +84,13 @@ Test projects specify the test runner using an ordinary `<PackageReference>` ele
 
 Where `Microsoft.NET.Test.Sdk` is the test host, `xunit` is the test framework. And `xunit.runner.visualstudio` is a test adapter, which allows the xUnit framework to work with the test host.
 
-### Implicit restore
+#### Implicit restore
 
 [!INCLUDE[dotnet restore note](~/includes/dotnet-restore-note.md)]
 
 [!INCLUDE [cli-advertising-manifests](../../../includes/cli-advertising-manifests.md)]
 
-### Arguments
+#### Arguments
 
 - **`PROJECT | SOLUTION | DIRECTORY | DLL | EXE`**
 
@@ -100,7 +102,7 @@ Where `Microsoft.NET.Test.Sdk` is the test host, `xunit` is the test framework. 
 
   If not specified, the effect is the same as using the `DIRECTORY` argument to specify the current directory.
 
-### Options
+#### Options
 
 > [!WARNING]
 > Breaking changes in options:
@@ -270,7 +272,7 @@ Where `Microsoft.NET.Test.Sdk` is the test host, `xunit` is the test framework. 
 
   For more information, see [Passing RunSettings arguments through command line](https://github.com/Microsoft/vstest-docs/blob/main/docs/RunSettingsArguments.md).
 
-### Examples
+#### Examples
 
 - Run the tests in the project in the current directory:
 
@@ -360,7 +362,7 @@ Where `Microsoft.NET.Test.Sdk` is the test host, `xunit` is the test framework. 
   dotnet test ~/projects/test1/test1.csproj -p:TestTfmsInParallel=false
   ```
 
-### Filter option details
+#### Filter option details
 
 `--filter <EXPRESSION>`
 
@@ -398,7 +400,7 @@ You can enclose expressions in parenthesis when using conditional operators (for
 
 For more information and examples on how to use selective unit test filtering, see [Running selective unit tests](../testing/selective-unit-tests.md).
 
-### See also
+#### See also
 
 - [Frameworks and Targets](../../standard/frameworks.md)
 - [.NET Runtime Identifier (RID) catalog](../rid-catalog.md)
@@ -408,7 +410,7 @@ For more information and examples on how to use selective unit test filtering, s
 
 **This article applies to:** ✔️ .NET 10 SDK and later versions
 
-### Synopsis
+#### Synopsis
 
 ```dotnetcli
 dotnet test
@@ -430,20 +432,20 @@ dotnet test
 dotnet test -h|--help
 ```
 
-### Description
+#### Description
 
 TO DO.
 
 > [!WARNING]
 > `dotnet test` doesn't run in an environment where we have test projects using VSTest and Microsoft Testing Platform in the same solution, as the two platforms have different command line options and different features.
 
-### Implicit restore
+#### Implicit restore
 
 [!INCLUDE[dotnet restore note](~/includes/dotnet-restore-note.md)]
 
 [!INCLUDE [cli-advertising-manifests](../../../includes/cli-advertising-manifests.md)]
 
-### Options
+#### Options
 
 - **`--arch <ARCHITECTURE>`**
 
@@ -518,7 +520,7 @@ TO DO.
 
   Specifies extra arguments to pass to the test application(s). Use a space to separate multiple arguments. For more information and examples on what to pass, see [Microsoft Testing Platform](../../../docs/core/testing/unit-testing-platform-intro.md) and [Microsoft.Testing.Platform extensions](../../../docs/core/testing/unit-testing-platform-extensions.md).
 
-### Examples
+#### Examples
 
 - Run the tests in the project in the current directory:
 
@@ -574,7 +576,7 @@ TO DO.
   dotnet test --project ./TestProject/TestProject.csproj -p:DefineConstants="DEV"
   ```
 
-### See also
+#### See also
 
 - [Frameworks and Targets](../../standard/frameworks.md)
 - [.NET Runtime Identifier (RID) catalog](../rid-catalog.md)

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -419,14 +419,17 @@ dotnet test
     [--directory <DIRECTORY_PATH>]
     [--test-modules <EXPRESSION>] 
     [--root-directory <ROOT_PATH>]
+    [--list-tests]
+    [--max-parallel-test-modules <NUMBER>]
     [-a|--arch <ARCHITECTURE>]
     [-c|--configuration <CONFIGURATION>]
-    [-t|--list-tests]
-    [--max-parallel-test-modules <NUMBER>]
-    [--no-ansi]
+    [-f|--framework <FRAMEWORK>]
+    [--os <OS>]
+    [-r|--runtime <RUNTIME_IDENTIFIER>]
     [--no-build]
-    [--no-progress]
     [--no-restore]
+    [--no-ansi]
+    [--no-progress]
     [--output <VERBOSITY_LEVEL>]
     [<args>...]
 
@@ -469,13 +472,7 @@ With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest.
 
   Specifies the root directory of the `--test-modules` option. It can only be used with the `--test-modules` option.
 
-- **`--arch <ARCHITECTURE>`**
-
-  Specifies the target architecture. This is a shorthand syntax for setting the [Runtime Identifier (RID)](../../../docs/core/rid-catalog.md), where the provided value is combined with the default RID. For example, on a `win-x64` machine, specifying `--arch x86` sets the RID to `win-x86`.
-
-[!INCLUDE [configuration](../../../includes/cli-configuration.md)]
-
-- **`-t|--list-tests`**
+  - **`-t|--list-tests`**
 
   Lists the discovered tests instead of running the tests.
 
@@ -483,21 +480,37 @@ With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest.
 
   Specifies the max number of test modules that can run in parallel.
 
-- **`--no-ansi`**
+[!INCLUDE [arch-no-a](../../../includes/cli-arch-no-a.md)]
 
-  Disables outputting ANSI escape characters to screen.
+[!INCLUDE [configuration](../../../includes/cli-configuration.md)]
+
+- **`-f|--framework <FRAMEWORK>`**
+
+  The [target framework moniker (TFM)](../../standard/frameworks.md) of the target framework to run tests for. The target framework must also be specified in the project file.
+
+[!INCLUDE [os](../../../includes/cli-os.md)]
+
+- **`-r|--runtime <RUNTIME_IDENTIFIER>`**
+
+  The target runtime to test for.
+
+  Short form `-r` available starting in .NET SDK 7.
 
 - **`--no-build`**
 
   Doesn't build the test project before running it. It also implicitly sets the `--no-restore` flag.
 
-- **`--no-progress`**
-
-  Disables reporting progress to screen.
-
 - **`--no-restore`**
 
   Doesn't execute an implicit restore when running the command.
+
+- **`--no-ansi`**
+
+  Disables outputting ANSI escape characters to screen.
+
+- **`--no-progress`**
+
+  Disables reporting progress to screen.
 
 - **`--output <VERBOSITY_LEVEL>`**
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -489,7 +489,7 @@ TO DO.
 
 - **`-h|--help`**
 
-  Prints out a description of how to use the command. The options will be dynamic, as they will be based on the registered extensions in the test project.
+  Prints out a description of how to use the command. The options will be dynamic and they may differ from one test application to another as they will be based on the registered extensions in the test project.
 
 - **`args`**
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -13,7 +13,7 @@ ms.date: 03/27/2024
 
 The `dotnet test` command builds the solution and runs the tests either with VSTest or with Microsoft Testing Platform (MTP). In order to enable MTP, you need to add a config file named `dotnet.config` using TOML format located at the root of the solution or repository.
 
-Some examples of the `dotnet.config` file
+Some examples of the `dotnet.config` file:
 
   ```toml
   [dotnet.test:runner]

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -11,18 +11,18 @@ ms.date: 03/27/2024
 
 ## Description
 
-The `dotnet test` command builds the solution and runs the tests either with VSTest or with Microsoft Testing Platform (MTP). In order to enable MTP, you need to add a config file named `dotnet.config` using INI format located at the root of the solution or repository.
+The `dotnet test` command builds the solution and runs the tests either with VSTest or with Microsoft Testing Platform (MTP). In order to enable MTP, you need to add a config file named `dotnet.config` using TOML format located at the root of the solution or repository.
 
 Some examples of the `dotnet.config` file
 
   ```toml
   [dotnet.test:runner]
-  name= "MicrosoftTestingPlatform"
+  name = "MicrosoftTestingPlatform"
   ```
 
   ```toml
   [dotnet.test:runner]
-  name= "VSTest"
+  name = "VSTest"
   ```
 
 ## VSTest and Microsoft Testing Platform (MTP)

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -539,10 +539,6 @@ TO DO.
   dotnet test --coverage
   ```
 
-  ```dotnetcli
-  dotnet test --directory ./TestProjects
-  ```
-
 - Run the tests in the `TestProject` project, providing the `-bl` (binary log) argument to `msbuild`:
 
   ```dotnetcli

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -487,7 +487,9 @@ TO DO.
   The short form `-p` can be used for `--property`. The same applies for `/property:property=value` and its short form is `/p`.
   More informatiom about the available arguments can be found in [the dotnet msbuild documentation](dotnet-msbuild.md).
 
-[!INCLUDE [help](../../../includes/cli-help.md)]
+- **`-h|--help`**
+
+  Prints out a description of how to use the command. The options will be dynamic, as they will be based on the registered extensions in the test project.
 
 - **`args`**
 
@@ -543,24 +545,26 @@ TO DO.
   dotnet test --architecture x64
   ```
 
-- Run the tests in the `test1` project, providing the `-bl` (binary log) argument to `msbuild`:
+- Run the tests in the current directory with code coverage:
+
+  ```dotnetcli
+  dotnet test --coverage
+  ```
+
+  ```dotnetcli
+  dotnet test --directory ./TestProjects
+  ```
+
+- Run the tests in the `TestProject` project, providing the `-bl` (binary log) argument to `msbuild`:
 
   ```dotnetcli
   dotnet test --project ./TestProject/TestProject.csproj -bl
   ```
 
-- Run the tests in the `test1` project, setting the MSBuild `DefineConstants` property to `DEV`:
+- Run the tests in the `TestProject` project, setting the MSBuild `DefineConstants` property to `DEV`:
 
   ```dotnetcli
   dotnet test --project ./TestProject/TestProject.csproj -p:DefineConstants="DEV"
-  ```
-
-  <a id="testtfmsinparallel"></a>
-
-- Run the tests in the `test1` project, setting the MSBuild `TestTfmsInParallel` property to `false`:
-
-  ```dotnetcli
-  dotnet test --project ./TestProject/TestProject.csproj -p:TestTfmsInParallel=false
   ```
 
 ### See also

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -434,7 +434,7 @@ TO DO.
 
 - **`--max-parallel-test-modules <NUMBER>`**
 
-  Specifies the max number of test modules that can run in parallel. 
+  Specifies the max number of test modules that can run in parallel.
 
 - **`--no-build`**
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -5,6 +5,12 @@ ms.date: 03/27/2024
 ---
 # dotnet test
 
+## Name
+
+`dotnet test` - .NET test driver used to execute unit tests.
+
+## Description
+
 The `dotnet test` command is used to execute unit tests in a given solution. The `dotnet test` command builds the solution and runs the tests either with VSTest or with Microsoft Testing Platform (MTP). In order to enable MTP, you need to add a config file named `dotnet.config` using INI format located at the root of the solution or repository.
 
 Some examples of the `dotnet.config` file
@@ -18,10 +24,6 @@ Some examples of the `dotnet.config` file
   [dotnet.test:runner]
   name= "VSTest"
   ```
-
-## Name
-
-`dotnet test` - .NET test driver used to execute unit tests.
 
 ## [dotnet test with VSTest](#tab/dotnet-test-with-vstest)
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -401,15 +401,16 @@ dotnet test
     [-a|--arch <ARCHITECTURE>]
     [-c|--configuration <CONFIGURATION>]
     [--directory <DIRECTORY_PATH>]
+    [-mptm|--max-parallel-test-modules <NUMBER>]
     [--no-build]
     [--no-restore]
     [--project <PROJECT_PATH>]
     [--solution <SOLUTION_PATH>]
     [-t|--list-tests]
-    [--test-modules <EXPRESSION>] [--root-directory <ROOT_DIRECTORY>]
+    [--test-modules <EXPRESSION>] [--root-directory <ROOT_PATH>]
     [--no-ansi]
     [--no-progress]
-    [--output]
+    [--output <VERBOSITY_LEVEL>]
     [<args>...]
 
 dotnet test -h|--help
@@ -430,6 +431,10 @@ TO DO.
 - **`--directory <DIRECTORY_PATH>`**
 
   Specifies the path to a directory that contains a project or a solution.
+
+- **`--max-parallel-test-modules <NUMBER>`**
+
+  Specifies the max number of test modules that can run in parallel. 
 
 - **`--no-build`**
 
@@ -455,7 +460,7 @@ TO DO.
 
   Filters test modules using file globbing in .NET. Only tests belonging to those test modules will run. For more information and examples on how to use file globbing in .NET, see [File globbing](../../../docs/core/extensions/file-globbing.md).
 
-- **`--root-directory <ROOT_DIRECTORY>`**
+- **`--root-directory <ROOT_PATH>`**
 
   Specifies the root directory of the `--test-modules` option. It can only be used with the `--test-modules` option.
 
@@ -467,7 +472,7 @@ TO DO.
 
   Disables reporting progress to screen.
 
-- **`--output`**
+- **`--output <VERBOSITY_LEVEL>`**
 
   Specifies the output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -472,7 +472,7 @@ With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest.
 
   Specifies the root directory of the `--test-modules` option. It can only be used with the `--test-modules` option.
 
-  - **`-t|--list-tests`**
+- **`-t|--list-tests`**
 
   Lists the discovered tests instead of running the tests.
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -15,12 +15,12 @@ The `dotnet test` command builds the solution and runs the tests either with VST
 
 Some examples of the `dotnet.config` file
 
-  ```dotnetcli
+  ```toml
   [dotnet.test:runner]
   name= "MicrosoftTestingPlatform"
   ```
 
-  ```dotnetcli
+  ```toml
   [dotnet.test:runner]
   name= "VSTest"
   ```

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -423,7 +423,7 @@ TO DO.
 
 ## Options
 
- - **`--arch <ARCHITECTURE>`**
+- **`--arch <ARCHITECTURE>`**
 
   Specifies the target architecture. This is a shorthand syntax for setting the [Runtime Identifier (RID)](../../../docs/core/rid-catalog.md), where the provided value is combined with the default RID. For example, on a `win-x64` machine, specifying `--arch x86` sets the RID to `win-x86`.
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -390,8 +390,6 @@ For more information and examples on how to use selective unit test filtering, s
 - [.NET Runtime Identifier (RID) catalog](../rid-catalog.md)
 - [Passing runsettings arguments through commandline](https://github.com/microsoft/vstest/blob/main/docs/RunSettingsArguments.md)
 
-
-
 ### [dotnet test with MTP](#tab/dotnet-test-with-mtp)
 
 **This article applies to:** ✔️ .NET 10 SDK and later versions

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -533,18 +533,6 @@ TO DO.
   dotnet test --test-modules "**/bin/**/Debug/net10.0/TestProject.dll" --root-directory "c:\code"
   ```
 
-- Run projects in the current directory, specifying Release configuration:
-
-  ```dotnetcli
-  dotnet test --configuration Release
-  ```
-
-- Run projects in the current directory, specifying x64 architecture:
-
-  ```dotnetcli
-  dotnet test --architecture x64
-  ```
-
 - Run the tests in the current directory with code coverage:
 
   ```dotnetcli

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -7,7 +7,7 @@ ms.date: 03/27/2024
 
 The `dotnet test` command is used to execute unit tests in a given solution. The `dotnet test` command builds the solution and runs the tests either with VSTest or with Microsoft Testing Platform (MTP). In order to enable MTP, you need to add a config file named `dotnet.config` using INI format located at the root of the solution or repository.
 
--  Some examples of the `dotnet.config` file
+- Some examples of the `dotnet.config` file
 
   ```dotnetcli
   [dotnet.test:runner]

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -434,7 +434,7 @@ dotnet test -h|--help
 
 #### Description
 
-With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest. The test related arguments are no longer fixed as they are tied to the registered extensions in the test project(s). Moreover, it supports globbing filter when running tests. For more information, see [Microsoft.Testing.Platform](../testing/unit-testing-platform-intro.md)
+With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest. The test related arguments are no longer fixed as they are tied to the registered extensions in the test project(s). Moreover, it supports globbing filter when running tests. For more information, see [Microsoft.Testing.Platform](../testing/unit-testing-platform-intro.md).
 
 > [!WARNING]
 > `dotnet test` doesn't run in an environment where we have test projects using VSTest and Microsoft Testing Platform in the same solution, as the two platforms have different command line options and different features.

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -443,8 +443,6 @@ TO DO.
 
 [!INCLUDE[dotnet restore note](~/includes/dotnet-restore-note.md)]
 
-[!INCLUDE [cli-advertising-manifests](../../../includes/cli-advertising-manifests.md)]
-
 #### Options
 
 - **`--arch <ARCHITECTURE>`**

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -11,7 +11,7 @@ ms.date: 03/27/2024
 
 ## Description
 
-The `dotnet test` command is used to execute unit tests in a given solution. The `dotnet test` command builds the solution and runs the tests either with VSTest or with Microsoft Testing Platform (MTP). In order to enable MTP, you need to add a config file named `dotnet.config` using INI format located at the root of the solution or repository.
+The `dotnet test` command builds the solution and runs the tests either with VSTest or with Microsoft Testing Platform (MTP). In order to enable MTP, you need to add a config file named `dotnet.config` using INI format located at the root of the solution or repository.
 
 Some examples of the `dotnet.config` file
 
@@ -434,8 +434,14 @@ dotnet test -h|--help
 
 TO DO.
 
-> [!NOTE]
+> [!WARNING]
 > `dotnet test` doesn't run in an environment where we have test projects using VSTest and Microsoft Testing Platform in the same solution, as the two platforms have different command line options and different features.
+
+### Implicit restore
+
+[!INCLUDE[dotnet restore note](~/includes/dotnet-restore-note.md)]
+
+[!INCLUDE [cli-advertising-manifests](../../../includes/cli-advertising-manifests.md)]
 
 ### Options
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -7,7 +7,7 @@ ms.date: 03/27/2024
 
 The `dotnet test` command is used to execute unit tests in a given solution. The `dotnet test` command builds the solution and runs the tests either with VSTest or with Microsoft Testing Platform (MTP). In order to enable MTP, you need to add a config file named `dotnet.config` using INI format located at the root of the solution or repository.
 
-- Some examples of the `dotnet.config` file
+Some examples of the `dotnet.config` file
 
   ```dotnetcli
   [dotnet.test:runner]

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -5,7 +5,19 @@ ms.date: 03/27/2024
 ---
 # dotnet test
 
-Add description how to enable vstest or mtp.
+The `dotnet test` command is used to execute unit tests in a given solution. The `dotnet test` command builds the solution and runs the tests either with VSTest or with Microsoft Testing Platform (MTP). In order to enable MTP, you need to add a config file named `dotnet.config` using INI format located at the root of the solution or repository.
+
+-  Some examples of the `dotnet.config` file
+
+  ```dotnetcli
+  [dotnet.test:runner]
+  name= "MicrosoftTestingPlatform"
+  ```
+
+  ```dotnetcli
+  [dotnet.test:runner]
+  name= "VSTest"
+  ```
 
 ## Name
 
@@ -419,6 +431,9 @@ dotnet test -h|--help
 ### Description
 
 TO DO.
+
+> [!NOTE]
+> `dotnet test` doesn't run in an environment where we have test projects using VSTest and Microsoft Testing Platform in the same solution, as the two platforms have different command line options and different features.
 
 ### Options
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -425,7 +425,7 @@ TO DO.
 
  - **`--arch <ARCHITECTURE>`**
 
-  Specifies the target architecture. This is a shorthand syntax for setting the [Runtime Identifier (RID)](../docs/core/rid-catalog.md), where the provided value is combined with the default RID. For example, on a `win-x64` machine, specifying `--arch x86` sets the RID to `win-x86`.
+  Specifies the target architecture. This is a shorthand syntax for setting the [Runtime Identifier (RID)](../../../docs/core/rid-catalog.md), where the provided value is combined with the default RID. For example, on a `win-x64` machine, specifying `--arch x86` sets the RID to `win-x86`.
 
 [!INCLUDE [configuration](../../../includes/cli-configuration.md)]
 
@@ -488,7 +488,7 @@ TO DO.
 
 - **`args`**
 
-  Specifies extra arguments to pass to the test application(s). Use a space to separate multiple arguments. For more information and examples on what to pass, see [Microsoft Testing Platform](../../../docs/core/testing/unit-testing-platform-intro.md) and [Microsoft.Testing.Platform extensions](unit-testing-platform-extensions.md).
+  Specifies extra arguments to pass to the test application(s). Use a space to separate multiple arguments. For more information and examples on what to pass, see [Microsoft Testing Platform](../../../docs/core/testing/unit-testing-platform-intro.md) and [Microsoft.Testing.Platform extensions](../../../docs/core/testing/unit-testing-platform-extensions.md).
 
 ## Examples
 
@@ -565,4 +565,4 @@ TO DO.
 - [Frameworks and Targets](../../standard/frameworks.md)
 - [.NET Runtime Identifier (RID) catalog](../rid-catalog.md)
 - [Microsoft Testing Platform](../../../docs/core/testing/unit-testing-platform-intro.md)
-- [Microsoft.Testing.Platform extensions](unit-testing-platform-extensions.md)
+- [Microsoft.Testing.Platform extensions](../../../docs/core/testing/unit-testing-platform-extensions.md)

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -5,11 +5,15 @@ ms.date: 03/27/2024
 ---
 # dotnet test
 
-**This article applies to:** ✔️ .NET Core 3.1 SDK and later versions
+Add description how to enable vstest or mtp.
 
 ## Name
 
 `dotnet test` - .NET test driver used to execute unit tests.
+
+## [dotnet test with VSTest](#tab/dotnet-test-with-vstest)
+
+**This article applies to:** ✔️ .NET Core 3.1 SDK and later versions
 
 ## Synopsis
 
@@ -385,3 +389,180 @@ For more information and examples on how to use selective unit test filtering, s
 - [Frameworks and Targets](../../standard/frameworks.md)
 - [.NET Runtime Identifier (RID) catalog](../rid-catalog.md)
 - [Passing runsettings arguments through commandline](https://github.com/microsoft/vstest/blob/main/docs/RunSettingsArguments.md)
+
+
+
+## [dotnet test with MTP](#tab/dotnet-test-with-mtp)
+
+**This article applies to:** ✔️ .NET 10 SDK and later versions
+
+## Synopsis
+
+```dotnetcli
+dotnet test
+    [-a|--arch <ARCHITECTURE>]
+    [-c|--configuration <CONFIGURATION>]
+    [--directory <DIRECTORY_PATH>]
+    [--no-build]
+    [--no-restore]
+    [--project <PROJECT_PATH>]
+    [--solution <SOLUTION_PATH>]
+    [-t|--list-tests]
+    [--test-modules <EXPRESSION>] [--root-directory <ROOT_DIRECTORY>]
+    [--no-ansi]
+    [--no-progress]
+    [--output]
+    [<args>...]
+
+dotnet test -h|--help
+```
+
+## Description
+
+TO DO.
+
+## Options
+
+ - **`--arch <ARCHITECTURE>`**
+
+  Specifies the target architecture. This is a shorthand syntax for setting the [Runtime Identifier (RID)](../docs/core/rid-catalog.md), where the provided value is combined with the default RID. For example, on a `win-x64` machine, specifying `--arch x86` sets the RID to `win-x86`.
+
+[!INCLUDE [configuration](../../../includes/cli-configuration.md)]
+
+- **`--directory <DIRECTORY_PATH>`**
+
+  Specifies the path to a directory that contains a project or a solution.
+
+- **`--no-build`**
+
+  Doesn't build the test project before running it. It also implicitly sets the `--no-restore` flag.
+
+- **`--no-restore`**
+
+  Doesn't execute an implicit restore when running the command.
+
+- **`--project <PROJECT_PATH>`**
+
+  Specifies the path to the test project.
+
+- **`--solution <SOLUTION_PATH>`**
+
+  Specifies the path to the solution.
+
+- **`-t|--list-tests`**
+
+  Lists the discovered tests instead of running the tests.
+
+- **`--test-modules <EXPRESSION>`**
+
+  Filters test modules using file globbing in .NET. Only tests belonging to those test modules will run. For more information and examples on how to use file globbing in .NET, see [File globbing](../../../docs/core/extensions/file-globbing.md).
+
+- **`--root-directory <ROOT_DIRECTORY>`**
+
+  Specifies the root directory of the `--test-modules` option. It can only be used with the `--test-modules` option.
+
+- **`--no-ansi`**
+
+  Disables outputting ANSI escape characters to screen.
+
+- **`--no-progress`**
+
+  Disables reporting progress to screen.
+
+- **`--output`**
+
+  Specifies the output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.
+
+- **`--property:<NAME>=<VALUE>`**
+
+  Sets one or more MSBuild properties. Specify multiple properties by repeating the option:
+
+  ```dotnetcli
+  --property:<NAME1>=<VALUE1> --property:<NAME2>=<VALUE2>
+  ```
+
+  The short form `-p` can be used for `--property`. The same applies for `/property:property=value` and its short form is `/p`.
+  More informatiom about the available arguments can be found in [the dotnet msbuild documentation](dotnet-msbuild.md).
+
+[!INCLUDE [help](../../../includes/cli-help.md)]
+
+- **`args`**
+
+  Specifies extra arguments to pass to the test application(s). Use a space to separate multiple arguments. For more information and examples on what to pass, see [Microsoft Testing Platform](../../../docs/core/testing/unit-testing-platform-intro.md) and [Microsoft.Testing.Platform extensions](unit-testing-platform-extensions.md).
+
+## Examples
+
+- Run the tests in the project in the current directory:
+
+  ```dotnetcli
+  dotnet test
+  ```
+
+- Run the tests in the `TestProject` project:
+
+  ```dotnetcli
+  dotnet test --project ./TestProject/TestProject.csproj
+  ```
+
+- Run the tests in the `TestProjects` solution:
+
+  ```dotnetcli
+  dotnet test --solution ./TestProjects/TestProjects.sln
+  ```
+
+- Run the tests in the `TestProjects` directory:
+
+  ```dotnetcli
+  dotnet test --directory ./TestProjects
+  ```
+
+- Run the tests using `TestProject.dll` assembly:
+
+  ```dotnetcli
+  dotnet test --test-modules "**/bin/**/Debug/net10.0/TestProject.dll"
+  ```
+
+- Run the tests using `TestProject.dll` assembly with the root directory:
+
+  ```dotnetcli
+  dotnet test --test-modules "**/bin/**/Debug/net10.0/TestProject.dll" --root-directory "c:\code"
+  ```
+
+- Run projects in the current directory, specifying Release configuration:
+
+  ```dotnetcli
+  dotnet test --configuration Release
+  ```
+
+- Run projects in the current directory, specifying x64 architecture:
+
+  ```dotnetcli
+  dotnet test --architecture x64
+  ```
+
+- Run the tests in the `test1` project, providing the `-bl` (binary log) argument to `msbuild`:
+
+  ```dotnetcli
+  dotnet test --project ./TestProject/TestProject.csproj -bl
+  ```
+
+- Run the tests in the `test1` project, setting the MSBuild `DefineConstants` property to `DEV`:
+
+  ```dotnetcli
+  dotnet test --project ./TestProject/TestProject.csproj -p:DefineConstants="DEV"
+  ```
+
+  <a id="testtfmsinparallel"></a>
+
+- Run the tests in the `test1` project, setting the MSBuild `TestTfmsInParallel` property to `false`:
+
+  ```dotnetcli
+  dotnet test --project ./TestProject/TestProject.csproj -p:TestTfmsInParallel=false
+  ```
+
+## See also
+
+- [Frameworks and Targets](../../standard/frameworks.md)
+- [.NET Runtime Identifier (RID) catalog](../rid-catalog.md)
+- [Microsoft Testing Platform](../../../docs/core/testing/unit-testing-platform-intro.md)
+- [Microsoft.Testing.Platform extensions](unit-testing-platform-extensions.md)

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -434,7 +434,7 @@ dotnet test -h|--help
 
 #### Description
 
-TO DO.
+With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest. The test related arguments are no longer fixed as they are tied to the registered extensions in the test project(s). Moreover, it supports globbing filter when running tests. For more information, see [Microsoft.Testing.Platform](../testing/unit-testing-platform-intro.md)
 
 > [!WARNING]
 > `dotnet test` doesn't run in an environment where we have test projects using VSTest and Microsoft Testing Platform in the same solution, as the two platforms have different command line options and different features.

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -15,7 +15,7 @@ Add description how to enable vstest or mtp.
 
 **This article applies to:** ✔️ .NET Core 3.1 SDK and later versions
 
-## Synopsis
+### Synopsis
 
 ```dotnetcli
 dotnet test [<PROJECT> | <SOLUTION> | <DIRECTORY> | <DLL> | <EXE>]
@@ -53,7 +53,7 @@ dotnet test [<PROJECT> | <SOLUTION> | <DIRECTORY> | <DLL> | <EXE>]
 dotnet test -h|--help
 ```
 
-## Description
+### Description
 
 The `dotnet test` command is used to execute unit tests in a given solution. The `dotnet test` command builds the solution and runs a test host application for each test project in the solution using `VSTest`. The test host executes tests in the given project using a test framework, for example: MSTest, NUnit, or xUnit, and reports the success or failure of each test. If all tests are successful, the test runner returns 0 as an exit code; otherwise if any test fails, it returns 1.
 
@@ -74,7 +74,7 @@ Where `Microsoft.NET.Test.Sdk` is the test host, `xunit` is the test framework. 
 
 [!INCLUDE [cli-advertising-manifests](../../../includes/cli-advertising-manifests.md)]
 
-## Arguments
+### Arguments
 
 - **`PROJECT | SOLUTION | DIRECTORY | DLL | EXE`**
 
@@ -86,7 +86,7 @@ Where `Microsoft.NET.Test.Sdk` is the test host, `xunit` is the test framework. 
 
   If not specified, the effect is the same as using the `DIRECTORY` argument to specify the current directory.
 
-## Options
+### Options
 
 > [!WARNING]
 > Breaking changes in options:
@@ -256,7 +256,7 @@ Where `Microsoft.NET.Test.Sdk` is the test host, `xunit` is the test framework. 
 
   For more information, see [Passing RunSettings arguments through command line](https://github.com/Microsoft/vstest-docs/blob/main/docs/RunSettingsArguments.md).
 
-## Examples
+### Examples
 
 - Run the tests in the project in the current directory:
 
@@ -346,7 +346,7 @@ Where `Microsoft.NET.Test.Sdk` is the test host, `xunit` is the test framework. 
   dotnet test ~/projects/test1/test1.csproj -p:TestTfmsInParallel=false
   ```
 
-## Filter option details
+### Filter option details
 
 `--filter <EXPRESSION>`
 
@@ -384,7 +384,7 @@ You can enclose expressions in parenthesis when using conditional operators (for
 
 For more information and examples on how to use selective unit test filtering, see [Running selective unit tests](../testing/selective-unit-tests.md).
 
-## See also
+### See also
 
 - [Frameworks and Targets](../../standard/frameworks.md)
 - [.NET Runtime Identifier (RID) catalog](../rid-catalog.md)
@@ -392,11 +392,11 @@ For more information and examples on how to use selective unit test filtering, s
 
 
 
-## [dotnet test with MTP](#tab/dotnet-test-with-mtp)
+### [dotnet test with MTP](#tab/dotnet-test-with-mtp)
 
 **This article applies to:** ✔️ .NET 10 SDK and later versions
 
-## Synopsis
+### Synopsis
 
 ```dotnetcli
 dotnet test
@@ -417,11 +417,11 @@ dotnet test
 dotnet test -h|--help
 ```
 
-## Description
+### Description
 
 TO DO.
 
-## Options
+### Options
 
 - **`--arch <ARCHITECTURE>`**
 
@@ -490,7 +490,7 @@ TO DO.
 
   Specifies extra arguments to pass to the test application(s). Use a space to separate multiple arguments. For more information and examples on what to pass, see [Microsoft Testing Platform](../../../docs/core/testing/unit-testing-platform-intro.md) and [Microsoft.Testing.Platform extensions](../../../docs/core/testing/unit-testing-platform-extensions.md).
 
-## Examples
+### Examples
 
 - Run the tests in the project in the current directory:
 
@@ -560,7 +560,7 @@ TO DO.
   dotnet test --project ./TestProject/TestProject.csproj -p:TestTfmsInParallel=false
   ```
 
-## See also
+### See also
 
 - [Frameworks and Targets](../../standard/frameworks.md)
 - [.NET Runtime Identifier (RID) catalog](../rid-catalog.md)

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -578,5 +578,5 @@ With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest.
 
 - [Frameworks and Targets](../../standard/frameworks.md)
 - [.NET Runtime Identifier (RID) catalog](../rid-catalog.md)
-- [Microsoft Testing Platform](../../../docs/core/testing/unit-testing-platform-intro.md)
+- [Microsoft.Testing.Platform](../../../docs/core/testing/unit-testing-platform-intro.md)
 - [Microsoft.Testing.Platform extensions](../../../docs/core/testing/unit-testing-platform-extensions.md)

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -462,7 +462,7 @@ With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest.
   Specifies the path to a directory that contains a project or a solution.
 
 > [!NOTE]
-> > You can use only one of the following options at a time: `--project`, `--solution`, or `--directory`. These options cannot be combined.
+> You can use only one of the following options at a time: `--project`, `--solution`, or `--directory`. These options cannot be combined.
 
 - **`--test-modules <EXPRESSION>`**
 


### PR DESCRIPTION
This pull request includes updates to the `dotnet test` documentation in the `docs/core/tools/dotnet-test.md` file. The most significant changes involve adding descriptions and examples for using VSTest and MTP with `dotnet test`.

### Updates to `dotnet test` documentation:

* Added a new section to describe how to enable VSTest.
* Introduced a new section for using `dotnet test` with MTP, including a detailed synopsis, description, options, and examples.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-test.md](https://github.com/dotnet/docs/blob/d6da026f88e1a265a8dd0a1e66e341319da49678/docs/core/tools/dotnet-test.md) | [dotnet test](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-test?branch=pr-en-us-44866) |


<!-- PREVIEW-TABLE-END -->