### PR TITLE
Add code example for CA2253 rule (#49089)

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca2253.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2253.md
@@ -9,6 +9,8 @@ helpviewer_keywords:
 - LoggerMessageDefineAnalyzer
 - CA2253
 author: Youssef1313
+dev_langs:
+- CSharp
 ---
 # CA2253: Named placeholders should not be numeric values
 
@@ -33,6 +35,10 @@ Named placeholders in the logging message template should not be composed of onl
 Rename the numeric placeholder.
 
 For usage examples, see the <xref:Microsoft.Extensions.Logging.LoggerExtensions.LogInformation%2A?displayProperty=nameWithType> method.
+
+## Example
+
+:::code language="csharp" source="snippets/csharp/all-rules/ca2253.cs" id="snippet1":::
 
 ## When to suppress errors
 

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca2253.cs
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca2253.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.Logging;
+
+namespace ca2253
+{
+    //<snippet1>
+    public class UserService
+    {
+        private readonly ILogger<UserService> _logger;
+
+        public UserService(ILogger<UserService> logger)
+        {
+            _logger = logger;
+        }
+
+        public void Add(string firstName, string lastName)
+        {
+            // This code violates the rule.
+            _logger.LogInformation("Adding user with first name {0} and last name {1}", firstName, lastName);
+
+            // This code satisfies the rule.
+            _logger.LogInformation("Adding user with first name {FirstName} and last name {LastName}", firstName, lastName);
+
+            // ...
+        }
+    }
+    //</snippet1>
+}


### PR DESCRIPTION
## Summary

Fixes #49089


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca2253.md](https://github.com/dotnet/docs/blob/5701a212da8cb4b6b82f473484574b6d128e24a8/docs/fundamentals/code-analysis/quality-rules/ca2253.md) | [CA2253: Named placeholders should not be numeric values](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2253?branch=pr-en-us-49090) |

<!-- PREVIEW-TABLE-END -->