### PR TITLE
Add what's new in C# 14

### DIFF
--- a/docs/csharp/language-reference/index.yml
+++ b/docs/csharp/language-reference/index.yml
@@ -33,7 +33,7 @@ landingContent:
         links:
           - text: "What's new in C# 14"
             url: ../whats-new/csharp-14.md
-            - text: "What's new in C# 13"
+          - text: "What's new in C# 13"
             url: ../whats-new/csharp-13.md
           - text: "What's new in C# 12"
             url: ../whats-new/csharp-12.md

--- a/docs/csharp/language-reference/index.yml
+++ b/docs/csharp/language-reference/index.yml
@@ -31,7 +31,9 @@ landingContent:
     linkLists:
       - linkListType: whats-new
         links:
-          - text: "What's new in C# 13"
+          - text: "What's new in C# 14"
+            url: ../whats-new/csharp-14.md
+            - text: "What's new in C# 13"
             url: ../whats-new/csharp-13.md
           - text: "What's new in C# 12"
             url: ../whats-new/csharp-12.md

--- a/docs/csharp/tour-of-csharp/index.yml
+++ b/docs/csharp/tour-of-csharp/index.yml
@@ -79,6 +79,8 @@ landingContent:
     linkLists:
       - linkListType: whats-new
         links:
+          - text: "What's new in C# 14"
+            url: ../whats-new/csharp-14.md        
           - text: "What's new in C# 13"
             url: ../whats-new/csharp-13.md
           - text: "What's new in C# 12"


### PR DESCRIPTION
Let me know if any version should be dropped or if we should also add to https://learn.microsoft.com/en-us/dotnet/whats-new/

Contributes to #45155

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/index.yml](https://github.com/dotnet/docs/blob/010bf6bad4966efef7c7d0866d214e30042c697a/docs/csharp/language-reference/index.yml) | ["C# language reference"](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/index?branch=pr-en-us-45452) |
| [docs/csharp/tour-of-csharp/index.yml](https://github.com/dotnet/docs/blob/010bf6bad4966efef7c7d0866d214e30042c697a/docs/csharp/tour-of-csharp/index.yml) | [docs/csharp/tour-of-csharp/index](https://review.learn.microsoft.com/en-us/dotnet/csharp/tour-of-csharp/index?branch=pr-en-us-45452) |


<!-- PREVIEW-TABLE-END -->