### PR TITLE
Fix property value errors

### DIFF
--- a/docs/core/deploying/deploy-with-cli.md
+++ b/docs/core/deploying/deploy-with-cli.md
@@ -137,7 +137,7 @@ In .NET 9 and later versions, you can configure the .NET installation search pat
 
 - `AppLocal`: app executable's folder
 - `AppRelative`: path relative to the app executable
-- `EnvironmentVariables`: value of [`DOTNET_ROOT[_<arch>]`](../tools/dotnet-environment-variables.md#dotnet_root-dotnet_rootx86-dotnet_root_x86-dotnet_root_x64) environment variables
+- `EnvironmentVariable`: value of [`DOTNET_ROOT[_<arch>]`](../tools/dotnet-environment-variables.md#dotnet_root-dotnet_rootx86-dotnet_root_x86-dotnet_root_x64) environment variables
 - `Global`: [registered](https://github.com/dotnet/designs/blob/main/accepted/2020/install-locations.md#global-install-to-custom-location) and [default](https://github.com/dotnet/designs/blob/main/accepted/2020/install-locations.md#global-install-to-default-location) global install locations
 
 `AppHostRelativeDotNet` specifies the path relative to the executable that will be searched when `AppHostDotNetSearch` contains `AppRelative`.

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -1628,7 +1628,7 @@ The following table lists valid values. You can specify multiple values, separat
 | --- | --- |
 | `AppLocal` | App executable's folder |
 | `AppRelative` | Path relative to the app executable as specified by [AppHostRelativeDotNet](#apphostrelativedotnet) |
-| `EnvironmentVariables` | Value of [`DOTNET_ROOT[_<arch>]`](../tools/dotnet-environment-variables.md#dotnet_root-dotnet_rootx86-dotnet_root_x86-dotnet_root_x64) environment variables |
+| `EnvironmentVariable` | Value of [`DOTNET_ROOT[_<arch>]`](../tools/dotnet-environment-variables.md#dotnet_root-dotnet_rootx86-dotnet_root_x86-dotnet_root_x64) environment variables |
 | `Global` | [Registered](https://github.com/dotnet/designs/blob/main/accepted/2020/install-locations.md#global-install-to-custom-location) and [default](https://github.com/dotnet/designs/blob/main/accepted/2020/install-locations.md#global-install-to-default-location) global install locations |
 
 This property was introduced in .NET 9.


### PR DESCRIPTION
## Summary

The argument in AppHostDotNetSearch should be `EnvironmentVariable` not `EnvironmentVariables`.

Fixes https://github.com/dotnet/docs/issues/47081

Reference: https://github.com/dotnet/docs/pull/42397

Cc @elinor-fung

See https://github.com/dotnet/runtime/blob/2548aa0f5fe0bfe12fc0acec0efb1e92d1f00182/src/installer/managed/Microsoft.NET.HostModel/AppHost/HostWriter.cs#L42-L50


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/deploying/deploy-with-cli.md](https://github.com/dotnet/docs/blob/c5286bceb14b8b139f6074bcf299e639ce8da012/docs/core/deploying/deploy-with-cli.md) | [Publish .NET apps with the .NET CLI](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/deploy-with-cli?branch=pr-en-us-47082) |
| [docs/core/project-sdk/msbuild-props.md](https://github.com/dotnet/docs/blob/c5286bceb14b8b139f6074bcf299e639ce8da012/docs/core/project-sdk/msbuild-props.md) | [MSBuild properties for Microsoft.NET.Sdk](https://review.learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props?branch=pr-en-us-47082) |


<!-- PREVIEW-TABLE-END -->