### PR TITLE
Add code example for CA1707 rule (#48934)

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1707.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1707.md
@@ -10,6 +10,8 @@ helpviewer_keywords:
 - IdentifiersShouldNotContainUnderscores
 author: gewarren
 ms.author: gewarren
+dev_langs:
+- CSharp
 ---
 # CA1707: Identifiers should not contain underscores
 
@@ -34,6 +36,10 @@ Naming conventions provide a common look for libraries that target the common la
 ## How to fix violations
 
 Remove all underscore characters from the name.
+
+## Example
+
+:::code language="csharp" source="snippets/csharp/all-rules/ca1707.cs" id="snippet1":::
 
 ## When to suppress warnings
 

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1707.cs
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1707.cs
@@ -1,0 +1,35 @@
+using System;
+
+// <Snippet1>
+namespace ca_1707
+{
+    public interface IUser_Service
+    {
+        void Add_User(User_Model user_Model);
+    }
+
+    public class User_Service : IUser_Service
+    {
+        public const string Admin_Name = "admin";
+        public event EventHandler? User_Added;
+
+        public void Add_User(User_Model user_Model)
+        {
+            // ...
+        }
+
+    }
+
+    public struct User_Model
+    {
+        public int User_Id { get; set; }
+    }
+
+    public enum User_Type
+    {
+        Client_User = 0,
+        Manager_Admin = 1,
+        Syper_Admin = 3,
+    }
+}
+// </Snippet1>

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1707.cs
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1707.cs
@@ -17,7 +17,6 @@ namespace ca_1707
         {
             // ...
         }
-
     }
 
     public struct User_Model

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1707.cs
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1707.cs
@@ -1,6 +1,7 @@
 using System;
 
 // <Snippet1>
+// This code violates the rule.
 namespace ca_1707
 {
     public interface IUser_Service


### PR DESCRIPTION
## Summary

Fixes #48934

P.S. If I forgot some identifiers, let me know about it, I will add it :)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1707.md](https://github.com/dotnet/docs/blob/55c5860222c60f9383c4d6eb0dabc88a6e7f2ad3/docs/fundamentals/code-analysis/quality-rules/ca1707.md) | [CA1707: Identifiers should not contain underscores](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1707?branch=pr-en-us-48935) |


<!-- PREVIEW-TABLE-END -->