### PR TITLE
Added a curl script into the Linux manual

### DIFF
--- a/docs/core/install/linux-scripted-manual.md
+++ b/docs/core/install/linux-scripted-manual.md
@@ -84,7 +84,7 @@ You can download the script with `wget`:
 wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh
 ```
 
-Or either with `curl`:
+Or, with `curl`:
 
 ```bash
 curl -L https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh

--- a/docs/core/install/linux-scripted-manual.md
+++ b/docs/core/install/linux-scripted-manual.md
@@ -84,6 +84,12 @@ You can download the script with `wget`:
 wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh
 ```
 
+Or either with `curl`:
+
+```bash
+curl -L https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh
+```
+
 Before running this script, make sure you grant permission for this script to run as an executable:
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a tiny `curl` based script into the Linux docs as not every system has `wget`.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/linux-scripted-manual.md](https://github.com/dotnet/docs/blob/7f050f152ad0534a2283da18d97c04ca5eb81ac6/docs/core/install/linux-scripted-manual.md) | [Install .NET on Linux by using an install script or by extracting binaries](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-scripted-manual?branch=pr-en-us-45043) |


<!-- PREVIEW-TABLE-END -->