### PR TITLE
Clarify Orleans silo shutdown behavior with respect to IHost lifetime

### DIFF
--- a/docs/orleans/host/configuration-guide/shutting-down-orleans.md
+++ b/docs/orleans/host/configuration-guide/shutting-down-orleans.md
@@ -28,7 +28,7 @@ await Host.CreateDefaultBuilder(args)
 
 The preceding code relies on the [Microsoft.Extensions.Hosting](https://www.nuget.org/packages/Microsoft.Extensions.Hosting) and [Microsoft.Orleans.Server](https://www.nuget.org/packages/Microsoft.Orleans.Server) NuGet packages. The <xref:Microsoft.Extensions.Hosting.HostingHostBuilderExtensions.RunConsoleAsync%2A> extension method extends <xref:Microsoft.Extensions.Hosting.IHostBuilder> to help manage the app's lifetime accordingly, listening for process termination signals and shutting down the silo gracefully.
 
-Internally, the `RunConsoleAsync` method calls <xref:Microsoft.Extensions.Hosting.HostingHostBuilderExtensions.UseConsoleLifetime%2A>, which ensures the app shuts down gracefully. **Because Orleans is hosted within the .NET Generic Host, it shuts down when the host application does—regardless of the lifetime model used.**
+Internally, the `RunConsoleAsync` method calls <xref:Microsoft.Extensions.Hosting.HostingHostBuilderExtensions.UseConsoleLifetime%2A>, which ensures the app shuts down gracefully. Orleans is hosted within the .NET Generic Host, so it shuts down when the host application does, regardless of the lifetime model used.
 
 For more information on host shutdown, see [.NET Generic Host: Host shutdown](../../../core/extensions/generic-host.md#host-shutdown).
 

--- a/docs/orleans/host/configuration-guide/shutting-down-orleans.md
+++ b/docs/orleans/host/configuration-guide/shutting-down-orleans.md
@@ -28,7 +28,9 @@ await Host.CreateDefaultBuilder(args)
 
 The preceding code relies on the [Microsoft.Extensions.Hosting](https://www.nuget.org/packages/Microsoft.Extensions.Hosting) and [Microsoft.Orleans.Server](https://www.nuget.org/packages/Microsoft.Orleans.Server) NuGet packages. The <xref:Microsoft.Extensions.Hosting.HostingHostBuilderExtensions.RunConsoleAsync%2A> extension method extends <xref:Microsoft.Extensions.Hosting.IHostBuilder> to help manage the app's lifetime accordingly, listening for process termination signals and shutting down the silo gracefully.
 
-Internally, the `RunConsoleAsync` method calls <xref:Microsoft.Extensions.Hosting.HostingHostBuilderExtensions.UseConsoleLifetime%2A>, which ensures the app shuts down gracefully. For more information on host shutdown, see [.NET Generic Host: Host shutdown](../../../core/extensions/generic-host.md#host-shutdown).
+Internally, the `RunConsoleAsync` method calls <xref:Microsoft.Extensions.Hosting.HostingHostBuilderExtensions.UseConsoleLifetime%2A>, which ensures the app shuts down gracefully. **Because Orleans is hosted within the .NET Generic Host, it shuts down when the host application does—regardless of the lifetime model used.**
+
+For more information on host shutdown, see [.NET Generic Host: Host shutdown](../../../core/extensions/generic-host.md#host-shutdown).
 
 ## See also
 


### PR DESCRIPTION

## Summary
Added a sentence explaining that Orleans follows the .NET Generic Host lifetime model and shuts down when the IHost does, regardless of the specific lifetime configuration.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/host/configuration-guide/shutting-down-orleans.md](https://github.com/dotnet/docs/blob/a757ba3ad378e0c75bf7294e40e576f28049a193/docs/orleans/host/configuration-guide/shutting-down-orleans.md) | [Shut down Orleans silos](https://review.learn.microsoft.com/en-us/dotnet/orleans/host/configuration-guide/shutting-down-orleans?branch=pr-en-us-47662) |


<!-- PREVIEW-TABLE-END -->