### PR TITLE
add info about accessibility modifiers in constructors for F# records

### DIFF
--- a/docs/fsharp/language-reference/records.md
+++ b/docs/fsharp/language-reference/records.md
@@ -22,7 +22,7 @@ type [accessibility-modifier] typename =
 ```
 
 > [!NOTE]
-> The `accessibility modifier` before the `typename` is `public` by default, and affects the entire type visibility. The second `accessibility modifier` only affects both constructor and fields.
+> The `accessibility modifier` before the `typename` affects the visibility of the entire type, and is `public` by default. The second `accessibility modifier` only affects the constructor and fields.
 
 ## Remarks
 
@@ -193,7 +193,7 @@ type internal internalRecd = { X: int }
 type recdWithInternalCtor = private { Y: int }
 ```
 
-In the `Test1.fs` file, the internal record must be initialized with the `internal` access modifier, that's because the protection level of the variable and the record must match, and both must belong to the same assembly.
+In the `Test1.fs` file, the internal record must be initialized with the `internal` access modifier, that's because the protection level of the value and the record must match, and both must belong to the same assembly.
 
 ```fsharp
 // Test1.fs

--- a/docs/fsharp/language-reference/records.md
+++ b/docs/fsharp/language-reference/records.md
@@ -6,16 +6,18 @@ ms.date: 12/21/2021
 ---
 # Records (F#)
 
-Records represent simple aggregates of named values, optionally with members. They can either be structs or reference types.  They are reference types by default.
+Records represent simple aggregates of named values, optionally with members. They can either be structs or reference types. They are reference types by default.
 
 ## Syntax
 
 ```fsharp
 [ attributes ]
 type [accessibility-modifier] typename =
-    { [ mutable ] label1 : type1;
-      [ mutable ] label2 : type2;
-      ... }
+    [accessibility-modifier] { 
+        [ mutable ] label1 : type1;
+        [ mutable ] label2 : type2;
+        ... 
+    }
     [ member-list ]
 ```
 
@@ -96,15 +98,15 @@ For example, the following code defines a `Person` and `Address` type as mutuall
 ```fsharp
 // Create a Person type and use the Address type that is not defined
 type Person =
-  { Name: string
-    Age: int
-    Address: Address }
+    { Name: string
+      Age: int
+      Address: Address }
 // Define the Address type which is used in the Person record
 and Address =
-  { Line1: string
-    Line2: string
-    PostCode: string
-    Occupant: Person }
+    { Line1: string
+      Line2: string
+      PostCode: string
+      Occupant: Person }
 ```
 
 To create instances of both, you do the following:
@@ -112,17 +114,17 @@ To create instances of both, you do the following:
 ```fsharp
 // Create a Person type and use the Address type that is not defined
 let rec person =
-  {
-      Name = "Person name"
-      Age = 12
-      Address =
-          {
-              Line1 = "line 1"
-              Line2 = "line 2"
-              PostCode = "abc123"
-              Occupant = person
-          }
-  }
+    {
+        Name = "Person name"
+        Age = 12
+        Address =
+            {
+                Line1 = "line 1"
+                Line2 = "line 2"
+                PostCode = "abc123"
+                Occupant = person
+            }
+    }
 ```
 
 If you were to define the previous example without the `and` keyword, then it would not compile. The `and` keyword is required for mutually recursive definitions.
@@ -147,9 +149,9 @@ You can specify members on records much like you can with classes. There is no s
 
 ```fsharp
 type Person =
