### PR TITLE
Update schema version in server.json

### DIFF
--- a/docs/ai/quickstarts/snippets/mcp-server/.mcp/server.json
+++ b/docs/ai/quickstarts/snippets/mcp-server/.mcp/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
   "description": "<your description here>",
   "name": "io.github.<your GitHub username here>/<your repo name>",
   "version": "<your package version here>",


### PR DESCRIPTION
This is the latest version, and expected by the MCP Registry and publish tool. The `mcpserver` template is already updated in source (not yet released).

There are no relevant changes for us except the schema URL.

See https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/server-json/CHANGELOG.md for more details.
