### PR TITLE
Fix link to Ubuntu

### DIFF
--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -29,8 +29,8 @@ items:
                   - name: Install
                     href: ../core/install/linux-ubuntu-install.md
                     displayName: ubuntu
-                  - name: Decision Guide
-                    href: ../core/install/linux-ubuntu.md
+                  - name: Decision guide
+                    href: ../core/install/linux-ubuntu-decision.md
                     displayName: ubuntu
               - name: Alpine
                 href: ../core/install/linux-alpine.md


### PR DESCRIPTION
Forgot to update TOC link

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/toc.yml](https://github.com/dotnet/docs/blob/366f3ca224612d5feef62cbd67325a2c73548c02/docs/fundamentals/toc.yml) | [docs/fundamentals/toc](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/toc?branch=pr-en-us-45575) |

<!-- PREVIEW-TABLE-END -->