### PR TITLE
Update operator-overloading.md to include Colon

### DIFF
--- a/docs/fsharp/language-reference/operator-overloading.md
+++ b/docs/fsharp/language-reference/operator-overloading.md
@@ -126,6 +126,9 @@ Other combinations of operator characters that are not listed here can be used a
 |`)`|`RParen`|
 |`[`|`LBrack`|
 |`]`|`RBrack`|
+|`:`|`Colon`|
+
+Use of `:` in custom operators is partially reserved. It may only be used in operators where the first character is `>` or `.` where the first character after any number of leading `.` is `>` e.g. `>:` or `.>:`.
 
 ## Prefix and Infix Operators
 


### PR DESCRIPTION
## Summary

Adds the Colon `:` operator to the list of available custom operators. This was previously reserved but with the merge of https://github.com/dotnet/fsharp/pull/15923 `:` became available for use in specific circumstances. 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/operator-overloading.md](https://github.com/dotnet/docs/blob/9180bd940ae486c170fd1d61543d406e590f48fa/docs/fsharp/language-reference/operator-overloading.md) | [Operator Overloading](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/operator-overloading?branch=pr-en-us-48765) |

<!-- PREVIEW-TABLE-END -->