### PR TITLE
Document Automatically Defined Compiler Symbols in F# Compiler Directives

### DIFF
--- a/docs/fsharp/language-reference/compiler-directives.md
+++ b/docs/fsharp/language-reference/compiler-directives.md
@@ -52,6 +52,27 @@ let str = "Debugging!"
 #endif
 ```
 
+### Automatically Defined Symbols
+
+The F# compiler automatically defines certain symbols based on the build configuration. These symbols can be used with `#if` directives for conditional compilation.
+
+| Symbol  | Description |
+|---------|-------------|
+| `DEBUG` | Automatically defined in debug builds when compiling with the `Debug` configuration. |
+| `TRACE` | Defined when tracing is enabled in the project settings. |
+
+For example, you can use these symbols in conditional compilation:
+
+```fsharp
+#if DEBUG
+printfn "Debugging mode is enabled."
+#else
+printfn "Release mode."
+#endif
+```
+
+These symbols are typically set by the compiler and do not require explicit definition in the source code.
+
 ## NULLABLE directive
 
 Starting with F# 9, you can enable nullable reference types in the project:

--- a/docs/fsharp/language-reference/compiler-directives.md
+++ b/docs/fsharp/language-reference/compiler-directives.md
@@ -54,12 +54,30 @@ let str = "Debugging!"
 
 ### Automatically Defined Symbols
 
-The F# compiler automatically defines certain symbols based on the build configuration. These symbols can be used with `#if` directives for conditional compilation.
+In addition to symbols explicitly defined via project settings or command-line options, **F# projects inherit a set of predefined symbols** based on the SDK, target framework, and build configuration.
 
-| Symbol  | Description |
-|---------|-------------|
-| `DEBUG` | Automatically defined in debug builds when compiling with the `Debug` configuration. |
-| `TRACE` | Defined when tracing is enabled in the project settings. |
+#### Debug, Tracing, and Nullable Settings  
+
+| Symbol    | Description |
+|-----------|-------------|
+| `DEBUG`   | Defined in debug builds when compiling with the `Debug` configuration. |
+| `TRACE`   | Defined when tracing is enabled in the project settings. |
+| `NULLABLE` | Defined when `<Nullable>enable</Nullable>` is set in the project file. |
+
+#### Target Framework Symbols  
+
+| Symbol | Description |
+|--------|-------------|
+| `NET`, `NETSTANDARD`, `NETCOREAPP` | General indicators of the .NET target type. |
+| `NET5_0_OR_GREATER`, `NET6_0_OR_GREATER`, `NET7_0_OR_GREATER` | Defined for specific .NET versions. |
+| `NETCOREAPP3_1_OR_GREATER`, `NETCOREAPP2_0_OR_GREATER` | Defined for .NET Core versions. |
+
+#### Build Configuration Symbols  
+
+| Symbol    | Description |
+|-----------|-------------|
+| `Release` | Defined in release builds. |
+| `COMPILED` | Used in compiled projects. |
 
 For example, you can use these symbols in conditional compilation:
 
@@ -71,7 +89,8 @@ printfn "Release mode."
 #endif
 ```
 
-These symbols are typically set by the compiler and do not require explicit definition in the source code.
+For a full list of predefined symbols, refer to the official documentation:
+[.NET SDK Predefined Compilation Symbols](https://learn.microsoft.com/dotnet/fsharp/tools/fsharp-interactive/#interactive-and-compiled-preprocessor-directives).
 
 ## NULLABLE directive
 


### PR DESCRIPTION
### **PR Description:**  
This PR enhances the F# **Compiler Directives** documentation by adding a section on **automatically defined symbols**, such as `DEBUG` and `TRACE`. These symbols are implicitly defined by the compiler in specific build configurations and can be used for **conditional compilation**.  

#### **Changes Made:**  
- **Added a new "Automatically Defined Symbols" section** under **Conditional Compilation Directives**.  
- **Documented** `DEBUG` (enabled in Debug builds) and `TRACE` (enabled in tracing configurations).  
- **Included a code example** demonstrating conditional compilation using `#if DEBUG`.  

This update helps developers understand which symbols are pre-defined by the F# compiler and how to use them effectively. 

Fixes #45478 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/compiler-directives.md](https://github.com/dotnet/docs/blob/1818a9c011f5ead9a7436709d01209be6daf1b3e/docs/fsharp/language-reference/compiler-directives.md) | [Compiler Directives](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/compiler-directives?branch=pr-en-us-45607) |


<!-- PREVIEW-TABLE-END -->