### PR TITLE
Update ca2249.md and fix typo in the example code

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca2249.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2249.md
@@ -110,22 +110,22 @@ class MyClass
         found = str.Contains('x');
 
         // No comparisonType in string overload, adds StringComparison.CurrentCulture to resulting fix
-        found = !string.Contains("text", StringComparison.CurrentCulture);
-        found = string.Contains("text", StringComparison.CurrentCulture);
+        found = !str.Contains("text", StringComparison.CurrentCulture);
+        found = str.Contains("text", StringComparison.CurrentCulture);
 
         // comparisonType equal to StringComparison.Ordinal, removes the argument
-        found = !string.Contains('x');
-        found = string.Contains('x');
+        found = !str.Contains('x');
+        found = str.Contains('x');
 
-        found = !string.Contains("text");
-        found = string.Contains("text");
+        found = !str.Contains("text");
+        found = str.Contains("text");
 
         // comparisonType different than StringComparison.Ordinal, preserves the argument
-        ;found = !string.Contains('x', StringComparison.OrdinalIgnoreCase)
-        found = string.Contains('x', StringComparison.CurrentCulture);
+        found = !str.Contains('x', StringComparison.OrdinalIgnoreCase);
+        found = str.Contains('x', StringComparison.CurrentCulture);
 
-        found = !string.Contains("text", StringComparison.InvariantCultureIgnoreCase);
-        found = string.Contains("text", StringComparison.InvariantCulture);
+        found = !str.Contains("text", StringComparison.InvariantCultureIgnoreCase);
+        found = str.Contains("text", StringComparison.InvariantCulture);
 
         // This case had to be manually fixed
         if (!str.Contains("text"))


### PR DESCRIPTION
## Update ca2249.md and fix typo in the example code

The code example is incorrect the variable name should be `str` instead of `string`.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca2249.md](https://github.com/dotnet/docs/blob/e4c621aa708702d03b5bbfc329e26912a2ba1e17/docs/fundamentals/code-analysis/quality-rules/ca2249.md) | [CA2249: Consider using String.Contains instead of String.IndexOf](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2249?branch=pr-en-us-45842) |

<!-- PREVIEW-TABLE-END -->