### PR TITLE
Update patterns.md with empty property pattern details

### DIFF
--- a/docs/csharp/language-reference/operators/patterns.md
+++ b/docs/csharp/language-reference/operators/patterns.md
@@ -183,19 +183,9 @@ You can also add a run-time type check and a variable declaration to a property 
 :::code language="csharp" source="snippets/patterns/PropertyPattern.cs" id="WithTypeCheck":::
 
 This specifially means that the *empty* property pattern `is { }` matches everything non-null, and can be used instead of the `is not null` to create a variable: `somethingPossiblyNull is { } somethingDefinitelyNotNull`.
---------- @BillWagner here's a code example to be put into a `:::code:::` block:
-```cs
-if (GetSomeNullableStringValue() is { } nonNullValue) // Empty property pattern with variable creation
-{
-    Console.WriteLine("NotNull:" + nonNullValue)
-}
-else
-{
-    nonNullValue = "NullFallback"; // we can access the variable here.
-    Console.WriteLine("it was null, here's the fallback: " + nonNullValue)
-}
-```
----------end of the example
+
+:::code language="csharp" source="snippets/patterns/PropertyPattern.cs" id="EmptyPropertyPattern":::
+
 A property pattern is a recursive pattern. You can use any pattern as a nested pattern. Use a property pattern to match parts of data against nested patterns, as the following example shows:
 
 :::code language="csharp" source="snippets/patterns/PropertyPattern.cs" id="RecursivePropertyPattern":::

--- a/docs/csharp/language-reference/operators/patterns.md
+++ b/docs/csharp/language-reference/operators/patterns.md
@@ -182,7 +182,7 @@ You can also add a run-time type check and a variable declaration to a property 
 
 :::code language="csharp" source="snippets/patterns/PropertyPattern.cs" id="WithTypeCheck":::
 
-This specifially means that the *empty* property pattern `is { }` matches everything non-null, and can be used instead of the `is not null` to create a variable: `somethingPossiblyNull is { } somethingDefinitelyNotNull`.
+This specifically means that the *empty* property pattern `is { }` matches everything non-null, and can be used instead of the `is not null` to create a variable: `somethingPossiblyNull is { } somethingDefinitelyNotNull`.
 
 :::code language="csharp" source="snippets/patterns/PropertyPattern.cs" id="EmptyPropertyPattern":::
 

--- a/docs/csharp/language-reference/operators/patterns.md
+++ b/docs/csharp/language-reference/operators/patterns.md
@@ -183,7 +183,19 @@ You can also add a run-time type check and a variable declaration to a property 
 :::code language="csharp" source="snippets/patterns/PropertyPattern.cs" id="WithTypeCheck":::
 
 This specifially means that the *empty* property pattern `is { }` matches everything non-null, and can be used instead of the `is not null` to create a variable: `somethingPossiblyNull is { } somethingDefinitelyNotNull`.
-
+--------- @BillWagner here's a code example to be put into a `:::code:::` block:
+```cs
+if (GetSomeNullableStringValue() is { } nonNullValue) // Empty property pattern with variable creation
+{
+    Console.WriteLine("NotNull:" + nonNullValue)
+}
+else
+{
+    nonNullValue = "NullFallback"; // we can access the variable here.
+    Console.WriteLine("it was null, here's the fallback: " + nonNullValue)
+}
+```
+---------end of the example
 A property pattern is a recursive pattern. You can use any pattern as a nested pattern. Use a property pattern to match parts of data against nested patterns, as the following example shows:
 
 :::code language="csharp" source="snippets/patterns/PropertyPattern.cs" id="RecursivePropertyPattern":::

--- a/docs/csharp/language-reference/operators/patterns.md
+++ b/docs/csharp/language-reference/operators/patterns.md
@@ -182,6 +182,8 @@ You can also add a run-time type check and a variable declaration to a property 
 
 :::code language="csharp" source="snippets/patterns/PropertyPattern.cs" id="WithTypeCheck":::
 
+This specifially means that the *empty* property pattern `is { }` matches everything non-null, and can be used instead of the `is not null` to create a variable: `somethingPossiblyNull is { } somethingDefinitelyNotNull`.
+
 A property pattern is a recursive pattern. You can use any pattern as a nested pattern. Use a property pattern to match parts of data against nested patterns, as the following example shows:
 
 :::code language="csharp" source="snippets/patterns/PropertyPattern.cs" id="RecursivePropertyPattern":::

--- a/docs/csharp/language-reference/operators/snippets/patterns/PropertyPattern.cs
+++ b/docs/csharp/language-reference/operators/snippets/patterns/PropertyPattern.cs
@@ -5,8 +5,27 @@ public static class PropertyPattern
     public static void Examples()
     {
         WithTypeCheck();
+
+        // <EmptyPropertyPattern>
+        if (GetSomeNullableStringValue() is { } nonNullValue) // Empty property pattern with variable creation
+        {
+            Console.WriteLine("NotNull:" + nonNullValue);
+        }
+        else
+        {
+            nonNullValue = "NullFallback"; // we can access the variable here.
+            Console.WriteLine("it was null, here's the fallback: " + nonNullValue);
+        }
+        // </EmptyPropertyPattern>
+
     }
 
+    private static string? GetSomeNullableStringValue()
+    {
+        // Simulate getting a nullable string value.
+        return DateTime.Now.Ticks % 2 == 0 ? "Hello, World!" : null;
+    }
+    
     // <BasicExample>
     static bool IsConferenceDay(DateTime date) => date is { Year: 2020, Month: 5, Day: 19 or 20 or 21 };
     // </BasicExample>


### PR DESCRIPTION
Clarify the behavior of the empty property pattern in C#.

## Summary

added note about the empty property pattern because it wasn't mentioned anywhere.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/patterns.md](https://github.com/dotnet/docs/blob/322304c4ae4e17691630799e7875f9b1fe33c7c2/docs/csharp/language-reference/operators/patterns.md) | [Pattern matching - the `is` and `switch` expressions, and operators `and`, `or`, and `not` in patterns](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/patterns?branch=pr-en-us-49385) |


<!-- PREVIEW-TABLE-END -->