### PR TITLE
Fix FIPS references for PQC

### DIFF
--- a/docs/core/whats-new/dotnet-10/libraries.md
+++ b/docs/core/whats-new/dotnet-10/libraries.md
@@ -59,7 +59,7 @@ If you want even more control, you can use [the overload](xref:System.Security.C
 
 ### Post-quantum cryptography (PQC)
 
-.NET 10 includes support for three new asymmetric algorithms: ML-KEM (FIPS 202), ML-DSA (FIPS 203), and SLH-DSA (FIPS 204). The new types are:
+.NET 10 includes support for three new asymmetric algorithms: ML-KEM (FIPS 203), ML-DSA (FIPS 204), and SLH-DSA (FIPS 205). The new types are:
 
 - `System.Security.Cryptography.MLKem` <!--xref:System.Security.Cryptography.MLKem-->
 - `System.Security.Cryptography.MLDsa` <!--xref:System.Security.Cryptography.MLDsa-->


### PR DESCRIPTION
## Summary

Same change as https://github.com/dotnet/core/pull/9929. The FIPS publication numbers for the PQC algorithms were off by one.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/whats-new/dotnet-10/libraries.md](https://github.com/dotnet/docs/blob/8097a10867fb9ef1c04c04b9ce736d198d31fe19/docs/core/whats-new/dotnet-10/libraries.md) | [What's new in .NET libraries for .NET 10](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-10/libraries?branch=pr-en-us-47267) |

<!-- PREVIEW-TABLE-END -->