### PR TITLE
Update What's new in F# link in overview.md

### DIFF
--- a/docs/core/whats-new/dotnet-10/overview.md
+++ b/docs/core/whats-new/dotnet-10/overview.md
@@ -75,7 +75,7 @@ The F# updates in .NET 10 include several new features and improvements across t
 
   General improvements and bug fixes in the compiler implementation.
 
-For more information, see the [F# release notes](https://fsharp.github.io/fsharp-compiler-docs/release-notes/About.html).
+For more information, see [What's new in F# 10](../../../fsharp/whats-new/fsharp-10.md) or the [F# release notes](https://fsharp.github.io/fsharp-compiler-docs/release-notes/About.html).
 
 ## Visual Basic
 


### PR DESCRIPTION
Updated the link to the "What's new in F# 10" in the overview.

That file does not exist yet on main at this moment, PR #49649 will add it


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/whats-new/dotnet-10/overview.md](https://github.com/dotnet/docs/blob/c17cc49b10f880ecdd4dbb49e5f47e63cd8644cd/docs/core/whats-new/dotnet-10/overview.md) | [What's new in .NET 10](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-10/overview?branch=pr-en-us-49650) |

<!-- PREVIEW-TABLE-END -->