### PR TITLE
add common data sources note in 'Standard query operators' section

### DIFF
--- a/docs/csharp/linq/includes/common-data-sources-reference.md
+++ b/docs/csharp/linq/includes/common-data-sources-reference.md
@@ -1,0 +1,9 @@
+---
+author: ''
+ms.author: ''
+ms.topic: include
+ms.date: 08/11/2025
+---
+
+> [!NOTE]
+> You can refer to the common data sources for this area in the [Standard Query Operators Overview](../standard-query-operators/index.md).

--- a/docs/csharp/linq/includes/common-data-sources-reference.md
+++ b/docs/csharp/linq/includes/common-data-sources-reference.md
@@ -6,4 +6,4 @@ ms.date: 08/11/2025
 ---
 
 > [!NOTE]
-> You can refer to the common data sources for this area in the [Standard Query Operators Overview](../standard-query-operators/index.md).
+> You can refer to the common data sources for this area in the [Standard Query Operators Overview](../standard-query-operators/index.md) article.

--- a/docs/csharp/linq/standard-query-operators/converting-data-types.md
+++ b/docs/csharp/linq/standard-query-operators/converting-data-types.md
@@ -34,6 +34,8 @@ The conversion methods in this table whose names start with "As" change the stat
 
 [!INCLUDE [Datasources](../includes/data-sources-definition.md)]
 
+[!INCLUDE [Common Datasources reference](../includes/common-data-sources-reference.md)]
+
 ## Query Expression Syntax Example
 
 The following code example uses an explicitly typed range variable to cast a type to a subtype before accessing a member that is available only on the subtype.

--- a/docs/csharp/linq/standard-query-operators/filtering-data.md
+++ b/docs/csharp/linq/standard-query-operators/filtering-data.md
@@ -22,6 +22,8 @@ The standard query operator methods that perform selection are listed in the fol
 
 The following example uses the `where` clause to filter from an array those strings that have a specific length.
 
+[!INCLUDE [Common Datasources reference](../includes/common-data-sources-reference.md)]
+
 :::code language="csharp" source="./snippets/standard-query-operators/WhereFilter.cs" id="FilterExampleQuery":::
 
 The equivalent query using method syntax is shown in the following code:

--- a/docs/csharp/linq/standard-query-operators/grouping-data.md
+++ b/docs/csharp/linq/standard-query-operators/grouping-data.md
@@ -28,6 +28,8 @@ The equivalent query using method syntax is shown in the following code:
 
 [!INCLUDE [Datasources](../includes/data-sources-definition.md)]
 
+[!INCLUDE [Common Datasources reference](../includes/common-data-sources-reference.md)]
+
 ## Group query results
 
 Grouping is one of the most powerful capabilities of LINQ. The following examples show how to group data in various ways:

--- a/docs/csharp/linq/standard-query-operators/join-operations.md
+++ b/docs/csharp/linq/standard-query-operators/join-operations.md
@@ -27,6 +27,8 @@ The following illustration shows a conceptual view of two sets and the elements 
 
 [!INCLUDE [Datasources](../includes/data-sources-definition.md)]
 
+[!INCLUDE [Common Datasources reference](../includes/common-data-sources-reference.md)]
+
 The following example uses the `join … in … on … equals …` clause to join two sequences based on specific value:
 
 :::code language="csharp" source="./snippets/standard-query-operators/JoinOverviewExamples.cs" id="JoinQuerySyntax":::

--- a/docs/csharp/linq/standard-query-operators/partitioning-data.md
+++ b/docs/csharp/linq/standard-query-operators/partitioning-data.md
@@ -27,6 +27,8 @@ The standard query operator methods that partition sequences are listed in the f
 
 All the following examples use <xref:System.Linq.Enumerable.Range(System.Int32,System.Int32)?displayProperty=nameWithType> to generate a sequence of numbers from 0 through 7.
 
+[!INCLUDE [Common Datasources reference](../includes/common-data-sources-reference.md)]
+
 You use the `Take` method to take only the first elements in a sequence:
 
 :::code source="snippets/standard-query-operators/PartitionExamples.cs" id="Take":::

--- a/docs/csharp/linq/standard-query-operators/projection-operations.md
+++ b/docs/csharp/linq/standard-query-operators/projection-operations.md
@@ -23,6 +23,8 @@ The standard query operator methods that perform projection are listed in the fo
 
 The following example uses the `select` clause to project the first letter from each string in a list of strings.
 
+[!INCLUDE [Common Datasources reference](../includes/common-data-sources-reference.md)]
+
 :::code language="csharp" source="./snippets/standard-query-operators/SelectProjectionExamples.cs" id="SelectSimpleQuery":::
 
 The equivalent query using method syntax is shown in the following code:

--- a/docs/csharp/linq/standard-query-operators/quantifier-operations.md
+++ b/docs/csharp/linq/standard-query-operators/quantifier-operations.md
@@ -24,6 +24,8 @@ The following illustration depicts two different quantifier operations on two di
 
 The following example uses the `All` to find students that scored above 70 on all exams.
 
+[!INCLUDE [Common Datasources reference](../includes/common-data-sources-reference.md)]
+
 :::code language="csharp" source="./snippets/standard-query-operators/QuantifierExamples.cs" id="AllQuantifier":::
   
 ## Any

--- a/docs/csharp/linq/standard-query-operators/set-operations.md
+++ b/docs/csharp/linq/standard-query-operators/set-operations.md
@@ -36,6 +36,8 @@ The following example depicts the behavior of <xref:System.Linq.Enumerable.Excep
 
 [!INCLUDE [Datasources](../includes/data-sources-definition.md)]
 
