### PR TITLE
Use ToUnixTimeMilliseconds

### DIFF
--- a/docs/standard/datetime/system-text-json-support.md
+++ b/docs/standard/datetime/system-text-json-support.md
@@ -22,7 +22,7 @@ The `System.Text.Json` library parses and writes <xref:System.DateTime> and <xre
 
 The <xref:System.Text.Json.JsonSerializer>, <xref:System.Text.Json.Utf8JsonReader>, <xref:System.Text.Json.Utf8JsonWriter>,
 and <xref:System.Text.Json.JsonElement> types parse and write <xref:System.DateTime> and <xref:System.DateTimeOffset>
-text representations according to the extended profile of the ISO 8601-1:2019 format. For example, `2019-07-26T16:59:57-05:00`.
+text representations according to the extended profile of the ISO 8601-1:2019 format, for example, `2019-07-26T16:59:57-05:00`.
 
 <xref:System.DateTime> and <xref:System.DateTimeOffset> data can be serialized with <xref:System.Text.Json.JsonSerializer>:
 
@@ -32,18 +32,16 @@ text representations according to the extended profile of the ISO 8601-1:2019 fo
 
 :::code language="csharp" source="snippets/system-text-json-support/csharp/deserializing-with-jsonserializer-valid/Program.cs":::
 
-With default options, input <xref:System.DateTime> and <xref:System.DateTimeOffset> text representations must conform to the extended ISO 8601-1:2019 profile.
-Attempting to deserialize representations that don't conform to the profile will cause <xref:System.Text.Json.JsonSerializer> to throw a <xref:System.Text.Json.JsonException>:
+With default options, input <xref:System.DateTime> and <xref:System.DateTimeOffset> text representations must conform to the extended ISO 8601-1:2019 profile. If you attempt to deserialize representations that don't conform to the profile, <xref:System.Text.Json.JsonSerializer> throws a <xref:System.Text.Json.JsonException>:
 
 :::code language="csharp" source="snippets/system-text-json-support/csharp/deserializing-with-jsonserializer-error/Program.cs":::
 
-The <xref:System.Text.Json.JsonDocument> provides structured access to the contents of a JSON payload, including <xref:System.DateTime>
-and <xref:System.DateTimeOffset> representations. The following example shows how to calculate the average
+<xref:System.Text.Json.JsonDocument> provides structured access to the contents of a JSON payload, including <xref:System.DateTime> and <xref:System.DateTimeOffset> representations. The following example shows how to calculate the average
 temperature on Mondays from a collection of temperatures:
 
 :::code language="csharp" source="snippets/system-text-json-support/csharp/computing-with-jsondocument-valid/Program.cs":::
 
-Attempting to compute the average temperature given a payload with non-compliant <xref:System.DateTime> representations will cause <xref:System.Text.Json.JsonDocument> to throw a <xref:System.FormatException>:
+If you attempt to compute the average temperature given a payload with non-compliant <xref:System.DateTime> representations, <xref:System.Text.Json.JsonDocument> throws a <xref:System.FormatException>:
 
 :::code language="csharp" source="snippets/system-text-json-support/csharp/computing-with-jsondocument-error/Program.cs":::
 
@@ -55,7 +53,7 @@ The lower level <xref:System.Text.Json.Utf8JsonWriter> writes <xref:System.DateT
 
 :::code language="csharp" source="snippets/system-text-json-support/csharp/reading-with-utf8jsonreader-valid/Program.cs":::
 
-Attempting to read non-compliant formats with <xref:System.Text.Json.Utf8JsonReader> will cause it to throw a <xref:System.FormatException>:
+If you attempt to read non-compliant formats with <xref:System.Text.Json.Utf8JsonReader>, it throws a <xref:System.FormatException>:
 
 :::code language="csharp" source="snippets/system-text-json-support/csharp/reading-with-utf8jsonreader-error/Program.cs":::
 
@@ -67,8 +65,12 @@ Attempting to read non-compliant formats with <xref:System.Text.Json.Utf8JsonRea
 
 ### When using <xref:System.Text.Json.JsonSerializer>
 
