### PR TITLE
Fix wrong order for default configuration

### DIFF
--- a/docs/core/extensions/configuration.md
+++ b/docs/core/extensions/configuration.md
@@ -56,8 +56,8 @@ The <xref:Microsoft.Extensions.Hosting.Host.CreateApplicationBuilder(System.Stri
 1. Command-line arguments using the [Command-line configuration provider](configuration-providers.md#command-line-configuration-provider).
 1. Environment variables using the [Environment Variables configuration provider](configuration-providers.md#environment-variable-configuration-provider).
 1. [App secrets](/aspnet/core/security/app-secrets) when the app runs in the `Development` environment.
-1. *appsettings.json* using the [JSON configuration provider](configuration-providers.md#file-configuration-provider).
 1. *appsettings.*`Environment`*.json* using the [JSON configuration provider](configuration-providers.md#file-configuration-provider). For example, *appsettings*.***Production***.*json* and *appsettings*.***Development***.*json*.
+1. *appsettings.json* using the [JSON configuration provider](configuration-providers.md#file-configuration-provider).
 1. [ChainedConfigurationProvider](xref:Microsoft.Extensions.Configuration.ChainedConfigurationSource) : Adds an existing `IConfiguration` as a source.
 
 Adding a configuration provider overrides previous configuration values. For example, the [Command-line configuration provider](configuration-providers.md#command-line-configuration-provider) overrides all values from other providers because it's added last. If `SomeKey` is set in both *appsettings.json* and the environment, the environment value is used because it was added after *appsettings.json*.


### PR DESCRIPTION
## Summary

This pull request includes a minor reordering of the configuration providers list in the `docs/core/extensions/configuration.md` file. The change ensures that the `appsettings.json` configuration provider is listed after the `appsettings.*Environment*.json` provider for better clarity and alignment with the intended configuration precedence.

Key change:

* [`docs/core/extensions/configuration.md`](diffhunk://#diff-953513d48c508fc5829e5dfa43d9b530f93a6a3cd8fab858e7a9e3ad9c7dfbadL59-R60): Reordered the `appsettings.json` entry to follow the `appsettings.*Environment*.json` entry in the list of configuration providers. This change ensures the order reflects the configuration precedence more accurately.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/configuration.md](https://github.com/dotnet/docs/blob/6606faef94919cb93fcf89463fd8d148eb86e43a/docs/core/extensions/configuration.md) | [Configuration in .NET](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/configuration?branch=pr-en-us-46538) |


<!-- PREVIEW-TABLE-END -->