### PR TITLE
Fix bad string interpolations

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.timespan.custom/cs/customexamples1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.timespan.custom/cs/customexamples1.cs
@@ -64,8 +64,8 @@ public class Example
       for (int ctr = 2; ctr <= 8; ctr++)
       {
          string fmt = new String('d', ctr) + @"\.hh\:mm\:ss";
-         Console.WriteLine($"{fmt} --> {ts1:" + fmt + "}");
-         Console.WriteLine($"{fmt} --> {ts2:" + fmt + "}");
+         Console.WriteLine($"{fmt} --> {ts1.ToString(fmt)}");
+         Console.WriteLine($"{fmt} --> {ts2.ToString(fmt)}");
          Console.WriteLine();
       }
       // The example displays the following output:

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.timespan.custom/cs/fspecifiers1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.timespan.custom/cs/fspecifiers1.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 public class Example
 {
@@ -11,15 +11,15 @@ public class Example
       Console.WriteLine();
 
       for (int ctr = 1; ctr <= 7; ctr++) {
-         fmt = new String('f', ctr);
+         fmt = new string('f', ctr);
          if (fmt.Length == 1) fmt = "%" + fmt;
          Console.WriteLine($"{fmt,10}: {ts.ToString(fmt)}");
       }
       Console.WriteLine();
 
       for (int ctr = 1; ctr <= 7; ctr++) {
-         fmt = new String('f', ctr);
-         Console.WriteLine($"{"s\\." + fmt,10}: {ts.ToString("s\\." + fmt)}");
+         fmt = $"s\\.{new string('f', ctr)}";
+         Console.WriteLine($"{fmt,10}: {ts.ToString(fmt)}");
       }
       // The example displays the following output:
       //               %f: 8

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.timespan.custom/cs/fspecifiers1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.timespan.custom/cs/fspecifiers1.cs
@@ -13,13 +13,13 @@ public class Example
       for (int ctr = 1; ctr <= 7; ctr++) {
          fmt = new String('f', ctr);
          if (fmt.Length == 1) fmt = "%" + fmt;
-         Console.WriteLine("{0,10}: {1:" + fmt + "}", fmt, ts);
+         Console.WriteLine($"{fmt,10}: {ts.ToString(fmt)}");
       }
       Console.WriteLine();
 
       for (int ctr = 1; ctr <= 7; ctr++) {
          fmt = new String('f', ctr);
-         Console.WriteLine("{0,10}: {1:s\\." + fmt + "}", "s\\." + fmt, ts);
+         Console.WriteLine($"{"s\\." + fmt,10}: {ts.ToString("s\\." + fmt)}");
       }
       // The example displays the following output:
       //               %f: 8

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.timespan.custom/cs/negativevalues1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.timespan.custom/cs/negativevalues1.cs
@@ -9,10 +9,10 @@ public class Example
       String fmt = (result < TimeSpan.Zero ?  "\\-" : "") + "dd\\.hh\\:mm";
 
       Console.WriteLine(result.ToString(fmt));
-      Console.WriteLine($"Interval: {result:" + fmt + "}");
+      Console.WriteLine($"Interval: {result.ToString(fmt)}");
    }
 }
 // The example displays output like the following:
-//       -1291.10:54
-//       Interval: -1291.10:54
+//       -5582.12:21
+//       Interval: -5582.12:21
 // </Snippet29>


### PR DESCRIPTION
## Summary

The automated string interpolation failed when the format was a variable instead of a string literal.

Fixes #45795
