### PR TITLE
[Breaking change]: [browser] streaming HTTP response is on by deafult

### DIFF
--- a/docs/core/compatibility/10.0.md
+++ b/docs/core/compatibility/10.0.md
@@ -2,7 +2,7 @@
 title: Breaking changes in .NET 10
 titleSuffix: ""
 description: Navigate to the breaking changes in .NET 10.
-ms.date: 04/03/2025
+ms.date: 04/08/2025
 ai-usage: ai-assisted
 no-loc: [Blazor, Razor, Kestrel]
 ---
@@ -46,6 +46,12 @@ If you're migrating an app to .NET 10, the breaking changes listed here might af
 | [X500DistinguishedName validation is stricter](cryptography/10.0/x500distinguishedname-validation.md)    | Behavioral change                     | Preview 1          |
 | [X509Certificate and PublicKey key parameters can be null](cryptography/10.0/x509-publickey-null.md)     | Behavioral/source incompatible change | Preview 3          |
 | [Environment variable renamed to DOTNET_OPENSSL_VERSION_OVERRIDE](cryptography/10.0/version-override.md) | Behavioral change                     | Preview 1          |
+
+## Networking
+
+| Title                                                                                                            | Type of change    | Introduced version |
+|------------------------------------------------------------------------------------------------------------------|-------------------|--------------------|
+| [Streaming HTTP responses enabled by default in browser HTTP clients](networking/10.0/default-http-streaming.md) | Behavioral change | Preview 3          |
 
 ## SDK and MSBuild
 

--- a/docs/core/compatibility/networking/10.0/default-http-streaming.md
+++ b/docs/core/compatibility/networking/10.0/default-http-streaming.md
@@ -1,0 +1,67 @@
+---
+title: "Breaking change - Streaming HTTP responses enabled by default in browser HTTP clients"
+description: "Learn about the breaking change in .NET 10 Preview 3 where streaming HTTP responses are enabled by default in browser HTTP clients."
+ms.date: 4/7/2025
+ai-usage: ai-assisted
+ms.custom: https://github.com/dotnet/docs/issues/45644
+---
+
+# Streaming HTTP responses enabled by default in browser HTTP clients
+
+Browser HTTP clients now enable streaming HTTP responses by default. Consequently, the <xref:System.Net.Http.HttpContent.ReadAsStreamAsync*?displayProperty=nameWithType> method now returns a `BrowserHttpReadStream` instead of a <xref:System.IO.MemoryStream>, which does not support synchronous operations. This may require updates to existing code that relies on synchronous stream operations.
+
+## Version introduced
+
+.NET 10 Preview 3
+
+## Previous behavior
+
+In browser environments such as WebAssembly (WASM) and Blazor, the HTTP client buffered the entire response by default. The <xref:System.Net.Http.HttpContent> object contained a <xref:System.IO.MemoryStream> unless you explicitly opted in to streaming responses using the `WebAssemblyEnableStreamingResponse` option.
+
+```csharp
+var response = await httpClient.GetAsync("https://example.com");
+var contentStream = await response.Content.ReadAsStreamAsync(); // Returns MemoryStream
+```
+
+## New behavior
+
+Streaming HTTP responses are now enabled by default. The <xref:System.Net.Http.HttpContent> no longer contains a <xref:System.IO.MemoryStream>. Instead, <xref:System.Net.Http.HttpContent.ReadAsStreamAsync*?displayProperty=nameWithType> returns a `BrowserHttpReadStream`, which does not support synchronous operations.
+
+```csharp
+var response = await httpClient.GetAsync("https://example.com");
+var contentStream = await response.Content.ReadAsStreamAsync(); // Returns BrowserHttpReadStream
+```
+
+## Type of breaking change
+
+This is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+This change supports use-cases around streaming <xref:System.Net.Http.Json.HttpClientJsonExtensions.GetFromJsonAsAsyncEnumerable*>.
+
+## Recommended action
+
+If your application relies on synchronous stream operations, update the code to use asynchronous alternatives. To disable streaming globally or for specific requests, use the provided configuration options.
+
+To disable streaming for individual requests, use the following:
+
+```csharp
+request.Options.Set(new HttpRequestOptionsKey<bool>("WebAssemblyEnableStreamingResponse"), false);
+// or
+request.SetBrowserResponseStreamingEnabled(false);
+```
+
+To disable streaming globally, set the environment variable `DOTNET_WASM_ENABLE_STREAMING_RESPONSE` or add the following to your project file:
+
+```xml
+<WasmEnableStreamingResponse>false</WasmEnableStreamingResponse>
+```
+
+> [!NOTE]
+> As of .NET 10 Preview 3 the `<WasmEnableStreamingResponse>` property is not yet available. It will be available in a future release. For more details, see the [GitHub issue](https://github.com/dotnet/runtime/issues/97449).
+
+## Affected APIs
+
+- <xref:System.Net.Http.HttpContent?displayProperty=fullName>
+- <xref:System.Net.Http.HttpContent.ReadAsStreamAsync*?displayProperty=fullName>

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -40,6 +40,10 @@ items:
             items:
               - name: Environment variable renamed to DOTNET_ICU_VERSION_OVERRIDE
                 href: globalization/10.0/version-override.md
+          - name: Networking
+            items:
+              - name: Streaming HTTP responses enabled by default in browser HTTP clients
+                href: networking/10.0/default-http-streaming.md
           - name: SDK and MSBuild
             items:
               - name: .NET CLI `--interactive` defaults to `true` in user scenarios
@@ -1858,6 +1862,10 @@ items:
                 href: maui/7.0/iwindowstatemanager-apis-removed.md
       - name: Networking
         items:
+          - name: .NET 10
+            items:
+              - name: Streaming HTTP responses enabled by default in browser HTTP clients
+                href: networking/10.0/default-http-streaming.md
           - name: .NET 9
             items:
               - name: HttpClient metrics report `server.port` unconditionally


### PR DESCRIPTION
Fixes #45644


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/10.0.md](https://github.com/dotnet/docs/blob/7b8d4a64b3998192a2e99ff6a6ddccb2469363ac/docs/core/compatibility/10.0.md) | [docs/core/compatibility/10.0](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/10.0?branch=pr-en-us-45667) |
| [docs/core/compatibility/networking/10.0/default-http-streaming.md](https://github.com/dotnet/docs/blob/7b8d4a64b3998192a2e99ff6a6ddccb2469363ac/docs/core/compatibility/networking/10.0/default-http-streaming.md) | [docs/core/compatibility/networking/10.0/default-http-streaming](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/networking/10.0/default-http-streaming?branch=pr-en-us-45667) |
| [docs/core/compatibility/toc.yml](https://github.com/dotnet/docs/blob/7b8d4a64b3998192a2e99ff6a6ddccb2469363ac/docs/core/compatibility/toc.yml) | [docs/core/compatibility/toc](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/toc?branch=pr-en-us-45667) |

<!-- PREVIEW-TABLE-END -->