### PR TITLE
Breaking change: Ambiguous overloads

### DIFF
--- a/docs/core/compatibility/9.0.md
+++ b/docs/core/compatibility/9.0.md
@@ -17,58 +17,59 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 
 ## ASP.NET Core
 
-| Title                                                                                    | Type of change      | Introduced version |
-|------------------------------------------------------------------------------------------|---------------------|--------------------|
-| [DefaultKeyResolution.ShouldGenerateNewKey has altered meaning](aspnet-core/9.0/key-resolution.md) | Behavioral change | Preview 3  |
-| [Dev cert export no longer creates folder](aspnet-core/9.0/certificate-export.md)        | Behavioral change   | RC 1               |
-| [HostBuilder enables ValidateOnBuild/ValidateScopes in development environment](aspnet-core/9.0/hostbuilder-validation.md) | Behavioral change | Preview 7  |
-| [Legacy Mono and Emscripten APIs not exported to global namespace](aspnet-core/9.0/legacy-apis.md) | Source incompatible | GA                |
-| [Middleware types with multiple constructors](aspnet-core/9.0/middleware-constructors.md) | Behavioral change  | RC 1               |
+| Title                                                                                                                      | Type of change      | Introduced version |
+|----------------------------------------------------------------------------------------------------------------------------|---------------------|--------------------|
+| [DefaultKeyResolution.ShouldGenerateNewKey has altered meaning](aspnet-core/9.0/key-resolution.md)                         | Behavioral change   | Preview 3          |
+| [Dev cert export no longer creates folder](aspnet-core/9.0/certificate-export.md)                                          | Behavioral change   | RC 1               |
+| [HostBuilder enables ValidateOnBuild/ValidateScopes in development environment](aspnet-core/9.0/hostbuilder-validation.md) | Behavioral change   | Preview 7          |
+| [Legacy Mono and Emscripten APIs not exported to global namespace](aspnet-core/9.0/legacy-apis.md)                         | Source incompatible | GA                 |
+| [Middleware types with multiple constructors](aspnet-core/9.0/middleware-constructors.md)                                  | Behavioral change   | RC 1               |
 
 ## Containers
 
-| Title                                                                       | Type of change    | Introduced version |
-|-----------------------------------------------------------------------------|-------------------|--------------------|
-| [Container images no longer install zlib](containers/9.0/no-zlib.md) | Behavioral change | Preview 7          |
-| [.NET Monitor images simplified to version-only tags](containers/9.0/monitor-images.md) | Behavioral change |Preview 5         |
+| Title                                                                                   | Type of change    | Introduced version |
+|-----------------------------------------------------------------------------------------|-------------------|--------------------|
+| [Container images no longer install zlib](containers/9.0/no-zlib.md)                    | Behavioral change | Preview 7          |
+| [.NET Monitor images simplified to version-only tags](containers/9.0/monitor-images.md) | Behavioral change | Preview 5          |
 
 ## Core .NET libraries
 
