### PR TITLE
Update csharp-14.md

### DIFF
--- a/docs/csharp/whats-new/csharp-14.md
+++ b/docs/csharp/whats-new/csharp-14.md
@@ -39,7 +39,7 @@ public static class Enumerable
         // Extension property:
         public bool IsEmpty => source.Any() == false;
         // Extension indexer:
-        public int this[int index] => source.Skip(index).First();
+        public TSource this[int index] => source.Skip(index).First();
 
         // Extension method:
         public IEnumerable<TSource> Where(Func<TSource, bool> predicate) { ... }


### PR DESCRIPTION
Fix indexer type in sample code

## Summary

The return type of indexer is wrong in sample, which is a bit confusing

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/whats-new/csharp-14.md](https://github.com/dotnet/docs/blob/f610dcd155edf8173b7a2ebc0dc121497cb7ed4d/docs/csharp/whats-new/csharp-14.md) | [What's new in C# 14](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-14?branch=pr-en-us-45907) |

<!-- PREVIEW-TABLE-END -->