### PR TITLE
Fix inconsistency in WCF message inspector doc

### DIFF
--- a/docs/framework/wcf/extending/how-to-inspect-and-modify-messages-on-the-service.md
+++ b/docs/framework/wcf/extending/how-to-inspect-and-modify-messages-on-the-service.md
@@ -9,7 +9,7 @@ ms.assetid: 9c5b1cc7-84f3-45f8-9226-d59c278e8c42
 ---
 # How to: Inspect and Modify Messages on the Service
 
-You can inspect or modify the incoming or outgoing messages across a Windows Communication Foundation (WCF) client by implementing a <xref:System.ServiceModel.Dispatcher.IDispatchMessageInspector?displayProperty=nameWithType> and inserting it into the service runtime. For more information, see [Extending Dispatchers](extending-dispatchers.md). The equivalent feature on the service is the <xref:System.ServiceModel.Dispatcher.IClientMessageInspector?displayProperty=nameWithType>.  
+You can inspect or modify the incoming or outgoing messages across a Windows Communication Foundation (WCF) service by implementing a <xref:System.ServiceModel.Dispatcher.IDispatchMessageInspector?displayProperty=nameWithType> and inserting it into the service runtime. For more information, see [Extending Dispatchers](extending-dispatchers.md). The equivalent feature on the client is the <xref:System.ServiceModel.Dispatcher.IClientMessageInspector?displayProperty=nameWithType>.  
   
 ### To inspect or modify messages  
   


### PR DESCRIPTION
Update how-to-inspect-and-modify-messages-on-the-service.md

## Summary

Current doc has mixes up client with service and vice versa and it's extremely confusing.

Side note, I'm also a Microsoft employee but couldn't figure out how to update this doc with my EMU account, I'd appreciate it if you reached out internally to help me with this.

No Issue #


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/wcf/extending/how-to-inspect-and-modify-messages-on-the-service.md](https://github.com/dotnet/docs/blob/a9e129afb38c3db7b5fa65ae0e988e5208ac8a5f/docs/framework/wcf/extending/how-to-inspect-and-modify-messages-on-the-service.md) | [How to: Inspect and Modify Messages on the Service](https://review.learn.microsoft.com/en-us/dotnet/framework/wcf/extending/how-to-inspect-and-modify-messages-on-the-service?branch=pr-en-us-46319) |

<!-- PREVIEW-TABLE-END -->