### PR TITLE
`implementing-dispose.md`:  Better illustration of SafeHandles

### DIFF
--- a/docs/standard/garbage-collection/implementing-dispose.md
+++ b/docs/standard/garbage-collection/implementing-dispose.md
@@ -15,7 +15,7 @@ ms.topic: how-to
 
 The <xref:System.IDisposable.Dispose%2A> method is primarily implemented to release unmanaged resources. When working with instance members that are <xref:System.IDisposable> implementations, it's common to cascade <xref:System.IDisposable.Dispose%2A> calls. There are other reasons for implementing <xref:System.IDisposable.Dispose%2A>, for example, to free memory that was allocated, remove an item that was added to a collection, or signal the release of a lock that was acquired.
 
-The [.NET garbage collector](index.md) doesn't allocate or release unmanaged memory. The pattern for disposing an object, referred to as the dispose pattern, imposes order on the lifetime of an object. The dispose pattern is used for objects that implement the <xref:System.IDisposable> interface. This pattern is common when interacting with file and pipe handles, registry handles, wait handles, or pointers to blocks of unmanaged memory, because the garbage collector is unable to reclaim unmanaged objects.
+The [.NET garbage collector](index.md) doesn't allocate or release unmanaged memory. The pattern for disposing an object, referred to as the [dispose pattern](../design-guidelines/dispose-pattern.md), imposes order on the lifetime of an object. The dispose pattern is used for objects that implement the <xref:System.IDisposable> interface. This pattern is common when interacting with file and pipe handles, registry handles, wait handles, or pointers to blocks of unmanaged memory, because the garbage collector is unable to reclaim unmanaged objects.
 
 To help ensure that resources are always cleaned up appropriately, a <xref:System.IDisposable.Dispose%2A> method should be idempotent, such that it's callable multiple times without throwing an exception. Furthermore, subsequent invocations of <xref:System.IDisposable.Dispose%2A> should do nothing.
 
@@ -23,23 +23,18 @@ The code example provided for the <xref:System.GC.KeepAlive%2A?displayProperty=n
 
 [!INCLUDE [disposables-and-dependency-injection](includes/disposables-and-dependency-injection.md)]
 
-## Safe handles
+## Cascade dispose calls
 
-Writing code for an object's finalizer is a complex task that can cause problems if not done correctly. Therefore, we recommend that you construct <xref:System.Runtime.InteropServices.SafeHandle?displayProperty=nameWithType> objects instead of implementing a finalizer.
+If your class owns an instance of another type that implements <xref:System.IDisposable> storing it in a field or property, the containing class itself should also implement <xref:System.IDisposable>. Typically a class that instantiates an <xref:System.IDisposable> implementation and stores it as an instance member is also responsible for its cleanup. This helps ensure that the referenced disposable types are given the opportunity to deterministically perform cleanup through the <xref:System.IDisposable.Dispose%2A> method. In the following example, the class is `sealed` (or `NotInheritable` in Visual Basic).
 
-A <xref:System.Runtime.InteropServices.SafeHandle?displayProperty=nameWithType> is an abstract managed type that wraps an <xref:System.IntPtr?displayProperty=nameWithType> that identifies an unmanaged resource. On Windows it might identify a handle, and on Unix, a file descriptor. The `SafeHandle` provides all of the logic necessary to ensure that this resource is released once and only once, either when the `SafeHandle` is disposed of or when all references to the `SafeHandle` have been dropped and the `SafeHandle` instance is finalized.
+:::code language="csharp" source="../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.disposable/cs/Foo.cs":::
+:::code language="vb" source="../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.disposable/vb/Foo.vb":::
 
