### PR TITLE
Add a sequester monthly mode.

### DIFF
--- a/.github/workflows/quest-bulk.yml
+++ b/.github/workflows/quest-bulk.yml
@@ -2,6 +2,8 @@ name: "bulk quest import"
 on:
   schedule:
     - cron: '0 10 * * *' # UTC time, that's 5:00 am EST, 2:00 am PST.
+    - cron: '0 9 6 * *'  # This is the morning of the 6th.
+
   workflow_dispatch:
     inputs:
       reason:
@@ -56,4 +58,4 @@ jobs:
           org: ${{ github.repository_owner }}
           repo: ${{ github.repository }}
           issue: '-1'
-          duration: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.duration || 5 }}
+          duration: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.duration || github.event.schedule == '0 9 6 * *' && -1 || 5 }}


### PR DESCRIPTION
This mode runs once per month on all open issues. That moves issues not slipped but not rescheduled into the backlog sprint.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/workflows/quest-bulk.yml](https://github.com/dotnet/docs/blob/e976e9972043207390a80f231bf305541340d255/.github/workflows/quest-bulk.yml) | [.github/workflows/quest-bulk](https://review.learn.microsoft.com/en-us/dotnet/.github/workflows/quest-bulk?branch=pr-en-us-45154) |

<!-- PREVIEW-TABLE-END -->