### PR TITLE
Add missing links for namespace aliases and extern alias in C# namespaces guide

### DIFF
--- a/docs/csharp/fundamentals/types/namespaces.md
+++ b/docs/csharp/fundamentals/types/namespaces.md
@@ -20,7 +20,7 @@ Namespaces are heavily used in C# programming in two ways. First, .NET uses name
 
 For more information, see the [using directive](../../language-reference/keywords/using-directive.md).
 
-You can also create an **alias** for a namespace or type using the [using alias directive](../../language-reference/keywords/using-alias-directive.md).  
+You can also create an **alias** for a namespace or type using the [using alias directive](../../language-reference/keywords/using-directive.md#the-using-alias).  
 In more advanced scenarios, you can reference multiple assemblies with the same namespaces or types by using the [extern alias](../../language-reference/keywords/extern-alias.md) feature.
 
 [!INCLUDE [csharp10-templates](../../../../includes/csharp10-templates.md)]

--- a/docs/csharp/fundamentals/types/namespaces.md
+++ b/docs/csharp/fundamentals/types/namespaces.md
@@ -18,7 +18,10 @@ Namespaces are heavily used in C# programming in two ways. First, .NET uses name
 
 :::code language="csharp" source="snippets/namespaces/Program.cs" ID="Snippet23":::
 
-For more information, see the [using Directive](../../language-reference/keywords/using-directive.md).
+For more information, see the [using directive](../../language-reference/keywords/using-directive.md).
+
+You can also create an **alias** for a namespace or type using the [using alias directive](../../language-reference/keywords/using-alias-directive.md).  
+In more advanced scenarios, you can reference multiple assemblies with the same namespaces or types by using the [extern alias](../../language-reference/keywords/extern-alias.md) feature.
 
 [!INCLUDE [csharp10-templates](../../../../includes/csharp10-templates.md)]
 


### PR DESCRIPTION
## Summary

This PR addresses feedback on the **C# namespaces** article where readers noted missing guidance on advanced namespace usage.

#### **Changes made**

* Added links to the [[using alias directive](https://chatgpt.com/language-reference/keywords/using-alias-directive.md)](../../language-reference/keywords/using-alias-directive.md) and [[extern alias](https://chatgpt.com/language-reference/keywords/extern-alias.md)](../../language-reference/keywords/extern-alias.md).
* Clarified how developers can use **aliases** and **extern alias** for advanced namespace management.
* Updated `ms.date` metadata.

#### **Impact**

* Improves discoverability of **advanced namespace techniques** directly from the fundamentals guide.
* Helps developers learn how to handle **type/namespace conflicts** and use **aliasing** effectively.
* Resolves issue [[#(insert issue number here)](https://github.com/dotnet/docs/issues/)](https://github.com/dotnet/docs/issues/) by ensuring the article provides both **basic and advanced namespace guidance**.

Fixes #48043 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/fundamentals/types/namespaces.md](https://github.com/dotnet/docs/blob/0f241418a8fa775f5f06e22d26cd773e9bc08572/docs/csharp/fundamentals/types/namespaces.md) | [Declare namespaces to organize types](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/types/namespaces?branch=pr-en-us-48060) |


<!-- PREVIEW-TABLE-END -->