### PR TITLE
Add example demonstrating generic extension blocks

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/extension-methods.md
+++ b/docs/csharp/programming-guide/classes-and-structs/extension-methods.md
@@ -34,7 +34,7 @@ Beginning with C# 14, you can declare *extension blocks*. An extension block is 
 
 :::code language="csharp" source="./snippets/ExtensionMembers/CustomExtensionMembers.cs" id="ExtensionBlock":::
 
-In an extension block, extension members can have open or concrete generics, with or without constraints:
+Extension members in an extension block can use open or closed generics. The type parameters can include constraints:
 
 :::code language="csharp" source="./snippets/ExtensionMembers/CustomExtensionMembers.cs" id="GenericExtensionBlock":::
 

--- a/docs/csharp/programming-guide/classes-and-structs/extension-methods.md
+++ b/docs/csharp/programming-guide/classes-and-structs/extension-methods.md
@@ -1,7 +1,7 @@
 ---
 title: "Extension members"
 description: Extension members in C# enable you to add methods, properties, or operators to existing types without creating a new derived type, recompiling, or otherwise modifying the original type.
-ms.date: 09/17/2025
+ms.date: 11/20/2025
 helpviewer_keywords: 
   - "methods [C#], adding to existing types"
   - "extension methods [C#]"
@@ -33,6 +33,10 @@ Extension methods are defined as static methods but are called by using instance
 Beginning with C# 14, you can declare *extension blocks*. An extension block is a block in a non-nested, nongeneric, static class that contains extension members for a type or an instance of that type. The following code example defines an extension block for the `string` type. The extension block contains one member: a method that counts the words in the string:
 
 :::code language="csharp" source="./snippets/ExtensionMembers/CustomExtensionMembers.cs" id="ExtensionBlock":::
+
+In an extension block, extension members can have open or concrete generics, with or without constraints:
+
+:::code language="csharp" source="./snippets/ExtensionMembers/CustomExtensionMembers.cs" id="GenericExtensionBlock":::
 
 Before C# 14, you declare an extension method by adding the `this` modifier to the first parameter:
 

--- a/docs/csharp/programming-guide/classes-and-structs/snippets/ExtensionMembers/CustomExtensionMembers.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/snippets/ExtensionMembers/CustomExtensionMembers.cs
@@ -11,6 +11,18 @@ public static class MyExtensions
 }
 // </ExtensionBlock>
 
+// <GenericExtensionBlock>
+public static class MyGenericExtensions
+{
+    extension<T>(IEnumerable<T> source)
+        where T : IEquatable<T>
+    {
+        public IEnumerable<T> ValuesEqualTo(T threshold)
+            => source.Where(x => x.Equals(threshold));
+    }
+}
+// </GenericExtensionBlock>
+
 public interface IMyInterface
 {
     void MethodB();


### PR DESCRIPTION
## Summary

Add paragraph demonstrating an example of a constrained generic for an extension block

Fixes #50068


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/classes-and-structs/extension-methods.md](https://github.com/dotnet/docs/blob/5596470cdb1eac98447e1d68e9c741859620e9f5/docs/csharp/programming-guide/classes-and-structs/extension-methods.md) | [Extension members (C# Programming Guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/extension-methods?branch=pr-en-us-50069) |


<!-- PREVIEW-TABLE-END -->