### PR TITLE
Address feedback on unsafe-code/best-practices.md

### DIFF
--- a/docs/standard/unsafe-code/best-practices.md
+++ b/docs/standard/unsafe-code/best-practices.md
@@ -988,7 +988,7 @@ Fuzz testing (or "fuzzing") is an automated software testing technique that invo
 
 ## 26. Compiler warnings
 
-Generally, C# compiler doesn't provide extensive support such as warnings and analyzers around incorrect unsafe code usage. However, there are some existing warnings that can help detect potential issues and should not be ignored or suppressed without careful consideration. Some examples include:
+Generally, the C# compiler doesn't provide extensive support such as warnings and analyzers around incorrect unsafe code usage. However, there are some existing warnings that can help detect potential issues and should not be ignored or suppressed without careful consideration. Some examples include:
 
 ```csharp
 nint ptr = 0;
@@ -1002,12 +1002,12 @@ await Task.Delay(100);
 // ptr is used here
 ```
 
-This code produces warning `warning CS9123: The '&' operator should not be used on parameters or local variables in async methods.` which implies the code is likely incorrect.
+This code produces warning CS9123 ("The '&' operator should not be used on parameters or local variables in async methods"), which implies the code is likely incorrect.
 
 ### Recommendations
 
 1. ✔️ DO pay attention to compiler warnings and fix the underlying issues instead of suppressing them.
-2. ❌ DON'T assume that the absence of compiler warnings implies the code is correct - C# compiler has very limited to no support for detecting incorrect unsafe code usage.
+2. ❌ DON'T assume that the absence of compiler warnings implies the code is correct. The C# compiler has limited to no support for detecting incorrect unsafe code usage.
 
 ## References
 

--- a/docs/standard/unsafe-code/best-practices.md
+++ b/docs/standard/unsafe-code/best-practices.md
@@ -1002,6 +1002,7 @@ await Task.Delay(100);
 
 // ptr is used here
 ```
+
 This code produces warning `warning CS9123: The '&' operator should not be used on parameters or local variables in async methods.` which implies the code is likely incorrect.
 
 ## References

--- a/docs/standard/unsafe-code/best-practices.md
+++ b/docs/standard/unsafe-code/best-practices.md
@@ -973,7 +973,7 @@ While most of the suggestions in this document apply to interop scenarios as wel
 
 ## 23. Thread safety
 
-Although memory safety and thread safety are orthogonal concepts, many of the highlighed issues in this document can lead to thread safety issues as well. For example, non-atomic coalesced writes. See [Managed threading best practices](../../standard/threading/managed-threading-best-practices.md) and [.NET Memory Model](https://github.com/dotnet/runtime/blob/main/docs/design/specs/Memory-model.md).
+Memory safety and thread safety are orthogonal concepts. Code can be memory safe yet still contain data races, torn reads, or visibility bugs; conversely, code can be thread safe while still invoking undefined behavior through unsafe memory manipulation. For broader guidance, see [Managed threading best practices](../../standard/threading/managed-threading-best-practices.md) and [.NET Memory Model](https://github.com/dotnet/runtime/blob/main/docs/design/specs/Memory-model.md).
 
 ## 24. Unsafe code around SIMD/Vectorization
 

--- a/docs/standard/unsafe-code/best-practices.md
+++ b/docs/standard/unsafe-code/best-practices.md
@@ -893,7 +893,7 @@ Avoid using such techniques unless absolutely necessary.
 2. ✔️ DO use Source Generators instead, if possible.
 3. ✔️ DO prefer [\[UnsafeAccessor\]](xref:System.Runtime.CompilerServices.UnsafeAccessorAttribute) instead of emitting raw IL for writing low overhead serialization code for private members if the need arises.
 4. ✔️ DO file an API proposal against [dotnet/runtime](https://github.com/dotnet/runtime) if some API is missing and you're forced to use raw IL code instead.
-5. ✔️ DO cuse `ilverify` or similar tools to validate the emitted IL code if you must use raw IL.
+5. ✔️ DO use `ilverify` or similar tools to validate the emitted IL code if you must use raw IL.
 
 ## 19. Uninitialized locals `[SkipLocalsInit]` and `Unsafe.SkipInit`
 

--- a/docs/standard/unsafe-code/best-practices.md
+++ b/docs/standard/unsafe-code/best-practices.md
@@ -989,7 +989,7 @@ Fuzz testing (or "fuzzing") is an automated software testing technique that invo
 
 ## 26. Compiler warnings
 
-Generally, Roslyn intentionally doesn't provide extensive support such as warnings and analyzers around incorrect unsafe code usage. However, there are some existing warnings that can help detect potential issues and should not be ignored or suppressed without careful consideration. Some examples include:
+Generally, C# compiler doesn't provide extensive support such as warnings and analyzers around incorrect unsafe code usage. However, there are some existing warnings that can help detect potential issues and should not be ignored or suppressed without careful consideration. Some examples include:
 
 ```csharp
 nint ptr = 0;

