### PR TITLE
Remove incorrect info about default calendar restriction

### DIFF
--- a/docs/fundamentals/runtime-libraries/system-globalization-persiancalendar.md
+++ b/docs/fundamentals/runtime-libraries/system-globalization-persiancalendar.md
@@ -1,7 +1,7 @@
 ---
 title: System.Globalization.PersianCalendar class
 description: Learn more about the System.Globalization.PersianCalendar class.
-ms.date: 12/28/2023
+ms.date: 04/09/2025
 ms.topic: conceptual
 ---
 # <xref:System.Globalization.PersianCalendar> class
@@ -19,24 +19,18 @@ The Persian calendar is based on a solar year and is approximately 365 days long
 
 Each of the first six months in the Persian calendar has 31 days, each of the next five months has 30 days, and the last month has 29 days in a common year and 30 days in a leap year. A leap year is a year that, when divided by 33, has a remainder of 1, 5, 9, 13, 17, 22, 26, or 30. For example, the year 1370 is a leap year because dividing it by 33 yields a remainder of 17. There are approximately eight leap years in every 33-year cycle.
 
-## The PersianCalendar class and .NET Framework versions
+## The PersianCalendar class and .NET versions
 
 Starting with .NET Framework 4.6, the <xref:System.Globalization.PersianCalendar> class uses the Hijri solar astronomical algorithm rather than an observational algorithm to calculate dates. This makes the <xref:System.Globalization.PersianCalendar> implementation consistent with the Persian calendar in use in Iran and Afghanistan, the two countries in which the Persian calendar is in most widespread use. The change affects all apps running on .NET Framework 4 or later if .NET Framework 4.6 is installed.
 
 As a result of the changed algorithm:
 
 - The two algorithms should return identical results when converting dates between 1800 and 2123 in the Gregorian calendar.
-
-- The two algorithms might return differentresults when converting dates before 1800 and after 2123 in the Gregorian calendar.
-
-- The <xref:System.Globalization.PersianCalendar.MinSupportedDateTime%2A> property value has changed from March 21, 0622 in the Gregorian calendar to March 22, 0622 in the Gregorian calendar.
-
-- The <xref:System.Globalization.PersianCalendar.MaxSupportedDateTime%2A> property value has changed from the 10th day of the 10th month of the year 9378 in the Persian calendar to the 13th day of the 10th month of the year 9378 in the Persian calendar.
-
-- The <xref:System.Globalization.PersianCalendar.IsLeapYear%2A> method may return a different result than it did previously.
+- The two algorithms might return different results when converting dates before 1800 and after 2123 in the Gregorian calendar.
+- The <xref:System.Globalization.PersianCalendar.MinSupportedDateTime> property value has changed from March 21, 0622 in the Gregorian calendar to March 22, 0622 in the Gregorian calendar.
+- The <xref:System.Globalization.PersianCalendar.MaxSupportedDateTime> property value has changed from the 10th day of the 10th month of the year 9378 in the Persian calendar to the 13th day of the 10th month of the year 9378 in the Persian calendar.
+- The <xref:System.Globalization.PersianCalendar.IsLeapYear%2A> method might return a different result than it did previously.
 
 ## Use the PersianCalendar class
 
-Applications use a <xref:System.Globalization.PersianCalendar> object to calculate dates in the Persian calendar or convert Persian dates to and from Gregorian dates.
-
-You cannot use a <xref:System.Globalization.PersianCalendar> object as the default calendar for a culture. The default calendar is specified by the <xref:System.Globalization.CultureInfo.Calendar%2A?displayProperty=nameWithType> property and must be one of the calendars returned by the <xref:System.Globalization.CultureInfo.OptionalCalendars%2A?displayProperty=nameWithType> property. Currently, the <xref:System.Globalization.PersianCalendar> class is not an optional calendar for any culture supported by the <xref:System.Globalization.CultureInfo> class and consequently cannot be a default calendar.
+You can use a <xref:System.Globalization.PersianCalendar> object to calculate dates in the Persian calendar or convert Persian dates to and from Gregorian dates. The Persian calendar is the [default calendar](xref:System.Globalization.CultureInfo.Calendar) for cultures such as Persian (Afghanistan) and Central Kurdish (Iran).


### PR DESCRIPTION
Fixes #45555.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/runtime-libraries/system-globalization-persiancalendar.md](https://github.com/dotnet/docs/blob/9ec02e4e43d9ffc81e64af70347f4f76bd07fa68/docs/fundamentals/runtime-libraries/system-globalization-persiancalendar.md) | [`System.Globalization.PersianCalendar` class](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-globalization-persiancalendar?branch=pr-en-us-45764) |

<!-- PREVIEW-TABLE-END -->