### PR TITLE
Update link to NetTrace format

### DIFF
--- a/docs/core/diagnostics/eventpipe.md
+++ b/docs/core/diagnostics/eventpipe.md
@@ -19,7 +19,7 @@ EventPipe aggregates events emitted by runtime components - for example, the Jus
 
 The events are then serialized in the `.nettrace` file format and can be written directly to a file or streamed through a [diagnostic port](./diagnostic-port.md) for out-of-process consumption.
 
-To learn more about the EventTrace format, refer to the [EventTrace format documentation](https://github.com/microsoft/perfview/blob/main/src/TraceEvent/EventPipe/NetTraceFormat.md).
+To learn more about the NetTrace format, see the [NetTrace format documentation](https://github.com/microsoft/perfview/blob/main/src/TraceEvent/EventPipe/NetTraceFormat.md).
 
 ## EventPipe vs. ETW/perf_events
 

--- a/docs/core/diagnostics/eventpipe.md
+++ b/docs/core/diagnostics/eventpipe.md
@@ -19,7 +19,7 @@ EventPipe aggregates events emitted by runtime components - for example, the Jus
 
 The events are then serialized in the `.nettrace` file format and can be written directly to a file or streamed through a [diagnostic port](./diagnostic-port.md) for out-of-process consumption.
 
-To learn more about the EventPipe serialization format, refer to the [EventPipe format documentation](https://github.com/microsoft/perfview/blob/main/src/TraceEvent/EventPipe/EventPipeFormat.md).
+To learn more about the EventTrace format, refer to the [EventTrace format documentation](https://github.com/microsoft/perfview/blob/main/src/TraceEvent/EventPipe/NetTraceFormat.md).
 
 ## EventPipe vs. ETW/perf_events
 


### PR DESCRIPTION
The EventPipe format was moved to a different file as part of https://github.com/microsoft/perfview/pull/2170.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/eventpipe.md](https://github.com/dotnet/docs/blob/86b510b575dd98891248f187713c975e4f8005b6/docs/core/diagnostics/eventpipe.md) | [EventPipe](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/eventpipe?branch=pr-en-us-46069) |


<!-- PREVIEW-TABLE-END -->