### PR TITLE
Update code snippet reference for enumeration method

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/how-to-create-a-new-method-for-an-enumeration.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-create-a-new-method-for-an-enumeration.md
@@ -24,7 +24,7 @@ Beginning with C# 14, you can declare *extension members* in an extension block.
 
 You call these new extension properties as though they're declared on the extended type:
 
-:::code language="csharp" source="./snippets/ExtensionMembers/CustomExtensionMembers.cs" id="EnumExtensionMembers":::
+:::code language="csharp" source="./snippets/ExtensionMembers/CustomExtensionMembers.cs" id="ExampleExtendEnum":::
 
 You can learn more about the new extension members in the article on [extension members](./extension-methods.md) and in the language reference article on the ['extension` keyword](../../language-reference/keywords/extension.md).
 

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-create-a-new-method-for-an-enumeration.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-create-a-new-method-for-an-enumeration.md
@@ -26,7 +26,7 @@ You call these new extension properties as though they're declared on the extend
 
 :::code language="csharp" source="./snippets/ExtensionMembers/CustomExtensionMembers.cs" id="ExampleExtendEnum":::
 
-You can learn more about the new extension members in the article on [extension members](./extension-methods.md) and in the language reference article on the ['extension` keyword](../../language-reference/keywords/extension.md).
+You can learn more about the new extension members in the article on [extension members](./extension-methods.md) and in the language reference article on the [`extension` keyword](../../language-reference/keywords/extension.md).
 
 ## See also
 


### PR DESCRIPTION
Fixes anonymous feedback. The referenced snippet was incorrect.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/classes-and-structs/how-to-create-a-new-method-for-an-enumeration.md](https://github.com/dotnet/docs/blob/f1e576641c2edb82b2c294552bd47c4900286463/docs/csharp/programming-guide/classes-and-structs/how-to-create-a-new-method-for-an-enumeration.md) | [How to create a new method for an enumeration (C# Programming Guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/how-to-create-a-new-method-for-an-enumeration?branch=pr-en-us-49890) |


<!-- PREVIEW-TABLE-END -->