### PR TITLE
fix 'Using Constructors' article main heading

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/using-constructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/using-constructors.md
@@ -5,7 +5,7 @@ ms.date: 01/15/2025
 helpviewer_keywords: 
   - "constructors [C#], about constructors"
 ---
-# Use constructors (C# programming guide)
+# Using constructors (C# programming guide)
 
 When a [class](../../language-reference/keywords/class.md) or [struct](../../language-reference/builtin-types/struct.md) is instantiated, the runtime calls its constructor. Constructors have the same name as the class or struct, and they usually initialize the data members of the new object.
 


### PR DESCRIPTION
## Summary

- This PR replaces the word '**Use**' in the `Using Constructors` article main heading with '**Using**'.

Fixes #48633


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/classes-and-structs/using-constructors.md](https://github.com/dotnet/docs/blob/993525f2737587ed0d679e0d4ae8636cb583fd2f/docs/csharp/programming-guide/classes-and-structs/using-constructors.md) | [docs/csharp/programming-guide/classes-and-structs/using-constructors](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/using-constructors?branch=pr-en-us-48647) |

<!-- PREVIEW-TABLE-END -->