### PR TITLE
[Diagnostics][dotnet-trace] Add collect-linux verb

### DIFF
--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -292,9 +292,7 @@ When `--providers`, `--profile`, `--clrevents`, and `--perf-events` aren’t spe
 - `dotnet-common` — lightweight .NET runtime diagnostics.
 - `cpu-sampling` — kernel CPU sampling (perf-based) via `Universal.Events/cpu`.
 
-By default, a machine-wide trace will be collected. .NET Processes are discovered through their diagnostics ports, which are located under the `TMPDIR` environment variable when set and otherwise under `/tmp`.
-
-If collecting events from all .NET Processes is undesired, `-n, --name <name>` or `-p|--process-id <PID>` can be used to specify a particular process.
+A machine-wide trace will be collected. .NET Processes are discovered through their diagnostics ports, which are located under the `TMPDIR` environment variable when set and otherwise under `/tmp`.
 
 ### Prerequisites
 
@@ -318,10 +316,6 @@ dotnet-trace collect-linux
     # Trace Collection
     [-o|--output <trace-file-path>]
     [--duration dd:hh:mm:ss]
-
-    # .NET Process Target (Optional)
-    [-n, --name <name>]
-    [-p|--process-id <pid>]
 ```
 
 ### Options
@@ -434,18 +428,6 @@ dotnet-trace collect-linux
 - **`--duration <time-to-run>`**
 
   The time for the trace to run. Use the `dd:hh:mm:ss` format. For example `00:00:00:05` will run it for 5 seconds.
-
-#### .NET Process Target Options
-
-See [Default collection behavior](#default-collection-behavior)
-
-- **`-n, --name <name>`**
-
-  The name of the process to collect the trace from.
-
-- **`-p|--process-id <PID>`**
-
-  The process ID to collect the trace from.
 
 > [!NOTE]
 

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -285,6 +285,9 @@ dotnet-trace collect
 > The collect-linux verb is a new preview feature and relies on an updated version of the .nettrace file format. The latest PerfView release supports these trace files but other ways of using the trace file may not work yet.
 
 > [!NOTE]
+> Currently supported Linux RIDs are linux-x64 and linux-arm64.
+
+> [!NOTE]
 > The generated NetTrace is not fully compatible with [`convert`](#dotnet-trace-convert) and [`report`](#dotnet-trace-report).
 
 Collects diagnostic traces using perf_events, a Linux OS technology. `collect-linux` requires admin privileges to capture kernel- and user-mode events, and by default, captures events from all processes.

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -659,16 +659,18 @@ To collect traces using `dotnet-trace collect-linux`:
   Provider Name                           Keywords            Level               Enabled By
   Microsoft-Windows-DotNETRuntime         0x000000100003801D  Informational(4)    --profile
 
-  Linux Events                                                                    Enabled By
+  Linux Perf Events                                                               Enabled By
   cpu-sampling                                                                    --profile
 
-  [00:00:00:04]   Recording trace.
+  Output File    : <path-to-nettrace>trace_20251008_181939.nettrace
+
+  [00:00:00:03]   Recording trace.
   Press <Enter> or <Ctrl-C> to exit...
 
   Recording stopped.
   Resolving symbols.
   Finished recording trace.
-  Trace written to trace_20251007_160232.nettrace
+  Trace written to <path-to-nettrace>trace_20251008_181939.nettrace
   ```
 
 ## View the trace captured from dotnet-trace

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -541,7 +541,7 @@ Output the parameters of each method in full. If not specified, parameters will 
 
 ## Collect a trace with dotnet-trace
 
-To collect traces using `dotnet-trace`:
+To collect traces using `dotnet-trace collect`:
 
 - Get the process identifier (PID) of the .NET Core application to collect traces from.
 
@@ -558,14 +558,22 @@ To collect traces using `dotnet-trace`:
   The preceding command generates output similar to the following:
 
   ```output
-  Press <Enter> to exit...
-  Connecting to process: <Full-Path-To-Process-Being-Profiled>/dotnet.exe
-  Collecting to file: <Full-Path-To-Trace>/trace.nettrace
-  Session Id: <SessionId>
-  Recording trace 721.025 (KB)
+  No profile or providers specified, defaulting to trace profiles 'dotnet-common' + 'dotnet-sampled-thread-time'.
+
+  Provider Name                           Keywords            Level               Enabled By
+  Microsoft-Windows-DotNETRuntime         0x000000100003801D  Informational(4)    --profile
+  Microsoft-DotNETCore-SampleProfiler     0x0000F00000000000  Informational(4)    --profile
+
+  Process        : <full-path-to-process-being-trace>
+  Output File    : <process>_20251007_154557.nettrace
+  [00:00:00:02]   Recording trace 178.172  (KB)
+  Press <Enter> or <Ctrl+C> to exit...
+  Stopping the trace. This may take several minutes depending on the application being traced.
+
+  Trace completed.
   ```
 
-- Stop collection by pressing the `<Enter>` key. `dotnet-trace` will finish logging events to the *trace.nettrace* file.
+- Stop collection by pressing the `<Enter>` key. `dotnet-trace` will finish logging events to the `.nettrace` file.
 
 ## Launch a child application and collect a trace from its startup using dotnet-trace
 
@@ -580,11 +588,11 @@ dotnet-trace collect -- hello.exe arg1 arg2
 The preceding command generates output similar to the following:
 
 ```output
-No profile or providers specified. Using default composition: dotnet-common + dotnet-thread-time
+No profile or providers specified, defaulting to trace profiles 'dotnet-common' + 'dotnet-sampled-thread-time'.
 
 Provider Name                           Keywords            Level               Enabled By
+Microsoft-Windows-DotNETRuntime         0x000000100003801D  Informational(4)    --profile
 Microsoft-DotNETCore-SampleProfiler     0x0000F00000000000  Informational(4)    --profile
-Microsoft-Windows-DotNETRuntime         0x00000014C14FCCBD  Informational(4)    --profile
 
 Process        : E:\temp\gcperfsim\bin\Debug\net5.0\gcperfsim.exe
 Output File    : E:\temp\gcperfsim\trace.nettrace
@@ -639,6 +647,29 @@ However, when you want to gain a finer control over the lifetime of the app bein
 
     > [!IMPORTANT]
     > Launching your app with `dotnet run` can be problematic because the dotnet CLI may spawn many child processes that are not your app and they can connect to `dotnet-trace` before your app, leaving your app to be suspended at run time. It is recommended you directly use a self-contained version of the app or use `dotnet exec` to launch the application.
+
+## (Linux-only) Collect a trace with Linux perf events using dotnet-trace
+
+To collect traces using `dotnet-trace collect-linux`:
+
+  ```output
+  $ sudo dotnet-trace collect-linux
+  No providers, profiles, ClrEvents, or PerfEvents were specified, defaulting to trace profiles 'dotnet-common' + 'cpu-sampling'.
+
+  Provider Name                           Keywords            Level               Enabled By
+  Microsoft-Windows-DotNETRuntime         0x000000100003801D  Informational(4)    --profile
+
+  Linux Events                                                                    Enabled By
+  cpu-sampling                                                                    --profile
+
+  [00:00:00:04]   Recording trace.
+  Press <Enter> or <Ctrl-C> to exit...
+
+  Recording stopped.
+  Resolving symbols.
+  Finished recording trace.
+  Trace written to trace_20251007_160232.nettrace
+  ```
 
 ## View the trace captured from dotnet-trace
 

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -310,8 +310,41 @@ Collects diagnostic traces using perf_events, a Linux OS technology. `collect-li
 - .NET 10+
 
 > [!NOTE]
