### PR TITLE
void should be int in example code

### DIFF
--- a/docs/core/whats-new/dotnet-10/runtime.md
+++ b/docs/core/whats-new/dotnet-10/runtime.md
@@ -218,7 +218,7 @@ public class Program
         public int[] arr;
     }
 
-    public static void Main()
+    public static int Main()
     {
         int[] x = new int[10];
         GCStruct y = new GCStruct() { arr = x };


### PR DESCRIPTION
## Summary

"void" should be "int" in example code.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/whats-new/dotnet-10/runtime.md](https://github.com/dotnet/docs/blob/30874216ab44034efc0dd267faeca3db95283c1f/docs/core/whats-new/dotnet-10/runtime.md) | [What's new in the .NET 10 runtime](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-10/runtime?branch=pr-en-us-49723) |

<!-- PREVIEW-TABLE-END -->