### PR TITLE
dotnet nuget verify outputs content hash

### DIFF
--- a/docs/core/tools/dotnet-nuget-verify.md
+++ b/docs/core/tools/dotnet-nuget-verify.md
@@ -27,6 +27,7 @@ dotnet nuget verify -h|--help
 ## Description
 
 The `dotnet nuget verify` command verifies a signed NuGet package.
+From .NET 10 it also outputs the package's content hash, which may be useful to investigate lock file validation errors.
 
   > [!NOTE]
   > This command requires a certificate root store that is valid for both code signing and timestamping. Also, this command may not be supported on some combinations of operating system and .NET SDK. For more information, see [NuGet signed package verification](nuget-signed-package-verification.md).

--- a/docs/core/tools/dotnet-nuget-verify.md
+++ b/docs/core/tools/dotnet-nuget-verify.md
@@ -27,7 +27,7 @@ dotnet nuget verify -h|--help
 ## Description
 
 The `dotnet nuget verify` command verifies a signed NuGet package.
-From .NET 10 it also outputs the package's content hash, which may be useful to investigate lock file validation errors.
+In .NET 10 and later versions, the command also outputs the package's content hash, which might be useful to investigate lock file validation errors.
 
   > [!NOTE]
   > This command requires a certificate root store that is valid for both code signing and timestamping. Also, this command may not be supported on some combinations of operating system and .NET SDK. For more information, see [NuGet signed package verification](nuget-signed-package-verification.md).


### PR DESCRIPTION
## Summary

NuGet is changing `dotnet nuget verify` in .NET 10, so that it will output the package hash. 

NuGet lock files ensure that the same package hash is used for every restore, but when different package sources have different package hashes, it can be hard to investigate what the package hash is from each source. This feature makes it easier to download the nupkg from each source, then run `dotnet nuget verify` on them, and find out what hash each one has, and compare to the ash in the lock file.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-nuget-verify.md](https://github.com/dotnet/docs/blob/ed434897817eb9effac5e9088e30753d710516c1/docs/core/tools/dotnet-nuget-verify.md) | [docs/core/tools/dotnet-nuget-verify](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-verify?branch=pr-en-us-47528) |


<!-- PREVIEW-TABLE-END -->