-  { Name: string
-    Age: int
-    Address: string }
+    { Name: string
+      Age: int
+      Address: string }
 
     static member Default =
         { Name = "Phillip"
@@ -163,9 +165,9 @@ If you use a self identifier, that identifier refers to the instance of the reco
 
 ```fsharp
 type Person =
-  { Name: string
-    Age: int
-    Address: string }
+    { Name: string
+      Age: int
+      Address: string }
 
     member this.WeirdToString() =
         this.Name + this.Address + string this.Age
@@ -173,6 +175,47 @@ type Person =
 let p = { Name = "a"; Age = 12; Address = "abc123" }
 let weirdString = p.WeirdToString()
 ```
+
+## Accessibility Modifiers on Constructors
+
+You can modify the accessibility of the respective properties of the record's constructor, which affects how they are accessed from outside the module. The following code example illustrates this.
+
+```fsharp
+module Person =
+
+    type Person =
+        private {
+            Name: string
+            Age: int
+            Address: string
+        }
+    
+    let createPerson name age address =
+        { Name = name; Age = age; Address = address }
+    
+    let getPersonInfo (person: Person) =
+        $"- Name: {person.Name}\n- Age: {person.Age}\n- Address: {person.Address}"
+
+module Main =
+    open Person
+
+    let person = createPerson "Phillip" 12 "123 happy fun street"
+
+    // Outside the 'Person' module, this line will cause a compiler error.
+    // let personName = person.Name 
+    
+    printfn "%s" (getPersonInfo person)
+```
+
+The output of this code is as follows:
+
+```console
+- Name: Phillip
+- Age: 12
+- Address: 123 happy fun street
+```
+
+For more information about accessibility modifiers, see the [Access Control](./access-control.md) article.
 
 ## Differences Between Records and Classes
 

--- a/docs/fsharp/language-reference/records.md
+++ b/docs/fsharp/language-reference/records.md
@@ -190,7 +190,7 @@ module Module1
 
 type internal internalRecd = { X: int }
 
-type recdWithInternalCtor = private { Y: int; }
+type recdWithInternalCtor = private { Y: int }
 ```
 
 In the `Test1.fs` file, the internal record must be initialized with the `internal` access modifier, that's because the protection level of the variable and the record must match, and both must belong to the same assembly.

--- a/docs/fsharp/language-reference/records.md
+++ b/docs/fsharp/language-reference/records.md
@@ -21,6 +21,9 @@ type [accessibility-modifier] typename =
     [ member-list ]
 ```
 
+> [!NOTE]
+> The `accessibility modifier` before the `typename` is `public` by default, and affects the entire type visibility. The second `accessibility modifier` only affects both constructor and fields.
+
 ## Remarks
 
 In the previous syntax, *typename* is the name of the record type, *label1* and *label2* are names of values, referred to as *labels*, and *type1* and *type2* are the types of these values. *member-list* is the optional list of members for the type.  You can use the `[<Struct>]` attribute to create a struct record rather than a record which is a reference type.
@@ -176,43 +179,44 @@ let p = { Name = "a"; Age = 12; Address = "abc123" }
 let weirdString = p.WeirdToString()
 ```
 
-## Accessibility Modifiers on Constructors
+## Accessibility Modifiers on Records
 
-You can modify the accessibility of the respective properties of the record's constructor, which affects how they are accessed from outside the module. The following code example illustrates this.
+The following code illustrates the use of accessibility modifiers. There are three files in the project: `Module1.fs`, `Test1.fs`, and `Test2.fs`. An internal record type and a record type with a private constructor are defined in Module1.
 
 ```fsharp
-module Person =
+// Module1.fs
 
-    type Person =
-        private {
-            Name: string
-            Age: int
-            Address: string
-        }
-    
-    let createPerson name age address =
-        { Name = name; Age = age; Address = address }
-    
-    let getPersonInfo (person: Person) =
-        $"- Name: {person.Name}\n- Age: {person.Age}\n- Address: {person.Address}"
+module Module1
 
-module Main =
-    open Person
+type internal internalRecd = { X: int }
 
-    let person = createPerson "Phillip" 12 "123 happy fun street"
-
-    // Outside the 'Person' module, this line will cause a compiler error.
-    // let personName = person.Name 
-    
-    printfn "%s" (getPersonInfo person)
+type recdWithInternalCtor = private { Y: int; }
 ```
 
-The output of this code is as follows:
+In the `Test1.fs` file, the internal record must be initialized with the `internal` access modifier, that's because the protection level of the variable and the record must match, and both must belong to the same assembly.
 
-```console
-- Name: Phillip
-- Age: 12
-- Address: 123 happy fun street
+```fsharp
+// Test1.fs
+
+module Test1
+
+open Module1
+
+let myInternalRecd1 = { X = 2 } // This line will cause a compiler error.
+
+let internal myInternalRecd2 = { X = 4 } // This is OK
+```
+
+In the `Test2.fs` file, the record with the private constructor cannot be initialized directly due the protection level of the constructor.
+
+```fsharp
+// Test2.fs
+
+module Test2
+
+open Module1
+
+let myRecdWithInternalCtor = { Y = 6 } // This line will cause a compiler error.
 ```
 
 For more information about accessibility modifiers, see the [Access Control](./access-control.md) article.

--- a/docs/fsharp/language-reference/records.md
+++ b/docs/fsharp/language-reference/records.md
@@ -21,8 +21,7 @@ type [accessibility-modifier] typename =
     [ member-list ]
 ```
 
-> [!NOTE]
-> The `accessibility modifier` before the `typename` affects the visibility of the entire type, and is `public` by default. The second `accessibility modifier` only affects the constructor and fields.
+The `accessibility modifier` before the `typename` affects the visibility of the entire type, and is `public` by default. The second `accessibility modifier` only affects the constructor and fields.
 
 ## Remarks
 


### PR DESCRIPTION
## Summary

- This PR adds the missing information about accessibility modifiers in constructors for F# `Records` and includes a mention of them in the syntax.

Fixes #48480


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/records.md](https://github.com/dotnet/docs/blob/d49edd7e6928718d20593e702657b18ecb3423fc/docs/fsharp/language-reference/records.md) | [Records (F#)](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/records?branch=pr-en-us-49028) |


<!-- PREVIEW-TABLE-END -->