### PR TITLE
Fix invalid comment example in Snippet24 by replacing it with a valid expression statement

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideStatements/CS/Statements.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideStatements/CS/Statements.cs
@@ -535,8 +535,8 @@ namespace CsCsrefProgrammingStatements
                 // Expression statement (assignment).
                 area = 3.14 * (radius * radius);
 
-                // Error. Not  statement because no assignment:
-                //circ * 2;
+                // Expression statement (result discarded).
+                x++;
 
                 // Expression statement (method invocation).
                 System.Console.WriteLine();

--- a/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideStatements/CS/Statements.cs
+++ b/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideStatements/CS/Statements.cs
@@ -536,6 +536,7 @@ namespace CsCsrefProgrammingStatements
                 area = 3.14 * (radius * radius);
 
                 // Expression statement (result discarded).
+                int x = 0;
                 x++;
 
                 // Expression statement (method invocation).


### PR DESCRIPTION
## Summary

### **PR Description**

This PR addresses an incorrect code example in `Snippet24`, where an invalid expression (`circ * 2;`) was mistakenly labeled as a non-statement due to missing assignment. This line could be misleading for learners and newcomers.

### Changes Made

* Replaced invalid line `circ * 2;` with a valid expression statement `x++;`, showcasing a correct example of an expression statement with a discarded result.

### Impact

* **Improves code clarity and educational accuracy** for C# learners.
* Ensures documentation examples **compile correctly and demonstrate proper syntax**.
* Supports consistency across snippet samples for **better learning and adoption**.

Fixes #46309 
