### PR TITLE
Emphasize that top file `using` is for top-level statements

### DIFF
--- a/docs/csharp/fundamentals/program-structure/top-level-statements.md
+++ b/docs/csharp/fundamentals/program-structure/top-level-statements.md
@@ -42,7 +42,7 @@ In a project with top-level statements, you can't use the [-main](../../language
 
 ## `using` directives
 
-If you include `using` directives, they must come first in the file, as in this example:
+For the single file containing top-level statements `using` directives must come first in that file, as in this example:
 
 :::code language="csharp" source="snippets/top-level-statements-1/Program.cs":::
 


### PR DESCRIPTION
This small PR closes #46102 
It makes clear that the rule described for `using` concerns only the top-level statement context.

There were other, relevant information mentioned in the ticket, however, I found those to be correct, but too much for this simple rule. Also, the fact that top-level statements must be in the global namespace, is already described right below in the next section, so I decided not to repeat any information.

All comments are most welcome in case of different ideas for this 🙏 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/fundamentals/program-structure/top-level-statements.md](https://github.com/dotnet/docs/blob/3c350485645d5504901ad08c4ee27f12e5dc510f/docs/csharp/fundamentals/program-structure/top-level-statements.md) | [Top-level statements - programs without `Main` methods](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/program-structure/top-level-statements?branch=pr-en-us-46354) |

<!-- PREVIEW-TABLE-END -->