### PR TITLE
docs: add .NET 9 SDK download link

### DIFF
--- a/docs/core/docker/build-container.md
+++ b/docs/core/docker/build-container.md
@@ -33,8 +33,18 @@ You explore the Docker container build and deploy tasks for a .NET application. 
 
 Install the following prerequisites:
 
+:::zone pivot="dotnet-9-0"
+
+- [.NET 9+ SDK](https://dotnet.microsoft.com/download/dotnet/9.0).\
+If you have .NET installed, use the `dotnet --info` command to determine which SDK you're using.
+
+:::zone-end
+:::zone pivot="dotnet-8-0"
+
 - [.NET 8+ SDK](https://dotnet.microsoft.com/download/dotnet/8.0).\
 If you have .NET installed, use the `dotnet --info` command to determine which SDK you're using.
+
+:::zone-end
 - [Docker Community Edition](https://www.docker.com/products/docker-desktop).
 - A temporary working folder for the _Dockerfile_ and .NET example app. In this tutorial, the name _docker-working_ is used as the working folder.
 

--- a/docs/core/docker/build-container.md
+++ b/docs/core/docker/build-container.md
@@ -45,6 +45,7 @@ If you have .NET installed, use the `dotnet --info` command to determine which S
 If you have .NET installed, use the `dotnet --info` command to determine which SDK you're using.
 
 :::zone-end
+
 - [Docker Community Edition](https://www.docker.com/products/docker-desktop).
 - A temporary working folder for the _Dockerfile_ and .NET example app. In this tutorial, the name _docker-working_ is used as the working folder.
 


### PR DESCRIPTION
## Summary

While browsing through the page I noticed all of the references to .NET 8 were changed to .NET 9, except for the prerequisites.
This adds a .NET 9 prerequisite.

Sorry if I didn't create an issue first, feel free to close the PR.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/docker/build-container.md](https://github.com/dotnet/docs/blob/8695a1425658d12ad2fded5018378d5b00a8c987/docs/core/docker/build-container.md) | [Tutorial: Containerize a .NET app](https://review.learn.microsoft.com/en-us/dotnet/core/docker/build-container?branch=pr-en-us-45464) |


<!-- PREVIEW-TABLE-END -->