### PR TITLE
Add `[--allow-roll-forward]` to the synopsis of dotnet tool install

### DIFF
--- a/docs/core/tools/dotnet-tool-install.md
+++ b/docs/core/tools/dotnet-tool-install.md
@@ -19,7 +19,7 @@ dotnet tool install <PACKAGE_NAME> -g|--global
     [--add-source <SOURCE>] [--configfile <FILE>] [--disable-parallel]
     [--framework <FRAMEWORK>] [--ignore-failed-sources] [--interactive]
     [--no-cache] [--prerelease]
-    [--tool-manifest <PATH>] [-v|--verbosity <LEVEL>]
+    [--tool-manifest <PATH>] [--allow-roll-forward] [-v|--verbosity <LEVEL>]
     [--version <VERSION_NUMBER>]
 
 dotnet tool install <PACKAGE_NAME> --tool-path <PATH>
@@ -27,7 +27,7 @@ dotnet tool install <PACKAGE_NAME> --tool-path <PATH>
     [--add-source <SOURCE>] [--configfile <FILE>] [--disable-parallel]
     [--framework <FRAMEWORK>] [--ignore-failed-sources] [--interactive]
     [--no-cache] [--prerelease]
-    [--tool-manifest <PATH>] [-v|--verbosity <LEVEL>]
+    [--tool-manifest <PATH>] [--allow-roll-forward] [-v|--verbosity <LEVEL>]
     [--version <VERSION_NUMBER>]
 
 dotnet tool install <PACKAGE_NAME> [--local]
@@ -36,7 +36,7 @@ dotnet tool install <PACKAGE_NAME> [--local]
     [--create-manifest-if-needed] [--disable-parallel]
     [--framework <FRAMEWORK>] [--ignore-failed-sources] [--interactive]
     [--no-cache] [--prerelease]
-    [--tool-manifest <PATH>] [-v|--verbosity <LEVEL>]
+    [--tool-manifest <PATH>] [--allow-roll-forward] [-v|--verbosity <LEVEL>]
     [--version <VERSION_NUMBER>]
 
 dotnet tool install -h|--help

--- a/docs/core/tools/dotnet-tool-install.md
+++ b/docs/core/tools/dotnet-tool-install.md
@@ -15,28 +15,28 @@ ms.date: 04/07/2025
 
 ```dotnetcli
 dotnet tool install <PACKAGE_NAME> -g|--global
-    [--allow-downgrade] [-a|--arch <ARCHITECTURE>]
+    [--allow-downgrade] [--allow-roll-forward] [-a|--arch <ARCHITECTURE>]
     [--add-source <SOURCE>] [--configfile <FILE>] [--disable-parallel]
     [--framework <FRAMEWORK>] [--ignore-failed-sources] [--interactive]
     [--no-cache] [--prerelease]
-    [--tool-manifest <PATH>] [--allow-roll-forward] [-v|--verbosity <LEVEL>]
+    [--tool-manifest <PATH>] [-v|--verbosity <LEVEL>]
     [--version <VERSION_NUMBER>]
 
 dotnet tool install <PACKAGE_NAME> --tool-path <PATH>
-    [--allow-downgrade] [-a|--arch <ARCHITECTURE>]
+    [--allow-downgrade] [--allow-roll-forward] [-a|--arch <ARCHITECTURE>]
     [--add-source <SOURCE>] [--configfile <FILE>] [--disable-parallel]
     [--framework <FRAMEWORK>] [--ignore-failed-sources] [--interactive]
     [--no-cache] [--prerelease]
-    [--tool-manifest <PATH>] [--allow-roll-forward] [-v|--verbosity <LEVEL>]
+    [--tool-manifest <PATH>] [-v|--verbosity <LEVEL>]
     [--version <VERSION_NUMBER>]
 
 dotnet tool install <PACKAGE_NAME> [--local]
-    [--allow-downgrade] [-a|--arch <ARCHITECTURE>]
+    [--allow-downgrade] [--allow-roll-forward] [-a|--arch <ARCHITECTURE>]
     [--add-source <SOURCE>] [--configfile <FILE>]
     [--create-manifest-if-needed] [--disable-parallel]
     [--framework <FRAMEWORK>] [--ignore-failed-sources] [--interactive]
     [--no-cache] [--prerelease]
-    [--tool-manifest <PATH>] [--allow-roll-forward] [-v|--verbosity <LEVEL>]
+    [--tool-manifest <PATH>] [-v|--verbosity <LEVEL>]
     [--version <VERSION_NUMBER>]
 
 dotnet tool install -h|--help
@@ -94,6 +94,10 @@ For more information, see [Install a local tool](global-tools.md#install-a-local
 ## Options
 
 [!INCLUDE [allow-downgrade](../../../includes/cli-allow-downgrade.md)]
+
+- **`--allow-roll-forward`**
+
+  Allow tool to use a newer version of the .NET runtime if the runtime it targets isn't installed.
 
 - **`-a|--arch <ARCHITECTURE>`**
 
@@ -160,10 +164,6 @@ For more information, see [Install a local tool](global-tools.md#install-a-local
 - **`--tool-path <PATH>`**
 
   Specifies the location to install the Global Tool. PATH can be absolute or relative. If PATH doesn't exist, the command tries to create it. Omitting both `--global` and `--tool-path` specifies a local tool installation.
-
-- **`--allow-roll-forward`**
-
-  Allow tool to use a newer version of the .NET runtime if the runtime it targets isn't installed.
 
 [!INCLUDE [verbosity](../../../includes/cli-verbosity.md)]
 


### PR DESCRIPTION
This pull request closes #44614.
It's a follow-up to the previous PR for this issue, and it's adding the missing option to the SYNOPSIS section of the `dotnet tool install`

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-tool-install.md](https://github.com/dotnet/docs/blob/4a78320024f5b552d061c0ec2b2b3c1ad6ed74c2/docs/core/tools/dotnet-tool-install.md) | [dotnet tool install](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-install?branch=pr-en-us-45951) |


<!-- PREVIEW-TABLE-END -->