### PR TITLE
add clarification for increment/decrement operator overloading

### DIFF
--- a/docs/csharp/language-reference/operators/operator-overloading.md
+++ b/docs/csharp/language-reference/operators/operator-overloading.md
@@ -18,7 +18,7 @@ Use the `operator` keyword to declare an operator. An operator declaration must 
 - It includes a `public` modifier.
 - A unary operator has one input parameter. A binary operator has two input parameters. In each case, at least one parameter must have type `T` or `T?` where `T` is the type that contains the operator declaration.
 - It includes the `static` modifier, except for the compound assignment operators, such as `+=`.
-- The increment (`++`) and decrement (`--`) operators can be implemented as either static or instance methods, new feature in C# 14.
+- The increment (`++`) and decrement (`--`) operators can be implemented as either static or instance methods. This is a new feature introduced in C# 14.
 
 The following example defines a simplified structure to represent a rational number. The structure overloads some of the [arithmetic operators](arithmetic-operators.md):
 

--- a/docs/csharp/language-reference/operators/operator-overloading.md
+++ b/docs/csharp/language-reference/operators/operator-overloading.md
@@ -18,7 +18,7 @@ Use the `operator` keyword to declare an operator. An operator declaration must 
 - It includes a `public` modifier.
 - A unary operator has one input parameter. A binary operator has two input parameters. In each case, at least one parameter must have type `T` or `T?` where `T` is the type that contains the operator declaration.
 - It includes the `static` modifier, except for the compound assignment operators, such as `+=`.
-- The increment (`++`) and decrement (`--`) operators can be implemented as either static or instance methods. This is a new feature introduced in C# 14.
+- The increment (`++`) and decrement (`--`) operators can be implemented as either static or instance methods. Instance method operators are a new feature introduced in C# 14.
 
 The following example defines a simplified structure to represent a rational number. The structure overloads some of the [arithmetic operators](arithmetic-operators.md):
 

--- a/docs/csharp/language-reference/operators/operator-overloading.md
+++ b/docs/csharp/language-reference/operators/operator-overloading.md
@@ -18,7 +18,7 @@ Use the `operator` keyword to declare an operator. An operator declaration must 
 - It includes a `public` modifier.
 - A unary operator has one input parameter. A binary operator has two input parameters. In each case, at least one parameter must have type `T` or `T?` where `T` is the type that contains the operator declaration.
 - It includes the `static` modifier, except for the compound assignment operators, such as `+=`.
-- The increment (`++`) and decrement (`--`) operators can be implemented as either static or instance methods.
+- The increment (`++`) and decrement (`--`) operators can be implemented as either static or instance methods, new feature in C# 14.
 
 The following example defines a simplified structure to represent a rational number. The structure overloads some of the [arithmetic operators](arithmetic-operators.md):
 


### PR DESCRIPTION
## Summary

This PR addresses issue #46891 by adding a subtle clarification regarding overloading of the `++` and `--` operators in C# 14.

Fixes #46891


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/operator-overloading.md](https://github.com/dotnet/docs/blob/32d660e6de36c70894b00f2bfcd740472f30e790/docs/csharp/language-reference/operators/operator-overloading.md) | [Operator overloading - predefined unary, arithmetic, equality, and comparison operators](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/operator-overloading?branch=pr-en-us-47710) |


<!-- PREVIEW-TABLE-END -->