### PR TITLE
Add code example for CA1725 rule (#48960)

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1725.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1725.md
@@ -10,6 +10,8 @@ helpviewer_keywords:
 - ParameterNamesShouldMatchBaseDeclaration
 author: gewarren
 ms.author: gewarren
+dev_langs:
+- CSharp
 ---
 # CA1725: Parameter names should match base declaration
 
@@ -34,6 +36,10 @@ Consistent naming of parameters in an override hierarchy increases the usability
 ## How to fix violations
 
 To fix a violation of this rule, rename the parameter to match the base declaration. The fix is a breaking change for callers who specify the parameter name.
+
+## Example
+
+:::code language="csharp" source="snippets/csharp/all-rules/ca1725.cs" id="snippet1":::
 
 ## When to suppress warnings
 

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1725.cs
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1725.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace ca1725
+{
+    //<snippet1>
+    public interface IUserService
+    {
+        int GetAge(int id);
+    }
+
+    public class UserService : IUserService
+    {
+        // Violates CA1725: Parameter name should match the base declaration ('id')
+        // for consistency with IUserService
+        public int GetAge(int userId)
+        {
+            throw new NotImplementedException();
+        }
+    }
+    //</snippet1>
+}


### PR DESCRIPTION
## Summary

Fixes #48960


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1725.md](https://github.com/dotnet/docs/blob/83cdb3012a122ae0a8a0c11ea59d1affdc4cf0b6/docs/fundamentals/code-analysis/quality-rules/ca1725.md) | [CA1725: Parameter names should match base declaration](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1725?branch=pr-en-us-48961) |

<!-- PREVIEW-TABLE-END -->