### PR TITLE
Correct fixes found in monthly chores

### DIFF
--- a/docs/csharp/language-reference/toc.yml
+++ b/docs/csharp/language-reference/toc.yml
@@ -919,8 +919,6 @@ items:
       href: ../misc/cs0241.md
     - name: CS0243
       href: ../misc/cs0243.md
-    - name: CS0245
-      href: ../misc/cs0245.md
     - name: CS0247
       href: ../misc/cs0247.md
     - name: CS0249
@@ -1405,22 +1403,10 @@ items:
       href: ../misc/cs1022.md
     - name: CS1023
       href: ../misc/cs1023.md
-    - name: CS1024
-      href: ../misc/cs1024.md
-    - name: CS1025
-      href: ../misc/cs1025.md
     - name: CS1026
       href: ./compiler-messages/cs1026.md
-    - name: CS1027
-      href: ../misc/cs1027.md
-    - name: CS1028
-      href: ../misc/cs1028.md
-    - name: CS1029
-      href: ./compiler-messages/cs1029.md
     - name: CS1031
       href: ../misc/cs1031.md
-    - name: CS1032
-      href: ../misc/cs1032.md
     - name: CS1033
       href: ../misc/cs1033.md
     - name: CS1034
@@ -1429,10 +1415,6 @@ items:
       href: ../misc/cs1035.md
     - name: CS1036
       href: ../misc/cs1036.md
-    - name: CS1038
-      href: ../misc/cs1038.md
-    - name: CS1040
-      href: ../misc/cs1040.md
     - name: CS1041
       href: ../misc/cs1041.md
     - name: CS1043
@@ -1477,8 +1459,6 @@ items:
       href: ../misc/cs1514.md
     - name: CS1515
       href: ../misc/cs1515.md
-    - name: CS1517
-      href: ../misc/cs1517.md
     - name: CS1518
       href: ../misc/cs1518.md
     - name: CS1519
@@ -1527,8 +1507,6 @@ items:
       href: ../misc/cs1558.md
     - name: CS1559
       href: ../misc/cs1559.md
-    - name: CS1560
-      href: ../misc/cs1560.md
     - name: CS1561
       href: ../misc/cs1561.md
     - name: CS1562
@@ -1547,12 +1525,8 @@ items:
       href: ../misc/cs1569.md
     - name: CS1575
       href: ../misc/cs1575.md
-    - name: CS1576
-      href: ../misc/cs1576.md
     - name: CS1577
       href: ../misc/cs1577.md
-    - name: CS1578
-      href: ../misc/cs1578.md
     - name: CS1579
       href: ./compiler-messages/cs1579.md
     - name: CS1583
@@ -1955,8 +1929,6 @@ items:
       href: ../misc/cs0688.md
     - name: CS0809
       href: ../misc/cs0809.md
-    - name: CS1030
-      href: ../misc/cs1030.md
     - name: CS1058
       href: ./compiler-messages/cs1058.md
     - name: CS1060
@@ -1993,12 +1965,6 @@ items:
       href: ./compiler-messages/cs1607.md
     - name: CS1616
       href: ./compiler-messages/cs1616.md
-    - name: CS1633
-      href: ../misc/cs1633.md
-    - name: CS1634
-      href: ../misc/cs1634.md
-    - name: CS1635
-      href: ../misc/cs1635.md
     - name: CS1645
       href: ../misc/cs1645.md
     - name: CS1658
@@ -2013,24 +1979,12 @@ items:
       href: ../misc/cs1687.md
     - name: CS1690
       href: ./compiler-messages/cs1690.md
-    - name: CS1691
-      href: ./compiler-messages/cs1691.md
-    - name: CS1692
-      href: ../misc/cs1692.md
-    - name: CS1694
-      href: ../misc/cs1694.md
-    - name: CS1695
-      href: ../misc/cs1695.md
-    - name: CS1696
-      href: ../misc/cs1696.md
     - name: CS1697
       href: ../misc/cs1697.md
     - name: CS1699
       href: ./compiler-messages/cs1699.md
     - name: CS1707
       href: ../misc/cs1707.md
-    - name: CS1709
-      href: ../misc/cs1709.md
     - name: CS1720
       href: ../misc/cs1720.md
     - name: CS1723
@@ -2139,8 +2093,6 @@ items:
       href: ./compiler-messages/cs0618.md
     - name: CS0652
       href: ../misc/cs0652.md
-    - name: CS0728
-      href: ../misc/cs0728.md
     - name: CS1571
       href: ../misc/cs1571.md
     - name: CS1572

--- a/docs/csharp/specification/toc.yml
+++ b/docs/csharp/specification/toc.yml
@@ -46,6 +46,8 @@ items:
     href: ../../../_csharpstandard/standard/structs.md
   - name: Arrays
     href: ../../../_csharpstandard/standard/arrays.md
+  - name: Extended indexing and slicing
+    href: ../../../_csharpstandard/standard/ranges.md
   - name: Interfaces
     href: ../../../_csharpstandard/standard/interfaces.md
   - name: Enums

--- a/docs/csharp/toc.yml
+++ b/docs/csharp/toc.yml
@@ -126,6 +126,8 @@ items:
     - name: Inheritance in C# and .NET
       href: fundamentals/tutorials/inheritance.md
     # programming to interfaces
+    - name: Generate API documentation with XML comments
+      href: fundamentals/tutorials/xml-documentation.md
     - name: Converting types
       displayName: cast, is, as
       href: fundamentals/tutorials/safely-cast-using-pattern-matching-is-and-as-operators.md


### PR DESCRIPTION
This PR Replaces the following monthly chores PRs:

#49554:  This PR redirected TOC entries for articles that were removed in earlier PRs for compiler diagnostics. Instead, these entries in the TOC should be removed. New displayName entries have been added for all these diagnostics.

#49555 and #49556:  Instead of removing the article and the associated snippets, the article should have been added to the TOC. That was missing in the original TOC.

Finally, add the new ranges clause to the TOC for the specification.




<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/toc.yml](https://github.com/dotnet/docs/blob/8263f2646e2c134f3cd79fc5676347597dcd6299/docs/csharp/language-reference/toc.yml) | [docs/csharp/language-reference/toc](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/toc?branch=pr-en-us-49567) |
| [docs/csharp/specification/toc.yml](https://github.com/dotnet/docs/blob/8263f2646e2c134f3cd79fc5676347597dcd6299/docs/csharp/specification/toc.yml) | [docs/csharp/specification/toc](https://review.learn.microsoft.com/en-us/dotnet/csharp/specification/toc?branch=pr-en-us-49567) |
| [docs/csharp/toc.yml](https://github.com/dotnet/docs/blob/8263f2646e2c134f3cd79fc5676347597dcd6299/docs/csharp/toc.yml) | [Taken from https://github.com/dotnet/roslyn/wiki/Samples-and-Walkthroughs](https://review.learn.microsoft.com/en-us/dotnet/csharp/toc?branch=pr-en-us-49567) |

<!-- PREVIEW-TABLE-END -->