### PR TITLE
CA1725 Correctly specify nature of breaking change

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1725.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1725.md
@@ -33,7 +33,7 @@ Consistent naming of parameters in an override hierarchy increases the usability
 
 ## How to fix violations
 
-To fix a violation of this rule, rename the parameter to match the base declaration. The fix is a breaking change for callers who specify the argument name.
+To fix a violation of this rule, rename the parameter to match the base declaration. The fix is a breaking change for callers who specify the parameter name.
 
 ## When to suppress warnings
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1725.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1725.md
@@ -33,11 +33,11 @@ Consistent naming of parameters in an override hierarchy increases the usability
 
 ## How to fix violations
 
-To fix a violation of this rule, rename the parameter to match the base declaration. The fix is a breaking change for COM visible methods.
+To fix a violation of this rule, rename the parameter to match the base declaration. The fix is a breaking change for callers who specify the argument name.
 
 ## When to suppress warnings
 
-Do not suppress a warning from this rule except for COM visible methods in libraries that have previously shipped.
+Do not suppress a warning from this rule except for visible methods in libraries that have previously shipped.
 
 ## Suppress a warning
 


### PR DESCRIPTION
This is a breaking change even when not COM visible, so the text should this. (I suspect the original text predates C# 4 adding support for named arguments.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1725.md](https://github.com/dotnet/docs/blob/4a204922784b27e090e864d5cd20574b218dd7ce/docs/fundamentals/code-analysis/quality-rules/ca1725.md) | [CA1725: Parameter names should match base declaration](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1725?branch=pr-en-us-45566) |

<!-- PREVIEW-TABLE-END -->