### PR TITLE
Add code example for CA1727 rule (#48962)

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1727.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1727.md
@@ -9,6 +9,8 @@ helpviewer_keywords:
 - CA1727
 - LoggerMessageDefineAnalyzer
 author: Youssef1313
+dev_langs:
+- CSharp
 ---
 # CA1727: Use PascalCase for named placeholders
 
@@ -31,6 +33,10 @@ A named placeholder used with <xref:Microsoft.Extensions.Logging.ILogger> should
 ## How to fix violations
 
 Use PascalCase for named placeholders. For example, change `{firstName}` to `{FirstName}`.
+
+## Example
+
+:::code language="csharp" source="snippets/csharp/all-rules/ca1727.cs" id="snippet1":::
 
 ## When to suppress warnings
 

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1727.cs
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1727.cs
@@ -1,0 +1,25 @@
+using Microsoft.Extensions.Logging;
+
+namespace ca1727
+{
+    //<snippet1>
+    public class UserService
+    {
+        private readonly ILogger<UserService> _logger;
+
+        public UserService(ILogger<UserService> logger)
+        {
+            _logger = logger;
+        }
+
+        public void Create(string firstName, string lastName)
+        {
+            // This code violates the rule.
+            _logger.LogInformation("Creating user {firstName} {lastName}", firstName, lastName);
+
+            // This code satisfies the rule.
+            _logger.LogInformation("Creating user {FirstName} {LastName}", firstName, lastName);
+        }
+    }
+    //</snippet1>
+}


### PR DESCRIPTION
## Summary

Fixes #48962


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1727.md](https://github.com/dotnet/docs/blob/abf1e82b746ed56fe2cb5a44a14e3e571ba8b3d5/docs/fundamentals/code-analysis/quality-rules/ca1727.md) | [CA1727: Use PascalCase for named placeholders](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1727?branch=pr-en-us-48963) |

<!-- PREVIEW-TABLE-END -->