### PR TITLE
Fix SeeAlso links in dotnet10 P1 announcement

### DIFF
--- a/docs/core/whats-new/dotnet-10/overview.md
+++ b/docs/core/whats-new/dotnet-10/overview.md
@@ -97,6 +97,6 @@ For more information, see [What's new in Windows Forms for .NET 10](/dotnet/desk
 
 ## See also
 
-- [.NET 10 Preview 1 container image updates](https://github.com/dotnet/core/blob/dotnet10p1/release-notes/10.0/preview/preview1/containers.md)
-- [F# updates in .NET 10 Preview 1](https://github.com/dotnet/core/blob/dotnet10p1/release-notes/10.0/preview/preview1/fsharp.md)
-- [Visual Basic updates in .NET 10 Preview 1](https://github.com/dotnet/core/blob/dotnet10p1/release-notes/10.0/preview/preview1/visualbasic.md)
+- [.NET 10 Preview 1 container image updates](https://github.com/dotnet/core/blob/main/release-notes/10.0/preview/preview1/containers.md)
+- [F# updates in .NET 10 Preview 1](https://github.com/dotnet/core/blob/main/release-notes/10.0/preview/preview1/fsharp.md)
+- [Visual Basic updates in .NET 10 Preview 1](https://github.com/dotnet/core/blob/main/release-notes/10.0/preview/preview1/visualbasic.md)


### PR DESCRIPTION
The links were linking to the dotnet10p1 branch, such as https://github.com/dotnet/core/blob/dotnet10p1/release-notes/10.0/preview/preview1/fsharp.md .

This branch does not exist, and links lead to 404 Not found. This makes a quick fix for it.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/whats-new/dotnet-10/overview.md](https://github.com/dotnet/docs/blob/44224adb15fd7fb4adad23ec01f48fb1ab8f2895/docs/core/whats-new/dotnet-10/overview.md) | [docs/core/whats-new/dotnet-10/overview](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-10/overview?branch=pr-en-us-45058) |

<!-- PREVIEW-TABLE-END -->