### PR TITLE
Update current Ubuntu version to 25.04

### DIFF
--- a/docs/core/install/linux-ubuntu-decision.md
+++ b/docs/core/install/linux-ubuntu-decision.md
@@ -21,7 +21,7 @@ The following table is a list of currently supported .NET releases and the versi
 
 | Ubuntu                                                             | Supported .NET versions | Available in<br>built-in Ubuntu feed | [Available in<br>.NET backports<br>Ubuntu feed](#register-the-ubuntu-net-backports-package-repository) | [Available in<br>Microsoft feed](#register-the-microsoft-package-repository) |
 |--------------------------------------------------------------------|-------------------------|--------------------------------------|--------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------|
-| [24.10](linux-ubuntu-install.md?pivots=os-linux-ubuntu-2410)       | 9.0, 8.0                | 9.0, 8.0                             | None                                                                                                   | None                                                                         |
+| [25.04](linux-ubuntu-install.md?pivots=os-linux-ubuntu-2504)       | 9.0, 8.0                | 9.0, 8.0                             | None                                                                                                   | None                                                                         |
 | [24.04 (LTS)](linux-ubuntu-install.md?pivots=os-linux-ubuntu-2404) | 9.0, 8.0                | 8.0                                  | 9.0, 7.0, 6.0                                                                                          | None                                                                         |
 | [22.04 (LTS)](linux-ubuntu-install.md?pivots=os-linux-ubuntu-2204) | 9.0, 8.0                | 8.0, 7.0, 6.0                        | 9.0                                                                                                    | 8.0, 7.0, 6.0, 3.1                                                           |
 
@@ -68,7 +68,7 @@ Use the following sections to determine how you should install .NET:
 
 If you don't need other Microsoft packages, such as `powershell`, `mdatp`, or `mssql`, install .NET through the Ubuntu feed. For more information, see the following pages:
 
-- [Install .NET on Ubuntu 24.10](linux-ubuntu-install.md?pivots=os-linux-ubuntu-2410).
+- [Install .NET on Ubuntu 25.04](linux-ubuntu-install.md?pivots=os-linux-ubuntu-2504).
 - [Install .NET on Ubuntu 24.04](linux-ubuntu-install.md?pivots=os-linux-ubuntu-2404).
 - [Install .NET on Ubuntu 22.04](linux-ubuntu-install.md?pivots=os-linux-ubuntu-2204).
 
@@ -132,7 +132,7 @@ Starting with .NET 8 on Ubuntu 24.04, Canonical supports .NET for the IBM System
 
 Install .NET through the built-in Ubuntu feed. For more information, see the following page:
 
-- [Install .NET 9 on Ubuntu 24.10](linux-ubuntu-install.md?pivots=os-linux-ubuntu-2410&tabs=dotnet9).
+- [Install .NET 9 on Ubuntu 25.04](linux-ubuntu-install.md?pivots=os-linux-ubuntu-2504&tabs=dotnet9).
 
 ## Register a package repository
 

--- a/docs/core/install/linux-ubuntu-decision.md
+++ b/docs/core/install/linux-ubuntu-decision.md
@@ -46,7 +46,7 @@ When your version of Ubuntu supports .NET through the built-in or .NET backports
 
 | Method | Pros | Cons |
 |--------|------|------|
-| [Package manager<br>(built-in<br>Ubuntu feed)](#supported-distributions) | <ul><li>Usually the latest version is available.</li><li>Patches are available right way.</li><li>Dependencies are included.</li><li>Easy removal.</li><li>Available .NET versions are supported for the support period of the particular Ubuntu version.</li><li>Support for the IBM System Z platform for .NET 8 on Ubuntu 24.04.</li></ul> | <ul><li>Not available for Ubuntu 16.04, 18.04, 20.04.</li><li>.NET versions available vary by Ubuntu version.</li><li>Preview releases aren't available.</li></ul> |
+| [Package manager<br>(built-in<br>Ubuntu feed)](#supported-distributions) | <ul><li>Usually the latest version is available.</li><li>Patches are available right way.</li><li>Dependencies are included.</li><li>Easy removal.</li><li>Available .NET versions are supported for the support period of the particular Ubuntu version.</li><li>Support for the IBM System Z and Power platforms for .NET 8 and newer.</li></ul> | <ul><li>Not available for Ubuntu 16.04, 18.04, 20.04.</li><li>.NET versions available vary by Ubuntu version.</li><li>Preview releases aren't available.</li></ul> |
 | [Package manager<br>(.NET backports<br>Ubuntu feed)](#register-the-ubuntu-net-backports-package-repository) | <ul><li>Contains any supported version, which is not contained in the built-in Ubuntu feed.</li><li>Patches are available right way.</li><li>Dependencies are included.</li><li>Easy removal.</li><li>Compatible with built-in Ubuntu feed.</li></ul> | <ul><li>Not available for Ubuntu 16.04, 18.04, 20.04.</li><li>Requires registering the Ubuntu .NET backports package repository.</li><li>Preview releases aren't available.</li></ul> |
 | [Package manager<br>(Microsoft feed)](#register-the-microsoft-package-repository) | <ul><li>Supported versions always available.</li><li>Patches are available right way.</li><li>Dependencies are included.</li><li>Easy removal.</li></ul> | <ul><li>Not available for Ubuntu 24.04+.</li><li>Requires registering the Microsoft package repository.</li><li>Preview releases aren't available.</li><li>Only supports x64 Ubuntu.</li></ul> |
 | [Script \ Manual extraction](linux-scripted-manual.md) | <ul><li>Control where .NET is installed.</li><li>Preview releases are available.</li></ul> | <ul><li>Manually install updates.</li><li>Manually install dependencies.</li><li>Manual removal.</li></ul> |
@@ -62,7 +62,7 @@ Use the following sections to determine how you should install .NET:
 - [I want to install a preview version](#i-want-to-install-a-preview-version)
 - [I don't want to use APT](#i-dont-want-to-use-apt)
 - [I'm using an Arm-based CPU](#im-using-an-arm-based-cpu)
-- [I'm using the IBM System Z platform](#im-using-the-ibm-system-z-platform)
+- [I'm using the IBM System Z or Power platform](#im-using-the-ibm-system-z-or-power-platform)
 
 ### I'm using Ubuntu 22.04 or later, and I only need .NET
 
@@ -126,9 +126,9 @@ If the version of .NET you want isn't available, try using one of the following 
 - [Install .NET with `install-dotnet` script.](linux-scripted-manual.md#scripted-install)
 - [Manually install .NET](linux-scripted-manual.md#manual-install)
 
-### I'm using the IBM System Z platform
+### I'm using the IBM System Z or Power platform
 
-Starting with .NET 8 on Ubuntu 24.04, Canonical supports .NET for the IBM System Z platform. Canonical works on extending the support to other .NET and Ubuntu versions.
+Starting with .NET 8 on Ubuntu 22.04, Canonical supports .NET for the IBM System Z and Power platforms. This support will now continue for every .NET release going forward.
 
 Install .NET through the built-in Ubuntu feed. For more information, see the following page:
 

--- a/docs/core/install/linux-ubuntu-decision.md
+++ b/docs/core/install/linux-ubuntu-decision.md
@@ -128,7 +128,7 @@ If the version of .NET you want isn't available, try using one of the following 
 
 ### I'm using the IBM System Z or Power platform
 
-Starting with .NET 8 on Ubuntu 22.04, Canonical supports .NET for the IBM System Z and Power platforms. This support will now continue for every .NET release going forward.
+Starting with .NET 8 on Ubuntu 22.04, Canonical supports .NET for the IBM System Z and Power platforms. This support will continue for every .NET release going forward.
 
 Install .NET through the built-in Ubuntu feed. For more information, see the following page:
 

--- a/docs/core/install/linux-ubuntu-install.md
+++ b/docs/core/install/linux-ubuntu-install.md
@@ -17,19 +17,20 @@ This article discusses how to install .NET on Ubuntu.
 [!INCLUDE [linux-install-package-manager-x64-vs-arm-ubuntu](includes/linux-install-package-manager-x64-vs-arm-ubuntu.md)]
 
 <!--
-===== Ubuntu 24.10
+===== Ubuntu 25.04
 -->
 
-::: zone pivot="os-linux-ubuntu-2410"
+::: zone pivot="os-linux-ubuntu-2504"
 
-## Ubuntu 24.10
+## Ubuntu 25.04
 
 [!INCLUDE [linux-ubuntu-package-feed-only](includes/linux-ubuntu-package-feed-only.md)]
 
-The following versions of .NET are supported or available for Ubuntu 24.10:
+The following versions of .NET are supported or available for Ubuntu 25.04:
 
-- 9.0
-- 8.0
+| Supported .NET versions | Available in<br>built-in Ubuntu feed | [Available in<br>backports<br>Ubuntu feed](linux-ubuntu-decision.md#ubuntu-net-backports-package-repository) | [Available in<br>Microsoft feed](linux-ubuntu-decision.md#register-the-microsoft-package-repository) |
+|-------------------------|--------------------------------------|-----------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
+| 9.0, 8.0                | 9.0, 8.0                                  | None                                                                                       |None                                                                                         |
 
 When an [Ubuntu version](https://wiki.ubuntu.com/Releases) falls out of support, .NET is no longer supported with that version.
 
@@ -181,7 +182,7 @@ When you install with a package manager, these libraries are installed for you. 
 ===== All versions
 -->
 
-::: zone pivot="os-linux-ubuntu-2410,os-linux-ubuntu-2404,os-linux-ubuntu-2204"
+::: zone pivot="os-linux-ubuntu-2504,os-linux-ubuntu-2404,os-linux-ubuntu-2204"
 
 ## Unsupported versions
 

--- a/docs/zone-pivot-groups.yml
+++ b/docs/zone-pivot-groups.yml
@@ -120,8 +120,8 @@ groups:
   title: Ubuntu Version
   prompt: Choose the Ubuntu distribution version
   pivots:
-    - id: os-linux-ubuntu-2410
-      title: "24.10"
+    - id: os-linux-ubuntu-2504
+      title: "25.04"
     - id: os-linux-ubuntu-2404
       title: "24.04"
     - id: os-linux-ubuntu-2204


### PR DESCRIPTION
## Summary

Ubuntu 24.10 [went end-of-life](https://lists.ubuntu.com/archives/ubuntu-announce/2025-July/000314.html) on July 10, 2025. This PR updates the latest Ubuntu version to 25.04.

It also updates remarks about IBM System Z support. Since this was last updated, we have also added support for IBM Power as far back as 22.04 for .NET 8 and newer.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/linux-ubuntu-decision.md](https://github.com/dotnet/docs/blob/ebac35110e992b261cffaceeacfd5a4b7f89489a/docs/core/install/linux-ubuntu-decision.md) | [Install .NET on Ubuntu decision guide](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu-decision?branch=pr-en-us-47688) |
| [docs/core/install/linux-ubuntu-install.md](https://github.com/dotnet/docs/blob/ebac35110e992b261cffaceeacfd5a4b7f89489a/docs/core/install/linux-ubuntu-install.md) | [[.NET 9](#tab/dotnet9)](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu-install?branch=pr-en-us-47688) |
| [docs/zone-pivot-groups.yml](https://github.com/dotnet/docs/blob/ebac35110e992b261cffaceeacfd5a4b7f89489a/docs/zone-pivot-groups.yml) | [docs/zone-pivot-groups](https://review.learn.microsoft.com/en-us/dotnet/zone-pivot-groups?branch=pr-en-us-47688) |


<!-- PREVIEW-TABLE-END -->