### PR TITLE
Remove 'additional' from description of sdk/paths global.json property

### DIFF
--- a/docs/core/tools/global-json.md
+++ b/docs/core/tools/global-json.md
@@ -91,7 +91,7 @@ The following table shows the possible values for the `rollForward` key:
 - Type: Array of `string`
 - Available since: .NET 10 Preview 3 SDK.
 
-Specifies additional locations that should be considered when searching for a compatible .NET SDK. Paths can be absolute or relative to the location of the *global.json* file. The special value `$host$` represents the location corresponding to the running `dotnet` executable.
+Specifies the locations that should be considered when searching for a compatible .NET SDK. Paths can be absolute or relative to the location of the *global.json* file. The special value `$host$` represents the location corresponding to the running `dotnet` executable.
 
 These paths are searched in the order they're defined and the first [matching](#matching-rules) SDK is used.
 


### PR DESCRIPTION
## Summary

The `paths` array specifies the locations to use (it is not in addition to any other locations).


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/global-json.md](https://github.com/dotnet/docs/blob/a7f08a790489a4d3466f408385e28d3fc14e5cce/docs/core/tools/global-json.md) | [global.json overview](https://review.learn.microsoft.com/en-us/dotnet/core/tools/global-json?branch=pr-en-us-45651) |

<!-- PREVIEW-TABLE-END -->