### PR TITLE
Update upgrade.md

### DIFF
--- a/docs/core/install/upgrade.md
+++ b/docs/core/install/upgrade.md
@@ -14,6 +14,9 @@ Common reasons to upgrade to a new .NET version:
 - The new version supports a new operating system
 - The new version has an important API, performance, or security feature
 
+> [!TIP]
+> The [GitHub Copilot app modernization - upgrade](../porting/github-copilot-app-modernization-overview.md) capability can make these changes automatically.
+
 ## Upgrade development environment
 
 To upgrade to a new .NET version, the .NET SDK is the primary component to install. It includes an updated .NET CLI, build system, and runtime version.
@@ -37,8 +40,6 @@ Here's how to do it:
 * Open the project file (the `*.csproj`, `*.vbproj`, or `*.fsproj` file).
 * Change the `<TargetFramework>` property value from, for example, `net6.0` to `net8.0`.
 * The same pattern applies for the `<TargetFrameworks>` property if it is being used.
-
-The [Upgrade Assistant](../porting/upgrade-assistant-overview.md) can make these changes automatically.
 
 The next step is to build the project (or solution) with the new SDK. If additional changes are needed, the SDK will provide warnings and errors that guide you.
 

--- a/docs/core/install/upgrade.md
+++ b/docs/core/install/upgrade.md
@@ -14,9 +14,6 @@ Common reasons to upgrade to a new .NET version:
 - The new version supports a new operating system
 - The new version has an important API, performance, or security feature
 
-> [!TIP]
-> The [GitHub Copilot app modernization - upgrade](../porting/github-copilot-app-modernization-overview.md) capability can make these changes automatically.
-
 ## Upgrade development environment
 
 To upgrade to a new .NET version, the .NET SDK is the primary component to install. It includes an updated .NET CLI, build system, and runtime version.
@@ -40,6 +37,9 @@ Here's how to do it:
 * Open the project file (the `*.csproj`, `*.vbproj`, or `*.fsproj` file).
 * Change the `<TargetFramework>` property value from, for example, `net6.0` to `net8.0`.
 * The same pattern applies for the `<TargetFrameworks>` property if it is being used.
+
+> [!TIP]
+> The [GitHub Copilot app modernization - upgrade](../porting/github-copilot-app-modernization-overview.md) capability can make these changes automatically.
 
 The next step is to build the project (or solution) with the new SDK. If additional changes are needed, the SDK will provide warnings and errors that guide you.
 


### PR DESCRIPTION
Changing the reference from Upgrade Assistant to GHCP upgrade capability

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/upgrade.md](https://github.com/dotnet/docs/blob/f652d835df11df264e560d0d20373f1d3485d079/docs/core/install/upgrade.md) | [Upgrade to a new .NET version](https://review.learn.microsoft.com/en-us/dotnet/core/install/upgrade?branch=pr-en-us-46271) |


<!-- PREVIEW-TABLE-END -->