### PR TITLE
Change package installation instructions to dotnet CLI

### DIFF
--- a/docs/core/diagnostics/observability-prgrja-example.md
+++ b/docs/core/diagnostics/observability-prgrja-example.md
@@ -36,15 +36,15 @@ The following code defines a new metric (`greetings.count`) for the number of ti
 
 Use the NuGet Package Manager or command line to add the following NuGet packages:
 
-    ```dotnetcli
-    dotnet add package OpenTelemetry.Exporter.Console
-    dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol
-    dotnet add package OpenTelemetry.Exporter.Prometheus.AspNetCore
-    dotnet add package OpenTelemetry.Exporter.Zipkin
-    dotnet add package OpenTelemetry.Extensions.Hosting
-    dotnet add package OpenTelemetry.Instrumentation.AspNetCore
-    dotnet add package OpenTelemetry.Instrumentation.Http
-    ```
+```dotnetcli
+dotnet add package OpenTelemetry.Exporter.Console
+dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol
+dotnet add package OpenTelemetry.Exporter.Prometheus.AspNetCore
+dotnet add package OpenTelemetry.Exporter.Zipkin
+dotnet add package OpenTelemetry.Extensions.Hosting
+dotnet add package OpenTelemetry.Instrumentation.AspNetCore
+dotnet add package OpenTelemetry.Instrumentation.Http
+```
 
 ## 5. Configure OpenTelemetry with the correct providers
 

--- a/docs/core/diagnostics/observability-prgrja-example.md
+++ b/docs/core/diagnostics/observability-prgrja-example.md
@@ -36,20 +36,15 @@ The following code defines a new metric (`greetings.count`) for the number of ti
 
 Use the NuGet Package Manager or command line to add the following NuGet packages:
 
-```xml
-<ItemGroup>
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.9.0-beta.2" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
-</ItemGroup>
-```
-
-> [!NOTE]
-> Use the latest versions, as the OTel APIs are constantly evolving.
+    ```dotnetcli
+    dotnet add package OpenTelemetry.Exporter.Console
+    dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol
+    dotnet add package OpenTelemetry.Exporter.Prometheus.AspNetCore
+    dotnet add package OpenTelemetry.Exporter.Zipkin
+    dotnet add package OpenTelemetry.Extensions.Hosting
+    dotnet add package OpenTelemetry.Instrumentation.AspNetCore
+    dotnet add package OpenTelemetry.Instrumentation.Http
+    ```
 
 ## 5. Configure OpenTelemetry with the correct providers
 


### PR DESCRIPTION
To avoid showing specific versions of packages. Fixes #48658.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/observability-prgrja-example.md](https://github.com/dotnet/docs/blob/041c76978edff19461f91a0be0dac4b6feb96b42/docs/core/diagnostics/observability-prgrja-example.md) | [Example: Use OpenTelemetry with Prometheus, Grafana, and Jaeger](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/observability-prgrja-example?branch=pr-en-us-50059) |


<!-- PREVIEW-TABLE-END -->