### PR TITLE
Fix package name in developer-app-secrets-storage.md

### DIFF
--- a/docs/architecture/microservices/secure-net-microservices-web-applications/developer-app-secrets-storage.md
+++ b/docs/architecture/microservices/secure-net-microservices-web-applications/developer-app-secrets-storage.md
@@ -35,7 +35,7 @@ To access these values from environment variables, the application just needs to
 
 ## Store secrets with the ASP.NET Core Secret Manager
 
-The ASP.NET Core [Secret Manager](/aspnet/core/security/app-secrets#secret-manager) tool provides another method of keeping secrets out of source code **during development**. To use the Secret Manager tool, install the package **Microsoft.Extensions.Configuration.SecretManager** in your project file. Once that dependency is present and has been restored, the `dotnet user-secrets` command can be used to set the value of secrets from the command line. These secrets will be stored in a JSON file in the user’s profile directory (details vary by OS), away from source code.
+The ASP.NET Core [Secret Manager](/aspnet/core/security/app-secrets#secret-manager) tool provides another method of keeping secrets out of source code **during development**. To use the Secret Manager tool, install the package **Microsoft.Extensions.Configuration.UserSecrets** in your project file. Once that dependency is present and has been restored, the `dotnet user-secrets` command can be used to set the value of secrets from the command line. These secrets will be stored in a JSON file in the user’s profile directory (details vary by OS), away from source code.
 
 Secrets set by the Secret Manager tool are organized by the `UserSecretsId` property of the project that's using the secrets. Therefore, you must be sure to set the UserSecretsId property in your project file, as shown in the snippet below. The default value is a GUID assigned by Visual Studio, but the actual string is not important as long as it's unique in your computer.
 


### PR DESCRIPTION
## Summary

`Microsoft.Extensions.Configuration.SecretManager` doesn't exist.
Proof:
- https://www.nuget.org/packages?q=Microsoft.Extensions.Configuration.SecretManager
- https://www.nuget.org/packages?q=Microsoft.Extensions.Configuration.UserSecrets


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/architecture/microservices/secure-net-microservices-web-applications/developer-app-secrets-storage.md](https://github.com/dotnet/docs/blob/eca569764fd32418fdd3faf9841dfa9747db9785/docs/architecture/microservices/secure-net-microservices-web-applications/developer-app-secrets-storage.md) | [docs/architecture/microservices/secure-net-microservices-web-applications/developer-app-secrets-storage](https://review.learn.microsoft.com/en-us/dotnet/architecture/microservices/secure-net-microservices-web-applications/developer-app-secrets-storage?branch=pr-en-us-45081) |

<!-- PREVIEW-TABLE-END -->