### PR TITLE
Add `libatomic1` to Ubuntu Dependencies

### DIFF
--- a/docs/core/install/linux-ubuntu-install.md
+++ b/docs/core/install/linux-ubuntu-install.md
@@ -57,6 +57,7 @@ When an [Ubuntu version](https://wiki.ubuntu.com/Releases) falls out of support,
 When you install with a package manager, these libraries are installed for you. But, if you manually install .NET or you publish a self-contained app, you'll need to make sure these libraries are installed:
 
 - ca-certificates
+- libatomic1
 - libc6
 - libgcc-s1
 - libgssapi-krb5-2


### PR DESCRIPTION
## Summary

`libatomic1` is a dependency that is explicitly installed in the [sdk docker image](https://github.com/dotnet/dotnet-docker/blob/efe021ac7b969ae2dd72a58646c784752b681e0f/src/sdk/10.0/noble/amd64/Dockerfile#L41), but is not specified as a dependency in the documentation, leading to unexpected behavior for users who perform manual/scripted installation of sdks.

Fixes: [Sdk#51677](https://github.com/dotnet/sdk/issues/51677)

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/linux-ubuntu-install.md](https://github.com/dotnet/docs/blob/e7b315cb50f0834b5923ed95ea0281f7b47d00a9/docs/core/install/linux-ubuntu-install.md) | [Install .NET SDK or .NET Runtime on Ubuntu](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu-install?branch=pr-en-us-49727) |

<!-- PREVIEW-TABLE-END -->