### PR TITLE
Add code example for CA2256 rule (#49105)

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca2256.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2256.md
@@ -9,6 +9,8 @@ helpviewer_keywords:
 - DynamicInterfaceCastableImplementationAnalyzer
 - CA2256
 author: Youssef1313
+dev_langs:
+- CSharp
 ---
 # CA2256: All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
 
@@ -32,6 +34,10 @@ Types attributed with <xref:System.Runtime.InteropServices.DynamicInterfaceCasta
 
 Implement the missing interface members.
 
+## Example
+
+:::code language="csharp" source="snippets/csharp/all-rules/ca2256.cs" id="snippet1" highlight="30":::
+
 ## When to suppress errors
 
 Do not suppress a warning from this rule.
@@ -39,3 +45,4 @@ Do not suppress a warning from this rule.
 ## See also
 
 - [Usage warnings](usage-warnings.md)
+- [CA2257: Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'](ca2257.md)

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca2256.cs
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca2256.cs
@@ -1,0 +1,36 @@
+using System.Runtime.InteropServices;
+
+namespace ca2256
+{
+    //<snippet1>
+    interface IParent
+    {
+        void ParentMethod();
+    }
+
+    // This interface violates the rule.
+    [DynamicInterfaceCastableImplementation]
+    interface IBadChild : IParent
+    {
+        static void ChildMethod()
+        {
+            // ...
+        }
+    }
+
+    // This interface satisfies the rule.
+    [DynamicInterfaceCastableImplementation]
+    interface IGoodChild : IParent
+    {
+        static void ChildMethod()
+        {
+            // ...
+        }
+
+        void IParent.ParentMethod()
+        {
+            // ...
+        }
+    }
+    //</snippet1>
+}


### PR DESCRIPTION
## Summary

Fixes #49105


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca2256.md](https://github.com/dotnet/docs/blob/c85c071fcbd9d3397b986ac1a73234ec22d96cc2/docs/fundamentals/code-analysis/quality-rules/ca2256.md) | [CA2256: All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2256?branch=pr-en-us-49107) |

<!-- PREVIEW-TABLE-END -->