### PR TITLE
Correct the syntax of accessing the `UseOrleans` call in Transactions page

### DIFF
--- a/docs/orleans/grains/transactions.md
+++ b/docs/orleans/grains/transactions.md
@@ -20,7 +20,7 @@ Orleans transactions are opt-in. Both the silo and the client must be configured
 
 ```csharp
 var builder = Host.CreateDefaultBuilder(args)
-    UseOrleans((context, siloBuilder) =>
+    .UseOrleans((context, siloBuilder) =>
     {
         siloBuilder.UseTransactions();
     });
@@ -30,7 +30,7 @@ Likewise, to enable transactions on the client, call <xref:Orleans.Hosting.Clien
 
 ```csharp
 var builder = Host.CreateDefaultBuilder(args)
-    UseOrleansClient((context, clientBuilder) =>
+    .UseOrleansClient((context, clientBuilder) =>
     {
         clientBuilder.UseTransactions();
     });


### PR DESCRIPTION
This small pull request fixes #47635, by adding the missing dot for calling the `UseOrleans` method of `Orleans.Transactions`.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/grains/transactions.md](https://github.com/dotnet/docs/blob/103cbe657eb221cb932fb48a35919c1f5fc156c4/docs/orleans/grains/transactions.md) | [Orleans transactions](https://review.learn.microsoft.com/en-us/dotnet/orleans/grains/transactions?branch=pr-en-us-47892) |

<!-- PREVIEW-TABLE-END -->