### PR TITLE
Add missing semicolon for C typedefs

### DIFF
--- a/docs/framework/unmanaged-api/debugging/corgcreferencetype-enumeration.md
+++ b/docs/framework/unmanaged-api/debugging/corgcreferencetype-enumeration.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: CorGCReferenceType Enumeration"
 title: "CorGCReferenceType Enumeration"
+description: "Learn more about: CorGCReferenceType Enumeration"
 ms.date: "03/30/2017"
 api_name:
   - "CorGCReferenceType"
@@ -12,7 +12,6 @@ f1_keywords:
   - "CorGCReferenceType"
 helpviewer_keywords:
   - "CorGCReferenceType"
-ms.assetid: d9f16439-5a36-4474-8ffd-4f0b2c2bb686
 topic_type:
   - "apiref"
 ---
@@ -40,7 +39,7 @@ typedef enum {
     CorHandleStrongOnly = 0x1E3,
     CorHandleWeakOnly = 0xC,
     CorHandleAll = 0x7FFFFFFF
-} CorGCReferenceType
+} CorGCReferenceType;
 ```
 
 ## Members

--- a/docs/standard/native-interop/best-practices.md
+++ b/docs/standard/native-interop/best-practices.md
@@ -419,7 +419,7 @@ typedef struct _SYSTEM_PROCESS_INFORMATION {
     BYTE Reserved1[48];
     UNICODE_STRING ImageName;
 ...
-} SYSTEM_PROCESS_INFORMATION
+} SYSTEM_PROCESS_INFORMATION;
 ```
 
 In C#, we can write it like this:


### PR DESCRIPTION
## Summary

Add missing semicolon for C typedefs and edit metadata.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/unmanaged-api/debugging/corgcreferencetype-enumeration.md](https://github.com/dotnet/docs/blob/0a565c081ed86d5e2c9765b21c0fe1a8c660aa63/docs/framework/unmanaged-api/debugging/corgcreferencetype-enumeration.md) | [CorGCReferenceType Enumeration](https://review.learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/corgcreferencetype-enumeration?branch=pr-en-us-45585) |
| [docs/standard/native-interop/best-practices.md](https://github.com/dotnet/docs/blob/0a565c081ed86d5e2c9765b21c0fe1a8c660aa63/docs/standard/native-interop/best-practices.md) | [Native interoperability best practices - .NET](https://review.learn.microsoft.com/en-us/dotnet/standard/native-interop/best-practices?branch=pr-en-us-45585) |

<!-- PREVIEW-TABLE-END -->