### PR TITLE
Correct end date for .NET SDK version 9.0.3xx

### DIFF
--- a/docs/core/porting/versioning-sdk-msbuild-vs.md
+++ b/docs/core/porting/versioning-sdk-msbuild-vs.md
@@ -60,7 +60,7 @@ The support timeframe for the SDK typically matches that of the Visual Studio ve
 | 8.0.4xx     | 17.11                         | Aug '24   | Nov '26<sup>2</sup> |
 | 9.0.1xx     | 17.12                         | Nov '24   | May '26             |
 | 9.0.2xx     | 17.13                         | Feb '25   | May '25             |
-| 9.0.3xx     | 17.14                         | May '25   | May '26             |
+| 9.0.3xx     | 17.14                         | May '25   | Nov '26             |
 | 10.0.1xx    | 18.0                          | Nov '25   | Nov '28             |
 
 > [!NOTE]


### PR DESCRIPTION
Updated the end date for .NET SDK version 9.0.3xx.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/porting/versioning-sdk-msbuild-vs.md](https://github.com/dotnet/docs/blob/24d25f469fdc504b228321832bac1c28d63f3de6/docs/core/porting/versioning-sdk-msbuild-vs.md) | [.NET SDK, MSBuild, and Visual Studio versioning](https://review.learn.microsoft.com/en-us/dotnet/core/porting/versioning-sdk-msbuild-vs?branch=pr-en-us-49721) |

<!-- PREVIEW-TABLE-END -->