### PR TITLE
Fix formatting for CA5391 rule

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca5391.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5391.md
@@ -123,7 +123,7 @@ class BlahClass
 {
     public static void BlahMethod()
     {
-        FilterCollection filterCollection = new FilterCollection ();
+        FilterCollection filterCollection = new FilterCollection();
         filterCollection.Add(typeof(FilterClass));
     }
 }

--- a/docs/fundamentals/code-analysis/quality-rules/ca5391.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5391.md
@@ -74,14 +74,14 @@ using Microsoft.AspNetCore.Mvc;
 class ExampleController : Controller
 {
     [HttpDelete]
-    public IActionResult ExampleAction (string actionName)
+    public IActionResult ExampleAction(string actionName)
     {
         return null;
     }
 
     [ValidateAntiForgeryToken]
     [HttpDelete]
-    public IActionResult AnotherAction (string actionName)
+    public IActionResult AnotherAction(string actionName)
     {
         return null;
     }
@@ -99,13 +99,13 @@ class ExampleController : Controller
 {
     [ValidateAntiForgeryToken]
     [HttpDelete]
-    public IActionResult AnotherAction (string actionName)
+    public IActionResult AnotherAction(string actionName)
     {
         return null;
     }
 
     [HttpDelete]
-    public IActionResult ExampleAction (string actionName)
+    public IActionResult ExampleAction(string actionName)
     {
         return null;
     }
@@ -113,7 +113,7 @@ class ExampleController : Controller
 
 class FilterClass : IAsyncAuthorizationFilter
 {
-    public Task OnAuthorizationAsync (AuthorizationFilterContext context)
+    public Task OnAuthorizationAsync(AuthorizationFilterContext context)
     {
         return null;
     }
@@ -121,7 +121,7 @@ class FilterClass : IAsyncAuthorizationFilter
 
 class BlahClass
 {
-    public static void BlahMethod ()
+    public static void BlahMethod()
     {
         FilterCollection filterCollection = new FilterCollection ();
         filterCollection.Add(typeof(FilterClass));
@@ -138,14 +138,14 @@ class ExampleController : Controller
 {
     [ValidateAntiForgeryToken]
     [HttpDelete]
-    public IActionResult ExampleAction ()
+    public IActionResult ExampleAction()
     {
         return null;
     }
 
     [ValidateAntiForgeryToken]
     [HttpDelete]
-    public IActionResult AnotherAction ()
+    public IActionResult AnotherAction()
     {
         return null;
     }


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca5391.md](https://github.com/dotnet/docs/blob/b24333fcdbe11806f4e38f8525ada3bd77e95618/docs/fundamentals/code-analysis/quality-rules/ca5391.md) | [CA5391: Use antiforgery tokens in ASP.NET Core MVC controllers](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca5391?branch=pr-en-us-48941) |


<!-- PREVIEW-TABLE-END -->