### PR TITLE
US-488186: Content Update - Localization fix: <dotnet-docs> - data types should not be translated

### DIFF
--- a/docs/standard/data/sqlite/types.md
+++ b/docs/standard/data/sqlite/types.md
@@ -2,48 +2,49 @@
 title: Data types
 ms.date: 12/13/2019
 description: Describes the supported data types and some of the limitations around them.
+no-loc: ["INTEGER", "BLOB", "TEXT", "REAL"]
 ---
 # Data types
 
 SQLite only has four primitive data types: INTEGER, REAL, TEXT, and BLOB. APIs that return database values as an `object` will only ever return one of these four types. Additional .NET types are supported by Microsoft.Data.Sqlite, but values are ultimately coerced between these types and one of the four primitive types.
 
-| .NET           | SQLite  | Remarks                                                       |
-| -------------- | ------- | ------------------------------------------------------------- |
-| Boolean        | INTEGER | `0` or `1`                                                    |
-| Byte           | INTEGER |                                                               |
-| Byte[]         | BLOB    |                                                               |
-| Char           | TEXT    | UTF-8                                                         |
-| DateOnly       | TEXT    | yyyy-MM-dd                                                    |
-| DateTime       | TEXT    | yyyy-MM-dd HH:mm:ss.FFFFFFF                                   |
-| DateTimeOffset | TEXT    | yyyy-MM-dd HH:mm:ss.FFFFFFFzzz                                |
-| Decimal        | TEXT    | `0.0###########################` format. REAL would be lossy. |
-| Double         | REAL    |                                                               |
-| Guid           | TEXT    | 00000000-0000-0000-0000-000000000000                          |
-| Int16          | INTEGER |                                                               |
-| Int32          | INTEGER |                                                               |
-| Int64          | INTEGER |                                                               |
-| SByte          | INTEGER |                                                               |
-| Single         | REAL    |                                                               |
-| String         | TEXT    | UTF-8                                                         |
-| TimeOnly       | TEXT    | HH:mm:ss.fffffff                                              |
-| TimeSpan       | TEXT    | d.hh:mm:ss.fffffff                                            |
-| UInt16         | INTEGER |                                                               |
-| UInt32         | INTEGER |                                                               |
-| UInt64         | INTEGER | Large values overflow                                         |
+| .NET           | SQLite  | Remarks                                                                           |
+| -------------- | ------- | ----------------------------------------------------------------------------------|
+| :::no-loc text="Boolean":::        | INTEGER | `0` or `1`                                                    |
+| :::no-loc text="Byte":::           | INTEGER |                                                               |
+| :::no-loc text="Byte[] ":::        | BLOB    |                                                               |
+| :::no-loc text="Char":::           | TEXT    | UTF-8                                                         |
+| :::no-loc text="DateOnly":::       | TEXT    | :::no-loc text="yyyy-MM-dd":::                                |
+| :::no-loc text="DateTime":::       | TEXT    | :::no-loc text="yyyy-MM-dd HH:mm:ss.FFFFFFF":::               |
+| :::no-loc text="DateTimeOffset"::: | TEXT    | :::no-loc text="yyyy-MM-dd HH:mm:ss.FFFFFFFzzz":::            |
+| :::no-loc text="Decimal":::        | TEXT    | `0.0###########################` format. REAL would be lossy. |
+| :::no-loc text="Double":::         | REAL    |                                                               |
+| :::no-loc text="Guid":::           | TEXT    | 00000000-0000-0000-0000-000000000000                          |
+| :::no-loc text="Int16":::          | INTEGER |                                                               |
+| :::no-loc text="Int32":::          | INTEGER |                                                               |
+| :::no-loc text="Int64":::          | INTEGER |                                                               |
+| :::no-loc text="SByte":::          | INTEGER |                                                               |
+| :::no-loc text="Single":::         | REAL    |                                                               |
+| :::no-loc text="String":::         | TEXT    | UTF-8                                                         |
+| :::no-loc text="TimeOnly":::       | TEXT    | HH:mm:ss.fffffff                                              |
+| :::no-loc text="TimeSpan":::       | TEXT    | d.hh:mm:ss.fffffff                                            |
+| :::no-loc text="UInt16":::         | INTEGER |                                                               |
+| :::no-loc text="UInt32":::         | INTEGER |                                                               |
+| :::no-loc text="UInt64":::         | INTEGER | Large values overflow                                         |
 
 ## Alternative types
 
 Some .NET types can be read from alternative SQLite types. Parameters can also be configured to use these alternative types. For more information, see [Parameters](parameters.md#alternative-types).
 
-| .NET           | SQLite  | Remarks          |
-| -------------- | ------- | ---------------- |
-| Char           | INTEGER | UTF-16           |
-| DateOnly       | REAL    | Julian day value |
-| DateTime       | REAL    | Julian day value |
-| DateTimeOffset | REAL    | Julian day value |
-| Guid           | BLOB    |                  |
-| TimeOnly       | REAL    | In days          |
-| TimeSpan       | REAL    | In days          |
+| .NET           | SQLite  | Remarks                              |
+| -------------- | ------- | ------------------------------------ |
+| :::no-loc text="Char":::           | INTEGER | UTF-16           |
+| :::no-loc text="DateOnly":::       | REAL    | Julian day value |
+| :::no-loc text="DateTime":::       | REAL    | Julian day value |
+| :::no-loc text="DateTimeOffset"::: | REAL    | Julian day value |
+| :::no-loc text="Guid":::           | BLOB    |                  |
+| :::no-loc text="TimeOnly":::       | REAL    | In days          |
+| :::no-loc text="TimeSpan":::       | REAL    | In days          |
 
 For example, the following query reads a TimeSpan value from a REAL column in the result set.
 


### PR DESCRIPTION
Per task: https://dev.azure.com/msft-skilling/Content/_workitems/edit/488186, adding no-loc tag to avoid over-localized issue.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/data/sqlite/types.md](https://github.com/dotnet/docs/blob/87ea1ff3a2b8121b9a483d15fd9cadaa1c7c612c/docs/standard/data/sqlite/types.md) | [Data types](https://review.learn.microsoft.com/en-us/dotnet/standard/data/sqlite/types?branch=pr-en-us-48439) |

<!-- PREVIEW-TABLE-END -->