### PR TITLE
Update APIs that always throw on .NET

### DIFF
--- a/docs/core/compatibility/cryptography/10.0/openssl-macos-unsupported.md
+++ b/docs/core/compatibility/cryptography/10.0/openssl-macos-unsupported.md
@@ -1,11 +1,11 @@
 ---
-title: "Breaking change: OpenSSL cryptographic primitives aren't supported on macOS"
+title: "Breaking change: OpenSSL cryptographic primitives not supported on macOS"
 description: "Learn about the breaking change in .NET 10 where OpenSSL cryptographic primitives are no longer supported on macOS."
 ms.date: 06/23/2025
 ai-usage: ai-assisted
 ms.custom: https://github.com/dotnet/docs/issues/46789
 ---
-# OpenSSL cryptographic primitives are not supported on macOS
+# OpenSSL cryptographic primitives not supported on macOS
 
 Starting in .NET 10, OpenSSL-backed cryptographic primitives are no longer supported on macOS. <xref:System.Security.Cryptography.AesCcm?displayProperty=fullName> and classes that are specific to OpenSSL, such as <xref:System.Security.Cryptography.RSAOpenSsl?displayProperty=fullName>, now throw a <xref:System.PlatformNotSupportedException> on macOS.
 

--- a/docs/core/compatibility/unsupported-apis.md
+++ b/docs/core/compatibility/unsupported-apis.md
@@ -2,7 +2,7 @@
 title: Unsupported APIs on .NET Core and .NET 5+
 titleSuffix: ""
 description: Learn which .NET APIs always throw an exception on .NET Core and .NET 5 and later versions.
-ms.date: 09/08/2025
+ms.date: 11/07/2025
 ---
 # APIs that always throw exceptions on .NET Core and .NET 5+
 
@@ -242,6 +242,7 @@ This article organizes the affected APIs by namespace.
 
 | Member | Platforms that throw |
 |--------|----------------------|
+| <xref:System.Security.Cryptography.AesCcm.%23ctor*> | macOS |
 | <xref:System.Security.Cryptography.AsymmetricAlgorithm.Create(System.String)?displayProperty=nameWithType> | All |
 | <xref:System.Security.Cryptography.CngAlgorithm?displayProperty=nameWithType> | Linux and macOS |
 | <xref:System.Security.Cryptography.CngAlgorithmGroup?displayProperty=nameWithType> | Linux and macOS |
@@ -264,14 +265,17 @@ This article organizes the affected APIs by namespace.
 | <xref:System.Security.Cryptography.CspKeyContainerInfo.RandomlyGenerated?displayProperty=nameWithType> | Linux and macOS |
 | <xref:System.Security.Cryptography.CspKeyContainerInfo.Removable?displayProperty=nameWithType> | Linux and macOS |
 | <xref:System.Security.Cryptography.CspKeyContainerInfo.UniqueKeyContainerName?displayProperty=nameWithType> | Linux and macOS |
+| <xref:System.Security.Cryptography.DSAOpenSsl.%23ctor*> | macOS |
 | <xref:System.Security.Cryptography.ECDiffieHellmanCng.FromXmlString(System.String,System.Security.Cryptography.ECKeyXmlFormat)?displayProperty=nameWithType> | All |
 | <xref:System.Security.Cryptography.ECDiffieHellmanCng.ToXmlString(System.Security.Cryptography.ECKeyXmlFormat)?displayProperty=nameWithType> | All |
 | <xref:System.Security.Cryptography.ECDiffieHellmanCngPublicKey.FromXmlString(System.String)?displayProperty=nameWithType> | All |
 | <xref:System.Security.Cryptography.ECDiffieHellmanCngPublicKey.ToXmlString?displayProperty=nameWithType> | All |
