### PR TITLE
List Source Link in the set of deterministic inputs

### DIFF
--- a/docs/csharp/language-reference/compiler-options/code-generation.md
+++ b/docs/csharp/language-reference/compiler-options/code-generation.md
@@ -80,6 +80,7 @@ By default, compiler output from a given set of inputs is unique, since the comp
   - @ response files
   - Analyzers
   - Rulesets
+  - [Source Link](https://github.com/dotnet/sourcelink) data extracted from the repository (e.g. git commit SHA, repository URL, etc.)
   - Other files that may be used by analyzers
 - The current culture (for the language in which diagnostics and exception messages are produced).
 - The default encoding (or the current code page) if the encoding isn't specified.


### PR DESCRIPTION
Follow-up on https://github.com/dotnet/sdk/issues/37371


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-options/code-generation.md](https://github.com/dotnet/docs/blob/3d75eca51a164eb351f85dd48ad587d9a80a41e8/docs/csharp/language-reference/compiler-options/code-generation.md) | [docs/csharp/language-reference/compiler-options/code-generation](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/code-generation?branch=pr-en-us-45110) |

<!-- PREVIEW-TABLE-END -->