### PR TITLE
Remove interactive snippets

### DIFF
--- a/docs/csharp/fundamentals/object-oriented/objects.md
+++ b/docs/csharp/fundamentals/object-oriented/objects.md
@@ -19,11 +19,11 @@ Because classes are reference types, a variable of a class object holds a refere
 
 Instances of classes are created by using the [`new` operator](../../language-reference/operators/new-operator.md). In the following example, `Person` is the type and `person1` and `person2` are instances, or objects, of that type.
 
-:::code language="csharp" source="./snippets/objects/Program.cs" interactive="try-dotnet":::
+:::code language="csharp" source="./snippets/objects/Program.cs":::
 
 Because structs are value types, a variable of a struct object holds a copy of the entire object. Instances of structs can also be created by using the `new` operator, but this isn't required, as shown in the following example:
 
-:::code language="csharp" source="./snippets/objects/Application.cs" interactive="try-dotnet":::
+:::code language="csharp" source="./snippets/objects/Application.cs":::
 
 The memory for both `p1` and `p2` is allocated on the thread stack. That memory is reclaimed along with the type or method in which it's declared. This is one reason why structs are copied on assignment. By contrast, the memory that is allocated for a class instance is automatically reclaimed (garbage collected) by the common language runtime when all references to the object are out of scope. It isn't possible to deterministically destroy a class object like you can in C++. For more information about garbage collection in .NET, see [Garbage Collection](../../../standard/garbage-collection/index.md).
 

--- a/docs/csharp/how-to/compare-strings.md
+++ b/docs/csharp/how-to/compare-strings.md
@@ -27,8 +27,6 @@ The <xref:System.StringComparison?displayProperty=fullName> enumeration fields r
 - **Ordinal**: Compare strings using ordinal (binary) sort rules.
 - **OrdinalIgnoreCase**: Compare strings using ordinal (binary) sort rules and ignoring the case of the strings being compared.
 
-[!INCLUDE[interactive-note](~/includes/csharp-interactive-note.md)]
-
 When you compare strings, you define an order among them. Comparisons are used to sort a sequence of strings. Once the sequence is in a known order, it's easier to search, both for software and for humans. Other comparisons might check if strings are the same. These sameness checks are similar to equality, but some differences, such as case differences, might be ignored.
 
 ## Default ordinal comparisons
@@ -38,7 +36,7 @@ By default, the most common operations:
 - <xref:System.String.Equals%2A?displayProperty=nameWithType>
 - <xref:System.String.op_Equality%2A?displayProperty=nameWithType> and <xref:System.String.op_Inequality%2A?displayProperty=nameWithType>, that is, [equality operators `==` and `!=`](../language-reference/operators/equality-operators.md#string-equality), respectively perform a case-sensitive, ordinal comparison. <xref:System.String.Equals%2A?displayProperty=nameWithType> has an overload where a <xref:System.StringComparison> argument can be provided to alter its sorting rules. The following example demonstrates that:
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/strings/CompareStrings.cs" id="Snippet1":::
+:::code language="csharp" source="./snippets/strings/CompareStrings.cs" id="Snippet1":::
 
 The default ordinal comparison doesn't take linguistic rules into account when comparing strings. It compares the binary value of each <xref:System.Char> object in two strings. As a result, the default ordinal comparison is also case-sensitive.
 
@@ -51,7 +49,7 @@ You can use the [`is`](../language-reference/operators/is.md) operator and a [co
 The <xref:System.String.Equals(System.String,System.StringComparison)?displayProperty=nameWithType> method enables you to specify a <xref:System.StringComparison> value of
 <xref:System.StringComparison.OrdinalIgnoreCase?displayProperty=nameWithType> for a case-insensitive ordinal comparison. There's also a static <xref:System.String.Compare(System.String,System.String,System.StringComparison)?displayProperty=nameWithType> method that performs a case-insensitive ordinal comparison if you specify a value of <xref:System.StringComparison.OrdinalIgnoreCase?displayProperty=nameWithType> for the <xref:System.StringComparison> argument. These comparisons are shown in the following code:
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/strings/CompareStrings.cs" id="Snippet2":::
+:::code language="csharp" source="./snippets/strings/CompareStrings.cs" id="Snippet2":::
 
 These methods use the casing conventions of the [invariant culture](xref:System.Globalization.CultureInfo.InvariantCulture) when performing a case-insensitive ordinal comparison.
 
@@ -59,7 +57,7 @@ These methods use the casing conventions of the [invariant culture](xref:System.
 
 Many string comparison methods (such as <xref:System.String.StartsWith%2A?displayProperty=nameWithType>) use linguistic rules for the _current culture_ by default to order their inputs. This linguistic comparison is sometimes referred to as "word sort order." When you perform a linguistic comparison, some nonalphanumeric Unicode characters might have special weights assigned. For example, the hyphen "-" might have a small weight assigned to it so that "co-op" and "coop" appear next to each other in sort order. Some nonprinting control characters might be ignored. In addition, some Unicode characters might be equivalent to a sequence of <xref:System.Char> instances. The following example uses the phrase "They dance in the street." in German with the "ss" (U+0073 U+0073) in one string and 'ß' (U+00DF) in another. Linguistically (in Windows), "ss" is equal to the German Esszet: 'ß' character in both the "en-US" and "de-DE" cultures.
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/strings/CompareStrings.cs" id="Snippet3":::
+:::code language="csharp" source="./snippets/strings/CompareStrings.cs" id="Snippet3":::
 
 On Windows, before .NET 5, the sort order of "cop", "coop", and "co-op" changes when you change from a linguistic comparison to an ordinal comparison. The two German sentences also compare differently using the different comparison types. Before .NET 5, the .NET globalization APIs used [National Language Support (NLS)](/windows/win32/intl/national-language-support) libraries. In .NET 5 and later versions, the .NET globalization APIs use [International Components for Unicode (ICU)](https://icu.unicode.org/) libraries, which unify .NET's globalization behavior across all supported operating systems.
 
@@ -67,7 +65,7 @@ On Windows, before .NET 5, the sort order of "cop", "coop", and "co-op" changes 
 
 The following example stores <xref:System.Globalization.CultureInfo> objects for the en-US and de-DE cultures. The comparisons are performed using a <xref:System.Globalization.CultureInfo> object to ensure a culture-specific comparison. The culture used affects linguistic comparisons. The following example shows the results of comparing the two German sentences using the "en-US" culture and the "de-DE" culture:
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/strings/CompareStrings.cs" id="Snippet4":::
+:::code language="csharp" source="./snippets/strings/CompareStrings.cs" id="Snippet4":::
 
 Culture-sensitive comparisons are typically used to compare and sort strings input by users with other strings input by users. The characters and sorting conventions of these strings might vary depending on the locale of the user's computer. Even strings that contain identical characters might sort differently depending on the culture of the current thread.
 
@@ -77,21 +75,21 @@ The following examples show how to sort and search for strings in an array using
 
 The following example shows how to sort an array of strings using the current culture:
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/strings/CompareStrings.cs" id="Snippet5":::
+:::code language="csharp" source="./snippets/strings/CompareStrings.cs" id="Snippet5":::
 
 Once the array is sorted, you can search for entries using a binary search. A binary search starts in the middle of the collection to determine which half of the collection would contain the sought string. Each subsequent comparison subdivides the remaining part of the collection in half. The array is sorted using the <xref:System.StringComparer.CurrentCulture?displayProperty=nameWithType>. The local function `ShowWhere` displays information about where the string was found. If the string wasn't found, the returned value indicates where it would be if it were found.
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/strings/CompareStrings.cs" id="Snippet6":::
+:::code language="csharp" source="./snippets/strings/CompareStrings.cs" id="Snippet6":::
 
 ## Ordinal sorting and searching in collections
 
 The following code uses the <xref:System.Collections.Generic.List%601?displayProperty=nameWithType> collection class to store strings. The strings are sorted using the <xref:System.Collections.Generic.List%601.Sort%2A?displayProperty=nameWithType> method. This method needs a delegate that compares and orders two strings. The <xref:System.String.CompareTo%2A?displayProperty=nameWithType> method provides that comparison function. Run the sample and observe the order. This sort operation uses an ordinal case-sensitive sort. You would use the static <xref:System.String.Compare%2A?displayProperty=nameWithType> methods to specify different comparison rules.
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/strings/CompareStrings.cs" id="Snippet7":::
+:::code language="csharp" source="./snippets/strings/CompareStrings.cs" id="Snippet7":::
 
 Once sorted, the list of strings can be searched using a binary search. The following sample shows how to search the sorted list using the same comparison function. The local function `ShowWhere` shows where the sought text is or would be:
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/strings/CompareStrings.cs" id="Snippet8":::
+:::code language="csharp" source="./snippets/strings/CompareStrings.cs" id="Snippet8":::
 
 Always make sure to use the same type of comparison for sorting and searching. Using different comparison types for sorting and searching produces unexpected results.
 

--- a/docs/csharp/how-to/concatenate-multiple-strings.md
+++ b/docs/csharp/how-to/concatenate-multiple-strings.md
@@ -12,8 +12,6 @@ ms.custom: copilot-scenario-highlight
 
 *Concatenation* is the process of appending one string to the end of another string. You concatenate strings by using the `+` operator. For string literals and string constants, concatenation occurs at compile time; no run-time concatenation occurs. For string variables, concatenation occurs only at run time.
 
-[!INCLUDE[interactive-note](~/includes/csharp-interactive-note.md)]
-
 > [!TIP]
 > You can use AI assistance to [concatenate strings](#use-ai-to-concatenate-strings).
 
@@ -21,19 +19,19 @@ ms.custom: copilot-scenario-highlight
 
 The following example splits a long string literal into smaller strings to improve readability in the source code. The code concatenates the smaller strings to create the long string literal. The parts are concatenated into a single string at compile time. There's no run-time performance cost regardless of the number of strings involved.
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/strings/Concatenate.cs" id="Snippet1":::
+:::code language="csharp" source="./snippets/strings/Concatenate.cs" id="Snippet1":::
 
 ## `+` and `+=` operators
 
 To concatenate string variables, you can use the `+` or `+=` operators, [string interpolation](../language-reference/tokens/interpolated.md) or the <xref:System.String.Format%2A?displayProperty=nameWithType>, <xref:System.String.Concat%2A?displayProperty=nameWithType>, <xref:System.String.Join%2A?displayProperty=nameWithType> or <xref:System.Text.StringBuilder.Append%2A?displayProperty=nameWithType> methods. The `+` operator is easy to use and makes for intuitive code. Even if you use several `+` operators in one statement, the string content is copied only once. The following code shows examples of using the `+` and `+=` operators to concatenate strings:
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/strings/Concatenate.cs" id="Snippet2":::
+:::code language="csharp" source="./snippets/strings/Concatenate.cs" id="Snippet2":::
 
 ## String interpolation
 
 In some expressions, it's easier to concatenate strings using string interpolation, as the following code shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/strings/Concatenate.cs" id="Snippet3":::
+:::code language="csharp" source="./snippets/strings/Concatenate.cs" id="Snippet3":::
 
 > [!NOTE]
 > In string concatenation operations, the C# compiler treats a null string the same as an empty string.
@@ -48,7 +46,7 @@ Another method to concatenate strings is <xref:System.String.Format%2A?displayPr
 
 In other cases, you might be combining strings in a loop where the actual number of source strings can be large. The <xref:System.Text.StringBuilder> class was designed for these scenarios. The following code uses the <xref:System.Text.StringBuilder.Append%2A> method of the <xref:System.Text.StringBuilder> class to concatenate strings.
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/strings/Concatenate.cs" id="Snippet4":::
+:::code language="csharp" source="./snippets/strings/Concatenate.cs" id="Snippet4":::
 
 You can read more about the [reasons to choose string concatenation or the `StringBuilder` class](/dotnet/api/system.text.stringbuilder#the-string-and-stringbuilder-types).
 
@@ -56,7 +54,7 @@ You can read more about the [reasons to choose string concatenation or the `Stri
 
 Another option to join strings from a collection is to use <xref:System.String.Concat%2A?displayProperty=nameWithType> method. Use <xref:System.String.Join%2A?displayProperty=nameWithType> method if a delimiter should separate source strings. The following code combines an array of words using both methods:
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/strings/Concatenate.cs" id="Snippet5":::
+:::code language="csharp" source="./snippets/strings/Concatenate.cs" id="Snippet5":::
 
 ## LINQ and `Enumerable.Aggregate`
 
@@ -66,7 +64,7 @@ the source strings using a lambda expression. The lambda expression does the
 work to add each string to the existing accumulation. The following example
 combines an array of words, adding a space between each word in the array:
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/strings/Concatenate.cs" id="Snippet6":::
+:::code language="csharp" source="./snippets/strings/Concatenate.cs" id="Snippet6":::
 
 This option can cause more allocations than other methods for concatenating collections, as it creates an intermediate string for each iteration. If optimizing performance is critical, consider the [`StringBuilder`](#stringbuilder) class or the [`String.Concat` or `String.Join`](#stringconcat-or-stringjoin) method to concatenate a collection, instead of `Enumerable.Aggregate`.
 

--- a/docs/csharp/how-to/modify-string-contents.md
+++ b/docs/csharp/how-to/modify-string-contents.md
@@ -17,13 +17,13 @@ There are several techniques demonstrated in this article. You can replace exist
 
 The following code creates a new string by replacing existing text with a substitute.
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/strings/ModifyStrings.cs" id="Snippet1":::
+:::code language="csharp" source="./snippets/strings/ModifyStrings.cs" id="Snippet1":::
 
 The preceding code demonstrates this *immutable* property of strings. You can see in the preceding example that the original string, `source`, isn't modified. The <xref:System.String.Replace%2A?displayProperty=nameWithType> method creates a new `string` containing the modifications.
 
 The <xref:System.String.Replace%2A> method can replace either strings or single characters. In both cases, every occurrence of the sought text is replaced. The following example replaces all ' ' characters with '\_':
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/strings/ModifyStrings.cs" id="Snippet2":::
+:::code language="csharp" source="./snippets/strings/ModifyStrings.cs" id="Snippet2":::
 
 The source string is unchanged, and a new string is returned with the replacement.
 
@@ -31,13 +31,13 @@ The source string is unchanged, and a new string is returned with the replacemen
 
 You can use the <xref:System.String.Trim%2A?displayProperty=nameWithType>, <xref:System.String.TrimStart%2A?displayProperty=nameWithType>, and <xref:System.String.TrimEnd%2A?displayProperty=nameWithType> methods to remove any leading or trailing white space. The following code shows an example of each. The source string doesn't change; these methods return a new string with the modified contents.
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/strings/ModifyStrings.cs" id="Snippet3":::
+:::code language="csharp" source="./snippets/strings/ModifyStrings.cs" id="Snippet3":::
 
 ## Remove text
 
 You can remove text from a string using the <xref:System.String.Remove%2A?displayProperty=nameWithType> method. This method removes the specified number of characters starting at a specific index. The following example shows how to use <xref:System.String.IndexOf%2A?displayProperty=nameWithType> followed by <xref:System.String.Remove%2A> to remove text from a string:
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/strings/ModifyStrings.cs" id="Snippet4":::
+:::code language="csharp" source="./snippets/strings/ModifyStrings.cs" id="Snippet4":::
 
 ## Replace matching patterns
 
@@ -45,7 +45,7 @@ You can use [regular expressions](../../standard/base-types/regular-expressions.
 
 Regular expressions are most useful for searching and replacing text that follows a pattern, rather than known text. For more information, see [How to search strings](search-strings.md). The search pattern, "the\s" searches for the word "the" followed by a white-space character. That part of the pattern ensures that it doesn't match "there" in the source string. For more information on regular expression language elements, see [Regular Expression Language - Quick Reference](../../standard/base-types/regular-expression-language-quick-reference.md).
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/strings/ModifyStrings.cs" id="Snippet5":::
+:::code language="csharp" source="./snippets/strings/ModifyStrings.cs" id="Snippet5":::
 
 The <xref:System.Text.StringBuilder.ToString%2A?displayProperty=nameWithType> method returns an immutable string with the contents in the <xref:System.Text.StringBuilder> object.
 
@@ -55,13 +55,13 @@ You can produce a character array from a string, modify the contents of the arra
 
 The following example shows how to replace a set of characters in a string. First, it uses the <xref:System.String.ToCharArray?displayProperty=nameWithType> method to create an array of characters. It uses the <xref:System.String.IndexOf%2A> method to find the starting index of the word "fox." The next three characters are replaced with a different word. Finally, a new string is constructed from the updated character array.
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/strings/ModifyStrings.cs" id="Snippet6":::
+:::code language="csharp" source="./snippets/strings/ModifyStrings.cs" id="Snippet6":::
 
 ## Programmatically build up string content
 
 Since strings are immutable, the previous examples all create temporary strings or character arrays. In high-performance scenarios, it's desirable to avoid these heap allocations. .NET provides a <xref:System.String.Create%2A?displayProperty=nameWithType> method that allows you to programmatically fill in the character content of a string via a callback while avoiding the intermediate temporary string allocations.
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/strings/ModifyStrings.cs" id="Snippet7":::
+:::code language="csharp" source="./snippets/strings/ModifyStrings.cs" id="Snippet7":::
 
 You could modify a string in a fixed block with unsafe code, but it's **strongly** discouraged to modify the string content after a string is created. Doing so causes unpredictable bugs. For example, if someone interns a string that has the same content as yours, they get your copy and didn't expect that you're modifying their string.
 

--- a/docs/csharp/how-to/modify-string-contents.md
+++ b/docs/csharp/how-to/modify-string-contents.md
@@ -9,8 +9,6 @@ helpviewer_keywords:
 
 This article demonstrates several techniques to produce a `string` by modifying an existing `string`. All the techniques demonstrated return the result of the modifications as a new `string` object. To demonstrate that the original and modified strings are distinct instances, the examples store the result in a new variable. You can examine the original `string` and the new, modified `string` when you run each example.
 
-[!INCLUDE[interactive-note](~/includes/csharp-interactive-note.md)]
-
 There are several techniques demonstrated in this article. You can replace existing text. You can search for patterns and replace matching text with other text. You can treat a string as a sequence of characters. You can also use convenience methods that remove white space. Choose the techniques that most closely match your scenario.
 
 ## Replace text

--- a/docs/csharp/how-to/parse-strings-using-split.md
+++ b/docs/csharp/how-to/parse-strings-using-split.md
@@ -13,8 +13,6 @@ ms.custom: copilot-scenario-highlight
 
 The <xref:System.String.Split%2A?displayProperty=nameWithType> method creates an array of substrings by splitting the input string based on one or more delimiters. This method is often the easiest way to separate a string on word boundaries.
 
-[!INCLUDE[interactive-note](~/includes/csharp-interactive-note.md)]
-
 > [!TIP]
 > You can use AI assistance to [split a string](#use-ai-to-split-a-string).
 
@@ -22,11 +20,11 @@ The <xref:System.String.Split%2A?displayProperty=nameWithType> method creates an
 
 The following code splits a common phrase into an array of strings for each word.
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/strings/ParseStringsUsingSplit.cs" id="Snippet1":::
+:::code language="csharp" source="./snippets/strings/ParseStringsUsingSplit.cs" id="Snippet1":::
 
 Every instance of a separator character produces a value in the returned array. Since arrays in C# are zero-indexed, each string in the array is indexed from 0 to the value returned by the <xref:System.Array.Length%2A?displayProperty=nameWithType> property minus 1:
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/strings/ParseStringsUsingSplit.cs" id="Snippet1.5":::
+:::code language="csharp" source="./snippets/strings/ParseStringsUsingSplit.cs" id="Snippet1.5":::
 
 The <xref:System.String.Split*?displayProperty=nameWithType> has many overloads. These overloads customize the behavior for splitting strings:
 
@@ -44,27 +42,27 @@ For more information about indices, see the [Explore indexes and ranges](../tuto
 
 <xref:System.String.Split%2A?displayProperty=nameWithType> can use multiple separator characters. The following example uses spaces, commas, periods, colons, and tabs as separating characters, which are passed to <xref:System.String.Split%2A> in an array. The loop at the bottom of the code displays each of the words in the returned array.
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/strings/ParseStringsUsingSplit.cs" id="Snippet3":::
+:::code language="csharp" source="./snippets/strings/ParseStringsUsingSplit.cs" id="Snippet3":::
 
 Consecutive instances of any separator produce the empty string in the output array:
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/strings/ParseStringsUsingSplit.cs" id="Snippet4":::
+:::code language="csharp" source="./snippets/strings/ParseStringsUsingSplit.cs" id="Snippet4":::
 
 <xref:System.String.Split%2A?displayProperty=nameWithType> can take an array of strings (character sequences that act as separators for parsing the target string, instead of single characters).
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/strings/ParseStringsUsingSplit.cs" id="Snippet5":::
+:::code language="csharp" source="./snippets/strings/ParseStringsUsingSplit.cs" id="Snippet5":::
 
 ## Limit output size
 
 The following example shows how to limit the output to the first four substrings in the source string.
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/strings/ParseStringsUsingSplit.cs" id="Snippet6":::
+:::code language="csharp" source="./snippets/strings/ParseStringsUsingSplit.cs" id="Snippet6":::
 
 ## Remove empty substrings
 
 Consecutive separator characters produce the empty string as a value in the returned array. You can see how an empty string is created in the following example, which uses the space character as a separator.
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/strings/ParseStringsUsingSplit.cs" id="Snippet2":::
+:::code language="csharp" source="./snippets/strings/ParseStringsUsingSplit.cs" id="Snippet2":::
 
 This behavior makes it easier for formats like comma-separated values (CSV) files representing tabular data. Consecutive commas represent a blank column.
 
@@ -74,7 +72,7 @@ You can pass an optional <xref:System.StringSplitOptions.RemoveEmptyEntries?disp
 
 The following example shows the effect of trimming entries:
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/strings/ParseStringsUsingSplit.cs" id="Snippet7":::
+:::code language="csharp" source="./snippets/strings/ParseStringsUsingSplit.cs" id="Snippet7":::
 
 The untrimmed entries have extra whitespace before the numerals.
 

--- a/docs/csharp/how-to/search-strings.md
+++ b/docs/csharp/how-to/search-strings.md
@@ -12,15 +12,13 @@ helpviewer_keywords:
 
 You can use two main strategies to search for text in strings. Methods of the <xref:System.String> class search for specific text. Regular expressions search for patterns in text.
 
-[!INCLUDE[interactive-note](~/includes/csharp-interactive-note.md)]
-
 The [string](../language-reference/builtin-types/reference-types.md#the-string-type) type, which is an alias for the <xref:System.String?displayProperty=nameWithType> class, provides many useful methods for searching the contents of a string. Among them are <xref:System.String.Contains%2A>, <xref:System.String.StartsWith%2A>, <xref:System.String.EndsWith%2A>, <xref:System.String.IndexOf%2A>, <xref:System.String.LastIndexOf%2A>. The <xref:System.Text.RegularExpressions.Regex?displayProperty=nameWithType> class provides a rich vocabulary to search for patterns in text. In this article, you learn these techniques and how to choose the best method for your needs.
 
 ## Does a string contain text?
 
 The <xref:System.String.Contains%2A?displayProperty=nameWithType>, <xref:System.String.StartsWith%2A?displayProperty=nameWithType>, and <xref:System.String.EndsWith%2A?displayProperty=nameWithType> methods search a string for specific text. The following example shows each of these methods and a variation that uses a case-insensitive search:
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/strings/SearchStrings.cs" id="Snippet1":::
+:::code language="csharp" source="./snippets/strings/SearchStrings.cs" id="Snippet1":::
 
 The preceding example demonstrates an important point for using these methods. Searches are **case-sensitive** by default. You use the <xref:System.StringComparison.CurrentCultureIgnoreCase?displayProperty=nameWithType> enumeration value to specify a case-insensitive search.
 
@@ -28,7 +26,7 @@ The preceding example demonstrates an important point for using these methods. S
 
 The <xref:System.String.IndexOf%2A> and <xref:System.String.LastIndexOf%2A> methods also search for text in strings. These methods return the location of the text being sought. If the text isn't found, they return `-1`. The following example shows a search for the first and last occurrence of the word "methods" and displays the text in between.
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/strings/SearchStrings.cs" id="Snippet2":::
+:::code language="csharp" source="./snippets/strings/SearchStrings.cs" id="Snippet2":::
 
 ## Finding specific text using regular expressions
 
@@ -44,7 +42,7 @@ The search pattern describes the text you search for. The following table descri
 | `(eir)?` | match 0 or 1 occurrence of "eir" |
 | `\s`     | match a white-space character    |
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/strings/SearchStrings.cs" id="Snippet3":::
+:::code language="csharp" source="./snippets/strings/SearchStrings.cs" id="Snippet3":::
 
 > [!TIP]
 > The `string` methods are generally better choices when you're searching for an exact string. Regular expressions are better when you're searching for some pattern in a source string.
@@ -61,7 +59,7 @@ The following code uses regular expressions to validate the format of each strin
 | `\d{4}` | matches exactly four digit characters  |
 | `$`     | matches the end of the string       |
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/\strings/SearchStrings.cs" id="Snippet4":::
+:::code language="csharp" source="./snippets/\strings/SearchStrings.cs" id="Snippet4":::
 
 This single search pattern matches many valid strings. Regular expressions are better to search for or validate against a pattern, rather than a single text string.
 

--- a/docs/csharp/language-reference/attributes/general.md
+++ b/docs/csharp/language-reference/attributes/general.md
@@ -33,7 +33,7 @@ The `Conditional` attribute makes the execution of a method dependent on a prepr
 
 In the following example, `Conditional` is applied to a method to enable or disable the display of program-specific diagnostic information:
 
-:::code language="csharp" source="snippets/trace.cs" interactive="try-dotnet" :::
+:::code language="csharp" source="snippets/trace.cs" :::
 
 If the `TRACE_ON` identifier isn't defined, the trace output isn't displayed. Explore for yourself in the interactive window.
 
@@ -59,7 +59,7 @@ The `Obsolete` attribute marks a code element as no longer recommended for use. 
 
 In the following example, the `Obsolete` attribute is applied to class `A` and to method `B.OldMethod`. Because the second argument of the attribute constructor applied to `B.OldMethod` is set to `true`, this method causes a compiler error, whereas using class `A` produces a warning. Calling `B.NewMethod`, however, produces no warning or error. For example, when you use it with the previous definitions, the following code generates two warnings and one error:
 
-:::code language="csharp" source="snippets/ObsoleteExample.cs" ID="Snippet1" interactive="try-dotnet" :::
+:::code language="csharp" source="snippets/ObsoleteExample.cs" ID="Snippet1" :::
 
 The string provided as the first argument to the attribute constructor is displayed as part of the warning or error. Two warnings for class `A` are generated: one for the declaration of the class reference, and one for the class constructor. The `Obsolete` attribute can be used without arguments, but including an explanation what to use instead is recommended. You can use constant string interpolation and the `nameof` operator to ensure the names match:
 

--- a/docs/csharp/language-reference/builtin-types/bool.md
+++ b/docs/csharp/language-reference/builtin-types/bool.md
@@ -26,7 +26,7 @@ The default value of the `bool` type is `false`.
 
 You can use the `true` and `false` literals to initialize a `bool` variable or to pass a `bool` value:
 
-[!code-csharp-interactive[bool literals](snippets/shared/BoolType.cs#Literals)]
+[!code-csharp[bool literals](snippets/shared/BoolType.cs#Literals)]
 
 ## Three-valued Boolean logic
 

--- a/docs/csharp/language-reference/builtin-types/char.md
+++ b/docs/csharp/language-reference/builtin-types/char.md
@@ -30,7 +30,7 @@ You can specify a `char` value with:
 - a Unicode escape sequence, which is `\u` followed by the four-symbol hexadecimal representation of a character code.
 - a hexadecimal escape sequence, which is `\x` followed by the hexadecimal representation of a character code.
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/CharType.cs" id="Literals":::
+:::code language="csharp" source="snippets/shared/CharType.cs" id="Literals":::
 
 As the preceding example shows, you can also cast the value of a character code into the corresponding `char` value.
 

--- a/docs/csharp/language-reference/builtin-types/nullable-value-types.md
+++ b/docs/csharp/language-reference/builtin-types/nullable-value-types.md
@@ -25,7 +25,7 @@ The default value of a nullable value type represents `null`, that is, it's an i
 
 You can use the [`is` operator with a type pattern](../operators/type-testing-and-cast.md#type-testing-with-pattern-matching) to both examine an instance of a nullable value type for `null` and retrieve a value of an underlying type:
 
-[!code-csharp-interactive[use pattern matching](snippets/shared/NullableValueTypes.cs#PatternMatching)]
+[!code-csharp[use pattern matching](snippets/shared/NullableValueTypes.cs#PatternMatching)]
 
 You always can use the following read-only properties to examine and get a value of a nullable value type variable:
 
@@ -35,17 +35,17 @@ You always can use the following read-only properties to examine and get a value
 
 The following example uses the `HasValue` property to test whether the variable contains a value before displaying it:
 
-[!code-csharp-interactive[use HasValue](snippets/shared/NullableValueTypes.cs#HasValue)]
+[!code-csharp[use HasValue](snippets/shared/NullableValueTypes.cs#HasValue)]
 
 You can also compare a variable of a nullable value type with `null` instead of using the `HasValue` property, as the following example shows:
 
-[!code-csharp-interactive[use comparison with null](snippets/shared/NullableValueTypes.cs#CompareWithNull)]
+[!code-csharp[use comparison with null](snippets/shared/NullableValueTypes.cs#CompareWithNull)]
 
 ## Conversion from a nullable value type to an underlying type
 
 If you want to assign a value of a nullable value type to a non-nullable value type variable, you might need to specify the value to be assigned in place of `null`. Use the [null-coalescing operator `??`](../operators/null-coalescing-operator.md) to do that (you can also use the <xref:System.Nullable%601.GetValueOrDefault(%600)?displayProperty=nameWithType> method for the same purpose):
 
-[!code-csharp-interactive[?? operator](snippets/shared/NullableValueTypes.cs#NullCoalescing)]
+[!code-csharp[?? operator](snippets/shared/NullableValueTypes.cs#NullCoalescing)]
 
 If you want to use the [default](default-values.md) value of the underlying value type in place of `null`, use the <xref:System.Nullable%601.GetValueOrDefault?displayProperty=nameWithType> method.
 
@@ -71,7 +71,7 @@ For the [comparison operators](../operators/comparison-operators.md) `<`, `>`, `
 - neither greater than or equal to `null`
 - nor less than `null`
 
-[!code-csharp-interactive[relational and equality operators](snippets/shared/NullableValueTypes.cs#ComparisonOperators)]
+[!code-csharp[relational and equality operators](snippets/shared/NullableValueTypes.cs#ComparisonOperators)]
 
 For the [equality operator](../operators/equality-operators.md#equality-operator-) `==`, if both operands are `null`, the result is `true`, if only one of the operands is `null`, the result is `false`; otherwise, the contained values of operands are compared.
 
@@ -88,23 +88,23 @@ An instance of a nullable value type `T?` is [boxed](../../programming-guide/typ
 
 You can unbox a boxed value of a value type `T` to the corresponding nullable value type `T?`, as the following example shows:
 
-[!code-csharp-interactive[boxing and unboxing](snippets/shared/NullableValueTypes.cs#Boxing)]
+[!code-csharp[boxing and unboxing](snippets/shared/NullableValueTypes.cs#Boxing)]
 
 ## How to identify a nullable value type
 
 The following example shows how to determine whether a <xref:System.Type?displayProperty=nameWithType> instance represents a constructed nullable value type, that is, the <xref:System.Nullable%601?displayProperty=nameWithType> type with a specified type parameter `T`:
 
-[!code-csharp-interactive[whether Type is nullable](snippets/shared/NullableValueTypes.cs#IsTypeNullable)]
+[!code-csharp[whether Type is nullable](snippets/shared/NullableValueTypes.cs#IsTypeNullable)]
 
 As the example shows, you use the [typeof](../operators/type-testing-and-cast.md#the-typeof-operator) operator to create a <xref:System.Type?displayProperty=nameWithType> instance.
 
 If you want to determine whether an instance is of a nullable value type, don't use the <xref:System.Object.GetType%2A?displayProperty=nameWithType> method to get a <xref:System.Type> instance to be tested with the preceding code. When you call the <xref:System.Object.GetType%2A?displayProperty=nameWithType> method on an instance of a nullable value type, the instance is [boxed](#boxing-and-unboxing) to <xref:System.Object>. As boxing of a non-null instance of a nullable value type is equivalent to boxing of a value of the underlying type, <xref:System.Object.GetType%2A> returns a <xref:System.Type> instance that represents the underlying type of a nullable value type:
 
-[!code-csharp-interactive[GetType example](snippets/shared/NullableValueTypes.cs#GetType)]
+[!code-csharp[GetType example](snippets/shared/NullableValueTypes.cs#GetType)]
 
 Also, don't use the [is](../operators/type-testing-and-cast.md#the-is-operator) operator to determine whether an instance is of a nullable value type. As the following example shows, you cannot distinguish types of a nullable value type instance and its underlying type instance with the `is` operator:
 
-[!code-csharp-interactive[is operator example](snippets/shared/NullableValueTypes.cs#IsOperator)]
+[!code-csharp[is operator example](snippets/shared/NullableValueTypes.cs#IsOperator)]
 
 Instead use the <xref:System.Nullable.GetUnderlyingType%2A?displayProperty=nameWithType> from the first example and [typeof](../operators/type-testing-and-cast.md#the-typeof-operator) operator to check if an instance is of a nullable value type.
 

--- a/docs/csharp/language-reference/builtin-types/value-tuples.md
+++ b/docs/csharp/language-reference/builtin-types/value-tuples.md
@@ -39,7 +39,7 @@ Typically, you use tuples to group loosely related data elements. In public APIs
 
 You explicitly specify tuple fields names in a tuple initialization expression or in the definition of a tuple type, as the following example shows:
 
-[!code-csharp-interactive[explicit field names](snippets/shared/ValueTuples.cs#ExplicitFieldNames)]
+[!code-csharp[explicit field names](snippets/shared/ValueTuples.cs#ExplicitFieldNames)]
 
 If you don't specify a field name, it may be inferred from the name of the corresponding variable in a tuple initialization expression, as the following example shows:
 

--- a/docs/csharp/language-reference/builtin-types/value-tuples.md
+++ b/docs/csharp/language-reference/builtin-types/value-tuples.md
@@ -9,11 +9,11 @@ helpviewer_keywords:
 
 The *tuples* feature provides concise syntax to group multiple data elements in a lightweight data structure. The following example shows how you can declare a tuple variable, initialize it, and access its data members:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ValueTuples.cs" id="Introduction":::
+:::code language="csharp" source="snippets/shared/ValueTuples.cs" id="Introduction":::
 
 As the preceding example shows, to define a tuple type, you specify types of all its data members and, optionally, the [field names](#tuple-field-names). You can't define methods in a tuple type, but you can use the methods provided by .NET, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ValueTuples.cs" id="MethodOnTuples":::
+:::code language="csharp" source="snippets/shared/ValueTuples.cs" id="MethodOnTuples":::
 
 Tuple types support [equality operators](../operators/equality-operators.md) `==` and `!=`. For more information, see the [Tuple equality](#tuple-equality) section.
 
@@ -21,13 +21,13 @@ Tuple types are [value types](value-types.md); tuple elements are public fields.
 
 You can define tuples with an arbitrary large number of elements:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ValueTuples.cs" id="LargeTuple":::
+:::code language="csharp" source="snippets/shared/ValueTuples.cs" id="LargeTuple":::
 
 ## Use cases of tuples
 
 One of the most common use cases of tuples is as a method return type. That is, instead of defining [`out` method parameters](../keywords/method-parameters.md#out-parameter-modifier), you can group method results in a tuple return type, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ValueTuples.cs" id="MultipleReturns":::
+:::code language="csharp" source="snippets/shared/ValueTuples.cs" id="MultipleReturns":::
 
 As the preceding example shows, you can work with the returned tuple instance directly or [deconstruct](#tuple-assignment-and-deconstruction) it in separate variables.
 
@@ -43,7 +43,7 @@ You explicitly specify tuple fields names in a tuple initialization expression o
 
 If you don't specify a field name, it may be inferred from the name of the corresponding variable in a tuple initialization expression, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ValueTuples.cs" id="InferFieldNames":::
+:::code language="csharp" source="snippets/shared/ValueTuples.cs" id="InferFieldNames":::
 
 That's called tuple projection initializers. The name of a variable isn't projected onto a tuple field name in the following cases:
 
@@ -54,7 +54,7 @@ In the preceding cases, you either explicitly specify the name of a field or acc
 
 The default names of tuple fields are `Item1`, `Item2`, `Item3` and so on. You can always use the default name of a field, even when a field name is specified explicitly or inferred, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ValueTuples.cs" id="DefaultFieldNames":::
+:::code language="csharp" source="snippets/shared/ValueTuples.cs" id="DefaultFieldNames":::
 
 [Tuple assignment](#tuple-assignment-and-deconstruction) and [tuple equality comparisons](#tuple-equality) don't take field names into account.
 
@@ -96,31 +96,31 @@ C# supports assignment between tuple types that satisfy both of the following co
 
 Tuple element values are assigned following the order of tuple elements. The names of tuple fields are ignored and not assigned, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ValueTuples.cs" id="Assignment":::
+:::code language="csharp" source="snippets/shared/ValueTuples.cs" id="Assignment":::
 
 You can also use the assignment operator `=` to *deconstruct* a tuple instance in separate variables. You can do that in many ways:
 
 - Use the `var` keyword outside the parentheses to declare implicitly typed variables and let the compiler infer their types:
 
-  :::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ValueTuples.cs" id="DeconstructVar":::
+  :::code language="csharp" source="snippets/shared/ValueTuples.cs" id="DeconstructVar":::
 
 - Explicitly declare the type of each variable inside parentheses:
 
-  :::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ValueTuples.cs" id="DeconstructExplicit":::
+  :::code language="csharp" source="snippets/shared/ValueTuples.cs" id="DeconstructExplicit":::
 
 - Declare some types explicitly and other types implicitly (with `var`) inside the parentheses:
 
-  :::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ValueTuples.cs" id="DeconstructMixed":::
+  :::code language="csharp" source="snippets/shared/ValueTuples.cs" id="DeconstructMixed":::
 
 - Use existing variables:
 
-  :::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ValueTuples.cs" id="DeconstructExisting":::
+  :::code language="csharp" source="snippets/shared/ValueTuples.cs" id="DeconstructExisting":::
 
 The destination of a deconstruct expression can include both existing variables and variables declared in the deconstruction declaration.
 
 You can also combine deconstruction with [pattern matching](../../fundamentals/functional/pattern-matching.md) to inspect the characteristics of fields in a tuple. The following example loops through several integers and prints those that are divisible by 3. It deconstructs the tuple result of <xref:System.Int32.DivRem%2A?displayProperty=nameWithType> and matches against a `Remainder` of 0:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ValueTuples.cs" id="DeconstructToPattern":::
+:::code language="csharp" source="snippets/shared/ValueTuples.cs" id="DeconstructToPattern":::
 
 For more information about deconstruction of tuples and other types, see [Deconstructing tuples and other types](../../fundamentals/functional/deconstruct.md).
 
@@ -128,7 +128,7 @@ For more information about deconstruction of tuples and other types, see [Decons
 
 Tuple types support the `==` and `!=` operators. These operators compare members of the left-hand operand with the corresponding members of the right-hand operand following the order of tuple elements.
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ValueTuples.cs" id="TupleEquality":::
+:::code language="csharp" source="snippets/shared/ValueTuples.cs" id="TupleEquality":::
 
 As the preceding example shows, the `==` and `!=` operations don't take into account tuple field names.
 
@@ -139,13 +139,13 @@ Two tuples are comparable when both of the following conditions are satisfied:
 
 The `==` and `!=` operators compare tuples in short-circuiting way. That is, an operation stops as soon as it meets a pair of non equal elements or reaches the ends of tuples. However, before any comparison, *all* tuple elements are evaluated, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ValueTuples.cs" id="TupleEvaluationForEquality":::
+:::code language="csharp" source="snippets/shared/ValueTuples.cs" id="TupleEvaluationForEquality":::
 
 ## Tuples as out parameters
 
 Typically, you refactor a method that has [`out` parameters](../keywords/method-parameters.md#out-parameter-modifier) into a method that returns a tuple. However, there are cases in which an `out` parameter can be of a tuple type. The following example shows how to work with tuples as `out` parameters:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ValueTuples.cs" id="TupleAsOutParameter":::
+:::code language="csharp" source="snippets/shared/ValueTuples.cs" id="TupleAsOutParameter":::
 
 ## Tuples vs `System.Tuple`
 

--- a/docs/csharp/language-reference/operators/addition-operator.md
+++ b/docs/csharp/language-reference/operators/addition-operator.md
@@ -24,11 +24,11 @@ For information about the arithmetic `+` operator, see the [Unary plus and minus
 
 When one or both operands are of type [string](../builtin-types/reference-types.md#the-string-type), the `+` operator concatenates the string representations of its operands (the string representation of `null` is an empty string):
 
-:::code interactive="try-dotnet-method" language="csharp" source="snippets/shared/AdditionOperator.cs" id="AddStrings":::
+:::code language="csharp" source="snippets/shared/AdditionOperator.cs" id="AddStrings":::
 
 [String interpolation](../tokens/interpolated.md) provides a more convenient way to format strings:
 
-:::code interactive="try-dotnet-method" language="csharp" source="snippets/shared/AdditionOperator.cs" id="UseStringInterpolation":::
+:::code language="csharp" source="snippets/shared/AdditionOperator.cs" id="UseStringInterpolation":::
 
 You can use string interpolation to initialize a constant string when all the expressions used for placeholders are also constant strings.
 
@@ -38,7 +38,7 @@ The `+` operator performs string concatenation for UTF-8 literal strings. This o
 
 For operands of the same [delegate](../builtin-types/reference-types.md#the-delegate-type) type, the `+` operator returns a new delegate instance that, when invoked, invokes the left-hand operand and then invokes the right-hand operand. If any of the operands is `null`, the `+` operator returns the value of another operand (which also might be `null`). The following example shows how delegates can be combined with the `+` operator:
 
-:::code interactive="try-dotnet-method" language="csharp" source="snippets/shared/AdditionOperator.cs" id="AddDelegates":::
+:::code language="csharp" source="snippets/shared/AdditionOperator.cs" id="AddDelegates":::
 
 To perform delegate removal, use the [`-` operator](subtraction-operator.md#delegate-removal).
 
@@ -62,7 +62,7 @@ Except that `x` is only evaluated once.
 
 The following example demonstrates the usage of the `+=` operator:
 
-:::code interactive="try-dotnet-method" language="csharp" source="snippets/shared/AdditionOperator.cs" id="AddAndAssign":::
+:::code language="csharp" source="snippets/shared/AdditionOperator.cs" id="AddAndAssign":::
 
 You also use the `+=` operator to specify an event handler method when you subscribe to an [event](../keywords/event.md). For more information, see [How to: subscribe to and unsubscribe from events](../../programming-guide/events/how-to-subscribe-to-and-unsubscribe-from-events.md).
 

--- a/docs/csharp/language-reference/operators/arithmetic-operators.md
+++ b/docs/csharp/language-reference/operators/arithmetic-operators.md
@@ -52,13 +52,13 @@ The increment operator is supported in two forms: the postfix increment operator
 
 The result of `x++` is the value of `x` *before* the operation, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ArithmeticOperators.cs" id="PostfixIncrement":::
+:::code language="csharp" source="snippets/shared/ArithmeticOperators.cs" id="PostfixIncrement":::
 
 ### Prefix increment operator
 
 The result of `++x` is the value of `x` *after* the operation, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ArithmeticOperators.cs" id="PrefixIncrement":::
+:::code language="csharp" source="snippets/shared/ArithmeticOperators.cs" id="PrefixIncrement":::
 
 ## Decrement operator --
 
@@ -70,19 +70,19 @@ The decrement operator is supported in two forms: the postfix decrement operator
 
 The result of `x--` is the value of `x` *before* the operation, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ArithmeticOperators.cs" id="PostfixDecrement":::
+:::code language="csharp" source="snippets/shared/ArithmeticOperators.cs" id="PostfixDecrement":::
 
 ### Prefix decrement operator
 
 The result of `--x` is the value of `x` *after* the operation, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ArithmeticOperators.cs" id="PrefixDecrement":::
+:::code language="csharp" source="snippets/shared/ArithmeticOperators.cs" id="PrefixDecrement":::
 
 ## Unary plus and minus operators
 
 The unary `+` operator returns the value of its operand. The unary `-` operator computes the numeric negation of its operand.
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ArithmeticOperators.cs" id="UnaryPlusAndMinus":::
+:::code language="csharp" source="snippets/shared/ArithmeticOperators.cs" id="UnaryPlusAndMinus":::
 
 The [ulong](../builtin-types/integral-numeric-types.md) type doesn't support the unary `-` operator.
 
@@ -90,7 +90,7 @@ The [ulong](../builtin-types/integral-numeric-types.md) type doesn't support the
 
 The multiplication operator `*` computes the product of its operands:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ArithmeticOperators.cs" id="Multiplication":::
+:::code language="csharp" source="snippets/shared/ArithmeticOperators.cs" id="Multiplication":::
 
 The unary `*` operator is the [pointer indirection operator](pointer-related-operators.md#pointer-indirection-operator-).
 
@@ -102,17 +102,17 @@ The division operator `/` divides its left-hand operand by its right-hand operan
 
 For the operands of integer types, the result of the `/` operator is of an integer type and equals the quotient of the two operands rounded towards zero:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ArithmeticOperators.cs" id="IntegerDivision":::
+:::code language="csharp" source="snippets/shared/ArithmeticOperators.cs" id="IntegerDivision":::
 
 To obtain the quotient of the two operands as a floating-point number, use the `float`, `double`, or `decimal` type:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ArithmeticOperators.cs" id="IntegerAsFloatingPointDivision":::
+:::code language="csharp" source="snippets/shared/ArithmeticOperators.cs" id="IntegerAsFloatingPointDivision":::
 
 ### Floating-point division
 
 For the `float`, `double`, and `decimal` types, the result of the `/` operator is the quotient of the two operands:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ArithmeticOperators.cs" id="FloatingPointDivision":::
+:::code language="csharp" source="snippets/shared/ArithmeticOperators.cs" id="FloatingPointDivision":::
 
 If one of the operands is `decimal`, another operand can't be `float` nor `double`, because neither `float` nor `double` is implicitly convertible to `decimal`. You must explicitly convert the `float` or `double` operand to the `decimal` type. For more information about conversions between numeric types, see [Built-in numeric conversions](../builtin-types/numeric-conversions.md).
 
@@ -124,7 +124,7 @@ The remainder operator `%` computes the remainder after dividing its left-hand o
 
 For the operands of integer types, the result of `a % b` is the value produced by `a - (a / b) * b`. The sign of the non-zero remainder is the same as the sign of the left-hand operand, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ArithmeticOperators.cs" id="IntegerRemainder":::
+:::code language="csharp" source="snippets/shared/ArithmeticOperators.cs" id="IntegerRemainder":::
 
 Use the <xref:System.Math.DivRem%2A?displayProperty=nameWithType> method to compute both integer division and remainder results.
 
@@ -144,13 +144,13 @@ For the `decimal` operands, the remainder operator `%` is equivalent to the [rem
 
 The following example demonstrates the behavior of the remainder operator with floating-point operands:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ArithmeticOperators.cs" id="FloatingPointRemainder":::
+:::code language="csharp" source="snippets/shared/ArithmeticOperators.cs" id="FloatingPointRemainder":::
 
 ## Addition operator +
 
 The addition operator `+` computes the sum of its operands:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ArithmeticOperators.cs" id="Addition":::
+:::code language="csharp" source="snippets/shared/ArithmeticOperators.cs" id="Addition":::
 
 You can also use the `+` operator for string concatenation and delegate combination. For more information, see the [`+` and `+=` operators](addition-operator.md) article.
 
@@ -158,7 +158,7 @@ You can also use the `+` operator for string concatenation and delegate combinat
 
 The subtraction operator `-` subtracts its right-hand operand from its left-hand operand:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ArithmeticOperators.cs" id="Subtraction":::
+:::code language="csharp" source="snippets/shared/ArithmeticOperators.cs" id="Subtraction":::
 
 You can also use the `-` operator for delegate removal. For more information, see the [`-` and `-=` operators](subtraction-operator.md) article.
 
@@ -180,11 +180,11 @@ Except that `x` is only evaluated once.
 
 The following example demonstrates the usage of compound assignment with arithmetic operators:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ArithmeticOperators.cs" id="CompoundAssignment":::
+:::code language="csharp" source="snippets/shared/ArithmeticOperators.cs" id="CompoundAssignment":::
 
 Because of [numeric promotions](~/_csharpstandard/standard/expressions.md#1247-numeric-promotions), the result of the `op` operation might be not implicitly convertible to the type `T` of `x`. In such a case, if `op` is a predefined operator and the result of the operation is explicitly convertible to the type `T` of `x`, a compound assignment expression of the form `x op= y` is equivalent to `x = (T)(x op y)`, except that `x` is only evaluated once. The following example demonstrates that behavior:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ArithmeticOperators.cs" id="CompoundAssignmentWithCast":::
+:::code language="csharp" source="snippets/shared/ArithmeticOperators.cs" id="CompoundAssignmentWithCast":::
 
 In the preceding example, value `44` is the result of converting value `300` to the `byte` type.
 
@@ -206,7 +206,7 @@ Binary arithmetic operators are left-associative. That is, operators with the sa
 
 Use parentheses, `()`, to change the order of evaluation imposed by operator precedence and associativity.
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ArithmeticOperators.cs" id="PrecedenceAndAssociativity":::
+:::code language="csharp" source="snippets/shared/ArithmeticOperators.cs" id="PrecedenceAndAssociativity":::
 
 For the complete list of C# operators ordered by precedence level, see the [Operator precedence](index.md#operator-precedence) section of the [C# operators](index.md) article.
 
@@ -225,7 +225,7 @@ If integer arithmetic overflow occurs, the overflow-checking context, which can 
 
 Along with the [checked and unchecked](../statements/checked-and-unchecked.md) statements, you can use the `checked` and `unchecked` operators to control the overflow-checking context, in which an expression is evaluated:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ArithmeticOperators.cs" id="CheckedUnchecked":::
+:::code language="csharp" source="snippets/shared/ArithmeticOperators.cs" id="CheckedUnchecked":::
 
 By default, arithmetic operations occur in an *unchecked* context.
 
@@ -233,7 +233,7 @@ By default, arithmetic operations occur in an *unchecked* context.
 
 Arithmetic operations with the `float` and `double` types never throw an exception. The result of arithmetic operations with those types can be one of special values that represent infinity and not-a-number:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ArithmeticOperators.cs" id="FloatingPointOverflow":::
+:::code language="csharp" source="snippets/shared/ArithmeticOperators.cs" id="FloatingPointOverflow":::
 
 For the operands of the `decimal` type, arithmetic overflow always throws an <xref:System.OverflowException>. Division by zero always throws a <xref:System.DivideByZeroException>.
 
@@ -241,7 +241,7 @@ For the operands of the `decimal` type, arithmetic overflow always throws an <xr
 
 Because of general limitations of the floating-point representation of real numbers and floating-point arithmetic, round-off errors might occur in calculations with floating-point types. That is, the produced result of an expression might differ from the expected mathematical result. The following example demonstrates several such cases:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ArithmeticOperators.cs" id="RoundOffErrors":::
+:::code language="csharp" source="snippets/shared/ArithmeticOperators.cs" id="RoundOffErrors":::
 
 For more information, see remarks at the [System.Double](/dotnet/api/system.double#remarks), [System.Single](/dotnet/api/system.single#remarks), or [System.Decimal](/dotnet/api/system.decimal#remarks) reference pages.
 

--- a/docs/csharp/language-reference/operators/assignment-operator.md
+++ b/docs/csharp/language-reference/operators/assignment-operator.md
@@ -37,7 +37,7 @@ Beginning with C# 14, the left hand side of a value assignment can include a [nu
 
 *Ref assignment* `= ref` makes its left-hand operand an alias to the right-hand operand, as the following example demonstrates:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/AssignmentOperator.cs" id="SnippetRefAssignment":::
+:::code language="csharp" source="snippets/shared/AssignmentOperator.cs" id="SnippetRefAssignment":::
 
 In the preceding example, the [local reference variable](../statements/declarations.md#reference-variables) `arrayElement` is initialized as an alias to the first array element. Then, it's `ref` reassigned to refer to the last array element. As it's an alias, when you update its value with an ordinary assignment operator `=`, the corresponding array element is also updated.
 

--- a/docs/csharp/language-reference/operators/bitwise-and-shift-operators.md
+++ b/docs/csharp/language-reference/operators/bitwise-and-shift-operators.md
@@ -54,7 +54,7 @@ Bitwise and shift operations never cause overflow and produce the same results i
 
 The `~` operator produces a bitwise complement of its operand by reversing each bit:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/BitwiseAndShiftOperators.cs" id="BitwiseComplement":::
+:::code language="csharp" source="snippets/shared/BitwiseAndShiftOperators.cs" id="BitwiseComplement":::
 
 You can also use the `~` symbol to declare finalizers. For more information, see [Finalizers](../../programming-guide/classes-and-structs/finalizers.md).
 
@@ -64,11 +64,11 @@ The `<<` operator shifts its left-hand operand left by the number of bits define
 
 The left-shift operation discards the high-order bits that are outside the range of the result type and sets the low-order empty bit positions to zero, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/BitwiseAndShiftOperators.cs" id="LeftShift":::
+:::code language="csharp" source="snippets/shared/BitwiseAndShiftOperators.cs" id="LeftShift":::
 
 Because the shift operators are defined only for the `int`, `uint`, `long`, and `ulong` types, the result of an operation always contains at least 32 bits. If the left-hand operand is of another integral type (`sbyte`, `byte`, `short`, `ushort`, or `char`), its value is converted to the `int` type, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/BitwiseAndShiftOperators.cs" id="LeftShiftPromoted":::
+:::code language="csharp" source="snippets/shared/BitwiseAndShiftOperators.cs" id="LeftShiftPromoted":::
 
 ## Right-shift operator >>
 
@@ -76,17 +76,17 @@ The `>>` operator shifts its left-hand operand right by the number of bits defin
 
 The right-shift operation discards the low-order bits, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/BitwiseAndShiftOperators.cs" id="RightShift":::
+:::code language="csharp" source="snippets/shared/BitwiseAndShiftOperators.cs" id="RightShift":::
 
 The high-order empty bit positions are set based on the type of the left-hand operand as follows:
 
 - If the left-hand operand is of type `int` or `long`, the right-shift operator performs an *arithmetic* shift: the value of the most significant bit (the sign bit) of the left-hand operand is propagated to the high-order empty bit positions. That is, the high-order empty bit positions are set to zero if the left-hand operand is non-negative and set to one if it's negative.
 
-  :::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/BitwiseAndShiftOperators.cs" id="ArithmeticRightShift":::
+  :::code language="csharp" source="snippets/shared/BitwiseAndShiftOperators.cs" id="ArithmeticRightShift":::
 
 - If the left-hand operand is of type `uint` or `ulong`, the right-shift operator performs a *logical* shift: the high-order empty bit positions are always set to zero.
 
-  :::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/BitwiseAndShiftOperators.cs" id="LogicalRightShift":::
+  :::code language="csharp" source="snippets/shared/BitwiseAndShiftOperators.cs" id="LogicalRightShift":::
 
 > [!NOTE]
 > Use the [unsigned right-shift operator](#unsigned-right-shift-operator-) to perform a *logical* shift on operands of signed integer types. The logical shift is preferred. Avoid casting the left-hand operand to an unsigned type and then casting the result of a shift operation back to a signed type.
@@ -103,7 +103,7 @@ The `>>>` operator always performs a *logical* shift. That is, the high-order em
 
 The `&` operator computes the bitwise logical AND of its integral operands:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/BitwiseAndShiftOperators.cs" id="BitwiseAnd":::
+:::code language="csharp" source="snippets/shared/BitwiseAndShiftOperators.cs" id="BitwiseAnd":::
 
 For `bool` operands, the `&` operator computes the [logical AND](boolean-logical-operators.md#logical-and-operator-) of its operands. The unary `&` operator is the [address-of operator](pointer-related-operators.md#address-of-operator-).
 
@@ -111,7 +111,7 @@ For `bool` operands, the `&` operator computes the [logical AND](boolean-logical
 
 The `^` operator computes the bitwise logical exclusive OR, also known as the bitwise logical XOR, of its integral operands:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/BitwiseAndShiftOperators.cs" id="BitwiseXor":::
+:::code language="csharp" source="snippets/shared/BitwiseAndShiftOperators.cs" id="BitwiseXor":::
 
 For `bool` operands, the `^` operator computes the [logical exclusive OR](boolean-logical-operators.md#logical-exclusive-or-operator-) of its operands.
 
@@ -119,7 +119,7 @@ For `bool` operands, the `^` operator computes the [logical exclusive OR](boolea
 
 The `|` operator computes the bitwise logical OR of its integral operands:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/BitwiseAndShiftOperators.cs" id="BitwiseOr":::
+:::code language="csharp" source="snippets/shared/BitwiseAndShiftOperators.cs" id="BitwiseOr":::
 
 For `bool` operands, the `|` operator computes the [logical OR](boolean-logical-operators.md#logical-or-operator-) of its operands.
 
@@ -145,7 +145,7 @@ The following example demonstrates the usage of compound assignment with bitwise
 
 Because of [numeric promotions](~/_csharpstandard/standard/expressions.md#1247-numeric-promotions), the result of the `op` operation might be not implicitly convertible to the type `T` of `x`. In such a case, if `op` is a predefined operator and the result of the operation is explicitly convertible to the type `T` of `x`, a compound assignment expression of the form `x op= y` is equivalent to `x = (T)(x op y)`, except that `x` is only evaluated once. The following example demonstrates that behavior:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/BitwiseAndShiftOperators.cs" id="CompoundAssignmentWithCast":::
+:::code language="csharp" source="snippets/shared/BitwiseAndShiftOperators.cs" id="CompoundAssignmentWithCast":::
 
 ## Operator precedence
 
@@ -159,7 +159,7 @@ The following list orders bitwise and shift operators starting from the highest 
 
 Use parentheses, `()`, to change the order of evaluation imposed by operator precedence:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/BitwiseAndShiftOperators.cs" id="Precedence":::
+:::code language="csharp" source="snippets/shared/BitwiseAndShiftOperators.cs" id="Precedence":::
 
 For the complete list of C# operators ordered by precedence level, see the [Operator precedence](index.md#operator-precedence) section of the [C# operators](index.md) article.
 
@@ -173,7 +173,7 @@ For the `x << count`, `x >> count`, and `x >>> count` expressions, the actual sh
 
 The following example demonstrates that behavior:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/BitwiseAndShiftOperators.cs" id="ShiftCount":::
+:::code language="csharp" source="snippets/shared/BitwiseAndShiftOperators.cs" id="ShiftCount":::
 
 > [!NOTE]
 > As the preceding example shows, the result of a shift operation can be non-zero even if the value of the right-hand operand is greater than the number of bits in the left-hand operand.

--- a/docs/csharp/language-reference/operators/boolean-logical-operators.md
+++ b/docs/csharp/language-reference/operators/boolean-logical-operators.md
@@ -50,7 +50,7 @@ For operands of the [integral numeric types](../builtin-types/integral-numeric-t
 
 The unary prefix `!` operator computes logical negation of its operand. That is, it produces `true`, if the operand evaluates to `false`, and `false`, if the operand evaluates to `true`:
 
-:::code interactive="try-dotnet-method" language="csharp" source="snippets/shared/BooleanLogicalOperators.cs" id="Negation":::
+:::code language="csharp" source="snippets/shared/BooleanLogicalOperators.cs" id="Negation":::
 
 The unary postfix `!` operator is the [null-forgiving operator](null-forgiving.md).
 
@@ -62,7 +62,7 @@ The `&` operator always evaluates both operands. When the left-hand operand eval
 
 In the following example, the right-hand operand of the `&` operator is a method call, which is performed regardless of the value of the left-hand operand:
 
-:::code interactive="try-dotnet-method" language="csharp" source="snippets/shared/BooleanLogicalOperators.cs" id="And":::
+:::code language="csharp" source="snippets/shared/BooleanLogicalOperators.cs" id="And":::
 
 The [conditional logical AND operator](#conditional-logical-and-operator-) `&&` also computes the logical AND of its operands, but doesn't evaluate the right-hand operand if the left-hand operand evaluates to `false`.
 
@@ -72,7 +72,7 @@ For operands of the [integral numeric types](../builtin-types/integral-numeric-t
 
 The `^` operator computes the logical exclusive OR, also known as the logical XOR, of its operands. The result of `x ^ y` is `true` if `x` evaluates to `true` and `y` evaluates to `false`, or `x` evaluates to `false` and `y` evaluates to `true`. Otherwise, the result is `false`. That is, for the `bool` operands, the `^` operator computes the same result as the [inequality operator](equality-operators.md#inequality-operator-) `!=`.
 
-:::code interactive="try-dotnet-method" language="csharp" source="snippets/shared/BooleanLogicalOperators.cs" id="Xor":::
+:::code language="csharp" source="snippets/shared/BooleanLogicalOperators.cs" id="Xor":::
 
 For operands of the [integral numeric types](../builtin-types/integral-numeric-types.md), the `^` operator computes the [bitwise logical exclusive OR](bitwise-and-shift-operators.md#logical-exclusive-or-operator-) of its operands.
 
@@ -84,7 +84,7 @@ The `|` operator always evaluates both operands. When the left-hand operand eval
 
 In the following example, the right-hand operand of the `|` operator is a method call, which is performed regardless of the value of the left-hand operand:
 
-:::code interactive="try-dotnet-method" language="csharp" source="snippets/shared/BooleanLogicalOperators.cs" id="Or":::
+:::code language="csharp" source="snippets/shared/BooleanLogicalOperators.cs" id="Or":::
 
 The [conditional logical OR operator](#conditional-logical-or-operator-) `||` also computes the logical OR of its operands, but doesn't evaluate the right-hand operand if the left-hand operand evaluates to `true`.
 
@@ -96,7 +96,7 @@ The conditional logical AND operator `&&`, also known as the "short-circuiting" 
 
 In the following example, the right-hand operand of the `&&` operator is a method call, which isn't performed if the left-hand operand evaluates to `false`:
 
-:::code interactive="try-dotnet-method" language="csharp" source="snippets/shared/BooleanLogicalOperators.cs" id="ConditionalAnd":::
+:::code language="csharp" source="snippets/shared/BooleanLogicalOperators.cs" id="ConditionalAnd":::
 
 The [logical AND operator](#logical-and-operator-) `&` also computes the logical AND of its operands, but always evaluates both operands.
 
@@ -106,7 +106,7 @@ The conditional logical OR operator `||`, also known as the "short-circuiting" l
 
 In the following example, the right-hand operand of the `||` operator is a method call, which isn't performed if the left-hand operand evaluates to `true`:
 
-:::code interactive="try-dotnet-method" language="csharp" source="snippets/shared/BooleanLogicalOperators.cs" id="ConditionalOr":::
+:::code language="csharp" source="snippets/shared/BooleanLogicalOperators.cs" id="ConditionalOr":::
 
 The [logical OR operator](#logical-or-operator-) `|` also computes the logical OR of its operands, but always evaluates both operands.
 
@@ -136,7 +136,7 @@ The behavior of those operators differs from the typical operator behavior with 
 
 You can also use the `!` and `^` operators with `bool?` operands, as the following example shows:
 
-:::code interactive="try-dotnet-method" language="csharp" source="snippets/shared/BooleanLogicalOperators.cs" id="WithNullableBoolean":::
+:::code language="csharp" source="snippets/shared/BooleanLogicalOperators.cs" id="WithNullableBoolean":::
 
 The conditional logical operators `&&` and `||` don't support `bool?` operands.
 
@@ -158,7 +158,7 @@ Except that `x` is only evaluated once.
 
 The `&`, `|`, and `^` operators support compound assignment, as the following example shows:
 
-:::code interactive="try-dotnet-method" language="csharp" source="snippets/shared/BooleanLogicalOperators.cs" id="CompoundAssignment":::
+:::code language="csharp" source="snippets/shared/BooleanLogicalOperators.cs" id="CompoundAssignment":::
 
 > [!NOTE]
 > The conditional logical operators `&&` and `||` don't support compound assignment.
@@ -176,7 +176,7 @@ The following list orders logical operators starting from the highest precedence
 
 Use parentheses, `()`, to change the order of evaluation imposed by operator precedence:
 
-:::code interactive="try-dotnet-method" language="csharp" source="snippets/shared/BooleanLogicalOperators.cs" id="Precedence":::
+:::code language="csharp" source="snippets/shared/BooleanLogicalOperators.cs" id="Precedence":::
 
 For the complete list of C# operators ordered by precedence level, see the [Operator precedence](index.md#operator-precedence) section of the [C# operators](index.md) article.
 

--- a/docs/csharp/language-reference/operators/comparison-operators.md
+++ b/docs/csharp/language-reference/operators/comparison-operators.md
@@ -37,25 +37,25 @@ The [`==` and `!=` operators](equality-operators.md) check if their operands are
 
 The `<` operator returns `true` if its left-hand operand is less than its right-hand operand, `false` otherwise:
 
-[!code-csharp-interactive[less than example](snippets/shared/ComparisonOperators.cs#Less)]
+[!code-csharp[less than example](snippets/shared/ComparisonOperators.cs#Less)]
 
 ## Greater than operator >
 
 The `>` operator returns `true` if its left-hand operand is greater than its right-hand operand, `false` otherwise:
 
-[!code-csharp-interactive[greater than example](snippets/shared/ComparisonOperators.cs#Greater)]
+[!code-csharp[greater than example](snippets/shared/ComparisonOperators.cs#Greater)]
 
 ## Less than or equal operator \<=
 
 The `<=` operator returns `true` if its left-hand operand is less than or equal to its right-hand operand, `false` otherwise:
 
-[!code-csharp-interactive[less than or equal example](snippets/shared/ComparisonOperators.cs#LessOrEqual)]
+[!code-csharp[less than or equal example](snippets/shared/ComparisonOperators.cs#LessOrEqual)]
 
 ## Greater than or equal operator >=
 
 The `>=` operator returns `true` if its left-hand operand is greater than or equal to its right-hand operand, `false` otherwise:
 
-[!code-csharp-interactive[greater than or equal example](snippets/shared/ComparisonOperators.cs#GreaterOrEqual)]
+[!code-csharp[greater than or equal example](snippets/shared/ComparisonOperators.cs#GreaterOrEqual)]
 
 ## Operator overloadability
 

--- a/docs/csharp/language-reference/operators/conditional-operator.md
+++ b/docs/csharp/language-reference/operators/conditional-operator.md
@@ -14,7 +14,7 @@ helpviewer_keywords:
 
 The conditional operator `?:`, also known as the ternary conditional operator, evaluates a Boolean expression and returns the result of one of the two expressions, depending on whether the Boolean expression evaluates to `true` or `false`, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ConditionalOperator.cs" id="BasicExample":::
+:::code language="csharp" source="snippets/shared/ConditionalOperator.cs" id="BasicExample":::
 
 As the preceding example shows, the syntax for the conditional operator is as follows:
 
@@ -53,7 +53,7 @@ a ? b : (c ? d : e)
 
 A conditional ref expression conditionally returns a variable reference, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/ConditionalOperator.cs" id="ConditionalRef":::
+:::code language="csharp" source="snippets/shared/ConditionalOperator.cs" id="ConditionalRef":::
 
 You can [`ref` assign](assignment-operator.md#ref-assignment) the result of a conditional ref expression, use it as a [reference return](../statements/jump-statements.md#ref-returns) or pass it as a `ref`, `out`, `in`, or `ref readonly` [method parameter](../keywords/method-parameters.md#reference-parameters). You can also assign to the result of a conditional ref expression, as the preceding example shows.
 

--- a/docs/csharp/language-reference/operators/default.md
+++ b/docs/csharp/language-reference/operators/default.md
@@ -17,7 +17,7 @@ You also use the `default` keyword as the default case label within a [`switch` 
 
 The argument to the `default` operator must be the name of a type or a type parameter, as the following example shows:
 
-[!code-csharp-interactive[default of T](snippets/shared/DefaultOperator.cs#WithOperand)]
+[!code-csharp[default of T](snippets/shared/DefaultOperator.cs#WithOperand)]
 
 ## default literal
 
@@ -30,7 +30,7 @@ You can use the `default` literal to produce the default value of a type when th
 
 The following example shows the usage of the `default` literal:
 
-[!code-csharp-interactive[default literal](snippets/shared/DefaultOperator.cs#DefaultLiteral)]
+[!code-csharp[default literal](snippets/shared/DefaultOperator.cs#DefaultLiteral)]
 
 > [!TIP]
 > Use .NET style rule [IDE0034](../../../fundamentals/code-analysis/style-rules/ide0034.md) to specify a preference on the use of the `default` literal in your codebase.

--- a/docs/csharp/language-reference/operators/delegate-operator.md
+++ b/docs/csharp/language-reference/operators/delegate-operator.md
@@ -10,18 +10,18 @@ helpviewer_keywords:
 
 The `delegate` operator creates an anonymous method that can be converted to a delegate type. An anonymous method can be converted to types such as <xref:System.Action?displayProperty=nameWithType> and <xref:System.Func%601?displayProperty=nameWithType> types used as arguments to many methods.
 
-[!code-csharp-interactive[anonymous method](snippets/shared/DelegateOperator.cs#AnonymousMethod)]
+[!code-csharp[anonymous method](snippets/shared/DelegateOperator.cs#AnonymousMethod)]
 
 > [!NOTE]
 > Lambda expressions provide a more concise and expressive way to create an anonymous function. Use the [=> operator](lambda-operator.md) to construct a lambda expression:
 >
-> [!code-csharp-interactive[lambda expression](snippets/shared/DelegateOperator.cs#Lambda)]
+> [!code-csharp[lambda expression](snippets/shared/DelegateOperator.cs#Lambda)]
 >
 > For more information about features of lambda expressions, for example, capturing outer variables, see [Lambda expressions](lambda-expressions.md).
 
 When you use the `delegate` operator, you might omit the parameter list. If you do that, the created anonymous method can be converted to a delegate type with any list of  parameters, as the following example shows:
 
-[!code-csharp-interactive[no parameter list](snippets/shared/DelegateOperator.cs#WithoutParameterList)]
+[!code-csharp[no parameter list](snippets/shared/DelegateOperator.cs#WithoutParameterList)]
 
 That's the only functionality of anonymous methods not supported by lambda expressions. In all other cases, a lambda expression is a preferred way to write inline code. You can use [discards](../../fundamentals/functional/discards.md) to specify two or more input parameters of an anonymous method that aren't used by the method:
 

--- a/docs/csharp/language-reference/operators/equality-operators.md
+++ b/docs/csharp/language-reference/operators/equality-operators.md
@@ -30,7 +30,7 @@ The equality operator `==` returns `true` if its operands are equal, `false` oth
 
 Operands of the [built-in value types](../builtin-types/value-types.md#built-in-value-types) are equal if their values are equal:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/EqualityOperators.cs" id="ValueTypesEquality":::
+:::code language="csharp" source="snippets/shared/EqualityOperators.cs" id="ValueTypesEquality":::
 
 > [!NOTE]
 > For the `==`, [`<`, `>`, `<=`, and `>=`](comparison-operators.md) operators, if any of the operands isn't a number (<xref:System.Double.NaN?displayProperty=nameWithType> or <xref:System.Single.NaN?displayProperty=nameWithType>), the result of operation is `false`. That means that the `NaN` value isn't greater than, less than, or equal to any other `double` (or `float`) value, including `NaN`. For more information and examples, see the <xref:System.Double.NaN?displayProperty=nameWithType> or <xref:System.Single.NaN?displayProperty=nameWithType> reference article.
@@ -61,7 +61,7 @@ As the preceding example shows, for reference-type members their reference value
 
 Two [string](../builtin-types/reference-types.md#the-string-type) operands are equal when both of them are `null` or both string instances are of the same length and have identical characters in each character position:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/EqualityOperators.cs" id="StringEquality":::
+:::code language="csharp" source="snippets/shared/EqualityOperators.cs" id="StringEquality":::
 
 String equality comparisons are case-sensitive ordinal comparisons. For more information about string comparison, see [How to compare strings in C#](../../how-to/compare-strings.md).
 
@@ -69,18 +69,18 @@ String equality comparisons are case-sensitive ordinal comparisons. For more inf
 
 Two [delegate](../../programming-guide/delegates/index.md) operands of the same run-time type are equal when both of them are `null` or their invocation lists are of the same length and have equal entries in each position:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/EqualityOperators.cs" id="DelegateEquality":::
+:::code language="csharp" source="snippets/shared/EqualityOperators.cs" id="DelegateEquality":::
 
 > [!IMPORTANT]
 > Equal entries in an invocation list include all fixed parameters in the invocation, including the receiver. The receiver is the instance of an object represented by `this` when the entry is invoked.
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/EqualityOperators.cs" id="SnippetCheckReceiver":::
+:::code language="csharp" source="snippets/shared/EqualityOperators.cs" id="SnippetCheckReceiver":::
 
 For more information, see the [Delegate equality operators](~/_csharpstandard/standard/expressions.md#12149-delegate-equality-operators) section of the [C# language specification](~/_csharpstandard/standard/README.md).
 
 Delegates that are produced from evaluation of semantically identical [lambda expressions](lambda-expressions.md) aren't equal, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/EqualityOperators.cs" id="IdenticalLambdas":::
+:::code language="csharp" source="snippets/shared/EqualityOperators.cs" id="IdenticalLambdas":::
 
 ## Inequality operator `!=`
 
@@ -88,7 +88,7 @@ The inequality operator `!=` returns `true` if its operands aren't equal, `false
 
 The following example demonstrates the usage of the `!=` operator:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/EqualityOperators.cs" id="NonEquality":::
+:::code language="csharp" source="snippets/shared/EqualityOperators.cs" id="NonEquality":::
 
 ## Operator overloadability
 

--- a/docs/csharp/language-reference/operators/index.md
+++ b/docs/csharp/language-reference/operators/index.md
@@ -38,15 +38,15 @@ Here are some other kinds of expressions that C# provides:
 
 - [Interpolated string expressions](../tokens/interpolated.md) that provide convenient syntax to create formatted strings:
 
-  [!code-csharp-interactive[interpolated string](snippets/shared/Overview.cs#InterpolatedString)]
+  [!code-csharp[interpolated string](snippets/shared/Overview.cs#InterpolatedString)]
 
 - [Lambda expressions](lambda-expressions.md) that allow you to create anonymous functions:
 
-  [!code-csharp-interactive[lambda expression](snippets/shared/Overview.cs#Lambda)]
+  [!code-csharp[lambda expression](snippets/shared/Overview.cs#Lambda)]
 
 - [Query expressions](../keywords/query-keywords.md) that allow you to use query capabilities directly in C#:
 
-  [!code-csharp-interactive[query expression](snippets/shared/Overview.cs#Query)]
+  [!code-csharp[query expression](snippets/shared/Overview.cs#Query)]
 
 You can use an [expression body definition](../../programming-guide/statements-expressions-operators/expression-bodied-members.md) to provide a concise definition for a method, constructor, property, indexer, or finalizer.
 

--- a/docs/csharp/language-reference/operators/lambda-expressions.md
+++ b/docs/csharp/language-reference/operators/lambda-expressions.md
@@ -29,15 +29,15 @@ To create a lambda expression, you specify input parameters (if any) on the left
 
 Any lambda expression can be converted to a [delegate](../builtin-types/reference-types.md#the-delegate-type) type. The types of its parameters and return value define the delegate type to which a lambda expression can be converted. If a lambda expression doesn't return a value, it can be converted to one of the `Action` delegate types; otherwise, it can be converted to one of the `Func` delegate types. For example, a lambda expression that has two parameters and returns no value can be converted to an <xref:System.Action%602> delegate. A lambda expression that has one parameter and returns a value can be converted to a <xref:System.Func%602> delegate. In the following example, the lambda expression `x => x * x`, which specifies a parameter named `x` and returns the value of `x` squared, is assigned to a variable of a delegate type:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/lambda-expressions/Introduction.cs" id="SnippetDelegate":::
+:::code language="csharp" source="snippets/lambda-expressions/Introduction.cs" id="SnippetDelegate":::
 
 Expression lambdas can also be converted to the [expression tree](../../advanced-topics/expression-trees/index.md) types, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/lambda-expressions/Introduction.cs" id="SnippetExpressionTree":::
+:::code language="csharp" source="snippets/lambda-expressions/Introduction.cs" id="SnippetExpressionTree":::
 
 You use lambda expressions in any code that requires instances of delegate types or expression trees. One example is the argument to the <xref:System.Threading.Tasks.Task.Run(System.Action)?displayProperty=nameWithType> method to pass the code that should be executed in the background. You can also use lambda expressions when you write [LINQ in C#](../../linq/index.md), as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/lambda-expressions/Introduction.cs" id="SnippetArgument":::
+:::code language="csharp" source="snippets/lambda-expressions/Introduction.cs" id="SnippetArgument":::
 
 When you use method-based syntax to call the <xref:System.Linq.Enumerable.Select%2A?displayProperty=nameWithType> method in the <xref:System.Linq.Enumerable?displayProperty=nameWithType> class, for example in LINQ to Objects and LINQ to XML, the parameter is a delegate type <xref:System.Func%602?displayProperty=nameWithType>. When you call the <xref:System.Linq.Queryable.Select%2A?displayProperty=nameWithType> method in the <xref:System.Linq.Queryable?displayProperty=nameWithType> class, for example in LINQ to SQL, the parameter type is an expression tree type [`Expression<Func<TSource,TResult>>`](<xref:System.Linq.Expressions.Expression%601>). In both cases, you can use the same lambda expression to specify the parameter value. That makes the two `Select` calls to look similar although in fact the type of objects created from the lambdas is different.
 
@@ -61,7 +61,7 @@ A statement lambda resembles an expression lambda except that its statements are
 
 The body of a statement lambda can consist of any number of statements; however, in practice there are typically no more than two or three.
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/lambda-expressions/GeneralExamples.cs" id="SnippetStatementLambda":::
+:::code language="csharp" source="snippets/lambda-expressions/GeneralExamples.cs" id="SnippetStatementLambda":::
 
 You can't use statement lambdas to create expression trees.
 
@@ -170,11 +170,11 @@ The C# language provides built-in support for [tuples](../builtin-types/value-tu
 
 You define a tuple by enclosing a comma-delimited list of its components in parentheses. The following example uses tuple with three components to pass a sequence of numbers to a lambda expression, which doubles each value and returns a tuple with three components that contains the result of the multiplications.
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/lambda-expressions/LambdasAndTuples.cs" id="SnippetWithoutComponentName":::
+:::code language="csharp" source="snippets/lambda-expressions/LambdasAndTuples.cs" id="SnippetWithoutComponentName":::
 
 Ordinarily, the fields of a tuple are named `Item1`, `Item2`, and so on. You can, however, define a tuple with named components, as the following example does.
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/lambda-expressions/LambdasAndTuples.cs" id="SnippetWithComponentName":::
+:::code language="csharp" source="snippets/lambda-expressions/LambdasAndTuples.cs" id="SnippetWithComponentName":::
 
 For more information about C# tuples, see [Tuple types](../../language-reference/builtin-types/value-tuples.md).
 
@@ -188,27 +188,27 @@ public delegate TResult Func<in T, out TResult>(T arg)
 
 The delegate can be instantiated as a `Func<int, bool>` instance where `int` is an input parameter and `bool` is the return value. The return value is always specified in the last type parameter. For example, `Func<int, string, bool>` defines a delegate with two input parameters, `int` and `string`, and a return type of `bool`. The following `Func` delegate, when invoked, returns Boolean value that indicates whether the input parameter is equal to five:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/lambda-expressions/LambdasWithQueryMethods.cs" id="SnippetFunc":::
+:::code language="csharp" source="snippets/lambda-expressions/LambdasWithQueryMethods.cs" id="SnippetFunc":::
 
 You can also supply a lambda expression when the argument type is an <xref:System.Linq.Expressions.Expression%601>, for example in the standard query operators that are defined in the <xref:System.Linq.Queryable> type. When you specify an <xref:System.Linq.Expressions.Expression%601> argument, the lambda is compiled to an expression tree.
 
 The following example uses the <xref:System.Linq.Enumerable.Count%2A> standard query operator:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/lambda-expressions/LambdasWithQueryMethods.cs" id="SnippetCount":::
+:::code language="csharp" source="snippets/lambda-expressions/LambdasWithQueryMethods.cs" id="SnippetCount":::
 
 The compiler can infer the type of the input parameter, or you can also specify it explicitly. This particular lambda expression counts those integers (`n`) which when divided by two have a remainder of 1.
 
 The following example produces a sequence that contains all elements in the `numbers` array that precede the 9, because that's the first number in the sequence that doesn't meet the condition:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/lambda-expressions/LambdasWithQueryMethods.cs" id="SnippetTakeWhile":::
+:::code language="csharp" source="snippets/lambda-expressions/LambdasWithQueryMethods.cs" id="SnippetTakeWhile":::
 
 The following example specifies multiple input parameters by enclosing them in parentheses. The method returns all the elements in the `numbers` array until it finds a number whose value is less than its ordinal position in the array:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/lambda-expressions/LambdasWithQueryMethods.cs" id="SnippetTakeWhileWithIndex":::
+:::code language="csharp" source="snippets/lambda-expressions/LambdasWithQueryMethods.cs" id="SnippetTakeWhileWithIndex":::
 
 You don't use lambda expressions directly in [query expressions](../keywords/query-keywords.md), but you can use them in method calls within query expressions, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/lambda-expressions/LambdasWithQueryMethods.cs" id="Query":::
+:::code language="csharp" source="snippets/lambda-expressions/LambdasWithQueryMethods.cs" id="Query":::
 
 ## Type inference in lambda expressions
 

--- a/docs/csharp/language-reference/operators/lambda-operator.md
+++ b/docs/csharp/language-reference/operators/lambda-operator.md
@@ -19,15 +19,15 @@ In [lambda expressions](lambda-expressions.md), the lambda operator `=>` separat
 
 The following example uses the [LINQ](../../linq/index.md) feature with method syntax to demonstrate the usage of lambda expressions:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/LambdaOperator.cs" id="InferredTypes":::
+:::code language="csharp" source="snippets/shared/LambdaOperator.cs" id="InferredTypes":::
 
 Input parameters of a lambda expression are strongly typed at compile time. When the compiler can infer the types of input parameters, like in the preceding example, you can omit type declarations. If you need to specify the type of input parameters, you must do that for each parameter, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/LambdaOperator.cs" id="ExplicitTypes":::
+:::code language="csharp" source="snippets/shared/LambdaOperator.cs" id="ExplicitTypes":::
 
 The following example shows how to define a lambda expression without input parameters:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/LambdaOperator.cs" id="WithoutInput":::
+:::code language="csharp" source="snippets/shared/LambdaOperator.cs" id="WithoutInput":::
 
 For more information, see [Lambda expressions](lambda-expressions.md).
 

--- a/docs/csharp/language-reference/operators/member-access-operators.md
+++ b/docs/csharp/language-reference/operators/member-access-operators.md
@@ -60,7 +60,7 @@ You use the `.` token to access a member of a namespace or a type, as the follow
 
 - Use `.` to access [type members](../../fundamentals/object-oriented/index.md#members), static and nonstatic, as the following code shows:
 
- :::code language="csharp" source="snippets/shared/MemberAccessOperators.cs" id="TypeMemberAccess" interactive="try-dotnet-method":::
+ :::code language="csharp" source="snippets/shared/MemberAccessOperators.cs" id="TypeMemberAccess":::
 
 You can also use `.` to access an [extension method](../../programming-guide/classes-and-structs/extension-methods.md).
 
@@ -72,7 +72,7 @@ Square brackets, `[]`, are typically used for array, indexer, or pointer element
 
 The following example demonstrates how to access array elements:
 
-:::code language="csharp" source="snippets/shared/MemberAccessOperators.cs" id="Arrays" interactive="try-dotnet-method":::
+:::code language="csharp" source="snippets/shared/MemberAccessOperators.cs" id="Arrays":::
 
 If an array index is outside the bounds of the corresponding dimension of an array, an <xref:System.IndexOutOfRangeException> is thrown.
 
@@ -84,7 +84,7 @@ For more information about arrays, see [Arrays](../builtin-types/arrays.md).
 
 The following example uses the .NET <xref:System.Collections.Generic.Dictionary%602> type to demonstrate indexer access:
 
-:::code language="csharp" source="snippets/shared/MemberAccessOperators.cs" id="Indexers" interactive="try-dotnet-method":::
+:::code language="csharp" source="snippets/shared/MemberAccessOperators.cs" id="Indexers":::
 
 Indexers allow you to index instances of a user-defined type in the similar way as array indexing. Unlike array indices, which must be integer, the indexer parameters can be declared to be of any type.
 
@@ -135,14 +135,14 @@ In the preceding example, `B` isn't evaluated and `C()` isn't called if `A` is n
 
 The following examples demonstrate the usage of the `?.` and `?[]` operators:
 
-:::code language="csharp" source="snippets/shared/MemberAccessOperators.cs" id="SnippetNullConditional" interactive="try-dotnet-method":::
-:::code language="csharp" source="snippets/shared/MemberAccessOperators2.cs" interactive="try-dotnet":::
+:::code language="csharp" source="snippets/shared/MemberAccessOperators.cs" id="SnippetNullConditional":::
+:::code language="csharp" source="snippets/shared/MemberAccessOperators2.cs":::
 
 The first preceding example also uses the [null-coalescing operator `??`](null-coalescing-operator.md) to specify an alternative expression to evaluate in case the result of a null-conditional operation is `null`.
 
 If `a.x` or `a[x]` is of a non-nullable value type `T`, `a?.x` or `a?[x]` is of the corresponding [nullable value type](../builtin-types/nullable-value-types.md) `T?`. If you need an expression of type `T`, apply the null-coalescing operator `??` to a null-conditional expression, as the following example shows:
 
-:::code language="csharp" source="snippets/shared/MemberAccessOperators.cs" id="NullConditionalWithNullCoalescing" interactive="try-dotnet-method":::
+:::code language="csharp" source="snippets/shared/MemberAccessOperators.cs" id="NullConditionalWithNullCoalescing":::
 
 In the preceding example, if you don't use the `??` operator, `numbers?.Length < 2` evaluates to `false` when `numbers` is `null`.
 
@@ -191,7 +191,7 @@ Use parentheses, `()`, to call a [method](../../programming-guide/classes-and-st
 
 The following code demonstrates how to call a method, with or without arguments, and invoke a delegate:
 
-:::code language="csharp" source="snippets/shared/MemberAccessOperators.cs" id="Invocation" interactive="try-dotnet-method":::
+:::code language="csharp" source="snippets/shared/MemberAccessOperators.cs" id="Invocation":::
 
 You also use parentheses when you invoke a [constructor](../../programming-guide/classes-and-structs/constructors.md) with the [`new`](new-operator.md) operator.
 

--- a/docs/csharp/language-reference/operators/nameof.md
+++ b/docs/csharp/language-reference/operators/nameof.md
@@ -14,7 +14,7 @@ helpviewer_keywords:
 
 A `nameof` expression produces the name of a variable, type, or member as the string constant. A `nameof` expression is evaluated at compile time and has no effect at run time. When the operand is a type or a namespace, the produced name isn't [fully qualified](~/_csharpstandard/standard/basic-concepts.md#783-fully-qualified-names). The following example shows the use of a `nameof` expression:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/NameOfOperator.cs" id="Examples":::
+:::code language="csharp" source="snippets/shared/NameOfOperator.cs" id="Examples":::
 
 The preceding example using `List<>` is supported in C# 14 and later. You can use a `nameof` expression to make the argument-checking code more maintainable:
 
@@ -28,7 +28,7 @@ A `nameof` expression with a parameter is useful when you use the [nullable anal
 
 When the operand is a [verbatim identifier](../tokens/verbatim.md), the `@` character isn't part of the name, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/shared/NameOfOperator.cs" id="Verbatim":::
+:::code language="csharp" source="snippets/shared/NameOfOperator.cs" id="Verbatim":::
 
 ## C# language specification
 

--- a/docs/csharp/language-reference/operators/new-operator.md
+++ b/docs/csharp/language-reference/operators/new-operator.md
@@ -16,11 +16,11 @@ The `new` operator creates a new instance of a type. You can also use the `new` 
 
 To create a new instance of a type, you typically invoke one of the [constructors](../../programming-guide/classes-and-structs/constructors.md) of that type using the `new` operator:
 
-[!code-csharp-interactive[invoke constructor](snippets/shared/NewOperator.cs#Constructor)]
+[!code-csharp[invoke constructor](snippets/shared/NewOperator.cs#Constructor)]
 
 You can use an [object or collection initializer](../../programming-guide/classes-and-structs/object-and-collection-initializers.md) with the `new` operator to instantiate and initialize an object in one statement, as the following example shows:
 
-[!code-csharp-interactive[constructor with initializer](snippets/shared/NewOperator.cs#ConstructorWithInitializer)]
+[!code-csharp[constructor with initializer](snippets/shared/NewOperator.cs#ConstructorWithInitializer)]
 
 ### Target-typed `new`
 
@@ -36,11 +36,11 @@ If a target type of a `new` expression is unknown (for example, when you use the
 
 You also use the `new` operator to create an array instance, as the following example shows:
 
-[!code-csharp-interactive[create array](snippets/shared/NewOperator.cs#Array)]
+[!code-csharp[create array](snippets/shared/NewOperator.cs#Array)]
 
 Use array initialization syntax to create an array instance and populate it with elements in one statement. The following example shows various ways how you can do that:
 
-[!code-csharp-interactive[initialize array](snippets/shared/NewOperator.cs#ArrayInitialization)]
+[!code-csharp[initialize array](snippets/shared/NewOperator.cs#ArrayInitialization)]
 
 For more information about arrays, see [Arrays](../builtin-types/arrays.md).
 
@@ -48,7 +48,7 @@ For more information about arrays, see [Arrays](../builtin-types/arrays.md).
 
 To create an instance of an [anonymous type](../../fundamentals/types/anonymous-types.md), use the `new` operator and object initializer syntax:
 
-[!code-csharp-interactive[anonymous type](snippets/shared/NewOperator.cs#AnonymousType)]
+[!code-csharp[anonymous type](snippets/shared/NewOperator.cs#AnonymousType)]
 
 ## Destruction of type instances
 

--- a/docs/csharp/language-reference/operators/null-coalescing-operator.md
+++ b/docs/csharp/language-reference/operators/null-coalescing-operator.md
@@ -47,17 +47,17 @@ The `??` and `??=` operators can be useful in the following scenarios:
 
 - In expressions with the [null-conditional operators `?.` and `?[]`](member-access-operators.md#null-conditional-operators--and-), you can use the `??` operator to provide an alternative expression to evaluate in case the result of the expression with null-conditional operations is `null`:
 
-  :::code language="csharp" source="snippets/shared/NullCoalescingOperator.cs" id="WithNullConditional" interactive="try-dotnet-method":::
+  :::code language="csharp" source="snippets/shared/NullCoalescingOperator.cs" id="WithNullConditional":::
 
 - When you work with [nullable value types](../builtin-types/nullable-value-types.md) and need to provide a value of an underlying value type, use the `??` operator to specify the value to provide in case a nullable type value is `null`:
 
-  :::code language="csharp" source="snippets/shared/NullCoalescingOperator.cs" id="WithNullableTypes" interactive="try-dotnet-method":::
+  :::code language="csharp" source="snippets/shared/NullCoalescingOperator.cs" id="WithNullableTypes":::
 
   Use the <xref:System.Nullable%601.GetValueOrDefault?displayProperty=nameWithType> method if the value to be used when a nullable type value is `null` should be the default value of the underlying value type.
 
 - You can use a [`throw` expression](../statements/exception-handling-statements.md#the-throw-expression) as the right-hand operand of the `??` operator to make the argument-checking code more concise:
 
-  :::code language="csharp" source="snippets/shared/NullCoalescingOperator.cs" id="WithThrowExpression" interactive="try-dotnet-method":::
+  :::code language="csharp" source="snippets/shared/NullCoalescingOperator.cs" id="WithThrowExpression":::
 
   The preceding example also demonstrates how to use [expression-bodied members](../../programming-guide/statements-expressions-operators/expression-bodied-members.md) to define a property.
 

--- a/docs/csharp/language-reference/operators/subtraction-operator.md
+++ b/docs/csharp/language-reference/operators/subtraction-operator.md
@@ -25,17 +25,17 @@ For operands of the same [delegate](../builtin-types/reference-types.md#the-dele
 
 - If both operands are non-null and the invocation list of the right-hand operand is a proper contiguous sublist of the invocation list of the left-hand operand, the result of the operation is a new invocation list that is obtained by removing the right-hand operand's entries from the invocation list of the left-hand operand. If the right-hand operand's list matches multiple contiguous sublists in the left-hand operand's list, only the right-most matching sublist is removed. If removal results in an empty list, the result is `null`.
 
-  :::code interactive="try-dotnet-method" language="csharp" source="snippets/shared/SubtractionOperator.cs" id="DelegateRemoval":::
+  :::code language="csharp" source="snippets/shared/SubtractionOperator.cs" id="DelegateRemoval":::
 
 - If the invocation list of the right-hand operand isn't a proper contiguous sublist of the invocation list of the left-hand operand, the result of the operation is the left-hand operand. For example, removing a delegate that isn't part of the multicast delegate does nothing and results in the unchanged multicast delegate.
 
-  :::code interactive="try-dotnet-method" language="csharp" source="snippets/shared/SubtractionOperator.cs" id="DelegateRemovalNoChange":::
+  :::code language="csharp" source="snippets/shared/SubtractionOperator.cs" id="DelegateRemovalNoChange":::
 
   The preceding example also demonstrates that during delegate removal delegate instances are compared. For example, delegates that are produced from evaluation of identical [lambda expressions](lambda-expressions.md) aren't equal. For more information about delegate equality, see the [Delegate equality operators](~/_csharpstandard/standard/expressions.md#12149-delegate-equality-operators) section of the [C# language specification](~/_csharpstandard/standard/README.md).
 
 - If the left-hand operand is `null`, the result of the operation is `null`. If the right-hand operand is `null`, the result of the operation is the left-hand operand.
 
-  :::code interactive="try-dotnet-method" language="csharp" source="snippets/shared/SubtractionOperator.cs" id="DelegateRemovalAndNull":::
+  :::code language="csharp" source="snippets/shared/SubtractionOperator.cs" id="DelegateRemovalAndNull":::
 
 To combine delegates, use the [`+` operator](addition-operator.md#delegate-combination).
 
@@ -59,7 +59,7 @@ Except that `x` is only evaluated once.
 
 The following example demonstrates the usage of the `-=` operator:
 
-:::code interactive="try-dotnet-method" language="csharp" source="snippets/shared/SubtractionOperator.cs" id="SubtractAndAssign":::
+:::code language="csharp" source="snippets/shared/SubtractionOperator.cs" id="SubtractAndAssign":::
 
 You also use the `-=` operator to specify an event handler method to remove when you unsubscribe from an [event](../keywords/event.md). For more information, see [How to subscribe to and unsubscribe from events](../../programming-guide/events/how-to-subscribe-to-and-unsubscribe-from-events.md).
 

--- a/docs/csharp/language-reference/operators/type-testing-and-cast.md
+++ b/docs/csharp/language-reference/operators/type-testing-and-cast.md
@@ -55,7 +55,7 @@ The following example demonstrates that the `is` operator returns `true` if the 
 
 The next example shows that the `is` operator takes into account boxing and unboxing conversions but doesn't consider [numeric conversions](../builtin-types/numeric-conversions.md):
 
-:::code interactive="try-dotnet-method" language="csharp" source="snippets/shared/TypeTestingAndConversionOperators.cs" id="IsWithInt":::
+:::code language="csharp" source="snippets/shared/TypeTestingAndConversionOperators.cs" id="IsWithInt":::
 
 For information about C# conversions, see the [Conversions](~/_csharpstandard/standard/conversions.md) chapter of the [C# language specification](~/_csharpstandard/standard/README.md).
 
@@ -63,7 +63,7 @@ For information about C# conversions, see the [Conversions](~/_csharpstandard/st
 
 The `is` operator also tests an expression result against a pattern. The following example shows how to use a [declaration pattern](patterns.md#declaration-and-type-patterns) to check the run-time type of an expression:
 
-:::code interactive="try-dotnet-method" language="csharp" source="snippets/shared/TypeTestingAndConversionOperators.cs" id="IsDeclarationPattern":::
+:::code language="csharp" source="snippets/shared/TypeTestingAndConversionOperators.cs" id="IsDeclarationPattern":::
 
 For information about the supported patterns, see [Patterns](patterns.md).
 
@@ -89,7 +89,7 @@ The `as` operator considers only reference, nullable, boxing, and unboxing conve
 
 The following example demonstrates the usage of the `as` operator:
 
-:::code interactive="try-dotnet-method" language="csharp" source="snippets/shared/TypeTestingAndConversionOperators.cs" id="AsOperator":::
+:::code language="csharp" source="snippets/shared/TypeTestingAndConversionOperators.cs" id="AsOperator":::
 
 > [!NOTE]
 > As the preceding example shows, you need to compare the result of the `as` expression with `null` to check if the conversion was successful. You can use the [`is` operator](#type-testing-with-pattern-matching) both to test if the conversion succeeds and, if it succeeds, assign its result to a new variable.
@@ -100,7 +100,7 @@ A cast expression of the form `(T)E` performs an explicit conversion of the resu
 
 The following example demonstrates explicit numeric and reference conversions:
 
-:::code interactive="try-dotnet-method" language="csharp" source="snippets/shared/TypeTestingAndConversionOperators.cs" id="Cast":::
+:::code language="csharp" source="snippets/shared/TypeTestingAndConversionOperators.cs" id="Cast":::
 
 For information about supported explicit conversions, see the [Explicit conversions](~/_csharpstandard/standard/conversions.md#103-explicit-conversions) section of the [C# language specification](~/_csharpstandard/standard/README.md). For information about how to define a custom explicit or implicit type conversion, see [User-defined conversion operators](user-defined-conversion-operators.md).
 
@@ -114,7 +114,7 @@ Other use of parentheses is to adjust the order in which to evaluate operations 
 
 The `typeof` operator obtains the <xref:System.Type?displayProperty=nameWithType> instance for a type. The argument to the `typeof` operator must be the name of a type or a type parameter, as the following example shows:
 
-:::code interactive="try-dotnet-method" language="csharp" source="snippets/shared/TypeTestingAndConversionOperators.cs" id="TypeOf":::
+:::code language="csharp" source="snippets/shared/TypeTestingAndConversionOperators.cs" id="TypeOf":::
 
 The argument mustn't be a type that requires metadata annotations. Examples include the following types:
 
@@ -125,7 +125,7 @@ These types aren't directly represented in metadata. The types include attribute
 
 You can also use the `typeof` operator with unbound generic types. The name of an unbound generic type must contain the appropriate number of commas, which is one less than the number of type parameters. The following example shows the usage of the `typeof` operator with an unbound generic type:
 
-:::code interactive="try-dotnet-method" language="csharp" source="snippets/shared/TypeTestingAndConversionOperators.cs" id="TypeOfUnboundGeneric":::
+:::code language="csharp" source="snippets/shared/TypeTestingAndConversionOperators.cs" id="TypeOfUnboundGeneric":::
 
 An expression can't be an argument of the `typeof` operator. To get the <xref:System.Type?displayProperty=nameWithType> instance for the run-time type of an expression result, use the <xref:System.Object.GetType%2A?displayProperty=nameWithType> method.
 
@@ -133,7 +133,7 @@ An expression can't be an argument of the `typeof` operator. To get the <xref:Sy
 
 Use the `typeof` operator to check if the run-time type of the expression result exactly matches a given type. The following example demonstrates the difference between type checking done with the `typeof` operator and the [`is` operator](#the-is-operator):
 
-:::code interactive="try-dotnet-method" language="csharp" source="snippets/shared/TypeTestingAndConversionOperators.cs" id="TypeCheckWithTypeOf":::
+:::code language="csharp" source="snippets/shared/TypeTestingAndConversionOperators.cs" id="TypeCheckWithTypeOf":::
 
 ## Operator overloadability
 

--- a/docs/csharp/language-reference/statements/checked-and-unchecked.md
+++ b/docs/csharp/language-reference/statements/checked-and-unchecked.md
@@ -15,7 +15,7 @@ helpviewer_keywords:
 
 The `checked` and `unchecked` statements specify the overflow-checking context for integral-type arithmetic operations and conversions. The default statement is `unchecked`. When integer arithmetic overflow occurs, the overflow-checking context defines what happens. In a checked context, a <xref:System.OverflowException?displayProperty=nameWithType> is thrown; if overflow happens in a constant expression, a compile-time error occurs. In an unchecked context, the operation result is truncated by discarding any high-order bits that don't fit in the destination type. For example, addition wraps from the maximum value to the minimum value. The following example shows the same operation in both a checked and unchecked context:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/checked-and-unchecked/Program.cs" id="MainExample":::
+:::code language="csharp" source="snippets/checked-and-unchecked/Program.cs" id="MainExample":::
 
 > [!NOTE]
 > The overflow behavior of *user-defined* operators and conversions can differ from the one described in the preceding paragraph. In particular, [user-defined checked operators](../operators/arithmetic-operators.md#user-defined-checked-operators) might not throw an exception in a checked context.
@@ -24,11 +24,11 @@ For more information, see the [Arithmetic overflow and division by zero](../oper
 
 To specify the overflow-checking context for an expression, you can also use the `checked` and `unchecked` operators, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/checked-and-unchecked/Program.cs" id="OperatorForm":::
+:::code language="csharp" source="snippets/checked-and-unchecked/Program.cs" id="OperatorForm":::
 
 The `checked` and `unchecked` statements and operators only affect the overflow-checking context for those operations that are *textually* inside the statement block or operator's parentheses, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/checked-and-unchecked/Program.cs" id="ScopeExample":::
+:::code language="csharp" source="snippets/checked-and-unchecked/Program.cs" id="ScopeExample":::
 
 At the preceding example, the first invocation of the `Multiply` local function shows that the `checked` statement doesn't affect the overflow-checking context within the `Multiply` function as no exception is thrown. At the second invocation of the `Multiply` function, the expression that calculates the second argument of the function is evaluated in a checked context and results in an exception as it's textually inside the block of the `checked` statement.
 

--- a/docs/csharp/language-reference/statements/declarations.md
+++ b/docs/csharp/language-reference/statements/declarations.md
@@ -34,7 +34,7 @@ For information about local reference variables, see the [Reference variables](#
 
 When you declare a local variable, you can let the compiler infer the type of the variable from the initialization expression. To do that use the `var` keyword instead of the name of a type:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/declarations/ImplicitlyTyped.cs" id="ImplicitlyTyped":::
+:::code language="csharp" source="snippets/declarations/ImplicitlyTyped.cs" id="ImplicitlyTyped":::
 
 As the preceding example shows, implicitly-typed local variables are strongly typed.
 
@@ -74,7 +74,7 @@ ref int aliasOfvariable = ref variable;
 
 A reference variable is a variable that refers to another variable, which is called the *referent*. That is, a reference variable is an *alias* to its referent. When you assign a value to a reference variable, that value is assigned to the referent. When you read the value of a reference variable, the referent's value is returned. The following example demonstrates that behavior:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/declarations/ReferenceVariables.cs" id="AliasToLocalVariable":::
+:::code language="csharp" source="snippets/declarations/ReferenceVariables.cs" id="AliasToLocalVariable":::
 
 Use the [`ref` assignment operator](../operators/assignment-operator.md#ref-assignment) `= ref` to change the referent of a reference variable, as the following example shows:
 

--- a/docs/csharp/language-reference/statements/iteration-statements.md
+++ b/docs/csharp/language-reference/statements/iteration-statements.md
@@ -28,7 +28,7 @@ At any point within the body of an iteration statement, you can break out of the
 
 The `for` statement executes a statement or a block of statements while a specified Boolean expression evaluates to `true`. The following example shows the `for` statement that executes its body while an integer counter is less than three:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/iteration-statements/ForStatement.cs" id="TypicalExample":::
+:::code language="csharp" source="snippets/iteration-statements/ForStatement.cs" id="TypicalExample":::
 
 The preceding example shows the elements of the `for` statement:
 
@@ -69,7 +69,7 @@ The iterator section can contain zero or more of the following statement express
 
 If you don't declare a loop variable in the initializer section, you can use zero or more of the expressions from the preceding list in the initializer section as well. The following example shows several less common usages of the initializer and iterator sections: assigning a value to an external variable in the initializer section, invoking a method in both the initializer and the iterator sections, and changing the values of two variables in the iterator section:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/iteration-statements/ForStatement.cs" id="MultipleExpressions":::
+:::code language="csharp" source="snippets/iteration-statements/ForStatement.cs" id="MultipleExpressions":::
 
 All the sections of the `for` statement are optional. For example, the following code defines the infinite `for` loop:
 
@@ -79,7 +79,7 @@ All the sections of the `for` statement are optional. For example, the following
 
 The `foreach` statement executes a statement or a block of statements for each element in an instance of the type that implements the <xref:System.Collections.IEnumerable?displayProperty=nameWithType> or <xref:System.Collections.Generic.IEnumerable%601?displayProperty=nameWithType> interface, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/iteration-statements/ForeachStatement.cs" id="WithIEnumerable":::
+:::code language="csharp" source="snippets/iteration-statements/ForeachStatement.cs" id="WithIEnumerable":::
 
 The `foreach` statement isn't limited to those types. You can use it with an instance of any type that satisfies the following conditions:
 
@@ -136,7 +136,7 @@ The `do` statement executes a statement or a block of statements while a specifi
 
 The following example shows the usage of the `do` statement:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/iteration-statements/DoStatement.cs" id="Example":::
+:::code language="csharp" source="snippets/iteration-statements/DoStatement.cs" id="Example":::
 
 ## The `while` statement
 
@@ -144,7 +144,7 @@ The `while` statement executes a statement or a block of statements while a spec
 
 The following example shows the usage of the `while` statement:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/iteration-statements/WhileStatement.cs" id="Example":::
+:::code language="csharp" source="snippets/iteration-statements/WhileStatement.cs" id="Example":::
 
 ## C# language specification
 

--- a/docs/csharp/language-reference/statements/jump-statements.md
+++ b/docs/csharp/language-reference/statements/jump-statements.md
@@ -27,11 +27,11 @@ For information about the `throw` statement that throws an exception and uncondi
 
 The `break` statement terminates the closest enclosing [iteration statement](iteration-statements.md) (that is, `for`, `foreach`, `while`, or `do` loop) or [`switch` statement](selection-statements.md#the-switch-statement). The `break` statement transfers control to the statement that follows the terminated statement, if any.
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/jump-statements/BreakStatement.cs" id="BasicExample":::
+:::code language="csharp" source="snippets/jump-statements/BreakStatement.cs" id="BasicExample":::
 
 In nested loops, the `break` statement terminates only the innermost loop that contains it, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/jump-statements/BreakStatement.cs" id="NestedLoop":::
+:::code language="csharp" source="snippets/jump-statements/BreakStatement.cs" id="NestedLoop":::
 
 When you use the `switch` statement inside a loop, a `break` statement at the end of a switch section transfers control only out of the `switch` statement. The loop that contains the `switch` statement is unaffected, as the following example shows:
 
@@ -41,7 +41,7 @@ When you use the `switch` statement inside a loop, a `break` statement at the en
 
 The `continue` statement starts a new iteration of the closest enclosing [iteration statement](iteration-statements.md) (that is, `for`, `foreach`, `while`, or `do` loop), as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/jump-statements/ContinueStatement.cs" id="BasicExample":::
+:::code language="csharp" source="snippets/jump-statements/ContinueStatement.cs" id="BasicExample":::
 
 ## The `return` statement
 
@@ -49,13 +49,13 @@ The `return` statement terminates execution of the function in which it appears 
 
 If a function member doesn't compute a value, you use the `return` statement without expression, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/jump-statements/ReturnStatement.cs" id="WithoutExpression":::
+:::code language="csharp" source="snippets/jump-statements/ReturnStatement.cs" id="WithoutExpression":::
 
 As the preceding example shows, you typically use the `return` statement without expression to terminate a function member early. If a function member doesn't contain the `return` statement, it terminates after its last statement is executed.
 
 If a function member computes a value, you use the `return` statement with an expression, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/jump-statements/ReturnStatement.cs" id="WithExpression":::
+:::code language="csharp" source="snippets/jump-statements/ReturnStatement.cs" id="WithExpression":::
 
 When the `return` statement has an expression, that expression must be implicitly convertible to the return type of a function member unless it's [async](../keywords/async.md). The expression returned from an `async` function must be implicitly convertible to the type argument of <xref:System.Threading.Tasks.Task%601> or <xref:System.Threading.Tasks.ValueTask%601>, whichever is the return type of the function. If the return type of an `async` function is <xref:System.Threading.Tasks.Task> or <xref:System.Threading.Tasks.ValueTask>, you use the `return` statement without expression.
 
@@ -63,7 +63,7 @@ When the `return` statement has an expression, that expression must be implicitl
 
 By default, the `return` statement returns the value of an expression. You can return a reference to a variable. Reference return values (or ref returns) are values that a method returns by reference to the caller. That is, the caller can modify the value returned by a method, and that change is reflected in the state of the object in the called method. To do that, use the `return` statement with the `ref` keyword, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/jump-statements/ReturnStatement.cs" id="RefReturn":::
+:::code language="csharp" source="snippets/jump-statements/ReturnStatement.cs" id="RefReturn":::
 
 A reference return value allows a method to return a reference to a variable, rather than a value, back to a caller. The caller can then choose to treat the returned variable as if it were returned by value or by reference. The caller can create a new variable that is itself a reference to the returned value, called a [ref local](declarations.md#reference-variables). A *reference return value* means that a method returns a *reference* (or an alias) to some variable. That variable's scope must include the method. That variable's lifetime must extend beyond the return of the method. Modifications to the method's return value by the caller are made to the variable that is returned by the method.
 
@@ -129,7 +129,7 @@ As the preceding example shows, you can use the `goto` statement to get out of a
 
 You can also use the `goto` statement in the [`switch` statement](selection-statements.md#the-switch-statement) to transfer control to a switch section with a constant case label, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet" source="snippets/jump-statements/GotoInSwitchExample.cs":::
+:::code language="csharp" source="snippets/jump-statements/GotoInSwitchExample.cs":::
 
 Within the `switch` statement, you can also use the statement `goto default;` to transfer control to the switch section with the `default` label.
 

--- a/docs/csharp/language-reference/statements/selection-statements.md
+++ b/docs/csharp/language-reference/statements/selection-statements.md
@@ -27,15 +27,15 @@ An `if` statement can be any of the following two forms:
 
 - An `if` statement with an `else` part selects one of the two statements to execute based on the value of a Boolean expression, as the following example shows:
 
-  :::code language="csharp" interactive="try-dotnet-method" source="snippets/selection-statements/IfStatement.cs" id="IfElse":::
+  :::code language="csharp" source="snippets/selection-statements/IfStatement.cs" id="IfElse":::
 
 - An `if` statement without an `else` part executes its body only if a Boolean expression evaluates to `true`, as the following example shows:
 
-  :::code language="csharp" interactive="try-dotnet-method" source="snippets/selection-statements/IfStatement.cs" id="OnlyIf":::
+  :::code language="csharp" source="snippets/selection-statements/IfStatement.cs" id="OnlyIf":::
 
 You can nest `if` statements to check multiple conditions, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/selection-statements/IfStatement.cs" id="NestedIf":::
+:::code language="csharp" source="snippets/selection-statements/IfStatement.cs" id="NestedIf":::
 
 In an expression context, you can use the [conditional operator `?:`](../operators/conditional-operator.md) to evaluate one of the two expressions based on the value of a Boolean expression.
 

--- a/docs/csharp/language-reference/statements/yield.md
+++ b/docs/csharp/language-reference/statements/yield.md
@@ -14,11 +14,11 @@ You use the `yield` statement in an [iterator](../../iterators.md) to provide th
 
 - `yield return`: to provide the next value in iteration, as the following example shows:
 
-  :::code language="csharp" interactive="try-dotnet-method" source="snippets/yield/Program.cs" id="YieldReturn":::
+  :::code language="csharp" source="snippets/yield/Program.cs" id="YieldReturn":::
 
 - `yield break`: to explicitly signal the end of iteration, as the following example shows:
 
-  :::code language="csharp" interactive="try-dotnet-method" source="snippets/yield/Program.cs" id="YieldBreak":::
+  :::code language="csharp" source="snippets/yield/Program.cs" id="YieldBreak":::
 
   Iteration also finishes when control reaches the end of an iterator.
 
@@ -44,7 +44,7 @@ You can't use the `yield` statements in:
 
 You can use [`using` statements](using.md) in iterator methods. Since `using` statements are compiled into `try` blocks with `finally` clauses (and no `catch` blocks), they work correctly with iterators. The disposable resources are properly managed throughout the iterator's execution:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/yield/Program.cs" id="UsingInIterator":::
+:::code language="csharp" source="snippets/yield/Program.cs" id="UsingInIterator":::
 
 As the preceding example shows, the resource acquired in the `using` statement remains available throughout the iterator's execution, even when the iterator suspends and resumes execution at `yield return` statements. The resource is disposed when the iterator completes (either by reaching the end or via `yield break`) or when the iterator itself is disposed (for example, when the caller breaks out of enumeration early).
 
@@ -52,7 +52,7 @@ As the preceding example shows, the resource acquired in the `using` statement r
 
 The call of an iterator doesn't execute it immediately, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="snippets/yield/Program.cs" id="IteratorExecution":::
+:::code language="csharp" source="snippets/yield/Program.cs" id="IteratorExecution":::
 
 As the preceding example shows, when you start to iterate over an iterator's result, an iterator is executed until the first `yield return` statement is reached. Then, the execution of an iterator is suspended and the caller gets the first iteration value and processes it. On each subsequent iteration, the execution of an iterator resumes after the `yield return` statement that caused the previous suspension and continues until the next `yield return` statement is reached. The iteration completes when control reaches the end of an iterator or a `yield break` statement.
 

--- a/docs/csharp/language-reference/tokens/interpolated.md
+++ b/docs/csharp/language-reference/tokens/interpolated.md
@@ -18,7 +18,7 @@ The `$` character identifies a string literal as an _interpolated string_. An in
 
 String interpolation provides a more readable, convenient syntax to format strings. It's easier to read than [string composite formatting](../../../standard/base-types/composite-formatting.md). The following example uses both features to produce the same output:
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/string-interpolation.cs" id="CompareWithCompositeFormatting":::
+:::code language="csharp" source="./snippets/string-interpolation.cs" id="CompareWithCompositeFormatting":::
 
 You can use an interpolated string to initialize a [constant](../keywords/const.md) string. You can do that only if all interpolation expressions within the interpolated string are constant strings as well.
 
@@ -42,7 +42,7 @@ Elements in square brackets are optional. The following table describes each ele
 
 The following example uses optional formatting components described in the preceding table:
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/string-interpolation.cs" id="AlignAndSpecifyFormat":::
+:::code language="csharp" source="./snippets/string-interpolation.cs" id="AlignAndSpecifyFormat":::
 
 You can use new-lines within an interpolation expression to make the expression's code more readable. The following example shows how new-lines can improve the readability of an expression involving [pattern matching](../operators/patterns.md):
 
@@ -70,7 +70,7 @@ The colon (":") has special meaning in an interpolation expression item. To use 
 
 The following example shows how to include a brace in a result string. It also shows how to use a conditional operator:
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/string-interpolation.cs" id="BraceAndConditional":::
+:::code language="csharp" source="./snippets/string-interpolation.cs" id="BraceAndConditional":::
 
 An interpolated [verbatim](verbatim.md) string starts with both the `$` and `@` characters. You can use `$` and `@` in any order: both `$@"..."` and `@$"..."` are valid interpolated verbatim strings. For more information about verbatim strings, see the [string](../builtin-types/reference-types.md) and [verbatim identifier](verbatim.md) articles.
 

--- a/docs/csharp/tutorials/string-interpolation.md
+++ b/docs/csharp/tutorials/string-interpolation.md
@@ -13,7 +13,7 @@ This tutorial shows you how to use [string interpolation](../language-reference/
 
 To identify a string literal as an interpolated string, prepend it with the `$` symbol. You can embed any valid C# expression that returns a value in an interpolated string. In the following example, as soon as an expression is evaluated, its result is converted into a string and included in a result string:
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/StringInterpolation/Program.cs" id="General":::
+:::code language="csharp" source="./snippets/StringInterpolation/Program.cs" id="General":::
 
 As the example shows, you include an expression in an interpolated string by enclosing it with braces:
 
@@ -41,7 +41,7 @@ To specify a format string supported by the type of the expression result, follo
 
 The following example shows how to specify standard and custom format strings for expressions that produce date and time or numeric results:
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/StringInterpolation/Program.cs" id="FormatString":::
+:::code language="csharp" source="./snippets/StringInterpolation/Program.cs" id="FormatString":::
 
 For more information, see the [Format string component](../../standard/base-types/composite-formatting.md#format-string-component) section of the [Composite formatting](../../standard/base-types/composite-formatting.md) article.
 
@@ -55,7 +55,7 @@ To specify the minimum field width and the alignment of the formatted expression
 
 The following code sample uses the minimum field width to create a tabular output:
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/StringInterpolation/Program.cs" id="AlignmentString":::
+:::code language="csharp" source="./snippets/StringInterpolation/Program.cs" id="AlignmentString":::
 
 If the *width* value is positive, the formatted expression result is right-aligned; if negative, it's left-aligned. Remove the `-` signs before the width specifier and run the sample again to see the results.
 
@@ -67,7 +67,7 @@ If you need to specify both width and a format string, start with the width comp
 
 The following example shows how to specify width and alignment, and uses pipe characters ("|") to delimit text fields:
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/StringInterpolation/Program.cs" id="AlignmentAndFormatString":::
+:::code language="csharp" source="./snippets/StringInterpolation/Program.cs" id="AlignmentAndFormatString":::
 
 As the example output shows, if the length of the formatted expression result exceeds specified field width, the *width* value is ignored.
 
@@ -83,7 +83,7 @@ To include a brace, "{" or "}", in a result string, use two braces, "{{" or "}}"
 
 The following example shows how to include braces in a result string and construct a verbatim interpolated string:
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/StringInterpolation/Program.cs" id="Escapes":::
+:::code language="csharp" source="./snippets/StringInterpolation/Program.cs" id="Escapes":::
 
 You can use [interpolated raw string literals](../language-reference/tokens/interpolated.md#interpolated-raw-string-literals).
 
@@ -91,7 +91,7 @@ You can use [interpolated raw string literals](../language-reference/tokens/inte
 
 As the colon (":") has special meaning in an item with an interpolation expression, in order to use a [conditional operator](../language-reference/operators/conditional-operator.md) in an expression, enclose it in parentheses, as the following example shows:
 
-:::code language="csharp" interactive="try-dotnet-method" source="./snippets/StringInterpolation/Program.cs" id="ConditionalOperator":::
+:::code language="csharp" source="./snippets/StringInterpolation/Program.cs" id="ConditionalOperator":::
 
 ## How to create a culture-specific result string with string interpolation
 

--- a/docs/fundamentals/runtime-libraries/system-boolean.md
+++ b/docs/fundamentals/runtime-libraries/system-boolean.md
@@ -29,19 +29,19 @@ You use the <xref:System.Boolean.ToString%2A> method to convert Boolean values t
 
 The following example illustrates formatting with the <xref:System.Boolean.ToString%2A> method. Note that the C# and VB examples use the [composite formatting](../../standard/base-types/composite-formatting.md) feature, while the F# example uses [string interpolation](../../fsharp/language-reference/interpolated-strings.md). In both cases the <xref:System.Boolean.ToString%2A> method is called implicitly.
 
-:::code language="csharp" source="./snippets/System/Boolean/Overview/csharp/tostring1.cs" interactive="try-dotnet" id="Snippet3":::
+:::code language="csharp" source="./snippets/System/Boolean/Overview/csharp/tostring1.cs" id="Snippet3":::
 :::code language="fsharp" source="./snippets/System/Boolean/Overview/fsharp/tostring1.fs" id="Snippet3":::
 :::code language="vb" source="./snippets/System/Boolean/Overview/vb/tostring1.vb" id="Snippet3":::
 
 Because the <xref:System.Boolean> structure can have only two values, it is easy to add custom formatting. For simple custom formatting in which other string literals are substituted for "True" and "False", you can use any conditional evaluation feature supported by your language, such as the [conditional operator](../../csharp/language-reference/operators/conditional-operator.md) in C# or the [If operator](../../visual-basic/language-reference/operators/if-operator.md) in Visual Basic. The following example uses this technique to format <xref:System.Boolean> values as "Yes" and "No" rather than "True" and "False".
 
-:::code language="csharp" source="./snippets/System/Boolean/Overview/csharp/tostring2.cs" interactive="try-dotnet" id="Snippet4":::
+:::code language="csharp" source="./snippets/System/Boolean/Overview/csharp/tostring2.cs" id="Snippet4":::
 :::code language="vb" source="./snippets/System/Boolean/Overview/vb/tostring2.vb" id="Snippet4":::
 :::code language="fsharp" source="./snippets/System/Boolean/Overview/fsharp/tostring2.fs" id="Snippet4":::
 
 For more complex custom formatting operations, including culture-sensitive formatting, you can call the <xref:System.String.Format%28System.IFormatProvider%2CSystem.String%2CSystem.Object%5B%5D%29?displayProperty=nameWithType> method and provide an <xref:System.ICustomFormatter> implementation. The following example implements the <xref:System.ICustomFormatter> and <xref:System.IFormatProvider> interfaces to provide culture-sensitive Boolean strings for the English (United States), French (France), and Russian (Russia) cultures.
 
-:::code language="csharp" source="./snippets/System/Boolean/Overview/csharp/format3.cs" interactive="try-dotnet" id="Snippet5":::
+:::code language="csharp" source="./snippets/System/Boolean/Overview/csharp/format3.cs" id="Snippet5":::
 :::code language="fsharp" source="./snippets/System/Boolean/Overview/fsharp/format3.fs" id="Snippet5":::
 :::code language="vb" source="./snippets/System/Boolean/Overview/vb/format3.vb" id="Snippet5":::
 
@@ -57,13 +57,13 @@ The <xref:System.Boolean> structure implements the <xref:System.IConvertible> in
 
 All conversions from integral or floating-point numbers to Boolean values convert non-zero values to `true` and zero values to `false`. The following example illustrates this by calling selected overloads of the <xref:System.Convert.ToBoolean%2A?displayProperty=nameWithType> class.
 
-:::code language="csharp" source="./snippets/System/Boolean/Overview/csharp/conversion1.cs" interactive="try-dotnet" id="Snippet6":::
+:::code language="csharp" source="./snippets/System/Boolean/Overview/csharp/conversion1.cs" id="Snippet6":::
 :::code language="fsharp" source="./snippets/System/Boolean/Overview/fsharp/conversion1.fs" id="Snippet6":::
 :::code language="vb" source="./snippets/System/Boolean/Overview/vb/conversion1.vb" id="Snippet6":::
 
 When converting from Boolean to numeric values, the conversion methods of the <xref:System.Convert> class convert `true` to 1 and `false` to 0. However, Visual Basic conversion functions convert `true` to either 255 (for conversions to <xref:System.Byte> values) or -1 (for all other numeric conversions). The following example converts `true` to numeric values by using a <xref:System.Convert> method, and, in the case of the Visual Basic example, by using the Visual Basic language's own conversion operator.
 
-:::code language="csharp" source="./snippets/System/Boolean/Overview/csharp/conversion3.cs" interactive="try-dotnet" id="Snippet8":::
+:::code language="csharp" source="./snippets/System/Boolean/Overview/csharp/conversion3.cs" id="Snippet8":::
 :::code language="fsharp" source="./snippets/System/Boolean/Overview/fsharp/conversion3.fs" id="Snippet8":::
 :::code language="vb" source="./snippets/System/Boolean/Overview/vb/conversion3.vb" id="Snippet8":::
 
@@ -75,13 +75,13 @@ The <xref:System.Boolean> structure includes two static parsing methods, <xref:S
 
 The following example uses the <xref:System.Boolean.Parse%2A> and <xref:System.Boolean.TryParse%2A> methods to parse a number of strings. Note that only the case-insensitive equivalents of "True" and "False" can be successfully parsed.
 
-:::code language="csharp" source="./snippets/System/Boolean/Overview/csharp/parse2.cs" interactive="try-dotnet" id="Snippet2":::
+:::code language="csharp" source="./snippets/System/Boolean/Overview/csharp/parse2.cs" id="Snippet2":::
 :::code language="fsharp" source="./snippets/System/Boolean/Overview/fsharp/parse2.fs" id="Snippet2":::
 :::code language="vb" source="./snippets/System/Boolean/Overview/vb/parse2.vb" id="Snippet2":::
 
 If you're programming in Visual Basic, you can use the `CBool` function to convert the string representation of a number to a Boolean value. "0" is converted to `false`, and the string representation of any non-zero value is converted to `true`. If you're not programming in Visual Basic, you must convert your numeric string to a number before converting it to a Boolean. The following example illustrates this by converting an array of integers to Boolean values.
 
-:::code language="csharp" source="./snippets/System/Boolean/Overview/csharp/parse3.cs" interactive="try-dotnet" id="Snippet9":::
+:::code language="csharp" source="./snippets/System/Boolean/Overview/csharp/parse3.cs" id="Snippet9":::
 :::code language="fsharp" source="./snippets/System/Boolean/Overview/fsharp/parse3.fs" id="Snippet9":::
 :::code language="vb" source="./snippets/System/Boolean/Overview/vb/parse3.vb" id="Snippet9":::
 
@@ -115,7 +115,7 @@ You can convert a Boolean value to its binary representation by calling the <xre
 
 The following example calls the <xref:System.BitConverter.GetBytes%2A?displayProperty=nameWithType> method to convert a Boolean value to its binary representation and displays the individual bits of the value, and then calls the <xref:System.BitConverter.ToBoolean%2A?displayProperty=nameWithType> method to restore the value from its binary representation.
 
-:::code language="csharp" source="./snippets/System/Boolean/Overview/csharp/binary1.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/Boolean/Overview/csharp/binary1.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/Boolean/Overview/fsharp/binary1.fs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/Boolean/Overview/vb/binary1.vb" id="Snippet1":::
 

--- a/docs/fundamentals/runtime-libraries/system-byte.md
+++ b/docs/fundamentals/runtime-libraries/system-byte.md
@@ -25,19 +25,19 @@ You can instantiate a <xref:System.Byte> value in several ways:
 
 - You can assign a non-byte numeric value to a byte. This is a narrowing conversion, so it requires a cast operator in C# and F#, or a conversion method in Visual Basic if `Option Strict` is on. If the non-byte value is a <xref:System.Single>, <xref:System.Double>, or <xref:System.Decimal> value that includes a fractional component, the handling of its fractional part depends on the compiler performing the conversion. The following example assigns several numeric values to <xref:System.Byte> variables.
 
-  :::code language="csharp" source="./snippets/System/Byte/Overview/csharp/byteinstantiation1.cs" interactive="try-dotnet-method" id="Snippet2":::
+  :::code language="csharp" source="./snippets/System/Byte/Overview/csharp/byteinstantiation1.cs" id="Snippet2":::
   :::code language="fsharp" source="./snippets/System/Byte/Overview/fsharp/byteinstantiation1.fs" id="Snippet2":::
   :::code language="vb" source="./snippets/System/Byte/Overview/vb/byteinstantiate1.vb" id="Snippet2":::
 
 - You can call a method of the <xref:System.Convert> class to convert any supported type to a <xref:System.Byte> value. This is possible because <xref:System.Byte> supports the <xref:System.IConvertible> interface. The following example illustrates the conversion of an array of <xref:System.Int32> values to <xref:System.Byte> values.
 
-  :::code language="csharp" source="./snippets/System/Byte/Overview/csharp/tobyte1.cs" interactive="try-dotnet-method" id="Snippet4":::
+  :::code language="csharp" source="./snippets/System/Byte/Overview/csharp/tobyte1.cs" id="Snippet4":::
   :::code language="fsharp" source="./snippets/System/Byte/Overview/fsharp/tobyte1.fs" id="Snippet4":::
   :::code language="vb" source="./snippets/System/Convert/Overview/vb/tobyte1.vb" id="Snippet4":::
 
 - You can call the <xref:System.Byte.Parse%2A> or <xref:System.Byte.TryParse%2A> method to convert the string representation of a <xref:System.Byte> value to a <xref:System.Byte>. The string can contain either decimal or hexadecimal digits. The following example illustrates the parse operation by using both a decimal and a hexadecimal string.
 
-  :::code language="csharp" source="./snippets/System/Byte/Overview/csharp/byteinstantiation1.cs" interactive="try-dotnet-method" id="Snippet3":::
+  :::code language="csharp" source="./snippets/System/Byte/Overview/csharp/byteinstantiation1.cs" id="Snippet3":::
   :::code language="fsharp" source="./snippets/System/Byte/Overview/fsharp/byteinstantiation1.fs" id="Snippet3":::
   :::code language="vb" source="./snippets/System/Byte/Overview/vb/byteinstantiate1.vb" id="Snippet3":::
 
@@ -55,13 +55,13 @@ The <xref:System.Byte> type provides full support for standard and custom numeri
 
 To format a <xref:System.Byte> value as an integral string with no leading zeros, you can call the parameterless <xref:System.Byte.ToString> method. By using the "D" format specifier, you can also include a specified number of leading zeros in the string representation. By using the "X" format specifier, you can represent a <xref:System.Byte> value as a hexadecimal string. The following example formats the elements in an array of <xref:System.Byte> values in these three ways.
 
-:::code language="csharp" source="./snippets/System/Byte/Overview/csharp/formatting1.cs" interactive="try-dotnet-method" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/Byte/Overview/csharp/formatting1.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/Byte/Overview/fsharp/formatting1.fs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/Byte/Overview/vb/formatting1.vb" id="Snippet1":::
 
 You can also format a <xref:System.Byte> value as a binary, octal, decimal, or hexadecimal string by calling the <xref:System.Convert.ToString%28System.Byte%2CSystem.Int32%29> method and supplying the base as the method's second parameter. The following example calls this method to display the binary, octal, and hexadecimal representations of an array of byte values.
 
-:::code language="csharp" source="./snippets/System/Byte/Overview/csharp/formatting1.cs" interactive="try-dotnet-method" id="Snippet2":::
+:::code language="csharp" source="./snippets/System/Byte/Overview/csharp/formatting1.cs" id="Snippet2":::
 :::code language="fsharp" source="./snippets/System/Byte/Overview/fsharp/formatting1.fs" id="Snippet2":::
 :::code language="vb" source="./snippets/System/Byte/Overview/vb/formatting1.vb" id="Snippet2":::
 
@@ -73,12 +73,12 @@ In addition to working with individual bytes as decimal values, you might want t
 
 When an operation is performed on two <xref:System.Byte> values, the values share the same representation, so the result is accurate. This is illustrated in the following example, which masks the lowest-order bit of a <xref:System.Byte> value to ensure that it is even.
 
-:::code language="csharp" source="./snippets/System/Byte/Overview/csharp/bitwise1.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/Byte/Overview/csharp/bitwise1.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/Byte/Overview/fsharp/bitwise1.fs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/Byte/Overview/vb/bitwise1.vb" id="Snippet1":::
 
 On the other hand, when you work with both unsigned and signed bits, bitwise operations are complicated by the fact that the <xref:System.SByte> values use sign-and-magnitude representation for positive values, and two's complement representation for negative values. In order to perform a meaningful bitwise operation, the values must be converted to two equivalent representations, and information about the sign bit must be preserved. The following example does this to mask out bits 2 and 4 of an array of 8-bit signed and unsigned values.
 
-:::code language="csharp" source="./snippets/System/Byte/Overview/csharp/bitwise2.cs" interactive="try-dotnet" id="Snippet2":::
+:::code language="csharp" source="./snippets/System/Byte/Overview/csharp/bitwise2.cs" id="Snippet2":::
 :::code language="fsharp" source="./snippets/System/Byte/Overview/fsharp/bitwise2.fs" id="Snippet2":::
 :::code language="vb" source="./snippets/System/Byte/Overview/vb/bitwise2.vb" id="Snippet2":::

--- a/docs/fundamentals/runtime-libraries/system-char.md
+++ b/docs/fundamentals/runtime-libraries/system-char.md
@@ -41,7 +41,7 @@ Each Unicode character or valid surrogate pair belongs to a Unicode category. In
 
 To determine the Unicode category of a character, call the <xref:System.Char.GetUnicodeCategory%2A> method. For example, the following example calls the <xref:System.Char.GetUnicodeCategory%2A> to display the Unicode category of each character in a string. The example works correctly only if there are no surrogate pairs in the <xref:System.String> instance.
 
-:::code language="csharp" source="./snippets/System/Char/Overview/csharp/GetUnicodeCategory3.cs" interactive="try-dotnet" id="Snippet6":::
+:::code language="csharp" source="./snippets/System/Char/Overview/csharp/GetUnicodeCategory3.cs" id="Snippet6":::
 :::code language="fsharp" source="./snippets/System/Char/Overview/fsharp/GetUnicodeCategory3.fs" id="Snippet6":::
 :::code language="vb" source="./snippets/System/Char/Overview/vb/GetUnicodeCategory3.vb" id="Snippet6":::
 
@@ -51,7 +51,7 @@ Internally, for characters outside the ASCII range (U+0000 through U+00FF), the 
 
 Because a single character can be represented by multiple <xref:System.Char> objects, it is not always meaningful to work with individual <xref:System.Char> objects. For instance, the following example converts the Unicode code points that represent the Aegean numbers zero through 9 to UTF-16 encoded code units. Because it erroneously equates <xref:System.Char> objects with characters, it inaccurately reports that the resulting string has 20 characters.
 
-:::code language="csharp" source="./snippets/System/Char/Overview/csharp/textelements2.cs" interactive="try-dotnet" id="Snippet3":::
+:::code language="csharp" source="./snippets/System/Char/Overview/csharp/textelements2.cs" id="Snippet3":::
 :::code language="fsharp" source="./snippets/System/Char/Overview/fsharp/textelements2.fs" id="Snippet3":::
 :::code language="vb" source="./snippets/System/Char/Overview/vb/textelements2.vb" id="Snippet3":::
 
@@ -66,13 +66,13 @@ You can do the following to avoid the assumption that a <xref:System.Char> objec
 
 - You can use the <xref:System.Globalization.StringInfo> class to work with text elements instead of individual <xref:System.Char> objects. The following example uses the <xref:System.Globalization.StringInfo> object to count the number of text elements in a string that consists of the Aegean numbers zero through nine. Because it considers a surrogate pair a single character, it correctly reports that the string contains ten characters.
 
-  :::code language="csharp" source="./snippets/System/Char/Overview/csharp/textelements2a.cs" interactive="try-dotnet" id="Snippet4":::
+  :::code language="csharp" source="./snippets/System/Char/Overview/csharp/textelements2a.cs" id="Snippet4":::
   :::code language="fsharp" source="./snippets/System/Char/Overview/fsharp/textelements2a.fs" id="Snippet4":::
   :::code language="vb" source="./snippets/System/Char/Overview/vb/textelements2a.vb" id="Snippet4":::
 
 - If a string contains a base character that has one or more combining characters, you can call the <xref:System.String.Normalize%2A?displayProperty=nameWithType> method to convert the substring to a single UTF-16 encoded code unit. The following example calls the <xref:System.String.Normalize%2A?displayProperty=nameWithType> method to convert the base character U+0061 (LATIN SMALL LETTER A) and combining character U+0308 (COMBINING DIAERESIS) to U+00E4 (LATIN SMALL LETTER A WITH DIAERESIS).
 
-  :::code language="csharp" source="./snippets/System/Char/Overview/csharp/normalized.cs" interactive="try-dotnet" id="Snippet5":::
+  :::code language="csharp" source="./snippets/System/Char/Overview/csharp/normalized.cs" id="Snippet5":::
   :::code language="fsharp" source="./snippets/System/Char/Overview/fsharp/normalized.fs" id="Snippet5":::
   :::code language="vb" source="./snippets/System/Char/Overview/vb/normalized.vb" id="Snippet5":::
 

--- a/docs/fundamentals/runtime-libraries/system-collections-generic-list{t}.md
+++ b/docs/fundamentals/runtime-libraries/system-collections-generic-list{t}.md
@@ -49,7 +49,7 @@ The <xref:System.Collections.Generic.List%601> class is used infrequently in F# 
 
 The following example demonstrates how to add, remove, and insert a simple business object in a <xref:System.Collections.Generic.List%601>.
 
-:::code language="csharp" source="./snippets/System.Collections.Generic/ListT/Overview/csharp/program.cs" interactive="try-dotnet" id="snippet1":::
+:::code language="csharp" source="./snippets/System.Collections.Generic/ListT/Overview/csharp/program.cs" id="snippet1":::
 :::code language="vb" source="./snippets/System.Collections.Generic/List/Overview/vb/module1.vb" id="snippet1":::
 :::code language="fsharp" source="./snippets/System.Collections.Generic/ListT/Overview/fsharp/addremoveinsert.fs" id="snippet1":::
 
@@ -65,6 +65,6 @@ The <xref:System.Collections.Generic.List%601.TrimExcess%2A> method is used to r
 
 Finally, the <xref:System.Collections.Generic.List%601.Clear%2A> method is used to remove all items from the list, and the <xref:System.Collections.Generic.List%601.Capacity%2A> and <xref:System.Collections.Generic.List%601.Count%2A> properties are displayed.
 
-:::code language="csharp" source="./snippets/System.Collections.Generic/ListT/Overview/csharp/source.cs" interactive="try-dotnet-method" id="Snippet1":::
+:::code language="csharp" source="./snippets/System.Collections.Generic/ListT/Overview/csharp/source.cs" id="Snippet1":::
 :::code language="vb" source="./snippets/System.Collections.Generic/List/Overview/vb/source.vb" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System.Collections.Generic/ListT/Overview/fsharp/listclass.fs" id="Snippet1":::

--- a/docs/fundamentals/runtime-libraries/system-convert.md
+++ b/docs/fundamentals/runtime-libraries/system-convert.md
@@ -63,7 +63,7 @@ The <xref:System.Convert> class includes static methods that you can call to con
 
 The following example converts the value of <xref:System.Int16.MaxValue?displayProperty=nameWithType> to a string in all supported numeric formats. It then converts the string value back to a <xref:System.Int16> value.
 
-:::code language="csharp" source="./snippets/System/Convert/Overview/csharp/NonDecimal1.cs" interactive="try-dotnet" id="Snippet2":::
+:::code language="csharp" source="./snippets/System/Convert/Overview/csharp/NonDecimal1.cs" id="Snippet2":::
 :::code language="fsharp" source="./snippets/System/Convert/Overview/fsharp/NonDecimal1.fs" id="Snippet2":::
 :::code language="vb" source="./snippets/System/Convert/Overview/vb/NonDecimal1.vb" id="Snippet2":::
 

--- a/docs/fundamentals/runtime-libraries/system-datetime.md
+++ b/docs/fundamentals/runtime-libraries/system-datetime.md
@@ -97,7 +97,7 @@ You invoke the `DateTime` structure's implicit parameterless constructor when yo
 
 <a name="initialization-02"></a>
 :::code language="vb" source="./snippets/System/DateTime/Overview/vb/Instantiation.vb" id="Snippet5":::
-:::code language="csharp" source="./snippets/System/DateTime/Overview/csharp/Instantiation.cs" interactive="try-dotnet-method" id="Snippet5":::
+:::code language="csharp" source="./snippets/System/DateTime/Overview/csharp/Instantiation.cs" id="Snippet5":::
 :::code language="fsharp" source="./snippets/System/DateTime/Overview/fsharp/Instantiation.fs" id="Snippet5":::
 
 ### Assign a computed value
@@ -141,7 +141,7 @@ The appearance of date and time values is dependent on culture, international st
 You may need to format dates in a specific culture to support web scenarios where the server may be in a different culture from the client. You specify the culture using the <xref:System.DateTime.ToString%28System.IFormatProvider%29?displayProperty=nameWithType> method to create the short date and long time representation in a specific culture. The following example uses the <xref:System.DateTime.ToString%28System.IFormatProvider%29?displayProperty=nameWithType> method to display the date and time using the short date and long time pattern for the fr-FR culture.
 
 <a name="formatting-02"></a>
-:::code language="csharp" source="./snippets/System/DateTime/Overview/csharp/StringFormat.cs" interactive="try-dotnet-method" id="Snippet2":::
+:::code language="csharp" source="./snippets/System/DateTime/Overview/csharp/StringFormat.cs" id="Snippet2":::
 :::code language="fsharp" source="./snippets/System/DateTime/Overview/fsharp/StringFormat.fs" id="Snippet2":::
 :::code language="vb" source="./snippets/System/DateTime/Overview/vb/StringFormat.vb" id="Snippet2":::
 
@@ -155,14 +155,14 @@ Other applications may require different string representations of a date. The <
 Finally, you can specify both the culture and the format using the <xref:System.DateTime.ToString%28System.String%2CSystem.IFormatProvider%29?displayProperty=nameWithType> method. The following example uses the <xref:System.DateTime.ToString%28System.String%2CSystem.IFormatProvider%29?displayProperty=nameWithType> method to display the full date and time pattern for the fr-FR culture.
 
 <a name="formatting-04"></a>
-:::code language="csharp" source="./snippets/System/DateTime/Overview/csharp/StringFormat.cs" interactive="try-dotnet-method" id="Snippet4":::
+:::code language="csharp" source="./snippets/System/DateTime/Overview/csharp/StringFormat.cs" id="Snippet4":::
 :::code language="fsharp" source="./snippets/System/DateTime/Overview/fsharp/StringFormat.fs" id="Snippet4":::
 :::code language="vb" source="./snippets/System/DateTime/Overview/vb/StringFormat.vb" id="Snippet4":::
 
 The <xref:System.DateTime.ToString%28System.String%29?displayProperty=nameWithType> overload can also be used with a custom format string to specify other formats. The following example shows how to format a string using the [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) standard format often used for web services. The Iso 8601 format does not have a corresponding standard format string.
 
 <a name="formatting-05"></a>
-:::code language="csharp" source="./snippets/System/DateTime/Overview/csharp/StringFormat.cs" interactive="try-dotnet-method" id="Snippet5":::
+:::code language="csharp" source="./snippets/System/DateTime/Overview/csharp/StringFormat.cs" id="Snippet5":::
 :::code language="fsharp" source="./snippets/System/DateTime/Overview/fsharp/StringFormat.fs" id="Snippet5":::
 :::code language="vb" source="./snippets/System/DateTime/Overview/vb/StringFormat.vb" id="Snippet5":::
 
@@ -179,7 +179,7 @@ Parsing converts the string representation of a date and time to a <xref:System.
 You use the <xref:System.DateTime.Parse%2A> or <xref:System.DateTime.TryParse%2A> method to convert a string from one of the common date and time formats used by a culture to a <xref:System.DateTime> value. The following example shows how you can use <xref:System.DateTime.TryParse%2A> to convert date strings in different culture-specific formats to a <xref:System.DateTime> value. It changes the current culture to English (United Kingdom) and calls the <xref:System.DateTime.GetDateTimeFormats> method to generate an array of date and time strings. It then passes each element in the array to the <xref:System.DateTime.TryParse%2A> method. The output from the example shows the parsing method was able to successfully convert each of the culture-specific date and time strings.
 
 <a name="parsing-01"></a>
-:::code language="csharp" source="./snippets/System/DateTime/Overview/csharp/Parsing.cs" interactive="try-dotnet-method" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/DateTime/Overview/csharp/Parsing.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/DateTime/Overview/fsharp/Parsing.fs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/DateTime/Overview/vb/Parsing.vb" id="Snippet1":::
 
@@ -193,7 +193,7 @@ You use the <xref:System.DateTime.ParseExact%2A> and <xref:System.DateTime.TryPa
 One common use for <xref:System.DateTime.ParseExact%2A> is to convert a string representation from a web service, usually in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) standard format. The following code shows the correct format string to use:
 
 <a name="parsing-03"></a>
-:::code language="csharp" source="./snippets/System/DateTime/Overview/csharp/Parsing.cs" interactive="try-dotnet-method" id="Snippet3":::
+:::code language="csharp" source="./snippets/System/DateTime/Overview/csharp/Parsing.cs" id="Snippet3":::
 :::code language="fsharp" source="./snippets/System/DateTime/Overview/fsharp/Parsing.fs" id="Snippet3":::
 :::code language="vb" source="./snippets/System/DateTime/Overview/vb/Parsing.vb" id="Snippet3":::
 
@@ -221,7 +221,7 @@ The <xref:System.DateTime.Ticks> property expresses date and time values in unit
 The following example illustrates the dependence of current date and time values on the resolution of the system clock. In the example, an outer loop repeats 20 times, and an inner loop serves to delay the outer loop. If the value of the outer loop counter is 10, a call to the <xref:System.Threading.Thread.Sleep%2A?displayProperty=nameWithType> method introduces a five-millisecond delay. The following example shows the number of milliseconds returned by the `DateTime.Now.Milliseconds` property changes only after the call to <xref:System.Threading.Thread.Sleep%2A?displayProperty=nameWithType>.
 
 <a name="resolution-01"></a>
-:::code language="csharp" source="./snippets/System/DateTime/Overview/csharp/Resolution.cs" interactive="try-dotnet-method" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/DateTime/Overview/csharp/Resolution.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/DateTime/Overview/fsharp/Resolution.fs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/DateTime/Overview/vb/Resolution.vb" id="Snippet1":::
 

--- a/docs/fundamentals/runtime-libraries/system-datetime.md
+++ b/docs/fundamentals/runtime-libraries/system-datetime.md
@@ -27,8 +27,6 @@ Time values are measured in 100-nanosecond units called ticks. A particular date
 
 ## Quick links to example code
 
-[!INCLUDE[interactive-note](./includes/csharp-interactive-with-utc-note.md)]
-
 This article includes several examples that use the `DateTime` type:
 
 ### Initialization examples

--- a/docs/fundamentals/runtime-libraries/system-decimal.md
+++ b/docs/fundamentals/runtime-libraries/system-decimal.md
@@ -13,13 +13,13 @@ dev_langs:
 
 The <xref:System.Decimal> value type represents decimal numbers ranging from positive 79,228,162,514,264,337,593,543,950,335 to negative 79,228,162,514,264,337,593,543,950,335. The default value of a `Decimal` is 0. The <xref:System.Decimal> value type is appropriate for financial calculations that require large numbers of significant integral and fractional digits and no round-off errors. The <xref:System.Decimal> type does not eliminate the need for rounding. Rather, it minimizes errors due to rounding. For example, the following code produces a result of 0.9999999999999999999999999999 instead of 1.
 
-:::code language="csharp" source="./snippets/System/Decimal/Overview/csharp/DecimalDivision_46630_1.cs" interactive="try-dotnet-method" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/Decimal/Overview/csharp/DecimalDivision_46630_1.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/Decimal/Overview/fsharp/DecimalDivision_46630_1.fs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/Decimal/Overview/vb/DecimalDivision_46630_1.vb" id="Snippet1":::
 
 When the result of the division and multiplication is passed to the <xref:System.Math.Round%2A> method, the result suffers no loss of precision, as the following code shows.
 
-:::code language="csharp" source="./snippets/System/Decimal/Overview/csharp/DecimalDivision_46630_1.cs" interactive="try-dotnet-method" id="Snippet2":::
+:::code language="csharp" source="./snippets/System/Decimal/Overview/csharp/DecimalDivision_46630_1.cs" id="Snippet2":::
 :::code language="fsharp" source="./snippets/System/Decimal/Overview/fsharp/DecimalDivision_46630_1.fs" id="Snippet2":::
 :::code language="vb" source="./snippets/System/Decimal/Overview/vb/DecimalDivision_46630_1.vb" id="Snippet2":::
 

--- a/docs/fundamentals/runtime-libraries/system-delegate-createdelegate.md
+++ b/docs/fundamentals/runtime-libraries/system-delegate-createdelegate.md
@@ -37,7 +37,7 @@ A second class named `Example` contains the code that creates the delegates.
 - A delegate of type `D1`, representing an open instance method, is created for the instance method `M1`. An instance must be passed when the delegate is invoked.
 - A delegate of type `D2`, representing an open static method, is created for the static method `M2`.
 
-:::code language="csharp" source="./snippets/System/Delegate/CreateDelegate/csharp/openClosedOver.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/Delegate/CreateDelegate/csharp/openClosedOver.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/Delegate/CreateDelegate/fsharp/openClosedOver.fs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/Delegate/CreateDelegate/vb/openClosedOver.vb" id="Snippet1":::
 
@@ -94,7 +94,7 @@ A third class named `Example` contains the code that creates the delegates.
 - Delegates are created for static method `M3` of type `C` and type `F`; these are open static delegates.
 - Finally, delegates are created for static method `M4` of type `C` and type `F`; each method has the declaring type as its first argument, and an instance of the type is supplied, so the delegates are closed over their first arguments. Method `M4` of type `C` displays the `ID` properties of the bound instance and of the argument.
 
-:::code language="csharp" source="./snippets/System/Delegate/CreateDelegate/csharp/source.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/Delegate/CreateDelegate/csharp/source.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/Delegate/CreateDelegate/fsharp/source.fs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/Delegate/CreateDelegate/vb/source1.vb" id="Snippet1":::
 

--- a/docs/fundamentals/runtime-libraries/system-double-compareto.md
+++ b/docs/fundamentals/runtime-libraries/system-double-compareto.md
@@ -15,7 +15,7 @@ dev_langs:
 
 Values must be identical to be considered equal. Particularly when floating-point values depend on multiple mathematical operations, it is common for them to lose precision and for their values to be nearly identical except for their least significant digits. Because of this, the return value of the <xref:System.Double.CompareTo%2A> method at times may seem surprising. For example, multiplication by a particular value followed by division by the same value should produce the original value. In the following example, however, the computed value turns out to be greater than the original value. Showing all significant digits of the two values by using the "R" [standard numeric format string](../../standard/base-types/standard-numeric-format-strings.md) indicates that the computed value differs from the original value in its least significant digits. For information on handling such comparisons, see the Remarks section of the <xref:System.Double.Equals(System.Double)> method.
 
-:::code language="csharp" source="./snippets/System/Double/CompareTo/csharp/compareto2.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/Double/CompareTo/csharp/compareto2.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/Double/CompareTo/fsharp/compareto2.fs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/Double/CompareTo/vb/compareto2.vb" id="Snippet1":::
 
@@ -29,7 +29,7 @@ The `value` parameter must be `null` or an instance of `Double`; otherwise, an e
 
 Values must be identical to be considered equal. Particularly when floating-point values depend on multiple mathematical operations, it is common for them to lose precision and for their values to be nearly identical except for their least significant digits. Because of this, the return value of the <xref:System.Double.CompareTo%2A> method at times may seem surprising. For example, multiplication by a particular value followed by division by the same value should produce the original value. In the following example, however, the computed value turns out to be greater than the original value. Showing all significant digits of the two values by using the "R" [standard numeric format string](../../standard/base-types/standard-numeric-format-strings.md) indicates that the computed value differs from the original value in its least significant digits. For information on handling such comparisons, see the Remarks section of the <xref:System.Double.Equals(System.Double)> method.
 
-:::code language="csharp" source="./snippets/System/Double/CompareTo/csharp/compareto3.cs" interactive="try-dotnet" id="Snippet2":::
+:::code language="csharp" source="./snippets/System/Double/CompareTo/csharp/compareto3.cs" id="Snippet2":::
 :::code language="fsharp" source="./snippets/System/Double/CompareTo/fsharp/compareto3.fs" id="Snippet2":::
 :::code language="vb" source="./snippets/System/Double/CompareTo/vb/compareto3.vb" id="Snippet2":::
 

--- a/docs/fundamentals/runtime-libraries/system-double-epsilon.md
+++ b/docs/fundamentals/runtime-libraries/system-double-epsilon.md
@@ -13,13 +13,13 @@ dev_langs:
 
 The value of the <xref:System.Double.Epsilon> property reflects the smallest positive <xref:System.Double> value that is significant in numeric operations or comparisons when the value of the <xref:System.Double> instance is zero. For example, the following code shows that zero and <xref:System.Double.Epsilon> are considered to be unequal values, whereas zero and half the value of <xref:System.Double.Epsilon> are considered to be equal.
 
-:::code language="csharp" source="./snippets/System/Double/Epsilon/csharp/epsilon.cs" interactive="try-dotnet" id="Snippet5":::
+:::code language="csharp" source="./snippets/System/Double/Epsilon/csharp/epsilon.cs" id="Snippet5":::
 :::code language="fsharp" source="./snippets/System/Double/Epsilon/fsharp/epsilon.fs" id="Snippet5":::
 :::code language="vb" source="./snippets/System/Double/Epsilon/vb/epsilon.vb" id="Snippet5":::
 
 More precisely, the floating point format consists of a sign, a 52-bit mantissa or significand, and an 11-bit exponent. As the following example shows, zero has an exponent of -1022 and a mantissa of 0. <xref:System.Double.Epsilon> has an exponent of -1022 and a mantissa of 1. This means that <xref:System.Double.Epsilon> is the smallest positive <xref:System.Double> value greater than zero and represents the smallest possible value and the smallest possible increment for a <xref:System.Double> whose exponent is -1022.
 
-:::code language="csharp" source="./snippets/System/Double/Epsilon/csharp/epsilon1.cs" interactive="try-dotnet" id="Snippet6":::
+:::code language="csharp" source="./snippets/System/Double/Epsilon/csharp/epsilon1.cs" id="Snippet6":::
 :::code language="fsharp" source="./snippets/System/Double/Epsilon/fsharp/epsilon1.fs" id="Snippet6":::
 :::code language="vb" source="./snippets/System/Double/Epsilon/vb/epsilon1.vb" id="Snippet6":::
 

--- a/docs/fundamentals/runtime-libraries/system-double-equals.md
+++ b/docs/fundamentals/runtime-libraries/system-double-equals.md
@@ -23,13 +23,13 @@ Consult your programming language's documentation to determine if its compiler p
 
 The <xref:System.Double.Equals%2A> method should be used with caution, because two apparently equivalent values can be unequal due to the differing precision of the two values. The following example reports that the <xref:System.Double> value .333333 and the <xref:System.Double> value returned by dividing 1 by 3 are unequal.
 
-:::code language="csharp" source="./snippets/System/Double/Epsilon/csharp/Equals_25051.cs" interactive="try-dotnet-method" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/Double/Epsilon/csharp/Equals_25051.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/Double/Epsilon/fsharp/Equals_25051.fs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/Double/Epsilon/vb/Equals_25051.vb" id="Snippet1":::
 
 Rather than comparing for equality, one technique involves defining an acceptable relative margin of difference between two values (such as .001% of one of the values). If the absolute value of the difference between the two values is less than or equal to that margin, the difference is likely to be due to differences in precision and, therefore, the values are likely to be equal. The following example uses this technique to compare .33333 and 1/3, the two <xref:System.Double> values that the previous code example found to be unequal. In this case, the values are equal.
 
-:::code language="csharp" source="./snippets/System/Double/Epsilon/csharp/Equals_25051.cs" interactive="try-dotnet-method" id="Snippet2":::
+:::code language="csharp" source="./snippets/System/Double/Epsilon/csharp/Equals_25051.cs" id="Snippet2":::
 :::code language="fsharp" source="./snippets/System/Double/Epsilon/fsharp/Equals_25051.fs" id="Snippet2":::
 :::code language="vb" source="./snippets/System/Double/Epsilon/vb/Equals_25051.vb" id="Snippet2":::
 
@@ -38,7 +38,7 @@ Rather than comparing for equality, one technique involves defining an acceptabl
 
 A second technique involves comparing the difference between two floating-point numbers with some absolute value. If the difference is less than or equal to that absolute value, the numbers are equal. If it's greater, the numbers are not equal. One alternative is to arbitrarily select an absolute value. That's problematic, however, because an acceptable margin of difference depends on the magnitude of the <xref:System.Double> values. A second alternative takes advantage of a design feature of the floating-point format: The difference between the integer representation of two floating-point values indicates the number of possible floating-point values that separates them. For example, the difference between 0.0 and <xref:System.Double.Epsilon> is 1, because <xref:System.Double.Epsilon> is the smallest representable value when working with a <xref:System.Double> whose value is zero. The following example uses this technique to compare .33333 and 1/3, which are the two <xref:System.Double> values that the previous code example with the <xref:System.Double.Equals(System.Double)> method found to be unequal. The example uses the <xref:System.BitConverter.DoubleToInt64Bits%2A?displayProperty=nameWithType> method to convert a double-precision floating-point value to its integer representation. The example declares the values as equal if there are no possible floating-point values between their integer representations.
 
-:::code language="csharp" source="./snippets/System/Double/Equals/csharp/equalsabs1.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/Double/Equals/csharp/equalsabs1.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/Double/Equals/fsharp/equalsabs1.fs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/Double/Equals/vb/equalsabs1.vb" id="Snippet1":::
 

--- a/docs/fundamentals/runtime-libraries/system-enum.md
+++ b/docs/fundamentals/runtime-libraries/system-enum.md
@@ -88,7 +88,7 @@ The <xref:System.Enum> class also includes a <xref:System.Enum.ToObject%2A> meth
 
 When converting an integer to an enumeration value, it is possible to assign a value that is not actually a member of the enumeration. To prevent this, you can pass the integer to the <xref:System.Enum.IsDefined%2A> method before performing the conversion. The following example uses this method to determine whether the elements in an array of integer values can be converted to `ArrivalStatus` values.
 
-:::code language="csharp" source="./snippets/System/Enum/Overview/csharp/classconversion1.cs" interactive="try-dotnet" id="Snippet7":::
+:::code language="csharp" source="./snippets/System/Enum/Overview/csharp/classconversion1.cs" id="Snippet7":::
 :::code language="fsharp" source="./snippets/System/Enum/Overview/fsharp/classconversion1.fs" id="Snippet7":::
 :::code language="vb" source="./snippets/System/Enum/Overview/vb/classconversion1.vb" id="Snippet7":::
 
@@ -182,7 +182,7 @@ Because enumeration types are defined by language structures, such as `enum` (C#
 
 In the following example, the `Grades` enumeration represents the possible letter grades that a student may receive in a class. An extension method named `Passing` is added to the `Grades` type so that each instance of that type now "knows" whether it represents a passing grade or not.      The `Extensions` class also contains a static read-write variable that defines the minimum passing grade. The return value of the `Passing` extension method reflects the current value of that variable.
 
-:::code language="csharp" source="./snippets/System/Enum/Overview/csharp/Extensions.cs" interactive="try-dotnet" id="Snippet18":::
+:::code language="csharp" source="./snippets/System/Enum/Overview/csharp/Extensions.cs" id="Snippet18":::
 :::code language="fsharp" source="./snippets/System/Enum/Overview/fsharp/Extensions.fs" id="Snippet18":::
 :::code language="vb" source="./snippets/System/Enum/Overview/vb/Extensions.vb" id="Snippet18":::
 
@@ -190,6 +190,6 @@ In the following example, the `Grades` enumeration represents the possible lette
 
 The following example demonstrates using an enumeration to represent named values and another enumeration to represent named bit fields.
 
-:::code language="csharp" source="./snippets/System/Enum/Overview/csharp/EnumMain.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/Enum/Overview/csharp/EnumMain.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/Enum/Overview/fsharp/EnumMain.fs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/Enum/Overview/vb/EnumMain.vb" id="Snippet1":::

--- a/docs/fundamentals/runtime-libraries/system-exception-message.md
+++ b/docs/fundamentals/runtime-libraries/system-exception-message.md
@@ -22,6 +22,6 @@ The value of the <xref:System.Exception.Message> property is included in the inf
 
 The following code example throws and then catches an <xref:System.Exception> exception and displays the exception's text message using the <xref:System.Exception.Message> property.
 
-:::code language="csharp" source="./snippets/System/Exception/HelpLink/csharp/properties.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/Exception/HelpLink/csharp/properties.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/Exception/HelpLink/fsharp/properties.fs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/Exception/HelpLink/vb/properties.vb" id="Snippet1":::

--- a/docs/fundamentals/runtime-libraries/system-exception.md
+++ b/docs/fundamentals/runtime-libraries/system-exception.md
@@ -25,7 +25,7 @@ Run-time errors can occur for a variety of reasons. However, not all errors shou
 
   The <xref:System.NullReferenceException> exception that results when `obj` is `null` can be eliminated by modifying the source code to explicitly test for null before calling the <xref:System.Object.Equals%2A?displayProperty=nameWithType> override and then re-compiling. The following example contains the corrected source code that handles a `null` argument.
 
-  :::code language="csharp" source="./snippets/System/Exception/Overview/csharp/usageerrors2.cs" interactive="try-dotnet" id="Snippet5":::
+  :::code language="csharp" source="./snippets/System/Exception/Overview/csharp/usageerrors2.cs" id="Snippet5":::
   :::code language="fsharp" source="./snippets/System/Exception/Overview/fsharp/usageerrors2.fs" id="Snippet5":::
   :::code language="vb" source="./snippets/System/Exception/Overview/vb/usageerrors2.vb" id="Snippet5":::
 
@@ -225,6 +225,6 @@ The following example makes two calls to the `GetPrimesFrom` method with non-pri
 
 The following example demonstrates a `catch` (`with` in F#) block that is defined to handle <xref:System.ArithmeticException> errors. This `catch` block also catches <xref:System.DivideByZeroException> errors, because <xref:System.DivideByZeroException> derives from <xref:System.ArithmeticException> and there is no `catch` block explicitly defined for <xref:System.DivideByZeroException> errors.
 
-:::code language="csharp" source="./snippets/System/Exception/Overview/csharp/catchexception.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/Exception/Overview/csharp/catchexception.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/Exception/Overview/fsharp/catchexception.fs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/Exception/Overview/vb/catchexception.vb" id="Snippet1":::

--- a/docs/fundamentals/runtime-libraries/system-flagsattribute.md
+++ b/docs/fundamentals/runtime-libraries/system-flagsattribute.md
@@ -47,7 +47,7 @@ Bit fields are generally used for lists of elements that might occur in combinat
 
 The following example illustrates the use of the `FlagsAttribute` attribute and shows the effect on the <xref:System.Enum.ToString%2A> method of using `FlagsAttribute` on an <xref:System.Enum> declaration.
 
-:::code language="csharp" source="./snippets/System/FlagsAttribute/Overview/csharp/flags.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/FlagsAttribute/Overview/csharp/flags.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/FlagsAttribute/Overview/fsharp/flags.fs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/FlagsAttribute/Overview/vb/flags.vb" id="Snippet1":::
 
@@ -55,6 +55,6 @@ The preceding example defines two color-related enumerations, `SingleHue` and `M
 
 The following example defines another enumeration with the `FlagsAttribute` attribute and shows how to use bitwise logical and equality operators to determine whether one or more bit fields are set in an enumeration value. You can also use the <xref:System.Enum.HasFlag%2A?displayProperty=nameWithType> method to do that, but that is not shown in this example.
 
-:::code language="csharp" source="./snippets/System/FlagsAttribute/Overview/csharp/flags1.cs" interactive="try-dotnet" id="Snippet2":::
+:::code language="csharp" source="./snippets/System/FlagsAttribute/Overview/csharp/flags1.cs" id="Snippet2":::
 :::code language="fsharp" source="./snippets/System/FlagsAttribute/Overview/fsharp/flags1.fs" id="Snippet2":::
 :::code language="vb" source="./snippets/System/FlagsAttribute/Overview/vb/flags1.vb" id="Snippet2":::

--- a/docs/fundamentals/runtime-libraries/system-globalization-cultureinfo-invariantculture.md
+++ b/docs/fundamentals/runtime-libraries/system-globalization-cultureinfo-invariantculture.md
@@ -26,7 +26,7 @@ For example, if you choose to persist date and time data in string form, you can
 
 The following example uses the invariant culture to persist a <xref:System.DateTime> value as a string. It then parses the string and displays its value by using the formatting conventions of the French (France) and German (Germany) cultures.
 
-:::code language="csharp" source="./snippets/System.Globalization/CultureInfo/InvariantCulture/csharp/persist1.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="./snippets/System.Globalization/CultureInfo/InvariantCulture/csharp/persist1.cs" id="Snippet1":::
 :::code language="vb" source="./snippets/System.Globalization/CultureInfo/InvariantCulture/vb/persist1.vb" id="Snippet1":::
 
 ## Security decisions

--- a/docs/fundamentals/runtime-libraries/system-globalization-datetimeformatinfo.md
+++ b/docs/fundamentals/runtime-libraries/system-globalization-datetimeformatinfo.md
@@ -31,7 +31,7 @@ The invariant culture represents a culture that is culture-insensitive. It is ba
 
 The following example uses each of these methods to instantiate a <xref:System.Globalization.DateTimeFormatInfo> object that represents the invariant culture. It then indicates whether the object is read-only.
 
-:::code language="csharp" source="./snippets/System.Globalization/DateTimeFormatInfo/csharp/create1.cs" interactive="try-dotnet-method" id="Snippet1":::
+:::code language="csharp" source="./snippets/System.Globalization/DateTimeFormatInfo/csharp/create1.cs" id="Snippet1":::
 
 ### Instantiate a DateTimeFormatInfo object for a specific culture
 
@@ -47,19 +47,19 @@ A specific culture represents a language that is spoken in a particular country/
 
 The following example illustrates each of these ways to instantiate a <xref:System.Globalization.DateTimeFormatInfo> object and indicates whether the resulting object is read-only.
 
-:::code language="csharp" source="./snippets/System.Globalization/DateTimeFormatInfo/csharp/create1.cs" interactive="try-dotnet-method" id="Snippet3":::
+:::code language="csharp" source="./snippets/System.Globalization/DateTimeFormatInfo/csharp/create1.cs" id="Snippet3":::
 
 ### Instantiate a DateTimeFormatInfo object for a neutral culture
 
 A neutral culture represents a culture or language that is independent of a country/region; it is typically the parent of one or more specific cultures. For example, Fr is a neutral culture for the French language and the parent of the fr-FR culture. You can instantiate a <xref:System.Globalization.DateTimeFormatInfo> object that represents the formatting conventions of a neutral culture in the same ways that you create a <xref:System.Globalization.DateTimeFormatInfo> object that represents the formatting conventions of a specific culture. In addition, you can retrieve a neutral culture's <xref:System.Globalization.DateTimeFormatInfo> object by retrieving a neutral culture from a specific culture's <xref:System.Globalization.CultureInfo.Parent%2A?displayProperty=nameWithType> property and retrieving the <xref:System.Globalization.DateTimeFormatInfo> object returned by its <xref:System.Globalization.CultureInfo.DateTimeFormat%2A?displayProperty=nameWithType> property. Unless the parent culture represents the invariant culture, the returned <xref:System.Globalization.DateTimeFormatInfo> object is read/write. The following example illustrates these ways of instantiating a <xref:System.Globalization.DateTimeFormatInfo> object that represents a neutral culture.
 
-:::code language="csharp" source="./snippets/System.Globalization/DateTimeFormatInfo/csharp/create1.cs" interactive="try-dotnet-method" id="Snippet2":::
+:::code language="csharp" source="./snippets/System.Globalization/DateTimeFormatInfo/csharp/create1.cs" id="Snippet2":::
 
 However, a neutral culture lacks culture-specific formatting information, because it is independent of a specific country/region. Instead of populating the <xref:System.Globalization.DateTimeFormatInfo> object with generic values, .NET returns a <xref:System.Globalization.DateTimeFormatInfo> object that reflects the formatting conventions of a specific culture that is a child of the neutral culture. For example, the <xref:System.Globalization.DateTimeFormatInfo> object for the neutral en culture reflects the formatting conventions of the en-US culture, and the <xref:System.Globalization.DateTimeFormatInfo> object for the fr culture reflects the formatting conventions of the fr-FR culture.
 
 You can use code like the following to determine which specific culture's formatting conventions a neutral culture represents. The example uses reflection to compare the <xref:System.Globalization.DateTimeFormatInfo> properties of a neutral culture with the properties of a specific child culture. It considers two calendars to be equivalent if they are the same calendar type and, for Gregorian calendars, if their <xref:System.Globalization.GregorianCalendar.CalendarType%2A?displayProperty=nameWithType> properties have identical values.
 
-:::code language="csharp" source="./snippets/System.Globalization/DateTimeFormatInfo/csharp/instantiate6.cs" interactive="try-dotnet" id="Snippet6":::
+:::code language="csharp" source="./snippets/System.Globalization/DateTimeFormatInfo/csharp/instantiate6.cs" id="Snippet6":::
 
 ### Instantiate a DateTimeFormatInfo object for the current culture
 
@@ -73,7 +73,7 @@ You can instantiate a <xref:System.Globalization.DateTimeFormatInfo> object that
 
 The following example uses each of these methods to instantiate a <xref:System.Globalization.DateTimeFormatInfo> object that represents the formatting conventions of the current culture. It then indicates whether the object is read-only.
 
-:::code language="csharp" source="./snippets/System.Globalization/DateTimeFormatInfo/csharp/create2.cs" interactive="try-dotnet-method" id="Snippet4":::
+:::code language="csharp" source="./snippets/System.Globalization/DateTimeFormatInfo/csharp/create2.cs" id="Snippet4":::
 
 You can create a writable <xref:System.Globalization.DateTimeFormatInfo> object that represents the conventions of the current culture in one of these ways:
 
@@ -193,19 +193,19 @@ There are two other ways to change the format of a result string:
 
 The following example changes the format of a result string produced by the "d" (short date) standard format string. It changes the associated <xref:System.Globalization.DateTimeFormatInfo.ShortDatePattern%2A> property for the en-US or English (United States) culture from its default of "M/d/yyyy" to "yyyy'-"MM"-"dd" and uses the "d" standard format string to display the date both before and after the <xref:System.Globalization.DateTimeFormatInfo.ShortDatePattern%2A> property is changed.
 
-:::code language="csharp" source="./snippets/System.Globalization/DateTimeFormatInfo/csharp/example1.cs" interactive="try-dotnet" id="Snippet10":::
+:::code language="csharp" source="./snippets/System.Globalization/DateTimeFormatInfo/csharp/example1.cs" id="Snippet10":::
 
 ### Change the date separator character
 
 The following example changes the date separator character in a <xref:System.Globalization.DateTimeFormatInfo> object that represents the formatting conventions of the fr-FR culture. The example uses the "g" standard format string to display the date both before and after the <xref:System.Globalization.DateTimeFormatInfo.DateSeparator%2A> property is changed.
 
-:::code language="csharp" source="./snippets/System.Globalization/DateTimeFormatInfo/csharp/example3.cs" interactive="try-dotnet" id="Snippet12":::
+:::code language="csharp" source="./snippets/System.Globalization/DateTimeFormatInfo/csharp/example3.cs" id="Snippet12":::
 
 ### Change day name abbreviations and the long date pattern
 
 In some cases, the long date pattern, which typically displays the full day and month name along with the number of the day of the month and the year, may be too long. The following example shortens the long date pattern for the en-US culture to return a one-character or two-character day name abbreviation followed by the day number, the month name abbreviation, and the year. It does this by assigning shorter day name abbreviations to the <xref:System.Globalization.DateTimeFormatInfo.AbbreviatedDayNames%2A> array, and by modifying the custom format string assigned to the <xref:System.Globalization.DateTimeFormatInfo.LongDatePattern%2A> property. This affects the result strings returned by the "D" and "f" standard format strings.
 
-:::code language="csharp" source="./snippets/System.Globalization/DateTimeFormatInfo/csharp/example2.cs" interactive="try-dotnet" id="Snippet13":::
+:::code language="csharp" source="./snippets/System.Globalization/DateTimeFormatInfo/csharp/example2.cs" id="Snippet13":::
 
 Ordinarily, the change to the <xref:System.Globalization.DateTimeFormatInfo.LongDatePattern%2A> property also affects the <xref:System.Globalization.DateTimeFormatInfo.FullDateTimePattern%2A> property, which in turn defines the result string returned by the "F" standard format string. To preserve the original full date and time pattern, the example reassigns the original custom format string assigned to the <xref:System.Globalization.DateTimeFormatInfo.FullDateTimePattern%2A> property after the <xref:System.Globalization.DateTimeFormatInfo.LongDatePattern%2A> property is modified.
 
@@ -213,7 +213,7 @@ Ordinarily, the change to the <xref:System.Globalization.DateTimeFormatInfo.Long
 
 For many cultures in .NET, the time is expressed by using a 12-hour clock and an AM/PM designator. The following example defines a `ReplaceWith24HourClock` method that replaces any time format that uses a 12-hour clock with a format that uses a 24-hour clock.
 
-:::code language="csharp" source="./snippets/System.Globalization/DateTimeFormatInfo/csharp/example5.cs" interactive="try-dotnet" id="Snippet14":::
+:::code language="csharp" source="./snippets/System.Globalization/DateTimeFormatInfo/csharp/example5.cs" id="Snippet14":::
 
 The example uses a regular expression to modify the format string. The regular expression pattern `@"^(?<openAMPM>\s*t+\s*)? (?(openAMPM) h+(?<nonHours>[^ht]+)$ | \s*h+(?<nonHours>[^ht]+)\s*t+)` is defined as follows:
 
@@ -238,7 +238,7 @@ The following example adds the "g" custom format specifier to the  <xref:System.
 
 The example also shows how to change the era name for a culture whose calendar has a single era. In this case, the en-US culture uses the Gregorian calendar, which is represented by a <xref:System.Globalization.GregorianCalendar> object. The <xref:System.Globalization.GregorianCalendar> class supports a single era, which it names A.D. (Anno Domini). The example changes the era name to C.E. (Common Era) by replacing the "g" custom format specifier in the format string assigned to the <xref:System.Globalization.DateTimeFormatInfo.FullDateTimePattern%2A> property with a literal string. The use of a literal string is necessary, because the era name is typically returned by the <xref:System.Globalization.DateTimeFormatInfo.GetEraName%2A> method from private data in the culture tables supplied by either .NET or the operating system.
 
-:::code language="csharp" source="./snippets/System.Globalization/DateTimeFormatInfo/csharp/example4.cs" interactive="try-dotnet" id="Snippet11":::
+:::code language="csharp" source="./snippets/System.Globalization/DateTimeFormatInfo/csharp/example4.cs" id="Snippet11":::
 
 ## Parse date and time strings
 
@@ -250,7 +250,7 @@ The parsing methods also implicitly or explicitly use a <xref:System.Globalizati
 
 The following example illustrates the culture-sensitive nature of parsing date and time strings. It tries to parse two date strings by using the conventions of the en-US, en-GB, fr-FR, and fi-FI cultures. The date that is interpreted as 8/18/2014 in the en-US culture throws a <xref:System.FormatException> exception in the other three cultures because 18 is interpreted as the month number. 1/2/2015 is parsed as the second day of the first month in the en-US culture, but as the first day of the second month in the remaining cultures.
 
-:::code language="csharp" source="./snippets/System.Globalization/DateTimeFormatInfo/csharp/parse1.cs" interactive="try-dotnet" id="Snippet15":::
+:::code language="csharp" source="./snippets/System.Globalization/DateTimeFormatInfo/csharp/parse1.cs" id="Snippet15":::
 
 Date and time strings are typically parsed for two reasons:
 

--- a/docs/fundamentals/runtime-libraries/system-globalization-numberformatinfo.md
+++ b/docs/fundamentals/runtime-libraries/system-globalization-numberformatinfo.md
@@ -26,7 +26,7 @@ You can instantiate a <xref:System.Globalization.NumberFormatInfo> object for th
 
 The following example uses these three ways to create <xref:System.Globalization.NumberFormatInfo> objects that represent the formatting conventions of the current culture. It also retrieves the value of the <xref:System.Globalization.NumberFormatInfo.IsReadOnly> property to illustrate that each object is read-only.
 
-:::code language="csharp" source="./snippets/System.Globalization/NumberFormatInfo/csharp/instantiate1.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="./snippets/System.Globalization/NumberFormatInfo/csharp/instantiate1.cs" id="Snippet1":::
 
 You can create a writable <xref:System.Globalization.NumberFormatInfo> object that represents the conventions of the current culture in any of the following ways:
 
@@ -58,7 +58,7 @@ You can instantiate a <xref:System.Globalization.NumberFormatInfo> object that r
 
 The following example uses each of these methods to instantiate a <xref:System.Globalization.NumberFormatInfo> object that represents the invariant culture. It then indicates whether the object is read-only,
 
-:::code language="csharp" source="./snippets/System.Globalization/NumberFormatInfo/csharp/instantiate4.cs" interactive="try-dotnet" id="Snippet4":::
+:::code language="csharp" source="./snippets/System.Globalization/NumberFormatInfo/csharp/instantiate4.cs" id="Snippet4":::
 
 ### Instantiate a NumberFormatInfo object for a specific culture
 
@@ -74,7 +74,7 @@ A specific culture represents a language that is spoken in a particular country/
 
 The following example uses these four ways to create a <xref:System.Globalization.NumberFormatInfo> object that reflects the formatting conventions of the Indonesian (Indonesia) culture. It also indicates whether each object is read-only.
 
-:::code language="csharp" source="./snippets/System.Globalization/NumberFormatInfo/csharp/instantiate5.cs" interactive="try-dotnet" id="Snippet5":::
+:::code language="csharp" source="./snippets/System.Globalization/NumberFormatInfo/csharp/instantiate5.cs" id="Snippet5":::
 
 ### Instantiate a NumberFormatInfo object for a neutral culture
 
@@ -141,11 +141,11 @@ If an <xref:System.IFormatProvider> implementation is not explicitly provided in
 
 Every formatting operation uses either a standard or a custom numeric format string to produce a result string from a number. In some cases, the use of a format string to produce a result string is explicit, as in the following example. This code calls the <xref:System.Decimal.ToString%28System.IFormatProvider%29?displayProperty=nameWithType> method to convert a <xref:System.Decimal> value to a number of different string representations by using the formatting conventions of the en-US culture.
 
-:::code language="csharp" source="./snippets/System.Globalization/NumberFormatInfo/csharp/properties1.cs" interactive="try-dotnet" id="Snippet2":::
+:::code language="csharp" source="./snippets/System.Globalization/NumberFormatInfo/csharp/properties1.cs" id="Snippet2":::
 
 In other cases, the use of a format string is implicit. For example, in the following method calls to the default or parameterless <xref:System.Decimal.ToString?displayProperty=nameWithType> method, the value of the <xref:System.Decimal> instance is formatted by using the general ("G") format specifier and the conventions of the current culture, which in this case is the en-US culture.
 
-:::code language="csharp" source="./snippets/System.Globalization/NumberFormatInfo/csharp/properties2.cs" interactive="try-dotnet" id="Snippet3":::
+:::code language="csharp" source="./snippets/System.Globalization/NumberFormatInfo/csharp/properties2.cs" id="Snippet3":::
 
 Each standard numeric format string uses one or more <xref:System.Globalization.NumberFormatInfo> properties to determine the pattern or the symbols used in the result string. Similarly, each custom numeric format specifier except "0" and "#" insert symbols in the result string that are defined by <xref:System.Globalization.NumberFormatInfo> properties. The following table lists the standard and custom numeric format specifiers and their associated <xref:System.Globalization.NumberFormatInfo> properties. To change the appearance of the result string for a particular culture, see the [Modify NumberFormatInfo properties](#modify-numberformatinfo-properties) section. For details about the use of these format specifiers, see [Standard Numeric Format Strings](../../standard/base-types/standard-numeric-format-strings.md) and [Custom Numeric Format Strings](../../standard/base-types/custom-numeric-format-strings.md).
 
@@ -187,13 +187,13 @@ The following sections provide some examples.
 
 The following example modifies a <xref:System.Globalization.NumberFormatInfo> object that represents the formatting conventions of the en-US culture. It assigns the ISO-4217 currency symbol to the <xref:System.Globalization.NumberFormatInfo.CurrencySymbol> property and defines a pattern for currency values that consists of the currency symbol followed by a space and a numeric value.
 
-:::code language="csharp" source="./snippets/System.Globalization/NumberFormatInfo/csharp/customize_currency1.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="./snippets/System.Globalization/NumberFormatInfo/csharp/customize_currency1.cs" id="Snippet1":::
 
 ### Format a national identification number
 
 Many national identification numbers consist exclusively of digits and so can easily be formatted by modifying the properties of a <xref:System.Globalization.NumberFormatInfo> object. For example, a social security number in the United States consists of 9 digits arranged as follows: `XXX-XX-XXXX`. The following example assumes that social security numbers are stored as integer values and formats them appropriately.
 
-:::code language="csharp" source="./snippets/System.Globalization/NumberFormatInfo/csharp/customize_ssn1.cs" interactive="try-dotnet" id="Snippet2":::
+:::code language="csharp" source="./snippets/System.Globalization/NumberFormatInfo/csharp/customize_ssn1.cs" id="Snippet2":::
 
 ## Parse numeric strings
 
@@ -205,7 +205,7 @@ The parsing methods also implicitly or explicitly use a <xref:System.Globalizati
 
 The following example illustrates the culture-sensitive nature of parsing strings. It tries to parse a string that include thousands separators by using the conventions of the en-US, fr-FR, and invariant cultures. A string that includes the comma as a group separator and the period as a decimal separator fails to parse in the fr-FR culture, and a string with white space as a group separator and a comma as a decimal separator fails to parse in the en-US and invariant cultures.
 
-:::code language="csharp" source="./snippets/System.Globalization/NumberFormatInfo/csharp/parse1.cs" interactive="try-dotnet" id="Snippet4":::
+:::code language="csharp" source="./snippets/System.Globalization/NumberFormatInfo/csharp/parse1.cs" id="Snippet4":::
 
 Parsing generally occurs in two contexts:
 
@@ -221,7 +221,7 @@ When you are parsing numeric strings input by the user, you should always instan
 
 The following example illustrates the difference between a parsing operation that reflects user cultural settings and one that does not. In this case, the default system culture is en-US, but the user has defined "," as the decimal symbol and "." as the group separator in Control Panel, **Region and Language**. Ordinarily, these symbols are reversed in the default en-US culture. When the user enters a string that reflects user settings, and the string is parsed by a <xref:System.Globalization.NumberFormatInfo> object that also reflects user settings (overrides), the parsing operation returns a correct result. However, when the string is parsed by a <xref:System.Globalization.NumberFormatInfo> object that reflects standard en-US cultural settings, it mistakes the comma symbol for a group separator and returns an incorrect result.
 
-:::code language="csharp" source="./snippets/System.Globalization/NumberFormatInfo/csharp/parseuser1.cs" interactive="try-dotnet" id="Snippet5":::
+:::code language="csharp" source="./snippets/System.Globalization/NumberFormatInfo/csharp/parseuser1.cs" id="Snippet5":::
 
 ### Serialize and deserialize numeric data
 
@@ -231,4 +231,4 @@ The following example illustrates what can happen when this principle is violate
 The data is then parsed by a thread that uses the culture-specific settings of the pt-BR culture. In this case, although each parsing operation succeeds, the data doesn't round-trip successfully and data corruption occurs.
 In other cases, a parsing operation could fail and a <xref:System.FormatException> exception could be thrown.
 
-:::code language="csharp" source="./snippets/System.Globalization/NumberFormatInfo/csharp/parsepersisted.cs" interactive="try-dotnet" id="Snippet6":::
+:::code language="csharp" source="./snippets/System.Globalization/NumberFormatInfo/csharp/parsepersisted.cs" id="Snippet6":::

--- a/docs/fundamentals/runtime-libraries/system-int32.md
+++ b/docs/fundamentals/runtime-libraries/system-int32.md
@@ -37,13 +37,13 @@ You can instantiate an <xref:System.Int32> value in several ways:
 
 - You can call a method of the <xref:System.Convert> class to convert any supported type to an <xref:System.Int32> value. This is possible because <xref:System.Int32> supports the <xref:System.IConvertible> interface. The following example illustrates the conversion of an array of <xref:System.Decimal> values to <xref:System.Int32> values.
 
-  :::code language="csharp" source="./snippets/System/Convert/ToInt32/csharp/toint32_1.cs" interactive="try-dotnet-method" id="Snippet4":::
+  :::code language="csharp" source="./snippets/System/Convert/ToInt32/csharp/toint32_1.cs" id="Snippet4":::
   :::code language="fsharp" source="./snippets/System/Int32/Overview/fsharp/toint32_1.fs" id="Snippet4":::
   :::code language="vb" source="./snippets/System/Convert/Overview/vb/toint32_1.vb" id="Snippet4":::
 
 - You can call the <xref:System.Int32.Parse%2A> or <xref:System.Int32.TryParse%2A> method to convert the string representation of an <xref:System.Int32> value to an <xref:System.Int32>. The string can contain either decimal or hexadecimal digits. The following example illustrates the parse operation by using both a decimal and a hexadecimal string.
 
-  :::code language="csharp" source="./snippets/System/Int32/Overview/csharp/Instantiate1.cs" interactive="try-dotnet-method" id="Snippet3":::
+  :::code language="csharp" source="./snippets/System/Int32/Overview/csharp/Instantiate1.cs" id="Snippet3":::
   :::code language="fsharp" source="./snippets/System/Int32/Overview/fsharp/Instantiate1.fs" id="Snippet3":::
   :::code language="vb" source="./snippets/System/Int32/Overview/vb/Instantiate1.vb" id="Snippet3":::
 
@@ -61,13 +61,13 @@ The <xref:System.Int32> type provides full support for standard and custom numer
 
 To format an <xref:System.Int32> value as an integral string with no leading zeros, you can call the parameterless <xref:System.Int32.ToString> method. By using the "D" format specifier, you can also include a specified number of leading zeros in the string representation. By using the "N" format specifier, you can include group separators and specify the number of decimal digits to appear in the string representation of the number. By using the "X" format specifier, you can represent an <xref:System.Int32> value as a hexadecimal string. The following example formats the elements in an array of <xref:System.Int32> values in these four ways.
 
-:::code language="csharp" source="./snippets/System/Int32/Overview/csharp/Formatting1.cs" interactive="try-dotnet-method" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/Int32/Overview/csharp/Formatting1.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/Int32/Overview/fsharp/Formatting1.fs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/Int32/Overview/vb/Formatting1.vb" id="Snippet1":::
 
 You can also format an <xref:System.Int32> value as a binary, octal, decimal, or hexadecimal string by calling the <xref:System.Convert.ToString%28System.Int32%2CSystem.Int32%29> method and supplying the base as the method's second parameter. The following example calls this method to display the binary, octal, and hexadecimal representations of an array of integer values.
 
-:::code language="csharp" source="./snippets/System/Int32/Overview/csharp/Formatting1.cs" interactive="try-dotnet-method" id="Snippet2":::
+:::code language="csharp" source="./snippets/System/Int32/Overview/csharp/Formatting1.cs" id="Snippet2":::
 :::code language="fsharp" source="./snippets/System/Int32/Overview/fsharp/Formatting1.fs" id="Snippet2":::
 :::code language="vb" source="./snippets/System/Int32/Overview/vb/Formatting1.vb" id="Snippet2":::
 

--- a/docs/fundamentals/runtime-libraries/system-int64.md
+++ b/docs/fundamentals/runtime-libraries/system-int64.md
@@ -37,13 +37,13 @@ You can instantiate an <xref:System.Int64> value in several ways:
 
 - You can call a method of the <xref:System.Convert> class to convert any supported type to an <xref:System.Int64> value. This is possible because <xref:System.Int64> supports the <xref:System.IConvertible> interface. The following example illustrates the conversion of an array of <xref:System.Decimal> values to <xref:System.Int64> values.
 
-  :::code language="csharp" source="./snippets/System/Convert/ToInt64/csharp/toint64_1.cs" interactive="try-dotnet-method" id="Snippet4":::
+  :::code language="csharp" source="./snippets/System/Convert/ToInt64/csharp/toint64_1.cs" id="Snippet4":::
   :::code language="fsharp" source="./snippets/System/Convert/ToInt64/fsharp/toint64_1.fs" id="Snippet4":::
   :::code language="vb" source="./snippets/System/Convert/Overview/vb/toint64_1.vb" id="Snippet4":::
 
 - You can call the <xref:System.Int64.Parse%2A> or <xref:System.Int64.TryParse%2A> method to convert the string representation of an <xref:System.Int64> value to an <xref:System.Int64>. The string can contain either decimal or hexadecimal digits. The following example illustrates the parse operation by using both a decimal and a hexadecimal string.
 
-  :::code language="csharp" source="./snippets/System/Int64/Overview/csharp/instantiate1.cs" interactive="try-dotnet-method" id="Snippet3":::
+  :::code language="csharp" source="./snippets/System/Int64/Overview/csharp/instantiate1.cs" id="Snippet3":::
   :::code language="fsharp" source="./snippets/System/Int64/Overview/fsharp/instantiate1.fs" id="Snippet3":::
   :::code language="vb" source="./snippets/System/Int64/Overview/vb/instantiate1.vb" id="Snippet3":::
 
@@ -61,13 +61,13 @@ The <xref:System.Int64> type provides full support for standard and custom numer
 
 To format an <xref:System.Int64> value as an integral string with no leading zeros, you can call the parameterless <xref:System.Int64.ToString> method. By using the "D" format specifier, you can also include a specified number of leading zeros in the string representation. By using the "N" format specifier, you can include group separators and specify the number of decimal digits to appear in the string representation of the number. By using the "X" format specifier, you can represent an <xref:System.Int64> value as a hexadecimal string. The following example formats the elements in an array of <xref:System.Int64> values in these four ways.
 
-:::code language="csharp" source="./snippets/System/Int64/Overview/csharp/formatting1.cs" interactive="try-dotnet-method" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/Int64/Overview/csharp/formatting1.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/Convert/ToInt64/fsharp/formatting1.fs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/Int64/Overview/vb/formatting1.vb" id="Snippet1":::
 
 You can also format an <xref:System.Int64> value as a binary, octal, decimal, or hexadecimal string by calling the <xref:System.Convert.ToString%28System.Int64%2CSystem.Int32%29> method and supplying the base as the method's second parameter. The following example calls this method to display the binary, octal, and hexadecimal representations of an array of integer values.
 
-:::code language="csharp" source="./snippets/System/Int64/Overview/csharp/formatting1.cs" interactive="try-dotnet-method" id="Snippet2":::
+:::code language="csharp" source="./snippets/System/Int64/Overview/csharp/formatting1.cs" id="Snippet2":::
 :::code language="fsharp" source="./snippets/System/Convert/ToInt64/fsharp/formatting1.fs" id="Snippet2":::
 :::code language="vb" source="./snippets/System/Int64/Overview/vb/formatting1.vb" id="Snippet2":::
 

--- a/docs/fundamentals/runtime-libraries/system-invalidcastexception.md
+++ b/docs/fundamentals/runtime-libraries/system-invalidcastexception.md
@@ -38,7 +38,7 @@ For a list of initial property values for an instance of <xref:System.InvalidCas
 
 You directly or indirectly call a primitive type's <xref:System.IConvertible> implementation that does not support a particular conversion. For example, trying to convert a <xref:System.Boolean> value to a <xref:System.Char> or a <xref:System.DateTime> value to an <xref:System.Int32> throws an <xref:System.InvalidCastException> exception. The following example calls both the <xref:System.Boolean.System%23IConvertible%23ToChar%2A?displayProperty=nameWithType> and <xref:System.Convert.ToChar%28System.Boolean%29?displayProperty=nameWithType> methods to convert a <xref:System.Boolean> value to a <xref:System.Char>. In both cases, the method call throws an <xref:System.InvalidCastException> exception.
 
-:::code language="csharp" source="./snippets/System/InvalidCastException/Overview/csharp/iconvertible1.cs" interactive="try-dotnet" id="Snippet2":::
+:::code language="csharp" source="./snippets/System/InvalidCastException/Overview/csharp/iconvertible1.cs" id="Snippet2":::
 :::code language="fsharp" source="./snippets/System/InvalidCastException/Overview/fsharp/iconvertible1.fs" id="Snippet2":::
 :::code language="vb" source="./snippets/System/InvalidCastException/Overview/vb/iconvertible1.vb" id="Snippet2":::
 
@@ -62,7 +62,7 @@ In most cases, because the conversion is not supported, there is no workaround.
 
 You're downcasting, that is, trying to convert an instance of a base type to one of its derived types. In the following example, trying to convert a `Person` object to a `PersonWithID` object fails.
 
-:::code language="csharp" source="./snippets/System/InvalidCastException/Overview/csharp/basetoderived1.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/InvalidCastException/Overview/csharp/basetoderived1.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/InvalidCastException/Overview/fsharp/basetoderived1.fs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/InvalidCastException/Overview/vb/basetoderived1.vb" id="Snippet1":::
 
@@ -90,7 +90,7 @@ You're trying to convert a value or an object to its string representation by us
 
 To successfully convert an instance of any type to its string representation, call its `ToString` method, as the following example does. The `ToString` method is always present, since the <xref:System.Object.ToString%2A> method is defined by the <xref:System.Object> class and therefore is either inherited or overridden by all managed types.
 
-:::code language="csharp" source="./snippets/System/InvalidCastException/Overview/csharp/ToString2.cs" interactive="try-dotnet" id="Snippet5":::
+:::code language="csharp" source="./snippets/System/InvalidCastException/Overview/csharp/ToString2.cs" id="Snippet5":::
 :::code language="fsharp" source="./snippets/System/InvalidCastException/Overview/fsharp/ToString2.fs" id="Snippet5":::
 
 ## Visual Basic 6.0 migration

--- a/docs/fundamentals/runtime-libraries/system-invalidoperationexception.md
+++ b/docs/fundamentals/runtime-libraries/system-invalidoperationexception.md
@@ -84,7 +84,7 @@ You can eliminate the exception in one of two ways, depending on your applicatio
 
 - If elements must be added to the collection while iterating it, you can iterate it by index using the `for` (`for..to` in F#) statement instead of `foreach`, `for...in`, or `For Each`. The following example uses the for statement to add the square of numbers in the collection to the collection.
 
-  :::code language="csharp" source="./snippets/System/InvalidOperationException/Overview/csharp/Other/Iterating2.cs" interactive="try-dotnet" id="Snippet2":::
+  :::code language="csharp" source="./snippets/System/InvalidOperationException/Overview/csharp/Other/Iterating2.cs" id="Snippet2":::
   :::code language="fsharp" source="./snippets/System/InvalidOperationException/Overview/fsharp/Iterating2.fs" id="Snippet2":::
   :::code language="vb" source="./snippets/System/InvalidOperationException/Overview/vb/Other/Iterating2.vb" id="Snippet2":::
 
@@ -92,7 +92,7 @@ You can eliminate the exception in one of two ways, depending on your applicatio
 
 - If it is not necessary to add elements to the collection while iterating it, you can store the elements to be added in a temporary collection that you add when iterating the collection has finished. The following example uses this approach to add the square of numbers in a collection to a temporary collection, and then to combine the collections into a single array object.
 
-  :::code language="csharp" source="./snippets/System/InvalidOperationException/Overview/csharp/Other/Iterating3.cs" interactive="try-dotnet" id="Snippet3":::
+  :::code language="csharp" source="./snippets/System/InvalidOperationException/Overview/csharp/Other/Iterating3.cs" id="Snippet3":::
   :::code language="fsharp" source="./snippets/System/InvalidOperationException/Overview/fsharp/Iterating3.fs" id="Snippet3":::
   :::code language="vb" source="./snippets/System/InvalidOperationException/Overview/vb/Other/Iterating3.vb" id="Snippet3":::
 
@@ -110,7 +110,7 @@ You can eliminate the exception in any of three ways:
 
   The following example uses this approach to provide an <xref:System.IComparable%601> implementation for the `Person` class. You can still call the collection or array's general sorting method and, as the output from the example shows, the collection sorts successfully.
 
-  :::code language="csharp" source="./snippets/System/InvalidOperationException/Overview/csharp/Other/List_Sort2.cs" interactive="try-dotnet" id="Snippet13":::
+  :::code language="csharp" source="./snippets/System/InvalidOperationException/Overview/csharp/Other/List_Sort2.cs" id="Snippet13":::
   :::code language="fsharp" source="./snippets/System/InvalidOperationException/Overview/fsharp/List_Sort2.fs" id="Snippet13":::
   :::code language="vb" source="./snippets/System/InvalidOperationException/Overview/vb/Other/List_Sort2.vb" id="Snippet13":::
 
@@ -118,7 +118,7 @@ You can eliminate the exception in any of three ways:
 
   The following example uses the approach by developing a custom `PersonComparer` class that is used to sort `Person` collections. It then passes an instance of this class to the <xref:System.Collections.Generic.List%601.Sort%28System.Collections.Generic.IComparer%7B%600%7D%29?displayProperty=nameWithType> method.
 
-  :::code language="csharp" source="./snippets/System/InvalidOperationException/Overview/csharp/Other/List_Sort3.cs" interactive="try-dotnet" id="Snippet14":::
+  :::code language="csharp" source="./snippets/System/InvalidOperationException/Overview/csharp/Other/List_Sort3.cs" id="Snippet14":::
   :::code language="fsharp" source="./snippets/System/InvalidOperationException/Overview/fsharp/List_Sort3.fs" id="Snippet14":::
   :::code language="vb" source="./snippets/System/InvalidOperationException/Overview/vb/Other/List_Sort3.vb" id="Snippet14":::
 
@@ -134,7 +134,7 @@ You can eliminate the exception in any of three ways:
 
   The following example uses the approach by defining a  `PersonComparison` method that matches the  <xref:System.Comparison%601> delegate signature. It then passes this delegate to the <xref:System.Collections.Generic.List%601.Sort%28System.Comparison%7B%600%7D%29?displayProperty=nameWithType> method.
 
-  :::code language="csharp" source="./snippets/System/InvalidOperationException/Overview/csharp/Other/List_Sort4.cs" interactive="try-dotnet" id="Snippet15":::
+  :::code language="csharp" source="./snippets/System/InvalidOperationException/Overview/csharp/Other/List_Sort4.cs" id="Snippet15":::
   :::code language="fsharp" source="./snippets/System/InvalidOperationException/Overview/fsharp/List_Sort4.fs" id="Snippet15":::
   :::code language="vb" source="./snippets/System/InvalidOperationException/Overview/vb/Other/List_Sort4.vb" id="Snippet15":::
 
@@ -155,7 +155,7 @@ To prevent the exception:
 
 The following example does both to avoid the  <xref:System.InvalidOperationException> exception.
 
-:::code language="csharp" source="./snippets/System/InvalidOperationException/Overview/csharp/Other/Nullable2.cs" interactive="try-dotnet" id="Snippet5":::
+:::code language="csharp" source="./snippets/System/InvalidOperationException/Overview/csharp/Other/Nullable2.cs" id="Snippet5":::
 :::code language="fsharp" source="./snippets/System/InvalidOperationException/Overview/fsharp/Nullable2.fs" id="Snippet5":::
 :::code language="vb" source="./snippets/System/InvalidOperationException/Overview/vb/Other/Nullable2.vb" id="Snippet5":::
 
@@ -195,7 +195,7 @@ The following example uses the <xref:System.Linq.Enumerable.Average%2A?displayPr
 
 The exception can be eliminated by calling the <xref:System.Linq.Enumerable.Any%2A> method to determine whether the sequence contains any elements before calling the method that processes the sequence, as the following example shows.
 
-:::code language="csharp" source="./snippets/System/InvalidOperationException/Overview/csharp/Other/Enumerable2.cs" interactive="try-dotnet" id="Snippet7":::
+:::code language="csharp" source="./snippets/System/InvalidOperationException/Overview/csharp/Other/Enumerable2.cs" id="Snippet7":::
 :::code language="fsharp" source="./snippets/System/InvalidOperationException/Overview/fsharp/Enumerable2.fs" id="Snippet7":::
 :::code language="vb" source="./snippets/System/InvalidOperationException/Overview/vb/Other/Enumerable2.vb" id="Snippet7":::
 
@@ -214,7 +214,7 @@ You can call the <xref:System.Linq.Enumerable.FirstOrDefault%2A?displayProperty=
 
 The following example calls the  <xref:System.Linq.Enumerable.FirstOrDefault%60%601%28System.Collections.Generic.IEnumerable%7B%60%600%7D%2CSystem.Func%7B%60%600%2CSystem.Boolean%7D%29?displayProperty=nameWithType> method to prevent the <xref:System.InvalidOperationException> exception thrown in the previous example.
 
-:::code language="csharp" source="./snippets/System/InvalidOperationException/Overview/csharp/Other/Enumerable4.cs" interactive="try-dotnet" id="Snippet9":::
+:::code language="csharp" source="./snippets/System/InvalidOperationException/Overview/csharp/Other/Enumerable4.cs" id="Snippet9":::
 :::code language="fsharp" source="./snippets/System/InvalidOperationException/Overview/fsharp/Enumerable4.fs" id="Snippet9":::
 :::code language="vb" source="./snippets/System/InvalidOperationException/Overview/vb/Other/Enumerable4.vb" id="Snippet9":::
 

--- a/docs/fundamentals/runtime-libraries/system-numerics-complex.md
+++ b/docs/fundamentals/runtime-libraries/system-numerics-complex.md
@@ -35,7 +35,7 @@ You can assign a value to a complex number in one of the following ways:
 
 The following example demonstrates each of these five ways of assigning a value to a complex number.
 
-:::code language="csharp" source="./snippets/System.Numerics/Complex/Overview/csharp/create1.cs" interactive="try-dotnet" id="Snippet2":::
+:::code language="csharp" source="./snippets/System.Numerics/Complex/Overview/csharp/create1.cs" id="Snippet2":::
 :::code language="vb" source="./snippets/System.Numerics/Complex/Overview/vb/create1.vb" id="Snippet2":::
 
 ## Operations with complex numbers

--- a/docs/fundamentals/runtime-libraries/system-object-equals.md
+++ b/docs/fundamentals/runtime-libraries/system-object-equals.md
@@ -17,7 +17,7 @@ The type of comparison between the current instance and the `obj` parameter depe
 
 - If the current instance is a reference type, the <xref:System.Object.Equals(System.Object)> method tests for reference equality, and a call to the <xref:System.Object.Equals(System.Object)> method is equivalent to a call to the <xref:System.Object.ReferenceEquals%2A> method. Reference equality means that the object variables that are compared refer to the same object. The following example illustrates the result of such a comparison. It defines a `Person` class, which is a reference type, and calls the `Person` class constructor to instantiate two new `Person` objects, `person1a` and `person2`, which have the same value. It also assigns `person1a` to another object variable, `person1b`. As the output from the example shows, `person1a` and `person1b` are equal because they reference the same object. However, `person1a` and `person2` are not equal, although they have the same value.
 
-  :::code language="csharp" source="./snippets/System/Object/Equals/csharp/equals_ref.cs" interactive="try-dotnet" id="Snippet2":::
+  :::code language="csharp" source="./snippets/System/Object/Equals/csharp/equals_ref.cs" id="Snippet2":::
   :::code language="fsharp" source="./snippets/System/Object/Equals/fsharp/equals_ref.fs" id="Snippet2":::
   :::code language="vb" source="./snippets/System/Object/Equals/vb/equals_ref.vb" id="Snippet2":::
 
@@ -25,7 +25,7 @@ The type of comparison between the current instance and the `obj` parameter depe
 
   - The two objects are of the same type. As the following example shows, a <xref:System.Byte> object that has a value of 12 does not equal an <xref:System.Int32> object that has a value of 12, because the two objects have different run-time types.
 
-    :::code language="csharp" source="./snippets/System/Object/Equals/csharp/equals_val1.cs" interactive="try-dotnet-method" id="Snippet3":::
+    :::code language="csharp" source="./snippets/System/Object/Equals/csharp/equals_val1.cs" id="Snippet3":::
     :::code language="fsharp" source="./snippets/System/Object/Equals/fsharp/equals_val1.fs" id="Snippet3":::
     :::code language="vb" source="./snippets/System/Object/Equals/vb/equals_val1.vb" id="Snippet3":::
 
@@ -50,7 +50,7 @@ Derived classes frequently override the <xref:System.Object.Equals(System.Object
 
 The following example provides an illustration. It instantiates three <xref:System.Text.StringBuilder> objects with identical strings, and then makes four calls to `Equals` methods. The first method call returns `true`, and the remaining three return `false`.
 
-:::code language="csharp" source="./snippets/System/Object/Equals/csharp/equalssb1.cs" interactive="try-dotnet" id="Snippet5":::
+:::code language="csharp" source="./snippets/System/Object/Equals/csharp/equalssb1.cs" id="Snippet5":::
 :::code language="fsharp" source="./snippets/System/Object/Equals/fsharp/equalssb1.fs" id="Snippet5":::
 :::code language="vb" source="./snippets/System/Object/Equals/vb/equalssb1.vb" id="Snippet5":::
 
@@ -130,7 +130,7 @@ The following guidelines apply to overriding <xref:System.Object.Equals(System.O
 
 The following example shows a `Point` class that overrides the <xref:System.Object.Equals%2A> method to provide value equality, and a `Point3D` class that is derived from `Point`. Because `Point` overrides <xref:System.Object.Equals(System.Object)?displayProperty=nameWithType> to test for value equality, the <xref:System.Object.Equals(System.Object)?displayProperty=nameWithType> method is not called. However, `Point3D.Equals` calls `Point.Equals` because `Point` implements <xref:System.Object.Equals(System.Object)?displayProperty=nameWithType> in a manner that provides value equality.
 
-:::code language="csharp" source="./snippets/System/Object/Equals/csharp/equals2.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/Object/Equals/csharp/equals2.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/Object/Equals/fsharp/equals2.fs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/Object/Equals/vb/equals2.vb" id="Snippet1":::
 
@@ -142,13 +142,13 @@ In `Point3D.Equals`, the inherited `Point.Equals` method, which overrides <xref:
 
 The following example defines a `Rectangle` class that internally implements a rectangle as two `Point` objects. The `Rectangle` class also overrides <xref:System.Object.Equals(System.Object)?displayProperty=nameWithType> to provide for value equality.
 
-:::code language="csharp" source="./snippets/System/Object/Equals/csharp/equals3.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/Object/Equals/csharp/equals3.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/Object/Equals/fsharp/equals3.fs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/Object/Equals/vb/equals3.vb" id="Snippet1":::
 
 Some languages such as C# and Visual Basic support operator overloading. When a type overloads the equality operator, it must also override the <xref:System.Object.Equals(System.Object)> method to provide the same functionality. This is typically accomplished by writing the <xref:System.Object.Equals(System.Object)> method in terms of the overloaded equality operator, as in the following example.
 
-:::code language="csharp" source="./snippets/System/Object/Equals/csharp/equals4.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/Object/Equals/csharp/equals4.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/Object/Equals/fsharp/equals4.fs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/Object/Equals/vb/equals4.vb" id="Snippet1":::
 

--- a/docs/fundamentals/runtime-libraries/system-object-gethashcode.md
+++ b/docs/fundamentals/runtime-libraries/system-object-gethashcode.md
@@ -48,19 +48,19 @@ When you call the <xref:System.Object.GetHashCode%2A> method on a class in the W
 
 One of the simplest ways to compute a hash code for a numeric value that has the same or a smaller range than the <xref:System.Int32> type is to simply return that value. The following example shows such an implementation for a `Number` structure.
 
-:::code language="csharp" source="./snippets/System/Object/GetHashCode/csharp/direct1.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/Object/GetHashCode/csharp/direct1.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/Object/GetHashCode/fsharp/direct1.fs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/Object/GetHashCode/vb/direct1.vb" id="Snippet1":::
 
 Frequently, a type has multiple data fields that can participate in generating the hash code. One way to generate a hash code is to combine these fields using an `XOR (eXclusive OR)` operation, as shown in the following example.
 
-:::code language="csharp" source="./snippets/System/Object/GetHashCode/csharp/xor1.cs" interactive="try-dotnet" id="Snippet2":::
+:::code language="csharp" source="./snippets/System/Object/GetHashCode/csharp/xor1.cs" id="Snippet2":::
 :::code language="fsharp" source="./snippets/System/Object/GetHashCode/fsharp/xor1.fs" id="Snippet2":::
 :::code language="vb" source="./snippets/System/Object/GetHashCode/vb/xor1.vb" id="Snippet2":::
 
 The previous example returns the same hash code for (n1, n2) and (n2, n1), and so may generate more collisions than are desirable. A number of solutions are available so that hash codes in these cases are not identical. One is to return the hash code of a `Tuple` object that reflects the order of each field. The following example shows a possible implementation that uses the <xref:System.Tuple%602> class. Note, though, that the performance overhead of instantiating a `Tuple` object may significantly impact the overall performance of an application that stores large numbers of objects in hash tables.
 
-:::code language="csharp" source="./snippets/System/Object/GetHashCode/csharp/xor2.cs" interactive="try-dotnet" id="Snippet3":::
+:::code language="csharp" source="./snippets/System/Object/GetHashCode/csharp/xor2.cs" id="Snippet3":::
 :::code language="fsharp" source="./snippets/System/Object/GetHashCode/fsharp/xor2.fs" id="Snippet3":::
 :::code language="vb" source="./snippets/System/Object/GetHashCode/vb/xor2.vb" id="Snippet3":::
 
@@ -72,6 +72,6 @@ A second alternative solution involves weighting the individual hash codes by le
 
 The following example then uses this shift-and-wrap method to compute the hash code of the `Point` structure used in the previous examples.
 
-:::code language="csharp" source="./snippets/System/Object/GetHashCode/csharp/shift1.cs" interactive="try-dotnet" id="Snippet5":::
+:::code language="csharp" source="./snippets/System/Object/GetHashCode/csharp/shift1.cs" id="Snippet5":::
 :::code language="fsharp" source="./snippets/System/Object/GetHashCode/fsharp/shift1.fs" id="Snippet5":::
 :::code language="vb" source="./snippets/System/Object/GetHashCode/vb/shift1.vb" id="Snippet5":::

--- a/docs/fundamentals/runtime-libraries/system-object-tostring.md
+++ b/docs/fundamentals/runtime-libraries/system-object-tostring.md
@@ -22,13 +22,13 @@ Types frequently override the <xref:System.Object.ToString%2A?displayProperty=na
 
 The default implementation of the <xref:System.Object.ToString%2A> method returns the fully qualified name of the type of the <xref:System.Object>, as the following example shows.
 
-:::code language="csharp" source="./snippets/System/Object/ToString/csharp/tostring1.cs" interactive="try-dotnet-method" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/Object/ToString/csharp/tostring1.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/Object/ToString/fsharp/tostring1.fs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/Object/ToString/vb/tostring1.vb" id="Snippet1":::
 
 Because <xref:System.Object> is the base class of all reference types in .NET, this behavior is inherited by reference types that do not override the <xref:System.Object.ToString%2A> method. The following example illustrates this. It defines a class named `Object1` that accepts the default implementation of all <xref:System.Object> members. Its <xref:System.Object.ToString%2A> method returns the object's fully qualified type name.
 
-:::code language="csharp" source="./snippets/System/Object/ToString/csharp/tostring2.cs" interactive="try-dotnet" id="Snippet2":::
+:::code language="csharp" source="./snippets/System/Object/ToString/csharp/tostring2.cs" id="Snippet2":::
 :::code language="fsharp" source="./snippets/System/Object/ToString/fsharp/tostring2.fs" id="Snippet2":::
 :::code language="vb" source="./snippets/System/Object/ToString/vb/tostring2.vb" id="Snippet2":::
 
@@ -36,7 +36,7 @@ Because <xref:System.Object> is the base class of all reference types in .NET, t
 
 Types commonly override the <xref:System.Object.ToString%2A?displayProperty=nameWithType> method to return a string that represents the object instance. For example, the base types such as <xref:System.Char>, <xref:System.Int32>, and <xref:System.String> provide <xref:System.Object.ToString%2A> implementations that return the string form of the value that the object represents. The following example defines a class, `Object2`, that overrides the <xref:System.Object.ToString%2A> method to return the type name along with its value.
 
-:::code language="csharp" source="./snippets/System/Object/ToString/csharp/tostring3.cs" interactive="try-dotnet" id="Snippet3":::
+:::code language="csharp" source="./snippets/System/Object/ToString/csharp/tostring3.cs" id="Snippet3":::
 :::code language="fsharp" source="./snippets/System/Object/ToString/fsharp/tostring3.fs" id="Snippet3":::
 :::code language="vb" source="./snippets/System/Object/ToString/vb/tostring3.vb" id="Snippet3":::
 
@@ -58,7 +58,7 @@ In addition to overriding the parameterless <xref:System.Object.ToString?display
 
 The following example overloads the `ToString` method to return a result string that includes the value of various fields of an `Automobile` class. It defines four format strings: G, which returns the model name and year; D, which returns the model name, year, and number of doors; C, which returns the model name, year, and number of cylinders; and A, which returns a string with all four field values.
 
-:::code language="csharp" source="./snippets/System/Object/ToString/csharp/tostringoverload1.cs" interactive="try-dotnet" id="Snippet4":::
+:::code language="csharp" source="./snippets/System/Object/ToString/csharp/tostringoverload1.cs" id="Snippet4":::
 :::code language="fsharp" source="./snippets/System/Object/ToString/fsharp/tostringoverload1.fs" id="Snippet4":::
 :::code language="vb" source="./snippets/System/Object/ToString/vb/tostringoverload1.vb" id="Snippet4":::
 
@@ -74,7 +74,7 @@ For more information on format strings and culture-sensitive formatting, see [Fo
 
 Because a type inherits the default <xref:System.Object.ToString%2A?displayProperty=nameWithType> method, you may find its behavior undesirable and want to change it. This is particularly true of arrays and collection classes. While you may expect the `ToString` method of an array or collection class to display the values of its members, it instead displays the type fully qualified type name, as the following example shows.
 
-:::code language="csharp" source="./snippets/System/Object/ToString/csharp/array1.cs" interactive="try-dotnet-method" id="Snippet6":::
+:::code language="csharp" source="./snippets/System/Object/ToString/csharp/array1.cs" id="Snippet6":::
 :::code language="fsharp" source="./snippets/System/Object/ToString/fsharp/array1.fs" id="Snippet6":::
 :::code language="vb" source="./snippets/System/Object/ToString/vb/array1.vb" id="Snippet6":::
 
@@ -89,7 +89,7 @@ You have several options to produce the result string that you'd like.
 
   The following example defines a wrapper class for the <xref:System.Collections.Generic.List%601> class. It overrides the <xref:System.Object.ToString%2A?displayProperty=nameWithType> method to display the value of each method of the collection rather than the fully qualified type name.
 
-  :::code language="csharp" source="./snippets/System/Object/ToString/csharp/customize1.cs" interactive="try-dotnet" id="Snippet7":::
+  :::code language="csharp" source="./snippets/System/Object/ToString/csharp/customize1.cs" id="Snippet7":::
   :::code language="fsharp" source="./snippets/System/Object/ToString/fsharp/customize1.fs" id="Snippet7":::
   :::code language="vb" source="./snippets/System/Object/ToString/vb/customize1.vb" id="Snippet7":::
 
@@ -97,7 +97,7 @@ You have several options to produce the result string that you'd like.
 
   The following example defines two methods that extend the <xref:System.Collections.Generic.List%601> class: a parameterless `ToString2` method, and a `ToString` method with a <xref:System.String> parameter that represents a format string.
 
-  :::code language="csharp" source="./snippets/System/Object/ToString/csharp/customize2.cs" interactive="try-dotnet" id="Snippet8":::
+  :::code language="csharp" source="./snippets/System/Object/ToString/csharp/customize2.cs" id="Snippet8":::
   :::code language="fsharp" source="./snippets/System/Object/ToString/fsharp/customize2.fs" id="Snippet8":::
   :::code language="vb" source="./snippets/System/Object/ToString/vb/customize2.vb" id="Snippet8":::
 

--- a/docs/fundamentals/runtime-libraries/system-random.md
+++ b/docs/fundamentals/runtime-libraries/system-random.md
@@ -30,7 +30,7 @@ If the same seed is used for separate <xref:System.Random> objects, they will ge
 
 To produce different sequences of random numbers, you can make the seed value time-dependent, thereby producing a different series with each new instance of <xref:System.Random>. The parameterized <xref:System.Random.%23ctor%28System.Int32%29> constructor can take an <xref:System.Int32> value based on the number of ticks in the current time, whereas the parameterless <xref:System.Random.%23ctor> constructor uses the system clock to generate its seed value. However, on .NET Framework only, because the clock has finite resolution, using the parameterless constructor to create different <xref:System.Random> objects in close succession creates random number generators that produce identical sequences of random numbers. The following example illustrates how two <xref:System.Random> objects that are instantiated in close succession in a .NET Framework application generate an identical series of random numbers. On most Windows systems, <xref:System.Random> objects created within 15 milliseconds of one another are likely to have identical seed values.
 
-:::code language="csharp" source="./snippets/System/Random/Overview/csharp/Random1.cs" interactive="try-dotnet-method" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/Random/Overview/csharp/Random1.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/Random/Overview/fsharp/Random1.fs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/Random/Overview/vb/Random1.vb" id="Snippet1":::
 
@@ -80,7 +80,7 @@ The random number generator provides methods that let you generate the following
 
 - A series of <xref:System.Byte> values. You determine the number of byte values by passing an array initialized to the number of elements you want the method to return to the <xref:System.Random.NextBytes%2A> method. The following example generates 20 bytes.
 
-  :::code language="csharp" source="./snippets/System/Random/Overview/csharp/nextbytes1.cs" interactive="try-dotnet-method" id="Snippet5":::
+  :::code language="csharp" source="./snippets/System/Random/Overview/csharp/nextbytes1.cs" id="Snippet5":::
   :::code language="fsharp" source="./snippets/System/Random/Overview/fsharp/nextbytes1.fs" id="Snippet5":::
   :::code language="vb" source="./snippets/System/Random/Overview/vb/nextbytes1.vb" id="Snippet5":::
 
@@ -88,13 +88,13 @@ The random number generator provides methods that let you generate the following
 
   The following example calls the <xref:System.Random.Next%28System.Int32%2CSystem.Int32%29> method to generate 10 random numbers between -10 and 10. Note that the second argument to the method specifies the exclusive upper bound of the range of random values returned by the method. In other words, the largest integer that the method can return is one less than this value.
 
-  :::code language="csharp" source="./snippets/System/Random/Overview/csharp/nextex1.cs" interactive="try-dotnet-method" id="Snippet6":::
+  :::code language="csharp" source="./snippets/System/Random/Overview/csharp/nextex1.cs" id="Snippet6":::
   :::code language="fsharp" source="./snippets/System/Random/Overview/fsharp/nextex1.fs" id="Snippet6":::
   :::code language="vb" source="./snippets/System/Random/Overview/vb/nextex1.vb" id="Snippet6":::
 
 - A single floating-point value from 0.0 to less than 1.0 by calling the <xref:System.Random.NextDouble%2A> method. The exclusive upper bound of the random number returned by the method is 1, so its actual upper bound is 0.99999999999999978. The following example generates 10 random floating-point numbers.
 
-  :::code language="csharp" source="./snippets/System/Random/Overview/csharp/nextdoubleex1.cs" interactive="try-dotnet-method" id="Snippet7":::
+  :::code language="csharp" source="./snippets/System/Random/Overview/csharp/nextdoubleex1.cs" id="Snippet7":::
   :::code language="fsharp" source="./snippets/System/Random/Overview/fsharp/nextdoubleex1.fs" id="Snippet7":::
   :::code language="vb" source="./snippets/System/Random/Overview/vb/nextdoubleex1.vb" id="Snippet7":::
 
@@ -115,7 +115,7 @@ Sometimes you want to generate the same sequence of random numbers in software t
 
 You can generate the same sequence of random numbers by providing the same seed value to the <xref:System.Random.%23ctor%28System.Int32%29> constructor. The seed value provides a starting value for the pseudo-random number generation algorithm. The following example uses 100100 as an arbitrary seed value to instantiate the <xref:System.Random> object, displays 20 random floating-point values, and persists the seed value. It then restores the seed value, instantiates a new random number generator, and displays the same 20 random floating-point values. Note that the example may produce different sequences of random numbers if run on different versions of .NET.
 
-:::code language="csharp" source="./snippets/System/Random/Overview/csharp/same1.cs" interactive="try-dotnet" id="Snippet12":::
+:::code language="csharp" source="./snippets/System/Random/Overview/csharp/same1.cs" id="Snippet12":::
 :::code language="fsharp" source="./snippets/System/Random/Overview/fsharp/same1.fs" id="Snippet12":::
 :::code language="vb" source="./snippets/System/Random/Overview/vb/same1.vb" id="Snippet12":::
 
@@ -123,7 +123,7 @@ You can generate the same sequence of random numbers by providing the same seed 
 
 Providing different seed values to instances of the <xref:System.Random> class causes each random number generator to produce a different sequence of values. You can provide a seed value either explicitly by calling the <xref:System.Random.%23ctor%28System.Int32%29> constructor, or implicitly by calling the <xref:System.Random.%23ctor> constructor. Most developers call the parameterless constructor, which uses the system clock. The following example uses this approach to instantiate two <xref:System.Random> instances. Each instance displays a series of 10 random integers.
 
-:::code language="csharp" source="./snippets/System/Random/Overview/csharp/unique.cs" interactive="try-dotnet" id="Snippet13":::
+:::code language="csharp" source="./snippets/System/Random/Overview/csharp/unique.cs" id="Snippet13":::
 :::code language="fsharp" source="./snippets/System/Random/Overview/fsharp/unique.fs" id="Snippet13":::
 :::code language="vb" source="./snippets/System/Random/Overview/vb/unique.vb" id="Snippet13":::
 
@@ -135,7 +135,7 @@ To prevent this from happening, we recommend that you instantiate a single <xref
 
 You can retrieve integers in a specified range by calling the <xref:System.Random.Next%28System.Int32%2CSystem.Int32%29> method, which lets you specify both the lower and the upper bound of the numbers you'd like the random number generator to return. The upper bound is an exclusive, not an inclusive, value. That is, it isn't included in the range of values returned by the method. The following example uses this method to generate random integers between -10 and 10. Note that it specifies 11, which is one greater than the desired value, as the value of the `maxValue` argument in the method call.
 
-:::code language="csharp" source="./snippets/System/Random/Overview/csharp/range1.cs" interactive="try-dotnet-method" id="Snippet15":::
+:::code language="csharp" source="./snippets/System/Random/Overview/csharp/range1.cs" id="Snippet15":::
 :::code language="fsharp" source="./snippets/System/Random/Overview/fsharp/range1.fs" id="Snippet15":::
 :::code language="vb" source="./snippets/System/Random/Overview/vb/range1.vb" id="Snippet15":::
 
@@ -143,7 +143,7 @@ You can retrieve integers in a specified range by calling the <xref:System.Rando
 
 You can call the <xref:System.Random.Next%28System.Int32%2CSystem.Int32%29> method to retrieve numbers with a specified number of digits. For example, to retrieve numbers with four digits (that is, numbers that range from 1000 to 9999), you call the <xref:System.Random.Next%28System.Int32%2CSystem.Int32%29> method with a `minValue` value of 1000 and a `maxValue` value of 10000, as the following example shows.
 
-:::code language="csharp" source="./snippets/System/Random/Overview/csharp/range2.cs" interactive="try-dotnet-method" id="Snippet16":::
+:::code language="csharp" source="./snippets/System/Random/Overview/csharp/range2.cs" id="Snippet16":::
 :::code language="fsharp" source="./snippets/System/Random/Overview/fsharp/range2.fs" id="Snippet16":::
 :::code language="vb" source="./snippets/System/Random/Overview/vb/range2.vb" id="Snippet16":::
 
@@ -153,13 +153,13 @@ The <xref:System.Random.NextDouble%2A> method returns random floating-point valu
 
 If the interval between the minimum and maximum desired values is 1, you can add the difference between the desired starting interval and 0 to the number returned by the <xref:System.Random.NextDouble%2A> method. The following example does this to generate 10 random numbers between -1 and 0.
 
-:::code language="csharp" source="./snippets/System/Random/Overview/csharp/doublerange2.cs" interactive="try-dotnet-method" id="Snippet17":::
+:::code language="csharp" source="./snippets/System/Random/Overview/csharp/doublerange2.cs" id="Snippet17":::
 :::code language="fsharp" source="./snippets/System/Random/Overview/fsharp/doublerange2.fs" id="Snippet17":::
 :::code language="vb" source="./snippets/System/Random/Overview/vb/doublerange2.vb" id="Snippet17":::
 
 To generate random floating-point numbers whose lower bound is 0 but upper bound is greater than 1 (or, in the case of negative numbers, whose lower bound is less than -1 and upper bound is 0), multiply the random number by the non-zero bound. The following example does this to generate 20 million random floating-point numbers that range from 0 to <xref:System.Int64.MaxValue?displayProperty=nameWithType>. In also displays the distribution of the random values generated by the method.
 
-:::code language="csharp" source="./snippets/System/Random/Overview/csharp/doublerange1.cs" interactive="try-dotnet-method" id="Snippet18":::
+:::code language="csharp" source="./snippets/System/Random/Overview/csharp/doublerange1.cs" id="Snippet18":::
 :::code language="fsharp" source="./snippets/System/Random/Overview/fsharp/doublerange1.fs" id="Snippet18":::
 :::code language="vb" source="./snippets/System/Random/Overview/vb/doublerange1.vb" id="Snippet18":::
 
@@ -171,7 +171,7 @@ Random.NextDouble() * (maxValue - minValue) + minValue
 
 The following example generates 1 million random numbers that range from 10.0 to 11.0, and displays their distribution.
 
-:::code language="csharp" source="./snippets/System/Random/Overview/csharp/doublerange3.cs" interactive="try-dotnet-method" id="Snippet19":::
+:::code language="csharp" source="./snippets/System/Random/Overview/csharp/doublerange3.cs" id="Snippet19":::
 :::code language="fsharp" source="./snippets/System/Random/Overview/fsharp/doublerange3.fs" id="Snippet19":::
 :::code language="vb" source="./snippets/System/Random/Overview/vb/doublerange3.vb" id="Snippet19":::
 
@@ -179,13 +179,13 @@ The following example generates 1 million random numbers that range from 10.0 to
 
 The <xref:System.Random> class doesn't provide methods that generate <xref:System.Boolean> values. However, you can define your own class or method to do that. The following example defines a class, `BooleanGenerator`, with a single method, `NextBoolean`. The `BooleanGenerator` class stores a <xref:System.Random> object as a private variable. The `NextBoolean` method calls the <xref:System.Random.Next%28System.Int32%2CSystem.Int32%29?displayProperty=nameWithType> method and passes the result to the <xref:System.Convert.ToBoolean%28System.Int32%29?displayProperty=nameWithType> method. Note that 2 is used as the argument to specify the upper bound of the random number. Since this is an exclusive value, the method call returns either 0 or 1.
 
-:::code language="csharp" source="./snippets/System/Random/Overview/csharp/booleans1.cs" interactive="try-dotnet" id="Snippet8":::
+:::code language="csharp" source="./snippets/System/Random/Overview/csharp/booleans1.cs" id="Snippet8":::
 :::code language="fsharp" source="./snippets/System/Random/Overview/fsharp/booleans1.fs" id="Snippet8":::
 :::code language="vb" source="./snippets/System/Random/Overview/vb/booleans1.vb" id="Snippet8":::
 
 Instead of creating a separate class to generate random <xref:System.Boolean> values, the example could simply have defined a single method. In that case, however, the <xref:System.Random> object should have been defined as a class-level variable to avoid instantiating a new <xref:System.Random> instance in each method call. In Visual Basic, the Random instance can be defined as a [Static](../../visual-basic/language-reference/modifiers/static.md) variable in the `NextBoolean` method. The following example provides an implementation.
 
-:::code language="csharp" source="./snippets/System/Random/Overview/csharp/booleans2.cs" interactive="try-dotnet-method" id="Snippet20":::
+:::code language="csharp" source="./snippets/System/Random/Overview/csharp/booleans2.cs" id="Snippet20":::
 :::code language="fsharp" source="./snippets/System/Random/Overview/fsharp/booleans2.fs" id="Snippet20":::
 :::code language="vb" source="./snippets/System/Random/Overview/vb/booleans2.vb" id="Snippet20":::
 
@@ -199,7 +199,7 @@ The overloads of the <xref:System.Random.Next%2A> method return 32-bit integers.
 
 The following example uses this technique to generate 20 million random long integers and categorizes them in 10 equal groups. It then evaluates the distribution of the random numbers by counting the number in each group from 0 to <xref:System.Int64.MaxValue?displayProperty=nameWithType>. As the output from the example shows, the numbers are distributed more or less equally through the range of a long integer.
 
-:::code language="csharp" source="./snippets/System/Random/Overview/csharp/long1.cs" interactive="try-dotnet-method" id="Snippet14":::
+:::code language="csharp" source="./snippets/System/Random/Overview/csharp/long1.cs" id="Snippet14":::
 :::code language="fsharp" source="./snippets/System/Random/Overview/fsharp/long1.fs" id="Snippet14":::
 :::code language="vb" source="./snippets/System/Random/Overview/vb/long1.vb" id="Snippet14":::
 
@@ -213,7 +213,7 @@ An alternative technique that uses bit manipulation does not generate truly rand
 
 The overloads of the <xref:System.Random.Next%2A> method allow you to specify the range of random numbers, but the <xref:System.Random.NextBytes%2A> method does not. The following example implements a `NextBytes` method that lets you specify the range of the returned bytes. It defines a `Random2` class that derives from <xref:System.Random> and overloads its `NextBytes` method.
 
-:::code language="csharp" source="./snippets/System/Random/Overview/csharp/bytes1.cs" interactive="try-dotnet" id="Snippet9":::
+:::code language="csharp" source="./snippets/System/Random/Overview/csharp/bytes1.cs" id="Snippet9":::
 :::code language="fsharp" source="./snippets/System/Random/Overview/fsharp/bytes1.fs" id="Snippet9":::
 :::code language="vb" source="./snippets/System/Random/Overview/vb/bytes1.vb" id="Snippet9":::
 
@@ -223,7 +223,7 @@ The `NextBytes(Byte[], Byte, Byte)` method wraps a call to the <xref:System.Rand
 
 Random numbers often serve as indexes to retrieve values from arrays or collections. To retrieve a random index value, you can call the <xref:System.Random.Next%28System.Int32%2CSystem.Int32%29> method, and use the lower bound of the array as the value of its `minValue` argument and one greater than the upper bound of the array as the value of its `maxValue` argument. For a zero-based array, this is equivalent to its <xref:System.Array.Length> property, or one greater than the value returned by the <xref:System.Array.GetUpperBound%2A?displayProperty=nameWithType> method. The following example randomly retrieves the name of a city in the United States from an array of cities.
 
-:::code language="csharp" source="./snippets/System/Random/Overview/csharp/array1.cs" interactive="try-dotnet-method" id="Snippet10":::
+:::code language="csharp" source="./snippets/System/Random/Overview/csharp/array1.cs" id="Snippet10":::
 :::code language="fsharp" source="./snippets/System/Random/Overview/fsharp/array1.fs" id="Snippet10":::
 :::code language="vb" source="./snippets/System/Random/Overview/vb/array1.vb" id="Snippet10":::
 
@@ -237,6 +237,6 @@ For example, if you're developing a Solitaire game, you want to ensure that each
 
 The following example illustrates this approach. It defines a `Card` class that represents a playing card and a `Dealer` class that deals a deck of shuffled cards. The `Dealer` class constructor populates two arrays: a `deck` array that has class scope and that represents all the cards in the deck; and a local `order` array that has the same number of elements as the `deck` array and is populated with randomly generated <xref:System.Double> values. The <xref:System.Array.Sort%28System.Array%2CSystem.Array%29?displayProperty=nameWithType> method is then called to sort the `deck` array based on the values in the `order` array.
 
-:::code language="csharp" source="./snippets/System/Random/Overview/csharp/uniquearray1.cs" interactive="try-dotnet" id="Snippet11":::
+:::code language="csharp" source="./snippets/System/Random/Overview/csharp/uniquearray1.cs" id="Snippet11":::
 :::code language="fsharp" source="./snippets/System/Random/Overview/fsharp/uniquearray1.fs" id="Snippet11":::
 :::code language="vb" source="./snippets/System/Random/Overview/vb/uniquearray1.vb" id="Snippet11":::

--- a/docs/fundamentals/runtime-libraries/system-single-compareto.md
+++ b/docs/fundamentals/runtime-libraries/system-single-compareto.md
@@ -19,7 +19,7 @@ Although an object whose value is <xref:System.Single.NaN> is not considered equ
 
 The `value` parameter must be `null` or an instance of <xref:System.Single>; otherwise, an exception is thrown. Any instance of <xref:System.Single>, regardless of its value, is considered greater than `null`.
 
-:::code language="csharp" source="./snippets/System/Single/CompareTo/csharp/compareto3.cs" interactive="try-dotnet" id="Snippet2":::
+:::code language="csharp" source="./snippets/System/Single/CompareTo/csharp/compareto3.cs" id="Snippet2":::
 :::code language="fsharp" source="./snippets/System/Single/CompareTo/fsharp/compareto3.fs" id="Snippet2":::
 :::code language="vb" source="./snippets/System/Single/CompareTo/vb/compareto3.vb" id="Snippet2":::
 
@@ -29,7 +29,7 @@ This method is implemented to support the <xref:System.IComparable> interface.
 
 This method implements the <xref:System.IComparable%601?displayProperty=nameWithType> interface and performs slightly better than the <xref:System.Single.CompareTo(System.Object)?displayProperty=nameWithType> overload because it doesn't have to convert the `value` parameter to an object.
 
-:::code language="csharp" source="./snippets/System/Single/CompareTo/csharp/compareto2.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/Single/CompareTo/csharp/compareto2.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/Single/CompareTo/fsharp/compareto2.fs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/Single/CompareTo/vb/compareto2.vb" id="Snippet1":::
 

--- a/docs/fundamentals/runtime-libraries/system-single-epsilon.md
+++ b/docs/fundamentals/runtime-libraries/system-single-epsilon.md
@@ -13,13 +13,13 @@ dev_langs:
 
 The value of the <xref:System.Single.Epsilon> property reflects the smallest positive <xref:System.Single> value that is significant in numeric operations or comparisons when the value of the <xref:System.Single> instance is zero. For example, the following code shows that zero and <xref:System.Single.Epsilon> are considered to be unequal values, whereas zero and half the value of <xref:System.Single.Epsilon> are considered to be equal.
 
-:::code language="csharp" source="./snippets/System/Single/Epsilon/csharp/epsilon.cs"  interactive="try-dotnet" id="Snippet5":::
+:::code language="csharp" source="./snippets/System/Single/Epsilon/csharp/epsilon.cs"  id="Snippet5":::
 :::code language="fsharp" source="./snippets/System/Single/Epsilon/fsharp/epsilon.fs"  id="Snippet5":::
 :::code language="vb" source="./snippets/System/Single/Epsilon/vb/epsilon.vb" id="Snippet5":::
 
 More precisely, the single-precision floating-point format consists of a sign, a 23-bit mantissa or significand, and an 8-bit exponent. As the following example shows, zero has an exponent of -126 and a mantissa of 0. <xref:System.Single.Epsilon> has an exponent of -126 and a mantissa of 1. This means that <xref:System.Single.Epsilon?displayProperty=nameWithType> is the smallest positive <xref:System.Single> value that is greater than zero and represents the smallest possible value and the smallest possible increment for a <xref:System.Single> whose exponent is -126.
 
-:::code language="csharp" source="./snippets/System/Single/Epsilon/csharp/epsilon1.cs"  interactive="try-dotnet" id="Snippet6":::
+:::code language="csharp" source="./snippets/System/Single/Epsilon/csharp/epsilon1.cs"  id="Snippet6":::
 :::code language="fsharp" source="./snippets/System/Single/Epsilon/fsharp/epsilon1.fs"  id="Snippet6":::
 :::code language="vb" source="./snippets/System/Single/Epsilon/vb/epsilon1.vb" id="Snippet6":::
 

--- a/docs/fundamentals/runtime-libraries/system-single-equals.md
+++ b/docs/fundamentals/runtime-libraries/system-single-equals.md
@@ -25,13 +25,13 @@ Consult your programming language's documentation to determine if its compiler p
 
 The <xref:System.Single.Equals%2A> method should be used with caution, because two apparently equivalent values can be unequal because of the differing precision of the two values. The following example reports that the <xref:System.Single> value .3333 and the <xref:System.Single> returned by dividing 1 by 3 are unequal.
 
-:::code language="csharp" source="./snippets/System/Single/Epsilon/csharp/SingleEquals_25051.cs" interactive="try-dotnet-method" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/Single/Epsilon/csharp/SingleEquals_25051.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/Single/Epsilon/fsharp/SingleEquals_25051.fs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/Single/Epsilon/vb/SingleEquals_25051.vb" id="Snippet1":::
 
 One comparison technique that avoids the problems associated with comparing for equality involves defining an acceptable margin of difference between two values (such as .01% of one of the values). If the absolute value of the difference between the two values is less than or equal to that margin, the difference is likely to be an outcome of differences in precision and, therefore, the values are likely to be equal. The following example uses this technique to compare .33333 and 1/3, which are the two <xref:System.Single> values that the previous code example found to be unequal.
 
-:::code language="csharp" source="./snippets/System/Single/Epsilon/csharp/SingleEquals_25051.cs" interactive="try-dotnet-method" id="Snippet2":::
+:::code language="csharp" source="./snippets/System/Single/Epsilon/csharp/SingleEquals_25051.cs" id="Snippet2":::
 :::code language="fsharp" source="./snippets/System/Single/Epsilon/fsharp/SingleEquals_25051.fs" id="Snippet2":::
 :::code language="vb" source="./snippets/System/Single/Epsilon/vb/SingleEquals_25051.vb" id="Snippet2":::
 
@@ -42,7 +42,7 @@ In this case, the values are equal.
 
 A second technique that avoids the problems associated with comparing for equality involves comparing the difference between two floating-point numbers with some absolute value. If the difference is less than or equal to that absolute value, the numbers are equal. If it is greater, the numbers are not equal. One way to do this is to arbitrarily select an absolute value. However, this is problematic, because an acceptable margin of difference depends on the magnitude of the <xref:System.Single> values. A second way takes advantage of a design feature of the floating-point format: The difference between the mantissa components in the integer representations of two floating-point values indicates the number of possible floating-point values that separates the two values. For example, the difference between 0.0 and <xref:System.Single.Epsilon> is 1, because <xref:System.Single.Epsilon> is the smallest representable value when working with a <xref:System.Single> whose value is zero. The following example uses this technique to compare .33333 and 1/3, which are the two <xref:System.Double> values that the previous code example with the <xref:System.Single.Equals(System.Single)> method found to be unequal. Note that the example uses the <xref:System.BitConverter.GetBytes%2A?displayProperty=nameWithType> and <xref:System.BitConverter.ToInt32%2A?displayProperty=nameWithType> methods to convert a single-precision floating-point value to its integer representation.
 
-:::code language="csharp" source="./snippets/System/Single/Equals/csharp/equalsabs1.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/Single/Equals/csharp/equalsabs1.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/Single/Equals/fsharp/equalsabs1.fs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/Single/Equals/vb/equalsabs1.vb" id="Snippet1":::
 

--- a/docs/fundamentals/runtime-libraries/system-single.md
+++ b/docs/fundamentals/runtime-libraries/system-single.md
@@ -27,7 +27,7 @@ The <xref:System.Single> data type stores single-precision floating-point values
 
 Just as decimal fractions are unable to precisely represent some fractional values (such as 1/3 or <xref:System.Math.PI?displayProperty=nameWithType>), binary fractions are unable to represent some fractional values. For example, 2/10, which is represented precisely by .2 as a decimal fraction, is represented by .0011111001001100 as a binary fraction, with the pattern "1100" repeating to infinity. In this case, the floating-point value provides an imprecise representation of the number that it represents. Performing additional mathematical operations on the original floating-point value often increases its lack of precision. For example, if you compare the results of multiplying .3 by 10 and adding .3 to .3 nine times, you will see that addition produces the less precise result, because it involves eight more operations than multiplication. Note that this disparity is apparent only if you display the two <xref:System.Single> values by using the "R" [standard numeric format string](../../standard/base-types/standard-numeric-format-strings.md), which, if necessary, displays all 9 digits of precision supported by the <xref:System.Single> type.
 
-:::code language="csharp" source="./snippets/System/Single/Overview/csharp/representation1.cs" interactive="try-dotnet" id="Snippet3":::
+:::code language="csharp" source="./snippets/System/Single/Overview/csharp/representation1.cs" id="Snippet3":::
 :::code language="fsharp" source="./snippets/System/Single/Overview/fsharp/representation1.fs" id="Snippet3":::
 :::code language="vb" source="./snippets/System/Single/Overview/vb/representation1.vb" id="Snippet3":::
 
@@ -35,7 +35,7 @@ Because some numbers cannot be represented exactly as fractional binary values, 
 
 All floating-point numbers have a limited number of significant digits, which also determines how accurately a floating-point value approximates a real number. A <xref:System.Single> value has up to 7 decimal digits of precision, although a maximum of 9 digits is maintained internally. This means that some floating-point operations may lack the precision to change a floating-point value. The following example defines a large single-precision floating-point value, and then adds the product of <xref:System.Single.Epsilon?displayProperty=nameWithType> and one quadrillion to it. However, the product is too small to modify the original floating-point value. Its least significant digit is thousandths, whereas the most significant digit in the product is 10<sup>-30</sup>.
 
-:::code language="csharp" source="./snippets/System/Single/Overview/csharp/representation2.cs" interactive="try-dotnet" id="Snippet4":::
+:::code language="csharp" source="./snippets/System/Single/Overview/csharp/representation2.cs" id="Snippet4":::
 :::code language="fsharp" source="./snippets/System/Single/Overview/fsharp/representation2.fs" id="Snippet4":::
 :::code language="vb" source="./snippets/System/Single/Overview/vb/representation2.vb" id="Snippet4":::
 
@@ -43,7 +43,7 @@ The limited precision of a floating-point number has several consequences:
 
 - Two floating-point numbers that appear equal for a particular precision might not compare equal because their least significant digits are different. In the following example, a series of numbers are added together, and their total is compared with their expected total. Although the two values appear to be the same, a call to the `Equals` method indicates that they are not.
 
-  :::code language="csharp" source="./snippets/System/Single/Overview/csharp/precisionlist3.cs" interactive="try-dotnet" id="Snippet6":::
+  :::code language="csharp" source="./snippets/System/Single/Overview/csharp/precisionlist3.cs" id="Snippet6":::
   :::code language="fsharp" source="./snippets/System/Single/Overview/fsharp/precisionlist3.fs" id="Snippet6":::
   :::code language="vb" source="./snippets/System/Single/Overview/vb/precisionlist3.vb" id="Snippet6":::
 
@@ -65,7 +65,7 @@ The limited precision of a floating-point number has several consequences:
 
 - <xref:System.Single> values have less precision than <xref:System.Double> values. A <xref:System.Single> value that is converted to a seemingly equivalent <xref:System.Double> often does not equal the <xref:System.Double> value because of differences in precision. In the following example, the result of identical division operations is assigned to a <xref:System.Double> value and a <xref:System.Single> value. After the <xref:System.Single> value is cast to a <xref:System.Double>, a comparison of the two values shows that they are unequal.
 
-  :::code language="csharp" source="./snippets/System/Double/Overview/csharp/precisionlist1.cs" interactive="try-dotnet" id="Snippet5":::
+  :::code language="csharp" source="./snippets/System/Double/Overview/csharp/precisionlist1.cs" id="Snippet5":::
   :::code language="fsharp" source="./snippets/System/Double/Overview/fsharp/precisionlist1.fs" id="Snippet5":::
   :::code language="vb" source="./snippets/System/Double/Overview/vb/precisionlist1.vb" id="Snippet5":::
 
@@ -75,13 +75,13 @@ The limited precision of a floating-point number has several consequences:
 
 To be considered equal, two <xref:System.Single> values must represent identical values. However, because of differences in precision between values, or because of a loss of precision by one or both values, floating-point values that are expected to be identical often turn out to be unequal due to differences in their least significant digits. As a result, calls to the <xref:System.Single.Equals%2A> method to determine whether two values are equal, or calls to the <xref:System.Single.CompareTo%2A> method to determine the relationship between two <xref:System.Single> values, often yield unexpected results. This is evident in the following example, where two apparently equal <xref:System.Single> values turn out to be unequal, because the first value has 7 digits of precision, whereas the second value has 9.
 
-:::code language="csharp" source="./snippets/System/Single/Overview/csharp/comparison1.cs" interactive="try-dotnet" id="Snippet9":::
+:::code language="csharp" source="./snippets/System/Single/Overview/csharp/comparison1.cs" id="Snippet9":::
 :::code language="fsharp" source="./snippets/System/Single/Overview/fsharp/comparison1.fs" id="Snippet9":::
 :::code language="vb" source="./snippets/System/Single/Overview/vb/comparison1.vb" id="Snippet9":::
 
 Calculated values that follow different code paths and that are manipulated in different ways often prove to be unequal. In the following example, one <xref:System.Single> value is squared, and then the square root is calculated to restore the original value. A second <xref:System.Single> is multiplied by 3.51 and squared before the square root of the result is divided by 3.51 to restore the original value. Although the two values appear to be identical, a call to the <xref:System.Single.Equals%28System.Single%29> method indicates that they are not equal. Using the "G9" standard format string to return a result string that displays all the significant digits of each <xref:System.Single> value shows that the second value is .0000000000001 less than the first.
 
-:::code language="csharp" source="./snippets/System/Single/Overview/csharp/comparison2.cs" interactive="try-dotnet" id="Snippet10":::
+:::code language="csharp" source="./snippets/System/Single/Overview/csharp/comparison2.cs" id="Snippet10":::
 :::code language="fsharp" source="./snippets/System/Single/Overview/fsharp/comparison2.fs" id="Snippet10":::
 :::code language="vb" source="./snippets/System/Single/Overview/vb/comparison2.vb" id="Snippet10":::
 
@@ -89,7 +89,7 @@ In cases where a loss of precision is likely to affect the result of a compariso
 
 - Call the <xref:System.Math.Round%2A?displayProperty=nameWithType> method to ensure that both values have the same precision. The following example modifies a previous example to use this approach so that two fractional values are equivalent.
 
-  :::code language="csharp" source="./snippets/System/Single/Overview/csharp/comparison3.cs" interactive="try-dotnet" id="Snippet11":::
+  :::code language="csharp" source="./snippets/System/Single/Overview/csharp/comparison3.cs" id="Snippet11":::
   :::code language="fsharp" source="./snippets/System/Single/Overview/fsharp/comparison3.fs" id="Snippet11":::
   :::code language="vb" source="./snippets/System/Single/Overview/vb/comparison3.vb" id="Snippet11":::
 
@@ -102,7 +102,7 @@ In cases where a loss of precision is likely to affect the result of a compariso
 
   The following example uses the latter approach to define an `IsApproximatelyEqual` method that tests the relative difference between two values. It also contrasts the result of calls to the `IsApproximatelyEqual` method and the <xref:System.Single.Equals%28System.Single%29> method.
 
-  :::code language="csharp" source="./snippets/System/Single/Overview/csharp/comparison4.cs" interactive="try-dotnet" id="Snippet12":::
+  :::code language="csharp" source="./snippets/System/Single/Overview/csharp/comparison4.cs" id="Snippet12":::
   :::code language="fsharp" source="./snippets/System/Single/Overview/fsharp/comparison4.fs" id="Snippet12":::
   :::code language="vb" source="./snippets/System/Single/Overview/vb/comparison4.vb" id="Snippet12":::
 
@@ -112,13 +112,13 @@ Operations with floating-point values do not throw exceptions, unlike operations
 
 - If the result of a floating-point operation is too small for the destination format, the result is zero. This can occur when two very small floating-point numbers are multiplied, as the following example shows.
 
-  :::code language="csharp" source="./snippets/System/Single/Overview/csharp/exceptional1.cs" interactive="try-dotnet" id="Snippet1":::
+  :::code language="csharp" source="./snippets/System/Single/Overview/csharp/exceptional1.cs" id="Snippet1":::
   :::code language="fsharp" source="./snippets/System/Single/Overview/fsharp/exceptional1.fs" id="Snippet1":::
   :::code language="vb" source="./snippets/System/Single/Overview/vb/exceptional1.vb" id="Snippet1":::
 
 - If the magnitude of the result of a floating-point operation exceeds the range of the destination format, the result of the operation is <xref:System.Single.PositiveInfinity> or <xref:System.Single.NegativeInfinity>, as appropriate for the sign of the result. The result of an operation that overflows <xref:System.Single.MaxValue?displayProperty=nameWithType> is <xref:System.Single.PositiveInfinity>, and the result of an operation that overflows <xref:System.Single.MinValue?displayProperty=nameWithType> is <xref:System.Single.NegativeInfinity>, as the following example shows.
 
-  :::code language="csharp" source="./snippets/System/Single/Overview/csharp/exceptional2.cs" interactive="try-dotnet" id="Snippet2":::
+  :::code language="csharp" source="./snippets/System/Single/Overview/csharp/exceptional2.cs" id="Snippet2":::
   :::code language="fsharp" source="./snippets/System/Single/Overview/fsharp/exceptional2.fs" id="Snippet2":::
   :::code language="vb" source="./snippets/System/Single/Overview/vb/exceptional2.vb" id="Snippet2":::
 
@@ -218,6 +218,6 @@ The <xref:System.Single> structure and related types provide methods to perform 
 
   The problem of precision most frequently affects <xref:System.Single> values that are converted to <xref:System.Double> values. In the following example, two values produced by identical division operations are unequal, because one of the values is a single-precision floating point value that is converted to a <xref:System.Double>.
 
-  :::code language="csharp" source="./snippets/System/Single/Overview/csharp/precisionlist1.cs" interactive="try-dotnet" id="Snippet5":::
+  :::code language="csharp" source="./snippets/System/Single/Overview/csharp/precisionlist1.cs" id="Snippet5":::
   :::code language="fsharp" source="./snippets/System/Single/Overview/fsharp/precisionlist1.fs" id="Snippet5":::
   :::code language="vb" source="./snippets/System/Single/Overview/vb/precisionlist1.vb" id="Snippet5":::

--- a/docs/fundamentals/runtime-libraries/system-string-ctor.md
+++ b/docs/fundamentals/runtime-libraries/system-string-ctor.md
@@ -148,7 +148,7 @@ Instead of converting each token into a new string, you can create a <xref:Syste
 
 The following example creates a new string by assigning it a string literal. It creates a second string by assigning the value of the first string to it. These are the two most common ways to instantiate a new <xref:System.String> object.
 
-:::code language="csharp" source="./snippets/System/String/.ctor/csharp/ctor1.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/String/.ctor/csharp/ctor1.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/String/.ctor/fsharp/ctor1.fs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/String/.ctor/vb/ctor1.vb" id="Snippet1":::
 
@@ -156,7 +156,7 @@ The following example creates a new string by assigning it a string literal. It 
 
 The following example demonstrates how to create a new <xref:System.String> object from a character array.
 
-:::code language="csharp" source="./snippets/System/String/.ctor/csharp/source.cs" interactive="try-dotnet-method" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/String/.ctor/csharp/source.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/String/.ctor/fsharp/source.fs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/String/.ctor/vb/source.vb" id="Snippet1":::
 
@@ -164,7 +164,7 @@ The following example demonstrates how to create a new <xref:System.String> obje
 
 The following example demonstrates how to create a new <xref:System.String> object from a portion of a character array, and how to create a new <xref:System.String> object that contains multiple occurrences of a single character.
 
-:::code language="csharp" source="./snippets/System/String/.ctor/csharp/source.cs" interactive="try-dotnet-method" id="Snippet3":::
+:::code language="csharp" source="./snippets/System/String/.ctor/csharp/source.cs" id="Snippet3":::
 :::code language="fsharp" source="./snippets/System/String/.ctor/fsharp/source.fs" id="Snippet3":::
 :::code language="vb" source="./snippets/System/String/.ctor/vb/source.vb" id="Snippet3":::
 

--- a/docs/fundamentals/runtime-libraries/system-string-format.md
+++ b/docs/fundamentals/runtime-libraries/system-string-format.md
@@ -47,7 +47,7 @@ The following are some of the examples included in the article:
 
 Use <xref:System.String.Format%2A?displayProperty=nameWithType> if you need to insert the value of an object, variable, or expression into another string. For example, you can insert the value of a <xref:System.Decimal> value into a string to display it to the user as a single string:
 
-:::code language="csharp" source="./snippets/System/FormatException/Overview/csharp/starting2.cs" interactive="try-dotnet-method" id="Snippet35":::
+:::code language="csharp" source="./snippets/System/FormatException/Overview/csharp/starting2.cs" id="Snippet35":::
 :::code language="fsharp" source="./snippets/System/FormatException/Overview/fsharp/starting2.fs" id="Snippet35":::
 :::code language="vb" source="./snippets/System/String/Format/vb/starting2.vb" id="Snippet35":::
 
@@ -63,7 +63,7 @@ Besides formatting, you can also control alignment and spacing.
 
 <xref:System.String.Format%2A?displayProperty=nameWithType> starts with a format string, followed by one or more objects or expressions that will be converted to strings and inserted at a specified place in the format string. For example:
 
-:::code language="csharp" source="./snippets/System/FormatException/Overview/csharp/starting1.cs" interactive="try-dotnet-method" id="Snippet30":::
+:::code language="csharp" source="./snippets/System/FormatException/Overview/csharp/starting1.cs" id="Snippet30":::
 :::code language="fsharp" source="./snippets/System/FormatException/Overview/fsharp/starting1.fs" id="Snippet30":::
 :::code language="vb" source="./snippets/System/String/Format/vb/starting1.vb" id="Snippet30":::
 
@@ -168,7 +168,7 @@ However, any custom type can implement <xref:System.IFormattable> or extend an e
 
 The following example uses the `width` and `formatString` arguments to produce formatted output.
 
-:::code language="csharp" source="./snippets/System/FormatException/Overview/csharp/formatoverload2.cs" interactive="try-dotnet-method" id="Snippet9":::
+:::code language="csharp" source="./snippets/System/FormatException/Overview/csharp/formatoverload2.cs" id="Snippet9":::
 :::code language="fsharp" source="./snippets/System/FormatException/Overview/fsharp/formatoverload2.fs" id="Snippet9":::
 :::code language="vb" source="./snippets/System/String/Format/vb/formatoverload2.vb" id="Snippet9":::
 
@@ -192,7 +192,7 @@ For more information, see [Processing order](../../standard/base-types/composite
 
 The <xref:System.String.Format%2A> method throws a <xref:System.FormatException> exception if the index of an index item is greater than or equal to the number of arguments in the argument list. However, `format` can include more format items than there are arguments, as long as multiple format items have the same index. In the call to the <xref:System.String.Format(System.String,System.Object)> method in following example, the argument list has a single argument, but the format string includes two format items: one displays the decimal value of a number, and the other displays its hexadecimal value.
 
-:::code language="csharp" source="./snippets/System/String/Format/csharp/Example1.cs" interactive="try-dotnet-method" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/String/Format/csharp/Example1.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/String/Format/fsharp/Example1.fs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/String/Format/vb/Example1.vb" id="Snippet1":::
 
@@ -216,7 +216,7 @@ For more information about providing custom formatting solutions, see [How to: D
 
 This example defines a format provider that formats an integer value as a customer account number in the form x-xxxxx-xx.
 
-:::code language="csharp" source="./snippets/System/FormatException/Overview/csharp/FormatExample2.cs" interactive="try-dotnet" id="Snippet2":::
+:::code language="csharp" source="./snippets/System/FormatException/Overview/csharp/FormatExample2.cs" id="Snippet2":::
 :::code language="fsharp" source="./snippets/System/FormatException/Overview/fsharp/FormatExample2.fs" id="Snippet2":::
 :::code language="vb" source="./snippets/System/String/Format/vb/FormatExample2.vb" id="Snippet2":::
 
@@ -280,7 +280,7 @@ All [standard numeric format strings](../../standard/base-types/standard-numeric
 
 If you're using a [custom numeric format string](../../standard/base-types/custom-numeric-format-strings.md), use the "0" format specifier to control the number of decimal digits in the result string, as the following example shows.
 
-:::code language="csharp" source="./snippets/System/FormatException/Overview/csharp/qa27.cs" interactive="try-dotnet-method" id="Snippet27":::
+:::code language="csharp" source="./snippets/System/FormatException/Overview/csharp/qa27.cs" id="Snippet27":::
 :::code language="fsharp" source="./snippets/System/FormatException/Overview/fsharp/qa27.fs" id="Snippet27":::
 :::code language="vb" source="./snippets/System/String/Format/vb/qa27.vb" id="Snippet27":::
 
@@ -288,13 +288,13 @@ If you're using a [custom numeric format string](../../standard/base-types/custo
 
 By default, formatting operations only display non-zero integral digits. If you're formatting integers, you can use a precision specifier with the "D" and "X" standard format strings to control the number of digits.
 
-:::code language="csharp" source="./snippets/System/FormatException/Overview/csharp/qa29.cs" interactive="try-dotnet-method" id="Snippet29":::
+:::code language="csharp" source="./snippets/System/FormatException/Overview/csharp/qa29.cs" id="Snippet29":::
 :::code language="fsharp" source="./snippets/System/FormatException/Overview/fsharp/qa29.fs" id="Snippet29":::
 :::code language="vb" source="./snippets/System/String/Format/vb/qa29.vb" id="Snippet29":::
 
 You can pad an integer or floating-point number with leading zeros to produce a result string with a specified number of integral digits by using the "0" [custom numeric format specifier](../../standard/base-types/custom-numeric-format-strings.md), as the following example shows.
 
-:::code language="csharp" source="./snippets/System/FormatException/Overview/csharp/qa28.cs" interactive="try-dotnet-method" id="Snippet28":::
+:::code language="csharp" source="./snippets/System/FormatException/Overview/csharp/qa28.cs" id="Snippet28":::
 :::code language="fsharp" source="./snippets/System/FormatException/Overview/fsharp/qa28.fs" id="Snippet28":::
 :::code language="vb" source="./snippets/System/String/Format/vb/qa28.vb" id="Snippet28":::
 
@@ -312,13 +312,13 @@ For example, how do you prevent the following method call from throwing a <xref:
 
 A single opening or closing brace is always interpreted as the beginning or end of a format item. To be interpreted literally, it must be escaped. You escape a brace by adding another brace ("{{" and "}}" instead of "{" and "}"), as in the following method call:
 
-:::code language="csharp" source="./snippets/System/FormatException/Overview/csharp/qa3.cs" interactive="try-dotnet-method" id="Snippet24":::
+:::code language="csharp" source="./snippets/System/FormatException/Overview/csharp/qa3.cs" id="Snippet24":::
 :::code language="fsharp" source="./snippets/System/FormatException/Overview/fsharp/qa3.fs" id="Snippet24":::
 :::code language="vb" source="./snippets/System/String/Format/vb/qa3.vb" id="Snippet24":::
 
 However, even escaped braces are easily misinterpreted. We recommend that you include braces in the format list and use format items to insert them in the result string, as the following example shows.
 
-:::code language="csharp" source="./snippets/System/FormatException/Overview/csharp/qa3.cs" interactive="try-dotnet-method" id="Snippet25":::
+:::code language="csharp" source="./snippets/System/FormatException/Overview/csharp/qa3.cs" id="Snippet25":::
 :::code language="fsharp" source="./snippets/System/FormatException/Overview/fsharp/qa3.fs" id="Snippet25":::
 :::code language="vb" source="./snippets/System/String/Format/vb/qa3.vb" id="Snippet25":::
 
@@ -338,6 +338,6 @@ This is a problem of compiler overload resolution. Because the compiler cannot c
 
 Because neither Visual Basic nor C# can convert an integer array to an object array, you have to perform the conversion yourself before calling the <xref:System.String.Format(System.String,System.Object%5B%5D)> method. The following example provides one implementation.
 
-:::code language="csharp" source="./snippets/System/FormatException/Overview/csharp/qa21.cs" interactive="try-dotnet-method" id="Snippet22":::
+:::code language="csharp" source="./snippets/System/FormatException/Overview/csharp/qa21.cs" id="Snippet22":::
 :::code language="fsharp" source="./snippets/System/FormatException/Overview/fsharp/qa21.fs" id="Snippet22":::
 :::code language="vb" source="./snippets/System/String/Format/vb/qa2.vb" id="Snippet22":::

--- a/docs/fundamentals/runtime-libraries/system-string-intern.md
+++ b/docs/fundamentals/runtime-libraries/system-string-intern.md
@@ -17,7 +17,7 @@ The <xref:System.String.Intern%2A> method uses the intern pool to search for a s
 
 In the following example, the string `s1`, which has a value of "MyTest", is already interned because it is a literal in the program. The <xref:System.Text.StringBuilder?displayProperty=nameWithType> class generates a new string object that has the same value as `s1`. A reference to that string is assigned to `s2`. The <xref:System.String.Intern%2A> method searches for a string that has the same value as `s2`. Because such a string exists, the method returns the same reference that's assigned to `s1`. That reference is then assigned to `s3`. References `s1` and `s2` compare unequal because they refer to different objects; references `s1` and `s3` compare equal because they refer to the same string.
 
-:::code language="csharp" source="./snippets/System/String/Intern/csharp/Intern1.cs" interactive="try-dotnet-method" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/String/Intern/csharp/Intern1.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/String/Intern/fsharp/Intern1.fs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/String/Intern/vb/Intern1.vb" id="Snippet1":::
 

--- a/docs/fundamentals/runtime-libraries/system-string-isnullorempty.md
+++ b/docs/fundamentals/runtime-libraries/system-string-isnullorempty.md
@@ -13,7 +13,7 @@ dev_langs:
 
 <xref:System.String.IsNullOrEmpty%2A> is a convenience method that enables you to simultaneously test whether a <xref:System.String> is `null` or its value is <xref:System.String.Empty?displayProperty=nameWithType>. It is equivalent to the following code:
 
-:::code language="csharp" source="./snippets/System/String/IsNullOrEmpty/csharp/isnullorempty1.cs" interactive="try-dotnet-method" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/String/IsNullOrEmpty/csharp/isnullorempty1.cs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/String/IsNullOrEmpty/vb/isnullorempty1.vb" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/String/IsNullOrEmpty/fsharp/isnullorempty1.fs" id="Snippet1":::
 
@@ -23,7 +23,7 @@ You can use the <xref:System.String.IsNullOrWhiteSpace%2A> method to test whethe
 
 A string is `null` if it has not been assigned a value (in C++ and Visual Basic) or if it has explicitly been assigned a value of `null`. Although the [composite formatting](../../standard/base-types/composite-formatting.md) feature can gracefully handle a null string, as the following example shows, attempting to call one if its members throws a <xref:System.NullReferenceException>.
 
-:::code language="csharp" source="./snippets/System/String/IsNullOrEmpty/csharp/NullString1.cs" interactive="try-dotnet-method" id="Snippet2":::
+:::code language="csharp" source="./snippets/System/String/IsNullOrEmpty/csharp/NullString1.cs" id="Snippet2":::
 :::code language="vb" source="./snippets/System/String/IsNullOrEmpty/vb/NullString1.vb" id="Snippet2":::
 :::code language="fsharp" source="./snippets/System/String/IsNullOrEmpty/fsharp/NullString1.fs" id="Snippet2":::
 
@@ -31,6 +31,6 @@ A string is `null` if it has not been assigned a value (in C++ and Visual Basic)
 
 A string is empty if it  is explicitly assigned an empty string ("") or <xref:System.String.Empty?displayProperty=nameWithType>. An empty string has a <xref:System.String.Length%2A> of 0. The following example creates an empty string and displays its value and its length.
 
-:::code language="csharp" source="./snippets/System/String/IsNullOrEmpty/csharp/NullString1.cs" interactive="try-dotnet-method" id="Snippet3":::
+:::code language="csharp" source="./snippets/System/String/IsNullOrEmpty/csharp/NullString1.cs" id="Snippet3":::
 :::code language="vb" source="./snippets/System/String/IsNullOrEmpty/vb/NullString1.vb" id="Snippet3":::
 :::code language="fsharp" source="./snippets/System/String/IsNullOrEmpty/fsharp/NullString2.fs" id="Snippet3":::

--- a/docs/fundamentals/runtime-libraries/system-string.md
+++ b/docs/fundamentals/runtime-libraries/system-string.md
@@ -21,7 +21,7 @@ You can instantiate a <xref:System.String> object in the following ways:
 
 - By assigning a string literal to a <xref:System.String> variable. This is the most commonly used method for creating a string. The following example uses assignment to create several strings. Note that in C# and F#, because the backslash (\\) is an escape character, literal backslashes in a string must be escaped or the entire string must be @-quoted.
 
-  :::code language="csharp" source="./snippets/System/String/Overview/csharp/program.cs" interactive="try-dotnet-method" id="Snippet1":::
+  :::code language="csharp" source="./snippets/System/String/Overview/csharp/program.cs" id="Snippet1":::
   :::code language="fsharp" source="./snippets/System/String/Overview/fsharp/program.fs" id="Snippet1":::
   :::code language="vb" source="./snippets/System/String/Overview/vb/instantiate1.vb" id="Snippet1":::
 
@@ -33,13 +33,13 @@ You can instantiate a <xref:System.String> object in the following ways:
 
 - By using the string concatenation operator (+ in C# and F#, and & or + in Visual Basic) to create a single string from any combination of <xref:System.String> instances and string literals. The following example illustrates the use of the string concatenation operator.
 
-  :::code language="csharp" source="./snippets/System/String/Overview/csharp/program.cs" interactive="try-dotnet-method" id="Snippet3":::
+  :::code language="csharp" source="./snippets/System/String/Overview/csharp/program.cs" id="Snippet3":::
   :::code language="fsharp" source="./snippets/System/String/Overview/fsharp/program.fs" id="Snippet3":::
   :::code language="vb" source="./snippets/System/String/Overview/vb/instantiate1.vb" id="Snippet3":::
 
 - By retrieving a property or calling a method that returns a string. The following example uses the methods of the <xref:System.String> class to extract a substring from a larger string.
 
-  :::code language="csharp" source="./snippets/System/String/Overview/csharp/program.cs" interactive="try-dotnet-method" id="Snippet4":::
+  :::code language="csharp" source="./snippets/System/String/Overview/csharp/program.cs" id="Snippet4":::
   :::code language="fsharp" source="./snippets/System/String/Overview/fsharp/program.fs" id="Snippet4":::
   :::code language="vb" source="./snippets/System/String/Overview/vb/instantiate1.vb" id="Snippet4":::
 
@@ -66,7 +66,7 @@ A single <xref:System.Char> object usually represents a single code point; that 
 
 - A Unicode supplementary code point (a surrogate pair) is represented by a <xref:System.Char> object whose code point is a high surrogate followed by a <xref:System.Char> object whose code point is a low surrogate. The code units of high surrogates range from U+D800 to U+DBFF. The code units of low surrogates range from U+DC00 to U+DFFF. Surrogate pairs are used to represent characters in the 16 Unicode supplementary planes. The following example creates a surrogate character and passes it to the <xref:System.Char.IsSurrogatePair(System.Char%2CSystem.Char)?displayProperty=nameWithType> method to determine whether it is a surrogate pair.
 
-  :::code language="csharp" source="./snippets/System/String/Overview/csharp/surrogate1.cs" interactive="try-dotnet-method" id="Snippet3":::
+  :::code language="csharp" source="./snippets/System/String/Overview/csharp/surrogate1.cs" id="Snippet3":::
   :::code language="fsharp" source="./snippets/System/String/Overview/fsharp/surrogate1.fs" id="Snippet3":::
   :::code language="vb" source="./snippets/System/String/Overview/vb/surrogate1.vb" id="Snippet3":::
 
@@ -104,19 +104,19 @@ An index is the position of a <xref:System.Char> object (not a Unicode character
 
 The <xref:System.String.Chars%2A> property lets you access individual <xref:System.Char> objects by their index position in the string. Because the <xref:System.String.Chars%2A> property is the default property (in Visual Basic) or the indexer (in C# and F#), you can access the individual <xref:System.Char> objects in a string by using code such as the following. This code looks for white space or punctuation characters in a string to determine how many words the string contains.
 
-:::code language="csharp" source="./snippets/System/String/Overview/csharp/index11.cs" interactive="try-dotnet-method" id="Snippet4":::
+:::code language="csharp" source="./snippets/System/String/Overview/csharp/index11.cs" id="Snippet4":::
 :::code language="fsharp" source="./snippets/System/String/Overview/fsharp/index11.fs" id="Snippet4":::
 :::code language="vb" source="./snippets/System/String/Overview/vb/index1.vb" id="Snippet4":::
 
 Because the <xref:System.String> class implements the <xref:System.Collections.IEnumerable> interface, you can also iterate through the <xref:System.Char> objects in a string by using a `foreach` construct, as the following example shows.
 
-:::code language="csharp" source="./snippets/System/String/Overview/csharp/index2.cs" interactive="try-dotnet-method" id="Snippet5":::
+:::code language="csharp" source="./snippets/System/String/Overview/csharp/index2.cs" id="Snippet5":::
 :::code language="fsharp" source="./snippets/System/String/Overview/fsharp/index2.fs" id="Snippet5":::
 :::code language="vb" source="./snippets/System/String/Overview/vb/index2.vb" id="Snippet5":::
 
 Consecutive index values might not correspond to consecutive Unicode characters, because a Unicode character might be encoded as more than one <xref:System.Char> object. In particular, a string may contain multi-character units of text that are formed by a base character followed by one or more combining characters or by surrogate pairs. To work with Unicode characters instead of <xref:System.Char> objects, use the <xref:System.Globalization.StringInfo?displayProperty=nameWithType> and <xref:System.Globalization.TextElementEnumerator> classes, or the <xref:System.String.EnumerateRunes%2A?displayProperty=nameWithType> method and the <xref:System.Text.Rune> struct. The following example illustrates the difference between code that works with <xref:System.Char> objects and code that works with Unicode characters. It compares the number of characters or text elements in each word of a sentence. The string includes two sequences of a base character followed by a combining character.
 
-:::code language="csharp" source="./snippets/System/String/Overview/csharp/index3.cs" interactive="try-dotnet-method" id="Snippet6":::
+:::code language="csharp" source="./snippets/System/String/Overview/csharp/index3.cs" id="Snippet6":::
 :::code language="fsharp" source="./snippets/System/String/Overview/fsharp/index3.fs" id="Snippet6":::
 :::code language="vb" source="./snippets/System/String/Overview/vb/index3.vb" id="Snippet6":::
 

--- a/docs/fundamentals/runtime-libraries/system-text-regularexpressions-regex-match.md
+++ b/docs/fundamentals/runtime-libraries/system-text-regularexpressions-regex-match.md
@@ -15,7 +15,7 @@ You can optionally specify a starting position in the string by using the `start
 
 Although the regular expression engine doesn't return any match starting before `startat`, it doesn't ignore the string before `startat`. This means that assertions such as [anchors](../../standard/base-types/anchors-in-regular-expressions.md) or [lookbehind assertions](../../standard/base-types/backtracking-in-regular-expressions.md#lookbehind-assertions) still apply to the input as a whole. For example, the following code includes a pattern with a lookbehind assertion that's satisfied even though it occurs before the `startat` index of 5 in the input string.
 
-:::code language="csharp" source="./snippets/System.Text.RegularExpressions/Regex/Match/csharp/startat.cs" interactive="try-dotnet":::
+:::code language="csharp" source="./snippets/System.Text.RegularExpressions/Regex/Match/csharp/startat.cs":::
 
 > [!TIP]
 >

--- a/docs/fundamentals/runtime-libraries/system-text-regularexpressions-regex.md
+++ b/docs/fundamentals/runtime-libraries/system-text-regularexpressions-regex.md
@@ -102,7 +102,7 @@ The following example uses a regular expression to check for repeated occurrence
 | `(\k<word>)`   | Match the captured group that's named `word`.                                             |
 | `\b`           | Match a word boundary.                                                                    |
 
-:::code language="csharp" source="./snippets/System.Text.RegularExpressions/Regex/Overview/csharp/words.cs" interactive="try-dotnet" id="Snippet0":::
+:::code language="csharp" source="./snippets/System.Text.RegularExpressions/Regex/Overview/csharp/words.cs" id="Snippet0":::
 :::code language="vb" source="./snippets/System.Text.RegularExpressions/Regex/Overview/vb/words.vb" id="Snippet0":::
 
 The next example illustrates the use of a regular expression to check whether a string either represents a currency value or has the correct format to represent a currency value. In this case, the regular expression is built dynamically from the <xref:System.Globalization.NumberFormatInfo.CurrencyDecimalSeparator%2A?displayProperty=nameWithType>, <xref:System.Globalization.NumberFormatInfo.CurrencyDecimalDigits%2A>, <xref:System.Globalization.NumberFormatInfo.CurrencySymbol%2A?displayProperty=nameWithType>, <xref:System.Globalization.NumberFormatInfo.NegativeSign%2A?displayProperty=nameWithType>, and <xref:System.Globalization.NumberFormatInfo.PositiveSign%2A?displayProperty=nameWithType> properties for the en-US culture. The resulting regular expression is `^\s*[\+-]?\s?\$?\s?(\d*\.?\d{2}?){1}$`. This regular expression can be interpreted as shown in the following table.
@@ -123,7 +123,7 @@ The next example illustrates the use of a regular expression to check whether a 
 
 In this case, the regular expression assumes that a valid currency string does not contain group separator symbols, and that it has either no fractional digits or the number of fractional digits defined by the specified culture's <xref:System.Globalization.NumberFormatInfo.CurrencyDecimalDigits> property.
 
-:::code language="csharp" source="./snippets/System.Text.RegularExpressions/Regex/Overview/csharp/regex_example1.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="./snippets/System.Text.RegularExpressions/Regex/Overview/csharp/regex_example1.cs" id="Snippet1":::
 :::code language="vb" source="./snippets/System.Text.RegularExpressions/Regex/Overview/vb/regex_example1.vb" id="Snippet1":::
 
 Because the regular expression in this example is built dynamically, you don't know at design time whether the currency symbol, decimal sign, or positive and negative signs of the specified culture (en-US in this example) might be misinterpreted by the regular expression engine as regular expression language operators. To prevent any misinterpretation, the example passes each dynamically generated string to the <xref:System.Text.RegularExpressions.Regex.Escape%2A> method.

--- a/docs/fundamentals/runtime-libraries/system-text-stringbuilder.md
+++ b/docs/fundamentals/runtime-libraries/system-text-stringbuilder.md
@@ -44,7 +44,7 @@ The <xref:System.Text.StringBuilder.Length?displayProperty=nameWithType> propert
 
 The following example illustrates how a <xref:System.Text.StringBuilder> object allocates new memory and increases its capacity dynamically as the string assigned to the object expands. The code creates a <xref:System.Text.StringBuilder> object by calling its default (parameterless) constructor. The default capacity of this object is 16 characters, and its maximum capacity is more than 2 billion characters. Appending the string "This is a sentence." results in a new memory allocation because the string length (19 characters) exceeds the default capacity of the <xref:System.Text.StringBuilder> object. The capacity of the object doubles to 32 characters, the new string is added, and the length of the object now equals 19 characters. The code then appends the string "This is an additional sentence." to the value of the <xref:System.Text.StringBuilder> object 11 times. Whenever the append operation causes the length of the <xref:System.Text.StringBuilder> object to exceed its capacity, its existing capacity is doubled and the <xref:System.Text.StringBuilder.Append%2A> operation succeeds.
 
-:::code language="csharp" source="./snippets/System.Text/StringBuilder/Overview/csharp/default1.cs" interactive="try-dotnet" id="Snippet3":::
+:::code language="csharp" source="./snippets/System.Text/StringBuilder/Overview/csharp/default1.cs" id="Snippet3":::
 :::code language="fsharp" source="./snippets/System.Text/StringBuilder/Overview/fsharp/default1.fs" id="Snippet3":::
 :::code language="vb" source="./snippets/System.Text/StringBuilder/Overview/vb/default1.vb" id="Snippet3":::
 
@@ -84,7 +84,7 @@ You instantiate a <xref:System.Text.StringBuilder> object by calling one of its 
 
 The following example uses three of these constructor overloads to instantiate <xref:System.Text.StringBuilder> objects.
 
-:::code language="csharp" source="./snippets/System.Text/StringBuilder/Overview/csharp/instantiate1.cs" interactive="try-dotnet" id="Snippet6":::
+:::code language="csharp" source="./snippets/System.Text/StringBuilder/Overview/csharp/instantiate1.cs" id="Snippet6":::
 :::code language="fsharp" source="./snippets/System.Text/StringBuilder/Overview/fsharp/instantiate1.fs" id="Snippet6":::
 :::code language="vb" source="./snippets/System.Text/StringBuilder/Overview/vb/instantiate1.vb" id="Snippet6":::
 
@@ -94,13 +94,13 @@ Most of the methods that modify the string in a <xref:System.Text.StringBuilder>
 
 - You can make individual method calls and ignore the return value, as the following example does.
 
-  :::code language="csharp" source="./snippets/System.Text/StringBuilder/Overview/csharp/call1.cs" interactive="try-dotnet" id="Snippet4":::
+  :::code language="csharp" source="./snippets/System.Text/StringBuilder/Overview/csharp/call1.cs" id="Snippet4":::
   :::code language="fsharp" source="./snippets/System.Text/StringBuilder/Overview/fsharp/call1.fs" id="Snippet4":::
   :::code language="vb" source="./snippets/System.Text/StringBuilder/Overview/vb/call1.vb" id="Snippet4":::
 
 - You can make a series of method calls in a single statement. This can be convenient if you want to write a single statement that chains successive operations. The following example consolidates three method calls from the previous example into a single line of code.
 
-  :::code language="csharp" source="./snippets/System.Text/StringBuilder/Overview/csharp/call2.cs" interactive="try-dotnet" id="Snippet5":::
+  :::code language="csharp" source="./snippets/System.Text/StringBuilder/Overview/csharp/call2.cs" id="Snippet5":::
   :::code language="fsharp" source="./snippets/System.Text/StringBuilder/Overview/fsharp/call2.fs" id="Snippet5":::
   :::code language="vb" source="./snippets/System.Text/StringBuilder/Overview/vb/call2.vb" id="Snippet5":::
 
@@ -114,7 +114,7 @@ You can access the characters in a <xref:System.Text.StringBuilder> object by us
 
 The following example illustrates the <xref:System.Text.StringBuilder.Chars%2A> property. It appends ten random numbers to a <xref:System.Text.StringBuilder> object, and then iterates each character. If the character's Unicode category is <xref:System.Globalization.UnicodeCategory.DecimalDigitNumber?displayProperty=nameWithType>, it decreases the number by 1 (or changes the number to 9 if its value is 0). The example displays the contents of the <xref:System.Text.StringBuilder> object both before and after the values of individual characters were changed.
 
-:::code language="csharp" source="./snippets/System.Text/StringBuilder/Overview/csharp/chars1.cs" interactive="try-dotnet" id="Snippet7":::
+:::code language="csharp" source="./snippets/System.Text/StringBuilder/Overview/csharp/chars1.cs" id="Snippet7":::
 :::code language="fsharp" source="./snippets/System.Text/StringBuilder/Overview/fsharp/chars1.fs" id="Snippet7":::
 :::code language="vb" source="./snippets/System.Text/StringBuilder/Overview/vb/chars1.vb" id="Snippet7":::
 
@@ -134,7 +134,7 @@ The <xref:System.Text.StringBuilder> class includes the following methods for ex
 
 The following example uses the <xref:System.Text.StringBuilder.Append%2A>, <xref:System.Text.StringBuilder.AppendLine%2A>, <xref:System.Text.StringBuilder.AppendFormat%2A>, and <xref:System.Text.StringBuilder.Insert%2A> methods to expand the text of a <xref:System.Text.StringBuilder> object.
 
-  :::code language="csharp" source="./snippets/System.Text/StringBuilder/Overview/csharp/expand1.cs" interactive="try-dotnet" id="Snippet9":::
+  :::code language="csharp" source="./snippets/System.Text/StringBuilder/Overview/csharp/expand1.cs" id="Snippet9":::
   :::code language="fsharp" source="./snippets/System.Text/StringBuilder/Overview/fsharp/expand1.fs" id="Snippet9":::
   :::code language="vb" source="./snippets/System.Text/StringBuilder/Overview/vb/expand1.vb" id="Snippet9":::
 
@@ -144,7 +144,7 @@ The <xref:System.Text.StringBuilder> class includes methods that can reduce the 
 
 The following example removes some of the text from a <xref:System.Text.StringBuilder> object, displays its resulting capacity, maximum capacity, and length property values, and then calls the <xref:System.Text.StringBuilder.Clear%2A> method to remove all the characters from the <xref:System.Text.StringBuilder> object.
 
-:::code language="csharp" source="./snippets/System.Text/StringBuilder/Overview/csharp/delete1.cs" interactive="try-dotnet" id="Snippet10":::
+:::code language="csharp" source="./snippets/System.Text/StringBuilder/Overview/csharp/delete1.cs" id="Snippet10":::
 :::code language="fsharp" source="./snippets/System.Text/StringBuilder/Overview/fsharp/delete1.fs" id="Snippet10":::
 :::code language="vb" source="./snippets/System.Text/StringBuilder/Overview/vb/delete1.vb" id="Snippet10":::
 
@@ -152,7 +152,7 @@ The following example removes some of the text from a <xref:System.Text.StringBu
 
 The <xref:System.Text.StringBuilder.Replace%2A?displayProperty=nameWithType> method replaces all occurrences of a character or a string in the entire <xref:System.Text.StringBuilder> object or in a particular character range. The following example uses the <xref:System.Text.StringBuilder.Replace%2A> method to replace all exclamation points (!) with question marks (?) in the <xref:System.Text.StringBuilder> object.
 
-:::code language="csharp" source="./snippets/System.Text/StringBuilder/Overview/csharp/replace1.cs" interactive="try-dotnet" id="Snippet11":::
+:::code language="csharp" source="./snippets/System.Text/StringBuilder/Overview/csharp/replace1.cs" id="Snippet11":::
 :::code language="fsharp" source="./snippets/System.Text/StringBuilder/Overview/fsharp/replace1.fs" id="Snippet11":::
 :::code language="vb" source="./snippets/System.Text/StringBuilder/Overview/vb/replace1.vb" id="Snippet11":::
 
@@ -171,7 +171,7 @@ Let's examine these techniques in greater detail.
 
 - If the goal of the search is to determine whether a particular substring exists (that is, if you aren't interested in the position of the substring), you can search strings before storing them in the <xref:System.Text.StringBuilder> object. The following example provides one possible implementation. It defines a `StringBuilderFinder` class whose constructor is passed a reference to a <xref:System.Text.StringBuilder> object and the substring to find in the string. In this case, the example tries to determine whether recorded temperatures are in Fahrenheit or Celsius, and adds the appropriate introductory text to the beginning of the <xref:System.Text.StringBuilder> object. A random number generator is used to select an array that contains data in either degrees Celsius or degrees Fahrenheit.
 
-  :::code language="csharp" source="./snippets/System.Text/StringBuilder/Overview/csharp/pattern1.cs" interactive="try-dotnet" id="Snippet12":::
+  :::code language="csharp" source="./snippets/System.Text/StringBuilder/Overview/csharp/pattern1.cs" id="Snippet12":::
   :::code language="fsharp" source="./snippets/System.Text/StringBuilder/Overview/fsharp/pattern1.fs" id="Snippet12":::
   :::code language="vb" source="./snippets/System.Text/StringBuilder/Overview/vb/pattern1.vb" id="Snippet12":::
 
@@ -182,7 +182,7 @@ Let's examine these techniques in greater detail.
 
   The following example illustrates this approach. It stores four occurrences of each letter of the English alphabet in a <xref:System.Text.StringBuilder> object. It then converts the text to a <xref:System.String> object and uses a regular expression to identify the starting position of each four-character sequence. Finally, it adds an underscore before each four-character sequence except for the first sequence, and converts the first character of the sequence to uppercase.
 
-  :::code language="csharp" source="./snippets/System.Text/StringBuilder/Overview/csharp/pattern2.cs" interactive="try-dotnet" id="Snippet13":::
+  :::code language="csharp" source="./snippets/System.Text/StringBuilder/Overview/csharp/pattern2.cs" id="Snippet13":::
   :::code language="fsharp" source="./snippets/System.Text/StringBuilder/Overview/fsharp/pattern2.fs" id="Snippet13":::
   :::code language="vb" source="./snippets/System.Text/StringBuilder/Overview/vb/pattern2.vb" id="Snippet13":::
 
@@ -190,7 +190,7 @@ Let's examine these techniques in greater detail.
 
   The following example is identical in functionality to the previous example but differs in implementation. It uses the <xref:System.Text.StringBuilder.Chars%2A> property to detect when a character value has changed, inserts an underscore at that position, and converts the first character in the new sequence to uppercase.
 
-  :::code language="csharp" source="./snippets/System.Text/StringBuilder/Overview/csharp/pattern3.cs" interactive="try-dotnet" id="Snippet14":::
+  :::code language="csharp" source="./snippets/System.Text/StringBuilder/Overview/csharp/pattern3.cs" id="Snippet14":::
   :::code language="fsharp" source="./snippets/System.Text/StringBuilder/Overview/fsharp/pattern3.fs" id="Snippet14":::
   :::code language="vb" source="./snippets/System.Text/StringBuilder/Overview/vb/pattern3.vb" id="Snippet14":::
 
@@ -198,7 +198,7 @@ Let's examine these techniques in greater detail.
 
   The following example is identical in functionality to the previous two examples but differs in implementation. It creates a <xref:System.Text.StringBuilder> object, converts it to a <xref:System.String> object, and then uses a regular expression to perform all remaining modifications on the string. The <xref:System.Text.RegularExpressions.Regex.Replace%28System.String%2CSystem.String%2CSystem.Text.RegularExpressions.MatchEvaluator%29?displayProperty=nameWithType> method uses a lambda expression to perform the replacement on each match.
 
-  :::code language="csharp" source="./snippets/System.Text/StringBuilder/Overview/csharp/pattern4.cs" interactive="try-dotnet" id="Snippet15":::
+  :::code language="csharp" source="./snippets/System.Text/StringBuilder/Overview/csharp/pattern4.cs" id="Snippet15":::
   :::code language="fsharp" source="./snippets/System.Text/StringBuilder/Overview/fsharp/pattern4.fs" id="Snippet15":::
   :::code language="vb" source="./snippets/System.Text/StringBuilder/Overview/vb/pattern4.vb" id="Snippet15":::
 

--- a/docs/fundamentals/runtime-libraries/system-timespan-parse.md
+++ b/docs/fundamentals/runtime-libraries/system-timespan-parse.md
@@ -40,6 +40,6 @@ The <xref:System.TimeSpan.Parse(System.String)> method tries to parse the input 
 
 When a time interval component in the string to be parsed contains more than seven digits, parsing operations in .NET Framework 3.5 and earlier versions may behave differently from parsing operations in .NET Framework 4 and later versions. In some cases, parsing operations that succeed in .NET Framework 3.5 and earlier versions may fail and throw an <xref:System.OverflowException> in .NET Framework 4 and later. In other cases, parsing operations that throw a <xref:System.FormatException> in .NET Framework 3.5 and earlier versions may fail and throw an <xref:System.OverflowException> in .NET Framework 4 and later. The following example illustrates both scenarios.
 
-:::code language="csharp" source="./snippets/System/TimeSpan/Parse/csharp/parsefailure1.cs" interactive="try-dotnet-method" id="Snippet3":::
+:::code language="csharp" source="./snippets/System/TimeSpan/Parse/csharp/parsefailure1.cs" id="Snippet3":::
 :::code language="fsharp" source="./snippets/System/TimeSpan/Parse/fsharp/parsefailure1.fs" id="Snippet3":::
 :::code language="vb" source="./snippets/System/TimeSpan/Parse/vb/parsefailure1.vb" id="Snippet3":::

--- a/docs/fundamentals/runtime-libraries/system-timespan.md
+++ b/docs/fundamentals/runtime-libraries/system-timespan.md
@@ -26,25 +26,25 @@ You can instantiate a <xref:System.TimeSpan> value in a number of ways:
 
 - By calling its implicit parameterless constructor. This creates an object whose value is <xref:System.TimeSpan.Zero?displayProperty=nameWithType>, as the following example shows.
 
-  :::code language="csharp" source="./snippets/System/TimeSpan/Overview/csharp/instantiate1.cs" interactive="try-dotnet-method" id="Snippet2":::
+  :::code language="csharp" source="./snippets/System/TimeSpan/Overview/csharp/instantiate1.cs" id="Snippet2":::
   :::code language="fsharp" source="./snippets/System/TimeSpan/Overview/fsharp/instantiate1.fs" id="Snippet2":::
   :::code language="vb" source="./snippets/System/TimeSpan/Overview/vb/instantiate1.vb" id="Snippet2":::
 
 - By calling one of its explicit constructors. The following example initializes a <xref:System.TimeSpan> value to a specified number of hours, minutes, and seconds.
 
-  :::code language="csharp" source="./snippets/System/TimeSpan/Overview/csharp/instantiate1.cs" interactive="try-dotnet-method" id="Snippet3":::
+  :::code language="csharp" source="./snippets/System/TimeSpan/Overview/csharp/instantiate1.cs" id="Snippet3":::
   :::code language="fsharp" source="./snippets/System/TimeSpan/Overview/fsharp/instantiate1.fs" id="Snippet3":::
   :::code language="vb" source="./snippets/System/TimeSpan/Overview/vb/instantiate1.vb" id="Snippet3":::
 
 - By calling a method or performing an operation that returns a <xref:System.TimeSpan> value. For example, you can instantiate a <xref:System.TimeSpan> value that represents the interval between two date and time values, as the following example shows.
 
-  :::code language="csharp" source="./snippets/System/TimeSpan/Overview/csharp/instantiate1.cs" interactive="try-dotnet-method" id="Snippet4":::
+  :::code language="csharp" source="./snippets/System/TimeSpan/Overview/csharp/instantiate1.cs" id="Snippet4":::
   :::code language="fsharp" source="./snippets/System/TimeSpan/Overview/fsharp/instantiate1.fs" id="Snippet4":::
   :::code language="vb" source="./snippets/System/TimeSpan/Overview/vb/instantiate1.vb" id="Snippet4":::
 
   You can also initialize a <xref:System.TimeSpan> object to a zero time value in this way, as the following example shows.
 
-  :::code language="csharp" source="./snippets/System/TimeSpan/Overview/csharp/zero1.cs" interactive="try-dotnet-method" id="Snippet6":::
+  :::code language="csharp" source="./snippets/System/TimeSpan/Overview/csharp/zero1.cs" id="Snippet6":::
   :::code language="fsharp" source="./snippets/System/TimeSpan/Overview/fsharp/zero1.fs" id="Snippet6":::
   :::code language="vb" source="./snippets/System/TimeSpan/Overview/vb/zero1.vb" id="Snippet6":::
 
@@ -52,7 +52,7 @@ You can instantiate a <xref:System.TimeSpan> value in a number of ways:
 
 - By parsing the string representation of a <xref:System.TimeSpan> value. You can use the <xref:System.TimeSpan.Parse%2A> and <xref:System.TimeSpan.TryParse%2A> methods to convert strings that contain time intervals to <xref:System.TimeSpan> values. The following example uses the <xref:System.TimeSpan.Parse%2A> method to convert an array of strings to <xref:System.TimeSpan> values.
 
-  :::code language="csharp" source="./snippets/System/TimeSpan/Overview/csharp/instantiate1.cs" interactive="try-dotnet-method" id="Snippet5":::
+  :::code language="csharp" source="./snippets/System/TimeSpan/Overview/csharp/instantiate1.cs" id="Snippet5":::
   :::code language="fsharp" source="./snippets/System/TimeSpan/Overview/fsharp/instantiate1.fs" id="Snippet5":::
   :::code language="vb" source="./snippets/System/TimeSpan/Overview/vb/instantiate1.vb" id="Snippet5":::
 
@@ -74,7 +74,7 @@ Beginning with .NET Framework 4, the <xref:System.TimeSpan> structure supports c
 
 In some cases, code that successfully formats <xref:System.TimeSpan> values in .NET Framework 3.5 and earlier versions fails in .NET Framework 4. This is most common in code that calls a [<TimeSpan_LegacyFormatMode> element](../../framework/configure-apps/file-schema/runtime/timespan-legacyformatmode-element.md) method to format a <xref:System.TimeSpan> value with a format string. The following example successfully formats a <xref:System.TimeSpan> value in .NET Framework 3.5 and earlier versions, but throws an exception in .NET Framework 4 and later versions. Note that it attempts to format a <xref:System.TimeSpan> value by using an unsupported format specifier, which is ignored in .NET Framework 3.5 and earlier versions.
 
-:::code language="csharp" source="./snippets/System/TimeSpan/Overview/csharp/legacycode1.cs" interactive="try-dotnet-method" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/TimeSpan/Overview/csharp/legacycode1.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/TimeSpan/Overview/fsharp/legacycode1.fs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/TimeSpan/Overview/vb/legacycode1.vb" id="Snippet1":::
 

--- a/docs/fundamentals/runtime-libraries/system-type.md
+++ b/docs/fundamentals/runtime-libraries/system-type.md
@@ -47,7 +47,7 @@ The <xref:System.Type> object associated with a particular type can be obtained 
 
   The following example calls the <xref:System.Object.GetType%2A?displayProperty=nameWithType> method to determine the runtime type of each object in an object array.
 
-  :::code language="csharp" source="./snippets/System/Type/Overview/csharp/GetType1.cs" interactive="try-dotnet-method" id="Snippet2":::
+  :::code language="csharp" source="./snippets/System/Type/Overview/csharp/GetType1.cs" id="Snippet2":::
   :::code language="fsharp" source="./snippets/System/Type/Overview/fsharp/GetType1.fs" id="Snippet2":::
   :::code language="vb" source="./snippets/System/Type/Overview/vb/GetType1.vb" id="Snippet2":::
 
@@ -79,6 +79,6 @@ The <xref:System.Type> object associated with a particular type can be obtained 
 
 A <xref:System.Type> object that represents a type is unique; that is, two <xref:System.Type> object references refer to the same object if and only if they represent the same type. This allows for comparison of <xref:System.Type> objects using reference equality. The following example compares the <xref:System.Type> objects that represent a number of integer values to determine whether they are of the same type.
 
-:::code language="csharp" source="./snippets/System/Type/Overview/csharp/Equals1.cs" interactive="try-dotnet-method" id="Snippet3":::
+:::code language="csharp" source="./snippets/System/Type/Overview/csharp/Equals1.cs" id="Snippet3":::
 :::code language="fsharp" source="./snippets/System/Type/Overview/fsharp/Equals1.fs" id="Snippet3":::
 :::code language="vb" source="./snippets/System/Type/Overview/vb/Equals1.vb" id="Snippet3":::

--- a/docs/fundamentals/runtime-libraries/system-version.md
+++ b/docs/fundamentals/runtime-libraries/system-version.md
@@ -82,12 +82,12 @@ Ordinarily, the <xref:System.Version> class is not used to assign a version numb
 
 You can use the <xref:System.Version.CompareTo%2A> method to determine whether one <xref:System.Version> object is earlier than, the same as, or later than a second <xref:System.Version> object. The following example indicates that Version 2.1 is later than Version 2.0.
 
-:::code language="csharp" source="./snippets/System/Version/Overview/csharp/comparisons1.cs" interactive="try-dotnet-method" id="Snippet1":::
+:::code language="csharp" source="./snippets/System/Version/Overview/csharp/comparisons1.cs" id="Snippet1":::
 :::code language="fsharp" source="./snippets/System/Version/Overview/fsharp/comparisons1.fs" id="Snippet1":::
 :::code language="vb" source="./snippets/System/Version/Overview/vb/comparisons1.vb" id="Snippet1":::
 
 For two versions to be equal, the major, minor, build, and revision numbers of the first <xref:System.Version> object must be identical to those of the second <xref:System.Version> object. If the build or revision number of a <xref:System.Version> object is undefined, that <xref:System.Version> object is considered to be earlier than a <xref:System.Version> object whose build or revision number is equal to zero. The following example illustrates this by comparing three <xref:System.Version> objects that have undefined version components.
 
-:::code language="csharp" source="./snippets/System/Version/Overview/csharp/comparisons2.cs" interactive="try-dotnet" id="Snippet2":::
+:::code language="csharp" source="./snippets/System/Version/Overview/csharp/comparisons2.cs" id="Snippet2":::
 :::code language="fsharp" source="./snippets/System/Version/Overview/fsharp/comparisons2.fs" id="Snippet2":::
 :::code language="vb" source="./snippets/System/Version/Overview/vb/comparisons2.vb" id="Snippet2":::

--- a/docs/standard/base-types/custom-date-and-time-format-strings.md
+++ b/docs/standard/base-types/custom-date-and-time-format-strings.md
@@ -26,11 +26,9 @@ A date and time format string defines the text representation of a <xref:System.
 
 Custom date and time format strings can be used with both <xref:System.DateTime> and <xref:System.DateTimeOffset> values.
 
-[!INCLUDE[C# interactive-note](~/includes/csharp-interactive-with-utc-partial-note.md)]
-
 In formatting operations, custom date and time format strings can be used either with the `ToString` method of a date and time instance or with a method that supports composite formatting. The following example illustrates both uses.
 
-[!code-csharp-interactive[Formatting.DateAndTime.Custom#17](~/samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Custom/cs/custandformatting1.cs#17)]
+[!code-csharp[Formatting.DateAndTime.Custom#17](~/samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Custom/cs/custandformatting1.cs#17)]
 [!code-vb[Formatting.DateAndTime.Custom#17](~/samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.DateAndTime.Custom/vb/custandformatting1.vb#17)]
 
 In parsing operations, custom date and time format strings can be used with the <xref:System.DateTime.ParseExact%2A?displayProperty=nameWithType>, <xref:System.DateTime.TryParseExact%2A?displayProperty=nameWithType>, <xref:System.DateTimeOffset.ParseExact%2A?displayProperty=nameWithType>, and <xref:System.DateTimeOffset.TryParseExact%2A?displayProperty=nameWithType> methods. These methods require that an input string conforms exactly to a particular pattern for the parse operation to succeed. The following example illustrates a call to the <xref:System.DateTimeOffset.ParseExact%28System.String%2CSystem.String%2CSystem.IFormatProvider%29?displayProperty=nameWithType> method to parse a date that must include a day, a month, and a two-digit year.
@@ -368,7 +366,7 @@ If the "K" format specifier is used without other custom format specifiers, it's
 
 The following example displays the string that results from using the "K" custom format specifier with various <xref:System.DateTime> and <xref:System.DateTimeOffset> values on a system in the U.S. Pacific Time zone.
 
-[!code-csharp-interactive[Formatting.DateAndTime.Custom#12](~/samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Custom/cs/Custom1.cs#12)]
+[!code-csharp[Formatting.DateAndTime.Custom#12](~/samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Custom/cs/Custom1.cs#12)]
 [!code-vb[Formatting.DateAndTime.Custom#12](~/samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.DateAndTime.Custom/vb/Custom1.vb#12)]
 
 [Back to table](#table)
@@ -511,7 +509,7 @@ If the "y" format specifier is used without other custom format specifiers, it's
 
 The following example includes the "y" custom format specifier in a custom format string.
 
-[!code-csharp-interactive[Formatting.DateAndTime.Custom#13](~/samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Custom/cs/Custom1.cs#13)]
+[!code-csharp[Formatting.DateAndTime.Custom#13](~/samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Custom/cs/Custom1.cs#13)]
 [!code-vb[Formatting.DateAndTime.Custom#13](~/samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.DateAndTime.Custom/vb/Custom1.vb#13)]
 
 [Back to table](#table)
@@ -522,7 +520,7 @@ The "yy" custom format specifier represents the year as a two-digit number. If t
 
 In a parsing operation, a two-digit year that is parsed using the "yy" custom format specifier is interpreted based on the <xref:System.Globalization.Calendar.TwoDigitYearMax%2A?displayProperty=nameWithType> property of the format provider's current calendar. The following example parses the string representation of a date that has a two-digit year by using the default Gregorian calendar of the en-US culture, which, in this case, is the current culture. It then changes the current culture's <xref:System.Globalization.CultureInfo> object to use a <xref:System.Globalization.GregorianCalendar> object whose <xref:System.Globalization.GregorianCalendar.TwoDigitYearMax%2A> property has been modified.
 
-[!code-csharp-interactive[Formatting.DateAndTime.Custom#19](~/samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Custom/cs/parseexact2digityear1.cs#19)]
+[!code-csharp[Formatting.DateAndTime.Custom#19](~/samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Custom/cs/parseexact2digityear1.cs#19)]
 [!code-vb[Formatting.DateAndTime.Custom#19](~/samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.DateAndTime.Custom/vb/parseexact2digityear1.vb#19)]
 
 The following example includes the "yy" custom format specifier in a custom format string.
@@ -541,7 +539,7 @@ The "yyy" custom format specifier represents the year with a minimum of three di
 
 The following example includes the "yyy" custom format specifier in a custom format string.
 
-[!code-csharp-interactive[Formatting.DateAndTime.Custom#13](~/samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Custom/cs/Custom1.cs#13)]
+[!code-csharp[Formatting.DateAndTime.Custom#13](~/samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Custom/cs/Custom1.cs#13)]
 [!code-vb[Formatting.DateAndTime.Custom#13](~/samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.DateAndTime.Custom/vb/Custom1.vb#13)]
 
 [Back to table](#table)
@@ -555,7 +553,7 @@ The "yyyy" custom format specifier represents the year with a minimum of four di
 
 The following example includes the "yyyy" custom format specifier in a custom format string.
 
-[!code-csharp-interactive[Formatting.DateAndTime.Custom#13](~/samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Custom/cs/Custom1.cs#13)]
+[!code-csharp[Formatting.DateAndTime.Custom#13](~/samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Custom/cs/Custom1.cs#13)]
 [!code-vb[Formatting.DateAndTime.Custom#13](~/samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.DateAndTime.Custom/vb/Custom1.vb#13)]
 
 [Back to table](#table)
@@ -568,7 +566,7 @@ If there are additional "y" specifiers, the number is padded with as many leadin
 
 The following example includes the "yyyyy" custom format specifier in a custom format string.
 
-[!code-csharp-interactive[Formatting.DateAndTime.Custom#13](~/samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Custom/cs/Custom1.cs#13)]
+[!code-csharp[Formatting.DateAndTime.Custom#13](~/samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Custom/cs/Custom1.cs#13)]
 [!code-vb[Formatting.DateAndTime.Custom#13](~/samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.DateAndTime.Custom/vb/Custom1.vb#13)]
 
 [Back to table](#table)
@@ -593,7 +591,7 @@ If the "z" format specifier is used without other custom format specifiers, it's
 
 The following example includes the "z" custom format specifier in a custom format string.
 
-[!code-csharp-interactive[Formatting.DateAndTime.Custom#14](~/samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Custom/cs/Custom1.cs#14)]
+[!code-csharp[Formatting.DateAndTime.Custom#14](~/samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Custom/cs/Custom1.cs#14)]
 [!code-vb[Formatting.DateAndTime.Custom#14](~/samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.DateAndTime.Custom/vb/Custom1.vb#14)]
 
 [Back to table](#table)
@@ -614,7 +612,7 @@ With <xref:System.DateTimeOffset> values, this format specifier represents the <
 
 The following example includes the "zz" custom format specifier in a custom format string.
 
-[!code-csharp-interactive[Formatting.DateAndTime.Custom#14](~/samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Custom/cs/Custom1.cs#14)]
+[!code-csharp[Formatting.DateAndTime.Custom#14](~/samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Custom/cs/Custom1.cs#14)]
 [!code-vb[Formatting.DateAndTime.Custom#14](~/samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.DateAndTime.Custom/vb/Custom1.vb#14)]
 
 [Back to table](#table)
@@ -635,7 +633,7 @@ With <xref:System.DateTimeOffset> values, this format specifier represents the <
 
 The following example includes the "zzz" custom format specifier in a custom format string.
 
-[!code-csharp-interactive[Formatting.DateAndTime.Custom#14](~/samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Custom/cs/Custom1.cs#14)]
+[!code-csharp[Formatting.DateAndTime.Custom#14](~/samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Custom/cs/Custom1.cs#14)]
 [!code-vb[Formatting.DateAndTime.Custom#14](~/samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.DateAndTime.Custom/vb/Custom1.vb#14)]
 
 [Back to table](#table)
@@ -719,7 +717,7 @@ To use any of the custom date and time format specifiers as the only specifier i
 
 For example, "`%h"` is interpreted as a custom date and time format string that displays the hour represented by the current date and time value. You can also use the " h" format string, although this includes a space in the result string along with the hour. The following example illustrates these format strings.
 
-[!code-csharp-interactive[Formatting.DateAndTime.Custom#16](~/samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Custom/cs/literal1.cs#16)]
+[!code-csharp[Formatting.DateAndTime.Custom#16](~/samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Custom/cs/literal1.cs#16)]
 [!code-vb[Formatting.DateAndTime.Custom#16](~/samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.DateAndTime.Custom/vb/literal1.vb#16)]
 
 #### <a name="escape"></a> Using the Escape character
@@ -733,7 +731,7 @@ To include a backslash in a result string, you must escape it with another backs
 
 The following example uses the escape character to prevent the formatting operation from interpreting the "h" and "m" characters as format specifiers.
 
-[!code-csharp-interactive[Formatting.DateAndTime.Custom#15](~/samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Custom/cs/escape1.cs#15)]
+[!code-csharp[Formatting.DateAndTime.Custom#15](~/samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Custom/cs/escape1.cs#15)]
 [!code-vb[Formatting.DateAndTime.Custom#15](~/samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.DateAndTime.Custom/vb/escape1.vb#15)]
 
 ### Control Panel settings

--- a/docs/standard/base-types/custom-numeric-format-strings.md
+++ b/docs/standard/base-types/custom-numeric-format-strings.md
@@ -43,8 +43,6 @@ Custom numeric format strings are supported by some overloads of the `ToString` 
 
 The following sections provide detailed information about each of the custom numeric format specifiers.
 
-[!INCLUDE[C# interactive-note](~/includes/csharp-interactive-partial-note.md)]
-
 <a name="Specifier0"></a>
 
 ## The "0" custom specifier
@@ -177,7 +175,7 @@ To include a backslash in a result string, you must escape it with another backs
 
 The following example uses the escape character to prevent the formatting operation from interpreting the "#", "0", and "\\" characters as either escape characters or format specifiers. The C# examples uses an additional backslash to ensure that a backslash is interpreted as a literal character.
 
-[!code-csharp-interactive[Formatting.Numeric.Custom#11](../../../samples/snippets/csharp/VS_Snippets_CLR/formatting.numeric.custom/cs/escape1.cs#11)]
+[!code-csharp[Formatting.Numeric.Custom#11](../../../samples/snippets/csharp/VS_Snippets_CLR/formatting.numeric.custom/cs/escape1.cs#11)]
 [!code-vb[Formatting.Numeric.Custom#11](../../../samples/snippets/visualbasic/VS_Snippets_CLR/formatting.numeric.custom/vb/escape1.vb#11)]
 
 [Back to table](#table)
@@ -198,7 +196,7 @@ Section separators ignore any preexisting formatting associated with a number wh
 
 The following example uses the ";" format specifier to format positive, negative, and zero numbers differently.
 
-[!code-csharp-interactive[Formatting.Numeric.Custom#8](../../../samples/snippets/csharp/VS_Snippets_CLR/formatting.numeric.custom/cs/custom.cs#8)]
+[!code-csharp[Formatting.Numeric.Custom#8](../../../samples/snippets/csharp/VS_Snippets_CLR/formatting.numeric.custom/cs/custom.cs#8)]
 [!code-vb[Formatting.Numeric.Custom#8](../../../samples/snippets/visualbasic/VS_Snippets_CLR/formatting.numeric.custom/vb/Custom.vb#8)]
 
 [Back to table](#table)
@@ -221,7 +219,7 @@ All other characters are always interpreted as character literals and, in a form
 
 The following example illustrates one common use of literal character units (in this case, thousands):
 
-[!code-csharp-interactive[literal characters](~/samples/snippets/csharp/VS_Snippets_CLR/formatting.numeric.custom/literal2.cs#1)]
+[!code-csharp[literal characters](~/samples/snippets/csharp/VS_Snippets_CLR/formatting.numeric.custom/literal2.cs#1)]
 [!code-vb[literal characters](~/samples/snippets/visualbasic/VS_Snippets_CLR/formatting.numeric.custom/literal2.vb#1)]
 
 There are two ways to indicate that characters are to be interpreted as literal characters and not as formatting characters, so that they can be included in a result string or successfully parsed in an input string:
@@ -232,7 +230,7 @@ There are two ways to indicate that characters are to be interpreted as literal 
 
 The following example uses both approaches to include reserved characters in a custom numeric format string.
 
-[!code-csharp-interactive[including reserved characters](~/samples/snippets/csharp/VS_Snippets_CLR/formatting.numeric.custom/literal1.cs#1)]
+[!code-csharp[including reserved characters](~/samples/snippets/csharp/VS_Snippets_CLR/formatting.numeric.custom/literal1.cs#1)]
 [!code-vb[including reserved characters](~/samples/snippets/visualbasic/VS_Snippets_CLR/formatting.numeric.custom/literal1.vb#1)]
 
 <a name="NotesCustomFormatting"></a>
@@ -261,7 +259,7 @@ For fixed-point format strings (that is, format strings that do not contain scie
 
 The following example demonstrates two custom numeric format strings. In both cases, the digit placeholder (`#`) displays the numeric data, and all other characters are copied to the result string.
 
-[!code-csharp-interactive[Formatting.Numeric.Custom#10](../../../samples/snippets/csharp/VS_Snippets_CLR/formatting.numeric.custom/cs/example1.cs#10)]
+[!code-csharp[Formatting.Numeric.Custom#10](../../../samples/snippets/csharp/VS_Snippets_CLR/formatting.numeric.custom/cs/example1.cs#10)]
 [!code-vb[Formatting.Numeric.Custom#10](../../../samples/snippets/visualbasic/VS_Snippets_CLR/formatting.numeric.custom/vb/example1.vb#10)]
 
 [Back to table](#table)

--- a/docs/standard/base-types/divide-up-strings.md
+++ b/docs/standard/base-types/divide-up-strings.md
@@ -41,7 +41,7 @@ The periods are gone from the substrings, but now two extra empty substrings hav
 
 If your string conforms to a fixed pattern, you can use a regular expression to extract and handle its elements. For example, if strings take the form "*number* *operand* *number*", you can use a [regular expression](regular-expressions.md) to extract and handle the string's elements. Here's an example:
 
-:::code language="csharp" source="snippets/parse-strings/csharp/regex.cs" id="1" interactive="try-dotnet":::
+:::code language="csharp" source="snippets/parse-strings/csharp/regex.cs" id="1":::
 :::code language="vb" source="snippets/parse-strings/vb/regex.vb" id="1":::
 
 The regular expression pattern `(\d+)\s+([-+*/])\s+(\d+)` is defined like this:
@@ -69,7 +69,7 @@ For example, the <xref:System.String.Split%2A> method cannot be used to split th
 
 A regular expression can split this string easily, as the following example shows.
 
-:::code language="csharp" source="snippets/parse-strings/csharp/regex.cs" id="2" interactive="try-dotnet":::
+:::code language="csharp" source="snippets/parse-strings/csharp/regex.cs" id="2":::
 :::code language="vb" source="snippets/parse-strings/vb/regex.vb" id="2":::
 
 The regular expression pattern `\[([^\[\]]+)\]` is defined like this:
@@ -82,7 +82,7 @@ The regular expression pattern `\[([^\[\]]+)\]` is defined like this:
 
 The <xref:System.Text.RegularExpressions.Regex.Split%2A?displayProperty=nameWithType> method is almost identical to <xref:System.String.Split%2A?displayProperty=nameWithType>, except that it splits a string based on a regular expression pattern instead of a fixed character set. For example, the following example uses the <xref:System.Text.RegularExpressions.Regex.Split%2A?displayProperty=nameWithType> method to split a string that contains substrings delimited by various combinations of hyphens and other characters.
 
-:::code language="csharp" source="snippets/parse-strings/csharp/regex.cs" id="3" interactive="try-dotnet":::
+:::code language="csharp" source="snippets/parse-strings/csharp/regex.cs" id="3":::
 :::code language="vb" source="snippets/parse-strings/vb/regex.vb" id="3":::
 
 The regular expression pattern `\s-\s?[+*]?\s?-\s` is defined like this:
@@ -109,7 +109,7 @@ If you aren't interested in all of the substrings in a string, you might prefer 
 
 The following example uses the <xref:System.String.IndexOf%2A> method to find the periods in a string. It then uses the <xref:System.String.Substring%2A> method to return full sentences.
 
-:::code language="csharp" source="snippets/parse-strings/csharp/indexof.cs" id="1" interactive="try-dotnet":::
+:::code language="csharp" source="snippets/parse-strings/csharp/indexof.cs" id="1":::
 :::code language="vb" source="snippets/parse-strings/vb/indexof.vb" id="1":::
 
 ## See also

--- a/docs/standard/base-types/divide-up-strings.md
+++ b/docs/standard/base-types/divide-up-strings.md
@@ -22,19 +22,19 @@ This article covers some different techniques for extracting parts of a string.
 
 The following examples show three different overloads of `String.Split()`. The first example calls the <xref:System.String.Split(System.Char[])> overload without passing any separator characters. When you don't specify any delimiting characters, `String.Split()` uses default delimiters, which are white-space characters, to split up the string.
 
-[!code-csharp-interactive[Intro#1](snippets/parse-strings/csharp/intro.cs#1)]
+[!code-csharp[Intro#1](snippets/parse-strings/csharp/intro.cs#1)]
 :::code language="vb" source="snippets/parse-strings/vb/intro.vb" id="1":::
 
 As you can see, the period characters (`.`) are included in two of the substrings. If you want to exclude the period characters, you can add the period character as an additional delimiting character. The next example shows how to do this.
 
-[!code-csharp-interactive[Intro#1](snippets/parse-strings/csharp/intro.cs#2)]
+[!code-csharp[Intro#1](snippets/parse-strings/csharp/intro.cs#2)]
 :::code language="vb" source="snippets/parse-strings/vb/intro.vb" id="2":::
 
 The periods are gone from the substrings, but now two extra empty substrings have been included. These empty substring represent the substring between the word and the period that follows it. To omit empty substrings from the resulting array, you can call the
 <xref:System.String.Split(System.Char[],System.StringSplitOptions)> overload and specify
 <xref:System.StringSplitOptions.RemoveEmptyEntries?displayProperty=nameWithType> for the `options` parameter.
 
-[!code-csharp-interactive[Intro#1](snippets/parse-strings/csharp/intro.cs#3)]
+[!code-csharp[Intro#1](snippets/parse-strings/csharp/intro.cs#3)]
 :::code language="vb" source="snippets/parse-strings/vb/intro.vb" id="3":::
 
 ## Regular expressions

--- a/docs/standard/base-types/parsing-datetime.md
+++ b/docs/standard/base-types/parsing-datetime.md
@@ -52,19 +52,19 @@ The following example illustrates the use of the <xref:System.DateTime.Parse%2A?
 > [!NOTE]
 > These examples are available in the GitHub docs repo for both [C#](https://github.com/dotnet/docs/tree/main/samples/snippets/csharp/how-to/conversions) and [Visual Basic](https://github.com/dotnet/docs/tree/main/samples/snippets/visualbasic/how-to/conversions).
 
-[!code-csharp-interactive[Parsing.DateAndTime#1](../../../samples/snippets/csharp/how-to/conversions/StringToDateTime.cs#1)]
+[!code-csharp[Parsing.DateAndTime#1](../../../samples/snippets/csharp/how-to/conversions/StringToDateTime.cs#1)]
 [!code-vb[Parsing.DateAndTime#1](../../../samples/snippets/visualbasic/how-to/conversions/Program.vb#1)]
 
 You can also explicitly define the culture whose formatting conventions are used when you parse a string. You specify one of the standard <xref:System.Globalization.DateTimeFormatInfo> objects returned by the <xref:System.Globalization.CultureInfo.DateTimeFormat%2A?displayProperty=nameWithType> property. The following example uses a format provider to parse a German string into a <xref:System.DateTime>. It creates a <xref:System.Globalization.CultureInfo> representing the `de-DE` culture. That `CultureInfo` object ensures successful parsing of this particular string. This process precludes whatever setting is in the <xref:System.Threading.Thread.CurrentCulture> of the <xref:System.Threading.Thread.CurrentThread>.
 
-[!code-csharp-interactive[Parsing.DateAndTime#2](../../../samples/snippets/csharp/how-to/conversions/StringToDateTime.cs#2)]
+[!code-csharp[Parsing.DateAndTime#2](../../../samples/snippets/csharp/how-to/conversions/StringToDateTime.cs#2)]
 [!code-vb[Parsing.DateAndTime#2](../../../samples/snippets/visualbasic/how-to/conversions/Program.vb#2)]
 
 However, you can use overloads of the <xref:System.DateTime.Parse%2A> method to specify custom format providers. The <xref:System.DateTime.Parse%2A> method doesn't support parsing non-standard formats. To parse a date and time expressed in a non-standard format, use the <xref:System.DateTime.ParseExact%2A> method instead.
 
 <a name="styles-example"></a>The following example uses the <xref:System.Globalization.DateTimeStyles> enumeration to specify that the current date and time information shouldn't be added to the <xref:System.DateTime> for unspecified fields.
 
-[!code-csharp-interactive[Parsing.DateAndTime#3](../../../samples/snippets/csharp/how-to/conversions/StringToDateTime.cs#3)]
+[!code-csharp[Parsing.DateAndTime#3](../../../samples/snippets/csharp/how-to/conversions/StringToDateTime.cs#3)]
 [!code-vb[Parsing.DateAndTime#3](../../../samples/snippets/visualbasic/how-to/conversions/Program.vb#3)]
 
 ## ParseExact
@@ -73,7 +73,7 @@ The <xref:System.DateTime.ParseExact%2A?displayProperty=nameWithType> method con
 
 In the following example, the <xref:System.DateTime.ParseExact%2A?displayProperty=nameWithType> method is passed a string object to parse, followed by a format specifier, followed by a <xref:System.Globalization.CultureInfo> object. This <xref:System.DateTime.ParseExact%2A> method can only parse strings that follow the long date pattern in the `en-US` culture.
 
-[!code-csharp-interactive[Parsing.DateAndTime#4](../../../samples/snippets/csharp/how-to/conversions/StringToDateTime.cs#4)]
+[!code-csharp[Parsing.DateAndTime#4](../../../samples/snippets/csharp/how-to/conversions/StringToDateTime.cs#4)]
 [!code-vb[Parsing.DateAndTime#4](../../../samples/snippets/visualbasic/how-to/conversions/Program.vb#4)]
 
 Each overload of the <xref:System.DateTime.Parse%2A> and <xref:System.DateTime.ParseExact%2A> methods also has an <xref:System.IFormatProvider> parameter that provides culture-specific information about the formatting of the string. The <xref:System.IFormatProvider> object is a <xref:System.Globalization.CultureInfo> object that represents a standard culture or a <xref:System.Globalization.DateTimeFormatInfo> object that is returned by the <xref:System.Globalization.CultureInfo.DateTimeFormat%2A?displayProperty=nameWithType> property. <xref:System.DateTime.ParseExact%2A> also uses an additional string or string array argument that defines one or more custom date and time formats.

--- a/docs/standard/base-types/standard-date-and-time-format-strings.md
+++ b/docs/standard/base-types/standard-date-and-time-format-strings.md
@@ -26,8 +26,6 @@ A standard date and time format string uses a single character as the format spe
 > [!TIP]
 > You can download the **Formatting Utility**, a .NET Windows Forms application that lets you apply format strings to either numeric or date and time values and display the result string. Source code is available for [C#](/samples/dotnet/samples/windowsforms-formatting-utility-cs) and [Visual Basic](/samples/dotnet/samples/windowsforms-formatting-utility-vb).
 
-[!INCLUDE[C# interactive-note](~/includes/csharp-interactive-with-utc-partial-note.md)]
-
 ## Table of format specifiers
 
 <a name="table"></a> The following table describes the standard date and time format specifiers. Unless otherwise noted, a particular standard date and time format specifier produces an identical string representation regardless of whether it is used with a <xref:System.DateTime> or a <xref:System.DateTimeOffset> value. Not all format specifiers can be used with <xref:System.DateOnly> and <xref:System.TimeOnly> values; for additional information, see [DateOnly and TimeOnly formatting](#dateonly-and-timeonly-formatting). For information about how regional settings on Windows and the current <xref:System.Globalization.DateTimeFormatInfo> object can affect date and time formatting, see [Control Panel Settings](#control-panel-settings) and [DateTimeFormatInfo Properties](#datetimeformatinfo-properties).
@@ -59,7 +57,7 @@ If a standard format string in a formatting operation maps to a particular cultu
 
 - You can use the default (or current) culture. The following example displays a date using the current culture's short date format. In this case, the current culture is en-US.
 
-  [!code-csharp-interactive[System.DateTime.Conceptual.Formatting#1](../../../samples/snippets/csharp/VS_Snippets_CLR_System/system.DateTime.Conceptual.Formatting/cs/StandardFormats1.cs#1)]
+  [!code-csharp[System.DateTime.Conceptual.Formatting#1](../../../samples/snippets/csharp/VS_Snippets_CLR_System/system.DateTime.Conceptual.Formatting/cs/StandardFormats1.cs#1)]
   [!code-vb[System.DateTime.Conceptual.Formatting#1](../../../samples/snippets/visualbasic/VS_Snippets_CLR_System/system.DateTime.Conceptual.Formatting/vb/StandardFormats1.vb#1)]
 
 - You can pass a <xref:System.Globalization.CultureInfo> object representing the culture whose formatting is to be used to a method that has an <xref:System.IFormatProvider> parameter. The following example displays a date using the short date format of the pt-BR culture.
@@ -302,7 +300,7 @@ Although the RFC 1123 standard expresses a time as Coordinated Universal Time (U
 
 The following example uses the "r" format specifier to display a <xref:System.DateTime> and a <xref:System.DateTimeOffset> value on a system in the U.S. Pacific Time zone.
 
-[!code-csharp-interactive[Formatting.DateAndTime.Standard#9](../../../samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Standard/cs/Standard1.cs#9)]
+[!code-csharp[Formatting.DateAndTime.Standard#9](../../../samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Standard/cs/Standard1.cs#9)]
 [!code-vb[Formatting.DateAndTime.Standard#9](../../../samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.DateAndTime.Standard/vb/Standard1.vb#9)]
 
 [Back to table](#table)
@@ -319,7 +317,7 @@ When this standard format specifier is used, the formatting or parsing operation
 
 The following example uses the "s" format specifier to display a <xref:System.DateTime> and a <xref:System.DateTimeOffset> value on a system in the U.S. Pacific Time zone.
 
-[!code-csharp-interactive[Formatting.DateAndTime.Standard#10](../../../samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Standard/cs/Standard1.cs#10)]
+[!code-csharp[Formatting.DateAndTime.Standard#10](../../../samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Standard/cs/Standard1.cs#10)]
 [!code-vb[Formatting.DateAndTime.Standard#10](../../../samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.DateAndTime.Standard/vb/Standard1.vb#10)]
 
 [Back to table](#table)
@@ -334,7 +332,7 @@ Although the result string should express a time as Coordinated Universal Time (
 
 The following example uses the "u" format specifier to display a date and time value.
 
-[!code-csharp-interactive[Formatting.DateAndTime.Standard#13](../../../samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Standard/cs/Standard1.cs#13)]
+[!code-csharp[Formatting.DateAndTime.Standard#13](../../../samples/snippets/csharp/VS_Snippets_CLR/Formatting.DateAndTime.Standard/cs/Standard1.cs#13)]
 [!code-vb[Formatting.DateAndTime.Standard#13](../../../samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.DateAndTime.Standard/vb/Standard1.vb#13)]
 
 [Back to table](#table)

--- a/docs/standard/base-types/standard-numeric-format-strings.md
+++ b/docs/standard/base-types/standard-numeric-format-strings.md
@@ -67,8 +67,6 @@ The following table describes the standard numeric format specifiers and display
 
 ## Use standard numeric format strings
 
-[!INCLUDE[interactive-note](~/includes/csharp-interactive-note.md)]
-
 A standard numeric format string can be used to define the formatting of a numeric value in one of the following ways:
 
 - It can be passed to the `TryFormat` method or an overload of the `ToString` method that has a `format` parameter. The following example formats a numeric value as a currency string in the current culture (in this case, the en-US culture).

--- a/docs/standard/base-types/standard-numeric-format-strings.md
+++ b/docs/standard/base-types/standard-numeric-format-strings.md
@@ -71,17 +71,17 @@ A standard numeric format string can be used to define the formatting of a numer
 
 - It can be passed to the `TryFormat` method or an overload of the `ToString` method that has a `format` parameter. The following example formats a numeric value as a currency string in the current culture (in this case, the en-US culture).
 
-  [!code-csharp-interactive[Formatting.Numeric.Standard#10](../../../samples/snippets/csharp/VS_Snippets_CLR/Formatting.Numeric.Standard/cs/standardusage1.cs#10)]
+  [!code-csharp[Formatting.Numeric.Standard#10](../../../samples/snippets/csharp/VS_Snippets_CLR/Formatting.Numeric.Standard/cs/standardusage1.cs#10)]
   [!code-vb[Formatting.Numeric.Standard#10](../../../samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.Numeric.Standard/vb/standardusage1.vb#10)]
 
 - It can be supplied as the `formatString` argument in a format item used with such methods as <xref:System.String.Format%2A?displayProperty=nameWithType>, <xref:System.Console.WriteLine%2A?displayProperty=nameWithType>, and <xref:System.Text.StringBuilder.AppendFormat%2A?displayProperty=nameWithType>. For more information, see [Composite Formatting](composite-formatting.md). The following example uses a format item to insert a currency value in a string.
 
-  [!code-csharp-interactive[Formatting.Numeric.Standard#11](../../../samples/snippets/csharp/VS_Snippets_CLR/Formatting.Numeric.Standard/cs/standardusage1.cs#11)]
+  [!code-csharp[Formatting.Numeric.Standard#11](../../../samples/snippets/csharp/VS_Snippets_CLR/Formatting.Numeric.Standard/cs/standardusage1.cs#11)]
   [!code-vb[Formatting.Numeric.Standard#11](../../../samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.Numeric.Standard/vb/standardusage1.vb#11)]
 
   Optionally, you can supply an `alignment` argument to specify the width of the numeric field and whether its value is right- or left-aligned. The following example left-aligns a currency value in a 28-character field, and it right-aligns a currency value in a 14-character field.
 
-  [!code-csharp-interactive[Formatting.Numeric.Standard#12](../../../samples/snippets/csharp/VS_Snippets_CLR/Formatting.Numeric.Standard/cs/standardusage1.cs#12)]
+  [!code-csharp[Formatting.Numeric.Standard#12](../../../samples/snippets/csharp/VS_Snippets_CLR/Formatting.Numeric.Standard/cs/standardusage1.cs#12)]
   [!code-vb[Formatting.Numeric.Standard#12](../../../samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.Numeric.Standard/vb/standardusage1.vb#12)]
 
 - It can be supplied as the `formatString` argument in an interpolated expression item of an interpolated string. For more information, see the [String interpolation](../../csharp/language-reference/tokens/interpolated.md) article in the C# reference or the [Interpolated strings](../../visual-basic/programming-guide/language-features/strings/interpolated-strings.md) article in the Visual Basic reference.
@@ -140,7 +140,7 @@ The result string is affected by the formatting information of the current <xref
 |<xref:System.Globalization.NumberFormatInfo.NegativeSign%2A>|Defines the string that indicates that a number is negative.|
 
 The following example formats an <xref:System.Int32> value with the decimal format specifier.
-[!code-csharp-interactive[Formatting.Numeric.Standard#2](../../../samples/snippets/csharp/VS_Snippets_CLR/Formatting.Numeric.Standard/cs/Standard.cs#2)]
+[!code-csharp[Formatting.Numeric.Standard#2](../../../samples/snippets/csharp/VS_Snippets_CLR/Formatting.Numeric.Standard/cs/Standard.cs#2)]
 [!code-vb[Formatting.Numeric.Standard#2](../../../samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.Numeric.Standard/vb/Standard.vb#2)]
 
 <a name="EFormatString"></a>
@@ -314,7 +314,7 @@ For <xref:System.Numerics.BigInteger>, positive values always have a leading zer
 The result string is not affected by the formatting information of the current <xref:System.Globalization.NumberFormatInfo> object.
 
 The following example formats <xref:System.Int32> values with the hexadecimal format specifier.
-[!code-csharp-interactive[Formatting.Numeric.Standard#9](../../../samples/snippets/csharp/VS_Snippets_CLR/Formatting.Numeric.Standard/cs/Standard.cs#9)]
+[!code-csharp[Formatting.Numeric.Standard#9](../../../samples/snippets/csharp/VS_Snippets_CLR/Formatting.Numeric.Standard/cs/Standard.cs#9)]
 [!code-vb[Formatting.Numeric.Standard#9](../../../samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.Numeric.Standard/vb/Standard.vb#9)]
 
 ## Notes

--- a/includes/csharp-interactive-note.md
+++ b/includes/csharp-interactive-note.md
@@ -1,3 +1,0 @@
-
-> [!NOTE]
-> The C# examples in this article run in the [Try.NET](https://dotnet.microsoft.com/platform/try-dotnet) inline code runner and playground. Select the **Run** button to run an example in an interactive window. Once you execute the code, you can modify it and run the modified code by selecting **Run** again. The modified code either runs in the interactive window or, if compilation fails, the interactive window displays all C# compiler error messages.  

--- a/includes/csharp-interactive-partial-note.md
+++ b/includes/csharp-interactive-partial-note.md
@@ -1,3 +1,0 @@
-
-> [!NOTE]
-> Some of the C# examples in this article run in the [Try.NET](https://dotnet.microsoft.com/platform/try-dotnet) inline code runner and playground. Select the **Run** button to run an example in an interactive window. Once you execute the code, you can modify it and run the modified code by selecting **Run** again. The modified code either runs in the interactive window or, if compilation fails, the interactive window displays all C# compiler error messages.  

--- a/includes/csharp-interactive-with-utc-partial-note.md
+++ b/includes/csharp-interactive-with-utc-partial-note.md
@@ -1,5 +1,0 @@
-
-> [!NOTE]
-> Some of the C# examples in this article run in the [Try.NET](https://dotnet.microsoft.com/platform/try-dotnet) inline code runner and playground. Select the **Run** button to run an example in an interactive window. Once you execute the code, you can modify it and run the modified code by selecting **Run** again. The modified code either runs in the interactive window or, if compilation fails, the interactive window displays all C# compiler error messages.
->
-> The [local time zone](xref:System.TimeZoneInfo.Local) of the [Try.NET](https://dotnet.microsoft.com/platform/try-dotnet) inline code runner and playground is Coordinated Universal Time, or UTC. This may affect the behavior and the output of examples that illustrate the <xref:System.DateTime>, <xref:System.DateTimeOffset>, and <xref:System.TimeZoneInfo> types and their members.


### PR DESCRIPTION
Remove interactive snippets from all docs *except* the introductory tutorials.

Contributes to #50331 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

<details><summary><strong>Toggle expand/collapse</strong></summary><br/>

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/how-to/compare-strings.md](https://github.com/dotnet/docs/blob/e6f7bbfbe9d02f5b70e8b032ea79d944fdffbdbf/docs/csharp/how-to/compare-strings.md) | [How to compare strings in C\#](https://review.learn.microsoft.com/en-us/dotnet/csharp/how-to/compare-strings?branch=pr-en-us-50074) |
| [docs/csharp/how-to/concatenate-multiple-strings.md](https://github.com/dotnet/docs/blob/e6f7bbfbe9d02f5b70e8b032ea79d944fdffbdbf/docs/csharp/how-to/concatenate-multiple-strings.md) | [How to concatenate multiple strings (C# Guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/how-to/concatenate-multiple-strings?branch=pr-en-us-50074) |
| [docs/csharp/how-to/modify-string-contents.md](https://github.com/dotnet/docs/blob/e6f7bbfbe9d02f5b70e8b032ea79d944fdffbdbf/docs/csharp/how-to/modify-string-contents.md) | ["How to modify string contents"](https://review.learn.microsoft.com/en-us/dotnet/csharp/how-to/modify-string-contents?branch=pr-en-us-50074) |
| [docs/csharp/how-to/parse-strings-using-split.md](https://github.com/dotnet/docs/blob/e6f7bbfbe9d02f5b70e8b032ea79d944fdffbdbf/docs/csharp/how-to/parse-strings-using-split.md) | [How to separate strings using String.Split in C\#](https://review.learn.microsoft.com/en-us/dotnet/csharp/how-to/parse-strings-using-split?branch=pr-en-us-50074) |
| [docs/csharp/language-reference/builtin-types/nullable-value-types.md](https://github.com/dotnet/docs/blob/e6f7bbfbe9d02f5b70e8b032ea79d944fdffbdbf/docs/csharp/language-reference/builtin-types/nullable-value-types.md) | [docs/csharp/language-reference/builtin-types/nullable-value-types](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/nullable-value-types?branch=pr-en-us-50074) |
| [docs/csharp/language-reference/builtin-types/value-tuples.md](https://github.com/dotnet/docs/blob/e6f7bbfbe9d02f5b70e8b032ea79d944fdffbdbf/docs/csharp/language-reference/builtin-types/value-tuples.md) | [Tuple types (C# reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/value-tuples?branch=pr-en-us-50074) |
| [docs/csharp/language-reference/operators/arithmetic-operators.md](https://github.com/dotnet/docs/blob/e6f7bbfbe9d02f5b70e8b032ea79d944fdffbdbf/docs/csharp/language-reference/operators/arithmetic-operators.md) | [Arithmetic operators (C# reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/arithmetic-operators?branch=pr-en-us-50074) |
| [docs/csharp/language-reference/operators/bitwise-and-shift-operators.md](https://github.com/dotnet/docs/blob/e6f7bbfbe9d02f5b70e8b032ea79d944fdffbdbf/docs/csharp/language-reference/operators/bitwise-and-shift-operators.md) | [Bitwise and shift operators (C# reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/bitwise-and-shift-operators?branch=pr-en-us-50074) |
| [docs/csharp/language-reference/operators/boolean-logical-operators.md](https://github.com/dotnet/docs/blob/e6f7bbfbe9d02f5b70e8b032ea79d944fdffbdbf/docs/csharp/language-reference/operators/boolean-logical-operators.md) | ["Boolean logical operators - the boolean and, or, not, and xor operators"](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/boolean-logical-operators?branch=pr-en-us-50074) |
| [docs/csharp/language-reference/operators/equality-operators.md](https://github.com/dotnet/docs/blob/e6f7bbfbe9d02f5b70e8b032ea79d944fdffbdbf/docs/csharp/language-reference/operators/equality-operators.md) | [Equality operators - test if two objects are equal or not](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/equality-operators?branch=pr-en-us-50074) |
| [docs/csharp/language-reference/operators/lambda-expressions.md](https://github.com/dotnet/docs/blob/e6f7bbfbe9d02f5b70e8b032ea79d944fdffbdbf/docs/csharp/language-reference/operators/lambda-expressions.md) | [docs/csharp/language-reference/operators/lambda-expressions](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/lambda-expressions?branch=pr-en-us-50074) |
| [docs/csharp/language-reference/operators/member-access-operators.md](https://github.com/dotnet/docs/blob/e6f7bbfbe9d02f5b70e8b032ea79d944fdffbdbf/docs/csharp/language-reference/operators/member-access-operators.md) | [Member access operators and expressions - the dot, indexer, and invocation operators.](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/member-access-operators?branch=pr-en-us-50074) |
| [docs/csharp/language-reference/operators/type-testing-and-cast.md](https://github.com/dotnet/docs/blob/e6f7bbfbe9d02f5b70e8b032ea79d944fdffbdbf/docs/csharp/language-reference/operators/type-testing-and-cast.md) | ["Type-testing operators and cast expressions test the runtime type of an object"](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/type-testing-and-cast?branch=pr-en-us-50074) |
| [docs/csharp/language-reference/statements/jump-statements.md](https://github.com/dotnet/docs/blob/e6f7bbfbe9d02f5b70e8b032ea79d944fdffbdbf/docs/csharp/language-reference/statements/jump-statements.md) | [Jump statements - `break`, `continue`, `return`, and `goto`](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/statements/jump-statements?branch=pr-en-us-50074) |
| [docs/csharp/tutorials/string-interpolation.md](https://github.com/dotnet/docs/blob/e6f7bbfbe9d02f5b70e8b032ea79d944fdffbdbf/docs/csharp/tutorials/string-interpolation.md) | [docs/csharp/tutorials/string-interpolation](https://review.learn.microsoft.com/en-us/dotnet/csharp/tutorials/string-interpolation?branch=pr-en-us-50074) |
| [docs/fundamentals/runtime-libraries/system-boolean.md](https://github.com/dotnet/docs/blob/e6f7bbfbe9d02f5b70e8b032ea79d944fdffbdbf/docs/fundamentals/runtime-libraries/system-boolean.md) | [System.Boolean struct](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-boolean?branch=pr-en-us-50074) |
| [docs/fundamentals/runtime-libraries/system-byte.md](https://github.com/dotnet/docs/blob/e6f7bbfbe9d02f5b70e8b032ea79d944fdffbdbf/docs/fundamentals/runtime-libraries/system-byte.md) | [System.Byte struct](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-byte?branch=pr-en-us-50074) |
| [docs/fundamentals/runtime-libraries/system-datetime.md](https://github.com/dotnet/docs/blob/e6f7bbfbe9d02f5b70e8b032ea79d944fdffbdbf/docs/fundamentals/runtime-libraries/system-datetime.md) | [System.DateTime struct](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-datetime?branch=pr-en-us-50074) |
| [docs/fundamentals/runtime-libraries/system-globalization-datetimeformatinfo.md](https://github.com/dotnet/docs/blob/e6f7bbfbe9d02f5b70e8b032ea79d944fdffbdbf/docs/fundamentals/runtime-libraries/system-globalization-datetimeformatinfo.md) | [`System.Globalization.DateTimeFormatInfo` class](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-globalization-datetimeformatinfo?branch=pr-en-us-50074) |
| [docs/fundamentals/runtime-libraries/system-globalization-numberformatinfo.md](https://github.com/dotnet/docs/blob/e6f7bbfbe9d02f5b70e8b032ea79d944fdffbdbf/docs/fundamentals/runtime-libraries/system-globalization-numberformatinfo.md) | [docs/fundamentals/runtime-libraries/system-globalization-numberformatinfo](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-globalization-numberformatinfo?branch=pr-en-us-50074) |
| [docs/fundamentals/runtime-libraries/system-invalidoperationexception.md](https://github.com/dotnet/docs/blob/e6f7bbfbe9d02f5b70e8b032ea79d944fdffbdbf/docs/fundamentals/runtime-libraries/system-invalidoperationexception.md) | [System.InvalidOperationException class](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-invalidoperationexception?branch=pr-en-us-50074) |
| [docs/fundamentals/runtime-libraries/system-object-equals.md](https://github.com/dotnet/docs/blob/e6f7bbfbe9d02f5b70e8b032ea79d944fdffbdbf/docs/fundamentals/runtime-libraries/system-object-equals.md) | [System.Object.Equals method](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-object-equals?branch=pr-en-us-50074) |
| [docs/fundamentals/runtime-libraries/system-object-tostring.md](https://github.com/dotnet/docs/blob/e6f7bbfbe9d02f5b70e8b032ea79d944fdffbdbf/docs/fundamentals/runtime-libraries/system-object-tostring.md) | [System.Object.ToString method](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-object-tostring?branch=pr-en-us-50074) |
| [docs/fundamentals/runtime-libraries/system-random.md](https://github.com/dotnet/docs/blob/e6f7bbfbe9d02f5b70e8b032ea79d944fdffbdbf/docs/fundamentals/runtime-libraries/system-random.md) | [docs/fundamentals/runtime-libraries/system-random](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-random?branch=pr-en-us-50074) |
| [docs/fundamentals/runtime-libraries/system-single.md](https://github.com/dotnet/docs/blob/e6f7bbfbe9d02f5b70e8b032ea79d944fdffbdbf/docs/fundamentals/runtime-libraries/system-single.md) | [System.Single struct](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-single?branch=pr-en-us-50074) |
| [docs/fundamentals/runtime-libraries/system-string-format.md](https://github.com/dotnet/docs/blob/e6f7bbfbe9d02f5b70e8b032ea79d944fdffbdbf/docs/fundamentals/runtime-libraries/system-string-format.md) | [System.String.Format method](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-string-format?branch=pr-en-us-50074) |
| [docs/fundamentals/runtime-libraries/system-string.md](https://github.com/dotnet/docs/blob/e6f7bbfbe9d02f5b70e8b032ea79d944fdffbdbf/docs/fundamentals/runtime-libraries/system-string.md) | [System.String class](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-string?branch=pr-en-us-50074) |
| [docs/fundamentals/runtime-libraries/system-text-stringbuilder.md](https://github.com/dotnet/docs/blob/e6f7bbfbe9d02f5b70e8b032ea79d944fdffbdbf/docs/fundamentals/runtime-libraries/system-text-stringbuilder.md) | [System.Text.StringBuilder class](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-text-stringbuilder?branch=pr-en-us-50074) |
| [docs/standard/base-types/custom-date-and-time-format-strings.md](https://github.com/dotnet/docs/blob/e6f7bbfbe9d02f5b70e8b032ea79d944fdffbdbf/docs/standard/base-types/custom-date-and-time-format-strings.md) | [Custom date and time format strings](https://review.learn.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings?branch=pr-en-us-50074) |
| [docs/standard/base-types/divide-up-strings.md](https://github.com/dotnet/docs/blob/e6f7bbfbe9d02f5b70e8b032ea79d944fdffbdbf/docs/standard/base-types/divide-up-strings.md) | [docs/standard/base-types/divide-up-strings](https://review.learn.microsoft.com/en-us/dotnet/standard/base-types/divide-up-strings?branch=pr-en-us-50074) |

</details>

> [!NOTE]
> This table shows preview links for the 30 files with the most changes. For preview links for other files in this PR, select <strong>OpenPublishing.Build Details</strong> within [checks](https://github.com/dotnet/docs/pull/50074/checks).


<!-- PREVIEW-TABLE-END -->