### PR TITLE
Use correct parameter order for verb-first form example

### DIFF
--- a/docs/core/tools/dotnet-reference-remove.md
+++ b/docs/core/tools/dotnet-reference-remove.md
@@ -12,7 +12,7 @@ ms.date: 04/02/2025
 `dotnet reference remove` - Removes project-to-project (P2P) references.
 
 > [!NOTE]
-> If you're using .NET 9 SDK or earlier, use the "verb first" form (`dotnet reference remove`) instead. The "noun first" form was introduced in .NET 10. For more information, see [More consistent command order](../whats-new/dotnet-10/sdk.md#more-consistent-command-order).
+> If you're using .NET 9 SDK or earlier, use the "verb first" form (`dotnet remove reference`) instead. The "noun first" form was introduced in .NET 10. For more information, see [More consistent command order](../whats-new/dotnet-10/sdk.md#more-consistent-command-order).
 
 ## Synopsis
 


### PR DESCRIPTION
## Summary

The example is noun-first form, not verb-first form as the sentence would indicate. The fixed order from this PR works in dotnet 9 and below.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-reference-remove.md](https://github.com/dotnet/docs/blob/992ea8c2203645c02abb9520e121cf12d77d45e1/docs/core/tools/dotnet-reference-remove.md) | [dotnet reference remove](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-reference-remove?branch=pr-en-us-47967) |

<!-- PREVIEW-TABLE-END -->