### PR TITLE
Add preview 4 breaking change

### DIFF
--- a/.github/prompts/breaking-change.md
+++ b/.github/prompts/breaking-change.md
@@ -1,4 +1,4 @@
-When you're assigned an issue that's labeled "breaking-change", or when you're given a link to an issue with this prompt file as context and asked to create a new breaking change document, follow the following guidelines:
+When you're assigned an issue that's labeled "breaking-change", or when you're given a link to an issue with this prompt file as context and asked to create a new breaking change document, follow these guidelines:
 
 The document should be in Markdown format.
 

--- a/.github/prompts/breaking-change.md
+++ b/.github/prompts/breaking-change.md
@@ -1,4 +1,4 @@
-When you're assigned an issue that's labeled "breaking-change", or when you're given a link to an issue that's labeled "breaking-change" and asked to create a new breaking change document, follow the following guidelines:
+When you're assigned an issue that's labeled "breaking-change", or when you're given a link to an issue with this prompt file as context and asked to create a new breaking change document, follow the following guidelines:
 
 The document should be in Markdown format.
 

--- a/docs/core/compatibility/10.0.md
+++ b/docs/core/compatibility/10.0.md
@@ -2,7 +2,7 @@
 title: Breaking changes in .NET 10
 titleSuffix: ""
 description: Navigate to the breaking changes in .NET 10.
-ms.date: 04/21/2025
+ms.date: 06/05/2025
 ai-usage: ai-assisted
 no-loc: [Blazor, Razor, Kestrel]
 ---
@@ -18,78 +18,79 @@ If you're migrating an app to .NET 10, the breaking changes listed here might af
 
 ## Containers
 
-| Title                                                                                                                      | Type of change      | Introduced version |
-|----------------------------------------------------------------------------------------------------------------------------|---------------------|--------------------|
-| [Default .NET images use Ubuntu](containers/10.0/default-images-use-ubuntu.md)                                             | Behavioral change   | Preview 1          |
+| Title                                                                          | Type of change    | Introduced version |
+|--------------------------------------------------------------------------------|-------------------|--------------------|
+| [Default .NET images use Ubuntu](containers/10.0/default-images-use-ubuntu.md) | Behavioral change | Preview 1          |
 
 ## Core .NET libraries
 
