### PR TITLE
Fix code examples in IDE2002.md

### DIFF
--- a/docs/fundamentals/code-analysis/style-rules/ide2002.md
+++ b/docs/fundamentals/code-analysis/style-rules/ide2002.md
@@ -34,18 +34,18 @@ Options specify the behavior that you want the rule to enforce. For information 
 
 ### csharp_style_allow_blank_lines_between_consecutive_braces_experimental
 
-| Property                 | Value                                        | Description |
-|--------------------------|----------------------------------------------|-------------|
-| **Option name**          | `csharp_style_allow_blank_lines_between_consecutive_braces_experimental` | |
-| **Option values**        | `true`                                       | Allow blank lines between consecutive braces |
-|                          | `false`                                      | Don't allow blank lines between consecutive braces |
-| **Default option value** | `true`                                       |             |
+| Property                 | Value                                                                    | Description                                        |
+|--------------------------|--------------------------------------------------------------------------|----------------------------------------------------|
+| **Option name**          | `csharp_style_allow_blank_lines_between_consecutive_braces_experimental` |                                                    |
+| **Option values**        | `true`                                                                   | Allow blank lines between consecutive braces       |
+|                          | `false`                                                                  | Don't allow blank lines between consecutive braces |
+| **Default option value** | `true`                                                                   |                                                    |
 
 ## Example
 
 ```csharp
 // csharp_style_allow_blank_lines_between_consecutive_braces_experimental = true
-public void Method
+public void Method()
 {
     if (true)
     {
@@ -57,7 +57,7 @@ public void Method
 
 ```csharp
 // csharp_style_allow_blank_lines_between_consecutive_braces_experimental = false
-public void Method
+public void Method()
 {
     if (true)
     {


### PR DESCRIPTION
## Summary

1) Add `()` for methods
2) Also fix `csharp_style_allow_blank_lines_between_consecutive_braces_experimental` table


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/style-rules/ide2002.md](https://github.com/dotnet/docs/blob/da2ee636bb6bd44fe931014891f837d912cf9a3d/docs/fundamentals/code-analysis/style-rules/ide2002.md) | [Consecutive braces must not have blank line between them (IDE2002)](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide2002?branch=pr-en-us-48630) |

<!-- PREVIEW-TABLE-END -->