### PR TITLE
Document the impact SdkAnalysisLevel has

### DIFF
--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -1461,7 +1461,7 @@ By setting the value in SDKAnalysisLevel column, you are getting the Current col
 | SDKAnalysisLevel | What | Previous | Current |
 |------------------------|-----------|--------|-------|
 | 9.0.100 | Restore HTTP sources diagnostic | [NU1803](/nuget/reference/errors-and-warnings/nu1803) warning | [NU1302](/nuget/reference/errors-and-warnings/nu1302) error. |  
-| 10.0.100 | Restore Package Pruning, [PrunePackageReference](/nuget/consume-packages/package-references-in-project-files#prunepackagereference), enabled by default | N/A | Enabled for projects targeting .NET 8+ & .NET Standard 2.0+ |
+| 10.0.100 | Restore package pruning, [PrunePackageReference](/nuget/consume-packages/package-references-in-project-files#prunepackagereference), enabled by default | N/A | Enabled for projects that target .NET 8+ or .NET Standard 2.0+ |
 | 10.0.100 | Restore resolver with lock files | Uses legacy dependency graph resolver (.NET 8 SDK and earlier) | Uses improved, [.NET 9 dependency graph resolver](/nuget/consume-packages/package-references-in-project-files#nuget-dependency-resolver) |
 | 10.0.100 | Restore behavior for PackageReference without a version | [NU1603](/nuget/reference/errors-and-warnings/nu1603) warning | [NU1015](/nuget/reference/errors-and-warnings/nu1015) error |
 

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -1462,7 +1462,6 @@ By setting the value in SDKAnalysisLevel column, you are getting the Current col
 |------------------------|-----------|--------|-------|
 | 9.0.100 | Restore HTTP sources diagnostic | [NU1803](/nuget/reference/errors-and-warnings/nu1803) warning | [NU1302](/nuget/reference/errors-and-warnings/nu1302) error. |  
 | 10.0.100 | Restore Package Pruning, [PrunePackageReference](/nuget/consume-packages/package-references-in-project-files#prunepackagereference), enabled by default | N/A | Enabled for projects targeting .NET 8+ & .NET Standard 2.0+ |
-| 10.0.100 | **TBD, I don't think I need this gate anymore** PrunePackageReference diagnostics | N/A | [NU1510](/nuget/reference/errors-and-warnings/nu1510), [NU1511](/nuget/reference/errors-and-warnings/nu1511). |
 | 10.0.100 | Restore resolver with lock files | Uses legacy dependency graph resolver (.NET 8 SDK and earlier) | Uses improved, [.NET 9 dependency graph resolver](/nuget/consume-packages/package-references-in-project-files#nuget-dependency-resolver) |
 | 10.0.100 | Restore behavior for PackageReference without a version | [NU1603](/nuget/reference/errors-and-warnings/nu1603) warning | [NU1015](/nuget/reference/errors-and-warnings/nu1015) error |
 

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -1455,6 +1455,16 @@ The allowed values of this property are SDK feature bands, for example, 8.0.100 
 
 For more information, see [SDK Analysis Level Property and Usage](https://github.com/dotnet/designs/blob/main/proposed/sdk-analysis-level.md).
 
+The following table summarizes summarizes which diagnostics SDKAnalysisLevel affects.
+By setting the value in SDKAnalysisLevel column, you are getting the Current column.
+
+| SDKAnalysisLevel | What | Previous | Current |
+|------------------------|-----------|--------|-------|
+| 9.0.100 | Restore HTTP sources diagnostic | [NU1803](/nuget/reference/errors-and-warnings/nu1803) warning | [NU1302](/nuget/reference/errors-and-warnings/nu1302) error. |  
+| 10.0.100 | Restore Package Pruning diagnostic | N/A | [NU1510](/nuget/reference/errors-and-warnings/nu1510), [NU1511](/nuget/reference/errors-and-warnings/nu1511). |
+| 10.0.100 | Restore resolver with lock files | Uses legacy dependency graph resolver (.NET 8 SDK and earlier) | Uses improved, [.NET 9 dependency graph resolver](/nuget/consume-packages/package-references-in-project-files#nuget-dependency-resolver) |
+| 10.0.100 | Restore behavior for PackageReference without a version | [NU1603](/nuget/reference/errors-and-warnings/nu1603) warning | [NU1015](/nuget/reference/errors-and-warnings/nu1015) error |
+
 ## Microsoft.Testing.Platform&ndash;related properties
 
 The following MSBuild properties are documented in this section:

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -1456,7 +1456,6 @@ The allowed values of this property are SDK feature bands, for example, 8.0.100 
 For more information, see [SDK Analysis Level Property and Usage](https://github.com/dotnet/designs/blob/main/proposed/sdk-analysis-level.md).
 
 The following table summarizes the diagnostics affected by `SDKAnalysisLevel`.
-By setting the value in SDKAnalysisLevel column, you are getting the Current column.
 
 | SDKAnalysisLevel | What | Previous | Current |
 |------------------------|-----------|--------|-------|

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -1455,7 +1455,7 @@ The allowed values of this property are SDK feature bands, for example, 8.0.100 
 
 For more information, see [SDK Analysis Level Property and Usage](https://github.com/dotnet/designs/blob/main/proposed/sdk-analysis-level.md).
 
-The following table summarizes summarizes which diagnostics SDKAnalysisLevel affects.
+The following table summarizes the diagnostics affected by `SDKAnalysisLevel`.
 By setting the value in SDKAnalysisLevel column, you are getting the Current column.
 
 | SDKAnalysisLevel | What | Previous | Current |

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -1461,7 +1461,8 @@ By setting the value in SDKAnalysisLevel column, you are getting the Current col
 | SDKAnalysisLevel | What | Previous | Current |
 |------------------------|-----------|--------|-------|
 | 9.0.100 | Restore HTTP sources diagnostic | [NU1803](/nuget/reference/errors-and-warnings/nu1803) warning | [NU1302](/nuget/reference/errors-and-warnings/nu1302) error. |  
-| 10.0.100 | Restore Package Pruning diagnostic | N/A | [NU1510](/nuget/reference/errors-and-warnings/nu1510), [NU1511](/nuget/reference/errors-and-warnings/nu1511). |
+| 10.0.100 | Restore Package Pruning, [PrunePackageReference](/nuget/consume-packages/package-references-in-project-files#prunepackagereference), enabled by default | N/A | Enabled for projects targeting .NET 8+ & .NET Standard 2.0+ |
+| 10.0.100 | **TBD, I don't think I need this gate anymore** PrunePackageReference diagnostics | N/A | [NU1510](/nuget/reference/errors-and-warnings/nu1510), [NU1511](/nuget/reference/errors-and-warnings/nu1511). |
 | 10.0.100 | Restore resolver with lock files | Uses legacy dependency graph resolver (.NET 8 SDK and earlier) | Uses improved, [.NET 9 dependency graph resolver](/nuget/consume-packages/package-references-in-project-files#nuget-dependency-resolver) |
 | 10.0.100 | Restore behavior for PackageReference without a version | [NU1603](/nuget/reference/errors-and-warnings/nu1603) warning | [NU1015](/nuget/reference/errors-and-warnings/nu1015) error |
 

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -1457,7 +1457,7 @@ For more information, see [SDK Analysis Level Property and Usage](https://github
 
 The following table summarizes the diagnostics affected by `SDKAnalysisLevel`.
 
-| SDKAnalysisLevel | What | Previous | Current |
+| SDKAnalysisLevel | Diagnostic | Previous | Current |
 |------------------------|-----------|--------|-------|
 | 9.0.100 | Restore HTTP sources diagnostic | [NU1803](/nuget/reference/errors-and-warnings/nu1803) warning | [NU1302](/nuget/reference/errors-and-warnings/nu1302) error. |  
 | 10.0.100 | Restore package pruning, [PrunePackageReference](/nuget/consume-packages/package-references-in-project-files#prunepackagereference), enabled by default | N/A | Enabled for projects that target .NET 8+ or .NET Standard 2.0+ |


### PR DESCRIPTION
## Summary

Document the impact SDKAnalysisLevel has. 
This is important because often customers may set this value to unblock themselves due to a particular warning, but they're potentially unknowingly disabling a lot more. 

I am starting this table to serve as a guide for customers setting SDKAnalysisLevel

I'd love to be able to reference this from the NuGet docs wherever we recommend that people can set SDKAnalysisLevel to go back to the old behavior.

Fixes https://github.com/NuGet/Home/issues/14369


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/project-sdk/msbuild-props.md](https://github.com/dotnet/docs/blob/29c20e9abaa813037048bce0a9b2741ff749a350/docs/core/project-sdk/msbuild-props.md) | [docs/core/project-sdk/msbuild-props](https://review.learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props?branch=pr-en-us-47456) |


<!-- PREVIEW-TABLE-END -->