### PR TITLE
Change ms.date to 09/09/2025

### DIFF
--- a/docs/core/compatibility/10.0.md
+++ b/docs/core/compatibility/10.0.md
@@ -2,7 +2,7 @@
 title: Breaking changes in .NET 10
 titleSuffix: ""
 description: Navigate to the breaking changes in .NET 10.
-ms.date: 08/08/2025
+ms.date: 09/09/2025
 ai-usage: ai-assisted
 no-loc: [Blazor, Razor, Kestrel]
 ---


### PR DESCRIPTION
Updated the date for breaking changes documentation.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/10.0.md](https://github.com/dotnet/docs/blob/2adc8a0416d5a3105ad9c30bf65c099a3ee347fa/docs/core/compatibility/10.0.md) | [Breaking changes in .NET 10](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/10.0?branch=pr-en-us-48313) |

<!-- PREVIEW-TABLE-END -->