### PR TITLE
Reorganize Documentation: Move ReadOlny Methods description its own section

### DIFF
--- a/docs/orleans/grains/request-scheduling.md
+++ b/docs/orleans/grains/request-scheduling.md
@@ -207,6 +207,8 @@ public interface IMyGrain : IGrainWithIntegerKey
 }
 ```
 
+The `GetCount` method doesn't modify the grain state, so it's marked with `ReadOnly`. Callers awaiting this method invocation aren't blocked by other `ReadOnly` requests to the grain, and the method returns immediately.
+
 ### Call chain reentrancy
 
 If a grain calls a method which on another grain which then calls back into the original grain, the call will result in a deadlock unless the call is reentrant. Reentrancy can be enabled on a per-call-site basis by using *call chain reentrancy*. To enable call chain reentrancy, call the <xref:Orleans.Runtime.RequestContext.AllowCallChainReentrancy> method, which returns a value that allows reentrance from any caller further down the call chain until it is disposed. This includes reentrance from the grain calling the method itself. Consider the following example:
@@ -253,8 +255,6 @@ If you were to instead prevent the deadlock by annotating the `GetDisplayName()`
 #### Suppress call chain reentrancy
 
 Call chain reentrance can also be *suppressed* using the <xref:Orleans.Runtime.RequestContext.SuppressCallChainReentrancy> method. This has limited usefulness to end developers, but it is important for internal use by libraries which extend Orleans grain functionality, such as [streaming](../streaming/index.md) and [broadcast channels](../streaming/broadcast-channel.md) to ensure that developers retain full control over when call chain reentrancy is enabled.
-
-The `GetCount` method doesn't modify the grain state, so it's marked with `ReadOnly`. Callers awaiting this method invocation aren't blocked by other `ReadOnly` requests to the grain, and the method returns immediately.
 
 ### Reentrancy using a predicate
 


### PR DESCRIPTION

## Summary

This PR moves the explanation of ReadOnly methods from the "Suppress Call Chain Reentrancy" section to the "ReadOnly Methods" section. It seems like this information was in the wrong place.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/grains/request-scheduling.md](https://github.com/dotnet/docs/blob/fb532e881e08b957791e41cbb796edcaf570cdd6/docs/orleans/grains/request-scheduling.md) | [Request scheduling](https://review.learn.microsoft.com/en-us/dotnet/orleans/grains/request-scheduling?branch=pr-en-us-44947) |

<!-- PREVIEW-TABLE-END -->