### PR TITLE
Improve System.Linq.Async exclusion guidance for .NET 10 migration

### DIFF
--- a/docs/core/compatibility/core-libraries/10.0/asyncenumerable.md
+++ b/docs/core/compatibility/core-libraries/10.0/asyncenumerable.md
@@ -43,6 +43,7 @@ If `System.Linq.Async` is consumed indirectly via another package, avoid ambigui
     <ExcludeAssets>compile</ExcludeAssets> 
   </PackageReference>
   ```
+
   This configuration prevents direct usage in your code while allowing other packages to continue using System.Linq.Async internally.
 
 - For complete exclusion, set `<ExcludeAssets>` to `all`:

--- a/docs/core/compatibility/core-libraries/10.0/asyncenumerable.md
+++ b/docs/core/compatibility/core-libraries/10.0/asyncenumerable.md
@@ -36,11 +36,21 @@ If upgrading to .NET 10 and the code includes a direct package reference to `Sys
 
 If `System.Linq.Async` is consumed indirectly via another package, avoid ambiguity errors by including this in the project:
 
+**Option 1 (Recommended): Allow transitive usage**
+```xml
+<PackageReference Include="System.Linq.Async" Version="6.0.1">
+  <ExcludeAssets>compile</ExcludeAssets> 
+</PackageReference>
+```
+This prevents direct usage in your code while allowing other packages to continue using System.Linq.Async internally.
+
+**Option 2: Complete exclusion**
 ```xml
 <PackageReference Include="System.Linq.Async" Version="6.0.1">
   <ExcludeAssets>all</ExcludeAssets>
 </PackageReference>
 ```
+Use this only if you're certain no dependencies require System.Linq.Async at runtime.
 
 Most consuming code should be compatible without changes, but some call sites might need updates to refer to newer names and signatures. For example, a `Select` call like `e.Select(i => i * 2)` will work the same before and after. However, the call `e.SelectAwait(async (int i, CancellationToken ct) => i * 2)` will need to be changed to use `Select` instead of `SelectAwait`, as in `e.Select(async (int i, CancellationToken ct) => i * 2)`.
 

--- a/docs/core/compatibility/core-libraries/10.0/asyncenumerable.md
+++ b/docs/core/compatibility/core-libraries/10.0/asyncenumerable.md
@@ -24,7 +24,7 @@ The <xref:System.Linq.AsyncEnumerable> class in .NET 10, and in the [`System.Lin
 
 ## Type of breaking change
 
-This is a [source incompatible](../../categories.md#source-compatibility) change.
+This change can affect [source compatibility](../../categories.md#source-compatibility).
 
 ## Reason for change
 
@@ -32,25 +32,28 @@ This is a [source incompatible](../../categories.md#source-compatibility) change
 
 ## Recommended action
 
-If upgrading to .NET 10 and the code includes a direct package reference to `System.Linq.Async`, remove that package reference. For multitargeting both .NET 10 and previous versions, add a package reference to `System.Linq.AsyncEnumerable` instead.
+If you're upgrading to .NET 10 and your code includes a direct package reference to `System.Linq.Async`, remove that package reference. For multitargeting both .NET 10 and a previous version, add a package reference to `System.Linq.AsyncEnumerable` instead.
 
-If `System.Linq.Async` is consumed indirectly via another package, avoid ambiguity errors by including this in the project:
+If `System.Linq.Async` is consumed indirectly via another package, avoid ambiguity errors by adding `<ExcludeAssets>` metadata with a value of `compile` or `all`:
 
-**Option 1 (Recommended): Allow transitive usage**
-```xml
-<PackageReference Include="System.Linq.Async" Version="6.0.1">
-  <ExcludeAssets>compile</ExcludeAssets> 
-</PackageReference>
-```
-This prevents direct usage in your code while allowing other packages to continue using System.Linq.Async internally.
+- To allow transitive use of `System.Linq.Async`, set `<ExcludeAssets>` to `compile`:
 
-**Option 2: Complete exclusion**
-```xml
-<PackageReference Include="System.Linq.Async" Version="6.0.1">
-  <ExcludeAssets>all</ExcludeAssets>
-</PackageReference>
-```
-Use this only if you're certain no dependencies require System.Linq.Async at runtime.
+  ```xml
+  <PackageReference Include="System.Linq.Async" Version="6.0.1">
+    <ExcludeAssets>compile</ExcludeAssets> 
+  </PackageReference>
+  ```
+  This configuration prevents direct usage in your code while allowing other packages to continue using System.Linq.Async internally.
+
+- For complete exclusion, set `<ExcludeAssets>` to `all`:
+
+  ```xml
+  <PackageReference Include="System.Linq.Async" Version="6.0.1">
+    <ExcludeAssets>all</ExcludeAssets>
+  </PackageReference>
+  ```
+
+  Use this configuration only if you're certain no dependencies require System.Linq.Async at run time.
 
 Most consuming code should be compatible without changes, but some call sites might need updates to refer to newer names and signatures. For example, a `Select` call like `e.Select(i => i * 2)` will work the same before and after. However, the call `e.SelectAwait(async (int i, CancellationToken ct) => i * 2)` will need to be changed to use `Select` instead of `SelectAwait`, as in `e.Select(async (int i, CancellationToken ct) => i * 2)`.
 


### PR DESCRIPTION
**Problem**: The current documentation recommends using ExcludeAssets="all" when dealing with System.Linq.Async conflicts in .NET 10. This approach is too restrictive and can break applications that depend on NuGet packages which internally use System.Linq.Async.

**Solution**: This PR updates the documentation to recommend ExcludeAssets="compile" as the preferred approach, with ExcludeAssets="all" as an alternative for specific scenarios.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/core-libraries/10.0/asyncenumerable.md](https://github.com/dotnet/docs/blob/203ddb2fe040a166d09e3c5632c2b8abb263731d/docs/core/compatibility/core-libraries/10.0/asyncenumerable.md) | [System.Linq.AsyncEnumerable in .NET 10](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/10.0/asyncenumerable?branch=pr-en-us-47931) |


<!-- PREVIEW-TABLE-END -->