### PR TITLE
Add guidance for configuring nullable context to fix CS8632, CS8636, CS8637

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/nullable-warnings.md
+++ b/docs/csharp/language-reference/compiler-messages/nullable-warnings.md
@@ -215,6 +215,32 @@ The following warnings indicate that you haven't set the nullable context correc
 - **CS8636** - *Invalid option for `/nullable`; must be `disable`, `enable`, `warnings` or `annotations`*
 - **CS8637** - *Expected `enable`, `disable`, or `restore`*
 
+To set the nullable context correctly, you have two options:
+
+1. **Project-level configuration**: Add the [`<Nullable>`](../compiler-options/language.md#nullable) element to your project file:
+
+```xml
+<PropertyGroup>
+    <Nullable>enable</Nullable>
+</PropertyGroup>
+```
+
+2. **File-level configuration**: Use [`#nullable`](../preprocessor-directives.md#nullable-context) preprocessor directives in your source code:
+
+```csharp
+#nullable enable
+```
+
+The nullable context has two independent flags that control different aspects:
+
+- **Annotation flag**: Controls whether you can use `?` to declare nullable reference types
+- **Warning flag**: Controls whether the compiler emits nullability warnings
+
+For detailed information about nullable contexts and migration strategies, see:
+
+- [Nullable reference types overview](../../nullable-references.md#nullable-context)
+- [Update a codebase with nullable reference types](../../nullable-migration-strategies.md)
+
 ## Incorrect annotation syntax
 
 These errors and warnings indicate that usage of the `!` or `?` annotation is incorrect.

--- a/docs/csharp/language-reference/compiler-messages/nullable-warnings.md
+++ b/docs/csharp/language-reference/compiler-messages/nullable-warnings.md
@@ -233,7 +233,7 @@ To set the nullable context correctly, you have two options:
 
 The nullable context has two independent flags that control different aspects:
 
-- **Annotation flag**: Controls whether you can use `?` to declare nullable reference types
+- **Annotation flag**: Controls whether you can use `?` to declare nullable reference types and `!` to surpress individual warnings.
 - **Warning flag**: Controls whether the compiler emits nullability warnings
 
 For detailed information about nullable contexts and migration strategies, see:

--- a/docs/csharp/language-reference/compiler-messages/nullable-warnings.md
+++ b/docs/csharp/language-reference/compiler-messages/nullable-warnings.md
@@ -218,15 +218,19 @@ The following warnings indicate that you haven't set the nullable context correc
 To set the nullable context correctly, you have two options:
 
 1. **Project-level configuration**: Add the [`<Nullable>`](../compiler-options/language.md#nullable) element to your project file:
-   ```xml
+
+      ```xml
    <PropertyGroup>
        <Nullable>enable</Nullable>
    </PropertyGroup>
    ```
+
 2. **File-level configuration**: Use [`#nullable`](../preprocessor-directives.md#nullable-context) preprocessor directives in your source code:
+
    ```csharp
    #nullable enable
    ```
+
 
 The nullable context has two independent flags that control different aspects:
 

--- a/docs/csharp/language-reference/compiler-messages/nullable-warnings.md
+++ b/docs/csharp/language-reference/compiler-messages/nullable-warnings.md
@@ -219,11 +219,11 @@ To set the nullable context correctly, you have two options:
 
 1. **Project-level configuration**: Add the [`<Nullable>`](../compiler-options/language.md#nullable) element to your project file:
 
-```xml
-<PropertyGroup>
-    <Nullable>enable</Nullable>
-</PropertyGroup>
-```
+  ```xml
+  <PropertyGroup>
+      <Nullable>enable</Nullable>
+  </PropertyGroup>
+  ```
 
 2. **File-level configuration**: Use [`#nullable`](../preprocessor-directives.md#nullable-context) preprocessor directives in your source code:
 

--- a/docs/csharp/language-reference/compiler-messages/nullable-warnings.md
+++ b/docs/csharp/language-reference/compiler-messages/nullable-warnings.md
@@ -231,7 +231,6 @@ To set the nullable context correctly, you have two options:
    #nullable enable
    ```
 
-
 The nullable context has two independent flags that control different aspects:
 
 - **Annotation flag**: Controls whether you can use `?` to declare nullable reference types and `!` to surpress individual warnings.

--- a/docs/csharp/language-reference/compiler-messages/nullable-warnings.md
+++ b/docs/csharp/language-reference/compiler-messages/nullable-warnings.md
@@ -218,16 +218,15 @@ The following warnings indicate that you haven't set the nullable context correc
 To set the nullable context correctly, you have two options:
 
 1. **Project-level configuration**: Add the [`<Nullable>`](../compiler-options/language.md#nullable) element to your project file:
-  ```xml
-  <PropertyGroup>
-      <Nullable>enable</Nullable>
-  </PropertyGroup>
-  ```
+   ```xml
+   <PropertyGroup>
+       <Nullable>enable</Nullable>
+   </PropertyGroup>
+   ```
 2. **File-level configuration**: Use [`#nullable`](../preprocessor-directives.md#nullable-context) preprocessor directives in your source code:
-
-```csharp
-#nullable enable
-```
+   ```csharp
+   #nullable enable
+   ```
 
 The nullable context has two independent flags that control different aspects:
 

--- a/docs/csharp/language-reference/compiler-messages/nullable-warnings.md
+++ b/docs/csharp/language-reference/compiler-messages/nullable-warnings.md
@@ -218,13 +218,11 @@ The following warnings indicate that you haven't set the nullable context correc
 To set the nullable context correctly, you have two options:
 
 1. **Project-level configuration**: Add the [`<Nullable>`](../compiler-options/language.md#nullable) element to your project file:
-
   ```xml
   <PropertyGroup>
       <Nullable>enable</Nullable>
   </PropertyGroup>
   ```
-
 2. **File-level configuration**: Use [`#nullable`](../preprocessor-directives.md#nullable-context) preprocessor directives in your source code:
 
 ```csharp


### PR DESCRIPTION
## Summary

This PR addresses issue #47305 by adding guidance to the "Configure nullable context" section in the nullable warnings documentation.

### Changes Made
- Added detailed instructions on how to properly set the nullable context to resolve configuration warnings
- Included both project-level (`<Nullable>` element) and file-level (`#nullable` directive) configuration options
- Explained the two independent flags (annotation and warning) that control nullable behavior
- Added links to relevant documentation for nullable contexts and migration strategies

### Why These Changes Are Needed
The original documentation listed the nullable context configuration warnings (CS8632, CS8636, CS8637) but didn't provide clear guidance on how to fix them. This enhancement helps developers quickly understand and resolve these configuration issues.

### Related Issue
Fixes #47305 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-messages/nullable-warnings.md](https://github.com/dotnet/docs/blob/c7abc4ca2e74ea987ab815e019f92a19af57d219/docs/csharp/language-reference/compiler-messages/nullable-warnings.md) | [Resolve nullable warnings](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/nullable-warnings?branch=pr-en-us-47306) |


<!-- PREVIEW-TABLE-END -->