### PR TITLE
Doc MSTEST0041 analyzer

### DIFF
--- a/docs/core/testing/mstest-analyzers/mstest0007.md
+++ b/docs/core/testing/mstest-analyzers/mstest0007.md
@@ -32,10 +32,11 @@ A method that's not marked with <xref:Microsoft.VisualStudio.TestTools.UnitTesti
 
 The following test attributes should only be applied on methods marked with the <xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute> attribute:
 
+- <xref:Microsoft.VisualStudio.TestTools.UnitTesting.ConditionBaseAttribute>
 - <xref:Microsoft.VisualStudio.TestTools.UnitTesting.CssIterationAttribute>
 - <xref:Microsoft.VisualStudio.TestTools.UnitTesting.CssProjectStructureAttribute>
 - <xref:Microsoft.VisualStudio.TestTools.UnitTesting.DescriptionAttribute>
-- <xref:Microsoft.VisualStudio.TestTools.UnitTesting.ExpectedExceptionAttribute>
+- <xref:Microsoft.VisualStudio.TestTools.UnitTesting.ExpectedExceptionBaseAttribute>
 - <xref:Microsoft.VisualStudio.TestTools.UnitTesting.OwnerAttribute>
 - <xref:Microsoft.VisualStudio.TestTools.UnitTesting.PriorityAttribute>
 - <xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestPropertyAttribute>

--- a/docs/core/testing/mstest-analyzers/mstest0041.md
+++ b/docs/core/testing/mstest-analyzers/mstest0041.md
@@ -1,0 +1,41 @@
+---
+title: "MSTEST0041: Use 'ConditionBaseAttribute' on test classes"
+description: "Learn about code analysis rule MSTEST0041: Use 'ConditionBaseAttribute' on test classes"
+ms.date: 02/13/2025
+f1_keywords:
+- MSTEST0041
+- UseConditionBaseWithTestClassAnalyzer
+helpviewer_keywords:
+- UseConditionBaseWithTestClassAnalyzer
+- MSTEST0041
+author: Youssef1313
+ms.author: ygerges
+---
+# MSTEST0041: Use 'ConditionBaseAttribute' on test classes
+
+| Property                            | Value                                                                  |
+|-------------------------------------|------------------------------------------------------------------------|
+| **Rule ID**                         | MSTEST0041                                                             |
+| **Title**                           | Use 'ConditionBaseAttribute' on test classes                           |
+| **Category**                        | Usage                                                                  |
+| **Fix is breaking or non-breaking** | Non-breaking                                                           |
+| **Enabled by default**              | Yes                                                                    |
+| **Default severity**                | Warning                                                                |
+| **Introduced in version**           | 3.8.0                                                                  |
+| **Is there a code fix**             | No                                                                     |
+
+## Cause
+
+The use of an attribute that inherits from <xref:Microsoft.VisualStudio.TestTools.UnitTesting.ConditionBaseAttribute> on a class that is not marked with <xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute>.
+
+## Rule description
+
+An attribute that derives from <xref:Microsoft.VisualStudio.TestTools.UnitTesting.ConditionBaseAttribute> only has an effect when applied to a class that's marked with <xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute>.
+
+## How to fix violations
+
+Depending on the intent, either add the missing <xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute> or remove the attribute that derives from <xref:Microsoft.VisualStudio.TestTools.UnitTesting.ConditionBaseAttribute>.
+
+## When to suppress warnings
+
+Do not suppress a warning from this rule.

--- a/docs/core/testing/mstest-analyzers/usage-rules.md
+++ b/docs/core/testing/mstest-analyzers/usage-rules.md
@@ -37,3 +37,4 @@ Identifier | Name | Description
 [MSTEST0038](mstest0038.md) | AvoidAssertAreSameWithValueTypesAnalyzer | Don't use `Assert.AreSame` or `Assert.AreNotSame` with value types
 [MSTEST0039](mstest0039.md) | UseNewerAssertThrowsAnalyzer | Use newer 'Assert.Throws' methods
 [MSTEST0040](mstest0040.md) | AvoidUsingAssertsInAsyncVoidContextAnalyzer | Do not assert inside 'async void' contexts
+[MSTEST0041](mstest0041.md) | UseConditionBaseWithTestClassAnalyzer | Use 'ConditionBaseAttribute' on test classes

--- a/docs/navigate/devops-testing/toc.yml
+++ b/docs/navigate/devops-testing/toc.yml
@@ -197,6 +197,8 @@ items:
                     href: ../../core/testing/mstest-analyzers/mstest0039.md
                   - name: MSTEST0040
                     href: ../../core/testing/mstest-analyzers/mstest0040.md
+                  - name: MSTEST0041
+                    href: ../../core/testing/mstest-analyzers/mstest0041.md
       - name: Microsoft Testing Platform
         items:
           - name: Overview


### PR DESCRIPTION
Fixes microsoft/testfx#4994

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/mstest-analyzers/mstest0007.md](https://github.com/dotnet/docs/blob/3b15a42105c6e070b7ad9bffef77a0b241209af7/docs/core/testing/mstest-analyzers/mstest0007.md) | [MSTEST0007: Use test attributes only on test methods](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0007?branch=pr-en-us-44882) |
| [docs/core/testing/mstest-analyzers/mstest0041.md](https://github.com/dotnet/docs/blob/3b15a42105c6e070b7ad9bffef77a0b241209af7/docs/core/testing/mstest-analyzers/mstest0041.md) | ["MSTEST0041: Use 'ConditionBaseAttribute' on test classes"](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0041?branch=pr-en-us-44882) |
| [docs/core/testing/mstest-analyzers/usage-rules.md](https://github.com/dotnet/docs/blob/3b15a42105c6e070b7ad9bffef77a0b241209af7/docs/core/testing/mstest-analyzers/usage-rules.md) | [MSTest usage rules](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/usage-rules?branch=pr-en-us-44882) |
| [docs/navigate/devops-testing/toc.yml](https://github.com/dotnet/docs/blob/3b15a42105c6e070b7ad9bffef77a0b241209af7/docs/navigate/devops-testing/toc.yml) | [docs/navigate/devops-testing/toc](https://review.learn.microsoft.com/en-us/dotnet/navigate/devops-testing/toc?branch=pr-en-us-44882) |


<!-- PREVIEW-TABLE-END -->