### PR TITLE
Add code example for CA1716 rule (#48956)

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1716.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1716.md
@@ -10,6 +10,9 @@ helpviewer_keywords:
 - CA1716
 author: gewarren
 ms.author: gewarren
+dev_langs:
+- CSharp
+- VB
 ---
 # CA1716: Identifiers should not match keywords
 
@@ -42,6 +45,10 @@ Case-insensitive comparison is used for Visual Basic keywords, and case-sensitiv
 ## How to fix violations
 
 Select a name that does not appear in the list of keywords.
+
+## Example
+
+:::code language="csharp" source="snippets/csharp/all-rules/ca1716.cs" id="snippet1":::
 
 ## When to suppress warnings
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1716.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1716.md
@@ -12,7 +12,6 @@ author: gewarren
 ms.author: gewarren
 dev_langs:
 - CSharp
-- VB
 ---
 # CA1716: Identifiers should not match keywords
 

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1716.cs
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1716.cs
@@ -1,0 +1,13 @@
+namespace ca1716
+{
+    //<snippet1>
+    // This code violates the rule.
+    public class Class { }
+    public class Event { }
+    public class String { }
+    public class Namespace { }
+    public class Object { }
+    public class Public { }
+    public class Static { }
+    //</snippet1>
+}


### PR DESCRIPTION
## Summary

Fixes #48956


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1716.md](https://github.com/dotnet/docs/blob/938a3ce2f4e836aba1a568899c5ef8f83e449db9/docs/fundamentals/code-analysis/quality-rules/ca1716.md) | [CA1716: Identifiers should not match keywords](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1716?branch=pr-en-us-48957) |


<!-- PREVIEW-TABLE-END -->