### PR TITLE
Fix incorrect "then" usage

### DIFF
--- a/docs/framework/tools/ngen-exe-native-image-generator.md
+++ b/docs/framework/tools/ngen-exe-native-image-generator.md
@@ -402,7 +402,7 @@ You can use the [jitCompilationStart](../debug-trace-profile/jitcompilationstart
 
 ### Opting out of native image generation
 
-In some cases, NGen.exe may have difficulty generating a native image for a specific method, or you may prefer that the method be JIT compiled rather then compiled to a native image. In this case, you can use the `System.Runtime.BypassNGenAttribute` attribute to prevent NGen.exe from generating a native image for a particular method. The attribute must be applied individually to each method whose code you do not want to include in the native image. NGen.exe recognizes the attribute and does not generate code in the native image for the corresponding method.
+In some cases, NGen.exe may have difficulty generating a native image for a specific method, or you may prefer that the method be JIT compiled rather than compiled to a native image. In this case, you can use the `System.Runtime.BypassNGenAttribute` attribute to prevent NGen.exe from generating a native image for a particular method. The attribute must be applied individually to each method whose code you do not want to include in the native image. NGen.exe recognizes the attribute and does not generate code in the native image for the corresponding method.
 
 Note, however, that `BypassNGenAttribute` is not defined as a type in the .NET Framework Class Library. In order to consume the attribute in your code, you must first define it as follows:
 

--- a/docs/framework/wcf/feature-details/messaging-protocols.md
+++ b/docs/framework/wcf/feature-details/messaging-protocols.md
@@ -1,8 +1,7 @@
 ---
-description: "Learn more about: Messaging Protocols"
 title: "Messaging Protocols"
+description: "Learn more about: Messaging Protocols"
 ms.date: "03/30/2017"
-ms.assetid: 5b20bca7-87b3-4c8f-811b-f215b5987104
 ---
 # Messaging Protocols
 
@@ -635,7 +634,7 @@ Content-Type: application/octet-stream
 
 #### WCF Secure SOAP 1.2 Message Encoded Using MTOM
 
-In this example, a message is encoded using MTOM and SOAP 1.2 that is protected using WS-Security. The binary parts identified for encoding are the contents of the `BinarySecurityToken`, `CipherValue` of the `EncryptedData` corresponding to the encrypted signature and encrypted body. Note that the `CipherValue` of the `EncryptedKey` was not identified for optimization by WCF, because its length is less then 1024 bytes.
+In this example, a message is encoded using MTOM and SOAP 1.2 that is protected using WS-Security. The binary parts identified for encoding are the contents of the `BinarySecurityToken`, `CipherValue` of the `EncryptedData` corresponding to the encrypted signature and encrypted body. Note that the `CipherValue` of the `EncryptedKey` was not identified for optimization by WCF, because its length is less than 1024 bytes.
 
 ```http
 POST http://131.107.72.15/Mtom/service.svc/Soap12MtomSecureSignEncrypt HTTP/1.1


### PR DESCRIPTION
## Summary

Fix 2 cases where "then" is used in place of "than".



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/tools/ngen-exe-native-image-generator.md](https://github.com/dotnet/docs/blob/77ff55473ff05a41adfb34ed0a88ed6d66616c19/docs/framework/tools/ngen-exe-native-image-generator.md) | [Ngen.exe (Native Image Generator)](https://review.learn.microsoft.com/en-us/dotnet/framework/tools/ngen-exe-native-image-generator?branch=pr-en-us-44953) |
| [docs/framework/wcf/feature-details/messaging-protocols.md](https://github.com/dotnet/docs/blob/77ff55473ff05a41adfb34ed0a88ed6d66616c19/docs/framework/wcf/feature-details/messaging-protocols.md) | ["Messaging Protocols"](https://review.learn.microsoft.com/en-us/dotnet/framework/wcf/feature-details/messaging-protocols?branch=pr-en-us-44953) |

<!-- PREVIEW-TABLE-END -->