### PR TITLE
Update documentation for #:sdk directive

### DIFF
--- a/docs/csharp/language-reference/preprocessor-directives.md
+++ b/docs/csharp/language-reference/preprocessor-directives.md
@@ -74,6 +74,7 @@ The `#:` directives that are used in file-based apps include:
   ```
 
   The two preceding preprocessors is translated into:
+
   ```xml
   <Project Sdk="Microsoft.NET.Sdk.Web" />
       <Sdk Name="Aspire.AppHost.Sdk" Version="9.4.1" />

--- a/docs/csharp/language-reference/preprocessor-directives.md
+++ b/docs/csharp/language-reference/preprocessor-directives.md
@@ -66,10 +66,17 @@ The `#:` directives that are used in file-based apps include:
 
 - `#:sdk`:
 
-  The first instance specifies the value for the `<Project Sdk="value" />` node. Subsequent instances specify the `<Sdk Name="value" Version="version" />` node. The version can be omitted. For example:
+  The first instance specifies the value for the `<Project Sdk="value" />` node. Subsequent instances specify the `<Sdk Name="value" Version="version" />` node. The version can be omitted (i.e. if specified in global.json or included in .NET SDK). For example:
 
   ```csharp
   #:sdk Microsoft.NET.Sdk.Web
+  #:sdk Aspire.AppHost.Sdk@9.4.1
+  ```
+
+  The two preceding preprocessors is translated into:
+  ```xml
+  <Project Sdk="Microsoft.NET.Sdk.Web" />
+      <Sdk Name="Aspire.AppHost.Sdk" Version="9.4.1" />
   ```
 
 - `#:property`:


### PR DESCRIPTION
Clarified the explanation of the `#:sdk` directive and its usage, including the handling of version specification.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/preprocessor-directives.md](https://github.com/dotnet/docs/blob/b0387430d2a8a80ade32933c43b9185667afb12e/docs/csharp/language-reference/preprocessor-directives.md) | [C# preprocessor directives](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/preprocessor-directives?branch=pr-en-us-48079) |


<!-- PREVIEW-TABLE-END -->