### PR TITLE
Correct the typo of `list` instead of `dry-run` in `dotnet core uninstall` command

### DIFF
--- a/docs/core/additional-tools/uninstall-tool-cli-dry-run.md
+++ b/docs/core/additional-tools/uninstall-tool-cli-dry-run.md
@@ -49,7 +49,7 @@ dotnet-core-uninstall dry-run -h|--help|-?
 
 ## Description
 
-The `dotnet-core-uninstall list` command simulates .NET SDK and runtime removal. A status output is provided for each .NET SDK and runtime that would have been removed by the tool.
+The `dotnet-core-uninstall dry-run` command simulates .NET SDK and runtime removal. A status output is provided for each .NET SDK and runtime that would have been removed by the tool.
 
 ### Arguments
 


### PR DESCRIPTION
## Summary

This small pull request fixes #47048 
It replaces the `list` with `dry-run` in the article to match what this article is about.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/additional-tools/uninstall-tool-cli-dry-run.md](https://github.com/dotnet/docs/blob/a02e9323c91ea27cdba82409bff90aa157c6999c/docs/core/additional-tools/uninstall-tool-cli-dry-run.md) | [dotnet-core-uninstall dry-run](https://review.learn.microsoft.com/en-us/dotnet/core/additional-tools/uninstall-tool-cli-dry-run?branch=pr-en-us-47098) |

<!-- PREVIEW-TABLE-END -->