### PR TITLE
Fix spacing for example in CA3077 rule

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca3077.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca3077.md
@@ -100,7 +100,7 @@ namespace TestNamespace
     {
         public TestClass2()
         {
-               XmlResolver = null;
+            XmlResolver = null;
         }
     }
 }


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca3077.md](https://github.com/dotnet/docs/blob/35682ee3342a7c16a4367281e3f51ffaf06de8c6/docs/fundamentals/code-analysis/quality-rules/ca3077.md) | [CA3077: Insecure Processing in API Design, XML Document and XML Text Reader](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca3077?branch=pr-en-us-48938) |

<!-- PREVIEW-TABLE-END -->