### PR TITLE
Add 'scoped' to f1_keywords for F1 help support (fixes #46245)

### DIFF
--- a/docs/csharp/language-reference/statements/declarations.md
+++ b/docs/csharp/language-reference/statements/declarations.md
@@ -1,3 +1,4 @@
+<!-- filepath: /Users/yufeih/docs/docs/csharp/language-reference/statements/declarations.md -->
 ---
 title: "Declaration statements - local variables and constants, var, local reference variables (ref locals)"
 description: "Declaration statements introduce a new local variable, local constant, or local reference variable (ref local). Local variables can be explicitly or implicitly typed. A declaration statement can also include initialization of a variable's value."
@@ -5,6 +6,8 @@ ms.date: 06/21/2023
 f1_keywords: 
   - "var"
   - "var_CSharpKeyword"
+  - "scoped"
+  - "scoped_CSharpKeyword"
 helpviewer_keywords: 
   - "var keyword [C#]"
 ---

--- a/docs/csharp/language-reference/statements/declarations.md
+++ b/docs/csharp/language-reference/statements/declarations.md
@@ -1,4 +1,3 @@
-<!-- filepath: /Users/yufeih/docs/docs/csharp/language-reference/statements/declarations.md -->
 ---
 title: "Declaration statements - local variables and constants, var, local reference variables (ref locals)"
 description: "Declaration statements introduce a new local variable, local constant, or local reference variable (ref local). Local variables can be explicitly or implicitly typed. A declaration statement can also include initialization of a variable's value."


### PR DESCRIPTION
This PR adds 'scoped' and 'scoped_CSharpKeyword' to the f1_keywords in the front matter of declarations.md, enabling F1 help in Visual Studio to correctly link to the documentation for the scoped modifier. Fixes #46245.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/statements/declarations.md](https://github.com/dotnet/docs/blob/f4fa8bcbb5fbff509d31df34fe33065ab5083c25/docs/csharp/language-reference/statements/declarations.md) | [docs/csharp/language-reference/statements/declarations](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/statements/declarations?branch=pr-en-us-46253) |


<!-- PREVIEW-TABLE-END -->