### PR TITLE
NO.2 | Update a code snippet in httpclient.md

### DIFF
--- a/docs/fundamentals/networking/snippets/httpclient/Program.CancellationStream.cs
+++ b/docs/fundamentals/networking/snippets/httpclient/Program.CancellationStream.cs
@@ -5,8 +5,8 @@
         // <helpers>
         try
         {
-            // These extension methods will throw HttpRequestException
-            // with StatusCode set when the HTTP request status code isn't 2xx:
+            // These methods will throw HttpRequestException
+            // with StatusCode set when the HTTP response status code isn't 2xx:
             //
             //   GetByteArrayAsync
             //   GetStreamAsync


### PR DESCRIPTION
Hi again 🙂.

* The `GetByteArrayAsync`, `GetStringAsync`, and `GetStreamAsync` methods are NOT extension methods. They're defiend directly in the `HttpClient` type. SEE: https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclient?view=net-9.0
* Changes *request* to *response*.
       
Please check them out. Thanks!
       