### PR TITLE
Add known pitfalls to the article of nullable warnings and include 'Constructors` section in it.

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/nullable-warnings.md
+++ b/docs/csharp/language-reference/compiler-messages/nullable-warnings.md
@@ -192,6 +192,9 @@ This article covers the following compiler warnings:
 
 The purpose of nullable warnings is to minimize the chance that your application throws a <xref:System.NullReferenceException?displayProperty=nameWithType> when run. To achieve this goal, the compiler uses static analysis and issues warnings when your code has constructs that might lead to null reference exceptions. You provide the compiler with information for its static analysis by applying type annotations and attributes. These annotations and attributes describe the nullability of arguments, parameters, and members of your types. In this article, you learn different techniques to address the nullable warnings the compiler generates from its static analysis. The techniques described here are for general C# code. Learn to work with nullable reference types and Entity Framework core in [Working with nullable reference types](/ef/core/miscellaneous/nullable-reference-types).
 
+> [!NOTE]
+> The static analysis can't always deduce in what order, in a specific scenario, are methods accessed, and whether the method will complete successfully without throwing an exception. Those known pitfalls are well described in [Known pitfalls](../../nullable-references#known-pitfalls) section.
+
 You address almost all warnings using one of five techniques:
 
 - Configuring the nullable context.

--- a/docs/csharp/language-reference/compiler-messages/nullable-warnings.md
+++ b/docs/csharp/language-reference/compiler-messages/nullable-warnings.md
@@ -193,7 +193,7 @@ This article covers the following compiler warnings:
 The purpose of nullable warnings is to minimize the chance that your application throws a <xref:System.NullReferenceException?displayProperty=nameWithType> when run. To achieve this goal, the compiler uses static analysis and issues warnings when your code has constructs that might lead to null reference exceptions. You provide the compiler with information for its static analysis by applying type annotations and attributes. These annotations and attributes describe the nullability of arguments, parameters, and members of your types. In this article, you learn different techniques to address the nullable warnings the compiler generates from its static analysis. The techniques described here are for general C# code. Learn to work with nullable reference types and Entity Framework core in [Working with nullable reference types](/ef/core/miscellaneous/nullable-reference-types).
 
 > [!NOTE]
-> The static analysis can't always deduce in what order, in a specific scenario, are methods accessed, and whether the method will complete successfully without throwing an exception. Those known pitfalls are well described in [Known pitfalls](../../nullable-references#known-pitfalls) section.
+> The static analysis can't always deduce in what order, in a specific scenario, methods are accessed, and whether the method completes successfully without throwing an exception. Those known pitfalls are well described in [Known pitfalls](../../nullable-references.md#known-pitfalls) section.
 
 You address almost all warnings using one of five techniques:
 

--- a/docs/csharp/nullable-references.md
+++ b/docs/csharp/nullable-references.md
@@ -380,6 +380,51 @@ public static class Program
 
 In the preceding example, the declaration of the array shows it holds non-nullable strings, while its elements are all initialized to `null`. Then, the variable `s` is assigned a `null` value (the first element of the array). Finally, the variable `s` is dereferenced causing a runtime exception.
 
+### Constructors
+
+Constructor of a class will still call the finalizer, even when there was an exception thrown by that constructor.
+<br/>The following example demonstrates that behavior:
+
+```csharp
+public class Foo
+{
+  private string _name;
+  private Bar _bar;
+
+  public Foo(string name)
+  {
+    ArgumentNullException.ThrowIfNullOrEmpty(name);
+    _name = name;
+    _bar = new Bar();
+  }
+
+  ~Foo()
+  {
+    Dispose();
+  }
+
+  public void Dispose()
+  {
+    _bar.Dispose();
+    GC.SuppressFinalize(this);
+  }
+}
+
+public class Bar: IDisposable
+{
+  public void Dispose() { }
+}
+
+public void Main()
+{
+  var foo = new Foo(string.Empty);
+}
+```
+
+In the preceding example, the <xref:System.NullReferenceException?displayProperty=nameWithType> will be thrown when `_bar.Dispose();` is executed.
+
+However, there's no warning issued by the compiler, because static analysis can't determine if a method (like a constructor) completes without a runtime exception being thrown.
+
 ## See also
 
 - [Nullable reference types specification](~/_csharpstandard/standard/types.md#893-nullable-reference-types)

--- a/docs/csharp/nullable-references.md
+++ b/docs/csharp/nullable-references.md
@@ -388,36 +388,36 @@ Constructor of a class will still call the finalizer, even when there was an exc
 ```csharp
 public class A
 {
-  private string _name;
-  private B _b;
+    private string _name;
+    private B _b;
 
-  public A(string name)
-  {
-    ArgumentNullException.ThrowIfNullOrEmpty(name);
-    _name = name;
-    _b = new B();
-  }
+    public A(string name)
+    {
+        ArgumentNullException.ThrowIfNullOrEmpty(name);
+        _name = name;
+        _b = new B();
+    }
 
   ~A()
   {
-    Dispose();
+      Dispose();
   }
 
   public void Dispose()
   {
-    _b.Dispose();
-    GC.SuppressFinalize(this);
+      _b.Dispose();
+      GC.SuppressFinalize(this);
   }
 }
 
 public class B: IDisposable
 {
-  public void Dispose() { }
+    public void Dispose() { }
 }
 
 public void Main()
 {
-  var a = new A(string.Empty);
+    var a = new A(string.Empty);
 }
 ```
 

--- a/docs/csharp/nullable-references.md
+++ b/docs/csharp/nullable-references.md
@@ -421,9 +421,7 @@ public void Main()
 }
 ```
 
-In the preceding example, the <xref:System.NullReferenceException?displayProperty=nameWithType> will be thrown when `_b.Dispose();` runs, if the `name` parameter was `null`. The call to `_b.Dispose();` won't ever throw when the constructor completes successfully.
-
-However, there's no warning issued by the compiler, because static analysis can't determine if a method (like a constructor) completes without a runtime exception being thrown.
+In the preceding example, the <xref:System.NullReferenceException?displayProperty=nameWithType> will be thrown when `_b.Dispose();` runs, if the `name` parameter was `null`. The call to `_b.Dispose();` won't ever throw when the constructor completes successfully. However, there's no warning issued by the compiler, because static analysis can't determine if a method (like a constructor) completes without a runtime exception being thrown.
 
 ## See also
 

--- a/docs/csharp/nullable-references.md
+++ b/docs/csharp/nullable-references.md
@@ -421,7 +421,7 @@ public void Main()
 }
 ```
 
