### PR TITLE
fix broken link in appmod dotnet doc

### DIFF
--- a/docs/azure/migration/appmod/overview.md
+++ b/docs/azure/migration/appmod/overview.md
@@ -10,7 +10,7 @@ ms.author: alexwolf
 
 # GitHub Copilot app modernization for .NET (Preview) overview
 
-[GitHub Copilot app modernization for .NET (Preview)](https://marketplace.visualstudio.com/items?itemName=vscjava.appmod-dotnet) helps you migrate .NET applications to Azure quickly and confidently by guiding you through assessment, solution recommendations, code fixes, and validation - all in one tool.
+[GitHub Copilot app modernization for .NET (Preview)](https://aka.ms/appmod-dotnet-marketplace) helps you migrate .NET applications to Azure quickly and confidently by guiding you through assessment, solution recommendations, code fixes, and validation - all in one tool.
 
 With this assistant, you can:
 

--- a/docs/azure/migration/appmod/quickstart.md
+++ b/docs/azure/migration/appmod/quickstart.md
@@ -10,7 +10,7 @@ ms.author: alexwolf
 
 # Quickstart: Assess and migrate a .NET Project with GitHub Copilot app modernization for .NET (Preview)
 
-In this quickstart, you assess and migrate a .NET project using [GitHub Copilot app modernization for .NET (Preview)](https://marketplace.visualstudio.com/items?itemName=vscjava.appmod-dotnet). You complete the following tasks:
+In this quickstart, you assess and migrate a .NET project using [GitHub Copilot app modernization for .NET (Preview)](https://aka.ms/appmod-dotnet-marketplace). You complete the following tasks:
 
 - Install and configure the GitHub Copilot app modernization for .NET extension
 - Assess a sample project (Contoso University)

--- a/docs/azure/migration/appmod/quickstart.md
+++ b/docs/azure/migration/appmod/quickstart.md
@@ -43,7 +43,7 @@ To complete the steps ahead, you need to install the GitHub Copilot app moderniz
 1. Follow the notification bar prompts to close Visual Studio and complete the installation.
 1. Relaunch Visual Studio after installation.
 
-You can also view the [GitHub Copilot app modernization for .NET (Preview)](https://marketplace.visualstudio.com/items?itemName=vscjava.appmod-dotnet) extension directly on the extension marketplace.
+You can also view the [GitHub Copilot app modernization for .NET (Preview)](https://aka.ms/appmod-dotnet-marketplace) extension directly on the extension marketplace.
 
 For more information, see [Find, install, and manage extensions for Visual Studio](/visualstudio/ide/finding-and-using-visual-studio-extensions?view=vs-2022).
 


### PR DESCRIPTION
## Summary

Fix an outdated link.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/azure/migration/appmod/overview.md](https://github.com/dotnet/docs/blob/618d9543d7d37c4273359303f768674d6f030210/docs/azure/migration/appmod/overview.md) | [GitHub Copilot app modernization for .NET (Preview) overview](https://review.learn.microsoft.com/en-us/dotnet/azure/migration/appmod/overview?branch=pr-en-us-47557) |
| [docs/azure/migration/appmod/quickstart.md](https://github.com/dotnet/docs/blob/618d9543d7d37c4273359303f768674d6f030210/docs/azure/migration/appmod/quickstart.md) | [GitHub Copilot app modernization for .NET (Preview) quickstart](https://review.learn.microsoft.com/en-us/dotnet/azure/migration/appmod/quickstart?branch=pr-en-us-47557) |


<!-- PREVIEW-TABLE-END -->