### PR TITLE
Update default severity change in MSTest 3.10

### DIFF
--- a/docs/core/testing/mstest-analyzers/mstest0006.md
+++ b/docs/core/testing/mstest-analyzers/mstest0006.md
@@ -23,7 +23,7 @@ dev_langs:
 | **Category**                        | Design                                             |
 | **Fix is breaking or non-breaking** | Non-breaking                                       |
 | **Enabled by default**              | Yes                                                |
-| **Default severity**                | Info                                               |
+| **Default severity**                | Warning starting with 3.10, Info before            |
 | **Introduced in version**           | 3.2.0                                              |
 | **Is there a code fix**             | Yes, starting with 3.7.0                           |
 

--- a/docs/core/testing/mstest-analyzers/mstest0039.md
+++ b/docs/core/testing/mstest-analyzers/mstest0039.md
@@ -20,7 +20,7 @@ ms.author: ygerges
 | **Category**                        | Usage                                                                  |
 | **Fix is breaking or non-breaking** | Non-breaking                                                           |
 | **Enabled by default**              | Yes                                                                    |
-| **Default severity**                | Info                                                                   |
+| **Default severity**                | Warning starting with 3.10, Info before                                |
 | **Introduced in version**           | 3.8.0                                                                  |
 | **Is there a code fix**             | Yes                                                                    |
 


### PR DESCRIPTION
## Summary

With the release of MSTest 3.10, some analyzers will have their severity bumped to `Warning` by default. Reflect this change in documentation.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/mstest-analyzers/mstest0006.md](https://github.com/dotnet/docs/blob/4f808e914bb9878ba488ba9ce21952f894d5e0a7/docs/core/testing/mstest-analyzers/mstest0006.md) | [MSTEST0006: Avoid `[ExpectedException]`](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0006?branch=pr-en-us-47551) |
| [docs/core/testing/mstest-analyzers/mstest0039.md](https://github.com/dotnet/docs/blob/4f808e914bb9878ba488ba9ce21952f894d5e0a7/docs/core/testing/mstest-analyzers/mstest0039.md) | ["MSTEST0039: Use newer 'Assert.Throws' methods"](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0039?branch=pr-en-us-47551) |

<!-- PREVIEW-TABLE-END -->