### PR TITLE
Update sentiment-analysis-model-builder.md

### DIFF
--- a/docs/machine-learning/tutorials/sentiment-analysis-model-builder.md
+++ b/docs/machine-learning/tutorials/sentiment-analysis-model-builder.md
@@ -98,7 +98,7 @@ The machine learning task used to train the sentiment analysis model in this tut
 
     - *SentimentAnalysis.consumption.cs* -  This file contains the `ModelInput` and `ModelOutput` schemas as well as the `Predict` function generated for consuming the model.
     - *SentimentAnalysis.training.cs* - This file contains the training pipeline (data transforms, trainer, trainer hyperparameters) chosen by Model Builder to train the model. You can use this pipeline for re-training your model.
-    - **SentimentAnalysis.zip* - This is a serialized zip file which represents your trained ML.NET model.
+    - **SentimentAnalysis.mlnet* - This file contains metadata and configuration details for an ML.NET model.
 
 1. Select the **Next step** button to move to the next step.
 
@@ -144,7 +144,7 @@ To make a single prediction, you have to create a <xref:Microsoft.ML.PredictionE
 
     ```csharp
     builder.Services.AddPredictionEnginePool<ModelInput, ModelOutput>()
-        .FromFile("SentimentAnalysis.zip");
+        .FromFile("SentimentAnalysis.mlnet");
     ```
 
 ### Create sentiment analysis handler


### PR DESCRIPTION
Correcting an incorrect extension used in the documentation related to a generated ML.NET model file.

## Summary

While completing a tutorial, I noticed an incorrect file format and description in the documentation, so I fixed it accordingly.
![image](https://github.com/user-attachments/assets/f89fbf16-312c-4046-86e0-37736a169a61)

Fixes #46585

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/machine-learning/tutorials/sentiment-analysis-model-builder.md](https://github.com/dotnet/docs/blob/64cbdc0d6666476c36487a97ef398d82929aa54b/docs/machine-learning/tutorials/sentiment-analysis-model-builder.md) | [Tutorial: Analyze sentiment of website comments in a web application using ML.NET Model Builder](https://review.learn.microsoft.com/en-us/dotnet/machine-learning/tutorials/sentiment-analysis-model-builder?branch=pr-en-us-46584) |

<!-- PREVIEW-TABLE-END -->