### PR TITLE
Enhance documentation for System.Numerics.Tensors

### DIFF
--- a/docs/core/whats-new/dotnet-10/libraries.md
+++ b/docs/core/whats-new/dotnet-10/libraries.md
@@ -363,7 +363,7 @@ All of this is serialized as JSON in the <xref:System.IO.Pipelines.Pipe> (format
 
 ### Tensor enhancements
 
-The <xref:System.Numerics.Tensors> interface now includes a nongeneric interface, <xref:System.Numerics.Tensors.IReadOnlyTensor>, for operations like accessing <xref:System.Numerics.Tensors.IReadOnlyTensor.Lengths> and <xref:System.Numerics.Tensors.IReadOnlyTensor.Strides>. Slice operations no longer copy data, which improves performance. Additionally, you can access data nongenerically by boxing to `object` when performance isn't critical.
+The <xref:System.Numerics.Tensors> namespace now includes a nongeneric interface, <xref:System.Numerics.Tensors.IReadOnlyTensor>, for operations like accessing <xref:System.Numerics.Tensors.IReadOnlyTensor.Lengths> and <xref:System.Numerics.Tensors.IReadOnlyTensor.Strides>. Slice operations no longer copy data, which improves performance. Additionally, you can access data nongenerically by boxing to `object` when performance isn't critical.
 
 The tensor APIs are now stable and no longer marked as experimental. While the APIs still require referencing the [System.Numerics.Tensors](https://www.nuget.org/packages/System.Numerics.Tensors) NuGet package, they have been thoroughly reviewed and finalized for the .NET 10 release. The types take advantage of C# 14 extension operators to provide arithmetic operations when the underlying type `T` supports the operation. If `T` implements the relevant [generic math](../../../standard/generics/math.md) interfaces, for example, `IAdditionOperators<TSelf, TOther, TResult>` or `INumber<TSelf>`, the operation is supported. For example, `tensor + tensor` is available for a `Tensor<int>`, but isn't available for a `Tensor<bool>`.
 


### PR DESCRIPTION
Typo correction (namespace vs interface)

## Summary

The System.Numerics.Tensors **namespace** now includes a nongeneric interface, IReadOnlyTensor...


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/whats-new/dotnet-10/libraries.md](https://github.com/dotnet/docs/blob/2fee9eab4ccf5cc49a4046214b1eb16fcae750fc/docs/core/whats-new/dotnet-10/libraries.md) | [What's new in .NET libraries for .NET 10](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-10/libraries?branch=pr-en-us-49729) |

<!-- PREVIEW-TABLE-END -->