### PR TITLE
Clarify record type definition with primary constructors

### DIFF
--- a/docs/ai/quickstarts/structured-output.md
+++ b/docs/ai/quickstarts/structured-output.md
@@ -97,7 +97,7 @@ Complete the following steps to create a console app that connects to the `gpt-4
 
    :::code language="csharp" source="./snippets/structured-output/Program.cs" id="InputOutputRecord":::
 
-   (This record type is defined using [primary constructor](../../csharp/programming-guide/classes-and-structs/instance-constructors.md#primary-constructors) syntax. Primary constructors, which are available in C# 12 and later versions, combine the class definition with the parameters that are necessary to instantiate any instance of the class. The C# compiler generates public properties for the primary constructor parameters.)
+   (This record type is defined using [primary constructor](../../csharp/programming-guide/classes-and-structs/instance-constructors.md#primary-constructors) syntax. Primary constructors combine the type definition with the parameters necessary to instantiate any instance of the class. The C# compiler generates public properties for the primary constructor parameters.)
 
    Send the request using the record type as the type argument to `GetResponseAsync<T>`:
 

--- a/docs/ai/quickstarts/structured-output.md
+++ b/docs/ai/quickstarts/structured-output.md
@@ -93,9 +93,11 @@ Complete the following steps to create a console app that connects to the `gpt-4
 
 1. And instead of requesting just the analyzed enumeration value, you can request the text response along with the analyzed value.
 
-   Define a record type to contain the text response and analyzed sentiment:
+   Define a [record type](../../csharp/language-reference/builtin-types/record.md) to contain the text response and analyzed sentiment:
 
    :::code language="csharp" source="./snippets/structured-output/Program.cs" id="InputOutputRecord":::
+
+   (This record type is defined using [primary constructor](../../csharp/programming-guide/classes-and-structs/instance-constructors.md#primary-constructors) syntax. Primary constructors, which are available in C# 12 and later versions, combine the class definition with the parameters that are necessary to instantiate any instance of the class. The C# compiler generates public properties for the primary constructor parameters.)
 
    Send the request using the record type as the type argument to `GetResponseAsync<T>`:
 


### PR DESCRIPTION
Fixes #47512.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/ai/quickstarts/structured-output.md](https://github.com/dotnet/docs/blob/7402fe848acc83bcff56da2863cbe60bc8324968/docs/ai/quickstarts/structured-output.md) | [Request a response with structured output](https://review.learn.microsoft.com/en-us/dotnet/ai/quickstarts/structured-output?branch=pr-en-us-48110) |


<!-- PREVIEW-TABLE-END -->