-The <xref:System.Runtime.InteropServices.SafeHandle?displayProperty=nameWithType> is an abstract base class. Derived classes provide specific instances for different kinds of handle. These derived classes validate what values for the <xref:System.IntPtr?displayProperty=nameWithType> are considered invalid and how to actually free the handle. For example, <xref:Microsoft.Win32.SafeHandles.SafeFileHandle> derives from `SafeHandle` to wrap `IntPtrs` that identify open file handles/descriptors, and overrides its <xref:System.Runtime.InteropServices.SafeHandle.ReleaseHandle?displayProperty=nameWithType> method to close it (via the `close` function on Unix or `CloseHandle` function on Windows). Most APIs in .NET libraries that create an unmanaged resource wraps it in a `SafeHandle` and return that `SafeHandle` to you as needed, rather than handing back the raw pointer. In situations where you interact with an unmanaged component and get an `IntPtr` for an unmanaged resource, you can create your own `SafeHandle` type to wrap it. As a result, few non-`SafeHandle` types need to implement finalizers. Most disposable pattern implementations only end up wrapping other managed resources, some of which may be `SafeHandle` objects.
-
-The following derived classes in the <xref:Microsoft.Win32.SafeHandles> namespace provide safe handles.
-
-| Class | Resources it holds |
-| - | - |
-| <xref:Microsoft.Win32.SafeHandles.SafeFileHandle><br/><xref:Microsoft.Win32.SafeHandles.SafeMemoryMappedFileHandle><br/><xref:Microsoft.Win32.SafeHandles.SafePipeHandle> | Files, memory mapped files, and pipes |
-| <xref:Microsoft.Win32.SafeHandles.SafeMemoryMappedViewHandle> | Memory views |
-| <xref:Microsoft.Win32.SafeHandles.SafeNCryptKeyHandle><br/><xref:Microsoft.Win32.SafeHandles.SafeNCryptProviderHandle><br/><xref:Microsoft.Win32.SafeHandles.SafeNCryptSecretHandle> |Cryptography constructs |
-| <xref:Microsoft.Win32.SafeHandles.SafeRegistryHandle> | Registry keys |
-| <xref:Microsoft.Win32.SafeHandles.SafeWaitHandle> | Wait handles |
+> [!TIP]
+>
+> - If your class has an <xref:System.IDisposable> field or property but doesn't *own* it, then the class doesn't need to implement <xref:System.IDisposable>.
+>   - It's the developers' responsibility to define a clean ownership model that ensures the disposal of all <xref:System.IDisposable> instances in an object graph. Typically a class creating and storing the <xref:System.IDisposable> child object also becomes the owner, but in some cases the ownership can be transferred to another <xref:System.IDisposable> type.
+> - There are cases when you may want to perform `null`-checking in a finalizer (which includes the `Dispose(false)` method invoked by a finalizer). One of the primary reasons is if you're unsure whether the instance got fully initialized (for example, an exception might be thrown in a constructor).
 
 ## Dispose() and Dispose(bool)
 
@@ -81,41 +76,43 @@ The body of the method consists of three blocks of code:
 
 If the method call comes from a finalizer, only the code that frees unmanaged resources should execute. The implementer is responsible for ensuring that the false path doesn't interact with managed objects that may have been disposed. This is important because the order in which the garbage collector disposes managed objects during finalization is nondeterministic.
 
-## Cascade dispose calls
-
-If your class owns a field or property and its type implements <xref:System.IDisposable>, the containing class itself should also implement <xref:System.IDisposable>. A class that instantiates an <xref:System.IDisposable> implementation and stores it as an instance member is also responsible for its cleanup. This helps ensure that the referenced disposable types are given the opportunity to deterministically perform cleanup through the <xref:System.IDisposable.Dispose%2A> method. In the following example, the class is `sealed` (or `NotInheritable` in Visual Basic).
-
-:::code language="csharp" source="../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.disposable/cs/Foo.cs":::
-:::code language="vb" source="../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.disposable/vb/Foo.vb":::
-
-> [!TIP]
->
-> - If your class has an <xref:System.IDisposable> field or property but doesn't *own* it, meaning the class doesn't create the object, then the class doesn't need to implement <xref:System.IDisposable>.
-> - There are cases when you may want to perform `null`-checking in a finalizer (which includes the `Dispose(false)` method invoked by a finalizer). One of the primary reasons is if you're unsure whether the instance got fully initialized (for example, an exception might be thrown in a constructor).
-
 ## Implement the dispose pattern
 
-All non-sealed classes (or Visual Basic classes not modified as `NotInheritable`) should be considered a potential base class, because they could be inherited. If you implement the dispose pattern for any potential base class, you must provide the following:
+All non-sealed classes (or Visual Basic classes not modified as `NotInheritable`) should be considered a potential base class, because they could be inherited. If you implement the dispose pattern for any potential base class, you must add the following methods to your class:
 
 - A <xref:System.IDisposable.Dispose%2A> implementation that calls the `Dispose(bool)` method.
 - A `Dispose(bool)` method that performs the actual cleanup.
-- Either a class derived from <xref:System.Runtime.InteropServices.SafeHandle> that wraps your unmanaged resource (recommended), or an override to the <xref:System.Object.Finalize%2A?displayProperty=nameWithType> method. The <xref:System.Runtime.InteropServices.SafeHandle> class provides a finalizer, so you don't have to write one yourself.
+- If your class deals with unmanaged resources either provide an override to the <xref:System.Object.Finalize%2A?displayProperty=nameWithType> method, or wrap the unmanaged resource in a <xref:System.Runtime.InteropServices.SafeHandle>.
+
+Either a class derived from <xref:System.Runtime.InteropServices.SafeHandle> that wraps your unmanaged resource (recommended)
 
 > [!IMPORTANT]
