### PR TITLE
Update default platform versions of Tizen

### DIFF
--- a/docs/standard/frameworks.md
+++ b/docs/standard/frameworks.md
@@ -115,8 +115,8 @@ The following table shows the default target platform values (TPV) for each .NET
 
 | .NET version | Android | iOS  | Mac Catalyst | macOS | tvOS | Tizen | Windows |
 |--------------|--------:|-----:|-------------:|------:|-----:|------:|--------:|
-| .NET 8       |    34.0 | 17.2 |         17.2 | 14.2  | 17.1 |   7.0 |    10.0 |
-| .NET 9       |    35.0 | 18.0 |         18.0 | 15.0  |      |   7.0 |    10.0 |
+| .NET 8       |    34.0 | 17.2 |         17.2 | 14.2  | 17.1 |  10.0 |    10.0 |
+| .NET 9       |    35.0 | 18.0 |         18.0 | 15.0  |      |  10.0 |    10.0 |
 
 > [!NOTE]
 > On Apple platforms (iOS, macOS, tvOS, and Mac Catalyst) in .NET 8 and earlier,


### PR DESCRIPTION
## Summary
This PR fixes the default platform versions of Tizen platform.
Tizen supports .NET8 from platform version 10.0. [Check out here for Tizen TFM(`net8.0-tizen10.0`)](https://github.com/samsung/TizenFX?tab=readme-ov-file#branches).
Therefore, Tizen workload for .NET8 and .NET9 sets Tizen 10.0 as a default platform version.
This can be found on the release notes of Tizen workloads.
  - [Tizen Workload 10.0.103 - .Net 8.0](https://github.com/Samsung/Tizen.NET/releases/tag/v10.0.103)
  - [Tizen Workload 10.0.105 - .Net 9.0](https://github.com/Samsung/Tizen.NET/releases/tag/v10.0.105)

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/frameworks.md](https://github.com/dotnet/docs/blob/02d82ac89159ab7df5f6f76ef8b7c0ee2e3e8398/docs/standard/frameworks.md) | [Target frameworks in SDK-style projects](https://review.learn.microsoft.com/en-us/dotnet/standard/frameworks?branch=pr-en-us-44881) |

<!-- PREVIEW-TABLE-END -->