### PR TITLE
Update dotnet-publish.md

### DIFF
--- a/docs/core/tools/dotnet-publish.md
+++ b/docs/core/tools/dotnet-publish.md
@@ -94,7 +94,7 @@ The following MSBuild properties change the output of `dotnet publish`.
 
 - `PublishSingleFile`
 
-  Packages the app into a platform-specific single-file executable. For more information about single-file publishing, see the [single-file bundler design document](https://github.com/dotnet/designs/blob/main/accepted/2020/single-file/design.md). This implicitly sets the `PublishSelfContained` property to `true` when this property is set to `true`.
+  Packages the app into a platform-specific single-file executable. For more information about single-file publishing, see the [single-file bundler design document](https://github.com/dotnet/designs/blob/main/accepted/2020/single-file/design.md). When this property is set to `true`, the `PublishSelfContained` property is implicitly set to `true`.
 
   We recommend that you specify this option in the project file rather than on the command line.
 

--- a/docs/core/tools/dotnet-publish.md
+++ b/docs/core/tools/dotnet-publish.md
@@ -94,7 +94,7 @@ The following MSBuild properties change the output of `dotnet publish`.
 
 - `PublishSingleFile`
 
-  Packages the app into a platform-specific single-file executable. For more information about single-file publishing, see the [single-file bundler design document](https://github.com/dotnet/designs/blob/main/accepted/2020/single-file/design.md).
+  Packages the app into a platform-specific single-file executable. For more information about single-file publishing, see the [single-file bundler design document](https://github.com/dotnet/designs/blob/main/accepted/2020/single-file/design.md). This implicitly sets the `PublishSelfContained` property to `true` when this property is set to `true`.
 
   We recommend that you specify this option in the project file rather than on the command line.
 


### PR DESCRIPTION
Call out that doing a single-file publish is self-contained, not framework-dependent.

## Summary

This information is kind of spread around, but since this flag has a pretty drastic impact let's make the implication an _ex_plication here.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-publish.md](https://github.com/dotnet/docs/blob/2204ecf979f59c5ff7179ae07e7ab92b0deafc93/docs/core/tools/dotnet-publish.md) | [dotnet publish](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-publish?branch=pr-en-us-45430) |


<!-- PREVIEW-TABLE-END -->