### PR TITLE
Clarify thread safety in IoT libraries

### DIFF
--- a/docs/iot/intro.md
+++ b/docs/iot/intro.md
@@ -46,6 +46,9 @@ Some commonly used device bindings include:
 - [Max7219 - LED Matrix driver](https://github.com/dotnet/iot/tree/main/src/devices/Max7219)
 - [RGBLedMatrix - RGB LED Matrix](https://github.com/dotnet/iot/tree/main/src/devices/RGBLedMatrix)
 
+## A word on threads
+By convention objects in these libraries are **not** designed to be **thread safe**. This means that all access to an object should be done from the thread it was created on. Be aware when using the libraries that they may run other threads internally for monitoring hardware and firing events. If you subscribe to an event it will likely be fired from a different thread. 
+
 ## Supported operating systems
 
 `System.Device.Gpio` is supported on any operating system that supports .NET, including most versions of Linux that support ARM/ARM64 and Windows 10 IoT Core.

--- a/docs/iot/intro.md
+++ b/docs/iot/intro.md
@@ -47,7 +47,8 @@ Some commonly used device bindings include:
 - [RGBLedMatrix - RGB LED Matrix](https://github.com/dotnet/iot/tree/main/src/devices/RGBLedMatrix)
 
 ## A word on threads
-By convention objects in these libraries are **not** designed to be **thread safe**. This means that all access to an object should be done from the thread it was created on. Be aware when using the libraries that they may run other threads internally for monitoring hardware and firing events. If you subscribe to an event it will likely be fired from a different thread. 
+
+By default objects in these libraries are **not thread safe**. This means that access to an object must only be from one thread at a time. When using the libraries you must be aware that they will often run other threads internally for monitoring hardware and firing events. If you subscribe to an event, it will be fired from a different thread. It is your responsibility as a user of the library user to control thread access to the object.
 
 ## Supported operating systems
 

--- a/docs/iot/intro.md
+++ b/docs/iot/intro.md
@@ -48,7 +48,7 @@ Some commonly used device bindings include:
 
 ## A word on threads
 
-By default objects in these libraries are **not thread safe**. This means that access to an object must only be from one thread at a time. When using the libraries you must be aware that they will often run other threads internally for monitoring hardware and firing events. If you subscribe to an event, it will be fired from a different thread. It is your responsibility as a user of the library user to control thread access to the object.
+By default, the objects in these libraries **aren't thread safe**. That means that access to an object must only be from one thread at a time. When using the libraries, you must be aware that they often run other threads internally for things like monitoring hardware and firing events. If you subscribe to an event, it's fired from a different thread. It's your responsibility to control thread access to the object.
 
 ## Supported operating systems
 


### PR DESCRIPTION
Added a section on thread safety for library objects.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/iot/intro.md](https://github.com/dotnet/docs/blob/9f77eb4523acfb05e71f7e98703776c68dde684b/docs/iot/intro.md) | [Develop apps for IoT devices with the .NET IoT Libraries](https://review.learn.microsoft.com/en-us/dotnet/iot/intro?branch=pr-en-us-48264) |


<!-- PREVIEW-TABLE-END -->