### PR TITLE
Removed incomplete sentence part from .NET 10 release notes

### DIFF
--- a/docs/core/whats-new/dotnet-10/overview.md
+++ b/docs/core/whats-new/dotnet-10/overview.md
@@ -52,7 +52,7 @@ C# 14 introduces several new features and enhancements to improve developer prod
 - First-class support for implicit conversions of `Span<T>` and `ReadOnlySpan<T>`.
 - Parameter modifiers like `ref`, `in`, or `out` are allowed in lambda expressions without specifying parameter types.
 - Support for partial instance constructors and partial events, complementing partial methods and properties introduced in C# 13.
-- New `extension` blocks add support for static extension methods, and static and instance extension properties.
+- New `extension` blocks add support for static extension methods and instance extension properties.
 - Null-conditional assignment using the `?.` operator.
 - User-defined compound assignment operators like `+=` and `-=`.
 - User-defined increment (`++`) and decrement (`--`) operators.


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/whats-new/dotnet-10/overview.md](https://github.com/dotnet/docs/blob/07aaa16ee6ceed1d5b66324e8f0cf8d6a8d9142c/docs/core/whats-new/dotnet-10/overview.md) | [What's new in .NET 10](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-10/overview?branch=pr-en-us-49710) |

<!-- PREVIEW-TABLE-END -->