### PR TITLE
Fix output of complex number formatting

### DIFF
--- a/docs/core/compatibility/core-libraries/8.0/complex-format.md
+++ b/docs/core/compatibility/core-libraries/8.0/complex-format.md
@@ -36,3 +36,7 @@ If you need the previous format, you can use a custom string formatting mechanis
 ## Affected APIs
 
 - <xref:System.Numerics.Complex.ToString%2A?displayProperty=fullName>
+
+## See also
+
+- [Format a complex number](../../../../fundamentals/runtime-libraries/system-numerics-complex.md#format-a-complex-number)

--- a/docs/fundamentals/runtime-libraries/snippets/System.Numerics/Complex/Overview/csharp/Program.cs
+++ b/docs/fundamentals/runtime-libraries/snippets/System.Numerics/Complex/Overview/csharp/Program.cs
@@ -1,0 +1,1 @@
+﻿CustomFormatEx.Run();

--- a/docs/fundamentals/runtime-libraries/snippets/System.Numerics/Complex/Overview/csharp/Project.csproj
+++ b/docs/fundamentals/runtime-libraries/snippets/System.Numerics/Complex/Overview/csharp/Project.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Library</OutputType>
-    <TargetFrameworks>net8</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net9</TargetFrameworks>
   </PropertyGroup>
 
  </Project>

--- a/docs/fundamentals/runtime-libraries/snippets/System.Numerics/Complex/Overview/csharp/create1.cs
+++ b/docs/fundamentals/runtime-libraries/snippets/System.Numerics/Complex/Overview/csharp/create1.cs
@@ -4,7 +4,7 @@ using System.Numerics;
 
 public class CreateEx
 {
-    public static void Main()
+    public static void Run()
     {
         // Create a complex number by calling its class constructor.
         Complex c1 = new Complex(12, 6);

--- a/docs/fundamentals/runtime-libraries/snippets/System.Numerics/Complex/Overview/csharp/customfmt1.cs
+++ b/docs/fundamentals/runtime-libraries/snippets/System.Numerics/Complex/Overview/csharp/customfmt1.cs
@@ -15,17 +15,16 @@ public class ComplexFormatter : IFormatProvider, ICustomFormatter
     public string Format(string format, object arg,
                          IFormatProvider provider)
     {
-        if (arg is Complex)
+        if (arg is Complex c1)
         {
-            Complex c1 = (Complex)arg;
             // Check if the format string has a precision specifier.
             int precision;
-            string fmtString = String.Empty;
+            string fmtString = string.Empty;
             if (format.Length > 1)
             {
                 try
                 {
-                    precision = Int32.Parse(format.Substring(1));
+                    precision = int.Parse(format.Substring(1));
                 }
                 catch (FormatException)
                 {
@@ -42,12 +41,12 @@ public class ComplexFormatter : IFormatProvider, ICustomFormatter
         }
         else
         {
-            if (arg is IFormattable)
-                return ((IFormattable)arg).ToString(format, provider);
+            if (arg is IFormattable formattable)
+                return formattable.ToString(format, provider);
             else if (arg != null)
                 return arg.ToString();
             else
-                return String.Empty;
+                return string.Empty;
         }
     }
 }
@@ -56,22 +55,21 @@ public class ComplexFormatter : IFormatProvider, ICustomFormatter
 // <Snippet4>
 public class CustomFormatEx
 {
-    public static void Main()
+    public static void Run()
     {
-        Complex c1 = new Complex(12.1, 15.4);
-        Console.WriteLine("Formatting with ToString():       " +
-                          c1.ToString());
-        Console.WriteLine("Formatting with ToString(format): " +
-                          c1.ToString("N2"));
-        Console.WriteLine("Custom formatting with I0:        " +
-                          String.Format(new ComplexFormatter(), "{0:I0}", c1));
-        Console.WriteLine("Custom formatting with J3:        " +
-                          String.Format(new ComplexFormatter(), "{0:J3}", c1));
+        Complex c1 = new(12.1, 15.4);
+        Console.WriteLine($"Formatting with ToString:         {c1}");
+        Console.WriteLine($"Formatting with ToString(format): {c1:N2}");
+        Console.WriteLine($"Custom formatting with I0:\t" +
+            $"  {string.Format(new ComplexFormatter(), "{0:I0}", c1)}");
+        Console.WriteLine($"Custom formatting with J3:\t" +
+            $"  {string.Format(new ComplexFormatter(), "{0:J3}", c1)}");
     }
 }
+
 // The example displays the following output:
-//    Formatting with ToString():       (12.1, 15.4)
-//    Formatting with ToString(format): (12.10, 15.40)
+//    Formatting with ToString():       <12.1; 15.4>
+//    Formatting with ToString(format): <12.10; 15.40>
 //    Custom formatting with I0:        12 + 15i
 //    Custom formatting with J3:        12.100 + 15.400j
 // </Snippet4>

--- a/docs/fundamentals/runtime-libraries/snippets/System.Numerics/Complex/Overview/csharp/nan1.cs
+++ b/docs/fundamentals/runtime-libraries/snippets/System.Numerics/Complex/Overview/csharp/nan1.cs
@@ -4,7 +4,7 @@ using System.Numerics;
 
 public class NaNEx
 {
-    public static void Main()
+    public static void Run()
     {
         Complex c1 = new Complex(Double.MaxValue / 2, Double.MaxValue / 2);
 

--- a/docs/fundamentals/runtime-libraries/snippets/System.Numerics/Complex/Overview/csharp/precision1.cs
+++ b/docs/fundamentals/runtime-libraries/snippets/System.Numerics/Complex/Overview/csharp/precision1.cs
@@ -1,9 +1,9 @@
-using System;
+﻿using System;
 using System.Numerics;
 
 public class PrecisionEx
 {
-    public static void Main()
+    public static void Run()
     {
         // <Snippet5>
         Complex value = new Complex(Double.MinValue / 2, Double.MinValue / 2);

--- a/docs/fundamentals/runtime-libraries/snippets/System.Numerics/Complex/Overview/vb/Program.vb
+++ b/docs/fundamentals/runtime-libraries/snippets/System.Numerics/Complex/Overview/vb/Program.vb
@@ -1,0 +1,5 @@
+﻿Public Class Program
+    Public Shared Sub Main()
+        Example2.Run()
+    End Sub
+End Class

--- a/docs/fundamentals/runtime-libraries/snippets/System.Numerics/Complex/Overview/vb/Project.vbproj
+++ b/docs/fundamentals/runtime-libraries/snippets/System.Numerics/Complex/Overview/vb/Project.vbproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Library</OutputType>
-    <TargetFrameworks>net8</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net9</TargetFrameworks>
   </PropertyGroup>
 
  </Project>

--- a/docs/fundamentals/runtime-libraries/snippets/System.Numerics/Complex/Overview/vb/create1.vb
+++ b/docs/fundamentals/runtime-libraries/snippets/System.Numerics/Complex/Overview/vb/create1.vb
@@ -5,7 +5,7 @@ Option Strict On
 Imports System.Numerics
 
 Module Example
-   Public Sub Main()
+   Public Sub Run()
       ' Create a complex number by calling its class constructor.
       Dim c1 As New Complex(12, 6)
       Console.WriteLine(c1)

--- a/docs/fundamentals/runtime-libraries/snippets/System.Numerics/Complex/Overview/vb/customfmt1.vb
+++ b/docs/fundamentals/runtime-libraries/snippets/System.Numerics/Complex/Overview/vb/customfmt1.vb
@@ -58,14 +58,16 @@ Module Example2
         Dim c1 As New Complex(12.1, 15.4)
         Console.WriteLine($"Formatting with ToString():       {c1}")
         Console.WriteLine($"Formatting with ToString(format): {c1:N2}")
-        Console.WriteLine($"Custom formatting with I0:        {String.Format(New ComplexFormatter(), "{0:I0}", c1)}")
-        Console.WriteLine($"Custom formatting with J3:        {String.Format(New ComplexFormatter(), "{0:J3}", c1)}")
+        Console.WriteLine($"Custom formatting with I0:        " +
+                          $"{String.Format(New ComplexFormatter(), "{0:I0}", c1)}")
+        Console.WriteLine($"Custom formatting with J3:        " +
+                          $"{String.Format(New ComplexFormatter(), "{0:J3}", c1)}")
     End Sub
 End Module
 
 ' The example displays the following output:
-'    Formatting with ToString():       (12.1, 15.4)
-'    Formatting with ToString(format): (12.10, 15.40)
+'    Formatting with ToString():       <12.1; 15.4>
+'    Formatting with ToString(format): <12.10; 15.40>
 '    Custom formatting with I0:        12 + 15i
 '    Custom formatting with J3:        12.100 + 15.400j
 ' </Snippet4>

--- a/docs/fundamentals/runtime-libraries/snippets/System.Numerics/Complex/Overview/vb/customfmt1.vb
+++ b/docs/fundamentals/runtime-libraries/snippets/System.Numerics/Complex/Overview/vb/customfmt1.vb
@@ -26,7 +26,7 @@ Public Class ComplexFormatter
             Dim fmtString As String = String.Empty
             If fmt.Length > 1 Then
                 Try
-                    precision = Int32.Parse(fmt.Substring(1))
+                    precision = Integer.Parse(fmt.Substring(1))
                 Catch e As FormatException
                     precision = 0
                 End Try
@@ -54,18 +54,15 @@ End Class
 
 ' <Snippet4>
 Module Example2
-    Public Sub Main()
-        Dim c1 As Complex = New Complex(12.1, 15.4)
-        Console.WriteLine("Formatting with ToString():       " +
-                          c1.ToString())
-        Console.WriteLine("Formatting with ToString(format): " +
-                          c1.ToString("N2"))
-        Console.WriteLine("Custom formatting with I0:        " +
-                          String.Format(New ComplexFormatter(), "{0:I0}", c1))
-        Console.WriteLine("Custom formatting with J3:        " +
-                          String.Format(New ComplexFormatter(), "{0:J3}", c1))
+    Public Sub Run()
+        Dim c1 As New Complex(12.1, 15.4)
+        Console.WriteLine($"Formatting with ToString():       {c1}")
+        Console.WriteLine($"Formatting with ToString(format): {c1:N2}")
+        Console.WriteLine($"Custom formatting with I0:        {String.Format(New ComplexFormatter(), "{0:I0}", c1)}")
+        Console.WriteLine($"Custom formatting with J3:        {String.Format(New ComplexFormatter(), "{0:J3}", c1)}")
     End Sub
 End Module
+
 ' The example displays the following output:
 '    Formatting with ToString():       (12.1, 15.4)
 '    Formatting with ToString(format): (12.10, 15.40)

--- a/docs/fundamentals/runtime-libraries/snippets/System.Numerics/Complex/Overview/vb/nan1.vb
+++ b/docs/fundamentals/runtime-libraries/snippets/System.Numerics/Complex/Overview/vb/nan1.vb
@@ -5,7 +5,7 @@ Option Strict On
 Imports System.Numerics
 
 Module Example4
-    Public Sub Main()
+    Public Sub Run()
         Dim c1 As Complex = New Complex(Double.MaxValue / 2, Double.MaxValue / 2)
 
         Dim c2 As Complex = c1 / Complex.Zero

--- a/docs/fundamentals/runtime-libraries/snippets/System.Numerics/Complex/Overview/vb/precision1.vb
+++ b/docs/fundamentals/runtime-libraries/snippets/System.Numerics/Complex/Overview/vb/precision1.vb
@@ -4,7 +4,7 @@ Option Strict On
 Imports System.Numerics
 
 Module Example3
-    Public Sub Main()
+    Public Sub Run()
         ' <Snippet5>
         Dim value As New Complex(Double.MinValue / 2, Double.MinValue / 2)
         Dim value2 As Complex = Complex.Exp(Complex.Log(value))

--- a/docs/fundamentals/runtime-libraries/system-numerics-complex.md
+++ b/docs/fundamentals/runtime-libraries/system-numerics-complex.md
@@ -1,7 +1,7 @@
 ---
 title: System.Numerics.Complex struct
 description: Learn about the System.Numerics.Complex struct.
-ms.date: 12/31/2023
+ms.date: 05/15/2025
 dev_langs:
   - CSharp
   - VB
@@ -85,11 +85,11 @@ Note that this applies to any intermediate calculations performed by a method. F
 
 ## Format a complex number
 
-By default, the string representation of a complex number takes the form `(`*real*`,` *imaginary*`)`, where *real* and *imaginary* are the string representations of the <xref:System.Double> values that form the complex number's real and imaginary components. Some overloads of the <xref:System.Numerics.Complex.ToString%2A> method allow customization of the string representations of these <xref:System.Double> values to reflect the formatting conventions of a particular culture or to appear in a particular format defined by a standard or custom numeric format string. (For more information, see [Standard Numeric Format Strings](../../standard/base-types/standard-numeric-format-strings.md) and [Custom Numeric Format Strings](../../standard/base-types/custom-numeric-format-strings.md).)
+By default, the string representation of a complex number takes the form `<`*real*`;` *imaginary*`>`, where *real* and *imaginary* are the string representations of the <xref:System.Double> values that form the complex number's real and imaginary components. Some overloads of the <xref:System.Numerics.Complex.ToString%2A> method allow customization of the string representations of these <xref:System.Double> values to reflect the formatting conventions of a particular culture or to appear in a particular format defined by a standard or custom numeric format string. (For more information, see [Standard Numeric Format Strings](../../standard/base-types/standard-numeric-format-strings.md) and [Custom Numeric Format Strings](../../standard/base-types/custom-numeric-format-strings.md).)
 
-One of the more common ways of expressing the string representation of a complex number takes the form a + bi, where a is the complex number's real component, and b is the complex number's imaginary component. In electrical engineering, a complex number is most commonly expressed as a + bj. You can return the string representation of a complex number in either of these two forms. To do this, define a custom format provider by implementing the <xref:System.ICustomFormatter> and <xref:System.IFormatProvider> interfaces, and then call the <xref:System.String.Format%28System.IFormatProvider%2CSystem.String%2CSystem.Object%5B%5D%29?displayProperty=nameWithType> method.
+One of the more common ways of expressing the string representation of a complex number takes the form `a + bi`, where `a` is the complex number's real component, and `b` is the complex number's imaginary component. In electrical engineering, a complex number is most commonly expressed as `a + bj`. You can return the string representation of a complex number in either of these two forms. To do this, define a custom format provider by implementing the <xref:System.ICustomFormatter> and <xref:System.IFormatProvider> interfaces, and then call the <xref:System.String.Format%28System.IFormatProvider%2CSystem.String%2CSystem.Object%5B%5D%29?displayProperty=nameWithType> method.
 
-The following example defines a `ComplexFormatter` class that represents a complex number as a string in the form of either a + bi or a + bj.
+The following example defines a `ComplexFormatter` class that represents a complex number as a string in the form of either `a + bi` or `a + bj`.
 
 :::code language="csharp" source="./snippets/System.Numerics/Complex/Overview/csharp/customfmt1.cs" id="Snippet1":::
 :::code language="vb" source="./snippets/System.Numerics/Complex/Overview/vb/customfmt1.vb" id="Snippet1":::


### PR DESCRIPTION
Fixes #46097

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/core-libraries/8.0/complex-format.md](https://github.com/dotnet/docs/blob/c07a47f57bd3282b9c88b73715a3d39441e838c8/docs/core/compatibility/core-libraries/8.0/complex-format.md) | [Complex.ToString format changed to `<a; b>`](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/8.0/complex-format?branch=pr-en-us-46235) |
| [docs/fundamentals/runtime-libraries/system-numerics-complex.md](https://github.com/dotnet/docs/blob/c07a47f57bd3282b9c88b73715a3d39441e838c8/docs/fundamentals/runtime-libraries/system-numerics-complex.md) | [System.Numerics.Complex struct](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-numerics-complex?branch=pr-en-us-46235) |

<!-- PREVIEW-TABLE-END -->