### PR TITLE
Fix reference to IsPrime method in unit testing docs

### DIFF
--- a/docs/core/testing/unit-testing-csharp-with-nunit.md
+++ b/docs/core/testing/unit-testing-csharp-with-nunit.md
@@ -176,7 +176,7 @@ Instead of creating new tests, apply this attribute to create a single data-driv
 
 [!code-csharp[Sample_TestCode](~/samples/snippets/core/testing/unit-testing-using-nunit/csharp/PrimeService.Tests/PrimeService_IsPrimeShould.cs?name=Sample_TestCode)]
 
-Run `dotnet test`, and two of these tests fail. To make all of the tests pass, change the `if` clause at the beginning of the `Main` method in the *PrimeService.cs* file:
+Run `dotnet test`, and two of these tests fail. To make all of the tests pass, change the `if` clause at the beginning of the `IsPrime` method in the *PrimeService.cs* file:
 
 ```csharp
 if (candidate < 2)


### PR DESCRIPTION
Corrected the reference to the method in the PrimeService.cs file for clarity.

## Summary
Corrected method name being tested

Describe your changes here.
Updated name of the method being tested

Fixes #Issue_Number (if available)
N/A

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-csharp-with-nunit.md](https://github.com/dotnet/docs/blob/57bfe65f33fba2f8eab7e0ef24fc2f9145defe66/docs/core/testing/unit-testing-csharp-with-nunit.md) | [Unit testing C# with NUnit and .NET Core](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-csharp-with-nunit?branch=pr-en-us-49648) |

<!-- PREVIEW-TABLE-END -->