### PR TITLE
Fix typo in Self-Describing Components page

### DIFF
--- a/docs/standard/metadata-and-self-describing-components.md
+++ b/docs/standard/metadata-and-self-describing-components.md
@@ -128,7 +128,7 @@ public class MyApp
 
 When the code runs, the runtime loads the module into memory and consults the metadata for this class. Once loaded, the runtime performs extensive analysis of the method's common intermediate language (CIL) stream to convert it to fast native machine instructions. The runtime uses a just-in-time (JIT) compiler to convert the CIL instructions to native machine code one method at a time as needed.
 
-The following example shows part of the CIL produced from the previous code's `Main` function. You can view the CIL and metadata from any .NET application using the [CIL Disassembler (Ildasm.exe)](../framework/tools/ildasm-exe-il-disassembler.md).
+The following example shows part of the CIL produced from the previous code's `Main` function. You can view the CIL and metadata from any .NET application using the [IL Disassembler (Ildasm.exe)](../framework/tools/ildasm-exe-il-disassembler.md).
 
 ```console
 .entrypoint


### PR DESCRIPTION
## Summary
Fixes #46818.
Fix typo error of IL Disassembler


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/metadata-and-self-describing-components.md](https://github.com/dotnet/docs/blob/27961be6a1c898c4b81603b87d81d919c64e1abc/docs/standard/metadata-and-self-describing-components.md) | [Metadata and Self-Describing Components](https://review.learn.microsoft.com/en-us/dotnet/standard/metadata-and-self-describing-components?branch=pr-en-us-46820) |

<!-- PREVIEW-TABLE-END -->