### PR TITLE
file-based program document enhancement

### DIFF
--- a/docs/csharp/fundamentals/tutorials/file-based-programs.md
+++ b/docs/csharp/fundamentals/tutorials/file-based-programs.md
@@ -86,7 +86,7 @@ On unix, you can run file-based apps directly, typing the source file name on th
 
 The location of `dotnet` can be different on different unix installations. Use the command `where dotnet` to local the `dotnet` host in your environment.
 
-Or you can use to resolve dotnet path by the PATH environment automatically
+Or you can use the following way to resolve the dotnet path by the PATH environment automatically
 
 ```csharp
 #!/usr/bin/env dotnet

--- a/docs/csharp/fundamentals/tutorials/file-based-programs.md
+++ b/docs/csharp/fundamentals/tutorials/file-based-programs.md
@@ -84,7 +84,13 @@ On unix, you can run file-based apps directly, typing the source file name on th
    #!/usr/local/share/dotnet/dotnet run
    ```
 
-The location of `dotnet` can be different on different unix installations. Use the command `whence dotnet` to local the `dotnet` host in your environment.
+The location of `dotnet` can be different on different unix installations. Use the command `where dotnet` to local the `dotnet` host in your environment.
+
+Or you can use to resolve dotnet path by the PATH environment automatically
+
+```csharp
+#!/usr/bin/env dotnet
+```
 
 After making these two changes, you can run the program from the command line directly:
 
@@ -211,7 +217,7 @@ The `System.CommandLine` library offers several key benefits:
    :::code language="csharp" source="./snippets/file-based-programs/AsciiArt.cs" id="CommandLinePackage":::
 
    > [!IMPORTANT]
-   > The version `2.0.0-beta6` was the latest version when this tutorial was last updated. If there's a newer version available, use the latest version to ensure you have the latest security packages. Check the package's [NuGet page](https://www.nuget.org/packages/System.CommandLine) for the latest version to ensure you use a package version with the latest security fixes.
+   > The version `2.0.0` was the latest version when this tutorial was last updated. If there's a newer version available, use the latest version to ensure you have the latest security packages. Check the package's [NuGet page](https://www.nuget.org/packages/System.CommandLine) for the latest version to ensure you use a package version with the latest security fixes.
 
 1. Add the necessary using statements at the top of your file (after the `#!` and `#:package` directives):
 

--- a/docs/csharp/fundamentals/tutorials/file-based-programs.md
+++ b/docs/csharp/fundamentals/tutorials/file-based-programs.md
@@ -84,9 +84,9 @@ On unix, you can run file-based apps directly, typing the source file name on th
    #!/usr/local/share/dotnet/dotnet run
    ```
 
-The location of `dotnet` can be different on different unix installations. Use the command `where dotnet` to local the `dotnet` host in your environment.
+The location of `dotnet` can be different on different unix installations. Use the command `which dotnet` to locate the `dotnet` host in your environment.
 
-Or you can use the following way to resolve the dotnet path by the PATH environment automatically
+Alternatively, you can use #!/usr/bin/env dotnet to resolve the dotnet path from the PATH environment variable automatically:
 
 ```csharp
 #!/usr/bin/env dotnet

--- a/docs/csharp/fundamentals/tutorials/snippets/file-based-programs/AsciiArt
+++ b/docs/csharp/fundamentals/tutorials/snippets/file-based-programs/AsciiArt
@@ -1,7 +1,7 @@
 #!/usr/local/share/dotnet/dotnet run
 
 #:package Colorful.Console@1.2.15
-#:package System.CommandLine@2.0.0-beta6
+#:package System.CommandLine@2.0.0
 
 using System.CommandLine;
 using System.CommandLine.Parsing;

--- a/docs/csharp/fundamentals/tutorials/snippets/file-based-programs/AsciiArt.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/file-based-programs/AsciiArt.cs
@@ -4,7 +4,7 @@
 #:package Colorful.Console@1.2.15
 // </ColorfulPackage>
 // <CommandLinePackage>
-#:package System.CommandLine@2.0.0-beta6
+#:package System.CommandLine@2.0.0
 // </CommandLinePackage>
 
 // <Usings>


### PR DESCRIPTION
This pull request updates the documentation for running file-based C# apps on Unix systems and revises the recommended version for the `System.CommandLine` NuGet package. The changes clarify how to resolve the `dotnet` executable path and ensure security by suggesting the latest stable package version.

Improvements to Unix execution instructions:

* Updated the guidance for locating the `dotnet` executable: replaced the incorrect `whence dotnet` command with `where dotnet`, and added an alternative using the shebang `#!/usr/bin/env dotnet` for automatic PATH resolution.

Documentation update for package versioning:

* Changed the recommended version of `System.CommandLine` from `2.0.0-beta6` to the stable `2.0.0`, ensuring users are directed to use the latest secure release.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/fundamentals/tutorials/file-based-programs.md](https://github.com/dotnet/docs/blob/fcfcf729faad8c79d3f4ce859c070d16ab2d3655/docs/csharp/fundamentals/tutorials/file-based-programs.md) | [Tutorial: Build file-based C# programs](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/tutorials/file-based-programs?branch=pr-en-us-49928) |


<!-- PREVIEW-TABLE-END -->