### PR TITLE
Mention HTTP-specific actions for revocation check breaking change

### DIFF
--- a/docs/core/compatibility/networking/10.0/ssl-certificate-revocation-check-default.md
+++ b/docs/core/compatibility/networking/10.0/ssl-certificate-revocation-check-default.md
@@ -10,7 +10,7 @@ ms.custom: https://github.com/dotnet/docs/issues/46824
 
 The default values of <xref:System.Net.Security.SslClientAuthenticationOptions.CertificateRevocationCheckMode?displayProperty=nameWithType> and <xref:System.Net.Security.SslServerAuthenticationOptions.CertificateRevocationCheckMode?displayProperty=nameWithType> have changed from `NoCheck` to `Online`.
 
-The default values of <xref:System.Net.Http.HttpClientHandler.CheckCertificateRevocationList?displayProperty=nameWithType> and <xref:System.Net.Http.WinHttpHandler.CheckCertificateRevocationList?displayProperty=nameWithType> has changed from `false` to `true`.
+The default values of <xref:System.Net.Http.HttpClientHandler.CheckCertificateRevocationList?displayProperty=nameWithType> and <xref:System.Net.Http.WinHttpHandler.CheckCertificateRevocationList?displayProperty=nameWithType> have changed from `false` to `true`.
 
 This change enhances security and makes the behavior consistent with <xref:System.Security.Cryptography.X509Certificates.X509ChainPolicy?displayProperty=nameWithType>.
 
@@ -20,11 +20,11 @@ This change enhances security and makes the behavior consistent with <xref:Syste
 
 ## Previous behavior
 
-Previously, the default values of <xref:System.Net.Security.SslClientAuthenticationOptions.CertificateRevocationCheckMode?displayProperty=nameWithType> and <xref:System.Net.Security.SslServerAuthenticationOptions.CertificateRevocationCheckMode?displayProperty=nameWithType> were <xref:System.Security.Cryptography.X509Certificates.X509RevocationMode.NoCheck?displayProperty=nameWithType>; and values of <xref:System.Net.Http.HttpClientHandler.CheckCertificateRevocationList?displayProperty=nameWithType> and <xref:System.Net.Http.WinHttpHandler.CheckCertificateRevocationList?displayProperty=nameWithType> were `false`, meaning revocation status of peer certificates wasn't checked by default.
+Previously, the default values of <xref:System.Net.Security.SslClientAuthenticationOptions.CertificateRevocationCheckMode?displayProperty=nameWithType> and <xref:System.Net.Security.SslServerAuthenticationOptions.CertificateRevocationCheckMode?displayProperty=nameWithType> were <xref:System.Security.Cryptography.X509Certificates.X509RevocationMode.NoCheck?displayProperty=nameWithType>, and the default values of <xref:System.Net.Http.HttpClientHandler.CheckCertificateRevocationList?displayProperty=nameWithType> and <xref:System.Net.Http.WinHttpHandler.CheckCertificateRevocationList?displayProperty=nameWithType> were `false`, meaning revocation status of peer certificates wasn't checked by default.
 
 ## New behavior
 
-Starting in .NET 10, the default values of <xref:System.Net.Security.SslClientAuthenticationOptions.CertificateRevocationCheckMode?displayProperty=nameWithType> and <xref:System.Net.Security.SslServerAuthenticationOptions.CertificateRevocationCheckMode?displayProperty=nameWithType> are <xref:System.Security.Cryptography.X509Certificates.X509RevocationMode.Online?displayProperty=nameWithType>; and values of <xref:System.Net.Http.HttpClientHandler.CheckCertificateRevocationList?displayProperty=nameWithType> and <xref:System.Net.Http.WinHttpHandler.CheckCertificateRevocationList?displayProperty=nameWithType> are `true`, meaning revocation status of peer certificates are checked online by default.
+Starting in .NET 10, the default values of <xref:System.Net.Security.SslClientAuthenticationOptions.CertificateRevocationCheckMode?displayProperty=nameWithType> and <xref:System.Net.Security.SslServerAuthenticationOptions.CertificateRevocationCheckMode?displayProperty=nameWithType> are <xref:System.Security.Cryptography.X509Certificates.X509RevocationMode.Online?displayProperty=nameWithType>, and the default values of <xref:System.Net.Http.HttpClientHandler.CheckCertificateRevocationList?displayProperty=nameWithType> and <xref:System.Net.Http.WinHttpHandler.CheckCertificateRevocationList?displayProperty=nameWithType> are `true`, meaning revocation status of peer certificates are checked online by default.
 
 ## Type of breaking change
 


### PR DESCRIPTION
This should make the recommended actions more easily applicable for users which do not use SslStream directly, but use HttpClient instead.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/networking/10.0/ssl-certificate-revocation-check-default.md](https://github.com/dotnet/docs/blob/e92f5cd057ef1a74d9914d9285f35214e7f2ba53/docs/core/compatibility/networking/10.0/ssl-certificate-revocation-check-default.md) | [HttpClient/SslStream default certificate revocation check mode changed to `Online`](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/networking/10.0/ssl-certificate-revocation-check-default?branch=pr-en-us-47384) |


<!-- PREVIEW-TABLE-END -->