### PR TITLE
FeatureSwitchDefinition section in "What's new .NET 9": Made the Feature.IsSupported a read-only property

### DIFF
--- a/docs/core/whats-new/dotnet-9/runtime.md
+++ b/docs/core/whats-new/dotnet-9/runtime.md
@@ -22,7 +22,7 @@ Two new attributes make it possible to define [feature switches](https://github.
   public class Feature
   {
       [FeatureSwitchDefinition("Feature.IsSupported")]
-      internal static bool IsSupported => AppContext.TryGetSwitch("Feature.IsSupported", out bool isEnabled) ? isEnabled : true;
+      internal static bool IsSupported { get; } = AppContext.TryGetSwitch("Feature.IsSupported", out bool isEnabled) ? isEnabled : true;
 
       internal static void Implementation() => ...;
   }


### PR DESCRIPTION
## Summary

ATM this page seems to be the only documentation for `FeatureSwitchDefinition`, thus there should be used best practices.

Here the property's getter was executed on every access, so the `AppContext.TryGetSwitch` was also called on every access.
This PR changes the property to be read-only (backed by a `static readonly field`), so in Tier-1 code the JIT can treat the value of the switch as constand and dead-code eliminate some things -- especially there's only one call to `AppContext.TryGetSwitch` needed.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/whats-new/dotnet-9/runtime.md](https://github.com/dotnet/docs/blob/2ea7fbfb92a7841688d5333d3c4f49140a70c04e/docs/core/whats-new/dotnet-9/runtime.md) | [What's new in the .NET 9 runtime](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-9/runtime?branch=pr-en-us-48482) |

<!-- PREVIEW-TABLE-END -->