### PR TITLE
Add missing "<PATH>" for "--additionalprobingpath" option in the "dotnet exec" cli command description

### DIFF
--- a/docs/core/tools/dotnet.md
+++ b/docs/core/tools/dotnet.md
@@ -35,7 +35,7 @@ dotnet [--additionalprobingpath <PATH>] [--additional-deps <PATH>]
     [--fx-version <VERSION>]  [--roll-forward <SETTING>]
     <PATH_TO_APPLICATION> [arguments]
 
-dotnet exec [--additionalprobingpath] [--additional-deps <PATH>]
+dotnet exec [--additionalprobingpath <PATH>] [--additional-deps <PATH>]
     [--depsfile <PATH>]
     [--fx-version <VERSION>]  [--roll-forward <SETTING>]
     [--runtimeconfig <PATH>]


### PR DESCRIPTION
```
dotnet exec [--additionalprobingpath] [--additional-deps <PATH>]
    [--depsfile <PATH>]
    [--fx-version <VERSION>]  [--roll-forward <SETTING>]
    [--runtimeconfig <PATH>]
    <PATH_TO_APPLICATION> [arguments]
```
changed to
```
dotnet exec [--additionalprobingpath <PATH>] [--additional-deps <PATH>]
    [--depsfile <PATH>]
    [--fx-version <VERSION>]  [--roll-forward <SETTING>]
    [--runtimeconfig <PATH>]
    <PATH_TO_APPLICATION> [arguments]
```

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet.md](https://github.com/dotnet/docs/blob/7f55635fc40bf57b7fe1e5c208790ad835b503b3/docs/core/tools/dotnet.md) | [dotnet command](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet?branch=pr-en-us-45505) |

<!-- PREVIEW-TABLE-END -->