### PR TITLE
Update configuration-providers.md

### DIFF
--- a/docs/core/extensions/configuration-providers.md
+++ b/docs/core/extensions/configuration-providers.md
@@ -47,7 +47,7 @@ The preceding code:
   - `reloadOnChange: true`: The file is reloaded when changes are saved.
 
 > [!IMPORTANT]
-> When [adding configuration providers](https://github.com/dotnet/runtime/blob/main/src%2Flibraries%2FMicrosoft.Extensions.Configuration%2Fsrc%2FConfigurationBuilder.cs#L30-L34) with <xref:Microsoft.Extensions.Configuration.IConfigurationBuilder.Add%2A?displayProperty=nameWithType>, the added configuration provider is added to the end of the end of the `IConfigurationSource` list. When keys are found by multiple providers, the last provider to read the key overrides previous providers.
+> When [adding configuration providers](https://github.com/dotnet/runtime/blob/main/src%2Flibraries%2FMicrosoft.Extensions.Configuration%2Fsrc%2FConfigurationBuilder.cs#L30-L34) with <xref:Microsoft.Extensions.Configuration.IConfigurationBuilder.Add%2A?displayProperty=nameWithType>, the added configuration provider is added to the end of the `IConfigurationSource` list. When keys are found by multiple providers, the last provider to read the key overrides previous providers.
 
 An example *appsettings.json* file with various configuration settings follows:
 


### PR DESCRIPTION
Hi,
* Removes the repeated '***end of the***'





<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/configuration-providers.md](https://github.com/dotnet/docs/blob/e5ff1162d3a48232caf39a7596b4542836f91782/docs/core/extensions/configuration-providers.md) | [Configuration providers in .NET](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/configuration-providers?branch=pr-en-us-48055) |

<!-- PREVIEW-TABLE-END -->