-> The current set of supported Linux RIDs is { linux-x64, linux-arm64 }.
-> The underlying trace recording library currently requires glibc 2.35+.
+> The `collect-linux` verb depends on assets currently available only on linux x64 and linux arm64 environments that have glibc 2.35+.
+> A quick way to check the version of a system's libc is with the command `ldd --version` or by executing the libc library directly.
+> From the [official .NET 10 Linux support document](https://github.com/dotnet/core/blob/main/release-notes/10.0/supported-os.md#linux), the tables below depict each distros support in addition to the minimum distro version that we have found to contain glibc 2.35+. (These values were obtained by using official Docker images.)
+
+| **Distro / Image**           | **libc type** | **Version** | **Compatible** |
+|------------------------------|---------------|-------------|----------------|
+| Alpine 3.22                  | musl          | 1.2.5       | **No**         |
+| Azure Linux 3.0              | glibc         | 2.38        | Yes            |
+| CentOS Stream 9              | glibc         | 2.34        | **No**         |
+| CentOS Stream 10             | glibc         | 2.39        | Yes            |
+| Debian 12                    | glibc         | 2.36        | Yes            |
+| Debian 13                    | glibc         | 2.41        | Yes            |
+| Fedora 42                    | glibc         | 2.41        | Yes            |
+| openSUSE Leap 15.6           | glibc         | 2.38        | Yes            |
+| openSUSE Leap 16.0           | glibc         | 2.40        | Yes            |
+| RHEL UBI 9                   | glibc         | 2.34        | **No**         |
+| RHEL UBI 10                  | glibc         | 2.39        | Yes            |
+| SUSE Enterprise Linux 15.6   | glibc         | 2.38        | Yes            |
+| SUSE Enterprise Linux 15.7   | glibc         | 2.38        | Yes            |
+| SUSE Enterprise Linux 16.0   | glibc         | 2.40        | Yes            |
+| Ubuntu 22.04                 | glibc         | 2.35        | Yes            |
+| Ubuntu 24.04                 | glibc         | 2.39        | Yes            |
+| Ubuntu 25.10                 | glibc         | 2.42        | Yes            |
+
+| **Distro / Image** | ** Min Version with glibc 2.35+ ** |
+|--------------------|------------------------------------|
+| Alpine             | No glibc                           |
+| AzureLinux         | 2.0                                |
+| CentOS             | stream10                           |
+| Debian             | 11                                 |
+| Fedora             | 36                                 |
+| openSUSE           | 15.6                               |
+| RHEL UBI           | 10                                 |
+| SUSE SLE           | 15.6                               |
+| Ubuntu             | 22.04                              |
 
 ### Synopsis
 

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -281,9 +281,11 @@ dotnet-trace collect
 
 ## dotnet-trace collect-linux
 
-> [!NOTE] The collect-linux verb is a new preview feature and relies on an updated version of the .nettrace file format. The latest PerfView release supports these trace files but other ways of using the trace file may not work yet.
+> [!NOTE]
+> The collect-linux verb is a new preview feature and relies on an updated version of the .nettrace file format. The latest PerfView release supports these trace files but other ways of using the trace file may not work yet.
 
-> [!NOTE] The generated NetTrace is not fully compatible with [`convert`](#dotnet-trace-convert) and [`report`](#dotnet-trace-report).
+> [!NOTE]
+> The generated NetTrace is not fully compatible with [`convert`](#dotnet-trace-convert) and [`report`](#dotnet-trace-report).
 
 Collects diagnostic traces using perf_events, a Linux OS technology. `collect-linux` requires admin privileges to capture kernel- and user-mode events, and by default, captures events from all processes.
 

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -93,7 +93,6 @@ dotnet-trace collect
     [--stopping-event-provider-name <stoppingEventProviderName>]
     [--stopping-event-event-name <stoppingEventEventName>]
     [--stopping-event-payload-filter <stoppingEventPayloadFilter>]
-    [--event-filters <list-of-comma-separated-event-filters>]
 ```
 
 ### Options
@@ -257,34 +256,6 @@ dotnet-trace collect
 
   A string, parsed as [payload_field_name]:[payload_field_value] pairs separated by commas, that will stop the trace upon hitting an event containing all specified payload pairs. Requires `--stopping-event-provider-name` and `--stopping-event-event-name` to be set. for example, `--stopping-event-provider-name Microsoft-Windows-DotNETRuntime --stopping-event-event-name Method/JittingStarted --stopping-event-payload-filter MethodNameSpace:Program,MethodName:OnButtonClick` to stop the trace upon the first `Method/JittingStarted` event for the method `OnButtonClick` in the `Program` namespace emitted by the `Microsoft-Windows-DotNETRuntime` event provider.
 
-- **`--event-filters <list-of-comma-separated-event-filters>`**
-
-  Defines an additional optional filter for each provider's events. When no `--event-filters` is specified for a provider, all events allowed by the provider's keywords and level configuration are collected. Event filters provide additional granular control beyond the keyword/level filtering.
-
-  **Format:** `ProviderName:<Enable>:<EventIds>`
-
-  Where:
-  - `ProviderName`: The EventPipe provider name (e.g., `Microsoft-Windows-DotNETRuntime`)
-  - `Enable` : Boolean value indicating whether EventIds will be enabled or disabled, defaults to false
-  - `EventIds`: Plus-delimited event IDs to enable or disable, defaults to empty.
-
-  **Examples:**
-  ```
-  # Scenario: Disable specific events from Microsoft-Windows-DotNETRuntime
-  --event-filters "Microsoft-Windows-DotNETRuntime:false:1+2+3+4+5+6+7+8+9"
-
-  # Scenario: Enable specific events from a provider
-  --event-filters "Microsoft-Windows-DotNETRuntime:true:80+129+130+250"
-  # Only events 80, 129, 130, and 250 will be collected from this provider (others are filtered out)
-
-  # Scenario: Multiple providers with mixed filtering - some providers have no filters
-  --providers "Microsoft-Windows-DotNETRuntime:0xFFFFFFFF:5,System.Threading.Tasks.TplEventSource:0xFFFFFFFF:5,MyCustomProvider:0xFFFFFFFF:5"
-  --event-filters "Microsoft-Windows-DotNETRuntime:false:1+2+3,System.Threading.Tasks.TplEventSource:true:7+8+9"
-  # Microsoft-Windows-DotNETRuntime: All events EXCEPT 1,2,3 are collected
-  # System.Threading.Tasks.TplEventSource: ONLY events 7,8,9 are collected
-  # MyCustomProvider: ALL events are collected (no filter specified - follows provider keywords/level)
-  ```
-
 > [!NOTE]
 
 > - Stopping the trace may take a long time (up to minutes) for large applications. The runtime needs to send over the type cache for all managed code that was captured in the trace.
@@ -329,7 +300,6 @@ dotnet-trace collect-linux
     [--stopping-event-provider-name <stoppingEventProviderName>]
     [--stopping-event-event-name <stoppingEventEventName>]
     [--stopping-event-payload-filter <stoppingEventPayloadFilter>]
-    [--event-filters <list-of-comma-separated-event-filters>]
     [--tracepoint-configs <list-of-comma-separated-tracepoint-configs>]
     [--kernel-events <list-of-kernel-events>]
 ```
@@ -352,9 +322,6 @@ dotnet-trace collect-linux
 
   > [!NOTE]
   > All tracepoint names are automatically prefixed with the provider name to avoid collisions. For example, `gc_events` for the `Microsoft-Windows-DotNETRuntime` provider becomes `Microsoft_Windows_DotNETRuntime_gc_events`.
-
-  > [!TIP]
-  > Use `--event-filters` to disable specific events before they are routed to tracepoints. Event filtering happens before tracepoint routing - only events that pass the filter will be sent to their assigned tracepoints.
 
   **Examples:**
   ```

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -425,7 +425,7 @@ By default all processes on the machine will be traced. Use `-n, --name <name>` 
 
 - **`--perf-events <list-of-perf-events>`**
 
-  A comma-separated list of perf events to include in the trace. Available events can be found under [tracefs](https://lwn.net/Articles/630526/), which is typically mounted at `/sys/kernel/tracing`, through `available_events` for all available events or through the `events/` subdirectory for categorized events.
+  A comma-separated list of perf events to include in the trace. Available events can be found under [tracefs](https://www.kernel.org/doc/html/latest/trace/ftrace.html#the-file-system), which is typically mounted at `/sys/kernel/tracing`, through `available_events` for all available events or through the `events/` subdirectory for categorized events.
 
   Example: `--perf-events syscalls:sys_enter_execve,sched:sched_switch,sched:sched_wakeup`
 

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -296,7 +296,9 @@ When `--providers`, `--profile`, `--clrevents`, and `--perf-events` aren’t spe
 - `dotnet-common` — lightweight .NET runtime diagnostics.
 - `cpu-sampling` — kernel CPU sampling (perf-based) via `Universal.Events/cpu`.
 
-A machine-wide trace will be collected. .NET Processes are discovered through their diagnostics ports, which are located under the `TMPDIR` environment variable when set and otherwise under `/tmp`.
+By default, a machine-wide trace will be collected. .NET Processes are discovered through their diagnostics ports, which are located under the `TMPDIR` environment variable when set and otherwise under `/tmp`.
+
+If collecting events from all .NET Processes is undesired, `-n, --name <name>` or `-p|--process-id <PID>` can be used to specify a particular process.
 
 ### Prerequisites
 
@@ -320,6 +322,10 @@ dotnet-trace collect-linux
     # Trace Collection
     [-o|--output <trace-file-path>]
     [--duration dd:hh:mm:ss]
+
+    # .NET Process Target (Optional)
+    [-n, --name <name>]
+    [-p|--process-id <pid>]
 ```
 
 ### Options
@@ -432,6 +438,18 @@ dotnet-trace collect-linux
 - **`--duration <time-to-run>`**
 
   The time for the trace to run. Use the `dd:hh:mm:ss` format. For example `00:00:00:05` will run it for 5 seconds.
+
+#### .NET Process Target Options
+
+See [Default collection behavior](#default-collection-behavior)
+
+- **`-n, --name <name>`**
+
+  The name of the process to collect the trace from.
+
+- **`-p|--process-id <PID>`**
+
+  The process ID to collect the trace from.
 
 > [!NOTE]
 

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -44,16 +44,17 @@ The `dotnet-trace` tool:
 * Enables the collection of .NET Core traces of a running process without a native profiler.
 * Is built on [`EventPipe`](./eventpipe.md) of the .NET Core runtime.
 * Supports two different ways of collecting traces:
-  - The [`collect` verb](#dotnet-trace-collect) offers consistent functionality on any OS
-  - The [`collect-linux` verb](#dotnet-trace-collect-linux) uses Linux-specific OS capabilities to provide additional features
 
-|                                          | collect  | collect-linux                     |
-|------------------------------------------|----------|-----------------------------------|
-| Supported OS                             | Any      | Linux only, kernel version >= 6.4 |
-| Requires Admin/Root Privilege            | No       | Yes                               |
-| Trace all processes simultaneously       | No       | Supported                         |
-| Capture native library and kernel events | No       | Supported                         |
-| Event callstacks include native frames   | No       | Yes                               |
+  - The [`collect` verb](#dotnet-trace-collect) offers consistent functionality on any OS.
+  - The [`collect-linux` verb](#dotnet-trace-collect-linux) uses Linux-specific OS capabilities to provide additional features.
+
+  | Characteristic                           | `collect` | `collect-linux`                  |
+  |------------------------------------------|----------|-----------------------------------|
+  | Supported OS                             | Any      | Linux only, kernel version >= 6.4 |
+  | Requires Admin/Root Privilege            | No       | Yes                               |
+  | Trace all processes simultaneously       | No       | Supported                         |
+  | Capture native library and kernel events | No       | Supported                         |
+  | Event callstacks include native frames   | No       | Yes                               |
 
 ## Options
 
@@ -130,7 +131,7 @@ dotnet-trace collect
 
 - **`--clrevents <clrevents>`**
 
-  A list of CLR runtime provider keywords to enable separated by `+` signs. This is a simple mapping that lets you specify event keywords via string aliases rather than their hex values. For example, `dotnet-trace collect --providers Microsoft-Windows-DotNETRuntime:3:4` requests the same set of events as `dotnet-trace collect --clrevents gc+gchandle --clreventlevel informational`. If the CLR runtime provider `Microsoft-Windows-DotNETRuntime` is also enabled through `--providers` or `--profile`, this option will be ignored. The table below shows the list of available keywords:
+  A list of CLR runtime provider keywords to enable separated by `+` signs. This is a simple mapping that lets you specify event keywords via string aliases rather than their hex values. For example, `dotnet-trace collect --providers Microsoft-Windows-DotNETRuntime:3:4` requests the same set of events as `dotnet-trace collect --clrevents gc+gchandle --clreventlevel informational`. If the CLR runtime provider `Microsoft-Windows-DotNETRuntime` is also enabled through `--providers` or `--profile`, this option is ignored. The following table shows the list of available keywords:
 
   | Keyword String Alias | Keyword Hex Value |
   | ------------ | ------------------- |
@@ -174,7 +175,7 @@ dotnet-trace collect
   | `waithandle` | `0x40000000000` |
   | `allocationsampling` | `0x80000000000` |
 
-  You can read about the CLR provider more in detail on the [.NET runtime provider reference documentation](../../fundamentals/diagnostics/runtime-events.md).
+  You can read about the CLR provider in more detail on the [.NET runtime provider reference documentation](../../fundamentals/diagnostics/runtime-events.md).
 
 - **`--dsrouter {ios|ios-sim|android|android-emu}**
 
@@ -222,7 +223,7 @@ dotnet-trace collect
 
 - **`--profile <list-of-comma-separated-profile-names>`**
 
-  A profile is a pre-defined set of provider configurations for common tracing scenarios. Multiple profiles can be specified at a time, delimited by commas. Providers configured through `--providers` will override the profile's configuration. Similarly, if any profile configures the CLR runtime provider, it will override any configurations prescribed through `--clrevents`.
+  A profile is a predefined set of provider configurations for common tracing scenarios. Multiple profiles can be specified at a time, delimited by commas. Providers configured through `--providers` override the profile's configuration. Similarly, if any profile configures the CLR runtime provider, it will override any configurations prescribed through `--clrevents`.
 
   When `--profile`, `--providers`, and `--clrevents` are all omitted, `dotnet-trace collect` enables profiles `dotnet-common` and `dotnet-sampled-thread-time` by default.
 
@@ -237,17 +238,16 @@ dotnet-trace collect
   |`database`|Captures ADO.NET and Entity Framework database commands.|
 
   > [!NOTE]
-  > In past versions of the dotnet-trace tool, the collect verb supported a profile called `cpu-sampling`. This profile was removed because the name was misleading. It sampled all threads regardless of their CPU usage. You can achieve a similar result now using `--profile dotnet-sampled-thread-time,dotnet-common`. If you need to match the former `cpu-sampling` behavior exactly use `--profile dotnet-sampled-thread-time --providers "Microsoft-Windows-DotNETRuntime:0x14C14FCCBD:4"`.
+  > In past versions of the dotnet-trace tool, the collect verb supported a profile called `cpu-sampling`. This profile was removed because the name was misleading. It sampled all threads regardless of their CPU usage. You can achieve a similar result now using `--profile dotnet-sampled-thread-time,dotnet-common`. If you need to match the former `cpu-sampling` behavior exactly, use `--profile dotnet-sampled-thread-time --providers "Microsoft-Windows-DotNETRuntime:0x14C14FCCBD:4"`.
 
 - **`--providers <list-of-comma-separated-providers>`**
 
   A comma-separated list of `EventPipe` providers to be enabled. These providers supplement any providers implied by `--profile <list-of-comma-separated-profile-names>`. If there's any inconsistency for a particular provider, this configuration takes precedence over the implicit configuration from `--profile` and `--clrevents`.
 
-  This list of providers is in the form:
+  This list of providers is in the form `Provider[,Provider]`:
 
-  - `Provider[,Provider]`
-  - `Provider` is in the form: `KnownProviderName[:Flags[:Level[:KeyValueArgs]]]`.
-  - `KeyValueArgs` is in the form: `[key1=value1][;key2=value2]`.
+  - `Provider` is in the form: `KnownProviderName[:Flags[:Level[:KeyValueArgs]]]`
+  - `KeyValueArgs` is in the form: `[key1=value1][;key2=value2]`
 
   To learn more about some of the well-known providers in .NET, refer to [Well-known Event Providers](./well-known-event-providers.md).
 
@@ -291,14 +291,14 @@ dotnet-trace collect
 ## dotnet-trace collect-linux
 
 > [!NOTE]
-> The collect-linux verb is a new preview feature and relies on an updated version of the .nettrace file format. The latest PerfView release supports these trace files but other ways of using the trace file such as [`convert`](#dotnet-trace-convert) and [`report`](#dotnet-trace-report) may not work yet.
+> The `collect-linux` verb is a new preview feature and relies on an updated version of the .nettrace file format. The latest PerfView release supports these trace files, but other ways of using the trace file, such as [`convert`](#dotnet-trace-convert) and [`report`](#dotnet-trace-report), might not work yet.
 
 Collects diagnostic traces using perf_events, a Linux OS technology. `collect-linux` enables the following additional features over [`collect`](#dotnet-trace-collect).
 
 |                                          | collect  | collect-linux                     |
 |------------------------------------------|----------|-----------------------------------|
 | Supported OS                             | Any      | Linux only, kernel version >= 6.4 |
-| Requires Admin/Root Privilege            | No       | Yes                               |
+| Requires Admin/Root privilege            | No       | Yes                               |
 | Trace all processes simultaneously       | No       | Supported                         |
 | Capture native library and kernel events | No       | Supported                         |
 | Event callstacks include native frames   | No       | Yes                               |
@@ -343,7 +343,7 @@ When `--providers`, `--profile`, `--clrevents`, and `--perf-events` aren’t spe
 - `dotnet-common` — lightweight .NET runtime diagnostics.
 - `cpu-sampling` — kernel CPU sampling.
 
-By default all processes on the machine will be traced. Use `-n, --name <name>` or `-p|--process-id <PID>` to trace only one process.
+By default, all processes on the machine are traced. To trace only one process, use `-n, --name <name>` or `-p|--process-id <PID>`.
 
 ### Options
 
@@ -353,13 +353,12 @@ By default all processes on the machine will be traced. Use `-n, --name <name>` 
 
   A comma-separated list of `EventPipe` providers to be enabled. These providers supplement any providers implied by `--profile <list-of-comma-separated-profile-names>`. If there's any inconsistency for a particular provider, this configuration takes precedence over the implicit configuration from `--profile` and `--clrevents`.
 
-  This list of providers is in the form:
+  This list of providers is in the form `Provider[,Provider]`:
 
-  - `Provider[,Provider]`
-  - `Provider` is in the form: `KnownProviderName[:Flags[:Level[:KeyValueArgs]]]`.
-  - `KeyValueArgs` is in the form: `[key1=value1][;key2=value2]`.
+  - `Provider` is in the form: `KnownProviderName[:Flags[:Level[:KeyValueArgs]]]`
+  - `KeyValueArgs` is in the form: `[key1=value1][;key2=value2]`
 
-  To learn more about some of the well-known providers in .NET, refer to [Well-known Event Providers](./well-known-event-providers.md).
+  To learn more about some of the well-known providers in .NET, see [Well-known Event Providers](./well-known-event-providers.md).
 
 - **`--clreventlevel <clreventlevel>`**
 
@@ -377,7 +376,7 @@ By default all processes on the machine will be traced. Use `-n, --name <name>` 
 
 - **`--clrevents <clrevents>`**
 
-    A list of CLR runtime provider keywords to enable separated by `+` signs. This is a simple mapping that lets you specify event keywords via string aliases rather than their hex values. For example, `dotnet-trace collect-linux --providers Microsoft-Windows-DotNETRuntime:3:4` requests the same set of events as `dotnet-trace collect-linux --clrevents gc+gchandle --clreventlevel informational`. If the CLR runtime provider `Microsoft-Windows-DotNETRuntime` is also enabled through `--providers` or `--profile`, this option will be ignored. The table below shows the list of available keywords:
+    A list of CLR runtime provider keywords to enable separated by `+` signs. This is a simple mapping that lets you specify event keywords via string aliases rather than their hex values. For example, `dotnet-trace collect-linux --providers Microsoft-Windows-DotNETRuntime:3:4` requests the same set of events as `dotnet-trace collect-linux --clrevents gc+gchandle --clreventlevel informational`. If the CLR runtime provider `Microsoft-Windows-DotNETRuntime` is also enabled through `--providers` or `--profile`, this option is ignored. The following table shows the list of available keywords:
 
   | Keyword String Alias | Keyword Hex Value |
   | ------------ | ------------------- |
@@ -421,7 +420,7 @@ By default all processes on the machine will be traced. Use `-n, --name <name>` 
   | `waithandle` | `0x40000000000` |
   | `allocationsampling` | `0x80000000000` |
 
-  You can read about the CLR provider more in detail on the [.NET runtime provider reference documentation](../../fundamentals/diagnostics/runtime-events.md).
+  You can read about the CLR provider in more detail on the [.NET runtime provider reference documentation](../../fundamentals/diagnostics/runtime-events.md).
 
 - **`--perf-events <list-of-perf-events>`**
 
@@ -431,7 +430,7 @@ By default all processes on the machine will be traced. Use `-n, --name <name>` 
 
 - **`--profile <list-of-comma-separated-profile-names>`**
 
-  A profile is a pre-defined set of provider configurations for common tracing scenarios. Multiple profiles can be specified at a time, delimited by commas. Providers configured through `--providers` will override the profile's configuration. Similarly, if any profile configures the CLR runtime provider, it will override any configurations prescribed through `--clrevents`.
+  A profile is a predefined set of provider configurations for common tracing scenarios. Multiple profiles can be specified at a time, delimited by commas. Providers configured through `--providers` override the profile's configuration. Similarly, if any profile configures the CLR runtime provider, it will override any configurations prescribed through `--clrevents`.
 
   When `--profile`, `--providers`, `--clrevents`, and `--perf-events` are all omitted, `dotnet-trace collect-linux` enables profiles `dotnet-common` and `cpu-sampling` by default.
 
@@ -470,7 +469,7 @@ See [Default collection behavior](#default-collection-behavior)
 
 > [!NOTE]
 
-> - To collect a trace using `dotnet-trace collect-linux`, it needs to be run with root permissions (`CAP_PERFMON`/`CAP_SYS_ADMIN`). Otherwise, the tool will fail to collect events.
+> To collect a trace using `dotnet-trace collect-linux`, it needs to be run with root permissions (`CAP_PERFMON`/`CAP_SYS_ADMIN`). Otherwise, the tool will fail to collect events.
 
 ## dotnet-trace convert
 
@@ -612,7 +611,7 @@ To collect traces using `dotnet-trace collect`:
   Trace completed.
   ```
 
-- Stop collection by pressing the `<Enter>` key. `dotnet-trace` will finish logging events to the `.nettrace` file.
+- Stop collection by pressing the <kbd>Enter</kbd> key. `dotnet-trace` will finish logging events to the `.nettrace` file.
 
 ## Launch a child application and collect a trace from its startup using dotnet-trace
 

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -222,7 +222,7 @@ dotnet-trace collect
 
 - **`--profile <list-of-comma-separated-profile-names>`**
 
-  In this context, a profile is a pre-defined set of provider configurations for common tracing scenarios. Multiple profiles can be specified at a time, delimited by commas. Providers configured through `--providers` will override the profile's configuration. Similarly, if any profile configures the CLR runtime provider, it will override any configurations prescribed through `--clrevents`.
+  A profile is a pre-defined set of provider configurations for common tracing scenarios. Multiple profiles can be specified at a time, delimited by commas. Providers configured through `--providers` will override the profile's configuration. Similarly, if any profile configures the CLR runtime provider, it will override any configurations prescribed through `--clrevents`.
 
   When `--profile`, `--providers`, and `--clrevents` are all omitted, `dotnet-trace collect` enables profiles `dotnet-common` and `dotnet-sampled-thread-time` by default.
 
@@ -310,8 +310,8 @@ Collects diagnostic traces using perf_events, a Linux OS technology. `collect-li
 - .NET 10+
 
 > [!NOTE]
-> The `collect-linux` verb depends on assets currently available only on linux x64 and linux arm64 environments that have glibc 2.35+.
-> Based on the [official .NET 10 Linux support document](https://github.com/dotnet/core/blob/main/release-notes/10.0/supported-os.md#linux), we've found (via Docker official images) that Alpine 3.22, CentOS Stream 9, and Red Hat Enterprise Linux 9 do not satisfy this requirement.
+> The `collect-linux` verb only runs on linux x64 and linux arm64 environments that have glibc version 2.35 or above.
+> All of the [.NET 10 officially supported Linux distros](https://github.com/dotnet/core/blob/main/release-notes/10.0/supported-os.md#linux) support this requirement except Alpine 3.22, CentOS Stream 9, and any distros based off Red Hat Enterprise Linux 9.
 > A quick way to check the version of a system's libc is with the command `ldd --version` or by executing the libc library directly.
 
 ### Synopsis
@@ -431,7 +431,7 @@ By default all processes on the machine will be traced. Use `-n, --name <name>` 
 
 - **`--profile <list-of-comma-separated-profile-names>`**
 
-  In this context, a profile is a pre-defined set of provider configurations for common tracing scenarios. Multiple profiles can be specified at a time, delimited by commas. Providers configured through `--providers` will override the profile's configuration. Similarly, if any profile configures the CLR runtime provider, it will override any configurations prescribed through `--clrevents`.
+  A profile is a pre-defined set of provider configurations for common tracing scenarios. Multiple profiles can be specified at a time, delimited by commas. Providers configured through `--providers` will override the profile's configuration. Similarly, if any profile configures the CLR runtime provider, it will override any configurations prescribed through `--clrevents`.
 
   When `--profile`, `--providers`, `--clrevents`, and `--perf-events` are all omitted, `dotnet-trace collect-linux` enables profiles `dotnet-common` and `cpu-sampling` by default.
 

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -43,7 +43,7 @@ The `dotnet-trace` tool:
 * Is a cross-platform .NET Core tool.
 * Enables the collection of .NET Core traces of a running process without a native profiler.
 * Is built on [`EventPipe`](./eventpipe.md) of the .NET Core runtime.
-* Delivers the same experience on Windows, Linux, or macOS.
+* On Linux, provides additional integration with kernel user_events for native tracing tool compatibility.
 
 ## Options
 
@@ -54,10 +54,6 @@ The `dotnet-trace` tool:
 - **`--version`**
 
   Displays the version of the dotnet-trace utility.
-
-- **`--duration`**
-
-  How long to run the trace. `--duration 00:00:00:05` will run it for 5 seconds.
 
 ## Commands
 
@@ -76,13 +72,23 @@ Collects a diagnostic trace from a running process or launches a child process a
 ### Synopsis
 
 ```dotnetcli
-dotnet-trace collect [--buffersize <size>] [--clreventlevel <clreventlevel>] [--clrevents <clrevents>]
+dotnet-trace collect
+    [--buffersize <size>]
+    [--clreventlevel <clreventlevel>]
+    [--clrevents <clrevents>]
     [--dsrouter <ios|ios-sim|android|android-emu>]
-    [--format <Chromium|NetTrace|Speedscope>] [-h|--help] [--duration dd:hh:mm:ss]
-    [-n, --name <name>] [--diagnostic-port] [-o|--output <trace-file-path>] [-p|--process-id <pid>]
-    [--profile <profile-name>] [--providers <list-of-comma-separated-providers>]
+    [--format <Chromium|NetTrace|Speedscope>]
+    [-h|--help]
+    [--duration dd:hh:mm:ss]
+    [-n, --name <name>]
+    [--diagnostic-port]
+    [-o|--output <trace-file-path>]
+    [-p|--process-id <pid>]
+    [--profile <profile-name>]
+    [--providers <list-of-comma-separated-providers>]
     [-- <command>] (for target applications running .NET 5 or later)
-    [--show-child-io] [--resume-runtime]
+    [--show-child-io]
+    [--resume-runtime]
     [--stopping-event-provider-name <stoppingEventProviderName>]
     [--stopping-event-event-name <stoppingEventEventName>]
     [--stopping-event-payload-filter <stoppingEventPayloadFilter>]
@@ -158,7 +164,7 @@ dotnet-trace collect [--buffersize <size>] [--clreventlevel <clreventlevel>] [--
 
 - **`--dsrouter {ios|ios-sim|android|android-emu}**
 
- Starts [dotnet-dsrouter](dotnet-dsrouter.md) and connects to it. Requires [dotnet-dsrouter](dotnet-dsrouter.md) to be installed. Run `dotnet-dsrouter -h` for more information.
+  Starts [dotnet-dsrouter](dotnet-dsrouter.md) and connects to it. Requires [dotnet-dsrouter](dotnet-dsrouter.md) to be installed. Run `dotnet-dsrouter -h` for more information.
 
 - **`--format {Chromium|NetTrace|Speedscope}`**
 
@@ -204,11 +210,11 @@ dotnet-trace collect [--buffersize <size>] [--clreventlevel <clreventlevel>] [--
 
   A named pre-defined set of provider configurations that allows common tracing scenarios to be specified succinctly. The following profiles are available:
 
- | Profile | Description |
- |---------|-------------|
- |`cpu-sampling`|Useful for tracking CPU usage and general .NET runtime information. This is the default option if no profile or providers are specified.|
- |`gc-verbose`|Tracks GC collections and samples object allocations.|
- |`gc-collect`|Tracks GC collections only at very low overhead.|
+  | Profile | Description |
+  |---------|-------------|
+  |`cpu-sampling`|Useful for tracking CPU usage and general .NET runtime information. This is the default option if no profile or providers are specified.|
+  |`gc-verbose`|Tracks GC collections and samples object allocations.|
+  |`gc-collect`|Tracks GC collections only at very low overhead.|
 
 - **`--providers <list-of-comma-separated-providers>`**
 

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -311,40 +311,8 @@ Collects diagnostic traces using perf_events, a Linux OS technology. `collect-li
 
 > [!NOTE]
 > The `collect-linux` verb depends on assets currently available only on linux x64 and linux arm64 environments that have glibc 2.35+.
+> Based on the [official .NET 10 Linux support document](https://github.com/dotnet/core/blob/main/release-notes/10.0/supported-os.md#linux), we've found (via Docker official images) that Alpine 3.22, CentOS Stream 9, and Red Hat Enterprise Linux 9 do not satisfy this requirement.
 > A quick way to check the version of a system's libc is with the command `ldd --version` or by executing the libc library directly.
-> From the [official .NET 10 Linux support document](https://github.com/dotnet/core/blob/main/release-notes/10.0/supported-os.md#linux), the tables below depict each distros support in addition to the minimum distro version that we have found to contain glibc 2.35+. (These values were obtained by using official Docker images.)
-
-| **Distro / Image**           | **libc type** | **Version** | **Compatible** |
-|------------------------------|---------------|-------------|----------------|
-| Alpine 3.22                  | musl          | 1.2.5       | **No**         |
-| Azure Linux 3.0              | glibc         | 2.38        | Yes            |
-| CentOS Stream 9              | glibc         | 2.34        | **No**         |
-| CentOS Stream 10             | glibc         | 2.39        | Yes            |
-| Debian 12                    | glibc         | 2.36        | Yes            |
-| Debian 13                    | glibc         | 2.41        | Yes            |
-| Fedora 42                    | glibc         | 2.41        | Yes            |
-| openSUSE Leap 15.6           | glibc         | 2.38        | Yes            |
-| openSUSE Leap 16.0           | glibc         | 2.40        | Yes            |
-| RHEL UBI 9                   | glibc         | 2.34        | **No**         |
-| RHEL UBI 10                  | glibc         | 2.39        | Yes            |
-| SUSE Enterprise Linux 15.6   | glibc         | 2.38        | Yes            |
-| SUSE Enterprise Linux 15.7   | glibc         | 2.38        | Yes            |
-| SUSE Enterprise Linux 16.0   | glibc         | 2.40        | Yes            |
-| Ubuntu 22.04                 | glibc         | 2.35        | Yes            |
-| Ubuntu 24.04                 | glibc         | 2.39        | Yes            |
-| Ubuntu 25.10                 | glibc         | 2.42        | Yes            |
-
-| **Distro / Image** | ** Min Version with glibc 2.35+ ** |
-|--------------------|------------------------------------|
-| Alpine             | No glibc                           |
-| AzureLinux         | 2.0                                |
-| CentOS             | stream10                           |
-| Debian             | 11                                 |
-| Fedora             | 36                                 |
-| openSUSE           | 15.6                               |
-| RHEL UBI           | 10                                 |
-| SUSE SLE           | 15.6                               |
-| Ubuntu             | 22.04                              |
 
 ### Synopsis
 

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -221,7 +221,7 @@ dotnet-trace collect
 
   | Profile | Description |
   |---------|-------------|
-  |`dotnet-common`|Lightweight .NET runtime diagnostics designed to stay low overhead. Includes:<br/><ul><li>GC</li><li>AssemblyLoader</li><li>Loader</li><li>Jit</li><li>Exception</li><li>Threading</li><li>JittedMethodILToNativeMap</li><li>Compilation</li></ul>Equivalent to `--providers "Microsoft-Windows-DotNETRuntime:0x100003801D:4"`.|
+  |`dotnet-common`|Lightweight .NET runtime diagnostics designed to stay low overhead.<br>Includes GC, AssemblyLoader, Loader, JIT, Exceptions, Threading, JittedMethodILToNativeMap, and Compilation events<br>Equivalent to `--providers "Microsoft-Windows-DotNETRuntime:0x100003801D:4"`.|
   |`dotnet-sampled-thread-time`|Samples .NET thread stacks (~100 Hz) to identify hotspots over time. Uses the runtime sample profiler with managed stacks.|
   |`gc-verbose`|Tracks GC collections and samples object allocations.|
   |`gc-collect`|Tracks GC collections only at very low overhead.|
@@ -280,6 +280,10 @@ dotnet-trace collect
 > - When specifying a stopping event through the `--stopping-event-*` options, as the EventStream is being parsed asynchronously, there will be some events that pass through between the time a trace event matching the specified stopping event options is parsed and the EventPipeSession is stopped.
 
 ## dotnet-trace collect-linux
+
+> [!NOTE] The collect-linux verb is a new preview feature and relies on an updated version of the .nettrace file format. The latest PerfView release supports these trace files but other ways of using the trace file may not work yet.
+
+> [!NOTE] The generated NetTrace is not fully compatible with [`convert`](#dotnet-trace-convert) and [`report`](#dotnet-trace-report).
 
 Collects diagnostic traces using perf_events, a Linux OS technology. `collect-linux` requires admin privileges to capture kernel- and user-mode events, and by default, captures events from all processes.
 
@@ -412,7 +416,7 @@ dotnet-trace collect-linux
 
   | Profile | Description |
   |---------|-------------|
-  |`dotnet-common`|Lightweight .NET runtime diagnostics designed to stay low overhead. Includes:<br/><ul><li>GC</li><li>AssemblyLoader</li><li>Loader</li><li>Jit</li><li>Exception</li><li>Threading</li><li>JittedMethodILToNativeMap</li><li>Compilation</li></ul>Equivalent to `--providers "Microsoft-Windows-DotNETRuntime:0x100003801D:4"`.|
+  |`dotnet-common`|Lightweight .NET runtime diagnostics designed to stay low overhead.<br>Includes GC, AssemblyLoader, Loader, JIT, Exceptions, Threading, JittedMethodILToNativeMap, and Compilation events<br>Equivalent to `--providers "Microsoft-Windows-DotNETRuntime:0x100003801D:4"`.|
   |`cpu-sampling`|Kernel CPU sampling (perf-based), emitted as `Universal.Events/cpu`, for precise on-CPU attribution.|
   |`thread-time`|Kernel thread context switches, emitted as `Universal.Events/cswitch`, for on/off-CPU and scheduler analysis.|
   |`gc-verbose`|Tracks GC collections and samples object allocations.|
@@ -654,6 +658,12 @@ To collect traces using `dotnet-trace collect-linux`:
 
   ```output
   $ sudo dotnet-trace collect-linux
+  ==========================================================================================
+  The collect-linux verb is a new preview feature and relies on an updated version of the
+  .nettrace file format. The latest PerfView release supports these trace files but other
+  ways of using the trace file may not work yet. For more details, see the docs at
+  https://learn.microsoft.com/dotnet/core/diagnostics/dotnet-trace.
+  ==========================================================================================
   No providers, profiles, ClrEvents, or PerfEvents were specified, defaulting to trace profiles 'dotnet-common' + 'cpu-sampling'.
 
   Provider Name                           Keywords            Level               Enabled By

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -474,7 +474,7 @@ See [Default collection behavior](#default-collection-behavior)
 
 - **`--probe [-n|--name] [-p|--process-id] [-o|--output <stdout|output-filename>]`**
 
-  Probe .NET processes for support of the EventPipe UserEvents IPC command used by collect-linux, without collecting a trace. Results list supported processes first. Use '-o stdout' to print CSV (pid,processName,supportsCollectLinux) to the console, or '-o <output-filename>' to write the CSV. Probe a single process with -n|--name or -p|--process-id.
+  Probe .NET processes for support of the EventPipe UserEvents IPC command used by collect-linux, without collecting a trace. Results list supported processes first. Use '-o stdout' to print CSV (pid,processName,supportsCollectLinux) to the console, or '-o output-filename' to write the CSV. Probe a single process with -n|--name or -p|--process-id.
 
   As running `collect-linux` in probe mode does not collect a trace, it does not require root permissions to run. It does not provide validation of the [prerequisites](#prerequisites), and .NET processes running on preview versions of .NET Runtime '10.0.0' are considered unsupported.
 

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -474,7 +474,7 @@ See [Default collection behavior](#default-collection-behavior)
 
 - **`--probe [-n|--name] [-p|--process-id] [-o|--output <stdout|output-filename>]`**
 
-  Probe .NET processes for support of the EventPipe UserEvents IPC command used by collect-linux, without collecting a trace. Results list supported processes first. Use '-o stdout' to print CSV (pid,processName,supportsCollectLinux) to the console, or '-o <file>' to write the CSV. Probe a single process with -n|--name or -p|--process-id.
+  Probe .NET processes for support of the EventPipe UserEvents IPC command used by collect-linux, without collecting a trace. Results list supported processes first. Use '-o stdout' to print CSV (pid,processName,supportsCollectLinux) to the console, or '-o <output-filename>' to write the CSV. Probe a single process with -n|--name or -p|--process-id.
 
   As running `collect-linux` in probe mode does not collect a trace, it does not require root permissions to run. It does not provide validation of the [prerequisites](#prerequisites), and .NET processes running on preview versions of .NET Runtime '10.0.0' are considered unsupported.
 

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -334,6 +334,9 @@ dotnet-trace collect-linux
     # .NET Process Target (Optional)
     [-n, --name <name>]
     [-p|--process-id <pid>]
+
+    # Probe mode
+    [--probe]
 ```
 
 ### Default collection behavior
@@ -466,6 +469,14 @@ See [Default collection behavior](#default-collection-behavior)
 - **`-p|--process-id <PID>`**
 
   The process ID to collect the trace from.
+
+#### Probe mode options
+
+- **`--probe [-n|--name] [-p|--process-id] [-o|--output <stdout|output-filename>]`**
+
+  Probe .NET processes for support of the EventPipe UserEvents IPC command used by collect-linux, without collecting a trace. Results list supported processes first. Use '-o stdout' to print CSV (pid,processName,supportsCollectLinux) to the console, or '-o <file>' to write the CSV. Probe a single process with -n|--name or -p|--process-id.
+
+  As running `collect-linux` in probe mode does not collect a trace, it does not require root permissions to run. It does not provide validation of the [prerequisites](#prerequisites), and .NET processes running on preview versions of .NET Runtime '10.0.0' are considered unsupported.
 
 > [!NOTE]
 
@@ -715,6 +726,24 @@ This example captures CPU samples for all processes on the machine. Any processe
   Resolving symbols.
   Finished recording trace.
   Trace written to <path-to-nettrace>trace_20251008_181939.nettrace
+  ```
+
+For environments with multiple .NET versions installed, running `collect-linux` in [probe mode](#probe-mode-options) helps discern whether a .NET process is capable of being traced with collect-linux.
+
+  ```output
+  $ dotnet-trace collect-linux --probe
+  ==========================================================================================
+  The collect-linux verb is a new preview feature and relies on an updated version of the
+  .nettrace file format. The latest PerfView release supports these trace files but other
+  ways of using the trace file may not work yet. For more details, see the docs at
+  https://learn.microsoft.com/dotnet/core/diagnostics/dotnet-trace.
+  ==========================================================================================
+  Probing .NET processes for support of the EventPipe UserEvents IPC command used by collect-linux. Requires runtime '10.0.0' or later.
+  .NET processes that support the command:
+  3802935 MyApp
+
+  .NET processes that do NOT support the command:
+  3809123 dotnet - Detected runtime: '10.0.0-rc.1.25451.107'
   ```
 
 ## View the trace captured from dotnet-trace

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -7,7 +7,7 @@ ms.custom: sfi-ropc-nochange
 ---
 # dotnet-trace performance analysis utility
 
-**This article applies to:** ✔️ `dotnet-trace` 9.0.625801 and later versions
+**This article applies to:** ✔️ `dotnet-trace` 9.0.661903 and later versions
 
 ## Install
 

--- a/docs/core/diagnostics/eventsource-collect-and-view-traces.md
+++ b/docs/core/diagnostics/eventsource-collect-and-view-traces.md
@@ -214,7 +214,7 @@ into other formats, such as Chromium or [Speedscope](https://www.speedscope.app/
    Trace completed.
    ```
 
-   dotnet-trace uses the [conventional text format](#conventions-for-describing-provider-configuration) for describing provider configuration in
+   dotnet-trace uses a comma-delimited variant of the [conventional text format](#conventions-for-describing-provider-configuration) for describing provider configuration in
    the `--providers` argument. For more options on how to take traces using dotnet-trace, see the
    [dotnet-trace docs](./dotnet-trace.md#collect-a-trace-with-dotnet-trace).
 

--- a/docs/core/diagnostics/eventsource-collect-and-view-traces.md
+++ b/docs/core/diagnostics/eventsource-collect-and-view-traces.md
@@ -214,7 +214,7 @@ into other formats, such as Chromium or [Speedscope](https://www.speedscope.app/
    Trace completed.
    ```
 
-   dotnet-trace uses a comma-delimited variant of the [conventional text format](#conventions-for-describing-provider-configuration) for describing provider configuration in
+   dotnet-trace uses the [conventional text format](#conventions-for-describing-provider-configuration) for describing provider configuration in
    the `--providers` argument. For more options on how to take traces using dotnet-trace, see the
    [dotnet-trace docs](./dotnet-trace.md#collect-a-trace-with-dotnet-trace).
 


### PR DESCRIPTION
## Summary

Add new `collect-linux` verb to utilize new user_events based event tracing.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/dotnet-trace.md](https://github.com/dotnet/docs/blob/e46d3272cc4c969bea40feac630b77703606722d/docs/core/diagnostics/dotnet-trace.md) | [dotnet-trace performance analysis utility](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-trace?branch=pr-en-us-47894) |


<!-- PREVIEW-TABLE-END -->