### PR TITLE
dotnet nuget why has optional project argument

### DIFF
--- a/docs/core/tools/dotnet-nuget-why.md
+++ b/docs/core/tools/dotnet-nuget-why.md
@@ -15,7 +15,7 @@ ms.date: 05/30/2024
 ## Synopsis
 
 ```dotnetcli
-dotnet nuget why <PROJECT|SOLUTION> <PACKAGE> [-f|--framework <FRAMEWORK>]
+dotnet nuget why [<PROJECT|SOLUTION>] <PACKAGE> [-f|--framework <FRAMEWORK>]
 
 dotnet nuget why -h|--help
 ```
@@ -38,7 +38,10 @@ To use the command with projects that can't be restored with the .NET SDK, you c
 
 - **`PROJECT|SOLUTION`**
 
-  The project or solution file to operate on. If a directory is specified, the command searches the directory for a project or solution file. If more than one project or solution is found, an error is thrown.
+  The project or solution file to operate on. 
+  If a directory is specified, the command searches the directory for a project or solution file.
+  If more than one project or solution is found, an error is thrown.
+  If no value is provided, the current working directory is used by default.
 
 - **`PACKAGE`**
 
@@ -54,22 +57,22 @@ To use the command with projects that can't be restored with the .NET SDK, you c
 
 ## Examples
 
-- Show the dependency graph for the package "System.Text.Json" for a given solution:
+- Show the dependency graph for the package "System.Text.Json":
 
     ```dotnetcli
-    dotnet nuget why .\DotnetNuGetWhyPackage.sln System.Text.Json
+    dotnet nuget why System.Text.Json
     ```
 
     ![Example: Solution with multiple projects](media/dotnet-nuget-why/dotnet-nuget-why-solution-with-multiple-projects.png)
 
-- Show the dependency graph for the package "System.Text.Json" for a single project:
+- Show the dependency graph for the package "System.Text.Json" for a specific project:
 
     ```dotnetcli
-    dotnet nuget why .\DotnetNuGetWhyPackage.csproj System.Text.Json
+    dotnet nuget why path\to\DotnetNuGetWhyPackage.csproj System.Text.Json
     ```
 
 - Show the dependency graph for a specific target framework:
 
     ```dotnetcli
-    dotnet nuget why .\DotnetNuGetWhyPackage.csproj System.Text.Json --framework net6.0
+    dotnet nuget why System.Text.Json --framework net6.0
     ```

--- a/docs/core/tools/dotnet-nuget-why.md
+++ b/docs/core/tools/dotnet-nuget-why.md
@@ -38,7 +38,7 @@ To use the command with projects that can't be restored with the .NET SDK, you c
 
 - **`PROJECT|SOLUTION`**
 
-  The project or solution file to operate on. 
+  The project or solution file to operate on.
   If a directory is specified, the command searches the directory for a project or solution file.
   If more than one project or solution is found, an error is thrown.
   If no value is provided, the current working directory is used by default.

--- a/docs/core/tools/dotnet-nuget-why.md
+++ b/docs/core/tools/dotnet-nuget-why.md
@@ -68,7 +68,7 @@ To use the command with projects that can't be restored with the .NET SDK, you c
 - Show the dependency graph for the package "System.Text.Json" for a specific project:
 
     ```dotnetcli
-    dotnet nuget why path\to\DotnetNuGetWhyPackage.csproj System.Text.Json
+    dotnet nuget why path/to/DotnetNuGetWhyPackage.csproj System.Text.Json
     ```
 
 - Show the dependency graph for a specific target framework:


### PR DESCRIPTION
## Summary

`dotnet nuget why` only had the project/solution argument mandatory in the first version. It's been optional for a while now.

Fixes https://github.com/NuGet/Home/issues/13709


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-nuget-why.md](https://github.com/dotnet/docs/blob/9c373506a58eb2b1fbb040f968f51453cd0f350f/docs/core/tools/dotnet-nuget-why.md) | [dotnet nuget why](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-why?branch=pr-en-us-48885) |


<!-- PREVIEW-TABLE-END -->