### PR TITLE
Remove extension indexer from "What's New for C# 14"

### DIFF
--- a/docs/csharp/whats-new/csharp-14.md
+++ b/docs/csharp/whats-new/csharp-14.md
@@ -40,8 +40,6 @@ public static class Enumerable
     {
         // Extension property:
         public bool IsEmpty => !source.Any();
-        // Extension indexer:
-        public TSource this[int index] => source.Skip(index).First();
 
         // Extension method:
         public IEnumerable<TSource> Where(Func<TSource, bool> predicate) { ... }


### PR DESCRIPTION
Extension indexers didn't make it into C# 14.
Fixes https://github.com/dotnet/roslyn/issues/80312

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/whats-new/csharp-14.md](https://github.com/dotnet/docs/blob/aaf562b5b2cbd4d8b5a4ef415881f463782a4bbb/docs/csharp/whats-new/csharp-14.md) | [What's new in C# 14](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-14?branch=pr-en-us-48560) |

<!-- PREVIEW-TABLE-END -->