### PR TITLE
Add note on BigInteger bin/hex formatting of positive values

### DIFF
--- a/docs/standard/base-types/parsing-numeric.md
+++ b/docs/standard/base-types/parsing-numeric.md
@@ -61,6 +61,7 @@ All numeric types have two static parsing methods, `Parse` and `TryParse`, that 
 |<xref:System.Globalization.NumberStyles.AllowThousands?displayProperty=nameWithType>|The group separator is permitted. The group separator character is determined by the <xref:System.Globalization.NumberFormatInfo.NumberGroupSeparator%2A?displayProperty=nameWithType> or <xref:System.Globalization.NumberFormatInfo.CurrencyGroupSeparator%2A?displayProperty=nameWithType> property.|
 |<xref:System.Globalization.NumberStyles.AllowCurrencySymbol?displayProperty=nameWithType>|The currency symbol is permitted. The currency symbol is defined by the <xref:System.Globalization.NumberFormatInfo.CurrencySymbol%2A?displayProperty=nameWithType> property.|
 |<xref:System.Globalization.NumberStyles.AllowHexSpecifier?displayProperty=nameWithType>|The string to be parsed is interpreted as a hexadecimal number. It can include the hexadecimal digits 0-9, A-F, and a-f. This flag can be used only to parse integer values.|
+|<xref:System.Globalization.NumberStyles.AllowBinarySpecifier?displayProperty=nameWithType>|The string to be parsed is interpreted as a binary number. It can include the binary digits 0 and 1. This flag can be used only to parse integer values.|
 
  In addition, the <xref:System.Globalization.NumberStyles> enumeration provides the following composite styles, which include multiple <xref:System.Globalization.NumberStyles> flags.
 
@@ -72,6 +73,13 @@ All numeric types have two static parsing methods, `Parse` and `TryParse`, that 
 |<xref:System.Globalization.NumberStyles.Currency?displayProperty=nameWithType>|Includes all styles except <xref:System.Globalization.NumberStyles.AllowExponent?displayProperty=nameWithType> and <xref:System.Globalization.NumberStyles.AllowHexSpecifier?displayProperty=nameWithType>.|
 |<xref:System.Globalization.NumberStyles.Any?displayProperty=nameWithType>|Includes all styles except <xref:System.Globalization.NumberStyles.AllowHexSpecifier?displayProperty=nameWithType>.|
 |<xref:System.Globalization.NumberStyles.HexNumber?displayProperty=nameWithType>|Includes the <xref:System.Globalization.NumberStyles.AllowLeadingWhite?displayProperty=nameWithType>, <xref:System.Globalization.NumberStyles.AllowTrailingWhite?displayProperty=nameWithType>, and <xref:System.Globalization.NumberStyles.AllowHexSpecifier?displayProperty=nameWithType> styles.|
+|<xref:System.Globalization.NumberStyles.BinaryNumber?displayProperty=nameWithType>|Includes the <xref:System.Globalization.NumberStyles.AllowLeadingWhite?displayProperty=nameWithType>, <xref:System.Globalization.NumberStyles.AllowTrailingWhite?displayProperty=nameWithType>, and <xref:System.Globalization.NumberStyles.AllowBinarySpecifier?displayProperty=nameWithType> styles.|
+
+## Parsing binary and hexadecimal BigIntegers
+
+When parsing <xref:System.Numerics.BigInteger> with the <xref:System.Globalization.NumberStyles.AllowHexSpecifier> or <xref:System.Globalization.NumberStyles.AllowBinarySpecifier> flags, the input string is interpreted as a hexadecimal/binary number of exactly the length the string has.
+For instance, parsing `"11"` as a binary BigInteger yields `-1`, because that is the interpretation of `11` as a signed two's complement value with exactly 2 digits.
+If you want a positive result, add a leading `0`, such as `"011"` which is parsed as `3`.
 
 ## Parsing and Unicode Digits
 

--- a/docs/standard/base-types/parsing-numeric.md
+++ b/docs/standard/base-types/parsing-numeric.md
@@ -77,9 +77,7 @@ All numeric types have two static parsing methods, `Parse` and `TryParse`, that 
 
 ## Parsing binary and hexadecimal BigIntegers
 
-When parsing <xref:System.Numerics.BigInteger> with the <xref:System.Globalization.NumberStyles.AllowHexSpecifier> or <xref:System.Globalization.NumberStyles.AllowBinarySpecifier> flags, the input string is interpreted as a hexadecimal/binary number of exactly the length the string has.
-For instance, parsing `"11"` as a binary BigInteger yields `-1`, because that is the interpretation of `11` as a signed two's complement value with exactly 2 digits.
-If you want a positive result, add a leading `0`, such as `"011"` which is parsed as `3`.
+When parsing <xref:System.Numerics.BigInteger> with the <xref:System.Globalization.NumberStyles.AllowHexSpecifier> or <xref:System.Globalization.NumberStyles.AllowBinarySpecifier> flags, the input string is interpreted as a hexadecimal/binary number of exactly the length the string has. For instance, parsing `"11"` as a binary BigInteger yields `-1`, because that is the interpretation of `11` as a signed two's complement value with exactly 2 digits. If you want a positive result, add a leading `0`, such as `"011"` which is parsed as `3`.
 
 ## Parsing and Unicode Digits
 

