### PR TITLE
Add non-sdk project heading to dotnet nuget why docs

### DIFF
--- a/docs/core/tools/dotnet-nuget-why.md
+++ b/docs/core/tools/dotnet-nuget-why.md
@@ -24,13 +24,15 @@ dotnet nuget why -h|--help
 
 The `dotnet nuget why` command shows the dependency graph for a particular package for a given project or solution.
 
+Starting with version 9.0.200, the command introduces support for runtime identifier (RID) specific packages by generating separate dependency trees for each RID and framework combination.
+For example, if a project targets `net9.0` with the `win-x64` RID, the command generates trees for `net9.0/win-x64` and `net9.0`.
+
+### Older project format
+
 Starting from the .NET 9 SDK, it's possible to pass a NuGet assets file in place of the project file, in order to use the command with projects that can't be restored with the .NET SDK.
 First, restore the project in Visual Studio, or `msbuild.exe`.
 By default the assets file is in the project's `obj\` directory, but you can find the location with `msbuild.exe path\to\project.proj -getProperty:ProjectAssetsFile`.
 Finally, run `dotnet nuget why path\to\project.assets.json SomePackage`.
-
-Starting with version 9.0.200, the command introduces support for runtime identifier (RID) specific packages by generating separate dependency trees for each RID and framework combination.
-For example, if a project targets `net9.0` with the `win-x64` RID, the command generates trees for `net9.0/win-x64` and `net9.0`.
 
 ## Arguments
 

--- a/docs/core/tools/dotnet-nuget-why.md
+++ b/docs/core/tools/dotnet-nuget-why.md
@@ -29,10 +29,10 @@ For example, if a project targets `net9.0` with the `win-x64` RID, the command g
 
 ### Older project format
 
-Starting from the .NET 9 SDK, it's possible to pass a NuGet assets file in place of the project file, in order to use the command with projects that can't be restored with the .NET SDK.
-First, restore the project in Visual Studio, or `msbuild.exe`.
-By default the assets file is in the project's `obj\` directory, but you can find the location with `msbuild.exe path\to\project.proj -getProperty:ProjectAssetsFile`.
-Finally, run `dotnet nuget why path\to\project.assets.json SomePackage`.
+To use the command with projects that can't be restored with the .NET SDK, you can pass a NuGet assets file in place of the project file (starting with the .NET 9 SDK):
+
+1. First, restore the project in Visual Studio or using `msbuild.exe`. By default, the assets file is in the project's `obj\` directory, but you can find the location with `msbuild.exe path\to\project.proj -getProperty:ProjectAssetsFile`.
+2. Run `dotnet nuget why path\to\project.assets.json SomePackage`.
 
 ## Arguments
 


### PR DESCRIPTION
## Summary

The `dotnet` CLI only supports SDK style projects, and if a customer tries to run `dotnet nuget why` on a project that is not, it outputs an error saying to see https://aka.ms/dotnet/nuget/why#older-project-format

I forgot to add his heading to https://github.com/dotnet/docs/pull/42101, so the anchor link doesn't exist.

Fixes #43742


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-nuget-why.md](https://github.com/dotnet/docs/blob/e2bda2a620f5499422ccb6897668162ee61dcdfe/docs/core/tools/dotnet-nuget-why.md) | [docs/core/tools/dotnet-nuget-why](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-why?branch=pr-en-us-47589) |


<!-- PREVIEW-TABLE-END -->