### PR TITLE
Fix anchor to updated link.

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/partial-classes-and-methods.md
+++ b/docs/csharp/programming-guide/classes-and-structs/partial-classes-and-methods.md
@@ -148,7 +148,7 @@ partial void OnNameChanged()
 
 ## C# Language Specification
 
-For more information, see [Partial types](~/_csharpstandard/standard/classes.md#1527-partial-declarations) and [Partial methods](~/_csharpstandard/standard/classes.md#1569-partial-methods) in the [C# Language Specification](~/_csharpstandard/standard/README.md). The language specification is the definitive source for C# syntax and usage. The new features for partial methods are defined in the [feature specification](~/_csharplang/proposals/csharp-9.0/extending-partial-methods.md).
+For more information, see [Partial types](~/_csharpstandard/standard/classes.md#1527-partial-type-declarations) and [Partial methods](~/_csharpstandard/standard/classes.md#1569-partial-methods) in the [C# Language Specification](~/_csharpstandard/standard/README.md). The language specification is the definitive source for C# syntax and usage. The new features for partial methods are defined in the [feature specification](~/_csharplang/proposals/csharp-9.0/extending-partial-methods.md).
 
 ## See also
 


### PR DESCRIPTION
One heading changed in the C# standard. Fix the link to that location.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/classes-and-structs/partial-classes-and-methods.md](https://github.com/dotnet/docs/blob/c86484c7d0582bdf8ec6e23addfa8269007759b1/docs/csharp/programming-guide/classes-and-structs/partial-classes-and-methods.md) | [Partial Classes and Methods (C# Programming Guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/partial-classes-and-methods?branch=pr-en-us-44979) |

<!-- PREVIEW-TABLE-END -->