### PR TITLE
Dotnet-counters docs updates w.r.t UI and list of counters

### DIFF
--- a/docs/core/diagnostics/debug-highcpu.md
+++ b/docs/core/diagnostics/debug-highcpu.md
@@ -32,60 +32,85 @@ The tutorial uses:
 
 ## CPU counters
 
+Before attempting this tutorial, please install the latest version of dotnet-counters:
+
+  ```dotnetcli
+  dotnet tool install --global dotnet-counters
+  ```
+
+If your app is running a version of .NET older than .NET 9, the output UI of dotnet-counters will look slightly different; see [dotnet-counters](dotnet-counters.md) for details.
+
 Before attempting to collect diagnostics data, you need to observe a high CPU condition. Run the [sample application](/samples/dotnet/samples/diagnostic-scenarios) using the following command from the project root directory.
 
 ```dotnetcli
 dotnet run
 ```
 
-To find the process ID, use the following command:
+To check the current CPU usage, use the [dotnet-counters](dotnet-counters.md) tool command:
 
 ```dotnetcli
-dotnet-trace ps
+dotnet-counters monitor -n DiagnosticScenarios --showDeltas
 ```
 
-Take note of the process ID from your command output. Our process ID was `22884`, but yours will be different. To check the current CPU usage, use the [dotnet-counters](dotnet-counters.md) tool command:
-
-```dotnetcli
-dotnet-counters monitor -p 22884 --refresh-interval 1 --counters EventCounters\System.Runtime
-```
-
-The `refresh-interval` is the number of seconds between the counter polling CPU values. The output should be similar to the following:
+The output should be similar to the following:
 
 ```console
 Press p to pause, r to resume, q to quit.
     Status: Running
 
+Name                                                            Current Value      Last Delta
 [System.Runtime]
-    % Time in GC since last GC (%)                         0
-    Allocation Rate / 1 sec (B)                            0
-    CPU Usage (%)                                          0
-    Exception Count / 1 sec                                0
-    GC Heap Size (MB)                                      4
-    Gen 0 GC Count / 60 sec                                0
-    Gen 0 Size (B)                                         0
-    Gen 1 GC Count / 60 sec                                0
-    Gen 1 Size (B)                                         0
-    Gen 2 GC Count / 60 sec                                0
-    Gen 2 Size (B)                                         0
-    LOH Size (B)                                           0
-    Monitor Lock Contention Count / 1 sec                  0
-    Number of Active Timers                                1
-    Number of Assemblies Loaded                          140
-    ThreadPool Completed Work Item Count / 1 sec           3
-    ThreadPool Queue Length                                0
-    ThreadPool Thread Count                                7
-    Working Set (MB)                                      63
+    dotnet.assembly.count ({assembly})                               111               0
+    dotnet.gc.collections ({collection})
+        gc.heap.generation
+        ------------------
+        gen0                                                           8               0
+        gen1                                                           1               0
+        gen2                                                           0               0
+    dotnet.gc.heap.total_allocated (By)                        4,042,656          24,512
+    dotnet.gc.last_collection.heap.fragmentation.size (By)
+        gc.heap.generation
+        ------------------
+        gen0                                                     801,728               0
+        gen1                                                       6,048               0
+        gen2                                                           0               0
+        loh                                                            0               0
+        poh                                                            0               0
+    dotnet.gc.last_collection.heap.size (By)
+        gc.heap.generation
+        ------------------
+        gen0                                                     811,512               0
+        gen1                                                     562,024               0
+        gen2                                                   1,095,056               0
+        loh                                                       98,384               0
+        poh                                                       24,528               0
+    dotnet.gc.last_collection.memory.committed_size (By)       5,623,808               0
+    dotnet.gc.pause.time (s)                                           0.019           0
+    dotnet.jit.compilation.time (s)                                    0.582           0
+    dotnet.jit.compiled_il.size (By)                             138,895               0
+    dotnet.jit.compiled_methods ({method})                         1,470               0
+    dotnet.monitor.lock_contentions ({contention})                     4               0
+    dotnet.process.cpu.count ({cpu})                                  22               0
+    dotnet.process.cpu.time (s)
+        cpu.mode
+        --------
+        system                                                         0.109           0
+        user                                                           0.453           0
+    dotnet.process.memory.working_set (By)                    65,515,520               0
+    dotnet.thread_pool.queue.length ({work_item})                      0               0
+    dotnet.thread_pool.thread.count ({thread})                         0               0
+    dotnet.thread_pool.work_item.count ({work_item})                   6               0
+    dotnet.timer.count ({timer})                                       0               0
 ```
 
-With the web app running, immediately after startup, the CPU isn't being consumed at all and is reported at `0%`. Navigate to the `api/diagscenario/highcpu` route with `60000` as the route parameter:
+Focusing in on the ```Last Delta``` values of ```dotnet.process.cpu.time```, these tell us how many seconds within the refresh period (currently set to the default of 1 s) the CPU has been active. With the web app running, immediately after startup, the CPU isn't being consumed at all and these deltas are both `0`. Navigate to the `api/diagscenario/highcpu` route with `60000` as the route parameter:
 
 `https://localhost:5001/api/diagscenario/highcpu/60000`
 
-Now, rerun the [dotnet-counters](dotnet-counters.md) command. If interested in monitoring just the `cpu-usage` counter, add '--counters System.Runtime[cpu-usage]` to the previous command. We are unsure if the CPU is being consumed, so we will monitor the same list of counters as above to verify counter values are within expected range for our application.
+Now, rerun the [dotnet-counters](dotnet-counters.md) command.
 
 ```dotnetcli
-dotnet-counters monitor -p 22884 --refresh-interval 1 --counters EventCounters\System.Runtime
+dotnet-counters monitor -n DiagnosticScenarios --showDeltas
 ```
 
 You should see an increase in CPU usage as shown below (depending on the host machine, expect varying CPU usage):
