### PR TITLE
Fix the links to moved file of portable PDB docs in "Compiler Options - code generation options" page

### DIFF
--- a/docs/csharp/language-reference/compiler-options/code-generation.md
+++ b/docs/csharp/language-reference/compiler-options/code-generation.md
@@ -36,10 +36,10 @@ The following values are valid:
 
 | Value      | Meaning                                                                                                 |
 |------------|---------------------------------------------------------------------------------------------------------|
-| `full`     | Emit debugging information to _.pdb_ file using default format for the current platform:<br>**Windows**: A Windows pdb file. <br>**Linux/macOS**: A [Portable PDB](https://github.com/dotnet/core/blob/main/Documentation/diagnostics/portable_pdb.md) file. |
+| `full`     | Emit debugging information to _.pdb_ file using default format for the current platform:<br>**Windows**: A Windows pdb file. <br>**Linux/macOS**: A [Portable PDB](https://github.com/dotnet/designs/blob/main/accepted/2020/diagnostics/portable-pdb.md) file. |
 | `pdbonly`  | Same as `full`. See the note below for more information. |
-| `portable` | Emit debugging information to .pdb file using cross-platform [Portable PDB](https://github.com/dotnet/core/blob/main/Documentation/diagnostics/portable_pdb.md) format. |
-| `embedded` | Emit debugging information into the _.dll/.exe_ itself (_.pdb_ file is not produced) using [Portable PDB](https://github.com/dotnet/core/blob/main/Documentation/diagnostics/portable_pdb.md) format. |
+| `portable` | Emit debugging information to .pdb file using cross-platform [Portable PDB](https://github.com/dotnet/designs/blob/main/accepted/2020/diagnostics/portable-pdb.md) format. |
+| `embedded` | Emit debugging information into the _.dll/.exe_ itself (_.pdb_ file is not produced) using [Portable PDB](https://github.com/dotnet/designs/blob/main/accepted/2020/diagnostics/portable-pdb.md) format. |
 
 > [!IMPORTANT]
 > The following information applies only to compilers older than C# 6.0.


### PR DESCRIPTION
This pull request fixes #46546 by replacing the old direction with the new, where Portable PDB doc has been moved to.
The issue mentions also on multiple links in that area, but other than those three corrected, I didn't find any more to cover.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-options/code-generation.md](https://github.com/dotnet/docs/blob/e748a6f8b9953c49ef6aeee71d1c93b77d286d0c/docs/csharp/language-reference/compiler-options/code-generation.md) | [C# Compiler Options that control code generation](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/code-generation?branch=pr-en-us-46577) |

<!-- PREVIEW-TABLE-END -->