### PR TITLE
fix incorrect data typo in code example at cs0266.md

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs0266.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0266.md
@@ -23,7 +23,7 @@ class MyClass
     public static void Main()
     {
         // You cannot implicitly convert a double to an integer.
-        double d = 3.2;
+        int d = 3.2;
 
         // The following line causes compiler error CS0266.
         int i1 = d;


### PR DESCRIPTION
fix typo at `You cannot implicitly convert a double to an integer`.

I checked in the line, that now this line is trigger the CS0266 error.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-messages/cs0266.md](https://github.com/dotnet/docs/blob/16c50377688846274af7173dcfb57ca3f5498b12/docs/csharp/language-reference/compiler-messages/cs0266.md) | [Compiler Error CS0266](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0266?branch=pr-en-us-46806) |

<!-- PREVIEW-TABLE-END -->