### PR TITLE
Enhance documentation on MCP tools

### DIFF
--- a/docs/ai/microsoft-extensions-ai.md
+++ b/docs/ai/microsoft-extensions-ai.md
@@ -100,7 +100,7 @@ The preceding code:
 - Calls `GetStreamingResponseAsync` on the client, passing a prompt and a list of tools that includes a function created with <xref:Microsoft.Extensions.AI.AIFunctionFactory.Create*>.
 - Iterates over the response, printing each update to the console.
 
-You can also use Model Context Protocol (MCP) tools with your `IChatClient`. For more details, see the [build a minimal MCP client](./quickstarts/build-mcp-client.md) article.
+You can also use Model Context Protocol (MCP) tools with your `IChatClient`. For more information, see [Build a minimal MCP client](./quickstarts/build-mcp-client.md).
 
 #### Cache responses
 

--- a/docs/ai/microsoft-extensions-ai.md
+++ b/docs/ai/microsoft-extensions-ai.md
@@ -100,6 +100,8 @@ The preceding code:
 - Calls `GetStreamingResponseAsync` on the client, passing a prompt and a list of tools that includes a function created with <xref:Microsoft.Extensions.AI.AIFunctionFactory.Create*>.
 - Iterates over the response, printing each update to the console.
 
+You can also use Model Context Protocol (MCP) tools with your `IChatClient`. For more details, see the [build a minimal MCP client](./quickstarts/build-mcp-client.md) article.
+
 #### Cache responses
 
 If you're familiar with [Caching in .NET](../core/extensions/caching.md), it's good to know that <xref:Microsoft.Extensions.AI> provides other such delegating `IChatClient` implementations. The <xref:Microsoft.Extensions.AI.DistributedCachingChatClient> is an `IChatClient` that layers caching around another arbitrary `IChatClient` instance. When a novel chat history is submitted to the `DistributedCachingChatClient`, it forwards it to the underlying client and then caches the response before sending it back to the consumer. The next time the same history is submitted, such that a cached response can be found in the cache, the `DistributedCachingChatClient` returns the cached response rather than forwarding the request along the pipeline.


### PR DESCRIPTION
This pull request adds documentation to clarify that Model Context Protocol (MCP) tools can be used with `IChatClient`, and provides a reference to a related article for further details.

Documentation improvements:

* Added a note explaining that MCP tools are compatible with `IChatClient`, and included a link to the "build a minimal MCP client" quickstart article for more information.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/ai/microsoft-extensions-ai.md](https://github.com/dotnet/docs/blob/b0205a96c0586cfc70e50e4f479dd2a7c5a174d4/docs/ai/microsoft-extensions-ai.md) | [Microsoft.Extensions.AI libraries](https://review.learn.microsoft.com/en-us/dotnet/ai/microsoft-extensions-ai?branch=pr-en-us-48553) |


<!-- PREVIEW-TABLE-END -->