### PR TITLE
Delete ASP.NET metrics breadcrumb entry

### DIFF
--- a/docs/breadcrumb/toc.yml
+++ b/docs/breadcrumb/toc.yml
@@ -31,9 +31,6 @@ items:
           - name: Orleans
             tocHref: /dotnet/orleans/
             topicHref: /dotnet/orleans/index
-          - name: ASP.NET Core metrics
-            tocHref: /aspnet/core/log-mon/metrics/built-in
-            topicHref: /aspnet/core/log-mon/metrics/built-in
           - name: .NET Framework
             tocHref: /dotnet/framework/
             topicHref: /dotnet/framework/index


### PR DESCRIPTION
Fast follow to #45791. This breadcrumb entry is incorrect and not needed.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/breadcrumb/toc.yml](https://github.com/dotnet/docs/blob/0768becec33d3930ba22b6ac6d88c364ee7fe104/docs/breadcrumb/toc.yml) | [docs/breadcrumb/toc](https://review.learn.microsoft.com/en-us/dotnet/breadcrumb/toc?branch=pr-en-us-45874) |

<!-- PREVIEW-TABLE-END -->