### PR TITLE
Fix braces for code example in CA1864 rule

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1864.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1864.md
@@ -41,7 +41,8 @@ The following code snippet shows a violation of CA1864:
 ```csharp
 void Run(IDictionary<int, string> dictionary)
 {
-    if(!dictionary.ContainsKey(2)) {
+    if (!dictionary.ContainsKey(2))
+    {
         dictionary.Add(2, "Hello World");
     }
 }


### PR DESCRIPTION
## Summary

Fixed brace formatting in the example to follow the standard C# coding conventions :)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1864.md](https://github.com/dotnet/docs/blob/0cb66e0fbadf081f69fc0d17c79b58449f825d19/docs/fundamentals/code-analysis/quality-rules/ca1864.md) | [CA1864: Prefer the 'IDictionary.TryAdd(TKey, TValue)' method](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1864?branch=pr-en-us-48937) |

<!-- PREVIEW-TABLE-END -->