### PR TITLE
Remove redundant line about metric method constraints

### DIFF
--- a/docs/core/diagnostics/metrics-generator.md
+++ b/docs/core/diagnostics/metrics-generator.md
@@ -87,7 +87,6 @@ Metric methods are constrained to the following:
 - Their names must not start with an underscore.
 - Their parameter names must not start with an underscore.
 - Their first parameter must be <xref:System.Diagnostics.Metrics.Meter> type.
-Metric methods are constrained to the following:
 
 ## See also
 


### PR DESCRIPTION
## Summary

This pull request makes a minor documentation update by removing a redundant section heading from the metrics generator documentation.

Fixes #49455


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/metrics-generator.md](https://github.com/dotnet/docs/blob/1cf6720d83525e79066b7ed95aa30e31dd468bf6/docs/core/diagnostics/metrics-generator.md) | [Compile-time metric source generation](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/metrics-generator?branch=pr-en-us-49502) |

<!-- PREVIEW-TABLE-END -->