### PR TITLE
Remove unnecessary 'using TourOfCsharp;' from HelloWorld.cs (fixes #46250)

### DIFF
--- a/docs/csharp/tour-of-csharp/snippets/shared/HelloWorld.cs
+++ b/docs/csharp/tour-of-csharp/snippets/shared/HelloWorld.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+﻿namespace TourOfCsharp;
 
 class Program
 {

--- a/docs/csharp/tour-of-csharp/snippets/shared/HelloWorld.cs
+++ b/docs/csharp/tour-of-csharp/snippets/shared/HelloWorld.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using TourOfCsharp;
 
 class Program
 {


### PR DESCRIPTION
This PR removes the unnecessary and incorrect `using TourOfCsharp;` directive from the `HelloWorld.cs` code sample, as reported in issue #46250. The directive referenced a non-existent namespace and could cause confusion for readers.