### PR TITLE
Add additional extension errors

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/extension-declarations.md
+++ b/docs/csharp/language-reference/compiler-messages/extension-declarations.md
@@ -1,7 +1,7 @@
 ---
 title: "Errors and warnings related to extension declarations"
 description: "These errors and warnings indicate that you need to modify the declaration of an extension method using the `this` modifier on the first parameter, or an extension declaration"
-ms.date: 05/23/2025
+ms.date: 10/16/2025
 f1_keywords:
   - "CS1100"
   - "CS1101"
@@ -32,6 +32,18 @@ f1_keywords:
   - "CS9303"
   - "CS9304"
   - "CS9305"
+  - "CS9306"
+  - "CS9309"
+  - "CS9316"
+  - "CS9317"
+  - "CS9318"
+  - "CS9319"
+  - "CS9320"
+  - "CS9321"
+  - "CS9322"
+  - "CS9323"
+  - "CS9326"
+  - "CS9329"
 helpviewer_keywords: 
   - "CS1100"
   - "CS1101"
@@ -64,6 +76,18 @@ helpviewer_keywords:
   - "CS9303"
   - "CS9304"
   - "CS9305"
+  - "CS9306"
+  - "CS9309"
+  - "CS9316"
+  - "CS9317"
+  - "CS9318"
+  - "CS9319"
+  - "CS9320"
+  - "CS9321"
+  - "CS9322"
+  - "CS9323"
+  - "CS9326"
+  - "CS9329"
 ---
 # Errors and warnings related to extension methods declared with `this` parameters or `extension` blocks
 
