### PR TITLE
.NET 10 is available on Fedora 41 as well

### DIFF
--- a/docs/core/install/linux-fedora.md
+++ b/docs/core/install/linux-fedora.md
@@ -26,7 +26,7 @@ The following table is a list of currently supported .NET releases and the versi
 |--------|----------|
 | 43     | 10, 9, 8 |
 | 42     | 10, 9, 8 |
-| 41     | 9, 8     |
+| 41     | 10, 9, 8 |
 
 [!INCLUDE [versions-not-supported](includes/versions-not-supported.md)]
 


### PR DESCRIPTION
.NET 10 is available in Fedora 41 as well. No Fedora version has the 10.0 GA release yet, but updates are in progress for all of them - 43, 42 and 41.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/linux-fedora.md](https://github.com/dotnet/docs/blob/a74f821b1ce9e7906da5d1d83daaf6a4cd000402/docs/core/install/linux-fedora.md) | [Install the .NET SDK or the .NET Runtime on Fedora](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-fedora?branch=pr-en-us-49897) |

<!-- PREVIEW-TABLE-END -->