### PR TITLE
Add information about multi-RID container publishing in 8.0.405, 9.0.102, and 9.0.2xx to SDK Containerization reference

### DIFF
--- a/docs/core/containers/publish-configuration.md
+++ b/docs/core/containers/publish-configuration.md
@@ -120,7 +120,7 @@ To specify multiple container runtime identifiers for multi-architecture images,
 
 > [!IMPORTANT]
 > The `ContainerRuntimeIdentifiers` property must be a subset of the `RuntimeIdentifiers` property. If this condition isn't met, critical parts of the build pipeline may fail.
-> 
+>
 > Setting multiple `ContainerRuntimeIdentifiers` results in a multi-architecture image being created. For more information, see [Multi-architecture images](#multi-architecture-images).
 
 For more information regarding the runtime identifiers supported by .NET, see [RID catalog](../rid-catalog.md).

--- a/docs/core/containers/publish-configuration.md
+++ b/docs/core/containers/publish-configuration.md
@@ -2,7 +2,7 @@
 title: Containerize a .NET app reference
 description: Reference material for containerizing a .NET app and configuring the container image.
 ms.topic: reference
-ms.date: 01/27/2025
+ms.date: 04/22/2025
 ---
 
 # Containerize a .NET app reference
@@ -14,7 +14,7 @@ In this reference article, you learn how to configure the container image genera
 You can control many aspects of the generated container through MSBuild properties. In general, if you can use a command in a _Dockerfile_ to set some configuration, you can do the same via MSBuild.
 
 > [!NOTE]
-> The only exceptions to this are `RUN` commands. Due to the way containers are built, those commands can't be emulated. If you need this functionality, you might consider using a _Dockerfile_ to build your container images.
+> The only exceptions to this are `RUN` commands. Due to the way containers are built, those commands can't be emulated. If you need this functionality, consider using a _Dockerfile_ to build your container images.
 
 There's no way of performing `RUN` commands with the .NET SDK. These commands are often used to install some OS packages or create a new OS user, or any number of arbitrary things. If you would like to keep using the .NET SDK container building feature, you can instead create a custom base image with these changes and then using this base image. For more information, see [`ContainerBaseImage`](#containerbaseimage).
 
@@ -119,7 +119,7 @@ To specify multiple container runtime identifiers for multi-architecture images,
 ```
 
 > [!IMPORTANT]
-> Setting multiple `ContainerRuntimeIdentifiers` results in a multi-architecture image being created. For more information, see [#multi-architecture-images](#multi-architecture-images).
+> Setting multiple `ContainerRuntimeIdentifiers` results in a multi-architecture image being created. For more information, see [Multi-architecture images](#multi-architecture-images).
 
 For more information regarding the runtime identifiers supported by .NET, see [RID catalog](../rid-catalog.md).
 

--- a/docs/core/containers/publish-configuration.md
+++ b/docs/core/containers/publish-configuration.md
@@ -445,6 +445,9 @@ Beginning with SDK versions 8.0.405, 9.0.102, and 9.0.2xx, multi-RID container p
 - If a single `RuntimeIdentifier` or `ContainerRuntimeIdentifier` is specified, a single-architecture container is generated as before.
 - If no single `RuntimeIdentifier` is specified but multiple `RuntimeIdentifiers` or `ContainerRuntimeIdentifiers` are set, the SDK publishes the app for each specified RID and combines the resulting images into an [OCI Image Index](https://specs.opencontainers.org/image-spec/image-index/). This index allows multiple architecture-specific images to share a single name.
 
+> [!NOTE]
+> The `ContainerRuntimeIdentifiers` property must be a subset of the `RuntimeIdentifiers` property. For more information, see [ContainerRuntimeIdentifiers](#containerruntimeidentifiers).
+
 This feature streamlines container workflows in mixed-architecture environments. For example, a developer on a `linux-x64` host can publish a container supporting both `linux-x64` and `linux-arm64`, enabling deployment to either architecture without changing image names or labels.
 
 The generated OCI Image Index is widely supported with modern container tooling, enhancing compatibility and ease of use.

--- a/docs/core/containers/publish-configuration.md
+++ b/docs/core/containers/publish-configuration.md
@@ -119,6 +119,8 @@ To specify multiple container runtime identifiers for multi-architecture images,
 ```
 
 > [!IMPORTANT]
+> The `ContainerRuntimeIdentifiers` property must be a subset of the `RuntimeIdentifiers` property. If this condition isn't met, critical parts of the build pipeline may fail.
+> 
 > Setting multiple `ContainerRuntimeIdentifiers` results in a multi-architecture image being created. For more information, see [Multi-architecture images](#multi-architecture-images).
 
 For more information regarding the runtime identifiers supported by .NET, see [RID catalog](../rid-catalog.md).


### PR DESCRIPTION
Fixes #44440

Also an Acrolynx pass.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/containers/publish-configuration.md](https://github.com/dotnet/docs/blob/c5bb0912039ec1673677ecc7cd49ce0ca5dc2209/docs/core/containers/publish-configuration.md) | [docs/core/containers/publish-configuration](https://review.learn.microsoft.com/en-us/dotnet/core/containers/publish-configuration?branch=pr-en-us-45894) |


<!-- PREVIEW-TABLE-END -->