### PR TITLE
Add code example for CA2201 rule (#49058)

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca2201.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2201.md
@@ -10,6 +10,8 @@ helpviewer_keywords:
 - DoNotRaiseReservedExceptionTypes
 author: gewarren
 ms.author: gewarren
+dev_langs:
+- CSharp
 ---
 # CA2201: Do not raise reserved exception types
 
@@ -77,6 +79,29 @@ For all other situations, consider creating your own type that derives from <xre
 ## How to fix violations
 
 To fix a violation of this rule, change the type of the thrown exception to a specific type that's not one of the reserved types.
+
+## Example
+
+```csharp
+// This code violates the rule.
+throw new Exception();
+throw new NullReferenceException();
+throw new IndexOutOfRangeException();
+// ...
+
+// This code satisfies the rule.
+throw new ArgumentException();
+throw new ArgumentNullException();
+throw new InvalidOperationException();
+// ...
+
+// A minimal implementation of inheritance from Exception
+public class CustomException : Exception { }
+
+// Or create your own type that derives from Exception
+// This code satisfies the rule too.
+throw new CustomException();
+```
 
 ## When to suppress warnings
 


### PR DESCRIPTION
## Summary

Fixes #49058


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca2201.md](https://github.com/dotnet/docs/blob/65b3aeb4fa8ae2be1085df6e5e9ec364e51b594c/docs/fundamentals/code-analysis/quality-rules/ca2201.md) | [CA2201: Do not raise reserved exception types](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2201?branch=pr-en-us-49059) |

<!-- PREVIEW-TABLE-END -->