### PR TITLE
Add note about IncludeTestAssembly default in MTP Code Coverage

### DIFF
--- a/docs/core/testing/microsoft-testing-platform-extensions-code-coverage.md
+++ b/docs/core/testing/microsoft-testing-platform-extensions-code-coverage.md
@@ -37,7 +37,7 @@ Microsoft Code Coverage provides the following options:
 For more information about the available options, see [settings](../additional-tools/dotnet-coverage.md#settings) and [samples](https://github.com/microsoft/codecoverage/tree/main/samples/Algorithms).
 
 > [!NOTE]
-> The default value of `IncludeTestAssembly` in Microsoft.Testing.Extensions.CodeCoverage is true, while it used to be false in VSTest. This means that test projects are excluded by default. For more information, see [Code Coverage configuration](https://github.com/microsoft/codecoverage/blob/main/docs/configuration.md).
+> The default value of `IncludeTestAssembly` in Microsoft.Testing.Extensions.CodeCoverage is `true`, while it used to be `false` in VSTest. This means that test projects are excluded by default. For more information, see [Code Coverage configuration](https://github.com/microsoft/codecoverage/blob/main/docs/configuration.md).
 
 ## Coverlet
 

--- a/docs/core/testing/microsoft-testing-platform-extensions-code-coverage.md
+++ b/docs/core/testing/microsoft-testing-platform-extensions-code-coverage.md
@@ -36,6 +36,9 @@ Microsoft Code Coverage provides the following options:
 
 For more information about the available options, see [settings](../additional-tools/dotnet-coverage.md#settings) and [samples](https://github.com/microsoft/codecoverage/tree/main/samples/Algorithms).
 
+> [!NOTE]
+> The default value of `IncludeTestAssembly` in Microsoft.Testing.Extensions.CodeCoverage is true, while it used to be false in VSTest. This means that test projects are excluded by default. For more information, see [Code Coverage configuration](https://github.com/microsoft/codecoverage/blob/main/docs/configuration.md).
+
 ## Coverlet
 
 > [!IMPORTANT]


### PR DESCRIPTION
Fixes https://github.com/dotnet/docs/issues/45500

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/microsoft-testing-platform-extensions-code-coverage.md](https://github.com/dotnet/docs/blob/ec13e4b77731243ac6e865e2b81a424c57a3f9e0/docs/core/testing/microsoft-testing-platform-extensions-code-coverage.md) | [Code coverage extensions](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-extensions-code-coverage?branch=pr-en-us-45521) |


<!-- PREVIEW-TABLE-END -->