### PR TITLE
change the type of the 'Version' property to string

### DIFF
--- a/docs/csharp/advanced-topics/reflection-and-attributes/creating-custom-attributes.md
+++ b/docs/csharp/advanced-topics/reflection-and-attributes/creating-custom-attributes.md
@@ -16,12 +16,12 @@ You can create your own custom attributes by defining an attribute class, a clas
 public class AuthorAttribute : System.Attribute
 {
     private string Name;
-    public double Version;
+    public string Version;
 
     public AuthorAttribute(string name)
     {
         Name = name;
-        Version = 1.0;
+        Version = "1.0";
     }
 }
 ```

--- a/docs/csharp/advanced-topics/reflection-and-attributes/snippets/conceptual/ReadAttributes.cs
+++ b/docs/csharp/advanced-topics/reflection-and-attributes/snippets/conceptual/ReadAttributes.cs
@@ -10,14 +10,14 @@
 public class AuthorAttribute : System.Attribute
 {
     string Name;
-    public double Version;
+    public string Version;
 
     public AuthorAttribute(string name)
     {
         Name = name;
 
         // Default value.
-        Version = 1.0;
+        Version = "1.0";
     }
 
     public string GetName() => Name;
@@ -39,7 +39,7 @@ public class SecondClass
 
 // Class with multiple Author attributes.
 // <MultipleAuthors>
-[Author("P. Ackerman"), Author("R. Koch", Version = 2.0)]
+[Author("P. Ackerman"), Author("R. Koch", Version = "2.0")]
 public class ThirdClass
 {
     // ...
@@ -67,23 +67,23 @@ class TestAuthorAttribute
         {
             if (attr is AuthorAttribute a)
             {
-                System.Console.WriteLine($"   {a.GetName()}, version {a.Version:f}");
+                System.Console.WriteLine($"   {a.GetName()}, version {a.Version}");
             }
         }
     }
 }
 /* Output:
     Author information for FirstClass
-       P. Ackerman, version 1.00
+       P. Ackerman, version 1.0
     Author information for SecondClass
     Author information for ThirdClass
-       R. Koch, version 2.00
-       P. Ackerman, version 1.00
+       R. Koch, version 2.0
+       P. Ackerman, version 1.0
 */
 // </DefineAndReadAttribute>
 
 // <SampleWithVersion>
-[Author("P. Ackerman", Version = 1.1)]
+[Author("P. Ackerman", Version = "1.1")]
 class SampleClass
 {
     // P. Ackerman's code goes here...


### PR DESCRIPTION
## Summary

- This PR changes the type of the 'Version' property for the attribute from `double` to `string`.

Fixes #49113


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/advanced-topics/reflection-and-attributes/creating-custom-attributes.md](https://github.com/dotnet/docs/blob/b05d4aa77d9dfaacfd51455c0596c3ee3b30716b/docs/csharp/advanced-topics/reflection-and-attributes/creating-custom-attributes.md) | [docs/csharp/advanced-topics/reflection-and-attributes/creating-custom-attributes](https://review.learn.microsoft.com/en-us/dotnet/csharp/advanced-topics/reflection-and-attributes/creating-custom-attributes?branch=pr-en-us-49114) |


<!-- PREVIEW-TABLE-END -->