### PR TITLE
Fix illogical caution: Dispose should say DisposeAsync

### DIFF
--- a/docs/standard/garbage-collection/implementing-disposeasync.md
+++ b/docs/standard/garbage-collection/implementing-disposeasync.md
@@ -19,7 +19,7 @@ The <xref:System.IAsyncDisposable?displayProperty=nameWithType> interface was in
 It's typical when implementing the <xref:System.IAsyncDisposable> interface that classes also implement the <xref:System.IDisposable> interface. A good implementation pattern of the <xref:System.IAsyncDisposable> interface is to be prepared for either synchronous or asynchronous disposal, however, it's not a requirement. If no synchronous disposable of your class is possible, having only <xref:System.IAsyncDisposable> is acceptable. All of the guidance for implementing the disposal pattern also applies to the asynchronous implementation. This article assumes that you're already familiar with how to [implement a Dispose method](implementing-dispose.md).
 
 > [!CAUTION]
-> If you implement the <xref:System.IAsyncDisposable> interface but not the <xref:System.IDisposable> interface, your app can potentially leak resources. If a class implements <xref:System.IAsyncDisposable>, but not <xref:System.IDisposable>, and a consumer only calls `Dispose`, your implementation would never call `DisposeAsync`. This would result in a resource leak.
+> If you implement the <xref:System.IAsyncDisposable> interface but not the <xref:System.IDisposable> interface, your app can potentially leak resources. If a class implements <xref:System.IAsyncDisposable>, but not <xref:System.IDisposable>, and a consumer only calls `DisposeAsync`, your implementation would never call `DisposeAsync`. This would result in a resource leak.
 
 [!INCLUDE [disposables-and-dependency-injection](includes/disposables-and-dependency-injection.md)]
 


### PR DESCRIPTION
## Summary
 
The warning says:

> If you implement the [IAsyncDisposable](https://learn.microsoft.com/en-us/dotnet/api/system.iasyncdisposable) interface but not the [IDisposable](https://learn.microsoft.com/en-us/dotnet/api/system.idisposable) interface, your app can potentially leak resources. If a class implements [IAsyncDisposable](https://learn.microsoft.com/en-us/dotnet/api/system.iasyncdisposable), but not [IDisposable](https://learn.microsoft.com/en-us/dotnet/api/system.idisposable), and a consumer only calls **Dispose**, your implementation would never call DisposeAsync. This would result in a resource leak. 

The warning is illogical. If you do not implement IDisposable, there is no Dispose method to call. IAsyncDisposable only supports DisposeAsync.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/garbage-collection/implementing-disposeasync.md](https://github.com/dotnet/docs/blob/de52f2f757b93e3946e85c29e9de74736e98e274/docs/standard/garbage-collection/implementing-disposeasync.md) | [docs/standard/garbage-collection/implementing-disposeasync](https://review.learn.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-disposeasync?branch=pr-en-us-45588) |

<!-- PREVIEW-TABLE-END -->