### PR TITLE
Add code example for CA2219 rule (#49062)

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca2219.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2219.md
@@ -10,6 +10,8 @@ helpviewer_keywords:
 - CA2219
 author: gewarren
 ms.author: gewarren
+dev_langs:
+- CSharp
 ---
 # CA2219: Do not raise exceptions in exception clauses
 
@@ -36,6 +38,20 @@ When an exception is raised in a filter clause, the runtime silently catches the
 ## How to fix violations
 
 To fix this violation of this rule, do not explicitly raise an exception from a `finally`, filter, or fault clause.
+
+## Example
+
+```csharp
+try
+{
+    // ...
+}
+finally
+{
+    // This code violates the rule.
+    throw new Exception();
+}
+```
 
 ## When to suppress warnings
 


### PR DESCRIPTION
## Summary

Fixes #49062


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca2219.md](https://github.com/dotnet/docs/blob/6b412692545a1e4dc0b4ad172972d2937799caec/docs/fundamentals/code-analysis/quality-rules/ca2219.md) | [CA2219: Do not raise exceptions in exception clauses](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2219?branch=pr-en-us-49063) |

<!-- PREVIEW-TABLE-END -->