### PR TITLE
Use new ASP.NET Core environment variable

### DIFF
--- a/docs/orleans/deployment/kubernetes.md
+++ b/docs/orleans/deployment/kubernetes.md
@@ -99,7 +99,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          - name: DOTNET_SHUTDOWNTIMEOUTSECONDS
+          - name: ASPNETCORE_SHUTDOWNTIMEOUTSECONDS # See .NET Generic Host in ASP.NET Core ShutdownTimeout https://learn.microsoft.com/en-us/aspnet/core/fundamentals/host/generic-host?view=aspnetcore-9.0#shutdowntimeout
             value: "120"
           request:
             # Set resource requests


### PR DESCRIPTION
Just found that it is necessary to update Orleans doc Kubernetes hosting - .NET | Microsoft Learn It sets old .NET Framework environment variable DOTNET_SHUTDOWNTIMEOUTSECONDS Please see https://learn.microsoft.com/en-us/aspnet/core/fundamentals/host/generic-host?view=aspnetcore-9.0#settings-for-all-app-types

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/deployment/kubernetes.md](https://github.com/dotnet/docs/blob/601ca8029dd494d2941c1266dacc68a9fb8d835b/docs/orleans/deployment/kubernetes.md) | [Kubernetes hosting](https://review.learn.microsoft.com/en-us/dotnet/orleans/deployment/kubernetes?branch=pr-en-us-47039) |

<!-- PREVIEW-TABLE-END -->