### PR TITLE
Add --tl option to 'dotnet test' based on 'dotnet build'

### DIFF
--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -68,6 +68,7 @@ dotnet test [<PROJECT> | <SOLUTION> | <DIRECTORY> | <DLL> | <EXE>]
     [-r|--runtime <RUNTIME_IDENTIFIER>]
     [-s|--settings <SETTINGS_FILE>]
     [-t|--list-tests]
+    [--tl:[auto|on|off]]
     [-v|--verbosity <LEVEL>]
     [<args>...]
     [[--] <RunSettings arguments>]
@@ -498,6 +499,8 @@ With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest.
 
   > [!NOTE]
   > Running tests for a solution with a global `RuntimeIdentifier` property (explicitly or via `--arch`, `--runtime`, or `--os`) is not supported. Set `RuntimeIdentifier` on an individual project level instead.
+
+[!INCLUDE [tl](../../../includes/cli-tl.md)]
 
 - **`-v|--verbosity <LEVEL>`**
   

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -261,6 +261,8 @@ Where `Microsoft.NET.Test.Sdk` is the test host, `xunit` is the test framework. 
 
   List the discovered tests instead of running the tests.
 
+[!INCLUDE [tl](../../../includes/cli-tl.md)]
+
 [!INCLUDE [verbosity](../../../includes/cli-verbosity-minimal.md)]
 
 - **`args`**
@@ -499,8 +501,6 @@ With Microsoft Testing Platform, `dotnet test` operates faster than with VSTest.
 
   > [!NOTE]
   > Running tests for a solution with a global `RuntimeIdentifier` property (explicitly or via `--arch`, `--runtime`, or `--os`) is not supported. Set `RuntimeIdentifier` on an individual project level instead.
-
-[!INCLUDE [tl](../../../includes/cli-tl.md)]
 
 - **`-v|--verbosity <LEVEL>`**
   


### PR DESCRIPTION
## Summary

This PR adds the `--tl` option to `dotnet test` command documentation based on how it is documented at `dotnet build`

Fixes #48872

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-test.md](https://github.com/dotnet/docs/blob/84e7eb3ba4f286d9b96ac335113cc0f7bdb6fa95/docs/core/tools/dotnet-test.md) | [dotnet test](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-test?branch=pr-en-us-48909) |


<!-- PREVIEW-TABLE-END -->