### PR TITLE
Update dependency-injection-usage.md

### DIFF
--- a/docs/core/extensions/dependency-injection-usage.md
+++ b/docs/core/extensions/dependency-injection-usage.md
@@ -105,10 +105,10 @@ Each `services.Add{LIFETIME}<{SERVICE}>` extension method adds (and potentially 
 
 The app:
 
-- Creates an <xref:Microsoft.Extensions.Hosting.IHostBuilder> instance with [host builder settings](generic-host.md#host-builder-settings).
+- Creates an <xref:Microsoft.Extensions.Hosting.IHostApplicationBuilder> instance with [host builder settings](generic-host.md#host-builder-settings).
 - Configures services and adds them with their corresponding service lifetime.
 - Calls <xref:Microsoft.Extensions.Hosting.IHostBuilder.Build> and assigns an instance of <xref:Microsoft.Extensions.Hosting.IHost>.
-- Calls `ExemplifyScoping`, passing in the <xref:Microsoft.Extensions.Hosting.IHost.Services?displayProperty=nameWithType>.
+- Calls `ExemplifyServiceLifetime`, passing in the <xref:Microsoft.Extensions.Hosting.IHost.Services?displayProperty=nameWithType>.
 
 ## Conclusion
 


### PR DESCRIPTION
***Hi, thank you very much for providing us with these great articles. They're very helpful.*** 👍🙂

There are two typo issues in the **Register services for DI** section (exactly the last part of it which starts with "*The app:* " )
that are as follows:
* The first line states that  the app creates an `IHostBuilder`, but `Host.CreateApplicationBuilder()` 
returns an `IHostApplicationBuilder`.

* In the last line, `ExemplifyScoping` changed to `ExemplifyServiceLifetime`.




<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/dependency-injection-usage.md](https://github.com/dotnet/docs/blob/122080dd801c78cefe609c1a0cafeecccf1c23b8/docs/core/extensions/dependency-injection-usage.md) | [Tutorial: Use dependency injection in .NET](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection-usage?branch=pr-en-us-47997) |

<!-- PREVIEW-TABLE-END -->