### PR TITLE
Remove misleading sample

### DIFF
--- a/docs/csharp/fundamentals/functional/discards.md
+++ b/docs/csharp/fundamentals/functional/discards.md
@@ -1,7 +1,7 @@
 ---
 title: Discards - unassigned discardable variables
 description: Describes C#'s support for discards, which are unassigned, discardable variables, and the ways in which discards can be used.
-ms.date: 11/14/2023
+ms.date: 02/19/2025
 f1_keywords:
   - "discard_CSharpKeyword"
 ---
@@ -74,8 +74,6 @@ Without assigning the task to a discard, the following code generates a compiler
    :::code language="csharp" source="snippets/discards/standalone-discard2.cs" ID="VariableIdentifier" :::
 - A compiler error for violating type safety. For example:
    :::code language="csharp" source="snippets/discards/standalone-discard2.cs" ID="VariableTypeInference" :::
-- Compiler error CS0136, "A local or parameter named '\_' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter." For example:
-   :::code language="csharp" source="snippets/discards/standalone-discard2.cs" ID="CannotRedeclare" :::
 
 ## See also
 

--- a/docs/csharp/fundamentals/functional/snippets/discards/standalone-discard2.cs
+++ b/docs/csharp/fundamentals/functional/snippets/discards/standalone-discard2.cs
@@ -32,21 +32,5 @@ public class DiscardOrVariable
     //      error CS0029: Cannot implicitly convert type 'bool' to 'int'
     // </VariableTypeInference>
     
-    // <CannotRedeclare>
-    public void DoSomething(int _)
-   {
-   	var _ = GetValue(); // Error: cannot declare local _ when one is already in scope
-   }
-   // The example displays the following compiler error:
-   // error CS0136:
-   //       A local or parameter named '_' cannot be declared in this scope
-   //       because that name is used in an enclosing local scope
-   //       to define a local or parameter
-   // </CannotRedeclare>
     */
-
-    private int GetValue()
-   {
-      return 3;
-   }
 }


### PR DESCRIPTION
Fixes #29824

This sample really doesn't involve a discard. It's trying to name two different variables `_`.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/fundamentals/functional/discards.md](https://github.com/dotnet/docs/blob/afbdc050776759e6b01523413890e1053d495969/docs/csharp/fundamentals/functional/discards.md) | [Discards - C# Fundamentals](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/functional/discards?branch=pr-en-us-44966) |

<!-- PREVIEW-TABLE-END -->