### PR TITLE
Add note about exhaustive enum matching

### DIFF
--- a/docs/fsharp/language-reference/enumerations.md
+++ b/docs/fsharp/language-reference/enumerations.md
@@ -44,6 +44,8 @@ The default `enum` function works with type `int32`. Therefore, it cannot be use
 
 Additionally, cases for enums are always emitted as `public`. This is so that they align with C# and the rest of the .NET platform.
 
+To enable [exhaustive matching](match-expressions.md) for only the defined enum cases, you can suppress warning FS0104 using the directive `#nowarn "104"`. This allows the compiler to treat only declared enum values as valid during pattern matching, avoiding the need for a catch-all case — useful when you're certain all values are covered.
+
 ## See also
 
 - [F# Language Reference](index.md)

--- a/docs/fsharp/language-reference/enumerations.md
+++ b/docs/fsharp/language-reference/enumerations.md
@@ -46,6 +46,8 @@ Additionally, cases for enums are always emitted as `public`. This is so that th
 
 To enable [exhaustive matching](match-expressions.md) for only the defined enum cases, you can suppress warning FS0104 using the directive `#nowarn "104"`. This allows the compiler to treat only declared enum values as valid during pattern matching, avoiding the need for a catch-all case — useful when you're certain all values are covered.
 
+The warning FS0104 (`Enums may take values outside known cases.`) exists because enums can be assigned arbitrary underlying values, e.g. directly or as a result of [bitwise operations](https://learn.microsoft.com/dotnet/csharp/language-reference/builtin-types/enum#enumeration-types-as-bit-flags)
+
 ## See also
 
 - [F# Language Reference](index.md)


### PR DESCRIPTION
Assuming the passed enum is defined / validation is done beforehand this is important for ensuring all cases are covered.

related to https://github.com/dotnet/fsharp/pull/4522

![image](https://github.com/user-attachments/assets/e0de8601-1609-4091-8396-13d977c8e6de)




<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/enumerations.md](https://github.com/dotnet/docs/blob/1a0e8b622a67f70916f00417ed0daf14b2a6bc92/docs/fsharp/language-reference/enumerations.md) | [Enumerations](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/enumerations?branch=pr-en-us-46067) |


<!-- PREVIEW-TABLE-END -->