### PR TITLE
Don't compare boolean with `false`

### DIFF
--- a/docs/csharp/whats-new/csharp-14.md
+++ b/docs/csharp/whats-new/csharp-14.md
@@ -37,7 +37,7 @@ public static class Enumerable
     extension<TSource>(IEnumerable<TSource> source) // extension members for IEnumerable<TSource>
     {
         // Extension property:
-        public bool IsEmpty => source.Any() == false;
+        public bool IsEmpty => !source.Any();
         // Extension indexer:
         public TSource this[int index] => source.Skip(index).First();
 


### PR DESCRIPTION
Alternatively pattern matching `is false` could be used.
Just to keep George Bool happy :wink:

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/whats-new/csharp-14.md](https://github.com/dotnet/docs/blob/ff9f82d01a0dc71d75605e0258732892e271ed18/docs/csharp/whats-new/csharp-14.md) | [What's new in C# 14](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-14?branch=pr-en-us-45934) |

<!-- PREVIEW-TABLE-END -->