### PR TITLE
Update default build configuration to 'Release'

### DIFF
--- a/docs/core/deploying/deploy-with-cli.md
+++ b/docs/core/deploying/deploy-with-cli.md
@@ -35,7 +35,7 @@ The `<TargetFramework>` setting of the project file specifies the default target
 
 If you want to target more than one framework, you can set the `<TargetFrameworks>` setting to multiple TFM values, separated by a semicolon. When you build your app, a build is produced for each target framework. However, when you publish your app, you must specify the target framework with the `dotnet publish -f <TFM>` command.
 
-The default **BUILD-CONFIGURATION** mode is **Debug** unless changed with the `-c` parameter.
+The default **BUILD-CONFIGURATION** mode is **Release** unless changed with the `-c` parameter.
 
 The default output directory of the [`dotnet publish`](../tools/dotnet-publish.md) command is `./bin/<BUILD-CONFIGURATION>/<TFM>/publish/`. For example, `dotnet publish -c Release -f net9.0` publishes to `./bin/Release/net9.0/publish/`. However, you can opt in to a simplified output path and folder structure for all build outputs. For more information, see [Artifacts output layout](../sdk/artifacts-output.md).
 


### PR DESCRIPTION
## Summary

Updated the default build configuration to 'Release' because of .NET 8 Breaking Change ['dotnet publish' uses Release configuration](https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/dotnet-publish-config)

Fixes #45845


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/deploying/deploy-with-cli.md](https://github.com/dotnet/docs/blob/c21491a8c4eec56d371bc0f31e09686f4be7a5c4/docs/core/deploying/deploy-with-cli.md) | [Publish .NET apps with the .NET CLI](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/deploy-with-cli?branch=pr-en-us-45846) |

<!-- PREVIEW-TABLE-END -->