### PR TITLE
Mention DOTNET_ env vars in collect-dumps-crash.md

### DIFF
--- a/docs/core/diagnostics/collect-dumps-crash.md
+++ b/docs/core/diagnostics/collect-dumps-crash.md
@@ -12,16 +12,13 @@ The following table shows the environment variables you can configure for collec
 
 | Environment variable | Description | Default value |
 |----------------------|-------------|---------------|
-|`DOTNET_DbgEnableMiniDump` or `COMPlus_DbgEnableMiniDump`|If set to 1, enable core dump generation.|0|
-|`DOTNET_DbgMiniDumpType` or `COMPlus_DbgMiniDumpType`|Type of dump to be collected. For more information, see [Types of mini dumps](#types-of-mini-dumps).|2 (`Heap`)|
-|`DOTNET_DbgMiniDumpName` or `COMPlus_DbgMiniDumpName`|Path to a file to write the dump to. Ensure that the user under which the dotnet process is running has write permissions to the specified directory.|`/tmp/coredump.<pid>`|
-|`DOTNET_CreateDumpDiagnostics` or `COMPlus_CreateDumpDiagnostics`|If set to 1, enables diagnostic logging of dump process.|0|
-|`DOTNET_EnableCrashReport` or `COMPlus_EnableCrashReport`|(Requires .NET 6 or later; not supported on Windows.)<br/>If set to 1, the runtime generates a JSON-formatted crash report that includes information about the threads and stack frames of the crashing application. The crash report name is the dump path or name with *.crashreport.json* appended.| |
-|`DOTNET_CreateDumpVerboseDiagnostics` or `COMPlus_CreateDumpVerboseDiagnostics`|(Requires .NET 7 or later.)<br/>If set to 1, enables verbose diagnostic logging of the dump process.|0|
-|`DOTNET_CreateDumpLogToFile` or `COMPlus_CreateDumpLogToFile`|(Requires .NET 7 or later.)<br/>The path of the file to which the diagnostic messages should be written. | If unset, the diagnostic messages are written to the console of the crashing application. |
-
-> [!NOTE]
-> .NET 7 standardizes on the prefix `DOTNET_` instead of `COMPlus_` for these environment variables. However, the `COMPlus_` prefix will continue to work. If you're using a previous version of the .NET runtime, you should still use the `COMPlus_` prefix for environment variables.
+|`DOTNET_DbgEnableMiniDump`|If set to 1, enable core dump generation.|0|
+|`DOTNET_DbgMiniDumpType`|Type of dump to be collected. For more information, see [Types of mini dumps](#types-of-mini-dumps).|2 (`Heap`)|
+|`DOTNET_DbgMiniDumpName`|Path to a file to write the dump to. Ensure that the user under which the dotnet process is running has write permissions to the specified directory.|`/tmp/coredump.<pid>`|
+|`DOTNET_CreateDumpDiagnostics`|If set to 1, enables diagnostic logging of dump process.|0|
+|`DOTNET_EnableCrashReport`|(not supported on Windows.)<br/>If set to 1, the runtime generates a JSON-formatted crash report that includes information about the threads and stack frames of the crashing application. The crash report name is the dump path or name with *.crashreport.json* appended.| |
+|`DOTNET_CreateDumpVerboseDiagnostics`|If set to 1, enables verbose diagnostic logging of the dump process.|0|
+|`DOTNET_CreateDumpLogToFile`|The path of the file to which the diagnostic messages should be written. | If unset, the diagnostic messages are written to the console of the crashing application. |
 
 ## File path templates
 

--- a/docs/core/diagnostics/collect-dumps-crash.md
+++ b/docs/core/diagnostics/collect-dumps-crash.md
@@ -12,13 +12,13 @@ The following table shows the environment variables you can configure for collec
 
 | Environment variable | Description | Default value |
 |----------------------|-------------|---------------|
-|`COMPlus_DbgEnableMiniDump` or `DOTNET_DbgEnableMiniDump`|If set to 1, enable core dump generation.|0|
-|`COMPlus_DbgMiniDumpType` or `DOTNET_DbgMiniDumpType`|Type of dump to be collected. For more information, see [Types of mini dumps](#types-of-mini-dumps).|2 (`Heap`)|
-|`COMPlus_DbgMiniDumpName` or `DOTNET_DbgMiniDumpName`|Path to a file to write the dump to. Ensure that the user under which the dotnet process is running has write permissions to the specified directory.|`/tmp/coredump.<pid>`|
-|`COMPlus_CreateDumpDiagnostics` or `DOTNET_CreateDumpDiagnostics`|If set to 1, enables diagnostic logging of dump process.|0|
-|`COMPlus_EnableCrashReport` or `DOTNET_EnableCrashReport`|(Requires .NET 6 or later; not supported on Windows.)<br/>If set to 1, the runtime generates a JSON-formatted crash report that includes information about the threads and stack frames of the crashing application. The crash report name is the dump path or name with *.crashreport.json* appended.| |
-|`COMPlus_CreateDumpVerboseDiagnostics` or `DOTNET_CreateDumpVerboseDiagnostics`|(Requires .NET 7 or later.)<br/>If set to 1, enables verbose diagnostic logging of the dump process.|0|
-|`COMPlus_CreateDumpLogToFile` or `DOTNET_CreateDumpLogToFile`|(Requires .NET 7 or later.)<br/>The path of the file to which the diagnostic messages should be written. | If unset, the diagnostic messages are written to the console of the crashing application. |
+|`DOTNET_DbgEnableMiniDump` or `COMPlus_DbgEnableMiniDump`|If set to 1, enable core dump generation.|0|
+|`DOTNET_DbgMiniDumpType` or `COMPlus_DbgMiniDumpType`|Type of dump to be collected. For more information, see [Types of mini dumps](#types-of-mini-dumps).|2 (`Heap`)|
+|`DOTNET_DbgMiniDumpName` or `COMPlus_DbgMiniDumpName`|Path to a file to write the dump to. Ensure that the user under which the dotnet process is running has write permissions to the specified directory.|`/tmp/coredump.<pid>`|
+|`DOTNET_CreateDumpDiagnostics` or `COMPlus_CreateDumpDiagnostics`|If set to 1, enables diagnostic logging of dump process.|0|
+|`DOTNET_EnableCrashReport` or `COMPlus_EnableCrashReport`|(Requires .NET 6 or later; not supported on Windows.)<br/>If set to 1, the runtime generates a JSON-formatted crash report that includes information about the threads and stack frames of the crashing application. The crash report name is the dump path or name with *.crashreport.json* appended.| |
+|`DOTNET_CreateDumpVerboseDiagnostics` or `COMPlus_CreateDumpVerboseDiagnostics`|(Requires .NET 7 or later.)<br/>If set to 1, enables verbose diagnostic logging of the dump process.|0|
+|`DOTNET_CreateDumpLogToFile` or `COMPlus_CreateDumpLogToFile`|(Requires .NET 7 or later.)<br/>The path of the file to which the diagnostic messages should be written. | If unset, the diagnostic messages are written to the console of the crashing application. |
 
 > [!NOTE]
 > .NET 7 standardizes on the prefix `DOTNET_` instead of `COMPlus_` for these environment variables. However, the `COMPlus_` prefix will continue to work. If you're using a previous version of the .NET runtime, you should still use the `COMPlus_` prefix for environment variables.


### PR DESCRIPTION
Since .NET 7 the standardized prefix is `DOTNET_` so we should mention that variant.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/collect-dumps-crash.md](https://github.com/dotnet/docs/blob/2c8d071cd34db598de01dec2369ae92995322cb9/docs/core/diagnostics/collect-dumps-crash.md) | [docs/core/diagnostics/collect-dumps-crash](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/collect-dumps-crash?branch=pr-en-us-46788) |


<!-- PREVIEW-TABLE-END -->