@@ -94,29 +119,52 @@ You should see an increase in CPU usage as shown below (depending on the host ma
 Press p to pause, r to resume, q to quit.
     Status: Running
 
+Name                                                            Current Value      Last Delta
 [System.Runtime]
-    % Time in GC since last GC (%)                         0
-    Allocation Rate / 1 sec (B)                            0
-    CPU Usage (%)                                         25
-    Exception Count / 1 sec                                0
-    GC Heap Size (MB)                                      4
-    Gen 0 GC Count / 60 sec                                0
-    Gen 0 Size (B)                                         0
-    Gen 1 GC Count / 60 sec                                0
-    Gen 1 Size (B)                                         0
-    Gen 2 GC Count / 60 sec                                0
-    Gen 2 Size (B)                                         0
-    LOH Size (B)                                           0
-    Monitor Lock Contention Count / 1 sec                  0
-    Number of Active Timers                                1
-    Number of Assemblies Loaded                          140
-    ThreadPool Completed Work Item Count / 1 sec           3
-    ThreadPool Queue Length                                0
-    ThreadPool Thread Count                                7
-    Working Set (MB)                                      63
+    dotnet.assembly.count ({assembly})                               111               0
+    dotnet.gc.collections ({collection})
+        gc.heap.generation
+        ------------------
+        gen0                                                           8               0
+        gen1                                                           1               0
+        gen2                                                           0               0
+    dotnet.gc.heap.total_allocated (By)                        4,042,656          24,512
+    dotnet.gc.last_collection.heap.fragmentation.size (By)
+        gc.heap.generation
+        ------------------
+        gen0                                                     801,728               0
+        gen1                                                       6,048               0
+        gen2                                                           0               0
+        loh                                                            0               0
+        poh                                                            0               0
+    dotnet.gc.last_collection.heap.size (By)
+        gc.heap.generation
+        ------------------
+        gen0                                                     811,512               0
+        gen1                                                     562,024               0
+        gen2                                                   1,095,056               0
+        loh                                                       98,384               0
+        poh                                                       24,528               0
+    dotnet.gc.last_collection.memory.committed_size (By)       5,623,808               0
+    dotnet.gc.pause.time (s)                                           0.019           0
+    dotnet.jit.compilation.time (s)                                    0.582           0
+    dotnet.jit.compiled_il.size (By)                             138,895               0
+    dotnet.jit.compiled_methods ({method})                         1,470               0
+    dotnet.monitor.lock_contentions ({contention})                     4               0
+    dotnet.process.cpu.count ({cpu})                                  22               0
+    dotnet.process.cpu.time (s)
+        cpu.mode
+        --------
+        system                                                         0.344           0.013
+        user                                                          14.203           0.963
+    dotnet.process.memory.working_set (By)                    65,515,520               0
+    dotnet.thread_pool.queue.length ({work_item})                      0               0
+    dotnet.thread_pool.thread.count ({thread})                         0               0
+    dotnet.thread_pool.work_item.count ({work_item})                   6               0
+    dotnet.timer.count ({timer})                                       0               0
 ```
 
-Throughout the duration of the request, the CPU usage will hover around the increased percentage.
+Throughout the duration of the request, the CPU usage will hover around the increased value.
 
 > [!TIP]
 > To visualize an even higher CPU usage, you can exercise this endpoint in multiple browser tabs simultaneously.

--- a/docs/core/diagnostics/debug-highcpu.md
+++ b/docs/core/diagnostics/debug-highcpu.md
@@ -47,7 +47,7 @@ dotnet-trace ps
 Take note of the process ID from your command output. Our process ID was `22884`, but yours will be different. To check the current CPU usage, use the [dotnet-counters](dotnet-counters.md) tool command:
 
 ```dotnetcli
-dotnet-counters monitor --refresh-interval 1 -p 22884
+dotnet-counters monitor -p 22884 --refresh-interval 1 --counters EventCounters\System.Runtime
 ```
 
 The `refresh-interval` is the number of seconds between the counter polling CPU values. The output should be similar to the following:
@@ -85,7 +85,7 @@ With the web app running, immediately after startup, the CPU isn't being consume
 Now, rerun the [dotnet-counters](dotnet-counters.md) command. If interested in monitoring just the `cpu-usage` counter, add '--counters System.Runtime[cpu-usage]` to the previous command. We are unsure if the CPU is being consumed, so we will monitor the same list of counters as above to verify counter values are within expected range for our application.
 
 ```dotnetcli
-dotnet-counters monitor -p 22884 --refresh-interval 1
+dotnet-counters monitor -p 22884 --refresh-interval 1 --counters EventCounters\System.Runtime
 ```
 
 You should see an increase in CPU usage as shown below (depending on the host machine, expect varying CPU usage):

--- a/docs/core/diagnostics/debug-memory-leak.md
+++ b/docs/core/diagnostics/debug-memory-leak.md
@@ -34,6 +34,8 @@ The tutorial uses:
 
 The tutorial assumes the sample apps and tools are installed and ready to use.
 
+If your app is running a version of .NET older than .NET 9, the output UI of dotnet-counters will look slightly different; see [dotnet-counters](dotnet-counters.md) for details.
+
 ## Examine managed memory usage
 
 Before you start collecting diagnostic data to help root cause this scenario, make sure you're actually seeing a memory leak (growth in memory usage). You can use the [dotnet-counters](dotnet-counters.md) tool to confirm that.
@@ -75,62 +77,66 @@ The live output should be similar to:
 Press p to pause, r to resume, q to quit.
 Status: Running
 
-Name                                  Current Value
+Name                                                            Current Value
 [System.Runtime]
-    dotnet.assembly.count ({assembly})    111
+    dotnet.assembly.count ({assembly})                              111
     dotnet.gc.collections ({collection})
     gc.heap.generation
-        gen0                              1
-        gen1                              0
-        gen2                              0
-    dotnet.gc.heap.total_allocated (By)   4,431,712
+    ------------------
+    gen0                                                              1
+    gen1                                                              0
+    gen2                                                              0
+    dotnet.gc.heap.total_allocated (By)                       4,431,712
     dotnet.gc.last_collection.heap.fragmentation.size (By)
     gc.heap.generation
-        gen0                              803,576
-        gen1                              15,456
-        gen2                              0
-        loh                               0
-        poh                               0
+    ------------------
+    gen0                                                        803,576
+    gen1                                                         15,456
+    gen2                                                              0
+    loh                                                               0
+    poh                                                               0
     dotnet.gc.last_collection.heap.size (By)
     gc.heap.generation
-        gen0                              811,960
-        gen1                              1,214,720
-        gen2                              0
-        loh                               0
-        poh                               24,528
-    dotnet.gc.last_collection.memory.committed_size (By)   4,296,704
-    dotnet.gc.pause.time (s)              0.003
-    dotnet.jit.compilation.time (s)       0.329
-    dotnet.jit.compiled_il.size (By)      120,212
-    dotnet.jit.compiled_methods ({method}) 1,202
-    dotnet.monitor.lock_contentions ({contention})  2
-    dotnet.process.cpu.count ({cpu})      22
+    ------------------
+    gen0                                                        811,960
+    gen1                                                      1,214,720
+    gen2                                                              0
+    loh                                                               0
+    poh                                                          24,528
+    dotnet.gc.last_collection.memory.committed_size (By)      4,296,704
+    dotnet.gc.pause.time (s)                                          0.003
+    dotnet.jit.compilation.time (s)                                   0.329
+    dotnet.jit.compiled_il.size (By)                            120,212
+    dotnet.jit.compiled_methods ({method})                            1,202
+    dotnet.monitor.lock_contentions ({contention})                    2
+    dotnet.process.cpu.count ({cpu})                                 22
     dotnet.process.cpu.time (s)
     cpu.mode
-        system                            0.344
-        user                              0.344
-    dotnet.process.memory.working_set (By) 64,331,776
-    dotnet.thread_pool.queue.length ({work_item})   0
-    dotnet.thread_pool.thread.count ({thread})      0
-    dotnet.thread_pool.work_item.count ({work_item}) 7
-    dotnet.timer.count ({timer})          0
+    --------
+    system                                                            0.344
+    user                                                              0.344
+    dotnet.process.memory.working_set (By)                   64,331,776
+    dotnet.thread_pool.queue.length ({work_item})                     0
+    dotnet.thread_pool.thread.count ({thread})                        0
+    dotnet.thread_pool.work_item.count ({work_item})                  7
+    dotnet.timer.count ({timer})                                      0
 
 ```
 
 Focusing on this line:
 
 ```console
-    dotnet.gc.heap.total_allocated (By)   4,431,712
+    dotnet.gc.last_collection.memory.committed_size (By)   4,296,704
 ```
 
 You can see that the managed heap memory is 4 MB right after startup.
 
 Now, go to the URL `https://localhost:5001/api/diagscenario/memleak/20000`.
 
-Observe that the memory usage has grown to over 30 MB.
+Observe that the memory usage has grown to over 20 MB.
 
 ```console
-    dotnet.gc.heap.total_allocated (By)   38,806,944
+    dotnet.gc.last_collection.memory.committed_size (By)   21,020,672
 ```
 
 By watching the memory usage, you can safely say that memory is growing or leaking. The next step is to collect the right data for memory analysis.

--- a/docs/core/diagnostics/debug-memory-leak.md
+++ b/docs/core/diagnostics/debug-memory-leak.md
@@ -73,44 +73,64 @@ The live output should be similar to:
 
 ```console
 Press p to pause, r to resume, q to quit.
-    Status: Running
+Status: Running
 
+Name                                  Current Value
 [System.Runtime]
-    # of Assemblies Loaded                           118
-    % Time in GC (since last GC)                       0
-    Allocation Rate (Bytes / sec)                 37,896
-    CPU Usage (%)                                      0
-    Exceptions / sec                                   0
-    GC Heap Size (MB)                                  4
-    Gen 0 GC / sec                                     0
-    Gen 0 Size (B)                                     0
-    Gen 1 GC / sec                                     0
-    Gen 1 Size (B)                                     0
-    Gen 2 GC / sec                                     0
-    Gen 2 Size (B)                                     0
-    LOH Size (B)                                       0
-    Monitor Lock Contention Count / sec                0
-    Number of Active Timers                            1
-    ThreadPool Completed Work Items / sec             10
-    ThreadPool Queue Length                            0
-    ThreadPool Threads Count                           1
-    Working Set (MB)                                  83
+    dotnet.assembly.count ({assembly})    111
+    dotnet.gc.collections ({collection})
+    gc.heap.generation
+        gen0                              1
+        gen1                              0
+        gen2                              0
+    dotnet.gc.heap.total_allocated (By)   4,431,712
+    dotnet.gc.last_collection.heap.fragmentation.size (By)
+    gc.heap.generation
+        gen0                              803,576
+        gen1                              15,456
+        gen2                              0
+        loh                               0
+        poh                               0
+    dotnet.gc.last_collection.heap.size (By)
+    gc.heap.generation
+        gen0                              811,960
+        gen1                              1,214,720
+        gen2                              0
+        loh                               0
+        poh                               24,528
+    dotnet.gc.last_collection.memory.committed_size (By)   4,296,704
+    dotnet.gc.pause.time (s)              0.003
+    dotnet.jit.compilation.time (s)       0.329
+    dotnet.jit.compiled_il.size (By)      120,212
+    dotnet.jit.compiled_methods ({method}) 1,202
+    dotnet.monitor.lock_contentions ({contention})  2
+    dotnet.process.cpu.count ({cpu})      22
+    dotnet.process.cpu.time (s)
+    cpu.mode
+        system                            0.344
+        user                              0.344
+    dotnet.process.memory.working_set (By) 64,331,776
+    dotnet.thread_pool.queue.length ({work_item})   0
+    dotnet.thread_pool.thread.count ({thread})      0
+    dotnet.thread_pool.work_item.count ({work_item}) 7
+    dotnet.timer.count ({timer})          0
+
 ```
 
 Focusing on this line:
 
 ```console
-    GC Heap Size (MB)                                  4
+    dotnet.gc.heap.total_allocated (By)   4,431,712
 ```
 
 You can see that the managed heap memory is 4 MB right after startup.
 
 Now, go to the URL `https://localhost:5001/api/diagscenario/memleak/20000`.
 
-Observe that the memory usage has grown to 30 MB.
+Observe that the memory usage has grown to over 30 MB.
 
 ```console
-    GC Heap Size (MB)                                 30
+    dotnet.gc.heap.total_allocated (By)   38,806,944
 ```
 
 By watching the memory usage, you can safely say that memory is growing or leaking. The next step is to collect the right data for memory analysis.

--- a/docs/core/diagnostics/debug-threadpool-starvation.md
+++ b/docs/core/diagnostics/debug-threadpool-starvation.md
@@ -102,24 +102,24 @@ Name                                                       Current Value
     dotnet.assembly.count ({assembly})                               115
     dotnet.gc.collections ({collection})
         gc.heap.generation
-        gen0                                                           2
-        gen1                                                           1
-        gen2                                                           1
+          gen0                                                         2
+          gen1                                                         1
+          gen2                                                         1
     dotnet.gc.heap.total_allocated (By)                       64,329,632
     dotnet.gc.last_collection.heap.fragmentation.size (By)
         gc.heap.generation
-        gen0                                                     199,920
-        gen1                                                      29,208
-        gen2                                                           0
-        loh                                                           32
-        poh                                                            0
+          gen0                                                   199,920
+          gen1                                                    29,208
+          gen2                                                         0
+          loh                                                         32
+          poh                                                          0
     dotnet.gc.last_collection.heap.size (By)
         gc.heap.generation
-        gen0                                                     208,712
-        gen1                                                   3,456,000
-        gen2                                                   5,065,600
-        loh                                                       98,384
-        poh                                                    3,147,488
+          gen0                                                   208,712
+          gen1                                                 3,456,000
+          gen2                                                 5,065,600
+          loh                                                     98,384
+          poh                                                  3,147,488
     dotnet.gc.last_collection.memory.committed_size (By)      31,096,832
     dotnet.gc.pause.time (s)                                           0.024
     dotnet.jit.compilation.time (s)                                    1.285

--- a/docs/core/diagnostics/debug-threadpool-starvation.md
+++ b/docs/core/diagnostics/debug-threadpool-starvation.md
@@ -97,29 +97,32 @@ dotnet-counters monitor -n DiagnosticScenarios
 Press p to pause, r to resume, q to quit.
     Status: Running
 
-Name                                                       Current Value
+Name                                                            Current Value
 [System.Runtime]
     dotnet.assembly.count ({assembly})                               115
     dotnet.gc.collections ({collection})
         gc.heap.generation
-          gen0                                                         2
-          gen1                                                         1
-          gen2                                                         1
+        ------------------
+        gen0                                                           2
+        gen1                                                           1
+        gen2                                                           1
     dotnet.gc.heap.total_allocated (By)                       64,329,632
     dotnet.gc.last_collection.heap.fragmentation.size (By)
         gc.heap.generation
-          gen0                                                   199,920
-          gen1                                                    29,208
-          gen2                                                         0
-          loh                                                         32
-          poh                                                          0
+        ------------------
+        gen0                                                     199,920
+        gen1                                                      29,208
+        gen2                                                           0
+        loh                                                           32
+        poh                                                            0
     dotnet.gc.last_collection.heap.size (By)
         gc.heap.generation
-          gen0                                                   208,712
-          gen1                                                 3,456,000
-          gen2                                                 5,065,600
-          loh                                                     98,384
-          poh                                                  3,147,488
+        ------------------
+        gen0                                                     208,712
+        gen1                                                   3,456,000
+        gen2                                                   5,065,600
+        loh                                                       98,384
+        poh                                                    3,147,488
     dotnet.gc.last_collection.memory.committed_size (By)      31,096,832
     dotnet.gc.pause.time (s)                                           0.024
     dotnet.jit.compilation.time (s)                                    1.285
@@ -129,6 +132,7 @@ Name                                                       Current Value
     dotnet.process.cpu.count ({cpu})                                  16
     dotnet.process.cpu.time (s)
         cpu.mode
+        --------
         system                                                         2.156
         user                                                           2.734
     dotnet.process.memory.working_set (By)                             1.3217e+08
@@ -137,6 +141,8 @@ Name                                                       Current Value
     dotnet.thread_pool.work_item.count ({work_item})              32,267
     dotnet.timer.count ({timer})                                       0
 ```
+
+If your app is running a version of .NET older than .NET 9, the output UI of dotnet-counters will look slightly different; see [dotnet-counters](dotnet-counters.md) for details.
 
 The preceding counters are an example while the web server wasn't serving any requests. Run Bombardier again with the `api/diagscenario/tasksleepwait` endpoint and sustained load for 2 minutes so there's plenty of time to observe what happens to the performance counters.
 
@@ -151,12 +157,14 @@ ThreadPool starvation occurs when there are no free threads to handle the queued
     dotnet.assembly.count ({assembly})                               115
     dotnet.gc.collections ({collection})
         gc.heap.generation
+        ------------------
         gen0                                                           5
         gen1                                                           1
         gen2                                                           1
     dotnet.gc.heap.total_allocated (By)                       1.6947e+08
     dotnet.gc.last_collection.heap.fragmentation.size (By)
         gc.heap.generation
+        ------------------
         gen0                                                           0
         gen1                                                     348,248
         gen2                                                           0
@@ -164,6 +172,7 @@ ThreadPool starvation occurs when there are no free threads to handle the queued
         poh                                                            0
     dotnet.gc.last_collection.heap.size (By)
         gc.heap.generation
+        ------------------
         gen0                                                           0
         gen1                                                  18,010,920
         gen2                                                   5,065,600
@@ -178,6 +187,7 @@ ThreadPool starvation occurs when there are no free threads to handle the queued
     dotnet.process.cpu.count ({cpu})                                  16
     dotnet.process.cpu.time (s)
         cpu.mode
+        --------
         system                                                         4.953
         user                                                           6.266
     dotnet.process.memory.working_set (By)                             1.3217e+08

--- a/docs/core/diagnostics/dotnet-counters.md
+++ b/docs/core/diagnostics/dotnet-counters.md
@@ -59,7 +59,6 @@ dotnet-counters [-h|--help] [--version] <command>
 | Command                                             |
 |-----------------------------------------------------|
 | [dotnet-counters collect](#dotnet-counters-collect) |
-| [dotnet-counters list](#dotnet-counters-list)       |
 | [dotnet-counters monitor](#dotnet-counters-monitor) |
 | [dotnet-counters ps](#dotnet-counters-ps)           |
 
@@ -109,7 +108,7 @@ dotnet-counters collect [-h|--help] [-p|--process-id] [-n|--name] [--diagnostic-
 
 - **`--counters <COUNTERS>`**
 
-  A comma-separated list of counters. Counters can be specified `provider_name[:counter_name]`. If the `provider_name` is used without a qualifying list of counters, then all counters from the provider are shown. To discover provider and counter names, use the [dotnet-counters list](#dotnet-counters-list) command. For [EventCounters](event-counters.md), `provider_name` is the name of the EventSource and for [Meters](metrics.md), `provider_name` is the name of the Meter.
+  A comma-separated list of counters. Counters can be specified `provider_name[:counter_name]`. If the `provider_name` is used without a qualifying list of counters, then all counters from the provider are shown. To discover provider and counter names, consult [built-in metrics docs](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/built-in-metrics). For [EventCounters](event-counters.md), `provider_name` is the name of the EventSource and for [Meters](metrics.md), `provider_name` is the name of the Meter.
 
 - **`--format <csv|json>`**
 
@@ -150,54 +149,6 @@ dotnet-counters collect [-h|--help] [-p|--process-id] [-n|--name] [--diagnostic-
   Starting a counter session. Press Q to quit.
   File saved to counter.json
   ```
-
-## dotnet-counters list
-
-Displays a list of counter names and descriptions, grouped by provider.
-
-### Synopsis
-
-```dotnetcli
-dotnet-counters list [-h|--help]
-```
-
-### Example
-
-```dotnetcli
-> dotnet-counters list
-Showing well-known counters only. Specific processes may support additional counters.
-
-System.Runtime
-    cpu-usage                                    Amount of time the process has utilized the CPU (ms)
-    working-set                                  Amount of working set used by the process (MB)
-    gc-heap-size                                 Total heap size reported by the GC (MB)
-    gen-0-gc-count                               Number of Gen 0 GCs per interval
-    gen-1-gc-count                               Number of Gen 1 GCs per interval
-    gen-2-gc-count                               Number of Gen 2 GCs per interval
-    time-in-gc                                   % time in GC since the last GC
-    gen-0-size                                   Gen 0 Heap Size
-    gen-1-size                                   Gen 1 Heap Size
-    gen-2-size                                   Gen 2 Heap Size
-    loh-size                                     LOH Heap Size
-    alloc-rate                                   Allocation Rate
-    assembly-count                               Number of Assemblies Loaded
-    exception-count                              Number of Exceptions per interval
-    threadpool-thread-count                      Number of ThreadPool Threads
-    monitor-lock-contention-count                Monitor Lock Contention Count
-    threadpool-queue-length                      ThreadPool Work Items Queue Length
-    threadpool-completed-items-count             ThreadPool Completed Work Items Count
-    active-timer-count                           Active Timers Count
-
-Microsoft.AspNetCore.Hosting
-    requests-per-second                  Request rate
-    total-requests                       Total number of requests
-    current-requests                     Current number of requests
-    failed-requests                      Failed number of requests
-```
-
-> [!NOTE]
-> The `Microsoft.AspNetCore.Hosting` counters are displayed when there are processes identified that support these counters, for example; when an ASP.NET Core application is running on the host machine.
-
 ## dotnet-counters monitor
 
 Displays periodically refreshing values of selected counters.
@@ -228,7 +179,7 @@ dotnet-counters monitor [-h|--help] [-p|--process-id] [-n|--name] [--diagnostic-
 
 - **`--counters <COUNTERS>`**
 
-  A comma-separated list of counters. Counters can be specified `provider_name[:counter_name]`. If the `provider_name` is used without a qualifying list of counters, then all counters from the provider are shown. To discover provider and counter names, use the [dotnet-counters list](#dotnet-counters-list) command. For [EventCounters](event-counters.md), `provider_name` is the name of the EventSource and for [Meters](metrics.md), `provider_name` is the name of the Meter.
+  A comma-separated list of counters. Counters can be specified `provider_name[:counter_name]`. If the `provider_name` is used without a qualifying list of counters, then all counters from the provider are shown. To discover provider and counter names, consult [built-in metrics docs](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/built-in-metrics). For [EventCounters](event-counters.md), `provider_name` is the name of the EventSource and for [Meters](metrics.md), `provider_name` is the name of the Meter.
 
  **`-- <command>`**
 
@@ -257,44 +208,92 @@ dotnet-counters monitor [-h|--help] [-p|--process-id] [-n|--name] [--diagnostic-
   > dotnet-counters monitor --process-id 1902  --refresh-interval 3 --counters System.Runtime
   Press p to pause, r to resume, q to quit.
       Status: Running
-
+  Name                                              Current Value
   [System.Runtime]
-      % Time in GC since last GC (%)                                 0
-      Allocation Rate (B / 1 sec)                                5,376
-      CPU Usage (%)                                                  0
-      Exception Count (Count / 1 sec)                                0
-      GC Fragmentation (%)                                          48.467
-      GC Heap Size (MB)                                              0
-      Gen 0 GC Count (Count / 1 sec)                                 1
-      Gen 0 Size (B)                                                24
-      Gen 1 GC Count (Count / 1 sec)                                 1
-      Gen 1 Size (B)                                                24
-      Gen 2 GC Count (Count / 1 sec)                                 1
-      Gen 2 Size (B)                                           272,000
-      IL Bytes Jitted (B)                                       19,449
-      LOH Size (B)                                              19,640
-      Monitor Lock Contention Count (Count / 1 sec)                  0
-      Number of Active Timers                                        0
-      Number of Assemblies Loaded                                    7
-      Number of Methods Jitted                                     166
-      POH (Pinned Object Heap) Size (B)                             24
-      ThreadPool Completed Work Item Count (Count / 1 sec)           0
-      ThreadPool Queue Length                                        0
-      ThreadPool Thread Count                                        2
-      Working Set (MB)                                              19
+    dotnet.assembly.count ({assembly})                  11
+    dotnet.gc.collections ({collection})
+      gc.heap.generation
+        gen0                                            0
+        gen1                                            0
+        gen2                                            0
+    dotnet.gc.heap.total_allocated (By)                 1,376,024
+    dotnet.gc.last_collection.heap.fragmentation.size (By)
+      gc.heap.generation
+        gen0                                            0
+        gen1                                            0
+        gen2                                            0
+        loh                                             0
+        poh                                             0
+    dotnet.gc.last_collection.heap.size (By)
+      gc.heap.generation
+        gen0                                            0
+        gen1                                            0
+        gen2                                            0
+        loh                                             0
+        poh                                             0
+    dotnet.gc.last_collection.memory.committed_size (By)   0
+    dotnet.gc.pause.time (s)                            0
+    dotnet.jit.compilation.time (s)                     0.253
+    dotnet.jit.compiled_il.size (By)                    79,536
+    dotnet.jit.compiled_methods ({method})              743
+    dotnet.monitor.lock_contentions ({contention})      0
+    dotnet.process.cpu.count ({cpu})                    22
+    dotnet.process.cpu.time (s)
+      cpu.mode
+        system                                          0.125
+        user                                            46.453
+    dotnet.process.memory.working_set (By)              34,447,360
+    dotnet.thread_pool.queue.length ({work_item})       0
+    dotnet.thread_pool.thread.count ({thread})          0
+    dotnet.thread_pool.work_item.count ({work_item})    0
+    dotnet.timer.count ({timer})                        0
   ```
 
-- Monitor just CPU usage and GC heap size from `System.Runtime`:
+  > [!NOTE]
+  > If you are using an older version of .NET (<=8), if you are specifically requesting EventCounters as opposed to the default meters (for example through the command ```dotnet-counters monitor -p 65492 --counters EventCounters\System.Runtime```), or if only EventCounters are available, then the UI will look slightly different. See below for an example.
+  >  ```
+  >  [System.Runtime]
+  >      % Time in GC since last GC (%)                                 0
+  >      Allocation Rate (B / 1 sec)                                5,376
+  >      CPU Usage (%)                                                  0
+  >      Exception Count (Count / 1 sec)                                0
+  >      GC Fragmentation (%)                                          48.467
+  >      GC Heap Size (MB)                                              0
+  >      Gen 0 GC Count (Count / 1 sec)                                 1
+  >      Gen 0 Size (B)                                                24
+  >      Gen 1 GC Count (Count / 1 sec)                                 1
+  >      Gen 1 Size (B)                                                24
+  >      Gen 2 GC Count (Count / 1 sec)                                 1
+  >      Gen 2 Size (B)                                           272,000
+  >      IL Bytes Jitted (B)                                       19,449
+  >      LOH Size (B)                                              19,640
+  >      Monitor Lock Contention Count (Count / 1 sec)                  0
+  >      Number of Active Timers                                        0
+  >      Number of Assemblies Loaded                                    7
+  >      Number of Methods Jitted                                     166
+  >      POH (Pinned Object Heap) Size (B)                             24
+  >      ThreadPool Completed Work Item Count (Count / 1 sec)           0
+  >      ThreadPool Queue Length                                        0
+  >      ThreadPool Thread Count                                        2
+  >      Working Set (MB)                                              19
+
+- Monitor just GC collections and GC heap allocation from `System.Runtime`:
 
   ```dotnetcli
-  > dotnet-counters monitor --process-id 1902 --counters System.Runtime[cpu-usage,gc-heap-size]
+  > dotnet-counters monitor --process-id 1902 --counters System.Runtime[dotnet.gc.collections,dotnet.gc.heap.total_allocated] 
 
   Press p to pause, r to resume, q to quit.
-    Status: Running
+  Status: Running
 
+  Name                                  Current Value
   [System.Runtime]
-      CPU Usage (%)                                 24
-      GC Heap Size (MB)                            811
+    dotnet.gc.collections ({collection})
+      gc.heap.generation
+        gen0                                0
+        gen1                                0
+        gen2                                0
+    dotnet.gc.heap.total_allocated (By)     9,943,384
+
   ```
 
 - Monitor `EventCounter` values from user-defined `EventSource`. For more information, see [Tutorial: Measure performance using EventCounters in .NET Core](event-counter-perf.md).
@@ -306,121 +305,36 @@ dotnet-counters monitor [-h|--help] [-p|--process-id] [-n|--name] [--diagnostic-
       request                                      100
   ```
 
-- View all well-known counters that are available in `dotnet-counters`:
-
-  ```dotnetcli
-  > dotnet-counters list
-
-  Showing well-known counters for .NET (Core) version 3.1 only. Specific processes may support additional counters.
-  System.Runtime
-      cpu-usage                          The percent of process' CPU usage relative to all of the system CPU resources [0-100]
-      working-set                        Amount of working set used by the process (MB)
-      gc-heap-size                       Total heap size reported by the GC (MB)
-      gen-0-gc-count                     Number of Gen 0 GCs between update intervals
-      gen-1-gc-count                     Number of Gen 1 GCs between update intervals
-      gen-2-gc-count                     Number of Gen 2 GCs between update intervals
-      time-in-gc                         % time in GC since the last GC
-      gen-0-size                         Gen 0 Heap Size
-      gen-1-size                         Gen 1 Heap Size
-      gen-2-size                         Gen 2 Heap Size
-      loh-size                           LOH Size
-      alloc-rate                         Number of bytes allocated in the managed heap between update intervals
-      assembly-count                     Number of Assemblies Loaded
-      exception-count                    Number of Exceptions / sec
-      threadpool-thread-count            Number of ThreadPool Threads
-      monitor-lock-contention-count      Number of times there were contention when trying to take the monitor lock between update intervals
-      threadpool-queue-length            ThreadPool Work Items Queue Length
-      threadpool-completed-items-count   ThreadPool Completed Work Items Count
-      active-timer-count                 Number of timers that are currently active
-
-  Microsoft.AspNetCore.Hosting
-      requests-per-second                Number of requests between update intervals
-      total-requests                     Total number of requests
-      current-requests                   Current number of requests
-      failed-requests                    Failed number of requests
-  ```
-
-- View all well-known counters that are available in `dotnet-counters` for .NET 5 apps:
-
-  ```dotnetcli
-  > dotnet-counters list --runtime-version 5.0
-
-  Showing well-known counters for .NET (Core) version 5.0 only. Specific processes may support additional counters.
-  System.Runtime
-      cpu-usage                          The percent of process' CPU usage relative to all of the system CPU resources [0-100]
-      working-set                        Amount of working set used by the process (MB)
-      gc-heap-size                       Total heap size reported by the GC (MB)
-      gen-0-gc-count                     Number of Gen 0 GCs between update intervals
-      gen-1-gc-count                     Number of Gen 1 GCs between update intervals
-      gen-2-gc-count                     Number of Gen 2 GCs between update intervals
-      time-in-gc                         % time in GC since the last GC
-      gen-0-size                         Gen 0 Heap Size
-      gen-1-size                         Gen 1 Heap Size
-      gen-2-size                         Gen 2 Heap Size
-      loh-size                           LOH Size
-      poh-size                           POH (Pinned Object Heap) Size
-      alloc-rate                         Number of bytes allocated in the managed heap between update intervals
-      gc-fragmentation                   GC Heap Fragmentation
-      assembly-count                     Number of Assemblies Loaded
-      exception-count                    Number of Exceptions / sec
-      threadpool-thread-count            Number of ThreadPool Threads
-      monitor-lock-contention-count      Number of times there were contention when trying to take the monitor lock between update intervals
-      threadpool-queue-length            ThreadPool Work Items Queue Length
-      threadpool-completed-items-count   ThreadPool Completed Work Items Count
-      active-timer-count                 Number of timers that are currently active
-      il-bytes-jitted                    Total IL bytes jitted
-      methods-jitted-count               Number of methods jitted
-
-  Microsoft.AspNetCore.Hosting
-      requests-per-second   Number of requests between update intervals
-      total-requests        Total number of requests
-      current-requests      Current number of requests
-      failed-requests       Failed number of requests
-
-  Microsoft-AspNetCore-Server-Kestrel
-      connections-per-second      Number of connections between update intervals
-      total-connections           Total Connections
-      tls-handshakes-per-second   Number of TLS Handshakes made between update intervals
-      total-tls-handshakes        Total number of TLS handshakes made
-      current-tls-handshakes      Number of currently active TLS handshakes
-      failed-tls-handshakes       Total number of failed TLS handshakes
-      current-connections         Number of current connections
-      connection-queue-length     Length of Kestrel Connection Queue
-      request-queue-length        Length total HTTP request queue
-
-  System.Net.Http
-      requests-started        Total Requests Started
-      requests-started-rate   Number of Requests Started between update intervals
-      requests-aborted        Total Requests Aborted
-      requests-aborted-rate   Number of Requests Aborted between update intervals
-      current-requests        Current Requests
-  ```
-
 - Launch `my-aspnet-server.exe` and monitor the # of assemblies loaded from its startup:
 
   ```dotnetcli
-  > dotnet-counters monitor --counters System.Runtime[assembly-count] -- my-aspnet-server.exe
-
+  > dotnet-counters monitor --counters System.Runtime[dotnet.assembly.count] -- my-aspnet-server.exe
   Press p to pause, r to resume, q to quit.
-    Status: Running
+  Status: Running
 
+  Name                               Current Value
   [System.Runtime]
-      Number of Assemblies Loaded                   24
+  dotnet.assembly.count ({assembly})      11
   ```
   
 - Launch `my-aspnet-server.exe` with `arg1` and `arg2` as command-line arguments and monitor its working set and GC heap size from its startup:
 
   ```dotnetcli
-  > dotnet-counters monitor --counters System.Runtime[working-set,gc-heap-size] -- my-aspnet-server.exe arg1 arg2
+  > dotnet-counters monitor --counters System.Runtime[dotnet.process.memory.working_set,dotnet.gc.last_collection.heap.size] -- my-aspnet-server.exe arg1 arg2
   ```
 
   ```output
-  Press p to pause, r to resume, q to quit.
-    Status: Running
-
+  Name                                  Current Value
   [System.Runtime]
-      GC Heap Size (MB)                                 39
-      Working Set (MB)                                  59
+    dotnet.gc.last_collection.heap.size (By)
+      gc.heap.generation
+        gen0                              560
+        gen1                              462,720
+        gen2                              0
+        loh                               0
+        poh                               8,184
+    dotnet.process.memory.working_set (By) 48,431,104
+
   ```
 
 ## dotnet-counters ps

--- a/docs/core/diagnostics/dotnet-counters.md
+++ b/docs/core/diagnostics/dotnet-counters.md
@@ -255,7 +255,7 @@ dotnet-counters monitor [-h|--help] [-p|--process-id] [-n|--name] [--diagnostic-
   ```
 
   > [!NOTE]
-  > If you are using an older version of .NET (<=8), if you are specifically requesting EventCounters as opposed to the default meters (for example through the command ```dotnet-counters monitor -p 65492 --counters EventCounters\System.Runtime```), or if only EventCounters are available, then the UI will look slightly different. See below for an example.
+  > If the app uses .NET version 8 or lower the [System.Runtime Meter](https://learn.microsoft.com/dotnet/core/diagnostics/built-in-metrics-runtime#systemruntime) didn't exist yet and dotnet-counters will fall back to display the older [System.Runtime EventCounters](https://learn.microsoft.com/dotnet/core/diagnostics/available-counters#systemruntime-counters) instead. The UI will look slightly different as shown below.
 
   ```
   [System.Runtime]

--- a/docs/core/diagnostics/dotnet-counters.md
+++ b/docs/core/diagnostics/dotnet-counters.md
@@ -211,43 +211,47 @@ dotnet-counters monitor [-h|--help] [-p|--process-id] [-n|--name] [--diagnostic-
       Status: Running
   Name                                              Current Value
   [System.Runtime]
-    dotnet.assembly.count ({assembly})                  11
-    dotnet.gc.collections ({collection})
-      gc.heap.generation
-        gen0                                            0
-        gen1                                            0
-        gen2                                            0
-    dotnet.gc.heap.total_allocated (By)                 1,376,024
-    dotnet.gc.last_collection.heap.fragmentation.size (By)
-      gc.heap.generation
-        gen0                                            0
-        gen1                                            0
-        gen2                                            0
-        loh                                             0
-        poh                                             0
-    dotnet.gc.last_collection.heap.size (By)
-      gc.heap.generation
-        gen0                                            0
-        gen1                                            0
-        gen2                                            0
-        loh                                             0
-        poh                                             0
-    dotnet.gc.last_collection.memory.committed_size (By)   0
-    dotnet.gc.pause.time (s)                            0
-    dotnet.jit.compilation.time (s)                     0.253
-    dotnet.jit.compiled_il.size (By)                    79,536
-    dotnet.jit.compiled_methods ({method})              743
-    dotnet.monitor.lock_contentions ({contention})      0
-    dotnet.process.cpu.count ({cpu})                    22
-    dotnet.process.cpu.time (s)
-      cpu.mode
-        system                                          0.125
-        user                                            46.453
-    dotnet.process.memory.working_set (By)              34,447,360
-    dotnet.thread_pool.queue.length ({work_item})       0
-    dotnet.thread_pool.thread.count ({thread})          0
-    dotnet.thread_pool.work_item.count ({work_item})    0
-    dotnet.timer.count ({timer})                        0
+      dotnet.assembly.count ({assembly})                               115
+      dotnet.gc.collections ({collection})
+          gc.heap.generation
+          ------------------
+          gen0                                                           5
+          gen1                                                           1
+          gen2                                                           1
+      dotnet.gc.heap.total_allocated (By)                       1.6947e+08
+      dotnet.gc.last_collection.heap.fragmentation.size (By)
+          gc.heap.generation
+          ------------------
+          gen0                                                           0
+          gen1                                                     348,248
+          gen2                                                           0
+          loh                                                           32
+          poh                                                            0
+      dotnet.gc.last_collection.heap.size (By)
+          gc.heap.generation
+          ------------------
+          gen0                                                           0
+          gen1                                                  18,010,920
+          gen2                                                   5,065,600
+          loh                                                       98,384
+          poh                                                    3,407,048
+      dotnet.gc.last_collection.memory.committed_size (By)      66,842,624
+      dotnet.gc.pause.time (s)                                           0.05
+      dotnet.jit.compilation.time (s)                                    1.317
+      dotnet.jit.compiled_il.size (By)                             574,886
+      dotnet.jit.compiled_methods ({method})                         6,008
+      dotnet.monitor.lock_contentions ({contention})                   194
+      dotnet.process.cpu.count ({cpu})                                  16
+      dotnet.process.cpu.time (s)
+          cpu.mode
+          --------
+          system                                                         4.953
+          user                                                           6.266
+      dotnet.process.memory.working_set (By)                             1.3217e+08
+      dotnet.thread_pool.queue.length ({work_item})                      0
+      dotnet.thread_pool.thread.count ({thread})                       133
+      dotnet.thread_pool.work_item.count ({work_item})              71,188
+      dotnet.timer.count ({timer})                                     124
   ```
 
   > [!NOTE]
@@ -290,12 +294,13 @@ dotnet-counters monitor [-h|--help] [-p|--process-id] [-n|--name] [--diagnostic-
 
   Name                                  Current Value
   [System.Runtime]
-    dotnet.gc.collections ({collection})
-      gc.heap.generation
-        gen0                                0
-        gen1                                0
-        gen2                                0
-    dotnet.gc.heap.total_allocated (By)     9,943,384
+      dotnet.gc.collections ({collection})
+          gc.heap.generation
+          ------------------
+          gen0                                0
+          gen1                                0
+          gen2                                0
+      dotnet.gc.heap.total_allocated (By)     9,943,384
 
   ```
 
@@ -327,16 +332,17 @@ dotnet-counters monitor [-h|--help] [-p|--process-id] [-n|--name] [--diagnostic-
   ```
 
   ```output
-  Name                                  Current Value
+  Name                                             Current Value
   [System.Runtime]
-    dotnet.gc.last_collection.heap.size (By)
-      gc.heap.generation
-        gen0                              560
-        gen1                              462,720
-        gen2                              0
-        loh                               0
-        poh                               8,184
-    dotnet.process.memory.working_set (By) 48,431,104
+      dotnet.gc.last_collection.heap.size (By)
+          gc.heap.generation
+          ------------------
+          gen0                                          560
+          gen1                                      462,720
+          gen2                                            0
+          loh                                             0
+          poh                                         8,184
+      dotnet.process.memory.working_set (By)     48,431,104
 
   ```
 

--- a/docs/core/diagnostics/dotnet-counters.md
+++ b/docs/core/diagnostics/dotnet-counters.md
@@ -108,7 +108,7 @@ dotnet-counters collect [-h|--help] [-p|--process-id] [-n|--name] [--diagnostic-
 
 - **`--counters <COUNTERS>`**
 
-  A comma-separated list of counters. Counters can be specified `provider_name[:counter_name]`. If the `provider_name` is used without a qualifying list of counters, then all counters from the provider are shown. To discover provider and counter names, consult [built-in metrics docs](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/built-in-metrics). For [EventCounters](event-counters.md), `provider_name` is the name of the EventSource and for [Meters](metrics.md), `provider_name` is the name of the Meter.
+  A comma-separated list of counters. Counters can be specified `provider_name[:counter_name]`. If the `provider_name` is used without a qualifying list of counters, then all counters from the provider are shown. To discover provider and counter names, consult [built-in metrics docs](https://learn.microsoft.com/dotnet/core/diagnostics/built-in-metrics). For [EventCounters](event-counters.md), `provider_name` is the name of the EventSource and for [Meters](metrics.md), `provider_name` is the name of the Meter.
 
 - **`--format <csv|json>`**
 
@@ -180,7 +180,7 @@ dotnet-counters monitor [-h|--help] [-p|--process-id] [-n|--name] [--diagnostic-
 
 - **`--counters <COUNTERS>`**
 
-  A comma-separated list of counters. Counters can be specified `provider_name[:counter_name]`. If the `provider_name` is used without a qualifying list of counters, then all counters from the provider are shown. To discover provider and counter names, consult [built-in metrics docs](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/built-in-metrics). For [EventCounters](event-counters.md), `provider_name` is the name of the EventSource and for [Meters](metrics.md), `provider_name` is the name of the Meter.
+  A comma-separated list of counters. Counters can be specified `provider_name[:counter_name]`. If the `provider_name` is used without a qualifying list of counters, then all counters from the provider are shown. To discover provider and counter names, consult [built-in metrics docs](https://learn.microsoft.com/dotnet/core/diagnostics/built-in-metrics). For [EventCounters](event-counters.md), `provider_name` is the name of the EventSource and for [Meters](metrics.md), `provider_name` is the name of the Meter.
 
  **`-- <command>`**
 

--- a/docs/core/diagnostics/dotnet-counters.md
+++ b/docs/core/diagnostics/dotnet-counters.md
@@ -252,33 +252,33 @@ dotnet-counters monitor [-h|--help] [-p|--process-id] [-n|--name] [--diagnostic-
 
   > [!NOTE]
   > If you are using an older version of .NET (<=8), if you are specifically requesting EventCounters as opposed to the default meters (for example through the command ```dotnet-counters monitor -p 65492 --counters EventCounters\System.Runtime```), or if only EventCounters are available, then the UI will look slightly different. See below for an example.
-  >
-  >  ```
-  > [System.Runtime]
-  >      % Time in GC since last GC (%)                                 0
-  >      Allocation Rate (B / 1 sec)                                5,376
-  >      CPU Usage (%)                                                  0
-  >      Exception Count (Count / 1 sec)                                0
-  >      GC Fragmentation (%)                                          48.467
-  >      GC Heap Size (MB)                                              0
-  >      Gen 0 GC Count (Count / 1 sec)                                 1
-  >      Gen 0 Size (B)                                                24
-  >      Gen 1 GC Count (Count / 1 sec)                                 1
-  >      Gen 1 Size (B)                                                24
-  >      Gen 2 GC Count (Count / 1 sec)                                 1
-  >      Gen 2 Size (B)                                           272,000
-  >      IL Bytes Jitted (B)                                       19,449
-  >      LOH Size (B)                                              19,640
-  >      Monitor Lock Contention Count (Count / 1 sec)                  0
-  >      Number of Active Timers                                        0
-  >      Number of Assemblies Loaded                                    7
-  >      Number of Methods Jitted                                     166
-  >      POH (Pinned Object Heap) Size (B)                             24
-  >      ThreadPool Completed Work Item Count (Count / 1 sec)           0
-  >      ThreadPool Queue Length                                        0
-  >      ThreadPool Thread Count                                        2
-  >      Working Set (MB)                                              19
-  > ```
+
+  ```
+  [System.Runtime]
+        % Time in GC since last GC (%)                                 0
+        Allocation Rate (B / 1 sec)                                5,376
+        CPU Usage (%)                                                  0
+        Exception Count (Count / 1 sec)                                0
+        GC Fragmentation (%)                                          48.467
+        GC Heap Size (MB)                                              0
+        Gen 0 GC Count (Count / 1 sec)                                 1
+        Gen 0 Size (B)                                                24
+        Gen 1 GC Count (Count / 1 sec)                                 1
+        Gen 1 Size (B)                                                24
+        Gen 2 GC Count (Count / 1 sec)                                 1
+        Gen 2 Size (B)                                           272,000
+        IL Bytes Jitted (B)                                       19,449
+        LOH Size (B)                                              19,640
+        Monitor Lock Contention Count (Count / 1 sec)                  0
+        Number of Active Timers                                        0
+        Number of Assemblies Loaded                                    7
+        Number of Methods Jitted                                     166
+        POH (Pinned Object Heap) Size (B)                             24
+        ThreadPool Completed Work Item Count (Count / 1 sec)           0
+        ThreadPool Queue Length                                        0
+        ThreadPool Thread Count                                        2
+        Working Set (MB)                                              19
+  ```
 
 - Monitor just GC collections and GC heap allocation from `System.Runtime`:
 

--- a/docs/core/diagnostics/dotnet-counters.md
+++ b/docs/core/diagnostics/dotnet-counters.md
@@ -149,6 +149,7 @@ dotnet-counters collect [-h|--help] [-p|--process-id] [-n|--name] [--diagnostic-
   Starting a counter session. Press Q to quit.
   File saved to counter.json
   ```
+
 ## dotnet-counters monitor
 
 Displays periodically refreshing values of selected counters.
@@ -251,8 +252,9 @@ dotnet-counters monitor [-h|--help] [-p|--process-id] [-n|--name] [--diagnostic-
 
   > [!NOTE]
   > If you are using an older version of .NET (<=8), if you are specifically requesting EventCounters as opposed to the default meters (for example through the command ```dotnet-counters monitor -p 65492 --counters EventCounters\System.Runtime```), or if only EventCounters are available, then the UI will look slightly different. See below for an example.
+  >
   >  ```
-  >  [System.Runtime]
+  > [System.Runtime]
   >      % Time in GC since last GC (%)                                 0
   >      Allocation Rate (B / 1 sec)                                5,376
   >      CPU Usage (%)                                                  0
@@ -276,6 +278,7 @@ dotnet-counters monitor [-h|--help] [-p|--process-id] [-n|--name] [--diagnostic-
   >      ThreadPool Queue Length                                        0
   >      ThreadPool Thread Count                                        2
   >      Working Set (MB)                                              19
+  > ```
 
 - Monitor just GC collections and GC heap allocation from `System.Runtime`:
 

--- a/docs/core/diagnostics/metrics-collection.md
+++ b/docs/core/diagnostics/metrics-collection.md
@@ -47,6 +47,8 @@ If the [dotnet-counters](dotnet-counters.md) tool isn't installed, run the follo
 dotnet tool update -g dotnet-counters
 ```
 
+If your app is running a version of .NET older than .NET 9, the output UI of dotnet-counters will look slightly different than below; see [dotnet-counters](dotnet-counters.md) for details.
+
 While the example app is running, launch [dotnet-counters](dotnet-counters.md). The following command shows an example of `dotnet-counters` monitoring all metrics from the `HatCo.HatStore` meter. The meter name is case-sensitive. Our sample app was metric-instr.exe, substitute this with the name of your sample app.
 
 ```dotnetcli
@@ -80,12 +82,14 @@ System.Runtime
   dotnet.assembly.count ({assembly})                    11
   dotnet.gc.collections ({collection})
     gc.heap.generation
+    ------------------
       gen0                                              0
       gen1                                              0
       gen2                                              0
   dotnet.gc.heap.total_allocated (By)                   1,376,024
   dotnet.gc.last_collection.heap.fragmentation.size (By)
     gc.heap.generation
+    ------------------
       gen0                                              0
       gen1                                              0
       gen2                                              0
@@ -93,6 +97,7 @@ System.Runtime
       poh                                               0
   dotnet.gc.last_collection.heap.size (By)
     gc.heap.generation
+    ------------------
       gen0                                              0
       gen1                                              0
       gen2                                              0
@@ -107,6 +112,7 @@ System.Runtime
   dotnet.process.cpu.count ({cpu})                      22
   dotnet.process.cpu.time (s)
     cpu.mode
+    --------
       system                                            0.125
       user                                              46.453
   dotnet.process.memory.working_set (By)                34,447,360

--- a/docs/core/diagnostics/metrics-collection.md
+++ b/docs/core/diagnostics/metrics-collection.md
@@ -72,29 +72,48 @@ dotnet-counters monitor -n metric-instr
 Output similar to the following is displayed:
 
 ```dotnetcli
-Press p to pause, r to resume, q to quit.
-    Status: Running
-
-[System.Runtime]
-    % Time in GC since last GC (%)                                 0
-    Allocation Rate (B / 1 sec)                                8,168
-    CPU Usage (%)                                                  0
-    Exception Count (Count / 1 sec)                                0
-    GC Heap Size (MB)                                              2
-    Gen 0 GC Count (Count / 1 sec)                                 0
-    Gen 0 Size (B)                                         2,216,256
-    Gen 1 GC Count (Count / 1 sec)                                 0
-    Gen 1 Size (B)                                           423,392
-    Gen 2 GC Count (Count / 1 sec)                                 0
-    Gen 2 Size (B)                                           203,248
-    LOH Size (B)                                             933,216
-    Monitor Lock Contention Count (Count / 1 sec)                  0
-    Number of Active Timers                                        1
-    Number of Assemblies Loaded                                   39
-    ThreadPool Completed Work Item Count (Count / 1 sec)           0
-    ThreadPool Queue Length                                        0
-    ThreadPool Thread Count                                        3
-    Working Set (MB)                                              30
+System.Runtime
+  Press p to pause, r to resume, q to quit.
+      Status: Running
+  Name                                              Current Value
+  [System.Runtime]
+  dotnet.assembly.count ({assembly})                    11
+  dotnet.gc.collections ({collection})
+    gc.heap.generation
+      gen0                                              0
+      gen1                                              0
+      gen2                                              0
+  dotnet.gc.heap.total_allocated (By)                   1,376,024
+  dotnet.gc.last_collection.heap.fragmentation.size (By)
+    gc.heap.generation
+      gen0                                              0
+      gen1                                              0
+      gen2                                              0
+      loh                                               0
+      poh                                               0
+  dotnet.gc.last_collection.heap.size (By)
+    gc.heap.generation
+      gen0                                              0
+      gen1                                              0
+      gen2                                              0
+      loh                                               0
+      poh                                               0
+  dotnet.gc.last_collection.memory.committed_size (By)   0
+  dotnet.gc.pause.time (s)                              0
+  dotnet.jit.compilation.time (s)                       0.253
+  dotnet.jit.compiled_il.size (By)                      79,536
+  dotnet.jit.compiled_methods ({method})                743
+  dotnet.monitor.lock_contentions ({contention})        0
+  dotnet.process.cpu.count ({cpu})                      22
+  dotnet.process.cpu.time (s)
+    cpu.mode
+      system                                            0.125
+      user                                              46.453
+  dotnet.process.memory.working_set (By)                34,447,360
+  dotnet.thread_pool.queue.length ({work_item})         0
+  dotnet.thread_pool.thread.count ({thread})            0
+  dotnet.thread_pool.work_item.count ({work_item})      0
+  dotnet.timer.count ({timer})                          0
 ```
 
 For more information, see [dotnet-counters](dotnet-counters.md). To learn more about metrics in .NET, see [built-in metrics](built-in-metrics.md).

--- a/docs/core/diagnostics/metrics-instrumentation.md
+++ b/docs/core/diagnostics/metrics-instrumentation.md
@@ -461,6 +461,7 @@ Name                                                  Current Value
 [HatCo.Store]
     hatco.store.hats_sold (Count)
         product.color product.size
+        ------------- ------------
         blue          19                                     73
         red           12                                    146
 ```
@@ -507,6 +508,7 @@ Name                                                  Current Value
 [HatCo.Store]
     hatco.store.orders_pending
         customer.country
+        ----------------
         Italy                                                 6
         Mexico                                                1
         Spain                                                 3


### PR DESCRIPTION
## Summary

* Updated the UI in the dotnet-counters docs to reflect the more modern UI.
* Removed dotnet-counters list and instead directed users to the appropriate Learn page.
* Opened a [PR](https://github.com/dotnet/diagnostics/pull/5551) in dotnet/diagnostics to indent tag sets such as those under gc.heap.generation data by an additional tab; this change is also reflected here in the docs.
See dotnet/diagnostics#4935


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/debug-highcpu.md](https://github.com/dotnet/docs/blob/57aa73f46805fc8376d76c170091a598db6a10a6/docs/core/diagnostics/debug-highcpu.md) | [Debug high CPU usage in .NET Core](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/debug-highcpu?branch=pr-en-us-48111) |
| [docs/core/diagnostics/debug-memory-leak.md](https://github.com/dotnet/docs/blob/57aa73f46805fc8376d76c170091a598db6a10a6/docs/core/diagnostics/debug-memory-leak.md) | [Debug a memory leak tutorial](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/debug-memory-leak?branch=pr-en-us-48111) |
| [docs/core/diagnostics/debug-threadpool-starvation.md](https://github.com/dotnet/docs/blob/57aa73f46805fc8376d76c170091a598db6a10a6/docs/core/diagnostics/debug-threadpool-starvation.md) | [Debug ThreadPool starvation](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/debug-threadpool-starvation?branch=pr-en-us-48111) |
| [docs/core/diagnostics/dotnet-counters.md](https://github.com/dotnet/docs/blob/57aa73f46805fc8376d76c170091a598db6a10a6/docs/core/diagnostics/dotnet-counters.md) | [Investigate performance counters (dotnet-counters)](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-counters?branch=pr-en-us-48111) |
| [docs/core/diagnostics/metrics-collection.md](https://github.com/dotnet/docs/blob/57aa73f46805fc8376d76c170091a598db6a10a6/docs/core/diagnostics/metrics-collection.md) | [docs/core/diagnostics/metrics-collection](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/metrics-collection?branch=pr-en-us-48111) |
| [docs/core/diagnostics/metrics-instrumentation.md](https://github.com/dotnet/docs/blob/57aa73f46805fc8376d76c170091a598db6a10a6/docs/core/diagnostics/metrics-instrumentation.md) | [Creating metrics](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/metrics-instrumentation?branch=pr-en-us-48111) |


<!-- PREVIEW-TABLE-END -->