### PR TITLE
Add example for CA1005 rule (#48911)

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1005.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1005.md
@@ -10,6 +10,8 @@ helpviewer_keywords:
 - CA1005
 author: gewarren
 ms.author: gewarren
+dev_langs:
+- CSharp
 ---
 # CA1005: Avoid excessive parameters on generic types
 
@@ -34,6 +36,10 @@ The more type parameters a generic type contains, the more difficult it is to kn
 ## How to fix violations
 
 To fix a violation of this rule, change the design to use no more than two type parameters.
+
+## Example
+
+:::code language="csharp" source="snippets/csharp/all-rules/ca1005.cs" id="snippet1":::
 
 ## When to suppress warnings
 

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1005.cs
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1005.cs
@@ -1,0 +1,22 @@
+namespace ca1005
+{
+    //<snippet1>
+    // This class violates the rule.
+    public class TooManyTypeParameters<T, K, V>
+    {
+        public void M1(T t, K k, V v)
+        {
+            // ...
+        }
+    }
+
+    // This class satisfies the rule.
+    public class CorrectTypeParameters<T, K>
+    {
+        public void M1(T t, K k)
+        {
+            // ...
+        }
+    }
+    //</snippet1>
+}


### PR DESCRIPTION
## Summary

Fixes #48911


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1005.md](https://github.com/dotnet/docs/blob/c49d97a31877af92ce10927fb2acc656be470365/docs/fundamentals/code-analysis/quality-rules/ca1005.md) | [CA1005: Avoid excessive parameters on generic types](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1005?branch=pr-en-us-48912) |

<!-- PREVIEW-TABLE-END -->