### PR TITLE
file-globbing: add docs for ordered pattern matching

### DIFF
--- a/docs/core/extensions/file-globbing.md
+++ b/docs/core/extensions/file-globbing.md
@@ -145,7 +145,7 @@ The additional `Match` overloads work in similar ways.
 
 By default, the matcher evaluates **all** include patterns first, then applies **all** exclude patterns, regardless of the order in which you added them. This means you can't re-include files that were previously excluded.
 
-Starting in version 10, you can opt into *ordered* evaluation, where includes and excludes are processed exactly in the sequence they were added:
+Starting in version 10 of the [📦 Microsoft.Extensions.FileSystemGlobbing package](https://www.nuget.org/packages/Microsoft.Extensions.FileSystemGlobbing), you can opt into *ordered* evaluation, where includes and excludes are processed exactly in the sequence they were added:
 
 ```csharp
 using Microsoft.Extensions.FileSystemGlobbing;

--- a/docs/core/extensions/file-globbing.md
+++ b/docs/core/extensions/file-globbing.md
@@ -145,7 +145,7 @@ The additional `Match` overloads work in similar ways.
 
 By default, the matcher evaluates **all** include patterns first, then applies **all** exclude patterns, regardless of the order in which you added them. This means you can't re-include files that were previously excluded.
 
-Starting in .NET 10, you can opt into *ordered* evaluation, where includes and excludes are processed exactly in the sequence they were added:
+Starting in version 10, you can opt into *ordered* evaluation, where includes and excludes are processed exactly in the sequence they were added:
 
 ```csharp
 using Microsoft.Extensions.FileSystemGlobbing;

--- a/docs/core/extensions/file-globbing.md
+++ b/docs/core/extensions/file-globbing.md
@@ -153,9 +153,9 @@ using Microsoft.Extensions.FileSystemGlobbing;
 // preserve the order of patterns when matching
 Matcher matcher = new(preserveFilterOrder: true);
 
-matcher.AddInclude("**/*");                                   // include everything
-matcher.AddExclude("logs/**/*");                              // exclude logs
-matcher.AddInclude("logs/important/**/*");                    // re-include important logs
+matcher.AddInclude("**/*");                // include everything
+matcher.AddExclude("logs/**/*");           // exclude logs
+matcher.AddInclude("logs/important/**/*"); // re-include important logs
 
 var result = matcher.Execute(new DirectoryInfoWrapper(new DirectoryInfo(root)));
 foreach (var file in result.Files)

--- a/docs/core/extensions/file-globbing.md
+++ b/docs/core/extensions/file-globbing.md
@@ -145,7 +145,7 @@ The additional `Match` overloads work in similar ways.
 
 By default, the matcher evaluates **all** include patterns first, then applies **all** exclude patterns—regardless of the order in which you added them. This means you cannot re-include files that were previously excluded.
 
-Starting in .NET 10, you can opt into *ordered* evaluation so that includes and excludes are processed exactly in the sequence they were added:
+Starting with version 10, you can opt into *ordered* evaluation so that includes and excludes are processed exactly in the sequence they were added:
 
 ```csharp
 using Microsoft.Extensions.FileSystemGlobbing;

--- a/docs/core/extensions/file-globbing.md
+++ b/docs/core/extensions/file-globbing.md
@@ -141,6 +141,36 @@ The preceding C# code:
 
 The additional `Match` overloads work in similar ways.
 
+### Ordered evaluation of include/exclude
+
+By default, the matcher evaluates **all** include patterns first, then applies **all** exclude patterns—regardless of the order in which you added them. This means you cannot re-include files that were previously excluded.
+
+Starting in .NET 10, you can opt into *ordered* evaluation so that includes and excludes are processed exactly in the sequence they were added:
+
+```csharp
+using Microsoft.Extensions.FileSystemGlobbing;
+
+// preserve the order of patterns when matching
+Matcher matcher = new(preserveFilterOrder: true);
+
+matcher.AddInclude("**/*");                                   // include everything
+matcher.AddExclude("logs/**/*");                              // exclude logs
+matcher.AddInclude("logs/important/**/*");                    // re-include important logs
+
+var result = matcher.Execute(new DirectoryInfoWrapper(new DirectoryInfo(root)));
+foreach (var file in result.Files)
+{
+    Console.WriteLine(file.Path);
+}
+```
+
+In this mode, patterns are applied one after another:  
+- `**/*` adds all files  
+- `logs/**/*` filters out anything in `logs/`  
+- `logs/important/**/*` adds back only files under `logs/important/`  
+
+Existing code that uses the default constructor will continue to run with the original “all includes, then all excludes” behavior.
+
 ## Pattern formats
 
 The patterns that are specified in the `AddExclude` and `AddInclude` methods can use the following formats to match multiple files or directories.

--- a/docs/core/extensions/file-globbing.md
+++ b/docs/core/extensions/file-globbing.md
@@ -143,14 +143,14 @@ The additional `Match` overloads work in similar ways.
 
 ### Ordered evaluation of include/exclude
 
-By default, the matcher evaluates **all** include patterns first, then applies **all** exclude patterns—regardless of the order in which you added them. This means you cannot re-include files that were previously excluded.
+By default, the matcher evaluates **all** include patterns first, then applies **all** exclude patterns, regardless of the order in which you added them. This means you can't re-include files that were previously excluded.
 
-Starting with version 10, you can opt into *ordered* evaluation so that includes and excludes are processed exactly in the sequence they were added:
+Starting in .NET 10, you can opt into *ordered* evaluation, where includes and excludes are processed exactly in the sequence they were added:
 
 ```csharp
 using Microsoft.Extensions.FileSystemGlobbing;
 
-// preserve the order of patterns when matching
+// Preserve the order of patterns when matching.
 Matcher matcher = new(preserveFilterOrder: true);
 
 matcher.AddInclude("**/*");                // include everything
@@ -165,11 +165,12 @@ foreach (var file in result.Files)
 ```
 
 In this mode, patterns are applied one after another:  
-- `**/*` adds all files  
-- `logs/**/*` filters out anything in `logs/`  
-- `logs/important/**/*` adds back only files under `logs/important/`  
 
-Existing code that uses the default constructor will continue to run with the original “all includes, then all excludes” behavior.
+- `**/*` adds all files.
+- `logs/**/*` filters out anything in `logs/`.
+- `logs/important/**/*` adds back only files under `logs/important/`.
+
+Existing code that uses the default constructor will continue to run with the original "all includes, then all excludes" behavior.
 
 ## Pattern formats
 


### PR DESCRIPTION
Explain how preserveFilterOrder enables ordered evaluation of include and exclude patterns in Matcher. Add example to illustrate re-including files previously excluded. Default behavior remains unchanged.

See dotnet/runtime#109408 for feature details.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/file-globbing.md](https://github.com/dotnet/docs/blob/0fd3b15399772a7fbcd3af71c59080e443afdb87/docs/core/extensions/file-globbing.md) | [File globbing in .NET](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/file-globbing?branch=pr-en-us-46913) |


<!-- PREVIEW-TABLE-END -->