### PR TITLE
Fix project reference path in documentation

### DIFF
--- a/docs/csharp/language-reference/preprocessor-directives.md
+++ b/docs/csharp/language-reference/preprocessor-directives.md
@@ -115,7 +115,7 @@ The `#:` directives that are used in file-based apps include:
   Instances of `#:project` are translated into `ProjectReference` elements to include the project with the specified path to the project. For example:
 
   ```csharp
-  #:project ../Path/To.Example.csproj
+  #:project ../Path/To.Example
   ```
 
   The preceding preprocessor token is translated into:


### PR DESCRIPTION
Updated project reference path in preprocessor directives documentation.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/preprocessor-directives.md](https://github.com/dotnet/docs/blob/0c300cd23137bd7631b73ad1024931f4cae4a2dc/docs/csharp/language-reference/preprocessor-directives.md) | [C# preprocessor directives](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/preprocessor-directives?branch=pr-en-us-48758) |

<!-- PREVIEW-TABLE-END -->