### PR TITLE
Merge main into live

### DIFF
--- a/docs/core/compatibility/10.0.md
+++ b/docs/core/compatibility/10.0.md
@@ -111,6 +111,7 @@ If you're migrating an app to .NET 10, the breaking changes listed here might af
 | [`dotnet` CLI commands log non-command-relevant data to stderr](sdk/10.0/dotnet-cli-stderr-output.md) | Behavioral change | RC 2 |
 | [.NET tool packaging creates RuntimeIdentifier-specific tool packages](sdk/10.0/dotnet-tool-pack-publish.md) | Behavioral change | Preview 6 |
 | [Default workload configuration from 'loose manifests' to 'workload sets' mode](sdk/10.0/default-workload-config.md) | Behavioral change | Preview 2 |
+| [dnx.ps1 file is no longer included in .NET SDK](sdk/10.0/dnx-ps1-removed.md) | Source incompatible | GA |
 | [`dotnet new sln` defaults to SLNX file format](sdk/10.0/dotnet-new-sln-slnx-default.md) | Behavioral change | RC 1 |
 | [`dotnet package list` performs restore](sdk/10.0/dotnet-package-list-restore.md) | Behavioral change | Preview 4 |
 | [`dotnet restore` audits transitive packages](sdk/10.0/nugetaudit-transitive-packages.md) | Behavioral change | Preview 3 |

