### PR TITLE
Add an example of installing multiple SDKs while not corrupting installs

### DIFF
--- a/docs/core/tools/dotnet-install-script.md
+++ b/docs/core/tools/dotnet-install-script.md
@@ -288,48 +288,47 @@ The install scripts do not update the registry on Windows. They just download th
   curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin <additional install-script args>
   ```
 
-- Install multiple versions while not overwriting `dotnet` binaries from prior installs
+- Install multiple versions while not overwriting `dotnet` binaries from prior installs.
 
-If you install .NET SDKs or the .NET Runtime from an earlier version on top of a newer version, you need to use `--skip-non-versioned-files` so that
-the 'unversioned' `dotnet` files from the earlier version do not overwrite the same files from the newer version.
+  If you install .NET SDKs or the .NET runtime from an earlier version on top of a newer version, you need to use `--skip-non-versioned-files` so that
+  the 'unversioned' `dotnet` files from the earlier version don't overwrite the same files from the newer version.
 
-```shell
-:~ $ ./dotnet-install.sh --channel 9.0 --install-dir local-dotnet  # installs the latest 9 SDK to the specified directory
-dotnet-install: Attempting to download using aka.ms link https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.303/dotnet-sdk-9.0.303-linux-x64.tar.gz
-dotnet-install: Remote file https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.303/dotnet-sdk-9.0.303-linux-x64.tar.gz size is 218004272 bytes.
-dotnet-install: Extracting archive from https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.303/dotnet-sdk-9.0.303-linux-x64.tar.gz
-dotnet-install: Downloaded file size is 218004272 bytes.
-dotnet-install: The remote and local file sizes are equal.
-dotnet-install: Installed version is 9.0.303
-dotnet-install: Adding to current process PATH: `$HOME/local-dotnet`. Note: This change will be visible only when sourcing script.
-dotnet-install: Note that the script does not resolve dependencies during installation.
-dotnet-install: To check the list of dependencies, go to https://learn.microsoft.com/dotnet/core/install, select your operating system and check the "Dependencies" section.
-dotnet-install: Installation finished successfully.
-:~ $ ./local-dotnet/dotnet --list-runtimes # see what runtimes we have available
-Microsoft.AspNetCore.App 9.0.7 [$HOME/local-dotnet/shared/Microsoft.AspNetCore.App]
-Microsoft.NETCore.App 9.0.7 [$HOME/local-dotnet/shared/Microsoft.NETCore.App]
-:~ $ ./local-dotnet/dotnet --list-sdks # see what SDKs we have available
-9.0.303 [$HOME/local-dotnet/sdk]
-:~ $ ./dotnet-install.sh --channel 8.0 --install-dir local-dotnet --skip-non-versioned-files # install the 8 SDK to the same place, but keep the 9 dotnet binaries
-dotnet-install: Attempting to download using aka.ms link https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.412/dotnet-sdk-8.0.412-linux-x64.tar.gz
-dotnet-install: Remote file https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.412/dotnet-sdk-8.0.412-linux-x64.tar.gz size is 216096947 bytes.
-dotnet-install: Extracting archive from https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.412/dotnet-sdk-8.0.412-linux-x64.tar.gz
-dotnet-install: Downloaded file size is 216096947 bytes.
-dotnet-install: The remote and local file sizes are equal.
-dotnet-install: Installed version is 8.0.412
-dotnet-install: Adding to current process PATH: `$HOME/local-dotnet`. Note: This change will be visible only when sourcing script.
-dotnet-install: Note that the script does not resolve dependencies during installation.
-dotnet-install: To check the list of dependencies, go to https://learn.microsoft.com/dotnet/core/install, select your operating system and check the "Dependencies" section.
-dotnet-install: Installation finished successfully.
-:~ $ ./local-dotnet/dotnet --list-runtimes # we should have 8 and 9 Runtimes now
-Microsoft.AspNetCore.App 8.0.18 [$HOME/local-dotnet/shared/Microsoft.AspNetCore.App]
-Microsoft.AspNetCore.App 9.0.7 [$HOME/local-dotnet/shared/Microsoft.AspNetCore.App]
-Microsoft.NETCore.App 8.0.18 [$HOME/local-dotnet/shared/Microsoft.NETCore.App]
-Microsoft.NETCore.App 9.0.7 [$HOME/local-dotnet/shared/Microsoft.NETCore.App]
-:~ $ ./local-dotnet/dotnet --list-sdks # we should have 2 SDKs now
-8.0.412 [$HOME/local-dotnet/sdk]
-9.0.303 [$HOME/local-dotnet/sdk]
-```
+  ```shell
+  :~ $ ./dotnet-install.sh --channel 9.0 --install-dir local-dotnet  # installs the latest 9 SDK to the specified directory
+  dotnet-install: Attempting to download using aka.ms link https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.303/dotnet-sdk-9.0.303-linux-x64.tar.gz
+  dotnet-install: Remote file https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.303/dotnet-sdk-9.0.303-linux-x64.tar.gz size is 218004272 bytes.
+  dotnet-install: Extracting archive from https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.303/dotnet-sdk-9.0.303-linux-x64.tar.gz
+  dotnet-install: Downloaded file size is 218004272 bytes.
+  dotnet-install: The remote and local file sizes are equal.
+  dotnet-install: Installed version is 9.0.303
+  dotnet-install: Adding to current process PATH: `$HOME/local-dotnet`. Note: This change will be visible only when sourcing script.
+  dotnet-install: Note that the script does not resolve dependencies during installation.
+  dotnet-install: To check the list of dependencies, go to https://learn.microsoft.com/dotnet/core/install, select your operating system and check the "Dependencies" section.
+  dotnet-install: Installation finished successfully.
+  :~ $ ./local-dotnet/dotnet --list-runtimes # see what runtimes we have available
+  Microsoft.AspNetCore.App 9.0.7 [$HOME/local-dotnet/shared/Microsoft.AspNetCore.App]
+  Microsoft.NETCore.App 9.0.7 [$HOME/local-dotnet/shared/Microsoft.NETCore.App]
+  :~ $ ./local-dotnet/dotnet --list-sdks # see what SDKs we have available
+  9.0.303 [$HOME/local-dotnet/sdk]
+  :~ $ ./dotnet-install.sh --channel 8.0 --install-dir local-dotnet --skip-non-versioned-files # install the 8 SDK to the same place, but keep the 9 dotnet binaries
+  dotnet-install: Attempting to download using aka.ms link https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.412/dotnet-sdk-8.0.412-linux-x64.tar.gz
+  dotnet-install: Remote file https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.412/dotnet-sdk-8.0.412-linux-x64.tar.gz size is 216096947 bytes.
+  dotnet-install: Extracting archive from https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.412/dotnet-sdk-8.0.412-linux-x64.tar.gz
+  dotnet-install: Downloaded file size is 216096947 bytes.
+  dotnet-install: The remote and local file sizes are equal.
+  dotnet-install: Installed version is 8.0.412
+  dotnet-install: Adding to current process PATH: `$HOME/local-dotnet`. Note: This change will be visible only when sourcing script.
+  dotnet-install: Note that the script does not resolve dependencies during installation.
+  dotnet-install: To check the list of dependencies, go to https://learn.microsoft.com/dotnet/core/install, select your operating system and check the "Dependencies" section.
+  dotnet-install: Installation finished successfully.
+  :~ $ ./local-dotnet/dotnet --list-runtimes # we should have 8 and 9 Runtimes now
+  Microsoft.AspNetCore.App 8.0.18 [$HOME/local-dotnet/shared/Microsoft.AspNetCore.App]
+  Microsoft.AspNetCore.App 9.0.7 [$HOME/local-dotnet/shared/Microsoft.AspNetCore.App]
+  Microsoft.NETCore.App 8.0.18 [$HOME/local-dotnet/shared/Microsoft.NETCore.App]
+  Microsoft.NETCore.App 9.0.7 [$HOME/local-dotnet/shared/Microsoft.NETCore.App]
+  :~ $ ./local-dotnet/dotnet --list-sdks # we should have 2 SDKs now
+  8.0.412 [$HOME/local-dotnet/sdk]
+  9.0.303 [$HOME/local-dotnet/sdk]
 
 ## Set environment variables
 

