### PR TITLE
Added info about .NET Framework 4.8.1 Release 533509 (Windows 11 25H2)

### DIFF
--- a/docs/framework/install/how-to-determine-which-versions-are-installed.md
+++ b/docs/framework/install/how-to-determine-which-versions-are-installed.md
@@ -1,7 +1,7 @@
 ---
 title: Determine which .NET Framework versions are installed
 description: Use code, regedit.exe, or PowerShell to detect which versions of .NET Framework are installed on a machine by querying the Windows registry. Or, check Control Panel.
-ms.date: 20/10/2025
+ms.date: 10/20/2025
 dev_langs:
   - "csharp"
   - "vb"

--- a/docs/framework/install/how-to-determine-which-versions-are-installed.md
+++ b/docs/framework/install/how-to-determine-which-versions-are-installed.md
@@ -1,7 +1,7 @@
 ---
 title: Determine which .NET Framework versions are installed
 description: Use code, regedit.exe, or PowerShell to detect which versions of .NET Framework are installed on a machine by querying the Windows registry. Or, check Control Panel.
-ms.date: 07/10/2025
+ms.date: 20/10/2025
 dev_langs:
   - "csharp"
   - "vb"

--- a/docs/framework/install/how-to-determine-which-versions-are-installed.md
+++ b/docs/framework/install/how-to-determine-which-versions-are-installed.md
@@ -86,7 +86,7 @@ The **Release** REG_DWORD value in the registry represents the version of .NET F
 | .NET Framework 4.7.1   | On Windows 10 Fall Creators Update and Windows Server, version 1709: **461308**<br/>On all other Windows operating systems (including other Windows 10 operating systems): **461310** |
 | .NET Framework 4.7.2   | On Windows 10 April 2018 Update and Windows Server, version 1803: **461808**<br/>On all Windows operating systems other than Windows 10 April 2018 Update and Windows Server, version 1803: **461814** |
 | .NET Framework 4.8     | On Windows 10 May 2019 Update and Windows 10 November 2019 Update: **528040**<br/>On Windows 10 May 2020 Update, October 2020 Update, May 2021 Update, November 2021 Update, and 2022 Update: **528372**<br/>On Windows 11 and Windows Server 2022: **528449**<br/>On all other Windows operating systems (including other Windows 10 operating systems): **528049** |
-| .NET Framework 4.8.1   | On Windows 11 2022 Update and Windows 11 2023 Update: **533320**<br/>All other Windows operating systems: **533325** |
+| .NET Framework 4.8.1   | On Windows 11 2025 Update: **533509**<br/>On Windows 11 2022 Update and Windows 11 2023 Update: **533320**<br/>All other Windows operating systems: **533325** |
 
 #### Minimum version
 

--- a/docs/framework/install/versions-and-dependencies.md
+++ b/docs/framework/install/versions-and-dependencies.md
@@ -1,7 +1,7 @@
 ---
 title: .NET Framework & Windows OS versions
 description: Learn about key features in each version of .NET Framework, including underlying CLR versions and versions installed by the Windows operating system.
-ms.date: 07/10/2025
+ms.date: 20/10/2025
 helpviewer_keywords:
   - "versions, .NET Framework"
 ---

--- a/docs/framework/install/versions-and-dependencies.md
+++ b/docs/framework/install/versions-and-dependencies.md
@@ -1,7 +1,7 @@
 ---
 title: .NET Framework & Windows OS versions
 description: Learn about key features in each version of .NET Framework, including underlying CLR versions and versions installed by the Windows operating system.
-ms.date: 20/10/2025
+ms.date: 10/20/2025
 helpviewer_keywords:
   - "versions, .NET Framework"
 ---

--- a/docs/framework/install/versions-and-dependencies.md
+++ b/docs/framework/install/versions-and-dependencies.md
@@ -63,6 +63,7 @@ Jump to:
 
 To determine the installed .NET version, use the following `Release` DWORD:
 
+- 533509 (Windows 11 September 2025 Release)
 - 533320 (Windows 11 September 2022 Release and Windows 11 October 2023 Release)
 - 533325 (all other OS versions)
 


### PR DESCRIPTION
## Summary

Added info about .NET Framework 4.8.1 Release 533509 (Windows 11 25H2) [here](https://learn.microsoft.com/en-us/dotnet/framework/install/how-to-determine-which-versions-are-installed#net-framework-45-and-later-versions) and [here](https://learn.microsoft.com/en-us/dotnet/framework/install/versions-and-dependencies#net-framework-481).

Fixes #49305


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/install/how-to-determine-which-versions-are-installed.md](https://github.com/dotnet/docs/blob/141e5caa3fb2560b4330d1c83464a246531039d5/docs/framework/install/how-to-determine-which-versions-are-installed.md) | [How to: Determine which .NET Framework versions are installed](https://review.learn.microsoft.com/en-us/dotnet/framework/install/how-to-determine-which-versions-are-installed?branch=pr-en-us-49306) |
| [docs/framework/install/versions-and-dependencies.md](https://github.com/dotnet/docs/blob/141e5caa3fb2560b4330d1c83464a246531039d5/docs/framework/install/versions-and-dependencies.md) | [.NET Framework & Windows OS versions](https://review.learn.microsoft.com/en-us/dotnet/framework/install/versions-and-dependencies?branch=pr-en-us-49306) |


<!-- PREVIEW-TABLE-END -->