### PR TITLE
Fix typo in architecture in RID graph

### DIFF
--- a/docs/core/rid-catalog.md
+++ b/docs/core/rid-catalog.md
@@ -56,7 +56,7 @@ The above RID specifies that `osx-x64` imports `unix-x64`. So, when NuGet restor
 The following example shows a slightly bigger RID graph also defined in the *runtime.json*  file:
 
 ```
-    linux-arm64     linux-arm32
+    linux-arm64     linux-x64
          |     \   /     |
          |     linux     |
          |       |       |


### PR DESCRIPTION
## Summary

Replaced linux-arm32 with linux-x64 in RID graph

Fixes #45898


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/rid-catalog.md](https://github.com/dotnet/docs/blob/c16d2018919c588c15fd5d9307a659892355616b/docs/core/rid-catalog.md) | [.NET RID Catalog](https://review.learn.microsoft.com/en-us/dotnet/core/rid-catalog?branch=pr-en-us-45906) |

<!-- PREVIEW-TABLE-END -->