### PR TITLE
Fix broken links in AI docs

### DIFF
--- a/docs/ai/includes/vector-databases.md
+++ b/docs/ai/includes/vector-databases.md
@@ -24,6 +24,6 @@ Semantic Kernel provides connectors for the following vector databases and servi
 | Postgres                      | [Microsoft.SemanticKernel.Connectors.Postgres](https://www.nuget.org/packages/Microsoft.SemanticKernel.Connectors.Postgres)            | [Npgsql](https://www.nuget.org/packages/Npgsql/)        |
 | Qdrant                        | [Microsoft.SemanticKernel.Connectors.Qdrant](https://www.nuget.org/packages/Microsoft.SemanticKernel.Connectors.Qdrant)               | [Qdrant.Client](https://www.nuget.org/packages/Qdrant.Client)         |
 | Redis                         | [Microsoft.SemanticKernel.Connectors.Redis](https://www.nuget.org/packages/Microsoft.SemanticKernel.Connectors.Redis)                    |  [StackExchange.Redis](https://www.nuget.org/packages/StackExchange.Redis)       |
-| Weaviate                      | [Microsoft.SemanticKernel.Connectors.Weaviate](https://www.nuget.org/packages/Microsoft.SemanticKernel.Connectors.Weaviate)            | [REST API](https://weaviate.io/developers/weaviate/api/rest)       |
+| Weaviate                      | [Microsoft.SemanticKernel.Connectors.Weaviate](https://www.nuget.org/packages/Microsoft.SemanticKernel.Connectors.Weaviate)            | [REST API](https://docs.weaviate.io/weaviate/api/rest)       |
 
 To discover .NET SDK and API support, visit the documentation for each respective service.

--- a/docs/ai/quickstarts/build-vector-search-app.md
+++ b/docs/ai/quickstarts/build-vector-search-app.md
@@ -80,7 +80,7 @@ Complete the following steps to create a .NET console app that can:
 
     - [`Azure.Identity`](https://www.nuget.org/packages/Azure.Identity) provides [`Microsoft Entra ID`](/entra/fundamentals/whatis) token authentication support across the Azure SDK using classes such as `DefaultAzureCredential`.
     - [`Azure.AI.OpenAI`](https://www.nuget.org/packages/Azure.AI.OpenAI) is the official package for using OpenAI's .NET library with the Azure OpenAI Service.
-    - [`Microsoft.Extensions.VectorData.Abstractions`](https://www.nuget.org/packages/Microsoft.Extensions.AI) enables Create-Read-Update-Delete (CRUD) and search operations on vector stores.
+    - [`Microsoft.Extensions.VectorData.Abstractions`](https://www.nuget.org/packages/Microsoft.Extensions.VectorData.Abstractions) enables Create-Read-Update-Delete (CRUD) and search operations on vector stores.
     - [`Microsoft.SemanticKernel.Connectors.InMemory`](https://www.nuget.org/packages/Microsoft.SemanticKernel.Connectors.InMemory) provides an in-memory vector store class to hold queryable vector data records.
     - [Microsoft.Extensions.Configuration](https://www.nuget.org/packages/Microsoft.Extensions.Configuration) provides an implementation of key-value pair&mdash;based configuration.
     - [`Microsoft.Extensions.Configuration.UserSecrets`](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.UserSecrets) is a user secrets configuration provider implementation for `Microsoft.Extensions.Configuration`.
@@ -101,7 +101,7 @@ Complete the following steps to create a .NET console app that can:
     The following list describes each package in the `VectorDataAI` app:
 
     - [`Microsoft.Extensions.AI.OpenAI`](https://www.nuget.org/packages/Microsoft.Extensions.AI.OpenAI) provides AI abstractions for OpenAI-compatible models or endpoints. This library also includes the official [`OpenAI`](https://www.nuget.org/packages/OpenAI) library for the OpenAI service API as a dependency.
-    - [`Microsoft.Extensions.VectorData.Abstractions`](https://www.nuget.org/packages/Microsoft.Extensions.AI) enables Create-Read-Update-Delete (CRUD) and search operations on vector stores.
+    - [`Microsoft.Extensions.VectorData.Abstractions`](https://www.nuget.org/packages/Microsoft.Extensions.VectorData.Abstractions) enables Create-Read-Update-Delete (CRUD) and search operations on vector stores.
     - [`Microsoft.SemanticKernel.Connectors.InMemory`](https://www.nuget.org/packages/Microsoft.SemanticKernel.Connectors.InMemory) provides an in-memory vector store class to hold queryable vector data records.
     - [Microsoft.Extensions.Configuration](https://www.nuget.org/packages/Microsoft.Extensions.Configuration) provides an implementation of key-value pair&mdash;based configuration.
     - [`Microsoft.Extensions.Configuration.UserSecrets`](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.UserSecrets) is a user secrets configuration provider implementation for `Microsoft.Extensions.Configuration`.


### PR DESCRIPTION
## Summary

Fix broken links in AI docs


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/ai/quickstarts/build-vector-search-app.md](https://github.com/dotnet/docs/blob/285dd67420c7bc49e24f4a99134c5714c5b09c89/docs/ai/quickstarts/build-vector-search-app.md) | [CustomerIntent: As a .NET developer new to AI, I want deploy and use sample code to interact to learn from the sample code.](https://review.learn.microsoft.com/en-us/dotnet/ai/quickstarts/build-vector-search-app?branch=pr-en-us-48070) |

<!-- PREVIEW-TABLE-END -->