### PR TITLE
Move 20.04 to unsupported

### DIFF
--- a/docs/core/install/linux-snap-runtime.md
+++ b/docs/core/install/linux-snap-runtime.md
@@ -11,7 +11,7 @@ ms.custom: linux-related-content
 
 # Install .NET Runtime with Snap
 
-This article describes how to install the .NET Runtime snap package. .NET Runtime snap packages are provided by and maintained by Canonical. Snaps are a great alternative to the package manager built into your Linux distribution.
+This article describes how to install the .NET Runtime snap package. .NET Runtime snap packages are provided by and maintained by Canonical. Snaps are a great alternative to the package manager built into your Linux distribution. If you need to install the SDK, see [Install .NET SDK with Snap](linux-snap-sdk.md).
 
 A snap is a bundle of an app and its dependencies that works across many different Linux distributions. Snaps are discoverable and installable from the Snap Store. For more information about Snap, see [Quickstart tour](https://snapcraft.io/docs/quickstart-tour).
 

--- a/docs/core/install/linux-ubuntu-decision.md
+++ b/docs/core/install/linux-ubuntu-decision.md
@@ -78,7 +78,7 @@ If you're going to install the Microsoft repository to use other Microsoft packa
 
 ### I'm using a version of Ubuntu prior to 22.04
 
-Use the instructions on the version-specific section of the [Install .NET SDK or .NET Runtime on Ubuntu](linux-ubuntu-install.md?pivots=os-linux-ubuntu-other)
+Use the instructions in the version-specific section of [Install .NET SDK or .NET Runtime on Ubuntu](linux-ubuntu-install.md?pivots=os-linux-ubuntu-other).
 
 Review the [Supported distributions](#supported-distributions) section for more information about what versions of .NET are supported for your version of Ubuntu. If you're installing a version that isn't supported, see [Register the Microsoft package repository](#register-the-microsoft-package-repository).
 

--- a/docs/core/install/linux-ubuntu-decision.md
+++ b/docs/core/install/linux-ubuntu-decision.md
@@ -24,7 +24,6 @@ The following table is a list of currently supported .NET releases and the versi
 | [24.10](linux-ubuntu-install.md?pivots=os-linux-ubuntu-2410)       | 9.0, 8.0                | 9.0, 8.0                             | None                                                                                                   | None                                                                         |
 | [24.04 (LTS)](linux-ubuntu-install.md?pivots=os-linux-ubuntu-2404) | 9.0, 8.0                | 8.0                                  | 9.0, 7.0, 6.0                                                                                          | None                                                                         |
 | [22.04 (LTS)](linux-ubuntu-install.md?pivots=os-linux-ubuntu-2204) | 9.0, 8.0                | 8.0, 7.0, 6.0                        | 9.0                                                                                                    | 8.0, 7.0, 6.0, 3.1                                                           |
-| [20.04 (LTS)](linux-ubuntu-install.md?pivots=os-linux-ubuntu-2004) | 9.0, 8.0                | None                                 | None                                                                                                   | 8.0, 7.0. 6.0, 5.0, 3.1, 2.1                                                 |
 
 When an [Ubuntu version](https://wiki.ubuntu.com/Releases) reaches the end of its support period, .NET is no longer supported with that particular Ubuntu version.
 
@@ -79,9 +78,7 @@ If you're going to install the Microsoft repository to use other Microsoft packa
 
 ### I'm using a version of Ubuntu prior to 22.04
 
-Use the instructions on the version-specific Ubuntu page.
-
-- [20.04 (LTS)](linux-ubuntu-install.md?pivots=os-linux-ubuntu-2004)
+Use the instructions on the version-specific section of the [Install .NET SDK or .NET Runtime on Ubuntu](linux-ubuntu-install.md?pivots=os-linux-ubuntu-other)
 
 Review the [Supported distributions](#supported-distributions) section for more information about what versions of .NET are supported for your version of Ubuntu. If you're installing a version that isn't supported, see [Register the Microsoft package repository](#register-the-microsoft-package-repository).
 

--- a/docs/core/install/linux-ubuntu-install.md
+++ b/docs/core/install/linux-ubuntu-install.md
@@ -193,76 +193,10 @@ You can install a recent version of _libgdiplus_ by [adding the Mono repository 
 ::: zone-end
 
 <!--
-===== Ubuntu 20.04
--->
-
-::: zone pivot="os-linux-ubuntu-2004"
-
-## Ubuntu 20.04
-
-[!INCLUDE [linux-ubuntu-package-feed-ms](includes/linux-ubuntu-package-feed-ms.md)]
-
-The following versions of .NET are supported or available for Ubuntu 20.04:
-
-| Supported .NET versions | Available in<br>built-in Ubuntu feed | [Available in<br>.NET backports<br>Ubuntu feed](linux-ubuntu-decision.md#ubuntu-net-backports-package-repository) | [Available in<br>Microsoft feed](linux-ubuntu-decision.md#register-the-microsoft-package-repository) |
-|-------------------------|--------------------------------------|----------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
-| 8.0                     | None                                 | None                                                                                                     | 8.0, 7.0. 6.0, 5.0, 3.1, 2.1                                                                |
-
-When an [Ubuntu version](https://wiki.ubuntu.com/Releases) falls out of support, .NET is no longer supported with that version.
-
-## Add the Microsoft package repository
-
-[!INCLUDE [linux-prep-intro-apt](includes/linux-prep-intro-apt.md)]
-
-```bash
-wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
-sudo dpkg -i packages-microsoft-prod.deb
-rm packages-microsoft-prod.deb
-```
-
-# [.NET 9](#tab/dotnet9)
-
-Because Ubuntu 20.04 reaches end of life in April 2025, Microsoft has decided not to support .NET 9 on Ubuntu 20.04.
-
-# [.NET 8](#tab/dotnet8)
-
-[!INCLUDE [linux-apt-install-80](includes/linux-install-80-apt.md)]
-
-# [.NET 6](#tab/dotnet6)
-
-> [!WARNING]
-> .NET 6 is no longer supported.
-
-[!INCLUDE [linux-apt-install-60](includes/linux-install-60-apt.md)]
-
----
-
-## Dependencies
-
-When you install with a package manager, these libraries are installed for you. But, if you manually install .NET or you publish a self-contained app, you'll need to make sure these libraries are installed:
-
-- ca-certificates
-- libc6
-- libgcc-s1
-- libgssapi-krb5-2
-- libicu66
-- libssl1.1
-- libstdc++6
-- zlib1g
-
-[!INCLUDE [linux-ubuntu-deps-example](includes/linux-ubuntu-deps-example.md)]
-
-[!INCLUDE [linux-libgdiplus-general](includes/linux-libgdiplus-general.md)]
-
-You can install a recent version of _libgdiplus_ by [adding the Mono repository to your system](https://www.mono-project.com/download/stable/#download-lin-ubuntu).
-
-::: zone-end
-
-<!--
 ===== All versions
 -->
 
-::: zone pivot="os-linux-ubuntu-2410,os-linux-ubuntu-2404,os-linux-ubuntu-2204,os-linux-ubuntu-2004"
+::: zone pivot="os-linux-ubuntu-2410,os-linux-ubuntu-2404,os-linux-ubuntu-2204"
 
 ## Unsupported versions
 
@@ -284,7 +218,7 @@ You can install a recent version of _libgdiplus_ by [adding the Mono repository 
 
 ## Manual install
 
-If your Ubuntu version isn't supported, you most likely need to install .NET by manually extracting the binaries, by using the install script. For more information, see [Install .NET on Linux without using a package manager](linux-scripted-manual.md).
+If your Ubuntu version isn't supported and the version of .NET you want to use wasn't available in a package repository, you most likely need to install .NET by manually extracting the binaries, by using the install script, or with Snap. For more information, see [Install .NET on Linux without using a package manager](linux-scripted-manual.md) and [Install .NET Runtime with Snap](linux-snap-runtime.md).
 
 <!--
 ===== Ubuntu 23.10
@@ -320,7 +254,7 @@ When an [Ubuntu version](https://wiki.ubuntu.com/Releases) falls out of support,
 
 ---
 
-## Dependencies
+### Dependencies
 
 When you install with a package manager, these libraries are installed for you. But, if you manually install .NET or you publish a self-contained app, you'll need to make sure these libraries are installed:
 
@@ -443,13 +377,75 @@ When you install with a package manager, these libraries are installed for you. 
 - libunwind8
 - zlib1g
 
-::: zone-end
+[!INCLUDE [linux-ubuntu-deps-example](includes/linux-ubuntu-deps-example.md)]
+
+[!INCLUDE [linux-libgdiplus-general](includes/linux-libgdiplus-general.md)]
+
+You can install a recent version of _libgdiplus_ by [adding the Mono repository to your system](https://www.mono-project.com/download/stable/#download-lin-ubuntu).
+
+<!--
+===== Ubuntu 20.04
+-->
+
+## Ubuntu 20.04
+
+[!INCLUDE [linux-ubuntu-package-feed-ms](includes/linux-ubuntu-package-feed-ms.md)]
+
+The following versions of .NET are supported or available for Ubuntu 20.04:
+
+| Supported .NET versions | Available in<br>built-in Ubuntu feed | [Available in<br>.NET backports<br>Ubuntu feed](linux-ubuntu-decision.md#ubuntu-net-backports-package-repository) | [Available in<br>Microsoft feed](linux-ubuntu-decision.md#register-the-microsoft-package-repository) |
+|-------------------------|--------------------------------------|----------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
+| 8.0                     | None                                 | None                                                                                                     | 8.0, 7.0. 6.0, 5.0, 3.1, 2.1                                                                |
+
+When an [Ubuntu version](https://wiki.ubuntu.com/Releases) falls out of support, .NET is no longer supported with that version.
+
+### Add the Microsoft package repository
+
+[!INCLUDE [linux-prep-intro-apt](includes/linux-prep-intro-apt.md)]
+
+```bash
+wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+sudo dpkg -i packages-microsoft-prod.deb
+rm packages-microsoft-prod.deb
+```
+
+# [.NET 9](#tab/dotnet9)
+
+Because Ubuntu 20.04 reaches end of life in April 2025, Microsoft has decided not to support .NET 9 on Ubuntu 20.04.
+
+# [.NET 8](#tab/dotnet8)
+
+[!INCLUDE [linux-apt-install-80](includes/linux-install-80-apt.md)]
+
+# [.NET 6](#tab/dotnet6)
+
+> [!WARNING]
+> .NET 6 is no longer supported.
+
+[!INCLUDE [linux-apt-install-60](includes/linux-install-60-apt.md)]
+
+---
+
+### Dependencies
+
+When you install with a package manager, these libraries are installed for you. But, if you manually install .NET or you publish a self-contained app, you'll need to make sure these libraries are installed:
+
+- ca-certificates
+- libc6
+- libgcc-s1
+- libgssapi-krb5-2
+- libicu66
+- libssl1.1
+- libstdc++6
+- zlib1g
 
 [!INCLUDE [linux-ubuntu-deps-example](includes/linux-ubuntu-deps-example.md)]
 
 [!INCLUDE [linux-libgdiplus-general](includes/linux-libgdiplus-general.md)]
 
 You can install a recent version of _libgdiplus_ by [adding the Mono repository to your system](https://www.mono-project.com/download/stable/#download-lin-ubuntu).
+
+::: zone-end
 
 ## Next steps
 

--- a/docs/core/install/linux-ubuntu-install.md
+++ b/docs/core/install/linux-ubuntu-install.md
@@ -411,7 +411,7 @@ rm packages-microsoft-prod.deb
 
 # [.NET 9](#tab/dotnet9)
 
-Because Ubuntu 20.04 reaches end of life in April 2025, Microsoft has decided not to support .NET 9 on Ubuntu 20.04.
+Because Ubuntu 20.04 reached end of life in April 2025, Microsoft doesn't support .NET 9 on Ubuntu 20.04.
 
 # [.NET 8](#tab/dotnet8)
 

--- a/docs/zone-pivot-groups.yml
+++ b/docs/zone-pivot-groups.yml
@@ -126,8 +126,6 @@ groups:
       title: "24.04"
     - id: os-linux-ubuntu-2204
       title: "22.04"
-    - id: os-linux-ubuntu-2004
-      title: "20.04"
     - id: os-linux-ubuntu-other
       title: "Other"
 - id: openai-library


### PR DESCRIPTION
## Summary

- Move 20.04 down to the unsupported section.
- Remove pivot.

Fixes #45534 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/linux-snap-runtime.md](https://github.com/dotnet/docs/blob/f03f4a25cfff25d468b152c3214cbe7e2ff0274b/docs/core/install/linux-snap-runtime.md) | [Install .NET Runtime with Snap](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-snap-runtime?branch=pr-en-us-46469) |
| [docs/core/install/linux-ubuntu-decision.md](https://github.com/dotnet/docs/blob/f03f4a25cfff25d468b152c3214cbe7e2ff0274b/docs/core/install/linux-ubuntu-decision.md) | [Get OS version info which adds the $ID and $VERSION_ID variables](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu-decision?branch=pr-en-us-46469) |
| [docs/core/install/linux-ubuntu-install.md](https://github.com/dotnet/docs/blob/f03f4a25cfff25d468b152c3214cbe7e2ff0274b/docs/core/install/linux-ubuntu-install.md) | [Install .NET on Ubuntu](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu-install?branch=pr-en-us-46469) |
| [docs/zone-pivot-groups.yml](https://github.com/dotnet/docs/blob/f03f4a25cfff25d468b152c3214cbe7e2ff0274b/docs/zone-pivot-groups.yml) | [docs/zone-pivot-groups](https://review.learn.microsoft.com/en-us/dotnet/zone-pivot-groups?branch=pr-en-us-46469) |


<!-- PREVIEW-TABLE-END -->