### PR TITLE
Fix EventIDs for Method Rundown Events

### DIFF
--- a/docs/framework/performance/method-etw-events.md
+++ b/docs/framework/performance/method-etw-events.md
@@ -91,8 +91,8 @@ The following table shows the event information:
 |-----------|--------------|-----------------|
 |`MethodLoadVerbose_V1`|143|Raised when a method is JIT-loaded or an NGEN image is loaded. Dynamic and generic methods always use this version for method loads. JIT helpers always use this version.|
 |`MethodUnLoadVerbose_V1`|144|Raised when a dynamic method is destroyed, a module is unloaded, or an application domain is destroyed. Dynamic methods always use this version for method unloads.|
-|`MethodDCStartVerbose_V1`|141|Enumerates methods during a start rundown.|
-|`MethodDCEndVerbose_V1`|142|Enumerates methods during an end rundown.|
+|`MethodDCStartVerbose_V1`|143|Enumerates methods during a start rundown.|
+|`MethodDCEndVerbose_V1`|144|Enumerates methods during an end rundown.|
 
 The following table shows the event data:
 


### PR DESCRIPTION
## Summary

Fixed the event IDs for the `MethodDCStartVerbose_V1` and `MethodDCEndVerbose_V1` events to match the ETW manifest at https://github.com/dotnet/runtime/blob/main/src/coreclr/vm/ClrEtwAll.man#L5062.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/performance/method-etw-events.md](https://github.com/dotnet/docs/blob/df42197d14ee7f8f8af858d337533d6a81fe1a2c/docs/framework/performance/method-etw-events.md) | [Method ETW Events](https://review.learn.microsoft.com/en-us/dotnet/framework/performance/method-etw-events?branch=pr-en-us-45080) |

<!-- PREVIEW-TABLE-END -->