### PR TITLE
docs: fix #47146 – improve email validation regex to prevent invalid formats

### DIFF
--- a/docs/navigate/tools-diagnostics/toc.yml
+++ b/docs/navigate/tools-diagnostics/toc.yml
@@ -180,7 +180,7 @@ items:
                 href: ../../core/tools/dotnet-nuget-config-paths.md
           - name: dotnet pack
             href: ../../core/tools/dotnet-pack.md
-          - name: dotnet package add/list/remove/earch
+          - name: dotnet package add/list/remove/search
             items:
               - name: dotnet package add
                 href: ../../core/tools/dotnet-package-add.md

--- a/docs/standard/base-types/how-to-verify-that-strings-are-in-valid-email-format.md
+++ b/docs/standard/base-types/how-to-verify-that-strings-are-in-valid-email-format.md
@@ -61,17 +61,17 @@ The `IsValidEmail` method merely determines whether the email format is valid fo
 
 :::code language="vb" source="snippets/how-to-verify-that-strings-are-in-valid-email-format/vb/RegexUtilities.vb":::
 
-In this example, the regular expression pattern `^[^@\s]+@[^@\s]+\.[^@\s]+$` is interpreted as shown in the following table. The regular expression is compiled using the <xref:System.Text.RegularExpressions.RegexOptions.IgnoreCase?displayProperty=nameWithType> flag.
+In this example, the regular expression pattern `^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$` is used, which better reflects common email rules by excluding invalid characters like commas. The regular expression is compiled using the <xref:System.Text.RegularExpressions.RegexOptions.IgnoreCase?displayProperty=nameWithType> flag.
 
-| Pattern   | Description                                                                              |
-|-----------|------------------------------------------------------------------------------------------|
-| `^`       | Begin the match at the start of the string.                                              |
-| `[^@\s]+` | Match one or more occurrences of any character other than the @ character or whitespace. |
-| `@`       | Match the @ character.                                                                   |
-| `[^@\s]+` | Match one or more occurrences of any character other than the @ character or whitespace. |
-| `\.`      | Match a single period character.                                                         |
-| `[^@\s]+` | Match one or more occurrences of any character other than the @ character or whitespace. |
-| `$`       | End the match at the end of the string.                                                  |
+| Pattern              | Description                                                                 |
+|----------------------|-----------------------------------------------------------------------------|
+| `^`                  | Start of the string                                                         |
+| `[a-zA-Z0-9._%+-]+`  | One or more valid characters in the local part (letters, digits, `.`, `_`, `%`, `+`, `-`) |
+| `@`                  | Matches the at-symbol (`@`)                                                 |
+| `[a-zA-Z0-9.-]+`     | One or more valid domain name characters                                    |
+| `\.`                 | Matches a dot (`.`)                                                         |
+| `[a-zA-Z]{2,}`       | Matches a top-level domain of at least two alphabetical characters          |
+| `$`                  | End of the string                                                           |
 
 > [!IMPORTANT]
 > This regular expression isn't intended to cover every aspect of a valid email address. It's provided as an example for you to extend as needed.


### PR DESCRIPTION
What this PR does:

This PR updates the email validation regex in the [How to verify that strings are in valid email format](https://learn.microsoft.com/en-us/dotnet/standard/base-types/how-to-verify-that-strings-are-in-valid-email-format) article to address an issue where invalid characters (like commas) were being accepted.
Problem:

The current regex pattern:

^[^@\s]+@[^@\s]+\.[^@\s]+$

allows email addresses like surname123@gmail.,com, which are structurally invalid.
Fix:

Replaced the regex pattern and its explanation with a more accurate expression:

^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$

This change:

    Restricts characters in the local and domain parts to common valid characters.

    Ensures the TLD has at least two alphabetical characters.

    Still remains readable and practical for general validation.

Related issue:

Fixes #47146

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/base-types/how-to-verify-that-strings-are-in-valid-email-format.md](https://github.com/dotnet/docs/blob/f4e9a16404c96724ddcc104d78873816b472b0f5/docs/standard/base-types/how-to-verify-that-strings-are-in-valid-email-format.md) | [How to verify that strings are in valid email format](https://review.learn.microsoft.com/en-us/dotnet/standard/base-types/how-to-verify-that-strings-are-in-valid-email-format?branch=pr-en-us-47285) |

<!-- PREVIEW-TABLE-END -->