### PR TITLE
Update disallow-edits.yml

### DIFF
--- a/.github/policies/disallow-edits.yml
+++ b/.github/policies/disallow-edits.yml
@@ -15,7 +15,7 @@ configuration:
           - isAction:
               action: Opened
           - filesMatchPattern:
-              pattern: .github/*
+              pattern: \.github/*
               matchAny: true
               excludedFiles:
                 - .github/CODEOWNERS


### PR DESCRIPTION
Policy was matching any folder with "github" in the name, e.g. https://github.com/dotnet/docs/pull/45449.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/policies/disallow-edits.yml](https://github.com/dotnet/docs/blob/148a8ba1a21595648ca35512d6cf05ab59193c69/.github/policies/disallow-edits.yml) | [.github/policies/disallow-edits](https://review.learn.microsoft.com/en-us/dotnet/.github/policies/disallow-edits?branch=pr-en-us-45450) |

<!-- PREVIEW-TABLE-END -->