### PR TITLE
JSON Polymorphic Serialization - Contract model example is incorrect

### DIFF
--- a/docs/standard/serialization/system-text-json/polymorphism.md
+++ b/docs/standard/serialization/system-text-json/polymorphism.md
@@ -578,13 +578,12 @@ public class PolymorphicTypeResolver : DefaultJsonTypeInfoResolver
             {
                 TypeDiscriminatorPropertyName = "$point-type",
                 IgnoreUnrecognizedTypeDiscriminators = true,
-                UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FailSerialization,
-                DerivedTypes =
-                {
-                    new JsonDerivedType(typeof(ThreeDimensionalPoint), "3d"),
-                    new JsonDerivedType(typeof(FourDimensionalPoint), "4d")
-                }
+                UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FailSerialization
             };
+            jsonTypeInfo.PolymorphismOptions.DerivedTypes.Add(
+                new JsonDerivedType(typeof(ThreeDimensionalPoint), "3d"));
+            jsonTypeInfo.PolymorphismOptions.DerivedTypes.Add(
+                new JsonDerivedType(typeof(FourDimensionalPoint), "4d"));
         }
 
         return jsonTypeInfo;


### PR DESCRIPTION
## Summary

Fixed C# example to match VB example

Fixes #45871


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/serialization/system-text-json/polymorphism.md](https://github.com/dotnet/docs/blob/a0a1dd96cdad764e340c5877896e92577134e69b/docs/standard/serialization/system-text-json/polymorphism.md) | [docs/standard/serialization/system-text-json/polymorphism](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/polymorphism?branch=pr-en-us-45873) |

<!-- PREVIEW-TABLE-END -->