--- a/docs/standard/base-types/standard-numeric-format-strings.md
+++ b/docs/standard/base-types/standard-numeric-format-strings.md
@@ -98,6 +98,9 @@ The binary ("B") format specifier converts a number to a string of binary digits
 
 The precision specifier indicates the minimum number of digits desired in the resulting string. If required, the number is padded with zeros to its left to produce the number of digits given by the precision specifier.
 
+For <xref:System.Numerics.BigInteger>, positive values always have a leading zero to distinguish them from negative values. This ensures the output round-trips to the original value when parsed.
+For instance, the number `3` converted with the format specifier `"B2"` is `011` because the binary number `11` represents the negative value `-1`.
+
 The result string is not affected by the formatting information of the current <xref:System.Globalization.NumberFormatInfo> object.
 
 <a name="CFormatString"></a>
@@ -308,6 +311,9 @@ To work around the problem of <xref:System.Double> values formatted with the "R"
 The hexadecimal ("X") format specifier converts a number to a string of hexadecimal digits. The case of the format specifier indicates whether to use uppercase or lowercase characters for hexadecimal digits that are greater than 9. For example, use "X" to produce "ABCDEF", and "x" to produce "abcdef". This format is supported only for integral types.
 
 The precision specifier indicates the minimum number of digits desired in the resulting string. If required, the number is padded with zeros to its left to produce the number of digits given by the precision specifier.
+
+For <xref:System.Numerics.BigInteger>, positive values always have a leading zero to distinguish them from negative values. This ensures the output round-trips to the original value when parsed.
+For instance, the number `F` converted with the format specifier `"X1"` is `0F` because the hexadecimal number `F` represents the negative value `-1`.
 
 The result string is not affected by the formatting information of the current <xref:System.Globalization.NumberFormatInfo> object.
 

--- a/docs/standard/base-types/standard-numeric-format-strings.md
+++ b/docs/standard/base-types/standard-numeric-format-strings.md
@@ -311,8 +311,7 @@ The hexadecimal ("X") format specifier converts a number to a string of hexadeci
 
 The precision specifier indicates the minimum number of digits desired in the resulting string. If required, the number is padded with zeros to its left to produce the number of digits given by the precision specifier.
 
-For <xref:System.Numerics.BigInteger>, positive values always have a leading zero to distinguish them from negative values. This ensures the output round-trips to the original value when parsed.
-For instance, the number `F` converted with the format specifier `"X1"` is `0F` because the hexadecimal number `F` represents the negative value `-1`.
+For <xref:System.Numerics.BigInteger>, positive values always have a leading zero to distinguish them from negative values. This ensures the output round-trips to the original value when parsed. For example, the number `F` converted with the format specifier `"X1"` is `0F` because the hexadecimal number `F` represents the negative value `-1`.
 
 The result string is not affected by the formatting information of the current <xref:System.Globalization.NumberFormatInfo> object.
 

--- a/docs/standard/base-types/standard-numeric-format-strings.md
+++ b/docs/standard/base-types/standard-numeric-format-strings.md
@@ -98,8 +98,7 @@ The binary ("B") format specifier converts a number to a string of binary digits
 
 The precision specifier indicates the minimum number of digits desired in the resulting string. If required, the number is padded with zeros to its left to produce the number of digits given by the precision specifier.
 
-For <xref:System.Numerics.BigInteger>, positive values always have a leading zero to distinguish them from negative values. This ensures the output round-trips to the original value when parsed.
-For instance, the number `3` converted with the format specifier `"B2"` is `011` because the binary number `11` represents the negative value `-1`.
+For <xref:System.Numerics.BigInteger>, positive values always have a leading zero to distinguish them from negative values. This ensures the output round-trips to the original value when parsed. For instance, the number `3` converted with the format specifier `"B2"` is `"011"`. That's because the binary number `"11"` represents the negative value `-1`, as it is interpreted as a number with exactly `2` bits due to the `"B2"` format.
 
 The result string is not affected by the formatting information of the current <xref:System.Globalization.NumberFormatInfo> object.
 


### PR DESCRIPTION
## Summary

Fixes dotnet/runtime#115618.

It's somewhat unexpected that "print `3` with 2 binary digits" returns a string of length 3 (`"011"`), but also makes sense given the round-trip requirement and the historical context of not using `-` for negative bin/hex numbers.

I think documenting this behavior would be useful.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/base-types/parsing-numeric.md](https://github.com/dotnet/docs/blob/536e1368e04db564b8add79796b084af864d9d15/docs/standard/base-types/parsing-numeric.md) | [Parsing numeric strings in .NET](https://review.learn.microsoft.com/en-us/dotnet/standard/base-types/parsing-numeric?branch=pr-en-us-46473) |
| [docs/standard/base-types/standard-numeric-format-strings.md](https://github.com/dotnet/docs/blob/536e1368e04db564b8add79796b084af864d9d15/docs/standard/base-types/standard-numeric-format-strings.md) | [Standard numeric format strings](https://review.learn.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings?branch=pr-en-us-46473) |


<!-- PREVIEW-TABLE-END -->