### PR TITLE
update breaking change to be actually correct with respect to the input

### DIFF
--- a/docs/core/compatibility/10.0.md
+++ b/docs/core/compatibility/10.0.md
@@ -103,7 +103,7 @@ If you're migrating an app to .NET 10, the breaking changes listed here might af
 | Title | Type of change    | Introduced version |
 |-------|-------------------|--------------------|
 | [.NET CLI `--interactive` defaults to `true` in user scenarios](sdk/10.0/dotnet-cli-interactive.md) | Behavioral change | Preview 3 |
-| [.NET tool packaging invokes Publish instead of Build](sdk/10.0/dotnet-tool-pack-publish.md) | Behavioral change | Preview 6 |
+| [.NET tool packaging creates RuntimeIdentifier-specific tool packages](sdk/10.0/dotnet-tool-pack-publish.md) | Behavioral change | Preview 6 |
 | [Default workload configuration from 'loose manifests' to 'workload sets' mode](sdk/10.0/default-workload-config.md) | Behavioral change | Preview 2 |
 | [`dotnet package list` performs restore](sdk/10.0/dotnet-package-list-restore.md) | Behavioral change | Preview 4 |
 | [`dotnet restore` audits transitive packages](sdk/10.0/nugetaudit-transitive-packages.md) | Behavioral change | Preview 3 |

--- a/docs/core/compatibility/sdk/10.0/dotnet-tool-pack-publish.md
+++ b/docs/core/compatibility/sdk/10.0/dotnet-tool-pack-publish.md
@@ -37,7 +37,7 @@ This change enables the creation of optimized, platform-specific .NET Tool packa
 
 ## Recommended action
 
-If you would like to create tools for only a subset of platforms, use `ToolPackageRuntimeIdentifiers`. If you would like to disable RID-specific tool packages entirely, you should conditionally include or exclude the `RuntimeIdentifiers` property in your project file.
+If you want to create tools for only a subset of platforms, use `ToolPackageRuntimeIdentifiers`. If you want to disable RID-specific tool packages entirely, you should conditionally include or exclude the `RuntimeIdentifiers` property in your project file.
 
 ## Affected APIs
 

--- a/docs/core/compatibility/sdk/10.0/dotnet-tool-pack-publish.md
+++ b/docs/core/compatibility/sdk/10.0/dotnet-tool-pack-publish.md
@@ -6,7 +6,7 @@ ai-usage: ai-assisted
 ms.custom: https://github.com/dotnet/docs/issues/47916
 ---
 
