### PR TITLE
Update CODEOWNERS for team changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -65,7 +65,7 @@
 
 ############### AI ################
 
-/docs/ai/ @gewarren @alexwolfmsft @dotnet/docs
+/docs/ai/ @gewarren @dotnet/docs
 
 ############### Azure ################
 
@@ -120,9 +120,9 @@
 # Testing
 /docs/core/testing/ @IEvangelist @dotnet/docs
 # Tools
-/docs/core/tools/ @tdykstra @dotnet/docs
+/docs/core/tools/ @adegeo @dotnet/docs
 # Tutorials
-/docs/core/tutorials/ @tdykstra @dotnet/docs
+/docs/core/tutorials/ @BillWagner @dotnet/docs
 # What's new
 /docs/core/whats-new/ @dotnet/docs
 
@@ -179,7 +179,7 @@
 # Collections
 /docs/standard/collections/ @IEvangelist @dotnet/docs
 # System.CommandLine
-/docs/standard/commandline/ @tdykstra @dotnet/docs
+/docs/standard/commandline/ @gewarren @dotnet/docs
 # Data
 /docs/standard/data/ @gewarren @dotnet/docs
 # Data - SQLite


### PR DESCRIPTION
This should have been done with https://github.com/dotnet/docs/pull/47951.