### PR TITLE
add CS8500 compiler warning

### DIFF
--- a/docs/csharp/misc/cs8500.md
+++ b/docs/csharp/misc/cs8500.md
@@ -1,0 +1,60 @@
+---
+description: "Learn more about: Compiler Warning (level 4) CS8500"
+title: "Compiler Warning (level 4) CS8500"
+ms.date: 10/23/2025
+f1_keywords:
+  - "CS8500"
+helpviewer_keywords:
+  - "CS8500"
+---
+
+# Compiler Warning (level 4) CS8500
+
+This takes the address of, gets the size of, or declares a pointer to a managed type ('type')
+
+Even when used with the [unsafe](../language-reference/keywords/unsafe.md) keyword, taking the address of a managed object, getting the size of a managed object, or declaring a pointer to a managed type is not allowed. A managed type is:  
+  
+- Any reference type  
+- Any struct that contains a reference type as a field or property  
+  
+For more information, see [Unmanaged types](../language-reference/builtin-types/unmanaged-types.md).
+
+The following sample generates CS8500:
+
+```csharp
+// CS8500.cs
+// Compile with: /unsafe
+
+class MyClass
+{
+    int a = 98;
+}  
+
+struct MyProblemStruct
+{
+    string s;
+    float f;
+}
+
+struct MyGoodStruct
+{
+    int i;
+    float f;
+}
+
+public class Program
+{
+    unsafe public static void Main()
+    {
+        // MyClass is a class, a managed type.
+        MyClass s = new MyClass();
+        MyClass* s2 = &s; // CS8500
+
+        // The struct contains a string, a managed type.
+        int i = sizeof(MyProblemStruct); // CS8500
+
+        // The struct contains only value types.
+        i = sizeof(MyGoodStruct); // OK
+    }
+}
+```


### PR DESCRIPTION
## Summary

- This PR adds the missing documentation for the `CS8500` compiler warning.

Fixes #48468


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/misc/cs8500.md](https://github.com/dotnet/docs/blob/384d96a5b8048284e6466b944dc531f7ebf2c949/docs/csharp/misc/cs8500.md) | [docs/csharp/misc/cs8500](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/cs8500?branch=pr-en-us-49433) |

<!-- PREVIEW-TABLE-END -->