### PR TITLE
Remove the first case in the context of name inference in anonymous types

### DIFF
--- a/docs/csharp/fundamentals/types/anonymous-types.md
+++ b/docs/csharp/fundamentals/types/anonymous-types.md
@@ -50,7 +50,6 @@ This simplified syntax is particularly useful when creating anonymous types with
 
 The member name isn't inferred in the following cases:
 
-- The candidate name is a member name of an anonymous type, such as `ToString` or `GetHashCode`.
 - The candidate name is a duplicate of another property member in the same anonymous type, either explicit or implicit.
 - The candidate name isn't a valid identifier (for example, it contains spaces or special characters).
 


### PR DESCRIPTION
## Summary

As discussed in [#49117](https://github.com/dotnet/docs/issues/49117), the first case `The candidate name is a member name of an anonymous type, such as ToString or GetHashCode.` should be removed since the C# language specification does not specify it. For more details please see #49117. 

Fixes #49117


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/fundamentals/types/anonymous-types.md](https://github.com/dotnet/docs/blob/532f9eeed13a68f5d27df2aca6665b26faf61d87/docs/csharp/fundamentals/types/anonymous-types.md) | [Anonymous types](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/types/anonymous-types?branch=pr-en-us-49133) |

<!-- PREVIEW-TABLE-END -->