-# .NET tool packaging invokes Publish instead of Build
+# .NET tool packaging creates RuntimeIdentifier-specific tool packages
 
 The .NET tool packaging process changed when `RuntimeIdentifiers` are present in the project.
 Since the SDK now supports creating [platform-specific tools](https://github.com/dotnet/core/blob/main/release-notes/10.0/preview/preview6/sdk.md#platform-specific-net-tools), `RuntimeIdentifiers` are used to determine the set of platforms for which to create tool packages.

--- a/docs/core/compatibility/sdk/10.0/dotnet-tool-pack-publish.md
+++ b/docs/core/compatibility/sdk/10.0/dotnet-tool-pack-publish.md
@@ -1,6 +1,6 @@
 ---
-title: "Breaking change: .NET tool packaging may create RuntimeIdentifier-specific tool packages"
-description: "Learn about the breaking change in the .NET 10 SDK where .NET tool packaging may use RuntimeIdentifiers to create platform-specific tools"
+title: "Breaking change: .NET tool packaging might create RuntimeIdentifier-specific tool packages"
+description: "Learn about the breaking change in the .NET 10 SDK where .NET tool packaging might use RuntimeIdentifiers to create platform-specific tools"
 ms.date: 08/11/2025
 ai-usage: ai-assisted
 ms.custom: https://github.com/dotnet/docs/issues/47916

--- a/docs/core/compatibility/sdk/10.0/dotnet-tool-pack-publish.md
+++ b/docs/core/compatibility/sdk/10.0/dotnet-tool-pack-publish.md
@@ -1,6 +1,6 @@
 ---
-title: "Breaking change: .NET tool packaging invokes Publish instead of Build"
-description: "Learn about the breaking change in the .NET 10 SDK where .NET tool packaging changed from invoking Build to Publish, affecting included assets."
+title: "Breaking change: .NET tool packaging may create RuntimeIdentifier-specific tool packages"
+description: "Learn about the breaking change in the .NET 10 SDK where .NET tool packaging may use RuntimeIdentifiers to create platform-specific tools"
 ms.date: 08/11/2025
 ai-usage: ai-assisted
 ms.custom: https://github.com/dotnet/docs/issues/47916
@@ -8,7 +8,8 @@ ms.custom: https://github.com/dotnet/docs/issues/47916
 
 # .NET tool packaging invokes Publish instead of Build
 
-The .NET tool packaging process changed from invoking the MSBuild `Build` target to the `Publish` target (logically, not precisely). This means that assets that are included in `Publish` but not in `Build`, like WebSDK StaticWebAssets, now appear in tool packages by default. If you explicitly copied those files into place, you might begin to receive build diagnostics warning of duplicate copies.
+The .NET tool packaging process changed when `RuntimeIdentifiers` are present in the project.
+Since the SDK now supports creating [platform-specific tools](https://github.com/dotnet/core/blob/main/release-notes/10.0/preview/preview6/sdk.md#platform-specific-net-tools), `RuntimeIdentifiers` are used to determine the set of platforms for which to create tool packages.
 
 ## Version introduced
 
@@ -16,11 +17,11 @@ The .NET tool packaging process changed from invoking the MSBuild `Build` target
 
 ## Previous behavior
 
-Previously when you ran `dotnet pack` on a project with `PackAsTool` set to `true`, it invoked the `Build` target, and only `Build`-created assets were included in the package.
+Previously when you ran `dotnet pack` on a project with `PackAsTool` set to `true`, it ignored any `RuntimeIdentifiers`.
 
 ## New behavior
 
-Starting in .NET 10, the tool packaging process invokes the `Publish` target, which means `Publish`-created assets are included in the package. This includes StaticWebAssets and minified and trimmed application assets.
+Starting in .NET 10, `RuntimeIdentifiers` are used to determine the set of platforms for which to create tool packages.
 
 ## Type of breaking change
 
@@ -36,7 +37,7 @@ This change enables the creation of optimized, platform-specific .NET Tool packa
 
 ## Recommended action
 
-If your project is impacted, remove any explicit file copy customizations.
+If you would like to create tools for only a subset of platforms, use `ToolPackageRuntimeIdentifiers`. If you would like to disable RID-specific tool packages entirely, you should conditionally include or exclude the `RuntimeIdentifiers` property in your project file.
 
 ## Affected APIs
 

--- a/docs/core/compatibility/sdk/10.0/dotnet-tool-pack-publish.md
+++ b/docs/core/compatibility/sdk/10.0/dotnet-tool-pack-publish.md
@@ -8,7 +8,7 @@ ms.custom: https://github.com/dotnet/docs/issues/47916
 
 # .NET tool packaging creates RuntimeIdentifier-specific tool packages
 
-The .NET tool packaging process changed when `RuntimeIdentifiers` are present in the project.
+The .NET tool packaging process has changed when `RuntimeIdentifiers` are present in the project.
 Since the SDK now supports creating [platform-specific tools](https://github.com/dotnet/core/blob/main/release-notes/10.0/preview/preview6/sdk.md#platform-specific-net-tools), `RuntimeIdentifiers` are used to determine the set of platforms for which to create tool packages.
 
 ## Version introduced

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -110,7 +110,7 @@ items:
             items:
               - name: .NET CLI `--interactive` defaults to `true` in user scenarios
                 href: sdk/10.0/dotnet-cli-interactive.md
-              - name: .NET tool packaging invokes Publish instead of Build
+              - name: .NET tool packaging creates RuntimeIdentifier-specific tool packages
                 href: sdk/10.0/dotnet-tool-pack-publish.md
               - name: "`dotnet restore` audits transitive packages"
                 href: sdk/10.0/nugetaudit-transitive-packages.md


### PR DESCRIPTION
## Summary

The previous breaking change issue was off somewhat - previous SDKs _did_ call Publish, the core difference is that Publish for a framework-dependent tool is inherently different from platform-specific publishing, which we now perform if `RuntimeIdentifiers` are present.

I updated the doc to be much more clear here.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/10.0.md](https://github.com/dotnet/docs/blob/36615606ec89b3409aa6eb2231357eb03ce83db2/docs/core/compatibility/10.0.md) | [docs/core/compatibility/10.0](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/10.0?branch=pr-en-us-48124) |
| [docs/core/compatibility/sdk/10.0/dotnet-tool-pack-publish.md](https://github.com/dotnet/docs/blob/36615606ec89b3409aa6eb2231357eb03ce83db2/docs/core/compatibility/sdk/10.0/dotnet-tool-pack-publish.md) | [docs/core/compatibility/sdk/10.0/dotnet-tool-pack-publish](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/10.0/dotnet-tool-pack-publish?branch=pr-en-us-48124) |
| [docs/core/compatibility/toc.yml](https://github.com/dotnet/docs/blob/36615606ec89b3409aa6eb2231357eb03ce83db2/docs/core/compatibility/toc.yml) | [docs/core/compatibility/toc](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/toc?branch=pr-en-us-48124) |


<!-- PREVIEW-TABLE-END -->