### PR TITLE
Fix wording for range operator spacing rule in F# style guide

### DIFF
--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -660,7 +660,7 @@ x ^^^ y // Bitwise xor, also for working with “flags” enumeration
 
 ### Formatting range operator expressions
 
-Only add spaces around the `..` when all expressions are non-atomic.
+Only add spaces around the `..` if any expression is non-atomic.
 Integers and single word identifiers are considered atomic.
 
 ```fsharp


### PR DESCRIPTION
## Summary
The F# style guide currently says:

    "Only add spaces around the `..` when all expressions are non-atomic."

This is inconsistent with the examples, which show that spaces are added when any expression is non-atomic.  

This PR updates the wording to:

    "Only add spaces around the `..` if any expression is non-atomic."

to match the examples and clarify the intended rule. All examples have been preserved as-is.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/style-guide/formatting.md](https://github.com/dotnet/docs/blob/eebfbe965566eb07d9089a4160041bf7cc6f0c28/docs/fsharp/style-guide/formatting.md) | [F# code formatting guidelines](https://review.learn.microsoft.com/en-us/dotnet/fsharp/style-guide/formatting?branch=pr-en-us-49311) |


<!-- PREVIEW-TABLE-END -->