### PR TITLE
VB: Fix typo in enum member syntax description

### DIFF
--- a/docs/visual-basic/language-reference/statements/enum-statement.md
+++ b/docs/visual-basic/language-reference/statements/enum-statement.md
@@ -66,7 +66,7 @@ End Enum
 
   Required. List of member constants being declared in this statement. Multiple members appear on individual source code lines.
 
-  Each `member` has the following syntax and parts: `[<attribute list>] member name [ = initializer ]`
+  Each `member` has the following syntax and parts: `[<attribute list>] membername [ = initializer ]`
 
   |Part|Description|
   |---|---|


### PR DESCRIPTION
## Summary

- Was: `[<attribute list>] member name [ = initializer ]`,
- Should be: `[<attribute list>] membername [ = initializer ]`,
- Reason: `membername` is a single identifier; later in the document it is referred to as `membername`.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/visual-basic/language-reference/statements/enum-statement.md](https://github.com/dotnet/docs/blob/94df9db3e424ba00f5f89f8bcb9992f8a0bf3d20/docs/visual-basic/language-reference/statements/enum-statement.md) | [Enum Statement (Visual Basic)](https://review.learn.microsoft.com/en-us/dotnet/visual-basic/language-reference/statements/enum-statement?branch=pr-en-us-49666) |

<!-- PREVIEW-TABLE-END -->