### PR TITLE
Clarify `--verbosity` usage in dotnet build

### DIFF
--- a/docs/core/tools/dotnet-build.md
+++ b/docs/core/tools/dotnet-build.md
@@ -154,7 +154,7 @@ Running `dotnet build` is equivalent to running `dotnet msbuild -restore`; howev
 
 - **`-v|--verbosity <LEVEL>`**
 
-  Sets the verbosity level of the command. Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`. The default is `minimal`. By default, MSBuild displays warnings and errors at all verbosity levels. To exclude warnings, use `/property:WarningLevel=0`. Terminal logger (see --tl), which is the default in interactive sessions from .NET 9, shows limited output at all verbosity levels. For more information, see <xref:Microsoft.Build.Framework.LoggerVerbosity> and [WarningLevel](../../csharp/language-reference/compiler-options/errors-warnings.md#warninglevel).
+  Sets the verbosity level of the command. Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`. The default is `minimal`. By default, MSBuild displays warnings and errors at all verbosity levels. To exclude warnings, use `/property:WarningLevel=0`. Terminal Logger (see --tl), which is the default in interactive sessions starting in .NET 9, shows limited output at all verbosity levels. For more information, see <xref:Microsoft.Build.Framework.LoggerVerbosity> and [WarningLevel](../../csharp/language-reference/compiler-options/errors-warnings.md#warninglevel).
 
 - **`--use-current-runtime, --ucr [true|false]`**
 

--- a/docs/core/tools/dotnet-build.md
+++ b/docs/core/tools/dotnet-build.md
@@ -154,7 +154,7 @@ Running `dotnet build` is equivalent to running `dotnet msbuild -restore`; howev
 
 - **`-v|--verbosity <LEVEL>`**
 
-  Sets the verbosity level of the command. Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`. The default is `minimal`. By default, MSBuild displays warnings and errors at all verbosity levels. To exclude warnings, use `/property:WarningLevel=0`. For more information, see <xref:Microsoft.Build.Framework.LoggerVerbosity> and [WarningLevel](../../csharp/language-reference/compiler-options/errors-warnings.md#warninglevel).
+  Sets the verbosity level of the command. Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`. The default is `minimal`. By default, MSBuild displays warnings and errors at all verbosity levels. To exclude warnings, use `/property:WarningLevel=0`. Terminal logger (see --tl), which is the default in interactive sessions from .NET 9, shows limited output at all verbosity levels. For more information, see <xref:Microsoft.Build.Framework.LoggerVerbosity> and [WarningLevel](../../csharp/language-reference/compiler-options/errors-warnings.md#warninglevel).
 
 - **`--use-current-runtime, --ucr [true|false]`**
 


### PR DESCRIPTION
## Summary

Document the using the option is less impactful than customers would expect.

Fixes https://github.com/dotnet/msbuild/issues/12465


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-build.md](https://github.com/dotnet/docs/blob/7d09c462dcad496a7db39fc87ec0246133681c21/docs/core/tools/dotnet-build.md) | [docs/core/tools/dotnet-build](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-build?branch=pr-en-us-48889) |


<!-- PREVIEW-TABLE-END -->