### PR TITLE
Temporarily removing the agents doc while we refactor it

### DIFF
--- a/docs/ai/toc.yml
+++ b/docs/ai/toc.yml
@@ -31,8 +31,6 @@ items:
   items:
   - name: How generative AI and LLMs work
     href: conceptual/how-genai-and-llms-work.md
-  - name: How agents and copilots work with LLMs
-    href: conceptual/agents.md
   - name: Tokens
     href: conceptual/understanding-tokens.md
   - name: Embeddings


### PR DESCRIPTION
## Summary

The current agents doc was accidentally added to the TOC with a recent update, removing for now while we re-work this doc.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/ai/toc.yml](https://github.com/dotnet/docs/blob/0e0726eb599b5fd338dc73bb04b99b66c65074a7/docs/ai/toc.yml) | [docs/ai/toc](https://review.learn.microsoft.com/en-us/dotnet/ai/toc?branch=pr-en-us-44993) |

<!-- PREVIEW-TABLE-END -->