### PR TITLE
Clarify guard behavior for OR patterns

### DIFF
--- a/docs/fsharp/language-reference/match-expressions.md
+++ b/docs/fsharp/language-reference/match-expressions.md
@@ -65,13 +65,13 @@ type Union =
     | B of int
 
 let foo() =
-    let test = A 42
+    let test = A 40
     match test with
     | A a
     | B a when a > 41 -> a // the guard applies to both patterns
     | _ -> 1
 
-foo() // returns 42
+foo() // returns 1
 ```
 
 ## See also


### PR DESCRIPTION
## Summary

As of now, the documentation poorly reflects the fact that a guard for a match is applied to the whole match because `A 42` matches 
```
| A a 
| B a when a > 41
```
 so it's unclear that the guard is applied to both `| A a` and `| B a` (i.e. `a > 41 = 42 > 41 = true` and does not reflect the fact that if `A a` is `A 40` it would not match `A a`)

This change would highlight that because `A a | B a when a > 41` would not match for `A 40` and instead it would match `_ -> 1`

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/match-expressions.md](https://github.com/dotnet/docs/blob/e90e31c8b60333d96cde56f6f6455b723218c22b/docs/fsharp/language-reference/match-expressions.md) | [Match expressions](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/match-expressions?branch=pr-en-us-45606) |

<!-- PREVIEW-TABLE-END -->