### PR TITLE
Update example to use const

### DIFF
--- a/docs/csharp/misc/cs0131.md
+++ b/docs/csharp/misc/cs0131.md
@@ -24,7 +24,7 @@ The left-hand side of an assignment must be a variable, property or indexer
 // CS0131.cs  
 public class MyClass  
 {  
-    public const int i = 0;  
+    public int i = 0;  
     public void MyMethod()  
     {  
         i++ = 1;   // CS0131  
@@ -33,14 +33,34 @@ public class MyClass
     }  
     public static void Main() { }  
 }  
-```  
+```
+
+## Example 2
+
+ The following sample generates CS0131 when assigning to a constant field.  
   
-## Example 2  
+```csharp  
+// CS0131b.cs  
+public class B  
+{
+    public static int Main()
+    {
+        const int j = 0;
+        j = 1; // CS0131  
+        // try the following lines instead
+        // int j = 0; 
+        // j = 1;
+        return j;
+    }  
+} 
+```
+
+## Example 3
 
  This error can also occur if you attempt to perform arithmetic operations on the left hand side of an assignment operator, as in the following example.  
   
 ```csharp  
-// CS0131b.cs  
+// CS0131c.cs  
 public class C  
 {  
     public static int Main()  

--- a/docs/csharp/misc/cs0131.md
+++ b/docs/csharp/misc/cs0131.md
@@ -24,7 +24,7 @@ The left-hand side of an assignment must be a variable, property or indexer
 // CS0131.cs  
 public class MyClass  
 {  
-    public int i = 0;  
+    public const int i = 0;  
     public void MyMethod()  
     {  
         i++ = 1;   // CS0131  


### PR DESCRIPTION
## Summary

Adds an example to show that assigning to a `const` value generates a CS0131 error.

Fixes #48254 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/misc/cs0131.md](https://github.com/dotnet/docs/blob/55144aa5456069e85a99e6b0a6f4f9477542624b/docs/csharp/misc/cs0131.md) | [Compiler Error CS0131](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/cs0131?branch=pr-en-us-48262) |


<!-- PREVIEW-TABLE-END -->