### PR TITLE
Fix the link for the `dotnet-tools-list` in the dotnet tools page

### DIFF
--- a/docs/core/tools/dotnet.md
+++ b/docs/core/tools/dotnet.md
@@ -195,7 +195,7 @@ The following options are available only when `dotnet` runs an application by us
 | Command                                           | Function                      |
 |---------------------------------------------------|-------------------------------|
 | [dotnet package add](dotnet-package-add.md)       | Adds a NuGet package.         |
-| [dotnet package list](dotnet-package-add.md)      | Lists NuGet packages.         |
+| [dotnet package list](dotnet-package-list.md)     | Lists NuGet packages.         |
 | [dotnet package remove](dotnet-package-remove.md) | Removes a NuGet package.      |
 | [dotnet package search](dotnet-package-search.md) | Searches for a NuGet package. |
 


### PR DESCRIPTION
## Summary

This small pull request fixes #47099 by correcting the link to the `dotnet-tools-list` page.
All other references and links seems to be fine 👍 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet.md](https://github.com/dotnet/docs/blob/2589b283860afba796f073f7924d59858f02c564/docs/core/tools/dotnet.md) | [dotnet command](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet?branch=pr-en-us-47111) |

<!-- PREVIEW-TABLE-END -->