### PR TITLE
Correct type reference in sentence of IHttpClientFactory with .NET documentation

### DIFF
--- a/docs/core/extensions/httpclient-factory.md
+++ b/docs/core/extensions/httpclient-factory.md
@@ -221,7 +221,7 @@ An <xref:Microsoft.Extensions.DependencyInjection.IHttpClientBuilder> is returne
 
 :::code source="snippets/http/configurehandler/Program.cs" id="configurehandler":::
 
-Configuring the `HttClientHandler` lets you specify a proxy for the `HttpClient` instance among various other properties of the handler. For more information, see [Proxy per client](../../fundamentals/networking/http/httpclient.md#configure-an-http-proxy).
+Configuring the `HttpClientHandler` lets you specify a proxy for the `HttpClient` instance among various other properties of the handler. For more information, see [Proxy per client](../../fundamentals/networking/http/httpclient.md#configure-an-http-proxy).
 
 ### Additional configuration
 


### PR DESCRIPTION
Change type name to `HttpClientHandler` from `HttClientHandler`.

## Summary

Update to intended type name `HttpClientHandler` (erroneously referenced as `HttClientHandler`) related to ‘HttpClient` configuration in the sentence after the related code snippet.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/httpclient-factory.md](https://github.com/dotnet/docs/blob/ddb3f869387bc15898ace776874cc4146c00114c/docs/core/extensions/httpclient-factory.md) | [IHttpClientFactory with .NET](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/httpclient-factory?branch=pr-en-us-47110) |

<!-- PREVIEW-TABLE-END -->