### PR TITLE
 Add two new docs into toc of dotnet app mod

### DIFF
--- a/docs/core/porting/github-copilot-app-modernization/toc.yml
+++ b/docs/core/porting/github-copilot-app-modernization/toc.yml
@@ -22,3 +22,7 @@ items:
         href: ../../../azure/migration/appmod/quickstart.md?toc=/dotnet/core/porting/github-copilot-app-modernization/toc.json&bc=/dotnet/breadcrumb/toc.json
       - name: Migration sample
         href: ../../../azure/migration/appmod/sample.md?toc=/dotnet/core/porting/github-copilot-app-modernization/toc.json&bc=/dotnet/breadcrumb/toc.json
+      - name: Copilot CLI Support
+        href: ../../../azure/migration/appmod/copilot-cli-support.md?toc=/dotnet/core/porting/github-copilot-app-modernization/toc.json&bc=/dotnet/breadcrumb/toc.json
+      - name: Coding Agent Support
+        href: ../../../azure/migration/appmod/coding-agent-support.md?toc=/dotnet/core/porting/github-copilot-app-modernization/toc.json&bc=/dotnet/breadcrumb/toc.json


### PR DESCRIPTION
## Summary

 Add two new docs into toc of dotnet app mod

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/porting/github-copilot-app-modernization/toc.yml](https://github.com/dotnet/docs/blob/63a6338a22207e38bdb42cb8c6aee69df7dd2959/docs/core/porting/github-copilot-app-modernization/toc.yml) | [docs/core/porting/github-copilot-app-modernization/toc](https://review.learn.microsoft.com/en-us/dotnet/core/porting/github-copilot-app-modernization/toc?branch=pr-en-us-49966) |

<!-- PREVIEW-TABLE-END -->