### PR TITLE
Add code example for CA1720 rule (#48958)

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1720.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1720.md
@@ -10,6 +10,8 @@ helpviewer_keywords:
 - CA1720
 author: gewarren
 ms.author: gewarren
+dev_langs:
+- CSharp
 ---
 # CA1720: Identifiers should not contain type names
 
@@ -90,6 +92,10 @@ Replace the data type identifier in the name of the parameter with either a term
 **If fired against a member:**
 
 Replace the language-specific data type identifier in the name of the member with a term that better describes its meaning, a language-independent equivalent, or a more generic term, such as 'value'.
+
+## Example
+
+:::code language="csharp" source="snippets/csharp/all-rules/ca1720.cs" id="snippet1":::
 
 ## When to suppress warnings
 

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1720.cs
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1720.cs
@@ -1,0 +1,13 @@
+namespace ca1715
+{
+    //<snippet1>
+    // This code violates the rule.
+    public class Short
+    {
+        public int Int32 { get; set; }
+        public Guid Guid { get; set; }
+
+        public void Float(int int32) { }
+    }
+    //</snippet1>
+}

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1720.cs
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1720.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace ca1715
 {
     //<snippet1>

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1720.cs
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1720.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace ca1715
+namespace ca1720
 {
     //<snippet1>
     // This code violates the rule.


### PR DESCRIPTION
## Summary

Fixes #48958


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1720.md](https://github.com/dotnet/docs/blob/b9067db6173ae547e65cbb63fbd8b63de41bb612/docs/fundamentals/code-analysis/quality-rules/ca1720.md) | [CA1720: Identifiers should not contain type names](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1720?branch=pr-en-us-48959) |


<!-- PREVIEW-TABLE-END -->