### PR TITLE
Make `car2` a type of `Car` instead of `ConvertibleCar` as per article

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/knowing-when-to-use-override-and-new-keywords.md
+++ b/docs/csharp/programming-guide/classes-and-structs/knowing-when-to-use-override-and-new-keywords.md
@@ -279,7 +279,7 @@ public static void TestCars1()
     // used in the definition of ShowDetails in the ConvertibleCar  
     // class.
   
-    ConvertibleCar car2 = new ConvertibleCar();  
+    Car car2 = new ConvertibleCar();  
     car2.DescribeCar();  
     System.Console.WriteLine("----------");  
   


### PR DESCRIPTION
This tiny pull request fixes #48486 in "Knowing When to Use Override and New Keywords" page.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/classes-and-structs/knowing-when-to-use-override-and-new-keywords.md](https://github.com/dotnet/docs/blob/38a048547fcbbb862225fd2e29045f2ebd3bebc2/docs/csharp/programming-guide/classes-and-structs/knowing-when-to-use-override-and-new-keywords.md) | [Knowing When to Use Override and New Keywords (C# Programming Guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/knowing-when-to-use-override-and-new-keywords?branch=pr-en-us-48495) |

<!-- PREVIEW-TABLE-END -->