### PR TITLE
Document container.memory.usage metric

### DIFF
--- a/docs/core/diagnostics/built-in-metrics-diagnostics.md
+++ b/docs/core/diagnostics/built-in-metrics-diagnostics.md
@@ -110,7 +110,7 @@ Available starting in: .NET 8.8.0.
 
 ##### Metric: `container.memory.usage`
 
-The instrument is only available on a system running on containers both on Windows and Linux.
+The instrument is only available on a system running on containers either on Windows or Linux.
 
 | Name | Instrument Type | Unit (UCUM) | Description |
 | ---- | --------------- | ----------- | ----------- |

--- a/docs/core/diagnostics/built-in-metrics-diagnostics.md
+++ b/docs/core/diagnostics/built-in-metrics-diagnostics.md
@@ -70,6 +70,7 @@ The `Microsoft.Extensions.Diagnostics.ResourceMonitoring` metrics report resourc
 - [`container.cpu.limit.utilization`](#metric-containercpulimitutilization)
 - [`container.cpu.request.utilization`](#metric-containercpurequestutilization)
 - [`container.memory.limit.utilization`](#metric-containermemorylimitutilization)
+- [`container.memory.usage`](#metric-containermemoryusage)
 - [`process.cpu.utilization`](#metric-processcpuutilization)
 - [`dotnet.process.memory.virtual.utilization`](#metric-dotnetprocessmemoryvirtualutilization)
 - [`system.network.connections`](#metric-systemnetworkconnections)
@@ -106,6 +107,16 @@ The instrument is only available on a system running on containers both on Windo
 | `container.memory.limit.utilization` | ObservableGauge | `1` | The memory consumption of the running containerized application relative to resource limit in range `[0, 1]`. |
 
 Available starting in: .NET 8.8.0.
+
+##### Metric: `container.memory.usage`
+
+The instrument is only available on a system running on containers both on Windows and Linux.
+
+| Name | Instrument Type | Unit (UCUM) | Description |
+| ---- | --------------- | ----------- | ----------- |
+| `container.memory.usage` | ObservableUpDownCounter | `By` | Memory usage of all processes in the container measured in bytes. |
+
+Available starting in: .NET 9.8.0.
 
 ##### Metric: `process.cpu.utilization`
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/dotnet/extensions/issues/6595.

The source code was merged in https://github.com/dotnet/extensions/pull/6586.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/built-in-metrics-diagnostics.md](https://github.com/dotnet/docs/blob/e6c7d06d15f3756583ec8c06e66720f61ceec725/docs/core/diagnostics/built-in-metrics-diagnostics.md) | [.NET extensions metrics](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/built-in-metrics-diagnostics?branch=pr-en-us-47304) |


<!-- PREVIEW-TABLE-END -->