### PR TITLE
Update preprocessor directives documentation

### DIFF
--- a/docs/csharp/language-reference/preprocessor-directives.md
+++ b/docs/csharp/language-reference/preprocessor-directives.md
@@ -1,7 +1,7 @@
 ---
 description: "Learn the different C# preprocessor directives that control conditional compilation, warnings, nullable analysis, and more"
 title: "Preprocessor directives"
-ms.date: 06/19/2025
+ms.date: 09/24/2025
 f1_keywords:
   - "cs.preprocessor"
   - "#nullable"
@@ -108,6 +108,20 @@ The `#:` directives that are used in file-based apps include:
 
   ```xml
   <PackageReference Include="System.CommandLine" Version="2.0.0-*">
+  ```
+
+- `#:project`:
+
+  Instance of `#:project` are translated into `ProjectReference` elements to include the project with the specified path to the project. For example:
+
+  ```csharp
+  #:project ../Path/To.Example.csproj
+  ```
+
+  The preceding preprocessor token is translated into:
+
+  ```xml
+  <ProjectReference Include="../Path/To.Example.csproj" />
   ```
   
 Tools can add new tokens following the `#:` convention.

--- a/docs/csharp/language-reference/preprocessor-directives.md
+++ b/docs/csharp/language-reference/preprocessor-directives.md
@@ -112,7 +112,7 @@ The `#:` directives that are used in file-based apps include:
 
 - `#:project`:
 
-  Instance of `#:project` are translated into `ProjectReference` elements to include the project with the specified path to the project. For example:
+  Instances of `#:project` are translated into `ProjectReference` elements to include the project with the specified path to the project. For example:
 
   ```csharp
   #:project ../Path/To.Example.csproj


### PR DESCRIPTION
Updated the date for the preprocessor directives documentation and added new information about the `#:project` token.

Fixes #48739

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/preprocessor-directives.md](https://github.com/dotnet/docs/blob/4c189c7c6216d2991ba348c50be0a6fa25c2851e/docs/csharp/language-reference/preprocessor-directives.md) | [C# preprocessor directives](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/preprocessor-directives?branch=pr-en-us-48740) |


<!-- PREVIEW-TABLE-END -->