### PR TITLE
Fix Broken Link in Enumeration Types Documentation

### DIFF
--- a/docs/csharp/language-reference/builtin-types/enum.md
+++ b/docs/csharp/language-reference/builtin-types/enum.md
@@ -50,7 +50,7 @@ If you want an enumeration type to represent a combination of choices, define en
 
 [!code-csharp[enum flags](snippets/shared/EnumType.cs#Flags)]
 
-For more information and examples, see the <xref:System.FlagsAttribute?displayProperty=nameWithType> API reference page and the [Non-exclusive members and the Flags attribute](/dotnet/api/system.enum#non-exclusive-members-and-the-flags-attribute) section of the <xref:System.Enum?displayProperty=nameWithType> API reference page.
+For more information and examples, see the <xref:System.FlagsAttribute?displayProperty=nameWithType> API reference page and the [Non-exclusive members and the Flags attribute](/dotnet/fundamentals/runtime-libraries/system-enum#non-exclusive-members-and-the-flags-attribute) section of the <xref:System.Enum?displayProperty=nameWithType> API reference page.
 
 ## The System.Enum type and enum constraint
 


### PR DESCRIPTION
## Summary

### Pull Request Description:
This pull request updates the link for "Non-exclusive members and the Flags attribute" under the "Enumeration types as bit flags" section in the C# documentation. The link now correctly points to the relevant section.

Updated link:
[Non-exclusive members and the Flags attribute](/dotnet/fundamentals/runtime-libraries/system-enum#non-exclusive-members-and-the-flags-attribute)

Fixes #45789 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/builtin-types/enum.md](https://github.com/dotnet/docs/blob/722f5e13d061653c76b0c5bca7b9bd6ccde986de/docs/csharp/language-reference/builtin-types/enum.md) | [Enumeration types (C# reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/enum?branch=pr-en-us-45804) |

<!-- PREVIEW-TABLE-END -->