### PR TITLE
Fix typo in cs3005.md

### DIFF
--- a/docs/csharp/misc/cs3005.md
+++ b/docs/csharp/misc/cs3005.md
@@ -16,7 +16,7 @@ Identifier 'identifier' differing only in case is not CLS-compliant
   
 ## Example  
 
- The following example generates CS3003:  
+ The following example generates CS3005:  
   
 ```csharp  
 // CS3005.cs  


### PR DESCRIPTION
## Summary

The CS3005 docs say that the example is for CS3003. This PR fixes that typo.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/misc/cs3005.md](https://github.com/dotnet/docs/blob/ecd4833c4e634a285b4fa05409d25c4023e945fc/docs/csharp/misc/cs3005.md) | [Compiler Warning (level 1) CS3005](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/cs3005?branch=pr-en-us-45984) |

<!-- PREVIEW-TABLE-END -->