### PR TITLE
Correct the folder name in the pack and install section of the templates article.

### DIFF
--- a/docs/core/tutorials/cli-templates-create-template-package.md
+++ b/docs/core/tutorials/cli-templates-create-template-package.md
@@ -127,7 +127,7 @@ These MSBuild tasks provide template validation and [localization of the templat
 
 ## Pack and install
 
-Save the project file. Before building the template package, verify that your folder structure is correct. Any template you want to pack should be placed in the _templates_ folder, in its own folder. The folder structure should look similar to the following hierarchy:
+Save the project file. Before building the template package, verify that your folder structure is correct. Any template you want to pack should be placed in the _content_ folder, in its own folder. The folder structure should look similar to the following hierarchy:
 
 ```console
 working


### PR DESCRIPTION
## Summary

Use the correct folder name.

Fixes #45757


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tutorials/cli-templates-create-template-package.md](https://github.com/dotnet/docs/blob/5c3e59460f0b74e70327ff6d7106d672429e3318/docs/core/tutorials/cli-templates-create-template-package.md) | [Tutorial: Create a template package](https://review.learn.microsoft.com/en-us/dotnet/core/tutorials/cli-templates-create-template-package?branch=pr-en-us-45786) |

<!-- PREVIEW-TABLE-END -->