### PR TITLE
Fix incorrect delegate type name in using-delegates.md

### DIFF
--- a/docs/csharp/programming-guide/delegates/using-delegates.md
+++ b/docs/csharp/programming-guide/delegates/using-delegates.md
@@ -39,7 +39,7 @@ When a delegate is constructed to wrap an instance method, the delegate referenc
 
 :::code language="csharp" source="./snippets/UsingDelegates.cs" id="InstanceMethods":::
 
-Along with the static `DelegateMethod` shown previously, we now have three methods that you can wrap in a `Del` instance.
+Along with the static `DelegateMethod` shown previously, we now have three methods that you can wrap in a `Callback` instance.
 
 A delegate can call more than one method when invoked, referred to as multicasting. To add an extra method to the delegate's list of methods—the invocation list—simply requires adding two delegates using the addition or addition assignment operators ('+' or '+='). For example:
 


### PR DESCRIPTION
The document declares a delegate named `Callback`:
```csharp
public delegate void Callback(string message);
```

However, later in the document it incorrectly refers to it as Del:

> "we now have three methods that you can wrap in a `Del` instance"

This should be Callback to match the actual delegate declaration used throughout the example.

## Summary

Fixed an inconsistency in the delegate documentation where `Del` was incorrectly used instead of `Callback`.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/delegates/using-delegates.md](https://github.com/dotnet/docs/blob/e37b66bb0e332e51d199c6a1170f2afc0cb59723/docs/csharp/programming-guide/delegates/using-delegates.md) | [Using Delegates (C# Programming Guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/delegates/using-delegates?branch=pr-en-us-49456) |

<!-- PREVIEW-TABLE-END -->