### PR TITLE
Change order of Ubuntu version selector and fix libicu version on Ubuntu 25.04

### DIFF
--- a/docs/core/install/linux-ubuntu-install.md
+++ b/docs/core/install/linux-ubuntu-install.md
@@ -55,7 +55,7 @@ When you install with a package manager, these libraries are installed for you. 
 - ca-certificates
 - libc6
 - libgcc-s1
-- libicu74
+- libicu76
 - liblttng-ust1
 - libssl3
 - libstdc++6

--- a/docs/zone-pivot-groups.yml
+++ b/docs/zone-pivot-groups.yml
@@ -120,12 +120,14 @@ groups:
   title: Ubuntu Version
   prompt: Choose the Ubuntu distribution version
   pivots:
-    - id: os-linux-ubuntu-2504
-      title: "25.04"
+  # order: lts versions (newest to oldest), interim versions (newest to oldest), other
+  # see: https://github.com/dotnet/docs/issues/47461
     - id: os-linux-ubuntu-2404
       title: "24.04"
     - id: os-linux-ubuntu-2204
       title: "22.04"
+    - id: os-linux-ubuntu-2504
+      title: "25.04"
     - id: os-linux-ubuntu-other
       title: "Other"
 - id: openai-library


### PR DESCRIPTION
## Summary

### change order of ubuntu version selector

Changing the order of the Ubuntu version selector to
 - Ubuntu LTS versions from newest to oldest, then
 - Ubuntu Interim versions from newest to oldest, then
 - other (unsupported) Ubuntu versions.

**Rationale:**
Some users skip over the article and miss the version selecter.
This leads to them beeing unable to install .NET. The new order
ensures that an LTS is displayed first. The Ubuntu LTS install
instructions let users successfully install .NET on an Ubuntu
interim machine. In the worst case they run the command
`sudo add-apt-repository ppa:dotnet/backports`, which has no
major side-effect.

### fix dependency version for Ubuntu 25.04

The version of libicu on Ubuntu 25.04 is 76.
See: https://launchpad.net/ubuntu/plucky/+source/icu

Fixes: https://github.com/dotnet/docs/issues/47461

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/linux-ubuntu-install.md](https://github.com/dotnet/docs/blob/14c5be84a670ae56fbe215f22ddbac7efa3a91bb/docs/core/install/linux-ubuntu-install.md) | [docs/core/install/linux-ubuntu-install](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu-install?branch=pr-en-us-48306) |
| [docs/zone-pivot-groups.yml](https://github.com/dotnet/docs/blob/14c5be84a670ae56fbe215f22ddbac7efa3a91bb/docs/zone-pivot-groups.yml) | [docs/zone-pivot-groups](https://review.learn.microsoft.com/en-us/dotnet/zone-pivot-groups?branch=pr-en-us-48306) |

<!-- PREVIEW-TABLE-END -->