### PR TITLE
Clarify global.json version support

### DIFF
--- a/docs/core/tools/global-json.md
+++ b/docs/core/tools/global-json.md
@@ -43,9 +43,9 @@ The version of the .NET SDK to use.
 
 This field:
 
+- Specify the full version number, such as 9.0.100. Doesn't support version numbers like 9, 9.0, or 9.0.x.
 - Doesn't have wildcard support; that is, you must specify the full version number.
 - Doesn't support version ranges.
-- Doesn't support versions such as 9, 9.0, or 9.0.x,
 
 #### `allowPrerelease`
 
@@ -210,12 +210,12 @@ The following example shows how to specify additional SDK search paths and a cus
 }
 ```
 
-The following example shows that when an invalid version is specified, the output  of `dotnet --info` shows: "Version '9.0' is not valid for the 'sdk/version' value."
+The following example shows an invalid version specified. The output of the command `dotnet --info` shows the error message: "Version '10.0' is not valid for the 'sdk/version' value."
 
 ```json
 {
   "sdk": {
-    "version": "9.0",
+    "version": "10.0",
     "rollForward": "latestFeature"
   }
 }

--- a/docs/core/tools/global-json.md
+++ b/docs/core/tools/global-json.md
@@ -43,7 +43,8 @@ The version of the .NET SDK to use.
 
 This field:
 
-- Specify the full version number, such as 9.0.100. Doesn't support version numbers like 9, 9.0, or 9.0.x.
+- Requires the full version number, such as 9.0.100.
+- Doesn't support version numbers like 9, 9.0, or 9.0.x.
 - Doesn't have wildcard support; that is, you must specify the full version number.
 - Doesn't support version ranges.
 

--- a/docs/core/tools/global-json.md
+++ b/docs/core/tools/global-json.md
@@ -45,7 +45,7 @@ This field:
 
 - Requires the full version number, such as 9.0.100.
 - Doesn't support version numbers like 9, 9.0, or 9.0.x.
-- Doesn't have wildcard support; that is, you must specify the full version number.
+- Doesn't have wildcard support.
 - Doesn't support version ranges.
 
 #### `allowPrerelease`

--- a/docs/core/tools/global-json.md
+++ b/docs/core/tools/global-json.md
@@ -45,6 +45,7 @@ This field:
 
 - Doesn't have wildcard support; that is, you must specify the full version number.
 - Doesn't support version ranges.
+- Doesn't support versions such as 9, 9.0, or 9.0.x,
 
 #### `allowPrerelease`
 
@@ -90,7 +91,7 @@ The following table shows the possible values for the `rollForward` key:
 #### `paths`
 
 - Type: Array of `string`
-- Available since: .NET 10 Preview 3 SDK.
+- Available since: .NET 10 SDK.
 
 Specifies the locations that should be considered when searching for a compatible .NET SDK. Paths can be absolute or relative to the location of the *global.json* file. The special value `$host$` represents the location corresponding to the running `dotnet` executable.
 
@@ -103,7 +104,7 @@ This feature enables using local SDK installations (such as SDKs relative to a r
 #### `errorMessage`
 
 - Type: `string`
-- Available since: .NET 10 Preview 3 SDK.
+- Available since: .NET 10 SDK.
 
 Specifies a custom error message displayed when the SDK resolver can't find a compatible .NET SDK.
 
@@ -205,6 +206,17 @@ The following example shows how to specify additional SDK search paths and a cus
     "version": "10.0.100",
     "paths": [ ".dotnet", "$host$" ],
     "errorMessage": "The required .NET SDK wasn't found. Please run ./install.sh to install it."
+  }
+}
+```
+
+The following example shows that when an invalid version is specified, the output  of `dotnet --info` shows: "Version '9.0' is not valid for the 'sdk/version' value."
+
+```json
+{
+  "sdk": {
+    "version": "9.0",
+    "rollForward": "latestFeature"
   }
 }
 ```


### PR DESCRIPTION
## Summary

This pull request updates the `global-json.md` documentation to clarify version support and correct feature availability information for the .NET SDK. The most important changes are:

**Clarifications on version support:**
* Added a note that versions such as `9`, `9.0`, or `9.0.x` are not supported in the `version` field.
* Added an example showing the error message when an invalid version like `9.0` is specified, demonstrating the expected output from `dotnet --info`.

**Corrections to feature availability:**
* Updated the availability notes for the `paths` and `errorMessage` keys to indicate they are available since .NET 10 SDK, not just the Preview 3 SDK. [[1]](diffhunk://#diff-360f326ade304e87f09c344edf5aa43c8bd69ad2f5eceb8bd537c17537572b17L93-R94) [[2]](diffhunk://#diff-360f326ade304e87f09c344edf5aa43c8bd69ad2f5eceb8bd537c17537572b17L106-R107)

Fixes #47455


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/global-json.md](https://github.com/dotnet/docs/blob/dae87692c4989dfbf53d262388f6232032e6155c/docs/core/tools/global-json.md) | [global.json overview](https://review.learn.microsoft.com/en-us/dotnet/core/tools/global-json?branch=pr-en-us-49941) |


<!-- PREVIEW-TABLE-END -->