### PR TITLE
Update MyClass.cs

### DIFF
--- a/docs/fundamentals/networking/http/snippets/httpclient-guidelines/MyClass.cs
+++ b/docs/fundamentals/networking/http/snippets/httpclient-guidelines/MyClass.cs
@@ -3,7 +3,7 @@ using Polly;
 
 class MyClass
 {
-    static HttpClient? httpClient;
+    static HttpClient? s_httpClient;
 
     MyClass()
     {
@@ -24,6 +24,6 @@ class MyClass
             InnerHandler = socketHandler,
         };
 
-        httpClient = new HttpClient(resilienceHandler);
+        s_httpClient = new HttpClient(resilienceHandler);
     }
 }


### PR DESCRIPTION
## Summary

Static fields should be named with the `s_` prefix. Follow up from #45026.
