### PR TITLE
Add code example for CA1030 rule (#48914)

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1030.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1030.md
@@ -10,6 +10,8 @@ helpviewer_keywords:
 - UseEventsWhereAppropriate
 author: gewarren
 ms.author: gewarren
+dev_langs:
+- CSharp
 ---
 # CA1030: Use events where appropriate
 
@@ -41,6 +43,10 @@ Some common examples of events are found in user interface applications where a 
 ## How to fix violations
 
 If the method is called when the state of an object changes, consider changing the design to use the .NET event model.
+
+## Example
+
+:::code language="csharp" source="snippets/csharp/all-rules/ca1030.cs" id="snippet1":::
 
 ## When to suppress warnings
 

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1030.cs
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1030.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+
+namespace ca1030
+{
+    //<snippet1>
+    // This class violates the rule.
+    public class BadButton
+    {
+        private readonly List<Action> _clickHandlers = new List<Action>();
+
+        public void AddOnClick(Action handler)
+        {
+            // Some internal logic...
+
+            _clickHandlers.Add(handler);
+        }
+
+        public void RemoveOnClick(Action handler)
+        {
+            // Some internal logic...
+
+            _clickHandlers.Remove(handler);
+        }
+
+        public void FireClick()
+        {
+            foreach (Action handler in _clickHandlers)
+            {
+                handler();
+            }
+        }
+    }
+
+    // This class satisfies the rule.
+    public class GoodButton
+    {
+        private EventHandler? _clickHandler;
+
+        public event EventHandler? ClickHandler
+        {
+            add
+            {
+                // Some internal logic...
+
+                _clickHandler += value;
+            }
+            remove
+            {
+                // Some internal logic...
+
+                _clickHandler -= value;
+            }
+        }
+
+        protected virtual void OnClick(EventArgs e)
+        {
+            _clickHandler?.Invoke(this, e);
+        }
+
+        public void Click()
+        {
+            OnClick(EventArgs.Empty);
+        }
+    }
+    //</snippet1>
+}

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1030.cs
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1030.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace ca1030


### PR DESCRIPTION
## Summary

Fixes #48914


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1030.md](https://github.com/dotnet/docs/blob/1306cc8accf5f1124521645da22d6c9b0c1350d5/docs/fundamentals/code-analysis/quality-rules/ca1030.md) | [CA1030: Use events where appropriate](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1030?branch=pr-en-us-48915) |


<!-- PREVIEW-TABLE-END -->