### PR TITLE
Update logger-message-generator.md

### DIFF
--- a/docs/core/extensions/logger-message-generator.md
+++ b/docs/core/extensions/logger-message-generator.md
@@ -118,7 +118,6 @@ When using the `LoggerMessageAttribute` on logging methods, some constraints mus
 - Logging methods must be `partial` and return `void`.
 - Logging method names must *not* start with an underscore.
 - Parameter names of logging methods must *not* start with an underscore.
-- Logging methods may *not* be defined in a nested type.
 - Logging methods *cannot* be generic.
 - If a logging method is `static`, the `ILogger` instance is required as a parameter.
 


### PR DESCRIPTION
## Summary

Remove the line that Log methods cannot be defined in nested types, as that restriction no longer appears to hold.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/logger-message-generator.md](https://github.com/dotnet/docs/blob/b08036fa3d343c64709adcda089467ddd3a11cb3/docs/core/extensions/logger-message-generator.md) | [Compile-time logging source generation](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/logger-message-generator?branch=pr-en-us-46379) |

<!-- PREVIEW-TABLE-END -->