### PR TITLE
remove --directory

### DIFF
--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -422,7 +422,6 @@ For more information and examples on how to use selective unit test filtering, s
 dotnet test
     [--project <PROJECT_PATH>]
     [--solution <SOLUTION_PATH>]
-    [--directory <DIRECTORY_PATH>]
     [--test-modules <EXPRESSION>] 
     [--root-directory <ROOT_PATH>]
     [--max-parallel-test-modules <NUMBER>]
@@ -458,20 +457,16 @@ With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest.
 #### Options
 
 > [!NOTE]
-> You can use only one of the following options at a time: `--project`, `--solution`, `--directory`, or `--test-modules`. These options can't be combined.
+> You can use only one of the following options at a time: `--project`, `--solution`, or `--test-modules`. These options can't be combined.
 > In addition, when using `--test-modules`, you can't specify `--arch`, `--configuration`, `--framework`, `--os`, or `--runtime`. These options are not relevant for an already-built module.
 
 - **`--project <PROJECT_PATH>`**
 
-  Specifies the path to the test project.
+  Specifies the path of the project file to run (folder name or full path). If not specified, it defaults to the current directory.
 
 - **`--solution <SOLUTION_PATH>`**
 
-  Specifies the path to the solution.
-
-- **`--directory <DIRECTORY_PATH>`**
-
-  Specifies the path to a directory that contains a project or a solution.
+  Specifies the path of the solution file to run (folder name or full path). If not specified, it defaults to the current directory.
 
 - **`--test-modules <EXPRESSION>`**
 
@@ -576,12 +571,6 @@ With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest.
 
   ```dotnetcli
   dotnet test --solution ./TestProjects/TestProjects.sln
-  ```
-
-- Run the tests in a solution or project that can be found in the `TestProjects` directory:
-
-  ```dotnetcli
-  dotnet test --directory ./TestProjects
   ```
 
 - Run the tests using `TestProject.dll` assembly:


### PR DESCRIPTION
This pull request updates the documentation for the `dotnet test` command to clarify and simplify option usage. The main changes remove the `--directory` option and update related descriptions and examples to reflect this deprecation.

**Command option updates:**

* Removed the `--directory` option from the documented command usage and option list, including its description. [[1]](diffhunk://#diff-a170f5d11ede8d772fd55cebbbbe6edf91005accfb409c17758cec4a12e8ac56L425) [[2]](diffhunk://#diff-a170f5d11ede8d772fd55cebbbbe6edf91005accfb409c17758cec4a12e8ac56L461-R469)
* Updated the descriptions for `--project` and `--solution` to clarify that they accept either a folder name or full path, and now default to the current directory if not specified.

**Documentation and examples:**

* Removed the example showing usage of the deprecated `--directory` option.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-test.md](https://github.com/dotnet/docs/blob/1a91aaa2cb7a90e4a39cf8315f1e8e0449254a23/docs/core/tools/dotnet-test.md) | [dotnet test](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-test?branch=pr-en-us-48054) |

<!-- PREVIEW-TABLE-END -->