### PR TITLE
Fix string interpolation typo in AsyncCultureEx1 code snippet

### DIFF
--- a/docs/fundamentals/runtime-libraries/snippets/System.Globalization/CultureInfo/csharp/asyncculture1.cs
+++ b/docs/fundamentals/runtime-libraries/snippets/System.Globalization/CultureInfo/csharp/asyncculture1.cs
@@ -14,7 +14,7 @@ public class AsyncCultureEx1
         string FormatDelegate()
         {
             string output = $"Formatting using the {CultureInfo.CurrentCulture.Name} " +
-            "culture on thread {Thread.CurrentThread.ManagedThreadId}.\n";
+                $"culture on thread {Thread.CurrentThread.ManagedThreadId}.\n";
             foreach (decimal value in values)
                 output += $"{value.ToString(formatString)}   ";
 


### PR DESCRIPTION
## Summary

Added missing string interpolation symbol `$`

Fixes #48797 
