### PR TITLE
Add note on which codes are build only

### DIFF
--- a/docs/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error.md
+++ b/docs/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error.md
@@ -118,7 +118,7 @@ f1_keywords:
   - "CS7019"
   - "CS7020"
   - "CS7021"
-  - "CS7022"
+  - "CS7022" # build only diagnostic
   - "CS7024"
   - "CS7025"
   - "CS7026"
@@ -130,7 +130,7 @@ f1_keywords:
   - "CS7033"
   - "CS7034"
   - "CS7035"
-  - "CS7038"
+  - "CS7038" # build only diagnostic
   - "CS7041"
   - "CS7042"
   - "CS7043"
@@ -173,23 +173,23 @@ f1_keywords:
   - "CS7098"
   - "CS7099"
   - "CS7100"
-  - "CS7101"
+  - "CS7101" # build only diagnostic
   - "CS7102"
   - "CS7103"
   - "CS8001"
   - "CS8002"
   - "CS8003"
-  - "CS8004"
-  - "CS8005"
-  - "CS8006"
-  - "CS8007"
-  - "CS8008"
+  - "CS8004" # build only diagnostic
+  - "CS8005" # build only diagnostic
+  - "CS8006" # build only diagnostic
+  - "CS8007" # build only diagnostic
+  - "CS8008" # build only diagnostic
   - "CS8009"
-  - "CS8010"
-  - "CS8011"
+  - "CS8010" # build only diagnostic
+  - "CS8011" # build only diagnostic
   - "CS8012"
-  - "CS8013"
-  - "CS8014"
+  - "CS8013" # build only diagnostic
+  - "CS8014" # build only diagnostic
   - "CS8015"
   - "CS8016"
   - "CS8017"
@@ -204,7 +204,7 @@ f1_keywords:
   - "CS8032"
   - "CS8033"
   - "CS8034"
-  - "CS8035"
+  - "CS8035" # build only diagnostic
   - "CS8036"
   - "CS8040"
   - "CS8050"
@@ -216,7 +216,7 @@ f1_keywords:
   - "CS8070"
   - "CS8076"
   - "CS8077"
-  - "CS8078"
+  - "CS8078" # build only diagnostic
   - "CS8079"
   - "CS8080"
   - "CS8081"


### PR DESCRIPTION
Fixes #47470

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error.md](https://github.com/dotnet/docs/blob/cb595befbaea2bd1d3a675c20d112fd76d424d35/docs/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error.md) | [C# 14 errors begin here](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error?branch=pr-en-us-47969) |

<!-- PREVIEW-TABLE-END -->