### PR TITLE
Correct .NET Aspire - what's new? link

### DIFF
--- a/docs/core/whats-new/dotnet-10/overview.md
+++ b/docs/core/whats-new/dotnet-10/overview.md
@@ -43,7 +43,7 @@ For more information, see [What's new in the SDK for .NET 10](sdk.md).
 
 .NET Aspire releases version 9.1, which focuses on quality-of-life fixes.
 
-For more information, see [.NET Aspire — what's new?](https://github.com/dotnet/docs-aspire/blob/main/docs/whats-new/dotnet-aspire-9.1.md).
+For more information, see [What's new in .NET Aspire 9.1](/dotnet/aspire/whats-new/dotnet-aspire-9.1).
 
 ## ASP.NET Core
 

--- a/docs/core/whats-new/dotnet-10/overview.md
+++ b/docs/core/whats-new/dotnet-10/overview.md
@@ -43,7 +43,7 @@ For more information, see [What's new in the SDK for .NET 10](sdk.md).
 
 .NET Aspire releases version 9.1, which focuses on quality-of-life fixes.
 
-For more information, see [.NET Aspire — what's new?](/dotnet/aspire/whats-new/).
+For more information, see [.NET Aspire — what's new?](https://github.com/dotnet/docs-aspire/blob/main/docs/whats-new/dotnet-aspire-9.1.md).
 
 ## ASP.NET Core
 


### PR DESCRIPTION
## Summary

Update link to point to documentation in docs-aspire repo as original link 404'd.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/whats-new/dotnet-10/overview.md](https://github.com/dotnet/docs/blob/63789be59e6a82510742c7611d2496b6dff62c05/docs/core/whats-new/dotnet-10/overview.md) | [What's new in .NET 10](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-10/overview?branch=pr-en-us-45027) |


<!-- PREVIEW-TABLE-END -->