### PR TITLE
Update the CS1031 page 

### DIFF
--- a/docs/csharp/misc/cs1031.md
+++ b/docs/csharp/misc/cs1031.md
@@ -13,6 +13,8 @@ ms.assetid: 14196659-aaac-4df2-a4ed-0bebb8097d59
 Type expected  
   
 A type has not been specified where expected, when [overloading an operator](../language-reference/operators/operator-overloading.md).
+<br/>Missing *type* in this case means that there's no *type* given for the return type of the overloaded operator.
+This error shouldn't be confused with missing [generic type parameter](../../csharp/programming-guide/generics/generic-type-parameters.md).
 
 ## Example
 
@@ -27,11 +29,14 @@ namespace x
 
     public class A
     {  
-        public static operator +(A aa)  // CS1031  
-                                        // try the following line instead  
-                                        // public static ii operator +(a aa)  
+        public static operator +(A a)    // CS1031 - Overloaded operator missing a type
         {
-            return new ii();
+            return new I();
+        }
+
+        public static I operator +(A a)  // Correct - type was specified
+        {
+            return new I();
         }
     }
 }

--- a/docs/csharp/misc/cs1031.md
+++ b/docs/csharp/misc/cs1031.md
@@ -12,35 +12,27 @@ ms.assetid: 14196659-aaac-4df2-a4ed-0bebb8097d59
 
 Type expected  
   
- A type parameter is expected.  
-  
-## Example  
+A type has not been specified where expected, when [overloading an operator](../language-reference/operators/operator-overloading.md).
 
- The following sample generates CS1031:  
-  
-```csharp  
-// CS1031.cs  
-namespace x  
-{  
-    public class ii  
+## Example
+
+The following sample generates CS1031:
+
+```csharp
+namespace x
+{
+    public class I
+    {
+    }
+
+    public class A
     {  
-    }  
-  
-    public class a  
-    {  
-        public static operator +(a aa)   // CS1031  
-        // try the following line instead  
-        // public static ii operator +(a aa)  
-        {  
-            return new ii();  
-        }  
-  
-        public static void Main()  
-        {  
-            e = new base;   // CS1031, not a type  
-            e = new this;   // CS1031, not a type  
-            e = new ();     // CS1031, not a type  
-        }  
-    }  
-}  
+        public static operator +(A aa)  // CS1031  
+                                        // try the following line instead  
+                                        // public static ii operator +(a aa)  
+        {
+            return new ii();
+        }
+    }
+}
 ```


### PR DESCRIPTION
This pull request closes #47132, by updating the page of CS1031.
The update includes:
* removal of incorrect examples of non-cs1031 errors
* update of the correct code - separated it between error and non-error samples
* updated explanation text, mentioning:
That this error is regarding overloaded operators - I couldn't reproduce this error with any other "type missing" scenario, often led it to syntax errors or other, non-relevant ones.
That this error shouldn't be confused between *type* and *type parameters*, with linking to generic type parameters, for better understanding of the difference.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/misc/cs1031.md](https://github.com/dotnet/docs/blob/89f923ac1324494697c52866c7686c0ee214b0d2/docs/csharp/misc/cs1031.md) | [Compiler Error CS1031](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/cs1031?branch=pr-en-us-47527) |

<!-- PREVIEW-TABLE-END -->