### PR TITLE
Add code example for CA1002 rule (#48762)

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1002.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1002.md
@@ -45,6 +45,9 @@ By default, this rule only looks at externally visible types, but this is [confi
 
 To fix a violation of this rule, change the <xref:System.Collections.Generic.List%601?displayProperty=fullName> type to one of the generic collections that's designed for inheritance.
 
+## Example
+:::code language="csharp" source="snippets/csharp/all-rules/ca1002.cs" id="snippet1":::
+
 ## When to suppress warnings
 
 Do not suppress a warning from this rule unless the assembly that raises this warning is not meant to be a reusable library. For example, it would be safe to suppress this warning in a performance-tuned application where a performance benefit was gained from the use of generic lists.

--- a/docs/fundamentals/code-analysis/quality-rules/ca1002.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1002.md
@@ -10,6 +10,8 @@ helpviewer_keywords:
 - DoNotExposeGenericLists
 author: gewarren
 ms.author: gewarren
+dev_langs:
+  - CSharp
 ---
 # CA1002: Do not expose generic lists
 
@@ -46,6 +48,7 @@ By default, this rule only looks at externally visible types, but this is [confi
 To fix a violation of this rule, change the <xref:System.Collections.Generic.List%601?displayProperty=fullName> type to one of the generic collections that's designed for inheritance.
 
 ## Example
+
 :::code language="csharp" source="snippets/csharp/all-rules/ca1002.cs" id="snippet1":::
 
 ## When to suppress warnings

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1002.cs
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1002.cs
@@ -6,7 +6,7 @@ namespace ca1001
     // This class violates the rule.
     public class MutableItems
     {
-        // CA1002: Change 'List<string>' in 'ViolationItems.Members' to use 'Collection<T>', 'ReadOnlyCollection<T>' or 'KeyedCollection<K,V>'
+        // CA1002: Change 'List<string>' in 'MutableItems.Items' to use 'Collection<T>', 'ReadOnlyCollection<T>' or 'KeyedCollection<K,V>'
         public List<string> Items { get; } = new List<string>();
 
         public void Add(string item)

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1002.cs
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1002.cs
@@ -6,7 +6,8 @@ namespace ca1001
     // This class violates the rule.
     public class MutableItems
     {
-        // CA1002: Change 'List<string>' in 'MutableItems.Items' to use 'Collection<T>', 'ReadOnlyCollection<T>' or 'KeyedCollection<K,V>'
+        // CA1002: Change 'List<string>' in 'MutableItems.Items' to
+        // use 'Collection<T>', 'ReadOnlyCollection<T>' or 'KeyedCollection<K,V>'.
         public List<string> Items { get; } = new List<string>();
 
         public void Add(string item)

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1002.cs
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1002.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+
+namespace ca1001
+{
+    //<snippet1>
+    // This class violates the rule.
+    public class MutableItems
+    {
+        // CA1002: Change 'List<string>' in 'ViolationItems.Members' to use 'Collection<T>', 'ReadOnlyCollection<T>' or 'KeyedCollection<K,V>'
+        public List<string> Items { get; } = new List<string>();
+
+        public void Add(string item)
+        {
+            Items.Add(item);
+        }
+    }
+
+    // This class satisfies the rule.
+    public class ReadOnlyItems
+    {
+        private readonly List<string> _items = new List<string>();
+
+        public IReadOnlyCollection<string> Items => _items.AsReadOnly();
+
+        public void Add(string item)
+        {
+            _items.Add(item);
+        }
+    }
+    //</snippet1>
+}


### PR DESCRIPTION
Fixes #48762

If it will be helpful, I will make more examples for other CA rules (in separate PR's) 😄

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1002.md](https://github.com/dotnet/docs/blob/2e1cef601ebc82805ff6cb88d28a827a3fa2677d/docs/fundamentals/code-analysis/quality-rules/ca1002.md) | [CA1002: Do not expose generic lists](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1002?branch=pr-en-us-48763) |


<!-- PREVIEW-TABLE-END -->