### PR TITLE
add FS0067 compiler message

### DIFF
--- a/docs/fsharp/language-reference/compiler-messages/fs0067.md
+++ b/docs/fsharp/language-reference/compiler-messages/fs0067.md
@@ -18,7 +18,7 @@ Redundant Type test:
 
 Redundant Downcast:
 
-[!code-fsharp[FS0067-redundant-downcast](~/samples/snippets/fsharp/compiler-messages/fs0003.fsx#L11-L18)]
+[!code-fsharp[FS0067-redundant-downcast](~/samples/snippets/fsharp/compiler-messages/fs0067.fsx#L11-L18)]
 
 The two examples above cause the compiler to display the following message:
 

--- a/docs/fsharp/language-reference/compiler-messages/fs0067.md
+++ b/docs/fsharp/language-reference/compiler-messages/fs0067.md
@@ -1,0 +1,32 @@
+---
+description: "Learn more about: FS0067: This type test or downcast will always hold"
+title: "Compiler error FS0067"
+ms.date: 9/10/2025
+f1_keywords:
+  - "FS0067"
+helpviewer_keywords:
+  - "FS0067"
+---
+
+# FS0067: This type test or downcast will always hold
+
+This message is given when attempting to perform a type test ([:?](https://learn.microsoft.com/en-us/dotnet/fsharp/language-reference/match-expressions)) or downcast ([:?>](https://learn.microsoft.com/en-us/dotnet/fsharp/language-reference/casting-and-conversions#downcasting)) that will always succeed based on the types involved, making the operation unnecessary.
+
+Redundant Type test:
+
+[!code-fsharp[FS0067-redundant-type-test](~/samples/snippets/fsharp/compiler-messages/fs0067.fsx#L2-L8)]
+
+Redundant Downcast:
+
+[!code-fsharp[FS0067-redundant-downcast](~/samples/snippets/fsharp/compiler-messages/fs0003.fsx#L11-L18)]
+
+The two examples above cause the compiler to display the following message:
+
+```text
+FS0067: This type test or downcast will always hold
+```
+
+The use of `:?` and `:?>` operators is preferable when working with:
+
+- Base classes when the runtime type might differ.
+- Values of type `obj` or interfaces types.

--- a/docs/fsharp/language-reference/compiler-messages/fs0067.md
+++ b/docs/fsharp/language-reference/compiler-messages/fs0067.md
@@ -10,7 +10,7 @@ helpviewer_keywords:
 
 # FS0067: This type test or downcast will always hold
 
-This message is given when attempting to perform a type test ([:?](https://learn.microsoft.com/en-us/dotnet/fsharp/language-reference/match-expressions)) or downcast ([:?>](https://learn.microsoft.com/en-us/dotnet/fsharp/language-reference/casting-and-conversions#downcasting)) that will always succeed based on the types involved, making the operation unnecessary.
+This message is given when attempting to perform a type test ([:?](../match-expressions.md)) or downcast ([:?>](../casting-and-conversions.md#downcasting)) that will always succeed based on the types involved, making the operation unnecessary.
 
 Redundant Type test:
 

--- a/docs/fsharp/language-reference/compiler-messages/toc.yml
+++ b/docs/fsharp/language-reference/compiler-messages/toc.yml
@@ -19,5 +19,7 @@
     href: ./fs0037.md
   - name: FS0052 - Defensive copy
     href: ./fs0052.md
+  - name: FS0067 - This type test or downcast will always hold
+    href: ./fs0067.md
   - name: FS0703 - Expected type parameter, not unit-of-measure parameter
     href: ./fs0703.md

--- a/samples/snippets/fsharp/compiler-messages/fs0067.fsx
+++ b/samples/snippets/fsharp/compiler-messages/fs0067.fsx
@@ -1,0 +1,18 @@
+(* Redundant Type test *)
+type Dog() =
+    member this.Name = "Dog"
+
+let dog = Dog()
+
+if dog :? Dog then
+    printfn "It always be a dog"
+
+(* Redundant Downcast *)
+type Cat(name: string) =
+    member this.Name = name
+
+let cat = Cat("Kitten")
+
+let sameCat = cat :?> Cat
+
+printfn "It's still a %s" sameCat.Name

--- a/samples/snippets/fsharp/compiler-messages/fs0067.fsx
+++ b/samples/snippets/fsharp/compiler-messages/fs0067.fsx
@@ -1,11 +1,11 @@
 (* Redundant Type test *)
 type Dog() =
-    member this.Name = "Dog"
+    member this.Bark() = printfn "Woof!"
 
 let dog = Dog()
 
 if dog :? Dog then
-    printfn "It always be a dog"
+    dog.Bark()
 
 (* Redundant Downcast *)
 type Cat(name: string) =


### PR DESCRIPTION
## Summary

- This PR adds the missing documentation for the `FS0067` compiler message.

Fixes #48293


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/compiler-messages/fs0067.md](https://github.com/dotnet/docs/blob/0091e2c7d5820a69dfbd14c9e4621adbe8619f83/docs/fsharp/language-reference/compiler-messages/fs0067.md) | [docs/fsharp/language-reference/compiler-messages/fs0067](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/compiler-messages/fs0067?branch=pr-en-us-48442) |
| [docs/fsharp/language-reference/compiler-messages/toc.yml](https://github.com/dotnet/docs/blob/0091e2c7d5820a69dfbd14c9e4621adbe8619f83/docs/fsharp/language-reference/compiler-messages/toc.yml) | [docs/fsharp/language-reference/compiler-messages/toc](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/compiler-messages/toc?branch=pr-en-us-48442) |


<!-- PREVIEW-TABLE-END -->