### PR TITLE
Fix typo (Mirate->Migrate) in MTP v2 migration doc

### DIFF
--- a/docs/core/testing/microsoft-testing-platform-migration-from-v1-to-v2.md
+++ b/docs/core/testing/microsoft-testing-platform-migration-from-v1-to-v2.md
@@ -6,7 +6,7 @@ ms.author: ygerges
 ms.date: 10/08/2025
 ---
 
-# Mirate from Microsoft.Testing.Platform v1 to v2
+# Migrate from Microsoft.Testing.Platform v1 to v2
 
 The stable version Microsoft.Testing.Platform v2 is now available. This migration guide explores what's changed in Microsoft.Testing.Platform v2 and how you can migrate to this version.
 


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/microsoft-testing-platform-migration-from-v1-to-v2.md](https://github.com/dotnet/docs/blob/c9de3bf7ad6c9329c5acbcc55526b7d7773b0f80/docs/core/testing/microsoft-testing-platform-migration-from-v1-to-v2.md) | [Migrate from Microsoft.Testing.Platform v1 to v2](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-migration-from-v1-to-v2?branch=pr-en-us-49537) |

<!-- PREVIEW-TABLE-END -->