### PR TITLE
Fix list-collection.md semicolon typo

### DIFF
--- a/docs/csharp/tour-of-csharp/tutorials/list-collection.md
+++ b/docs/csharp/tour-of-csharp/tutorials/list-collection.md
@@ -67,7 +67,7 @@ That creates a list of integers, and sets the first two integers to the value 1.
 
 :::code language="csharp" source="./snippets/ListCollection/Program.cs" id="Fibonacci":::
 
-Press **Run** to see the results;
+Press **Run** to see the results.
 
 ## Challenge
 


### PR DESCRIPTION
## Summary

"Press **Run** to see the results." Now ends with proper period instead of incorrect semicolon.

Fixes #47141


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/tour-of-csharp/tutorials/list-collection.md](https://github.com/dotnet/docs/blob/d52d306cd6b478e1491ba7c8a68fc6fadc8aa0ff/docs/csharp/tour-of-csharp/tutorials/list-collection.md) | [docs/csharp/tour-of-csharp/tutorials/list-collection](https://review.learn.microsoft.com/en-us/dotnet/csharp/tour-of-csharp/tutorials/list-collection?branch=pr-en-us-47142) |


<!-- PREVIEW-TABLE-END -->