### PR TITLE
Fix JSON deserialization errors in C# 'REST Client' tutorial. Closes …

### DIFF
--- a/docs/csharp/tutorials/console-webapiclient.md
+++ b/docs/csharp/tutorials/console-webapiclient.md
@@ -229,7 +229,7 @@ In the following steps, we extend the code to process more properties from the J
 
    JSON often uses `lowercase` or `snake_case` for property names. Fields like `html_url` and `pushed_at` do not follow C# PascalCase naming conventions. Using `[JsonPropertyName]` ensures that these JSON keys are correctly bound to their corresponding C# properties, even when their names differ in case or contain underscores. This approach guarantees predictable and stable deserialization while allowing PascalCase property names in C#.
 Additionally, the `GetFromJsonAsync` method is `case-insensitive` when matching property names, so no further conversion is necessary.
-1. Update the `foreach` loop in the *Program.cs* file to display the property values:
+2. Update the `foreach` loop in the *Program.cs* file to display the property values:
 
     ```csharp
     foreach (var repo in repositories)
@@ -243,7 +243,7 @@ Additionally, the `GetFromJsonAsync` method is `case-insensitive` when matching 
     }
     ```
 
-1. Run the app.
+3. Run the app.
 
    The list now includes the additional properties.
 

--- a/docs/csharp/tutorials/console-webapiclient.md
+++ b/docs/csharp/tutorials/console-webapiclient.md
@@ -213,18 +213,18 @@ In the following steps, we extend the code to process more properties from the J
 
 1. Replace the contents of the `Repository` class with the following `record` definition. Make sure to import the `System.Text.Json.Serialization` namespace and apply the `[JsonPropertyName]` attribute to map JSON fields to C# properties explicitly.
 
- ```csharp
-  using System.Text.Json.Serialization;
+   ```csharp
+    using System.Text.Json.Serialization;
 
-  public record class Repository(
-    string Name,
-    string Description,
-    [property: JsonPropertyName("html_url")] Uri GitHubHomeUrl,
-    Uri Homepage,
-    int Watchers,
-    [property: JsonPropertyName("pushed_at")] DateTime LastPushUtc
-   );
- ```
+    public record class Repository(
+      string Name,
+      string Description,
+      [property: JsonPropertyName("html_url")] Uri GitHubHomeUrl,
+      Uri Homepage,
+      int Watchers,
+      [property: JsonPropertyName("pushed_at")] DateTime LastPushUtc
+     );
+   ```
 
    The <xref:System.Uri> and `int` types have built-in functionality to convert to and from string representation. No extra code is needed to deserialize from JSON string format to those target types. If the JSON packet contains data that doesn't convert to a target type, the serialization action throws an exception.
 

--- a/docs/csharp/tutorials/console-webapiclient.md
+++ b/docs/csharp/tutorials/console-webapiclient.md
@@ -213,7 +213,7 @@ The following steps add code to process more of the properties in the received J
 
 1. Replace the contents of `Repository` class, with the following `record` definition:
 
-    ```csharp
+ ```csharp
   using System.Text.Json.Serialization;
 
   public record class Repository(
@@ -226,7 +226,7 @@ The following steps add code to process more of the properties in the received J
  {
     public DateTime LastPush => LastPushUtc.ToLocalTime();
  }
-    ```
+ ```
 
    The <xref:System.Uri> and `int` types have built-in functionality to convert to and from string representation. No extra code is needed to deserialize from JSON string format to those target types. If the JSON packet contains data that doesn't convert to a target type, the serialization action throws an exception.
 

--- a/docs/csharp/tutorials/console-webapiclient.md
+++ b/docs/csharp/tutorials/console-webapiclient.md
@@ -223,7 +223,7 @@ The following steps add code to process more of the properties in the received J
     Uri Homepage,
     int Watchers,
     [property: JsonPropertyName("pushed_at")] DateTime LastPushUtc
-   )
+   );
 
  ```
 

--- a/docs/csharp/tutorials/console-webapiclient.md
+++ b/docs/csharp/tutorials/console-webapiclient.md
@@ -229,6 +229,7 @@ In the following steps, we extend the code to process more properties from the J
 
    JSON often uses `lowercase` or `snake_case` for property names. Fields like `html_url` and `pushed_at` do not follow C# PascalCase naming conventions. Using `[JsonPropertyName]` ensures that these JSON keys are correctly bound to their corresponding C# properties, even when their names differ in case or contain underscores. This approach guarantees predictable and stable deserialization while allowing PascalCase property names in C#.
 Additionally, the `GetFromJsonAsync` method is `case-insensitive` when matching property names, so no further conversion is necessary.
+
 2. Update the `foreach` loop in the *Program.cs* file to display the property values:
 
     ```csharp

--- a/docs/csharp/tutorials/console-webapiclient.md
+++ b/docs/csharp/tutorials/console-webapiclient.md
@@ -214,14 +214,18 @@ The following steps add code to process more of the properties in the received J
 1. Replace the contents of `Repository` class, with the following `record` definition:
 
     ```csharp
-    public record class Repository(
-        string Name,
-        string Description,
-        Uri GitHubHomeUrl,
-        Uri Homepage,
-        int Watchers,
-        DateTime LastPushUtc
-    );
+  using System.Text.Json.Serialization;
+
+  public record class Repository(
+    string Name,
+    string Description,
+    [property: JsonPropertyName("html_url")] Uri GitHubHomeUrl,
+    Uri Homepage,
+    int Watchers,
+    [property: JsonPropertyName("pushed_at")] DateTime LastPushUtc)
+ {
+    public DateTime LastPush => LastPushUtc.ToLocalTime();
+ }
     ```
 
    The <xref:System.Uri> and `int` types have built-in functionality to convert to and from string representation. No extra code is needed to deserialize from JSON string format to those target types. If the JSON packet contains data that doesn't convert to a target type, the serialization action throws an exception.

