### PR TITLE
Fix typo 'earch' to 'search' in TOC entry

### DIFF
--- a/docs/navigate/tools-diagnostics/toc.yml
+++ b/docs/navigate/tools-diagnostics/toc.yml
@@ -180,7 +180,7 @@ items:
                 href: ../../core/tools/dotnet-nuget-config-paths.md
           - name: dotnet pack
             href: ../../core/tools/dotnet-pack.md
-          - name: dotnet package add/list/remove/earch
+          - name: dotnet package add/list/remove/search
             items:
               - name: dotnet package add
                 href: ../../core/tools/dotnet-package-add.md


### PR DESCRIPTION
## Summary

Fix typo in the Table of Contents for the dotnet package documentation. Changed "earch" to "search" in docs/navigate/tools-diagnostics/toc.yml.

Fixes #46907

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/navigate/tools-diagnostics/toc.yml](https://github.com/dotnet/docs/blob/1784ae36134e2b212358c042295ae58cc197bf11/docs/navigate/tools-diagnostics/toc.yml) | [docs/navigate/tools-diagnostics/toc](https://review.learn.microsoft.com/en-us/dotnet/navigate/tools-diagnostics/toc?branch=pr-en-us-46914) |

<!-- PREVIEW-TABLE-END -->