### PR TITLE
Fixed typo on System.Type.GetType methods page.

### DIFF
--- a/docs/fundamentals/runtime-libraries/system-type-gettype.md
+++ b/docs/fundamentals/runtime-libraries/system-type-gettype.md
@@ -83,7 +83,7 @@ The combination of `assemblyResolver` and `typeResolver` that you provide must b
 "System.Collections.Generic.Dictionary`2[System.String,[MyNamespace.MyType, MyAssembly]]"
 ```
 
-Notice that `MyType` is the only assembly-qualified type argument. The names of the <xref:System.Collections.Generic.Dictionary%602> and <xref:System.String> classes are not assembly-qualified. Your `typeResolver` must be able handle either an assembly or `null`, because it will receive `null` for <xref:System.Collections.Generic.Dictionary%602> and <xref:System.String>. It can handle that case by calling an overload of the <xref:System.Type.GetType%2A> method that takes a string, because both of the unqualified type names are in mscorlib.dll/System.Private.CoreLib.dll:
+Notice that `MyType` is the only assembly-qualified type argument. The names of the <xref:System.Collections.Generic.Dictionary%602> and <xref:System.String> classes are not assembly-qualified. Your `typeResolver` must be able to handle either an assembly or `null`, because it will receive `null` for <xref:System.Collections.Generic.Dictionary%602> and <xref:System.String>. It can handle that case by calling an overload of the <xref:System.Type.GetType%2A> method that takes a string, because both of the unqualified type names are in mscorlib.dll/System.Private.CoreLib.dll:
 
 :::code language="csharp" source="./snippets/System/Type/GetType/csharp/source.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/Type/GetType/fsharp/source.fs" id="Snippet1":::


### PR DESCRIPTION
## Summary

Fixed typo on System.Type.GetType methods page.

Fixes #45639 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/runtime-libraries/system-type-gettype.md](https://github.com/dotnet/docs/blob/a9ffc4fe26115c99801722c39131fb57bbbd6644/docs/fundamentals/runtime-libraries/system-type-gettype.md) | [System.Type.GetType methods](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-type-gettype?branch=pr-en-us-45646) |

<!-- PREVIEW-TABLE-END -->