### PR TITLE
RoundtripToUtf8: Fix spacing

### DIFF
--- a/docs/standard/serialization/system-text-json/snippets/how-to/csharp/RoundtripToUtf8.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to/csharp/RoundtripToUtf8.cs
@@ -22,7 +22,7 @@ namespace RoundtripToUtf8Bytes1
             };
 
             // <Serialize>
-            byte[] jsonUtf8Bytes =JsonSerializer.SerializeToUtf8Bytes(weatherForecast);
+            byte[] jsonUtf8Bytes = JsonSerializer.SerializeToUtf8Bytes(weatherForecast);
             // </Serialize>
 
             Console.WriteLine(Encoding.UTF8.GetString(jsonUtf8Bytes));


### PR DESCRIPTION
## Summary
Adds a missing space after the assignment of `jsonUtf8Bytes`.