### PR TITLE
Correct stack allocated arrays in what's new

### DIFF
--- a/docs/core/whats-new/dotnet-10/overview.md
+++ b/docs/core/whats-new/dotnet-10/overview.md
@@ -23,7 +23,7 @@ The .NET 10 runtime introduces new features and performance improvements. Key up
 - **Array enumeration de-abstraction**: Enhancements to reduce abstraction overhead for array iteration via enumerators, enabling better inlining and stack allocation.
 - **Inlining of late devirtualized methods**: The JIT can now inline methods that become eligible for devirtualization due to previous inlining.
 - **Devirtualization based on inlining observations**: The JIT uses precise type information from inlining to devirtualize subsequent calls.
-- **Stack allocation of arrays of value types**: Small, fixed-sized arrays of value types without GC pointers can now be stack-allocated.
+- **Stack allocation of arrays**: Small, fixed-sized arrays can now be stack-allocated.
 - **AVX10.2 support**: Introduced support for Advanced Vector Extensions (AVX) 10.2 for x64-based processors, though currently disabled by default.
 - **NativeAOT enhancements**: Support for casting and negation in NativeAOT's type preinitializer.
 


### PR DESCRIPTION
## Summary

Since .NET 10 preview 3, arrays of types containing GC pointers (including reference types) can also be stack allocated.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/whats-new/dotnet-10/overview.md](https://github.com/dotnet/docs/blob/af10dbfeb09fb2b0368034424e045c85d2626618/docs/core/whats-new/dotnet-10/overview.md) | [What's new in .NET 10](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-10/overview?branch=pr-en-us-45866) |

<!-- PREVIEW-TABLE-END -->