### PR TITLE
Remove license notice from TRX

### DIFF
--- a/docs/core/testing/microsoft-testing-platform-extensions-test-reports.md
+++ b/docs/core/testing/microsoft-testing-platform-extensions-test-reports.md
@@ -16,9 +16,6 @@ A test report is a file that contains information about the execution and outcom
 
 The Visual Studio test result file (or TRX) is the default format for publishing test results. This extension is shipped as part of [Microsoft.Testing.Extensions.TrxReport](https://nuget.org/packages/Microsoft.Testing.Extensions.TrxReport) package.
 
-> [!IMPORTANT]
-> The package is shipped with Microsoft .NET library closed-source free to use licensing model.
-
 The available options as follows:
 
 | Option | Description |


### PR DESCRIPTION
## Summary

TRX plugin is open sourced in github.com/microsoft/testfx repo. The notice is no longer relevant.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/microsoft-testing-platform-extensions-test-reports.md](https://github.com/dotnet/docs/blob/109ecf03b4c418c3b431d32a3ac00db6aeca0dab/docs/core/testing/microsoft-testing-platform-extensions-test-reports.md) | [docs/core/testing/microsoft-testing-platform-extensions-test-reports](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-extensions-test-reports?branch=pr-en-us-49950) |

<!-- PREVIEW-TABLE-END -->