### PR TITLE
Add code example for CA2251 rule (#49091)

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca2251.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2251.md
@@ -32,6 +32,19 @@ The result of a call to <xref:System.String.Compare%2A?displayProperty=nameWithT
 
 To fix violations of this rule, replace the expression comparing the result of <xref:System.String.Compare%2A?displayProperty=nameWithType> with a call to <xref:System.String.Equals%2A?displayProperty=nameWithType>.
 
+## Example
+
+```csharp
+string leftValue = "...";
+string rightValue = "...";
+
+// This code violates the rule.
+bool areEqualUsingCompare = string.Compare(leftValue, rightValue, StringComparison.OrdinalIgnoreCase) == 0;
+
+// This code satisfies the rule.
+bool areEqualUsingEquals = string.Equals(leftValue, rightValue, StringComparison.OrdinalIgnoreCase);
+```
+
 ## When to suppress warnings
 
 It is safe to suppress warnings from this rule.


### PR DESCRIPTION
## Summary

Fixes #49091

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca2251.md](https://github.com/dotnet/docs/blob/355fafd961339b278c9d854948ab276d40bf7f60/docs/fundamentals/code-analysis/quality-rules/ca2251.md) | [CA2251: Use `String.Equals` over `String.Compare`](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2251?branch=pr-en-us-49092) |

<!-- PREVIEW-TABLE-END -->