### PR TITLE
Adding documentation for CA1516 - Use cross-platform intrinsics

### DIFF
--- a/docs/fundamentals/code-analysis/code-quality-rule-options.md
+++ b/docs/fundamentals/code-analysis/code-quality-rule-options.md
@@ -135,7 +135,7 @@ This section lists the available configuration options for code analyzers. For m
 
 | Description | Allowable values | Default value | Configurable rules |
 |-------------|------------------|---------------|--------------------|
-| Specifies that code in a project that generates this type of assembly should be analyzed | One or more fields of the <xref:Microsoft.CodeAnalysis.OutputKind> enumeration<br/><br/>Separate multiple values with a comma (,) | All output kinds | [CA1515](quality-rules/ca1515.md) [CA2007](quality-rules/ca2007.md) |
+| Specifies that code in a project that generates this type of assembly should be analyzed | One or more fields of the <xref:Microsoft.CodeAnalysis.OutputKind> enumeration<br/><br/>Separate multiple values with a comma (,) | All output kinds | [CA1515](quality-rules/ca1515.md), [CA1516](quality-rules/ca1516.md), [CA2007](quality-rules/ca2007.md) |
 
 ### required_modifiers
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1516.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1516.md
@@ -1,0 +1,104 @@
+---
+title: "CA1516: Use cross-platform intrinsics"
+description: "Learn about code analyzer rule CA1516 - Use cross-platform intrinsics"
+ms.date: 07/09/2025
+ms.topic: reference
+f1_keywords:
+ - CA1516
+ - UseCrossPlatformIntrinsicsAnalyzer
+helpviewer_keywords:
+ - CA1516
+author: TannerGooding
+dev_langs:
+ - CSharp
+---
+
+# CA1516: Use cross-platform intrinsics
+
+| Property                            | Value                                          |
+|-------------------------------------|------------------------------------------------|
+| **Rule ID**                         | CA1516                                         |
+| **Title**                           | Use cross-platform intrinsics                  |
+| **Category**                        | [Maintainability](maintainability-warnings.md) |
+| **Fix is breaking or non-breaking** | Non-breaking                                   |
+| **Enabled by default in .NET 9**    | No                                             |
+
+## Cause
+
+A platform or architecture specific intrinsic is used when a cross-platform equivalent exists.
+
+## Rule description
+
+This rule detects usage of platform-specific intrinsics that can be replaced with an equivalent cross-platform intrinsic instead.
+
+## How to fix violations
+
+Apply the fixer that switches the code to use the equivalent cross-platform intrinsic.
+
+## Example
+
+The following code snippet shows three similar violations of CA1516:
+
+```csharp
+using System;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.Wasm;
+using System.Runtime.Intrinsics.X86;
+
+class C
+{
+    Vector128<byte> M1(Vector128<byte> x, Vector128<byte> y) => AdvSimd.Add(x, y);
+    Vector128<byte> M2(Vector128<byte> x, Vector128<byte> y) => Sse2.Add(x, y);
+    Vector128<byte> M3(Vector128<byte> x, Vector128<byte> y) => PackedSimd.Add(x, y);
+}
+```
+
+The following code snippet fixes the violation and would be applied by the fixer:
+
+```csharp
+using System;
+using System.Runtime.Intrinsics;
+
+class C
+{
+    Vector128<byte> M1(Vector128<byte> x, Vector128<byte> y) => x + y;
+    Vector128<byte> M2(Vector128<byte> x, Vector128<byte> y) => x + y;
+    Vector128<byte> M3(Vector128<byte> x, Vector128<byte> y) => x + y;
+}
+```
+
+Once the fix has been applied, it becomes more obvious that the three methods could be simplified to be a single method that works on all platforms.
+
+## When to suppress warnings
+
+It's safe to suppress a violation of this rule if you're not concerned about the maintainability of your code.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable CA1516
+// The code that's violating the rule is on this line.
+#pragma warning restore CA1516
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.CA1516.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
+## Configure code to analyze
+
+You can configure which _output assembly kinds_ to apply this rule to. For example, to only apply this rule to code that produces a console application or a dynamically linked library (that is, not a UI app), add the following key-value pair to an *.editorconfig* file in your project:
+
+```ini
+dotnet_code_quality.CA1516.output_kind = ConsoleApplication, DynamicallyLinkedLibrary
+```
+
+For more information, see [output_kind](../code-quality-rule-options.md#output_kind).

--- a/docs/fundamentals/code-analysis/quality-rules/index.md
+++ b/docs/fundamentals/code-analysis/quality-rules/index.md
@@ -94,6 +94,7 @@ The following table lists code quality analysis rules.
 > | [CA1513: Use ObjectDisposedException throw helper](ca1513.md) | Throw helpers are simpler and more efficient than `if` blocks that construct a new exception instance. |
 > | [CA1514: Avoid redundant length argument](ca1514.md) | A redundant length argument is used when slicing to the end of a string or buffer. A calculated length can be error-prone and is also unnecessary. |
 > | [CA1515: Consider making public types internal](ca1515.md) | Unlike a class library, an application's API isn't typically referenced publicly, so types can be marked internal. |
+> | [CA1516: Use cross-platform intrinsics](ca1516.md) | This rule detects usage of platform-specific intrinsics that can be replaced with an equivalent cross-platform intrinsic instead. |
 > | [CA1700: Do not name enum values 'Reserved'](ca1700.md) | This rule assumes that an enumeration member that has a name that contains "reserved" is not currently used but is a placeholder to be renamed or removed in a future version. Renaming or removing a member is a breaking change. |
 > | [CA1707: Identifiers should not contain underscores](ca1707.md) | By convention, identifier names do not contain the underscore (_) character. This rule checks namespaces, types, members, and parameters. |
 > | [CA1708: Identifiers should differ by more than case](ca1708.md) | Identifiers for namespaces, types, members, and parameters cannot differ only by case because languages that target the common language runtime are not required to be case-sensitive. |

--- a/docs/fundamentals/code-analysis/quality-rules/maintainability-warnings.md
+++ b/docs/fundamentals/code-analysis/quality-rules/maintainability-warnings.md
@@ -32,6 +32,7 @@ Maintainability rules support library and application maintenance.
 | [CA1513: Use ObjectDisposedException throw helper](ca1513.md) | Throw helpers are simpler and more efficient than `if` blocks that construct a new exception instance. |
 | [CA1514: Avoid redundant length argument](ca1514.md) | A redundant length argument is used when slicing to the end of a string or buffer. A calculated length can be error-prone and is also unnecessary. |
 | [CA1515: Consider making public types internal](ca1515.md) | Unlike a class library, an application's API isn't typically referenced publicly, so types can be marked internal. |
+| [CA1516: Use cross-platform intrinsics](ca1516.md) | This rule detects usage of platform-specific intrinsics that can be replaced with an equivalent cross-platform intrinsic instead. |
 
 ## See also
 

--- a/docs/navigate/tools-diagnostics/toc.yml
+++ b/docs/navigate/tools-diagnostics/toc.yml
@@ -951,6 +951,8 @@ items:
                     href: ../../fundamentals/code-analysis/quality-rules/ca1514.md
                   - name: CA1515
                     href: ../../fundamentals/code-analysis/quality-rules/ca1515.md
+                  - name: CA1516
+                    href: ../../fundamentals/code-analysis/quality-rules/ca1516.md
               - name: Naming rules
                 items:
                   - name: Overview


### PR DESCRIPTION
This is the docs side change for https://github.com/dotnet/roslyn-analyzers/pull/7721

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/code-quality-rule-options.md](https://github.com/dotnet/docs/blob/ffcabb4e9544c375112e8d8c668bc1377b4d54fd/docs/fundamentals/code-analysis/code-quality-rule-options.md) | [Code quality rule configuration options](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/code-quality-rule-options?branch=pr-en-us-47276) |
| [docs/fundamentals/code-analysis/quality-rules/ca1516.md](https://github.com/dotnet/docs/blob/ffcabb4e9544c375112e8d8c668bc1377b4d54fd/docs/fundamentals/code-analysis/quality-rules/ca1516.md) | [CA1516: Use cross-platform intrinsics](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1516?branch=pr-en-us-47276) |
| [docs/fundamentals/code-analysis/quality-rules/index.md](https://github.com/dotnet/docs/blob/ffcabb4e9544c375112e8d8c668bc1377b4d54fd/docs/fundamentals/code-analysis/quality-rules/index.md) | [Code quality rules overview](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/index?branch=pr-en-us-47276) |
| [docs/fundamentals/code-analysis/quality-rules/maintainability-warnings.md](https://github.com/dotnet/docs/blob/ffcabb4e9544c375112e8d8c668bc1377b4d54fd/docs/fundamentals/code-analysis/quality-rules/maintainability-warnings.md) | [Maintainability rules](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/maintainability-warnings?branch=pr-en-us-47276) |
| [docs/navigate/tools-diagnostics/toc.yml](https://github.com/dotnet/docs/blob/ffcabb4e9544c375112e8d8c668bc1377b4d54fd/docs/navigate/tools-diagnostics/toc.yml) | [docs/navigate/tools-diagnostics/toc](https://review.learn.microsoft.com/en-us/dotnet/navigate/tools-diagnostics/toc?branch=pr-en-us-47276) |


<!-- PREVIEW-TABLE-END -->