### PR TITLE
Update debug-memory-leak to add now needed step

### DIFF
--- a/docs/core/diagnostics/debug-memory-leak.md
+++ b/docs/core/diagnostics/debug-memory-leak.md
@@ -56,6 +56,14 @@ The output should be similar to:
 4807 DiagnosticScena /home/user/git/samples/core/diagnostics/DiagnosticScenarios/bin/Debug/netcoreapp3.0/DiagnosticScenarios
 ```
 
+
+> [!NOTE]
+> If the above command does not work, or is not found, you likely need to install the `dotnet-counters` tool first, with the following command. 
+
+```console
+dotnet tool install --global dotnet-counters
+```
+
 Now, check managed memory usage with the [dotnet-counters](dotnet-counters.md) tool. The `--refresh-interval` specifies the number of seconds between refreshes:
 
 ```console

--- a/docs/core/diagnostics/debug-memory-leak.md
+++ b/docs/core/diagnostics/debug-memory-leak.md
@@ -58,11 +58,11 @@ The output should be similar to:
 
 
 > [!NOTE]
-> If the above command does not work, or is not found, you likely need to install the `dotnet-counters` tool first, with the following command. 
-
-```console
-dotnet tool install --global dotnet-counters
-```
+> If the previous command doesn't work or isn't found, you likely need to install the `dotnet-counters` tool first. Use the following command:
+>
+> ```console
+> dotnet tool install --global dotnet-counters
+> ```
 
 Now, check managed memory usage with the [dotnet-counters](dotnet-counters.md) tool. The `--refresh-interval` specifies the number of seconds between refreshes:
 

--- a/docs/core/diagnostics/debug-memory-leak.md
+++ b/docs/core/diagnostics/debug-memory-leak.md
@@ -56,7 +56,6 @@ The output should be similar to:
 4807 DiagnosticScena /home/user/git/samples/core/diagnostics/DiagnosticScenarios/bin/Debug/netcoreapp3.0/DiagnosticScenarios
 ```
 
-
 > [!NOTE]
 > If the previous command doesn't work or isn't found, you likely need to install the `dotnet-counters` tool first. Use the following command:
 >


### PR DESCRIPTION
Users will need to install the dotnet counters tool before invoking that, adding that step to improve this guide.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/debug-memory-leak.md](https://github.com/dotnet/docs/blob/45b768fbe5da313103a2cbda07197cb25a179b58/docs/core/diagnostics/debug-memory-leak.md) | [Debug a memory leak in .NET](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/debug-memory-leak?branch=pr-en-us-47291) |


<!-- PREVIEW-TABLE-END -->