### PR TITLE
Fix typo in dependency-injection documentation

### DIFF
--- a/docs/core/extensions/dependency-injection.md
+++ b/docs/core/extensions/dependency-injection.md
@@ -81,7 +81,7 @@ The host contains the dependency injection service provider. It also contains al
 
 By using the DI pattern, the worker service:
 
-- Doesn't use the concrete type `MessageWriter`, only the `IMessageWriter` interface that implements it. That makes it easy to change the implementation that the worker service uses without modifying the worker service.
+- Doesn't use the concrete type `MessageWriter`, only the `IMessageWriter` interface that it implements. That makes it easy to change the implementation that the worker service uses without modifying the worker service.
 - Doesn't create an instance of `MessageWriter`. The instance is created by the DI container.
 
 The implementation of the `IMessageWriter` interface can be improved by using the built-in logging API:


### PR DESCRIPTION
## Summary

Clarify that `MessageWriter` implements the interface `IMessageWriter`.

Fixes #48268


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/dependency-injection.md](https://github.com/dotnet/docs/blob/918260e37b3da4f2eede8f9d6cd0c204691c7096/docs/core/extensions/dependency-injection.md) | [.NET dependency injection](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection?branch=pr-en-us-48277) |

<!-- PREVIEW-TABLE-END -->