### PR TITLE
Add `--all` option to the dotnet tool update

### DIFF
--- a/docs/core/tools/dotnet-tool-update.md
+++ b/docs/core/tools/dotnet-tool-update.md
@@ -15,6 +15,7 @@ ms.date: 03/15/2024
 
 ```dotnetcli
 dotnet tool update <PACKAGE_ID> -g|--global
+    [--all]
     [--add-source <SOURCE>] [--allow-downgrade]
     [--configfile <FILE>]
     [--disable-parallel] [--framework <FRAMEWORK>]
@@ -23,6 +24,7 @@ dotnet tool update <PACKAGE_ID> -g|--global
     [-v|--verbosity <LEVEL>] [--version <VERSION>]
 
 dotnet tool update <PACKAGE_ID> --tool-path <PATH>
+    [--all]
     [--add-source <SOURCE>] [--allow-downgrade]
     [--configfile <FILE>]
     [--disable-parallel] [--framework <FRAMEWORK>]
@@ -31,6 +33,7 @@ dotnet tool update <PACKAGE_ID> --tool-path <PATH>
     [-v|--verbosity <LEVEL>] [--version <VERSION>]
 
 dotnet tool update <PACKAGE_ID> --local
+    [--all]
     [--add-source <SOURCE>] [--allow-downgrade]
     [--configfile <FILE>]
     [--disable-parallel] [--framework <FRAMEWORK>]
@@ -57,6 +60,10 @@ The `dotnet tool update` command provides a way for you to update .NET tools on 
   Name/ID of the NuGet package that contains the .NET global tool to update. You can find the package name using the [dotnet tool list](dotnet-tool-list.md) command.
 
 ## Options
+
+- **`--all`**
+
+  Update all tools.
 
 [!INCLUDE [add-source](../../../includes/cli-add-source.md)]
 

--- a/docs/core/tools/dotnet-tool-update.md
+++ b/docs/core/tools/dotnet-tool-update.md
@@ -15,8 +15,7 @@ ms.date: 03/15/2024
 
 ```dotnetcli
 dotnet tool update <PACKAGE_ID> -g|--global
-    [--all]
-    [--add-source <SOURCE>] [--allow-downgrade]
+    [--add-source <SOURCE>] [--all] [--allow-downgrade]
     [--configfile <FILE>]
     [--disable-parallel] [--framework <FRAMEWORK>]
     [--ignore-failed-sources] [--interactive]
@@ -24,8 +23,7 @@ dotnet tool update <PACKAGE_ID> -g|--global
     [-v|--verbosity <LEVEL>] [--version <VERSION>]
 
 dotnet tool update <PACKAGE_ID> --tool-path <PATH>
-    [--all]
-    [--add-source <SOURCE>] [--allow-downgrade]
+    [--add-source <SOURCE>] [--all] [--allow-downgrade]
     [--configfile <FILE>]
     [--disable-parallel] [--framework <FRAMEWORK>]
     [--ignore-failed-sources] [--interactive] 
@@ -33,8 +31,7 @@ dotnet tool update <PACKAGE_ID> --tool-path <PATH>
     [-v|--verbosity <LEVEL>] [--version <VERSION>]
 
 dotnet tool update <PACKAGE_ID> --local
-    [--all]
-    [--add-source <SOURCE>] [--allow-downgrade]
+    [--add-source <SOURCE>] [--all] [--allow-downgrade]
     [--configfile <FILE>]
     [--disable-parallel] [--framework <FRAMEWORK>]
     [--ignore-failed-sources] [--interactive]
@@ -61,11 +58,11 @@ The `dotnet tool update` command provides a way for you to update .NET tools on 
 
 ## Options
 
+[!INCLUDE [add-source](../../../includes/cli-add-source.md)]
+
 - **`--all`**
 
   Update all tools.
-
-[!INCLUDE [add-source](../../../includes/cli-add-source.md)]
 
 [!INCLUDE [allow-downgrade](../../../includes/cli-allow-downgrade.md)]
 


### PR DESCRIPTION
This pull request closes #46592 
It adds the `--all` option to the page of `dotnet tool update` as per suggestion in the issue.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-tool-update.md](https://github.com/dotnet/docs/blob/1d47401c2fb5cdba9dddcfa6e79dee8e33384bc1/docs/core/tools/dotnet-tool-update.md) | [dotnet tool update](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-update?branch=pr-en-us-46888) |


<!-- PREVIEW-TABLE-END -->