### PR TITLE
Fix invalid code in extension members example

### DIFF
--- a/docs/csharp/whats-new/csharp-14.md
+++ b/docs/csharp/whats-new/csharp-14.md
@@ -52,7 +52,7 @@ public static class Enumerable
         public static IEnumerable<TSource> Combine(IEnumerable<TSource> first, IEnumerable<TSource> second) { ... }
 
         // static extension property:
-        public static IEnumerable<TSource> Identity => yield return default;
+        public static IEnumerable<TSource> Identity => Enumerable.Empty<TSource>();
     }
 }
 ```


### PR DESCRIPTION
## Summary

`yield return` is not supported in expression bodied members, and the extension members feature doesn't change that.

Fixes #45980 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/whats-new/csharp-14.md](https://github.com/dotnet/docs/blob/1a0a887b7dde3fdfb571a00fbd3cfb6c3296722c/docs/csharp/whats-new/csharp-14.md) | [What's new in C# 14](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-14?branch=pr-en-us-45983) |

<!-- PREVIEW-TABLE-END -->