### PR TITLE
Fix entrypoint name for MessageBox sample

### DIFF
--- a/samples/snippets/standard/interop/pinvoke/messagebox.cs
+++ b/samples/snippets/standard/interop/pinvoke/messagebox.cs
@@ -5,7 +5,7 @@ public partial class Program
 {
     // Import user32.dll (containing the function we need) and define
     // the method corresponding to the native function.
-    [LibraryImport("user32.dll", StringMarshalling = StringMarshalling.Utf16, SetLastError = true)]
+    [LibraryImport("user32.dll", EntryPoint = "MessageBoxW", StringMarshalling = StringMarshalling.Utf16, SetLastError = true)]
     private static partial int MessageBox(IntPtr hWnd, string lpText, string lpCaption, uint uType);
 
     public static void Main(string[] args)

--- a/samples/snippets/standard/interop/pinvoke/messagebox.cs
+++ b/samples/snippets/standard/interop/pinvoke/messagebox.cs
@@ -5,12 +5,12 @@ public partial class Program
 {
     // Import user32.dll (containing the function we need) and define
     // the method corresponding to the native function.
-    [LibraryImport("user32.dll", EntryPoint = "MessageBoxW", StringMarshalling = StringMarshalling.Utf16, SetLastError = true)]
-    private static partial int MessageBox(IntPtr hWnd, string lpText, string lpCaption, uint uType);
+    [LibraryImport("user32.dll", StringMarshalling = StringMarshalling.Utf16, SetLastError = true)]
+    private static partial int MessageBoxW(IntPtr hWnd, string lpText, string lpCaption, uint uType);
 
     public static void Main(string[] args)
     {
         // Invoke the function as a regular managed method.
-        MessageBox(IntPtr.Zero, "Command-line message box", "Attention!", 0);
+        MessageBoxW(IntPtr.Zero, "Command-line message box", "Attention!", 0);
     }
 }


### PR DESCRIPTION


## Summary

Add missing `EntryPoint` property.

Fixes https://github.com/dotnet/docs/issues/45016
Fixes https://github.com/dotnet/docs/issues/41186
