### PR TITLE
Mention how non-public fields of inherited classes are serialized

### DIFF
--- a/docs/standard/serialization/binaryformatter-migration-guide/functionality-reference.md
+++ b/docs/standard/serialization/binaryformatter-migration-guide/functionality-reference.md
@@ -20,7 +20,7 @@ The <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter> was fi
 
 ## Member names
 
-In most common scenario, the type is annotated with `[Serializable]` and the serializer uses reflection to serialize **all fields** (both public and non-public) except those that are annotated with `[NonSerialized]`. By default, the serialized member names will match the type's field names. This historically led to incompatibilities when even private fields are renamed on `[Serializable]` types. During migrations away from BinaryFormatter, it becomes necessary to understand how serialized field names were handled and overridden.
+In most common scenario, the type is annotated with `[Serializable]` and the serializer uses reflection to serialize **all fields** (both public and non-public) except those that are annotated with `[NonSerialized]`. By default, the serialized member names of public fields will match the type's field names. For non-public fields defined in inherited classes, the member names consist of inherited type name, a `+` sign and the field name (`$InheritedClassName+$nonPublicFieldName`). Serializing field names has historically led to incompatibilities when even private fields are renamed on `[Serializable]` types. During migrations away from BinaryFormatter, it becomes necessary to understand how serialized field names were handled and overridden.
 
 ### C# auto properties
 

--- a/docs/standard/serialization/binaryformatter-migration-guide/functionality-reference.md
+++ b/docs/standard/serialization/binaryformatter-migration-guide/functionality-reference.md
@@ -20,7 +20,7 @@ The <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter> was fi
 
 ## Member names
 
-In most common scenario, the type is annotated with `[Serializable]` and the serializer uses reflection to serialize **all fields** (both public and non-public) except those that are annotated with `[NonSerialized]`. By default, the serialized member names of public fields will match the type's field names. For non-public fields defined in inherited classes, the member names consist of inherited type name, a `+` sign and the field name (`$InheritedClassName+$nonPublicFieldName`). Serializing field names has historically led to incompatibilities when even private fields are renamed on `[Serializable]` types. During migrations away from BinaryFormatter, it becomes necessary to understand how serialized field names were handled and overridden.
+In the most common scenario, the type is annotated with `[Serializable]` and the serializer uses reflection to serialize **all fields** (both public and non-public) except those that are annotated with `[NonSerialized]`. By default, the serialized member names of public fields will match the type's field names. For non-public fields defined in inherited classes, the member names consist of inherited type name, a `+` sign, and the field name (`$InheritedClassName+$nonPublicFieldName`). Serializing field names has historically led to incompatibilities when even private fields are renamed on `[Serializable]` types. During migrations away from BinaryFormatter, it became necessary to understand how serialized field names were handled and overridden.
 
 ### C# auto properties
 


### PR DESCRIPTION
Repro:

```cs
using System.Formats.Nrbf;
using System.Runtime.Serialization.Formatters.Binary;

namespace NrbfBestPractices
{
    internal class Program
    {
        static void Main(string[] args)
        {
            using MemoryStream payload = new();
#pragma warning disable SYSLIB0011 // Type or member is obsolete
            BinaryFormatter formatter = new();
#pragma warning restore SYSLIB0011 // Type or member is obsolete
            formatter.Serialize(payload, new Derived(42)
            {
                Text = "Hello, World!",
            });
            payload.Position = 0;

            ClassRecord rootRecord = NrbfDecoder.DecodeClassRecord(payload);
            Derived decoded = new(rootRecord.GetInt32("Base+integer")) // HERE
            {
                Text = rootRecord.GetString(nameof(Derived.Text)),
            };
            Console.WriteLine($"Integer: {decoded.Integer}, Text: {decoded.Text}");
        }
    }

    [Serializable]
    public class Base
    {
        private int integer;

        public int Integer => integer;

        public Base(int _)
        {
            integer = _;
        }
    }

    [Serializable]
    public class Derived : Base
    {
        public string Text;
        public Derived(int integer) : base(integer)
        {
        }
    }
}

```

Source of confusion:

https://github.com/dotnet/runtime/blob/513ff1acc981118e4b981e965dce614c3b8770f5/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/FormatterServices.cs#L42-L44

https://github.com/dotnet/runtime/blob/513ff1acc981118e4b981e965dce614c3b8770f5/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/FormatterServices.cs#L68

https://github.com/dotnet/runtime/blob/513ff1acc981118e4b981e965dce614c3b8770f5/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/SerializationFieldInfo.cs#L21




<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/serialization/binaryformatter-migration-guide/functionality-reference.md](https://github.com/dotnet/docs/blob/508902adf01d8ceaa3cd2ee3fa98ab7ceeb420fd/docs/standard/serialization/binaryformatter-migration-guide/functionality-reference.md) | [BinaryFormatter functionality reference](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/binaryformatter-migration-guide/functionality-reference?branch=pr-en-us-47148) |


<!-- PREVIEW-TABLE-END -->