### PR TITLE
Add LLDB docs

### DIFF
--- a/docs/core/diagnostics/debugger-extensions.md
+++ b/docs/core/diagnostics/debugger-extensions.md
@@ -28,7 +28,7 @@ Install Windbg from the [Windows SDK](/windows-hardware/drivers/debugger/debugge
 
 ### Linux
 
-Follow the instructions [here](lldb-linux.md) to install LLDB and the .NET debugger extensions on Linux.
+To install LLDB and the .NET debugger extensions, see [Install and use LLDB on Linux](lldb-linux.md).
 
 ## Syntax
 

--- a/docs/core/diagnostics/debugger-extensions.md
+++ b/docs/core/diagnostics/debugger-extensions.md
@@ -11,7 +11,7 @@ helpviewer_keywords:
 
 # .NET debugger extensions
 
-The .NET debugger extensions let you view information about code that's running inside the .NET runtime, both on live processes and dumps. The extensions are preinstalled with [Windbg](/windows-hardware/drivers/debugger/debugger-download-tools), and can be [downloaded](dotnet-debugger-extensions.md) for use with LLDB. You can use the .NET debugger extensions to:
+The .NET debugger extensions let you view information about code that's running inside the .NET runtime, both on live processes and dumps. The extensions work with [Windbg](/windows-hardware/drivers/debugger/debugger-download-tools) and [LLDB](https://lldb.llvm.org/). You can use the .NET debugger extensions to:
 
 - Collect information about the managed heap.
 - Look for heap corruptions.
@@ -19,6 +19,16 @@ The .NET debugger extensions let you view information about code that's running 
 - View information about all managed code running inside the runtime.
 
 The .NET debugger extensions include commands from the existing [dotnet-sos](dotnet-sos.md) tool as well as new commands. A limited set of commands are also now supported for the Native AOT runtime.
+
+## Install
+
+### Windows
+
+Install Windbg from the [Windows SDK](/windows-hardware/drivers/debugger/debugger-download-tools). Windbg versions 10.0.18317.1001 and later automatically load the extensions from the Microsoft extension gallery.
+
+### Linux
+
+Follow the instructions [here](lldb-linux.md) to install LLDB and the .NET debugger extensions on Linux.
 
 ## Syntax
 

--- a/docs/core/diagnostics/lldb-linux.md
+++ b/docs/core/diagnostics/lldb-linux.md
@@ -102,77 +102,81 @@ Install the .NET debugger extensions using the [dotnet-debugger-extensions](dotn
 
 ## Getting started with LLDB
 
-This example shows using LLDB to attach to a pre-existing .NET application that is running on the machine.
+This example shows using LLDB to attach to a pre-existing .NET application (`dotnet webapp.dll`) that's running on the machine.
 
 1. Use the `ps` command to find the process ID (PID) of the .NET application you want to debug.
 
-```console
-    $ ps -ao pid,cmd
-    PID CMD
-    697 -bash
-    229233 dotnet webapp.dll
-    229696 ps -ao pid,cmd
-    ... other processes omitted for brevity ...
-```
+   ```console
+       $ ps -ao pid,cmd
+       PID CMD
+       697 -bash
+       229233 dotnet webapp.dll
+       229696 ps -ao pid,cmd
+       ... other processes omitted for brevity ...
+   ```
 
-In this case the PID of the .NET application we want to debug is 229233.
+   In this case, the PID of the .NET application to debug is 229233.
 
 1. Run LLDB and attach to the process.
 
-Launch LLDB using the command appropriate for your distribution (shown above in the Install LLDB section). Often this is just `lldb` but some distros require a version number in the name like `lldb-3.9`.
+   Launch LLDB using the appropriate command for your distribution (shown previously in the [Install LLDB](#install-lldb) section). Often this is just `lldb`, but some distros require a version number in the name, like `lldb-3.9`.
 
-```console
-    $ lldb
-    Current symbol store settings:
-    -> Cache: /home/username/.dotnet/symbolcache
-    -> Server: https://msdl.microsoft.com/download/symbols/ Timeout: 4 RetryCount: 0
-    (lldb)
-```
+   ```console
+       $ lldb
+       Current symbol store settings:
+       -> Cache: /home/username/.dotnet/symbolcache
+       -> Server: https://msdl.microsoft.com/download/symbols/ Timeout: 4 RetryCount: 0
+       (lldb)
+   ```
 
 1. At the `(lldb)` prompt, run the process attach command.
 
-```console
-    (lldb) process attach --pid 229233
-    Process 229233 stopped
-    * thread #1, name = 'dotnet', stop reason = signal SIGSTOP
-        frame #0: 0x00007f2ca7c11117 libc.so.6`___lldb_unnamed_symbol3457 + 231
-    libc.so.6`___lldb_unnamed_symbol3457:
-    ->  0x7f2ca7c11117 <+231>: movl   %r12d, %edi
-        0x7f2ca7c1111a <+234>: movq   %rax, %rbx
-        0x7f2ca7c1111d <+237>: callq  0x7f2ca7c10a60            ; ___lldb_unnamed_symbol3445
-        0x7f2ca7c11122 <+242>: jmp    0x7f2ca7c11089            ; <+89>
-      thread #2, name = 'dotnet-ust', stop reason = signal SIGSTOP
-        frame #0: 0x00007f2ca7c9e88d libc.so.6`syscall + 29
-    libc.so.6`syscall:
-    ... more output omitted ...
-```
+   ```console
+       (lldb) process attach --pid 229233
+       Process 229233 stopped
+       * thread #1, name = 'dotnet', stop reason = signal SIGSTOP
+           frame #0: 0x00007f2ca7c11117 libc.so.6`___lldb_unnamed_symbol3457 + 231
+       libc.so.6`___lldb_unnamed_symbol3457:
+       ->  0x7f2ca7c11117 <+231>: movl   %r12d, %edi
+           0x7f2ca7c1111a <+234>: movq   %rax, %rbx
+           0x7f2ca7c1111d <+237>: callq  0x7f2ca7c10a60            ; ___lldb_unnamed_symbol3445
+           0x7f2ca7c11122 <+242>: jmp    0x7f2ca7c11089            ; <+89>
+         thread #2, name = 'dotnet-ust', stop reason = signal SIGSTOP
+           frame #0: 0x00007f2ca7c9e88d libc.so.6`syscall + 29
+       libc.so.6`syscall:
+       ... more output omitted ...
+   ```
 
-The debugger is now attached and you can use both built-in LLDB commands and .NET debugger extension commands to inspect the process state.
+   The debugger is now attached and you can use both built-in LLDB commands and .NET debugger extension commands to inspect the process state.
 
-> [!NOTE]
-> If LLDB outputs 'error: attach failed: Operation not permitted' this means you don't have sufficient privileges to do debugging. The most reliable way to resolve this is to quit LLDB and restart using sudo. When elevated LLDB won't automatically run the normal .lldbinit script but you can do so explicitly by using the --source argument on the command line: `sudo lldb --source ~/.lldbinit`.
+   > [!NOTE]
+   > If LLDB outputs 'error: attach failed: Operation not permitted', this means you don't have sufficient privileges to debug. The most reliable way to resolve this is to quit LLDB and restart using sudo. When elevated LLDB won't automatically run the normal .lldbinit script, you can do so explicitly by using the `--source` argument on the command line: `sudo lldb --source ~/.lldbinit`.
 
 1. Run an example command
 
-The clrstack command displays the stack trace for .NET code on the currently selected thread.
+   The clrstack command displays the stack trace for .NET code on the currently selected thread.
 
-```console
-    (lldb) clrstack
-    OS Thread Id: 0x497 (1)
-            Child SP               IP Call Site
-    00007FFD0877D260 00007f2ca7c11117 [HelperMethodFrame_1OBJ: 00007ffd0877d260] System.Threading.Monitor.ObjWait(Int32, System.Object)
-    00007FFD0877D390 00007F2C2864AA0E System.Threading.Monitor.Wait(System.Object, Int32)
-    00007FFD0877D3A0 00007F2C28654625 System.Threading.ManualResetEventSlim.Wait(Int32, System.Threading.CancellationToken)
-    00007FFD0877D420 00007F2C286684A8 System.Threading.Tasks.Task.SpinThenBlockingWait(Int32, System.Threading.CancellationToken)
-    00007FFD0877D480 00007F2C2866832D System.Threading.Tasks.Task.InternalWaitCore(Int32, System.Threading.CancellationToken)
-    00007FFD0877D4D0 00007F2C286B2508 System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task, System.Threading.Tasks.ConfigureAwaitOptions)
-    00007FFD0877D4F0 00007F2C29281B45 Microsoft.Extensions.Hosting.HostingAbstractionsHostExtensions.Run(Microsoft.Extensions.Hosting.IHost)
-    00007FFD0877D510 00007F2C29121A7D Program.<Main>$(System.String[]) [/home/username/app/Program.cs @ 25]
-```
+   ```console
+       (lldb) clrstack
+       OS Thread Id: 0x497 (1)
+               Child SP               IP Call Site
+       00007FFD0877D260 00007f2ca7c11117 [HelperMethodFrame_1OBJ: 00007ffd0877d260] 
+   System.Threading.Monitor.ObjWait(Int32, System.Object)
+       00007FFD0877D390 00007F2C2864AA0E System.Threading.Monitor.Wait(System.Object, Int32)
+       00007FFD0877D3A0 00007F2C28654625 System.Threading.ManualResetEventSlim.Wait(Int32, 
+   System.Threading.CancellationToken)
+       00007FFD0877D420 00007F2C286684A8 System.Threading.Tasks.Task.SpinThenBlockingWait(Int32, 
+   System.Threading.CancellationToken)
+       00007FFD0877D480 00007F2C2866832D System.Threading.Tasks.Task.InternalWaitCore(Int32, 
+   System.Threading.CancellationToken)
+       00007FFD0877D4D0 00007F2C286B2508 System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task, System.Threading.Tasks.ConfigureAwaitOptions)
+       00007FFD0877D4F0 00007F2C29281B45 Microsoft.Extensions.Hosting.HostingAbstractionsHostExtensions.Run(Microsoft.Extensions.Hosting.IHost)
+       00007FFD0877D510 00007F2C29121A7D Program.<Main>$(System.String[]) [/home/username/app/Program.cs @ 25]
+   ```
 
 ## Next steps
 
-Read the documentation for the [.NET debugger extensions](debugger-extensions.md) and [LLDB](https://lldb.llvm.org/) to learn more about the commands available when debugging .NET applications with LLDB.
+To learn more about the commands available when debugging .NET applications with LLDB, see the documentation for the [.NET debugger extensions](debugger-extensions.md) and [LLDB](https://lldb.llvm.org/).
 
 ## See also
 

--- a/docs/core/diagnostics/lldb-linux.md
+++ b/docs/core/diagnostics/lldb-linux.md
@@ -1,0 +1,181 @@
+---
+title: Install and use LLDB on Linux
+description: Instructions for installing and using LLDB to debug a .NET application on Linux
+ms.date: 02/13/2025
+---
+
+# Install and use LLDB on Linux
+
+[LLDB](https://lldb.llvm.org/) is a powerful, open-source debugger that's part of the LLVM project. When you're debugging .NET applications on Linux, you can use LLDB with the [.NET debugger extensions](debugger-extensions.md) to inspect managed application state. LLDB can work with both dumps and live processes.
+
+## Install
+
+### Install LLDB
+
+The .NET debugger extensions require at least LLDB 3.9 but version 10.0 or later is recommended. The following sections provide instructions for installing LLDB on popular Linux distributions.
+
+#### AzureLinux 2.0 and later
+
+To install the LLDB packages:
+
+```console
+    sudo tdnf install lldb
+```
+
+To launch LLDB:
+
+```console
+    lldb
+```
+
+#### Ubuntu 20.04 and later
+
+To install the LLDB packages:
+
+```console
+    sudo apt-get update
+    sudo apt-get install lldb
+```
+
+To launch LLDB:
+
+```console
+    lldb
+```
+
+#### Alpine 3.9 and later
+
+To install the LLDB packages:
+
+```console
+    apk update
+    apk add lldb
+```
+
+To launch LLDB:
+
+```console
+    lldb
+```
+
+#### Debian 9 and later
+
+To install the LLDB packages:
+
+```console
+    sudo apt-get install lldb-3.9 python-lldb-3.9
+```
+
+To launch LLDB:
+
+```console
+    lldb-3.9
+```
+
+#### Fedora 29 and later
+
+To install the LLDB packages:
+
+```console
+    sudo dnf install lldb python2-lldb
+```
+
+To launch LLDB:
+
+```console
+    lldb
+```
+
+#### RHEL 7.5 and later
+
+See [LLDB](https://access.redhat.com/documentation/en-us/red_hat_developer_tools/1/html/using_llvm_12.0.1_toolset/assembly_llvm#proc_installing-comp-toolset_assembly_llvm) on RedHat's website.
+
+### Install the .NET debugger extensions
+
+Install the .NET debugger extensions using the [dotnet-debugger-extensions](dotnet-debugger-extensions.md) install tool. The installer creates a `.lldbinit` file in your home directory that automatically loads the extensions when you start LLDB.
+
+> [!NOTE]
+> The version of the debugger extensions does not need to match the version of the .NET runtime. We recommend using the latest extension version.
+
+> [!NOTE]
+> Installing with [dotnet-sos](dotnet-sos.md) instead of [dotnet-debugger-extensions](dotnet-debugger-extensions.md) also works, but only installs a subset of the extension commands.
+
+## Getting started with LLDB
+
+This example shows using LLDB to attach to a pre-existing .NET application that is running on the machine.
+
+1. Use the `ps` command to find the process ID (PID) of the .NET application you want to debug.
+
+```console
+    $ ps -ao pid,cmd
+    PID CMD
+    697 -bash
+    229233 dotnet webapp.dll
+    229696 ps -ao pid,cmd
+    ... other processes omitted for brevity ...
+```
+
+In this case the PID of the .NET application we want to debug is 229233.
+
+1. Run LLDB and attach to the process.
+
+Launch LLDB using the command appropriate for your distribution (shown above in the Install LLDB section). Often this is just `lldb` but some distros require a version number in the name like `lldb-3.9`.
+
+```console
+    $ lldb
+    Current symbol store settings:
+    -> Cache: /home/username/.dotnet/symbolcache
+    -> Server: https://msdl.microsoft.com/download/symbols/ Timeout: 4 RetryCount: 0
+    (lldb)
+```
+
+1. At the `(lldb)` prompt, run the process attach command.
+
+```console
+    (lldb) process attach --pid 229233
+    Process 229233 stopped
+    * thread #1, name = 'dotnet', stop reason = signal SIGSTOP
+        frame #0: 0x00007f2ca7c11117 libc.so.6`___lldb_unnamed_symbol3457 + 231
+    libc.so.6`___lldb_unnamed_symbol3457:
+    ->  0x7f2ca7c11117 <+231>: movl   %r12d, %edi
+        0x7f2ca7c1111a <+234>: movq   %rax, %rbx
+        0x7f2ca7c1111d <+237>: callq  0x7f2ca7c10a60            ; ___lldb_unnamed_symbol3445
+        0x7f2ca7c11122 <+242>: jmp    0x7f2ca7c11089            ; <+89>
+      thread #2, name = 'dotnet-ust', stop reason = signal SIGSTOP
+        frame #0: 0x00007f2ca7c9e88d libc.so.6`syscall + 29
+    libc.so.6`syscall:
+    ... more output omitted ...
+```
+
+The debugger is now attached and you can use both built-in LLDB commands and .NET debugger extension commands to inspect the process state.
+
+> [!NOTE]
+> If LLDB outputs 'error: attach failed: Operation not permitted' this means you don't have sufficient privileges to do debugging. The most reliable way to resolve this is to quit LLDB and restart using sudo. When elevated LLDB won't automatically run the normal .lldbinit script but you can do so explicitly by using the --source argument on the command line: `sudo lldb --source ~/.lldbinit`.
+
+1. Run an example command
+
+The clrstack command displays the stack trace for .NET code on the currently selected thread.
+
+```console
+    (lldb) clrstack
+    OS Thread Id: 0x497 (1)
+            Child SP               IP Call Site
+    00007FFD0877D260 00007f2ca7c11117 [HelperMethodFrame_1OBJ: 00007ffd0877d260] System.Threading.Monitor.ObjWait(Int32, System.Object)
+    00007FFD0877D390 00007F2C2864AA0E System.Threading.Monitor.Wait(System.Object, Int32)
+    00007FFD0877D3A0 00007F2C28654625 System.Threading.ManualResetEventSlim.Wait(Int32, System.Threading.CancellationToken)
+    00007FFD0877D420 00007F2C286684A8 System.Threading.Tasks.Task.SpinThenBlockingWait(Int32, System.Threading.CancellationToken)
+    00007FFD0877D480 00007F2C2866832D System.Threading.Tasks.Task.InternalWaitCore(Int32, System.Threading.CancellationToken)
+    00007FFD0877D4D0 00007F2C286B2508 System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task, System.Threading.Tasks.ConfigureAwaitOptions)
+    00007FFD0877D4F0 00007F2C29281B45 Microsoft.Extensions.Hosting.HostingAbstractionsHostExtensions.Run(Microsoft.Extensions.Hosting.IHost)
+    00007FFD0877D510 00007F2C29121A7D Program.<Main>$(System.String[]) [/home/username/app/Program.cs @ 25]
+```
+
+## Next steps
+
+Read the documentation for the [.NET debugger extensions](debugger-extensions.md) and [LLDB](https://lldb.llvm.org/) to learn more about the commands available when debugging .NET applications with LLDB.
+
+## See also
+
+- [LLDB](https://lldb.llvm.org/) for more information about the LLDB debugger.
+- [.NET debugger extensions](debugger-extensions.md) for a reference of the extension commands available.
+- [dotnet-symbol](dotnet-symbol.md) for more details on installing and using the symbol download tool.

--- a/docs/navigate/tools-diagnostics/toc.yml
+++ b/docs/navigate/tools-diagnostics/toc.yml
@@ -487,6 +487,8 @@ items:
                 href: ../../core/diagnostics/collect-dumps-crash.md
               - name: Frequently asked questions
                 href: ../../core/diagnostics/faq-dumps.yml
+              - name: Install and use LLDB on Linux
+                href: ../../core/diagnostics/lldb-linux.md
           - name: Symbols
             href: ../../core/diagnostics/symbols.md
           - name: EventPipe


### PR DESCRIPTION
Adding docs that show how to install and use LLDB and dotnet debugger extensions together. We've long had docs about the extensions themselves, but learn.microsoft.com had nothing that showed how to put it together with LLDB.

Some of the LLDB info comes from https://github.com/dotnet/diagnostics/blob/main/documentation/lldb/linux-instructions.md. I left out distros where users need to build LLDB, but we could add that in the future if needed.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/debugger-extensions.md](https://github.com/dotnet/docs/blob/38b21214098f79bc50cad7ac60f018d3eb241f82/docs/core/diagnostics/debugger-extensions.md) | [.NET debugger extensions](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/debugger-extensions?branch=pr-en-us-44902) |
| [docs/core/diagnostics/lldb-linux.md](https://github.com/dotnet/docs/blob/38b21214098f79bc50cad7ac60f018d3eb241f82/docs/core/diagnostics/lldb-linux.md) | [Install and use LLDB on Linux](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/lldb-linux?branch=pr-en-us-44902) |
| [docs/navigate/tools-diagnostics/toc.yml](https://github.com/dotnet/docs/blob/38b21214098f79bc50cad7ac60f018d3eb241f82/docs/navigate/tools-diagnostics/toc.yml) | [docs/navigate/tools-diagnostics/toc](https://review.learn.microsoft.com/en-us/dotnet/navigate/tools-diagnostics/toc?branch=pr-en-us-44902) |


<!-- PREVIEW-TABLE-END -->