### PR TITLE
Miscellaneous AI docs cleanup

### DIFF
--- a/docs/ai/ai-extensions.md
+++ b/docs/ai/ai-extensions.md
@@ -10,7 +10,7 @@ ms.author: alexwolf
 
 # Unified AI building blocks for .NET using Microsoft.Extensions.AI
 
-The .NET ecosystem provides abstractions for integrating AI services into .NET applications and libraries using the <xref:Microsoft.Extensions.AI> and [`Microsoft.Extensions.AI.Abstractions`](https://www.nuget.org/packages/Microsoft.Extensions.AI.Abstractions) libraries. The .NET team also enhanced the core `Microsoft.Extensions.*` libraries with these abstractions for .NET generative AI applications and libraries. In the sections ahead, you learn:
+The .NET ecosystem provides abstractions for integrating AI services into .NET applications and libraries using the <xref:Microsoft.Extensions.AI> and <xref:Microsoft.Extensions.AI.Abstractions> libraries. The .NET team has also enhanced the core `Microsoft.Extensions` libraries with these abstractions for .NET generative AI applications and libraries. In the sections ahead, you learn:
 
 - Core concepts and capabilities of the `Microsoft.Extensions.AI` libraries.
 - How to work with AI abstractions in your apps and the benefits they offer.
@@ -18,13 +18,13 @@ The .NET ecosystem provides abstractions for integrating AI services into .NET a
 
 For more information, see [Introduction to Microsoft.Extensions.AI](../core/extensions/artificial-intelligence.md).
 
-## What is the Microsoft.Extensions.AI library?
+## What are the Microsoft.Extensions.AI libraries?
 
-<xref:Microsoft.Extensions.AI> is a set of core .NET libraries created in collaboration with developers across the .NET ecosystem, including Semantic Kernel. These libraries provide a unified layer of C# abstractions for interacting with AI services, such as small and large language models (SLMs and LLMs), embeddings, and middleware.
+The `Microsoft.Extensions.AI` libraries provides core exchange types and abstractions for interacting with AI services, such as small and large language models (SLMs and LLMs). They also provide the ability to register services like logging and caching in your dependency injection (DI) container.
 
 :::image type="content" source="media/ai-extensions/meai-architecture-diagram.png" lightbox="media/ai-extensions/meai-architecture-diagram.png" alt-text="An architectural diagram of the AI extensions libraries.":::
 
-`Microsoft.Extensions.AI` provides abstractions that can be implemented by various services, all adhering to the same core concepts. This library is not intended to provide APIs tailored to any specific provider's services. The goal of `Microsoft.Extensions.AI` is to act as a unifying layer within the .NET ecosystem, enabling developers to choose their preferred frameworks and libraries while ensuring seamless integration and collaboration across the ecosystem.
+The `Microsoft.Extensions.AI` namespaces provide abstractions that can be implemented by various services, all adhering to the same core concepts. This library is not intended to provide APIs tailored to any specific provider's services. The goal of `Microsoft.Extensions.AI` is to act as a unifying layer within the .NET ecosystem, enabling developers to choose their preferred frameworks and libraries while ensuring seamless integration and collaboration across the ecosystem.
 
 ## Work with abstractions for common AI services
 
@@ -34,9 +34,9 @@ AI capabilities are rapidly evolving, with patterns emerging for common function
 - Embedding generation to integrate with vector search capabilities.
 - Tool calling to integrate with other services, platforms, or code.
 
-The `Microsoft.Extensions.AI` library provides abstractions for these types of tasks, so developers can focus on coding against conceptual AI capabilities rather than specific platforms or provider implementations. Unified abstractions are crucial for developers to work effectively across different sources.
+The `Microsoft.Extensions.AI.Abstractions` library provides abstractions for these types of tasks, so developers can focus on coding against conceptual AI capabilities rather than specific platforms or provider implementations. Unified abstractions are crucial for developers to work effectively across different sources.
 
-For example, the `IChatClient` interface allows consumption of language models from various providers, whether you're connecting to an Azure OpenAI service or running a local Ollama installation. Any .NET package that provides an AI client can implement the `IChatClient` interface, enabling seamless integration with consuming .NET code:
+For example, the <xref:Microsoft.Extensions.AI.IChatClient> interface allows consumption of language models from various providers, such as an Azure OpenAI service or a local Ollama installation. Any .NET package that provides an AI client can implement the `IChatClient` interface to enable seamless integration with consuming .NET code:
 
 ```csharp
 IChatClient client =
@@ -45,7 +45,7 @@ IChatClient client =
     new AzureAIInferenceChatClient(...);
 ```
 
-Then, regardless of the provider you're using, you can send requests as follows:
+Then, regardless of the provider you're using, you can send requests by calling <xref:Microsoft.Extensions.AI.IChatClient.CompleteAsync(System.Collections.Generic.IList{Microsoft.Extensions.AI.ChatMessage},Microsoft.Extensions.AI.ChatOptions,System.Threading.CancellationToken)>, as follows:
 
 ```csharp
 var response = await chatClient.CompleteAsync(
@@ -54,7 +54,7 @@ var response = await chatClient.CompleteAsync(
 Console.WriteLine(response.Message);
 ```
 
-These abstractions allow for idiomatic C# code for various scenarios with minimal code changes, whether you're using different services for development and production, addressing hybrid scenarios, or exploring other service providers.
+These abstractions allow for idiomatic C# code for various scenarios with minimal code changes. They make it easy to use different services for development and production, addressing hybrid scenarios, or exploring other service providers.
 
 Library authors who implement these abstractions make their clients interoperable with the broader `Microsoft.Extensions.AI` ecosystem. Service-specific APIs remain accessible if needed, allowing consumers to code against the standard abstractions and pass through to proprietary APIs only when required.
 
@@ -69,9 +69,9 @@ In the future, implementations of these `Microsoft.Extensions.AI` abstractions w
 
 ## Middleware implementations for AI services
 
-Connecting to and using AI services is just one aspect of building robust applications. Production-ready applications require additional features like telemetry, logging, and tool-calling capabilities. The `Microsoft.Extensions.AI` abstractions enable you to easily integrate these components into your applications using familiar patterns.
+Connecting to and using AI services is just one aspect of building robust applications. Production-ready applications require additional features like telemetry, logging, caching, and tool-calling capabilities. The `Microsoft.Extensions.AI` library enables you to easily integrate these components into your applications using familiar dependency injection and middleware patterns.
 
-The following sample demonstrates how to register an OpenAI `IChatClient`. `IChatClient` allows you to attach the capabilities in a consistent way across various providers.
+The following sample demonstrates how to register an OpenAI `IChatClient`. `IChatClient` allows you to attach the capabilities in a consistent way across various providers by calling methods such as <xref:Microsoft.Extensions.AI.FunctionInvokingChatClientBuilderExtensions.UseFunctionInvocation(Microsoft.Extensions.AI.ChatClientBuilder,Microsoft.Extensions.Logging.ILoggerFactory,System.Action{Microsoft.Extensions.AI.FunctionInvokingChatClient})> on a <xref:Microsoft.Extensions.AI.ChatClientBuilder>.
 
 ```csharp
 app.Services.AddChatClient(builder => builder
@@ -82,16 +82,16 @@ app.Services.AddChatClient(builder => builder
     .Use(new OpenAIClient(...)).AsChatClient(...));
 ```
 
-The capabilities demonstrated in this snippet are included in the `Microsoft.Extensions.AI` library, but they are only a small subset of the capabilities that can be layered in with this approach. .NET developers are able to expose many types of middleware to create powerful AI functionality.
+The capabilities demonstrated in this snippet are included in the `Microsoft.Extensions.AI` library, but they're only a small subset of the capabilities that can be layered in with this approach. .NET developers are able to expose many types of middleware to create powerful AI functionality.
 
 ## Build with Microsoft.Extensions.AI
 
 You can start building with `Microsoft.Extensions.AI` in the following ways:
 
-- **Library Developers**: If you own libraries that provide clients for AI services, consider implementing the interfaces in your libraries. This allows users to easily integrate your NuGet package via the abstractions.
-- **Service Consumers**: If you're developing libraries that consume AI services, use the abstractions instead of hardcoding to a specific AI service. This approach gives your consumers the flexibility to choose their preferred service.
-- **Application Developers**: Use the abstractions to simplify integration into your apps. This enables portability across models and services, facilitates testing and mocking, leverages middleware provided by the ecosystem, and maintains a consistent API throughout your app, even if you use different services in different parts of your application.
-- **Ecosystem Contributors**: If you're interested in contributing to the ecosystem, consider writing custom middleware components.
+- **Library developers**: If you own libraries that provide clients for AI services, consider implementing the interfaces in your libraries. This allows users to easily integrate your NuGet package via the abstractions.
+- **Service consumers**: If you're developing libraries that consume AI services, use the abstractions instead of hardcoding to a specific AI service. This approach gives your consumers the flexibility to choose their preferred service.
+- **Application developers**: Use the abstractions to simplify integration into your apps. This enables portability across models and services, facilitates testing and mocking, leverages middleware provided by the ecosystem, and maintains a consistent API throughout your app, even if you use different services in different parts of your application.
+- **Ecosystem contributors**: If you're interested in contributing to the ecosystem, consider writing custom middleware components.
 
 To get started, see the samples in the [dotnet/ai-samples](https://aka.ms/meai-samples) GitHub repository.
 

--- a/docs/ai/ai-extensions.md
+++ b/docs/ai/ai-extensions.md
@@ -10,7 +10,7 @@ ms.author: alexwolf
 
 # Unified AI building blocks for .NET using Microsoft.Extensions.AI
 
-The .NET ecosystem provides abstractions for integrating AI services into .NET applications and libraries using the <xref:Microsoft.Extensions.AI> and <xref:Microsoft.Extensions.AI.Abstractions> libraries. The .NET team has also enhanced the core `Microsoft.Extensions` libraries with these abstractions for .NET generative AI applications and libraries. In the sections ahead, you learn:
+The .NET ecosystem provides abstractions for integrating AI services into .NET applications and libraries using the <xref:Microsoft.Extensions.AI> libraries. The .NET team has also enhanced the core `Microsoft.Extensions` libraries with these abstractions for use in generative AI .NET applications and libraries. In the sections ahead, you learn:
 
 - Core concepts and capabilities of the `Microsoft.Extensions.AI` libraries.
 - How to work with AI abstractions in your apps and the benefits they offer.
@@ -34,7 +34,7 @@ AI capabilities are rapidly evolving, with patterns emerging for common function
 - Embedding generation to integrate with vector search capabilities.
 - Tool calling to integrate with other services, platforms, or code.
 
-The `Microsoft.Extensions.AI.Abstractions` library provides abstractions for these types of tasks, so developers can focus on coding against conceptual AI capabilities rather than specific platforms or provider implementations. Unified abstractions are crucial for developers to work effectively across different sources.
+The `Microsoft.Extensions.AI.Abstractions` package provides abstractions for these types of tasks, so developers can focus on coding against conceptual AI capabilities rather than specific platforms or provider implementations. Unified abstractions are crucial for developers to work effectively across different sources.
 
 For example, the <xref:Microsoft.Extensions.AI.IChatClient> interface allows consumption of language models from various providers, such as an Azure OpenAI service or a local Ollama installation. Any .NET package that provides an AI client can implement the `IChatClient` interface to enable seamless integration with consuming .NET code:
 
@@ -69,9 +69,9 @@ In the future, implementations of these `Microsoft.Extensions.AI` abstractions w
 
 ## Middleware implementations for AI services
 
-Connecting to and using AI services is just one aspect of building robust applications. Production-ready applications require additional features like telemetry, logging, caching, and tool-calling capabilities. The `Microsoft.Extensions.AI` library enables you to easily integrate these components into your applications using familiar dependency injection and middleware patterns.
+Connecting to and using AI services is just one aspect of building robust applications. Production-ready applications require additional features like telemetry, logging, caching, and tool-calling capabilities. The `Microsoft.Extensions.AI` packages provides APIs that enable you to easily integrate these components into your applications using familiar dependency injection and middleware patterns.
 
-The following sample demonstrates how to register an OpenAI `IChatClient`. `IChatClient` allows you to attach the capabilities in a consistent way across various providers by calling methods such as <xref:Microsoft.Extensions.AI.FunctionInvokingChatClientBuilderExtensions.UseFunctionInvocation(Microsoft.Extensions.AI.ChatClientBuilder,Microsoft.Extensions.Logging.ILoggerFactory,System.Action{Microsoft.Extensions.AI.FunctionInvokingChatClient})> on a <xref:Microsoft.Extensions.AI.ChatClientBuilder>.
+The following sample demonstrates how to register an OpenAI `IChatClient`. You can attach capabilities in a consistent way across various providers by calling methods such as <xref:Microsoft.Extensions.AI.FunctionInvokingChatClientBuilderExtensions.UseFunctionInvocation(Microsoft.Extensions.AI.ChatClientBuilder,Microsoft.Extensions.Logging.ILoggerFactory,System.Action{Microsoft.Extensions.AI.FunctionInvokingChatClient})> on a <xref:Microsoft.Extensions.AI.ChatClientBuilder>.
 
 ```csharp
 app.Services.AddChatClient(builder => builder

--- a/docs/ai/dotnet-ai-ecosystem.md
+++ b/docs/ai/dotnet-ai-ecosystem.md
@@ -13,15 +13,19 @@ The .NET ecosystem provides many powerful tools, libraries, and services to deve
 > [!IMPORTANT]
 > Not all of the SDKs and services presented in this doc are maintained by Microsoft. When considering an SDK, make sure to evaluate its quality, licensing, support, and compatibility to ensure they meet your requirements.
 
-## Microsoft.Extensions.AI library for .NET
+## Microsoft.Extensions.AI libraries
 
-[`Microsoft.Extensions.AI`](ai-extensions.md) is a set of core .NET libraries created in collaboration with developers across the .NET ecosystem, including Semantic Kernel. These libraries provide a unified layer of C# abstractions for interacting with AI services, such as small and large language models (SLMs and LLMs), embeddings, and middleware.
+[`Microsoft.Extensions.AI`](ai-extensions.md) is a set of core .NET libraries that provide a unified layer of C# abstractions for interacting with AI services, such as small and large language models (SLMs and LLMs), embeddings, and middleware. These APIs were created in collaboration with developers across the .NET ecosystem, including Semantic Kernel. The low-level APIs, such as <xref:Microsoft.Extensions.AI.IChatClient> and <xref:Microsoft.Extensions.AI.IEmbeddingGenerator`2>, were extracted from Semantic Kernel and moved into the <xref:Microsoft.Extensions.AI> namespace.
 
 `Microsoft.Extensions.AI` provides abstractions that can be implemented by various services, all adhering to the same core concepts. This library is not intended to provide APIs tailored to any specific provider's services. The goal of `Microsoft.Extensions.AI` is to act as a unifying layer within the .NET ecosystem, enabling developers to choose their preferred frameworks and libraries while ensuring seamless integration and collaboration across the ecosystem.
 
 ## Semantic Kernel for .NET
 
-[Semantic Kernel](semantic-kernel-dotnet-overview.md) is an open-source SDK that enables AI integration and orchestration capabilities in your .NET apps. This SDK is generally the recommended AI orchestration tool for .NET apps that use one or more AI services in combination with other APIs or web services, data stores, and custom code. Semantic Kernel benefits enterprise developers in the following ways:
+If you just want to use the low-level services, such as <xref:Microsoft.Extensions.AI.IChatClient> and <xref:Microsoft.Extensions.AI.IEmbeddingGenerator`2>, you can reference the `Microsoft.Extensions.AI.Abstractions` package directly from your app. However, if you want to use higher-level, more opinionated approaches to AI, then you should use [Semantic Kernel](semantic-kernel-dotnet-overview.md).
+
+Semantic Kernel, which has a dependency on the `Microsoft.Extensions.AI.Abstractions` package, is an open-source library that enables AI integration and orchestration capabilities in your .NET apps. Its connectors provides concrete implementations of <xref:Microsoft.Extensions.AI.IChatClient> and <xref:Microsoft.Extensions.AI.IEmbeddingGenerator`2> for different services, including OpenAI, Amazon Bedrock, and Google Gemini.
+
+The Semantic Kernel SDK is generally the recommended AI orchestration tool for .NET apps that use one or more AI services in combination with other APIs or web services, data stores, and custom code. Semantic Kernel benefits enterprise developers in the following ways:
 
 - Streamlines integration of AI capabilities into existing applications to enable a cohesive solution for enterprise products.
 - Minimizes the learning curve of working with different AI models or services by providing abstractions that reduce complexity.
@@ -31,7 +35,7 @@ For more information, see the [Semantic Kernel documentation](/semantic-kernel/o
 
 ## .NET SDKs for building AI apps
 
-Many different SDKs are available for .NET to build apps with AI capabilities depending on the target platform or AI model. OpenAI models offer powerful generative AI capabilities, while other Azure AI Services provide intelligent solutions for a variety of specific scenarios.
+Many different SDKs are available to build .NET apps with AI capabilities depending on the target platform or AI model. OpenAI models offer powerful generative AI capabilities, while other Azure AI Services provide intelligent solutions for a variety of specific scenarios.
 
 ### .NET SDKs for OpenAI models
 
@@ -45,9 +49,9 @@ Many different SDKs are available for .NET to build apps with AI capabilities de
 
 Azure offers many other AI services to build specific application capabilities and workflows. Most of these services provide a .NET SDK to integrate their functionality into custom apps. Some of the most commonly used services are shown in the following table. For a complete list of available services and learning resources, see the [Azure AI Services](/azure/ai-services/what-are-ai-services) documentation.
 
-| Service                                                       | Description                                                |
-|---------------------------------------------------------------|------------------------------------------------------------|
-| [Azure AI Search](/azure/search/)                             | Bring AI-powered cloud search to your mobile and web apps. |
+| Service                           | Description                                  |
+|-----------------------------------|----------------------------------------------|
+| [Azure AI Search](/azure/search/) | Bring AI-powered cloud search to your mobile and web apps. |
 | [Azure AI Content Safety](/azure/ai-services/content-safety/) | Detect unwanted or offensive content.                      |
 | [Azure AI Document Intelligence](/azure/ai-services/document-intelligence/) | Turn documents into intelligent data-driven solutions. |
 | [Azure AI Language](/azure/ai-services/language-service/)     | Build apps with industry-leading natural language understanding capabilities. |
@@ -59,15 +63,15 @@ Azure offers many other AI services to build specific application capabilities a
 
 .NET apps can also connect to local AI models for many different development scenarios. [Semantic Kernel](https://github.com/microsoft/semantic-kernel) is the recommended tool to connect to local models using .NET. Semantic Kernel can connect to many different models hosted across a variety of platforms and abstracts away lower-level implementation details.
 
-For example, you can use [Ollama](https://ollama.com/) to [connect to local AI models with .NET](quickstarts/quickstart-local-ai.md), including several Small Language Models (SLMs) developed by Microsoft:
+For example, you can use [Ollama](https://ollama.com/) to [connect to local AI models with .NET](quickstarts/quickstart-local-ai.md), including several small language models (SLMs) developed by Microsoft:
 
-| Model               | Description                                                                            |
-|---------------------|----------------------------------------------------------------------------------------|
+| Model               | Description                                               |
+|---------------------|-----------------------------------------------------------|
 | [phi3 models][phi3] | A family of powerful SLMs with groundbreaking performance at low cost and low latency. |
 | [orca models][orca] | Research models in tasks such as reasoning over user-provided data, reading comprehension, math problem solving, and text summarization. |
 
 > [!NOTE]
-> The preceding SLMs can also be hosted on other services such as Azure.
+> The preceding SLMs can also be hosted on other services, such as Azure.
 
 ## Connect to vector databases and services
 
@@ -77,10 +81,10 @@ For example, you can use [Ollama](https://ollama.com/) to [connect to local AI m
 
 This article summarized the tools and SDKs in the .NET ecosystem, with a focus on services that provide official support for .NET. Depending on your needs and stage of app development, you might also want to take a look at the open-source options for the ecosystem in [the unofficial list of .NET + AI resources](https://github.com/jmatthiesen/dotnet-ai-resources?tab=readme-ov-file#models). Microsoft is not the maintainer of many of these projects, so be sure to review their quality, licensing, and support.
 
-## Next Steps
+## Next steps
 
 - [What is Semantic Kernel?](/semantic-kernel/overview/)
 - [Quickstart - Summarize text using Azure AI chat app with .NET](./quickstarts/quickstart-openai-summarize-text.md)
 
 [phi3]: https://azure.microsoft.com/products/phi-3
-[orca]: https://www.microsoft.com/en-us/research/project/orca/
+[orca]: https://www.microsoft.com/research/project/orca/

--- a/docs/ai/includes/vector-databases.md
+++ b/docs/ai/includes/vector-databases.md
@@ -9,8 +9,8 @@ AI applications often use data vector databases and services to improve relevanc
 
 Semantic Kernel provides connectors for the following vector databases and services:
 
-| Vector service | Semantic Kernel connector | .NET SDK |
-|----------------|---------------------------|----------|
+| Vector service                | Semantic Kernel connector | .NET SDK |
+|-------------------------------|---------------------------|----------|
 | Azure AI Search               | [Microsoft.SemanticKernel.Connectors.AzureAISearch](https://www.nuget.org/packages/Microsoft.SemanticKernel.Connectors.AzureAISearch)        | [Azure.Search.Documents](https://www.nuget.org/packages/Azure.Search.Documents/)        |
 | Azure Cosmos DB for NoSQL     | [Microsoft.SemanticKernel.Connectors.AzureCosmosDBNoSQL](https://www.nuget.org/packages/Microsoft.SemanticKernel.Connectors.AzureCosmosDBNoSQL)        | [Microsoft.Azure.Cosmos](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/)        |
 | Azure Cosmos DB for MongoDB   | [Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB](https://www.nuget.org/packages/Microsoft.SemanticKernel.Connectors.AzureCosmosDBMongoDB)        | [MongoDb.Driver](https://www.nuget.org/packages/MongoDB.Driver)        |

--- a/docs/ai/toc.yml
+++ b/docs/ai/toc.yml
@@ -13,8 +13,6 @@ items:
     href: ai-extensions.md
   - name: Semantic Kernel
     href: semantic-kernel-dotnet-overview.md
-- name: Learning resources and samples
-  href: azure-ai-for-dotnet-developers.md
 - name: Quickstarts
   items:
   - name: Build a chat app
@@ -79,3 +77,7 @@ items:
   items:
   - name: Evaluate LLM prompt completions
     href: tutorials/llm-eval.md
+- name: Resources
+  items:
+  - name: Azure AI samples and docs
+    href: azure-ai-for-dotnet-developers.md

--- a/docs/ai/toc.yml
+++ b/docs/ai/toc.yml
@@ -53,7 +53,7 @@ items:
     href: conceptual/understanding-openai-functions.md
 - name: Chat with your data (RAG)
   items:
-    - name: Get started with the chat sample 
+    - name: Get started with the RAG sample
       href: get-started-app-chat-template.md
     - name: Implement RAG using vector search
       href: tutorials/tutorial-ai-vector-search.md

--- a/docs/core/extensions/artificial-intelligence.md
+++ b/docs/core/extensions/artificial-intelligence.md
@@ -1,6 +1,6 @@
 ---
 title: Artificial Intelligence in .NET (Preview)
-description: Learn how to use the Microsoft.Extensions.AI library to integrate and interact with various AI services in your .NET applications.
+description: Learn how to use the Microsoft.Extensions.AI libraries to integrate and interact with various AI services in your .NET applications.
 author: IEvangelist
 ms.author: dapine
 ms.date: 01/06/2025
@@ -9,11 +9,15 @@ ms.collection: ce-skilling-ai-copilot
 
 # Artificial intelligence in .NET (Preview)
 
-With a growing variety of artificial intelligence (AI) services available, developers need a way to integrate and interact with these services in their .NET applications. The `Microsoft.Extensions.AI` library provides a unified approach for representing generative AI components, which enables seamless integration and interoperability with various AI services. This article introduces the library and provides installation instructions and usage examples to help you get started.
+With a growing variety of artificial intelligence (AI) services available, developers need a way to integrate and interact with these services in their .NET applications. The `Microsoft.Extensions.AI` libraries provide a unified approach for representing generative AI components, which enables seamless integration and interoperability with various AI services. This article introduces the libraries and provides installation instructions and usage examples to help you get started.
+
+The [📦 Microsoft.Extensions.AI.Abstractions](https://www.nuget.org/packages/Microsoft.Extensions.AI.Abstractions) package provides the core exchange types: <xref:Microsoft.Extensions.AI.IChatClient> and <xref:Microsoft.Extensions.AI.IEmbeddingGenerator`2>. Any .NET library that provides an AI client can implement the `IChatClient` interface to enable seamless integration with consuming code.
+
+The [📦 Microsoft.Extensions.AI](https://www.nuget.org/packages/Microsoft.Extensions.AI) package has an implicit dependency on the `Microsoft.Extensions.AI.Abstractions` package. This package enables you to easily integrate components such as telemetry and caching into your applications using familiar dependency injection and middleware patterns. For example, it provides the <xref:Microsoft.Extensions.AI.OpenTelemetryChatClientBuilderExtensions.UseOpenTelemetry(Microsoft.Extensions.AI.ChatClientBuilder,Microsoft.Extensions.Logging.ILoggerFactory,System.String,System.Action{Microsoft.Extensions.AI.OpenTelemetryChatClient})> extension method, which adds OpenTelemetry support to the chat client pipeline.
 
 ## Install the package
 
-To install the [📦 Microsoft.Extensions.AI](https://www.nuget.org/packages/Microsoft.Extensions.AI) NuGet package, use the .NET CLI or add a package reference directly to your C# project file:
+To install the [📦 Microsoft.Extensions.AI](https://www.nuget.org/packages/Microsoft.Extensions.AI) and [📦 Microsoft.Extensions.AI.Abstractions](https://www.nuget.org/packages/Microsoft.Extensions.AI.Abstractions) NuGet packages, use the .NET CLI or add package references directly to your C# project file:
 
 ### [.NET CLI](#tab/dotnet-cli)
 
@@ -32,31 +36,12 @@ dotnet add package Microsoft.Extensions.AI --prerelease
 
 For more information, see [dotnet add package](../tools/dotnet-add-package.md) or [Manage package dependencies in .NET applications](../tools/dependencies.md).
 
-## Usage examples
+## The `IChatClient` interface
 
 The <xref:Microsoft.Extensions.AI.IChatClient> interface defines a client abstraction responsible for interacting with AI services that provide chat capabilities. It includes methods for sending and receiving messages with multi-modal content (such as text, images, and audio), either as a complete set or streamed incrementally. Additionally, it provides metadata information about the client and allows retrieving strongly typed services.
 
 > [!IMPORTANT]
 > For more usage examples and real-world scenarios, see [AI for .NET developers](../../ai/index.yml).
-
-**In this section**
-
-- [The `IChatClient` interface](#the-ichatclient-interface)
-  - [Request chat completion](#request-chat-completion)
-  - [Request chat completion with streaming](#request-chat-completion-with-streaming)
-  - [Tool calling](#tool-calling)
-  - [Cache responses](#cache-responses)
-  - [Use telemetry](#use-telemetry)
-  - [Provide options](#provide-options)
-  - [Functionality pipelines](#functionality-pipelines)
-  - [Custom `IChatClient` middleware](#custom-ichatclient-middleware)
-  - [Dependency injection](#dependency-injection)
-- [The `IEmbeddingGenerator` interface](#the-iembeddinggenerator-interface)
-  - [Sample implementation](#sample-implementation)
-  - [Create embeddings](#create-embeddings)
-  - [Custom `IEmbeddingGenerator` middleware](#custom-iembeddinggenerator-middleware)
-
-### The `IChatClient` interface
 
 The following sample implements `IChatClient` to show the general structure.
 
@@ -68,7 +53,19 @@ You can find other concrete implementations of `IChatClient` in the following Nu
 - [📦 Microsoft.Extensions.AI.Ollama](https://www.nuget.org/packages/Microsoft.Extensions.AI.Ollama): Implementation backed by [Ollama](https://ollama.com/).
 - [📦 Microsoft.Extensions.AI.OpenAI](https://www.nuget.org/packages/Microsoft.Extensions.AI.OpenAI): Implementation backed by either [OpenAI](https://openai.com/) or OpenAI-compatible endpoints (such as [Azure OpenAI](https://azure.microsoft.com/products/ai-services/openai-service)).
 
-#### Request chat completion
+The following subsections show specific `IChatClient` usage examples:
+
+- [Request chat completion](#request-chat-completion)
+- [Request chat completion with streaming](#request-chat-completion-with-streaming)
+- [Tool calling](#tool-calling)
+- [Cache responses](#cache-responses)
+- [Use telemetry](#use-telemetry)
+- [Provide options](#provide-options)
+- [Functionality pipelines](#functionality-pipelines)
+- [Custom `IChatClient` middleware](#custom-ichatclient-middleware)
+- [Dependency injection](#dependency-injection)
+
+### Request chat completion
 
 To request a completion, call the <xref:Microsoft.Extensions.AI.IChatClient.CompleteAsync*?displayProperty=nameWithType> method. The request is composed of one or more messages, each of which is composed of one or more pieces of content. Accelerator methods exist to simplify common cases, such as constructing a request for a single piece of text content.
 
@@ -95,7 +92,7 @@ Each chat message is instantiated, assigning to its <xref:Microsoft.Extensions.A
 - <xref:Microsoft.Extensions.AI.TextContent>
 - <xref:Microsoft.Extensions.AI.UsageContent>
 
-#### Request chat completion with streaming
+### Request chat completion with streaming
 
 The inputs to <xref:Microsoft.Extensions.AI.IChatClient.CompleteStreamingAsync*?displayProperty=nameWithType> are identical to those of `CompleteAsync`. However, rather than returning the complete response as part of a <xref:Microsoft.Extensions.AI.ChatCompletion> object, the method returns an <xref:System.Collections.Generic.IAsyncEnumerable`1> where `T` is <xref:Microsoft.Extensions.AI.StreamingChatCompletionUpdate>, providing a stream of updates that collectively form the single response.
 
@@ -104,7 +101,7 @@ The inputs to <xref:Microsoft.Extensions.AI.IChatClient.CompleteStreamingAsync*?
 > [!TIP]
 > Streaming APIs are nearly synonymous with AI user experiences. C# enables compelling scenarios with its `IAsyncEnumerable<T>` support, allowing for a natural and efficient way to stream data.
 
-#### Tool calling
+### Tool calling
 
 Some models and services support _tool calling_, where requests can include tools for the model to invoke functions to gather additional information. Instead of sending a final response, the model requests a function invocation with specific arguments. The client then invokes the function and sends the results back to the model along with the conversation history. The `Microsoft.Extensions.AI` library includes abstractions for various message content types, including function call requests and results. While consumers can interact with this content directly, `Microsoft.Extensions.AI` automates these interactions and provides:
 
@@ -126,7 +123,7 @@ The preceding code:
 - Calls `CompleteStreamingAsync` on the client, passing a prompt and a list of tools that includes a function created with <xref:Microsoft.Extensions.AI.AIFunctionFactory.Create*>.
 - Iterates over the response, printing each update to the console.
 
-#### Cache responses
+### Cache responses
 
 If you're familiar with [Caching in .NET](caching.md), it's good to know that <xref:Microsoft.Extensions.AI> provides other such delegating `IChatClient` implementations. The <xref:Microsoft.Extensions.AI.DistributedCachingChatClient> is an `IChatClient` that layers caching around another arbitrary `IChatClient` instance. When a unique chat history is submitted to the `DistributedCachingChatClient`, it forwards it to the underlying client and then caches the response before sending it back to the consumer. The next time the same prompt is submitted, such that a cached response can be found in the cache, the `DistributedCachingChatClient` returns the cached response rather than needing to forward the request along the pipeline.
 
@@ -134,7 +131,7 @@ If you're familiar with [Caching in .NET](caching.md), it's good to know that <x
 
 The preceding example depends on the [📦 Microsoft.Extensions.Caching.Memory](https://www.nuget.org/packages/Microsoft.Extensions.Caching.Memory) NuGet package. For more information, see [Caching in .NET](caching.md).
 
-#### Use telemetry
+### Use telemetry
 
 Another example of a delegating chat client is the <xref:Microsoft.Extensions.AI.OpenTelemetryChatClient>. This implementation adheres to the [OpenTelemetry Semantic Conventions for Generative AI systems](https://opentelemetry.io/docs/specs/semconv/gen-ai/). Similar to other `IChatClient` delegators, it layers metrics and spans around any underlying `IChatClient` implementation, providing enhanced observability.
 
@@ -142,7 +139,7 @@ Another example of a delegating chat client is the <xref:Microsoft.Extensions.AI
 
 The preceding example depends on the [📦 OpenTelemetry.Exporter.Console](https://www.nuget.org/packages/OpenTelemetry.Exporter.Console) NuGet package.
 
-#### Provide options
+### Provide options
 
 Every call to <xref:Microsoft.Extensions.AI.IChatClient.CompleteAsync*> or <xref:Microsoft.Extensions.AI.IChatClient.CompleteStreamingAsync*> can optionally supply a <xref:Microsoft.Extensions.AI.ChatOptions> instance containing additional parameters for the operation. The most common parameters among AI models and services show up as strongly typed properties on the type, such as <xref:Microsoft.Extensions.AI.ChatOptions.Temperature?displayProperty=nameWithType>. Other parameters can be supplied by name in a weakly typed manner via the <xref:Microsoft.Extensions.AI.ChatOptions.AdditionalProperties?displayProperty=nameWithType> dictionary.
 
@@ -152,7 +149,7 @@ You can also specify options when building an `IChatClient` with the fluent <xre
 
 The preceding example depends on the [📦 Microsoft.Extensions.AI.Ollama](https://www.nuget.org/packages/Microsoft.Extensions.AI.Ollama) NuGet package.
 
-#### Functionality pipelines
+### Functionality pipelines
 
 `IChatClient` instances can be layered to create a pipeline of components, each adding specific functionality. These components can come from `Microsoft.Extensions.AI`, other NuGet packages, or custom implementations. This approach allows you to augment the behavior of the `IChatClient` in various ways to meet your specific needs. Consider the following example code that layers a distributed cache, function invocation, and OpenTelemetry tracing around a sample chat client:
 
@@ -164,7 +161,7 @@ The preceding example depends on the following NuGet packages:
 - [📦 Microsoft.Extensions.AI.Ollama](https://www.nuget.org/packages/Microsoft.Extensions.AI.Ollama)
 - [📦 OpenTelemetry.Exporter.Console](https://www.nuget.org/packages/OpenTelemetry.Exporter.Console)
 
-#### Custom `IChatClient` middleware
+### Custom `IChatClient` middleware
 
 To add additional functionality, you can implement `IChatClient` directly or use the <xref:Microsoft.Extensions.AI.DelegatingChatClient> class. This class serves as a base for creating chat clients that delegate operations to another `IChatClient` instance. It simplifies chaining multiple clients, allowing calls to pass through to an underlying client.
 
@@ -207,7 +204,7 @@ The preceding overload internally uses an `AnonymousDelegatingChatClient`, which
 
 For scenarios where the developer would like to specify delegating implementations of `CompleteAsync` and `CompleteStreamingAsync` inline, and where it's important to be able to write a different implementation for each in order to handle their unique return types specially, another overload of `Use` exists that accepts a delegate for each.
 
-#### Dependency injection
+### Dependency injection
 
 <xref:Microsoft.Extensions.AI.IChatClient> implementations will typically be provided to an application via [dependency injection (DI)](dependency-injection.md). In this example, an <xref:Microsoft.Extensions.Caching.Distributed.IDistributedCache> is added into the DI container, as is an `IChatClient`. The registration for the `IChatClient` employs a builder that creates a pipeline containing a caching client (which will then use an `IDistributedCache` retrieved from DI) and the sample client. The injected `IChatClient` can be retrieved and used elsewhere in the app.
 
@@ -220,7 +217,7 @@ The preceding example depends on the following NuGet packages:
 
 What instance and configuration is injected can differ based on the current needs of the application, and multiple pipelines can be injected with different keys.
 
-### The `IEmbeddingGenerator` interface
+## The `IEmbeddingGenerator` interface
 
 The <xref:Microsoft.Extensions.AI.IEmbeddingGenerator`2> interface represents a generic generator of embeddings. Here, `TInput` is the type of input values being embedded, and `TEmbedding` is the type of generated embedding, which inherits from the <xref:Microsoft.Extensions.AI.Embedding> class.
 
@@ -228,9 +225,7 @@ The `Embedding` class serves as a base class for embeddings generated by an `IEm
 
 The `IEmbeddingGenerator` interface defines a method to asynchronously generate embeddings for a collection of input values, with optional configuration and cancellation support. It also provides metadata describing the generator and allows for the retrieval of strongly typed services that can be provided by the generator or its underlying services.
 
-#### Sample implementation
-
-Consider the following sample implementation of an `IEmbeddingGenerator` to show the general structure but that just generates random embedding vectors.
+The following sample implementation of `IEmbeddingGenerator` shows the general structure (however, it just generates random embedding vectors).
 
 :::code language="csharp" source="snippets/ai/AI.Shared/SampleEmbeddingGenerator.cs":::
 
@@ -248,13 +243,18 @@ You can find actual concrete implementations in the following packages:
 - [📦 Microsoft.Extensions.AI.OpenAI](https://www.nuget.org/packages/Microsoft.Extensions.AI.OpenAI)
 - [📦 Microsoft.Extensions.AI.Ollama](https://www.nuget.org/packages/Microsoft.Extensions.AI.Ollama)
 
-#### Create embeddings
+The following sections show specific `IEmbeddingGenerator` usage examples:
+
+- [Create embeddings](#create-embeddings)
+- [Custom `IEmbeddingGenerator` middleware](#custom-iembeddinggenerator-middleware)
+
+### Create embeddings
 
 The primary operation performed with an <xref:Microsoft.Extensions.AI.IEmbeddingGenerator`2> is embedding generation, which is accomplished with its <xref:Microsoft.Extensions.AI.IEmbeddingGenerator`2.GenerateAsync*> method.
 
 :::code language="csharp" source="snippets/ai/ConsoleAI.CreateEmbeddings/Program.cs":::
 
-#### Custom `IEmbeddingGenerator` middleware
+### Custom `IEmbeddingGenerator` middleware
 
 As with `IChatClient`, `IEmbeddingGenerator` implementations can be layered. Just as `Microsoft.Extensions.AI` provides delegating implementations of `IChatClient` for caching and telemetry, it provides an implementation for `IEmbeddingGenerator` as well.
 


### PR DESCRIPTION
- Add xrefs
- Clarify M.E.AI vs. Semantic Kernel
- Move Azure AI resources to bottom of AI TOC
- In core/extensions/artificial-intelligence.md, move IChatClient and IEmbeddingGenerator interface headings up to H2

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/ai/ai-extensions.md](https://github.com/dotnet/docs/blob/83508907310bdd113abaf4d9a4d0a34a380c4582/docs/ai/ai-extensions.md) | [Unified AI building blocks for .NET using Microsoft.Extensions.AI](https://review.learn.microsoft.com/en-us/dotnet/ai/ai-extensions?branch=pr-en-us-44899) |
| [docs/ai/dotnet-ai-ecosystem.md](https://github.com/dotnet/docs/blob/83508907310bdd113abaf4d9a4d0a34a380c4582/docs/ai/dotnet-ai-ecosystem.md) | [Overview of the .NET + AI ecosystem](https://review.learn.microsoft.com/en-us/dotnet/ai/dotnet-ai-ecosystem?branch=pr-en-us-44899) |
| [docs/ai/toc.yml](https://github.com/dotnet/docs/blob/83508907310bdd113abaf4d9a4d0a34a380c4582/docs/ai/toc.yml) | [docs/ai/toc](https://review.learn.microsoft.com/en-us/dotnet/ai/toc?branch=pr-en-us-44899) |
| [docs/core/extensions/artificial-intelligence.md](https://github.com/dotnet/docs/blob/83508907310bdd113abaf4d9a4d0a34a380c4582/docs/core/extensions/artificial-intelligence.md) | [Artificial intelligence in .NET (Preview)](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/artificial-intelligence?branch=pr-en-us-44899) |


<!-- PREVIEW-TABLE-END -->