### PR TITLE
Close the bracket for the IDE0304 rule

### DIFF
--- a/docs/fundamentals/code-analysis/style-rules/language-rules.md
+++ b/docs/fundamentals/code-analysis/style-rules/language-rules.md
@@ -167,7 +167,7 @@ C# style rules:
 - [Use collection expression for empty (IDE0301)](ide0301.md)
 - [Use collection expression for stack alloc (IDE0302)](ide0302.md)
 - [Use collection expression for `Create()` (IDE0303)](ide0303.md)
-- [Use collection expression for builder (IDE0304](ide0304.md)
+- [Use collection expression for builder (IDE0304)](ide0304.md)
 - [Use collection expression for fluent (IDE0305)](ide0305.md)
 - [Use collection expression for new (IDE0306)](ide0306.md)
 - [Use unbound generic type (IDE0340)](ide0340.md)


### PR DESCRIPTION
## Summary

Edit `Use collection expression for builder (IDE0304` -> `Use collection expression for builder (IDE0304)`


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/style-rules/language-rules.md](https://github.com/dotnet/docs/blob/e1d5e827e8820042a85f1f5abe1e0c3979b79050/docs/fundamentals/code-analysis/style-rules/language-rules.md) | [Language and unnecessary rules](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/language-rules?branch=pr-en-us-48289) |

<!-- PREVIEW-TABLE-END -->