### PR TITLE
Fix freshness technical error

### DIFF
--- a/docs/csharp/whats-new/tutorials/primary-constructors.md
+++ b/docs/csharp/whats-new/tutorials/primary-constructors.md
@@ -56,7 +56,7 @@ Consider the following code:
 
 :::code source="./snippets/primary-constructors/Distance.cs" id="MutableStruct":::
 
-In this example, the `Translate` method changes the `dx` and `dy` components, which requires the `Magnitude` and `Direction` properties be computed when accessed. The greater than or equal to (`=>`) operator designates an expression-bodied `get` accessor, whereas the equal to (`=`) operator designates an initializer.
+In this example, the `Translate` method changes the `dx` and `dy` components, which requires the `Magnitude` and `Direction` properties be computed when accessed. The lambda (`=>`) operator designates an expression-bodied `get` accessor, whereas the equal to (`=`) operator designates an initializer.
 
 This version of the code adds a parameterless constructor to the struct. The parameterless constructor must invoke the primary constructor, which ensures all primary constructor parameters are initialized. The primary constructor properties are accessed in a method, and the compiler creates hidden fields to represent each parameter.
 

--- a/docs/csharp/whats-new/tutorials/primary-constructors.md
+++ b/docs/csharp/whats-new/tutorials/primary-constructors.md
@@ -56,7 +56,7 @@ Consider the following code:
 
 :::code source="./snippets/primary-constructors/Distance.cs" id="MutableStruct":::
 
-In this example, the `Translate` method changes the `dx` and `dy` components, which requires the `Magnitude` and `Direction` properties be computed when accessed. The lambda (`=>`) operator designates an expression-bodied `get` accessor, whereas the equal to (`=`) operator designates an initializer.
+In this example, the `Translate` method changes the `dx` and `dy` components, which requires the `Magnitude` and `Direction` properties be computed when accessed. The lambda operator (`=>`) designates an expression-bodied `get` accessor, whereas the equal-to operator (`=`) designates an initializer.
 
 This version of the code adds a parameterless constructor to the struct. The parameterless constructor must invoke the primary constructor, which ensures all primary constructor parameters are initialized. The primary constructor properties are accessed in a method, and the compiler creates hidden fields to represent each parameter.
 


### PR DESCRIPTION
Fixes #47713

The last freshness edit incorrectly referred to `=>` as "greater than or equal", rather than as the "lambda operator". 

Revert that.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/whats-new/tutorials/primary-constructors.md](https://github.com/dotnet/docs/blob/0fd17f83ee41a9005b24b4bcc06b67c5f26fb931/docs/csharp/whats-new/tutorials/primary-constructors.md) | [Declare primary constructors for classes and structs](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/tutorials/primary-constructors?branch=pr-en-us-47724) |


<!-- PREVIEW-TABLE-END -->