--- a/docs/csharp/tutorials/console-webapiclient.md
+++ b/docs/csharp/tutorials/console-webapiclient.md
@@ -222,10 +222,9 @@ The following steps add code to process more of the properties in the received J
     [property: JsonPropertyName("html_url")] Uri GitHubHomeUrl,
     Uri Homepage,
     int Watchers,
-    [property: JsonPropertyName("pushed_at")] DateTime LastPushUtc)
- {
-    public DateTime LastPush => LastPushUtc.ToLocalTime();
- }
+    [property: JsonPropertyName("pushed_at")] DateTime LastPushUtc
+   )
+
  ```
 
    The <xref:System.Uri> and `int` types have built-in functionality to convert to and from string representation. No extra code is needed to deserialize from JSON string format to those target types. If the JSON packet contains data that doesn't convert to a target type, the serialization action throws an exception.

--- a/docs/csharp/tutorials/console-webapiclient.md
+++ b/docs/csharp/tutorials/console-webapiclient.md
@@ -209,10 +209,9 @@ The `ProcessRepositoriesAsync` method can do the async work and return a collect
 
 ## Deserialize more properties
 
-The following steps add code to process more of the properties in the received JSON packet. You probably won't want to process every property, but adding a few more demonstrates other features of C#.
+In the following steps, we extend the code to process more properties from the JSON payload returned by the GitHub API. You probably won't need to process every property, but adding a few demonstrates additional C# features.
 
-1. Replace the contents of `Repository` class, with the following `record` definition:
-
+1. Replace the contents of the `Repository` class with the following `record` definition. Make sure to import the `System.Text.Json.Serialization` namespace and apply the `[JsonPropertyName]` attribute to map JSON fields to C# properties explicitly.
  ```csharp
   using System.Text.Json.Serialization;
 
@@ -224,13 +223,12 @@ The following steps add code to process more of the properties in the received J
     int Watchers,
     [property: JsonPropertyName("pushed_at")] DateTime LastPushUtc
    );
-
  ```
 
    The <xref:System.Uri> and `int` types have built-in functionality to convert to and from string representation. No extra code is needed to deserialize from JSON string format to those target types. If the JSON packet contains data that doesn't convert to a target type, the serialization action throws an exception.
 
-   JSON most often uses lowercase for names of it's objects, however we don't need to make any conversion and can keep the uppercase of the fields names, because, like mentioned in one of previous points, the `GetFromJsonAsync` extension method is case-insensitive when it comes to property names.
-
+   JSON often uses `lowercase` or `snake_case` for property names. Fields like `html_url` and `pushed_at` do not follow C# PascalCase naming conventions. Using `[JsonPropertyName]` ensures that these JSON keys are correctly bound to their corresponding C# properties, even when their names differ in case or contain underscores. This approach guarantees predictable and stable deserialization while allowing PascalCase property names in C#.
+Additionally, the `GetFromJsonAsync` method is `case-insensitive` when matching property names, so no further conversion is necessary.
 1. Update the `foreach` loop in the *Program.cs* file to display the property values:
 
     ```csharp

--- a/docs/csharp/tutorials/console-webapiclient.md
+++ b/docs/csharp/tutorials/console-webapiclient.md
@@ -212,6 +212,7 @@ The `ProcessRepositoriesAsync` method can do the async work and return a collect
 In the following steps, we extend the code to process more properties from the JSON payload returned by the GitHub API. You probably won't need to process every property, but adding a few demonstrates additional C# features.
 
 1. Replace the contents of the `Repository` class with the following `record` definition. Make sure to import the `System.Text.Json.Serialization` namespace and apply the `[JsonPropertyName]` attribute to map JSON fields to C# properties explicitly.
+
  ```csharp
   using System.Text.Json.Serialization;
 

--- a/docs/csharp/tutorials/snippets/WebAPIClient/Repository.cs
+++ b/docs/csharp/tutorials/snippets/WebAPIClient/Repository.cs
@@ -1,11 +1,13 @@
-﻿public record class Repository(
+using System.Text.Json.Serialization;
+
+public record class Repository(
     string Name,
     string Description,
-    Uri GitHubHomeUrl,
+    [property: JsonPropertyName("html_url")] Uri GitHubHomeUrl,
     Uri Homepage,
     int Watchers,
-    DateTime LastPushUtc
-)
+    [property: JsonPropertyName("pushed_at")] DateTime LastPushUtc
+    )
 {
     public DateTime LastPush => LastPushUtc.ToLocalTime();
 }


### PR DESCRIPTION
…#49387

Fix the deserialization issue in the Repository model.

## Summary

Corrected property names in the Repository model to match the JSON fields returned by the GitHub API.

GitHubHomeUrl → maps to html_url

LastPushUtc → maps to pushed_at

Fixes #49387 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/tutorials/console-webapiclient.md](https://github.com/dotnet/docs/blob/12a03a93a6c769803a57bed17a512cac7434f085/docs/csharp/tutorials/console-webapiclient.md) | [Tutorial: Make HTTP requests in a .NET console app using C\#](https://review.learn.microsoft.com/en-us/dotnet/csharp/tutorials/console-webapiclient?branch=pr-en-us-49442) |


<!-- PREVIEW-TABLE-END -->