### PR TITLE
usepackagetargets  updates to #r nuget syntax

### DIFF
--- a/docs/fsharp/tools/fsharp-interactive/index.md
+++ b/docs/fsharp/tools/fsharp-interactive/index.md
@@ -158,7 +158,7 @@ let f (x: Tensor) = sin (sqrt x)
 printfn $"{f (dsharp.tensor 1.2)}"
 ```
 
-By default ````#r "nuget: ...." ```` will not use build targets from the package being referenced during restore.  There is a usepackagetargets option to enable the use of these build targets when required, only add usepackagetargets=true if the referenced package was authored to require it during restore.
+By default ````#r "nuget: ...."```` will not use build targets from the package being referenced during restore.  There is a usepackagetargets option to enable the use of these build targets when required, only add usepackagetargets=true if the referenced package was authored to require it during restore.
 examples:
 
 ```fsharp

--- a/docs/fsharp/tools/fsharp-interactive/index.md
+++ b/docs/fsharp/tools/fsharp-interactive/index.md
@@ -158,8 +158,8 @@ let f (x: Tensor) = sin (sqrt x)
 printfn $"{f (dsharp.tensor 1.2)}"
 ```
 
-By default ````#r "nuget: ...."```` will not use build targets from the package being referenced during restore.  There is a usepackagetargets option to enable the use of these build targets when required, only add usepackagetargets=true if the referenced package was authored to require it during restore.
-examples:
+By default, ````#r "nuget: ...."```` doesn't use build targets from the package being referenced during restore. The `usepackagetargets` option enables the use of these build targets when required. Only add `usepackagetargets=true` if the referenced package was authored to require it during restore.
+Examples:
 
 ```fsharp
 // load fsharp.data nugetpackage and consume buildtargets from fsharp.data package during restore.

--- a/docs/fsharp/tools/fsharp-interactive/index.md
+++ b/docs/fsharp/tools/fsharp-interactive/index.md
@@ -157,6 +157,15 @@ let f (x: Tensor) = sin (sqrt x)
 
 printfn $"{f (dsharp.tensor 1.2)}"
 ```
+By default ````#r "nuget: ...." ```` will not use build targets from the package being referenced during restore.  There is a usepackagetargets open in the ````#r "nuget:````  syntax.
+examples:
+````
+// load fsharp.data nugetpackage and consume buildtargets from fsharp.data package during restore.
+#r "nuget:fsharp.data,usepackagetargets=true"
+#r "nuget:fsharp.data,6.6.0,usepackagetargets=false"
+#r "nuget:fsharp.data,6.6.0,usepackagetargets=true"
+````
+Only add usepackagetargets=true if the package was authored to require it during restore.
 
 ### Specifying a package source
 

--- a/docs/fsharp/tools/fsharp-interactive/index.md
+++ b/docs/fsharp/tools/fsharp-interactive/index.md
@@ -157,7 +157,7 @@ let f (x: Tensor) = sin (sqrt x)
 
 printfn $"{f (dsharp.tensor 1.2)}"
 ```
-By default ````#r "nuget: ...." ```` will not use build targets from the package being referenced during restore.  There is a usepackagetargets open in the ````#r "nuget:````  syntax.
+By default ````#r "nuget: ...." ```` will not use build targets from the package being referenced during restore.  There is a usepackagetargets option to enable the use of these build targets when required, only add usepackagetargets=true if the referenced package was authored to require it during restore.
 examples:
 ````
 // load fsharp.data nugetpackage and consume buildtargets from fsharp.data package during restore.
@@ -165,8 +165,6 @@ examples:
 #r "nuget:fsharp.data,6.6.0,usepackagetargets=false"
 #r "nuget:fsharp.data,6.6.0,usepackagetargets=true"
 ````
-Only add usepackagetargets=true if the package was authored to require it during restore.
-
 ### Specifying a package source
 
 You can also specify a package source with the `#i` command. The following example specifies a remote and a local source:

--- a/docs/fsharp/tools/fsharp-interactive/index.md
+++ b/docs/fsharp/tools/fsharp-interactive/index.md
@@ -157,14 +157,17 @@ let f (x: Tensor) = sin (sqrt x)
 
 printfn $"{f (dsharp.tensor 1.2)}"
 ```
+
 By default ````#r "nuget: ...." ```` will not use build targets from the package being referenced during restore.  There is a usepackagetargets option to enable the use of these build targets when required, only add usepackagetargets=true if the referenced package was authored to require it during restore.
 examples:
-````
+
+```fsharp
 // load fsharp.data nugetpackage and consume buildtargets from fsharp.data package during restore.
 #r "nuget:fsharp.data,usepackagetargets=true"
 #r "nuget:fsharp.data,6.6.0,usepackagetargets=false"
 #r "nuget:fsharp.data,6.6.0,usepackagetargets=true"
-````
+```
+
 ### Specifying a package source
 
 You can also specify a package source with the `#i` command. The following example specifies a remote and a local source:


### PR DESCRIPTION
This PR on the fsharp repo adds an option to #r "nuget:https://github.com/dotnet/fsharp/pull/18400

This change updates the release documentation for it.
New text:
![image](https://github.com/user-attachments/assets/034eb82e-b96b-4275-bc52-6ee946668bca)




<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/tools/fsharp-interactive/index.md](https://github.com/dotnet/docs/blob/1ceb1a14b76985bbe3da91d96085d2f7a3454b26/docs/fsharp/tools/fsharp-interactive/index.md) | [Interactive programming with F\#](https://review.learn.microsoft.com/en-us/dotnet/fsharp/tools/fsharp-interactive/index?branch=pr-en-us-45467) |


<!-- PREVIEW-TABLE-END -->