### PR TITLE
Update public2.cs - Fix typo in CLS-compliance example C#

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.clscompliant/cs/public2.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.clscompliant/cs/public2.cs
@@ -5,7 +5,7 @@ using System;
 
 public class Person
 {
-   private Int16 personAge = 0;
+   private UInt16 personAge = 0;
 
    public Int16 Age
    { get { return personAge; } }


### PR DESCRIPTION
## Summary

- Fixing typo mentioned in (https://github.com/dotnet/docs/issues/49691) where example for CLS compliance might be confusing. 

- As checked this is fine for the VB example the C# example needs update

Fixes #49691 
