### PR TITLE
Fix missing dash in --ignore-exit-code flag

### DIFF
--- a/docs/core/testing/microsoft-testing-platform-intro.md
+++ b/docs/core/testing/microsoft-testing-platform-intro.md
@@ -251,7 +251,7 @@ The list below described only the platform options. To see the specific options 
 
   Prints out a description of how to use the command.
 
-- **`-ignore-exit-code`**
+- **`--ignore-exit-code`**
 
   Allows some non-zero exit codes to be ignored, and instead returned as `0`. For more information, see [Ignore specific exit codes](./microsoft-testing-platform-exit-codes.md#ignore-specific-exit-codes).
 


### PR DESCRIPTION
## Summary

Fix missing dash in the `--ignore-exit-code` flag

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/microsoft-testing-platform-intro.md](https://github.com/dotnet/docs/blob/d0d5e9d47db837d0423e4bda6485864e351ddcbd/docs/core/testing/microsoft-testing-platform-intro.md) | [Microsoft.Testing.Platform overview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-intro?branch=pr-en-us-45812) |

<!-- PREVIEW-TABLE-END -->