### PR TITLE
Fix the .net 8 end dates

### DIFF
--- a/docs/core/porting/versioning-sdk-msbuild-vs.md
+++ b/docs/core/porting/versioning-sdk-msbuild-vs.md
@@ -55,10 +55,10 @@ The support timeframe for the SDK typically matches that of the Visual Studio ve
 
 | SDK version | MSBuild/Visual Studio version | Ship date | Lifecycle           |
 |-------------|-------------------------------|-----------|---------------------|
-| 8.0.1xx     | 17.8                          | Nov '23   | Nov '25<sup>1</sup> |
+| 8.0.1xx     | 17.8                          | Nov '23   | Nov '26<sup>1</sup> |
 | 8.0.2xx     | 17.9                          | Feb '24   | May '24             |
 | 8.0.3xx     | 17.10                         | May '24   | Jan '26                 |
-| 8.0.4xx     | 17.11                         | Aug '24   | Nov '25<sup>2</sup> |
+| 8.0.4xx     | 17.11                         | Aug '24   | Nov '26<sup>2</sup> |
 | 9.0.1xx     | 17.12                         | Nov '24   | May '26             |
 | 9.0.2xx     | 17.13                         | Feb '25   | May '25             |
 | 9.0.3xx     | 17.14                         | May '25   | May '26             |


### PR DESCRIPTION
I was off by a year. These last three years.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/porting/versioning-sdk-msbuild-vs.md](https://github.com/dotnet/docs/blob/09bbb64515bf76d4343d0bfc8f36375d48d34399/docs/core/porting/versioning-sdk-msbuild-vs.md) | [docs/core/porting/versioning-sdk-msbuild-vs](https://review.learn.microsoft.com/en-us/dotnet/core/porting/versioning-sdk-msbuild-vs?branch=pr-en-us-45317) |

<!-- PREVIEW-TABLE-END -->