### PR TITLE
Add an example of using `UnscopedRefAttribute` to fix CS8170

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs8170.md
+++ b/docs/csharp/language-reference/compiler-messages/cs8170.md
@@ -83,3 +83,30 @@ public class Other
     }
 }
 ```
+
+Another approach is to use the <xref:System.Diagnostics.CodeAnalysis.UnscopedRefAttribute?displayProperty=nameWithType> attribute. It will mark the reference to be allowed to escape the scope.
+Below is the example of applying <xref:System.Diagnostics.CodeAnalysis.UnscopedRefAttribute?displayProperty=nameWithType> to `int M()` method, which fixes the CS8170:
+
+```csharp
+using System.Diagnostics.CodeAnalysis;
+
+struct Program
+{
+    public int d;
+
+    [UnscopedRef]
+    public ref int M()
+    {
+        return ref d;    // No error - ref is valid to escape the scope in this line of that method
+    }
+}
+
+public class Other
+{
+    public void Method()
+    {
+        var p = new Program();
+        var d = p.M();
+    }
+}
+```

--- a/docs/csharp/language-reference/compiler-messages/cs8170.md
+++ b/docs/csharp/language-reference/compiler-messages/cs8170.md
@@ -84,7 +84,8 @@ public class Other
 }
 ```
 
-Another approach is to use the <xref:System.Diagnostics.CodeAnalysis.UnscopedRefAttribute?displayProperty=nameWithType> attribute. It will mark the reference to be allowed to escape the scope.
+Another approach is to use the <xref:System.Diagnostics.CodeAnalysis.UnscopedRefAttribute?displayProperty=nameWithType> attribute. It will mark the reference to be allowed to escape the scope.<br/>
+Use this only when you know that it is safe for the reference to leave the scope.
 Below is the example of applying <xref:System.Diagnostics.CodeAnalysis.UnscopedRefAttribute?displayProperty=nameWithType> to `int M()` method, which fixes the CS8170:
 
 ```csharp

--- a/docs/csharp/language-reference/compiler-messages/cs8170.md
+++ b/docs/csharp/language-reference/compiler-messages/cs8170.md
@@ -35,7 +35,7 @@ public class Other
     public void Method()
     {
         var p = new Program();
-        var d = p.M();
+        ref int d = ref p.M();
     }
 }
 ```
@@ -106,7 +106,7 @@ public class Other
     public void Method()
     {
         var p = new Program();
-        var d = p.M();
+        ref int d = ref p.M();
     }
 }
 ```


### PR DESCRIPTION
This pull request fixes #46499 
It adds the example of how `UnscopedRefAttribute` can be used to mark a method through which a ref is allowed to escape the scope.

I didn't add the "See also" section with a link to this attribute, because it is already linked twice when mentioned.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-messages/cs8170.md](https://github.com/dotnet/docs/blob/5cb6f63abdaf61e2172bc4eb5f6847d984d6c98a/docs/csharp/language-reference/compiler-messages/cs8170.md) | [Compiler Error CS8170](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs8170?branch=pr-en-us-47078) |


<!-- PREVIEW-TABLE-END -->