### PR TITLE
Add warning for untrusted .NET templates

### DIFF
--- a/docs/core/tools/custom-templates.md
+++ b/docs/core/tools/custom-templates.md
@@ -230,7 +230,7 @@ project_folder
 
 Use the [dotnet new install](dotnet-new-install.md) command to install a template package.
 
-[!WARNING] Templates can run msbuild code when triggering the template so do not install or run untrusted .NET templates.
+[!WARNING] Templates can run MSBuild code when triggered, do not install or run untrusted .NET templates.
 
 ### To install a template package from a NuGet package stored at nuget.org
 

--- a/docs/core/tools/custom-templates.md
+++ b/docs/core/tools/custom-templates.md
@@ -230,6 +230,8 @@ project_folder
 
 Use the [dotnet new install](dotnet-new-install.md) command to install a template package.
 
+[!WARNING] Templates can run msbuild code when triggering the template so do not install or run untrusted .NET templates.
+
 ### To install a template package from a NuGet package stored at nuget.org
 
 Use the NuGet package identifier to install a template package.

--- a/docs/core/tools/custom-templates.md
+++ b/docs/core/tools/custom-templates.md
@@ -230,7 +230,8 @@ project_folder
 
 Use the [dotnet new install](dotnet-new-install.md) command to install a template package.
 
-[!WARNING] Templates can run MSBuild code when triggered, do not install or run untrusted .NET templates.
+> [!WARNING]
+> Templates can run MSBuild code when triggered, don't install or run untrusted .NET templates.
 
 ### To install a template package from a NuGet package stored at nuget.org
 

--- a/docs/core/tools/dotnet-new-install.md
+++ b/docs/core/tools/dotnet-new-install.md
@@ -11,9 +11,6 @@ ms.date: 04/15/2022
 
 `dotnet new install` - installs a template package.
 
-> [!WARNING]
-> Templates can run MSBuild code when triggered, don't install or run untrusted .NET templates.
-
 ## Synopsis
 
 ```dotnetcli
@@ -44,6 +41,9 @@ Starting with .NET SDK 6.0.100, installed template packages are available in lat
 >   ```dotnetcli
 >   dotnet new --install Microsoft.Azure.WebJobs.ProjectTemplates
 >   ```
+
+> [!WARNING]
+> Templates can run MSBuild code when triggered, don't install or run untrusted .NET templates.
 
 ## Arguments
 

--- a/docs/core/tools/dotnet-new-install.md
+++ b/docs/core/tools/dotnet-new-install.md
@@ -11,6 +11,8 @@ ms.date: 04/15/2022
 
 `dotnet new install` - installs a template package.
 
+[!WARNING] Templates can run MSBuild code when triggered, do not install or run untrusted .NET templates.
+
 ## Synopsis
 
 ```dotnetcli

--- a/docs/core/tools/dotnet-new-install.md
+++ b/docs/core/tools/dotnet-new-install.md
@@ -11,7 +11,8 @@ ms.date: 04/15/2022
 
 `dotnet new install` - installs a template package.
 
-[!WARNING] Templates can run MSBuild code when triggered, do not install or run untrusted .NET templates.
+> [!WARNING]
+> Templates can run MSBuild code when triggered, don't install or run untrusted .NET templates.
 
 ## Synopsis
 


### PR DESCRIPTION
Added a warning about untrusted .NET templates.

## Summary

We wanted to make sure customers knew that installing and running untrusted templates came with risk. Let me know if I should update the dotnet new install documentation as well.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/custom-templates.md](https://github.com/dotnet/docs/blob/4da8dfb2b1b24e0ad04ec4e365bf91029818bdea/docs/core/tools/custom-templates.md) | [docs/core/tools/custom-templates](https://review.learn.microsoft.com/en-us/dotnet/core/tools/custom-templates?branch=pr-en-us-49074) |
| [docs/core/tools/dotnet-new-install.md](https://github.com/dotnet/docs/blob/4da8dfb2b1b24e0ad04ec4e365bf91029818bdea/docs/core/tools/dotnet-new-install.md) | [docs/core/tools/dotnet-new-install](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-new-install?branch=pr-en-us-49074) |


<!-- PREVIEW-TABLE-END -->