### PR TITLE
removing 2 quality options from dotnet-install-script.md

### DIFF
--- a/docs/core/tools/dotnet-install-script.md
+++ b/docs/core/tools/dotnet-install-script.md
@@ -155,13 +155,11 @@ The install scripts do not update the registry on Windows. They just download th
 
 - **`-Quality|--quality <QUALITY>`**
 
-  Downloads the latest build of the specified quality in the channel. The possible values are: `daily`, `signed`, `validated`, `preview`, and `GA`. Most users should use `daily`, `preview`, or `GA` qualities.
+  Downloads the latest build of the specified quality in the channel. The possible values are: `daily`, `preview`, and `GA`.
 
   The different quality values signal different stages of the release process of the SDK or Runtime installed.
 
   * `daily`: The latest builds of the SDK or Runtime. They're built every day and aren't tested. They aren't recommended for production use but can often be used to test specific features or fixes immediately after they are merged into the product. These builds are from the `dotnet/installer` repo, and so if you're looking for fixes from `dotnet/sdk` you must wait for code to flow and be merged from SDK to Installer before it appears in a daily build.
-  * `signed`: Microsoft-signed builds that aren't validated or publicly released. Signed builds are candidates for validation, preview, and GA release. This quality level is not intended for public use.
-  * `validated`: Builds that have had some internal testing done on them but are not yet released as preview or GA. This quality level is not intended for public use.
   * `preview`: The monthly public releases of the next version of .NET, intended for public use. Not recommended for production use. Intended to allow users to experiment and test the new major version before release.
   * `GA`: The final stable releases of the .NET SDK and Runtime. Intended for public use as well as production support.
 


### PR DESCRIPTION
## Summary
`signed` and `validated` quality options are removed from the install script since they're not used externally and not necessary internally

Follow-up to https://github.com/dotnet/install-scripts/pull/593


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-install-script.md](https://github.com/dotnet/docs/blob/a80ce6ee276abc8b6896b1b950260c144791a613/docs/core/tools/dotnet-install-script.md) | [docs/core/tools/dotnet-install-script](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script?branch=pr-en-us-45843) |

<!-- PREVIEW-TABLE-END -->