### PR TITLE
Fix highlight in ca2256 rule

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca2256.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2256.md
@@ -36,7 +36,7 @@ Implement the missing interface members.
 
 ## Example
 
-:::code language="csharp" source="snippets/csharp/all-rules/ca2256.cs" id="snippet1" highlight="30":::
+:::code language="csharp" source="snippets/csharp/all-rules/ca2256.cs" id="snippet1" highlight="25":::
 
 ## When to suppress errors
 


### PR DESCRIPTION
## Summary

I made a mistake with the highlight position https://github.com/dotnet/docs/blob/main/docs/fundamentals/code-analysis/quality-rules/snippets/csharp/all-rules/ca2256.cs#L30
<img width="927" height="782" alt="image" src="https://github.com/user-attachments/assets/f0b28382-ff71-4121-9c6a-8bee0143e3c2" />

<img width="595" height="863" alt="image" src="https://github.com/user-attachments/assets/4f43e9f7-3910-4013-97a2-7acb976da1f6" />


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca2256.md](https://github.com/dotnet/docs/blob/c9681b79423eb7086035e64decdec0ed078cd72d/docs/fundamentals/code-analysis/quality-rules/ca2256.md) | [CA2256: All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2256?branch=pr-en-us-49564) |

<!-- PREVIEW-TABLE-END -->