### PR TITLE
Clarify method renaming and async return types

### DIFF
--- a/docs/csharp/asynchronous-programming/index.md
+++ b/docs/csharp/asynchronous-programming/index.md
@@ -42,7 +42,7 @@ You can start by updating the code so the thread doesn't block while tasks are r
 
 :::code language="csharp" source="snippets/index/AsyncBreakfast-V2/Program.cs" ID="SnippetMain":::
 
-The code updates the method bodies of `FryEggsAsync`, `FryBaconAsync`, and `ToastBreadAsync` to return `Task<Egg>`, `Task<Bacon>`, and `Task<Toast>` objects, respectively. The method names include the "Async" suffix. The `Main` method returns the `Task` object, although it doesn't have a `return` expression, which is by design. For more information, see [Evaluation of a void-returning async function](/dotnet/csharp/language-reference/language-specification/classes#14153-evaluation-of-a-void-returning-async-function).
+The code updates the original method bodies of `FryEggs`, `FryBacon`, and `ToastBread` to return `Task<Egg>`, `Task<Bacon>`, and `Task<Toast>` objects, respectively. The updated method names include the "Async" suffix: `FryEggsAsync`, `FryBaconAsync`, and `ToastBreadAsync`. The `Main` method returns the `Task` object, although it doesn't have a `return` expression, which is by design. For more information, see [Evaluation of a void-returning async function](/dotnet/csharp/language-reference/language-specification/classes#14153-evaluation-of-a-void-returning-async-function).
 
 > [!NOTE]
 > The updated code doesn't yet take advantage of key features of asynchronous programming, which can result in shorter completion times. The code processes the tasks in roughly the same amount of time as the initial synchronous version. For the full method implementations, see the [final version of the code](#review-final-code) later in this article.


### PR DESCRIPTION
## Summary
Updated the documentation to clarify that the original methods—FryEggs, FryBacon, and ToastBread—were modified to return Task<Egg>, Task<Bacon>, and Task<Toast> respectively. The asynchronous versions—FryEggsAsync, FryBaconAsync, and ToastBreadAsync—did not exist prior to this point in the documentation; they are being introduced here for the first time, not updated.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/asynchronous-programming/index.md](https://github.com/dotnet/docs/blob/99234c39c80ddff284a3b703d567fe1cd9a2ebe0/docs/csharp/asynchronous-programming/index.md) | [docs/csharp/asynchronous-programming/index](https://review.learn.microsoft.com/en-us/dotnet/csharp/asynchronous-programming/index?branch=pr-en-us-46110) |

<!-- PREVIEW-TABLE-END -->