### PR TITLE
Remove note about preview-to-preview break

### DIFF
--- a/docs/core/testing/unit-testing-with-dotnet-test.md
+++ b/docs/core/testing/unit-testing-with-dotnet-test.md
@@ -90,12 +90,9 @@ To address the issues encountered when running `dotnet test` with MTP in VSTest 
 To enable this mode, add a `dotnet.config` file to the root of the repository or solution.
 
 ```ini
-[dotnet.test:runner]
+[dotnet.test.runner]
 name = "Microsoft.Testing.Platform"
 ```
-
-> [!NOTE]
-> The format will change from `dotnet.test:runner` to `dotnet.test.runner` in .NET 10 SDK Preview 4.
 
 Since this mode is specifically designed for Microsoft.Testing.Platform, neither `TestingPlatformDotnetTestSupport` nor the additional `--` are required.
 


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-with-dotnet-test.md](https://github.com/dotnet/docs/blob/5d655a68da80e729a0ae86f088b47bdca770eaf8/docs/core/testing/unit-testing-with-dotnet-test.md) | [Testing with 'dotnet test'](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-with-dotnet-test?branch=pr-en-us-46590) |

<!-- PREVIEW-TABLE-END -->