### PR TITLE
Refresh testing docs

### DIFF
--- a/docs/ai/conceptual/evaluation-libraries.md
+++ b/docs/ai/conceptual/evaluation-libraries.md
@@ -18,7 +18,7 @@ The evaluation libraries, which are built on top of the [Microsoft.Extensions.AI
 
 ## Test integration
 
-The libraries are designed to integrate smoothly with existing .NET apps, allowing you to leverage existing testing infrastructures and familiar syntax to evaluate intelligent apps. You can use any test framework (for example, [MSTest](../../core/testing/index.md#mstest), [xUnit](../../core/testing/index.md#xunit), or [NUnit](../../core/testing/index.md#nunit)) and testing workflow (for example, [Test Explorer](/visualstudio/test/run-unit-tests-with-test-explorer), [dotnet test](../../core/tools/dotnet-test.md), or a CI/CD pipeline). The library also provides easy ways to do online evaluations of your application by publishing evaluation scores to telemetry and monitoring dashboards.
+The libraries are designed to integrate smoothly with existing .NET apps, allowing you to leverage existing testing infrastructures and familiar syntax to evaluate intelligent apps. You can use any test framework (for example, [MSTest](../../core/testing/index.md#mstest), [xUnit](../../core/testing/index.md#xunitnet), or [NUnit](../../core/testing/index.md#nunit)) and testing workflow (for example, [Test Explorer](/visualstudio/test/run-unit-tests-with-test-explorer), [dotnet test](../../core/tools/dotnet-test.md), or a CI/CD pipeline). The library also provides easy ways to do online evaluations of your application by publishing evaluation scores to telemetry and monitoring dashboards.
 
 ## Comprehensive evaluation metrics
 

--- a/docs/core/testing/index.md
+++ b/docs/core/testing/index.md
@@ -72,7 +72,7 @@ For more information, see the following resources:
 
 [TUnit](https://thomhurst.github.io/TUnit/) is entirely built on top of Microsoft.Testing.Platform and doesn't support VSTest. For more information, refer to TUnit documentation.
 
-#### xUnit
+#### xUnit.net
 
 [xUnit](https://xunit.net) is a free, open-source, community-focused unit testing tool for .NET. The original inventor of NUnit v2 wrote xUnit.net. xUnit.net is the latest technology for unit testing .NET apps. It also works with ReSharper, CodeRush, and TestDriven.NET. xUnit.net is a project of the [.NET Foundation](https://dotnetfoundation.org) and operates under its code of conduct. It also supports running with both VSTest and Microsoft.Testing.Platform
 

--- a/docs/core/testing/index.md
+++ b/docs/core/testing/index.md
@@ -39,7 +39,7 @@ When running tests in .NET, there are two components involved: the test platform
 
 ### Test platforms
 
-The test platform is the engine that runs the tests and acts as a communication channel with IDEs. For example, the IDE (e.g, Test Explorer) can send a discovery request to the test platform so that the IDE is able to show the tests you have. The test platform responds, in some way, back to the IDE with the tests it found. Similar communication happens for test execution.
+The test platform is the engine that runs the tests and acts as a communication channel with IDEs. For example, Visual Studio can send a discovery request to the test platform so that it can display the available tests in Test Explorer. The test platform responds back to the IDE with the tests it found. Similar communication happens for test execution.
 
 VSTest has been used for many years in .NET and was the only test platform in the ecosystem. Early in 2024, the first stable version of a new test platform, called [Microsoft.Testing.Platform (MTP)](./unit-testing-platform-intro.md), was released.
 

--- a/docs/core/testing/index.md
+++ b/docs/core/testing/index.md
@@ -39,17 +39,17 @@ When running tests in .NET, there are two components involved. The test platform
 
 ### Test platforms
 
-The test platform is the engine that runs the tests as well as acting as a communication channel with IDEs. For example, the IDE (e.g, Test Explorer) can send a discovery request to the test platform so that the IDE is able to show the tests you have. The test platform responds, in some way, back to the IDE with the tests it found. Similar communication happens for test execution.
+The test platform is the engine that runs the tests and acts as a communication channel with IDEs. For example, the IDE (e.g, Test Explorer) can send a discovery request to the test platform so that the IDE is able to show the tests you have. The test platform responds, in some way, back to the IDE with the tests it found. Similar communication happens for test execution.
 
 In .NET, VSTest has been used for many years and was the only test platform in the ecosystem. Very early in 2024, we released the first stable version of a new test platform, called [Microsoft.Testing.Platform (MTP)](./unit-testing-platform-intro.md).
 
 ### Test frameworks
 
-The test framework is built on top of the test platform. It defines the set of attributes and APIs that are available to you, as a test author, and is usually powered by a test adapter, which acts as a communication layer between the test framework and the test platform. The popular test frameworks as of today are MSTest, NUnit, TUnit, and xUnit.
+The test framework is built on top of the test platform. It defines the set of attributes and APIs that are available to you, as a test author, and is usually powered by a test adapter, which acts as a communication layer between the test framework and the test platform. The popular test frameworks as of today are MSTest, NUnit, TUnit, and xUnit.net.
 
 #### MSTest
 
-[MSTest](https://github.com/microsoft/testfx) is the Microsoft test framework for all .NET languages. It's extensible and works with .NET CLI, Visual Studio, Visual Studio Code, and Rider. It supports running with both VSTest and Microsoft.Testing.Platform.
+[MSTest](https://github.com/microsoft/testfx) is the Microsoft test framework for all .NET languages. It's extensible and works with .NET CLI, Visual Studio, Visual Studio Code, and Rider. It supports both VSTest and Microsoft.Testing.Platform.
 
 For more information, see the following resources:
 
@@ -60,7 +60,7 @@ For more information, see the following resources:
 
 #### NUnit
 
-[NUnit](https://nunit.org) is a unit-testing framework for all .NET languages. Initially, NUnit was ported from JUnit, and the current production release has been rewritten with many new features and support for a wide range of .NET platforms. It's a project of the [.NET Foundation](https://dotnetfoundation.org). It supports running with both VSTest and Microsoft.Testing.Platform.
+[NUnit](https://nunit.org) is a unit-testing framework for all .NET languages. Initially, NUnit was ported from JUnit, and the current production release has been rewritten with many new features and support for a wide range of .NET platforms. It's a project of the [.NET Foundation](https://dotnetfoundation.org). It supports both VSTest and Microsoft.Testing.Platform.
 
 For more information, see the following resources:
 
@@ -74,7 +74,7 @@ For more information, see the following resources:
 
 #### xUnit.net
 
-[xUnit](https://xunit.net) is a free, open-source, community-focused unit testing tool for .NET. The original inventor of NUnit v2 wrote xUnit.net. xUnit.net is the latest technology for unit testing .NET apps. It also works with ReSharper, CodeRush, and TestDriven.NET. xUnit.net is a project of the [.NET Foundation](https://dotnetfoundation.org) and operates under its code of conduct. It also supports running with both VSTest and Microsoft.Testing.Platform
+[xUnit.net](https://xunit.net) is a free, open-source, community-focused unit testing tool for .NET. The original inventor of NUnit v2 wrote xUnit.net. xUnit.net is the latest technology for unit testing .NET apps. It also works with ReSharper, CodeRush, and TestDriven.NET. xUnit.net is a project of the [.NET Foundation](https://dotnetfoundation.org) and operates under its code of conduct. It supports both VSTest and Microsoft.Testing.Platform
 
 For more information, see the following resources:
 

--- a/docs/core/testing/index.md
+++ b/docs/core/testing/index.md
@@ -35,17 +35,17 @@ Keep in mind there are [best practices](unit-testing-best-practices.md) for writ
 
 ## Testing tools
 
-When running tests in .NET, there are two components involved. The test platform and the test framework.
+When running tests in .NET, there are two components involved: the test platform and the test framework.
 
 ### Test platforms
 
 The test platform is the engine that runs the tests and acts as a communication channel with IDEs. For example, the IDE (e.g, Test Explorer) can send a discovery request to the test platform so that the IDE is able to show the tests you have. The test platform responds, in some way, back to the IDE with the tests it found. Similar communication happens for test execution.
 
-In .NET, VSTest has been used for many years and was the only test platform in the ecosystem. Very early in 2024, we released the first stable version of a new test platform, called [Microsoft.Testing.Platform (MTP)](./unit-testing-platform-intro.md).
+VSTest has been used for many years in .NET and was the only test platform in the ecosystem. Early in 2024, the first stable version of a new test platform, called [Microsoft.Testing.Platform (MTP)](./unit-testing-platform-intro.md), was released.
 
 ### Test frameworks
 
-The test framework is built on top of the test platform. It defines the set of attributes and APIs that are available to you, as a test author, and is usually powered by a test adapter, which acts as a communication layer between the test framework and the test platform. The popular test frameworks as of today are MSTest, NUnit, TUnit, and xUnit.net.
+The test framework is built on top of the test platform. It defines the set of attributes and APIs that are available to you, as a test author. It's usually powered by a test adapter, which acts as a communication layer between the test framework and the test platform. The popular test frameworks are MSTest, NUnit, TUnit, and xUnit.net.
 
 #### MSTest
 
@@ -53,7 +53,7 @@ The test framework is built on top of the test platform. It defines the set of a
 
 For more information, see the following resources:
 
-- [Microsoft.Testing.Platform support in MSTest (aka MSTest runner)](unit-testing-mstest-runner-intro.md)
+- [Microsoft.Testing.Platform support in MSTest (MSTest runner)](unit-testing-mstest-runner-intro.md)
 - [Unit testing with C#](unit-testing-with-mstest.md)
 - [Unit testing with F#](unit-testing-fsharp-with-mstest.md)
 - [Unit testing with Visual Basic](unit-testing-visual-basic-with-mstest.md)
@@ -64,7 +64,7 @@ For more information, see the following resources:
 
 For more information, see the following resources:
 
-- [Microsoft.Testing.Platform support in NUnit (aka NUnit runner)](unit-testing-nunit-runner-intro.md)
+- [Microsoft.Testing.Platform support in NUnit (NUnit runner)](unit-testing-nunit-runner-intro.md)
 - [Unit testing with C#](unit-testing-with-nunit.md)
 - [Unit testing with F#](unit-testing-fsharp-with-nunit.md)
 - [Unit testing with Visual Basic](unit-testing-visual-basic-with-nunit.md)

--- a/docs/core/testing/index.md
+++ b/docs/core/testing/index.md
@@ -35,21 +35,32 @@ Keep in mind there are [best practices](unit-testing-best-practices.md) for writ
 
 ## Testing tools
 
-.NET is a multi-language development platform, and you can write various test types for [C#](../../csharp/index.yml), [F#](../../fsharp/index.yml), and [Visual Basic](../../visual-basic/index.yml). For each of these languages, you can choose between several test frameworks.
+When running tests in .NET, there are two components involved. The test platform and the test framework.
 
-### xUnit
+### Test platforms
 
-[xUnit](https://xunit.net) is a free, open-source, community-focused unit testing tool for .NET. The original inventor of NUnit v2 wrote xUnit.net. xUnit.net is the latest technology for unit testing .NET apps. It also works with ReSharper, CodeRush, and TestDriven.NET. xUnit.net is a project of the [.NET Foundation](https://dotnetfoundation.org) and operates under its code of conduct.
+The test platform is the engine that runs the tests as well as acting as a communication channel with IDEs. For example, the IDE (e.g, Test Explorer) can send a discovery request to the test platform so that the IDE is able to show the tests you have. The test platform responds, in some way, back to the IDE with the tests it found. Similar communication happens for test execution.
+
+In .NET, VSTest has been used for many years and was the only test platform in the ecosystem. Very early in 2024, we released the first stable version of a new test platform, called [Microsoft.Testing.Platform (MTP)](./unit-testing-platform-intro.md).
+
+### Test frameworks
+
+The test framework is built on top of the test platform. It defines the set of attributes and APIs that are available to you, as a test author, and is usually powered by a test adapter, which acts as a communication layer between the test framework and the test platform. The popular test frameworks as of today are MSTest, NUnit, TUnit, and xUnit.
+
+#### MSTest
+
+[MSTest](https://github.com/microsoft/testfx) is the Microsoft test framework for all .NET languages. It's extensible and works with .NET CLI, Visual Studio, Visual Studio Code, and Rider. It supports running with both VSTest and Microsoft.Testing.Platform.
 
 For more information, see the following resources:
 
-- [Unit testing with C#](unit-testing-with-dotnet-test.md)
-- [Unit testing with F#](unit-testing-fsharp-with-dotnet-test.md)
-- [Unit testing with Visual Basic](unit-testing-visual-basic-with-dotnet-test.md)
+- [MSTest runner overview (running MSTest with Microsoft.Testing.Platform)](unit-testing-mstest-runner-intro.md)
+- [Unit testing with C#](unit-testing-with-mstest.md)
+- [Unit testing with F#](unit-testing-fsharp-with-mstest.md)
+- [Unit testing with Visual Basic](unit-testing-visual-basic-with-mstest.md)
 
-### NUnit
+#### NUnit
 
-[NUnit](https://nunit.org) is a unit-testing framework for all .NET languages. Initially, NUnit was ported from JUnit, and the current production release has been rewritten with many new features and support for a wide range of .NET platforms. It's a project of the [.NET Foundation](https://dotnetfoundation.org).
+[NUnit](https://nunit.org) is a unit-testing framework for all .NET languages. Initially, NUnit was ported from JUnit, and the current production release has been rewritten with many new features and support for a wide range of .NET platforms. It's a project of the [.NET Foundation](https://dotnetfoundation.org). It supports running with both VSTest and Microsoft.Testing.Platform.
 
 For more information, see the following resources:
 
@@ -57,25 +68,29 @@ For more information, see the following resources:
 - [Unit testing with F#](unit-testing-fsharp-with-nunit.md)
 - [Unit testing with Visual Basic](unit-testing-visual-basic-with-nunit.md)
 
-### MSTest
+#### TUnit
 
-[MSTest](https://github.com/microsoft/testfx) is the Microsoft test framework for all .NET languages. It's extensible and works with both .NET CLI and Visual Studio. For more information, see the following resources:
+[TUnit](https://thomhurst.github.io/TUnit/) is entirely built on top of Microsoft.Testing.Platform and doesn't support VSTest. For more information, refer to TUnit documentation.
 
-- [Unit testing with C#](unit-testing-with-mstest.md)
-- [Unit testing with F#](unit-testing-fsharp-with-mstest.md)
-- [Unit testing with Visual Basic](unit-testing-visual-basic-with-mstest.md)
+#### xUnit
 
-#### MSTest runner
+[xUnit](https://xunit.net) is a free, open-source, community-focused unit testing tool for .NET. The original inventor of NUnit v2 wrote xUnit.net. xUnit.net is the latest technology for unit testing .NET apps. It also works with ReSharper, CodeRush, and TestDriven.NET. xUnit.net is a project of the [.NET Foundation](https://dotnetfoundation.org) and operates under its code of conduct. It also supports running with both VSTest and Microsoft.Testing.Platform
 
-The MSTest runner is a lightweight and portable alternative to [VSTest](https://github.com/microsoft/vstest) for running tests in continuous integration (CI) pipelines, and in Visual Studio Test Explorer. For more information, see [MSTest runner overview](unit-testing-mstest-runner-intro.md).
+For more information, see the following resources:
+
+- [Unit testing with C#](unit-testing-with-dotnet-test.md)
+- [Unit testing with F#](unit-testing-fsharp-with-dotnet-test.md)
+- [Unit testing with Visual Basic](unit-testing-visual-basic-with-dotnet-test.md)
+
+## Running tests
 
 ### .NET CLI
 
-You can run a solutions unit test from the [.NET CLI](../tools/index.md) with the [dotnet test](../tools/dotnet-test.md) command. The .NET CLI exposes most of the functionality that [Integrated Development Environments (IDEs)](#ide) make available through user interfaces. The .NET CLI is cross-platform and available to use as part of continuous integration and delivery pipelines. The .NET CLI is used with scripted processes to automate common tasks.
+You can run unit tests from all test projects in a solution using the [.NET CLI](../tools/index.md) with the [dotnet test](../tools/dotnet-test.md) command. The .NET CLI exposes most of the functionality that [Integrated Development Environments (IDEs)](#ide) make available through user interfaces. The .NET CLI is cross-platform and available to use as part of continuous integration and delivery pipelines. The .NET CLI is used with scripted processes to automate common tasks.
 
 ### IDE
 
-Whether you're using Visual Studio or Visual Studio Code, there are graphical user interfaces for testing functionality. There are more features available to IDEs than the CLI, for example, [Live Unit Testing](/visualstudio/test/live-unit-testing). For more information, see [Including and excluding tests with Visual Studio](/visualstudio/test/live-unit-testing#include-and-exclude-test-projects-and-test-methods).
+Whether you're using Visual Studio, Visual Studio Code, or Rider, there are graphical user interfaces for testing functionality. There are more features available to IDEs than the CLI, for example, [Live Unit Testing](/visualstudio/test/live-unit-testing). For more information, see [Including and excluding tests with Visual Studio](/visualstudio/test/live-unit-testing#include-and-exclude-test-projects-and-test-methods).
 
 ## See also
 

--- a/docs/core/testing/index.md
+++ b/docs/core/testing/index.md
@@ -53,7 +53,7 @@ The test framework is built on top of the test platform. It defines the set of a
 
 For more information, see the following resources:
 
-- [MSTest runner overview (running MSTest with Microsoft.Testing.Platform)](unit-testing-mstest-runner-intro.md)
+- [Microsoft.Testing.Platform support in MSTest (aka MSTest runner)](unit-testing-mstest-runner-intro.md)
 - [Unit testing with C#](unit-testing-with-mstest.md)
 - [Unit testing with F#](unit-testing-fsharp-with-mstest.md)
 - [Unit testing with Visual Basic](unit-testing-visual-basic-with-mstest.md)
@@ -64,6 +64,7 @@ For more information, see the following resources:
 
 For more information, see the following resources:
 
+- [Microsoft.Testing.Platform support in NUnit (aka NUnit runner)](unit-testing-nunit-runner-intro.md)
 - [Unit testing with C#](unit-testing-with-nunit.md)
 - [Unit testing with F#](unit-testing-fsharp-with-nunit.md)
 - [Unit testing with Visual Basic](unit-testing-visual-basic-with-nunit.md)
@@ -78,6 +79,7 @@ For more information, see the following resources:
 
 For more information, see the following resources:
 
+- [Microsoft.Testing.Platform support in xUnit.net v3](https://xunit.net/docs/getting-started/v3/microsoft-testing-platform)
 - [Unit testing with C#](unit-testing-with-dotnet-test.md)
 - [Unit testing with F#](unit-testing-fsharp-with-dotnet-test.md)
 - [Unit testing with Visual Basic](unit-testing-visual-basic-with-dotnet-test.md)

--- a/docs/core/testing/unit-testing-mstest-runner-intro.md
+++ b/docs/core/testing/unit-testing-mstest-runner-intro.md
@@ -6,7 +6,7 @@ ms.author: jajares
 ms.date: 12/15/2023
 ---
 
-# MSTest runner overview
+# Microsoft.Testing.Platform support in MSTest (aka MSTest runner)
 
 MSTest supports running tests with both VSTest and [Microsoft.Testing.Platform (MTP)](./unit-testing-platform-intro.md). The support for MTP is powered by the MSTest runner which can run tests in all contexts (for example, continuous integration (CI) pipelines, CLI, Visual Studio Test Explorer, and VS Code Text Explorer). The MSTest runner is embedded directly in your MSTest test projects, and there are no other app dependencies, such as `vstest.console` or `dotnet test`, needed to run your tests. However, you can still run your tests using `dotnet test`.
 

--- a/docs/core/testing/unit-testing-mstest-runner-intro.md
+++ b/docs/core/testing/unit-testing-mstest-runner-intro.md
@@ -6,11 +6,11 @@ ms.author: jajares
 ms.date: 12/15/2023
 ---
 
-# Microsoft.Testing.Platform support in MSTest (aka MSTest runner)
+# Microsoft.Testing.Platform support in MSTest (MSTest runner)
 
-MSTest supports running tests with both VSTest and [Microsoft.Testing.Platform (MTP)](./unit-testing-platform-intro.md). The support for MTP is powered by the MSTest runner which can run tests in all contexts (for example, continuous integration (CI) pipelines, CLI, Visual Studio Test Explorer, and VS Code Text Explorer). The MSTest runner is embedded directly in your MSTest test projects, and there are no other app dependencies, such as `vstest.console` or `dotnet test`, needed to run your tests. However, you can still run your tests using `dotnet test`.
+MSTest supports running tests with both VSTest and [Microsoft.Testing.Platform (MTP)](./unit-testing-platform-intro.md). The support for MTP is powered by the MSTest runner, which can run tests in all contexts (for example, continuous integration (CI) pipelines, CLI, Visual Studio Test Explorer, and VS Code Text Explorer). The MSTest runner is embedded directly in your MSTest test projects, and there are no other app dependencies, such as `vstest.console` or `dotnet test`, needed to run your tests. However, you can still run your tests using `dotnet test`.
 
-The MSTest runner is open source, and builds on a [`Microsoft.Testing.Platform`](./unit-testing-platform-intro.md) library. You can find `Microsoft.Testing.Platform` code in [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Platform) GitHub repository. The MSTest runner comes bundled with `MSTest in 3.2.0` or newer.
+The MSTest runner is open source and builds on the [`Microsoft.Testing.Platform`](./unit-testing-platform-intro.md) library. You can find `Microsoft.Testing.Platform` code in the [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Platform) GitHub repository. The MSTest runner comes bundled with `MSTest in 3.2.0` or newer.
 
 ## Enable MSTest runner in an MSTest project
 
@@ -83,7 +83,7 @@ Consider the following example project file:
 ```
 
 > [!TIP]
-> It's advised to set the `EnableMSTestRunner` and `TestingPlatformDotnetTestSupport` properties in *Directory.Build.props* file instead of individual project files to ensure all test projects in your solution are using the MSTest runner.
+> To ensure all test projects in your solution use the MSTest runner, set the `EnableMSTestRunner` and `TestingPlatformDotnetTestSupport` properties in *Directory.Build.props* file instead of individual project files.
 
 ## Configurations and filters
 

--- a/docs/core/testing/unit-testing-mstest-runner-intro.md
+++ b/docs/core/testing/unit-testing-mstest-runner-intro.md
@@ -83,7 +83,7 @@ Consider the following example project file:
 ```
 
 > [!TIP]
-> It's advised to set the `EnableMSTestRunner` and `TestingPlatformDotnetTestSupport` properties in *Directory.Build.props* file instead of *csproj* file to ensure all test projects in your solution are using the MSTest runner.
+> It's advised to set the `EnableMSTestRunner` and `TestingPlatformDotnetTestSupport` properties in *Directory.Build.props* file instead of individual project files to ensure all test projects in your solution are using the MSTest runner.
 
 ## Configurations and filters
 

--- a/docs/core/testing/unit-testing-mstest-runner-intro.md
+++ b/docs/core/testing/unit-testing-mstest-runner-intro.md
@@ -1,5 +1,5 @@
 ---
-title: Microsoft.Testing.Platform support in MSTest (aka MSTest runner)
+title: Microsoft.Testing.Platform support in MSTest (MSTest runner)
 description: Learn about the MSTest runner, a lightweight way to run tests without depending on the .NET SDK.
 author: nohwnd
 ms.author: jajares

--- a/docs/core/testing/unit-testing-mstest-runner-intro.md
+++ b/docs/core/testing/unit-testing-mstest-runner-intro.md
@@ -1,5 +1,5 @@
 ---
-title: MSTest runner overview
+title: Microsoft.Testing.Platform support in MSTest (aka MSTest runner)
 description: Learn about the MSTest runner, a lightweight way to run tests without depending on the .NET SDK.
 author: nohwnd
 ms.author: jajares
@@ -8,9 +8,9 @@ ms.date: 12/15/2023
 
 # MSTest runner overview
 
-The MSTest runner is a lightweight and portable alternative to [VSTest](https://github.com/microsoft/vstest) for running tests in all contexts (for example, continuous integration (CI) pipelines, CLI, Visual Studio Test Explorer, and VS Code Test Explorer). The MSTest runner is embedded directly in your MSTest test projects, and there are no other app dependencies, such as `vstest.console` or `dotnet test`, needed to run your tests.
+MSTest supports running tests with both VSTest and [Microsoft.Testing.Platform (MTP)](./unit-testing-platform-intro.md). The support for MTP is powered by the MSTest runner which can run tests in all contexts (for example, continuous integration (CI) pipelines, CLI, Visual Studio Test Explorer, and VS Code Text Explorer). The MSTest runner is embedded directly in your MSTest test projects, and there are no other app dependencies, such as `vstest.console` or `dotnet test`, needed to run your tests. However, you can still run your tests using `dotnet test`.
 
-The MSTest runner is open source, and builds on a [`Microsoft.Testing.Platform`](./unit-testing-platform-intro.md) library. You can find `Microsoft.Testing.Platform` code in [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Platform) GitHub repository. The MSTest runner comes bundled with `MSTest in 3.2.0-preview.23623.1` or newer.
+The MSTest runner is open source, and builds on a [`Microsoft.Testing.Platform`](./unit-testing-platform-intro.md) library. You can find `Microsoft.Testing.Platform` code in [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Platform) GitHub repository. The MSTest runner comes bundled with `MSTest in 3.2.0` or newer.
 
 ## Enable MSTest runner in an MSTest project
 
@@ -19,7 +19,7 @@ It's recommended to use [MSTest SDK](./unit-testing-mstest-sdk.md) as it greatly
 When you use `MSTest SDK`, by default you're opted in to using MSTest runner.
 
 ```xml
-<Project Sdk="MSTest.Sdk/3.3.1">
+<Project Sdk="MSTest.Sdk/3.8.2">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -30,7 +30,7 @@ When you use `MSTest SDK`, by default you're opted in to using MSTest runner.
 </Project>
 ```
 
-Alternatively, you can enable MSTest runner by adding the `EnableMSTestRunner` property and setting `OutputType` to `Exe` in your project file. You also need to ensure that you're using `MSTest 3.2.0-preview.23623.1` or newer.
+Alternatively, you can enable MSTest runner by adding the `EnableMSTestRunner` property and setting `OutputType` to `Exe` in your project file. You also need to ensure that you're using `MSTest 3.2.0` or newer. We strongly recommend you update to the latest MSTest version available.
 
 Consider the following example project file:
 
@@ -40,14 +40,19 @@ Consider the following example project file:
   <PropertyGroup>
     <!-- Enable the MSTest runner, this is an opt-in feature -->
     <EnableMSTestRunner>true</EnableMSTestRunner>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+
+    <!--
+      Displays error on console in addition to the log file. Note that this feature comes with a performance impact.
+      For more information, visit https://learn.microsoft.com/dotnet/core/testing/unit-testing-platform-integration-dotnet-test#show-failure-per-test
+      -->
+    <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
+
     <OutputType>Exe</OutputType>
 
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
@@ -58,8 +63,11 @@ Consider the following example project file:
           MSTest.TestAdapter
           MSTest.TestFramework
           MSTest.Analyzers
+      Starting with 3.8, it also includes:
+          Microsoft.Testing.Extensions.TrxReport
+          Microsoft.Testing.Extensions.CodeCoverage
     -->
-    <PackageReference Include="MSTest" Version="3.2.0" />
+    <PackageReference Include="MSTest" Version="3.8.0" />
 
     <!--
       Coverlet collector isn't compatible with MSTest runner, you can
@@ -75,7 +83,7 @@ Consider the following example project file:
 ```
 
 > [!TIP]
-> It's advised to set the `EnableMSTestRunner` property in *Directory.Build.props* file instead of *csproj* file to ensure all test projects in your solution are using the MSTest runner.
+> It's advised to set the `EnableMSTestRunner` and `TestingPlatformDotnetTestSupport` properties in *Directory.Build.props* file instead of *csproj* file to ensure all test projects in your solution are using the MSTest runner.
 
 ## Configurations and filters
 

--- a/docs/core/testing/unit-testing-nunit-runner-intro.md
+++ b/docs/core/testing/unit-testing-nunit-runner-intro.md
@@ -1,20 +1,23 @@
 ---
-title: NUnit runner overview
+title: Microsoft.Testing.Platform support in NUnit (aka NUnit runner)
 description: Learn about the NUnit runner, a lightweight way to run tests without depending on the .NET SDK.
 author: Evangelink
 ms.author: amauryleve
 ms.date: 05/21/2024
 ---
 
-# NUnit runner overview
+# Microsoft.Testing.Platform support in NUnit (aka NUnit runner)
 
-The NUnit runner is a lightweight and portable alternative to [VSTest](https://github.com/microsoft/vstest) for running tests in all contexts (for example, continuous integration (CI) pipelines, CLI, Visual Studio Test Explorer, and VS Code Text Explorer). The NUnit runner is embedded directly in your NUnit test projects, and there are no other app dependencies, such as `vstest.console` or `dotnet test`, needed to run your tests.
+NUnit supports running tests with both VSTest and [Microsoft.Testing.Platform (MTP)](./unit-testing-platform-intro.md). The support for MTP is powered by the NUnit runner which can run tests in all contexts (for example, continuous integration (CI) pipelines, CLI, Visual Studio Test Explorer, and VS Code Text Explorer). The NUnit runner is embedded directly in your NUnit test projects, and there are no other app dependencies, such as `vstest.console` or `dotnet test`, needed to run your tests. However, you can still run your tests using `dotnet test`.
 
-The NUnit runner is open source, and builds on a [`Microsoft.Testing.Platform`](./unit-testing-platform-intro.md) library. You can find `Microsoft.Testing.Platform` code in [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Platform) GitHub repository. The NUnit runner comes bundled with `NUnit 5.0.0-beta.2` or newer.
+The NUnit runner is open source, and builds on top of [`Microsoft.Testing.Platform`](./unit-testing-platform-intro.md). You can find `Microsoft.Testing.Platform` code in [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Platform) GitHub repository. The NUnit runner is supported in NUnit3TestAdapter version 5.0 or greater. For more information, see [NUnit and Microsoft.Testing.Platform](https://docs.nunit.org/articles/vs-test-adapter/NUnit-And-Microsoft-Test-Platform.html)
 
 ## Enable NUnit runner in a NUnit project
 
-You can enable NUnit runner by adding the `EnableNUnitRunner` property and setting `OutputType` to `Exe` in your project file. You also need to ensure that you're using `NUnit 5.0.0-beta.2` or newer.
+You can enable NUnit runner by adding the `EnableNUnitRunner` property and setting `OutputType` to `Exe` in your project file. You also need to ensure that you're using `NUnit3TestAdapter` version 5.0 or newer.
+
+> [!TIP]
+> We do recommend you set `EnableNUnitRunner` property in `Directory.Build.props` rather than individual project files. This ensures that it applies to all your projects.
 
 Consider the following example project file:
 
@@ -24,24 +27,29 @@ Consider the following example project file:
   <PropertyGroup>
     <!-- Enable the NUnit runner, this is an opt-in feature -->
     <EnableNUnitRunner>true</EnableNUnitRunner>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+
+    <!--
+      Displays error on console in addition to the log file. Note that this feature comes with a performance impact.
+      For more information, visit https://learn.microsoft.com/dotnet/core/testing/unit-testing-platform-integration-dotnet-test#show-failure-per-test
+      -->
+    <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
+
     <OutputType>Exe</OutputType>
 
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="NUnit" Version="4.1.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0-beta.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
 
     <!--
       Coverlet collector isn't compatible with NUnit runner, you can

--- a/docs/core/testing/unit-testing-nunit-runner-intro.md
+++ b/docs/core/testing/unit-testing-nunit-runner-intro.md
@@ -1,5 +1,5 @@
 ---
-title: Microsoft.Testing.Platform support in NUnit (aka NUnit runner)
+title: Microsoft.Testing.Platform support in NUnit (NUnit runner)
 description: Learn about the NUnit runner, a lightweight way to run tests without depending on the .NET SDK.
 author: Evangelink
 ms.author: amauryleve

--- a/docs/core/testing/unit-testing-nunit-runner-intro.md
+++ b/docs/core/testing/unit-testing-nunit-runner-intro.md
@@ -17,7 +17,7 @@ The NUnit runner is open source, and builds on top of [`Microsoft.Testing.Platfo
 You can enable NUnit runner by adding the `EnableNUnitRunner` property and setting `OutputType` to `Exe` in your project file. You also need to ensure that you're using `NUnit3TestAdapter` version 5.0 or newer.
 
 > [!TIP]
-> We do recommend you set `EnableNUnitRunner` property in `Directory.Build.props` rather than individual project files. This ensures that it applies to all your projects.
+> It's advised to set the `EnableNUnitRunner` and `TestingPlatformDotnetTestSupport` properties in *Directory.Build.props* file instead of individual project files to ensure all test projects in your solution are using the NUnit runner.
 
 Consider the following example project file:
 

--- a/docs/core/testing/unit-testing-nunit-runner-intro.md
+++ b/docs/core/testing/unit-testing-nunit-runner-intro.md
@@ -6,9 +6,9 @@ ms.author: amauryleve
 ms.date: 05/21/2024
 ---
 
-# Microsoft.Testing.Platform support in NUnit (aka NUnit runner)
+# Microsoft.Testing.Platform support in NUnit (NUnit runner)
 
-NUnit supports running tests with both VSTest and [Microsoft.Testing.Platform (MTP)](./unit-testing-platform-intro.md). The support for MTP is powered by the NUnit runner which can run tests in all contexts (for example, continuous integration (CI) pipelines, CLI, Visual Studio Test Explorer, and VS Code Text Explorer). The NUnit runner is embedded directly in your NUnit test projects, and there are no other app dependencies, such as `vstest.console` or `dotnet test`, needed to run your tests. However, you can still run your tests using `dotnet test`.
+NUnit supports running tests with both VSTest and [Microsoft.Testing.Platform (MTP)](./unit-testing-platform-intro.md). The support for MTP is powered by the NUnit runner, which can run tests in all contexts (for example, continuous integration (CI) pipelines, CLI, Visual Studio Test Explorer, and VS Code Text Explorer). The NUnit runner is embedded directly in your NUnit test projects, and there are no other app dependencies, such as `vstest.console` or `dotnet test`, needed to run your tests. However, you can still run your tests using `dotnet test`.
 
 The NUnit runner is open source, and builds on top of [`Microsoft.Testing.Platform`](./unit-testing-platform-intro.md). You can find `Microsoft.Testing.Platform` code in [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Platform) GitHub repository. The NUnit runner is supported in NUnit3TestAdapter version 5.0 or greater. For more information, see [NUnit and Microsoft.Testing.Platform](https://docs.nunit.org/articles/vs-test-adapter/NUnit-And-Microsoft-Test-Platform.html)
 
@@ -17,7 +17,7 @@ The NUnit runner is open source, and builds on top of [`Microsoft.Testing.Platfo
 You can enable NUnit runner by adding the `EnableNUnitRunner` property and setting `OutputType` to `Exe` in your project file. You also need to ensure that you're using `NUnit3TestAdapter` version 5.0 or newer.
 
 > [!TIP]
-> It's advised to set the `EnableNUnitRunner` and `TestingPlatformDotnetTestSupport` properties in *Directory.Build.props* file instead of individual project files to ensure all test projects in your solution are using the NUnit runner.
+> To ensure all test projects in your solution use the NUnit runner, set the `EnableNUnitRunner` and `TestingPlatformDotnetTestSupport` properties in *Directory.Build.props* file instead of individual project files.
 
 Consider the following example project file:
 

--- a/docs/navigate/devops-testing/toc.yml
+++ b/docs/navigate/devops-testing/toc.yml
@@ -38,215 +38,221 @@ items:
         href: ../../core/testing/index.md
       - name: Unit testing best practices
         href: ../../core/testing/unit-testing-best-practices.md
-      - name: xUnit
+      - name: Test frameworks
         items:
-          - name: C# unit testing
-            href: ../../core/testing/unit-testing-with-dotnet-test.md
-          - name: F# unit testing
-            href: ../../core/testing/unit-testing-fsharp-with-dotnet-test.md
-          - name: VB unit testing
-            href: ../../core/testing/unit-testing-visual-basic-with-dotnet-test.md
-          - name: Organize a project and test with xUnit
-            href: ../../core/tutorials/testing-with-cli.md
-            displayName: tutorials, cli
-      - name: NUnit
-        items:
-          - name: C# unit testing
-            href: ../../core/testing/unit-testing-with-nunit.md
-          - name: F# unit testing
-            href: ../../core/testing/unit-testing-fsharp-with-nunit.md
-          - name: VB unit testing
-            href: ../../core/testing/unit-testing-visual-basic-with-nunit.md
-          - name: NUnit runner
-            href: ../../core/testing/unit-testing-nunit-runner-intro.md
-      - name: MSTest
-        items:
-          - name: Overview
-            href: ../../core/testing/unit-testing-mstest-intro.md
-          - name: Migrate MSTest from v1 to v3
-            href: ../../core/testing/unit-testing-mstest-migration-from-v1-to-v3.md
-          - name: Getting started
+          - name: xUnit
+            items:
+              - name: C# unit testing
+                href: ../../core/testing/unit-testing-with-dotnet-test.md
+              - name: F# unit testing
+                href: ../../core/testing/unit-testing-fsharp-with-dotnet-test.md
+              - name: VB unit testing
+                href: ../../core/testing/unit-testing-visual-basic-with-dotnet-test.md
+              - name: Microsoft.Testing.Platform support in xUnit.net v3
+                href: https://xunit.net/docs/getting-started/v3/microsoft-testing-platform
+              - name: Organize a project and test with xUnit
+                href: ../../core/tutorials/testing-with-cli.md
+                displayName: tutorials, cli
+          - name: NUnit
+            items:
+              - name: C# unit testing
+                href: ../../core/testing/unit-testing-with-nunit.md
+              - name: F# unit testing
+                href: ../../core/testing/unit-testing-fsharp-with-nunit.md
+              - name: VB unit testing
+                href: ../../core/testing/unit-testing-visual-basic-with-nunit.md
+              - name: Microsoft.Testing.Platform support in NUnit (aka NUnit runner)
+                href: ../../core/testing/unit-testing-nunit-runner-intro.md
+          - name: MSTest
             items:
               - name: Overview
-                href: ../../core/testing/unit-testing-mstest-getting-started.md
-              - name: MSTest SDK
-                href: ../../core/testing/unit-testing-mstest-sdk.md
-          - name: Writing tests
-            items:
-              - name: Overview
-                href: ../../core/testing/unit-testing-mstest-writing-tests.md
-              - name: Examples
-                items:
-                - name: C# example
-                  href: ../../core/testing/unit-testing-with-mstest.md
-                - name: F# example
-                  href: ../../core/testing/unit-testing-fsharp-with-mstest.md
-                - name: VB example
-                  href: ../../core/testing/unit-testing-visual-basic-with-mstest.md
-              - name: Attributes
-                href: ../../core/testing/unit-testing-mstest-writing-tests-attributes.md
-              - name: Assertions
-                href: ../../core/testing/unit-testing-mstest-writing-tests-assertions.md
-              - name: TestContext
-                href: ../../core/testing/unit-testing-mstest-writing-tests-testcontext.md
-          - name: Running tests
-            items:
-              - name: Overview
-                href: ../../core/testing/unit-testing-mstest-running-tests.md
-              - name: MSTest runner
+                href: ../../core/testing/unit-testing-mstest-intro.md
+              - name: Migrate MSTest from v1 to v3
+                href: ../../core/testing/unit-testing-mstest-migration-from-v1-to-v3.md
+              - name: Microsoft.Testing.Platform support in MSTest (aka MSTest runner)
                 href: ../../core/testing/unit-testing-mstest-runner-intro.md
-              - name: Configure MSTest
-                href: ../../core/testing/unit-testing-mstest-configure.md
-          - name: Code analysis
-            items:
-              - name: Overview
-                href: ../../core/testing/mstest-analyzers/overview.md
-              - name: Design
+              - name: Getting started
                 items:
                   - name: Overview
-                    href: ../../core/testing/mstest-analyzers/design-rules.md
-                  - name: MSTEST0004
-                    href: ../../core/testing/mstest-analyzers/mstest0004.md
-                  - name: MSTEST0006
-                    href: ../../core/testing/mstest-analyzers/mstest0006.md
-                  - name: MSTEST0015
-                    href: ../../core/testing/mstest-analyzers/mstest0015.md
-                  - name: MSTEST0016
-                    href: ../../core/testing/mstest-analyzers/mstest0016.md
-                  - name: MSTEST0019
-                    href: ../../core/testing/mstest-analyzers/mstest0019.md
-                  - name: MSTEST0020
-                    href: ../../core/testing/mstest-analyzers/mstest0020.md
-                  - name: MSTEST0021
-                    href: ../../core/testing/mstest-analyzers/mstest0021.md
-                  - name: MSTEST0022
-                    href: ../../core/testing/mstest-analyzers/mstest0022.md
-                  - name: MSTEST0025
-                    href: ../../core/testing/mstest-analyzers/mstest0025.md
-                  - name: MSTEST0029
-                    href: ../../core/testing/mstest-analyzers/mstest0029.md
-                  - name: MSTEST0036
-                    href: ../../core/testing/mstest-analyzers/mstest0036.md
-              - name: Performance
+                    href: ../../core/testing/unit-testing-mstest-getting-started.md
+                  - name: MSTest SDK
+                    href: ../../core/testing/unit-testing-mstest-sdk.md
+              - name: Writing tests
                 items:
                   - name: Overview
-                    href: ../../core/testing/mstest-analyzers/performance-rules.md
-                  - name: MSTEST0001
-                    href: ../../core/testing/mstest-analyzers/mstest0001.md
-              - name: Suppression
+                    href: ../../core/testing/unit-testing-mstest-writing-tests.md
+                  - name: Examples
+                    items:
+                    - name: C# example
+                      href: ../../core/testing/unit-testing-with-mstest.md
+                    - name: F# example
+                      href: ../../core/testing/unit-testing-fsharp-with-mstest.md
+                    - name: VB example
+                      href: ../../core/testing/unit-testing-visual-basic-with-mstest.md
+                  - name: Attributes
+                    href: ../../core/testing/unit-testing-mstest-writing-tests-attributes.md
+                  - name: Assertions
+                    href: ../../core/testing/unit-testing-mstest-writing-tests-assertions.md
+                  - name: TestContext
+                    href: ../../core/testing/unit-testing-mstest-writing-tests-testcontext.md
+              - name: Running tests
                 items:
                   - name: Overview
-                    href: ../../core/testing/mstest-analyzers/suppression-rules.md
-                  - name: MSTEST0027
-                    href: ../../core/testing/mstest-analyzers/mstest0027.md
-                  - name: MSTEST0028
-                    href: ../../core/testing/mstest-analyzers/mstest0028.md
-                  - name: MSTEST0033
-                    href: ../../core/testing/mstest-analyzers/mstest0033.md
-              - name: Usage
+                    href: ../../core/testing/unit-testing-mstest-running-tests.md
+                  - name: Configure MSTest
+                    href: ../../core/testing/unit-testing-mstest-configure.md
+              - name: Code analysis
                 items:
                   - name: Overview
-                    href: ../../core/testing/mstest-analyzers/usage-rules.md
-                  - name: MSTEST0002
-                    href: ../../core/testing/mstest-analyzers/mstest0002.md
-                  - name: MSTEST0003
-                    href: ../../core/testing/mstest-analyzers/mstest0003.md
-                  - name: MSTEST0005
-                    href: ../../core/testing/mstest-analyzers/mstest0005.md
-                  - name: MSTEST0007
-                    href: ../../core/testing/mstest-analyzers/mstest0007.md
-                  - name: MSTEST0008
-                    href: ../../core/testing/mstest-analyzers/mstest0008.md
-                  - name: MSTEST0009
-                    href: ../../core/testing/mstest-analyzers/mstest0009.md
-                  - name: MSTEST0010
-                    href: ../../core/testing/mstest-analyzers/mstest0010.md
-                  - name: MSTEST0011
-                    href: ../../core/testing/mstest-analyzers/mstest0011.md
-                  - name: MSTEST0012
-                    href: ../../core/testing/mstest-analyzers/mstest0012.md
-                  - name: MSTEST0013
-                    href: ../../core/testing/mstest-analyzers/mstest0013.md
-                  - name: MSTEST0014
-                    href: ../../core/testing/mstest-analyzers/mstest0014.md
-                  - name: MSTEST0017
-                    href: ../../core/testing/mstest-analyzers/mstest0017.md
-                  - name: MSTEST0018
-                    href: ../../core/testing/mstest-analyzers/mstest0018.md
-                  - name: MSTEST0023
-                    href: ../../core/testing/mstest-analyzers/mstest0023.md
-                  - name: MSTEST0024
-                    href: ../../core/testing/mstest-analyzers/mstest0024.md
-                  - name: MSTEST0026
-                    href: ../../core/testing/mstest-analyzers/mstest0026.md
-                  - name: MSTEST0030
-                    href: ../../core/testing/mstest-analyzers/mstest0030.md
-                  - name: MSTEST0031
-                    href: ../../core/testing/mstest-analyzers/mstest0031.md
-                  - name: MSTEST0032
-                    href: ../../core/testing/mstest-analyzers/mstest0032.md
-                  - name: MSTEST0034
-                    href: ../../core/testing/mstest-analyzers/mstest0034.md
-                  - name: MSTEST0035
-                    href: ../../core/testing/mstest-analyzers/mstest0035.md
-                  - name: MSTEST0037
-                    href: ../../core/testing/mstest-analyzers/mstest0037.md
-                  - name: MSTEST0038
-                    href: ../../core/testing/mstest-analyzers/mstest0038.md
-                  - name: MSTEST0039
-                    href: ../../core/testing/mstest-analyzers/mstest0039.md
-                  - name: MSTEST0040
-                    href: ../../core/testing/mstest-analyzers/mstest0040.md
-                  - name: MSTEST0041
-                    href: ../../core/testing/mstest-analyzers/mstest0041.md
-      - name: Microsoft Testing Platform
+                    href: ../../core/testing/mstest-analyzers/overview.md
+                  - name: Design
+                    items:
+                      - name: Overview
+                        href: ../../core/testing/mstest-analyzers/design-rules.md
+                      - name: MSTEST0004
+                        href: ../../core/testing/mstest-analyzers/mstest0004.md
+                      - name: MSTEST0006
+                        href: ../../core/testing/mstest-analyzers/mstest0006.md
+                      - name: MSTEST0015
+                        href: ../../core/testing/mstest-analyzers/mstest0015.md
+                      - name: MSTEST0016
+                        href: ../../core/testing/mstest-analyzers/mstest0016.md
+                      - name: MSTEST0019
+                        href: ../../core/testing/mstest-analyzers/mstest0019.md
+                      - name: MSTEST0020
+                        href: ../../core/testing/mstest-analyzers/mstest0020.md
+                      - name: MSTEST0021
+                        href: ../../core/testing/mstest-analyzers/mstest0021.md
+                      - name: MSTEST0022
+                        href: ../../core/testing/mstest-analyzers/mstest0022.md
+                      - name: MSTEST0025
+                        href: ../../core/testing/mstest-analyzers/mstest0025.md
+                      - name: MSTEST0029
+                        href: ../../core/testing/mstest-analyzers/mstest0029.md
+                      - name: MSTEST0036
+                        href: ../../core/testing/mstest-analyzers/mstest0036.md
+                  - name: Performance
+                    items:
+                      - name: Overview
+                        href: ../../core/testing/mstest-analyzers/performance-rules.md
+                      - name: MSTEST0001
+                        href: ../../core/testing/mstest-analyzers/mstest0001.md
+                  - name: Suppression
+                    items:
+                      - name: Overview
+                        href: ../../core/testing/mstest-analyzers/suppression-rules.md
+                      - name: MSTEST0027
+                        href: ../../core/testing/mstest-analyzers/mstest0027.md
+                      - name: MSTEST0028
+                        href: ../../core/testing/mstest-analyzers/mstest0028.md
+                      - name: MSTEST0033
+                        href: ../../core/testing/mstest-analyzers/mstest0033.md
+                  - name: Usage
+                    items:
+                      - name: Overview
+                        href: ../../core/testing/mstest-analyzers/usage-rules.md
+                      - name: MSTEST0002
+                        href: ../../core/testing/mstest-analyzers/mstest0002.md
+                      - name: MSTEST0003
+                        href: ../../core/testing/mstest-analyzers/mstest0003.md
+                      - name: MSTEST0005
+                        href: ../../core/testing/mstest-analyzers/mstest0005.md
+                      - name: MSTEST0007
+                        href: ../../core/testing/mstest-analyzers/mstest0007.md
+                      - name: MSTEST0008
+                        href: ../../core/testing/mstest-analyzers/mstest0008.md
+                      - name: MSTEST0009
+                        href: ../../core/testing/mstest-analyzers/mstest0009.md
+                      - name: MSTEST0010
+                        href: ../../core/testing/mstest-analyzers/mstest0010.md
+                      - name: MSTEST0011
+                        href: ../../core/testing/mstest-analyzers/mstest0011.md
+                      - name: MSTEST0012
+                        href: ../../core/testing/mstest-analyzers/mstest0012.md
+                      - name: MSTEST0013
+                        href: ../../core/testing/mstest-analyzers/mstest0013.md
+                      - name: MSTEST0014
+                        href: ../../core/testing/mstest-analyzers/mstest0014.md
+                      - name: MSTEST0017
+                        href: ../../core/testing/mstest-analyzers/mstest0017.md
+                      - name: MSTEST0018
+                        href: ../../core/testing/mstest-analyzers/mstest0018.md
+                      - name: MSTEST0023
+                        href: ../../core/testing/mstest-analyzers/mstest0023.md
+                      - name: MSTEST0024
+                        href: ../../core/testing/mstest-analyzers/mstest0024.md
+                      - name: MSTEST0026
+                        href: ../../core/testing/mstest-analyzers/mstest0026.md
+                      - name: MSTEST0030
+                        href: ../../core/testing/mstest-analyzers/mstest0030.md
+                      - name: MSTEST0031
+                        href: ../../core/testing/mstest-analyzers/mstest0031.md
+                      - name: MSTEST0032
+                        href: ../../core/testing/mstest-analyzers/mstest0032.md
+                      - name: MSTEST0034
+                        href: ../../core/testing/mstest-analyzers/mstest0034.md
+                      - name: MSTEST0035
+                        href: ../../core/testing/mstest-analyzers/mstest0035.md
+                      - name: MSTEST0037
+                        href: ../../core/testing/mstest-analyzers/mstest0037.md
+                      - name: MSTEST0038
+                        href: ../../core/testing/mstest-analyzers/mstest0038.md
+                      - name: MSTEST0039
+                        href: ../../core/testing/mstest-analyzers/mstest0039.md
+                      - name: MSTEST0040
+                        href: ../../core/testing/mstest-analyzers/mstest0040.md
+                      - name: MSTEST0041
+                        href: ../../core/testing/mstest-analyzers/mstest0041.md
+      - name: Test platforms
         items:
-          - name: Overview
-            href: ../../core/testing/unit-testing-platform-intro.md
-          - name: FAQ
-            href: ../../core/testing/unit-testing-platform-faq.md
-          - name: Comparison with VSTest
-            href: ../../core/testing/unit-testing-platform-vs-vstest.md
-          - name: Configure the test platform
-            href: ../../core/testing/unit-testing-platform-config.md
-          - name: Extensions
+          - name: Microsoft Testing Platform
             items:
               - name: Overview
-                href: ../../core/testing/unit-testing-platform-extensions.md
-              - name: Code Coverage
-                href: ../../core/testing/unit-testing-platform-extensions-code-coverage.md
-              - name: Diagnostics
-                href: ../../core/testing/unit-testing-platform-extensions-diagnostics.md
-              - name: Fakes
-                href: ../../core/testing/unit-testing-platform-extensions-fakes.md
-              - name: Hosting
-                href: ../../core/testing/unit-testing-platform-extensions-hosting.md
-              - name: Output
-                href: ../../core/testing/unit-testing-platform-extensions-output.md
-              - name: Policy
-                href: ../../core/testing/unit-testing-platform-extensions-policy.md
-              - name: Test Reports
-                href: ../../core/testing/unit-testing-platform-extensions-test-reports.md
-              - name: VSTest Bridge
-                href: ../../core/testing/unit-testing-platform-extensions-vstest-bridge.md
-          - name: Diagnostics overview
-            href: ../../core/testing/unit-testing-platform-diagnostics.md
-          - name: Optional telemetry
-            href: ../../core/testing/unit-testing-platform-telemetry.md
-          - name: Known exit codes
-            href: ../../core/testing/unit-testing-platform-exit-codes.md
-          - name: Integration with dotnet test
-            href: ../../core/testing/unit-testing-platform-integration-dotnet-test.md
-          - name: Testing platform Architecture
-            items:
-              - name: Overview
-                href: ../../core/testing/unit-testing-platform-architecture.md
-              - name: Capabilities
-                href: ../../core/testing/unit-testing-platform-architecture-capabilities.md
+                href: ../../core/testing/unit-testing-platform-intro.md
+              - name: FAQ
+                href: ../../core/testing/unit-testing-platform-faq.md
+              - name: Comparison with VSTest
+                href: ../../core/testing/unit-testing-platform-vs-vstest.md
+              - name: Configure the test platform
+                href: ../../core/testing/unit-testing-platform-config.md
               - name: Extensions
-                href: ../../core/testing/unit-testing-platform-architecture-extensions.md
-              - name: Services
-                href: ../../core/testing/unit-testing-platform-architecture-services.md
+                items:
+                  - name: Overview
+                    href: ../../core/testing/unit-testing-platform-extensions.md
+                  - name: Code Coverage
+                    href: ../../core/testing/unit-testing-platform-extensions-code-coverage.md
+                  - name: Diagnostics
+                    href: ../../core/testing/unit-testing-platform-extensions-diagnostics.md
+                  - name: Fakes
+                    href: ../../core/testing/unit-testing-platform-extensions-fakes.md
+                  - name: Hosting
+                    href: ../../core/testing/unit-testing-platform-extensions-hosting.md
+                  - name: Output
+                    href: ../../core/testing/unit-testing-platform-extensions-output.md
+                  - name: Policy
+                    href: ../../core/testing/unit-testing-platform-extensions-policy.md
+                  - name: Test Reports
+                    href: ../../core/testing/unit-testing-platform-extensions-test-reports.md
+                  - name: VSTest Bridge
+                    href: ../../core/testing/unit-testing-platform-extensions-vstest-bridge.md
+              - name: Diagnostics overview
+                href: ../../core/testing/unit-testing-platform-diagnostics.md
+              - name: Optional telemetry
+                href: ../../core/testing/unit-testing-platform-telemetry.md
+              - name: Known exit codes
+                href: ../../core/testing/unit-testing-platform-exit-codes.md
+              - name: Integration with dotnet test
+                href: ../../core/testing/unit-testing-platform-integration-dotnet-test.md
+              - name: Testing platform Architecture
+                items:
+                  - name: Overview
+                    href: ../../core/testing/unit-testing-platform-architecture.md
+                  - name: Capabilities
+                    href: ../../core/testing/unit-testing-platform-architecture-capabilities.md
+                  - name: Extensions
+                    href: ../../core/testing/unit-testing-platform-architecture-extensions.md
+                  - name: Services
+                    href: ../../core/testing/unit-testing-platform-architecture-services.md
       - name: Run selective unit tests
         href: ../../core/testing/selective-unit-tests.md
       - name: Order unit tests

--- a/docs/navigate/devops-testing/toc.yml
+++ b/docs/navigate/devops-testing/toc.yml
@@ -61,7 +61,7 @@ items:
                 href: ../../core/testing/unit-testing-fsharp-with-nunit.md
               - name: VB unit testing
                 href: ../../core/testing/unit-testing-visual-basic-with-nunit.md
-              - name: Microsoft.Testing.Platform support in NUnit (aka NUnit runner)
+              - name: Microsoft.Testing.Platform support (NUnit runner)
                 href: ../../core/testing/unit-testing-nunit-runner-intro.md
           - name: MSTest
             items:
@@ -69,7 +69,7 @@ items:
                 href: ../../core/testing/unit-testing-mstest-intro.md
               - name: Migrate MSTest from v1 to v3
                 href: ../../core/testing/unit-testing-mstest-migration-from-v1-to-v3.md
-              - name: Microsoft.Testing.Platform support in MSTest (aka MSTest runner)
+              - name: Microsoft.Testing.Platform support (MSTest runner)
                 href: ../../core/testing/unit-testing-mstest-runner-intro.md
               - name: Getting started
                 items:


### PR DESCRIPTION
### Summary of the changes:

- Restructures the ToC
  - MTP and the test frameworks are now not at the same level. Having them at the same level is misleading. The test frameworks are now grouped under "Test frameworks" node, and MTP is added under "Test platforms" node.
- nit: Rename xUnit header to xUnit.net in testing/index.md
- Enrich the documentation for Testing tools section in testing/index.md
  - Instead of talking right away about test frameworks in that section. It's now divided into two parts. The test platforms and test frameworks. The test platforms gives a quick history overview and mentions MTP. It wasn't ideal that testing/index.md didn't mention MTP at all. As that page is expected to be the first page for users looking into information related to testing.
  - For each major frameworks, there is now a link to enabling MTP support.
- Improve MSTest runner page
  - Clarify that page by making "Microsoft.Testing.Platform" more mainstream in wording and title.
  - Avoid mentioning a preview version. 
  - Add `TestingPlatformDotnetTestSupport` as part of the steps to enable MTP. I have seen projects in reality that enabled MTP only by EnableMSTestRunner, which seems to be like they followed the documentation. So they are not completely migrating to MTP due to that.
- Update NUnit runner page with similar changes as MSTest runner page
- Add xUnit official doc for MTP in ToC 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/ai/conceptual/evaluation-libraries.md](https://github.com/dotnet/docs/blob/6495d8ea105f637d2b59987551587ba8227d6dcd/docs/ai/conceptual/evaluation-libraries.md) | [The Microsoft.Extensions.AI.Evaluation libraries (Preview)](https://review.learn.microsoft.com/en-us/dotnet/ai/conceptual/evaluation-libraries?branch=pr-en-us-45032) |
| [docs/core/testing/index.md](https://github.com/dotnet/docs/blob/6495d8ea105f637d2b59987551587ba8227d6dcd/docs/core/testing/index.md) | [Testing in .NET](https://review.learn.microsoft.com/en-us/dotnet/core/testing/index?branch=pr-en-us-45032) |
| [docs/core/testing/unit-testing-mstest-runner-intro.md](https://github.com/dotnet/docs/blob/6495d8ea105f637d2b59987551587ba8227d6dcd/docs/core/testing/unit-testing-mstest-runner-intro.md) | [Microsoft.Testing.Platform support in MSTest (MSTest runner)](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-runner-intro?branch=pr-en-us-45032) |
| [docs/core/testing/unit-testing-nunit-runner-intro.md](https://github.com/dotnet/docs/blob/6495d8ea105f637d2b59987551587ba8227d6dcd/docs/core/testing/unit-testing-nunit-runner-intro.md) | [docs/core/testing/unit-testing-nunit-runner-intro](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-nunit-runner-intro?branch=pr-en-us-45032) |
| [docs/navigate/devops-testing/toc.yml](https://github.com/dotnet/docs/blob/6495d8ea105f637d2b59987551587ba8227d6dcd/docs/navigate/devops-testing/toc.yml) | [docs/navigate/devops-testing/toc](https://review.learn.microsoft.com/en-us/dotnet/navigate/devops-testing/toc?branch=pr-en-us-45032) |


<!-- PREVIEW-TABLE-END -->