### PR TITLE
Warn about dotnet-dump memory usage

### DIFF
--- a/docs/core/diagnostics/dotnet-dump.md
+++ b/docs/core/diagnostics/dotnet-dump.md
@@ -123,6 +123,11 @@ dotnet-dump collect [-h|--help] [-p|--process-id] [-n|--name] [--type] [-o|--out
 > [!NOTE]
 > To collect a dump using `dotnet-dump`, it needs to be run as the same user as the user running target process or as root. Otherwise, the tool will fail to establish a connection with the target process.
 
+> [!NOTE]
+> Collecting a full or heap dump may cause the OS to page in substantial virtual memory for the target process. If the target process is running in a container with an enforced memory limit, the increased memory usage
+> may cause the OS to terminate the container if the limit was exceeded. We recommend testing to ensure the memory limit is set high enough. Another option is to temporarily change or remove the limit
+> prior to dump collection if your environment supports doing so.
+
 ## dotnet-dump analyze
 
 Starts an interactive shell to explore a dump. The shell accepts various [SOS commands](#analyze-sos-commands).


### PR DESCRIPTION
There has been a long known issue ( https://github.com/dotnet/runtime/issues/71472 ) that dotnet-dump increases memory usage, sometimes substantially. We haven't identified any quick/easy solution to reduce that memory usage so far. I want to make sure users are aware of it as a known limitation when working with the tool.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/dotnet-dump.md](https://github.com/dotnet/docs/blob/eb347dc4555e8e57c86b90ff44ee738060a10542/docs/core/diagnostics/dotnet-dump.md) | [Dump collection and analysis utility (dotnet-dump)](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-dump?branch=pr-en-us-45841) |

<!-- PREVIEW-TABLE-END -->