### PR TITLE
Add docs for tpv0 removal

### DIFF
--- a/docs/core/testing/unit-testing-mstest-migration-from-tmi.md
+++ b/docs/core/testing/unit-testing-mstest-migration-from-tmi.md
@@ -34,7 +34,7 @@ The error can appear for multiple reasons:
 
 - [Using a .testsettings file](#using-a-testsettings-file)
 - [Setting ForcedLegacyMode](#setting-forcedlegacymode)
-- [Web and Load tests (WLT)](web-and-load-tests-wlt)
+- [Web and Load tests (WLT)](#web-and-load-tests-wlt)
 - [Coded UI tests (CUIT)](#coded-ui-tests-cuit)
 - [Manual tests](#manual-tests)
 - [Generic tests](#generic-tests)

--- a/docs/core/testing/unit-testing-mstest-migration-from-tmi.md
+++ b/docs/core/testing/unit-testing-mstest-migration-from-tmi.md
@@ -1,0 +1,61 @@
+---
+title: MSTest migration from Legacy Test runner
+description: Learn about migrating from Legacy test runner to latest MSTest.
+author: nohwnd
+ms.author: jajares
+ms.date: 08/21/2025
+---
+
+# MSTest legacy runner migration guide
+
+This guide assists users in upgrading their MSTest tests that rely on legacy test runner in Visual Studio and VSTest, to move to latest MSTest.
+
+### Who is impacted?
+
+Users who upgrade to VSTest 18.0.0 or newer and encounter error:
+
+```plaintext
+MSTest v1 run was offloaded to legacy TestPlatform runner, this is typically caused by:
+- using .testsettings file
+- setting ForcedLegacyMode in your runsettings file
+- running Web and Load test (WLT)
+- running Coded UI Tests (CUIT)
+- running manual tests
+- running generic tests
+
+This runner was removed from the product and can no longer be used. 
+```
+
+Version 18 of VSTest removed the ability to run MSTest v1 tests via the legacy runner (running MSTest v1 tests via VSTest remains unaffected.). The legacy runner, also called TMI, TPv0, QTAgent, was removed from VSTest and VisualStudio.
+
+### Solving the error
+
+The error can show up for multiple reasons, typically the reasons that are listed.
+
+#### Using .testsettings file
+
+Providing `.testsettings` file to the run will trigger this error. Test settings files are no longer supported in VSTest and you should replace them with `.runsettings` file.
+
+To migrate from testsettings to run settings you can use the TestSettings migrator tool that is shipped with VisualStudio 2022. See <https://learn.microsoft.com/visualstudio/test/migrate-testsettings-to-runsettings?view=vs-2022>
+
+When moving away from testsettings, please also consider upgrading from MSTest v1 to latest MSTest following [this migration guide](unit-testing-mstest-migration-from-v1-to-v3.md).
+
+#### Setting ForcedLegacyMode in runsettings
+
+Inspect your runsettings file to see if `<ForcedLegacyMode>true</ForcedLegacyMode>` is set explicitly. This will force switching to the legacy MSTest runner. You need to remove this explicit setting.
+
+#### Running Web and Load test (WLT)
+
+Web and Load test workload and adapter was deprecated and removed. If you still have the need to run Web and Load tests, avoid upgrading from VSTest 17.x.
+
+#### Running Coded UI Tests (CUIT)
+
+Coded UI test workload and adapter was deprecated and removed. If you still have the need to run Coded UI tests, avoid upgrading from VSTest 17.x.
+
+#### Running manual tests
+
+Manual test test type was deprecated and removed. If you still have the need to manual tests, avoid upgrading from VSTest 17.x.
+
+#### Generic tests tests
+
+Generic test test type was deprecated and removed. If you still have the need to manual tests, avoid upgrading from VSTest 17.x.

--- a/docs/core/testing/unit-testing-mstest-migration-from-tmi.md
+++ b/docs/core/testing/unit-testing-mstest-migration-from-tmi.md
@@ -8,11 +8,11 @@ ms.date: 08/21/2025
 
 # MSTest legacy runner migration guide
 
-This guide assists users in upgrading their MSTest tests that rely on legacy test runner in Visual Studio and VSTest, to move to latest MSTest.
+This guide assists you in upgrading your MSTest tests that rely on legacy test runner in Visual Studio and VSTest to the latest MSTest.
 
 ### Who is impacted?
 
-Users who upgrade to VSTest 18.0.0 or newer and encounter error:
+If you upgrade to VSTest 18.0.0 or later and encounter error the following error, you need to migrate:
 
 ```plaintext
 MSTest v1 run was offloaded to legacy TestPlatform runner, this is typically caused by:
@@ -28,34 +28,41 @@ This runner was removed from the product and can no longer be used.
 
 Version 18 of VSTest removed the ability to run MSTest v1 tests via the legacy runner (running MSTest v1 tests via VSTest remains unaffected.). The legacy runner, also called TMI, TPv0, QTAgent, was removed from VSTest and Visual Studio.
 
-### Solving the error
+### Resolve the error
 
-The error can show up for multiple reasons, typically the reasons that are listed.
+The error can appear for multiple reasons:
 
-#### Using .testsettings file
+- [Using a .testsettings file](#using-a-testsettings-file)
+- [Setting ForcedLegacyMode](#setting-forcedlegacymode)
+- [Web and Load tests (WLT)](web-and-load-tests-wlt)
+- [Coded UI tests (CUIT)](#coded-ui-tests-cuit)
+- [Manual tests](#manual-tests)
+- [Generic tests](#generic-tests)
 
-Providing `.testsettings` file to the run will trigger this error. Test settings files are no longer supported in VSTest and you should replace them with `.runsettings` file.
+#### Using a .testsettings file
 
-To migrate from testsettings to runsettings, you can use the TestSettings migrator tool that is shipped with Visual Studio 2022. For more information, see [Upgrade from .testsettings to .runsettings](https://learn.microsoft.com/visualstudio/test/migrate-testsettings-to-runsettings).
+Providing a `.testsettings` file to the run triggers this error. Test settings files are no longer supported in VSTest. Replace them with `.runsettings` files.
+
+To migrate from testsettings to runsettings, you can use the TestSettings migrator tool that shipped with Visual Studio 2022. For more information, see [Upgrade from .testsettings to .runsettings](/visualstudio/test/migrate-testsettings-to-runsettings).
 
 When moving away from testsettings, consider upgrading from MSTest v1 to latest MSTest following [this migration guide](unit-testing-mstest-migration-from-v1-to-v3.md).
 
-#### Setting ForcedLegacyMode in runsettings
+#### Setting ForcedLegacyMode
 
 Inspect your runsettings file to see if `<ForcedLegacyMode>true</ForcedLegacyMode>` is set explicitly. This will force switching to the legacy MSTest runner. You need to remove this explicit setting.
 
-#### Running Web and Load test (WLT)
+#### Web and Load tests (WLT)
 
-Web and Load test workload and adapter was deprecated and removed. If you still have the need to run Web and Load tests, avoid upgrading from VSTest 17.x.
+The Web and Load test workload and adapter was deprecated and removed. If you still need to run Web and Load tests, avoid upgrading from VSTest 17.x.
 
-#### Running Coded UI Tests (CUIT)
+#### Coded UI tests (CUIT)
 
-Coded UI test workload and adapter was deprecated and removed. If you still have the need to run Coded UI tests, avoid upgrading from VSTest 17.x.
+The Coded UI test workload and adapter was deprecated and removed. If you still need to run Coded UI tests, avoid upgrading from VSTest 17.x.
 
-#### Running manual tests
+#### Manual tests
 
-Manual test test type was deprecated and removed. If you still have the need to manual tests, avoid upgrading from VSTest 17.x.
+The manual-test test type was deprecated and removed. If you still need to run manual tests, avoid upgrading from VSTest 17.x.
 
-#### Generic tests tests
+#### Generic tests
 
-Generic test test type was deprecated and removed. If you still have the need to manual tests, avoid upgrading from VSTest 17.x.
+The generic-test test type was deprecated and removed. If you still need to run generic tests, avoid upgrading from VSTest 17.x.

--- a/docs/core/testing/unit-testing-mstest-migration-from-tmi.md
+++ b/docs/core/testing/unit-testing-mstest-migration-from-tmi.md
@@ -12,7 +12,7 @@ This guide assists you in upgrading your MSTest tests that rely on legacy test r
 
 ### Who is impacted?
 
-If you upgrade to VSTest 18.0.0 or later and encounter error the following error, you need to migrate:
+If you upgrade to VSTest 18.0.0 or later and encounter the following error, you need to migrate:
 
 ```plaintext
 MSTest v1 run was offloaded to legacy TestPlatform runner, this is typically caused by:

--- a/docs/core/testing/unit-testing-mstest-migration-from-tmi.md
+++ b/docs/core/testing/unit-testing-mstest-migration-from-tmi.md
@@ -26,7 +26,7 @@ MSTest v1 run was offloaded to legacy TestPlatform runner, this is typically cau
 This runner was removed from the product and can no longer be used. 
 ```
 
-Version 18 of VSTest removed the ability to run MSTest v1 tests via the legacy runner (running MSTest v1 tests via VSTest remains unaffected.). The legacy runner, also called TMI, TPv0, QTAgent, was removed from VSTest and VisualStudio.
+Version 18 of VSTest removed the ability to run MSTest v1 tests via the legacy runner (running MSTest v1 tests via VSTest remains unaffected.). The legacy runner, also called TMI, TPv0, QTAgent, was removed from VSTest and Visual Studio.
 
 ### Solving the error
 
@@ -36,9 +36,9 @@ The error can show up for multiple reasons, typically the reasons that are liste
 
 Providing `.testsettings` file to the run will trigger this error. Test settings files are no longer supported in VSTest and you should replace them with `.runsettings` file.
 
-To migrate from testsettings to run settings you can use the TestSettings migrator tool that is shipped with VisualStudio 2022. See <https://learn.microsoft.com/visualstudio/test/migrate-testsettings-to-runsettings?view=vs-2022>
+To migrate from testsettings to runsettings, you can use the TestSettings migrator tool that is shipped with Visual Studio 2022. For more information, see [Upgrade from .testsettings to .runsettings](https://learn.microsoft.com/visualstudio/test/migrate-testsettings-to-runsettings).
 
-When moving away from testsettings, please also consider upgrading from MSTest v1 to latest MSTest following [this migration guide](unit-testing-mstest-migration-from-v1-to-v3.md).
+When moving away from testsettings, consider upgrading from MSTest v1 to latest MSTest following [this migration guide](unit-testing-mstest-migration-from-v1-to-v3.md).
 
 #### Setting ForcedLegacyMode in runsettings
 

--- a/docs/navigate/devops-testing/toc.yml
+++ b/docs/navigate/devops-testing/toc.yml
@@ -75,6 +75,8 @@ items:
                 href: ../../core/testing/unit-testing-mstest-migration-from-v1-to-v3.md
               - name: Migrate from MSTest v3 to MSTest v4
                 href: ../../core/testing/unit-testing-mstest-migration-v3-v4.md
+              - name: MSTest migration from Legacy Test runner
+                href: ../../core/testing/unit-testing-mstest-migration-from-tmi.md
               - name: Microsoft.Testing.Platform support (MSTest runner)
                 href: ../../core/testing/unit-testing-mstest-runner-intro.md
               - name: Getting started


### PR DESCRIPTION
## Summary
Adds short doc that is linked from the error shown when tpv0 is used in VSTest 18. The component was removed and this doc will help dispatching the users to migration documents, especially mstest v1 to mstest v3 where we expect the most "traffic". This is also a place that we can update with additional FAQ etc as more people encounter this error.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-mstest-migration-from-tmi.md](https://github.com/dotnet/docs/blob/887c7a524dbd34b65b202a88f751d8ec83b388bd/docs/core/testing/unit-testing-mstest-migration-from-tmi.md) | [MSTest legacy runner migration guide](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-migration-from-tmi?branch=pr-en-us-48173) |
| [docs/navigate/devops-testing/toc.yml](https://github.com/dotnet/docs/blob/887c7a524dbd34b65b202a88f751d8ec83b388bd/docs/navigate/devops-testing/toc.yml) | [docs/navigate/devops-testing/toc](https://review.learn.microsoft.com/en-us/dotnet/navigate/devops-testing/toc?branch=pr-en-us-48173) |


<!-- PREVIEW-TABLE-END -->