### PR TITLE
Fix the issues with `CS0163` page

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs0163.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0163.md
@@ -48,12 +48,10 @@ public class MyClass
             case 3:  
                 i = 0;  
                 return;  
-  
-            // Compiler error CS0163 is reported on the following line.  
+
             default:  
                 Console.WriteLine("Default");  
-                // To resolve the error, uncomment the following line:  
-            //break;  
+                break;  
         }  
     }  
 ```

--- a/docs/csharp/language-reference/compiler-messages/cs0163.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0163.md
@@ -56,3 +56,26 @@ public class MyClass
     }  
 }
 ```
+
+Note that it is correct to have several `case`s for one implementation, like in the following snippet:
+
+```csharp
+public class MyClass
+{
+    public static void Main()
+    {
+        int i = 0;
+
+        switch(i)
+        {
+            case 1:
+            case 2:    // No CS0163
+                i++
+                break;
+
+            default:
+                break;
+        }
+    }
+}
+```

--- a/docs/csharp/language-reference/compiler-messages/cs0163.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0163.md
@@ -54,4 +54,5 @@ public class MyClass
                 break;  
         }  
     }  
+}
 ```

--- a/docs/csharp/language-reference/compiler-messages/cs0163.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0163.md
@@ -47,7 +47,7 @@ public class MyClass
   
             case 3:  
                 i = 0;  
-                return;  
+                break;  
 
             default:  
                 Console.WriteLine("Default");  


### PR DESCRIPTION
This pull request fixes issues with the page of `CS0163`, such as:
* Removes the misleading example of `CS8070` claimed to be `CS0163`.
This fixes #48944
* Adds the missing closing bracket to the `MyClass` snippet
* Replaces `return` with `break` statement for the `case 3` so that both exiting statement mentioned as potential solutions are presented in the snippet as working correctly examples.

In this PR I also went ahead and decided to add a mention of a possibility to have several `case`s for one implementation.
This is done in the last commit - let me know if you find it a good idea.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-messages/cs0163.md](https://github.com/dotnet/docs/blob/27eae5d23c71b47f54a5c94f2f1ad41753ae636e/docs/csharp/language-reference/compiler-messages/cs0163.md) | [Compiler Error CS0163](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0163?branch=pr-en-us-48950) |


<!-- PREVIEW-TABLE-END -->