### PR TITLE
Fix increment and decrement static operator

### DIFF
--- a/docs/csharp/language-reference/operators/snippets/shared/OperatorOverloading.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/OperatorOverloading.cs
@@ -36,10 +36,10 @@
 
     // Define increment and decrement to add 1/den, rather than 1/1.
     public static Fraction operator ++(Fraction operand)
-        => new Fraction(operand.numerator++, operand.denominator);
+        => new Fraction(operand.numerator + 1, operand.denominator);
 
     public static Fraction operator --(Fraction operand) =>
-        new Fraction(operand.numerator--, operand.denominator);
+        new Fraction(operand.numerator - 1, operand.denominator);
 
     public override string ToString() => $"{numerator} / {denominator}";
 


### PR DESCRIPTION
## Summary

The increment and decrement static operator currently are no-op. This fix ensure they actually do increment and decrement the value of the numerator in the fraction.

Change the operator from an increment to a non mutating operand.numerator + 1 because otherwise the call to a reference version of Fraction would result in `Console.WriteLine(a++);` to print a after its mutation instead of the before value.

Fixes #48626