### PR TITLE
Link the app config file explanation and schema in CS1702 page

### DIFF
--- a/docs/csharp/misc/cs1702.md
+++ b/docs/csharp/misc/cs1702.md
@@ -12,4 +12,8 @@ ms.assetid: 106b9994-c762-44b9-942e-5417cf3dbbab
 
 Assuming assembly reference "Assembly Name #1" matches "Assembly Name #2", you may need to supply runtime policy
 
- The two assembly references have differing build and/or revision numbers, so will not automatically unify. You may need to supply run-time policy to force unification by `using` directives in the application .config file.
+ The two assembly references have differing build and/or revision numbers, so will not automatically unify. You may need to supply run-time policy to force unification by `using` directives in the application [.config file](../../framework/configure-apps/index.md#application-configuration-files).
+
+## See also
+
+- [Configuration File Schema](../../framework/configure-apps/file-schema/application-settings-schema.md)


### PR DESCRIPTION
This pull request closes #48183 
It makes the ".config file" part a link to the app config file explanation, and adds the link to config schema to "See also" section.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/misc/cs1702.md](https://github.com/dotnet/docs/blob/ad5f32fb8029cba62c133e479310d840f2153e04/docs/csharp/misc/cs1702.md) | [Compiler Warning (level 3) CS1702](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/cs1702?branch=pr-en-us-48194) |

<!-- PREVIEW-TABLE-END -->