### PR TITLE
Fix note syntax for mstest analyzer docs

### DIFF
--- a/docs/core/testing/mstest-analyzers/mstest0034.md
+++ b/docs/core/testing/mstest-analyzers/mstest0034.md
@@ -24,7 +24,7 @@ ms.author: enjieid
 | **Introduced in version**           | 3.6.0                                                            |
 | **Is there a code fix**             | No                                                               |
 
-> [NOTE]
+> [!NOTE]
 > This analyzer is no longer relevant for MSTest 4 as `ClassCleanupBehavior` was removed.
 
 ## Cause

--- a/docs/core/testing/mstest-analyzers/mstest0039.md
+++ b/docs/core/testing/mstest-analyzers/mstest0039.md
@@ -24,7 +24,7 @@ ms.author: ygerges
 | **Introduced in version**           | 3.8.0                                                                  |
 | **Is there a code fix**             | Yes                                                                    |
 
-> [NOTE]
+> [!NOTE]
 > This analyzer is no longer relevant for MSTest 4 as the old assertion APIs were removed.
 
 ## Cause

--- a/docs/core/testing/mstest-analyzers/mstest0053.md
+++ b/docs/core/testing/mstest-analyzers/mstest0053.md
@@ -25,7 +25,7 @@ ai-usage: ai-generated
 | **Introduced in version**           | 3.11.0                                                                                   |
 | **Is there a code fix**             | Yes                                                                                      |
 
-> [NOTE]
+> [!NOTE]
 > This analyzer is no longer relevant for MSTest 4 as the assertion APIs with format parameters were removed.
 
 ## Cause


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/mstest-analyzers/mstest0034.md](https://github.com/dotnet/docs/blob/78a0fe0745849e37c44323d7a87db9d524c070eb/docs/core/testing/mstest-analyzers/mstest0034.md) | [MSTEST0034: Use `ClassCleanupBehavior.EndOfClass` with the `[ClassCleanup]`](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0034?branch=pr-en-us-49679) |
| [docs/core/testing/mstest-analyzers/mstest0039.md](https://github.com/dotnet/docs/blob/78a0fe0745849e37c44323d7a87db9d524c070eb/docs/core/testing/mstest-analyzers/mstest0039.md) | ["MSTEST0039: Use newer 'Assert.Throws' methods"](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0039?branch=pr-en-us-49679) |
| [docs/core/testing/mstest-analyzers/mstest0053.md](https://github.com/dotnet/docs/blob/78a0fe0745849e37c44323d7a87db9d524c070eb/docs/core/testing/mstest-analyzers/mstest0053.md) | [MSTEST0053: Avoid using Assert methods with format parameters](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0053?branch=pr-en-us-49679) |

<!-- PREVIEW-TABLE-END -->