### PR TITLE
Update dotnet test --arch and --runtime options

### DIFF
--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -497,7 +497,7 @@ With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest.
   Short form `-r` available starting in .NET SDK 7.
 
   > [!NOTE]
-  > Running tests for a solution with a global `RuntimeIdentifier` property (explicitly or via `--arch`, `--runtime`, or `--os`) is not supported. You can set `RuntimeIdentifier` on individual project level instead.
+  > Running tests for a solution with a global `RuntimeIdentifier` property (explicitly or via `--arch`, `--runtime`, or `--os`) is not supported. Set `RuntimeIdentifier` on an individual project level instead.
 
 - **`-v|--verbosity <LEVEL>`**
   

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -482,9 +482,6 @@ With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest.
 
 [!INCLUDE [arch-no-a](../../../includes/cli-arch-no-a.md)]
 
-> [!NOTE]
-> Running tests for a solution with a specific `Architecture` is not supported. If needed, this should be specified at the individual project level instead.
-
 [!INCLUDE [configuration](../../../includes/cli-configuration.md)]
 
 - **`-f|--framework <FRAMEWORK>`**
@@ -499,8 +496,8 @@ With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest.
 
   Short form `-r` available starting in .NET SDK 7.
 
-> [!NOTE]
-> Running tests for a solution with a specific `Runtime Identifier` is not supported. If needed, this should be specified at the individual project level instead.
+  > [!NOTE]
+  > Running tests for a solution with a global `RuntimeIdentifier` property (explicitly or via `--arch`, `--runtime`, or `--os`) is not supported. You can set `RuntimeIdentifier` on individual project level instead.
 
 - **`-v|--verbosity <LEVEL>`**
   

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -482,6 +482,9 @@ With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest.
 
 [!INCLUDE [arch-no-a](../../../includes/cli-arch-no-a.md)]
 
+> [!NOTE]
+> Running tests for a solution with a specific `Architecture` is not supported. If needed, this should be specified at the individual project level instead.
+
 [!INCLUDE [configuration](../../../includes/cli-configuration.md)]
 
 - **`-f|--framework <FRAMEWORK>`**
@@ -495,6 +498,9 @@ With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest.
   The target runtime to test for.
 
   Short form `-r` available starting in .NET SDK 7.
+
+> [!NOTE]
+> Running tests for a solution with a specific `Runtime Identifier` is not supported. If needed, this should be specified at the individual project level instead.
 
 - **`-v|--verbosity <LEVEL>`**
   


### PR DESCRIPTION
This pull request updates the documentation for the `dotnet test` command to clarify limitations when specifying certain parameters at the solution level. The changes help users avoid common pitfalls by highlighting that some options must be set at the project level instead of the solution level.

Documentation improvements:

* Added a note explaining that specifying the `Architecture` for test runs is not supported at the solution level, and should be set per project if needed.
* Added a note clarifying that setting a `Runtime Identifier` for test runs is also not supported at the solution level, and should be set per project if needed.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-test.md](https://github.com/dotnet/docs/blob/60e0aa5083fc97073f9ea8a019d12b421f8498ea/docs/core/tools/dotnet-test.md) | [dotnet test](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-test?branch=pr-en-us-48181) |


<!-- PREVIEW-TABLE-END -->