### PR TITLE
toc.yml: Move "Built-in types" to the top

### DIFF
--- a/docs/csharp/language-reference/toc.yml
+++ b/docs/csharp/language-reference/toc.yml
@@ -10,6 +10,8 @@ items:
     href: ./configure-language-version.md
 - name: Types
   items:
+  - name: Built-in types
+    href: ./builtin-types/built-in-types.md
   - name: Value types
     items:
     - name: Overview
@@ -68,8 +70,6 @@ items:
         href: ./builtin-types/arrays.md
   - name: void
     href: ./builtin-types/void.md
-  - name: Built-in types
-    href: ./builtin-types/built-in-types.md
   - name: Unmanaged types
     href: ./builtin-types/unmanaged-types.md
   - name: Default values


### PR DESCRIPTION
This PR proposes moving the "Built-in types" node to top, above every other node and subbranch under the "Types" branch. Reason: The "Types" branch exclusively talks about built-in types.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/toc.yml](https://github.com/dotnet/docs/blob/95fb943a85d1b8fe7767f085242493dbca0da76c/docs/csharp/language-reference/toc.yml) | [docs/csharp/language-reference/toc](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/toc?branch=pr-en-us-45834) |

<!-- PREVIEW-TABLE-END -->