### PR TITLE
Update code snippet reference for null assignment

### DIFF
--- a/docs/csharp/language-reference/operators/member-access-operators.md
+++ b/docs/csharp/language-reference/operators/member-access-operators.md
@@ -155,7 +155,7 @@ Beginning in C# 14, assignment is permissible with a null conditional access exp
 
 The preceding example shows assignment to a property and an indexed element on a reference type that might be null. An important behavior for this assignment is that the expression on the right-hand side of the `=` is evaluated only when the left-hand side is known to be non-null. For example, in the following code, the function `GenerateNextIndex` is called only when the `values` array isn't null. If the `values` array is null, `GenerateNextIndex` isn't called:
 
-:::code language="csharp" source="snippets/shared/NullCoalescingOperator.cs" id="NullForgivingAssignment":::
+:::code language="csharp" source="snippets/shared/NullCoalescingOperator.cs" id="ConditionalRHS":::
 
 In other words, the preceding code is equivalent to the following code using an `if` statement for the null check:
 


### PR DESCRIPTION
## Summary

A snippet was used twice. I believe I replaced it with the correct sample.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/member-access-operators.md](https://github.com/dotnet/docs/blob/aeffa19071ac13c400fba4cfbea7c7fe6fb5c786/docs/csharp/language-reference/operators/member-access-operators.md) | [docs/csharp/language-reference/operators/member-access-operators](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/member-access-operators?branch=pr-en-us-49299) |

<!-- PREVIEW-TABLE-END -->