### PR TITLE
[HttpClient guidelines] Remove a note saying that Http Resilience is experimental

### DIFF
--- a/docs/fundamentals/networking/http/httpclient-guidelines.md
+++ b/docs/fundamentals/networking/http/httpclient-guidelines.md
@@ -68,9 +68,6 @@ The preceding code:
 - Passes the `socketHandler` to the `resilienceHandler` with the retry logic.
 - Instantiates a shared `HttpClient` given the `resilienceHandler`.
 
-> [!IMPORTANT]
-> The `Microsoft.Extensions.Http.Resilience` library is currently marked as [experimental](../../../csharp/language-reference/attributes/general.md#experimental-attributes) and it might change in the future.
-
 ## See also
 
 - [HTTP support in .NET](http-overview.md)


### PR DESCRIPTION
`Microsoft.Extensions.Http.Resiliece` is already [`stable`](https://github.com/dotnet/extensions/blob/6694f06d2f081f1d847fe810f4654cd6760d417d/src/Libraries/Microsoft.Extensions.Http.Resilience/Microsoft.Extensions.Http.Resilience.csproj#L23). We can remove a note saying that it is `experimental`.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/networking/http/httpclient-guidelines.md](https://github.com/dotnet/docs/blob/5d9c9f3fc726e3faa028258ae07df5dbf77932a3/docs/fundamentals/networking/http/httpclient-guidelines.md) | [docs/fundamentals/networking/http/httpclient-guidelines](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient-guidelines?branch=pr-en-us-45444) |

<!-- PREVIEW-TABLE-END -->