### PR TITLE
Update using-directive.md to reflect unqualified types within namespaces.

### DIFF
--- a/docs/csharp/language-reference/keywords/using-directive.md
+++ b/docs/csharp/language-reference/keywords/using-directive.md
@@ -82,10 +82,13 @@ Analyzers issue diagnostics if you duplicate `global` using directives in differ
 The `using static` directive names a type whose static members and nested types you can access without specifying a type name. Its syntax is:
 
 ```csharp
+// not within a namespace
 using static <fully-qualified-type-name>;
 ```
 
 The `<fully-qualified-type-name>` is the name of the type whose static members and nested types can be referenced without specifying a type name. If you don't provide a fully qualified type name (the full namespace name along with the type name), C# generates compiler error [CS0246](../compiler-messages/assembly-references.md): "The type or namespace name 'type/namespace' couldn't be found (are you missing a using directive or an assembly reference?)".
+
+If the `using static` directive is applied within the context of a namespace (either file-scoped or nested in a `namespace` block, it is not necessary to fully qualify the type.
 
 The `using static` directive applies to any type that has static members (or nested types), even if it also has instance members. However, instance members can only be invoked through the type instance.
 


### PR DESCRIPTION
using static doesn't require a fully qualified type if it is in the scope of a namespace. see:
https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/namespaces.md#1354-using-static-directives here the grammar is:
> using_static_directive
>    : 'using' 'static' type_name ';'
>    ;

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/using-directive.md](https://github.com/dotnet/docs/blob/ce201e00f40eb56f0e92c0059836def547ee3e68/docs/csharp/language-reference/keywords/using-directive.md) | [The `using` directive](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-directive?branch=pr-en-us-47993) |

<!-- PREVIEW-TABLE-END -->