### PR TITLE
Improve snippets in XML documentation comments example page

### DIFF
--- a/docs/csharp/language-reference/xmldoc/snippets/xmldoc/DocComments.cs
+++ b/docs/csharp/language-reference/xmldoc/snippets/xmldoc/DocComments.cs
@@ -164,8 +164,8 @@ namespace XmlTags
     /// This tag will apply to the primary constructor parameter.
     /// </param>
     public record Person(string FirstName, string LastName);
+    //</ClassExample>
 }
-//</ClassExample>
 
 namespace InheritDoc
 {

--- a/docs/csharp/language-reference/xmldoc/snippets/xmldoc/tagged-library.cs
+++ b/docs/csharp/language-reference/xmldoc/snippets/xmldoc/tagged-library.cs
@@ -4,7 +4,7 @@
         The main Math class
         Contains all methods for performing basic math functions
     */
-        /// <summary>
+    /// <summary>
     /// The main <c>Math</c> class.
     /// Contains all methods for performing basic math functions.
     /// <list type="bullet">


### PR DESCRIPTION
## Summary

Move `ClassExample` snippet closing tag inside of the namespace, to prevent an extra level of indentation and a stray closing brace in the rendered output. This PR also includes a slight formatting fix in `tagged-library.cs`.
