### PR TITLE
Update for-next-statement.md

### DIFF
--- a/docs/visual-basic/language-reference/statements/for-next-statement.md
+++ b/docs/visual-basic/language-reference/statements/for-next-statement.md
@@ -27,7 +27,7 @@ ms.assetid: f5fc0d51-67ce-4c36-9f09-31c9a91c94e9
 ---
 # For...Next Statement (Visual Basic)
 
-Repeats a group of statements a specified number of times.
+Repeats a group of statements while the loop counter approaches its final value.
 
 ## Syntax
 


### PR DESCRIPTION
For...Next Statement does not specify the number of times to repeat.

## Summary

Change the definition to remove wrong statement about a specified number of times.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/visual-basic/language-reference/statements/for-next-statement.md](https://github.com/dotnet/docs/blob/8b88714b646fd5772ddfc8d04eede214b811b175/docs/visual-basic/language-reference/statements/for-next-statement.md) | [For...Next Statement (Visual Basic)](https://review.learn.microsoft.com/en-us/dotnet/visual-basic/language-reference/statements/for-next-statement?branch=pr-en-us-47302) |

<!-- PREVIEW-TABLE-END -->