### PR TITLE
Update Refit GitHub link

### DIFF
--- a/docs/core/extensions/httpclient-factory.md
+++ b/docs/core/extensions/httpclient-factory.md
@@ -129,7 +129,7 @@ The typed client is registered as transient with DI. In the preceding code, `Add
 
 ### Generated clients
 
-`IHttpClientFactory` can be used in combination with third-party libraries such as [Refit](https://github.com/paulcbetts/refit). Refit is a REST library for .NET. It allows for declarative REST API definitions, mapping interface methods to endpoints. An implementation of the interface is generated dynamically by the `RestService`, using `HttpClient` to make the external HTTP calls.
+`IHttpClientFactory` can be used in combination with third-party libraries such as [Refit](https://github.com/reactiveui/refit). Refit is a REST library for .NET. It allows for declarative REST API definitions, mapping interface methods to endpoints. An implementation of the interface is generated dynamically by the `RestService`, using `HttpClient` to make the external HTTP calls.
 
 Consider the following `record` type:
 


### PR DESCRIPTION
## Summary

Update the Refit GitHub repository link to the correct one (not the recently created empty one). Based on a cursory search, there are no other occurrences in the docs that needs updating.

Fixes #44728.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/httpclient-factory.md](https://github.com/dotnet/docs/blob/b1ececadda96e5a8217cfedd0f2f1d0382fb60b0/docs/core/extensions/httpclient-factory.md) | [IHttpClientFactory with .NET](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/httpclient-factory?branch=pr-en-us-44913) |

<!-- PREVIEW-TABLE-END -->