### PR TITLE
Add links to latest breaking changes

### DIFF
--- a/docs/visual-basic/whats-new/breaking-changes.md
+++ b/docs/visual-basic/whats-new/breaking-changes.md
@@ -10,6 +10,8 @@ ms.date: 08/18/2020
 
 The [Roslyn](https://github.com/dotnet/roslyn) team maintains a list of breaking changes in the C# and Visual Basic compilers. You can find information on those changes at these links on their GitHub repository:
 
+- [Compiler breaking changes in .NET 10](https://github.com/dotnet/roslyn/blob/main/docs/compilers/Visual%20Basic/Compiler%20Breaking%20Changes%20-%20DotNet%2010.md)
+- [Compiler breaking changes in .NET 7](https://github.com/dotnet/roslyn/blob/main/docs/compilers/Visual%20Basic/Compiler%20Breaking%20Changes%20-%20DotNet%207.md)
 - [Breaking changes in VS2019 Update 1 and beyond compared to VS2019](https://github.com/dotnet/roslyn/blob/main/docs/compilers/Visual%20Basic/Compiler%20Breaking%20Changes%20-%20post%20VS2019.md)
 - [Breaking changes since VS2017 (VB 15)](https://github.com/dotnet/roslyn/blob/main/docs/compilers/Visual%20Basic/Compiler%20Breaking%20Changes%20-%20post%20VS2017.md)
 - [Breaking changes in Roslyn 3.0 (VS2019) from Roslyn 2.* (VS2017)](https://github.com/dotnet/roslyn/blob/main/docs/compilers/Visual%20Basic/Compiler%20Breaking%20Changes%20-%20VS2019.md)


### PR DESCRIPTION
Add links to the last two breaking changes docs.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/visual-basic/whats-new/breaking-changes.md](https://github.com/dotnet/docs/blob/82565c6ea557766fe1cbcdc1bfed0a599f9cf5bf/docs/visual-basic/whats-new/breaking-changes.md) | [Learn about any breaking changes in the Visual Basic compiler](https://review.learn.microsoft.com/en-us/dotnet/visual-basic/whats-new/breaking-changes?branch=pr-en-us-45048) |

<!-- PREVIEW-TABLE-END -->