### PR TITLE
Updating version and prompt for dotnet-coverage tool

### DIFF
--- a/docs/core/additional-tools/dotnet-coverage.md
+++ b/docs/core/additional-tools/dotnet-coverage.md
@@ -6,7 +6,7 @@ ms.topic: reference
 ---
 # dotnet-coverage code coverage utility
 
-**This article applies to:** ✔️ .NET Core 8 SDK and later versions
+**This article applies to:** ✔️ .NET 8 SDK and later versions
 
 ## Synopsis
 

--- a/docs/core/additional-tools/dotnet-coverage.md
+++ b/docs/core/additional-tools/dotnet-coverage.md
@@ -6,7 +6,7 @@ ms.topic: reference
 ---
 # dotnet-coverage code coverage utility
 
-**This article applies to:** ✔️ .NET Core 3.1 SDK and later versions
+**This article applies to:** ✔️ .NET Core 8 SDK and later versions
 
 ## Synopsis
 
@@ -594,8 +594,7 @@ If you don't want to use the `instrument` command, then the files to be instrume
 
 ```console
 D:\examples\ConsoleApp> dotnet-coverage collect --include-files .\bin\Debug\net7.0\*.dll dotnet run
-Microsoft (R) Code Coverage Command Line Tool (x64)
-Copyright (c) Microsoft Corporation. All rights reserved.
+dotnet-coverage v17.14.1.0 [win-x64 - .NET 9.0.2]
 
 SessionId: 57862ec0-e512-49a5-8b66-2804174680fc
 Hello, World!
@@ -618,8 +617,7 @@ In this case, first binary needs to be instrumented as follows:
 
 ```console
 D:\examples\ConsoleApp> dotnet-coverage instrument .\bin\Debug\net7.0\ConsoleApp.dll
-Microsoft (R) Code Coverage Command Line Tool (x64)
-Copyright (c) Microsoft Corporation. All rights reserved.
+dotnet-coverage v17.14.1.0 [win-x64 - .NET 9.0.2]
 
 Input file successfully instrumented.
 ```
@@ -628,8 +626,7 @@ Then you can collect code coverage as follows:
 
 ```console
 D:\examples\ConsoleApp> dotnet-coverage collect .\bin\Debug\net7.0\ConsoleApp.exe
-Microsoft (R) Code Coverage Command Line Tool (x64)
-Copyright (c) Microsoft Corporation. All rights reserved.
+dotnet-coverage v17.14.1.0 [win-x64 - .NET 9.0.2]
 
 SessionId: a09e6bef-ff64-4b5f-8bb8-fc495ebb50ba
 Hello, World!
@@ -642,8 +639,7 @@ In this case, you can completely separate coverage collection from running your 
 
 ```console
 D:\examples\ConsoleApp> dotnet-coverage instrument --session-id 73c34ce5-501c-4369-a4cb-04d31427d1a4 .\bin\Debug\net7.0\ConsoleApp.dll
-Microsoft (R) Code Coverage Command Line Tool (x64)
-Copyright (c) Microsoft Corporation. All rights reserved.
+dotnet-coverage v17.14.1.0 [win-x64 - .NET 9.0.2]
 
 Input file successfully instrumented.
 ```
@@ -655,8 +651,7 @@ In the second step, you need to start coverage collector as follows:
 
 ```console
 D:\examples\ConsoleApp> dotnet-coverage collect --session-id 73c34ce5-501c-4369-a4cb-04d31427d1a4 --server-mode
-Microsoft (R) Code Coverage Command Line Tool (x64)
-Copyright (c) Microsoft Corporation. All rights reserved.
+dotnet-coverage v17.14.1.0 [win-x64 - .NET 9.0.2]
 
 SessionId: 73c34ce5-501c-4369-a4cb-04d31427d1a4
 ```
@@ -672,8 +667,7 @@ Finally, the collector can be closed as follows:
 
 ```console
 D:\examples\ConsoleApp> dotnet-coverage shutdown 73c34ce5-501c-4369-a4cb-04d31427d1a4
-Microsoft (R) Code Coverage Command Line Tool (x64)
-Copyright (c) Microsoft Corporation. All rights reserved.
+dotnet-coverage v17.14.1.0 [win-x64 - .NET 9.0.2]
 ```
 
 ### Settings

--- a/docs/core/additional-tools/dotnet-coverage.md
+++ b/docs/core/additional-tools/dotnet-coverage.md
@@ -593,7 +593,7 @@ Hello, World!
 If you don't want to use the `instrument` command, then the files to be instrumented can be specified using `--include-files` option as follows:
 
 ```console
-D:\examples\ConsoleApp> dotnet-coverage collect --include-files .\bin\Debug\net7.0\*.dll dotnet run
+D:\examples\ConsoleApp> dotnet-coverage collect --include-files .\bin\Debug\net9.0\*.dll dotnet run
 dotnet-coverage v17.14.1.0 [win-x64 - .NET 9.0.2]
 
 SessionId: 57862ec0-e512-49a5-8b66-2804174680fc


### PR DESCRIPTION
Updating version and prompt for dotnet-coverage tool

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/additional-tools/dotnet-coverage.md](https://github.com/dotnet/docs/blob/a2b9691bb45f17cac8b629ba1c67d25db465cfc1/docs/core/additional-tools/dotnet-coverage.md) | [dotnet-coverage code coverage utility](https://review.learn.microsoft.com/en-us/dotnet/core/additional-tools/dotnet-coverage?branch=pr-en-us-44954) |


<!-- PREVIEW-TABLE-END -->