### PR TITLE
Fix the typo in ComponentGuaranteesAttribute class page

### DIFF
--- a/docs/fundamentals/runtime-libraries/system-runtime-versioning-componentguaranteesattribute.md
+++ b/docs/fundamentals/runtime-libraries/system-runtime-versioning-componentguaranteesattribute.md
@@ -126,7 +126,7 @@ The following example tests whether a type is marked as <xref:System.Runtime.Ver
 :::code language="csharp" source="./snippets/System.Runtime.Versioning/ComponentGuaranteesAttribute/Overview/csharp/apply1.cs" id="Snippet2":::
 :::code language="vb" source="./snippets/System.Runtime.Versioning/ComponentGuaranteesAttribute/Overview/vb/apply1.vb" id="Snippet2":::
 
-The following example tests wither a type is marked as <xref:System.Runtime.Versioning.ComponentGuaranteesOptions.None> (that is, neither <xref:System.Runtime.Versioning.ComponentGuaranteesOptions.Stable> nor <xref:System.Runtime.Versioning.ComponentGuaranteesOptions.Exchange>).
+The following example tests whether a type is marked as <xref:System.Runtime.Versioning.ComponentGuaranteesOptions.None> (that is, neither <xref:System.Runtime.Versioning.ComponentGuaranteesOptions.Stable> nor <xref:System.Runtime.Versioning.ComponentGuaranteesOptions.Exchange>).
 
 :::code language="csharp" source="./snippets/System.Runtime.Versioning/ComponentGuaranteesAttribute/Overview/csharp/apply1.cs" id="Snippet3":::
 :::code language="vb" source="./snippets/System.Runtime.Versioning/ComponentGuaranteesAttribute/Overview/vb/apply1.vb" id="Snippet3":::


### PR DESCRIPTION
This small pull request fixes #45655.
It covers the noticed typo in the page.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/runtime-libraries/system-runtime-versioning-componentguaranteesattribute.md](https://github.com/dotnet/docs/blob/bbb1b5b3f3bee80bd00f7317846ca06856673eb5/docs/fundamentals/runtime-libraries/system-runtime-versioning-componentguaranteesattribute.md) | [System.Runtime.Versioning.ComponentGuaranteesAttribute class](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-runtime-versioning-componentguaranteesattribute?branch=pr-en-us-45664) |

<!-- PREVIEW-TABLE-END -->