### PR TITLE
Clarify DOTNET_ROOT documentation

### DIFF
--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -206,7 +206,7 @@ These environment variables are used only when running apps via generated execut
         -  `DOTNET_ROOT_ARM64` is used for an arm64 process
         -  `DOTNET_ROOT_X64`  is used for an x64 process. This may be running on x64 or arm64 architecture.
         - `DOTNET_ROOT_X86`  is used for an x86 process. This may be running on x86 or x64 architecture.
-2. If running 32-bit executable on 64-bit OS, `DOTNET_ROOT(x86)` is considered.
+2. `DOTNET_ROOT(x86)` is used when running 32-bit process on 64-bit Windows. In other cases this environment variable is ignored.
 3. `DOTNET_ROOT` is used as a fallback.
 
 ### `DOTNET_HOST_PATH`

--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -202,7 +202,10 @@ Specifies the location of the .NET runtimes, if they are not installed in the de
 These environment variables are used only when running apps via generated executables (apphosts). The order in which the environment variables are considered is:
 
 1. `DOTNET_ROOT_<ARCH>`, where `<ARCH>` is the architecture of the running executable (apphost).
-    - For example, if running 64-bit executable on ARM64 OS or 64-bit OS, `DOTNET_ROOT_X64` is used. 
+    - For example: 
+        -  `DOTNET_ROOT_ARM64` is used for an arm64 process
+        -  `DOTNET_ROOT_X64`  is used for an x64 process. This may be running on x64 or arm64 architecture.
+        - `DOTNET_ROOT_X86`  is used for an x86 process. This may be running on x86 or x64 architecture.
 2. If running 32-bit executable on 64-bit OS, `DOTNET_ROOT(x86)` is considered.
 3. `DOTNET_ROOT` is used as a fallback.
 

