### PR TITLE
Update strong naming guidance for .NET libraries to only apply to applicable platforms

### DIFF
--- a/docs/standard/library-guidance/strong-naming.md
+++ b/docs/standard/library-guidance/strong-naming.md
@@ -41,7 +41,9 @@ You should strong name your open-source .NET libraries if their targets include 
 > [!NOTE]
 > This guidance is specific to publicly distributed .NET libraries, such as .NET libraries published on NuGet.org. Strong naming is not required by most .NET applications and should not be done by default.
 
-✔️ CONSIDER strong naming your library's assemblies.
+✔️ CONSIDER strong naming your library's assemblies if you target .NET Framework or .NET Standard.
+
+> Strong naming has no impact on modern .NET Runtimes, so if you only target .NET then you can skip it.
 
 ✔️ CONSIDER adding the strong naming key pair (public + private) to your source control system.
 

--- a/docs/standard/library-guidance/strong-naming.md
+++ b/docs/standard/library-guidance/strong-naming.md
@@ -1,7 +1,7 @@
 ---
 title: Strong naming and .NET libraries
 description: Best practice recommendations for strong naming .NET libraries.
-ms.date: 10/16/2018
+ms.date: 10/13/2025
 ---
 # Strong naming
 
@@ -34,9 +34,9 @@ The benefits of strong naming on .NET Framework are:
 
 Strong naming has no benefits on .NET Core/5+. C# compiler produces CS8002 warning for strong-named assemblies referencing non-strong named assemblies. It is fine to suppress this warning for libraries that target .NET Core/5+ only.
 
-## Create strong named .NET libraries
+## When to strong name .NET libraries
 
-You should strong name your open-source .NET libraries if their targets include .NET Framework or .NET Standard. Strong naming is not required for libraries that target .NET Core/5+ only.
+Strong naming is not required for libraries that target .NET Core/5+ only. You should strong name your open-source .NET libraries if their targets include .NET Framework or .NET Standard.
 
 > [!NOTE]
 > This guidance is specific to publicly distributed .NET libraries, such as .NET libraries published on NuGet.org. Strong naming is not required by most .NET applications and should not be done by default.

--- a/docs/standard/library-guidance/strong-naming.md
+++ b/docs/standard/library-guidance/strong-naming.md
@@ -44,6 +44,7 @@ You should strong name your open-source .NET libraries if their targets include 
 ✔️ CONSIDER strong naming your library's assemblies if you only target .NET Framework or .NET Standard.
 
 > Strong naming has no impact on modern .NET runtimes. If your library only targets modern .NET, then you don't need to strong name your assemblies.
+
 > If you multi-target across .NET Framework/.NET Standard _and_ modern .NET, then you should strong name across all of your Target Frameworks.
 
 ✔️ CONSIDER adding the strong naming key pair (public + private) to your source control system.

--- a/docs/standard/library-guidance/strong-naming.md
+++ b/docs/standard/library-guidance/strong-naming.md
@@ -41,9 +41,10 @@ You should strong name your open-source .NET libraries if their targets include 
 > [!NOTE]
 > This guidance is specific to publicly distributed .NET libraries, such as .NET libraries published on NuGet.org. Strong naming is not required by most .NET applications and should not be done by default.
 
-✔️ CONSIDER strong naming your library's assemblies if you target .NET Framework or .NET Standard.
+✔️ CONSIDER strong naming your library's assemblies if you only target .NET Framework or .NET Standard.
 
-> Strong naming has no impact on modern .NET runtimes. If your library only targets .NET, then you don't need to strong name your assemblies.
+> Strong naming has no impact on modern .NET runtimes. If your library only targets modern .NET, then you don't need to strong name your assemblies.
+> If you multi-target across .NET Framework/.NET Standard _and_ modern .NET, then you should strong name across all of your Target Frameworks.
 
 ✔️ CONSIDER adding the strong naming key pair (public + private) to your source control system.
 

--- a/docs/standard/library-guidance/strong-naming.md
+++ b/docs/standard/library-guidance/strong-naming.md
@@ -43,7 +43,7 @@ You should strong name your open-source .NET libraries if their targets include 
 
 ✔️ CONSIDER strong naming your library's assemblies if you target .NET Framework or .NET Standard.
 
-> Strong naming has no impact on modern .NET Runtimes, so if you only target .NET then you can skip it.
+> Strong naming has no impact on modern .NET runtimes. If your library only targets .NET, then you don't need to strong name your assemblies.
 
 ✔️ CONSIDER adding the strong naming key pair (public + private) to your source control system.
 


### PR DESCRIPTION
Since Strong Naming has no impact on modern .NET Runtimes, limit the scope of guidance to .NET Framework and .NET Standard


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/library-guidance/strong-naming.md](https://github.com/dotnet/docs/blob/9efc8978441d1c59634197bfcd68c3848dd7ee77/docs/standard/library-guidance/strong-naming.md) | [Strong naming](https://review.learn.microsoft.com/en-us/dotnet/standard/library-guidance/strong-naming?branch=pr-en-us-49026) |


<!-- PREVIEW-TABLE-END -->