### PR TITLE
Fix `--test-parameter` typo

### DIFF
--- a/docs/core/testing/microsoft-testing-platform-extensions-vstest-bridge.md
+++ b/docs/core/testing/microsoft-testing-platform-extensions-vstest-bridge.md
@@ -55,7 +55,7 @@ When enabled by the test framework, you can use `--filter <FILTER_EXPRESSION>`.
 
 ## TestRun parameters
 
-You can pass parameters to the test run by using the `--test-parameters` command line option in the format `key=value`. This option can be specified multiple times, one for each parameter to set.
+You can pass parameters to the test run by using the `--test-parameter` command line option in the format `key=value`. This option can be specified multiple times, one for each parameter to set.
 
 These parameters can then be accessed by the test framework in the test run:
 


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/microsoft-testing-platform-extensions-vstest-bridge.md](https://github.com/dotnet/docs/blob/8ebdc2101815cd01d36a207ea231a10ce3ee7399/docs/core/testing/microsoft-testing-platform-extensions-vstest-bridge.md) | [VSTest Bridge extension](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-extensions-vstest-bridge?branch=pr-en-us-45546) |

<!-- PREVIEW-TABLE-END -->