+| <xref:System.Security.Cryptography.ECDiffieHellmanOpenSsl.%23ctor*> | macOS |
 | <xref:System.Security.Cryptography.ECDiffieHellmanPublicKey.ToByteArray?displayProperty=nameWithType> | Linux and macOS |
 | <xref:System.Security.Cryptography.ECDiffieHellmanPublicKey.ToXmlString?displayProperty=nameWithType> | All |
 | <xref:System.Security.Cryptography.ECDsaCng.FromXmlString(System.String,System.Security.Cryptography.ECKeyXmlFormat)?displayProperty=nameWithType> | All |
 | <xref:System.Security.Cryptography.ECDsaCng.ToXmlString(System.Security.Cryptography.ECKeyXmlFormat)?displayProperty=nameWithType> | All |
+| <xref:System.Security.Cryptography.ECDsaOpenSsl.%23ctor*> | macOS |
 | <xref:System.Security.Cryptography.HashAlgorithm.Create?displayProperty=nameWithType> | All |
 | <xref:System.Security.Cryptography.HMAC.Create?displayProperty=nameWithType> | All |
 | <xref:System.Security.Cryptography.HMAC.Create(System.String)?displayProperty=nameWithType> | All |
@@ -284,10 +288,12 @@ This article organizes the affected APIs by namespace.
 | <xref:System.Security.Cryptography.ProtectedData.Unprotect%2A?displayProperty=nameWithType> | Linux and macOS |
 | <xref:System.Security.Cryptography.RSACryptoServiceProvider.DecryptValue(System.Byte[])?displayProperty=fullName> | All |
 | <xref:System.Security.Cryptography.RSACryptoServiceProvider.EncryptValue(System.Byte[])?displayProperty=fullName> | All |
+| <xref:System.Security.Cryptography.RSAOpenSsl.%23ctor*> | macOS |
 | <xref:System.Security.Cryptography.RSA.DecryptValue(System.Byte[])?displayProperty=fullName> | All |
 | <xref:System.Security.Cryptography.RSA.EncryptValue(System.Byte[])?displayProperty=fullName> | All |
 | <xref:System.Security.Cryptography.RSA.FromXmlString%2A?displayProperty=nameWithType> | All |
 | <xref:System.Security.Cryptography.RSA.ToXmlString%2A?displayProperty=nameWithType> | All |
+| <xref:System.Security.Cryptography.SafeEvpPKeyHandle?displayProperty=nameWithType> | macOS |
 | <xref:System.Security.Cryptography.SymmetricAlgorithm.Create?displayProperty=nameWithType> | All |
 | <xref:System.Security.Cryptography.SymmetricAlgorithm.Create(System.String)?displayProperty=nameWithType> | All |
 

--- a/docs/core/compatibility/unsupported-apis.md
+++ b/docs/core/compatibility/unsupported-apis.md
@@ -4,9 +4,9 @@ titleSuffix: ""
 description: Learn which .NET APIs always throw an exception on .NET Core and .NET 5 and later versions.
 ms.date: 11/07/2025
 ---
-# APIs that always throw exceptions on .NET Core and .NET 5+
+# APIs that always throw exceptions on .NET (Core)
 
-The following APIs will always throw an exception on .NET (Core) on all or a subset of platforms. In most cases, the exception that's thrown is <xref:System.PlatformNotSupportedException>.
+The following APIs always throw an exception on .NET (Core) on all or a subset of platforms. In most cases, the exception that's thrown is <xref:System.PlatformNotSupportedException>.
 
 This article organizes the affected APIs by namespace.
 


### PR DESCRIPTION
Contributes to #48865 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/cryptography/10.0/openssl-macos-unsupported.md](https://github.com/dotnet/docs/blob/fdc4c17a88b0e91f9e6a8176d478eeb80c1f5496/docs/core/compatibility/cryptography/10.0/openssl-macos-unsupported.md) | [OpenSSL cryptographic primitives not supported on macOS](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/cryptography/10.0/openssl-macos-unsupported?branch=pr-en-us-49682) |
| [docs/core/compatibility/unsupported-apis.md](https://github.com/dotnet/docs/blob/fdc4c17a88b0e91f9e6a8176d478eeb80c1f5496/docs/core/compatibility/unsupported-apis.md) | [Unsupported APIs on .NET Core and .NET 5+](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/unsupported-apis?branch=pr-en-us-49682) |

<!-- PREVIEW-TABLE-END -->