### PR TITLE
Csharp language reference attributes: add missing AsyncMethodBuilder.SetStateMachine member

### DIFF
--- a/docs/csharp/language-reference/attributes/general.md
+++ b/docs/csharp/language-reference/attributes/general.md
@@ -147,8 +147,14 @@ The constructor to the `AsyncMethodBuilder` attribute specifies the type of the 
 * A `Start` method with the following API signature:
 
   ```csharp
-  void Start<TStateMachine>(ref TStateMachine stateMachine)
+  public void Start<TStateMachine>(ref TStateMachine stateMachine)
             where TStateMachine : System.Runtime.CompilerServices.IAsyncStateMachine
+  ```
+
+* A `SetStateMachine` method with the following API signature:
+
+  ```csharp
+  public void SetStateMachine(System.Runtime.CompilerServices.IAsyncStateMachine stateMachine)
   ```
 
 * An `AwaitOnCompleted` method with the following signature:


### PR DESCRIPTION
This method is mentioned in the Roslyn documentation:

https://github.com/dotnet/roslyn/blob/main/docs/features/task-types.md

If it is not included when implementing the AsyncMethodBuilder pattern, the C# compiler fails to compile with a CS0656 error.

I also added a `public` to the `Start` method to match the other methods described in this section.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/attributes/general.md](https://github.com/dotnet/docs/blob/87b5e636fcc06b9f5c129a255fa78786210c4177/docs/csharp/language-reference/attributes/general.md) | [Miscellaneous attributes interpreted by the C# compiler](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/attributes/general?branch=pr-en-us-45929) |

<!-- PREVIEW-TABLE-END -->