### PR TITLE
Fix formatting for dotnet shebang code example

### DIFF
--- a/docs/csharp/fundamentals/tutorials/file-based-programs.md
+++ b/docs/csharp/fundamentals/tutorials/file-based-programs.md
@@ -86,7 +86,7 @@ On unix, you can run file-based apps directly, typing the source file name on th
 
 The location of `dotnet` can be different on different unix installations. Use the command `which dotnet` to locate the `dotnet` host in your environment.
 
-Alternatively, you can use #!/usr/bin/env dotnet to resolve the dotnet path from the PATH environment variable automatically:
+Alternatively, you can use `#!/usr/bin/env dotnet` to resolve the dotnet path from the PATH environment variable automatically:
 
 ```csharp
 #!/usr/bin/env dotnet


### PR DESCRIPTION
## Summary

This pull request makes a minor documentation fix to improve clarity in the C# file-based program tutorial.

* Documentation: Corrected the formatting of the shebang example by wrapping `#!/usr/bin/env dotnet` in backticks for proper code highlighting.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/fundamentals/tutorials/file-based-programs.md](https://github.com/dotnet/docs/blob/566ed5cba1cb4d1efab125e5ae972c1406f355b3/docs/csharp/fundamentals/tutorials/file-based-programs.md) | [Tutorial: Build file-based C# programs](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/tutorials/file-based-programs?branch=pr-en-us-49951) |

<!-- PREVIEW-TABLE-END -->