### PR TITLE
Remove mention of NuGet Audit auditing all dependencies in .NET 9 SDKs because we rolled that back.

### DIFF
--- a/docs/core/whats-new/dotnet-9/overview.md
+++ b/docs/core/whats-new/dotnet-9/overview.md
@@ -45,7 +45,6 @@ For more information, see [What's new in the .NET 9 libraries](libraries.md).
 The .NET 9 SDK introduces _workload sets_, where all of your workloads stay at a single, specific version until explicitly updated. For tools, a new option for [`dotnet tool install`](../../tools/dotnet-tool-install.md) lets users (instead of tool authors) decide whether a tool is allowed to run on a newer .NET runtime version than the version the tool targets. In addition:
 
 - Unit testing has better MSBuild integration that allows you to run tests in parallel.
-- NuGet security audits run on both direct and transitive package references, by default.
 - The terminal logger is enabled by default and also has improved usability. For example, the total count of failures and warnings is now summarized at the end of a build.
 - New MSBuild script analyzers ("build checks") are available.
 - The SDK can detect and adjust for version mismatches between the .NET SDK and MSBuild.

--- a/docs/core/whats-new/dotnet-9/sdk.md
+++ b/docs/core/whats-new/dotnet-9/sdk.md
@@ -111,10 +111,6 @@ The message lines of the warning no longer have the repeated project and locatio
 
 If you have feedback about the terminal logger, you can provide it in the [MSBuild repository](https://github.com/dotnet/msbuild/issues).
 
-## NuGet security audits
-
-Starting in .NET 8, `dotnet restore` [audits NuGet package references for known vulnerabilities](../../tools/dotnet-restore.md#audit-for-security-vulnerabilities). In .NET 9, the default mode has changed from auditing only _direct_ package references to auditing both _direct_ and _transitive_ package references.
-
 ## Faster NuGet dependency resolution for large repos
 
 The NuGet dependency resolver has been overhauled to improve performance and scalability for all `<PackageReference>` projects. Enabled by default, the new algorithm speeds up restore operations without compromising on functionality, strictly adhering to the core dependency resolution rules.


### PR DESCRIPTION
## Summary

Remove mention of NuGet Audit auditing all dependencies in .NET 9 SDKs because we rolled that back.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/whats-new/dotnet-9/overview.md](https://github.com/dotnet/docs/blob/2385f877b01f725afef8485738cbeac0804c3e55/docs/core/whats-new/dotnet-9/overview.md) | [docs/core/whats-new/dotnet-9/overview](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-9/overview?branch=pr-en-us-45333) |
| [docs/core/whats-new/dotnet-9/sdk.md](https://github.com/dotnet/docs/blob/2385f877b01f725afef8485738cbeac0804c3e55/docs/core/whats-new/dotnet-9/sdk.md) | [docs/core/whats-new/dotnet-9/sdk](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-9/sdk?branch=pr-en-us-45333) |

<!-- PREVIEW-TABLE-END -->