### PR TITLE
Add clarifying text, correctly defining scoped service intent and resolution.

### DIFF
--- a/docs/core/extensions/dependency-injection.md
+++ b/docs/core/extensions/dependency-injection.md
@@ -248,13 +248,19 @@ For web applications, a scoped lifetime indicates that services are created once
 
 In apps that process requests, scoped services are disposed at the end of the request.
 
-When using Entity Framework Core, the <xref:Microsoft.Extensions.DependencyInjection.EntityFrameworkServiceCollectionExtensions.AddDbContext%2A> extension method registers `DbContext` types with a scoped lifetime by default.
-
 > [!NOTE]
-> Do ***not*** resolve a scoped service from a singleton and be careful not to do so indirectly, for example, through a transient service. It may cause the service to have incorrect state when processing subsequent requests. It's fine to:
->
-> - Resolve a singleton service from a scoped or transient service.
-> - Resolve a scoped service from another scoped or transient service.
+> When using Entity Framework Core, the <xref:Microsoft.Extensions.DependencyInjection.EntityFrameworkServiceCollectionExtensions.AddDbContext%2A> extension method registers `DbContext` types with a scoped lifetime by default.
+
+A scoped service should always be used from within a scope—either an implicit scope (such as ASP.NET Core's per-request scope) or an explicit scope created with <xref:Microsoft.Extensions.DependencyInjection.IServiceScopeFactory.CreateScope?displayProperty=nameWithType>.
+
+Do ***not*** resolve a scoped service directly from a singleton using constructor injection or by requesting it from <xref:System.IServiceProvider> in the singleton. Doing so causes the scoped service to behave like a singleton, which can lead to incorrect state when processing subsequent requests.
+
+It's acceptable to resolve a scoped service within a singleton if you create and use an explicit scope with <xref:Microsoft.Extensions.DependencyInjection.IServiceScopeFactory>.
+
+It's also fine to:
+
+- Resolve a singleton service from a scoped or transient service.
+- Resolve a scoped service from another scoped or transient service.
 
 By default, in the development environment, resolving a service from another service with a longer lifetime throws an exception. For more information, see [Scope validation](#scope-validation).
 

--- a/docs/core/extensions/scoped-service.md
+++ b/docs/core/extensions/scoped-service.md
@@ -3,7 +3,7 @@ title: Use scoped services within a BackgroundService
 description: Learn how to use scoped services within a BackgroundService in .NET.
 author: IEvangelist
 ms.author: dapine
-ms.date: 11/06/2024
+ms.date: 05/27/2025
 ms.topic: tutorial
 ---
 
@@ -15,7 +15,7 @@ In this tutorial, you learn how to:
 
 > [!div class="checklist"]
 >
-> - Resolve scoped dependencies in a singleton <xref:Microsoft.Extensions.Hosting.BackgroundService>.
+> - Correctly resolve scoped dependencies in a singleton <xref:Microsoft.Extensions.Hosting.BackgroundService>.
 > - Delegate work to a scoped service.
 > - Implement an `override` of <xref:Microsoft.Extensions.Hosting.BackgroundService.StopAsync(System.Threading.CancellationToken)?displayProperty=nameWithType>.
 


### PR DESCRIPTION
## Summary

Add clarifying text, correctly defining scoped service intent and resolution.

Fixes #45617


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/dependency-injection.md](https://github.com/dotnet/docs/blob/e62133f7eda7ac976dc98e1d207393a0a4f624cb/docs/core/extensions/dependency-injection.md) | [.NET dependency injection](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection?branch=pr-en-us-46459) |
| [docs/core/extensions/scoped-service.md](https://github.com/dotnet/docs/blob/e62133f7eda7ac976dc98e1d207393a0a4f624cb/docs/core/extensions/scoped-service.md) | [Use scoped services within a BackgroundService](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/scoped-service?branch=pr-en-us-46459) |

<!-- PREVIEW-TABLE-END -->