### PR TITLE
Mention public signing in Strong Name docs

### DIFF
--- a/docs/standard/library-guidance/strong-naming.md
+++ b/docs/standard/library-guidance/strong-naming.md
@@ -43,11 +43,13 @@ You should strong name your open-source .NET libraries if their targets include 
 
 ✔️ CONSIDER strong naming your library's assemblies.
 
-✔️ CONSIDER adding the strong naming key to your source control system.
+✔️ CONSIDER adding the strong naming key pair (public+private) to your source control system.
 
-> A publicly available key lets developers modify and recompile your library source code with the same key.
+> A publicly available key pair lets developers modify and recompile your library source code with the same key.
 >
-> You shouldn't make the strong naming key public if it has been used in the past to give special permissions in [partial-trust scenarios](/previous-versions/dotnet/framework/code-access-security/using-libraries-from-partially-trusted-code). Otherwise, you might compromise existing environments.
+> You shouldn't make the strong naming key pair public if it has been used in the past to give special permissions in [partial-trust scenarios](/previous-versions/dotnet/framework/code-access-security/using-libraries-from-partially-trusted-code). Otherwise, you might compromise existing environments.
+>
+> If you cannot check in the public+private key pair, then check in the public key, and use [public signing](https://github.com/dotnet/runtime/blob/main/docs/project/public-signing.md) for regular builds.  Public signing will still allow developers to recompile and use your library in most scenarios.
 
 > [!IMPORTANT]
 > When the identity of the publisher of the code is desired, [Authenticode](/windows-hardware/drivers/install/authenticode) and [NuGet Package Signing](/nuget/create-packages/sign-a-package) are recommended. Code Access Security (CAS) should not be used as a security mitigation.

--- a/docs/standard/library-guidance/strong-naming.md
+++ b/docs/standard/library-guidance/strong-naming.md
@@ -49,7 +49,7 @@ You should strong name your open-source .NET libraries if their targets include 
 >
 > You shouldn't make the strong naming key pair public if it has been used in the past to give special permissions in [partial-trust scenarios](/previous-versions/dotnet/framework/code-access-security/using-libraries-from-partially-trusted-code). Otherwise, you might compromise existing environments.
 >
-> If you cannot check in the public+private key pair, then check in the public key, and use [public signing](https://github.com/dotnet/runtime/blob/main/docs/project/public-signing.md) for regular builds.  Public signing will still allow developers to recompile and use your library in most scenarios.
+> If you cannot check in the public+private key pair, then check in the public key, and use [public signing](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/security#publicsign) for regular builds.  Public signing will still allow developers to recompile and use your library in most scenarios.
 
 > [!IMPORTANT]
 > When the identity of the publisher of the code is desired, [Authenticode](/windows-hardware/drivers/install/authenticode) and [NuGet Package Signing](/nuget/create-packages/sign-a-package) are recommended. Code Access Security (CAS) should not be used as a security mitigation.

--- a/docs/standard/library-guidance/strong-naming.md
+++ b/docs/standard/library-guidance/strong-naming.md
@@ -43,13 +43,13 @@ You should strong name your open-source .NET libraries if their targets include 
 
 ✔️ CONSIDER strong naming your library's assemblies.
 
-✔️ CONSIDER adding the strong naming key pair (public+private) to your source control system.
+✔️ CONSIDER adding the strong naming key pair (public + private) to your source control system.
 
 > A publicly available key pair lets developers modify and recompile your library source code with the same key.
 >
 > You shouldn't make the strong naming key pair public if it has been used in the past to give special permissions in [partial-trust scenarios](/previous-versions/dotnet/framework/code-access-security/using-libraries-from-partially-trusted-code). Otherwise, you might compromise existing environments.
 >
-> If you cannot check in the public+private key pair, then check in the public key, and use [public signing](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/security#publicsign) for regular builds.  Public signing will still allow developers to recompile and use your library in most scenarios.
+> If you can't check in the public + private key pair, then check in the public key and use [public signing](../../csharp/language-reference/compiler-options/security.md#publicsign) for regular builds. Public signing still allows developers to recompile and use your library in most scenarios.
 
 > [!IMPORTANT]
 > When the identity of the publisher of the code is desired, [Authenticode](/windows-hardware/drivers/install/authenticode) and [NuGet Package Signing](/nuget/create-packages/sign-a-package) are recommended. Code Access Security (CAS) should not be used as a security mitigation.


### PR DESCRIPTION
Clarifies when public signing should be used.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/library-guidance/strong-naming.md](https://github.com/dotnet/docs/blob/bbfaf3e8a95c6514a48ee1295dc7373dd2ba55cd/docs/standard/library-guidance/strong-naming.md) | [docs/standard/library-guidance/strong-naming](https://review.learn.microsoft.com/en-us/dotnet/standard/library-guidance/strong-naming?branch=pr-en-us-45914) |


<!-- PREVIEW-TABLE-END -->