### PR TITLE
YMM embedded rounding breaking change

### DIFF
--- a/docs/core/compatibility/10.0.md
+++ b/docs/core/compatibility/10.0.md
@@ -33,6 +33,7 @@ If you're migrating an app to .NET 10, the breaking changes listed here might af
 | [LDAP DirectoryControl parsing is now more stringent](core-libraries/10.0/ldap-directorycontrol-parsing.md) | Behavioral change | Preview 1 |
 | [MacCatalyst version normalization](core-libraries/10.0/maccatalyst-version-normalization.md) | Behavioral change | Preview 1 |
 | [System.Linq.AsyncEnumerable included in core libraries](core-libraries/10.0/asyncenumerable.md) | Source incompatible | Preview 1 |
+| [YMM embedded rounding removed from AVX10.2](core-libraries/10.0/ymm-embedded-rounding.md) | Behavioral change | Preview 5 |
 
 ## Extensions
 

--- a/docs/core/compatibility/core-libraries/10.0/ymm-embedded-rounding.md
+++ b/docs/core/compatibility/core-libraries/10.0/ymm-embedded-rounding.md
@@ -1,0 +1,55 @@
+---
+title: "Breaking change: YMM embedded rounding removed from AVX10.2"
+description: Learn about the .NET 10 breaking change in core .NET libraries where support for YMM embedded rounding was removed from AVX10.2.
+ms.date: 06/06/2025
+---
+
+# YMM embedded rounding removed from AVX10.2
+
+Support for YMM embedded rounding has been removed from the <xref:System.Runtime.Intrinsics.X86.Avx10v2> type.
+
+## Previous behavior
+
+In previous .NET 10 Preview versions, the [affected APIs](#affected-apis) in <xref:System.Runtime.Intrinsics.X86.Avx10v2> were available.
+
+## New behavior
+
+Starting in Preview 5, the [affected APIs](#affected-apis) are removed and no longer available.
+
+## Version introduced
+
+.NET 10 Preview 5
+
+## Type of breaking change
+
+This change can affect [binary compatibility](../../categories.md#binary-compatibility) and [source compatibility](../../categories.md#source-compatibility).
+
+## Reason for change
+
+Intel pivoted direction and now requires that AVX10.2 also implement AVX512. Since ZMM embedded rounding is always available, the YMM embedded rounding feature isn't necessary.
+
+## Recommended action
+
+Because the hardware isn't yet available, no users should be affected by this change.
+
+## Affected APIs
+
+- <xref:System.Runtime.Intrinsics.X86.Avx10v2.ConvertToSByteWithSaturationAndZeroExtendToInt32(System.Runtime.Intrinsics.Vector256{System.Single},System.Runtime.Intrinsics.X86.FloatRoundingMode)?displayProperty=fullName>
+- <xref:System.Runtime.Intrinsics.X86.Avx10v2.ConvertToByteWithSaturationAndZeroExtendToInt32(System.Runtime.Intrinsics.Vector256{System.Single},System.Runtime.Intrinsics.X86.FloatRoundingMode)?displayProperty=fullName>
+- <xref:System.Runtime.Intrinsics.X86.Avx10v2.Add*?displayProperty=fullName>
+- <xref:System.Runtime.Intrinsics.X86.Avx10v2.Divide*?displayProperty=fullName>
+- <xref:System.Runtime.Intrinsics.X86.Avx10v2.Multiply*?displayProperty=fullName>
+- <xref:System.Runtime.Intrinsics.X86.Avx10v2.Scale*?displayProperty=fullName>
+- <xref:System.Runtime.Intrinsics.X86.Avx10v2.Sqrt*?displayProperty=fullName>
+- <xref:System.Runtime.Intrinsics.X86.Avx10v2.Subtract*?displayProperty=fullName>
+- <xref:System.Runtime.Intrinsics.X86.Avx10v2.ConvertToVector128Single*?displayProperty=fullName>
+- <xref:System.Runtime.Intrinsics.X86.Avx10v2.ConvertToVector256Single*?displayProperty=fullName>
+- <xref:System.Runtime.Intrinsics.X86.Avx10v2.ConvertToVector256Double*?displayProperty=fullName>
+- <xref:System.Runtime.Intrinsics.X86.Avx10v2.ConvertToVector128Int32*?displayProperty=fullName>
+- <xref:System.Runtime.Intrinsics.X86.Avx10v2.ConvertToVector128Single*?displayProperty=fullName>
+- <xref:System.Runtime.Intrinsics.X86.Avx10v2.ConvertToVector256Int32*?displayProperty=fullName>
+- <xref:System.Runtime.Intrinsics.X86.Avx10v2.ConvertToVector256Int64*?displayProperty=fullName>
+- <xref:System.Runtime.Intrinsics.X86.Avx10v2.ConvertToVector128UInt32*?displayProperty=fullName>
+- <xref:System.Runtime.Intrinsics.X86.Avx10v2.ConvertToVector256UInt32*?displayProperty=fullName>
+- <xref:System.Runtime.Intrinsics.X86.Avx10v2.ConvertToVector256UInt64*?displayProperty=fullName>
+-

--- a/docs/core/compatibility/core-libraries/10.0/ymm-embedded-rounding.md
+++ b/docs/core/compatibility/core-libraries/10.0/ymm-embedded-rounding.md
@@ -14,7 +14,7 @@ In previous .NET 10 Preview versions, the [affected APIs](#affected-apis) in <xr
 
 ## New behavior
 
-Starting in Preview 5, the [affected APIs](#affected-apis) are removed and no longer available.
+Starting in Preview 5, the [affected APIs](#affected-apis) in <xref:System.Runtime.Intrinsics.X86.Avx10v2> are removed and no longer available.
 
 ## Version introduced
 
@@ -34,22 +34,20 @@ Because the hardware isn't yet available, no users should be affected by this ch
 
 ## Affected APIs
 
-- <xref:System.Runtime.Intrinsics.X86.Avx10v2.ConvertToSByteWithSaturationAndZeroExtendToInt32(System.Runtime.Intrinsics.Vector256{System.Single},System.Runtime.Intrinsics.X86.FloatRoundingMode)?displayProperty=fullName>
-- <xref:System.Runtime.Intrinsics.X86.Avx10v2.ConvertToByteWithSaturationAndZeroExtendToInt32(System.Runtime.Intrinsics.Vector256{System.Single},System.Runtime.Intrinsics.X86.FloatRoundingMode)?displayProperty=fullName>
-- <xref:System.Runtime.Intrinsics.X86.Avx10v2.Add*?displayProperty=fullName>
-- <xref:System.Runtime.Intrinsics.X86.Avx10v2.Divide*?displayProperty=fullName>
-- <xref:System.Runtime.Intrinsics.X86.Avx10v2.Multiply*?displayProperty=fullName>
-- <xref:System.Runtime.Intrinsics.X86.Avx10v2.Scale*?displayProperty=fullName>
-- <xref:System.Runtime.Intrinsics.X86.Avx10v2.Sqrt*?displayProperty=fullName>
-- <xref:System.Runtime.Intrinsics.X86.Avx10v2.Subtract*?displayProperty=fullName>
-- <xref:System.Runtime.Intrinsics.X86.Avx10v2.ConvertToVector128Single*?displayProperty=fullName>
-- <xref:System.Runtime.Intrinsics.X86.Avx10v2.ConvertToVector256Single*?displayProperty=fullName>
-- <xref:System.Runtime.Intrinsics.X86.Avx10v2.ConvertToVector256Double*?displayProperty=fullName>
-- <xref:System.Runtime.Intrinsics.X86.Avx10v2.ConvertToVector128Int32*?displayProperty=fullName>
-- <xref:System.Runtime.Intrinsics.X86.Avx10v2.ConvertToVector128Single*?displayProperty=fullName>
-- <xref:System.Runtime.Intrinsics.X86.Avx10v2.ConvertToVector256Int32*?displayProperty=fullName>
-- <xref:System.Runtime.Intrinsics.X86.Avx10v2.ConvertToVector256Int64*?displayProperty=fullName>
-- <xref:System.Runtime.Intrinsics.X86.Avx10v2.ConvertToVector128UInt32*?displayProperty=fullName>
-- <xref:System.Runtime.Intrinsics.X86.Avx10v2.ConvertToVector256UInt32*?displayProperty=fullName>
-- <xref:System.Runtime.Intrinsics.X86.Avx10v2.ConvertToVector256UInt64*?displayProperty=fullName>
--
+- `System.Runtime.Intrinsics.X86.Avx10v2.ConvertToSByteWithSaturationAndZeroExtendToInt32`
+- `System.Runtime.Intrinsics.X86.Avx10v2.ConvertToByteWithSaturationAndZeroExtendToInt32`
+- `System.Runtime.Intrinsics.X86.Avx10v2.Add`
+- `System.Runtime.Intrinsics.X86.Avx10v2.Divide`
+- `System.Runtime.Intrinsics.X86.Avx10v2.Multiply`
+- `System.Runtime.Intrinsics.X86.Avx10v2.Scale`
+- `System.Runtime.Intrinsics.X86.Avx10v2.Sqrt`
+- `System.Runtime.Intrinsics.X86.Avx10v2.Subtract`
+- `System.Runtime.Intrinsics.X86.Avx10v2.ConvertToVector128Int32`
+- `System.Runtime.Intrinsics.X86.Avx10v2.ConvertToVector128Single`
+- `System.Runtime.Intrinsics.X86.Avx10v2.ConvertToVector128UInt32`
+- `System.Runtime.Intrinsics.X86.Avx10v2.ConvertToVector256Double`
+- `System.Runtime.Intrinsics.X86.Avx10v2.ConvertToVector256Int32`
+- `System.Runtime.Intrinsics.X86.Avx10v2.ConvertToVector256Int64`
+- `System.Runtime.Intrinsics.X86.Avx10v2.ConvertToVector256Single`
+- `System.Runtime.Intrinsics.X86.Avx10v2.ConvertToVector256UInt32`
+- `System.Runtime.Intrinsics.X86.Avx10v2.ConvertToVector256UInt64`

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -30,6 +30,8 @@ items:
                 href: core-libraries/10.0/maccatalyst-version-normalization.md
               - name: System.Linq.AsyncEnumerable included in core libraries
                 href: core-libraries/10.0/asyncenumerable.md
+              - name: YMM embedded rounding removed from AVX10.2
+                href: core-libraries/10.0/ymm-embedded-rounding.md
           - name: Cryptography
             items:
               - name: X500DistinguishedName validation is stricter
@@ -1334,6 +1336,16 @@ items:
                 href: aspnet-core/5.0/static-files-csv-content-type-changed.md
               - name: .NET Core 3.0-3.1
                 href: aspnetcore.md
+      - name: .NET Aspire
+        items:
+          - name: Aspire 9.3
+            href: /dotnet/aspire/compatibility/9.3/?toc=/dotnet/core/compatibility/toc.json&bc=/dotnet/breadcrumb/toc.json
+          - name: Aspire 9.2
+            href: /dotnet/aspire/compatibility/9.2/?toc=/dotnet/core/compatibility/toc.json&bc=/dotnet/breadcrumb/toc.json
+          - name: Aspire 9.1
+            href: /dotnet/aspire/compatibility/9.1/?toc=/dotnet/core/compatibility/toc.json&bc=/dotnet/breadcrumb/toc.json
+          - name: Aspire 9.0
+            href: /dotnet/aspire/compatibility/9.0/?toc=/dotnet/core/compatibility/toc.json&bc=/dotnet/breadcrumb/toc.json
       - name: Code analysis
         items:
           - name: .NET 5
@@ -1414,6 +1426,8 @@ items:
                 href: core-libraries/10.0/maccatalyst-version-normalization.md
               - name: System.Linq.AsyncEnumerable included in core libraries
                 href: core-libraries/10.0/asyncenumerable.md
+              - name: YMM embedded rounding removed from AVX10.2
+                href: core-libraries/10.0/ymm-embedded-rounding.md
           - name: .NET 9
             items:
               - name: Adding a ZipArchiveEntry sets header general-purpose bit flags
@@ -1736,6 +1750,8 @@ items:
                 href: deployment/7.0/x86-host-path.md
       - name: Entity Framework Core
         items:
+          - name: EF Core 10
+            href: /ef/core/what-is-new/ef-core-10.0/breaking-changes?toc=/dotnet/core/compatibility/toc.json&bc=/dotnet/breadcrumb/toc.json
           - name: EF Core 9
             href: /ef/core/what-is-new/ef-core-9.0/breaking-changes?toc=/dotnet/core/compatibility/toc.json&bc=/dotnet/breadcrumb/toc.json
           - name: EF Core 8


### PR DESCRIPTION
Fixes #46000

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/10.0.md](https://github.com/dotnet/docs/blob/ba1f1ca6dca6c78ac39f49a3fb80978739469ef3/docs/core/compatibility/10.0.md) | [Breaking changes in .NET 10](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/10.0?branch=pr-en-us-46598) |
| [docs/core/compatibility/core-libraries/10.0/ymm-embedded-rounding.md](https://github.com/dotnet/docs/blob/ba1f1ca6dca6c78ac39f49a3fb80978739469ef3/docs/core/compatibility/core-libraries/10.0/ymm-embedded-rounding.md) | [YMM embedded rounding removed from AVX10.2](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/10.0/ymm-embedded-rounding?branch=pr-en-us-46598) |
| [docs/core/compatibility/toc.yml](https://github.com/dotnet/docs/blob/ba1f1ca6dca6c78ac39f49a3fb80978739469ef3/docs/core/compatibility/toc.yml) | [docs/core/compatibility/toc](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/toc?branch=pr-en-us-46598) |


<!-- PREVIEW-TABLE-END -->