### PR TITLE
Fix the style of code examples in "Using Properties (C#)"

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/snippets/properties/Person.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/snippets/properties/Person.cs
@@ -51,6 +51,7 @@ namespace VersionThree
     }
     // </Initializer>
 }
+
 namespace VersionFour
 {
     // <AccessorModifiers>
@@ -76,6 +77,7 @@ namespace VersionFive
     }
     // </Readonly>
 }
+
 namespace VersionSix
 {
     // <InitOnly>
@@ -90,6 +92,7 @@ namespace VersionSix
     }
     // </InitOnly>
 }
+
 namespace VersionSeven
 {
     // <Required>
@@ -130,6 +133,7 @@ namespace VersionEight
     }
     // </ExpressionBodiedProperty>
 }
+
 namespace VersionNine
 {
     // <CachedBackingStore>
@@ -160,6 +164,7 @@ namespace VersionNine
     }
     // </CachedBackingStore>
 }
+
 namespace VersionTen
 {
     // <UseBackingFields>
@@ -206,29 +211,29 @@ namespace properties
 
     // <UsingEmployeeExample>
     class Employee
-{
-    private string _name;  // the name field
-    public string Name => _name;     // the Name property
-}
-// </UsingEmployeeExample>
-
-// <ManageExample>
-class Manager
-{
-    private string _name;
-    public string Name => _name != null ? _name : "NA";
-}
-// </ManageExample>
-
-//<StudentExample>
-class Student
-{
-    private string _name;  // the name field
-    public string Name    // the Name property
     {
-        get => _name;
-        set => _name = value;
+        private string _name;           // the name field
+        public string Name => _name;    // the Name property
     }
-}
-//</StudentExample>
+    // </UsingEmployeeExample>
+
+    // <ManageExample>
+    class Manager
+    {
+        private string _name;
+        public string Name => _name != null ? _name : "NA";
+    }
+    // </ManageExample>
+
+    //<StudentExample>
+    class Student
+    {
+        private string _name;      // the name field
+        public string Name         // the Name property
+        {
+            get => _name;
+            set => _name = value;
+        }
+    }
+    //</StudentExample>
 }

--- a/docs/csharp/programming-guide/classes-and-structs/snippets/properties/Program.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/snippets/properties/Program.cs
@@ -4,24 +4,24 @@ using properties;
 using VersionSeven;
 
 //<GetAccessor>
-var employee= new Employee();
+var employee = new Employee();
 //...
 
-System.Console.Write(employee.Name);  // the get accessor is invoked here
+System.Console.Write(employee.Name); // the get accessor is invoked here
 //</GetAccessor>
 
 //<SetAccessor>
 var student = new Student();
-student.Name = "Joe";  // the set accessor is invoked here
+student.Name = "Joe"; // the set accessor is invoked here
 
-System.Console.Write(student.Name);  // the get accessor is invoked here
+System.Console.Write(student.Name); // the get accessor is invoked here
 //</SetAccessor>
 
 HidingExample.TestHiding.Test();
 
 // <SnippetInitialize>
 var aPerson = new Person("John");
-aPerson = new Person{ FirstName = "John"};
+aPerson = new Person { FirstName = "John"};
 // Error CS9035: Required member `Person.FirstName` must be set:
 //aPerson2 = new Person();
 // </SnippetInitialize>


### PR DESCRIPTION
## Summary

Make consistent indentation and spacing for code examples in [The get accessor](https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/using-properties#the-get-accessor) section of [Using Properties (C# Programming Guide)](https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/using-properties).

