### PR TITLE
 Improve CS0449 compiler error doc by clarifying constraint order and fixing example

### DIFF
--- a/docs/csharp/misc/cs0449.md
+++ b/docs/csharp/misc/cs0449.md
@@ -10,24 +10,25 @@ ms.assetid: 32c07a2c-4c48-4d07-b643-72422a6b9fac
 ---
 # Compiler Error CS0449
 
-The 'class' or 'struct' constraint must come before any other constraints  
-  
- The constraints on the type parameter of a generic type or method must occur in a specific order: `class` or `struct` must be first, if present, then any interface constraints, and finally any constructor constraints. This error is caused by the `class` or `struct` constraint not appearing first. To resolve this error, reorder the constraint clauses.  
-  
+The `'class'`, `'struct'`, `'unmanaged'`, `'notnull'`, and `'default'` constraints cannot be combined or duplicated, and must be specified first in the constraints list.  
+
+The constraints on the type parameter of a generic type or method must occur in a specific order: `class` or `struct` must be first, if present, then any interface constraints, and finally any constructor constraints. This error is caused by the `class` or `struct` constraint not appearing first. To resolve this error, reorder the constraint clauses.  
+
 ## Example  
 
  The following sample generates CS0449.  
-  
+
 ```csharp  
 // CS0449.cs  
 // compile with: /target:library  
-interface I {}  
+public interface I {}  // Made public to avoid CS0703  
+
 public class C4
 {  
    public void F1<T>() where T : class, struct, I {}   // CS0449  
    public void F2<T>() where T : I, struct {}   // CS0449  
    public void F3<T>() where T : I, class {}   // CS0449  
-  
+
    // OK  
    public void F4<T>() where T : class {}  
    public void F5<T>() where T : struct {}  


### PR DESCRIPTION
## Summary
This PR improves the documentation for **CS0449** by:

- Updating the opening explanation to match the **actual compiler error message** for better clarity and accuracy.
- Correcting the example to avoid the unrelated **CS0703** error by marking the interface `I` as `public`.
- Preserving the original structure and content wherever possible to minimize disruption.

These changes enhance the accuracy and learning experience for developers encountering this constraint ordering error.

Fixes #46008 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/misc/cs0449.md](https://github.com/dotnet/docs/blob/da28ca72809eb97787419cd4e46721230e9c1170/docs/csharp/misc/cs0449.md) | [Compiler Error CS0449](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/cs0449?branch=pr-en-us-46014) |

<!-- PREVIEW-TABLE-END -->