-| Title                                                                                    | Type of change      | Introduced version |
-|------------------------------------------------------------------------------------------|---------------------|--------------------|
-| [Adding a ZipArchiveEntry with CompressionLevel sets ZIP central directory header general-purpose bit flags](core-libraries/9.0/compressionlevel-bits.md) | Behavioral change | Preview 5 |
-| [Altered UnsafeAccessor support for non-open generics](core-libraries/9.0/unsafeaccessor-generics.md) | Behavioral change   | Preview 6          |
-| [API obsoletions with custom diagnostic IDs](core-libraries/9.0/obsolete-apis-with-custom-diagnostics.md) | Source incompatible | (Multiple) |
-| [BigInteger maximum length](core-libraries/9.0/biginteger-limit.md) | Behavioral change | Preview 6  |
-| [BinaryReader.GetString() returns "\uFFFD" on malformed sequences](core-libraries/9.0/binaryreader.md) | Behavioral change | Preview 7  |
-| [C# overload resolution prefers `params` span-type overloads](core-libraries/9.0/params-overloads.md) | Source incompatible |       |
-| [Creating type of array of System.Void not allowed](core-libraries/9.0/type-instance.md) | Behavioral change   | Preview 1          |
-| [Default `Equals()` and `GetHashCode()` throw for types marked with `InlineArrayAttribute`](core-libraries/9.0/inlinearrayattribute.md) | Behavioral change   | Preview 6          |
-| [EnumConverter validates registered types to be enum](core-libraries/9.0/enumconverter.md) | Behavioral change | Preview 7          |
-| [FromKeyedServicesAttribute no longer injects non-keyed parameter](core-libraries/9.0/non-keyed-params.md) | Behavioral change   | RC 1               |
-| [IncrementingPollingCounter initial callback is asynchronous](core-libraries/9.0/async-callback.md) | Behavioral change   | RC 1               |
-| [Inline array struct size limit is enforced](core-libraries/9.0/inlinearray-size.md) | Behavioral change   | Preview 1          |
-| [InMemoryDirectoryInfo prepends rootDir to files](core-libraries/9.0/inmemorydirinfo-prepends-rootdir.md) | Behavioral change   | Preview 1          |
-| [New TimeSpan.From*() overloads that take integers](core-libraries/9.0/timespan-from-overloads.md) | Source incompatible   | Preview 3          |
-| [New version of some OOB packages](core-libraries/9.0/oob-packages.md) | Source incompatible   | Preview 5          |
-| [RuntimeHelpers.GetSubArray returns different type](core-libraries/9.0/getsubarray-return.md) | Behavioral change   | Preview 1          |
-| [String.Trim(params ReadOnlySpan\<char>) overload removed](core-libraries/9.0/string-trim.md) | Source/binary incompatible   | GA          |
-| [Support for empty environment variables](core-libraries/9.0/empty-env-variable.md) | Behavioral change   | Preview 6          |
-| [ZipArchiveEntry names and comments respect UTF8 flag](core-libraries/9.0/ziparchiveentry-encoding.md)    | Behavioral change   | RC 1               |
+| Title                                                                                                                                                     | Type of change             | Introduced version |
+|-----------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------|--------------------|
+| [Adding a ZipArchiveEntry with CompressionLevel sets ZIP central directory header general-purpose bit flags](core-libraries/9.0/compressionlevel-bits.md) | Behavioral change          | Preview 5          |
+| [Altered UnsafeAccessor support for non-open generics](core-libraries/9.0/unsafeaccessor-generics.md)                                                     | Behavioral change          | Preview 6          |
+| [API obsoletions with custom diagnostic IDs](core-libraries/9.0/obsolete-apis-with-custom-diagnostics.md)                                                 | Source incompatible        | (Multiple)         |
+| [Ambiguous overload resolution affecting StringValues intrinsic operators](core-libraries/9.0/ambiguous-overload.md)                                      | Source incompatible        | GA                 |
+| [BigInteger maximum length](core-libraries/9.0/biginteger-limit.md)                                                                                       | Behavioral change          | Preview 6          |
+| [BinaryReader.GetString() returns "\uFFFD" on malformed sequences](core-libraries/9.0/binaryreader.md)                                                    | Behavioral change          | Preview 7          |
+| [C# overload resolution prefers `params` span-type overloads](core-libraries/9.0/params-overloads.md)                                                     | Source incompatible        |                    |
+| [Creating type of array of System.Void not allowed](core-libraries/9.0/type-instance.md)                                                                  | Behavioral change          | Preview 1          |
+| [Default `Equals()` and `GetHashCode()` throw for types marked with `InlineArrayAttribute`](core-libraries/9.0/inlinearrayattribute.md)                   | Behavioral change          | Preview 6          |
+| [EnumConverter validates registered types to be enum](core-libraries/9.0/enumconverter.md)                                                                | Behavioral change          | Preview 7          |
+| [FromKeyedServicesAttribute no longer injects non-keyed parameter](core-libraries/9.0/non-keyed-params.md)                                                | Behavioral change          | RC 1               |
+| [IncrementingPollingCounter initial callback is asynchronous](core-libraries/9.0/async-callback.md)                                                       | Behavioral change          | RC 1               |
+| [Inline array struct size limit is enforced](core-libraries/9.0/inlinearray-size.md)                                                                      | Behavioral change          | Preview 1          |
+| [InMemoryDirectoryInfo prepends rootDir to files](core-libraries/9.0/inmemorydirinfo-prepends-rootdir.md)                                                 | Behavioral change          | Preview 1          |
+| [New TimeSpan.From*() overloads that take integers](core-libraries/9.0/timespan-from-overloads.md)                                                        | Source incompatible        | Preview 3          |
+| [New version of some OOB packages](core-libraries/9.0/oob-packages.md)                                                                                    | Source incompatible        | Preview 5          |
+| [RuntimeHelpers.GetSubArray returns different type](core-libraries/9.0/getsubarray-return.md)                                                             | Behavioral change          | Preview 1          |
+| [String.Trim(params ReadOnlySpan\<char>) overload removed](core-libraries/9.0/string-trim.md)                                                             | Source/binary incompatible | GA                 |
+| [Support for empty environment variables](core-libraries/9.0/empty-env-variable.md)                                                                       | Behavioral change          | Preview 6          |
+| [ZipArchiveEntry names and comments respect UTF8 flag](core-libraries/9.0/ziparchiveentry-encoding.md)                                                    | Behavioral change          | RC 1               |
 
 ## Cryptography
 
-| Title | Type of change | Introduced version |
-|-------|----------------|--------------------|
-| [SafeEvpPKeyHandle.DuplicateHandle up-refs the handle](cryptography/9.0/evp-pkey-handle.md) | Behavioral change | Preview 7 |
-| [Some X509Certificate2 and X509Certificate constructors are obsolete](cryptography/9.0/x509-certificates.md) | Source incompatible | Preview 7 |
-| [Windows private key lifetime simplified](cryptography/9.0/private-key-lifetime.md) | Behavioral change | Preview 7 |
+| Title                                                                                                        | Type of change      | Introduced version |
+|--------------------------------------------------------------------------------------------------------------|---------------------|--------------------|
+| [SafeEvpPKeyHandle.DuplicateHandle up-refs the handle](cryptography/9.0/evp-pkey-handle.md)                  | Behavioral change   | Preview 7          |
+| [Some X509Certificate2 and X509Certificate constructors are obsolete](cryptography/9.0/x509-certificates.md) | Source incompatible | Preview 7          |
+| [Windows private key lifetime simplified](cryptography/9.0/private-key-lifetime.md)                          | Behavioral change   | Preview 7          |
 
 ## Deployment
 
-| Title                                                                             | Type of change      | Introduced version |
-|-----------------------------------------------------------------------------------|---------------------|--------------------|
-| [Deprecated desktop Windows/macOS/Linux MonoVM runtime packages](deployment/9.0/monovm-packages.md) | Source incompatible | Preview 7 |
+| Title                                                                                               | Type of change      | Introduced version |
+|-----------------------------------------------------------------------------------------------------|---------------------|--------------------|
+| [Deprecated desktop Windows/macOS/Linux MonoVM runtime packages](deployment/9.0/monovm-packages.md) | Source incompatible | Preview 7          |
 
 ## Interop
 
@@ -85,30 +86,30 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 
 ## Networking
 
-| Title                                                                             | Type of change      | Introduced version |
-|-----------------------------------------------------------------------------------|---------------------|--------------------|
-| [API obsoletions](core-libraries/9.0/obsolete-apis-with-custom-diagnostics.md)    | Source incompatible | Preview 6          |
-| [HttpClient metrics report `server.port` unconditionally](networking/9.0/server-port-attribute.md) | Behavioral change | Preview 7 |
-| [HttpClientFactory logging redacts header values by default](networking/9.0/redact-headers.md) | Behavioral change | RC 1    |
-| [HttpClientFactory uses SocketsHttpHandler as primary handler](networking/9.0/default-handler.md) | Behavioral change | Preview 6 |
-| [HttpListenerRequest.UserAgent is nullable](networking/9.0/useragent-nullable.md) | Source incompatible | Preview 1          |
-| [URI query redaction in HttpClient EventSource events](networking/9.0/query-redaction-events.md) | Behavioral change | Preview 7 |
-| [URI query redaction in IHttpClientFactory logs](networking/9.0/query-redaction-logs.md) | Behavioral change | Preview 7 |
+| Title                                                                                              | Type of change      | Introduced version |
+|----------------------------------------------------------------------------------------------------|---------------------|--------------------|
+| [API obsoletions](core-libraries/9.0/obsolete-apis-with-custom-diagnostics.md)                     | Source incompatible | Preview 6          |
+| [HttpClient metrics report `server.port` unconditionally](networking/9.0/server-port-attribute.md) | Behavioral change   | Preview 7          |
+| [HttpClientFactory logging redacts header values by default](networking/9.0/redact-headers.md)     | Behavioral change   | RC 1               |
+| [HttpClientFactory uses SocketsHttpHandler as primary handler](networking/9.0/default-handler.md)  | Behavioral change   | Preview 6          |
+| [HttpListenerRequest.UserAgent is nullable](networking/9.0/useragent-nullable.md)                  | Source incompatible | Preview 1          |
+| [URI query redaction in HttpClient EventSource events](networking/9.0/query-redaction-events.md)   | Behavioral change   | Preview 7          |
+| [URI query redaction in IHttpClientFactory logs](networking/9.0/query-redaction-logs.md)           | Behavioral change   | Preview 7          |
 
 ## SDK and MSBuild
 
-| Title                                                                         | Type of change    | Introduced version |
-|-------------------------------------------------------------------------------|-------------------|--------------------|
-| [`dotnet restore` audits transitive packages](sdk/9.0/nugetaudit-transitive-packages.md) | Behavioral change | Preview 6 |
-| [`dotnet sln add` doesn't allow invalid file names](sdk/9.0/dotnet-sln.md) | Behavioral change | 9.0.2xx |
-| [`dotnet watch` incompatible with Hot Reload for old frameworks](sdk/9.0/dotnet-watch.md) | Behavioral change | RC 1   |
-| [`dotnet workload` commands output change](sdk/9.0/dotnet-workload-output.md) | Behavioral change | Preview 1          |
-| [`installer` repo version no longer documented](sdk/9.0/productcommits-versions.md) | Behavioral change | Preview 5    |
-| [New default RID used when targeting .NET Framework](sdk/9.0/default-rid.md) | Source incompatible | GA |
-| [Terminal logger is default](sdk/9.0/terminal-logger.md)                      | Behavioral change | Preview 1          |
-| [Version requirements for .NET 9 SDK](sdk/9.0/version-requirements.md)        | Source incompatible | GA               |
-| [Warning emitted for .NET Standard 1.x target](sdk/9.0/netstandard-warning.md) | Source incompatible | Preview 6       |
-| [Warning emitted for .NET 7 target](sdk/9.0/net70-warning.md)                 | Source incompatible | GA               |
+| Title                                                                                     | Type of change      | Introduced version |
+|-------------------------------------------------------------------------------------------|---------------------|--------------------|
+| [`dotnet restore` audits transitive packages](sdk/9.0/nugetaudit-transitive-packages.md)  | Behavioral change   | Preview 6          |
+| [`dotnet sln add` doesn't allow invalid file names](sdk/9.0/dotnet-sln.md)                | Behavioral change   | 9.0.2xx            |
+| [`dotnet watch` incompatible with Hot Reload for old frameworks](sdk/9.0/dotnet-watch.md) | Behavioral change   | RC 1               |
+| [`dotnet workload` commands output change](sdk/9.0/dotnet-workload-output.md)             | Behavioral change   | Preview 1          |
+| [`installer` repo version no longer documented](sdk/9.0/productcommits-versions.md)       | Behavioral change   | Preview 5          |
+| [New default RID used when targeting .NET Framework](sdk/9.0/default-rid.md)              | Source incompatible | GA                 |
+| [Terminal logger is default](sdk/9.0/terminal-logger.md)                                  | Behavioral change   | Preview 1          |
+| [Version requirements for .NET 9 SDK](sdk/9.0/version-requirements.md)                    | Source incompatible | GA                 |
+| [Warning emitted for .NET Standard 1.x target](sdk/9.0/netstandard-warning.md)            | Source incompatible | Preview 6          |
+| [Warning emitted for .NET 7 target](sdk/9.0/net70-warning.md)                             | Source incompatible | GA                 |
 
 ## Serialization
 

--- a/docs/core/compatibility/9.0.md
+++ b/docs/core/compatibility/9.0.md
@@ -39,7 +39,7 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 | [Adding a ZipArchiveEntry with CompressionLevel sets ZIP central directory header general-purpose bit flags](core-libraries/9.0/compressionlevel-bits.md) | Behavioral change          | Preview 5          |
 | [Altered UnsafeAccessor support for non-open generics](core-libraries/9.0/unsafeaccessor-generics.md)                                                     | Behavioral change          | Preview 6          |
 | [API obsoletions with custom diagnostic IDs](core-libraries/9.0/obsolete-apis-with-custom-diagnostics.md)                                                 | Source incompatible        | (Multiple)         |
-| [Ambiguous overload resolution affecting StringValues intrinsic operators](core-libraries/9.0/ambiguous-overload.md)                                      | Source incompatible        | GA                 |
+| [Ambiguous overload resolution affecting StringValues implicit operators](core-libraries/9.0/ambiguous-overload.md)                                      | Source incompatible        | GA                 |
 | [BigInteger maximum length](core-libraries/9.0/biginteger-limit.md)                                                                                       | Behavioral change          | Preview 6          |
 | [BinaryReader.GetString() returns "\uFFFD" on malformed sequences](core-libraries/9.0/binaryreader.md)                                                    | Behavioral change          | Preview 7          |
 | [C# overload resolution prefers `params` span-type overloads](core-libraries/9.0/params-overloads.md)                                                     | Source incompatible        |                    |

--- a/docs/core/compatibility/core-libraries/9.0/ambiguous-overload.md
+++ b/docs/core/compatibility/core-libraries/9.0/ambiguous-overload.md
@@ -1,0 +1,48 @@
+---
+title: "Breaking change: Ambiguous overload resolution affecting StringValues intrinsic operators"
+description: Learn about the .NET 9 breaking change in core .NET libraries where ambiguous overload resolution now throws error CS0121.
+ms.date: 02/24/2025
+ai-usage: ai-assisted
+---
+
+# Ambiguous overload resolution affecting StringValues intrinsic operators
+
+In .NET 9, a breaking change the [`params Span<T>` lang feature](../../../whats-new/dotnet-9/libraries.md#params-readonlyspant-overloads) creates ambiguity with the implicit operators of <xref:Microsoft.Extensions.Primitives.StringValues>. This change results in the compiler throwing error `CS0121` when it encounters ambiguous method calls.
+
+## Previous behavior
+
+The APIs mentioned in the [Affected APIs](#affected-apis) section previously had no overloads ambiguous with the implicit operators of <xref:Microsoft.Extensions.Primitives.StringValues>. As a result, the compiler would resolve the overloads without any issues.
+
+## New behavior
+
+The compiler throws error `CS0121` for ambiguous overloads. The same code will now result in the following error:
+
+```output
+CS0121: The call is ambiguous between the following methods or properties: 'Program.Join(string, params string[])' and 'Program.Join(string, params ReadOnlySpan<string>)'
+```
+
+## Version introduced
+
+.NET 9
+
+## Type of breaking change
+
+This change is a [source compatibility](../../categories.md#source-compatibility) change.
+
+## Reason for change
+
+<xref:Microsoft.Extensions.Primitives.StringValues> has implicit operators for `string` and `string[]` that cause conflicts with the [`params Span<T>` lang feature](../../../whats-new/dotnet-9/libraries.md#params-readonlyspant-overloads).
+
+## Recommended action
+
+Explicitly specify the method you intend to call by casting the arguments to the appropriate type or apply named parameters. 
+
+## Affected APIs
+
+- <xref:System.String.Concat(System.ReadOnlySpan{System.String})?displayProperty=fullName>
+- <xref:System.String.Join(System.Char,System.ReadOnlySpan{System.String})?displayProperty=fullName>
+- <xref:System.String.Join(System.String,System.ReadOnlySpan{System.String})?displayProperty=fullName>
+- <xref:System.IO.Path.Combine(System.ReadOnlySpan{System.String})?displayProperty=fullName>
+- <xref:System.IO.Path.Join(System.ReadOnlySpan{System.String})?displayProperty=fullName>
+- <xref:System.Text.StringBuilder.AppendJoin(System.String,System.ReadOnlySpan{System.String})?displayProperty=fullName>
+- <xref:System.Text.StringBuilder.AppendJoin(System.Char,System.ReadOnlySpan{System.Object})?displayProperty=fullName>

--- a/docs/core/compatibility/core-libraries/9.0/ambiguous-overload.md
+++ b/docs/core/compatibility/core-libraries/9.0/ambiguous-overload.md
@@ -5,7 +5,7 @@ ms.date: 02/24/2025
 ai-usage: ai-assisted
 ---
 
-# Ambiguous overload resolution affecting StringValues intrinsic operators
+# Ambiguous overload resolution affecting StringValues implicit operators
 
 In .NET 9, a breaking change in the [`params Span<T>` lang feature](../../../whats-new/dotnet-9/libraries.md#params-readonlyspant-overloads) creates ambiguity with the implicit operators of <xref:Microsoft.Extensions.Primitives.StringValues>. This change results in the compiler throwing error `CS0121` when it encounters ambiguous method calls.
 

--- a/docs/core/compatibility/core-libraries/9.0/ambiguous-overload.md
+++ b/docs/core/compatibility/core-libraries/9.0/ambiguous-overload.md
@@ -35,7 +35,7 @@ This change is a [source compatibility](../../categories.md#source-compatibility
 
 ## Recommended action
 
-Explicitly specify the method you intend to call by casting the arguments to the appropriate type or apply named parameters. 
+Explicitly specify the method you intend to call by casting the arguments to the appropriate type or apply named parameters.
 
 ## Affected APIs
 

--- a/docs/core/compatibility/core-libraries/9.0/ambiguous-overload.md
+++ b/docs/core/compatibility/core-libraries/9.0/ambiguous-overload.md
@@ -7,7 +7,7 @@ ai-usage: ai-assisted
 
 # Ambiguous overload resolution affecting StringValues intrinsic operators
 
-In .NET 9, a breaking change the [`params Span<T>` lang feature](../../../whats-new/dotnet-9/libraries.md#params-readonlyspant-overloads) creates ambiguity with the implicit operators of <xref:Microsoft.Extensions.Primitives.StringValues>. This change results in the compiler throwing error `CS0121` when it encounters ambiguous method calls.
+In .NET 9, a breaking change in the [`params Span<T>` lang feature](../../../whats-new/dotnet-9/libraries.md#params-readonlyspant-overloads) creates ambiguity with the implicit operators of <xref:Microsoft.Extensions.Primitives.StringValues>. This change results in the compiler throwing error `CS0121` when it encounters ambiguous method calls.
 
 ## Previous behavior
 

--- a/docs/core/compatibility/core-libraries/9.0/ambiguous-overload.md
+++ b/docs/core/compatibility/core-libraries/9.0/ambiguous-overload.md
@@ -1,5 +1,5 @@
 ---
-title: "Breaking change: Ambiguous overload resolution affecting StringValues intrinsic operators"
+title: "Breaking change: Ambiguous overload resolution affecting StringValues implicit operators"
 description: Learn about the .NET 9 breaking change in core .NET libraries where ambiguous overload resolution now throws error CS0121.
 ms.date: 02/24/2025
 ai-usage: ai-assisted

--- a/docs/core/compatibility/core-libraries/9.0/ambiguous-overload.md
+++ b/docs/core/compatibility/core-libraries/9.0/ambiguous-overload.md
@@ -15,7 +15,7 @@ The APIs mentioned in the [Affected APIs](#affected-apis) section previously had
 
 ## New behavior
 
-The compiler throws error `CS0121` for ambiguous overloads. The same code will now result in the following error:
+The compiler throws error `CS0121` when encountering these ambiguous overloads, resulting in the following error:
 
 ```output
 CS0121: The call is ambiguous between the following methods or properties: 'Program.Join(string, params string[])' and 'Program.Join(string, params ReadOnlySpan<string>)'

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -68,7 +68,7 @@ items:
                 href: core-libraries/9.0/compressionlevel-bits.md
               - name: Altered UnsafeAccessor support for non-open generics
                 href: core-libraries/9.0/unsafeaccessor-generics.md
-              - name: Ambiguous overload resolution affecting StringValues intrinsic operators
+              - name: Ambiguous overload resolution affecting StringValues implicit operators
                 href: core-libraries/9.0/ambiguous-overload.md         
               - name: API obsoletions with custom diagnostic IDs
                 href: core-libraries/9.0/obsolete-apis-with-custom-diagnostics.md
@@ -1360,7 +1360,7 @@ items:
                 href: core-libraries/9.0/compressionlevel-bits.md
               - name: Altered UnsafeAccessor support for non-open generics
                 href: core-libraries/9.0/unsafeaccessor-generics.md
-              - name: Ambiguous overload resolution affecting StringValues intrinsic operators
+              - name: Ambiguous overload resolution affecting StringValues implicit operators
                 href: core-libraries/9.0/ambiguous-overload.md    
               - name: API obsoletions with custom diagnostic IDs
                 href: core-libraries/9.0/obsolete-apis-with-custom-diagnostics.md

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -68,6 +68,8 @@ items:
                 href: core-libraries/9.0/compressionlevel-bits.md
               - name: Altered UnsafeAccessor support for non-open generics
                 href: core-libraries/9.0/unsafeaccessor-generics.md
+              - name: Ambiguous overload resolution affecting StringValues intrinsic operators
+                href: core-libraries/9.0/ambiguous-overload.md         
               - name: API obsoletions with custom diagnostic IDs
                 href: core-libraries/9.0/obsolete-apis-with-custom-diagnostics.md
               - name: BigInteger maximum length
@@ -1358,6 +1360,8 @@ items:
                 href: core-libraries/9.0/compressionlevel-bits.md
               - name: Altered UnsafeAccessor support for non-open generics
                 href: core-libraries/9.0/unsafeaccessor-generics.md
+              - name: Ambiguous overload resolution affecting StringValues intrinsic operators
+                href: core-libraries/9.0/ambiguous-overload.md    
               - name: API obsoletions with custom diagnostic IDs
                 href: core-libraries/9.0/obsolete-apis-with-custom-diagnostics.md
               - name: BigInteger maximum length


### PR DESCRIPTION
Fixes #44102

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/9.0.md](https://github.com/dotnet/docs/blob/560a855f73af8b0bf89bf3b418a7518bbc6c75d0/docs/core/compatibility/9.0.md) | [docs/core/compatibility/9.0](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/9.0?branch=pr-en-us-45007) |
| [docs/core/compatibility/core-libraries/9.0/ambiguous-overload.md](https://github.com/dotnet/docs/blob/560a855f73af8b0bf89bf3b418a7518bbc6c75d0/docs/core/compatibility/core-libraries/9.0/ambiguous-overload.md) | [docs/core/compatibility/core-libraries/9.0/ambiguous-overload](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/9.0/ambiguous-overload?branch=pr-en-us-45007) |
| [docs/core/compatibility/toc.yml](https://github.com/dotnet/docs/blob/560a855f73af8b0bf89bf3b418a7518bbc6c75d0/docs/core/compatibility/toc.yml) | [docs/core/compatibility/toc](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/toc?branch=pr-en-us-45007) |


<!-- PREVIEW-TABLE-END -->