### PR TITLE
Fix: microsoft - contoso example in <schemeSettings> page

### DIFF
--- a/docs/framework/configure-apps/file-schema/network/schemesettings-element-uri-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/schemesettings-element-uri-settings.md
@@ -53,7 +53,7 @@ Specifies how a <xref:System.Uri> will be parsed for specific schemes.
   
  For this reason, <xref:System.Uri?displayProperty=nameWithType> class first un-escapes path delimiters and then applies path compression. The result of passing the malicious URL above to <xref:System.Uri?displayProperty=nameWithType> class constructor results in the following URI:  
   
- `http://www.microsoft.com/Windows/System32/cmd.exe?/c+dir+c:\`  
+ `http://www.contoso.com/Windows/System32/cmd.exe?/c+dir+c:\`  
   
  This default behavior can be modified to not un-escape percent encoded path delimiters using the schemeSettings configuration option for a specific scheme.  
   


### PR DESCRIPTION
This pull request quickly fixes #45193.
It replaces "microsoft" with "contoso" in the example of safe URL handling in schemeSettings page.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/configure-apps/file-schema/network/schemesettings-element-uri-settings.md](https://github.com/dotnet/docs/blob/ce023e59ccfbf136bb07cac4ee0ff4b581cba9bd/docs/framework/configure-apps/file-schema/network/schemesettings-element-uri-settings.md) | [\<schemeSettings> Element (Uri Settings)](https://review.learn.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/network/schemesettings-element-uri-settings?branch=pr-en-us-45665) |

<!-- PREVIEW-TABLE-END -->