### PR TITLE
Fix RegexOptions.ECMAScript combinations

### DIFF
--- a/docs/standard/base-types/regular-expression-options.md
+++ b/docs/standard/base-types/regular-expression-options.md
@@ -333,7 +333,7 @@ By default, the regular expression engine uses canonical behavior when matching 
 > [!NOTE]
 > ECMAScript-compliant behavior is available only by supplying the <xref:System.Text.RegularExpressions.RegexOptions.ECMAScript?displayProperty=nameWithType> value to the `options` parameter of a <xref:System.Text.RegularExpressions.Regex> class constructor or static pattern-matching method. It is not available as an inline option.
 
-The <xref:System.Text.RegularExpressions.RegexOptions.ECMAScript?displayProperty=nameWithType> option can be combined only with the <xref:System.Text.RegularExpressions.RegexOptions.IgnoreCase?displayProperty=nameWithType> and <xref:System.Text.RegularExpressions.RegexOptions.Multiline?displayProperty=nameWithType> options. The use of any other option in a regular expression results in an <xref:System.ArgumentOutOfRangeException>.
+The <xref:System.Text.RegularExpressions.RegexOptions.ECMAScript?displayProperty=nameWithType> option can be combined only with the <xref:System.Text.RegularExpressions.RegexOptions.IgnoreCase?displayProperty=nameWithType>, <xref:System.Text.RegularExpressions.RegexOptions.Multiline?displayProperty=nameWithType>, and <xref:System.Text.RegularExpressions.RegexOptions.Compiled?displayProperty=nameWithType> options. The use of any other option in a regular expression results in an <xref:System.ArgumentOutOfRangeException>.
 
 The behavior of ECMAScript and canonical regular expressions differs in three areas: character class syntax, self-referencing capturing groups, and octal versus backreference interpretation.
 


### PR DESCRIPTION
`ECMAScript` can be used in conjunction with `Compiled` according to https://learn.microsoft.com/dotnet/api/system.text.regularexpressions.regexoptions


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/base-types/regular-expression-options.md](https://github.com/dotnet/docs/blob/05c56dcbea5e59a41e3af49ab5da065ce787adca/docs/standard/base-types/regular-expression-options.md) | [Regular expression options](https://review.learn.microsoft.com/en-us/dotnet/standard/base-types/regular-expression-options?branch=pr-en-us-49453) |

<!-- PREVIEW-TABLE-END -->