### PR TITLE
Fix broken xrefs in System.CommandLine

### DIFF
--- a/docs/standard/commandline/get-started-tutorial.md
+++ b/docs/standard/commandline/get-started-tutorial.md
@@ -1,7 +1,7 @@
 ---
 title: "Tutorial: Get started with System.CommandLine"
 description: Learn how to use the System.CommandLine library for command-line apps.
-ms.date: 04/07/2022
+ms.date: 08/13/2025
 ms.topic: tutorial
 no-loc: [System.CommandLine]
 helpviewer_keywords:
@@ -166,7 +166,7 @@ Options:
   --file          The file to read and display on the conso
 ```
 
-<xref:System.CommandLine.RootCommand> by default provides [Help option](how-to-customize-help.md#customize-help-output), [Version option](syntax.md#version-option), and [Suggest directive](syntax.md#suggest-directive). The <xref:System.CommandLine.ParseResult.Invoke?displayProperty=nameWithType> method is responsible for invoking the action of parsed symbol. It could be the action explicitly defined for the command, or the help action defined by `System.CommandLine` for `System.CommandLine.Help.HelpOption`. Moreover, when it detects any parse errors, it prints them to the standard error, prints help to standard output, and returns `1` as the exit code:
+<xref:System.CommandLine.RootCommand> by default provides [Help option](how-to-customize-help.md#customize-help-output), [Version option](syntax.md#version-option), and [Suggest directive](syntax.md#suggest-directive). The <xref:System.CommandLine.ParseResult.Invoke(System.CommandLine.InvocationConfiguration)?displayProperty=nameWithType> method is responsible for invoking the action of parsed symbol. It could be the action explicitly defined for the command, or the help action defined by `System.CommandLine` for `System.CommandLine.Help.HelpOption`. Moreover, when it detects any parse errors, it prints them to the standard error, prints help to standard output, and returns `1` as the exit code:
 
 ```console
 scl --invalid bla

--- a/docs/standard/commandline/how-to-configure-the-parser.md
+++ b/docs/standard/commandline/how-to-configure-the-parser.md
@@ -14,41 +14,41 @@ ms.topic: how-to
 
 [!INCLUDE [scl-preview](./includes/preview.md)]
 
-<xref:System.CommandLine.CommandLineConfiguration> is a class that provides properties to configure the parser. It is an optional argument for every `Parse` method, such as <xref:System.CommandLine.Command.Parse*?displayProperty=nameWithType> and <xref:System.CommandLine.Parsing.CommandLineParser.Parse*?displayProperty=nameWithType>. When it isn't provided, the default configuration is used.
+<xref:System.CommandLine.ParserConfiguration> is a class that provides properties to configure the parser. It is an optional argument for every `Parse` method, such as <xref:System.CommandLine.Command.Parse*?displayProperty=nameWithType> and <xref:System.CommandLine.Parsing.CommandLineParser.Parse*?displayProperty=nameWithType>. When it isn't provided, the default configuration is used.
 
 <xref:System.CommandLine.ParseResult> has a <xref:System.CommandLine.ParseResult.Configuration> property that returns the configuration used for parsing.
 
 ## Standard output and error
 
-`CommandLineConfiguration` makes testing, as well as many extensibility scenarios, easier than using `System.Console`. It exposes two `TextWriter` properties: `Output` and `Error`. These can be set to any `TextWriter` instance, such as a `StringWriter`, which can be used to capture output for testing.
+<xref:System.CommandLine.InvocationConfiguration> makes testing, as well as many extensibility scenarios, easier than using `System.Console`. It exposes two `TextWriter` properties: <xref:System.CommandLine.InvocationConfiguration.Output> and <xref:System.CommandLine.InvocationConfiguration.Error>. You can set these properties to any `TextWriter` instance, such as a `StringWriter`, which you can use to capture output for testing.
 
 Define a simple command that writes to standard output:
 
 :::code language="csharp" source="snippets/configuration/csharp/Program.cs" id="rootcommand":::
 
-Now, use `CommandLineConfiguration` to capture the output:
+Now, use <xref:System.CommandLine.InvocationConfiguration> to capture the output:
 
 :::code language="csharp" source="snippets/configuration/csharp/Program.cs" id="captureoutput":::
 
 ## EnablePosixBundling
 
