### PR TITLE
Fix wording in CA2224 doc

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca2224.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2224.md
@@ -1,6 +1,6 @@
 ---
-title: "CA2224: Override equals on overloading operator equals"
-description: "Learn about code analysis rule CA2224: Override equals on overloading operator equals"
+title: "CA2224: Override Equals() on overloading operator equals"
+description: "Learn about code analysis rule CA2224: Override Equals() on overloading operator equals"
 ms.date: 11/04/2016
 f1_keywords:
   - "CA2224"
@@ -10,7 +10,7 @@ helpviewer_keywords:
   - "OverrideEqualsOnOverloadingOperatorEquals"
   - "CA2224"
 ---
-# CA2224: Override Equals on overloading operator equals
+# CA2224: Override Equals() on overloading operator equals
 
 | Property                            | Value                                          |
 |-------------------------------------|------------------------------------------------|
@@ -22,7 +22,7 @@ helpviewer_keywords:
 
 ## Cause
 
-A public type implements the equality operator but doesn't override <xref:System.Object.Equals%2A?displayProperty=fullName>.
+A public type implements the equality operator but doesn't override the <xref:System.Object.Equals%2A?displayProperty=fullName> method.
 
 ## Rule description
 
@@ -33,11 +33,11 @@ The equality operator is intended to be a syntactically convenient way to access
 
 ## How to fix violations
 
-To fix a violation of this rule, you should either remove the implementation of the equality operator, or override <xref:System.Object.Equals%2A> and have the two methods return the same values. If the equality operator does not introduce inconsistent behavior, you can fix the violation by providing an implementation of <xref:System.Object.Equals%2A> that calls the <xref:System.Object.Equals%2A> method in the base class.
+To fix a violation of this rule, you should either remove the implementation of the equality operator, or override <xref:System.Object.Equals%2A> and have the two methods return the same values. If the equality operator doesn't introduce inconsistent behavior, you can fix the violation by providing an implementation of <xref:System.Object.Equals%2A> that calls the <xref:System.Object.Equals%2A> method in the base class.
 
 ## When to suppress warnings
 
-It is safe to suppress a warning from this rule if the equality operator returns the same value as the inherited implementation of <xref:System.Object.Equals%2A>. The examples in this article include a type that could safely suppress a warning from this rule.
+It's safe to suppress a warning from this rule if the equality operator returns the same value as the inherited implementation of <xref:System.Object.Equals%2A>. The examples in this article include a type that could safely suppress a warning from this rule.
 
 ## Suppress a warning
 


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca2224.md](https://github.com/dotnet/docs/blob/baaf5466b2e0a5f52db9a9ba467e5f637e0f9381/docs/fundamentals/code-analysis/quality-rules/ca2224.md) | [CA2224: Override Equals() on overloading operator equals](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2224?branch=pr-en-us-49498) |

<!-- PREVIEW-TABLE-END -->