### PR TITLE
Add code example for CA2257 rule (#49109)

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca2257.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2257.md
@@ -9,6 +9,8 @@ helpviewer_keywords:
 - DynamicInterfaceCastableImplementationAnalyzer
 - CA2257
 author: Youssef1313
+dev_langs:
+- CSharp
 ---
 # CA2257: Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
 
@@ -32,6 +34,10 @@ Since a type that implements `IDynamicInterfaceCastable` may not implement a dyn
 
 Mark the interface member `static`.
 
+## Example
+
+:::code language="csharp" source="snippets/csharp/all-rules/ca2257.cs" id="snippet1":::
+
 ## When to suppress errors
 
 Do not suppress a warning from this rule.
@@ -39,3 +45,4 @@ Do not suppress a warning from this rule.
 ## See also
 
 - [Usage warnings](usage-warnings.md)
+- [CA2256: All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface](ca2256.md)

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca2257.cs
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca2257.cs
@@ -1,0 +1,19 @@
+using System.Runtime.InteropServices;
+
+namespace ca2257
+{
+    //<snippet1>
+    [DynamicInterfaceCastableImplementation]
+    interface IExample
+    {
+        // This method violates the rule.
+        void BadMethod();
+
+        // This method satisfies the rule.
+        static void GoodMethod()
+        {
+            // ...
+        }
+    }
+    //</snippet1>
+}


### PR DESCRIPTION
## Summary

Fixes #49109

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca2257.md](https://github.com/dotnet/docs/blob/1fab87cad0d7c09ce33a3d918cb5714c75d31181/docs/fundamentals/code-analysis/quality-rules/ca2257.md) | [CA2257: Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2257?branch=pr-en-us-49110) |

<!-- PREVIEW-TABLE-END -->