### PR TITLE
Change string marshalling to LPUTF8Str

### DIFF
--- a/docs/standard/native-interop/type-marshalling.md
+++ b/docs/standard/native-interop/type-marshalling.md
@@ -12,7 +12,7 @@ Marshalling is needed because the types in the managed and unmanaged code are di
 
 ```csharp
 [LibraryImport("somenativelibrary.dll")]
-static extern int MethodA([MarshalAs(UnmanagedType.LPStr)] string parameter);
+static extern int MethodA([MarshalAs(UnmanagedType.LPUTF8Str)] string parameter);
 
 // or
 


### PR DESCRIPTION
Updated the P/Invoke method signature to use LPUTF8Str for UTF-8 string marshalling.

Fixes #48785



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/native-interop/type-marshalling.md](https://github.com/dotnet/docs/blob/928d6dde73b7efe639af9b327cee3f6ad8d39cff/docs/standard/native-interop/type-marshalling.md) | [Type marshalling](https://review.learn.microsoft.com/en-us/dotnet/standard/native-interop/type-marshalling?branch=pr-en-us-48795) |

<!-- PREVIEW-TABLE-END -->