### PR TITLE
Fix ProjectReference path in preprocessor directives

### DIFF
--- a/docs/csharp/language-reference/preprocessor-directives.md
+++ b/docs/csharp/language-reference/preprocessor-directives.md
@@ -121,7 +121,7 @@ The `#:` directives that are used in file-based apps include:
   The preceding preprocessor token is translated into:
 
   ```xml
-  <ProjectReference Include="../Path/To.Example.csproj" />
+  <ProjectReference Include="../Path/To.Example/To.Example.csproj" />
   ```
   
 Tools can add new tokens following the `#:` convention.


### PR DESCRIPTION
those two samples should refer to the same folder structure. which they did not, previously.

## Reasoning
i.e. the <ProjectReference> in the .csproj needs to reference the target project's .csproj
whereas the #:project entry in the .cs references the folder the project is in.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/preprocessor-directives.md](https://github.com/dotnet/docs/blob/4f4e5e474f92444b4dfde35e400cdee0373c3742/docs/csharp/language-reference/preprocessor-directives.md) | [C# preprocessor directives](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/preprocessor-directives?branch=pr-en-us-49507) |

<!-- PREVIEW-TABLE-END -->