### PR TITLE
Fix left outer join - null reference exception issue

### DIFF
--- a/docs/csharp/linq/standard-query-operators/snippets/standard-query-operators/LeftOuterJoins.cs
+++ b/docs/csharp/linq/standard-query-operators/snippets/standard-query-operators/LeftOuterJoins.cs
@@ -48,7 +48,7 @@ public class LeftOuterJoins
                 {
                     student.student.FirstName,
                     student.student.LastName,
-                    Department = department.Name
+                    Department = department?.Name ?? string.Empty
                 });
 
         foreach (var v in query)


### PR DESCRIPTION
## Summary

Added the null conditional operator and the null-coalescing operator similarly to what is presented in the query syntax in order to prevent the snippet from throwing a null reference exception when a student is assigned to a department that does not exist.

Fixes #46938