### PR TITLE
Add TFM for .NET nanoFramework

### DIFF
--- a/docs/standard/frameworks.md
+++ b/docs/standard/frameworks.md
@@ -42,6 +42,7 @@ A target framework is typically referenced by a TFM. The following table shows t
 | .NET Standard              | netstandard1.0<br>netstandard1.1<br>netstandard1.2<br>netstandard1.3<br>netstandard1.4<br>netstandard1.5<br>netstandard1.6<br>netstandard2.0<br>netstandard2.1 |
 | .NET Framework             | net11<br>net20<br>net35<br>net40<br>net403<br>net45<br>net451<br>net452<br>net46<br>net461<br>net462<br>net47<br>net471<br>net472<br>net48<br>net481 |
 | Windows Store              | netcore [netcore45]<br>netcore45 [win] [win8]<br>netcore451 [win81] |
+| .NET nanoFramework         | netnano1.0 |
 | .NET Micro Framework       | netmf |
 | Silverlight                | sl4<br>sl5 |
 | Windows Phone              | wp [wp7]<br>wp7<br>wp75<br>wp8<br>wp81<br>wpa81 |


### PR DESCRIPTION
## Summary

- Add entry for .NET nanoFramework TFM. This was made available for quite some time, but it was missing in this doc.

For reference:
- https://github.com/dotnet/designs/discussions/180
- [TFM for .NET nanoFramework](https://github.com/dotnet/designs/blob/main/accepted/2021/nano-framework-tfm/nano-framework-tfm.md)
- NuGet/Home#10800



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/frameworks.md](https://github.com/dotnet/docs/blob/b72b2c13d58d94128fd1d734a0829a86b6da44ad/docs/standard/frameworks.md) | [Target frameworks in SDK-style projects](https://review.learn.microsoft.com/en-us/dotnet/standard/frameworks?branch=pr-en-us-45973) |

<!-- PREVIEW-TABLE-END -->