### PR TITLE
Fix spelling in `custombuildeventargs.md`

### DIFF
--- a/docs/core/compatibility/sdk/8.0/custombuildeventargs.md
+++ b/docs/core/compatibility/sdk/8.0/custombuildeventargs.md
@@ -29,7 +29,7 @@ This change is a [behavioral change](../../categories.md#behavioral-change).
 
 ## Reason for change
 
-<xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter> serialization is obsolete in .NET 8 and later versions. Any use of <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter> is deamed unsecure and throws an exception at run time. Since MSBuild custom derived build events use <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter>, your build would crash if you use these events in your build. The new build error provides a more graceful failure.
+<xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter> serialization is obsolete in .NET 8 and later versions. Any use of <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter> is deemed insecure and throws an exception at run time. Since MSBuild custom derived build events use <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter>, your build would crash if you used these events in your build. The new build error provides a more graceful failure.
 
 ## Recommended action
 


### PR DESCRIPTION
## Summary

This PR fixes spelling mistakes.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/sdk/8.0/custombuildeventargs.md](https://github.com/dotnet/docs/blob/a06e551e32197d704269877c9d3f89be35ebd721/docs/core/compatibility/sdk/8.0/custombuildeventargs.md) | [MSBuild custom derived build events deprecated](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/custombuildeventargs?branch=pr-en-us-48208) |

<!-- PREVIEW-TABLE-END -->