### PR TITLE
Add Win10 22H2 in versions-and-dependencies.md

### DIFF
--- a/docs/framework/install/versions-and-dependencies.md
+++ b/docs/framework/install/versions-and-dependencies.md
@@ -58,7 +58,7 @@ Jump to:
 |                    | Versions              |
 |--------------------|-----------------------|
 | **CLR**            | 4                     |
-| **Windows**        | ✔️ 11 version 24H2 (version 26100)<br/>✔️ 11 October 2023 Release (version 22631)<br/>✔️ 11 September 2022 Release (version 22621)<br/>➕ 11 October 2021 Release (version 22000)<br/>➕ 10 2022 Update (22H2)<br/>➕ 10 November 2021 Update<br/>➕ 10 May 2021 Update<br/>➕ 10 October 2020 Update<br/>|
+| **Windows**        | ✔️ 11 version 24H2 (version 26100)<br/>✔️ 11 October 2023 Release (version 22631)<br/>✔️ 11 September 2022 Release (version 22621)<br/>➕ 11 October 2021 Release (version 22000)<br/>➕ 10 October 2022 Update (22H2)<br/>➕ 10 November 2021 Update<br/>➕ 10 May 2021 Update<br/>➕ 10 October 2020 Update<br/>|
 | **Windows Server** | ✔️ Windows Server 2025<br/>➕ Windows Server 2022 |
 
 To determine the installed .NET version, use the following `Release` DWORD:
@@ -77,7 +77,7 @@ For more information, see [instructions](how-to-determine-which-versions-are-ins
 |         | Versions |
 |---------|----------|
 | **CLR** | 4        |
-|**Windows**|✔️ 11 October 2021 Release (Version 22000)<br/>✔️ 10 November 2021 Update<br/>✔️ 10 May 2021 Update<br/>✔️ 10 October 2020 Update<br/>✔️ 10 May 2020 Update<br/>✔️ 10 November 2019 Update<br/>✔️ 10 May 2019 Update<br/>➕ 10 October 2018 Update (Version 1809)<br/>➕ 10 April 2018 Update (Version 1803)<br/>➕ 10 Fall Creators Update (Version 1709)<br/>➕ 10 Creators Update (Version 1703)<br/>➕ 10 Anniversary Update (Version 1607)<br/>➕ 8.1<br/>➕7|
+|**Windows**|✔️ 11 October 2021 Release (Version 22000)<br/>✔️ 10 October 2022 Update (22H2)<br/>✔️ 10 November 2021 Update<br/>✔️ 10 May 2021 Update<br/>✔️ 10 October 2020 Update<br/>✔️ 10 May 2020 Update<br/>✔️ 10 November 2019 Update<br/>✔️ 10 May 2019 Update<br/>➕ 10 October 2018 Update (Version 1809)<br/>➕ 10 April 2018 Update (Version 1803)<br/>➕ 10 Fall Creators Update (Version 1709)<br/>➕ 10 Creators Update (Version 1703)<br/>➕ 10 Anniversary Update (Version 1607)<br/>➕ 8.1<br/>➕7|
 |**Windows Server**|✔️ Windows Server 2022<br/>➕ Windows Server 2019<br/>➕ Windows Server, version 1809<br/>➕ Windows Server, version 1803<br/>➕ 2016<br/>➕ 2012 R2<br/>➕ 2012<br/>➕ 2008 R2 SP1|
 
 To determine the installed .NET version, use the following `Release` DWORD:


### PR DESCRIPTION
## Summary

Windows 10 22H2 is preinstalled on .NET Framework 4.8.
However, this document lacks that information.
(The following document describes it.)
https://learn.microsoft.com/en-us/dotnet/framework/install/on-windows-and-server#windows-10


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/install/versions-and-dependencies.md](https://github.com/dotnet/docs/blob/2fcb1c99ca72db576c2308a5f372c51a331a3f15/docs/framework/install/versions-and-dependencies.md) | [.NET Framework versions and dependencies](https://review.learn.microsoft.com/en-us/dotnet/framework/install/versions-and-dependencies?branch=pr-en-us-45630) |

<!-- PREVIEW-TABLE-END -->