### PR TITLE
.NET 10 is available on RHEL 8 too

### DIFF
--- a/docs/core/install/linux-rhel.md
+++ b/docs/core/install/linux-rhel.md
@@ -15,7 +15,7 @@ ms.custom: linux-related-content
 
 ## Register your Red Hat subscription
 
-To install .NET from Red Hat on RHEL, you first need to register using the Red Hat Subscription Manager. If this hasn't been done on your system, or if you're unsure, see the [Red Hat Product Documentation for .NET](https://access.redhat.com/documentation/en-us/net/8.0).
+To install .NET from Red Hat on RHEL, you first need to register using the Red Hat Subscription Manager. If this hasn't been done on your system, or if you're unsure, see the [Red Hat Product Documentation for .NET](https://access.redhat.com/documentation/en-us/net/10.0).
 
 > [!IMPORTANT]
 > The previous statement doesn't apply to CentOS Stream.
@@ -28,7 +28,7 @@ The following table is a list of currently supported .NET releases on both RHEL 
 |---------------------------------------|----------|
 | [RHEL 10](#rhel-10)                   | 10, 9, 8 |
 | [RHEL 9](#rhel-9)                     | 10, 9, 8 |
-| [RHEL 8](#rhel-8)                     | 9, 8     |
+| [RHEL 8](#rhel-8)                     | 10, 9, 8 |
 | [CentOS Stream 10](#centos-stream-10) | 10, 9, 8 |
 | [CentOS Stream 9](#centos-stream-9)   | 10, 9, 8 |
 
@@ -60,7 +60,7 @@ The following table is a list of currently supported .NET releases on both RHEL 
 
 .NET is included in the [AppStream repositories](https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle) for RHEL 8.
 
-[!INCLUDE [linux-dnf-install-90](includes/linux-install-90-dnf.md)]
+[!INCLUDE [linux-dnf-install-100](includes/linux-install-100-dnf.md)]
 
 ## CentOS Stream 10
 


### PR DESCRIPTION
## .NET 10 is available on RHEL 8 too

.NET 10 is available on RHEL 8 too, in addition to RHEL 9 and 10.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/linux-rhel.md](https://github.com/dotnet/docs/blob/c69ef1668f1d65cca0a355f0ccae3a3e97f64dd3/docs/core/install/linux-rhel.md) | [Install the .NET SDK or the .NET Runtime on RHEL and CentOS Stream](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-rhel?branch=pr-en-us-49894) |

<!-- PREVIEW-TABLE-END -->