-If you want the serializer to perform custom parsing or formatting, you can implement [custom converters](xref:System.Text.Json.Serialization.JsonConverter%601).
-Here are a few examples:
+If you want the serializer to perform custom parsing or formatting, you can implement [custom converters](xref:System.Text.Json.Serialization.JsonConverter%601). The following sections show a few examples:
+
+- [DateTime(Offset).Parse and DateTime(Offset).ToString](#datetimeoffsetparse-and-datetimeoffsettostring)
+- [<xref:System.Buffers.Text.Utf8Parser> and <xref:System.Buffers.Text.Utf8Formatter>](#xrefsystembufferstextutf8parser-and-xrefsystembufferstextutf8formatter)
+- [Use DateTime(Offset).Parse as a fallback](#use-datetimeoffsetparse-as-a-fallback)
+- [Use Unix epoch date format](#use-unix-epoch-date-format)
 
 #### DateTime(Offset).Parse and DateTime(Offset).ToString
 
@@ -135,7 +137,7 @@ and then written with the <xref:System.Text.Json.Utf8JsonWriter.WriteStringValue
 ### When using <xref:System.Text.Json.Utf8JsonReader>
 
 If you want to read a custom <xref:System.DateTime> or <xref:System.DateTimeOffset> text representation with <xref:System.Text.Json.Utf8JsonReader>,
-you can get the value of the current JSON token as a <xref:System.String> using <xref:System.Text.Json.Utf8JsonReader.GetString> method, then parse the value using custom logic.
+you can get the value of the current JSON token as a <xref:System.String> using the <xref:System.Text.Json.Utf8JsonReader.GetString> method, then parse the value using custom logic.
 
 The following example shows how a custom <xref:System.DateTimeOffset> text representation can be retrieved using the <xref:System.Text.Json.Utf8JsonReader.GetString> method,
 then parsed using <xref:System.DateTimeOffset.ParseExact(System.String,System.String,System.IFormatProvider)>:
@@ -146,24 +148,23 @@ then parsed using <xref:System.DateTimeOffset.ParseExact(System.String,System.St
 
 ### Date and time components
 
-The extended ISO 8601-1:2019 profile implemented in <xref:System.Text.Json?displayProperty=fullName> defines the following components for
-date and time representations. These components are used to define various supported levels of granularity
+The extended ISO 8601-1:2019 profile implemented in <xref:System.Text.Json?displayProperty=fullName> defines the following components for date and time representations. These components are used to define various supported levels of granularity
 when parsing and formatting <xref:System.DateTime> and <xref:System.DateTimeOffset> representations.
 
-| Component       | Format                      | Description                                                                     |
-|-----------------|-----------------------------|---------------------------------------------------------------------------------|
-| Year            | "yyyy"                      | 0001-9999                                                                       |
-| Month           | "MM"                        | 01-12                                                                           |
-| Day             | "dd"                        | 01-28, 01-29, 01-30, 01-31 based on month/year.                                 |
-| Hour            | "HH"                        | 00-23                                                                           |
-| Minute          | "mm"                        | 00-59                                                                           |
-| Second          | "ss"                        | 00-59                                                                           |
-| Second fraction | "FFFFFFF"                   | Minimum of one digit, maximum of 16 digits.                                     |
-| Time offset     | "K"                         | Either "Z" or "('+'/'-')HH':'mm".                                               |
-| Partial time    | "HH':'mm':'ss[FFFFFFF]"     | Time without UTC offset information.                                            |
-| Full date       | "yyyy'-'MM'-'dd"            | Calendar date.                                                                  |
-| Full time       | "'Partial time'K"           | UTC of day or Local time of day with the time offset between local time and UTC.|
-| Date time       | "'Full date''T''Full time'" | Calendar date and time of day, for example, 2019-07-26T16:59:57-05:00.                  |
+| Component       | Format                  | Description                                     |
+|-----------------|-------------------------|-------------------------------------------------|
+| Year            | "yyyy"                  | 0001-9999                                       |
+| Month           | "MM"                    | 01-12                                           |
+| Day             | "dd"                    | 01-28, 01-29, 01-30, 01-31 based on month/year. |
+| Hour            | "HH"                    | 00-23                                           |
+| Minute          | "mm"                    | 00-59                                           |
+| Second          | "ss"                    | 00-59                                           |
+| Second fraction | "FFFFFFF"               | Minimum of one digit, maximum of 16 digits.     |
+| Time offset     | "K"                     | Either "Z" or "('+'/'-')HH':'mm".               |
+| Partial time    | "HH':'mm':'ss[FFFFFFF]" | Time without UTC offset information.            |
+| Full date       | "yyyy'-'MM'-'dd"        | Calendar date.                                  |
+| Full time       | "'Partial time'K"       | UTC of day or Local time of day with the time offset between local time and UTC.|
+| Date time       | "'Full date''T''Full time'" | Calendar date and time of day, for example, 2019-07-26T16:59:57-05:00. |
 
 ### Support for parsing
 

--- a/docs/standard/datetime/system-text-json-support.md
+++ b/docs/standard/datetime/system-text-json-support.md
@@ -68,7 +68,7 @@ If you attempt to read non-compliant formats with <xref:System.Text.Json.Utf8Jso
 If you want the serializer to perform custom parsing or formatting, you can implement [custom converters](xref:System.Text.Json.Serialization.JsonConverter%601). The following sections show a few examples:
 
 - [DateTime(Offset).Parse and DateTime(Offset).ToString](#datetimeoffsetparse-and-datetimeoffsettostring)
-- [<xref:System.Buffers.Text.Utf8Parser> and <xref:System.Buffers.Text.Utf8Formatter>](#xrefsystembufferstextutf8parser-and-xrefsystembufferstextutf8formatter)
+- [Utf8Parser and Utf8Formatter](#-and-)
 - [Use DateTime(Offset).Parse as a fallback](#use-datetimeoffsetparse-as-a-fallback)
 - [Use Unix epoch date format](#use-unix-epoch-date-format)
 

--- a/docs/standard/serialization/system-text-json/migrate-from-newtonsoft.md
+++ b/docs/standard/serialization/system-text-json/migrate-from-newtonsoft.md
@@ -23,8 +23,8 @@ The `System.Text.Json` namespace provides functionality for serializing to and d
 * .NET Framework 4.6.2 and later versions
 * .NET Core 2.0, 2.1, and 2.2
 
->[!TIP]
-> You can use AI assistance to [migrate from `Newtonsoft.Json` with GitHub Copilot](#use-github-copilot-to-migrate).
+> [!TIP]
+> You can use AI assistance to [migrate from `Newtonsoft.Json`](#use-github-copilot-to-migrate).
 
 `System.Text.Json` focuses primarily on performance, security, and standards compliance. It has some key differences in default behavior and doesn't aim to have feature parity with `Newtonsoft.Json`. For some scenarios, `System.Text.Json` currently has no built-in functionality, but there are recommended workarounds. For other scenarios, workarounds are impractical.
 
@@ -380,7 +380,7 @@ Starting in .NET 7, you can use the C# `required` modifier or the <xref:System.T
 * The `DateTimeZoneHandling` setting can be used to serialize all `DateTime` values as UTC dates.
 * The `DateFormatString` setting and `DateTime` converters can be used to customize the format of date strings.
 
-<xref:System.Text.Json?displayProperty=fullName> supports ISO 8601-1:2019, including the RFC 3339 profile. This format is widely adopted, unambiguous, and makes round trips precisely. To use any other format, create a custom converter. For example, the following converters serialize and deserialize JSON that uses Unix epoch format with or without a time zone offset (values such as `/Date(1590863400000-0700)/` or `/Date(1590863400000)/`):
+<xref:System.Text.Json> supports ISO 8601-1:2019, including the RFC 3339 profile. This format is widely adopted, unambiguous, and makes round trips precisely. To use any other format, create a custom converter. For example, the following converters serialize and deserialize JSON that uses Unix epoch format with or without a time zone offset (values such as `/Date(1590863400000-0700)/` or `/Date(1590863400000)/`):
 
 :::code language="csharp" source="snippets/how-to-contd/csharp/CustomConverterUnixEpochDate.cs" id="ConverterOnly":::
 

--- a/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/CopyOptions.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/CopyOptions.cs
@@ -11,7 +11,7 @@ namespace CopyOptions
 
     public class Program
     {
-        public static void Main()
+        public static void Run()
         {
             Forecast forecast = new()
             {

--- a/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/CustomConverterHandleNull.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/CustomConverterHandleNull.cs
@@ -31,7 +31,7 @@ namespace CustomConverterHandleNull
 
     public class Program
     {
-        public static void Main()
+        public static void Run()
         {
             string json = @"{""x"":1,""y"":2,""Description"":null}";
 

--- a/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/CustomConverterInferredTypesToObject.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/CustomConverterInferredTypesToObject.cs
@@ -35,7 +35,7 @@ namespace CustomConverterInferredTypesToObject
 
     public class Program
     {
-        public static void Main()
+        public static void Run()
         {
             string jsonString = """
                 {

--- a/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/CustomConverterPreserveReferences.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/CustomConverterPreserveReferences.cs
@@ -101,7 +101,7 @@ namespace CustomConverterPreserveReferences
 
     public class Program
     {
-        public static void Main()
+        public static void Run()
         {
             Employee tyler = new()
             {

--- a/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/CustomConverterUnixEpochDate.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/CustomConverterUnixEpochDate.cs
@@ -2,29 +2,51 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
+using Newtonsoft.Json;
 
 namespace CustomConverterUnixEpochDate
 {
     class Program
     {
-        public static void Main()
+        public static void Main(DateTimeOffset date)
         {
             var forecast = new Forecast()
             {
-                Date = DateTimeOffset.Now,
+                Date = date,
                 TemperatureCelsius = 19,
                 Summary = "warm"
             };
 
             var options = new JsonSerializerOptions();
             options.Converters.Add(new UnixEpochDateTimeOffsetConverter());
-            options.WriteIndented = true;
+            //options.WriteIndented = true;
 
-            string json = JsonSerializer.Serialize(forecast, options);
-            Console.WriteLine(json);
+            string json = System.Text.Json.JsonSerializer.Serialize(forecast, options);
+            Console.WriteLine($"System.Text.Json: {json}");
 
-            Forecast forecastDeserialized = JsonSerializer.Deserialize<Forecast>(json, options)!;
-            Console.WriteLine($"Deserialized date = {forecastDeserialized.Date}");
+            Forecast forecastDeserialized = System.Text.Json.JsonSerializer.Deserialize<Forecast>(json, options)!;
+            Console.WriteLine($"System.Text.Json deserialized date = {forecastDeserialized.Date}");
+        }
+
+        public static void Main2(DateTimeOffset date)
+        {
+            var forecast = new Forecast()
+            {
+                Date = date,
+                TemperatureCelsius = 19,
+                Summary = "warm"
+            };
+
+            var settings = new JsonSerializerSettings
+            {
+                DateFormatHandling = DateFormatHandling.MicrosoftDateFormat,
+            };
+
+            string json = JsonConvert.SerializeObject(forecast, settings);
+            Console.WriteLine($"{Environment.NewLine}Newtonsoft: {json}");
+
+            Forecast forecastDeserialized = JsonConvert.DeserializeObject<Forecast>(json, settings)!;
+            Console.WriteLine($"Newtonsoft deserialized date = {forecastDeserialized.Date}");
         }
     }
 
@@ -36,23 +58,28 @@ namespace CustomConverterUnixEpochDate
     }
 
     // <ConverterOnly>
-    sealed class UnixEpochDateTimeOffsetConverter : JsonConverter<DateTimeOffset>
+    sealed class UnixEpochDateTimeOffsetConverter : System.Text.Json.Serialization.JsonConverter<DateTimeOffset>
     {
         static readonly DateTimeOffset s_epoch = new(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
-        static readonly Regex s_regex = new("^/Date\\(([+-]*\\d+)([+-])(\\d{2})(\\d{2})\\)/$", RegexOptions.CultureInvariant);
+        static readonly Regex s_regex = new(
+            "^/Date\\(([+-]*\\d+)([+-])(\\d{2})(\\d{2})\\)/$",
+            RegexOptions.CultureInvariant);
 
-        public override DateTimeOffset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        public override DateTimeOffset Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options)
         {
             string formatted = reader.GetString()!;
             Match match = s_regex.Match(formatted);
 
             if (
                     !match.Success
-                    || !long.TryParse(match.Groups[1].Value, System.Globalization.NumberStyles.Integer, CultureInfo.InvariantCulture, out long unixTime)
-                    || !int.TryParse(match.Groups[3].Value, System.Globalization.NumberStyles.Integer, CultureInfo.InvariantCulture, out int hours)
-                    || !int.TryParse(match.Groups[4].Value, System.Globalization.NumberStyles.Integer, CultureInfo.InvariantCulture, out int minutes))
+                    || !long.TryParse(match.Groups[1].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out long unixTime)
+                    || !int.TryParse(match.Groups[3].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int hours)
+                    || !int.TryParse(match.Groups[4].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int minutes))
             {
-                throw new JsonException();
+                throw new System.Text.Json.JsonException();
             }
 
             int sign = match.Groups[2].Value[0] == '+' ? 1 : -1;
@@ -63,10 +90,13 @@ namespace CustomConverterUnixEpochDate
 
         public override void Write(Utf8JsonWriter writer, DateTimeOffset value, JsonSerializerOptions options)
         {
-            long unixTime = Convert.ToInt64((value - s_epoch).TotalMilliseconds);
+            long unixTime = value.ToUnixTimeMilliseconds();
+
             TimeSpan utcOffset = value.Offset;
 
-            string formatted = string.Create(CultureInfo.InvariantCulture, $"/Date({unixTime}{(utcOffset >= TimeSpan.Zero ? "+" : "-")}{utcOffset:hhmm})/");
+            string formatted = string.Create(
+                CultureInfo.InvariantCulture,
+                $"/Date({unixTime}{(utcOffset >= TimeSpan.Zero ? "+" : "-")}{utcOffset:hhmm})/");
 
             writer.WriteStringValue(formatted);
         }

--- a/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/CustomConverterUnixEpochDate.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/CustomConverterUnixEpochDate.cs
@@ -19,7 +19,6 @@ namespace CustomConverterUnixEpochDate
 
             var options = new JsonSerializerOptions();
             options.Converters.Add(new UnixEpochDateTimeOffsetConverter());
-            //options.WriteIndented = true;
 
             string json = System.Text.Json.JsonSerializer.Serialize(forecast, options);
             Console.WriteLine($"System.Text.Json: {json}");
@@ -88,7 +87,10 @@ namespace CustomConverterUnixEpochDate
             return s_epoch.AddMilliseconds(unixTime).ToOffset(utcOffset);
         }
 
-        public override void Write(Utf8JsonWriter writer, DateTimeOffset value, JsonSerializerOptions options)
+        public override void Write(
+            Utf8JsonWriter writer,
+            DateTimeOffset value,
+            JsonSerializerOptions options)
         {
             long unixTime = value.ToUnixTimeMilliseconds();
 

--- a/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/CustomConverterUnixEpochDate.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/CustomConverterUnixEpochDate.cs
@@ -8,7 +8,7 @@ namespace CustomConverterUnixEpochDate
 {
     class Program
     {
-        public static void Main(DateTimeOffset date)
+        public static void STJExample(DateTimeOffset date)
         {
             var forecast = new Forecast()
             {
@@ -27,7 +27,7 @@ namespace CustomConverterUnixEpochDate
             Console.WriteLine($"System.Text.Json deserialized date = {forecastDeserialized.Date}");
         }
 
-        public static void Main2(DateTimeOffset date)
+        public static void NewtonsoftExample(DateTimeOffset date)
         {
             var forecast = new Forecast()
             {

--- a/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/CustomConverterUnixEpochDateNoZone.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/CustomConverterUnixEpochDateNoZone.cs
@@ -7,7 +7,7 @@ namespace CustomConverterUnixEpochDateNoZone
 {
     class Program
     {
-        public static void Main(DateTime date)
+        public static void STJExample(DateTime date)
         {
             var forecast = new Forecast()
             {
@@ -26,7 +26,7 @@ namespace CustomConverterUnixEpochDateNoZone
             Console.WriteLine($"System.Text.Json deserialized date = {forecastDeserialized.Date}");
         }
 
-        public static void Main2(DateTime date)
+        public static void NewtonsoftExample(DateTime date)
         {
             var forecast = new Forecast()
             {

--- a/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/CustomConverterUnixEpochDateNoZone.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/CustomConverterUnixEpochDateNoZone.cs
@@ -1,6 +1,5 @@
 ﻿using System.Globalization;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 
@@ -60,16 +59,21 @@ namespace CustomConverterUnixEpochDateNoZone
     sealed class UnixEpochDateTimeConverter : System.Text.Json.Serialization.JsonConverter<DateTime>
     {
         static readonly DateTime s_epoch = new(1970, 1, 1, 0, 0, 0);
-        static readonly Regex s_regex = new("^/Date\\(([+-]*\\d+)\\)/$", RegexOptions.CultureInvariant);
+        static readonly Regex s_regex = new(
+            "^/Date\\(([+-]*\\d+)\\)/$",
+            RegexOptions.CultureInvariant);
 
-        public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        public override DateTime Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options)
         {
             string formatted = reader.GetString()!;
             Match match = s_regex.Match(formatted);
 
             if (
-                    !match.Success
-                    || !long.TryParse(match.Groups[1].Value, System.Globalization.NumberStyles.Integer, CultureInfo.InvariantCulture, out long unixTime))
+                !match.Success
+                || !long.TryParse(match.Groups[1].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out long unixTime))
             {
                 throw new System.Text.Json.JsonException();
             }
@@ -77,7 +81,10 @@ namespace CustomConverterUnixEpochDateNoZone
             return s_epoch.AddMilliseconds(unixTime);
         }
 
-        public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+        public override void Write(
+            Utf8JsonWriter writer,
+            DateTime value,
+            JsonSerializerOptions options)
         {
             long unixTime = (value - s_epoch).Ticks / TimeSpan.TicksPerMillisecond;
 

--- a/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/CustomConverterUnixEpochDateNoZone.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/CustomConverterUnixEpochDateNoZone.cs
@@ -2,29 +2,50 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
+using Newtonsoft.Json;
 
 namespace CustomConverterUnixEpochDateNoZone
 {
     class Program
     {
-        public static void Main()
+        public static void Main(DateTime date)
         {
             var forecast = new Forecast()
             {
-                Date = DateTime.Now,
+                Date = date,
                 TemperatureCelsius = 19,
                 Summary = "warm"
             };
 
             var options = new JsonSerializerOptions();
             options.Converters.Add(new UnixEpochDateTimeConverter());
-            options.WriteIndented = true;
 
-            string json = JsonSerializer.Serialize(forecast, options);
-            Console.WriteLine(json);
+            string json = System.Text.Json.JsonSerializer.Serialize(forecast, options);
+            Console.WriteLine($"System.Text.Json: {json}");
 
-            Forecast forecastDeserialized = JsonSerializer.Deserialize<Forecast>(json, options)!;
-            Console.WriteLine($"Deserialized date = {forecastDeserialized.Date}");
+            Forecast forecastDeserialized = System.Text.Json.JsonSerializer.Deserialize<Forecast>(json, options)!;
+            Console.WriteLine($"System.Text.Json deserialized date = {forecastDeserialized.Date}");
+        }
+
+        public static void Main2(DateTime date)
+        {
+            var forecast = new Forecast()
+            {
+                Date = date,
+                TemperatureCelsius = 19,
+                Summary = "warm"
+            };
+
+            var settings = new JsonSerializerSettings
+            {
+                DateFormatHandling = DateFormatHandling.MicrosoftDateFormat,
+            };
+
+            string json = JsonConvert.SerializeObject(forecast, settings);
+            Console.WriteLine($"{Environment.NewLine}Newtonsoft: {json}");
+
+            Forecast forecastDeserialized = JsonConvert.DeserializeObject<Forecast>(json, settings)!;
+            Console.WriteLine($"Newtonsoft deserialized date = {forecastDeserialized.Date}");
         }
     }
 
@@ -36,7 +57,7 @@ namespace CustomConverterUnixEpochDateNoZone
     }
 
     // <ConverterOnly>
-    sealed class UnixEpochDateTimeConverter : JsonConverter<DateTime>
+    sealed class UnixEpochDateTimeConverter : System.Text.Json.Serialization.JsonConverter<DateTime>
     {
         static readonly DateTime s_epoch = new(1970, 1, 1, 0, 0, 0);
         static readonly Regex s_regex = new("^/Date\\(([+-]*\\d+)\\)/$", RegexOptions.CultureInvariant);
@@ -50,7 +71,7 @@ namespace CustomConverterUnixEpochDateNoZone
                     !match.Success
                     || !long.TryParse(match.Groups[1].Value, System.Globalization.NumberStyles.Integer, CultureInfo.InvariantCulture, out long unixTime))
             {
-                throw new JsonException();
+                throw new System.Text.Json.JsonException();
             }
 
             return s_epoch.AddMilliseconds(unixTime);
@@ -58,7 +79,7 @@ namespace CustomConverterUnixEpochDateNoZone
 
         public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
         {
-            long unixTime = Convert.ToInt64((value - s_epoch).TotalMilliseconds);
+            long unixTime = (value - s_epoch).Ticks / TimeSpan.TicksPerMillisecond;
 
             string formatted = string.Create(CultureInfo.InvariantCulture, $"/Date({unixTime})/");
             writer.WriteStringValue(formatted);

--- a/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/Fields.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/Fields.cs
@@ -22,7 +22,7 @@ namespace Fields
 
     public class Program
     {
-        public static void Main()
+        public static void Run()
         {
             string json = """
                 {

--- a/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/GuidReferenceResolverExample.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/GuidReferenceResolverExample.cs
@@ -49,7 +49,7 @@ namespace GuidReferenceResolverExample
 
     static class Program
     {
-        public static void Main()
+        public static void Run()
         {
             Person tyler = new() { Id = Guid.NewGuid(), Name = "Tyler" };
             Person adrian = new() { Id = Guid.NewGuid(), Name = "Adrian" };

--- a/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/HttpClientExtensionMethods.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/HttpClientExtensionMethods.cs
@@ -12,7 +12,7 @@ namespace HttpClientExtensionMethods
 
     public class Program
     {
-        public static async Task Main()
+        public static async Task Run()
         {
             using HttpClient client = new()
             {

--- a/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/IgnoreNullOnSerialize.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/IgnoreNullOnSerialize.cs
@@ -12,7 +12,7 @@ namespace IgnoreNullOnSerialize
 
     public class Program
     {
-        public static void Main()
+        public static void Run()
         {
             Forecast forecast = new()
             {

--- a/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/IgnoreValueDefaultOnSerialize.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/IgnoreValueDefaultOnSerialize.cs
@@ -12,7 +12,7 @@ namespace IgnoreValueDefaultOnSerialize
 
     public class Program
     {
-        public static void Main()
+        public static void Run()
         {
             Forecast forecast = new()
             {

--- a/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/ImmutableTypes.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/ImmutableTypes.cs
@@ -16,7 +16,7 @@ namespace ImmutableTypes
 
     public class Program
     {
-        public static void Main()
+        public static void Run()
         {
             string json = """
                 {

--- a/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/ImmutableTypesCtorParms.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/ImmutableTypesCtorParms.cs
@@ -17,7 +17,7 @@ namespace ImmutableTypesCtorParms
 
     public class Program
     {
-        public static void Main()
+        public static void Run()
         {
             string json = """
                 {

--- a/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/JsonIgnoreAttributeExample.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/JsonIgnoreAttributeExample.cs
@@ -17,7 +17,7 @@ namespace JsonIgnoreAttributeExample
 
     public class Program
     {
-        public static void Main()
+        public static void Run()
         {
             Forecast forecast = new()
             {

--- a/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/NonPublicAccessors.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/NonPublicAccessors.cs
@@ -16,7 +16,7 @@ namespace NonPublicAccessors
 
     public class Program
     {
-        public static void Main()
+        public static void Run()
         {
             string json = """
                 {

--- a/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/NonStringKeyDictionary.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/NonStringKeyDictionary.cs
@@ -4,7 +4,7 @@ namespace NonStringKeyDictionary
 {
     public class Program
     {
-        public static void Main()
+        public static void Run()
         {
             Dictionary<int, string> numbers = new()
             {

--- a/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/OptionsDefaults.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/OptionsDefaults.cs
@@ -11,7 +11,7 @@ namespace OptionsDefaults
 
     public class Program
     {
-        public static void Main()
+        public static void Run()
         {
             Forecast forecast = new()
             {

--- a/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/PreserveReferences.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/PreserveReferences.cs
@@ -12,7 +12,7 @@ namespace PreserveReferences
 
     public class Program
     {
-        public static void Main()
+        public static void Run()
         {
             Employee tyler = new()
             {

--- a/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/PreserveReferencesMultipleCalls.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/PreserveReferencesMultipleCalls.cs
@@ -68,7 +68,7 @@ namespace PreserveReferencesMultipleCalls
 
     public class Program
     {
-        public static void Main()
+        public static void Run()
         {
             Employee tyler = new()
             {

--- a/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/Program.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/Program.cs
@@ -6,90 +6,90 @@
         {
             Console.WriteLine("======== Custom converter Unix Epoch DateTimeOffset =========");
             DateTimeOffset date = DateTimeOffset.Now;
-            CustomConverterUnixEpochDate.Program.Main(date);
-            CustomConverterUnixEpochDate.Program.Main2(date);
+            CustomConverterUnixEpochDate.Program.STJExample(date);
+            CustomConverterUnixEpochDate.Program.NewtonsoftExample(date);
             Console.WriteLine();
 
             Console.WriteLine("======== Custom converter Unix Epoch DateTime =========");
             DateTime date2 = DateTime.Now;
-            CustomConverterUnixEpochDateNoZone.Program.Main(date2);
-            CustomConverterUnixEpochDateNoZone.Program.Main2(date2);
+            CustomConverterUnixEpochDateNoZone.Program.STJExample(date2);
+            CustomConverterUnixEpochDateNoZone.Program.NewtonsoftExample(date2);
             Console.WriteLine();
 
             Console.WriteLine("======== Preserve references =========");
-            PreserveReferences.Program.Main();
+            PreserveReferences.Program.Run();
             Console.WriteLine();
 
             Console.WriteLine("======== Custom converter Preserve references =========");
-            CustomConverterPreserveReferences.Program.Main();
+            CustomConverterPreserveReferences.Program.Run();
             Console.WriteLine();
 
             Console.WriteLine("======== Preserve references Multiple calls =========");
-            PreserveReferencesMultipleCalls.Program.Main();
+            PreserveReferencesMultipleCalls.Program.Run();
             Console.WriteLine();
 
             Console.WriteLine("======== Immutable types =========");
-            ImmutableTypes.Program.Main();
+            ImmutableTypes.Program.Run();
             Console.WriteLine();
 
             Console.WriteLine("======== Immutable types =========");
-            ImmutableTypesCtorParms.Program.Main();
+            ImmutableTypesCtorParms.Program.Run();
             Console.WriteLine();
 
             Console.WriteLine("======== Record support =========");
-            Records.Program.Main();
+            Records.Program.Run();
             Console.WriteLine();
 
             Console.WriteLine("======== Field support =========");
-            Fields.Program.Main();
+            Fields.Program.Run();
             Console.WriteLine();
 
             Console.WriteLine("======== Non-string key dictionary =========");
-            NonStringKeyDictionary.Program.Main();
+            NonStringKeyDictionary.Program.Run();
             Console.WriteLine();
 
             Console.WriteLine("======== HttpClient extension methods =========");
-            await HttpClientExtensionMethods.Program.Main();
+            await HttpClientExtensionMethods.Program.Run();
             Console.WriteLine();
 
             Console.WriteLine("======== Custom converter handle null =========");
-            CustomConverterHandleNull.Program.Main();
+            CustomConverterHandleNull.Program.Run();
             Console.WriteLine();
 
             Console.WriteLine("======== Custom converter inferred types to object =========");
-            CustomConverterInferredTypesToObject.Program.Main();
+            CustomConverterInferredTypesToObject.Program.Run();
             Console.WriteLine();
 
             Console.WriteLine("======== Ignore value type default on serialize =========");
-            IgnoreValueDefaultOnSerialize.Program.Main();
+            IgnoreValueDefaultOnSerialize.Program.Run();
             Console.WriteLine();
 
             Console.WriteLine("======== Ignore null on serialize =========");
-            IgnoreNullOnSerialize.Program.Main();
+            IgnoreNullOnSerialize.Program.Run();
             Console.WriteLine();
 
             Console.WriteLine("======== Conditionally ignore selected properties on serialize =========");
-            JsonIgnoreAttributeExample.Program.Main();
+            JsonIgnoreAttributeExample.Program.Run();
             Console.WriteLine();
 
             Console.WriteLine("======== Non-public accessors =========");
-            NonPublicAccessors.Program.Main();
+            NonPublicAccessors.Program.Run();
             Console.WriteLine();
 
             Console.WriteLine("======== Copy options instance =========");
-            CopyOptions.Program.Main();
+            CopyOptions.Program.Run();
             Console.WriteLine();
 
             Console.WriteLine("======== Create options instance with specified defaults =========");
-            OptionsDefaults.Program.Main();
+            OptionsDefaults.Program.Run();
             Console.WriteLine();
 
             Console.WriteLine("======== Quoted numbers =========");
-            QuotedNumbers.Program.Main();
+            QuotedNumbers.Program.Run();
             Console.WriteLine();
 
             Console.WriteLine("======== GuidReferenceResolver =========");
-            GuidReferenceResolverExample.Program.Main();
+            GuidReferenceResolverExample.Program.Run();
             Console.WriteLine();
         }
     }

--- a/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/Program.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/Program.cs
@@ -4,11 +4,11 @@
     {
         static async Task Main(string[] args)
         {
-            //Console.WriteLine("======== Custom converter Unix Epoch DateTimeOffset =========");
-            //DateTimeOffset date = DateTimeOffset.Now;
-            //CustomConverterUnixEpochDate.Program.Main(date);
-            //CustomConverterUnixEpochDate.Program.Main2(date);
-            //Console.WriteLine();
+            Console.WriteLine("======== Custom converter Unix Epoch DateTimeOffset =========");
+            DateTimeOffset date = DateTimeOffset.Now;
+            CustomConverterUnixEpochDate.Program.Main(date);
+            CustomConverterUnixEpochDate.Program.Main2(date);
+            Console.WriteLine();
 
             Console.WriteLine("======== Custom converter Unix Epoch DateTime =========");
             DateTime date2 = DateTime.Now;
@@ -16,81 +16,81 @@
             CustomConverterUnixEpochDateNoZone.Program.Main2(date2);
             Console.WriteLine();
 
-            //Console.WriteLine("======== Preserve references =========");
-            //PreserveReferences.Program.Main();
-            //Console.WriteLine();
+            Console.WriteLine("======== Preserve references =========");
+            PreserveReferences.Program.Main();
+            Console.WriteLine();
 
-            //Console.WriteLine("======== Custom converter Preserve references =========");
-            //CustomConverterPreserveReferences.Program.Main();
-            //Console.WriteLine();
+            Console.WriteLine("======== Custom converter Preserve references =========");
+            CustomConverterPreserveReferences.Program.Main();
+            Console.WriteLine();
 
-            //Console.WriteLine("======== Preserve references Multiple calls =========");
-            //PreserveReferencesMultipleCalls.Program.Main();
-            //Console.WriteLine();
+            Console.WriteLine("======== Preserve references Multiple calls =========");
+            PreserveReferencesMultipleCalls.Program.Main();
+            Console.WriteLine();
 
-            //Console.WriteLine("======== Immutable types =========");
-            //ImmutableTypes.Program.Main();
-            //Console.WriteLine();
+            Console.WriteLine("======== Immutable types =========");
+            ImmutableTypes.Program.Main();
+            Console.WriteLine();
 
-            //Console.WriteLine("======== Immutable types =========");
-            //ImmutableTypesCtorParms.Program.Main();
-            //Console.WriteLine();
+            Console.WriteLine("======== Immutable types =========");
+            ImmutableTypesCtorParms.Program.Main();
+            Console.WriteLine();
 
-            //Console.WriteLine("======== Record support =========");
-            //Records.Program.Main();
-            //Console.WriteLine();
+            Console.WriteLine("======== Record support =========");
+            Records.Program.Main();
+            Console.WriteLine();
 
-            //Console.WriteLine("======== Field support =========");
-            //Fields.Program.Main();
-            //Console.WriteLine();
+            Console.WriteLine("======== Field support =========");
+            Fields.Program.Main();
+            Console.WriteLine();
 
-            //Console.WriteLine("======== Non-string key dictionary =========");
-            //NonStringKeyDictionary.Program.Main();
-            //Console.WriteLine();
+            Console.WriteLine("======== Non-string key dictionary =========");
+            NonStringKeyDictionary.Program.Main();
+            Console.WriteLine();
 
-            //Console.WriteLine("======== HttpClient extension methods =========");
-            //await HttpClientExtensionMethods.Program.Main();
-            //Console.WriteLine();
+            Console.WriteLine("======== HttpClient extension methods =========");
+            await HttpClientExtensionMethods.Program.Main();
+            Console.WriteLine();
 
-            //Console.WriteLine("======== Custom converter handle null =========");
-            //CustomConverterHandleNull.Program.Main();
-            //Console.WriteLine();
+            Console.WriteLine("======== Custom converter handle null =========");
+            CustomConverterHandleNull.Program.Main();
+            Console.WriteLine();
 
-            //Console.WriteLine("======== Custom converter inferred types to object =========");
-            //CustomConverterInferredTypesToObject.Program.Main();
-            //Console.WriteLine();
+            Console.WriteLine("======== Custom converter inferred types to object =========");
+            CustomConverterInferredTypesToObject.Program.Main();
+            Console.WriteLine();
 
-            //Console.WriteLine("======== Ignore value type default on serialize =========");
-            //IgnoreValueDefaultOnSerialize.Program.Main();
-            //Console.WriteLine();
+            Console.WriteLine("======== Ignore value type default on serialize =========");
+            IgnoreValueDefaultOnSerialize.Program.Main();
+            Console.WriteLine();
 
-            //Console.WriteLine("======== Ignore null on serialize =========");
-            //IgnoreNullOnSerialize.Program.Main();
-            //Console.WriteLine();
+            Console.WriteLine("======== Ignore null on serialize =========");
+            IgnoreNullOnSerialize.Program.Main();
+            Console.WriteLine();
 
-            //Console.WriteLine("======== Conditionally ignore selected properties on serialize =========");
-            //JsonIgnoreAttributeExample.Program.Main();
-            //Console.WriteLine();
+            Console.WriteLine("======== Conditionally ignore selected properties on serialize =========");
+            JsonIgnoreAttributeExample.Program.Main();
+            Console.WriteLine();
 
-            //Console.WriteLine("======== Non-public accessors =========");
-            //NonPublicAccessors.Program.Main();
-            //Console.WriteLine();
+            Console.WriteLine("======== Non-public accessors =========");
+            NonPublicAccessors.Program.Main();
+            Console.WriteLine();
 
-            //Console.WriteLine("======== Copy options instance =========");
-            //CopyOptions.Program.Main();
-            //Console.WriteLine();
+            Console.WriteLine("======== Copy options instance =========");
+            CopyOptions.Program.Main();
+            Console.WriteLine();
 
-            //Console.WriteLine("======== Create options instance with specified defaults =========");
-            //OptionsDefaults.Program.Main();
-            //Console.WriteLine();
+            Console.WriteLine("======== Create options instance with specified defaults =========");
+            OptionsDefaults.Program.Main();
+            Console.WriteLine();
 
-            //Console.WriteLine("======== Quoted numbers =========");
-            //QuotedNumbers.Program.Main();
-            //Console.WriteLine();
+            Console.WriteLine("======== Quoted numbers =========");
+            QuotedNumbers.Program.Main();
+            Console.WriteLine();
 
-            //Console.WriteLine("======== GuidReferenceResolver =========");
-            //GuidReferenceResolverExample.Program.Main();
-            //Console.WriteLine();
+            Console.WriteLine("======== GuidReferenceResolver =========");
+            GuidReferenceResolverExample.Program.Main();
+            Console.WriteLine();
         }
     }
 }

--- a/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/Program.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/Program.cs
@@ -4,89 +4,93 @@
     {
         static async Task Main(string[] args)
         {
-            Console.WriteLine("======== Custom converter Unix Epoch DateTimeOffset =========");
-            CustomConverterUnixEpochDate.Program.Main();
-            Console.WriteLine();
+            //Console.WriteLine("======== Custom converter Unix Epoch DateTimeOffset =========");
+            //DateTimeOffset date = DateTimeOffset.Now;
+            //CustomConverterUnixEpochDate.Program.Main(date);
+            //CustomConverterUnixEpochDate.Program.Main2(date);
+            //Console.WriteLine();
 
             Console.WriteLine("======== Custom converter Unix Epoch DateTime =========");
-            CustomConverterUnixEpochDateNoZone.Program.Main();
+            DateTime date2 = DateTime.Now;
+            CustomConverterUnixEpochDateNoZone.Program.Main(date2);
+            CustomConverterUnixEpochDateNoZone.Program.Main2(date2);
             Console.WriteLine();
 
-            Console.WriteLine("======== Preserve references =========");
-            PreserveReferences.Program.Main();
-            Console.WriteLine();
+            //Console.WriteLine("======== Preserve references =========");
+            //PreserveReferences.Program.Main();
+            //Console.WriteLine();
 
-            Console.WriteLine("======== Custom converter Preserve references =========");
-            CustomConverterPreserveReferences.Program.Main();
-            Console.WriteLine();
+            //Console.WriteLine("======== Custom converter Preserve references =========");
+            //CustomConverterPreserveReferences.Program.Main();
+            //Console.WriteLine();
 
-            Console.WriteLine("======== Preserve references Multiple calls =========");
-            PreserveReferencesMultipleCalls.Program.Main();
-            Console.WriteLine();
+            //Console.WriteLine("======== Preserve references Multiple calls =========");
+            //PreserveReferencesMultipleCalls.Program.Main();
+            //Console.WriteLine();
 
-            Console.WriteLine("======== Immutable types =========");
-            ImmutableTypes.Program.Main();
-            Console.WriteLine();
+            //Console.WriteLine("======== Immutable types =========");
+            //ImmutableTypes.Program.Main();
+            //Console.WriteLine();
 
-            Console.WriteLine("======== Immutable types =========");
-            ImmutableTypesCtorParms.Program.Main();
-            Console.WriteLine();
+            //Console.WriteLine("======== Immutable types =========");
+            //ImmutableTypesCtorParms.Program.Main();
+            //Console.WriteLine();
 
-            Console.WriteLine("======== Record support =========");
-            Records.Program.Main();
-            Console.WriteLine();
+            //Console.WriteLine("======== Record support =========");
+            //Records.Program.Main();
+            //Console.WriteLine();
 
-            Console.WriteLine("======== Field support =========");
-            Fields.Program.Main();
-            Console.WriteLine();
+            //Console.WriteLine("======== Field support =========");
+            //Fields.Program.Main();
+            //Console.WriteLine();
 
-            Console.WriteLine("======== Non-string key dictionary =========");
-            NonStringKeyDictionary.Program.Main();
-            Console.WriteLine();
+            //Console.WriteLine("======== Non-string key dictionary =========");
+            //NonStringKeyDictionary.Program.Main();
+            //Console.WriteLine();
 
-            Console.WriteLine("======== HttpClient extension methods =========");
-            await HttpClientExtensionMethods.Program.Main();
-            Console.WriteLine();
+            //Console.WriteLine("======== HttpClient extension methods =========");
+            //await HttpClientExtensionMethods.Program.Main();
+            //Console.WriteLine();
 
-            Console.WriteLine("======== Custom converter handle null =========");
-            CustomConverterHandleNull.Program.Main();
-            Console.WriteLine();
+            //Console.WriteLine("======== Custom converter handle null =========");
+            //CustomConverterHandleNull.Program.Main();
+            //Console.WriteLine();
 
-            Console.WriteLine("======== Custom converter inferred types to object =========");
-            CustomConverterInferredTypesToObject.Program.Main();
-            Console.WriteLine();
+            //Console.WriteLine("======== Custom converter inferred types to object =========");
+            //CustomConverterInferredTypesToObject.Program.Main();
+            //Console.WriteLine();
 
-            Console.WriteLine("======== Ignore value type default on serialize =========");
-            IgnoreValueDefaultOnSerialize.Program.Main();
-            Console.WriteLine();
+            //Console.WriteLine("======== Ignore value type default on serialize =========");
+            //IgnoreValueDefaultOnSerialize.Program.Main();
+            //Console.WriteLine();
 
-            Console.WriteLine("======== Ignore null on serialize =========");
-            IgnoreNullOnSerialize.Program.Main();
-            Console.WriteLine();
+            //Console.WriteLine("======== Ignore null on serialize =========");
+            //IgnoreNullOnSerialize.Program.Main();
+            //Console.WriteLine();
 
-            Console.WriteLine("======== Conditionally ignore selected properties on serialize =========");
-            JsonIgnoreAttributeExample.Program.Main();
-            Console.WriteLine();
+            //Console.WriteLine("======== Conditionally ignore selected properties on serialize =========");
+            //JsonIgnoreAttributeExample.Program.Main();
+            //Console.WriteLine();
 
-            Console.WriteLine("======== Non-public accessors =========");
-            NonPublicAccessors.Program.Main();
-            Console.WriteLine();
+            //Console.WriteLine("======== Non-public accessors =========");
+            //NonPublicAccessors.Program.Main();
+            //Console.WriteLine();
 
-            Console.WriteLine("======== Copy options instance =========");
-            CopyOptions.Program.Main();
-            Console.WriteLine();
+            //Console.WriteLine("======== Copy options instance =========");
+            //CopyOptions.Program.Main();
+            //Console.WriteLine();
 
-            Console.WriteLine("======== Create options instance with specified defaults =========");
-            OptionsDefaults.Program.Main();
-            Console.WriteLine();
+            //Console.WriteLine("======== Create options instance with specified defaults =========");
+            //OptionsDefaults.Program.Main();
+            //Console.WriteLine();
 
-            Console.WriteLine("======== Quoted numbers =========");
-            QuotedNumbers.Program.Main();
-            Console.WriteLine();
+            //Console.WriteLine("======== Quoted numbers =========");
+            //QuotedNumbers.Program.Main();
+            //Console.WriteLine();
 
-            Console.WriteLine("======== GuidReferenceResolver =========");
-            GuidReferenceResolverExample.Program.Main();
-            Console.WriteLine();
+            //Console.WriteLine("======== GuidReferenceResolver =========");
+            //GuidReferenceResolverExample.Program.Main();
+            //Console.WriteLine();
         }
     }
 }

--- a/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/QuotedNumbers.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/QuotedNumbers.cs
@@ -12,7 +12,7 @@ namespace QuotedNumbers
 
     public class Program
     {
-        public static void Main()
+        public static void Run()
         {
             Forecast forecast = new()
             {

--- a/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/Records.cs
+++ b/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/Records.cs
@@ -9,7 +9,7 @@ namespace Records
 
     public class Program
     {
-        public static void Main()
+        public static void Run()
         {
             Forecast forecast = new(DateTime.Now, 40)
             {

--- a/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/SystemTextJsonHowTo.csproj
+++ b/docs/standard/serialization/system-text-json/snippets/how-to-contd/csharp/SystemTextJsonHowTo.csproj
@@ -8,4 +8,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Fixes #44666

Also:

- Adds a Newtonsoft example for comparison
- Breaks up long lines of code

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/datetime/system-text-json-support.md](https://github.com/dotnet/docs/blob/6790238bcedd484e1ccdf595eea773286fadc3d2/docs/standard/datetime/system-text-json-support.md) | [DateTime and DateTimeOffset support in System.Text.Json](https://review.learn.microsoft.com/en-us/dotnet/standard/datetime/system-text-json-support?branch=pr-en-us-46036) |
| [docs/standard/serialization/system-text-json/migrate-from-newtonsoft.md](https://github.com/dotnet/docs/blob/6790238bcedd484e1ccdf595eea773286fadc3d2/docs/standard/serialization/system-text-json/migrate-from-newtonsoft.md) | ["Migrate from Newtonsoft.Json to System.Text.Json - .NET"](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/migrate-from-newtonsoft?branch=pr-en-us-46036) |


<!-- PREVIEW-TABLE-END -->