### PR TITLE
Add --configfile option to dotnet nuget push command 

### DIFF
--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -20,6 +20,7 @@ dotnet nuget push [<ROOT>] [-d|--disable-buffering] [--force-english-output]
     [--no-service-endpoint] [-s|--source <SOURCE>] [--skip-duplicate]
     [-sk|--symbol-api-key <API_KEY>] [-ss|--symbol-source <SOURCE>]
     [-t|--timeout <TIMEOUT>]
+    [--configfile <FILE>]
 
 dotnet nuget push -h|--help
 ```
@@ -93,6 +94,10 @@ Alternatively, use the NuGet CLI for the first package, then you can use `dotnet
 - **`-t|--timeout <TIMEOUT>`**
 
   Specifies the timeout for pushing to a server in seconds. Defaults to 300 seconds (5 minutes). Specifying 0 applies the default value.
+
+- **`--configfile`**
+
+  The NuGet configuration file (*nuget.config*) to use. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see [Common NuGet Configurations](/nuget/consume-packages/configuring-nuget-behavior).
 
 ## Examples
 


### PR DESCRIPTION
## Summary

Describe your changes here.

Fixes https://github.com/NuGet/Home/issues/4879

Adds documentation for the option --configfile to the command dotnet nuget push. 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-nuget-push.md](https://github.com/dotnet/docs/blob/1d4e59982ac321ec6920061acbb07503b5e2dd73/docs/core/tools/dotnet-nuget-push.md) | [docs/core/tools/dotnet-nuget-push](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-push?branch=pr-en-us-45050) |

<!-- PREVIEW-TABLE-END -->