### PR TITLE
[F#] Update properties.md

### DIFF
--- a/docs/fsharp/language-reference/members/properties.md
+++ b/docs/fsharp/language-reference/members/properties.md
@@ -66,8 +66,8 @@ Private values that hold the data for properties are called *backing stores*. To
 
 ```fsharp
 type MyClass(property1 : int) =
-member val Property1 = property1
-member val Property2 = "" with get, set
+    member val Property1 = property1
+    member val Property2 = "" with get, set
 ```
 
 Automatically implemented properties are part of the initialization of a type, so they must be included before any other member definitions, just like `let` bindings and `do` bindings in a type definition. Note that the expression that initializes an automatically implemented property is only evaluated upon initialization, and not every time the property is accessed. This behavior is in contrast to the behavior of an explicitly implemented property. What this effectively means is that the code to initialize these properties is added to the constructor of a class. Consider the following code that shows this difference:
@@ -93,7 +93,7 @@ class1.ExplicitProperty = 978922705
 class1.ExplicitProperty = 1131210765
 ```
 
-The output of the preceding code shows that the value of AutoProperty is unchanged when called repeatedly, whereas the ExplicitProperty changes each time it is called. This demonstrates that the expression for an automatically implemented property is not evaluated each time, as is the getter method for the explicit property.
+The output of the preceding code shows that the value of `AutoProperty` is unchanged when called repeatedly, whereas the `ExplicitProperty` changes each time it is called. This demonstrates that the expression for an automatically implemented property is not evaluated each time, as is the getter method for the explicit property.
 
 >[!WARNING]
 >There are some libraries, such as the Entity Framework (`System.Data.Entity`) that perform custom operations in base class constructors that don't work well with the initialization of automatically implemented properties. In those cases, try using explicit properties.


### PR DESCRIPTION
## Summary

- Fix code example indentation
- Add single backticks to highlight class properties at the text


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/members/properties.md](https://github.com/dotnet/docs/blob/11b3e26725d5755d792e1a70577e6ff0b8fca5a5/docs/fsharp/language-reference/members/properties.md) | [Properties (F#)](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/members/properties?branch=pr-en-us-47613) |

<!-- PREVIEW-TABLE-END -->