### PR TITLE
Clarify shebang requirement for running C# files directly on Unix systems.

### DIFF
--- a/docs/csharp/tour-of-csharp/overview.md
+++ b/docs/csharp/tour-of-csharp/overview.md
@@ -42,7 +42,7 @@ Beginning with C# 14 and .NET 10, you can create *file based programs*, which si
 
 :::code language="csharp" source="./snippets/file-based-programs/hello-world.cs":::
 
-The first line of the program contains the `#!` sequence for unix shells. The location of the `dotnet` CLI can vary on different distributions. On any unix system, if you set the *execute* (`+x`) permission on a C# file, you can run the C# file from the command line:
+The first line of the program contains the `#!` sequence (shebang) for unix shells. The location of the `dotnet` CLI can vary on different distributions. On any unix system, if you set the *execute* (`+x`) permission on such a C# file that contains the shebang directive, you can run the C# file directly from the command line:
 
 ```bash
 ./hello-world.cs


### PR DESCRIPTION
## Summary

Clarifies that C# files need a shebang (`#!`) directive to be directly executable on Unix systems with `./filename.cs`.

**Changes:**
- Added "(shebang)" after `#!` for clarity
- Modified sentence to specify "such a C# file that contains the shebang directive"
- Added "directly" to distinguish from `dotnet run`

**Before:** 
> On any unix system, if you set the execute (+x) permission on a C# file, you can run the C# file from the command line:

**After:**
> On any unix system, if you set the execute (+x) permission on such a C# file that contains the shebang directive, you can run the C# file directly from the command line:

This prevents beginner confusion about why `./hello.cs` doesn't work without the shebang.

Fixes #47108 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/tour-of-csharp/overview.md](https://github.com/dotnet/docs/blob/0eab32255675f887fc91c9acbe04a95d4acc8ca3/docs/csharp/tour-of-csharp/overview.md) | [A tour of the C# language](https://review.learn.microsoft.com/en-us/dotnet/csharp/tour-of-csharp/overview?branch=pr-en-us-47121) |

<!-- PREVIEW-TABLE-END -->