### PR TITLE
Typo error fix in Arrays doc

### DIFF
--- a/docs/csharp/language-reference/builtin-types/arrays.md
+++ b/docs/csharp/language-reference/builtin-types/arrays.md
@@ -85,7 +85,7 @@ You can pass an initialized single-dimensional array to a method. In the followi
 
 ## Multidimensional arrays
 
-Arrays can have more than one dimension. For example, the following declarations create four arrays. Two arrays have have two dimensions. Two arrays have three dimensions. The first two declarations declare the length of each dimension, but don't initialize the values of the array. The second two declarations use an initializer to set the values of each element in the multidimensional array.
+Arrays can have more than one dimension. For example, the following declarations create four arrays. Two arrays have two dimensions. Two arrays have three dimensions. The first two declarations declare the length of each dimension, but don't initialize the values of the array. The second two declarations use an initializer to set the values of each element in the multidimensional array.
 
 :::code language="csharp" source="./snippets/shared/Arrays.cs" id="MultiDimensionalArrayDeclaration":::
 


### PR DESCRIPTION
## Summary
A simple typographical error under the Multidimensional arrays topic.

## Changes made
Under Multidimensional arrays, the third sentence of the first paragraph contains multiple occurrence of the word 'have'. One of these occurrence was removed.

![Issue 1](https://github.com/user-attachments/assets/d81ad1a7-d4e8-42fd-bc7c-2464f92e3a11)

## Link to documentation
https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/arrays#multidimensional-arrays


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/builtin-types/arrays.md](https://github.com/dotnet/docs/blob/5814ccdb64ea24566d9dc5f4c8c57659fcf17e36/docs/csharp/language-reference/builtin-types/arrays.md) | [docs/csharp/language-reference/builtin-types/arrays](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/arrays?branch=pr-en-us-45529) |

<!-- PREVIEW-TABLE-END -->