--- a/docs/core/compatibility/10.0.md
+++ b/docs/core/compatibility/10.0.md
@@ -125,6 +125,7 @@ If you're migrating an app to .NET 10, the breaking changes listed here might af
 | [NuGet packages with no runtime assets aren't included in deps.json](sdk/10.0/deps-json-trimmed-packages.md) | Source incompatible | Preview 5 |
 | [PackageReference without a version raises an error](sdk/10.0/nu1015-packagereference-version.md) | Behavioral change | Preview 6 |
 | [PrunePackageReference privatizes direct prunable references](sdk/10.0/prune-packagereference-privateassets.md) | Behavioral change | Preview 7 |
+| [Version requirements for .NET 10 SDK](sdk/10.0/version-requirements.md) | Behavioral change | RC 2 |
 | [HTTP warnings promoted to errors in `dotnet package list` and `dotnet package search`](sdk/10.0/http-warnings-to-errors.md) | Behavioral/source incompatible change | Preview 4 |
 | [NUGET_ENABLE_ENHANCED_HTTP_RETRY environment variable removed](sdk/10.0/nuget-enhanced-http-retry-removed.md) | Behavioral change | Preview 6 |
 | [NuGet logs an error for invalid package IDs](sdk/10.0/nuget-packageid-validation.md) | Behavioral change | RC 1 |

--- a/docs/core/compatibility/10.0.md
+++ b/docs/core/compatibility/10.0.md
@@ -76,6 +76,7 @@ If you're migrating an app to .NET 10, the breaking changes listed here might af
 
 | Title | Type of change      | Introduced version |
 |-------|---------------------|--------------------|
+| [BackgroundService runs all of ExecuteAsync as a Task](extensions/10.0/backgroundservice-executeasync-task.md) | Behavioral change | Preview 1 |
 | [Null values preserved in configuration](extensions/10.0/configuration-null-values-preserved.md) | Behavioral change | Preview 7 |
 | [Message no longer duplicated in Console log output](extensions/10.0/console-json-logging-duplicate-messages.md) | Behavioral change | Preview 7 |
 | [ProviderAliasAttribute moved to Microsoft.Extensions.Logging.Abstractions assembly](extensions/10.0/provideraliasattribute-moved-assembly.md) | Source incompatible | Preview 4 |

--- a/docs/core/compatibility/10.0.md
+++ b/docs/core/compatibility/10.0.md
@@ -41,6 +41,7 @@ If you're migrating an app to .NET 10, the breaking changes listed here might af
 |-------|-------------------|--------------------|
 | [ActivitySource.CreateActivity and ActivitySource.StartActivity behavior change](core-libraries/10.0/activity-sampling.md) | Behavioral change | Preview 1 |
 | [Arm64 SVE nonfaulting loads require mask](core-libraries/10.0/sve-nonfaulting-loads-mask-parameter.md) | Binary/source incompatible | Preview 1 |
+| [BufferedStream.WriteByte no longer performs implicit flush](core-libraries/10.0/bufferedstream-writebyte-flush.md) | Behavioral change | Preview 4 |
 | [C# 14 overload resolution with span parameters](core-libraries/10.0/csharp-overload-resolution.md) | Behavioral change | Preview 1 |
 | [Consistent shift behavior in generic math](core-libraries/10.0/generic-math.md) | Behavioral change | Preview 1 |
 | [Default trace context propagator updated to W3C standard](core-libraries/10.0/default-trace-context-propagator.md) | Behavioral change | Preview 4 |

--- a/docs/core/compatibility/8.0.md
+++ b/docs/core/compatibility/8.0.md
@@ -56,6 +56,7 @@ If you're migrating an app to .NET 8, the breaking changes listed here might aff
 | [GetFolderPath behavior on Unix](core-libraries/8.0/getfolderpath-unix.md)                                | Behavioral change   |
 | [GetSystemVersion no longer returns ImageRuntimeVersion](core-libraries/8.0/getsystemversion.md)          | Behavioral change   |
 | [ITypeDescriptorContext nullable annotations](core-libraries/8.0/itypedescriptorcontext-props.md)         | Source incompatible |
+| [LDAP APIs not available on .NET Standard / .NET Framework](core-libraries/8.0/ldap-netstandard-apis.md)  | Binary incompatible |
 | [Legacy Console.ReadKey removed](core-libraries/8.0/console-readkey-legacy.md)                            | Behavioral change   |
 | [Method builders generate parameters with HasDefaultValue set to false](core-libraries/8.0/parameterinfo-hasdefaultvalue.md) | Behavioral change   |
 | [Package part URIs are now compared case-insensitively in System.IO.Packaging](core-libraries/8.0/system-io-packaging-case-insensitive-uri.md) | Behavioral change   |

--- a/docs/core/compatibility/core-libraries/10.0/bufferedstream-writebyte-flush.md
+++ b/docs/core/compatibility/core-libraries/10.0/bufferedstream-writebyte-flush.md
@@ -1,0 +1,57 @@
+---
+title: "Breaking change - BufferedStream.WriteByte no longer performs implicit flush"
+description: "Learn about the breaking change in .NET 10 where BufferedStream.WriteByte no longer performs an implicit flush when the internal buffer is full."
+ms.date: 10/13/2025
+ai-usage: ai-assisted
+ms.custom: https://github.com/dotnet/docs/issues/496356
+dev_langs:
+  - "csharp"
+  - "vb"
+---
+
+# BufferedStream.WriteByte no longer performs implicit flush
+
+The <xref:System.IO.BufferedStream.WriteByte(System.Byte)?displayProperty=nameWithType> method no longer performs an implicit flush when the internal buffer is full. This change aligns the behavior of `BufferedStream.WriteByte` with other `Write` methods in the <xref:System.IO.BufferedStream> class, such as <xref:System.IO.BufferedStream.Write(System.Byte[],System.Int32,System.Int32)?displayProperty=nameWithType> and <xref:System.IO.BufferedStream.WriteAsync(System.Byte[],System.Int32,System.Int32,System.Threading.CancellationToken)?displayProperty=nameWithType>, which don't perform an implicit flush.
+
+## Version introduced
+
+.NET 10 Preview 4
+
+## Previous behavior
+
+Previously, when the internal buffer of a `BufferedStream` was full, calling `WriteByte` automatically flushed the buffer to the underlying stream. This behavior was inconsistent with other `Write` methods in `BufferedStream`.
+
+The following example demonstrates the previous behavior:
+
+:::code language="csharp" source="./snippets/bufferedstream-writebyte-flush/csharp/Program.cs" id="PreviousBehavior":::
+:::code language="vb" source="./snippets/bufferedstream-writebyte-flush/vb/Program.vb" id="PreviousBehavior":::
+
+## New behavior
+
+Starting in .NET 10, the `WriteByte` method no longer performs an implicit flush when the internal buffer is full. The buffer is only flushed when the <xref:System.IO.BufferedStream.Flush?displayProperty=nameWithType> method is explicitly called or when the `BufferedStream` is disposed.
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+The implicit flush behavior of <xref:System.IO.BufferedStream.WriteByte(System.Byte)?displayProperty=nameWithType> was inconsistent with other `Write` methods in the `BufferedStream` class, such as `Write` and `WriteAsync`. This inconsistency could lead to unexpected performance issues or unintended side effects when working with streams that are sensitive to flush operations. Removing the implicit flush ensures consistent behavior across all `Write` methods in `BufferedStream`.
+
+## Recommended action
+
+If your application relies on the implicit flush behavior of `BufferedStream.WriteByte`, update your code to explicitly call the `Flush` method when needed. For example:
+
+**Before:**
+
+:::code language="csharp" source="./snippets/bufferedstream-writebyte-flush/csharp/Program.cs" id="Before":::
+:::code language="vb" source="./snippets/bufferedstream-writebyte-flush/vb/Program.vb" id="Before":::
+
+**After:**
+
+:::code language="csharp" source="./snippets/bufferedstream-writebyte-flush/csharp/Program.cs" id="After":::
+:::code language="vb" source="./snippets/bufferedstream-writebyte-flush/vb/Program.vb" id="After":::
+
+## Affected APIs
+
+- <xref:System.IO.BufferedStream.WriteByte(System.Byte)?displayProperty=fullName>

--- a/docs/core/compatibility/core-libraries/10.0/snippets/bufferedstream-writebyte-flush/csharp/BufferedStreamWriteByteFlush.csproj
+++ b/docs/core/compatibility/core-libraries/10.0/snippets/bufferedstream-writebyte-flush/csharp/BufferedStreamWriteByteFlush.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/docs/core/compatibility/core-libraries/10.0/snippets/bufferedstream-writebyte-flush/csharp/Program.cs
+++ b/docs/core/compatibility/core-libraries/10.0/snippets/bufferedstream-writebyte-flush/csharp/Program.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.IO;
+
+// <PreviousBehavior>
+StreamWithFlush streamWithFlush = new();
+BufferedStream bufferedStream = new(streamWithFlush, bufferSize: 4);
+
+// Write 4 bytes to fill the buffer
+bufferedStream.WriteByte(1);
+bufferedStream.WriteByte(2);
+bufferedStream.WriteByte(3);
+bufferedStream.WriteByte(4); // In .NET 9 and earlier, this caused an implicit flush
+
+class StreamWithFlush : MemoryStream
+{
+    public override void Flush()
+    {
+        Console.WriteLine("Flush was called.");
+
+        base.Flush();
+    }
+}
+// </PreviousBehavior>
+
+class BeforeExample
+{
+    static void Example()
+    {
+        // <Before>
+        BufferedStream bufferedStream = new(new MemoryStream(), bufferSize: 4);
+        bufferedStream.WriteByte(1);
+        bufferedStream.WriteByte(2);
+        bufferedStream.WriteByte(3);
+        bufferedStream.WriteByte(4); // Implicit flush occurred here in .NET 9 and earlier
+        // </Before>
+    }
+}
+
+class AfterExample
+{
+    static void Example()
+    {
+        // <After>
+        BufferedStream bufferedStream = new(new MemoryStream(), bufferSize: 4);
+        bufferedStream.WriteByte(1);
+        bufferedStream.WriteByte(2);
+        bufferedStream.WriteByte(3);
+        bufferedStream.WriteByte(4);
+        bufferedStream.Flush(); // Explicit flush
+        // </After>
+    }
+}

--- a/docs/core/compatibility/core-libraries/10.0/snippets/bufferedstream-writebyte-flush/vb/BufferedStreamWriteByteFlush.vbproj
+++ b/docs/core/compatibility/core-libraries/10.0/snippets/bufferedstream-writebyte-flush/vb/BufferedStreamWriteByteFlush.vbproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>BufferedStreamWriteByteFlush</RootNamespace>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/docs/core/compatibility/core-libraries/10.0/snippets/bufferedstream-writebyte-flush/vb/Program.vb
+++ b/docs/core/compatibility/core-libraries/10.0/snippets/bufferedstream-writebyte-flush/vb/Program.vb
@@ -1,0 +1,58 @@
+Imports System
+Imports System.IO
+
+Module Program
+    Sub Main()
+        ' Main entry point
+    End Sub
+End Module
+
+' <PreviousBehavior>
+Module PreviousBehaviorExample
+    Sub Example()
+        Dim streamWithFlush As New StreamWithFlush()
+        Dim bufferedStream As New BufferedStream(streamWithFlush, bufferSize:=4)
+
+        ' Write 4 bytes to fill the buffer
+        bufferedStream.WriteByte(1)
+        bufferedStream.WriteByte(2)
+        bufferedStream.WriteByte(3)
+        bufferedStream.WriteByte(4) ' In .NET 9 and earlier, this caused an implicit flush
+    End Sub
+
+    Class StreamWithFlush
+        Inherits MemoryStream
+
+        Public Overrides Sub Flush()
+            Console.WriteLine("Flush was called.")
+            MyBase.Flush()
+        End Sub
+    End Class
+End Module
+' </PreviousBehavior>
+
+Module BeforeExample
+    Sub Example()
+        ' <Before>
+        Dim bufferedStream As New BufferedStream(New MemoryStream(), bufferSize:=4)
+        bufferedStream.WriteByte(1)
+        bufferedStream.WriteByte(2)
+        bufferedStream.WriteByte(3)
+        bufferedStream.WriteByte(4) ' Implicit flush occurred here in .NET 9 and earlier
+        ' </Before>
+    End Sub
+End Module
+
+Module AfterExample
+    Sub Example()
+        ' <After>
+        Dim bufferedStream As New BufferedStream(New MemoryStream(), bufferSize:=4)
+        bufferedStream.WriteByte(1)
+        bufferedStream.WriteByte(2)
+        bufferedStream.WriteByte(3)
+        bufferedStream.WriteByte(4)
+        bufferedStream.Flush() ' Explicit flush
+        ' </After>
+    End Sub
+End Module
+

--- a/docs/core/compatibility/core-libraries/8.0/ldap-netstandard-apis.md
+++ b/docs/core/compatibility/core-libraries/8.0/ldap-netstandard-apis.md
@@ -1,0 +1,44 @@
+---
+title: "Breaking change: TrustedCertificatesDirectory and StartNewTlsSessionContext are not available on .NET Standard / .NET Framework"
+description: Learn about the .NET 8 breaking change in core .NET libraries where TrustedCertificatesDirectory and StartNewTlsSessionContext are not available when targeting .NET Standard 2.0.
+ms.date: 10/14/2025
+ai-usage: ai-assisted
+ms.custom: https://github.com/dotnet/docs/issues/48879
+---
+# TrustedCertificatesDirectory and StartNewTlsSessionContext are not available on .NET Standard / .NET Framework
+
+The following APIs were accidentally exposed in the `netstandard2.0` version of the System.DirectoryServices.Protocols NuGet package version 8.0.1:
+
+- <xref:System.DirectoryServices.Protocols.LdapSessionOptions.TrustedCertificatesDirectory?displayProperty=nameWithType>
+- <xref:System.DirectoryServices.Protocols.LdapSessionOptions.StartNewTlsSessionContext?displayProperty=nameWithType>
+
+These APIs aren't implemented on .NET Framework and weren't intended to be exposed when targeting `netstandard2.0`. Starting with version 8.0.2 of the System.DirectoryServices.Protocols NuGet package, these APIs are unavailable when targeting `netstandard2.0`.
+
+## Previous behavior
+
+In System.DirectoryServices.Protocols NuGet package version 8.0.1, the <xref:System.DirectoryServices.Protocols.LdapSessionOptions.TrustedCertificatesDirectory?displayProperty=nameWithType> property and <xref:System.DirectoryServices.Protocols.LdapSessionOptions.StartNewTlsSessionContext?displayProperty=nameWithType> method could be used from a `netstandard2.0` library.
+
+## New behavior
+
+Starting with System.DirectoryServices.Protocols NuGet package version 8.0.2, attempting to use these APIs from a `netstandard2.0` library results in a compilation error.
+
+## Version introduced
+
+System.DirectoryServices.Protocols NuGet package version 8.0.2
+
+## Type of breaking change
+
+This change can affect [binary compatibility](../../categories.md#binary-compatibility).
+
+## Reason for change
+
+The APIs didn't work on all compatible frameworks.
+
+## Recommended action
+
+If you need to use these APIs, target .NET instead of `netstandard2.0`.
+
+## Affected APIs
+
+- <xref:System.DirectoryServices.Protocols.LdapSessionOptions.TrustedCertificatesDirectory?displayProperty=fullName>
+- <xref:System.DirectoryServices.Protocols.LdapSessionOptions.StartNewTlsSessionContext?displayProperty=fullName>

--- a/docs/core/compatibility/extensions/10.0/backgroundservice-executeasync-task.md
+++ b/docs/core/compatibility/extensions/10.0/backgroundservice-executeasync-task.md
@@ -1,0 +1,44 @@
+---
+title: "Breaking change: BackgroundService runs all of ExecuteAsync as a Task"
+description: "Learn about the breaking change in .NET 10 where BackgroundService now runs the entirety of ExecuteAsync on a background thread instead of running the synchronous portion on the main thread."
+ms.date: 10/13/2025
+ai-usage: ai-assisted
+ms.custom: https://github.com/dotnet/runtime/issues/116181
+---
+
+# BackgroundService runs all of ExecuteAsync as a Task
+
+<xref:Microsoft.Extensions.Hosting.BackgroundService> now runs the entirety of <xref:Microsoft.Extensions.Hosting.BackgroundService.ExecuteAsync%2A> on a background thread. Previously, the synchronous portion of `ExecuteAsync` (before the first `await`) ran on the main thread during service startup, blocking other services from starting. Only code after the first `await` ran on a background thread.
+
+## Version introduced
+
+.NET 10
+
+## Previous behavior
+
+Previously, the synchronous portion of `ExecuteAsync` ran on the main thread and blocked other services from starting.
+
+## New behavior
+
+Starting in .NET 10, all of `ExecuteAsync` runs on a background thread, and no part of it blocks other services from starting.
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+The previous behavior was a common pitfall that didn't meet user expectations. Most implementers of `BackgroundService` didn't understand that the synchronous portion before the first `await` blocked other services from starting during application startup.
+
+## Recommended action
+
+If you require any part of your `BackgroundService.ExecuteAsync` to run earlier during startup (synchronously and blocking other services), you can do any one of the following:
+
+- Place the code that needs to run synchronously in the constructor, and it executes as part of the service construction.
+- Override `StartAsync` and do some work before calling `base.StartAsync`. `StartAsync` retains the behavior that its synchronous portion runs synchronously during startup and blocks other services from starting.
+- If you want to run code at a more specific time during service startup, implement <xref:Microsoft.Extensions.Hosting.IHostedLifecycleService?displayProperty=fullName> on your `BackgroundService`.
+- Forgo `BackgroundService` entirely and implement your own <xref:Microsoft.Extensions.Hosting.IHostedService?displayProperty=fullName>.
+
+## Affected APIs
+
+- <xref:Microsoft.Extensions.Hosting.BackgroundService.ExecuteAsync%2A?displayProperty=fullName>

--- a/docs/core/compatibility/sdk/10.0/dnx-ps1-removed.md
+++ b/docs/core/compatibility/sdk/10.0/dnx-ps1-removed.md
@@ -1,0 +1,39 @@
+---
+title: "Breaking change - dnx.ps1 file is no longer included in .NET SDK"
+description: "Learn about the breaking change in .NET 10 where the dnx.ps1 script is no longer included in Windows versions of the .NET SDK."
+ms.date: 10/13/2025
+ai-usage: ai-assisted
+ms.custom: https://github.com/dotnet/docs/issues/497988
+---
+
+# dnx.ps1 file is no longer included in .NET SDK
+
+The `dnx.ps1` shim script is no longer included in the .NET SDK.
+
+## Version introduced
+
+.NET 10 GA
+
+## Previous behavior
+
+Since .NET 10 Preview 7, on Windows versions of the .NET SDK, a `dnx.ps1` script was included in the dotnet root folder, alongside `dotnet.exe` and `dnx.cmd`.
+
+## New behavior
+
+The `dnx.ps1` script is no longer included. The `dnx.cmd` script remains available for executing tools.
+
+## Type of breaking change
+
+This change can affect <a>source compatibility</a>.
+
+## Reason for change
+
+The `dnx.ps1` script was added to avoid an extra `Terminate Batch Job` prompt when cancelling tools run via `dnx` with <kbd>Ctrl+C</kbd>. However, PowerShell has special handling for `--`, so if `--` was passed on the command line, it never made it through to `dnx`. This meant that in PowerShell, it was impossible to pass options to a tool using `dnx` if `dnx` itself has the same option. For example, `dnx dotnet-serve -- --help` showed the help for `dnx` instead of the help for `dotnet-serve`.
+
+## Recommended action
+
+In most cases, the `dnx.cmd` script is used instead so no action is necessary. If you were calling `dnx.ps1` directly, switch to `dnx.cmd`.
+
+## Affected APIs
+
+None.

--- a/docs/core/compatibility/sdk/10.0/version-requirements.md
+++ b/docs/core/compatibility/sdk/10.0/version-requirements.md
@@ -1,0 +1,45 @@
+---
+title: "Breaking change: Version requirements for .NET 10 SDK"
+description: Learn about the breaking change in the .NET 10 SDK where specific versions of Visual Studio and MSBuild are required.
+ms.date: 10/08/2025
+ai-usage: ai-generated
+---
+# Version requirements for .NET 10 SDK
+
+Per the [published support rules](../../../porting/versioning-sdk-msbuild-vs.md#targeting-and-support-rules), the minimum Visual Studio and MSBuild version for each new major release is updated with a one quarter delay. For the .NET 10 release:
+
+- 10.0.100 requires version 17.14 to be loaded but only supports targeting .NET 9 in that version.
+- To target `net10.0`, you must use version 18.0 or later.
+
+## Version introduced
+
+.NET 10 RC 2
+
+## Previous behavior
+
+The previous minimum Visual Studio version for .NET 10 previews was 17.13 to allow time for release and more adoption of Visual Studio version 17.14.
+
+## New behavior
+
+- .NET 10.0.100 will only load on Visual Studio version 17.14 or later.
+- .NET 10.0.100 warns when targeting `net10.0` on Visual Studio version 17.14. To target `net10.0`, you must use Visual Studio version 18.0 or later.
+
+## Type of breaking change
+
+This change is a [behavioral change](../../categories.md#behavioral-change).
+
+## Reason for change
+
+This change is part of the standard support policy for the SDK as not all prior versions of Visual Studio and MSBuild can be supported.
+
+## Recommended action
+
+Upgrade to Visual Studio 2026 to target `net10.0`. If you only need to target `net9.0` or earlier, you can use Visual Studio version 17.14 or later.
+
+## Affected APIs
+
+N/A
+
+## See also
+
+- [Targeting and support rules](../../../porting/versioning-sdk-msbuild-vs.md#targeting-and-support-rules)

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -86,6 +86,8 @@ items:
             href: /ef/core/what-is-new/ef-core-10.0/breaking-changes?toc=/dotnet/core/compatibility/toc.json&bc=/dotnet/breadcrumb/toc.json
           - name: Extensions
             items:
+              - name: BackgroundService runs all of ExecuteAsync as a Task
+                href: extensions/10.0/backgroundservice-executeasync-task.md
               - name: Message no longer duplicated in Console log output
                 href: extensions/10.0/console-json-logging-duplicate-messages.md
               - name: Null values preserved in configuration

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -126,6 +126,8 @@ items:
                 href: sdk/10.0/dotnet-cli-stderr-output.md
               - name: .NET tool packaging creates RuntimeIdentifier-specific tool packages
                 href: sdk/10.0/dotnet-tool-pack-publish.md
+              - name: dnx.ps1 file is no longer included in .NET SDK
+                href: sdk/10.0/dnx-ps1-removed.md
               - name: "`dotnet restore` audits transitive packages"
                 href: sdk/10.0/nugetaudit-transitive-packages.md
               - name: project.json not supported in `dotnet restore`

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -40,6 +40,8 @@ items:
                 href: core-libraries/10.0/activity-sampling.md
               - name: Arm64 SVE nonfaulting loads require mask
                 href: core-libraries/10.0/sve-nonfaulting-loads-mask-parameter.md
+              - name: BufferedStream.WriteByte no longer performs implicit flush
+                href: core-libraries/10.0/bufferedstream-writebyte-flush.md
               - name: C# 14 overload resolution with span parameters
                 href: core-libraries/10.0/csharp-overload-resolution.md
               - name: Consistent shift behavior in generic math

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -408,6 +408,8 @@ items:
                 href: core-libraries/8.0/itypedescriptorcontext-props.md
               - name: Legacy Console.ReadKey removed
                 href: core-libraries/8.0/console-readkey-legacy.md
+              - name: LDAP APIs not available on .NET Standard / .NET Framework
+                href: core-libraries/8.0/ldap-netstandard-apis.md
               - name: Method builders generate parameters with HasDefaultValue=false
                 href: core-libraries/8.0/parameterinfo-hasdefaultvalue.md
               - name: Package part URIs are now compared case-insensitively in System.IO.Packaging

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -160,6 +160,8 @@ items:
                 href: sdk/10.0/nu1015-packagereference-version.md
               - name: PrunePackageReference privatizes direct prunable references
                 href: sdk/10.0/prune-packagereference-privateassets.md
+              - name: Version requirements for .NET 10 SDK
+                href: sdk/10.0/version-requirements.md
           - name: Windows Forms
             items:
               - name: API obsoletions

--- a/docs/core/porting/versioning-sdk-msbuild-vs.md
+++ b/docs/core/porting/versioning-sdk-msbuild-vs.md
@@ -4,7 +4,7 @@ description: Learn about the versioning relationship between the .NET SDK and MS
 author: StephenBonikowsky
 ms.author: stebon
 ms.custom: updateeachrelease
-ms.date: 11/06/2024
+ms.date: 10/08/2025
 ---
 # .NET SDK, MSBuild, and Visual Studio versioning
 
@@ -19,7 +19,7 @@ For example, version 7.0.203 ships with .NET 7, is the second minor Visual Studi
 An installation of Visual Studio includes a single matching copy of the .NET SDK. If you update your Visual Studio instance, the .NET SDK installed by Visual Studio is also updated, including across .NET SDK feature bands and major bands. If you want to use a different .NET SDK than what's installed by Visual Studio, you can install it from the [.NET download page](https://aka.ms/dotnet/download), and Visual Studio upgrade won't touch that version. You're responsible for updating that copy of the .NET SDK from then on.
 
 > [!NOTE]
-The .NET SDK supports targeting down-level versions of .NET, so we recommend always updating your .NET SDK along with your Visual Studio version.
+> The .NET SDK supports targeting down-level versions of .NET, so we recommend always updating your .NET SDK along with your Visual Studio version.
 
 ## Lifecycle
 
@@ -74,7 +74,7 @@ The support timeframe for the SDK typically matches that of the Visual Studio ve
 
 ## Targeting and support rules
 
-A the following policy dictates which versions of MSBuild and Visual Studio a given version of the .NET SDK will run in:
+The following policy dictates which versions of MSBuild and Visual Studio a given version of the .NET SDK will run in:
 
 - Each new TargetFramework **requires** a new Visual Studio version or a new `dotnet` version.
 - The first version of Visual Studio that supports a new TargetFramework becomes a floor for the feature bands of that SDK for Roslyn API surface, MSBuild targets, source generators, analyzers, and so on.
@@ -89,6 +89,7 @@ A the following policy dictates which versions of MSBuild and Visual Studio a gi
 | 9.0.100 | 17.12 | 17.11            | Net8.0 | Net9.0 |
 | 9.0.200 | 17.13 | 17.12            | Net9.0 | Net9.0 |
 | 9.0.300 | 17.14 | 17.12            | Net9.0 | Net9.0 |
+| 10.0.100 | 18.0 | 17.14            | Net9.0 | Net10.0 |
 
 > [!NOTE]
 > The table depicts how these versioning rules are applied, starting with .NET SDK 7.0.100 and .NET SDK 6.0.300. It also depicts how the policy would have applied to previously shipped versions of the .NET SDK, had it been in place then. However, the requirements for previous versions of the SDK don't change&mdash;that is, the minimum required version of Visual Studio for .NET SDK 6.0.100 or 6.0.200 remains 16.10.
@@ -96,6 +97,8 @@ A the following policy dictates which versions of MSBuild and Visual Studio a gi
 > Targeting `net8.0` is officially supported in Visual Studio 17.8+ only.
 >
 > Targeting `net9.0` is officially supported in Visual Studio 17.12+ only.
+>
+> Targeting `net10.0` is officially supported in Visual Studio 18.0+ only.
 
 To ensure consistent tooling, you should use `dotnet build` rather than `msbuild` to build your application when possible.
 
@@ -111,6 +114,7 @@ Major versions of the .NET SDK are typically released within a few days of a Vis
 | 10.0.100 Preview 1  | 17.14 Preview 1       |
 | 10.0.100 Preview 2  | 17.14 Preview 2       |
 | 10.0.100 Preview 3  | 17.14 Preview 3       |
+| 10.0.100 RC 2       | 17.14                 |
 
 ## Reference
 

--- a/docs/csharp/advanced-topics/reflection-and-attributes/creating-custom-attributes.md
+++ b/docs/csharp/advanced-topics/reflection-and-attributes/creating-custom-attributes.md
@@ -16,12 +16,12 @@ You can create your own custom attributes by defining an attribute class, a clas
 public class AuthorAttribute : System.Attribute
 {
     private string Name;
-    public double Version;
+    public string Version;
 
     public AuthorAttribute(string name)
     {
         Name = name;
-        Version = 1.0;
+        Version = "1.0";
     }
 }
 ```

--- a/docs/csharp/advanced-topics/reflection-and-attributes/snippets/conceptual/ReadAttributes.cs
+++ b/docs/csharp/advanced-topics/reflection-and-attributes/snippets/conceptual/ReadAttributes.cs
@@ -10,14 +10,14 @@
 public class AuthorAttribute : System.Attribute
 {
     string Name;
-    public double Version;
+    public string Version;
 
     public AuthorAttribute(string name)
     {
         Name = name;
 
         // Default value.
-        Version = 1.0;
+        Version = "1.0";
     }
 
     public string GetName() => Name;
@@ -39,7 +39,7 @@ public class SecondClass
 
 // Class with multiple Author attributes.
 // <MultipleAuthors>
-[Author("P. Ackerman"), Author("R. Koch", Version = 2.0)]
+[Author("P. Ackerman"), Author("R. Koch", Version = "2.0")]
 public class ThirdClass
 {
     // ...
@@ -67,23 +67,23 @@ class TestAuthorAttribute
         {
             if (attr is AuthorAttribute a)
             {
-                System.Console.WriteLine($"   {a.GetName()}, version {a.Version:f}");
+                System.Console.WriteLine($"   {a.GetName()}, version {a.Version}");
             }
         }
     }
 }
 /* Output:
     Author information for FirstClass
-       P. Ackerman, version 1.00
+       P. Ackerman, version 1.0
     Author information for SecondClass
     Author information for ThirdClass
-       R. Koch, version 2.00
-       P. Ackerman, version 1.00
+       R. Koch, version 2.0
+       P. Ackerman, version 1.0
 */
 // </DefineAndReadAttribute>
 
 // <SampleWithVersion>
-[Author("P. Ackerman", Version = 1.1)]
+[Author("P. Ackerman", Version = "1.1")]
 class SampleClass
 {
     // P. Ackerman's code goes here...

--- a/docs/csharp/fundamentals/types/anonymous-types.md
+++ b/docs/csharp/fundamentals/types/anonymous-types.md
@@ -50,7 +50,6 @@ This simplified syntax is particularly useful when creating anonymous types with
 
 The member name isn't inferred in the following cases:
 
-- The candidate name is a member name of an anonymous type, such as `ToString` or `GetHashCode`.
 - The candidate name is a duplicate of another property member in the same anonymous type, either explicit or implicit.
 - The candidate name isn't a valid identifier (for example, it contains spaces or special characters).
 

--- a/docs/framework/release-notes/2025/01-14-january-cumulative-update.md
+++ b/docs/framework/release-notes/2025/01-14-january-cumulative-update.md
@@ -71,7 +71,7 @@ The following table is for earlier Windows and Windows Server versions for Secur
 | .NET Framework 4.8 | [5049614](https://support.microsoft.com/kb/5049614) |
 | **Windows Server 2012** | **[5050184](https://support.microsoft.com/kb/5050184)** |
 | .NET Framework 3.5 | [5044009](https://support.microsoft.com/kb/5044009) |
-| .NET Framework 4.6.2, 4.7, 4.7.1, 4.7.2 | [55049609](https://support.microsoft.com/kb/5049610) |
+| .NET Framework 4.6.2, 4.7, 4.7.1, 4.7.2 | [5049609](https://support.microsoft.com/kb/5049609) |
 | .NET Framework 4.8 | [5049618](https://support.microsoft.com/kb/5049618) |
 | **Windows Server 2008 R2** | **[5046543](https://support.microsoft.com/kb/5046543)** |
 | .NET Framework 3.5.1 | [5044011](https://support.microsoft.com/kb/5044011) |

--- a/docs/framework/release-notes/2025/09-09-september-cumulative-update.md
+++ b/docs/framework/release-notes/2025/09-09-september-cumulative-update.md
@@ -18,8 +18,6 @@ There are no new security improvements in this release. This update is cumulativ
 
 ### Quality and reliability improvements
 
-This release contains the following quality and reliability improvements.
-
 #### ASP.NET
 
 Addressed an issue in ASP.NET where some error events fail to log properly in the Windows Event log. (*Applies to: .NET Framework 4.6.2, 4.7, 4.7.1, 4.7.2, 4.8, 4.8.1.*)
@@ -30,27 +28,27 @@ Addressed an update for GB18030 certificate for Chinese language changes. (*Appl
 
 ## Known issues
 
-This release contains no known issues.
+This release contains no known issues.  
 
 ## Summary tables
 
 | Product version | Cumulative update |
 | --- | --- |
 | **Windows 11, version 24H2** | |
-| .NET Framework 3.5, 4.8.1 | [5064401](https://support.microsoft.com/topic/august-28-2025-kb5064401-cumulative-update-for-net-framework-3-5-and-4-8-1-for-windows-11-version-24h2-and-microsoft-server-operating-system-version-24h2-71f4180b-3364-4d0e-8032-e8aca043b0fe) |
+| .NET Framework 3.5, 4.8.1 | [5064401](https://support.microsoft.com/kb/5064401) |
 | **Microsoft server operating system, version 24H2** | |
 | .NET Framework 3.5, 4.8.1 | [5064401](https://support.microsoft.com/kb/5064401) |
 | **Microsoft server operating system, version 23H2** | |
 | .NET Framework 3.5, 4.8.1 | [5065756](https://support.microsoft.com/kb/5065756) |
 | **Windows 11, version 22H2 and Windows 11, version 23H2** | |
 | .NET Framework 3.5, 4.8.1 | [5064403](https://support.microsoft.com/kb/5064403) |
-| **Microsoft server operating system, version 22H2** | **[5065962](https://support.microsoft.com/topic/september-9-2025-kb5065962-cumulative-update-for-net-framework-3-5-4-8-and-4-8-1-for-windows-server-2022-55389349-2511-4062-ba42-aa3434986582)** |
+| **Microsoft server operating system, version 22H2** | **[5065962](https://support.microsoft.com/kb/5065962)** |
 | .NET Framework 3.5, 4.8 | [5065748](https://support.microsoft.com/kb/5065748) |
 | .NET Framework 3.5, 4.8.1 | [5065753](https://support.microsoft.com/kb/5065753) |
 | **Microsoft server operating system, version 21H2** | **[5065962](https://support.microsoft.com/kb/5065962)** |
 | .NET Framework 3.5, 4.8 | [5065748](https://support.microsoft.com/kb/5065748) |
 | .NET Framework 3.5, 4.8.1 | [5065753](https://support.microsoft.com/kb/5065753) |
-| **Windows 10, version 22H2** | **[5065956](https://support.microsoft.com/kb/5065956)** |
+| **Windows 10, version 22H2** | **[5065957](https://support.microsoft.com/kb/5065957)** |
 | .NET Framework 3.5, 4.8 | [5064399](https://support.microsoft.com/kb/5064399) |
 | .NET Framework 3.5, 4.8.1 | [5064400](https://support.microsoft.com/kb/5064400) |
 | **Windows 10, version 21H2** | **[5065956](https://support.microsoft.com/kb/5065956)** |
@@ -59,6 +57,9 @@ This release contains no known issues.
 | **Windows 10 1809 and Windows Server 2019** | **[5065955](https://support.microsoft.com/kb/5065955)** |
 | .NET Framework 3.5, 4.7.2 | [5065744](https://support.microsoft.com/kb/5065744) |
 | .NET Framework 3.5, 4.8 | [5065755](https://support.microsoft.com/kb/5065755) |
+| **Windows 10 1607 and Windows Server 2016** | |
+| .NET Framework 3.5, 4.6.2, 4.7, 4.7.1, 4.7.2 | [5065427](https://support.microsoft.com/kb/5065427) |
+| .NET Framework 4.8 | [5065749](https://support.microsoft.com/kb/5065749) |
 
 The following table is for earlier Windows and Windows Server versions for Security and Quality Rollup updates.  
 
@@ -70,13 +71,13 @@ The following table is for earlier Windows and Windows Server versions for Secur
 | .NET Framework 4.8 | [5065752](https://support.microsoft.com/kb/5065752) |
 | **Windows Server 2012** | **[5065959](https://support.microsoft.com/kb/5065959)** |
 | .NET Framework 3.5 | [5044009](https://support.microsoft.com/kb/5044009) |
-| .NET Framework 4.6.2, 4.7, 4.7.1, 4.7.2 | [5065746](https://support.microsoft.com/kb/5065746)|
+| .NET Framework 4.6.2, 4.7, 4.7.1, 4.7.2 | [5065746](https://support.microsoft.com/kb/5065746) |
 | .NET Framework 4.8 | [5065751](https://support.microsoft.com/kb/5065751) |
 | **Windows Server 2008 R2** | **[5065958](https://support.microsoft.com/kb/5065958)** |
-| .NET Framework 3.5.1 | [5044011](https://support.microsoft/kb/5044011) |
+| .NET Framework 3.5.1 | [5044011](https://support.microsoft.com/kb/5044011) |
 | .NET Framework 4.6.2, 4.7, 4.7.1, 4.7.2 | [5065745](https://support.microsoft.com/kb/5065745) |
-| .NET Framework 4.8 | [5065750](https://support.microsoft.com/kb/5065750) |
-| **Windows Server 2008** | **[5065961](https://support.microsoft.com/kb/5065961)**|
+| .NET Framework 4.8 |[5065750](https://support.microsoft.com/kb/5065750) |
+| **Windows Server 2008** | **[5065961](https://support.microsoft.com/kb/5065961)** |
 | .NET Framework 2.0, 3.0 | [5044010](https://support.microsoft.com/kb/5044010) |
 | .NET Framework 3.5 SP1 | [5040673](https://support.microsoft.com/kb/5040673) |
 | .NET Framework 4.6.2 | [5065745](https://support.microsoft.com/kb/5065745) |

--- a/docs/framework/release-notes/2025/10-14-october-cumulative-update.md
+++ b/docs/framework/release-notes/2025/10-14-october-cumulative-update.md
@@ -1,0 +1,97 @@
+---
+title: October 2025 cumulative update
+description: Learn about the improvements in the .NET Framework October 2025 cumulative update.
+ms.date: 10/14/2025
+---
+# October 2025 cumulative update
+
+_Released October 14, 2025_
+
+## Summary of what's new in this release
+
+- [Security improvements](#security-improvements)
+- [Quality and reliability improvements](#quality-and-reliability-improvements)
+
+### Security improvements
+
+#### CVE-2025-21176 – Remote Code Execution vulnerability
+
+This security update addresses a remote code execution vulnerability detailed in [CVE 2025-21176](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2025-21176).
+
+### Quality and reliability improvements
+
+There are no new quality and reliability improvements in this update.
+
+## Known issues in this release
+
+This release contains no known issues.
+
+## Summary tables
+
+The following table outlines the updates in this release.
+
+| Product version | Cumulative update |
+| --- | --- |
+| **Windows 11, version 25H2** | |
+| .NET Framework 3.5, 4.8.1 | [5066128](https://support.microsoft.com/kb/5066128) |
+| **Windows 11, version 24H2** | |
+| .NET Framework 3.5, 4.8.1 | [5066131](https://support.microsoft.com/kb/5066131) |
+| **Microsoft server operating system, version 24H2** | |
+| .NET Framework 3.5, 4.8.1 | [5066131](https://support.microsoft.com/kb/5066131) |
+| **Microsoft server operating system, version 23H2** | |
+| .NET Framework 3.5, 4.8.1 | [5066129](https://support.microsoft.com/kb/5066129) |
+| **Windows 11, version 22H2 and Windows 11, version 23H2** | |
+| .NET Framework 3.5, 4.8.1 | [5066133](https://support.microsoft.com/kb/5066133) |
+| **Microsoft server operating system, version 22H2** | **[5066743](https://support.microsoft.com/kb/5066743)** |
+| .NET Framework 3.5, 4.8 | [5066139](https://support.microsoft.com/kb/5066139) |
+| .NET Framework 3.5, 4.8.1 | [5066134](https://support.microsoft.com/kb/5066134) |
+| **Microsoft server operating system, version 21H2** | **[5066743](https://support.microsoft.com/kb/5066743)** |
+| .NET Framework 3.5, 4.8 | [5066139](https://support.microsoft.com/kb/5066139) |
+| .NET Framework 3.5, 4.8.1 | [5066134](https://support.microsoft.com/kb/5066134) |
+| **Windows 10, version 22H2** | **[5066747](https://support.microsoft.com/kb/5066747)** |
+| .NET Framework 3.5, 4.8 | [5066135](https://support.microsoft.com/kb/5066135) |
+| .NET Framework 3.5, 4.8.1 | [5066130](https://support.microsoft.com/kb/5066130) |
+| **Windows 10, version 21H2** | **[5066746](https://support.microsoft.com/kb/5066746)** |
+| .NET Framework 3.5, 4.8 | [5066135](https://support.microsoft.com/kb/5066135) |
+| .NET Framework 3.5, 4.8.1 | [5066130](https://support.microsoft.com/kb/5066130) |
+| **Windows 10 1809 and Windows Server 2019** | **[5066738](https://support.microsoft.com/kb/5066738)** |
+| .NET Framework 3.5, 4.7.2 | [5066143](https://support.microsoft.com/kb/5066143) |
+| .NET Framework 3.5, 4.8 | [5066137](https://support.microsoft.com/kb/5066137) |
+| **Windows 10 1607 and Windows Server 2016** | |
+| .NET Framework 3.5, 4.6.2, 4.7, 4.7.1, 4.7.2 | [5066836](https://support.microsoft.com/kb/5066836) |
+| .NET Framework 4.8 | [5066136](https://support.microsoft.com/kb/5066136) |
+| **Windows 10 1507** | |
+| .NET Framework 3.5, 4.6, 4.6.2 | [5066837](https://support.microsoft.com/kb/5066837) |
+
+The following table is for earlier Windows and Windows Server versions for Security and Quality Rollup updates.  
+
+| Product version | Security and quality rollup |
+| --- | --- |
+| **Windows Server 2012 R2** | **[5066741](https://support.microsoft.com/kb/5066741)** |
+| .NET Framework 3.5 | [5066151](https://support.microsoft.com/kb/5066151) |
+| .NET Framework 4.6.2, 4.7, 4.7.1, 4.7.2 | [5066145](https://support.microsoft.com/kb/5066145) |
+| .NET Framework 4.8 | [5066140](https://support.microsoft.com/kb/5066140) |
+| **Windows Server 2012** | **[5066740](https://support.microsoft.com/kb/5066740)** |
+| .NET Framework 3.5 | [5066148](https://support.microsoft.com/kb/5066148) |
+| .NET Framework 4.6.2, 4.7, 4.7.1, 4.7.2 | [5066144](https://support.microsoft.com/kb/5066144) |
+| .NET Framework 4.8 | [5066138](https://support.microsoft.com/kb/5066138) |
+| **Windows Server 2008 R2** | **[5066739](https://support.microsoft.com/kb/5066739)** |
+| .NET Framework 3.5.1 | [5066150](https://support.microsoft.com/kb/5066150) |
+| .NET Framework 4.6.2, 4.7, 4.7.1, 4.7.2 | [5066146](https://support.microsoft.com/kb/5066146)|
+| .NET Framework 4.8 |[5066141](https://support.microsoft.com/kb/5066141) |
+| **Windows Server 2008** | **[5066742](https://support.microsoft.com/kb/5066742)** |
+| .NET Framework 2.0, 3.0 | [5066149](https://support.microsoft.com/kb/5066149) |
+| .NET Framework 3.5 SP1 | [5040673](https://support.microsoft.com/kb/5040673) |
+| .NET Framework 4.6.2 | [5066146](https://support.microsoft.com/kb/5066146) |
+
+| Product version | Security Only Update |
+| --- | --- |
+| **Windows Server 2008 R2** | **[5066748](https://support.microsoft.com/kb/5066748)** |
+| .NET Framework 3.5.1 | [5066728](https://support.microsoft.com/kb/5066728) |
+| .NET Framework 4.6.2, 4.7, 4.7.1, 4.7.2 | [5066726](https://support.microsoft.com/kb/5066726)|
+| .NET Framework 4.8 |[5066725](https://support.microsoft.com/kb/5066725) |
+| **Windows Server 2008** | **[5066749](https://support.microsoft.com/kb/5066749)** |
+| .NET Framework 2.0, 3.0 | [5066727](https://support.microsoft.com/kb/5066727) |
+| .NET Framework 4.6.2 | [5066726](https://support.microsoft.com/kb/5066726) |
+
+The operating system rows list a KB that's used for update-offering purposes. When the operating system KB is offered, the applicability logic determines the specific .NET Framework updates that will be installed. Updates for individual .NET Framework versions are installed based on the version of .NET Framework that's already present on the device. Because of this, the operating system KB is not expected to be listed as an installed update on the device. The expected updates to be installed are the .NET Framework specific version updates listed in the preceding table.

--- a/docs/framework/release-notes/release-notes.md
+++ b/docs/framework/release-notes/release-notes.md
@@ -11,7 +11,8 @@ The .NET Framework updates include cumulative security and reliability improveme
 
 .NET Framework cumulative update releases are discussed in detail in the following individual release notes:
 
-* September 9, 2025 - [cumulative update](./2025/09-09-september-cumulative-update.md) **New Release**
+* October 14, 2025 - [cumulative update preview](./2025/10-14-october-cumulative-update.md) **New Release**
+* September 9, 2025 - [cumulative update preview](./2025/09-09-september-cumulative-update.md)
 * August 26, 2025 - [cumulative update preview](./2025/08-26-august-cumulative-update-preview.md)
 * July 8, 2025 - [cumulative update](./2025/07-08-july-cumulative-update.md)
 * April 22, 2025 - [cumulative update preview](./2025/04-22-april-cumulative-update-preview.md)

--- a/docs/framework/toc.yml
+++ b/docs/framework/toc.yml
@@ -703,6 +703,8 @@ items:
       href: release-notes/2025/08-26-august-cumulative-update-preview.md
     - name: September 2025 cumulative update
       href: release-notes/2025/09-09-september-cumulative-update.md
+    - name: October 2025 cumulative update
+      href: release-notes/2025/10-14-october-cumulative-update.md
   - name: What's new
     href: whats-new/index.md
   - name: What's new in accessibility

--- a/docs/fsharp/language-reference/compiler-messages/fs0001.md
+++ b/docs/fsharp/language-reference/compiler-messages/fs0001.md
@@ -1,7 +1,7 @@
 ---
 description: "Learn more about: FS0001: Error from adding type equation"
 title: "Compiler error FS0001"
-ms.date: 12/21/2019
+ms.date: 10/10/2025
 f1_keywords:
   - "FS0001"
 helpviewer_keywords:
@@ -30,6 +30,18 @@ Here, the type of the `booleanBinding` is required to be `bool` by the type anno
 This message can be issued in many different circumstances, and they all follow this same pattern. Type inference (or programmer-given type annotations) 'fixes' the type of a function or value to a certain type, and then later that type is used as if it were of a different type than the 'fixed' type.  The following code demonstrates a more complex version of the error, where inference across functions causes the error to appear far away from where you might expect:
 
 [!code-fsharp[FS0001-complex](~/samples/snippets/fsharp/compiler-messages/fs0001.fsx#L5-L26)]
+
+## Partial Application and Type Inference
+
+Another common scenario where this error occurs involves partial application of functions. When you define a function with multiple parameters using [`let` bindings](../functions/index.md), F# treats it as a curried function. This means that applying fewer arguments than the function expects returns a new function that expects the remaining arguments, as shown in the following example:
+
+[!code-fsharp[FS0001-partial-application](~/samples/snippets/fsharp/compiler-messages/fs0001.fsx#L29-L48)]
+
+In this example, `Sum` is a function with type `int -> int -> int`. When you pass it to `RegisterFunction1`, the type inference system maps `'A` to `int` and `'B` to `int -> int` (the partially applied function). However, when you try to pass it to `RegisterFunction2`, which expects `'A -> int`, the type system correctly identifies that `Sum` returns `int -> int` (a function), not `int` (a value), causing the type mismatch error.
+
+For more information about how F# handles function definitions and partial application, see [Functions](../functions/index.md).
+
+## How to Fix This Error
 
 To solve this message, you must change one of the two parts of the binding: the type annotation or the value binding.
 

--- a/docs/fsharp/language-reference/pattern-matching.md
+++ b/docs/fsharp/language-reference/pattern-matching.md
@@ -138,6 +138,10 @@ The cons pattern is used to decompose a list into the first element, the *head*,
 
 [!code-fsharp[Main](~/samples/snippets/fsharp/lang-ref-2/snippet4809.fs)]
 
+You can also chain multiple cons patterns together to match lists that start with specific sequences of elements.
+
+[!code-fsharp[Main](~/samples/snippets/fsharp/lang-ref-2/snippet4819.fs)]
+
 ## List Pattern
 
 The list pattern enables lists to be decomposed into a number of elements. The list pattern itself can match only lists of a specific number of elements.

--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -245,6 +245,17 @@ SomeClass.Invoke ()
 String.Format (x.IngredientName, x.Quantity)
 ```
 
+These same formatting conventions apply to pattern matching. F# style values consistent formatting:
+
+```fsharp
+// ✔️ OK - Consistent formatting for expressions and patterns
+let result = Some(value)
+
+match result with
+| Some(x) -> x
+| None -> 0
+```
+
 You may need to pass arguments to a function on a new line as a matter of readability or because the list of arguments or the argument names are too long. In that case, indent one level:
 
 ```fsharp
@@ -1150,6 +1161,37 @@ match l with
     | { him = x; her = "Posh" } :: tail -> x
     | _ :: tail -> findDavid tail
     | [] -> failwith "Couldn't find David"
+```
+
+Pattern matching formatting should be consistent with expression formatting. Do not add a space before the opening parenthesis of pattern arguments:
+
+```fsharp
+// ✔️ OK
+match x with
+| Some(y) -> y
+| None -> 0
+
+// ✔️ OK
+match data with
+| Success(value) -> value
+| Error(msg) -> failwith msg
+
+// ❌ Not OK, pattern formatting should match expression formatting
+match x with
+| Some (y) -> y
+| None -> 0
+```
+
+However, do use spaces between separate curried arguments in patterns, just as in expressions:
+
+```fsharp
+// ✔️ OK - space between curried arguments
+match x with
+| Pattern arg (a, b) -> processValues arg a b
+
+// ❌ Not OK - missing space between curried arguments
+match x with
+| Pattern arg(a, b) -> processValues arg a b
 ```
 
 If the expression on the right of the pattern matching arrow is too large, move it to the following line, indented one step from the `match`/`|`.

--- a/docs/fundamentals/code-analysis/quality-rules/ca1030.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1030.md
@@ -10,6 +10,8 @@ helpviewer_keywords:
 - UseEventsWhereAppropriate
 author: gewarren
 ms.author: gewarren
+dev_langs:
+- CSharp
 ---
 # CA1030: Use events where appropriate
 
@@ -41,6 +43,10 @@ Some common examples of events are found in user interface applications where a 
 ## How to fix violations
 
 If the method is called when the state of an object changes, consider changing the design to use the .NET event model.
+
+## Example
+
+:::code language="csharp" source="snippets/csharp/all-rules/ca1030.cs" id="snippet1":::
 
 ## When to suppress warnings
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1711.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1711.md
@@ -10,6 +10,8 @@ helpviewer_keywords:
 - IdentifiersShouldNotHaveIncorrectSuffix
 author: gewarren
 ms.author: gewarren
+dev_langs:
+ - CSharp
 ---
 # CA1711: Identifiers should not have incorrect suffix
 
@@ -60,6 +62,21 @@ Naming conventions provide a common look for libraries that target the .NET comm
 ## How to fix violations
 
 Remove the suffix from the type name.
+
+## Example
+
+```csharp
+class BadEmployeeCollection { } // Violates CA1711
+
+// Good
+class Employee { }
+class GoodEmployeeCollection : ICollection<Employee>
+{
+    // Implementations
+}
+
+class Employees { } // Good
+```
 
 ## When to suppress warnings
 

--- a/docs/fundamentals/code-analysis/quality-rules/ca1713.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1713.md
@@ -10,6 +10,8 @@ helpviewer_keywords:
 - EventsShouldNotHaveBeforeOrAfterPrefix
 author: gewarren
 ms.author: gewarren
+dev_langs:
+- CSharp
 ---
 # CA1713: Events should not have before or after prefix
 
@@ -34,6 +36,10 @@ Naming conventions provide a common look for libraries that target the common la
 ## How to fix violations
 
 Remove the prefix from the event name, and consider changing the name to use the present or past tense of a verb.
+
+## Example
+
+:::code language="csharp" source="snippets/csharp/all-rules/ca1713.cs" id="snippet1":::
 
 ## When to suppress warnings
 

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1030.cs
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1030.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+
+namespace ca1030
+{
+    //<snippet1>
+    // This class violates the rule.
+    public class BadButton
+    {
+        private readonly List<Action> _clickHandlers = new List<Action>();
+
+        public void AddOnClick(Action handler)
+        {
+            // Some internal logic...
+
+            _clickHandlers.Add(handler);
+        }
+
+        public void RemoveOnClick(Action handler)
+        {
+            // Some internal logic...
+
+            _clickHandlers.Remove(handler);
+        }
+
+        public void FireClick()
+        {
+            foreach (Action handler in _clickHandlers)
+            {
+                handler();
+            }
+        }
+    }
+
+    // This class satisfies the rule.
+    public class GoodButton
+    {
+        private EventHandler? _clickHandler;
+
+        public event EventHandler? ClickHandler
+        {
+            add
+            {
+                // Some internal logic...
+
+                _clickHandler += value;
+            }
+            remove
+            {
+                // Some internal logic...
+
+                _clickHandler -= value;
+            }
+        }
+
+        protected virtual void OnClick(EventArgs e)
+        {
+            _clickHandler?.Invoke(this, e);
+        }
+
+        public void Click()
+        {
+            OnClick(EventArgs.Empty);
+        }
+    }
+    //</snippet1>
+}

--- a/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1713.cs
+++ b/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca1713.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace ca1713
+{
+    //<snippet1>
+    public class Session
+    {
+        // This code violates the rule.
+        public event EventHandler? BeforeClose;
+        public event EventHandler? AfterClose;
+
+        // This code satisfies the rule.
+        public event EventHandler? Closing;
+        public event EventHandler? Closed;
+    }
+    //</snippet1>
+}

--- a/samples/snippets/fsharp/compiler-messages/fs0001.fsx
+++ b/samples/snippets/fsharp/compiler-messages/fs0001.fsx
@@ -24,3 +24,26 @@ let printThenAdd i =
 // because `printThenAdd` has been inferred to have type `int -> int`, but a string was passed in as the `int` parameter
 printThenAdd "a number"
 |> ignore
+
+(* partial application type inference example *)
+// Define a function that takes two arguments and returns their sum
+let Sum x y = x + y
+
+// This works: RegisterFunction1 accepts a function with generic types 'A -> 'B
+// When passed Sum (which is int -> int -> int), type inference maps:
+// 'A to int (the first parameter type)
+// 'B to int -> int (the remaining function after partial application)
+let RegisterFunction1 (fn:'A->'B) = ()
+let Test1 = RegisterFunction1 Sum
+
+// This fails: RegisterFunction2 expects a function 'A -> int (returning int, not a function)
+// When passed Sum (which is int -> int -> int), type inference maps:
+// 'A to int (the first parameter type)
+// But then expects the return type to be int, not int -> int (the partially applied function)
+let RegisterFunction2 (fn:'A->int) = ()
+// Uncommenting the next line would trigger the error:
+// > This expression was expected to have type
+// >   'int -> int'
+// > but here has type
+// >   'int -> int -> int'
+// let Test2 = RegisterFunction2 Sum

--- a/samples/snippets/fsharp/lang-ref-2/snippet4819.fs
+++ b/samples/snippets/fsharp/lang-ref-2/snippet4819.fs
@@ -1,0 +1,13 @@
+let charList = ['A'; 'B'; 'C'; 'D']
+
+// This example demonstrates multiple cons patterns.
+let matchChars xs =
+    match xs with
+    | 'A'::'B'::t -> printfn "starts with 'AB', rest: %A" t
+    | 'A'::t -> printfn "starts with 'A', rest: %A" t
+    | 'C'::'D'::t -> printfn "starts with 'CD', rest: %A" t
+    | _ -> printfn "does not match"
+
+matchChars charList
+matchChars ['A'; 'X']
+matchChars ['C'; 'D'; 'E']


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

<details><summary><strong>Toggle expand/collapse</strong></summary><br/>

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/10.0.md](https://github.com/dotnet/docs/blob/e4d5897c1122cf0faeab99049cbf75d3c17e4319/docs/core/compatibility/10.0.md) | [Breaking changes in .NET 10](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/10.0?branch=pr-en-us-49136) |
| [docs/core/compatibility/8.0.md](https://github.com/dotnet/docs/blob/e4d5897c1122cf0faeab99049cbf75d3c17e4319/docs/core/compatibility/8.0.md) | [Breaking changes in .NET 8](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/8.0?branch=pr-en-us-49136) |
| [docs/core/compatibility/core-libraries/10.0/bufferedstream-writebyte-flush.md](https://github.com/dotnet/docs/blob/e4d5897c1122cf0faeab99049cbf75d3c17e4319/docs/core/compatibility/core-libraries/10.0/bufferedstream-writebyte-flush.md) | [BufferedStream.WriteByte no longer performs implicit flush](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/10.0/bufferedstream-writebyte-flush?branch=pr-en-us-49136) |
| [docs/core/compatibility/core-libraries/8.0/ldap-netstandard-apis.md](https://github.com/dotnet/docs/blob/e4d5897c1122cf0faeab99049cbf75d3c17e4319/docs/core/compatibility/core-libraries/8.0/ldap-netstandard-apis.md) | [docs/core/compatibility/core-libraries/8.0/ldap-netstandard-apis](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/8.0/ldap-netstandard-apis?branch=pr-en-us-49136) |
| [docs/core/compatibility/extensions/10.0/backgroundservice-executeasync-task.md](https://github.com/dotnet/docs/blob/e4d5897c1122cf0faeab99049cbf75d3c17e4319/docs/core/compatibility/extensions/10.0/backgroundservice-executeasync-task.md) | [BackgroundService runs all of ExecuteAsync as a Task](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/extensions/10.0/backgroundservice-executeasync-task?branch=pr-en-us-49136) |
| [docs/core/compatibility/sdk/10.0/dnx-ps1-removed.md](https://github.com/dotnet/docs/blob/e4d5897c1122cf0faeab99049cbf75d3c17e4319/docs/core/compatibility/sdk/10.0/dnx-ps1-removed.md) | ["Breaking change - dnx.ps1 file is no longer included in .NET SDK"](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/10.0/dnx-ps1-removed?branch=pr-en-us-49136) |
| [docs/core/compatibility/sdk/10.0/version-requirements.md](https://github.com/dotnet/docs/blob/e4d5897c1122cf0faeab99049cbf75d3c17e4319/docs/core/compatibility/sdk/10.0/version-requirements.md) | [Version requirements for .NET 10 SDK](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/10.0/version-requirements?branch=pr-en-us-49136) |
| [docs/core/compatibility/toc.yml](https://github.com/dotnet/docs/blob/e4d5897c1122cf0faeab99049cbf75d3c17e4319/docs/core/compatibility/toc.yml) | [docs/core/compatibility/toc](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/toc?branch=pr-en-us-49136) |
| [docs/core/porting/versioning-sdk-msbuild-vs.md](https://github.com/dotnet/docs/blob/e4d5897c1122cf0faeab99049cbf75d3c17e4319/docs/core/porting/versioning-sdk-msbuild-vs.md) | [.NET SDK, MSBuild, and Visual Studio versioning](https://review.learn.microsoft.com/en-us/dotnet/core/porting/versioning-sdk-msbuild-vs?branch=pr-en-us-49136) |
| [docs/csharp/advanced-topics/reflection-and-attributes/creating-custom-attributes.md](https://github.com/dotnet/docs/blob/e4d5897c1122cf0faeab99049cbf75d3c17e4319/docs/csharp/advanced-topics/reflection-and-attributes/creating-custom-attributes.md) | ["Create custom attributes"](https://review.learn.microsoft.com/en-us/dotnet/csharp/advanced-topics/reflection-and-attributes/creating-custom-attributes?branch=pr-en-us-49136) |
| [docs/csharp/fundamentals/types/anonymous-types.md](https://github.com/dotnet/docs/blob/e4d5897c1122cf0faeab99049cbf75d3c17e4319/docs/csharp/fundamentals/types/anonymous-types.md) | [Anonymous types](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/types/anonymous-types?branch=pr-en-us-49136) |
| [docs/framework/release-notes/2025/01-14-january-cumulative-update.md](https://github.com/dotnet/docs/blob/e4d5897c1122cf0faeab99049cbf75d3c17e4319/docs/framework/release-notes/2025/01-14-january-cumulative-update.md) | [docs/framework/release-notes/2025/01-14-january-cumulative-update](https://review.learn.microsoft.com/en-us/dotnet/framework/release-notes/2025/01-14-january-cumulative-update?branch=pr-en-us-49136) |
| [docs/framework/release-notes/2025/09-09-september-cumulative-update.md](https://github.com/dotnet/docs/blob/e4d5897c1122cf0faeab99049cbf75d3c17e4319/docs/framework/release-notes/2025/09-09-september-cumulative-update.md) | [September 2025 security and quality rollup](https://review.learn.microsoft.com/en-us/dotnet/framework/release-notes/2025/09-09-september-cumulative-update?branch=pr-en-us-49136) |
| [docs/framework/release-notes/2025/10-14-october-cumulative-update.md](https://github.com/dotnet/docs/blob/e4d5897c1122cf0faeab99049cbf75d3c17e4319/docs/framework/release-notes/2025/10-14-october-cumulative-update.md) | [October 2025 cumulative update](https://review.learn.microsoft.com/en-us/dotnet/framework/release-notes/2025/10-14-october-cumulative-update?branch=pr-en-us-49136) |
| [docs/framework/release-notes/release-notes.md](https://github.com/dotnet/docs/blob/e4d5897c1122cf0faeab99049cbf75d3c17e4319/docs/framework/release-notes/release-notes.md) | [.NET Framework release notes](https://review.learn.microsoft.com/en-us/dotnet/framework/release-notes/release-notes?branch=pr-en-us-49136) |
| [docs/framework/toc.yml](https://github.com/dotnet/docs/blob/e4d5897c1122cf0faeab99049cbf75d3c17e4319/docs/framework/toc.yml) | [docs/framework/toc](https://review.learn.microsoft.com/en-us/dotnet/framework/toc?branch=pr-en-us-49136) |
| [docs/fsharp/language-reference/compiler-messages/fs0001.md](https://github.com/dotnet/docs/blob/e4d5897c1122cf0faeab99049cbf75d3c17e4319/docs/fsharp/language-reference/compiler-messages/fs0001.md) | [FS0001: Error from adding type equation](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/compiler-messages/fs0001?branch=pr-en-us-49136) |
| [docs/fsharp/language-reference/pattern-matching.md](https://github.com/dotnet/docs/blob/e4d5897c1122cf0faeab99049cbf75d3c17e4319/docs/fsharp/language-reference/pattern-matching.md) | [Pattern Matching](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/pattern-matching?branch=pr-en-us-49136) |
| [docs/fsharp/style-guide/formatting.md](https://github.com/dotnet/docs/blob/e4d5897c1122cf0faeab99049cbf75d3c17e4319/docs/fsharp/style-guide/formatting.md) | [F# code formatting guidelines](https://review.learn.microsoft.com/en-us/dotnet/fsharp/style-guide/formatting?branch=pr-en-us-49136) |
| [docs/fundamentals/code-analysis/quality-rules/ca1030.md](https://github.com/dotnet/docs/blob/e4d5897c1122cf0faeab99049cbf75d3c17e4319/docs/fundamentals/code-analysis/quality-rules/ca1030.md) | [CA1030: Use events where appropriate](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1030?branch=pr-en-us-49136) |
| [docs/fundamentals/code-analysis/quality-rules/ca1711.md](https://github.com/dotnet/docs/blob/e4d5897c1122cf0faeab99049cbf75d3c17e4319/docs/fundamentals/code-analysis/quality-rules/ca1711.md) | [CA1711: Identifiers should not have incorrect suffix](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1711?branch=pr-en-us-49136) |
| [docs/fundamentals/code-analysis/quality-rules/ca1713.md](https://github.com/dotnet/docs/blob/e4d5897c1122cf0faeab99049cbf75d3c17e4319/docs/fundamentals/code-analysis/quality-rules/ca1713.md) | [docs/fundamentals/code-analysis/quality-rules/ca1713](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1713?branch=pr-en-us-49136) |

</details>

<!-- PREVIEW-TABLE-END -->