### PR TITLE
add CS8070 compiler error

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs8070.md
+++ b/docs/csharp/language-reference/compiler-messages/cs8070.md
@@ -1,0 +1,65 @@
+---
+description: "Compiler Error CS8070"
+title: "Compiler Error CS8070"
+ms.date: 9/05/2025
+f1_keywords:
+  - "CS8070"
+helpviewer_keywords:
+  - "CS8070"
+author: "StuartMosquera"
+---
+# Compiler Error CS8070
+
+Control cannot fall out of switch from final case label ('label')
+
+This error occurs when the last `case` or `default` case of a [switch statement](../statements/selection-statements.md#the-switch-statement) does not end with a jump statement such as:
+
+- [break](../statements/jump-statements.md#the-break-statement)
+- [return](../statements/jump-statements.md#the-return-statement)
+- [throw](../statements/exception-handling-statements.md#the-throw-statement)
+
+The following sample generates CS8070.
+
+```csharp
+// CS8070.cs
+public class MyClass
+{
+    public static void Main()
+    {
+        int i = 2;
+        int j = 0;
+
+        switch (i)
+        {
+            case 1:
+                i++;
+                break;
+            
+            // Compiler error CS8070 is reported on the following line.
+            case 2:
+                i += 2;
+            // To resolve the error, uncomment one of the following example statements.  
+            // break;
+            // return;
+            // throw new Exception("Fin");
+        }
+
+        switch (j)
+        {
+            case 1:
+                j++;
+                break;
+            
+            case 2:
+                j += 2;
+                break;
+
+            // Compiler error CS8070 is reported on the following line.
+            default:
+                Console.WriteLine("Default");
+            // To resolve the error, uncomment the following line:
+            // break;
+        }
+    }
+}
+```

--- a/docs/csharp/language-reference/compiler-messages/cs8070.md
+++ b/docs/csharp/language-reference/compiler-messages/cs8070.md
@@ -12,13 +12,13 @@ author: "StuartMosquera"
 
 Control cannot fall out of switch from final case label ('label')
 
-This error occurs when the last `case` or `default` case of a [switch statement](../statements/selection-statements.md#the-switch-statement) does not end with a jump statement such as:
+This error occurs when the last `case` or `default` case of a [switch statement](../statements/selection-statements.md#the-switch-statement) doesn't end with a jump statement such as:
 
 - [break](../statements/jump-statements.md#the-break-statement)
 - [return](../statements/jump-statements.md#the-return-statement)
 - [throw](../statements/exception-handling-statements.md#the-throw-statement)
 
-The following sample generates CS8070.
+The following sample generates CS8070:
 
 ```csharp
 // CS8070.cs

--- a/docs/csharp/language-reference/toc.yml
+++ b/docs/csharp/language-reference/toc.yml
@@ -192,7 +192,7 @@ items:
     - name: when (filter condition)
       href: ./keywords/when.md
     - name: field
-      href: ./keywords/field.md  
+      href: ./keywords/field.md
     - name: value (implicit parameter)
       href: ./keywords/value.md
   - name: Query Keywords
@@ -382,8 +382,8 @@ items:
 - name: Attributes read by the compiler
   items:
   - name: Global attributes
-    displayName: > 
-      AssemblyName, AssemblyVersion, AssemblyCulture, AssemblyFlags, AssemblyProduct, AssemblyTrademark, AssemblyInformationalVersion, 
+    displayName: >
+      AssemblyName, AssemblyVersion, AssemblyCulture, AssemblyFlags, AssemblyProduct, AssemblyTrademark, AssemblyInformationalVersion,
       AssemblyCompany, AssemblyCopyright, AssemblyFileVersion, CLSCompliant, AssemblyTitle, AssemblyDescription, AssemblyConfiguration,
       AssemblyDefaultAlias
     href: ./attributes/global.md
@@ -396,7 +396,7 @@ items:
       DoesNotReturn, DoesNotReturnIf
     href: ./attributes/nullable-analysis.md
   - name: Miscellaneous
-    displayName: > 
+    displayName: >
       Conditional, Obsolete, Deprecated, Experimental, SetsRequiredMembers, AttributeUsage, AsyncMethodBuilder, InterpolatedStringHandler,
       ModuleInitializer, SkipLocalsInit, UnscopedRef, OverloadResolutionPriority. EnumeratorCancellation, CollectionBuilder,
       IUnknownConstant, IDispatchConstant, module initializer
@@ -407,7 +407,7 @@ items:
       OptionalAttribute, OutAttribute, PreserveSigAttribute, SerializableAttribute, StructLayoutAttribute, IndexerNameAttribute,
       DefaultParameterValueAttribute, InAttribute, SpecialNameAttribute, UnmanagedCallersOnlyAttribute, CompilerFeatureRequiredAttribute,
       DecimalConstantAttribute, DefaultMemberAttribute, DynamicAttribute, ExtensionAttribute, FixedBufferAttribute, IsByRefLikeAttribute,
-      IsReadOnlyAttribute, RequiresLocationAttribute, IsUnmanagedAttribute, NullableAttribute, NullableContextAttribute, 
+      IsReadOnlyAttribute, RequiresLocationAttribute, IsUnmanagedAttribute, NullableAttribute, NullableContextAttribute,
       NullablePublicOnlyAttribute, ParamArrayAttribute, ParamCollectionAttribute, RefSafetyRulesAttribute, RequiredMemberAttribute,
       TupleElementNamesAttribute
     href: ./attributes/pseudo-attributes.md
@@ -1878,6 +1878,8 @@ items:
       href: ../misc/cs5001.md
     - name: CS7003
       href: ./compiler-messages/cs7003.md
+    - name: CS8070
+      href: ./compiler-messages/cs8070.md
     - name: CS8124
       href: ./compiler-messages/cs8124.md
     - name: CS8125


### PR DESCRIPTION
## Summary

- This PR adds the missing documentation for the `CS8070` compiler error.

Fixes #26798


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-messages/cs8070.md](https://github.com/dotnet/docs/blob/abc59305ca10e23c99b3d61cf3ea1a72503f09ea/docs/csharp/language-reference/compiler-messages/cs8070.md) | [docs/csharp/language-reference/compiler-messages/cs8070](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs8070?branch=pr-en-us-48282) |
| [docs/csharp/language-reference/toc.yml](https://github.com/dotnet/docs/blob/abc59305ca10e23c99b3d61cf3ea1a72503f09ea/docs/csharp/language-reference/toc.yml) | [docs/csharp/language-reference/toc](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/toc?branch=pr-en-us-48282) |


<!-- PREVIEW-TABLE-END -->