### PR TITLE
dotnet dump docs: mention Triage dump type

### DIFF
--- a/docs/core/diagnostics/dotnet-dump.md
+++ b/docs/core/diagnostics/dotnet-dump.md
@@ -94,7 +94,8 @@ dotnet-dump collect [-h|--help] [-p|--process-id] [-n|--name] [--type] [-o|--out
 
   - `Full` - The largest dump containing all memory including the module images.
   - `Heap` - A large and relatively comprehensive dump containing module lists, thread lists, all stacks, exception information, handle information, and all memory except for mapped images.
-  - `Mini` - A small dump containing module lists, thread lists, exception information, and all stacks.
+  - `Mini` - A small dump containing module lists, thread lists, exception information and all stacks.
+  - `Triage` - A small dump containing module lists, thread lists, exception information, all stacks and PII removed.
 
   If not specified, `Full` is the default.
 

--- a/docs/core/diagnostics/dotnet-dump.md
+++ b/docs/core/diagnostics/dotnet-dump.md
@@ -94,8 +94,8 @@ dotnet-dump collect [-h|--help] [-p|--process-id] [-n|--name] [--type] [-o|--out
 
   - `Full` - The largest dump containing all memory including the module images.
   - `Heap` - A large and relatively comprehensive dump containing module lists, thread lists, all stacks, exception information, handle information, and all memory except for mapped images.
-  - `Mini` - A small dump containing module lists, thread lists, exception information and all stacks.
-  - `Triage` - A small dump containing module lists, thread lists, exception information, all stacks and PII removed.
+  - `Mini` - A small dump containing module lists, thread lists, exception information, and all stacks.
+  - `Triage` - A small dump containing module lists, thread lists, exception information, all stacks, and PII removed.
 
   If not specified, `Full` is the default.
 


### PR DESCRIPTION
## Summary

Add the `Triage` dump type to the dotnet dump docs page with the help text as shown in the CLI.

Fixes #47106

```
❯ dotnet dump collect -h
Description:
  Capture dumps from a process

Usage:
  dotnet-dump collect [options]

Options:
  -p, --process-id                The process id to collect a memory dump.
  -o, --output                    The path where collected dumps should be written. Defaults to
                                  '.\dump_YYYYMMDD_HHMMSS.dmp' on Windows and './core_YYYYMMDD_HHMMSS'
                                  on Linux where YYYYMMDD is Year/Month/Day and HHMMSS is Hour/Minute/Second.
                                  Otherwise, it is the full path and file name of the dump.
  --diag                          Enable dump collection diagnostic logging.
  --crashreport                   Enable crash report generation.
  --type <Full|Heap|Mini|Triage>  The dump type determines the kinds of information that are collected from the
                                  process. There are several types: Full - The largest dump containing all memory
                                  including the module images. Heap - A large and relatively comprehensive dump
                                  containing module lists, thread lists, all stacks, exception information, handle
                                  information, and all memory except for mapped images. Mini - A small dump containing
                                  module lists, thread lists, exception information and all stacks. Triage - A small
                                  dump containing module lists, thread lists, exception information, all stacks and PII
                                  removed. [default: Full]
  -n, --name                      The name of the process to collect a memory dump.
  --diagnostic-port, --dport      The path to a diagnostic port to be used. Must be a runtime connect port.
  -?, -h, --help                  Show help and usage information
```

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/dotnet-dump.md](https://github.com/dotnet/docs/blob/8c3b7a7df98ce0d9ddec9fbb58cec091d840e588/docs/core/diagnostics/dotnet-dump.md) | [Dump collection and analysis utility (dotnet-dump)](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-dump?branch=pr-en-us-47107) |


<!-- PREVIEW-TABLE-END -->