### PR TITLE
Update pruning breaking change for RC 1

### DIFF
--- a/docs/core/compatibility/10.0.md
+++ b/docs/core/compatibility/10.0.md
@@ -115,7 +115,7 @@ If you're migrating an app to .NET 10, the breaking changes listed here might af
 | [NU1510 is raised for direct references pruned by NuGet](sdk/10.0/nu1510-pruned-references.md) | Source incompatible | Preview 1 |
 | [NuGet packages with no runtime assets aren't included in deps.json](sdk/10.0/deps-json-trimmed-packages.md) | Source incompatible | Preview 5 |
 | [PackageReference without a version raises an error](sdk/10.0/nu1015-packagereference-version.md) | Behavioral change | Preview 6 |
-| [PrunePackageReference marks direct prunable references with PrivateAssets=all and IncludeAssets=none](sdk/10.0/prune-packagereference-privateassets.md) | Behavioral change | Preview 7 |
+| [PrunePackageReference privatizes direct prunable references](sdk/10.0/prune-packagereference-privateassets.md) | Behavioral change | Preview 7 |
 | [HTTP warnings promoted to errors in `dotnet package list` and `dotnet package search`](sdk/10.0/http-warnings-to-errors.md) | Behavioral/source incompatible change | Preview 4 |
 | [NUGET_ENABLE_ENHANCED_HTTP_RETRY environment variable removed](sdk/10.0/nuget-enhanced-http-retry-removed.md) | Behavioral change | Preview 6 |
 

--- a/docs/core/compatibility/sdk/10.0/nu1510-pruned-references.md
+++ b/docs/core/compatibility/sdk/10.0/nu1510-pruned-references.md
@@ -1,18 +1,18 @@
 ---
 title: "Breaking change - NU1510 is raised for direct references pruned by NuGet"
 description: "Learn about the breaking change in the .NET 10 SDK where NU1510 is raised for unnecessary direct package references."
-ms.date: 08/11/2025
+ms.date: 09/04/2025
 ai-usage: ai-assisted
 ms.custom: https://github.com/dotnet/docs/issues/45462
 ---
 
 # NU1510 is raised for direct references pruned by NuGet
 
-Starting in .NET 10, NuGet raises a [`NU1510` warning](/nuget/reference/errors-and-warnings/nu1510) when a project includes a direct package reference that overlaps with a framework-provided library and isn't required.
+Starting in the .NET 10 SDK, pruning is enabled by default for projects that target or multi-target .NET 10. When pruning is enabled, NuGet raises a [`NU1510` warning](/nuget/reference/errors-and-warnings/nu1510) when a project includes a direct package reference that overlaps with a framework-provided library and isn't required.
 
 ## Version introduced
 
-.NET 10 Preview 1
+.NET 10
 
 ## Previous behavior
 
@@ -20,10 +20,10 @@ Previously, the .NET SDK ignored the contents of a package if it overlapped with
 
 ## New behavior
 
-Starting in .NET 10, NuGet handles any unnecessary package references by raising a `NU1510` warning to notify you of the issue.
+Starting with the .NET 10 SDK, if pruning is enabled, NuGet notifies you of any unnecessary package references by raising a `NU1510` warning.
 
 > [!NOTE]
-> In a later .NET 10 preview, this behavior changed again such that direct prunable package references are automatically excluded from the `.nuspec` file. For more information, see [PrunePackageReference marks direct prunable references with PrivateAssets=all and IncludeAssets=none](prune-packagereference-privateassets.md).
+> In a later .NET 10 preview, a related change was made such that direct prunable package references are automatically excluded from the `.nuspec` file instead of raising `NU1510`. For more information, see [PrunePackageReference marks direct prunable references with PrivateAssets=all and IncludeAssets=none](prune-packagereference-privateassets.md).
 
 ## Type of breaking change
 

--- a/docs/core/compatibility/sdk/10.0/nu1510-pruned-references.md
+++ b/docs/core/compatibility/sdk/10.0/nu1510-pruned-references.md
@@ -8,7 +8,10 @@ ms.custom: https://github.com/dotnet/docs/issues/45462
 
 # NU1510 is raised for direct references pruned by NuGet
 
-Starting in the .NET 10 SDK, pruning is enabled by default for projects that target or multi-target .NET 10. When pruning is enabled, NuGet raises a [`NU1510` warning](/nuget/reference/errors-and-warnings/nu1510) when a project includes a direct package reference that overlaps with a framework-provided library and isn't required.
+Starting in the .NET 10 SDK, when pruning is enabled, NuGet raises a [`NU1510` warning](/nuget/reference/errors-and-warnings/nu1510) for projects that:
+
+- Target or multi-target .NET 10 or a later version.
+- Include a direct package reference that overlaps with a framework-provided library (that is, the reference isn't necessary).
 
 ## Version introduced
 
@@ -20,10 +23,10 @@ Previously, the .NET SDK ignored the contents of a package if it overlapped with
 
 ## New behavior
 
-Starting with the .NET 10 SDK, if pruning is enabled, NuGet notifies you of any unnecessary package references by raising a `NU1510` warning.
+Starting with the .NET 10 SDK, if pruning is enabled and the project targets .NET 10 or a later version, NuGet notifies you of any unnecessary package references by raising a `NU1510` warning.
 
 > [!NOTE]
-> In a later .NET 10 preview, a related change was made such that direct prunable package references are automatically excluded from the `.nuspec` file instead of raising `NU1510`. For more information, see [PrunePackageReference marks direct prunable references with PrivateAssets=all and IncludeAssets=none](prune-packagereference-privateassets.md).
+> In a later .NET 10 preview, a related change was made such that [direct prunable package references](prune-packagereference-privateassets.md) are automatically excluded from the `.nuspec` file. However, you'll still get the `NU1510` warning to clean up your project.
 
 ## Type of breaking change
 
@@ -56,4 +59,4 @@ None.
 
 ## See also
 
-- [PrunePackageReference marks direct prunable references with PrivateAssets=all and IncludeAssets=none](prune-packagereference-privateassets.md)
+- [PrunePackageReference privatizes direct prunable references](prune-packagereference-privateassets.md)

--- a/docs/core/compatibility/sdk/10.0/prune-packagereference-privateassets.md
+++ b/docs/core/compatibility/sdk/10.0/prune-packagereference-privateassets.md
@@ -44,7 +44,7 @@ Such a project file generated a *.nuspec* file with dependencies for both target
 
 ## New behavior
 
-Starting in .NET 10 Preview 7, when pruning is enabled, directly prunable `PackageReference` items are automatically marked with `PrivateAssets=all` and `IncludeAssets=none`, which excludes them from the generated dependencies for target frameworks where they're provided by the platform. (However, you'll still get the `NU1510` warning until you remove the reference from your project.)
+Starting in .NET 10 Preview 7, when pruning is enabled, directly prunable `PackageReference` items are automatically marked with `PrivateAssets=all` and `IncludeAssets=none`, which excludes them from the generated dependencies for target frameworks where they're provided by the platform. (However, if your project targets .NET 10 or later, you'll still get the `NU1510` warning until you remove the reference from your project.)
 
 The same project configuration now generates a *.nuspec* file with the prunable dependency removed from the target framework that provides it (.NET 10):
 