@@ -98,6 +122,18 @@ helpviewer_keywords:
 - [**CS9303**](#errors-related-to-extension-block-declarations): *Cannot declare instance members in an extension block with an unnamed receiver parameter.*
 - [**CS9304**](#errors-related-to-extension-block-declarations): *Cannot declare init-only accessors in an extension block.*
 - [**CS9305**](#errors-related-to-extension-block-declarations): *Cannot use modifiers on the unnamed receiver parameter of extension block.*
+- [**CS9306**](#errors-related-to-extension-block-declarations): *Types and aliases cannot be named 'extension'.*
+- [**CS9309**](#errors-related-to-extension-block-declarations): *An extension member syntax is disallowed in nested position within an extension member syntax.*
+- [**CS9316**](#errors-related-to-extension-block-declarations): *Extension members are not allowed as an argument to '`nameof`'.*
+- [**CS9317**](#errors-related-to-extension-block-declarations): *The parameter of a unary operator must be the extended type.*
+- [**CS9318**](#errors-related-to-extension-block-declarations): *The parameter type for ++ or -- operator must be the extended type.*
+- [**CS9319**](#errors-related-to-extension-block-declarations): *One of the parameters of a binary operator must be the extended type.*
+- [**CS9320**](#errors-related-to-extension-block-declarations): *The first operand of an overloaded shift operator must have the same type as the extended type.*
+- [**CS9321**](#errors-related-to-extension-block-declarations): *An extension block extending a static class cannot contain user-defined operators.*
+- [**CS9322**](#errors-related-to-extension-block-declarations): *Cannot declare instance operator for a struct unless containing extension block receiver parameter is a '`ref`' parameter.*
+- [**CS9323**](#errors-related-to-extension-block-declarations): *Cannot declare instance extension operator for a type that is not known to be a struct and is not known to be a class.*
+- [**CS9326**](#errors-related-to-extension-block-declarations): *'`name`': extension member names cannot be the same as their extended type.*
+- [**CS9329**](#errors-related-to-extension-block-declarations): *This extension block collides with another extension block. They result in conflicting content-based type names in metadata.*
 
 ## Common errors on extension declarations
 
@@ -143,6 +179,20 @@ These errors are specific to extension blocks, a C# 14 feature. Extension blocks
 - **CS9303**: *Cannot declare instance members in an extension block with an unnamed receiver parameter.*
 - **CS9304**: *Cannot declare init-only accessors in an extension block.*
 - **CS9305**: *Cannot use modifiers on the unnamed receiver parameter of extension block.*
+- **CS9306**: *Types and aliases cannot be named 'extension'.*
+- **CS9309**: *An extension member syntax is disallowed in nested position within an extension member syntax.*
+- **CS9316**: *Extension members are not allowed as an argument to '`nameof`'.*
+- **CS9317**: *The parameter of a unary operator must be the extended type.*
+- **CS9318**: *The parameter type for ++ or -- operator must be the extended type.*
+- **CS9319**: *One of the parameters of a binary operator must be the extended type.*
+- **CS9320**: *The first operand of an overloaded shift operator must have the same type as the extended type.*
+- **CS9321**: *An extension block extending a static class cannot contain user-defined operators.*
+- **CS9322**: *Cannot declare instance operator for a struct unless containing extension block receiver parameter is a '`ref`' parameter.*
+- **CS9323**: *Cannot declare instance extension operator for a type that is not known to be a struct and is not known to be a class.*
+- **CS9326**: *'`name`': extension member names cannot be the same as their extended type.*
+- **CS9329**: *This extension block collides with another extension block. They result in conflicting content-based type names in metadata.*
+
+The contextual keyword [`extension`](../keywords/extension.md) declares an extension block. It can't be used for a type.
 
 Extension declarations must follow these rules:
 
@@ -155,6 +205,23 @@ Extension members declared in an extension block must follow these rules, in add
 - The extension must provide a parameter name for the receiver in order to contain members that extend an instance.
 - The receiver parameter name must be unique in that extension block.
 - All extension members must use all type parameters declared on the extension. They can add more type parameters.
+- Extension blocks can't be nested within another extension block.
+
+**CS9316** is emitted when you attempt to use an extension member as an argument to the `nameof` operator. Extension members aren't allowed in this context.
+
+**CS9317**, **CS9318**, **CS9319**, **CS9320**, **CS9321**, **CS9322**, and **CS9323** are operator-related errors in extension blocks:
+
+- **CS9317**: Unary operators must have the extended type as their parameter.
+- **CS9318**: Increment (`++`) and decrement (`--`) operators must have the extended type as their parameter.
+- **CS9319**: Binary operators must have at least one parameter that is the extended type.
+- **CS9320**: Shift operators must have the extended type as their first operand.
+- **CS9321**: You can't declare user-defined operators in extension blocks that extend static classes.
+- **CS9322**: When extending a struct with instance operators, the receiver parameter must use the `ref` modifier.
+- **CS9323**: You can't declare instance operators for types that aren't constrained to be either a struct or a class.
+
+**CS9326** is emitted when an extension member has the same name as the extended type. Choose a different name for the member.
+
+**CS9329** occurs when two extension blocks result in conflicting content-based type names in the compiled metadata. This typically happens when multiple extension blocks with the same receiver type and similar characteristics are declared. Consolidate the extension blocks or differentiate them in a way that produces unique metadata names.
 
 ## Errors related to `this` parameter extension methods
 

--- a/docs/csharp/language-reference/compiler-messages/pattern-matching-warnings.md
+++ b/docs/csharp/language-reference/compiler-messages/pattern-matching-warnings.md
@@ -5,11 +5,14 @@ f1_keywords:
   - "CS8509" # WRN_SwitchNotAllPossibleValues: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '...' is not covered.
   - "CS9134"
   - "CS9135"
+  - "CS9335"
+  - "CS9337"
 helpviewer_keywords:
   - "CS8509"
   - "CS9134"
-  - "CS9135"
-ms.date: 11/02/2022
+  - "CS9335"
+  - "CS9337"
+ms.date: 10/16/2025
 ---
 # Pattern matching errors and warnings
 
@@ -17,6 +20,8 @@ The compiler generates the following errors for invalid pattern match expression
 
 - **CS9134**: *A switch expression arm does not begin with a 'case' keyword.*
 - **CS9135**: *A constant value of type is expected*
+- **CS9335**: *The pattern is redundant.*
+- **CS9337**: *The pattern is too complex to analyze for redundancy.*
 
 The compiler generates the following warnings for incomplete pattern matching expressions:
 
@@ -44,5 +49,13 @@ To address this warning, add switch arms that cover all possible input values. F
 :::code language="csharp" source="./snippets/pattern-matching-warnings/Switch.cs" id="SwitchAllPossibleValues":::
 
 The `_` pattern matches all remaining values. One scenario for the `_` pattern is matching invalid values, as shown in the preceding example.
+
+The compiler generates CS9335 when you wrote a pattern where an `or` is redundant:
+
+:::code language="csharp" source="./snippets/pattern-matching-warnings/Switch.cs" id="RedundantPattern":::
+
+This warning indicates you likely meant `is not (null or 42)` or `is not (int or string)` instead.
+
+You can construct patterns that are too complex to analyze for redundancy. If you do that, the compiler warns you with CS9337.
 
 For more information, see [Switch](../statements/selection-statements.md#the-switch-statement).

--- a/docs/csharp/language-reference/compiler-messages/snippets/pattern-matching-warnings/Switch.cs
+++ b/docs/csharp/language-reference/compiler-messages/snippets/pattern-matching-warnings/Switch.cs
@@ -21,6 +21,15 @@
             };
         }
         // </SwitchNotAllPossibleValues>
+
+        public static void RedundantPattern()
+        {
+            object? o = null;
+            // <RedundantPattern>
+            _ = o is not null or 42; // warning: pattern "42" is redundant
+            _ = o is not int or string; // warning: pattern "string" is redundant
+            // </RedundantPattern>
+        }
     }
 }
 

--- a/docs/csharp/language-reference/toc.yml
+++ b/docs/csharp/language-reference/toc.yml
@@ -544,7 +544,7 @@ items:
       CS8768, CS8670, CS8714, CS8767, CS8769, CS8770, CS8774, CS8776, CS8775, CS8777, CS8819, CS8824, CS8825, CS8847
   - name: Pattern matching warnings
     href: ./compiler-messages/pattern-matching-warnings.md
-    displayName: CS8509, CS9134, CS9135,CS9335, CS9337
+    displayName: CS8509, CS9134, CS9135, CS9335, CS9337
   - name: String literal declarations
     href: ./compiler-messages/string-literal.md
     displayName: >

--- a/docs/csharp/language-reference/toc.yml
+++ b/docs/csharp/language-reference/toc.yml
@@ -520,7 +520,8 @@ items:
     displayName: >
       CS1100, CS1101, CS1102, CS1103, CS1105, CS1106, CS1109, CS1110, CS1113, CS1112, CS1100, CS1101, CS1102, CS1103,
       CS1105, CS1106, CS1109, CS1110, CS1112, CS1113, CS1754, CS9281, CS9282, CS9283, CS9284, CS9285, CS9287, CS9288,
-      CS9289, CS9290, CS9292, CS9293, CS9295, CS9300, CS9301, CS9302, CS9303, CS9304, CS9305
+      CS9289, CS9290, CS9292, CS9293, CS9295, CS9300, CS9301, CS9302, CS9303, CS9304, CS9305, CS9306, CS9309, CS9316,
+      CS9317, CS9318, CS9319, CS9320, CS9321, CS9322, CS9323, CS9326, CS9329
   - name: Partial declarations
     href: ./compiler-messages/partial-declarations.md
     displayName: >
@@ -543,7 +544,7 @@ items:
       CS8768, CS8670, CS8714, CS8767, CS8769, CS8770, CS8774, CS8776, CS8775, CS8777, CS8819, CS8824, CS8825, CS8847
   - name: Pattern matching warnings
     href: ./compiler-messages/pattern-matching-warnings.md
-    displayName: CS8509, CS9134, CS9135
+    displayName: CS8509, CS9134, CS9135,CS9335, CS9337
   - name: String literal declarations
     href: ./compiler-messages/string-literal.md
     displayName: >
@@ -574,7 +575,7 @@ items:
     displayName: >
       CS0765, CS0831, CS0832, CS0834, CS0835, CS0838, CS0845, CS0853, CS0854, CS0855, CS1944, CS1945, CS1946, CS1951, CS1952,
       CS1963, CS2037, CS7053, CS8072, CS8074, CS8075, CS8110, CS8122, CS8143, CS8144, CS8153, CS8155, CS8198, CS8207, CS8382,
-      CS8514, CS8640, CS8642, CS8790, CS8791, CS8792, CS8810, CS8849, CS8927, CS8952, CS9170, CS9175
+      CS8514, CS8640, CS8642, CS8790, CS8791, CS8792, CS8810, CS8849, CS8927, CS8952, CS9170, CS9175, CS9307
   - name: Using directive and aliases
     href: ./compiler-messages/using-directive-errors.md
     displayName: >

--- a/docs/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error.md
+++ b/docs/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error.md
@@ -593,22 +593,14 @@ f1_keywords:
   - "CS9235"
   - "CS9236"
 # C# 14 errors begin here
-## using `extension` as type name. (valid identifiers).
-  - "CS9306"
-## More extension errors
-  - "CS9316"
-  - "CS9317"
-  - "CS9318"
-  - "CS9319"
-  - "CS9326"
   - "CS9327"
   - "CS9328"
-  - "CS9329"
   - "CS9330"
   - "CS9331"
   - "CS9332"
   - "CS9333"
   - "CS9334"
+  - "CS9338"
 helpviewer_keywords:
   - "errors [C#], additional information"
 ---


### PR DESCRIPTION
Fixes #46453

After new operators were added, new diagnostics were necessary in the area of extensions.

Also, pick up a few other stragglers added for other features.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-messages/extension-declarations.md](https://github.com/dotnet/docs/blob/0bcd904504eba7e65d75e89873650ed3ebe46791/docs/csharp/language-reference/compiler-messages/extension-declarations.md) | [Errors and warnings related to extension methods declared with `this` parameters or `extension` blocks](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/extension-declarations?branch=pr-en-us-49290) |
| [docs/csharp/language-reference/compiler-messages/pattern-matching-warnings.md](https://github.com/dotnet/docs/blob/0bcd904504eba7e65d75e89873650ed3ebe46791/docs/csharp/language-reference/compiler-messages/pattern-matching-warnings.md) | [Pattern matching errors and warnings](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/pattern-matching-warnings?branch=pr-en-us-49290) |
| [docs/csharp/language-reference/toc.yml](https://github.com/dotnet/docs/blob/0bcd904504eba7e65d75e89873650ed3ebe46791/docs/csharp/language-reference/toc.yml) | [docs/csharp/language-reference/toc](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/toc?branch=pr-en-us-49290) |
| [docs/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error.md](https://github.com/dotnet/docs/blob/0bcd904504eba7e65d75e89873650ed3ebe46791/docs/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error.md) | [C# 14 errors begin here](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error?branch=pr-en-us-49290) |


<!-- PREVIEW-TABLE-END -->