--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -199,7 +199,10 @@ Specifies the location of the .NET runtimes, if they are not installed in the de
 - GitHub issue [dotnet/core#7699](https://github.com/dotnet/core/issues/7699)
 - GitHub issue [dotnet/runtime#79237](https://github.com/dotnet/runtime/issues/79237)
 
-This environment variable is used only when running apps via generated executables (apphosts). `DOTNET_ROOT(x86)` is used instead when running a 32-bit executable on a 64-bit OS. `DOTNET_ROOT_X64` is used instead when running a 64-bit executable on an ARM64 OS.
+This environment variable is used only when running apps via generated executables (apphosts).
+
+- If running 64-bit executable on either ARM64 OS or 64-bit OS, `DOTNET_ROOT_X64` is used first, and if not set, `DOTNET_ROOT` is used instead.
+- If running 32-bit executable on either 64-bit OS or 32-bit OS, `DOTNET_ROOT_X86` is used first. Then, `DOTNET_ROOT(x86)` is considered only under 64-bit OS. Then, `DOTNET_ROOT` is used.
 
 ### `DOTNET_HOST_PATH`
 

--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -202,7 +202,7 @@ Specifies the location of the .NET runtimes, if they are not installed in the de
 These environment variables are used only when running apps via generated executables (apphosts). The order in which the environment variables are considered is:
 
 1. `DOTNET_ROOT_<ARCH>`, where `<ARCH>` is the architecture of the running executable (apphost).
-    - For example: 
+    - For example:
         - `DOTNET_ROOT_ARM64` is used for an arm64 process.
         - `DOTNET_ROOT_X64` is used for an x64 process. This may be running on x64 or arm64 architecture.
         - `DOTNET_ROOT_X86` is used for an x86 process. This may be running on x86 or x64 architecture.

--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -203,7 +203,7 @@ These environment variables are used only when running apps via generated execut
 
 1. `DOTNET_ROOT_<ARCH>`, where `<ARCH>` is the architecture of the running executable (apphost).
     - For example: 
-        - `DOTNET_ROOT_ARM64` is used for an arm64 process
+        - `DOTNET_ROOT_ARM64` is used for an arm64 process.
         - `DOTNET_ROOT_X64` is used for an x64 process. This may be running on x64 or arm64 architecture.
         - `DOTNET_ROOT_X86` is used for an x86 process. This may be running on x86 or x64 architecture.
 2. `DOTNET_ROOT(x86)` is used when running 32-bit process on 64-bit Windows. In other cases this environment variable is ignored.

--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -207,7 +207,7 @@ These environment variables are used only when running apps via generated execut
         -  `DOTNET_ROOT_X64`  is used for an x64 process. This may be running on x64 or arm64 architecture.
         - `DOTNET_ROOT_X86`  is used for an x86 process. This may be running on x86 or x64 architecture.
 2. `DOTNET_ROOT(x86)` is used when running 32-bit process on 64-bit Windows. In other cases this environment variable is ignored.
-3. `DOTNET_ROOT` is used as a fallback.
+3. `DOTNET_ROOT`
 
 ### `DOTNET_HOST_PATH`
 

--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -203,9 +203,9 @@ These environment variables are used only when running apps via generated execut
 
 1. `DOTNET_ROOT_<ARCH>`, where `<ARCH>` is the architecture of the running executable (apphost).
     - For example: 
-        -  `DOTNET_ROOT_ARM64` is used for an arm64 process
-        -  `DOTNET_ROOT_X64`  is used for an x64 process. This may be running on x64 or arm64 architecture.
-        - `DOTNET_ROOT_X86`  is used for an x86 process. This may be running on x86 or x64 architecture.
+        - `DOTNET_ROOT_ARM64` is used for an arm64 process
+        - `DOTNET_ROOT_X64` is used for an x64 process. This may be running on x64 or arm64 architecture.
+        - `DOTNET_ROOT_X86` is used for an x86 process. This may be running on x86 or x64 architecture.
 2. `DOTNET_ROOT(x86)` is used when running 32-bit process on 64-bit Windows. In other cases this environment variable is ignored.
 3. `DOTNET_ROOT`
 

--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -199,10 +199,12 @@ Specifies the location of the .NET runtimes, if they are not installed in the de
 - GitHub issue [dotnet/core#7699](https://github.com/dotnet/core/issues/7699)
 - GitHub issue [dotnet/runtime#79237](https://github.com/dotnet/runtime/issues/79237)
 
-This environment variable is used only when running apps via generated executables (apphosts).
+These environment variables are used only when running apps via generated executables (apphosts). The order in which the environment variables are considered is:
 
-- If running 64-bit executable on either ARM64 OS or 64-bit OS, `DOTNET_ROOT_X64` is used first, and if not set, `DOTNET_ROOT` is used instead.
-- If running 32-bit executable on either 64-bit OS or 32-bit OS, `DOTNET_ROOT_X86` is used first. Then, `DOTNET_ROOT(x86)` is considered only under 64-bit OS. Then, `DOTNET_ROOT` is used.
+1. `DOTNET_ROOT_<ARCH>`, where `<ARCH>` is the architecture of the running executable (apphost).
+    - For example, if running 64-bit executable on ARM64 OS or 64-bit OS, `DOTNET_ROOT_X64` is used. 
+2. If running 32-bit executable on 64-bit OS, `DOTNET_ROOT(x86)` is considered.
+3. `DOTNET_ROOT` is used as a fallback.
 
 ### `DOTNET_HOST_PATH`
 

--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -206,7 +206,7 @@ These environment variables are used only when running apps via generated execut
         - `DOTNET_ROOT_ARM64` is used for an arm64 process.
         - `DOTNET_ROOT_X64` is used for an x64 process. This may be running on x64 or arm64 architecture.
         - `DOTNET_ROOT_X86` is used for an x86 process. This may be running on x86 or x64 architecture.
-2. `DOTNET_ROOT(x86)` is used when running 32-bit process on 64-bit Windows. In other cases this environment variable is ignored.
+2. `DOTNET_ROOT(x86)` is used when a 32-bit process is running on 64-bit Windows. In other cases, this environment variable is ignored.
 3. `DOTNET_ROOT`
 
 ### `DOTNET_HOST_PATH`

--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -202,7 +202,7 @@ Specifies the location of the .NET runtimes, if they are not installed in the de
 These environment variables are used only when running apps via generated executables (apphosts). The order in which the environment variables are considered is:
 
 1. `DOTNET_ROOT_<ARCH>`, where `<ARCH>` is the architecture of the running executable (apphost).
-    - For example:
+   For example:
         - `DOTNET_ROOT_ARM64` is used for an arm64 process.
         - `DOTNET_ROOT_X64` is used for an x64 process. This may be running on x64 or arm64 architecture.
         - `DOTNET_ROOT_X86` is used for an x86 process. This may be running on x86 or x64 architecture.

--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -203,9 +203,9 @@ These environment variables are used only when running apps via generated execut
 
 1. `DOTNET_ROOT_<ARCH>`, where `<ARCH>` is the architecture of the running executable (apphost).
    For example:
-        - `DOTNET_ROOT_ARM64` is used for an arm64 process.
-        - `DOTNET_ROOT_X64` is used for an x64 process. This may be running on x64 or arm64 architecture.
-        - `DOTNET_ROOT_X86` is used for an x86 process. This may be running on x86 or x64 architecture.
+     - `DOTNET_ROOT_ARM64` is used for an Arm64 process.
+     - `DOTNET_ROOT_X64` is used for an x64 process. This process might be running on x64 or Arm64 architecture.
+     - `DOTNET_ROOT_X86` is used for an x86 process. This process might be running on x86 or x64 architecture.
 2. `DOTNET_ROOT(x86)` is used when a 32-bit process is running on 64-bit Windows. In other cases, this environment variable is ignored.
 3. `DOTNET_ROOT`
 

--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -207,7 +207,7 @@ These environment variables are used only when running apps via generated execut
      - `DOTNET_ROOT_X64` is used for an x64 process. This process might be running on x64 or Arm64 architecture.
      - `DOTNET_ROOT_X86` is used for an x86 process. This process might be running on x86 or x64 architecture.
 2. `DOTNET_ROOT(x86)` is used when a 32-bit process is running on 64-bit Windows. In other cases, this environment variable is ignored.
-3. `DOTNET_ROOT`
+3. `DOTNET_ROOT`.
 
 ### `DOTNET_HOST_PATH`
 


### PR DESCRIPTION
@elinor-fung @agocke Can you please confirm if the suggested changes are accurate? I think the existing documentation is misleading because it indicates that `DOTNET_ROOT_X64` is only used under ARM64 OS, which doesn't seem to be the case per the implementation [here](https://github.com/dotnet/runtime/blob/f77f791953e7e8af4bd1ce33981a9059f4c9f207/src/native/corehost/hostmisc/utils.cpp#L360-L362)

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-environment-variables.md](https://github.com/dotnet/docs/blob/8e9e8ef10d809dafad1dc7a2b46a6826d1506adc/docs/core/tools/dotnet-environment-variables.md) | [docs/core/tools/dotnet-environment-variables](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables?branch=pr-en-us-47059) |


<!-- PREVIEW-TABLE-END -->