### PR TITLE
Update csrefKeywordsModifiers.cs

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs
@@ -785,7 +785,7 @@ namespace csrefKeywordsModifiers
             protected Shape(string color)
             {
                 Color = color;
-                Console.WriteLine("Created a shape with color {color}.");
+                Console.WriteLine($"Created a shape with color {color}.");
             }
 
             // Abstract method that must be implemented by derived classes
@@ -813,7 +813,7 @@ namespace csrefKeywordsModifiers
             public static void Main(string[] args)
              {
                     Square square = new Square("red", 5);
-                    Console.WriteLine("Area of the square: {square.CalculateArea()}");            
+                    Console.WriteLine($"Area of the square: {square.CalculateArea()}");            
              }
         }
         //</snippet27>


### PR DESCRIPTION
Added '$' in two locations to enable string interpolation.

## Summary
There were two instances in code snippet 27 where string interpolation was intended to be used, but the '$' was omitted. 


Fixes #45787 
