### PR TITLE
Remove semester specific labels.

### DIFF
--- a/quest-config.json
+++ b/quest-config.json
@@ -8,43 +8,9 @@
     "ImportedLabel": ":pushpin: seQUESTered",
     "ParentNodes": [
         {
-            "Semester": "Bromine",
             "Label": "dotnet-csharp/svc",
             "ParentNodeId": 410745
         },
-        {
-            "Semester": "Bromine",
-            "ParentNodeId": 410746
-        },
-        {
-            "Semester": "Selenium",
-            "Label": "okr-freshness",
-            "ParentNodeId": 286034
-        },
-        {
-            "Semester": "Selenium",
-            "Label": "okr-curation",
-            "ParentNodeId": 286038
-        },
-        {
-            "Semester": "Selenium",
-            "Label": "user-feedback",
-            "ParentNodeId": 286039
-        },
-        {
-            "Semester": "Selenium",
-            "Label": "okr-quality",
-            "ParentNodeId": 286038
-        },
-        {
-            "Semester": "Selenium",
-            "Label": "doc-bug",
-            "ParentNodeId": 286039
-        },
-        {
-            "Semester": "Selenium",
-            "ParentNodeId": 308199
-        }
     ],
     "DefaultParentNode": 410746,
     "WorkItemTags": [


### PR DESCRIPTION
Semester specific parent IDs in Azure DevOps aren't used anymore.
