### PR TITLE
Add code example for CA1713 rule (#48953)

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1713.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1713.md
@@ -10,6 +10,8 @@ helpviewer_keywords:
 - EventsShouldNotHaveBeforeOrAfterPrefix
 author: gewarren
 ms.author: gewarren
+dev_langs:
+- CSharp
 ---
 # CA1713: Events should not have before or after prefix
 
@@ -34,6 +36,10 @@ Naming conventions provide a common look for libraries that target the common la
 ## How to fix violations
 
 Remove the prefix from the event name, and consider changing the name to use the present or past tense of a verb.
+
+## Example
+
+:::code language="csharp" source="snippets/csharp/all-rules/ca1713.cs" id="snippet1":::
 
 ## When to suppress warnings
 

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1713.cs
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1713.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace ca1713
+{
+    //<snippet1>
+    public class Session
+    {
+        // This code violates the rule.
+        public event EventHandler? BeforeClose;
+        public event EventHandler? AfterClose;
+
+        // This code satisfies the rule.
+        public event EventHandler? Closing;
+        public event EventHandler? Closed;
+    }
+    //</snippet1>
+}


### PR DESCRIPTION
## Summary

Fixes #48953


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1713.md](https://github.com/dotnet/docs/blob/9a77f9954a65edfc83762828557e2532f8ca20e1/docs/fundamentals/code-analysis/quality-rules/ca1713.md) | [CA1713: Events should not have before or after prefix](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1713?branch=pr-en-us-48954) |

<!-- PREVIEW-TABLE-END -->