### PR TITLE
globally disable MD059

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -59,7 +59,8 @@
         "MD050": {
             "style": "asterisk"
         },
-        "MD051": false
+        "MD051": false,
+        "MD059": false
     },
     "ignores": [
         ".github/",


### PR DESCRIPTION
We have a lot of links where the link text is "here", but the description is outside the link.

We might consider fixing more of these, but this gets builds unstuck.
