### PR TITLE
Use actual link instead of aka.ms

### DIFF
--- a/docs/standard/serialization/system-text-json/customize-properties.md
+++ b/docs/standard/serialization/system-text-json/customize-properties.md
@@ -273,7 +273,7 @@ change the serialized property name to use underscores between words.
 Use built-in serialization attributes.
 ```
 
-GitHub Copilot is powered by AI, so surprises and mistakes are possible. For more information, see [Copilot FAQs](https://aka.ms/copilot-general-use-faqs).
+Review Copilot's suggestions before applying them. For more information GitHub Copilot, see GitHub's [FAQs](https://github.com/features/copilot#faq).
 
 ## See also
 

--- a/docs/standard/serialization/system-text-json/customize-properties.md
+++ b/docs/standard/serialization/system-text-json/customize-properties.md
@@ -259,7 +259,7 @@ Use built-in serialization attributes.
 Here's a more complete version of the example that includes a simple class.
 
 ```copilot-prompt
-Take this C# class: 
+Take this C# class:
 public class WeatherForecast
 {
     public DateTime Date { get; set; }
@@ -273,7 +273,9 @@ change the serialized property name to use underscores between words.
 Use built-in serialization attributes.
 ```
 
-Review Copilot's suggestions before applying them. For more information GitHub Copilot, see GitHub's [FAQs](https://github.com/features/copilot#faq).
+Review Copilot's suggestions before applying them.
+
+For more information about GitHub Copilot, see GitHub's [FAQs](https://github.com/features/copilot#faq).
 
 ## See also
 

--- a/docs/standard/serialization/system-text-json/deserialization.md
+++ b/docs/standard/serialization/system-text-json/deserialization.md
@@ -99,7 +99,9 @@ Map property names & values.
 Provide example output.
 ```
 
-Review Copilot's suggestions before applying them. For more information GitHub Copilot, see GitHub's [FAQs](https://github.com/features/copilot#faq).
+Review Copilot's suggestions before applying them.
+
+For more information about GitHub Copilot, see GitHub's [FAQs](https://github.com/features/copilot#faq).
 
 ## See also
 

--- a/docs/standard/serialization/system-text-json/deserialization.md
+++ b/docs/standard/serialization/system-text-json/deserialization.md
@@ -99,7 +99,7 @@ Map property names & values.
 Provide example output.
 ```
 
-GitHub Copilot is powered by AI, so surprises and mistakes are possible. For more information, see [Copilot FAQs](https://aka.ms/copilot-general-use-faqs).
+Review Copilot's suggestions before applying them. For more information GitHub Copilot, see GitHub's [FAQs](https://github.com/features/copilot#faq).
 
 ## See also
 

--- a/docs/standard/serialization/system-text-json/how-to.md
+++ b/docs/standard/serialization/system-text-json/how-to.md
@@ -120,7 +120,7 @@ The object contains the following fields: FirstName (string), Lastname (string),
 Provide example output.
 ```
 
-GitHub Copilot is powered by AI, so surprises and mistakes are possible. For more information, see [Copilot FAQs](https://aka.ms/copilot-general-use-faqs).
+Review Copilot's suggestions before applying them. For more information GitHub Copilot, see GitHub's [FAQs](https://github.com/features/copilot#faq).
 
 ## See also
 

--- a/docs/standard/serialization/system-text-json/how-to.md
+++ b/docs/standard/serialization/system-text-json/how-to.md
@@ -120,7 +120,9 @@ The object contains the following fields: FirstName (string), Lastname (string),
 Provide example output.
 ```
 
-Review Copilot's suggestions before applying them. For more information GitHub Copilot, see GitHub's [FAQs](https://github.com/features/copilot#faq).
+Review Copilot's suggestions before applying them.
+
+For more information about GitHub Copilot, see GitHub's [FAQs](https://github.com/features/copilot#faq).
 
 ## See also
 

--- a/docs/standard/serialization/system-text-json/migrate-from-newtonsoft.md
+++ b/docs/standard/serialization/system-text-json/migrate-from-newtonsoft.md
@@ -647,14 +647,16 @@ Here's an example prompt you can use in Visual Studio Copilot Chat to migrate a 
 
 ```copilot-prompt
 Convert all serialization code in this #solution from Newtonsoft.Json to System.Text.Json, using the recommended approach for my current .NET version.
-- Update attributes and properties, including rules for skipping or renaming during serialization 
+- Update attributes and properties, including rules for skipping or renaming during serialization
 - Ensure polymorphic serialization continues to work correctly
 - Respect existing custom converters and project-level settings (for example, from the Utilities folder or appsettings.json)
 - Update related unit tests and highlight any potential breaking changes
 - Generate a migration summary
 ```
 
-Review Copilot's suggestions before applying them. For more information GitHub Copilot, see GitHub's [FAQs](https://github.com/features/copilot#faq).
+Review Copilot's suggestions before applying them.
+
+For more information about GitHub Copilot, see GitHub's [FAQs](https://github.com/features/copilot#faq).
 
 ## Additional resources
 

--- a/docs/standard/serialization/system-text-json/migrate-from-newtonsoft.md
+++ b/docs/standard/serialization/system-text-json/migrate-from-newtonsoft.md
@@ -654,7 +654,7 @@ Convert all serialization code in this #solution from Newtonsoft.Json to System.
 - Generate a migration summary
 ```
 
-Review Copilot's suggestions before applying. For more information, see [Copilot FAQs](https://aka.ms/copilot-general-use-faqs).
+Review Copilot's suggestions before applying them. For more information GitHub Copilot, see GitHub's [FAQs](https://github.com/features/copilot#faq).
 
 ## Additional resources
 


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/serialization/system-text-json/customize-properties.md](https://github.com/dotnet/docs/blob/c48a78d05adeacb36f016f1c36e5cb3966a0fa7d/docs/standard/serialization/system-text-json/customize-properties.md) | [How to customize property names and values with System.Text.Json](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/customize-properties?branch=pr-en-us-48899) |
| [docs/standard/serialization/system-text-json/deserialization.md](https://github.com/dotnet/docs/blob/c48a78d05adeacb36f016f1c36e5cb3966a0fa7d/docs/standard/serialization/system-text-json/deserialization.md) | [How to read JSON as .NET objects (deserialize)](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/deserialization?branch=pr-en-us-48899) |
| [docs/standard/serialization/system-text-json/how-to.md](https://github.com/dotnet/docs/blob/c48a78d05adeacb36f016f1c36e5cb3966a0fa7d/docs/standard/serialization/system-text-json/how-to.md) | ["How to serialize JSON in C#"](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/how-to?branch=pr-en-us-48899) |
| [docs/standard/serialization/system-text-json/migrate-from-newtonsoft.md](https://github.com/dotnet/docs/blob/c48a78d05adeacb36f016f1c36e5cb3966a0fa7d/docs/standard/serialization/system-text-json/migrate-from-newtonsoft.md) | [Migrate from Newtonsoft.Json to System.Text.Json](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/migrate-from-newtonsoft?branch=pr-en-us-48899) |

<!-- PREVIEW-TABLE-END -->