### PR TITLE
Change TUnit Documentation URL

### DIFF
--- a/docs/core/testing/microsoft-testing-platform-intro.md
+++ b/docs/core/testing/microsoft-testing-platform-intro.md
@@ -41,7 +41,7 @@ The main driving factors for the evolution of the new testing platform are detai
 * MSTest. In MSTest, the support of `Microsoft.Testing.Platform` is done via [MSTest runner](unit-testing-mstest-runner-intro.md).
 * NUnit. In NUnit, the support of `Microsoft.Testing.Platform` is done via [NUnit runner](unit-testing-nunit-runner-intro.md).
 * xUnit.net: In xUnit.net, the support of `Microsoft.Testing.Platform` is done via [xUnit.net runner](https://xunit.net/docs/getting-started/v3/microsoft-testing-platform).
-* TUnit: entirely constructed on top of the `Microsoft.Testing.Platform`, for more information, see [TUnit documentation](https://thomhurst.github.io/TUnit/).
+* TUnit: entirely constructed on top of the `Microsoft.Testing.Platform`, for more information, see [TUnit documentation](https://tunit.dev/).
 
 ## Run and debug tests
 


### PR DESCRIPTION
Change the TUnit documentation URL.

Heya - This was previously linking to a GitHub pages URL.

It's still on GitHub pages, but I've bought a new domain now.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/microsoft-testing-platform-intro.md](https://github.com/dotnet/docs/blob/0bb056232021d3b01106de5439fca7b2acd9a7f1/docs/core/testing/microsoft-testing-platform-intro.md) | [Microsoft.Testing.Platform overview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-intro?branch=pr-en-us-45560) |

<!-- PREVIEW-TABLE-END -->