### PR TITLE
Remove --no-cache

### DIFF
--- a/docs/core/tools/dotnet-restore.md
+++ b/docs/core/tools/dotnet-restore.md
@@ -18,7 +18,7 @@ dotnet restore [<PROJECT>|<SOLUTION>|<FILE>]
   [-a|--arch <ARCHITECTURE>] [--configfile <FILE>] [--disable-build-servers]
   [--disable-parallel] [-f|--force] [--force-evaluate]
   [--ignore-failed-sources] [--interactive] [--lock-file-path <LOCK_FILE_PATH>]
-  [--locked-mode] [--no-cache] [--no-dependencies] [--no-http-cache]
+  [--locked-mode] [--no-dependencies] [--no-http-cache]
   [--os <OS>] [--packages <PACKAGES_DIRECTORY>]
   [-r|--runtime <RUNTIME_IDENTIFIER>] [-s|--source <SOURCE>]
   [--tl:[auto|on|off]] [--ucr|--use-current-runtime] [--use-lock-file]
@@ -122,10 +122,6 @@ There are three specific settings that `dotnet restore` ignores:
 - **`--locked-mode`**
 
   Don't allow updating project lock file.
-
-- **`--no-cache`**
-
-  Specifies to not cache HTTP requests.
 
 - **`--no-dependencies`**
 


### PR DESCRIPTION
## Summary

It's been replaced by --no-http-cache and we shouldn't be documented it anymore as we want people to use `--no-http-cache`

Fixes [#Issue_Number (if available)](https://github.com/NuGet/Home/issues/14582)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-restore.md](https://github.com/dotnet/docs/blob/002fe570a1c61b988285a51fb2378511c5bf8b42/docs/core/tools/dotnet-restore.md) | [docs/core/tools/dotnet-restore](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-restore?branch=pr-en-us-49029) |

<!-- PREVIEW-TABLE-END -->