--- a/docs/core/compatibility/sdk/10.0/prune-packagereference-privateassets.md
+++ b/docs/core/compatibility/sdk/10.0/prune-packagereference-privateassets.md
@@ -1,13 +1,13 @@
 ---
-title: "Breaking change - PrunePackageReference marks direct prunable references with PrivateAssets=all and IncludeAssets=none"
+title: "Breaking change - PrunePackageReference privatizes direct prunable references"
 description: "Learn about the breaking change in the .NET 10 SDK where PrunePackageReference automatically marks directly prunable PackageReference with PrivateAssets=all and IncludeAssets=none."
 ms.date: 09/04/2025
 ai-usage: ai-assisted
 ---
 
-# PrunePackageReference marks direct prunable references with PrivateAssets=all and IncludeAssets=none
+# PrunePackageReference privatizes direct prunable references"
 
-The [PrunePackageReference](/nuget/consume-packages/package-references-in-project-files#prunepackagereference) feature automatically removes *transitive* packages that are provided by the target platform. With this change, the feature also marks *directly* prunable `PackageReference` items with `PrivateAssets=all` and `IncludeAssets=none` attributes. These attributes prevent the packages from appearing in generated dependency lists for packages.
+The [PrunePackageReference](/nuget/consume-packages/package-references-in-project-files#prunepackagereference) feature automatically removes *transitive* packages that are provided by the target platform. This pruning feature is enabled by default for projects that target or multi-target .NET 10. Now, the feature also marks *directly* prunable `PackageReference` items with `PrivateAssets=all` and `IncludeAssets=none` attributes. These attributes prevent the packages from appearing in generated dependency lists for packages.
 
 ## Version introduced
 
@@ -15,7 +15,7 @@ The [PrunePackageReference](/nuget/consume-packages/package-references-in-projec
 
 ## Previous behavior
 
-In earlier .NET 10 previews, directly prunable `PackageReference` items might have generated an [`NU1510` warning](/nuget/reference/errors-and-warnings/nu1510) but still appeared in the generated *.nuspec* dependencies for all target frameworks, even those where the package is provided by the platform.
+Prior to .NET 10, all `PackageReference` items appeared in the generated *.nuspec* dependencies for all target frameworks, even those where the package is provided by the platform. Starting in .NET 10 Preview 1, if pruning was enabled, directly prunable `PackageReference` items might have generated an [`NU1510` warning](/nuget/reference/errors-and-warnings/nu1510) but still appeared in the dependencies list.
 
 For example, consider a multi-targeting project with the following configuration:
 
@@ -44,7 +44,7 @@ Such a project file generated a *.nuspec* file with dependencies for both target
 
 ## New behavior
 
-Starting in .NET 10 Preview 7, directly prunable `PackageReference` items are automatically marked with `PrivateAssets=all` and `IncludeAssets=none`, which excludes them from the generated dependencies for target frameworks where they're provided by the platform.
+Starting in .NET 10 Preview 7, if pruning is enabled, directly prunable `PackageReference` items are automatically marked with `PrivateAssets=all` and `IncludeAssets=none`, which excludes them from the generated dependencies for target frameworks where they're provided by the platform.
 
 The same project configuration now generates a *.nuspec* file with the prunable dependency removed from the target framework that provides it (.NET 9):
 
@@ -57,9 +57,6 @@ The same project configuration now generates a *.nuspec* file with the prunable 
   </group>
 </dependencies>
 ```
-
-> [!NOTE]
-> Another change was made in .NET 10 RC1 that narrows the scope of this breaking change somewhat. Now, prunable dependencies are removed only for projects with a `net10.0` target framework moniker (TFM).
 
 ## Type of breaking change
 

--- a/docs/core/compatibility/sdk/10.0/prune-packagereference-privateassets.md
+++ b/docs/core/compatibility/sdk/10.0/prune-packagereference-privateassets.md
@@ -5,9 +5,9 @@ ms.date: 09/04/2025
 ai-usage: ai-assisted
 ---
 
-# PrunePackageReference privatizes direct prunable references"
+# PrunePackageReference privatizes direct prunable references
 
-The [PrunePackageReference](/nuget/consume-packages/package-references-in-project-files#prunepackagereference) feature automatically removes *transitive* packages that are provided by the target platform. This pruning feature is enabled by default for projects that target or multi-target .NET 10. Now, the feature also marks *directly* prunable `PackageReference` items with `PrivateAssets=all` and `IncludeAssets=none` attributes. These attributes prevent the packages from appearing in generated dependency lists for packages.
+The [PrunePackageReference](/nuget/consume-packages/package-references-in-project-files#prunepackagereference) feature automatically removes *transitive* packages that are provided by the target platform. With this change, the feature also marks *directly* prunable `PackageReference` items with `PrivateAssets=all` and `IncludeAssets=none` attributes. These attributes prevent the packages from appearing in generated dependency lists for packages.
 
 ## Version introduced
 
@@ -15,17 +15,17 @@ The [PrunePackageReference](/nuget/consume-packages/package-references-in-projec
 
 ## Previous behavior
 
-Prior to .NET 10, all `PackageReference` items appeared in the generated *.nuspec* dependencies for all target frameworks, even those where the package is provided by the platform. Starting in .NET 10 Preview 1, if pruning was enabled, directly prunable `PackageReference` items might have generated an [`NU1510` warning](/nuget/reference/errors-and-warnings/nu1510) but still appeared in the dependencies list.
+Starting in .NET 10 Preview 1, if pruning was enabled, directly prunable `PackageReference` items might have generated an [`NU1510` warning](/nuget/reference/errors-and-warnings/nu1510) but still appeared in the generated *.nuspec* dependencies list, even if the package was provided by the platform.
 
 For example, consider a multi-targeting project with the following configuration:
 
 ```xml
 <PropertyGroup>
-  <TargetFramework>net9.0;net472</TargetFramework>
+  <TargetFramework>net10.0;net472</TargetFramework>
 </PropertyGroup>
 
 <ItemGroup>
-  <PackageReference Include="System.Text.Json" Version="9.0.4" />
+  <PackageReference Include="System.Text.Json" Version="9.0.8" />
 </ItemGroup>
 ```
 
@@ -34,26 +34,26 @@ Such a project file generated a *.nuspec* file with dependencies for both target
 ```xml
 <dependencies>
   <group targetFramework=".NETFramework4.7.2">
-    <dependency id="System.Text.Json" version="9.0.4" />
+    <dependency id="System.Text.Json" version="9.0.8" />
   </group>
-  <group targetFramework="net9.0">
-    <dependency id="System.Text.Json" version="9.0.4" />
+  <group targetFramework="net10.0">
+    <dependency id="System.Text.Json" version="9.0.8" />
   </group>
 </dependencies>
 ```
 
 ## New behavior
 
-Starting in .NET 10 Preview 7, if pruning is enabled, directly prunable `PackageReference` items are automatically marked with `PrivateAssets=all` and `IncludeAssets=none`, which excludes them from the generated dependencies for target frameworks where they're provided by the platform.
+Starting in .NET 10 Preview 7, when pruning is enabled, directly prunable `PackageReference` items are automatically marked with `PrivateAssets=all` and `IncludeAssets=none`, which excludes them from the generated dependencies for target frameworks where they're provided by the platform. (However, you'll still get the `NU1510` warning until you remove the reference from your project.)
 
-The same project configuration now generates a *.nuspec* file with the prunable dependency removed from the target framework that provides it (.NET 9):
+The same project configuration now generates a *.nuspec* file with the prunable dependency removed from the target framework that provides it (.NET 10):
 
 ```xml
 <dependencies>
   <group targetFramework=".NETFramework4.7.2">
-    <dependency id="System.Text.Json" version="9.0.4" />
+    <dependency id="System.Text.Json" version="9.0.8" />
   </group>
-  <group targetFramework="net9.0">
+  <group targetFramework="net10.0">
   </group>
 </dependencies>
 ```

--- a/docs/core/compatibility/sdk/10.0/prune-packagereference-privateassets.md
+++ b/docs/core/compatibility/sdk/10.0/prune-packagereference-privateassets.md
@@ -1,7 +1,7 @@
 ---
 title: "Breaking change - PrunePackageReference marks direct prunable references with PrivateAssets=all and IncludeAssets=none"
 description: "Learn about the breaking change in the .NET 10 SDK where PrunePackageReference automatically marks directly prunable PackageReference with PrivateAssets=all and IncludeAssets=none."
-ms.date: 01/03/2025
+ms.date: 09/04/2025
 ai-usage: ai-assisted
 ---
 
@@ -57,6 +57,9 @@ The same project configuration now generates a *.nuspec* file with the prunable 
   </group>
 </dependencies>
 ```
+
+> [!NOTE]
+> Another change was made in .NET 10 RC1 that narrows the scope of this breaking change somewhat. Now, prunable dependencies are removed only for projects with a `net10.0` target framework moniker (TFM).
 
 ## Type of breaking change
 

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -132,7 +132,7 @@ items:
                 href: sdk/10.0/deps-json-trimmed-packages.md
               - name: PackageReference without a version raises error
                 href: sdk/10.0/nu1015-packagereference-version.md
-              - name: PrunePackageReference marks direct prunable references with PrivateAssets=all and IncludeAssets=none
+              - name: PrunePackageReference privatizes direct prunable references
                 href: sdk/10.0/prune-packagereference-privateassets.md
               - name: HTTP warnings promoted to errors in package list and search
                 href: sdk/10.0/http-warnings-to-errors.md


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/10.0.md](https://github.com/dotnet/docs/blob/5a9d6f6b6a51b4cd299f9876ecced1f628737fa4/docs/core/compatibility/10.0.md) | [Breaking changes in .NET 10](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/10.0?branch=pr-en-us-48261) |
| [docs/core/compatibility/sdk/10.0/nu1510-pruned-references.md](https://github.com/dotnet/docs/blob/5a9d6f6b6a51b4cd299f9876ecced1f628737fa4/docs/core/compatibility/sdk/10.0/nu1510-pruned-references.md) | [NU1510 is raised for direct references pruned by NuGet](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/10.0/nu1510-pruned-references?branch=pr-en-us-48261) |
| [docs/core/compatibility/sdk/10.0/prune-packagereference-privateassets.md](https://github.com/dotnet/docs/blob/5a9d6f6b6a51b4cd299f9876ecced1f628737fa4/docs/core/compatibility/sdk/10.0/prune-packagereference-privateassets.md) | ["Breaking change - PrunePackageReference privatizes direct prunable references"](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/10.0/prune-packagereference-privateassets?branch=pr-en-us-48261) |
| [docs/core/compatibility/toc.yml](https://github.com/dotnet/docs/blob/5a9d6f6b6a51b4cd299f9876ecced1f628737fa4/docs/core/compatibility/toc.yml) | [docs/core/compatibility/toc](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/toc?branch=pr-en-us-48261) |


<!-- PREVIEW-TABLE-END -->