### PR TITLE
increase two predefined tasks

### DIFF
--- a/docs/azure/migration/appmod/predefined-tasks.md
+++ b/docs/azure/migration/appmod/predefined-tasks.md
@@ -23,9 +23,9 @@ Predefined tasks capture industry best practices for using Azure services. Curre
 
 App Modernization for .NET currently supports the following predefined tasks:
 
-- **Migrate to Managed Identity based Database on Azure, including Azure SQL DB and Azure PostgreSQL**
+- **Migrate to Managed Identity based Database on Azure, including Azure SQL DB, Azure SQL MI and Azure PostgreSQL**
   
-  Modernize your data layer by migrating from on-premises or legacy databases (such as DB2, Oracle DB, or SQL Server) to Azure SQL DB or Azure PostgreSQL, using secure managed identity authentication.
+  Modernize your data layer by migrating from on-premises or legacy databases (such as DB2, Oracle DB, or SQL Server) to Azure SQL DB, Azure SQL Managed Instance or Azure PostgreSQL, using secure managed identity authentication.
 
 - **Migrate to Azure File Storage**
   
@@ -54,3 +54,7 @@ App Modernization for .NET currently supports the following predefined tasks:
 - **Migrate to Confluent Cloud/Azure Event Hub for Apache Kafka**
   
   Transition from local or on-premises Kafka to managed event streaming with Confluent Cloud or Azure Event Hubs.
+
+- **Migrate to OpenTelemetry on Azure**
+
+  Transition from local logging frameworks like log4net, serilog, windows event log to OpenTelemetry on Azure.


### PR DESCRIPTION
## Summary

add two predefined tasks:
1. migrate to Azure SQL MI
2. migrate to OpenTelemetry on Azure


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/azure/migration/appmod/predefined-tasks.md](https://github.com/dotnet/docs/blob/8935a9acd9dcb02a822dcdea52411fb288f29305/docs/azure/migration/appmod/predefined-tasks.md) | [Predefined tasks for GitHub Copilot app modernization for .NET (Preview)](https://review.learn.microsoft.com/en-us/dotnet/azure/migration/appmod/predefined-tasks?branch=pr-en-us-47720) |

<!-- PREVIEW-TABLE-END -->