-> It's possible for a base class to only reference managed objects and implement the dispose pattern. In these cases, a finalizer is unnecessary. A finalizer is only required if you directly reference unmanaged resources.
+> A finalizer (a <xref:System.Object.Finalize%2A?displayProperty=nameWithType> override) is only required if you directly reference unmanaged resources. This is only needed in a few advanced scenarios, therefore in most cases finalizers can be avoided.
+>
+> - It's possible for a class to only reference managed objects and implement the dispose pattern. There is no need to implement a finalizer in such cases and the base class will always call `Dispose(bool)` with `disposing: true`. The reason the dispose pattern is still encouraged is that it enables sub classes to implement a finalizer and call `Dispose(disposing: false)` on the base class.
+> - In the rare cases when it's necessary to deal with unmanaged resources (which are typically represented by <xref:System.IntPtr> handles), **we strongly recommend to wrap the handle into a <xref:System.Runtime.InteropServices.SafeHandle>**. The <xref:System.Runtime.InteropServices.SafeHandle> provides a finalizer so you don't have to write one yourself. See the [Safe handles](#safe-handles) paragraph for more information.
 
-Here's a general example of implementing the dispose pattern for a base class that uses a safe handle.
+### Base class with managed resources
+
+Here's a general example of implementing the dispose pattern for a base class that only owns managed resources.
 
 :::code language="csharp" source="../../../samples/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/base1.cs":::
 :::code language="vb" source="../../../samples/snippets/visualbasic/VS_Snippets_CLR_System/system.idisposable/vb/base1.vb":::
 
 > [!NOTE]
-> The previous example uses a <xref:Microsoft.Win32.SafeHandles.SafeFileHandle> object to illustrate the pattern; any object derived from <xref:System.Runtime.InteropServices.SafeHandle> could be used instead. Note that the example does not properly instantiate its <xref:Microsoft.Win32.SafeHandles.SafeFileHandle> object.
+> The previous example uses a **dummy** <xref:System.IO.MemoryStream> object to illustrate the pattern. Any <xref:System.IDisposable> could be used instead.
 
-Here's the general pattern for implementing the dispose pattern for a base class that overrides <xref:System.Object.Finalize%2A?displayProperty=nameWithType>.
+### Base class with unmanaged resources
+
+Here's an example for implementing the dispose pattern for a base class that overrides <xref:System.Object.Finalize%2A?displayProperty=nameWithType> in order to clean up unmanaged resources it owns. The example also demonstrates a way to implement `Dispose(bool)` in a thread-safe manner. Synchronization might be critical when dealing with unmanaged resources in a multi-threaded application.
 
 :::code language="csharp" source="../../../samples/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/base2.cs":::
 :::code language="vb" source="../../../samples/snippets/visualbasic/VS_Snippets_CLR_System/system.idisposable/vb/base2.vb":::
+
+> [!NOTE]
+>
+> - The previous example uses <xref:System.Runtime.InteropServices.AllocHGlobal%2> to allocate 10 bytes on the unmanaged heap in the constructor and free the buffer in `Dispose(bool)` by calling <xref:System.Runtime.InteropServices.FreeHGlobal%2>. This is a **dummy** allocation for illustrational purpose.
+> - The approach in the previous example might lead to complex code and it's discouraged. It is recommended to avoid implementing a finalizer by [wrapping unmanaged resources into <xref:System.Runtime.InteropServices.SafeHandle> instances](#implement-the-dispose-pattern-using-a-custom-safe-handle).
 
 > [!TIP]
 > In C#, you implement a finalization by providing a [finalizer](../../csharp/programming-guide/classes-and-structs/finalizers.md), not by overriding <xref:System.Object.Finalize%2A?displayProperty=nameWithType>. In Visual Basic, you create a finalizer with `Protected Overrides Sub Finalize()`.
@@ -140,6 +137,36 @@ Here's the general pattern for implementing the dispose pattern for a derived cl
 :::code language="csharp" source="../../../samples/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/derived2.cs":::
 :::code language="vb" source="../../../samples/snippets/visualbasic/VS_Snippets_CLR_System/system.idisposable/vb/derived2.vb":::
 
+## Safe handles
+
+Writing code for an object's finalizer is a complex task that can cause problems if not done correctly. Therefore, we recommend that you construct <xref:System.Runtime.InteropServices.SafeHandle?displayProperty=nameWithType> objects instead of implementing a finalizer.
+
+A <xref:System.Runtime.InteropServices.SafeHandle?displayProperty=nameWithType> is an abstract managed type that wraps an <xref:System.IntPtr?displayProperty=nameWithType> that identifies an unmanaged resource. On Windows it might identify a handle, and on Unix, a file descriptor. The `SafeHandle` provides all of the logic necessary to ensure that this resource is released once and only once, either when the `SafeHandle` is disposed of or when all references to the `SafeHandle` have been dropped and the `SafeHandle` instance is finalized.
+
+The <xref:System.Runtime.InteropServices.SafeHandle?displayProperty=nameWithType> is an abstract base class. Derived classes provide specific instances for different kinds of handle. These derived classes validate what values for the <xref:System.IntPtr?displayProperty=nameWithType> are considered invalid and how to actually free the handle. For example, <xref:Microsoft.Win32.SafeHandles.SafeFileHandle> derives from `SafeHandle` to wrap `IntPtrs` that identify open file handles/descriptors, and overrides its <xref:System.Runtime.InteropServices.SafeHandle.ReleaseHandle?displayProperty=nameWithType> method to close it (via the `close` function on Unix or `CloseHandle` function on Windows). Most APIs in .NET libraries that create an unmanaged resource wraps it in a `SafeHandle` and return that `SafeHandle` to you as needed, rather than handing back the raw pointer. In situations where you interact with an unmanaged component and get an `IntPtr` for an unmanaged resource, you can create your own `SafeHandle` type to wrap it. As a result, few non-`SafeHandle` types need to implement finalizers. Most disposable pattern implementations only end up wrapping other managed resources, some of which may be `SafeHandle` objects.
+
+### Implement the dispose pattern using a custom safe handle
+
+The following code demonstrates how to handle unmanaged resources by implementing a <xref:System.Runtime.InteropServices.SafeHandle>. It's behavior is equivalent to the code [in the previous example](#base-class-with-unmanaged-resources) demonstrating unmanaged resource handling, however this approach is considered to be safer:
+
+- There is no need to implement a finalizer, <xref:System.Runtime.InteropServices.SafeHandle> will take care of finalization.
+- There is no need for synchronization to guarantee thread-safety. Even though there is a race condition allowing the `if (!_isDisposed)` branch to be entered multiple times, <xref:System.Runtime.InteropServices.SafeHandle.Dispose%2> guarantees that <xref:System.Runtime.InteropServices.SafeHandle.ReleaseHandle%2> will be only called once.
+
+:::code language="csharp" source="../../../samples/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/safe.cs":::
+:::code language="vb" source="../../../samples/snippets/visualbasic/VS_Snippets_CLR_System/system.idisposable/vb/safe.vb":::
+
+### Built-in safe handles in .NET
+
+The following derived classes in the <xref:Microsoft.Win32.SafeHandles> namespace provide safe handles.
+
+| Class | Resources it holds |
+| - | - |
+| <xref:Microsoft.Win32.SafeHandles.SafeFileHandle><br/><xref:Microsoft.Win32.SafeHandles.SafeMemoryMappedFileHandle><br/><xref:Microsoft.Win32.SafeHandles.SafePipeHandle> | Files, memory mapped files, and pipes |
+| <xref:Microsoft.Win32.SafeHandles.SafeMemoryMappedViewHandle> | Memory views |
+| <xref:Microsoft.Win32.SafeHandles.SafeNCryptKeyHandle><br/><xref:Microsoft.Win32.SafeHandles.SafeNCryptProviderHandle><br/><xref:Microsoft.Win32.SafeHandles.SafeNCryptSecretHandle> |Cryptography constructs |
+| <xref:Microsoft.Win32.SafeHandles.SafeRegistryHandle> | Registry keys |
+| <xref:Microsoft.Win32.SafeHandles.SafeWaitHandle> | Wait handles |
+
 ## See also
 
 - [Disposal of services](../../core/extensions/dependency-injection-guidelines.md#disposal-of-services)
@@ -150,3 +177,4 @@ Here's the general pattern for implementing the dispose pattern for a derived cl
 - <xref:System.Runtime.InteropServices.SafeHandle?displayProperty=nameWithType>
 - <xref:System.Object.Finalize%2A?displayProperty=nameWithType>
 - [Define and consume classes and structs (C++/CLI)](/cpp/dotnet/how-to-define-and-consume-classes-and-structs-cpp-cli)
+- [The SafeHandle class](../../fundamentals/runtime-libraries/system-runtime-interopservices-safehandle.md)

--- a/docs/standard/garbage-collection/implementing-dispose.md
+++ b/docs/standard/garbage-collection/implementing-dispose.md
@@ -108,7 +108,7 @@ Here's an example for implementing the dispose pattern for a base class that ove
 
 > [!NOTE]
 >
-> - The previous example uses <xref:System.Runtime.InteropServices.Marshal.AllocHGlobal%2> to allocate 10 bytes on the unmanaged heap in the constructor and free the buffer in `Dispose(bool)` by calling <xref:System.Runtime.Marshal.InteropServices.FreeHGlobal%2>. This is a dummy allocation for illustrational purpose.
+> - The previous example uses <xref:System.Runtime.InteropServices.Marshal.AllocHGlobal%2A> to allocate 10 bytes on the unmanaged heap in the constructor and free the buffer in `Dispose(bool)` by calling <xref:System.Runtime.Marshal.InteropServices.FreeHGlobal%2A>. This is a dummy allocation for illustrational purpose.
 > - Again, it's recommended to avoid implementing a finalizer. See [Implement the dispose pattern using a custom safe handle](#implement-the-dispose-pattern-using-a-custom-safe-handle) for an equivalent of the previous example that delegates non-deterministic finalization and synchronization to <xref:System.Runtime.InteropServices.SafeHandle>.
 
 > [!TIP]

--- a/docs/standard/garbage-collection/implementing-dispose.md
+++ b/docs/standard/garbage-collection/implementing-dispose.md
@@ -108,7 +108,7 @@ Here's an example for implementing the dispose pattern for a base class that ove
 
 > [!NOTE]
 >
-> - The previous example uses <xref:System.Runtime.InteropServices.Marshal.AllocHGlobal%2A> to allocate 10 bytes on the unmanaged heap in the constructor and free the buffer in `Dispose(bool)` by calling <xref:System.Runtime.Marshal.InteropServices.FreeHGlobal%2A>. This is a dummy allocation for illustrational purpose.
+> - The previous example uses <xref:System.Runtime.InteropServices.Marshal.AllocHGlobal%2A> to allocate 10 bytes on the unmanaged heap in the constructor and free the buffer in `Dispose(bool)` by calling <xref:System.Runtime.InteropServices.Marshal.FreeHGlobal%2A>. This is a dummy allocation for illustrational purpose.
 > - Again, it's recommended to avoid implementing a finalizer. See [Implement the dispose pattern using a custom safe handle](#implement-the-dispose-pattern-using-a-custom-safe-handle) for an equivalent of the previous example that delegates non-deterministic finalization and synchronization to <xref:System.Runtime.InteropServices.SafeHandle>.
 
 > [!TIP]

--- a/samples/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/Program.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/Program.cs
@@ -1,7 +1,10 @@
-﻿static class Program
+﻿Test();
+
+void Test()
 {
-    static void Main()
-    {
-        using var disposable = new BaseClassWithSafeHandle();
-    }
+    using DisposableDerived a = new();
+    using DisposableDerivedWithFinalizer b = new();
+    b.Dispose();
+    using DisposableWithSafeHandle c = new();
 }
+

--- a/samples/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/Program.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/Program.cs
@@ -5,6 +5,6 @@ void Test()
     using DisposableDerived a = new();
     using DisposableDerivedWithFinalizer b = new();
     b.Dispose();
-    using DisposableWithSafeHandle c = new();
+    using DisposableBaseWithSafeHandle c = new();
 }
 

--- a/samples/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/base1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/base1.cs
@@ -1,14 +1,13 @@
-﻿using Microsoft.Win32.SafeHandles;
-using System;
-using System.Runtime.InteropServices;
+﻿using System;
+using System.IO;
 
-public class BaseClassWithSafeHandle : IDisposable
+public class DisposableBase : IDisposable
 {
-    // To detect redundant calls
-    private bool _disposedValue;
+    // Detect redundant Dispose() calls.
+    private bool _isDisposed;
 
-    // Instantiate a SafeHandle instance.
-    private SafeHandle? _safeHandle = new SafeFileHandle(IntPtr.Zero, true);
+    // Instantiate a disposable object owned by this class.
+    private Stream? _managedResource = new MemoryStream();
 
     // Public implementation of Dispose pattern callable by consumers.
     public void Dispose()
@@ -20,15 +19,16 @@ public class BaseClassWithSafeHandle : IDisposable
     // Protected implementation of Dispose pattern.
     protected virtual void Dispose(bool disposing)
     {
-        if (!_disposedValue)
+        if (!_isDisposed)
         {
+            _isDisposed = true;
+
             if (disposing)
             {
-                _safeHandle?.Dispose();
-                _safeHandle = null;
+                // Dispose managed state.
+                _managedResource?.Dispose();
+                _managedResource = null;
             }
-
-            _disposedValue = true;
         }
     }
 }

--- a/samples/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/base2.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/base2.cs
@@ -1,11 +1,22 @@
 ﻿using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
 
-public class BaseClassWithFinalizer : IDisposable
+public class DisposableBaseWithFinalizer : IDisposable
 {
-    // To detect redundant calls
-    private bool _disposedValue;
+    // Detect redundant Dispose() calls in a thread-safe manner.
+    // _isDisposed == 0 means Dispose(bool) has not been called yet.
+    // _isDisposed == 1 means Dispose(bool) has been already called.
+    private int _isDisposed;
 
-    ~BaseClassWithFinalizer() => Dispose(false);
+    // Instantiate a disposable object owned by this class.
+    private Stream? _managedResource = new MemoryStream();
+
+    // A pointer to 10 bytes allocated on the unmanaged heap.
+    private IntPtr _unmanagedResource = Marshal.AllocHGlobal(10);
+
+    ~DisposableBaseWithFinalizer() => Dispose(false);
 
     // Public implementation of Dispose pattern callable by consumers.
     public void Dispose()
@@ -17,16 +28,17 @@ public class BaseClassWithFinalizer : IDisposable
     // Protected implementation of Dispose pattern.
     protected virtual void Dispose(bool disposing)
     {
-        if (!_disposedValue)
+        // In case _isDisposed is 0, atomically set it to 1.
+        // Enter the branch only if the original value is 0.
+        if (Interlocked.CompareExchange(ref _isDisposed, 1, 0) == 0)
         {
             if (disposing)
             {
-                // TODO: dispose managed state (managed objects)
+                _managedResource?.Dispose();
+                _managedResource = null;
             }
 
-            // TODO: free unmanaged resources (unmanaged objects) and override finalizer
-            // TODO: set large fields to null
-            _disposedValue = true;
+            Marshal.FreeHGlobal(_unmanagedResource);
         }
     }
 }

--- a/samples/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/derived1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/derived1.cs
@@ -1,27 +1,25 @@
-﻿using Microsoft.Win32.SafeHandles;
-using System;
-using System.Runtime.InteropServices;
+﻿using System.IO;
 
-public class DerivedClassWithSafeHandle : BaseClassWithSafeHandle
+public class DisposableDerived : DisposableBase
 {
     // To detect redundant calls
-    private bool _disposedValue;
+    private bool _isDisposed;
 
-    // Instantiate a SafeHandle instance.
-    private SafeHandle? _safeHandle = new SafeFileHandle(IntPtr.Zero, true);
+    // Instantiate a disposable object owned by this class.
+    private Stream? _managedResource = new MemoryStream();
 
     // Protected implementation of Dispose pattern.
     protected override void Dispose(bool disposing)
     {
-        if (!_disposedValue)
+        if (!_isDisposed)
         {
+            _isDisposed = true;
+
             if (disposing)
             {
-                _safeHandle?.Dispose();
-                _safeHandle = null;
+                _managedResource?.Dispose();
+                _managedResource = null;
             }
-
-            _disposedValue = true;
         }
 
         // Call base class implementation.

--- a/samples/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/derived2.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/derived2.cs
@@ -1,14 +1,20 @@
-﻿public class DerivedClassWithFinalizer : BaseClassWithFinalizer
-{
-    // To detect redundant calls
-    private bool _disposedValue;
+﻿using System.Threading;
 
-    ~DerivedClassWithFinalizer() => Dispose(false);
+public class DisposableDerivedWithFinalizer : DisposableBaseWithFinalizer
+{
+    // Detect redundant Dispose() calls in a thread-safe manner.
+    // _isDisposed == 0 means Dispose(bool) has not been called yet.
+    // _isDisposed == 1 means Dispose(bool) has been already called.
+    private int _isDisposed;
+
+    ~DisposableDerivedWithFinalizer() => Dispose(false);
 
     // Protected implementation of Dispose pattern.
     protected override void Dispose(bool disposing)
     {
-        if (!_disposedValue)
+        // In case _isDisposed is 0, atomically set it to 1.
+        // Enter the branch only if the original value is 0.
+        if (Interlocked.CompareExchange(ref _isDisposed, 1, 0) == 0)
         {
             if (disposing)
             {
@@ -17,7 +23,6 @@
 
             // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
             // TODO: set large fields to null.
-            _disposedValue = true;
         }
 
         // Call the base class implementation.

--- a/samples/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/safe.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/safe.cs
@@ -25,7 +25,7 @@ class LocalAllocHandle : SafeHandleZeroOrMinusOneIsInvalid
     }
 }
 
-public class DisposableWithSafeHandle : IDisposable
+public class DisposableBaseWithSafeHandle : IDisposable
 {
     // Detect redundant Dispose() calls.
     private bool _isDisposed;

--- a/samples/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/safe.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR_System/system.idisposable/cs/safe.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+// Wraps the IntPtr allocated by Marshal.AllocHGlobal() into a SafeHandle.
+class LocalAllocHandle : SafeHandleZeroOrMinusOneIsInvalid
+{
+    private LocalAllocHandle() : base(ownsHandle: true) { }
+
+    // No need to implement a finalizer - SafeHandle's finalizer will call ReleaseHandle for you.
+    protected override bool ReleaseHandle()
+    {
+        Marshal.FreeHGlobal(handle);
+        return true;
+    }
+
+    // Allocate bytes with Marshal.AllocHGlobal() and wrap the result into a SafeHandle.
+    public static LocalAllocHandle Allocate(int numberOfBytes)
+    {
+        IntPtr nativeHandle = Marshal.AllocHGlobal(numberOfBytes);
+        LocalAllocHandle safeHandle = new LocalAllocHandle();
+        safeHandle.SetHandle(nativeHandle);
+        return safeHandle;
+    }
+}
+
+public class DisposableWithSafeHandle : IDisposable
+{
+    // Detect redundant Dispose() calls.
+    private bool _isDisposed;
+
+    // Managed disposable objects owned by this class
+    private LocalAllocHandle? _safeHandle = LocalAllocHandle.Allocate(10);
+    private Stream? _otherUnmanagedResource = new MemoryStream();
+
+    // Public implementation of Dispose pattern callable by consumers.
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    // Protected implementation of Dispose pattern.
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!_isDisposed)
+        {
+            _isDisposed = true;
+
+            if (disposing)
+            {
+                // Dispose managed state.
+                _otherUnmanagedResource?.Dispose();
+                _safeHandle?.Dispose();
+                _otherUnmanagedResource = null;
+                _safeHandle = null;
+            }
+        }
+    }
+}

--- a/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.idisposable/vb/Program.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.idisposable/vb/Program.vb
@@ -7,7 +7,7 @@
             b.Dispose()
         End Using
 
-        Using c As New DisposableWithSafeHandle
+        Using c As New DisposableBaseWithSafeHandle
         End Using
     End Sub
 End Module

--- a/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.idisposable/vb/Program.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.idisposable/vb/Program.vb
@@ -1,6 +1,13 @@
 ﻿Module Program
     Sub Main()
-        Using disposable As New BaseClassWithSafeHandle
+        Using a As New DisposableDerived
+        End Using
+
+        Using b As New DisposableDerivedWithFinalizer
+            b.Dispose()
+        End Using
+
+        Using c As New DisposableWithSafeHandle
         End Using
     End Sub
 End Module

--- a/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.idisposable/vb/base1.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.idisposable/vb/base1.vb
@@ -1,32 +1,30 @@
-﻿Imports Microsoft.Win32.SafeHandles
-Imports System.Runtime.InteropServices
+﻿Imports System.IO
 
-Public Class BaseClassWithSafeHandle
+Public Class DisposableBase
     Implements IDisposable
 
-    ' To detect redundant calls
-    Private _disposedValue As Boolean
+    ' Detect redundant Dispose() calls.
+    Private _isDisposed As Boolean
 
-    ' Instantiate a SafeHandle instance.
-    Private _safeHandle As SafeHandle = New SafeFileHandle(IntPtr.Zero, True)
+    ' Instantiate a disposable object owned by this class.
+    Private _managedResource As Stream = New MemoryStream()
 
     ' Public implementation of Dispose pattern callable by consumers.
-    Public Sub Dispose() _
-               Implements IDisposable.Dispose
+    Public Sub Dispose() Implements IDisposable.Dispose
         Dispose(True)
         GC.SuppressFinalize(Me)
     End Sub
 
     ' Protected implementation of Dispose pattern.
-    Protected Overridable Sub Dispose(ByVal disposing As Boolean)
-        If Not _disposedValue Then
+    Protected Overridable Sub Dispose(disposing As Boolean)
+        If Not _isDisposed Then
+            _isDisposed = True
 
             If disposing Then
-                _safeHandle?.Dispose()
-                _safeHandle = Nothing
+                ' Dispose managed state.
+                _managedResource?.Dispose()
+                _managedResource = Nothing
             End If
-
-            _disposedValue = True
         End If
     End Sub
 End Class

--- a/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.idisposable/vb/derived1.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.idisposable/vb/derived1.vb
@@ -1,24 +1,23 @@
-﻿Imports Microsoft.Win32.SafeHandles
-Imports System.Runtime.InteropServices
+﻿Imports System.IO
 
-Public Class DerivedClassWithSafeHandle
-    Inherits BaseClassWithSafeHandle
+Public Class DisposableDerived
+    Inherits DisposableBase
 
     ' To detect redundant calls
-    Private _disposedValue As Boolean
+    Private _isDisposed As Boolean
 
-    ' Instantiate a SafeHandle instance.
-    Private _safeHandle As SafeHandle = New SafeFileHandle(IntPtr.Zero, True)
+    ' Instantiate a disposable object owned by this class.
+    Private _managedResource As Stream = New MemoryStream()
 
-    Protected Overrides Sub Dispose(ByVal disposing As Boolean)
-        If Not _disposedValue Then
+    ' Protected implementation of Dispose pattern.
+    Protected Overrides Sub Dispose(disposing As Boolean)
+        If Not _isDisposed Then
+            _isDisposed = True
 
             If disposing Then
-                _safeHandle?.Dispose()
-                _safeHandle = Nothing
+                _managedResource?.Dispose()
+                _managedResource = Nothing
             End If
-
-            _disposedValue = True
         End If
 
         ' Call base class implementation.

--- a/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.idisposable/vb/derived2.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.idisposable/vb/derived2.vb
@@ -1,24 +1,28 @@
-﻿Public Class DerivedClassWithFinalizer
-    Inherits BaseClassWithFinalizer
+﻿Imports System.Threading
 
-    ' To detect redundant calls
-    Private _disposedValue As Boolean
+Public Class DisposableDerivedWithFinalizer
+    Inherits DisposableBaseWithFinalizer
+
+    ' Detect redundant Dispose() calls in a thread-safe manner.
+    ' _isDisposed == 0 means Dispose(bool) has not been called yet.
+    ' _isDisposed == 1 means Dispose(bool) has been already called.
+    Private _isDisposed As Integer
 
     Protected Overrides Sub Finalize()
         Dispose(False)
     End Sub
 
     ' Protected implementation of Dispose pattern.
-    Protected Overrides Sub Dispose(ByVal disposing As Boolean)
-        If Not _disposedValue Then
-
+    Protected Overrides Sub Dispose(disposing As Boolean)
+        ' In case _isDisposed is 0, atomically set it to 1.
+        ' Enter the branch only if the original value is 0.
+        If Interlocked.CompareExchange(_isDisposed, 1, 0) = 0 Then
             If disposing Then
                 ' TODO: dispose managed state (managed objects).
             End If
 
-            ' TODO free unmanaged resources (unmanaged objects) And override a finalizer below.
+            ' TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
             ' TODO: set large fields to null.
-            _disposedValue = True
         End If
 
         ' Call the base class implementation.

--- a/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.idisposable/vb/safe.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.idisposable/vb/safe.vb
@@ -26,7 +26,7 @@ Public Class LocalAllocHandle
     End Function
 End Class
 
-Public Class DisposableWithSafeHandle
+Public Class DisposableBaseWithSafeHandle
     Implements IDisposable
 
     ' Detect redundant Dispose() calls.

--- a/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.idisposable/vb/safe.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.idisposable/vb/safe.vb
@@ -1,0 +1,59 @@
+﻿Imports System
+Imports System.IO
+Imports System.Runtime.InteropServices
+Imports Microsoft.Win32.SafeHandles
+
+' Wraps the IntPtr allocated by Marshal.AllocHGlobal() into a SafeHandle.
+Public Class LocalAllocHandle
+    Inherits SafeHandleZeroOrMinusOneIsInvalid
+
+    Private Sub New()
+        MyBase.New(True)
+    End Sub
+
+    ' No need to implement a finalizer - SafeHandle's finalizer will call ReleaseHandle for you.
+    Protected Overrides Function ReleaseHandle() As Boolean
+        Marshal.FreeHGlobal(handle)
+        Return True
+    End Function
+
+    ' Allocate bytes with Marshal.AllocHGlobal() and wrap the result into a SafeHandle.
+    Public Shared Function Allocate(numberOfBytes As Integer) As LocalAllocHandle
+        Dim nativeHandle As IntPtr = Marshal.AllocHGlobal(numberOfBytes)
+        Dim safeHandle As New LocalAllocHandle()
+        safeHandle.SetHandle(nativeHandle)
+        Return safeHandle
+    End Function
+End Class
+
+Public Class DisposableWithSafeHandle
+    Implements IDisposable
+
+    ' Detect redundant Dispose() calls.
+    Private _isDisposed As Boolean
+
+    ' Managed disposable objects owned by this class
+    Private _safeHandle As LocalAllocHandle = LocalAllocHandle.Allocate(10)
+    Private _otherUnmanagedResource As Stream = New MemoryStream()
+
+    ' Public implementation of Dispose pattern callable by consumers.
+    Public Sub Dispose() Implements IDisposable.Dispose
+        Dispose(True)
+        GC.SuppressFinalize(Me)
+    End Sub
+
+    ' Protected implementation of Dispose pattern.
+    Protected Overridable Sub Dispose(disposing As Boolean)
+        If Not _isDisposed Then
+            _isDisposed = True
+
+            If disposing Then
+                ' Dispose managed state.
+                _otherUnmanagedResource?.Dispose()
+                _safeHandle?.Dispose()
+                _otherUnmanagedResource = Nothing
+                _safeHandle = Nothing
+            End If
+        End If
+    End Sub
+End Class


### PR DESCRIPTION
Implement the plan described in https://github.com/dotnet/docs/issues/44201#issuecomment-2669711016 and apply some further changes:
- Use `MemoryStream` to demonstrate managed only dispose pattern
- For the unmanaged dispose pattern, actually allocate a handle
- Define a new example for working with SafeHandle in the Safe handles paragraph
- Reshuffle the order of paragraphs so it aligns with the new content better
- An adjustment on https://github.com/dotnet/docs/pull/34144, changing the text in "Cascade dispose calls" that talks about ownership. (There is no such rule that only the members created by the class should be disposed by the class, sometimes ownership can be transferred to another IDisposable.)

Fixes #44201


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/garbage-collection/implementing-dispose.md](https://github.com/dotnet/docs/blob/8915bbaa46714a0624ed6d8204a854063766e876/docs/standard/garbage-collection/implementing-dispose.md) | [Implement a Dispose method](https://review.learn.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose?branch=pr-en-us-45173) |


<!-- PREVIEW-TABLE-END -->