### PR TITLE
Update reflection vs source generation documentation

### DIFF
--- a/docs/standard/serialization/system-text-json/reflection-vs-source-generation.md
+++ b/docs/standard/serialization/system-text-json/reflection-vs-source-generation.md
@@ -60,3 +60,5 @@ Choose reflection or source-generation modes based on the following benefits tha
 
 \* The source generator supports *some* non-public members, for example, internal types in the same assembly.
 † Source-generated contracts can be modified using the contract customization API.
+
+Source generation-based deserialization does not support reference preservation when using constructor parameters. Constructor parameters are used for explicit constructor-based deserialization or when any of the object's properties are required or init-only. For more information, see [dotnet/runtime issue 73302](https://github.com/dotnet/runtime/issues/73302).


### PR DESCRIPTION
Clarify source generation limitations regarding reference preservation in deserialization.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/serialization/system-text-json/reflection-vs-source-generation.md](https://github.com/dotnet/docs/blob/127092596235d88645a0b0ca1524bdbb48277551/docs/standard/serialization/system-text-json/reflection-vs-source-generation.md) | [Reflection versus source generation in System.Text.Json](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/reflection-vs-source-generation?branch=pr-en-us-49542) |

<!-- PREVIEW-TABLE-END -->