### PR TITLE
Document equivalent of `-- <RunSettings arguments>` in MTP

### DIFF
--- a/docs/core/testing/microsoft-testing-platform-vs-vstest.md
+++ b/docs/core/testing/microsoft-testing-platform-vs-vstest.md
@@ -98,7 +98,7 @@ The test related arguments are VSTest specific and so need to be transformed to 
 | `--results-directory <RESULTS_DIR>` | `--results-directory <RESULTS_DIR>` |
 | `-s\|--settings <SETTINGS_FILE>` | Depends upon the selected test framework |
 | `-t\|--list-tests` | `--list-tests` |
-| `-- <RunSettings arguments>` | Not supported |
+| `-- <RunSettings arguments>` | `--test-parameter` (provided by [VSTestBridge](microsoft-testing-platform-extensions-vstest-bridge.md)) |
 
 > [!IMPORTANT]
 > Before specifying any `Microsoft.Testing.Platform` arguments, you need to add `--` to separate the `dotnet test` arguments from the new platform arguments. For example, `dotnet test --no-build -- --list-tests`.


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/microsoft-testing-platform-vs-vstest.md](https://github.com/dotnet/docs/blob/0c57a94790947e7496319fd84511178831666642/docs/core/testing/microsoft-testing-platform-vs-vstest.md) | [Microsoft.Testing.Platform and VSTest comparison](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-vs-vstest?branch=pr-en-us-45545) |

<!-- PREVIEW-TABLE-END -->