### PR TITLE
Fix the dash typo in lang flag of classlib in Unit testing Visual Basic page

### DIFF
--- a/docs/core/testing/unit-testing-visual-basic-with-xunit.md
+++ b/docs/core/testing/unit-testing-visual-basic-with-xunit.md
@@ -38,7 +38,7 @@ The following instructions provide the steps to create the test solution. See [C
 * Run the following command:
 
   ```dotnetcli
-  dotnet new classlib -o PrimeService --lang VB
+  dotnet new classlib -o PrimeService -lang VB
   ```
 
    The [`dotnet new classlib`](../tools/dotnet-new.md) command creates a new class library project  in the *PrimeService* folder. The new class library will contain the code to be tested.

--- a/docs/core/testing/unit-testing-visual-basic-with-xunit.md
+++ b/docs/core/testing/unit-testing-visual-basic-with-xunit.md
@@ -72,7 +72,7 @@ The following instructions provide the steps to create the test solution. See [C
 * Create the *PrimeService.Tests* project by running the following command:
 
   ```dotnetcli
-  dotnet new xunit -o PrimeService.Tests
+  dotnet new xunit -o PrimeService.Tests -lang VB
   ```
 
 * The preceding command:
@@ -108,7 +108,7 @@ cd unit-testing-using-dotnet-test
 dotnet new classlib -o PrimeService
 ren .\PrimeService\Class1.vb PrimeService.vb
 dotnet sln add ./PrimeService/PrimeService.vbproj
-dotnet new xunit -o PrimeService.Tests
+dotnet new xunit -o PrimeService.Tests -lang VB
 dotnet add ./PrimeService.Tests/PrimeService.Tests.vbproj reference ./PrimeService/PrimeService.vbproj
 dotnet sln add ./PrimeService.Tests/PrimeService.Tests.vbproj
 ```


### PR DESCRIPTION
This pull request fixes #46461 by correcting mistakes reported in the issue:
 - removes a dash typo from the `-lang` option
 - adds the `-lang` option to two `dotnet new xunit` calls
 By default, this command creates the C# project, but this page is about the VB, hence adding this `-lang` option to make sure VB project is created seems logical.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-visual-basic-with-xunit.md](https://github.com/dotnet/docs/blob/344a76406c027aac898fc78e00998b1698714e07/docs/core/testing/unit-testing-visual-basic-with-xunit.md) | [Unit testing Visual Basic .NET Core libraries using dotnet test and xUnit](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-visual-basic-with-xunit?branch=pr-en-us-46481) |

<!-- PREVIEW-TABLE-END -->