### PR TITLE
Update links on welcome article

### DIFF
--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -15,15 +15,13 @@ You can build many types of apps with .NET, such as cloud, IoT, and games, using
 For news about .NET, check the following blogs:
 
 - [.NET Blog](https://devblogs.microsoft.com/dotnet/)
-- [ASP.NET Blog](https://devblogs.microsoft.com/aspnet/)
 - [The Visual Studio Blog](https://devblogs.microsoft.com/visualstudio/)
-- [The Visual Basic Team](https://devblogs.microsoft.com/vbteam/)
 
 Also follow the latest .NET events:
 
 - [.NET Conf](https://www.dotnetconf.net/)
-- [Microsoft Ignite](https://www.microsoft.com/ignite)
-- [Microsoft Build](https://www.microsoft.com/build)
+- [Microsoft Ignite](https://ignite.microsoft.com/)
+- [Microsoft Build](https://build.microsoft.com/)
 
 For information about the latest features added to the .NET implementations and supported languages, see the following articles:
 


### PR DESCRIPTION
I was searching for some info on the repo and noticed some broken/outdated URLs and also aspnet blog no longer exists and VB blog doesn't have a post since 2020.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/welcome.md](https://github.com/dotnet/docs/blob/a5a3733ff86504159ef6314d1dc0b91973ad6e03/docs/welcome.md) | [Welcome to .NET](https://review.learn.microsoft.com/en-us/dotnet/welcome?branch=pr-en-us-45552) |

<!-- PREVIEW-TABLE-END -->