### PR TITLE
Update shebang line for hello-world.cs

### DIFF
--- a/docs/csharp/fundamentals/program-structure/snippets/file-based-program/hello-world.cs
+++ b/docs/csharp/fundamentals/program-structure/snippets/file-based-program/hello-world.cs
@@ -1,2 +1,2 @@
-#!/usr/local/share/dotnet/dotnet run
+#!/usr/bin/env dotnet
 Console.WriteLine("Hello, World!");


### PR DESCRIPTION
Changed the file-based apps `hello-world.cs` snipped to use a more widely usable shebang line:

`#!/usr/bin/env dotnet`

This should work on most *nix systems (including macOS) assuming `dotnet` is on the path.