### PR TITLE
Update: Document --expiration parameter in dotnet-monitor (Fixes #44948)

### DIFF
--- a/docs/core/diagnostics/dotnet-monitor.md
+++ b/docs/core/diagnostics/dotnet-monitor.md
@@ -183,7 +183,8 @@ dotnet-monitor config show [-h|--help] [-u|--urls] [-m|--metrics] [--metricUrls]
 
 ## dotnet-monitor generatekey
 
- Generate an API key and hash for HTTP authentication.
+Generate an API key and hash for HTTP authentication.
+
 ### Synopsis
 
 ```console

--- a/docs/core/diagnostics/dotnet-monitor.md
+++ b/docs/core/diagnostics/dotnet-monitor.md
@@ -1,7 +1,7 @@
 ---
 title: dotnet-monitor diagnostic tool - .NET
 description: Learn how to install and use the dotnet-monitor tool to collect dumps, traces, logs, and metrics from applications in production environments.
-ms.date: 06/16/2022
+ms.date: 03/04/2025
 ms.topic: reference
 ---
 # Diagnostic monitoring and collection utility (dotnet-monitor)

--- a/docs/core/diagnostics/dotnet-monitor.md
+++ b/docs/core/diagnostics/dotnet-monitor.md
@@ -184,6 +184,7 @@ dotnet-monitor config show [-h|--help] [-u|--urls] [-m|--metrics] [--metricUrls]
 ## dotnet-monitor generatekey
 
  Generate an API key and hash for HTTP authentication.
+ 
 ### Synopsis
 
 ```console

--- a/docs/core/diagnostics/dotnet-monitor.md
+++ b/docs/core/diagnostics/dotnet-monitor.md
@@ -184,7 +184,6 @@ dotnet-monitor config show [-h|--help] [-u|--urls] [-m|--metrics] [--metricUrls]
 ## dotnet-monitor generatekey
 
  Generate an API key and hash for HTTP authentication.
- 
 ### Synopsis
 
 ```console
@@ -211,8 +210,8 @@ dotnet-monitor generatekey [-h|--help] [-o|--output] [-e|--expiration]
 
 - **`-e|--expiration <expiration>`**
 
-  The expiration time after which the generated API key will no longer be accepted. The value must be in TimeSpan format (e.g., "7.00:00:00" for 7 days). Default: "7.00:00:00" (7 days).
+  The expiration time after which the generated API key will no longer be accepted. The value must be in <xref:System.TimeSpan> format (for example, "7.00:00:00" for 7 days). Default: "7.00:00:00" (7 days).
 
-## See Also
+## See also
 
 - [dotnet/dotnet-monitor](https://github.com/dotnet/dotnet-monitor/tree/main/documentation)

--- a/docs/core/diagnostics/dotnet-monitor.md
+++ b/docs/core/diagnostics/dotnet-monitor.md
@@ -184,11 +184,10 @@ dotnet-monitor config show [-h|--help] [-u|--urls] [-m|--metrics] [--metricUrls]
 ## dotnet-monitor generatekey
 
  Generate an API key and hash for HTTP authentication.
-
 ### Synopsis
 
 ```console
-dotnet-monitor generatekey [-h|--help] [-o|--output]
+dotnet-monitor generatekey [-h|--help] [-o|--output] [-e|--expiration]
 ```
 
 ### Options
@@ -208,6 +207,10 @@ dotnet-monitor generatekey [-h|--help] [-o|--output]
   - `PowerShell` - Outputs in a format usable in PowerShell prompts and scripts.
   - `Shell` - Outputs in a format usable in Linux shells such as Bash.
   - `Text` - Outputs in a format that is plain text.
+
+- **`-e|--expiration <expiration>`**
+
+  The expiration time after which the generated API key will no longer be accepted. The value must be in TimeSpan format (e.g., "7.00:00:00" for 7 days). Default: "7.00:00:00" (7 days).
 
 ## See Also
 


### PR DESCRIPTION
This PR updates the [dotnet-monitor documentation](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-monitor) to include information about the newly added --expiration parameter. Fixes #44948 

Changes made:

- Added details about the --expiration parameter, including usage and format.
- Clarified that dotnet-monitor generated API key with expiration.
- Updated examples to demonstrate correct usage of the parameter.

Why this fix is needed?

- The --expiration parameter was introduced in newer versions of dotnet-monitor, but was missing from the documentation.
- Users need clear guidance on how to set expiration times for API keys.

Verification:

- Cross-referenced with dotnet/dotnet-monitor#6620 to ensure accuracy.
- Confirmed formatting and consistency with the rest of the documentation.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/dotnet-monitor.md](https://github.com/dotnet/docs/blob/897a29b00412bee2f9a13330b1b30ac66f6728c1/docs/core/diagnostics/dotnet-monitor.md) | [Diagnostic monitoring and collection utility (dotnet-monitor)](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-monitor?branch=pr-en-us-44976) |


<!-- PREVIEW-TABLE-END -->