### PR TITLE
Fix type in dotnet-install-script.md

### DIFF
--- a/docs/core/tools/dotnet-install-script.md
+++ b/docs/core/tools/dotnet-install-script.md
@@ -207,7 +207,7 @@ The install scripts do not update the registry on Windows. They just download th
 
 - **`-ZipPath|--zip-path <PATH>`**
 
- If set, the downloaded SDK archive is stored at the specified path.
+  If set, the downloaded SDK archive is stored at the specified path.
 
 - **`-Verbose|--verbose`**
 


### PR DESCRIPTION
Fix missing space that was causing incorrect indentation in options list for the `-ZipPath` option.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-install-script.md](https://github.com/dotnet/docs/blob/40f7796828d659b070b5e7dd1bf3a92c832eedcf/docs/core/tools/dotnet-install-script.md) | [docs/core/tools/dotnet-install-script](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script?branch=pr-en-us-45896) |

<!-- PREVIEW-TABLE-END -->