### PR TITLE
NO.1 | Update a code snippet in httpclient.md

### DIFF
--- a/docs/fundamentals/networking/snippets/httpclient/Program.CancellationInnerTimeout.cs
+++ b/docs/fundamentals/networking/snippets/httpclient/Program.CancellationInnerTimeout.cs
@@ -3,16 +3,18 @@
     static async Task WithCancellationAndInnerTimeoutAsync(HttpClient httpClient)
     {
         // <innertimeout>
+        using var cts = new CancellationTokenSource();
         try
         {
             // Assuming:
             //   httpClient.Timeout = TimeSpan.FromSeconds(10)
 
             using var response = await httpClient.GetAsync(
-                "http://localhost:5001/sleepFor?seconds=100");
+                "http://localhost:5001/sleepFor?seconds=100", cts.Token);
         }
         catch (OperationCanceledException ex) when (ex.InnerException is TimeoutException tex)
         {
+            // when the time-out occurred. Here the cancellation token has not been canceled.
             Console.WriteLine($"Timed out: {ex.Message}, {tex.Message}");
         }
         // </innertimeout>


### PR DESCRIPTION
Hi, regarding to this sentence of the article :
***In the code, when the inner exception is an `TimeoutException` type, then the time-out occurred and the cancellation token doesn't cancel the request.***
* Declares a variable named `cts` which is of `CancellationTokenSource` type and adds it as argument to the `httpClient.GetAsync` method.
* To clarify more, adds a single-line comment about the exception.


Please check them out. Thanks!