### PR TITLE
Fix note syntax in MSTEST0006 doc

### DIFF
--- a/docs/core/testing/mstest-analyzers/mstest0006.md
+++ b/docs/core/testing/mstest-analyzers/mstest0006.md
@@ -27,7 +27,7 @@ dev_langs:
 | **Introduced in version**           | 3.2.0                                              |
 | **Is there a code fix**             | Yes, starting with 3.7.0                           |
 
-> [NOTE]
+> [!NOTE]
 > This analyzer is no longer relevant for MSTest 4 as the attribute was removed.
 
 ## Cause


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/mstest-analyzers/mstest0006.md](https://github.com/dotnet/docs/blob/8fbe989c9b59e556c039cbf2088f12fb6c54ea13/docs/core/testing/mstest-analyzers/mstest0006.md) | [MSTEST0006: Avoid `[ExpectedException]`](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0006?branch=pr-en-us-49653) |

<!-- PREVIEW-TABLE-END -->