### PR TITLE
Update docs for SRC.MemoryCache configuration element

### DIFF
--- a/docs/framework/configure-apps/file-schema/runtime/memorycache-element-cache-settings.md
+++ b/docs/framework/configure-apps/file-schema/runtime/memorycache-element-cache-settings.md
@@ -38,9 +38,9 @@ Defines an element that is used to configure a cache that is based on the <xref:
   
 |Attribute|Description|  
 |---------------|-----------------|  
-|`CacheMemoryLimitMegabytes`|The maximum memory size, in megabytes, that an instance of a <xref:System.Runtime.Caching.MemoryCache> object can grow to. The default value is 0, which means that the <xref:System.Runtime.Caching.MemoryCache> class's autosize heuristics are used by default.|  
+|`CacheMemoryLimitMegabytes`|The maximum memory size, in megabytes, that an instance of a <xref:System.Runtime.Caching.MemoryCache> object can grow to. The default value is 0, which means that the <xref:System.Runtime.Caching.MemoryCache> class's autosize heuristics are used by default. (This setting is only effective on .Net Framework.)|  
 |`Name`|The name of the cache configuration.|  
-|`PhysicalMemoryLimitPercentage`|The percentage of physical memory that can be used by the cache. The default value is 0, which means that the <xref:System.Runtime.Caching.MemoryCache> class's autosize heuristics are used by default.|  
+|`PhysicalMemoryLimitPercentage`|percentage of total physical memory usage on the system (by all processes) at which the cache will begin to evict entries. The default value is 0, which means that the <xref:System.Runtime.Caching.MemoryCache> class's autosize heuristics are used by default.|  
 |`PollingInterval`|A value that indicates the time interval after which the cache implementation compares the current memory load against the absolute and percentage-based memory limits that are set for the cache instance. The value is entered in "HH:MM:SS" format.|  
   
 ### Child Elements  


### PR DESCRIPTION
This pull request updates the documentation for cache settings in the .NET Framework, providing clearer descriptions for certain attributes in the `memorycache-element-cache-settings.md` file. This mirrors the updates we just made for the MemoryCache API in https://github.com/dotnet/dotnet-api-docs/pull/11375

Documentation updates:

* [`CacheMemoryLimitMegabytes`](diffhunk://#diff-5eff8229fd2932804c8042541f936270f907351601a09337cdaddfd5eed4d170L41-R43): Clarified that this setting is only effective on the .NET Framework.
* [`PhysicalMemoryLimitPercentage`](diffhunk://#diff-5eff8229fd2932804c8042541f936270f907351601a09337cdaddfd5eed4d170L41-R43): Updated the description to specify that the percentage refers to total physical memory usage by all processes, at which point the cache begins to evict entries.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/configure-apps/file-schema/runtime/memorycache-element-cache-settings.md](https://github.com/dotnet/docs/blob/f44ad8010d4245479076c9ce0f6b1f125a573e4c/docs/framework/configure-apps/file-schema/runtime/memorycache-element-cache-settings.md) | [docs/framework/configure-apps/file-schema/runtime/memorycache-element-cache-settings](https://review.learn.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/runtime/memorycache-element-cache-settings?branch=pr-en-us-46805) |

<!-- PREVIEW-TABLE-END -->