### PR TITLE
Change logging to use AddSimpleConsole method

### DIFF
--- a/docs/core/extensions/logging.md
+++ b/docs/core/extensions/logging.md
@@ -603,7 +603,7 @@ The following code enables scopes for the console provider:
 HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
 
 builder.Logging.ClearProviders();
-builder.Logging.AddConsole(options => options.IncludeScopes = true);
+builder.Logging.AddSimpleConsole(options => options.IncludeScopes = true);
 
 using IHost host = builder.Build();
 


### PR DESCRIPTION
## Summary

The previous approach, `builder.Logging.AddConsole(options => options.IncludeScopes = true);`, using `ConsoleLoggerFormat` was [deprecated in .NET 5](https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/5.0/obsolete-consoleloggeroptions-properties). It's now recommended to use `ConsoleFormatterOptions` (see [Console log formatting](https://learn.microsoft.com/en-us/dotnet/core/extensions/console-log-formatter#simple)).

Fixes #49141 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/logging.md](https://github.com/dotnet/docs/blob/e7cee3818859bd1d897031c6d3c8f3c4918a6465/docs/core/extensions/logging.md) | [Logging in C# and .NET](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/logging?branch=pr-en-us-49142) |

<!-- PREVIEW-TABLE-END -->