### PR TITLE
Fix misspelling end tag

### DIFF
--- a/docs/csharp/advanced-topics/interop/walkthrough-creating-and-using-dynamic-objects.md
+++ b/docs/csharp/advanced-topics/interop/walkthrough-creating-and-using-dynamic-objects.md
@@ -94,7 +94,7 @@ In **Solution Explorer**, double-click the *Program.cs* file. Add the following 
 
 :::code language="csharp" source="./snippets/dynamic-walkthrough/program.cs" id="Snippet8":::
 
-Save the file and press <kbd>Ctrl</kdb>+<kbd>F5</kbd> to build and run the application.
+Save the file and press <kbd>Ctrl</kbd>+<kbd>F5</kbd> to build and run the application.
 
 ## Call a dynamic language library
 
@@ -114,7 +114,7 @@ After the code to load the random.py module, add the following code to create an
 
 :::code language="csharp" source="./snippets/dynamic-iron-python-walkthrough/program.cs" id="Snippet3":::
 
-Save the file and press <kbd>Ctrl</kdb>+<kbd>F5</kbd> to build and run the application.
+Save the file and press <kbd>Ctrl</kbd>+<kbd>F5</kbd> to build and run the application.
 
 ## See also
 


### PR DESCRIPTION
## Summary

This is to fix a misspelling HTML end tag (should be kbd instead of kdb)

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/advanced-topics/interop/walkthrough-creating-and-using-dynamic-objects.md](https://github.com/dotnet/docs/blob/92e91f51ed834f9e63faccdcb0bdcd9029f4084a/docs/csharp/advanced-topics/interop/walkthrough-creating-and-using-dynamic-objects.md) | [Walkthrough: Creating and Using Dynamic Objects in C\#](https://review.learn.microsoft.com/en-us/dotnet/csharp/advanced-topics/interop/walkthrough-creating-and-using-dynamic-objects?branch=pr-en-us-46940) |

<!-- PREVIEW-TABLE-END -->