### PR TITLE
Mention py3-lldb for SOS on Alpine Linux

### DIFF
--- a/docs/core/diagnostics/lldb-linux.md
+++ b/docs/core/diagnostics/lldb-linux.md
@@ -49,7 +49,7 @@ To install the LLDB packages:
 
 ```console
     apk update
-    apk add lldb
+    apk add lldb py3-lldb
 ```
 
 To launch LLDB:


### PR DESCRIPTION
## Summary

Without py3-lldb on Alpine Linux, we get:

```sh
$ lldb dist/testsos
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'lldb'
```

Noticed while making this repro https://github.com/dotnet/diagnostics/issues/5364.

cc @hoyosjs @mikem8361


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/lldb-linux.md](https://github.com/dotnet/docs/blob/116a4c7383ae485b1592c72dd2b50161944e4040/docs/core/diagnostics/lldb-linux.md) | [docs/core/diagnostics/lldb-linux](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/lldb-linux?branch=pr-en-us-45470) |

<!-- PREVIEW-TABLE-END -->