### PR TITLE
Add code example for CA1711 rule (#48951)

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1711.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1711.md
@@ -10,6 +10,8 @@ helpviewer_keywords:
 - IdentifiersShouldNotHaveIncorrectSuffix
 author: gewarren
 ms.author: gewarren
+dev_langs:
+ - CSharp
 ---
 # CA1711: Identifiers should not have incorrect suffix
 
@@ -60,6 +62,21 @@ Naming conventions provide a common look for libraries that target the .NET comm
 ## How to fix violations
 
 Remove the suffix from the type name.
+
+## Example
+
+```csharp
+class BadEmployeeCollection { } // Violates CA1711
+
+// Good
+class Employee { }
+class GoodEmployeeCollection : ICollection<Employee>
+{
+    // Implementations
+}
+
+class Employees { } // Good
+```
 
 ## When to suppress warnings
 


### PR DESCRIPTION
## Summary

Fixes #48951


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1711.md](https://github.com/dotnet/docs/blob/c94a62e4f363af3c3f0c542214b858d0c4e3a521/docs/fundamentals/code-analysis/quality-rules/ca1711.md) | [CA1711: Identifiers should not have incorrect suffix](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1711?branch=pr-en-us-48952) |

<!-- PREVIEW-TABLE-END -->