### PR TITLE
Update default enabled state for CA2025

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca2025.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2025.md
@@ -21,7 +21,7 @@ dev_langs:
 | **Title**                           | Do not pass 'IDisposable' instances into unawaited tasks |
 | **Category**                        | [Reliability](reliability-warnings.md)               |
 | **Fix is breaking or non-breaking** | Non-breaking                                         |
-| **Enabled by default in .NET 10**   | As warning                                           |
+| **Enabled by default in .NET 10**   | No                                                   |
 
 ## Cause
 


### PR DESCRIPTION
We make the new analyzer opt-in for now: https://github.com/dotnet/roslyn-analyzers/pull/7689



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca2025.md](https://github.com/dotnet/docs/blob/c54f195e921b6545a9f0547ee3ada99ecbef060f/docs/fundamentals/code-analysis/quality-rules/ca2025.md) | [docs/fundamentals/code-analysis/quality-rules/ca2025](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2025?branch=pr-en-us-46826) |

<!-- PREVIEW-TABLE-END -->