### PR TITLE
Update C# linq-related snippet 'GroupQueryResults.cs'

### DIFF
--- a/docs/csharp/linq/standard-query-operators/snippets/standard-query-operators/GroupQueryResults.cs
+++ b/docs/csharp/linq/standard-query-operators/snippets/standard-query-operators/GroupQueryResults.cs
@@ -51,7 +51,7 @@ public class GroupQueryResults
     public static void GroupByPropertyMethod()
     {
         // <GroupByPropertyMethod>
-        // Variable groupByLastNamesQuery is an IEnumerable<IGrouping<string,
+        // Variable groupByYearQuery is an IEnumerable<IGrouping<GradeLevel,
         // DataClass.Student>>.
         var groupByYearQuery = students
             .GroupBy(student => student.Year)


### PR DESCRIPTION
Hi, First of all, thanks a lot for your efforts and your rich contents. In the first lines of 'GroupByPropertyMethod' method's body, which are  commented lines, the query variable name should be changed to GroupByYearQuery , and also the type of it should be modified to IEnumerable<IGrouping<GradeLevel,DataClass.Student>>.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
