### PR TITLE
Fix CC note about IncludeTestAssembly default

### DIFF
--- a/docs/core/testing/microsoft-testing-platform-extensions-code-coverage.md
+++ b/docs/core/testing/microsoft-testing-platform-extensions-code-coverage.md
@@ -37,7 +37,7 @@ Microsoft Code Coverage provides the following options:
 For more information about the available options, see [settings](../additional-tools/dotnet-coverage.md#settings) and [samples](https://github.com/microsoft/codecoverage/tree/main/samples/Algorithms).
 
 > [!NOTE]
-> The default value of `IncludeTestAssembly` in Microsoft.Testing.Extensions.CodeCoverage is `true`, while it used to be `false` in VSTest. This means that test projects are excluded by default. For more information, see [Code Coverage configuration](https://github.com/microsoft/codecoverage/blob/main/docs/configuration.md).
+> The default value of `IncludeTestAssembly` in Microsoft.Testing.Extensions.CodeCoverage is `false`, while it used to be `true` in VSTest. This means that test projects are excluded by default. For more information, see [Code Coverage configuration](https://github.com/microsoft/codecoverage/blob/main/docs/configuration.md).
 
 ## Coverlet
 


### PR DESCRIPTION
I had the defaults swapped in #45521 :(

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/microsoft-testing-platform-extensions-code-coverage.md](https://github.com/dotnet/docs/blob/992a0cb02283ed8e6a00e3b8b66c425d0219218e/docs/core/testing/microsoft-testing-platform-extensions-code-coverage.md) | [Code coverage extensions](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-extensions-code-coverage?branch=pr-en-us-45587) |

<!-- PREVIEW-TABLE-END -->