### PR TITLE
[Breaking change]: --interactive option for dotnet CLI can now default to `true` in user-centric scenarios

### DIFF
--- a/docs/core/compatibility/10.0.md
+++ b/docs/core/compatibility/10.0.md
@@ -2,7 +2,7 @@
 title: Breaking changes in .NET 10
 titleSuffix: ""
 description: Navigate to the breaking changes in .NET 10.
-ms.date: 03/26/2025
+ms.date: 04/03/2025
 ai-usage: ai-assisted
 no-loc: [Blazor, Razor, Kestrel]
 ---
@@ -51,6 +51,7 @@ If you're migrating an app to .NET 10, the breaking changes listed here might af
 
 | Title                                                                                                                | Type of change      | Introduced version |
 |----------------------------------------------------------------------------------------------------------------------|---------------------|--------------------|
+| [.NET CLI `--interactive` defaults to `true` in user scenarios](sdk/10.0/dotnet-cli-interactive.md)                  | Behavioral change   | Preview 3          |
 | [Default workload configuration from 'loose manifests' to 'workload sets' mode](sdk/10.0/default-workload-config.md) | Behavioral change   | Preview 2          |
 | [`dotnet restore` audits transitive packages](sdk/10.0/nugetaudit-transitive-packages.md)                            | Behavioral change   | Preview 3          |
 | [MSBUILDCUSTOMBUILDEVENTWARNING escape hatch removed](sdk/10.0/custom-build-event-warning.md)                        | Behavioral change   | Preview 1          |

--- a/docs/core/compatibility/sdk/10.0/dotnet-cli-interactive.md
+++ b/docs/core/compatibility/sdk/10.0/dotnet-cli-interactive.md
@@ -8,7 +8,7 @@ ms.custom: https://github.com/dotnet/docs/issues/45548
 
 # .NET CLI `--interactive` defaults to `true` in user scenarios
 
-Starting in .NET 10 Preview 3, the `--interactive` flag for the .NET CLI defaults to `true` in user-centric scenarios. This change aims to improve NuGet authentication and enable future CLI features that rely on interactivity. The behavior remains unchanged for CI/CD environments.
+The `--interactive` flag for the .NET CLI now defaults to `true` in user-centric scenarios. The behavior remains unchanged for CI/CD environments.
 
 ## Version introduced
 

--- a/docs/core/compatibility/sdk/10.0/dotnet-cli-interactive.md
+++ b/docs/core/compatibility/sdk/10.0/dotnet-cli-interactive.md
@@ -1,0 +1,56 @@
+---
+title: "Breaking change - .NET CLI `--interactive` defaults to `true` in user scenarios"
+description: "Learn about the breaking change in .NET 10 Preview 3 where the --interactive flag defaults to true in user-centric scenarios."
+ms.date: 4/3/2025
+ai-usage: ai-assisted
+ms.custom: https://github.com/dotnet/docs/issues/45548
+---
+
+# .NET CLI `--interactive` defaults to `true` in user scenarios
+
+Starting in .NET 10 Preview 3, the `--interactive` flag for the .NET CLI defaults to `true` in user-centric scenarios. This change aims to improve NuGet authentication and enable future CLI features that rely on interactivity. The behavior remains unchanged for CI/CD environments.
+
+## Version introduced
+
+.NET 10 Preview 3
+
+## Previous behavior
+
+The `--interactive` flag always defaulted to `false` unless explicitly specified by the user.
+
+```bash
+dotnet restore --interactive
+# Required explicitly to enable interactivity
+```
+
+## New behavior
+
+The `--interactive` flag defaults to `true` in user-centric scenarios, such as when commands are run directly by a user. In CI/CD environments or when the process output stream is redirected, the flag defaults to `false`.
+
+```bash
+dotnet restore
+# Interactivity is enabled by default in user-centric scenarios
+```
+
+## Type of breaking change
+
+This is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+This change improves the user experience by:
+
+- Simplifying NuGet authentication, addressing a common pain point.
+- Providing a unified signal for enabling future CLI interactivity features.
+
+## Recommended action
+
+No action is required for most users. To explicitly disable interactivity, pass the `--interactive false` flag:
+
+```bash
+dotnet restore --interactive false
+```
+
+## Affected APIs
+
+None.

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -42,6 +42,8 @@ items:
                 href: globalization/10.0/version-override.md
           - name: SDK and MSBuild
             items:
+              - name: .NET CLI `--interactive` defaults to `true` in user scenarios
+                href: sdk/10.0/dotnet-cli-interactive.md
               - name: "`dotnet restore` audits transitive packages"
                 href: sdk/10.0/nugetaudit-transitive-packages.md
               - name: Default workload configuration from 'loose manifests' to 'workload sets' mode
@@ -1910,6 +1912,8 @@ items:
         items:
           - name: .NET 10
             items:
+              - name: .NET CLI `--interactive` defaults to `true` in user scenarios
+                href: sdk/10.0/dotnet-cli-interactive.md
               - name: "`dotnet restore` audits transitive packages"
                 href: sdk/10.0/nugetaudit-transitive-packages.md
               - name: Default workload configuration from 'loose manifests' to 'workload sets' mode


### PR DESCRIPTION
Fixes #45548


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/10.0.md](https://github.com/dotnet/docs/blob/dd05f00e546d83d4173cb129904126a4ee571942/docs/core/compatibility/10.0.md) | [docs/core/compatibility/10.0](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/10.0?branch=pr-en-us-45628) |
| [docs/core/compatibility/sdk/10.0/dotnet-cli-interactive.md](https://github.com/dotnet/docs/blob/dd05f00e546d83d4173cb129904126a4ee571942/docs/core/compatibility/sdk/10.0/dotnet-cli-interactive.md) | [docs/core/compatibility/sdk/10.0/dotnet-cli-interactive](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/10.0/dotnet-cli-interactive?branch=pr-en-us-45628) |
| [docs/core/compatibility/toc.yml](https://github.com/dotnet/docs/blob/dd05f00e546d83d4173cb129904126a4ee571942/docs/core/compatibility/toc.yml) | [docs/core/compatibility/toc](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/toc?branch=pr-en-us-45628) |


<!-- PREVIEW-TABLE-END -->