### PR TITLE
Fix run-on heading

### DIFF
--- a/docs/fundamentals/runtime-libraries/system-type-getproperty.md
+++ b/docs/fundamentals/runtime-libraries/system-type-getproperty.md
@@ -1,21 +1,21 @@
 ---
 title: System.Type.GetProperty methods
 description: Learn about the System.Type.GetProperty methods.
-ms.date: 01/24/2024
+ms.date: 03/30/2025
 ---
 # System.Type.GetProperty methods
 
 [!INCLUDE [context](includes/context.md)]
 
+The following guidance applies to all overloads:
+
+- A property is considered public to reflection if it has at least one accessor that is public. Otherwise the property is considered private, and you must use <xref:System.Reflection.BindingFlags.NonPublic?displayProperty=nameWithType> &#124; <xref:System.Reflection.BindingFlags.Instance?displayProperty=nameWithType> &#124; <xref:System.Reflection.BindingFlags.Static?displayProperty=nameWithType> (in Visual Basic, combine the values using ` Or `) to get it.
+- If the current <xref:System.Type> represents a constructed generic type, this method returns the <xref:System.Reflection.PropertyInfo> with the type parameters replaced by the appropriate type arguments.
+- If the current <xref:System.Type> represents a type parameter in the definition of a generic type or generic method, this method searches the properties of the class constraint.
+
 ## <xref:System.Type.GetProperty(System.String)> method
 
 The search for `name` is case-sensitive. The search includes public static and public instance properties.
-
-A property is considered public to reflection if it has at least one accessor that is public. Otherwise the property is considered private, and you must use <xref:System.Reflection.BindingFlags.NonPublic?displayProperty=nameWithType> &#124; <xref:System.Reflection.BindingFlags.Instance?displayProperty=nameWithType> &#124; <xref:System.Reflection.BindingFlags.Static?displayProperty=nameWithType> (in Visual Basic, combine the values using ` Or `) to get it.
-
-If the current <xref:System.Type> represents a constructed generic type, this method returns the <xref:System.Reflection.PropertyInfo> with the type parameters replaced by the appropriate type arguments.
-
-If the current <xref:System.Type> represents a type parameter in the definition of a generic type or generic method, this method searches the properties of the class constraint.
 
 Situations in which <xref:System.Reflection.AmbiguousMatchException> occurs include the following:
 
@@ -23,8 +23,6 @@ Situations in which <xref:System.Reflection.AmbiguousMatchException> occurs incl
 - A derived type declares a property that hides an inherited property with the same name, by using the `new` modifier (`Shadows` in Visual Basic). To resolve the ambiguity, use the <xref:System.Type.GetProperty(System.String,System.Reflection.BindingFlags)> method overload and add the <xref:System.Reflection.BindingFlags.DeclaredOnly?displayProperty=nameWithType> flag to restrict the search to members that aren't inherited.
 
 ## <xref:System.Type.GetProperty(System.String,System.Reflection.BindingFlags)> method
-
-A property is considered public to reflection if it has at least one accessor that is public. Otherwise the property is considered private, and you must use <xref:System.Reflection.BindingFlags.NonPublic?displayProperty=nameWithType> &#124; <xref:System.Reflection.BindingFlags.Instance?displayProperty=nameWithType> &#124; <xref:System.Reflection.BindingFlags.Static?displayProperty=nameWithType> (in Visual Basic, combine the values using ` Or `) to get it.
 
 The following <xref:System.Reflection.BindingFlags> filter flags can be used to define which properties to include in the search:
 
@@ -38,20 +36,12 @@ The following <xref:System.Reflection.BindingFlags> modifier flags can be used t
 - `BindingFlags.IgnoreCase` to ignore the case of `name`.
 - `BindingFlags.DeclaredOnly` to search only the properties declared on the <xref:System.Type>, not properties that were simply inherited.
 