-In the preceding example, the <xref:System.NullReferenceException?displayProperty=nameWithType> will be thrown when `_bar.Dispose();` is executed.
+In the preceding example, the <xref:System.NullReferenceException?displayProperty=nameWithType> will be thrown when `_bar.Dispose();` runs, if the `name` parameter was `null`. The call to `_bar.Dispose();` won't ever throw when the constructor completes successfully.
 
 However, there's no warning issued by the compiler, because static analysis can't determine if a method (like a constructor) completes without a runtime exception being thrown.
 

--- a/docs/csharp/nullable-references.md
+++ b/docs/csharp/nullable-references.md
@@ -386,42 +386,42 @@ Constructor of a class will still call the finalizer, even when there was an exc
 <br/>The following example demonstrates that behavior:
 
 ```csharp
-public class Foo
+public class A
 {
   private string _name;
-  private Bar _bar;
+  private B _b;
 
-  public Foo(string name)
+  public A(string name)
   {
     ArgumentNullException.ThrowIfNullOrEmpty(name);
     _name = name;
-    _bar = new Bar();
+    _b = new B();
   }
 
-  ~Foo()
+  ~A()
   {
     Dispose();
   }
 
   public void Dispose()
   {
-    _bar.Dispose();
+    _b.Dispose();
     GC.SuppressFinalize(this);
   }
 }
 
-public class Bar: IDisposable
+public class B: IDisposable
 {
   public void Dispose() { }
 }
 
 public void Main()
 {
-  var foo = new Foo(string.Empty);
+  var a = new A(string.Empty);
 }
 ```
 
-In the preceding example, the <xref:System.NullReferenceException?displayProperty=nameWithType> will be thrown when `_bar.Dispose();` runs, if the `name` parameter was `null`. The call to `_bar.Dispose();` won't ever throw when the constructor completes successfully.
+In the preceding example, the <xref:System.NullReferenceException?displayProperty=nameWithType> will be thrown when `_b.Dispose();` runs, if the `name` parameter was `null`. The call to `_b.Dispose();` won't ever throw when the constructor completes successfully.
 
 However, there's no warning issued by the compiler, because static analysis can't determine if a method (like a constructor) completes without a runtime exception being thrown.
 


### PR DESCRIPTION
This pull request closes #44184 

It adds a note regarding the known pitfalls of nullable warning not always being issued and adds the example (well presented by the issue's author) to that "Known pitfalls" section as a "Constructors" case.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-messages/nullable-warnings.md](https://github.com/dotnet/docs/blob/1a11dd210a8287bc21beb0d4e0587bda4f91f8f6/docs/csharp/language-reference/compiler-messages/nullable-warnings.md) | [Resolve nullable warnings](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/nullable-warnings?branch=pr-en-us-44985) |
| [docs/csharp/nullable-references.md](https://github.com/dotnet/docs/blob/1a11dd210a8287bc21beb0d4e0587bda4f91f8f6/docs/csharp/nullable-references.md) | [Nullable reference types](https://review.learn.microsoft.com/en-us/dotnet/csharp/nullable-references?branch=pr-en-us-44985) |


<!-- PREVIEW-TABLE-END -->