### PR TITLE
Remove IsTestProject from MTP doc page

### DIFF
--- a/docs/core/testing/microsoft-testing-platform-integration-dotnet-test.md
+++ b/docs/core/testing/microsoft-testing-platform-integration-dotnet-test.md
@@ -41,7 +41,6 @@ By default, `dotnet test` is using VSTest behavior to run tests. You can enable 
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
 
     <OutputType>Exe</OutputType>
     <EnableMSTestRunner>true</EnableMSTestRunner>
@@ -137,7 +136,6 @@ Or in project file:
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
 
     <OutputType>Exe</OutputType>
     <EnableMSTestRunner>true</EnableMSTestRunner>
@@ -179,7 +177,6 @@ Or in project file:
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
 
     <OutputType>Exe</OutputType>
     <EnableMSTestRunner>true</EnableMSTestRunner>


### PR DESCRIPTION
IsTestProject is VSTest-specific property and is irrelevant for MTP.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/microsoft-testing-platform-integration-dotnet-test.md](https://github.com/dotnet/docs/blob/347931bf97c278fb891a572d3468a6f2a210c827/docs/core/testing/microsoft-testing-platform-integration-dotnet-test.md) | [Use Microsoft.Testing.Platform with `dotnet test`](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-integration-dotnet-test?branch=pr-en-us-45175) |

<!-- PREVIEW-TABLE-END -->