### PR TITLE
[UUF] Remove confusing info

### DIFF
--- a/docs/core/tools/dotnet-msbuild.md
+++ b/docs/core/tools/dotnet-msbuild.md
@@ -25,7 +25,7 @@ The `dotnet msbuild` command allows access to a fully functional MSBuild.
 
 The command has the exact same capabilities as the existing MSBuild command-line client for SDK-style projects only. The options are all the same. For more information about the available options, see the [MSBuild command-line reference](/visualstudio/msbuild/msbuild-command-line-reference).
 
-The [dotnet build](dotnet-build.md) command is equivalent to `dotnet msbuild -restore`. When you don't want to build the project and you have a specific target you want to run, use `dotnet build` or `dotnet msbuild` and specify the target.
+The [dotnet build](dotnet-build.md) command is equivalent to `dotnet msbuild -restore`.
 
 ## Examples
 


### PR DESCRIPTION
This is in response to some UUF feedback:

> Description contains: "When you don't want to build the project and you have a specific target you want to run, use dotnet build or dotnet msbuild and specify the target." This makes no sense and is actually self contradictory.   It starts by assuming a distinction you want to achieve, but then provides both options as viable... So Why point this out? How does one use `dotnet build` to run a specific target? (Docs for that command don't indicate such a thing is even possible)

Looks like the confusing sentence was modified in [this PR](https://github.com/dotnet/docs/pull/18965).

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-msbuild.md](https://github.com/dotnet/docs/blob/dd389358ac884877dbdecceb83b3e0cab8ef8116/docs/core/tools/dotnet-msbuild.md) | [dotnet msbuild](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-msbuild?branch=pr-en-us-47506) |

<!-- PREVIEW-TABLE-END -->