### PR TITLE
Fix build warnings/suggestions

### DIFF
--- a/.openpublishing.redirection.core.json
+++ b/.openpublishing.redirection.core.json
@@ -1344,6 +1344,10 @@
             "redirect_url": "/dotnet/core/versions/selection"
         },
         {
+            "source_path_from_root": "/docs/whats-new/dotnet-7-docs.md",
+            "redirect_url": "/dotnet/whats-new"
+        },
+        {
             "source_path_from_root": "/docs/core/whats-new/dotnet-8.md",
             "redirect_url": "/dotnet/core/whats-new/dotnet-8/overview",
             "redirect_document_id": true

--- a/.openpublishing.redirection.core.json
+++ b/.openpublishing.redirection.core.json
@@ -1344,11 +1344,6 @@
             "redirect_url": "/dotnet/core/versions/selection"
         },
         {
-            "source_path_from_root": "/docs/whats-new/dotnet-7-docs.md",
-            "redirect_url": "/dotnet/whats-new/dotnet-docs-mod0",
-            "redirect_document_id": true
-        },
-        {
             "source_path_from_root": "/docs/core/whats-new/dotnet-8.md",
             "redirect_url": "/dotnet/core/whats-new/dotnet-8/overview",
             "redirect_document_id": true

--- a/docs/core/compatibility/aspnet-core/8.0/securitytoken-events.md
+++ b/docs/core/compatibility/aspnet-core/8.0/securitytoken-events.md
@@ -5,7 +5,7 @@ ms.date: 07/31/2023
 ---
 # Security token events return a JsonWebToken
 
-The <xref:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerEvents>, <xref:Microsoft.AspNetCore.Authentication.WsFederation.WsFederationEvents>, and <xref:Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectEvents> events are authentication events fired respectively by the [JwtBearer](xref:Microsoft.AspNetCore.Authentication.JwtBearer), [WsFederation](xref:Microsoft.AspNetCore.Authentication.WsFederation), and [OpenIdConnect](xref:Microsoft.AspNetCore.Authentication.OpenIdConnect) authentication handlers. For example, the <xref:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerEvents.OnTokenValidated> event is fired when a security token is validated. These events are fired with a context (for example, <xref:Microsoft.AspNetCore.Authentication.JwtBearer.TokenValidatedContext>) that exposes a <xref:Microsoft.AspNetCore.Authentication.JwtBearer.TokenValidatedContext.SecurityToken?displayProperty=nameWithType> property of abstract type <xref:System.IdentityModel.Tokens.SecurityToken>. The default real implementation of <xref:Microsoft.AspNetCore.Authentication.JwtBearer.TokenValidatedContext.SecurityToken?displayProperty=nameWithType> changed from <xref:System.IdentityModel.Tokens.Jwt.JwtSecurityToken> to <xref:Microsoft.IdentityModel.JsonWebTokens.JsonWebToken>.
+The <xref:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerEvents>, <xref:Microsoft.AspNetCore.Authentication.WsFederation.WsFederationEvents>, and <xref:Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectEvents> events are authentication events fired respectively by the [JwtBearer](xref:Microsoft.AspNetCore.Authentication.JwtBearer), [WsFederation](xref:Microsoft.AspNetCore.Authentication.WsFederation), and [OpenIdConnect](xref:Microsoft.AspNetCore.Authentication.OpenIdConnect) authentication handlers. For example, the <xref:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerEvents.OnTokenValidated> event is fired when a security token is validated. These events are fired with a context (for example, <xref:Microsoft.AspNetCore.Authentication.JwtBearer.TokenValidatedContext>) that exposes a <xref:Microsoft.AspNetCore.Authentication.JwtBearer.TokenValidatedContext.SecurityToken?displayProperty=nameWithType> property of abstract type <xref:System.IdentityModel.Tokens.SecurityToken>. The default real implementation of <xref:Microsoft.AspNetCore.Authentication.JwtBearer.TokenValidatedContext.SecurityToken?displayProperty=nameWithType> changed from `System.IdentityModel.Tokens.Jwt.JwtSecurityToken` to <xref:Microsoft.IdentityModel.JsonWebTokens.JsonWebToken>.
 
 ## Version introduced
 
@@ -13,13 +13,13 @@ ASP.NET Core 8.0 Preview 7
 
 ## Previous behavior
 
-Previously, the affected `SecurityToken` properties were implemented by <xref:System.IdentityModel.Tokens.Jwt.JwtSecurityToken>, which derives from <xref:System.IdentityModel.Tokens.SecurityToken>. <xref:System.IdentityModel.Tokens.Jwt.JwtSecurityToken> is the previous generation of JSON Web Token (JWT) implementation. The <xref:System.IdentityModel.Tokens.Jwt.JwtSecurityToken> tokens were produced by <xref:Microsoft.AspNetCore.Builder.JwtBearerOptions.SecurityTokenValidators>.
+Previously, the affected `SecurityToken` properties were implemented by `System.IdentityModel.Tokens.Jwt.JwtSecurityToken`, which derives from <xref:System.IdentityModel.Tokens.SecurityToken>. `JwtSecurityToken` is the previous generation of JSON Web Token (JWT) implementation. The `JwtSecurityToken` tokens were produced by <xref:Microsoft.AspNetCore.Builder.JwtBearerOptions.SecurityTokenValidators>.
 
-In addition, the <xref:System.IdentityModel.Tokens.Jwt.JwtSecurityTokenHandler.DefaultInboundClaimTypeMap?displayProperty=nameWithType> field provided the default claim type mapping for inbound claims.
+In addition, the `JwtSecurityTokenHandler.DefaultInboundClaimTypeMap` field provided the default claim type mapping for inbound claims.
 
 ## New behavior
 
-Starting in ASP.NET Core 8.0, the <xref:Microsoft.IdentityModel.JsonWebTokens> class, which also derives from <xref:System.IdentityModel.Tokens.SecurityToken>, implements the `SecurityToken` properties, by default. <xref:Microsoft.IdentityModel.JsonWebTokens> tokens are produced by more optimized <xref:Microsoft.IdentityModel.Tokens.TokenHandler> handlers.
+Starting in ASP.NET Core 8.0, the <xref:Microsoft.IdentityModel.JsonWebTokens> class, which also derives from <xref:System.IdentityModel.Tokens.SecurityToken>, implements the `SecurityToken` properties, by default. <xref:Microsoft.IdentityModel.JsonWebTokens> tokens are produced by more optimized `TokenHandler` handlers.
 
 In addition, the <xref:Microsoft.IdentityModel.JsonWebTokens.JsonWebTokenHandler.DefaultInboundClaimTypeMap?displayProperty=nameWithType> field provides the default claim type mapping for inbound claims.
 
@@ -37,7 +37,7 @@ This change was made because <xref:Microsoft.IdentityModel.JsonWebTokens.JsonWeb
 
 ## Recommended action
 
-For most users, this change shouldn't be a problem as the type of the properties ([SecurityToken](xref:Microsoft.IdentityModel.Tokens.SecurityToken)) hasn't changed, and you weren't supposed to look at the real type.
+For most users, this change shouldn't be a problem as the type of the properties (`SecurityToken`) hasn't changed, and you weren't supposed to look at the real type.
 
 However, if you were down-casting one of the affected `SecurityToken` properties to `JwtSecurityToken` (for example, to get the claims), you have two options:
 

--- a/docs/core/extensions/httpclient-http3.md
+++ b/docs/core/extensions/httpclient-http3.md
@@ -2,7 +2,6 @@
 title: Use HTTP/3 with HttpClient
 description: Learn how to use the HttpClient to access HTTP/3 servers in .NET
 author: IEvangelist
-ms.author: samsp
 ms.date: 05/19/2023
 ---
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1835.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1835.md
@@ -9,7 +9,6 @@ helpviewer_keywords:
   - "PreferStreamAsyncMemoryOverloads"
   - "CA1835"
 author: carlossanlop
-ms.author: calope
 dev_langs:
  - CSharp
  - VB
@@ -37,8 +36,8 @@ The rule works on `ReadAsync` and `WriteAsync` invocations of any class that inh
 
 The rule only works when the method is preceded by the `await` keyword.
 
-|Detected method|Suggested method|
-|-|-|
+| Detected method | Suggested method |
+|-----------------|------------------|
 |<xref:System.IO.Stream.ReadAsync(System.Byte[],System.Int32,System.Int32,System.Threading.CancellationToken)>|<xref:System.IO.Stream.ReadAsync(System.Memory{System.Byte},System.Threading.CancellationToken)>|
 |<xref:System.IO.Stream.ReadAsync(System.Byte[],System.Int32,System.Int32)>|<xref:System.IO.Stream.ReadAsync(System.Memory{System.Byte},System.Threading.CancellationToken)> with `CancellationToken` set to `default` in C#, or `Nothing` in Visual Basic.|
 |<xref:System.IO.Stream.WriteAsync(System.Byte[],System.Int32,System.Int32,System.Threading.CancellationToken)>|<xref:System.IO.Stream.WriteAsync(System.ReadOnlyMemory{System.Byte},System.Threading.CancellationToken)>|

--- a/docs/fundamentals/code-analysis/quality-rules/ca2016.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2016.md
@@ -9,7 +9,6 @@ helpviewer_keywords:
   - "ForwardCancellationTokenToInvocations"
   - "CA2016"
 author: carlossanlop
-ms.author: calope
 dev_langs:
  - CSharp
  - VB

--- a/docs/fundamentals/code-analysis/quality-rules/ca5404.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5404.md
@@ -18,7 +18,7 @@ f1_keywords:
 
 ## Cause
 
-Setting  <xref:Microsoft.IdentityModel.Tokens.TokenValidationParameters> properties `RequireExpirationTime`, `ValidateAudience`, `ValidateIssuer`, or `ValidateLifetime` to `false`.
+Setting the  `Microsoft.IdentityModel.Tokens.TokenValidationParameters` properties `RequireExpirationTime`, `ValidateAudience`, `ValidateIssuer`, or `ValidateLifetime` to `false`.
 
 ## Rule description
 
@@ -28,7 +28,7 @@ More details about best practices for token validation can be found on the [libr
 
 ## How to fix violations
 
-Set <xref:Microsoft.IdentityModel.Tokens.TokenValidationParameters> properties `RequireExpirationTime`, `ValidateAudience`, `ValidateIssuer`, or `ValidateLifetime` to `true`. Or, remove the assignment to `false` because the default value is `true`.
+Set the `Microsoft.IdentityModel.Tokens.TokenValidationParameters` properties `RequireExpirationTime`, `ValidateAudience`, `ValidateIssuer`, and `ValidateLifetime` to `true`. Or, remove the assignment to `false` because the default value is `true`.
 
 ## When to suppress warnings
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca5405.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5405.md
@@ -18,7 +18,7 @@ f1_keywords:
 
 ## Cause
 
-The callback assigned to <xref:Microsoft.IdentityModel.Tokens.AudienceValidator>  or <xref:Microsoft.IdentityModel.Tokens.LifetimeValidator> always returns `true`.
+The callback assigned to `AudienceValidator`  or `LifetimeValidator` always returns `true`.
 
 ## Rule description
 

--- a/docs/fundamentals/code-analysis/quality-rules/index.md
+++ b/docs/fundamentals/code-analysis/quality-rules/index.md
@@ -331,8 +331,8 @@ The following table lists code quality analysis rules.
 > | [CA5401: Do not use CreateEncryptor with non-default IV](ca5401.md) | Symmetric encryption should always use a non-repeatable initialization vector to prevent dictionary attacks. |
 > | [CA5402: Use CreateEncryptor with the default IV](ca5402.md) | Symmetric encryption should always use a non-repeatable initialization vector to prevent dictionary attacks. |
 > | [CA5403: Do not hard-code certificate](ca5403.md) | The `data` or `rawData` parameter of a <xref:System.Security.Cryptography.X509Certificates.X509Certificate> or <xref:System.Security.Cryptography.X509Certificates.X509Certificate2> constructor is hard-coded. |
-> | [CA5404: Do not disable token validation checks](ca5404.md) | <xref:Microsoft.IdentityModel.Tokens.TokenValidationParameters> properties that control token validation should not be set to `false`. |
-> | [CA5405: Do not always skip token validation in delegates](ca5405.md) | The callback assigned to <xref:Microsoft.IdentityModel.Tokens.AudienceValidator>  or <xref:Microsoft.IdentityModel.Tokens.LifetimeValidator> always returns `true`. |
+> | [CA5404: Do not disable token validation checks](ca5404.md) | `TokenValidationParameters` properties that control token validation should not be set to `false`. |
+> | [CA5405: Do not always skip token validation in delegates](ca5405.md) | The callback assigned to `AudienceValidator`  or `LifetimeValidator` always returns `true`. |
 > | [IL3000: Avoid accessing Assembly file path when publishing as a single file](../../../core/deploying/single-file/warnings/il3000.md) | Avoid accessing Assembly file path when publishing as a single file. |
 > | [IL3001: Avoid accessing Assembly file path when publishing as a single-file](../../../core/deploying/single-file/warnings/il3001.md) | Avoid accessing Assembly file path when publishing as a single file. |
 > | [IL3002: Avoid calling members annotated with 'RequiresAssemblyFilesAttribute' when publishing as a single file](../../../core/deploying/single-file/warnings/il3002.md) | Avoid calling members annotated with 'RequiresAssemblyFilesAttribute' when publishing as a single file|

--- a/docs/fundamentals/code-analysis/quality-rules/security-warnings.md
+++ b/docs/fundamentals/code-analysis/quality-rules/security-warnings.md
@@ -112,5 +112,5 @@ Security rules support safer libraries and applications. These rules help preven
 |[CA5401: Do not use CreateEncryptor with non-default IV](ca5401.md)|Symmetric encryption should always use a non-repeatable initialization vector to prevent dictionary attacks.|
 |[CA5402: Use CreateEncryptor with the default IV](ca5402.md)|Symmetric encryption should always use a non-repeatable initialization vector to prevent dictionary attacks.|
 |[CA5403: Do not hard-code certificate](ca5403.md)|The `data` or `rawData` parameter of a <xref:System.Security.Cryptography.X509Certificates.X509Certificate> or <xref:System.Security.Cryptography.X509Certificates.X509Certificate2> constructor is hard-coded.|
-| [CA5404: Do not disable token validation checks](ca5404.md) | <xref:Microsoft.IdentityModel.Tokens.TokenValidationParameters> properties that control token validation should not be set to `false`. |
-| [CA5405: Do not always skip token validation in delegates](ca5405.md) | The callback assigned to <xref:Microsoft.IdentityModel.Tokens.AudienceValidator>  or <xref:Microsoft.IdentityModel.Tokens.LifetimeValidator> always returns `true`. |
+| [CA5404: Do not disable token validation checks](ca5404.md) | `TokenValidationParameters` properties that control token validation should not be set to `false`. |
+| [CA5405: Do not always skip token validation in delegates](ca5405.md) | The callback assigned to `AudienceValidator`  or `LifetimeValidator` always returns `true`. |

--- a/docs/fundamentals/networking/telemetry/tracing.md
+++ b/docs/fundamentals/networking/telemetry/tracing.md
@@ -1,8 +1,7 @@
 ---
 title: Networking tracing
-description: Learn how to consume .NET networking Tracing.
+description: Learn how to consume .NET networking tracing.
 author: samsp-msft
-ms.author: samsp
 ms.date: 10/4/2024
 ---
 

--- a/docs/machine-learning/how-to-guides/ner-dataset-guide.md
+++ b/docs/machine-learning/how-to-guides/ner-dataset-guide.md
@@ -3,7 +3,6 @@ title: How to format data for Named Entity Recognition (NER)
 description: Learn how to format data for the Named Entity Recognition (NER) scenario in Model Builder
 ms.date: 02/23/2024
 author: zewditu
-ms.author: zehailem
 ms.custom: mvc,how-to
 ms.topic: how-to
 #Customer intent: As a non-developer, I want to be able to format training data for Model Builder to use for training NER scenarios


### PR DESCRIPTION
Contributes to #46530.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/aspnet-core/8.0/securitytoken-events.md](https://github.com/dotnet/docs/blob/a4019c1b240fc83058cdded50b6928d809c82242/docs/core/compatibility/aspnet-core/8.0/securitytoken-events.md) | [Security token events return a JsonWebToken](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/aspnet-core/8.0/securitytoken-events?branch=pr-en-us-47432) |
| [docs/core/extensions/httpclient-http3.md](https://github.com/dotnet/docs/blob/a4019c1b240fc83058cdded50b6928d809c82242/docs/core/extensions/httpclient-http3.md) | [Use HTTP/3 with HttpClient](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/httpclient-http3?branch=pr-en-us-47432) |
| [docs/fundamentals/code-analysis/quality-rules/ca1835.md](https://github.com/dotnet/docs/blob/a4019c1b240fc83058cdded50b6928d809c82242/docs/fundamentals/code-analysis/quality-rules/ca1835.md) | [CA1835: Prefer the memory-based overloads of ReadAsync/WriteAsync methods in stream-based classes](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1835?branch=pr-en-us-47432) |
| [docs/fundamentals/code-analysis/quality-rules/ca2016.md](https://github.com/dotnet/docs/blob/a4019c1b240fc83058cdded50b6928d809c82242/docs/fundamentals/code-analysis/quality-rules/ca2016.md) | [docs/fundamentals/code-analysis/quality-rules/ca2016](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2016?branch=pr-en-us-47432) |
| [docs/fundamentals/code-analysis/quality-rules/ca5404.md](https://github.com/dotnet/docs/blob/a4019c1b240fc83058cdded50b6928d809c82242/docs/fundamentals/code-analysis/quality-rules/ca5404.md) | [CA5404: Do not disable token validation checks](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca5404?branch=pr-en-us-47432) |
| [docs/fundamentals/code-analysis/quality-rules/ca5405.md](https://github.com/dotnet/docs/blob/a4019c1b240fc83058cdded50b6928d809c82242/docs/fundamentals/code-analysis/quality-rules/ca5405.md) | ["CA5405: Do not always skip token validation in delegates (code analysis)"](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca5405?branch=pr-en-us-47432) |
| [docs/fundamentals/code-analysis/quality-rules/index.md](https://github.com/dotnet/docs/blob/a4019c1b240fc83058cdded50b6928d809c82242/docs/fundamentals/code-analysis/quality-rules/index.md) | [Code quality rules](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/index?branch=pr-en-us-47432) |
| [docs/fundamentals/code-analysis/quality-rules/security-warnings.md](https://github.com/dotnet/docs/blob/a4019c1b240fc83058cdded50b6928d809c82242/docs/fundamentals/code-analysis/quality-rules/security-warnings.md) | [Security rules](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/security-warnings?branch=pr-en-us-47432) |
| [docs/fundamentals/networking/telemetry/tracing.md](https://github.com/dotnet/docs/blob/a4019c1b240fc83058cdded50b6928d809c82242/docs/fundamentals/networking/telemetry/tracing.md) | [docs/fundamentals/networking/telemetry/tracing](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/networking/telemetry/tracing?branch=pr-en-us-47432) |
| [docs/machine-learning/how-to-guides/ner-dataset-guide.md](https://github.com/dotnet/docs/blob/a4019c1b240fc83058cdded50b6928d809c82242/docs/machine-learning/how-to-guides/ner-dataset-guide.md) | [How to format data for Named Entity Recognition (NER)](https://review.learn.microsoft.com/en-us/dotnet/machine-learning/how-to-guides/ner-dataset-guide?branch=pr-en-us-47432) |


<!-- PREVIEW-TABLE-END -->