### PR TITLE
Add code example for CA2008 rule (#49035)

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca2008.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2008.md
@@ -9,6 +9,8 @@ helpviewer_keywords:
 - CA2008
 author: gewarren
 ms.author: gewarren
+dev_langs:
+- CSharp
 ---
 # CA2008: Do not create tasks without passing a TaskScheduler
 
@@ -41,6 +43,44 @@ For further information and detailed examples, see [New TaskCreationOptions and 
 ## How to fix violations
 
 To fix violations, call the method overload that takes a <xref:System.Threading.Tasks.TaskScheduler> and explicitly pass in <xref:System.Threading.Tasks.TaskScheduler.Default%2A> or <xref:System.Threading.Tasks.TaskScheduler.Current%2A> to make the intent clear.
+
+## Example
+
+```csharp
+// This code violates the rule.
+var badTask = Task.Factory.StartNew(
+    () =>
+    {
+        // ...
+    }
+);
+badTask.ContinueWith(
+    t =>
+    {
+        // ...
+    }
+);
+
+// This code satisfies the rule.
+var goodTask = Task.Factory.StartNew(
+    () =>
+    {
+        // ...
+    },
+    CancellationToken.None,
+    TaskCreationOptions.None,
+    TaskScheduler.Default
+);
+goodTask.ContinueWith(
+    t =>
+    {
+        // ...
+    },
+    CancellationToken.None,
+    TaskContinuationOptions.None,
+    TaskScheduler.Default
+);
+```
 
 ## When to suppress warnings
 


### PR DESCRIPTION
## Summary

Fixes #49035


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca2008.md](https://github.com/dotnet/docs/blob/5e94f3d8c465574a4b9c757ac13041d3e40d2930/docs/fundamentals/code-analysis/quality-rules/ca2008.md) | [CA2008: Do not create tasks without passing a TaskScheduler](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2008?branch=pr-en-us-49036) |

<!-- PREVIEW-TABLE-END -->