### PR TITLE
Add example to System.Linq.AsyncEnumerable breaking change notice

### DIFF
--- a/docs/core/compatibility/core-libraries/10.0/asyncenumerable.md
+++ b/docs/core/compatibility/core-libraries/10.0/asyncenumerable.md
@@ -42,7 +42,7 @@ If `System.Linq.Async` is consumed indirectly via another package, avoid ambigui
 </PackageReference>
 ```
 
-Most consuming code should be compatible without changes, but some call sites might need updates to refer to newer names and signatures.
+Most consuming code should be compatible without changes, but some call sites might need updates to refer to newer names and signatures. For example, a `Select` call like `e.Select(i => i * 2)` will work the same before and after. However, the call `e.SelectAwait(async (int i, CancellationToken ct) => i * 2)` will need to be changed to use `Select` instead of `SelectAwait`, as in `e.Select(async (int i, CancellationToken ct) => i * 2)`.
 
 Refer to the [System.Linq.AsyncEnumerable API documentation](xref:System.Linq.AsyncEnumerable) for the full set of LINQ extension methods available for <xref:System.Collections.Generic.IAsyncEnumerable`1>.
 


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/core-libraries/10.0/asyncenumerable.md](https://github.com/dotnet/docs/blob/fb46985672c02687c86d68003cafddf93a5c0529/docs/core/compatibility/core-libraries/10.0/asyncenumerable.md) | [System.Linq.AsyncEnumerable in .NET 10](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/10.0/asyncenumerable?branch=pr-en-us-45861) |

<!-- PREVIEW-TABLE-END -->