### PR TITLE
Fix example on Composit format string

### DIFF
--- a/docs/standard/base-types/composite-formatting.md
+++ b/docs/standard/base-types/composite-formatting.md
@@ -41,7 +41,7 @@ Consider the following <xref:System.String.Format%2A> code fragment:
 :::code language="vb" source="./snippets/composite-formatting/net/vb/Program.vb" id="basic":::
 
 <!-- markdownlint-disable-next-line no-space-in-code -->
-The fixed text is `Name = `&nbsp;and `, hours = `. The format items are `{0}`, whose index of 0 corresponds to the object `name`, and `{1:hh}`, whose index of 1 corresponds to the object `DateTime.Now`.
+The fixed text is `Name = `&nbsp;and `, hours = `. The format items are `{0}`, whose index of 0 corresponds to the string `"Fred"`, and `{1:hh}`, whose index of 1 corresponds to the object `DateTime.Now`.
 
 ## Format item syntax
 

--- a/docs/standard/base-types/composite-formatting.md
+++ b/docs/standard/base-types/composite-formatting.md
@@ -41,7 +41,7 @@ Consider the following <xref:System.String.Format%2A> code fragment:
 :::code language="vb" source="./snippets/composite-formatting/net/vb/Program.vb" id="basic":::
 
 <!-- markdownlint-disable-next-line no-space-in-code -->
-The fixed text is `Name = `&nbsp;and `, hours = `. The format items are `{0}`, whose index of 0 corresponds to the string `"Fred"`, and `{1:hh}`, whose index of 1 corresponds to the object `DateTime.Now`.
+The fixed text is `Name = `&nbsp;and `, hours = `. The format items are `{0}`, whose index of 0 corresponds to the string literal `"Fred"`, and `{1:hh}`, whose index of 1 corresponds to the value of `DateTime.Now`.
 
 ## Format item syntax
 


### PR DESCRIPTION
## Summary

The example on Composite format string formatting was reffering to an object called name. However, the String.Format method was using simply a string.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/base-types/composite-formatting.md](https://github.com/dotnet/docs/blob/4ad6ae417f853fcb5c7cb744309b7152ecc38cca/docs/standard/base-types/composite-formatting.md) | [Composite formatting](https://review.learn.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting?branch=pr-en-us-49284) |


<!-- PREVIEW-TABLE-END -->