-See <xref:System.Reflection.BindingFlags?displayProperty=nameWithType> for more information.
-
-If the current <xref:System.Type> represents a constructed generic type, this method returns the <xref:System.Reflection.PropertyInfo> with the type parameters replaced by the appropriate type arguments.
-
-If the current <xref:System.Type> represents a type parameter in the definition of a generic type or generic method, this method searches the properties of the class constraint.
-
 Situations in which <xref:System.Reflection.AmbiguousMatchException> occurs include the following:
 
 - A type contains two indexed properties that have the same name but different numbers of parameters. To resolve the ambiguity, use an overload of the <xref:System.Type.GetProperty%2A> method that specifies parameter types.
 - A derived type declares a property that hides an inherited property with the same name, using the `new` modifier (`Shadows` in Visual Basic). To resolve the ambiguity, include <xref:System.Reflection.BindingFlags.DeclaredOnly?displayProperty=nameWithType> to restrict the search to members that are not inherited.
 
-## GetProperty(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Type,System.Type[],System.Reflection.ParameterModifier[])
-
-A property is considered public to reflection if it has at least one accessor that is public. Otherwise the property is considered private, and you must use <xref:System.Reflection.BindingFlags.NonPublic?displayProperty=nameWithType> &#124; <xref:System.Reflection.BindingFlags.Instance?displayProperty=nameWithType> &#124; <xref:System.Reflection.BindingFlags.Static?displayProperty=nameWithType> (in Visual Basic, combine the values using ` Or `) to get it.
+## [GetProperty(System.String, System.Reflection.BindingFlags, System.Reflection.Binder, System.Type, System.Type[], System.Reflection.ParameterModifier[])](xref:System.Type.GetProperty(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Type,System.Type[],System.Reflection.ParameterModifier[])) method
 
 Although the default binder does not process <xref:System.Reflection.ParameterModifier> (the `modifiers` parameter), you can use the abstract <xref:System.Reflection.Binder?displayProperty=nameWithType> class to write a custom binder that does process `modifiers`. `ParameterModifier` is only used when calling through COM interop, and only parameters that are passed by reference are handled.
 
@@ -68,9 +58,9 @@ The following table shows what members of a base class are returned by the `Get`
 
 Notes:
 
-1. Hide-by-name-and-signature considers all of the parts of the signature, including custom modifiers, return types, parameter types, sentinels, and unmanaged calling conventions. This is a binary comparison.
-2. For reflection, properties and events are hide-by-name-and-signature. If you have a property with both a get and a set accessor in the base class, but the derived class has only a get accessor, the derived class property hides the base class property, and you will not be able to access the setter on the base class.
-3. Custom attributes are not part of the common type system.
+- Hide-by-name-and-signature considers all of the parts of the signature, including custom modifiers, return types, parameter types, sentinels, and unmanaged calling conventions. This is a binary comparison.
+- For reflection, properties and events are hide-by-name-and-signature. If you have a property with both a get and a set accessor in the base class, but the derived class has only a get accessor, the derived class property hides the base class property, and you will not be able to access the setter on the base class.
+- Custom attributes are not part of the common type system.
 
 The following <xref:System.Reflection.BindingFlags> filter flags can be used to define which properties to include in the search:
 
@@ -83,12 +73,6 @@ The following <xref:System.Reflection.BindingFlags> modifier flags can be used t
 
 - `BindingFlags.IgnoreCase` to ignore the case of `name`.
 - `BindingFlags.DeclaredOnly` to search only the properties declared on the <xref:System.Type>, not properties that were simply inherited.
-
-See <xref:System.Reflection.BindingFlags?displayProperty=nameWithType> for more information.
-
-If the current <xref:System.Type> represents a constructed generic type, this method returns the <xref:System.Reflection.PropertyInfo> with the type parameters replaced by the appropriate type arguments.
-
-If the current <xref:System.Type> represents a type parameter in the definition of a generic type or generic method, this method searches the properties of the class constraint.
 
 ## Indexers and default properties
 


### PR DESCRIPTION
Fixes #45570.

Also moves common text to the top of the page.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/runtime-libraries/system-type-getproperty.md](https://github.com/dotnet/docs/blob/6d45abb449a8bdc08db278a2759189ea6082e2eb/docs/fundamentals/runtime-libraries/system-type-getproperty.md) | [System.Type.GetProperty methods](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-type-getproperty?branch=pr-en-us-45572) |

<!-- PREVIEW-TABLE-END -->