### PR TITLE
Update outdated documentation about MTP extensions licensing

### DIFF
--- a/docs/core/testing/microsoft-testing-platform-extensions-diagnostics.md
+++ b/docs/core/testing/microsoft-testing-platform-extensions-diagnostics.md
@@ -38,9 +38,6 @@ You can also enable the diagnostics logs using the environment variables:
 
 This extension allows you to create a crash dump file if the process crashes. This extension is shipped as part of [Microsoft.Testing.Extensions.CrashDump](https://nuget.org/packages/Microsoft.Testing.Extensions.CrashDump) NuGet package.
 
-> [!IMPORTANT]
-> The package is shipped with Microsoft .NET library closed-source free to use licensing model.
-
 To configure the crash dump file generation, use the following options:
 
 | Option | Description |
@@ -55,9 +52,6 @@ To configure the crash dump file generation, use the following options:
 ## Hang dump
 
 This extension allows you to create a dump file after a given timeout. This extension is shipped as part of [Microsoft.Testing.Extensions.HangDump](https://nuget.org/packages/Microsoft.Testing.Extensions.HangDump) package.
-
-> [!IMPORTANT]
-> The package is shipped with Microsoft .NET library closed-source free to use licensing model.
 
 To configure the hang dump file generation, use the following options:
 


### PR DESCRIPTION
This was open-sourced in https://github.com/microsoft/testfx/pull/3133

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/microsoft-testing-platform-extensions-diagnostics.md](https://github.com/dotnet/docs/blob/d46aa7e778806ed79c96f5df5adcfd45b331165f/docs/core/testing/microsoft-testing-platform-extensions-diagnostics.md) | [Diagnostics extensions](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-extensions-diagnostics?branch=pr-en-us-49384) |

<!-- PREVIEW-TABLE-END -->