### PR TITLE
[F#] Add FS0410 compiler message

### DIFF
--- a/docs/fsharp/language-reference/compiler-messages/fs0410.md
+++ b/docs/fsharp/language-reference/compiler-messages/fs0410.md
@@ -1,7 +1,7 @@
 ---
 description: "Learn more about: FS0410: The type %s is less accessible than the value, member or type %s it is used in"
 title: "Compiler error FS0410"
-ms.date: 12/10/2025
+ms.date: 10/12/2025
 f1_keywords:
   - "FS0410"
 helpviewer_keywords:

--- a/docs/fsharp/language-reference/compiler-messages/fs0410.md
+++ b/docs/fsharp/language-reference/compiler-messages/fs0410.md
@@ -1,5 +1,5 @@
 ---
-description: "Learn more about: FS0410: The type %s is less accessible than the value, member or type %s it is used in"
+description: "Learn more about: FS0410: A type is less accessible than the value, member or type it is used in"
 title: "Compiler error FS0410"
 ms.date: 10/12/2025
 f1_keywords:

--- a/docs/fsharp/language-reference/compiler-messages/fs0410.md
+++ b/docs/fsharp/language-reference/compiler-messages/fs0410.md
@@ -1,0 +1,27 @@
+---
+description: "Learn more about: FS0410: The type %s is less accessible than the value, member or type %s it is used in"
+title: "Compiler error FS0410"
+ms.date: 12/10/2025
+f1_keywords:
+  - "FS0410"
+helpviewer_keywords:
+  - "FS0410"
+---
+
+# FS0410: The type %s is less accessible than the value, member or type %s it is used in
+
+This message, as the text suggests, is given when attempting to use a type that is less [accessible](../access-control.md) than the value, member or type it is used in.
+
+For example:
+
+[!code-fsharp[FS0410-less-accessible-type](~/samples/snippets/fsharp/compiler-messages/fs0410.fsx#L8-L11)]
+
+Notice that in this example, the type `Person` is `private`, but the function `_getName` is `public`. Also, the function `_getName` uses the type `Person` in its signature, which is not allowed since `Person` is less accessible than `_getName`.
+
+The example above cause the compiler to display the following message:
+
+```text
+FS0410: The type 'Person' is less accessible than the value, member or type 'val _getName: p: Person.Person -> string' it is used in.
+```
+
+A workaround would be changing either the `Person` type or the `_getName` function accessibility.

--- a/docs/fsharp/language-reference/compiler-messages/fs0410.md
+++ b/docs/fsharp/language-reference/compiler-messages/fs0410.md
@@ -8,7 +8,7 @@ helpviewer_keywords:
   - "FS0410"
 ---
 
-# FS0410: The type %s is less accessible than the value, member or type %s it is used in
+# FS0410: A type is less accessible than the value, member or type it is used in
 
 This message, as the text suggests, is given when attempting to use a type that is less [accessible](../access-control.md) than the value, member or type it is used in.
 

--- a/docs/fsharp/language-reference/compiler-messages/fs0410.md
+++ b/docs/fsharp/language-reference/compiler-messages/fs0410.md
@@ -10,7 +10,7 @@ helpviewer_keywords:
 
 # FS0410: A type is less accessible than the value, member or type it is used in
 
-This message, as the text suggests, is given when attempting to use a type that is less [accessible](../access-control.md) than the value, member or type it is used in.
+This message is given when you use a type that is less [accessible](../access-control.md) than the value, member or type it is used in.
 
 For example:
 

--- a/docs/fsharp/language-reference/compiler-messages/fs0410.md
+++ b/docs/fsharp/language-reference/compiler-messages/fs0410.md
@@ -24,4 +24,4 @@ The example above causes the compiler to display the following message:
 FS0410: The type 'Person' is less accessible than the value, member or type 'val _getName: p: Person.Person -> string' it is used in.
 ```
 
-A workaround would be changing either the `Person` type or the `_getName` function accessibility.
+A workaround would be changing the `Person` type to public accessibility, or the `_getName` function to private accessibility.

--- a/docs/fsharp/language-reference/compiler-messages/fs0410.md
+++ b/docs/fsharp/language-reference/compiler-messages/fs0410.md
@@ -18,7 +18,7 @@ For example:
 
 Notice that in this example, the type `Person` is `private`, but the function `_getName` is `public`. Also, the function `_getName` uses the type `Person` in its signature, which is not allowed since `Person` is less accessible than `_getName`.
 
-The example above cause the compiler to display the following message:
+The example above causes the compiler to display the following message:
 
 ```text
 FS0410: The type 'Person' is less accessible than the value, member or type 'val _getName: p: Person.Person -> string' it is used in.

--- a/docs/fsharp/language-reference/compiler-messages/toc.yml
+++ b/docs/fsharp/language-reference/compiler-messages/toc.yml
@@ -21,5 +21,7 @@
     href: ./fs0052.md
   - name: FS0067 - This type test or downcast will always hold
     href: ./fs0067.md
+  - name: FS0410 - The type %s is less accessible than the value, member or type %s it is used in
+    href: ./fs0410.md
   - name: FS0703 - Expected type parameter, not unit-of-measure parameter
     href: ./fs0703.md

--- a/docs/fsharp/language-reference/compiler-messages/toc.yml
+++ b/docs/fsharp/language-reference/compiler-messages/toc.yml
@@ -21,7 +21,7 @@
     href: ./fs0052.md
   - name: FS0067 - This type test or downcast will always hold
     href: ./fs0067.md
-  - name: FS0410 - The type %s is less accessible than the value, member or type %s it is used in
+  - name: FS0410 - A type is less accessible than the value, member or type it is used in
     href: ./fs0410.md
   - name: FS0703 - Expected type parameter, not unit-of-measure parameter
     href: ./fs0703.md

--- a/samples/snippets/fsharp/compiler-messages/fs0410.fsx
+++ b/samples/snippets/fsharp/compiler-messages/fs0410.fsx
@@ -1,0 +1,11 @@
+(*
+Compiler error: The type %s is less accessible than the value, member or type %s it is used in
+
+Notice that in this example, the type Person is private, but the function _getName is public by default.
+Also, the function _getName uses the type Person in its signature, which is not allowed since Person is
+less accessible than _getName.
+*)
+module Person =
+    type private Person = { Name: string; Email: string }
+
+    let _getName (p: Person) = p.Name


### PR DESCRIPTION
## Summary

This PR adds the missing documentation for the FS0410 compiler message. 

It's defined at the [FSComp.txt](https://github.com/dotnet/fsharp/blob/main/src/Compiler/FSComp.txt) document.

Related to https://github.com/dotnet/docs/pull/48442.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/compiler-messages/fs0410.md](https://github.com/dotnet/docs/blob/737e088b96f0a68a71bd5847967c830814b199f6/docs/fsharp/language-reference/compiler-messages/fs0410.md) | [FS0410: A type is less accessible than the value, member or type it is used in](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/compiler-messages/fs0410?branch=pr-en-us-49100) |
| [docs/fsharp/language-reference/compiler-messages/toc.yml](https://github.com/dotnet/docs/blob/737e088b96f0a68a71bd5847967c830814b199f6/docs/fsharp/language-reference/compiler-messages/toc.yml) | [docs/fsharp/language-reference/compiler-messages/toc](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/compiler-messages/toc?branch=pr-en-us-49100) |


<!-- PREVIEW-TABLE-END -->