--- a/docs/core/tools/dotnet-install-script.md
+++ b/docs/core/tools/dotnet-install-script.md
@@ -288,6 +288,49 @@ The install scripts do not update the registry on Windows. They just download th
   curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin <additional install-script args>
   ```
 
+- Install multiple versions while not overwriting `dotnet` binaries from prior installs
+
+If you install .NET SDKs or the .NET Runtime from an earlier version on top of a newer version, you need to use `--skip-non-versioned-files` so that 
+the 'unversioned' `dotnet` files from the earlier version do not overwrite the same files from the newer version.
+
+```shell
+:~ $ ./dotnet-install.sh --channel 9.0 --install-dir local-dotnet  # installs the latest 9 SDK to the specified directory
+dotnet-install: Attempting to download using aka.ms link https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.303/dotnet-sdk-9.0.303-linux-x64.tar.gz
+dotnet-install: Remote file https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.303/dotnet-sdk-9.0.303-linux-x64.tar.gz size is 218004272 bytes.
+dotnet-install: Extracting archive from https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.303/dotnet-sdk-9.0.303-linux-x64.tar.gz
+dotnet-install: Downloaded file size is 218004272 bytes.
+dotnet-install: The remote and local file sizes are equal.
+dotnet-install: Installed version is 9.0.303
+dotnet-install: Adding to current process PATH: `$HOME/local-dotnet`. Note: This change will be visible only when sourcing script.
+dotnet-install: Note that the script does not resolve dependencies during installation.
+dotnet-install: To check the list of dependencies, go to https://learn.microsoft.com/dotnet/core/install, select your operating system and check the "Dependencies" section.
+dotnet-install: Installation finished successfully.
+:~ $ ./local-dotnet/dotnet --list-runtimes # see what runtimes we have available
+Microsoft.AspNetCore.App 9.0.7 [$HOME/local-dotnet/shared/Microsoft.AspNetCore.App]
+Microsoft.NETCore.App 9.0.7 [$HOME/local-dotnet/shared/Microsoft.NETCore.App]
+:~ $ ./local-dotnet/dotnet --list-sdks # see what SDKs we have available
+9.0.303 [$HOME/local-dotnet/sdk]
+:~ $ ./dotnet-install.sh --channel 8.0 --install-dir local-dotnet --skip-non-versioned-files # install the 8 SDK to the same place, but keep the 9 dotnet binaries
+dotnet-install: Attempting to download using aka.ms link https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.412/dotnet-sdk-8.0.412-linux-x64.tar.gz
+dotnet-install: Remote file https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.412/dotnet-sdk-8.0.412-linux-x64.tar.gz size is 216096947 bytes.
+dotnet-install: Extracting archive from https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.412/dotnet-sdk-8.0.412-linux-x64.tar.gz
+dotnet-install: Downloaded file size is 216096947 bytes.
+dotnet-install: The remote and local file sizes are equal.
+dotnet-install: Installed version is 8.0.412
+dotnet-install: Adding to current process PATH: `$HOME/local-dotnet`. Note: This change will be visible only when sourcing script.
+dotnet-install: Note that the script does not resolve dependencies during installation.
+dotnet-install: To check the list of dependencies, go to https://learn.microsoft.com/dotnet/core/install, select your operating system and check the "Dependencies" section.
+dotnet-install: Installation finished successfully.
+:~ $ ./local-dotnet/dotnet --list-runtimes # we should have 8 and 9 Runtimes now
+Microsoft.AspNetCore.App 8.0.18 [$HOME/local-dotnet/shared/Microsoft.AspNetCore.App]
+Microsoft.AspNetCore.App 9.0.7 [$HOME/local-dotnet/shared/Microsoft.AspNetCore.App]
+Microsoft.NETCore.App 8.0.18 [$HOME/local-dotnet/shared/Microsoft.NETCore.App]
+Microsoft.NETCore.App 9.0.7 [$HOME/local-dotnet/shared/Microsoft.NETCore.App]
+:~ $ ./local-dotnet/dotnet --list-sdks # we should have 2 SDKs now
+8.0.412 [$HOME/local-dotnet/sdk]
+9.0.303 [$HOME/local-dotnet/sdk]
+```
+
 ## Set environment variables
 
 Manually installing .NET doesn't add the environment variables system-wide, and generally only works for the session in which .NET was installed. There are two environment variables you should set for your operating system:

--- a/docs/core/tools/dotnet-install-script.md
+++ b/docs/core/tools/dotnet-install-script.md
@@ -290,7 +290,7 @@ The install scripts do not update the registry on Windows. They just download th
 
 - Install multiple versions while not overwriting `dotnet` binaries from prior installs
 
-If you install .NET SDKs or the .NET Runtime from an earlier version on top of a newer version, you need to use `--skip-non-versioned-files` so that 
+If you install .NET SDKs or the .NET Runtime from an earlier version on top of a newer version, you need to use `--skip-non-versioned-files` so that
 the 'unversioned' `dotnet` files from the earlier version do not overwrite the same files from the newer version.
 
 ```shell


### PR DESCRIPTION
## Summary

In https://github.com/dotnet/install-scripts/issues/622, a user pointed out that using the scripts in the straightforward way leads you to corrupting your local install dir. 

This adds an example of how to do multi-SDK installs safely so we have something to point to.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-install-script.md](https://github.com/dotnet/docs/blob/6f32621bd70a194399660d7e1c131730526356eb/docs/core/tools/dotnet-install-script.md) | [docs/core/tools/dotnet-install-script](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script?branch=pr-en-us-47462) |


<!-- PREVIEW-TABLE-END -->