### PR TITLE
Fix formatting for CA5358 code examples

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca5358.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5358.md
@@ -68,8 +68,10 @@ For more information, see [How to suppress code analysis warnings](../suppress-w
 ```csharp
 using System.Security.Cryptography;
 
-class ExampleClass {
-    private static void ExampleMethod () {
+class ExampleClass
+{
+    private static void ExampleMethod()
+    {
         RijndaelManaged rijn = new RijndaelManaged
         {
             Mode = CipherMode.ECB
@@ -98,8 +100,10 @@ class ExampleClass
 ```csharp
 using System.Security.Cryptography;
 
-class ExampleClass {
-    private static void ExampleMethod () {
+class ExampleClass
+{
+    private static void ExampleMethod()
+    {
         RijndaelManaged rijn = new RijndaelManaged
         {
             Mode = CipherMode.CBC


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca5358.md](https://github.com/dotnet/docs/blob/96c4f398338db59bc51616ee65dfc2dd5d6bad73/docs/fundamentals/code-analysis/quality-rules/ca5358.md) | [CA5358: Do Not Use Unsafe Cipher Modes](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca5358?branch=pr-en-us-48939) |

<!-- PREVIEW-TABLE-END -->