### PR TITLE
Update Invalid TransactionType Logic

### DIFF
--- a/docs/csharp/tour-of-csharp/tutorials/snippets/PatternMatching/FirstEnumExample.cs
+++ b/docs/csharp/tour-of-csharp/tutorials/snippets/PatternMatching/FirstEnumExample.cs
@@ -58,7 +58,9 @@ public static class ExampleProgram
                 else if (transactionType?.ToUpper() is "WITHDRAWAL")
                     yield return (TransactionType.Withdrawal, amount);
             }
+            else {
             yield return (TransactionType.Invalid, 0.0);
+            }
         }
     }
 }


### PR DESCRIPTION
Example snippet returns an Invalid parse per row as follows:

"Deposit => Parsed Amount: 10000, New Balance: 10000
Invalid => Parsed Amount: 0, New Balance: 10000
Deposit => Parsed Amount: 500, New Balance: 10500
Invalid => Parsed Amount: 0, New Balance: 10500"

## Summary

Added else statement and brackets around Invalid TransactionType logic


