### PR TITLE
Fix formatting and add method signature for CA5372 rule

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca5372.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5372.md
@@ -65,7 +65,10 @@ The type of the first parameter of `XPathDocument` is not `XmlReader`.
 using System.IO;
 using System.Xml.XPath;
 ...
-var obj = new XPathDocument(stream);
+public void TestMethod(Stream stream)
+{
+    var obj = new XPathDocument(stream);
+}
 ```
 
 ### Solution
@@ -76,6 +79,6 @@ using System.Xml.XPath;
 ...
 public void TestMethod(XmlReader reader)
 {
-var obj = new XPathDocument(reader);
+    var obj = new XPathDocument(reader);
 }
 ```


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca5372.md](https://github.com/dotnet/docs/blob/ff47644835e2ad70f144b68761c0bd88d9ba3a17/docs/fundamentals/code-analysis/quality-rules/ca5372.md) | [CA5372: Use XmlReader for XPathDocument](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca5372?branch=pr-en-us-48940) |

<!-- PREVIEW-TABLE-END -->