### PR TITLE
Add formatting for CA2247 example

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca2247.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2247.md
@@ -35,11 +35,10 @@ The TaskCompletionSource type has a constructor that accepts a <xref:System.Thre
 To fix the violation, replace the <xref:System.Threading.Tasks.TaskContinuationOptions?displayProperty=fullName> enum value with the corresponding <xref:System.Threading.Tasks.TaskCreationOptions?displayProperty=fullName> enum value.
 
 ```csharp
-    // Violation
-    var tcs = new TaskCompletionSource<int>(TaskContinuationOptions.RunContinuationsAsynchronously);
-
-    // Fixed
-    var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+// Violation
+var tcs = new TaskCompletionSource<int>(TaskContinuationOptions.RunContinuationsAsynchronously);
+// Fixed
+var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
 ```
 
 ## When to suppress warnings

--- a/docs/fundamentals/code-analysis/quality-rules/ca2247.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2247.md
@@ -37,6 +37,7 @@ To fix the violation, replace the <xref:System.Threading.Tasks.TaskContinuationO
 ```csharp
 // Violation
 var tcs = new TaskCompletionSource<int>(TaskContinuationOptions.RunContinuationsAsynchronously);
+
 // Fixed
 var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
 ```


### PR DESCRIPTION
## Summary

https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2247


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca2247.md](https://github.com/dotnet/docs/blob/f4978c8b03f17c599446d8bd2d625924fa952a60/docs/fundamentals/code-analysis/quality-rules/ca2247.md) | [CA2247: Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2247?branch=pr-en-us-49088) |


<!-- PREVIEW-TABLE-END -->