### PR TITLE
Vb.net: Fix typo in join clause syntax in documentation

### DIFF
--- a/docs/visual-basic/language-reference/queries/join-clause.md
+++ b/docs/visual-basic/language-reference/queries/join-clause.md
@@ -22,7 +22,7 @@ Combines two collections into a single collection. The join operation is based o
 Join element In collection _
   [ joinClause _ ]
   [ groupJoinClause ... _ ]
-On key1 Equals key2 [ And key3 Equals key4 [... ]
+On key1 Equals key2 [ And key3 Equals key4 [... ] ]
 ```
 
 ## Parts


### PR DESCRIPTION
## Summary

Fix for a missing closing square bracket in the Syntax section


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/visual-basic/language-reference/queries/join-clause.md](https://github.com/dotnet/docs/blob/e7b9274c333729ee3982feb6f30ea30a60bc77c3/docs/visual-basic/language-reference/queries/join-clause.md) | [Join Clause (Visual Basic)](https://review.learn.microsoft.com/en-us/dotnet/visual-basic/language-reference/queries/join-clause?branch=pr-en-us-49704) |

<!-- PREVIEW-TABLE-END -->