### PR TITLE
Correct code snippet in vector-search tutorial

### DIFF
--- a/docs/ai/tutorials/tutorial-ai-vector-search.md
+++ b/docs/ai/tutorials/tutorial-ai-vector-search.md
@@ -74,7 +74,7 @@ When you run the app for the first time, it connects to Azure Cosmos DB and repo
                 var jsonString= System.IO.File.ReadAllText(f);
                 Recipe recipe = JsonConvert.DeserializeObject<Recipe>(jsonString);
                 recipe.id = recipe.name.ToLower().Replace(" ", "");
-                ret.Add(recipe);
+                recipes.Add(recipe);
             }
         );
 


### PR DESCRIPTION
This PR fixes a typo in the C# code snippet found in the AI vector search tutorial (`tutorial-ai-vector-search.md`).

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/ai/tutorials/tutorial-ai-vector-search.md](https://github.com/dotnet/docs/blob/362b5a4cbfe85fdd4ae54c90f25c15a86248b7e6/docs/ai/tutorials/tutorial-ai-vector-search.md) | [docs/ai/tutorials/tutorial-ai-vector-search](https://review.learn.microsoft.com/en-us/dotnet/ai/tutorials/tutorial-ai-vector-search?branch=pr-en-us-46607) |

<!-- PREVIEW-TABLE-END -->