### PR TITLE
Show the `Task.WhenEach` usage example in "Process asynchronous tasks as they complete" tutorial

### DIFF
--- a/docs/csharp/asynchronous-programming/start-multiple-async-tasks-and-process-them-as-they-complete.md
+++ b/docs/csharp/asynchronous-programming/start-multiple-async-tasks-and-process-them-as-they-complete.md
@@ -203,4 +203,5 @@ The following code is the complete text of the *Program.cs* file for the example
 ## See also
 
 - <xref:System.Threading.Tasks.Task.WhenAny%2A>
+- <xref:System.Threading.Tasks.Task.WhenEach%2A>
 - [Asynchronous programming with async and await (C#)](index.md)

--- a/docs/csharp/asynchronous-programming/start-multiple-async-tasks-and-process-them-as-they-complete.md
+++ b/docs/csharp/asynchronous-programming/start-multiple-async-tasks-and-process-them-as-they-complete.md
@@ -166,6 +166,9 @@ For any given URL, the method will use the `client` instance provided to get the
 
 Run the program several times to verify that the downloaded lengths don't always appear in the same order.
 
+> [!CAUTION]
+> You can use `WhenAny` in a loop, as described in the example, to solve problems that involve a small number of tasks. However, other approaches are more efficient if you have a large number of tasks to process. For more information and examples, see [Processing tasks as they complete](https://devblogs.microsoft.com/pfxteam/processing-tasks-as-they-complete).
+
 ## Simplify the approach using `Task.WhenEach`
 
 The `while` loop implemented in `SumPageSizesAsync` method can be simplified using the new <xref:System.Threading.Tasks.Task.WhenEach%2A?displayProperty=nameWithType> method introduced in .NET 9, by calling it in `await foreach` loop.
@@ -188,9 +191,6 @@ with the simplified `await foreach`:
         total += await t;
     }
 ```
-
-> [!CAUTION]
-> You can use `WhenAny` in a loop, as described in the example, to solve problems that involve a small number of tasks. However, other approaches are more efficient if you have a large number of tasks to process. For more information and examples, see [Processing tasks as they complete](https://devblogs.microsoft.com/pfxteam/processing-tasks-as-they-complete).
 
 ## Complete example
 

--- a/docs/csharp/asynchronous-programming/start-multiple-async-tasks-and-process-them-as-they-complete.md
+++ b/docs/csharp/asynchronous-programming/start-multiple-async-tasks-and-process-them-as-they-complete.md
@@ -166,6 +166,29 @@ For any given URL, the method will use the `client` instance provided to get the
 
 Run the program several times to verify that the downloaded lengths don't always appear in the same order.
 
+## Simplify the approach using `Task.WhenEach`
+
+The `while` loop implemented in `SumPageSizesAsync` method can be simplified using the new <xref:System.Threading.Tasks.Task.WhenEach%2A?displayProperty=nameWithType> method introduced in .NET 9, by calling it in `await foreach` loop.
+<br/>Replace the previously implemented `while` loop:
+
+```csharp
+    while (downloadTasks.Any())
+    {
+        Task<int> finishedTask = await Task.WhenAny(downloadTasks);
+        downloadTasks.Remove(finishedTask);
+        total += await finishedTask;
+    }
+```
+
+with the simplified `await foreach`:
+
+```csharp
+    await foreach (Task<int> t in Task.WhenEach(downloadTasks))
+    {
+        total += await t;
+    }
+```
+
 > [!CAUTION]
 > You can use `WhenAny` in a loop, as described in the example, to solve problems that involve a small number of tasks. However, other approaches are more efficient if you have a large number of tasks to process. For more information and examples, see [Processing tasks as they complete](https://devblogs.microsoft.com/pfxteam/processing-tasks-as-they-complete).
 

--- a/docs/csharp/asynchronous-programming/start-multiple-async-tasks-and-process-them-as-they-complete.md
+++ b/docs/csharp/asynchronous-programming/start-multiple-async-tasks-and-process-them-as-they-complete.md
@@ -192,6 +192,8 @@ with the simplified `await foreach`:
     }
 ```
 
+This new approach allows to no longer repeatedly call `Task.WhenAny` to manually call a task and remove the one that finishes, because `Task.WhenEach` iterates through task *in an order of their completion*.
+
 ## Complete example
 
 The following code is the complete text of the *Program.cs* file for the example.


### PR DESCRIPTION
This pull request closes #48252, by introducing `Task.WhenEach` with an example of how to simplify the tasks loop handling in the tutorial.

There is a full example in snippets, but I decided **not to** add this simplify approach to that example to avoid confusions on why the full code has two approaches, how to combine them both in `Main`, etc.
Let me know if this would actually be good idea to add it there.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/asynchronous-programming/start-multiple-async-tasks-and-process-them-as-they-complete.md](https://github.com/dotnet/docs/blob/cee4bc4f4a8af7d2304d51104cec7dd88091fb23/docs/csharp/asynchronous-programming/start-multiple-async-tasks-and-process-them-as-they-complete.md) | [Process asynchronous tasks as they complete (C#)](https://review.learn.microsoft.com/en-us/dotnet/csharp/asynchronous-programming/start-multiple-async-tasks-and-process-them-as-they-complete?branch=pr-en-us-48302) |

<!-- PREVIEW-TABLE-END -->