--- a/docs/standard/unsafe-code/best-practices.md
+++ b/docs/standard/unsafe-code/best-practices.md
@@ -740,8 +740,7 @@ ms.buffer[7] = 0; // Bounds check elided; index is known to be in range.
 ms.buffer[10] = 0; // Compiler knows this is out of range and produces compiler error CS9166.
 ```
 
-It's also worth noting that fixed-size buffers might have non-zeroed contents in certain scenarios, which
-is another reason to avoid them in favor of inline arrays which are always zero-initialized by default.
+Another reason to avoid fixed-size buffers in favor of inline arrays, which are always zero-initialized by default, is that fixed-size buffers might have non-zeroed contents in certain scenarios.
 
 ### Recommendations
 

--- a/docs/standard/unsafe-code/best-practices.md
+++ b/docs/standard/unsafe-code/best-practices.md
@@ -1005,6 +1005,11 @@ await Task.Delay(100);
 
 This code produces warning `warning CS9123: The '&' operator should not be used on parameters or local variables in async methods.` which implies the code is likely incorrect.
 
+### Recommendations
+
+1. ✔️ DO pay attention to compiler warnings and fix the underlying issues instead of suppressing them.
+2. ❌ DON'T assume that the absence of compiler warnings implies the code is correct - C# compiler has very limited to no support for detecting incorrect unsafe code usage.
+
 ## References
 
 * [Unsafe code, pointer types, and function pointers](../../csharp/language-reference/unsafe-code.md).

--- a/docs/standard/unsafe-code/best-practices.md
+++ b/docs/standard/unsafe-code/best-practices.md
@@ -989,7 +989,7 @@ Fuzz testing (or "fuzzing") is an automated software testing technique that invo
 
 ## 26. Compiler warnings
 
-Generally, Roslyn intentionally doesn't provide extensive support such as warnings and analyzers around incorrect unsafe code usage to motivate developers to use safe code instead. However, there are some existing warnings that can help detect potential issues and should not be ignored or suppressed without careful consideration. Some examples include:
+Generally, Roslyn intentionally doesn't provide extensive support such as warnings and analyzers around incorrect unsafe code usage. However, there are some existing warnings that can help detect potential issues and should not be ignored or suppressed without careful consideration. Some examples include:
 
 ```csharp
 nint ptr = 0;

--- a/docs/standard/unsafe-code/best-practices.md
+++ b/docs/standard/unsafe-code/best-practices.md
@@ -42,7 +42,7 @@ or memory corruption. Heap corruption bugs are particularly challenging to diagn
 
 The next sections describe common unsafe patterns with ✔️ DO and ❌ DON'T recommendations.
 
-## 1. Untracked managed pointers (<xref:System.Runtime.CompilerServices.Unsafe.AsPointer``1(``0@)?displayProperty=nameWithType> and friends)
+## 1. Untracked managed pointers (`Unsafe.AsPointer` and friends)
 
 It's not possible to convert a managed (tracked) pointer to an unmanaged (untracked)
 pointer in safe C#. When such need arises, it might be tempting to use <xref:System.Runtime.CompilerServices.Unsafe.AsPointer``1(``0@)?displayProperty=nameWithType>


### PR DESCRIPTION
## Summary

This PR addresses community feedback on https://github.com/dotnet/docs/pull/48557 article + some cleanup

1) Added more xrefs
2) Inlined a couple of sub-bullets because they were not rendered nicely
3) Added an example about RVA + AsPointer + ALC
4) Non-zeroed fixed size buffers (see https://github.com/dotnet/runtime/issues/119903 for more context)
5) Reduced stackalloc size from int[512] to int[256] because previously we recommended to use 1024 bytes threshold
6) added a new section `26. Compiler warnings`



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/unsafe-code/best-practices.md](https://github.com/dotnet/docs/blob/7ae24a157776d70f5413ccb6217082126307716d/docs/standard/unsafe-code/best-practices.md) | [docs/standard/unsafe-code/best-practices](https://review.learn.microsoft.com/en-us/dotnet/standard/unsafe-code/best-practices?branch=pr-en-us-48629) |


<!-- PREVIEW-TABLE-END -->