### PR TITLE
Clarify variable name

### DIFF
--- a/docs/csharp/linq/standard-query-operators/snippets/standard-query-operators/SelectProjectionExamples.cs
+++ b/docs/csharp/linq/standard-query-operators/snippets/standard-query-operators/SelectProjectionExamples.cs
@@ -90,7 +90,7 @@ internal class SelectProjectionExamples
         // <SelectManyMethod>
         List<string> phrases = ["an apple a day", "the quick brown fox"];
 
-        var query = phrases.SelectMany(phrases => phrases.Split(' '));
+        var query = phrases.SelectMany(phrase => phrase.Split(' '));
 
         foreach (string s in query)
         {


### PR DESCRIPTION
Fixes #46793

The previous code worked, but this clarifies its use.
