### PR TITLE
Update notes on IHttpClientFactory and cookies

### DIFF
--- a/docs/core/extensions/httpclient-factory.md
+++ b/docs/core/extensions/httpclient-factory.md
@@ -12,8 +12,9 @@ In this article, you'll learn how to use the `IHttpClientFactory` interface to c
 
 With modern application development principles driving best practices, the <xref:System.Net.Http.IHttpClientFactory> serves as a factory abstraction that can create `HttpClient` instances with custom configurations. <xref:System.Net.Http.IHttpClientFactory> was introduced in .NET Core 2.1. Common HTTP-based .NET workloads can take advantage of resilient and transient-fault-handling third-party middleware with ease.
 
-> [!NOTE]
-> If your app requires cookies, it might be better to avoid using <xref:System.Net.Http.IHttpClientFactory> in your app. For alternative ways of managing clients, see [Guidelines for using HTTP clients](../../fundamentals/networking/http/httpclient-guidelines.md).
+> [!WARNING]
+> If your app requires cookies, it's recommended to avoid using <xref:System.Net.Http.IHttpClientFactory>. Pooling the <xref:System.Net.Http.HttpMessageHandler> instances results in sharing of <xref:System.Net.CookieContainer> objects. Unanticipated <xref:System.Net.CookieContainer> sharing might leak cookies between unrelated parts of the application. Moreover, when <xref:Microsoft.Extensions.Http.HttpClientFactoryOptions.HandlerLifetime> expires, the handler is recycled, meaning that all cookies stored in its <xref:System.Net.CookieContainer> are lost.
+> For alternative ways of managing clients, see [Guidelines for using HTTP clients](../../fundamentals/networking/http/httpclient-guidelines.md).
 
 > [!IMPORTANT]
 > Lifetime management of `HttpClient` instances created by `IHttpClientFactory` is completely different from instances created manually. The strategies are to use either **short-lived** clients created by `IHttpClientFactory` or **long-lived** clients with `PooledConnectionLifetime` set up. For more information, see the [HttpClient lifetime management](#httpclient-lifetime-management) section and [Guidelines for using HTTP clients](../../fundamentals/networking/http/httpclient-guidelines.md).

--- a/docs/fundamentals/networking/http/httpclient-guidelines.md
+++ b/docs/fundamentals/networking/http/httpclient-guidelines.md
@@ -49,8 +49,8 @@ To summarize recommended `HttpClient` use in terms of lifetime management, you s
 
 - In .NET Framework, use <xref:System.Net.Http.IHttpClientFactory> to manage your `HttpClient` instances. If you don't use the factory and instead create a new client instance for each request yourself, you can exhaust available ports.
 
-    > [!TIP]
-    > If your app requires cookies, consider disabling automatic cookie handling or avoiding <xref:System.Net.Http.IHttpClientFactory>. Pooling the <xref:System.Net.Http.HttpMessageHandler> instances results in sharing of <xref:System.Net.CookieContainer> objects. Unanticipated <xref:System.Net.CookieContainer> object sharing often results in incorrect code.
+    > [!WARNING]
+    > If your app requires cookies, it's recommended to avoid using <xref:System.Net.Http.IHttpClientFactory>. Pooling the <xref:System.Net.Http.HttpMessageHandler> instances results in sharing of <xref:System.Net.CookieContainer> objects. Unanticipated <xref:System.Net.CookieContainer> sharing might leak cookies between unrelated parts of the application. Moreover, when <xref:Microsoft.Extensions.Http.HttpClientFactoryOptions.HandlerLifetime> expires, the handler is recycled, meaning that all cookies stored in its <xref:System.Net.CookieContainer> are lost.
 
 For more information about managing `HttpClient` lifetime with `IHttpClientFactory`, see [`IHttpClientFactory` guidelines](../../../core/extensions/httpclient-factory.md#httpclient-lifetime-management).
 


### PR DESCRIPTION
There seems to be a confusion around the reasons why we advise against HttpClientFactory when the app needs to use cookies. https://github.com/dotnet/dotnet-api-docs/issues/10770 and https://github.com/dotnet/dotnet-api-docs/issues/1535 imply that users often think the problem might be related to `CookieContainer` thread safety which is not the case.

This PR updates the notes, describing the actual reasons: cookie leaking and unexpected recycling of cookies.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/httpclient-factory.md](https://github.com/dotnet/docs/blob/d39ddcb15d47b1bfa8b8b80ca07cf0edd4fb5aa0/docs/core/extensions/httpclient-factory.md) | [IHttpClientFactory with .NET](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/httpclient-factory?branch=pr-en-us-45658) |
| [docs/fundamentals/networking/http/httpclient-guidelines.md](https://github.com/dotnet/docs/blob/d39ddcb15d47b1bfa8b8b80ca07cf0edd4fb5aa0/docs/fundamentals/networking/http/httpclient-guidelines.md) | [HttpClient guidelines for .NET](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient-guidelines?branch=pr-en-us-45658) |

<!-- PREVIEW-TABLE-END -->