### PR TITLE
Fix heading level for test.runner in global.json

### DIFF
--- a/docs/core/tools/global-json.md
+++ b/docs/core/tools/global-json.md
@@ -118,7 +118,7 @@ Lets you control the project SDK version in one place rather than in each indivi
 
 Specifies information about tests.
 
-### `runner`
+#### `runner`
 
 - Type: `string`
 - Available since: .NET 10.0 SDK.


### PR DESCRIPTION
Follow-up to #48295
Noticed this after merge.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/global-json.md](https://github.com/dotnet/docs/blob/27f9b2585e8ee7614b48bad0f8318626f8887941/docs/core/tools/global-json.md) | [global.json overview](https://review.learn.microsoft.com/en-us/dotnet/core/tools/global-json?branch=pr-en-us-49138) |

<!-- PREVIEW-TABLE-END -->