### PR TITLE
clarify breaking changes template

### DIFF
--- a/.github/ISSUE_TEMPLATE/02-breaking-change.yml
+++ b/.github/ISSUE_TEMPLATE/02-breaking-change.yml
@@ -1,5 +1,5 @@
 name: ".NET breaking change"
-description: Report a change in .NET that breaks something that worked in a previous version. Intended mostly for product-team use.
+description: This template is for .NET product team members to report breaking changes to documentation content developers. Please report user-discovered issues in the appropriate product repo.
 title: "[Breaking change]: "
 labels:
   - breaking-change


### PR DESCRIPTION
Reason: Just in the month since I've taken over breaking changes, I've had two issues created by users who think they've discovered a breaking change. It's my position that these need to be routed first to the appropriate product repo, who can then make a determination as to whether or not they qualify as a breaking change that needs to be documented.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/ISSUE_TEMPLATE/02-breaking-change.yml](https://github.com/dotnet/docs/blob/3f28e86a906aeed3f56ecc8d1b544fc9eb01d2bc/.github/ISSUE_TEMPLATE/02-breaking-change.yml) | [.github/ISSUE_TEMPLATE/02-breaking-change](https://review.learn.microsoft.com/en-us/dotnet/.github/ISSUE_TEMPLATE/02-breaking-change?branch=pr-en-us-45191) |

<!-- PREVIEW-TABLE-END -->