### PR TITLE
Add more info about output type

### DIFF
--- a/docs/fundamentals/code-analysis/code-quality-rule-options.md
+++ b/docs/fundamentals/code-analysis/code-quality-rule-options.md
@@ -135,7 +135,7 @@ This section lists the available configuration options for code analyzers. For m
 
 | Description | Allowable values | Default value | Configurable rules |
 |-------------|------------------|---------------|--------------------|
-| Specifies that code in a project that generates this type of assembly should be analyzed | One or more fields of the <xref:Microsoft.CodeAnalysis.OutputKind> enumeration<br/><br/>Separate multiple values with a comma (,) | All output kinds | [CA2007](quality-rules/ca2007.md) |
+| Specifies that code in a project that generates this type of assembly should be analyzed | One or more fields of the <xref:Microsoft.CodeAnalysis.OutputKind> enumeration<br/><br/>Separate multiple values with a comma (,) | All output kinds | [CA1515](quality-rules/ca1515.md) [CA2007](quality-rules/ca2007.md) |
 
 ### required_modifiers
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1515.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1515.md
@@ -53,7 +53,7 @@ public class Program
 ```
 
 ```vb
-// Inside a project with <OutputKind>Exe</OutputKind>.
+' Inside a project with <OutputKind>Exe</OutputKind>.
 Public Class Program
     Public Shared Sub Main(args As string())
     End Sub
@@ -73,11 +73,14 @@ internal class Program
 ```
 
 ```vb
+' Inside a project with <OutputKind>Exe</OutputKind>.
 Friend Class Program
     Public Shared Sub Main(args As string())
     End Sub
 End Class
 ```
+
+(For more information about the output type of a project, see [the "Output type" section of .NET Project Designer](/visualstudio/ide/reference/project-designer-dotnet-csharp#application-general-settings).)
 
 ## When to suppress warnings
 
@@ -110,4 +113,4 @@ You can configure which _output assembly kinds_ to apply this rule to. For examp
 dotnet_code_quality.CA1515.output_kind = ConsoleApplication, DynamicallyLinkedLibrary
 ```
 
-For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).
+For more information, see [output_kind](../code-quality-rule-options.md#output_kind).

--- a/docs/fundamentals/code-analysis/quality-rules/ca1515.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1515.md
@@ -1,7 +1,7 @@
 ---
 title: "CA1515: Consider making public types internal"
 description: "Learn about code analyzer rule CA1515 - Consider making public types internal"
-ms.date: 12/07/2023
+ms.date: 06/04/2025
 ms.topic: reference
 f1_keywords:
  - CA1515
@@ -43,7 +43,7 @@ Mark the type as `internal`.
 The following code snippet shows a violation of CA1515:
 
 ```csharp
-// Inside a project with <OutputKind>Exe</OutputKind>
+// Inside a project with <OutputKind>Exe</OutputKind>.
 public class Program
 {
     public static void Main(string[] args)
@@ -53,6 +53,7 @@ public class Program
 ```
 
 ```vb
+// Inside a project with <OutputKind>Exe</OutputKind>.
 Public Class Program
     Public Shared Sub Main(args As string())
     End Sub
@@ -62,7 +63,7 @@ End Class
 The following code snippet fixes the violation:
 
 ```csharp
-// Inside a project with <OutputKind>Exe</OutputKind>
+// Inside a project with <OutputKind>Exe</OutputKind>.
 internal class Program
 {
     public static void Main(string[] args)
@@ -100,3 +101,13 @@ dotnet_diagnostic.CA1515.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
+## Configure code to analyze
+
+You can configure which _output assembly kinds_ to apply this rule to. For example, to only apply this rule to code that produces a console application or a dynamically linked library (that is, not a UI app), add the following key-value pair to an *.editorconfig* file in your project:
+
+```ini
+dotnet_code_quality.CA1515.output_kind = ConsoleApplication, DynamicallyLinkedLibrary
+```
+
+For more information, see [Code quality rule configuration options](../code-quality-rule-options.md).


### PR DESCRIPTION
Fixes #46567.
Also adds configurable option info that was missing.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/code-quality-rule-options.md](https://github.com/dotnet/docs/blob/4175d0ba14256ca87b2beb361a52170b81da1d0e/docs/fundamentals/code-analysis/code-quality-rule-options.md) | [Code quality rule configuration options](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/code-quality-rule-options?branch=pr-en-us-46573) |
| [docs/fundamentals/code-analysis/quality-rules/ca1515.md](https://github.com/dotnet/docs/blob/4175d0ba14256ca87b2beb361a52170b81da1d0e/docs/fundamentals/code-analysis/quality-rules/ca1515.md) | [CA1515: Consider making public types internal](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1515?branch=pr-en-us-46573) |


<!-- PREVIEW-TABLE-END -->