+[!INCLUDE [Common Datasources reference](../includes/common-data-sources-reference.md)]
+
 :::code language="csharp" source="./snippets/standard-query-operators/SetOperations.cs" id="Except":::
 
 The <xref:System.Linq.Enumerable.ExceptBy%2A> method is an alternative approach to `Except` that takes two sequences of possibly heterogenous types and a `keySelector`. The `keySelector` is the same type as the first collection's type. Consider the following `Teacher` array and teacher IDs to exclude. To find teachers in the first collection that aren't in the second collection, you can project the teacher's ID onto the second collection:

--- a/docs/csharp/linq/standard-query-operators/sorting-data.md
+++ b/docs/csharp/linq/standard-query-operators/sorting-data.md
@@ -27,6 +27,8 @@ The standard query operator methods that sort data are listed in the following s
 
 [!INCLUDE [Datasources](../includes/data-sources-definition.md)]
 
+[!INCLUDE [Common Datasources reference](../includes/common-data-sources-reference.md)]
+
 ## Primary Ascending Sort
 
 The following example demonstrates how to use the `orderby` clause in a LINQ query to sort the array of teachers by family name, in ascending order.


### PR DESCRIPTION
## Summary

This PR adds:

- A new note in an include file referencing the common data sources for the `Standard query operators` section.
- The new note to each `Standard query operators` article (except `index.md`).

Fixes #41525


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/linq/standard-query-operators/converting-data-types.md](https://github.com/dotnet/docs/blob/0eafa8cab61f6fccfd976cfe5a536a23791df0fe/docs/csharp/linq/standard-query-operators/converting-data-types.md) | [docs/csharp/linq/standard-query-operators/converting-data-types](https://review.learn.microsoft.com/en-us/dotnet/csharp/linq/standard-query-operators/converting-data-types?branch=pr-en-us-47928) |
| [docs/csharp/linq/standard-query-operators/filtering-data.md](https://github.com/dotnet/docs/blob/0eafa8cab61f6fccfd976cfe5a536a23791df0fe/docs/csharp/linq/standard-query-operators/filtering-data.md) | [docs/csharp/linq/standard-query-operators/filtering-data](https://review.learn.microsoft.com/en-us/dotnet/csharp/linq/standard-query-operators/filtering-data?branch=pr-en-us-47928) |
| [docs/csharp/linq/standard-query-operators/grouping-data.md](https://github.com/dotnet/docs/blob/0eafa8cab61f6fccfd976cfe5a536a23791df0fe/docs/csharp/linq/standard-query-operators/grouping-data.md) | [docs/csharp/linq/standard-query-operators/grouping-data](https://review.learn.microsoft.com/en-us/dotnet/csharp/linq/standard-query-operators/grouping-data?branch=pr-en-us-47928) |
| [docs/csharp/linq/standard-query-operators/join-operations.md](https://github.com/dotnet/docs/blob/0eafa8cab61f6fccfd976cfe5a536a23791df0fe/docs/csharp/linq/standard-query-operators/join-operations.md) | [docs/csharp/linq/standard-query-operators/join-operations](https://review.learn.microsoft.com/en-us/dotnet/csharp/linq/standard-query-operators/join-operations?branch=pr-en-us-47928) |
| [docs/csharp/linq/standard-query-operators/partitioning-data.md](https://github.com/dotnet/docs/blob/0eafa8cab61f6fccfd976cfe5a536a23791df0fe/docs/csharp/linq/standard-query-operators/partitioning-data.md) | [docs/csharp/linq/standard-query-operators/partitioning-data](https://review.learn.microsoft.com/en-us/dotnet/csharp/linq/standard-query-operators/partitioning-data?branch=pr-en-us-47928) |
| [docs/csharp/linq/standard-query-operators/projection-operations.md](https://github.com/dotnet/docs/blob/0eafa8cab61f6fccfd976cfe5a536a23791df0fe/docs/csharp/linq/standard-query-operators/projection-operations.md) | [docs/csharp/linq/standard-query-operators/projection-operations](https://review.learn.microsoft.com/en-us/dotnet/csharp/linq/standard-query-operators/projection-operations?branch=pr-en-us-47928) |
| [docs/csharp/linq/standard-query-operators/quantifier-operations.md](https://github.com/dotnet/docs/blob/0eafa8cab61f6fccfd976cfe5a536a23791df0fe/docs/csharp/linq/standard-query-operators/quantifier-operations.md) | [docs/csharp/linq/standard-query-operators/quantifier-operations](https://review.learn.microsoft.com/en-us/dotnet/csharp/linq/standard-query-operators/quantifier-operations?branch=pr-en-us-47928) |
| [docs/csharp/linq/standard-query-operators/set-operations.md](https://github.com/dotnet/docs/blob/0eafa8cab61f6fccfd976cfe5a536a23791df0fe/docs/csharp/linq/standard-query-operators/set-operations.md) | [docs/csharp/linq/standard-query-operators/set-operations](https://review.learn.microsoft.com/en-us/dotnet/csharp/linq/standard-query-operators/set-operations?branch=pr-en-us-47928) |
| [docs/csharp/linq/standard-query-operators/sorting-data.md](https://github.com/dotnet/docs/blob/0eafa8cab61f6fccfd976cfe5a536a23791df0fe/docs/csharp/linq/standard-query-operators/sorting-data.md) | [docs/csharp/linq/standard-query-operators/sorting-data](https://review.learn.microsoft.com/en-us/dotnet/csharp/linq/standard-query-operators/sorting-data?branch=pr-en-us-47928) |


<!-- PREVIEW-TABLE-END -->