### PR TITLE
Add RHEL native aot dependencies

### DIFF
--- a/docs/core/deploying/native-aot/index.md
+++ b/docs/core/deploying/native-aot/index.md
@@ -43,7 +43,7 @@ The Native AOT deployment model uses an ahead-of-time compiler to compile IL to 
 - RHEL (8+)
 
   ```sh
-  sudo dnf install clang zlib-devel
+  sudo dnf install clang zlib-devel zlib-ng-devel zlib-ng-compat-devel
   ```
 
 # [Ubuntu](#tab/linux-ubuntu)


### PR DESCRIPTION
Missing dependencies for RHEL to compile for Native AOT


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/deploying/native-aot/index.md](https://github.com/dotnet/docs/blob/ce744c2d7770ffbb545340a18507da250f8c1348/docs/core/deploying/native-aot/index.md) | [Native AOT deployment](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/index?branch=pr-en-us-45429) |

<!-- PREVIEW-TABLE-END -->