### PR TITLE
Add code example for CA1700 rule (#48932)

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1700.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1700.md
@@ -10,6 +10,8 @@ helpviewer_keywords:
 - CA1700
 author: gewarren
 ms.author: gewarren
+dev_langs:
+- CSharp
 ---
 # CA1700: Do not name enum values &#39;Reserved&#39;
 
@@ -42,6 +44,10 @@ In a limited number of cases the addition of a member is a breaking change even 
 ## How to fix violations
 
 To fix a violation of this rule, remove or rename the member.
+
+## Example
+
+:::code language="csharp" source="snippets/csharp/all-rules/ca1700.cs" id="snippet1":::
 
 ## When to suppress warnings
 

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1700.cs
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1700.cs
@@ -1,7 +1,7 @@
 namespace ca1700
 {
     //<snippet1>
-    // This class violates the rule.
+    // This enum violates the rule.
     public enum BadPaymentStatus
     {
         Pending = 0,
@@ -10,7 +10,7 @@ namespace ca1700
         Reserved = 3,
     }
 
-    // This class satisfies the rule.
+    // This enum satisfies the rule.
     public enum GoodPaymentStatus
     {
         Pending = 0,

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1700.cs
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1700.cs
@@ -1,0 +1,22 @@
+namespace ca1700
+{
+    //<snippet1>
+    // This class violates the rule.
+    public enum BadPaymentStatus
+    {
+        Pending = 0,
+        Completed = 1,
+        ReservedError = 2,
+        Reserved = 3,
+    }
+
+    // This class satisfies the rule.
+    public enum GoodPaymentStatus
+    {
+        Pending = 0,
+        Completed = 1,
+        Error = 2,
+        Unknown = 3,
+    }
+    //</snippet1>
+}


### PR DESCRIPTION
## Summary

Fixes #48932


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1700.md](https://github.com/dotnet/docs/blob/bcd86ec0f264c16db88d3c5e157d2a5f9d2954fa/docs/fundamentals/code-analysis/quality-rules/ca1700.md) | [CA1700: Do not name enum values &#39;Reserved&#39;](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1700?branch=pr-en-us-48933) |


<!-- PREVIEW-TABLE-END -->