### PR TITLE
Remove explicit using in HTTP examples

### DIFF
--- a/docs/core/extensions/httpclient-factory.md
+++ b/docs/core/extensions/httpclient-factory.md
@@ -3,7 +3,7 @@ title: Use the IHttpClientFactory
 description: Learn how to use the HttpClient and IHttpClientFactory implementations with dependency injection in your .NET workloads.
 author: IEvangelist
 ms.author: dapine
-ms.date: 08/13/2024
+ms.date: 05/06/2025
 ---
 
 # IHttpClientFactory with .NET

--- a/docs/core/extensions/snippets/http/basic/TodoService.cs
+++ b/docs/core/extensions/snippets/http/basic/TodoService.cs
@@ -12,7 +12,7 @@ public sealed class TodoService(
     public async Task<Todo[]> GetUserTodosAsync(int userId)
     {
         // Create the client
-        using HttpClient client = httpClientFactory.CreateClient();
+        HttpClient client = httpClientFactory.CreateClient();
         
         try
         {

--- a/docs/core/extensions/snippets/http/named/TodoService.cs
+++ b/docs/core/extensions/snippets/http/named/TodoService.cs
@@ -23,7 +23,7 @@ public sealed class TodoService
     {
         // Create the client
         string? httpClientName = _configuration["TodoHttpClientName"];
-        using HttpClient client = _httpClientFactory.CreateClient(httpClientName ?? "");
+        HttpClient client = _httpClientFactory.CreateClient(httpClientName ?? "");
 
         try
         {

--- a/docs/core/extensions/snippets/http/typed/TodoService.cs
+++ b/docs/core/extensions/snippets/http/typed/TodoService.cs
@@ -7,7 +7,7 @@ namespace TypedHttp.Example;
 
 public sealed class TodoService(
     HttpClient httpClient,
-    ILogger<TodoService> logger) : IDisposable
+    ILogger<TodoService> logger)
 {
     public async Task<Todo[]> GetUserTodosAsync(int userId)
     {
@@ -28,6 +28,4 @@ public sealed class TodoService(
 
         return [];
     }
-
-    public void Dispose() => httpClient?.Dispose();
 }


### PR DESCRIPTION
## Summary

Remove explicit using in HTTP examples

Fixes #46020 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/httpclient-factory.md](https://github.com/dotnet/docs/blob/df3c529a90ea294c484fcb6f046559fd79434da5/docs/core/extensions/httpclient-factory.md) | [IHttpClientFactory with .NET](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/httpclient-factory?branch=pr-en-us-46026) |


<!-- PREVIEW-TABLE-END -->