### PR TITLE
Replace dotnet.config with global.json in dotnet test

### DIFF
--- a/docs/core/testing/unit-testing-with-dotnet-test.md
+++ b/docs/core/testing/unit-testing-with-dotnet-test.md
@@ -91,11 +91,14 @@ Due to these issues, .NET has introduced a new `dotnet test` mode specifically d
 
 To address the issues encountered when running `dotnet test` with MTP in VSTest mode, .NET introduced a new mode in the .NET 10 SDK that's specifically designed for MTP.
 
-To enable this mode, add a `dotnet.config` file to the root of the repository or solution.
+To enable this mode, add the following configuration to your `global.json` file:
 
-```ini
-[dotnet.test.runner]
-name = "Microsoft.Testing.Platform"
+```json
+{
+    "test": {
+        "runner": "Microsoft.Testing.Platform"
+    }
+}
 ```
 
 > [!IMPORTANT]
@@ -123,7 +126,7 @@ Since this mode is specifically designed for Microsoft.Testing.Platform, neither
 
 For users of MTP that are using the VSTest mode of `dotnet test`, there are few actions needed to migrate to the newer `dotnet test` experience:
 
-1. Add `dotnet.config` in the root of your repository, as shown above.
+1. Add some configuration to your `global.json` file, as shown above.
 1. Remove `TestingPlatformDotnetTestSupport` MSBuild property, as it's no longer required.
 1. Remove `TestingPlatformCaptureOutput` and `TestingPlatformShowTestsFailure` MSBuild properties, as they are no longer used by the new `dotnet test`.
 1. Remove the extra `--`, for example `dotnet test -- --report-trx` should become `dotnet test --report-trx`.

--- a/docs/core/testing/unit-testing-with-dotnet-test.md
+++ b/docs/core/testing/unit-testing-with-dotnet-test.md
@@ -126,7 +126,7 @@ Since this mode is specifically designed for Microsoft.Testing.Platform, neither
 
 For users of MTP that are using the VSTest mode of `dotnet test`, there are few actions needed to migrate to the newer `dotnet test` experience:
 
-1. Add some configuration to your `global.json` file, as shown above.
+1. Add `test` section to your `global.json` file, as shown above.
 1. Remove `TestingPlatformDotnetTestSupport` MSBuild property, as it's no longer required.
 1. Remove `TestingPlatformCaptureOutput` and `TestingPlatformShowTestsFailure` MSBuild properties, as they are no longer used by the new `dotnet test`.
 1. Remove the extra `--`, for example `dotnet test -- --report-trx` should become `dotnet test --report-trx`.

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -13,7 +13,7 @@ ms.date: 03/27/2024
 
 The `dotnet test` command builds the solution and runs the tests with either VSTest or Microsoft Testing Platform (MTP). To enable MTP, you need to specify the test runner in the `global.json` file.
 
-Some examples of how to specify the test runner in the `global.json` file:
+Some examples of how to specify the test runner in the [`global.json`](global-json.md) file:
 
   ```json
   {

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -11,18 +11,24 @@ ms.date: 03/27/2024
 
 ## Description
 
-The `dotnet test` command builds the solution and runs the tests with either VSTest or Microsoft Testing Platform (MTP). To enable MTP, you need to add a config file named `dotnet.config` with an INI-like format located at the root of the solution or repository.
+The `dotnet test` command builds the solution and runs the tests with either VSTest or Microsoft Testing Platform (MTP). To enable MTP, you need to specify the test runner in the `global.json` file.
 
-Some examples of the `dotnet.config` file:
+Some examples of how to specify the test runner in the `global.json` file:
 
-  ```ini
-  [dotnet.test.runner]
-  name = "Microsoft.Testing.Platform"
+  ```json
+  {
+      "test": {
+          "runner": "Microsoft.Testing.Platform"
+      }
+  }
   ```
 
-  ```ini
-  [dotnet.test.runner]
-  name = "VSTest"
+  ```json
+  {
+      "test": {
+          "runner": "VSTest"
+      }
+  }
   ```
 
 > [!IMPORTANT]
@@ -448,7 +454,7 @@ dotnet test -h|--help
 With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest. The test-related arguments are no longer fixed, as they are tied to the registered extensions in the test project(s). Moreover, MTP supports a globbing filter when running tests. For more information, see [Microsoft.Testing.Platform](../testing/microsoft-testing-platform-intro.md).
 
 > [!WARNING]
-> When Microsoft.Testing.Platform is opted in via `dotnet.config`, `dotnet test` expects all test projects to use Microsoft.Testing.Platform. It is an error if any of the test projects use VSTest.
+> When Microsoft.Testing.Platform is opted in via `global.json`, `dotnet test` expects all test projects to use Microsoft.Testing.Platform. It is an error if any of the test projects use VSTest.
 
 #### Implicit restore
 

--- a/docs/core/tools/global-json.md
+++ b/docs/core/tools/global-json.md
@@ -112,7 +112,7 @@ Type: `object`
 
 Lets you control the project SDK version in one place rather than in each individual project. For more information, see [How project SDKs are resolved](/visualstudio/msbuild/how-to-use-project-sdk#how-project-sdks-are-resolved).
 
-### test
+### `test`
 
 - Type: `object`
 

--- a/docs/core/tools/global-json.md
+++ b/docs/core/tools/global-json.md
@@ -118,7 +118,7 @@ Lets you control the project SDK version in one place rather than in each indivi
 
 Specifies information about tests.
 
-### runner
+### `runner`
 
 - Type: `string`
 - Available since: .NET 10.0 SDK.

--- a/docs/core/tools/global-json.md
+++ b/docs/core/tools/global-json.md
@@ -112,6 +112,19 @@ Type: `object`
 
 Lets you control the project SDK version in one place rather than in each individual project. For more information, see [How project SDKs are resolved](/visualstudio/msbuild/how-to-use-project-sdk#how-project-sdks-are-resolved).
 
+### test
+
+- Type: `object`
+
+Specifies information about tests.
+
+### runner
+
+- Type: `string`
+- Available since: .NET 10.0 SDK.
+
+The test runner to discover/run tests with.
+
 ### Comments in global.json
 
 Comments in *global.json* files are supported using JavaScript or C# style comments. For example:
@@ -192,6 +205,16 @@ The following example shows how to specify additional SDK search paths and a cus
     "paths": [ ".dotnet", "$host$" ],
     "errorMessage": "The required .NET SDK wasn't found. Please run ./install.sh to install it."
   }
+}
+```
+
+The following example shows how to specify `Microsoft.Testing.Platform` as the test runner:
+
+```json
+{
+    "test": {
+        "runner": "Microsoft.Testing.Platform"
+    }
 }
 ```
 

--- a/docs/core/whats-new/dotnet-10/sdk.md
+++ b/docs/core/whats-new/dotnet-10/sdk.md
@@ -215,11 +215,14 @@ A new `<ContainerImageFormat>` property allows you to explicitly set the format 
 
 ## Support for Microsoft Testing Platform in `dotnet test`
 
-Starting in .NET 10, `dotnet test` natively supports [Microsoft.Testing.Platform](../../testing/microsoft-testing-platform-intro.md). To enable this feature, add the following configuration to your *dotnet.config* file:
+Starting in .NET 10, `dotnet test` natively supports [Microsoft.Testing.Platform](../../testing/microsoft-testing-platform-intro.md). To enable this feature, add the following configuration to your *global.json* file:
 
-```ini
-[dotnet.test.runner]
-name = "Microsoft.Testing.Platform"
+```json
+{
+    "test": {
+        "runner": "Microsoft.Testing.Platform"
+    }
+}
 ```
 
 For more details, see [Testing with `dotnet test`](../../testing/unit-testing-with-dotnet-test.md).


### PR DESCRIPTION
This pull request updates the documentation for the `dotnet test` command to clarify how to enable the Microsoft Testing Platform (MTP) test runner. The instructions now reference `global.json` instead of the deprecated `dotnet.config`, and the example configurations have been updated accordingly.

Documentation updates for test runner configuration:

* Updated the description to specify that enabling MTP is now done by setting the test runner in the `global.json` file, rather than using a `dotnet.config` file.
* Replaced all example configurations from INI-style `dotnet.config` to JSON-style `global.json` format.
* Updated warning messages to reference opting in via `global.json` instead of `dotnet.config`.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-with-dotnet-test.md](https://github.com/dotnet/docs/blob/7ab586610130138da59331404fe0ee5cae4f5c8d/docs/core/testing/unit-testing-with-dotnet-test.md) | [Testing with 'dotnet test'](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-with-dotnet-test?branch=pr-en-us-48295) |
| [docs/core/tools/dotnet-test.md](https://github.com/dotnet/docs/blob/7ab586610130138da59331404fe0ee5cae4f5c8d/docs/core/tools/dotnet-test.md) | [dotnet test command](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-test?branch=pr-en-us-48295) |
| [docs/core/tools/global-json.md](https://github.com/dotnet/docs/blob/7ab586610130138da59331404fe0ee5cae4f5c8d/docs/core/tools/global-json.md) | [global.json overview](https://review.learn.microsoft.com/en-us/dotnet/core/tools/global-json?branch=pr-en-us-48295) |
| [docs/core/whats-new/dotnet-10/sdk.md](https://github.com/dotnet/docs/blob/7ab586610130138da59331404fe0ee5cae4f5c8d/docs/core/whats-new/dotnet-10/sdk.md) | [1. Create a single-file C# app with a shebang](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-10/sdk?branch=pr-en-us-48295) |


<!-- PREVIEW-TABLE-END -->