### PR TITLE
Add code example for CA2014 rule (#49039)

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca2014.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2014.md
@@ -10,6 +10,8 @@ helpviewer_keywords:
   - "CA2014"
 author: stephentoub
 ms.author: stoub
+dev_langs:
+- CSharp
 ---
 # CA2014: Do not use stackalloc in loops
 
@@ -32,6 +34,10 @@ The C# `stackalloc` expression allocates memory from the current stack frame, an
 ## How to fix violations
 
 Move the `stackalloc` expression outside of all loops in the method.
+
+## Example
+
+:::code language="csharp" source="snippets/csharp/all-rules/ca2014.cs" id="snippet1":::
 
 ## When to suppress warnings
 

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca2014.cs
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca2014.cs
@@ -1,0 +1,36 @@
+using System;
+
+namespace ca2014
+{
+    public class Example
+    {
+        //<snippet1>
+        // This method violates the rule.
+        public void ProcessDataBad()
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                // CA2014: Potential stack overflow.
+                // Move the stackalloc out of the loop.
+                Span<int> buffer = stackalloc int[100];
+                buffer[0] = i;
+
+                // ...
+            }
+        }
+
+        // This method satisfies the rule.
+        public void ProcessDataGood()
+        {
+            Span<int> buffer = stackalloc int[100];
+
+            for (int i = 0; i < 100; i++)
+            {
+                buffer[0] = i;
+
+                // ...
+            }
+        }
+        //</snippet1>
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #49039


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca2014.md](https://github.com/dotnet/docs/blob/7c5bc973f0f9523f6a548e1ba0dd0771add17352/docs/fundamentals/code-analysis/quality-rules/ca2014.md) | [CA2014: Do not use stackalloc in loops](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2014?branch=pr-en-us-49040) |

<!-- PREVIEW-TABLE-END -->