### PR TITLE
Update link in CA2008 doc to new location

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca2008.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2008.md
@@ -36,7 +36,7 @@ Always specify an explicit <xref:System.Threading.Tasks.TaskScheduler> argument 
 For further information and detailed examples, see [New TaskCreationOptions and TaskContinuationOptions in .NET Framework 4.5](https://devblogs.microsoft.com/pfxteam/new-taskcreationoptions-and-taskcontinuationoptions-in-net-4-5/).
 
 > [!NOTE]
-> [VSTHRD105 - Avoid method overloads that assume TaskScheduler.Current](https://github.com/microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD105.md) is a similar rule implemented in [Microsoft.VisualStudio.Threading.Analyzers](https://www.nuget.org/packages/Microsoft.VisualStudio.Threading.Analyzers) package.
+> [VSTHRD105 - Avoid method overloads that assume TaskScheduler.Current](https://microsoft.github.io/vs-threading/analyzers/VSTHRD105.html) is a similar rule implemented in [Microsoft.VisualStudio.Threading.Analyzers](https://www.nuget.org/packages/Microsoft.VisualStudio.Threading.Analyzers) package.
 
 ## How to fix violations
 


### PR DESCRIPTION
## Summary

The old link pointed to a placeholder file in a GitHub repo, referring to the new GitHub pages location. This updates the link to point directly there.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca2008.md](https://github.com/dotnet/docs/blob/45443cc3968368299c00689180004271f5140434/docs/fundamentals/code-analysis/quality-rules/ca2008.md) | [CA2008: Do not create tasks without passing a TaskScheduler](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2008?branch=pr-en-us-45847) |

<!-- PREVIEW-TABLE-END -->