### PR TITLE
Update MTP name in config file

### DIFF
--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -17,7 +17,7 @@ Some examples of the `dotnet.config` file:
 
   ```toml
   [dotnet.test:runner]
-  name = "MicrosoftTestingPlatform"
+  name = "Microsoft.Testing.Platform"
   ```
 
   ```toml


### PR DESCRIPTION
This pull request includes a small change to the `docs/core/tools/dotnet-test.md` file. The change corrects the name of the testing platform in the `dotnet.config` file example.

* [`docs/core/tools/dotnet-test.md`](diffhunk://#diff-a170f5d11ede8d772fd55cebbbbe6edf91005accfb409c17758cec4a12e8ac56L20-R20): Updated the name from "MicrosoftTestingPlatform" to "Microsoft.Testing.Platform" in the `dotnet.config` file example.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-test.md](https://github.com/dotnet/docs/blob/cb51f9e76f054ac39fcdf9057d1b7b3fbf3eb9c9/docs/core/tools/dotnet-test.md) | [dotnet test](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-test?branch=pr-en-us-45030) |

<!-- PREVIEW-TABLE-END -->