### PR TITLE
Replace UWP with WinUI

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -271,8 +271,8 @@ additionalContent:
         # Card
         - title: Desktop
           links:
-            - url: /uwp
-              text: Universal Windows apps
+            - url: /windows/apps/winui
+              text: WinUI apps
             - url: /dotnet/desktop/wpf/
               text: Windows Presentation Foundation
             - url: /dotnet/desktop/winforms/


### PR DESCRIPTION
The Windows docs team wants to emphasize WinUI over UWP


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/index.yml](https://github.com/dotnet/docs/blob/3874e96527a6ebdedbc08446ddab45e81d8785cc/docs/index.yml) | [highlightedContent section (optional)](https://review.learn.microsoft.com/en-us/dotnet/index?branch=pr-en-us-49672) |

<!-- PREVIEW-TABLE-END -->