-| Title                                                                                                                      | Type of change      | Introduced version |
-|----------------------------------------------------------------------------------------------------------------------------|---------------------|--------------------|
-| [ActivitySource.CreateActivity and ActivitySource.StartActivity behavior change](core-libraries/10.0/activity-sampling.md) | Behavioral change   | Preview 1          |
-| [C# 14 overload resolution with span parameters](core-libraries/10.0/csharp-overload-resolution.md)                        | Behavioral change   | Preview 1          |
-| [Consistent shift behavior in generic math](core-libraries/10.0/generic-math.md)                                           | Behavioral change   | Preview 1          |
-| [Default trace context propagator updated to W3C standard](core-libraries/10.0/default-trace-context-propagator.md)        | Behavioral change   | Preview 4          |
-| [LDAP DirectoryControl parsing is now more stringent](core-libraries/10.0/ldap-directorycontrol-parsing.md)                | Behavioral change   | Preview 1          |
-| [MacCatalyst version normalization](core-libraries/10.0/maccatalyst-version-normalization.md)                              | Behavioral change   | Preview 1          |
-| [System.Linq.AsyncEnumerable included in core libraries](core-libraries/10.0/asyncenumerable.md)                           | Source incompatible | Preview 1          |
+| Title | Type of change    | Introduced version |
+|-------|-------------------|--------------------|
+| [ActivitySource.CreateActivity and ActivitySource.StartActivity behavior change](core-libraries/10.0/activity-sampling.md) | Behavioral change | Preview 1 |
+| [C# 14 overload resolution with span parameters](core-libraries/10.0/csharp-overload-resolution.md) | Behavioral change | Preview 1 |
+| [Consistent shift behavior in generic math](core-libraries/10.0/generic-math.md) | Behavioral change | Preview 1 |
+| [Default trace context propagator updated to W3C standard](core-libraries/10.0/default-trace-context-propagator.md) | Behavioral change | Preview 4 |
+| [LDAP DirectoryControl parsing is now more stringent](core-libraries/10.0/ldap-directorycontrol-parsing.md) | Behavioral change | Preview 1 |
+| [MacCatalyst version normalization](core-libraries/10.0/maccatalyst-version-normalization.md) | Behavioral change | Preview 1 |
+| [System.Linq.AsyncEnumerable included in core libraries](core-libraries/10.0/asyncenumerable.md) | Source incompatible | Preview 1 |
 
 ## Extensions
 
-| Title                                                                                                     | Type of change      | Introduced version |
-|-----------------------------------------------------------------------------------------------------------|---------------------|--------------------|
-| [ProviderAliasAttribute moved to Microsoft.Extensions.Logging.Abstractions assembly](extensions/10.0/provideraliasattribute-moved-assembly.md) | Source incompatible | Preview 4          |
+| Title | Type of change      | Introduced version |
+|-------|---------------------|--------------------|
+| [ProviderAliasAttribute moved to Microsoft.Extensions.Logging.Abstractions assembly](extensions/10.0/provideraliasattribute-moved-assembly.md) | Source incompatible | Preview 4 |
 
 ## Globalization
 
-| Title                                                                                                 | Type of change    | Introduced version |
-|-------------------------------------------------------------------------------------------------------|-------------------|--------------------|
-| [Environment variable renamed to DOTNET_ICU_VERSION_OVERRIDE](globalization/10.0/version-override.md) | Behavioral change | Preview 1          |
+| Title | Type of change    | Introduced version |
+|-------|-------------------|--------------------|
+| [Environment variable renamed to DOTNET_ICU_VERSION_OVERRIDE](globalization/10.0/version-override.md) | Behavioral change | Preview 1 |
 
 ## Cryptography
 
-| Title                                                                                                    | Type of change                        | Introduced version |
-|----------------------------------------------------------------------------------------------------------|---------------------------------------|--------------------|
-| [X500DistinguishedName validation is stricter](cryptography/10.0/x500distinguishedname-validation.md)    | Behavioral change                     | Preview 1          |
-| [X509Certificate and PublicKey key parameters can be null](cryptography/10.0/x509-publickey-null.md)     | Behavioral/source incompatible change | Preview 3          |
-| [Environment variable renamed to DOTNET_OPENSSL_VERSION_OVERRIDE](cryptography/10.0/version-override.md) | Behavioral change                     | Preview 1          |
+| Title | Type of change    | Introduced version |
+|-------|-------------------|--------------------|
+| [X500DistinguishedName validation is stricter](cryptography/10.0/x500distinguishedname-validation.md) | Behavioral change | Preview 1 |
+| [X509Certificate and PublicKey key parameters can be null](cryptography/10.0/x509-publickey-null.md) | Behavioral/source incompatible change | Preview 3 |
+| [Environment variable renamed to DOTNET_OPENSSL_VERSION_OVERRIDE](cryptography/10.0/version-override.md) | Behavioral change | Preview 1 |
 
 ## Interop
 
-| Title                                                                                                                              | Type of change    | Introduced version |
-|------------------------------------------------------------------------------------------------------------------------------------|-------------------|--------------------|
-| [Specifying DllImportSearchPath.AssemblyDirectory only searches the assembly directory](interop/10.0/search-assembly-directory.md) | Behavioral change | Preview 5          |
+| Title | Type of change    | Introduced version |
+|-------|-------------------|--------------------|
+| [Specifying DllImportSearchPath.AssemblyDirectory only searches the assembly directory](interop/10.0/search-assembly-directory.md) | Behavioral change | Preview 5 |
 
 ## Networking
 
-| Title                                                                                                            | Type of change    | Introduced version |
-|------------------------------------------------------------------------------------------------------------------|-------------------|--------------------|
-| [Streaming HTTP responses enabled by default in browser HTTP clients](networking/10.0/default-http-streaming.md) | Behavioral change | Preview 3          |
+| Title | Type of change    | Introduced version |
+|-------|-------------------|--------------------|
+| [Streaming HTTP responses enabled by default in browser HTTP clients](networking/10.0/default-http-streaming.md) | Behavioral change | Preview 3 |
 
 ## SDK and MSBuild
 
-| Title                                                                                                                        | Type of change                        | Introduced version |
-|------------------------------------------------------------------------------------------------------------------------------|---------------------------------------|--------------------|
-| [.NET CLI `--interactive` defaults to `true` in user scenarios](sdk/10.0/dotnet-cli-interactive.md)                          | Behavioral change                     | Preview 3          |
-| [Default workload configuration from 'loose manifests' to 'workload sets' mode](sdk/10.0/default-workload-config.md)         | Behavioral change                     | Preview 2          |
-| [`dotnet restore` audits transitive packages](sdk/10.0/nugetaudit-transitive-packages.md)                                    | Behavioral change                     | Preview 3          |
-| [MSBUILDCUSTOMBUILDEVENTWARNING escape hatch removed](sdk/10.0/custom-build-event-warning.md)                                | Behavioral change                     | Preview 1          |
-| [MSBuild custom culture resource handling](sdk/10.0/msbuild-custom-culture.md)                                               | Behavioral change                     | Preview 1          |
-| [NU1510 is raised for direct references pruned by NuGet](sdk/10.0/nu1510-pruned-references.md)                               | Source incompatible                   | Preview 1          |
-| [HTTP warnings promoted to errors in `dotnet package list` and `dotnet package search`](sdk/10.0/http-warnings-to-errors.md) | Behavioral/source incompatible change | Preview 4          |
+| Title | Type of change    | Introduced version |
+|-------|-------------------|--------------------|
+| [.NET CLI `--interactive` defaults to `true` in user scenarios](sdk/10.0/dotnet-cli-interactive.md) | Behavioral change | Preview 3 |
+| [Default workload configuration from 'loose manifests' to 'workload sets' mode](sdk/10.0/default-workload-config.md) | Behavioral change | Preview 2 |
+| [`dotnet package list` performs restore](sdk/10.0/dotnet-package-list-restore.md) | Behavioral change | Preview 4 |
+| [`dotnet restore` audits transitive packages](sdk/10.0/nugetaudit-transitive-packages.md) | Behavioral change | Preview 3 |
+| [MSBUILDCUSTOMBUILDEVENTWARNING escape hatch removed](sdk/10.0/custom-build-event-warning.md) | Behavioral change | Preview 1 |
+| [MSBuild custom culture resource handling](sdk/10.0/msbuild-custom-culture.md) | Behavioral change | Preview 1 |
+| [NU1510 is raised for direct references pruned by NuGet](sdk/10.0/nu1510-pruned-references.md) | Source incompatible | Preview 1 |
+| [HTTP warnings promoted to errors in `dotnet package list` and `dotnet package search`](sdk/10.0/http-warnings-to-errors.md) | Behavioral/source incompatible change | Preview 4 |
 
 ## Windows Forms
 
-| Title                                                                                                                                         | Type of change      | Introduced version |
-|-----------------------------------------------------------------------------------------------------------------------------------------------|---------------------|--------------------|
-| [API obsoletions](windows-forms/10.0/obsolete-apis.md)                                                                                        | Source incompatible | Preview 1          |
-| [Applications referencing both WPF and WinForms must disambiguate MenuItem and ContextMenu types](windows-forms/10.0/menuitem-contextmenu.md) | Source incompatible | Preview 1          |
-| [Renamed parameter in HtmlElement.InsertAdjacentElement](windows-forms/10.0/insertadjacentelement-orientation.md)                             | Source incompatible | Preview 1          |
-| [TreeView checkbox image truncation](windows-forms/10.0/treeview-text-location.md)                                                            | Behavioral change   | Preview 1          |
-| [StatusStrip uses System RenderMode by default](windows-forms/10.0/statusstrip-renderer.md)                                                   | Behavioral change   | Preview 1          |
+| Title                                                  | Type of change      | Introduced version |
+|--------------------------------------------------------|---------------------|--------------------|
+| [API obsoletions](windows-forms/10.0/obsolete-apis.md) | Source incompatible | Preview 1          |
+| [Applications referencing both WPF and WinForms must disambiguate MenuItem and ContextMenu types](windows-forms/10.0/menuitem-contextmenu.md) | Source incompatible | Preview 1 |
+| [Renamed parameter in HtmlElement.InsertAdjacentElement](windows-forms/10.0/insertadjacentelement-orientation.md) | Source incompatible | Preview 1 |
+| [TreeView checkbox image truncation](windows-forms/10.0/treeview-text-location.md) | Behavioral change   | Preview 1 |
+| [StatusStrip uses System RenderMode by default](windows-forms/10.0/statusstrip-renderer.md) | Behavioral change   | Preview 1 |
 
 ## Windows Presentation Foundation (WPF)
 
-| Title                                                                                            | Type of change                        | Introduced version |
-|--------------------------------------------------------------------------------------------------|---------------------------------------|--------------------|
+| Title | Type of change                        | Introduced version |
+|-------|---------------------------------------|--------------------|
 | [Incorrect usage of DynamicResource causes application crash](wpf/10.0/dynamicresource-crash.md) | Source incompatible/behavioral change | Preview 4          |

--- a/docs/core/compatibility/sdk/10.0/dotnet-package-list-restore.md
+++ b/docs/core/compatibility/sdk/10.0/dotnet-package-list-restore.md
@@ -1,0 +1,43 @@
+---
+title: "Breaking change - dotnet package list command now performs restore by default"
+description: "Learn about the breaking change in .NET 10 where the dotnet package list command now performs a restore before listing packages."
+ms.date: 06/05/2025
+ai-usage: ai-assisted
+ms.custom: https://github.com/dotnet/docs/issues/46103
+---
+
+# dotnet package list command now performs restore by default
+
+The `dotnet package list` command now automatically performs a restore operation before listing packages to ensure accurate and up-to-date results. This is a behavioral change from the previous implementation where the command did not require a restore step. Additionally, if the restore operation fails, an error message is logged.
+
+## Version introduced
+
+.NET 10 Preview 4
+
+## Previous behavior
+
+The `dotnet package list` command listed project packages without performing a restore. If a restore was needed, you had to run it manually before using the command.
+
+## New behavior
+
+The `dotnet package list` command now automatically performs a restore before listing packages. If the restore fails, the command doesn't list packages and instead logs an error message in both plain text and JSON formats, depending on the command usage.
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+This change ensures the `dotnet package list` command provides accurate and up-to-date package information.
+
+## Recommended action
+
+If this change causes issues in your workflow:
+
+- Use the `--no-restore` option with `dotnet package list` if you want to bypass the implicit restore step.
+- Make sure your project is ready for restore before running the `dotnet package list` command.
+- Alternatively, run `dotnet restore` manually before using `dotnet package list` to decouple the restore step.
+
+## Affected APIs
+
+None.

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -29,7 +29,7 @@ items:
               - name: MacCatalyst version normalization
                 href: core-libraries/10.0/maccatalyst-version-normalization.md
               - name: System.Linq.AsyncEnumerable included in core libraries
-                href: core-libraries/10.0/asyncenumerable.md         
+                href: core-libraries/10.0/asyncenumerable.md
           - name: Cryptography
             items:
               - name: X500DistinguishedName validation is stricter
@@ -62,13 +62,15 @@ items:
                 href: sdk/10.0/nugetaudit-transitive-packages.md
               - name: Default workload configuration from 'loose manifests' to 'workload sets' mode
                 href: sdk/10.0/default-workload-config.md
+              - name: "`dotnet package list` performs restore"
+                href: sdk/10.0/dotnet-package-list-restore.md
               - name: MSBUILDCUSTOMBUILDEVENTWARNING escape hatch removed
                 href: sdk/10.0/custom-build-event-warning.md
               - name: MSBuild custom culture resource handling
                 href: sdk/10.0/msbuild-custom-culture.md
               - name: NU1510 is raised for direct references pruned by NuGet
                 href: sdk/10.0/nu1510-pruned-references.md
-              - name: HTTP warnings promoted to errors in 'dotnet package list' and 'dotnet package search'
+              - name: HTTP warnings promoted to errors in package list and search
                 href: sdk/10.0/http-warnings-to-errors.md
           - name: Windows Forms
             items:
@@ -85,7 +87,7 @@ items:
           - name: WPF
             items:
               - name: Incorrect usage of DynamicResource causes application crash
-                href: wpf/10.0/dynamicresource-crash.md         
+                href: wpf/10.0/dynamicresource-crash.md
       - name: .NET 9
         items:
           - name: Overview
@@ -115,11 +117,13 @@ items:
               - name: Altered UnsafeAccessor support for non-open generics
                 href: core-libraries/9.0/unsafeaccessor-generics.md
               - name: Ambiguous overload resolution affecting StringValues implicit operators
-                href: core-libraries/9.0/ambiguous-overload.md         
+                href: core-libraries/9.0/ambiguous-overload.md
               - name: API obsoletions with custom diagnostic IDs
                 href: core-libraries/9.0/obsolete-apis-with-custom-diagnostics.md
               - name: BigInteger maximum length
                 href: core-libraries/9.0/biginteger-limit.md
+              - name: BinaryReader.GetString() returns "/uFFFD" on malformed sequences
+                href: core-libraries/9.0/binaryreader.md
               - name: C# overload resolution prefers `params` span-type overloads
                 href: core-libraries/9.0/params-overloads.md
               - name: Creating type of array of System.Void not allowed
@@ -200,8 +204,6 @@ items:
                 href: sdk/9.0/dotnet-workload-output.md
               - name: "`installer` repo version no longer documented"
                 href: sdk/9.0/productcommits-versions.md
-              - name: MSBuild custom culture resource handling
-                href: sdk/10.0/msbuild-custom-culture.md
               - name: New default RID used when targeting .NET Framework
                 href: sdk/9.0/default-rid.md
               - name: Terminal logger is default
@@ -219,7 +221,7 @@ items:
               - name: Nullable JsonDocument properties deserialize to JsonValueKind.Null
                 href: serialization/9.0/jsondocument-props.md
               - name: System.Text.Json metadata reader now unescapes metadata property names
-                href: serialization/9.0/json-metadata-reader.md         
+                href: serialization/9.0/json-metadata-reader.md
           - name: Windows Forms
             items:
               - name: BindingSource.SortDescriptions doesn't return null
@@ -292,8 +294,6 @@ items:
                 href: core-libraries/8.0/file-path-backslash.md
               - name: Base64.DecodeFromUtf8 methods ignore whitespace
                 href: core-libraries/8.0/decodefromutf8-whitespace.md
-              - name: BinaryReader.GetString() returns "/uFFFD" on malformed sequences
-                href: core-libraries/9.0/binaryreader.md
               - name: Boolean-backed enum type support removed
                 href: core-libraries/8.0/bool-backed-enum.md
               - name: Complex.ToString format changed to `<a; b>`
@@ -496,6 +496,10 @@ items:
                 href: aspnet-core/7.0/output-caching-renames.md
               - name: SignalR Hub methods try to resolve parameters from DI
                 href: aspnet-core/7.0/signalr-hub-method-parameters-di.md
+          - name: Configuration
+            items:
+              - name: System.diagnostics entry in app.config
+                href: configuration/7.0/diagnostics-config-section.md
           - name: Core .NET libraries
             items:
               - name: API obsoletions with default diagnostic ID
@@ -538,10 +542,6 @@ items:
                 href: core-libraries/7.0/memorycache-tracking.md
               - name: Validate CompressionLevel for BrotliStream
                 href: core-libraries/7.0/compressionlevel-validation.md
-          - name: Configuration
-            items:
-              - name: System.diagnostics entry in app.config
-                href: configuration/7.0/diagnostics-config-section.md
           - name: Cryptography
             items:
               - name: Dynamic X509ChainPolicy verification time
@@ -1421,7 +1421,7 @@ items:
               - name: Altered UnsafeAccessor support for non-open generics
                 href: core-libraries/9.0/unsafeaccessor-generics.md
               - name: Ambiguous overload resolution affecting StringValues implicit operators
-                href: core-libraries/9.0/ambiguous-overload.md    
+                href: core-libraries/9.0/ambiguous-overload.md
               - name: API obsoletions with custom diagnostic IDs
                 href: core-libraries/9.0/obsolete-apis-with-custom-diagnostics.md
               - name: BigInteger maximum length
@@ -1960,13 +1960,15 @@ items:
                 href: sdk/10.0/nugetaudit-transitive-packages.md
               - name: Default workload configuration from 'loose manifests' to 'workload sets' mode
                 href: sdk/10.0/default-workload-config.md
+              - name: "`dotnet package list` performs restore"
+                href: sdk/10.0/dotnet-package-list-restore.md
               - name: MSBUILDCUSTOMBUILDEVENTWARNING escape hatch removed
                 href: sdk/10.0/custom-build-event-warning.md
               - name: MSBuild custom culture resource handling
                 href: sdk/10.0/msbuild-custom-culture.md
               - name: NU1510 is raised for direct references pruned by NuGet
                 href: sdk/10.0/nu1510-pruned-references.md
-              - name: HTTP warnings promoted to errors in dotnet package list and dotnet package search
+              - name: HTTP warnings promoted to errors in package list and search
                 href: sdk/10.0/http-warnings-to-errors.md
           - name: .NET 9
             items:
@@ -1978,8 +1980,6 @@ items:
                 href: sdk/9.0/dotnet-workload-output.md
               - name: "`installer` repo version no longer documented"
                 href: sdk/9.0/productcommits-versions.md
-              - name: MSBuild custom culture resource handling
-                href: sdk/10.0/msbuild-custom-culture.md
               - name: New default RID used when targeting .NET Framework
                 href: sdk/9.0/default-rid.md
               - name: Terminal logger is default
@@ -2125,7 +2125,7 @@ items:
               - name: Nullable JsonDocument properties deserialize to JsonValueKind.Null
                 href: serialization/9.0/jsondocument-props.md
               - name: System.Text.Json metadata reader now unescapes metadata property names
-                href: serialization/9.0/json-metadata-reader.md    
+                href: serialization/9.0/json-metadata-reader.md
           - name: .NET 8
             items:
               - name: BinaryFormatter disabled for most projects
@@ -2305,7 +2305,7 @@ items:
           - name: .NET 10
             items:
               - name: Incorrect usage of DynamicResource causes application crash
-                href: wpf/10.0/dynamicresource-crash.md        
+                href: wpf/10.0/dynamicresource-crash.md
           - name: .NET 9
             items:
               - name: "'GetXmlNamespaceMaps' type change"


### PR DESCRIPTION
- Fixes #46103 
- Fixes up some errors in the breaking change TOC.
- Reformats breaking changes tables (hide whitespace changes).

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/prompts/breaking-change.md](https://github.com/dotnet/docs/blob/c728bfd10c892074f2ba2115c4d6ec3214104be5/.github/prompts/breaking-change.md) | [.github/prompts/breaking-change](https://review.learn.microsoft.com/en-us/dotnet/.github/prompts/breaking-change?branch=pr-en-us-46587) |
| [docs/core/compatibility/10.0.md](https://github.com/dotnet/docs/blob/c728bfd10c892074f2ba2115c4d6ec3214104be5/docs/core/compatibility/10.0.md) | [Breaking changes in .NET 10](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/10.0?branch=pr-en-us-46587) |
| [docs/core/compatibility/sdk/10.0/dotnet-package-list-restore.md](https://github.com/dotnet/docs/blob/c728bfd10c892074f2ba2115c4d6ec3214104be5/docs/core/compatibility/sdk/10.0/dotnet-package-list-restore.md) | [dotnet package list command now performs restore by default](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/10.0/dotnet-package-list-restore?branch=pr-en-us-46587) |
| [docs/core/compatibility/toc.yml](https://github.com/dotnet/docs/blob/c728bfd10c892074f2ba2115c4d6ec3214104be5/docs/core/compatibility/toc.yml) | [docs/core/compatibility/toc](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/toc?branch=pr-en-us-46587) |


<!-- PREVIEW-TABLE-END -->