### PR TITLE
Remove link to https://github.com/MicrosoftDocs/feedback

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: learn.microsoft.com site feedback
-    url: https://github.com/MicrosoftDocs/feedback/issues/new/choose
-    about: Log general learn.microsoft.com site issues here
   - name: .NET platform and other product feedback
     url: https://aka.ms/feedback/report?space=61
     about: Log product issues here


### PR DESCRIPTION
The feedback repo is now read-only.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/ISSUE_TEMPLATE/config.yml](https://github.com/dotnet/docs/blob/61405ee4dcd56c5269fdf375f7a78480d035517c/.github/ISSUE_TEMPLATE/config.yml) | [.github/ISSUE_TEMPLATE/config](https://review.learn.microsoft.com/en-us/dotnet/.github/ISSUE_TEMPLATE/config?branch=pr-en-us-45077) |

<!-- PREVIEW-TABLE-END -->