### PR TITLE
Update linq/projection-operations-article/Zip section).md

### DIFF
--- a/docs/csharp/linq/standard-query-operators/projection-operations.md
+++ b/docs/csharp/linq/standard-query-operators/projection-operations.md
@@ -76,7 +76,7 @@ The third overload accepts a `Func<TFirst, TSecond, TResult>` argument that acts
 
 :::code source="./snippets/standard-query-operators/SelectProjectionExamples.cs" id="ZipResultSelector":::
 
-With the preceding `Zip` overload, the specified function is applied to the corresponding elements `numbers` and `letter`, producing a sequence of the `string` results.
+With the preceding `Zip` overload, the specified function is applied to the corresponding elements `number` and `letter`, producing a sequence of the `string` results.
 
 ## `Select` versus `SelectMany`
 


### PR DESCRIPTION
there is a typo issue , right below the last code snippet in the Zip section. In there, The word 'numbers' should be replaced with  word 'number'. The sentence is :

With the preceding Zip overload, the specified function is applied to the corresponding elements numbers and letter, producing a sequence of the string results.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/linq/standard-query-operators/projection-operations.md](https://github.com/dotnet/docs/blob/0e89b37f9afd396b658ecb0862e45a6eeef8584c/docs/csharp/linq/standard-query-operators/projection-operations.md) | [Projection operations (C#)](https://review.learn.microsoft.com/en-us/dotnet/csharp/linq/standard-query-operators/projection-operations?branch=pr-en-us-46792) |

<!-- PREVIEW-TABLE-END -->