### PR TITLE
fix sentence for standalone discard with Task

### DIFF
--- a/docs/csharp/fundamentals/functional/discards.md
+++ b/docs/csharp/fundamentals/functional/discards.md
@@ -57,7 +57,7 @@ You can use a standalone discard to indicate any variable that you choose to ign
 
 :::code language="csharp" source="snippets/discards/standalone-discard1.cs" ID="ArgNullCheck" :::
 
-The following example uses a standalone discard to ignore the <xref:System.Threading.Tasks.Task> object returned by an asynchronous operation. Assigning the task has the effect of suppressing the exception that the operation throws as it is about to complete. It makes your intent clear: You want to discard the `Task`, and ignore any errors generated from that asynchronous operation.
+The following example uses a standalone discard to ignore the <xref:System.Threading.Tasks.Task> object returned by an asynchronous operation. Assigning the task has the effect of suppressing the compiler warning about unobserved exceptions. It makes your intent clear: You want to discard the `Task`, and ignore any errors generated from that asynchronous operation.
 
 :::code language="csharp" source="snippets/discards/standalone-discard1.cs" ID="SnippetDiscardTask" :::
 

--- a/docs/csharp/fundamentals/functional/discards.md
+++ b/docs/csharp/fundamentals/functional/discards.md
@@ -57,7 +57,7 @@ You can use a standalone discard to indicate any variable that you choose to ign
 
 :::code language="csharp" source="snippets/discards/standalone-discard1.cs" ID="ArgNullCheck" :::
 
-The following example uses a standalone discard to ignore the <xref:System.Threading.Tasks.Task> object returned by an asynchronous operation. Assigning the task has the effect of suppressing the compiler warning about unobserved exceptions. It makes your intent clear: You want to discard the `Task`, and ignore any errors generated from that asynchronous operation.
+The following example uses a standalone discard to ignore the <xref:System.Threading.Tasks.Task> object returned by an asynchronous operation. Assigning the task has the effect of suppressing the compiler warning about unobserved exceptions. It makes your intent clear: You want to discard the `Task`, and propagate any errors generated from that asynchronous operation to callers.
 
 :::code language="csharp" source="snippets/discards/standalone-discard1.cs" ID="SnippetDiscardTask" :::
 


### PR DESCRIPTION
## Summary

- This PR corrects the sentence about using a standalone discard with `Task`, clarifying that it only suppresses the compiler warning.

Fixes #48632


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/fundamentals/functional/discards.md](https://github.com/dotnet/docs/blob/7bc2fd0295b919151231cabb72506270cfbdf490/docs/csharp/fundamentals/functional/discards.md) | [docs/csharp/fundamentals/functional/discards](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/functional/discards?branch=pr-en-us-48663) |


<!-- PREVIEW-TABLE-END -->