### PR TITLE
Update branches-and-loops doc to improve if statement explanation

### DIFF
--- a/docs/csharp/tour-of-csharp/tutorials/branches-and-loops-local.md
+++ b/docs/csharp/tour-of-csharp/tutorials/branches-and-loops-local.md
@@ -103,7 +103,7 @@ else
 
 The `==` symbol tests for *equality*. Using `==` distinguishes the test for equality from assignment, which you saw in `a = 5`.
 
-The `&&` represents "and". It means both conditions must be true to execute the statement in the true branch.  These examples also show that you can have multiple statements in each conditional branch, provided you enclose them in `{` and `}`. You can also use  `||` to represent "or". Add the following code after what you've written so far:
+The `&&` represents "and". It means both conditions must be true to execute the statement in the true branch.  These examples also show that you can have multiple statements in each conditional branch, as long as you enclose them in `{` and `}`. You can also use  `||` to represent "or". Add the following code after what you've written so far:
 
 ```csharp
 if ((a + b + c > 10) || (a == b))


### PR DESCRIPTION
Clarify conditional statement explanation by replacing 'provided' with 'as long as' to improve readability

## Summary

Replaced 'provided' with 'as long as' to improve readability for users.




<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/tour-of-csharp/tutorials/branches-and-loops-local.md](https://github.com/dotnet/docs/blob/96dfd013c5aff958a4977bce4cff6be5b54e3ca2/docs/csharp/tour-of-csharp/tutorials/branches-and-loops-local.md) | [C# `if` statements and loops - conditional logic tutorial](https://review.learn.microsoft.com/en-us/dotnet/csharp/tour-of-csharp/tutorials/branches-and-loops-local?branch=pr-en-us-45061) |

<!-- PREVIEW-TABLE-END -->