### PR TITLE
Update MSTest v4 migration notes for MSTest.Sdk break around VSTest

### DIFF
--- a/docs/core/testing/unit-testing-mstest-migration-v3-v4.md
+++ b/docs/core/testing/unit-testing-mstest-migration-v3-v4.md
@@ -213,3 +213,9 @@ To address long outstanding bugs that many users filed, the generation of `TestC
 ### TreatDiscoveryWarningsAsErrors now defaults to true
 
 v4 uses stricter defaults. As such, the default value of `TreatDiscoveryWarningsAsErrors` is now `true`. This should be a transparent change for most users and should help other users to uncover hidden bugs.
+
+### MSTest.Sdk no longer adds `Microsoft.NET.Test.Sdk` reference when using Microsoft.Testing.Platform
+
+MSTest.Sdk, by default, uses Microsoft.Testing.Platform, unless `UseVSTest` MSBuild property is set to true. In MSTest 3.x, the SDK still adds reference to Microsoft.NET.Test.Sdk (which brings VSTest support) even when using Microsoft.Testing.Platform. This package reference is unneeded when running with Microsoft.Testing.Platform, and thus is removed in MSTest v4.
+
+If you still want to have VSTest supported (for example, if you want to run with vstest.console), you need to manually add a package reference to `Microsoft.NET.Test.Sdk` NuGet package to your project.

--- a/docs/core/testing/unit-testing-mstest-migration-v3-v4.md
+++ b/docs/core/testing/unit-testing-mstest-migration-v3-v4.md
@@ -216,6 +216,6 @@ v4 uses stricter defaults. As such, the default value of `TreatDiscoveryWarnings
 
 ### MSTest.Sdk no longer adds `Microsoft.NET.Test.Sdk` reference when using Microsoft.Testing.Platform
 
-MSTest.Sdk, by default, uses Microsoft.Testing.Platform, unless `UseVSTest` MSBuild property is set to true. In MSTest 3.x, the SDK still adds reference to Microsoft.NET.Test.Sdk (which brings VSTest support) even when using Microsoft.Testing.Platform. This package reference is unneeded when running with Microsoft.Testing.Platform, and thus is removed in MSTest v4.
+By default, MSTest.Sdk uses Microsoft.Testing.Platform. If the `UseVSTest` MSBuild property is set to true, it will use VSTest instead. In MSTest 3.x, the SDK added a reference to Microsoft.NET.Test.Sdk (which brings VSTest support) even when using Microsoft.Testing.Platform. This package reference is unnecessary when running with Microsoft.Testing.Platform and has been removed in MSTest v4.
 
 If you still want to have VSTest supported (for example, if you want to run with vstest.console), you need to manually add a package reference to `Microsoft.NET.Test.Sdk` NuGet package to your project.


### PR DESCRIPTION
Related to https://github.com/microsoft/testfx/issues/6763

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-mstest-migration-v3-v4.md](https://github.com/dotnet/docs/blob/3d8834d779b037fb47db5496bc96891141bfe00a/docs/core/testing/unit-testing-mstest-migration-v3-v4.md) | [Migrate from MSTest v3 to v4](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-migration-v3-v4?branch=pr-en-us-49303) |


<!-- PREVIEW-TABLE-END -->