### PR TITLE
Fix challenge example solution not displayed

### DIFF
--- a/docs/csharp/tour-of-csharp/tutorials/branches-and-loops.md
+++ b/docs/csharp/tour-of-csharp/tutorials/branches-and-loops.md
@@ -141,6 +141,7 @@ Did you come up with something like this?
 
 <!-- markdownlint-disable MD033 -->
 <details>
+
 :::code language="csharp" interactive="try-dotnet-method" source="./snippets/BranchesAndLoops/Program.cs" id="Challenge":::
 </details>
 <!-- markdownlint-enable MD033 -->

--- a/docs/csharp/tour-of-csharp/tutorials/hello-world.md
+++ b/docs/csharp/tour-of-csharp/tutorials/hello-world.md
@@ -121,6 +121,7 @@ Did you come up with something like the following (expand to see the answer):
 
 <!-- markdownlint-disable MD033 -->
 <details>
+
 :::code language="csharp" interactive="try-dotnet-method" source="./snippets/HelloWorld/Program.cs" id="Challenge":::
 </details>
 <!-- markdownlint-enable MD033 -->

--- a/docs/csharp/tour-of-csharp/tutorials/list-collection.md
+++ b/docs/csharp/tour-of-csharp/tutorials/list-collection.md
@@ -77,6 +77,7 @@ Did you come up with something like this?
 
 <!-- markdownlint-disable MD033 -->
 <details>
+
 :::code language="csharp" interactive="try-dotnet-method" source="./snippets/ListCollection/Program.cs" id="Answer":::
 
 With each iteration of the loop, you're taking the last two integers in the list, summing them, and adding that value to the list. The loop repeats until you added 20 items to the list.

--- a/docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp.md
+++ b/docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp.md
@@ -128,6 +128,7 @@ Once you try it, open the details pane to see how you did:
 
 <!-- markdownlint-disable MD033 -->
 <details>
+
 :::code language="csharp" interactive="try-dotnet-method" source="./snippets/NumbersInCsharp/Program.cs" id="Challenge":::
 </details>
 <!-- markdownlint-enable MD033 -->


### PR DESCRIPTION
## Summary

Added a linebreak between the details tag and the code block in. This makes the code block actually display the snippet.

Fixes #47140


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/tour-of-csharp/tutorials/branches-and-loops.md](https://github.com/dotnet/docs/blob/8ced436921fcbcec8b5d428a25b948baf8ab1b28/docs/csharp/tour-of-csharp/tutorials/branches-and-loops.md) | [docs/csharp/tour-of-csharp/tutorials/branches-and-loops](https://review.learn.microsoft.com/en-us/dotnet/csharp/tour-of-csharp/tutorials/branches-and-loops?branch=pr-en-us-47143) |
| [docs/csharp/tour-of-csharp/tutorials/hello-world.md](https://github.com/dotnet/docs/blob/8ced436921fcbcec8b5d428a25b948baf8ab1b28/docs/csharp/tour-of-csharp/tutorials/hello-world.md) | [docs/csharp/tour-of-csharp/tutorials/hello-world](https://review.learn.microsoft.com/en-us/dotnet/csharp/tour-of-csharp/tutorials/hello-world?branch=pr-en-us-47143) |
| [docs/csharp/tour-of-csharp/tutorials/list-collection.md](https://github.com/dotnet/docs/blob/8ced436921fcbcec8b5d428a25b948baf8ab1b28/docs/csharp/tour-of-csharp/tutorials/list-collection.md) | [docs/csharp/tour-of-csharp/tutorials/list-collection](https://review.learn.microsoft.com/en-us/dotnet/csharp/tour-of-csharp/tutorials/list-collection?branch=pr-en-us-47143) |
| [docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp.md](https://github.com/dotnet/docs/blob/8ced436921fcbcec8b5d428a25b948baf8ab1b28/docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp.md) | [docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp](https://review.learn.microsoft.com/en-us/dotnet/csharp/tour-of-csharp/tutorials/numbers-in-csharp?branch=pr-en-us-47143) |


<!-- PREVIEW-TABLE-END -->