### PR TITLE
Add missing lightbox for Observability OTLP Example

### DIFF
--- a/docs/core/diagnostics/observability-otlp-example.md
+++ b/docs/core/diagnostics/observability-otlp-example.md
@@ -98,7 +98,7 @@ mcr.microsoft.com/dotnet/aspire-dashboard:latest
 
 Data displayed in the dashboard can be sensitive. By default, the dashboard is secured with authentication that requires a token to login. The token is displayed in the resulting output when running the container.
 
-[![Aspire Dashboard](./media/aspire-dashboard-auth.png)]
+[![Aspire Dashboard](./media/aspire-dashboard-auth.png)](./media/aspire-dashboard-auth.png#lightbox)
 
 Copy the url shown, and replace `0.0.0.0` with `localhost`, eg `http://localhost:18888/login?t=123456780abcdef123456780` and open that in your browser, or you can also paste the key after `/login?t=` when the login dialog is shown. The token will change each time you start the container.
 


### PR DESCRIPTION
## Summary

The Aspire Dashboard Auth image is missing a lightbox link (use lightbox to maintain uniformity with all other images in the article) causing the enclosing square brackets to be rendered verbatim.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/observability-otlp-example.md](https://github.com/dotnet/docs/blob/ec535585c2da120d0fad837b870ae82a24f35570/docs/core/diagnostics/observability-otlp-example.md) | [Example: Use OpenTelemetry with OTLP and the standalone Aspire Dashboard](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/observability-otlp-example?branch=pr-en-us-45542) |

<!-- PREVIEW-TABLE-END -->