-[Bundling](syntax.md#option-bundling) of single-character options is enabled by default, but you can disable it by setting the `System.CommandLine.CommandLineConfiguration.EnablePosixBundling` property to `false`.
+[Bundling](syntax.md#option-bundling) of single-character options is enabled by default, but you can disable it by setting the <xref:System.CommandLine.ParserConfiguration.EnablePosixBundling?displayProperty=nameWithType> property to `false`.
 
 ## ProcessTerminationTimeout
 
-[Process termination timeout](how-to-parse-and-invoke.md#process-termination-timeout) can be configured via the `System.CommandLine.CommandLineConfiguration.ProcessTerminationTimeout` property. The default value is 2 seconds.
+[Process termination timeout](how-to-parse-and-invoke.md#process-termination-timeout) can be configured via the <xref:System.CommandLine.InvocationConfiguration.ProcessTerminationTimeout> property. The default value is 2 seconds.
 
 ## ResponseFileTokenReplacer
 
-[Response files](syntax.md#response-files) are enabled by default, but you can disable them by setting the `System.CommandLine.CommandLineConfiguration.ResponseFileTokenReplacer` property to `null`. You can also provide a custom implementation to customize how response files are processed.
+[Response files](syntax.md#response-files) are enabled by default, but you can disable them by setting the <xref:System.CommandLine.ParserConfiguration.ResponseFileTokenReplacer> property to `null`. You can also provide a custom implementation to customize how response files are processed.
 
 ## EnableDefaultExceptionHandler
 
-By default, all unhandled exceptions thrown during the invocation of a command are caught and reported to the user. This behavior can be disabled by setting the `System.CommandLine.CommandLineConfiguration.EnableDefaultExceptionHandler` property to `false`. This is useful when you want to handle exceptions in a custom way, such as logging them or providing a different user experience.
+By default, all unhandled exceptions thrown during the invocation of a command are caught and reported to the user. You can disable this behavior by setting the <xref:System.CommandLine.InvocationConfiguration.EnableDefaultExceptionHandler> property to `false`. This is useful when you want to handle exceptions in a custom way, such as logging them or providing a different user experience.
 
 ## Derived classes
 
-`System.CommandLine.CommandLineConfiguration` is not sealed, so you can derive from it to add custom properties or methods. This is useful when you want to provide additional configuration options specific to your application.
+<xref:System.CommandLine.InvocationConfiguration> is not sealed, so you can derive from it to add custom properties or methods. This is useful when you want to provide additional configuration options specific to your application.
 
 ## See also
 

--- a/docs/standard/commandline/how-to-parse-and-invoke.md
+++ b/docs/standard/commandline/how-to-parse-and-invoke.md
@@ -53,7 +53,7 @@ This overload of `GetValue` gets the parsed or default value for the specified s
 
 The <xref:System.CommandLine.ParseResult.Errors?displayProperty=nameWithType> property contains a list of parse errors that occurred during the parsing process. Each error is represented by a <xref:System.CommandLine.Parsing.ParseError> object, which contains information about the error, such as the error message and the token that caused the error.
 
-When you call the <xref:System.CommandLine.ParseResult.Invoke?displayProperty=nameWithType> method, it returns an exit code that indicates whether the parsing was successful or not. If there were any parse errors, the exit code is non-zero, and all the parse errors are printed to the standard error.
+When you call the <xref:System.CommandLine.ParseResult.Invoke(System.CommandLine.InvocationConfiguration)?displayProperty=nameWithType> method, it returns an exit code that indicates whether the parsing was successful or not. If there were any parse errors, the exit code is non-zero, and all the parse errors are printed to the standard error.
 
 If you don't call the `ParseResult.Invoke` method, you need to handle the errors on your own, for example, by printing them:
 
@@ -85,7 +85,7 @@ You don't need to create a derived type to define an action. You can use the <xr
 
 Synchronous and asynchronous actions should not be mixed in the same application. If you want to use asynchronous actions, your application needs to be asynchronous throughout. This means that all actions should be asynchronous, and you should use the `System.CommandLine.Command.SetAction` method that accepts a delegate returning a `Task<int>` exit code. Moreover, the <xref:System.Threading.CancellationToken> that's passed to the action delegate needs to be passed further to all the methods that can be canceled, such as file I/O operations or network requests.
 
-You also need to ensure that the <xref:System.CommandLine.ParseResult.InvokeAsync(System.Threading.CancellationToken)?displayProperty=nameWithType> method is used instead of `Invoke`. This method is asynchronous and returns a `Task<int>` exit code. It also accepts an optional <xref:System.Threading.CancellationToken> parameter that can be used to cancel the action.
+You also need to ensure that the <xref:System.CommandLine.ParseResult.InvokeAsync(System.CommandLine.InvocationConfiguration,System.Threading.CancellationToken)?displayProperty=nameWithType> method is used instead of `Invoke`. This method is asynchronous and returns a `Task<int>` exit code. It also accepts an optional <xref:System.Threading.CancellationToken> parameter that can be used to cancel the action.
 
 The following code uses a `SetAction` overload that gets a [ParseResult](#parseresult) and a <xref:System.Threading.CancellationToken> rather than just `ParseResult`:
 
@@ -93,7 +93,7 @@ The following code uses a `SetAction` overload that gets a [ParseResult](#parser
 
 #### Process termination timeout
 
-<xref:System.CommandLine.CommandLineConfiguration.ProcessTerminationTimeout> enables signaling and handling of process termination (<kbd>Ctrl</kbd>+<kbd>C</kbd>, `SIGINT`, `SIGTERM`) via a <xref:System.Threading.CancellationToken> that's passed to every async action during invocation. It's enabled by default (2 seconds), but you can set it to `null` to disable it.
+<xref:System.CommandLine.InvocationConfiguration.ProcessTerminationTimeout> enables signaling and handling of process termination (<kbd>Ctrl</kbd>+<kbd>C</kbd>, `SIGINT`, `SIGTERM`) via a <xref:System.Threading.CancellationToken> that's passed to every async action during invocation. It's enabled by default (2 seconds), but you can set it to `null` to disable it.
 
 When enabled, if the action doesn't complete within the specified timeout, the process will be terminated. This is useful for handling the termination gracefully, for example, by saving the state before the process is terminated.
 

--- a/docs/standard/commandline/migration-guide-2.0.0-beta5.md
+++ b/docs/standard/commandline/migration-guide-2.0.0-beta5.md
@@ -1,7 +1,7 @@
 ---
-title: System.CommandLine migration guide to 2.0.0-beta5
-description: "Learn about how to migrate to System.CommandLine 2.0.0-beta5."
-ms.date: 06/19/2025
+title: System.CommandLine migration guide to 2.0.0-beta7
+description: "Learn about how to migrate to System.CommandLine 2.0.0-beta7."
+ms.date: 08/13/2025
 no-loc: [System.CommandLine]
 helpviewer_keywords:
   - "command line interface"
@@ -9,15 +9,15 @@ helpviewer_keywords:
   - "System.CommandLine"
 ---
 
-# System.CommandLine 2.0.0-beta5 migration guide
+# System.CommandLine 2.0.0-beta7 migration guide
 
 [!INCLUDE [scl-preview](./includes/preview.md)]
 
-The main focus for the 2.0.0-beta5 release was to improve the APIs and take a step toward releasing a stable version of System.CommandLine. The APIs have been simplified and made more coherent and consistent with the [Framework design guidelines](../design-guidelines/index.md). This article describes the breaking changes that were made in 2.0.0-beta5 and the reasoning behind them.
+The main focus for the 2.0.0-beta7 release was to improve the APIs and take a step toward releasing a stable version of System.CommandLine. The APIs have been simplified and made more coherent and consistent with the [Framework design guidelines](../design-guidelines/index.md). This article describes the breaking changes that were made in 2.0.0-beta7 and the reasoning behind them.
 
 ## Renaming
 
-In 2.0.0-beta4, not all types and members followed the [naming guidelines](../design-guidelines/naming-guidelines.md). Some were not consistent with the naming conventions, such as using the `Is` prefix for Boolean properties. In 2.0.0-beta5, some types and members have been renamed. The following table shows the old and new names:
+In 2.0.0-beta4, not all types and members followed the [naming guidelines](../design-guidelines/naming-guidelines.md). Some were not consistent with the naming conventions, such as using the `Is` prefix for Boolean properties. In 2.0.0-beta7, some types and members have been renamed. The following table shows the old and new names:
 
 | Old name                                               | New name                                                       |
 |--------------------------------------------------------|----------------------------------------------------------------|
@@ -36,7 +36,7 @@ In 2.0.0-beta4, not all types and members followed the [naming guidelines](../de
 
 Version 2.0.0-beta4 had numerous `Add` methods that were used to add items to collections, such as arguments, options, subcommands, validators, and completions. Some of these collections were exposed via properties as read-only collections. Because of that, it was impossible to remove items from those collections.
 
-In 2.0.0-beta5, the APIs were changed to expose mutable collections instead of `Add` methods and (sometimes) read-only collections. This allows you to not only add items or enumerate them, but also remove them. The following table shows the old method and new property names:
+In 2.0.0-beta7, the APIs were changed to expose mutable collections instead of `Add` methods and (sometimes) read-only collections. This allows you to not only add items or enumerate them, but also remove them. The following table shows the old method and new property names:
 
 | Old method name           | New property                     |
 |---------------------------|----------------------------------|
@@ -56,7 +56,7 @@ The `RemoveAlias` and `HasAlias` methods were also removed, as the `Aliases` pro
 
 ## Names and aliases
 
-Before 2.0.0-beta5, there was no clear separation between the name and [aliases](syntax.md#aliases) of a symbol. When `name` was not provided for the `Option<T>` constructor, the symbol reported its name as the longest alias with prefixes like `--`, `-`, or `/` removed. That was confusing.
+Before 2.0.0-beta7, there was no clear separation between the name and [aliases](syntax.md#aliases) of a symbol. When `name` was not provided for the `Option<T>` constructor, the symbol reported its name as the longest alias with prefixes like `--`, `-`, or `/` removed. That was confusing.
 
 Moreover, to get the parsed value, users had to store a reference to an option or an argument and then use it to get the value from `ParseResult`.
 
@@ -83,7 +83,7 @@ int number = parseResult.GetValue<int>("--number");
 
 In the past, `Option<T>` exposed many constructors, some of which accepted the name. Since the name is now mandatory and aliases will frequently be provided for `Option<T>`, there's only a single constructor. It accepts the name and a `params` array of aliases.
 
-Before 2.0.0-beta5, `Option<T>` had a constructor that took a name and a description. Because of that, the second argument might now be treated as an alias rather than a description. It's the only known breaking change in the API that doesn't cause a compiler error.
+Before 2.0.0-beta7, `Option<T>` had a constructor that took a name and a description. Because of that, the second argument might now be treated as an alias rather than a description. It's the only known breaking change in the API that doesn't cause a compiler error.
 
 Old code that used the constructor with a description should be updated to use the new constructor that takes a name and aliases, and then set the `Description` property separately. For example:
 
@@ -92,7 +92,7 @@ Option<bool> beta4 = new("--help", "An option with aliases.");
 beta4b.Aliases.Add("-h");
 beta4b.Aliases.Add("/h");
 
-Option<bool> beta5 = new("--help", "-h", "/h")
+Option<bool> beta7 = new("--help", "-h", "/h")
 {
     Description = "An option with aliases."
 };
@@ -150,7 +150,7 @@ In 2.0.0-beta4, it was possible to separate the parsing and invoking of commands
 
 ### Configuration
 
-Before 2.0.0-beta5, it was possible to customize the parsing, but only with some of the public `Parse` methods. There was a `Parser` class that exposed two public constructors: one accepting a `Command` and another accepting a `CommandLineConfiguration`. `CommandLineConfiguration` was immutable, and to create it, you had to use a builder pattern exposed by the `CommandLineBuilder` class. The following changes were made to simplify the API:
+Before 2.0.0-beta7, it was possible to customize the parsing, but only with some of the public `Parse` methods. There was a `Parser` class that exposed two public constructors: one accepting a `Command` and another accepting a `CommandLineConfiguration`. `CommandLineConfiguration` was immutable, and to create it, you had to use a builder pattern exposed by the `CommandLineBuilder` class. The following changes were made to simplify the API:
 
 - `CommandLineConfiguration` was made mutable and `CommandLineBuilder` was removed. Creating a configuration is now as simple as creating an instance of `CommandLineConfiguration` and setting the properties you want to customize. Moreover, creating a new instance of configuration is the equivalent of calling `CommandLineBuilder`'s `UseDefaults` method.
 - Every `Parse` method now accepts an optional `CommandLineConfiguration` parameter that can be used to customize the parsing. When it's not provided, the default configuration is used.
@@ -179,9 +179,9 @@ Before 2.0.0-beta5, it was possible to customize the parsing, but only with some
   ```
 
 - `UseLocalizationResources` and `LocalizationResources` were removed. This feature was used mostly by the `dotnet` CLI to add missing translations to `System.CommandLine`. All those translations were moved to the System.CommandLine itself, so this feature is no longer needed. If support for your language is missing, please [report an issue](https://github.com/dotnet/command-line-api/issues/new/choose).
-- `UseTokenReplacer` was removed. [Response files](syntax.md#response-files) are enabled by default, but you can disable them by setting the <xref:System.CommandLine.CommandLineConfiguration.ResponseFileTokenReplacer> property to `null`. You can also provide a custom implementation to customize how response files are processed.
+- `UseTokenReplacer` was removed. [Response files](syntax.md#response-files) are enabled by default, but you can disable them by setting the <xref:System.CommandLine.ParserConfiguration.ResponseFileTokenReplacer> property to `null`. You can also provide a custom implementation to customize how response files are processed.
 
-Last but not least, the `IConsole` and all related interfaces (`IStandardOut`, `IStandardError`, `IStandardIn`) were removed. <xref:System.CommandLine.CommandLineConfiguration> exposes two `TextWriter` properties: <xref:System.CommandLine.CommandLineConfiguration.Output> and <xref:System.CommandLine.CommandLineConfiguration.Error>. You can set these properties to any <xref:System.IO.TextWriter> instance, such as a `StringWriter`, which can be used to capture output for testing. The motivation for this change was to expose fewer types and reuse existing abstractions.
+Last but not least, the `IConsole` and all related interfaces (`IStandardOut`, `IStandardError`, `IStandardIn`) were removed. <xref:System.CommandLine.InvocationConfiguration> exposes two `TextWriter` properties: <xref:System.CommandLine.InvocationConfiguration.Output> and <xref:System.CommandLine.InvocationConfiguration.Error>. You can set these properties to any <xref:System.IO.TextWriter> instance, such as a `StringWriter`, which can be used to capture output for testing. The motivation for this change was to expose fewer types and reuse existing abstractions.
 
 ### Invocation
 
@@ -233,7 +233,7 @@ For more details about how to use actions, see [How to parse and invoke commands
 
 ## The benefits of the simplified API
 
-The changes made in 2.0.0-beta5 make the API more consistent, future-proof, and easier to use for existing and new users.
+The changes made in 2.0.0-beta7 make the API more consistent, future-proof, and easier to use for existing and new users.
 
 New users need to learn fewer concepts and types, as the number of public interfaces decreased from 11 to 0, and public classes (and structs) decreased from 56 to 38. The public method count dropped from 378 to 235, and public properties from 118 to 99.
 

--- a/docs/standard/commandline/migration-guide-2.0.0-beta5.md
+++ b/docs/standard/commandline/migration-guide-2.0.0-beta5.md
@@ -1,6 +1,6 @@
 ---
-title: System.CommandLine migration guide to 2.0.0-beta7
-description: "Learn about how to migrate to System.CommandLine 2.0.0-beta7."
+title: System.CommandLine migration guide to 2.0.0-beta5+
+description: "Learn about how to migrate to System.CommandLine 2.0.0-beta5+."
 ms.date: 08/13/2025
 no-loc: [System.CommandLine]
 helpviewer_keywords:
@@ -9,15 +9,15 @@ helpviewer_keywords:
   - "System.CommandLine"
 ---
 
-# System.CommandLine 2.0.0-beta7 migration guide
+# System.CommandLine 2.0.0-beta5+ migration guide
 
 [!INCLUDE [scl-preview](./includes/preview.md)]
 
-The main focus for the 2.0.0-beta7 release was to improve the APIs and take a step toward releasing a stable version of System.CommandLine. The APIs have been simplified and made more coherent and consistent with the [Framework design guidelines](../design-guidelines/index.md). This article describes the breaking changes that were made in 2.0.0-beta7 and the reasoning behind them.
+The main focus for the 2.0.0-beta5 release was to improve the APIs and take a step toward releasing a stable version of System.CommandLine. The APIs have been simplified and made more coherent and consistent with the [Framework design guidelines](../design-guidelines/index.md). This article describes the breaking changes that were made in 2.0.0-beta5 and 2.0.0-beta7, and the reasoning behind them.
 
 ## Renaming
 
-In 2.0.0-beta4, not all types and members followed the [naming guidelines](../design-guidelines/naming-guidelines.md). Some were not consistent with the naming conventions, such as using the `Is` prefix for Boolean properties. In 2.0.0-beta7, some types and members have been renamed. The following table shows the old and new names:
+In 2.0.0-beta4, not all types and members followed the [naming guidelines](../design-guidelines/naming-guidelines.md). Some weren't consistent with the naming conventions, such as using the `Is` prefix for Boolean properties. In 2.0.0-beta5, some types and members have been renamed. The following table shows the old and new names:
 
 | Old name                                               | New name                                                       |
 |--------------------------------------------------------|----------------------------------------------------------------|
@@ -36,7 +36,7 @@ In 2.0.0-beta4, not all types and members followed the [naming guidelines](../de
 
 Version 2.0.0-beta4 had numerous `Add` methods that were used to add items to collections, such as arguments, options, subcommands, validators, and completions. Some of these collections were exposed via properties as read-only collections. Because of that, it was impossible to remove items from those collections.
 
-In 2.0.0-beta7, the APIs were changed to expose mutable collections instead of `Add` methods and (sometimes) read-only collections. This allows you to not only add items or enumerate them, but also remove them. The following table shows the old method and new property names:
+In 2.0.0-beta5, the APIs were changed to expose mutable collections instead of `Add` methods and (sometimes) read-only collections. This allows you to not only add items or enumerate them, but also remove them. The following table shows the old method and new property names:
 
 | Old method name           | New property                     |
 |---------------------------|----------------------------------|
@@ -56,14 +56,14 @@ The `RemoveAlias` and `HasAlias` methods were also removed, as the `Aliases` pro
 
 ## Names and aliases
 
-Before 2.0.0-beta7, there was no clear separation between the name and [aliases](syntax.md#aliases) of a symbol. When `name` was not provided for the `Option<T>` constructor, the symbol reported its name as the longest alias with prefixes like `--`, `-`, or `/` removed. That was confusing.
+Before 2.0.0-beta5, there was no clear separation between the name and [aliases](syntax.md#aliases) of a symbol. When `name` wasn't provided for the `Option<T>` constructor, the symbol reported its name as the longest alias with prefixes like `--`, `-`, or `/` removed. That was confusing.
 
-Moreover, to get the parsed value, users had to store a reference to an option or an argument and then use it to get the value from `ParseResult`.
+Moreover, to get the parsed value, you had to store a reference to an option or an argument and then use it to get the value from `ParseResult`.
 
 To promote simplicity and explicitness, the name of a symbol is now a mandatory parameter for every symbol constructor (including `Argument<T>`). The concept of a name and aliases is now separate: aliases are just aliases and don't include the name of the symbol. Of course, they're optional. As a result, the following changes were made:
 
 - `name` is now a mandatory argument for every public constructor of <xref:System.CommandLine.Argument`1>, <xref:System.CommandLine.Option`1>, and <xref:System.CommandLine.Command>. In the case of `Argument<T>`, it isn't used for parsing, but to generate the help. In the case of `Option<T>` and `Command`, it's used to identify the symbol during parsing and also for help and completions.
-- The `Symbol.Name` property is no longer `virtual`; it's now read-only and returns the name as it was provided when the symbol was created. Because of that, `Symbol.DefaultName` was removed and `Option.Name` no longer removes the `--`, `-`, or `/` or any other prefix from the longest alias.
+- The <xref:System.CommandLine.Symbol.Name?displayProperty=nameWithType> property is no longer `virtual`; it's now read-only and returns the name as it was provided when the symbol was created. Because of that, `Symbol.DefaultName` was removed and <xref:System.CommandLine.Option.Name?displayProperty=nameWithType> no longer removes the `--`, `-`, or `/` or any other prefix from the longest alias.
 - The `Aliases` property exposed by [`Option`](xref:System.CommandLine.Option.Aliases) and [`Command`](xref:System.CommandLine.Command.Aliases) is now a mutable collection. This collection no longer includes the name of the symbol.
 - `System.CommandLine.Parsing.IdentifierSymbol` was removed (it was a base type for both `Command` and `Option`).
 
@@ -81,18 +81,18 @@ int number = parseResult.GetValue<int>("--number");
 
 ### Creating options with aliases
 
-In the past, `Option<T>` exposed many constructors, some of which accepted the name. Since the name is now mandatory and aliases will frequently be provided for `Option<T>`, there's only a single constructor. It accepts the name and a `params` array of aliases.
+In the past, <xref:System.CommandLine.Option`1> exposed many constructors, some of which accepted the name. Since the name is now mandatory and aliases will frequently be provided for `Option<T>`, there's only a single constructor. It accepts the name and a `params` array of aliases.
 
-Before 2.0.0-beta7, `Option<T>` had a constructor that took a name and a description. Because of that, the second argument might now be treated as an alias rather than a description. It's the only known breaking change in the API that doesn't cause a compiler error.
-
-Old code that used the constructor with a description should be updated to use the new constructor that takes a name and aliases, and then set the `Description` property separately. For example:
+> [!NOTE]
+> Before 2.0.0-beta5, `Option<T>` had a constructor that took a name and a description. Because of that, the second argument might now be treated as an alias rather than a description. It's the only known breaking change in the API that doesn't cause a compiler error.
+> Update any code that passed a description to the constructor to use the new constructor that takes a name and aliases, and then set the `Description` property separately. For example:
 
 ```csharp
 Option<bool> beta4 = new("--help", "An option with aliases.");
 beta4b.Aliases.Add("-h");
 beta4b.Aliases.Add("/h");
 
-Option<bool> beta7 = new("--help", "-h", "/h")
+Option<bool> beta5 = new("--help", "-h", "/h")
 {
     Description = "An option with aliases."
 };
@@ -100,16 +100,17 @@ Option<bool> beta7 = new("--help", "-h", "/h")
 
 ## Default values and custom parsing
 
-In 2.0.0-beta4, you could set default values for options and arguments by using the `SetDefaultValue` methods. Those methods accepted an `object` value, which wasn't type-safe and could lead to run-time errors if the value was not compatible with the option or argument type:
+In 2.0.0-beta4, you could set default values for options and arguments by using the `SetDefaultValue` methods. Those methods accepted an `object` value, which wasn't type safe and could lead to run-time errors if the value wasn't compatible with the option or argument type:
 
 ```csharp
 Option<int> option = new("--number");
-option.SetDefaultValue("text"); // This is not type-safe, as the value is a string, not an int.
+// This is not type safe, as the value is a string, not an int:
+option.SetDefaultValue("text");
 ```
 
-Moreover, some of the `Option` and `Argument` constructors accepted a parse delegate and a Boolean indicating whether the delegate was a custom parser or a default value provider. This was confusing.
+Moreover, some of the `Option` and `Argument` constructors accepted a parse delegate and a Boolean indicating whether the delegate was a custom parser or a default value provider, which was confusing.
 
-`Option<T>` and `Argument<T>` classes now have a <xref:System.CommandLine.Option`1.DefaultValueFactory> property that can be used to set a delegate that can be called to get the default value for the option or argument. This delegate is invoked when the option or argument is not found in the parsed command line input.
+`Option<T>` and `Argument<T>` classes now have a <xref:System.CommandLine.Option`1.DefaultValueFactory> property that you can use to set a delegate that can be called to get the default value for the option or argument. This delegate is invoked when the option or argument isn't found in the parsed command-line input.
 
 ```csharp
 Option<int> number = new("--number")
@@ -118,7 +119,7 @@ Option<int> number = new("--number")
 };
 ```
 
-`Argument<T>` and `Option<T>` also come with a <xref:System.CommandLine.Option`1.CustomParser> property that can be used to set a custom parser for the symbol:
+`Argument<T>` and `Option<T>` also come with a <xref:System.CommandLine.Option`1.CustomParser> property that you can use to set a custom parser for the symbol:
 
 ```csharp
 Argument<Uri> uri = new("arg")
@@ -140,25 +141,25 @@ Moreover, `CustomParser` accepts a delegate of type `Func<ParseResult,T>`, rathe
 
 For more examples of how to use `DefaultValueFactory` and `CustomParser`, see [How to customize parsing and validation in System.CommandLine](how-to-customize-parsing-and-validation.md).
 
-## The separation of parsing and invocation
+## Separation of parsing and invocation
 
-In 2.0.0-beta4, it was possible to separate the parsing and invoking of commands, but it wasn't clear how to do it. `Command` did not expose a `Parse` method, but `CommandExtensions` provided `Parse`, `Invoke`, and `InvokeAsync` extension methods for `Command`. This was confusing, as it was not clear which method to use and when. The following changes were made to simplify the API:
+In 2.0.0-beta4, it was possible to separate the parsing and invoking of commands, but it wasn't clear how to do it. `Command` didn't expose a `Parse` method, but `CommandExtensions` provided `Parse`, `Invoke`, and `InvokeAsync` extension methods for `Command`. This was confusing, as it wasn't clear which method to use and when. The following changes were made to simplify the API:
 
-- `Command` now exposes a `Parse` method that returns a `ParseResult` object. This method is used to parse the command line input and return the result of the parse operation. Moreover, it makes it clear that the command is not invoked, but only parsed and only in synchronous manner.
-- `ParseResult` now exposes both `Invoke` and `InvokeAsync` methods that can be used to invoke the command. This makes it clear that the command is invoked after parsing, and allows for both synchronous and asynchronous invocation.
+- <xref:System.CommandLine.Command> now exposes a `Parse` method that returns a `ParseResult` object. This method is used to parse the command-line input and return the result of the parse operation. Moreover, it makes it clear that the command isn't invoked but parsed, and only in synchronous manner.
+- `ParseResult` now exposes both `Invoke` and `InvokeAsync` methods that you can use to invoke the command. This pattern makes it clear that the command is invoked after parsing, and allows for both synchronous and asynchronous invocation.
 - The `CommandExtensions` class was removed, as it's no longer needed.
 
 ### Configuration
 
 Before 2.0.0-beta5, it was possible to customize the parsing, but only with some of the public `Parse` methods. There was a `Parser` class that exposed two public constructors: one accepting a `Command` and another accepting a `CommandLineConfiguration`. `CommandLineConfiguration` was immutable, and to create it, you had to use a builder pattern exposed by the `CommandLineBuilder` class. The following changes were made to simplify the API:
 
-- `CommandLineConfiguration` was split into two *mutable* classes (in beta7): <xref:System.CommandLine.ParserConfiguration> and <xref:System.CommandLine.InvocationConfiguration>. Creating an invocation configuration is now as simple as creating an instance of `InvocationConfiguration` and setting the properties you want to customize.
-- Every `Parse` method now accepts an optional <xref:System.CommandLine.ParserConfiguration> parameter that can be used to customize the parsing. When it's not provided, the default configuration is used.
-- To avoid name conflicts, `Parser` was renamed to <xref:Microsoft.CodeAnalysis.CommandLineParser> to disambiguate from other parser types. Since it's stateless, it's now a static class with only static methods. It exposes two `Parse` parse methods: one accepting an `IReadOnlyList<string> args` and another accepting a `string args`. The latter uses `CommandLineParser.SplitCommandLine` (also public) to split the command line input into [tokens](syntax.md#tokens) before parsing it.
+- `CommandLineConfiguration` was split into two *mutable* classes (in 2.0.0-beta7): <xref:System.CommandLine.ParserConfiguration> and <xref:System.CommandLine.InvocationConfiguration>. Creating an invocation configuration is now as simple as creating an instance of `InvocationConfiguration` and setting the properties you want to customize.
+- Every `Parse` method now accepts an optional <xref:System.CommandLine.ParserConfiguration> parameter that you can use to customize the parsing. When it isn't provided, the default configuration is used.
+- To avoid name conflicts, `Parser` was renamed to <xref:Microsoft.CodeAnalysis.CommandLineParser> to disambiguate from other parser types. Since it's stateless, it's now a static class with only static methods. It exposes two `Parse` parse methods: one accepting an `IReadOnlyList<string> args` and another accepting a `string args`. The latter uses <xref:System.CommandLine.Parsing.CommandLineParser.SplitCommandLine(System.String)?displayProperty=nameWithType> (also public) to split the command line input into [tokens](syntax.md#tokens) before parsing it.
 
 `CommandLineBuilderExtensions` was also removed. Here is how you can map its methods to the new APIs:
 
-- `CancelOnProcessTermination` is now a property of <xref:System.CommandLine.InvocationConfiguration> called [ProcessTerminationTimeout](how-to-parse-and-invoke.md#process-termination-timeout). It's enabled by default, with a 2 second timeout. To disable it, set it to `null`.
+- `CancelOnProcessTermination` is now a property of <xref:System.CommandLine.InvocationConfiguration> called <xref:System.CommandLine.InvocationConfiguration.ProcessTerminationTimeout>. It's enabled by default, with a 2 second timeout. To disable it, set it to `null`. For more information, see [Process termination timeout](how-to-parse-and-invoke.md#process-termination-timeout).
 - `EnableDirectives`, `UseEnvironmentVariableDirective`, `UseParseDirective`, and `UseSuggestDirective` were removed. A new [Directive](syntax.md#directives) type was introduced and [RootCommand](syntax.md#root-command) now exposes a <xref:System.CommandLine.RootCommand.Directives> property. You can add, remove, and iterate directives by using this collection. [Suggest directive](syntax.md#suggest-directive) is included by default; you can also use other directives like [DiagramDirective](syntax.md#the-diagram-directive) or <xref:System.CommandLine.EnvironmentVariablesDirective>.
 - `EnableLegacyDoubleDashBehavior` was removed. All unmatched tokens are now exposed by the <xref:System.CommandLine.ParseResult.UnmatchedTokens?displayProperty=nameWithType> property. For more information, see [Unmatched tokens](how-to-parse-and-invoke.md#unmatched-tokens).
 - `EnablePosixBundling` was removed. The bundling is now enabled by default, you can disable it by setting the <xref:System.CommandLine.ParserConfiguration.EnablePosixBundling?displayProperty=nameWithType> property to `false`. For more information, see [EnablePosixBundling](how-to-configure-the-parser.md#enableposixbundling).
@@ -181,7 +182,7 @@ Before 2.0.0-beta5, it was possible to customize the parsing, but only with some
 - `UseLocalizationResources` and `LocalizationResources` were removed. This feature was used mostly by the `dotnet` CLI to add missing translations to `System.CommandLine`. All those translations were moved to the System.CommandLine itself, so this feature is no longer needed. If support for your language is missing, please [report an issue](https://github.com/dotnet/command-line-api/issues/new/choose).
 - `UseTokenReplacer` was removed. [Response files](syntax.md#response-files) are enabled by default, but you can disable them by setting the <xref:System.CommandLine.ParserConfiguration.ResponseFileTokenReplacer> property to `null`. You can also provide a custom implementation to customize how response files are processed.
 
-Last but not least, the `IConsole` and all related interfaces (`IStandardOut`, `IStandardError`, `IStandardIn`) were removed. <xref:System.CommandLine.InvocationConfiguration> exposes two `TextWriter` properties: <xref:System.CommandLine.InvocationConfiguration.Output> and <xref:System.CommandLine.InvocationConfiguration.Error>. You can set these properties to any <xref:System.IO.TextWriter> instance, such as a `StringWriter`, which can be used to capture output for testing. The motivation for this change was to expose fewer types and reuse existing abstractions.
+Last but not least, the `IConsole` and all related interfaces (`IStandardOut`, `IStandardError`, `IStandardIn`) were removed. <xref:System.CommandLine.InvocationConfiguration> exposes two `TextWriter` properties: <xref:System.CommandLine.InvocationConfiguration.Output> and <xref:System.CommandLine.InvocationConfiguration.Error>. You can set these properties to any <xref:System.IO.TextWriter> instance, such as a `StringWriter`, which you can use to capture output for testing. The motivation for this change was to expose fewer types and reuse existing abstractions.
 
 ### Invocation
 
@@ -225,15 +226,15 @@ As a result of these and other aforementioned changes, the `InvocationContext` c
 To summarize these changes:
 
 - The `ICommandHandler` interface was removed. `SynchronousCommandLineAction` and `AsynchronousCommandLineAction` were introduced.
-- The `Command.SetHandler` method was renamed to `SetAction`.
-- The `Command.Handler` property was renamed to `Command.Action`. `Option` was extended with `Option.Action`.
+- The `Command.SetHandler` method was renamed to <xref:System.CommandLine.Command.SetAction*>.
+- The `Command.Handler` property was renamed to <xref:System.CommandLine.Command.Action?displayProperty=nameWithType>. `Option` was extended with <xref:System.CommandLine.Option.Action?displayProperty=nameWithType>.
 - `InvocationContext` was removed. The `ParseResult` is now passed directly to the action.
 
 For more details about how to use actions, see [How to parse and invoke commands in System.CommandLine](how-to-parse-and-invoke.md).
 
 ## The benefits of the simplified API
 
-The changes made in 2.0.0-beta7 make the API more consistent, future-proof, and easier to use for existing and new users.
+The changes made in 2.0.0-beta5 make the API more consistent, future-proof, and easier to use for existing and new users.
 
 New users need to learn fewer concepts and types, as the number of public interfaces decreased from 11 to 0, and public classes (and structs) decreased from 56 to 38. The public method count dropped from 378 to 235, and public properties from 118 to 99.
 

--- a/docs/standard/commandline/migration-guide-2.0.0-beta5.md
+++ b/docs/standard/commandline/migration-guide-2.0.0-beta5.md
@@ -83,9 +83,9 @@ int number = parseResult.GetValue<int>("--number");
 
 In the past, <xref:System.CommandLine.Option`1> exposed many constructors, some of which accepted the name. Since the name is now mandatory and aliases will frequently be provided for `Option<T>`, there's only a single constructor. It accepts the name and a `params` array of aliases.
 
-> [!NOTE]
-> Before 2.0.0-beta5, `Option<T>` had a constructor that took a name and a description. Because of that, the second argument might now be treated as an alias rather than a description. It's the only known breaking change in the API that doesn't cause a compiler error.
-> Update any code that passed a description to the constructor to use the new constructor that takes a name and aliases, and then set the `Description` property separately. For example:
+Before 2.0.0-beta5, `Option<T>` had a constructor that took a name and a description. Because of that, the second argument might now be treated as an alias rather than a description. It's the only known breaking change in the API that doesn't cause a compiler error.
+
+Update any code that passed a description to the constructor to use the new constructor that takes a name and aliases, and then set the `Description` property separately. For example:
 
 ```csharp
 Option<bool> beta4 = new("--help", "An option with aliases.");

--- a/docs/standard/commandline/migration-guide-2.0.0-beta5.md
+++ b/docs/standard/commandline/migration-guide-2.0.0-beta5.md
@@ -150,24 +150,24 @@ In 2.0.0-beta4, it was possible to separate the parsing and invoking of commands
 
 ### Configuration
 
-Before 2.0.0-beta7, it was possible to customize the parsing, but only with some of the public `Parse` methods. There was a `Parser` class that exposed two public constructors: one accepting a `Command` and another accepting a `CommandLineConfiguration`. `CommandLineConfiguration` was immutable, and to create it, you had to use a builder pattern exposed by the `CommandLineBuilder` class. The following changes were made to simplify the API:
+Before 2.0.0-beta5, it was possible to customize the parsing, but only with some of the public `Parse` methods. There was a `Parser` class that exposed two public constructors: one accepting a `Command` and another accepting a `CommandLineConfiguration`. `CommandLineConfiguration` was immutable, and to create it, you had to use a builder pattern exposed by the `CommandLineBuilder` class. The following changes were made to simplify the API:
 
-- `CommandLineConfiguration` was made mutable and `CommandLineBuilder` was removed. Creating a configuration is now as simple as creating an instance of `CommandLineConfiguration` and setting the properties you want to customize. Moreover, creating a new instance of configuration is the equivalent of calling `CommandLineBuilder`'s `UseDefaults` method.
-- Every `Parse` method now accepts an optional `CommandLineConfiguration` parameter that can be used to customize the parsing. When it's not provided, the default configuration is used.
-- `Parser` was renamed to `CommandLineParser` to disambiguate from other parser types to avoid name conflicts. Since it's stateless, it's now a static class with only static methods. It exposes two `Parse` parse methods: one accepting a `IReadOnlyList<string> args` and another accepting a `string args`. The latter uses `CommandLineParser.SplitCommandLine` (also public) to split the command line input into [tokens](syntax.md#tokens) before parsing it.
+- `CommandLineConfiguration` was split into two *mutable* classes (in beta7): <xref:System.CommandLine.ParserConfiguration> and <xref:System.CommandLine.InvocationConfiguration>. Creating an invocation configuration is now as simple as creating an instance of `InvocationConfiguration` and setting the properties you want to customize.
+- Every `Parse` method now accepts an optional <xref:System.CommandLine.ParserConfiguration> parameter that can be used to customize the parsing. When it's not provided, the default configuration is used.
+- To avoid name conflicts, `Parser` was renamed to <xref:Microsoft.CodeAnalysis.CommandLineParser> to disambiguate from other parser types. Since it's stateless, it's now a static class with only static methods. It exposes two `Parse` parse methods: one accepting an `IReadOnlyList<string> args` and another accepting a `string args`. The latter uses `CommandLineParser.SplitCommandLine` (also public) to split the command line input into [tokens](syntax.md#tokens) before parsing it.
 
 `CommandLineBuilderExtensions` was also removed. Here is how you can map its methods to the new APIs:
 
-- `CancelOnProcessTermination` is now a property of `CommandLineConfiguration` called [ProcessTerminationTimeout](how-to-parse-and-invoke.md#process-termination-timeout). It's enabled by default, with a 2s timeout. Set it to `null` to disable it.
-- `EnableDirectives`, `UseEnvironmentVariableDirective`, `UseParseDirective`, and `UseSuggestDirective` were removed. A new [Directive](syntax.md#directives) type was introduced and the [RootCommand](syntax.md#root-command) now exposes `System.CommandLine.RootCommand.Directives` property. You can add, remove, and iterate directives by using this collection. [Suggest directive](syntax.md#suggest-directive) is included by default; you can also use other directives like [DiagramDirective](syntax.md#the-diagram-directive) or `EnvironmentVariablesDirective`.
-- `EnableLegacyDoubleDashBehavior` was removed. All unmatched tokens are now exposed by the [ParseResult.UnmatchedTokens](how-to-parse-and-invoke.md#unmatched-tokens) property.
-- `EnablePosixBundling` was removed. The bundling is now enabled by default, you can disable it by setting the [CommandLineConfiguration.EnableBundling](how-to-configure-the-parser.md#enableposixbundling) property to `false`.
+- `CancelOnProcessTermination` is now a property of <xref:System.CommandLine.InvocationConfiguration> called [ProcessTerminationTimeout](how-to-parse-and-invoke.md#process-termination-timeout). It's enabled by default, with a 2 second timeout. To disable it, set it to `null`.
+- `EnableDirectives`, `UseEnvironmentVariableDirective`, `UseParseDirective`, and `UseSuggestDirective` were removed. A new [Directive](syntax.md#directives) type was introduced and [RootCommand](syntax.md#root-command) now exposes a <xref:System.CommandLine.RootCommand.Directives> property. You can add, remove, and iterate directives by using this collection. [Suggest directive](syntax.md#suggest-directive) is included by default; you can also use other directives like [DiagramDirective](syntax.md#the-diagram-directive) or <xref:System.CommandLine.EnvironmentVariablesDirective>.
+- `EnableLegacyDoubleDashBehavior` was removed. All unmatched tokens are now exposed by the <xref:System.CommandLine.ParseResult.UnmatchedTokens?displayProperty=nameWithType> property. For more information, see [Unmatched tokens](how-to-parse-and-invoke.md#unmatched-tokens).
+- `EnablePosixBundling` was removed. The bundling is now enabled by default, you can disable it by setting the <xref:System.CommandLine.ParserConfiguration.EnablePosixBundling?displayProperty=nameWithType> property to `false`. For more information, see [EnablePosixBundling](how-to-configure-the-parser.md#enableposixbundling).
 - `RegisterWithDotnetSuggest` was removed as it performed an expensive operation, typically during application startup. Now you must register commands with `dotnet suggest` [manually](how-to-enable-tab-completion.md#enable-tab-completion).
-- `UseExceptionHandler` was removed. The default exception handler is now enabled by default, you can disable it by setting the [CommandLineConfiguration.EnableDefaultExceptionHandler](how-to-configure-the-parser.md#enabledefaultexceptionhandler) property to `false`. This is useful when you want to handle exceptions in a custom way, by just wrapping the `Invoke` or `InvokeAsync` methods in a try-catch block.
-- `UseHelp` and `UseVersion` were removed. The help and version are now exposed by the [HelpOption](how-to-customize-help.md#customize-help-output) and [VersionOption](syntax.md#version-option) public types. They are both included by default in the options defined by [RootCommand](syntax.md#root-command).
+- `UseExceptionHandler` was removed. The default exception handler is now enabled by default; you can disable it by setting the <xref:System.CommandLine.InvocationConfiguration.EnableDefaultExceptionHandler?displayProperty=nameWithType> property to `false`. This is useful when you want to handle exceptions in a custom way, by just wrapping the `Invoke` or `InvokeAsync` methods in a try-catch block. For more information, see [EnableDefaultExceptionHandler](how-to-configure-the-parser.md#enabledefaultexceptionhandler).
+- `UseHelp` and `UseVersion` were removed. The help and version are now exposed by the <xref:System.CommandLine.Help.HelpOption> and <xref:System.CommandLine.VersionOption> public types. They are both included by default in the options defined by [RootCommand](syntax.md#root-command). For more information, see [Customize help output](how-to-customize-help.md#customize-help-output) and [Version option](syntax.md#version-option).
 - `UseHelpBuilder` was removed. For more information on how to customize the help output, see [How to customize help in System.CommandLine](how-to-customize-help.md).
 - `AddMiddleware` was removed. It slowed down the application startup, and features can be expressed without it.
-- `UseParseErrorReporting` and `UseTypoCorrections` were removed. The parse errors are now reported by default when invoking `ParseResult`. You can configure it by using the <xref:System.CommandLine.Invocation.ParseErrorAction> action exposed by `ParseResult.Action` property.
+- `UseParseErrorReporting` and `UseTypoCorrections` were removed. The parse errors are now reported by default when invoking `ParseResult`. You can configure it by using the <xref:System.CommandLine.Invocation.ParseErrorAction> action exposed by the <xref:System.CommandLine.ParseResult.Action?displayProperty=nameWithType> property.
 
   ```csharp
   ParseResult result = rootCommand.Parse("myArgs", config);
@@ -254,49 +254,7 @@ System.Runtime
 - System.Threading
 ```
 
-It allowed us to reduce the size of the library by 32% and the size of the following NativeAOT app by 20%:
-
-```csharp
-Option<bool> boolOption = new Option<bool>(new[] { "--bool", "-b" }, "Bool option");
-Option<string> stringOption = new Option<string>(new[] { "--string", "-s" }, "String option");
-
-RootCommand command = new RootCommand
-{
-    boolOption,
-    stringOption
-};
-
-command.SetHandler<bool, string>(Run, boolOption, stringOption);
-
-return new CommandLineBuilder(command).UseDefaults().Build().Invoke(args);
-
-static void Run(bool boolean, string text)
-{
-    Console.WriteLine($"Bool option: {text}");
-    Console.WriteLine($"String option: {boolean}");
-}
-```
-
-```csharp
-Option<bool> boolOption = new Option<bool>("--bool", "-b") { Description = "Bool option" };
-Option<string> stringOption = new Option<string>("--string", "-s") { Description = "String option" };
-
-RootCommand command = new ()
-{
-    boolOption,
-    stringOption,
-};
-
-command.SetAction(parseResult => Run(parseResult.GetValue(boolOption), parseResult.GetValue(stringOption)));
-
-return new CommandLineConfiguration(command).Invoke(args);
-
-static void Run(bool boolean, string text)
-{
-    Console.WriteLine($"Bool option: {text}");
-    Console.WriteLine($"String option: {boolean}");
-}
-```
+The size of the library is reduced (by 32%) and so is the size of NativeAOT apps that use the library.
 
 Simplicity has also improved the performance of the library (it's a side effect of the work, not the main goal of it). The [benchmarks](https://github.com/adamsitnik/commandline-perf/tree/update) show that the parsing and invoking of commands is now faster than in 2.0.0-beta4, especially for large commands with many options and arguments. The performance improvements are visible in both synchronous and asynchronous scenarios.
 

--- a/docs/standard/commandline/snippets/configuration/csharp/Program.cs
+++ b/docs/standard/commandline/snippets/configuration/csharp/Program.cs
@@ -20,19 +20,15 @@ class Program
         rootCommand.SetAction((parseResult) =>
         {
             FileInfo? fileOptionValue = parseResult.GetValue(fileOption);
-            parseResult.Configuration.Output.WriteLine($"File option value: {fileOptionValue?.FullName}");
+            parseResult.InvocationConfiguration.Output.WriteLine(
+                $"File option value: {fileOptionValue?.FullName}"
+                );
         });
         // </rootcommand>
 
         // <captureoutput>
         StringWriter output = new();
-        CommandLineConfiguration configuration = new(rootCommand)
-        {
-            Output = output,
-            Error = TextWriter.Null
-        };
-
-        configuration.Parse("-h").Invoke();
+        rootCommand.Parse("-h").Invoke(new() { Output = output });
         Debug.Assert(output.ToString().Contains("Configuration sample"));
         // </captureoutput>
     }

--- a/docs/standard/commandline/snippets/configuration/csharp/scl.csproj
+++ b/docs/standard/commandline/snippets/configuration/csharp/scl.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/docs/standard/commandline/snippets/configuration/csharp/scl.csproj
+++ b/docs/standard/commandline/snippets/configuration/csharp/scl.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta5.25277.114" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta7.25380.108" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Caused by https://github.com/dotnet/command-line-api/pull/2606.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/commandline/get-started-tutorial.md](https://github.com/dotnet/docs/blob/47b4dca35dec7e93027287765766ef1c9436203d/docs/standard/commandline/get-started-tutorial.md) | [Tutorial: Get started with System.CommandLine](https://review.learn.microsoft.com/en-us/dotnet/standard/commandline/get-started-tutorial?branch=pr-en-us-47952) |
| [docs/standard/commandline/how-to-configure-the-parser.md](https://github.com/dotnet/docs/blob/47b4dca35dec7e93027287765766ef1c9436203d/docs/standard/commandline/how-to-configure-the-parser.md) | [How to configure the parser in System.CommandLine](https://review.learn.microsoft.com/en-us/dotnet/standard/commandline/how-to-configure-the-parser?branch=pr-en-us-47952) |
| [docs/standard/commandline/how-to-parse-and-invoke.md](https://github.com/dotnet/docs/blob/47b4dca35dec7e93027287765766ef1c9436203d/docs/standard/commandline/how-to-parse-and-invoke.md) | [Parsing and invocation in System.CommandLine](https://review.learn.microsoft.com/en-us/dotnet/standard/commandline/how-to-parse-and-invoke?branch=pr-en-us-47952) |
| [docs/standard/commandline/migration-guide-2.0.0-beta5.md](https://github.com/dotnet/docs/blob/47b4dca35dec7e93027287765766ef1c9436203d/docs/standard/commandline/migration-guide-2.0.0-beta5.md) | [docs/standard/commandline/migration-guide-2.0.0-beta5](https://review.learn.microsoft.com/en-us/dotnet/standard/commandline/migration-guide-2.0.0-beta5?branch=pr-en-us-47952) |


<!-- PREVIEW-TABLE-END -->