### PR TITLE
Try again with files match pattern

### DIFF
--- a/.github/policies/disallow-edits.yml
+++ b/.github/policies/disallow-edits.yml
@@ -73,6 +73,9 @@ configuration:
           - commentContains:
               pattern: '#sign-off'
               isRegex: False
+          - filesMatchPattern:
+              pattern: docs/csharp/*
+              matchAny: True
           - not:
               isActivitySender:
                 user: BillWagner


### PR DESCRIPTION
Since I changed two things last time instead of just one, and now that the policy is working.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/policies/disallow-edits.yml](https://github.com/dotnet/docs/blob/4d0baa0c4a7fa710f5bbba8c73f8e7199d43b390/.github/policies/disallow-edits.yml) | [.github/policies/disallow-edits](https://review.learn.microsoft.com/en-us/dotnet/.github/policies/disallow-edits?branch=pr-en-us-45156) |

<!-- PREVIEW-TABLE-END -->