### PR TITLE
Update deconstruction.md (C# reference)

### DIFF
--- a/docs/csharp/language-reference/operators/deconstruction.md
+++ b/docs/csharp/language-reference/operators/deconstruction.md
@@ -23,7 +23,7 @@ In the preceding example, the `Y` and `label` members are discarded. You can spe
 
 ## Record deconstruction
 
-[Record](../builtin-types/record.md) types that have a [primary constructor](../builtin-types/record.md#positional-syntax-for-property-and-field-definition) support deconstruction for positional parameters. The compiler synthesizes a `Deconstruct` method that extracts the properties synthesized from positional parameters in the primary constructor. The compiler-synthesized `Deconstruction` method doesn't extract properties declared as properties in the record type.
+[Record](../builtin-types/record.md) types that have a [primary constructor](../builtin-types/record.md#positional-syntax-for-property-and-field-definition) support deconstruction for positional parameters. The compiler synthesizes a `Deconstruct` method that extracts the properties synthesized from positional parameters in the primary constructor. The compiler-synthesized `Deconstruct` method doesn't extract properties declared as properties in the record type.
 
 The `record` shown in the following code declares two positional properties, `SquareFeet` and `Address`, along with another property, `RealtorNotes`:
 
@@ -37,7 +37,7 @@ You can make use of this behavior to specify which properties of your record typ
 
 ## Declare `Deconstruct` methods
 
-You can add deconstruction support to any class, struct, or interface you declare. You declare one or `Deconstruct` methods in your type, or as extension methods on that type. A deconstruction expression calls a  method `void Deconstruct(out var p1, ..., out var pn)`. The `Deconstruct` method can be either an instance method or an extension method. The type of each parameter in the `Deconstruct` method must match the type of the corresponding argument in the deconstruction expression. The deconstruction expression assigns the value of each argument to the value of the corresponding `out` parameter in the `Deconstruct` method. If multiple `Deconstruct` methods match the deconstruction expression, the compiler reports an error for the ambiguity.
+You can add deconstruction support to any class, struct, or interface you declare. You declare one or more `Deconstruct` methods in your type, or as extension methods on that type. A deconstruction expression calls a  method `void Deconstruct(out var p1, ..., out var pn)`. The `Deconstruct` method can be either an instance method or an extension method. The type of each parameter in the `Deconstruct` method must match the type of the corresponding argument in the deconstruction expression. The deconstruction expression assigns the value of each argument to the value of the corresponding `out` parameter in the `Deconstruct` method. If multiple `Deconstruct` methods match the deconstruction expression, the compiler reports an error for the ambiguity.
 
 The following code declares a `Point3D` struct that has two `Deconstruct` methods:
 


### PR DESCRIPTION
## Summary

Describe your changes here.
Hi, I found two typos. Please check them out.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/deconstruction.md](https://github.com/dotnet/docs/blob/619551e0fd0fb9957e233b39365d30c8485fa8ab/docs/csharp/language-reference/operators/deconstruction.md) | [Deconstruction expression - Extract properties of fields from a tuple or other user-defined type](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/deconstruction?branch=pr-en-us-47877) |

<!-- PREVIEW-TABLE-END -->