### PR TITLE
Remove extraneous COMPLUS_ info

### DIFF
--- a/docs/core/diagnostics/debug-highcpu.md
+++ b/docs/core/diagnostics/debug-highcpu.md
@@ -181,8 +181,6 @@ The `perf` tool can be used to generate .NET Core app profiles. We will demonstr
 
 Set the `DOTNET_PerfMapEnabled` environment variable to cause the .NET app to create a `map` file in the `/tmp` directory. This `map` file is used by `perf` to map CPU addresses to JIT-generated functions by name. For more information, see [Export perf maps and jit dumps](../runtime-config/debugging-profiling.md#export-perf-maps-and-jit-dumps).
 
-[!INCLUDE [complus-prefix](../../../includes/complus-prefix.md)]
-
 Run the [sample debug target](/samples/dotnet/samples/diagnostic-scenarios) in the same terminal session.
 
 ```dotnetcli

--- a/docs/core/diagnostics/debug-stackoverflow.md
+++ b/docs/core/diagnostics/debug-stackoverflow.md
@@ -10,7 +10,7 @@ A <xref:System.StackOverflowException> is thrown when the execution stack overfl
 
 For example, suppose you have an app as follows:
 
-````csharp
+```csharp
 using System;
 
 namespace temp
@@ -23,11 +23,11 @@ namespace temp
         }
     }
 }
-````
+```
 
 The `Main` method will continuously call itself until there is no more stack space. Once there is no more stack space, execution cannot continue and so it will throw a <xref:System.StackOverflowException>.
 
-````
+```dotnetcli
 > dotnet run
 Stack overflow.
    at temp.Program.Main(System.String[])
@@ -37,7 +37,7 @@ Stack overflow.
    at temp.Program.Main(System.String[])
    at temp.Program.Main(System.String[])
    <this output repeats many more times>
-````
+```
 
 When you see the program exit with output like this, you can find the source code for the repeating method(s) and investigate the logic that causes the large number of calls.
 
@@ -51,25 +51,23 @@ This example creates a core dump when the StackOverflowException occurs, then lo
 
 1. Run the app with it configured to collect a dump on crash.
 
-    ````
+    ```dotnetcli
     > export DOTNET_DbgEnableMiniDump=1
     > dotnet run
     Stack overflow.
     Writing minidump with heap to file /tmp/coredump.6412
     Written 58191872 bytes (14207 pages) to core file
-    ````
-
-   [!INCLUDE [complus-prefix](../../../includes/complus-prefix.md)]
+    ```
 
 2. Install the SOS extension using [dotnet-sos](dotnet-sos.md).
 
-    ````
+    ```bash
     dotnet-sos install
-    ````
+    ```
 
 3. Open the dump in lldb and use the `bt` (backtrace) command to display the stack.
 
-    ````
+    ```bash
     lldb --core /temp/coredump.6412
     (lldb) bt
     ...
@@ -83,11 +81,11 @@ This example creates a core dump when the StackOverflowException occurs, then lo
         frame #261937: 0x00007f5a2d3cc468 libcoreclr.so`MethodDescCallSite::CallTargetWorker(this=<unavailable>, pArguments=0x00007ffe8222e7b0, pReturnValue=0x0000000000000000, cbReturnValue=0) at callhelpers.cpp:604
         frame #261938: 0x00007f5a2d4b6182 libcoreclr.so`RunMain(MethodDesc*, short, int*, PtrArray**) [inlined] MethodDescCallSite::Call(this=<unavailable>, pArguments=<unavailable>) at callhelpers.h:468
     ...
-    ````
+    ```
 
 4. The top frame `0x00007f59b40900cc` is repeated several times. Use the [SOS](sos-debugging-extension.md) `ip2md` command to figure out what managed method is located at the `0x00007f59b40900cc` address.
 
-    ````
+    ```bash
     (lldb) ip2md 0x00007f59b40900cc
     MethodDesc:   00007f59b413ffa8
     Method Name:          temp.Program.Main(System.String[])
@@ -104,7 +102,7 @@ This example creates a core dump when the StackOverflowException occurs, then lo
          CodeAddr:           00007f59b40900a0  (MinOptJitted)
          NativeCodeVersion:  0000000000000000
     Source file:  /temp/Program.cs @ 9
-    ````
+    ```
 
 5. Go look at the indicated method temp.Program.Main(System.String[]) and source "/temp/Program.cs @ 9" to see if you can figure out what the code is doing wrong. If additional information is needed, you can use further debugger or [SOS](sos-debugging-extension.md) commands to inspect the process.
 

--- a/docs/core/diagnostics/diagnostic-port.md
+++ b/docs/core/diagnostics/diagnostic-port.md
@@ -21,8 +21,6 @@ The diagnostic port supports different transports depending on platform. Current
 
 The diagnostic port exposes sensitive information about a running application. If an untrusted user gains access to this channel, they could observe detailed program state, including any secrets that are in memory, and arbitrarily modify the execution of the program. On the CoreCLR runtime, the default diagnostic port is configured to only be accessible by the same user account that launched the app or by an account with super-user permissions. If your security model does not trust other processes with the same user account credentials, you can disable all diagnostic ports by setting environment variable `DOTNET_EnableDiagnostics=0`. This setting will block your ability to use external tooling such as .NET debugging or any of the dotnet-* diagnostic tools.
 
-[!INCLUDE [complus-prefix](../../../includes/complus-prefix.md)]
-
 ## Default diagnostic port
 
 On Windows, Linux, and macOS, the runtime has one diagnostic port open by default at a well-known endpoint. This is the port that the dotnet-* diagnostic tools connect to automatically when they haven't been explicitly configured to use an alternate port. The endpoint is:

--- a/docs/core/diagnostics/diagnostics-in-containers.md
+++ b/docs/core/diagnostics/diagnostics-in-containers.md
@@ -51,8 +51,6 @@ The [`PerfCollect`](./trace-perfcollect-lttng.md) script is useful for collectin
 > [!NOTE]
 > When executing the app with .NET 7, you must also set `DOTNET_EnableWriteXorExecute=0` in addition to the preceding environment variables.
 
-  [!INCLUDE [complus-prefix](../../../includes/complus-prefix.md)]
-
 ### Use `PerfCollect` in a sidecar container
 
 If you want to run `PerfCollect` in one container to profile a .NET process in a different container, the experience is almost the same. The differences are:

--- a/docs/core/diagnostics/eventpipe.md
+++ b/docs/core/diagnostics/eventpipe.md
@@ -93,10 +93,8 @@ However, you can use the following environment variables to set up an EventPipe 
 
   If this environment variable is not set but EventPipe is enabled by `DOTNET_EnableEventPipe`, it will start tracing by enabling the following providers with the following keywords and levels:
 
-  - `Microsoft-Windows-DotNETRuntime:4c14fccbd:5`
-  - `Microsoft-Windows-DotNETRuntimePrivate:4002000b:5`
-  - `Microsoft-DotNETCore-SampleProfiler:0:5`
+  * `Microsoft-Windows-DotNETRuntime:4c14fccbd:5`
+  * `Microsoft-Windows-DotNETRuntimePrivate:4002000b:5`
+  * `Microsoft-DotNETCore-SampleProfiler:0:5`
 
   To learn more about some of the well-known providers in .NET, refer to [Well-known Event Providers](./well-known-event-providers.md).
-
-[!INCLUDE [complus-prefix](../../../includes/complus-prefix.md)]

--- a/docs/core/diagnostics/trace-perfcollect-lttng.md
+++ b/docs/core/diagnostics/trace-perfcollect-lttng.md
@@ -81,8 +81,6 @@ For resolving method names of native runtime DLLs (such as libcoreclr.so), `perf
     > ```
     >
 
-    [!INCLUDE [complus-prefix](../../../includes/complus-prefix.md)]
-
 1. **[App]** Run the app - let it run as long as you need to in order to capture the performance problem. The exact length can be as short as you need as long as it sufficiently captures the window of time where the performance problem you want to investigate occurs.
 
     ```bash

--- a/docs/core/docker/build-container.md
+++ b/docs/core/docker/build-container.md
@@ -260,8 +260,6 @@ The next command, `ENTRYPOINT`, tells Docker to configure the container to run a
 >
 > For more information on various .NET environment variables, see [.NET environment variables](../tools/dotnet-environment-variables.md).
 
-[!INCLUDE [complus-prefix](../../../includes/complus-prefix.md)]
-
 ## Create a container
 
 Now that you have an image that contains your app, you can create a container. You can create a container in two ways. First, create a new container that is stopped.

--- a/docs/core/runtime-config/compilation.md
+++ b/docs/core/runtime-config/compilation.md
@@ -7,8 +7,6 @@ ms.date: 10/29/2021
 
 This article details the settings you can use to configure .NET compilation.
 
-[!INCLUDE [complus-prefix](../../../includes/complus-prefix.md)]
-
 ## Tiered compilation
 
 - Configures whether the just-in-time (JIT) compiler uses [tiered compilation](../whats-new/dotnet-core-3-0.md#tiered-compilation). Tiered compilation transitions methods through two tiers:
@@ -22,7 +20,7 @@ This article details the settings you can use to configure .NET compilation.
 | - | - | - |
 | **runtimeconfig.json** | `System.Runtime.TieredCompilation` | `true` - enabled<br/>`false` - disabled |
 | **MSBuild property** | `TieredCompilation` | `true` - enabled<br/>`false` - disabled |
-| **Environment variable** | `COMPlus_TieredCompilation` or `DOTNET_TieredCompilation` | `1` - enabled<br/>`0` - disabled |
+| **Environment variable** | `DOTNET_TieredCompilation` | `1` - enabled<br/>`0` - disabled |
 
 ### Examples
 
@@ -72,7 +70,7 @@ Project file:
 | - | - | - |
 | **runtimeconfig.json** | `System.Runtime.TieredCompilation.QuickJit` | `true` - enabled<br/>`false` - disabled |
 | **MSBuild property** | `TieredCompilationQuickJit` | `true` - enabled<br/>`false` - disabled |
-| **Environment variable** | `COMPlus_TC_QuickJit` or `DOTNET_TC_QuickJit` | `1` - enabled<br/>`0` - disabled |
+| **Environment variable** | `DOTNET_TC_QuickJit` | `1` - enabled<br/>`0` - disabled |
 
 ### Examples
 
@@ -121,7 +119,7 @@ Project file:
 | - | - | - |
 | **runtimeconfig.json** | `System.Runtime.TieredCompilation.QuickJitForLoops` | `false` - disabled<br/>`true` - enabled |
 | **MSBuild property** | `TieredCompilationQuickJitForLoops` | `false` - disabled<br/>`true` - enabled |
-| **Environment variable** | `COMPlus_TC_QuickJitForLoops` or `DOTNET_TC_QuickJitForLoops` | `0` - disabled<br/>`1` - enabled |
+| **Environment variable** | `DOTNET_TC_QuickJitForLoops` | `0` - disabled<br/>`1` - enabled |
 
 ### Examples
 
@@ -161,22 +159,22 @@ Project file:
 
 ## ReadyToRun
 
-- Configures whether the .NET Core runtime uses pre-compiled code for images with available ReadyToRun data. Disabling this option forces the runtime to JIT-compile framework code.
+- Configures whether the .NET runtime uses pre-compiled code for images with available ReadyToRun data. Disabling this option forces the runtime to JIT-compile framework code.
 - For more information, see [Ready to Run](../deploying/ready-to-run.md).
 - If you omit this setting, .NET uses ReadyToRun data when it's available. This is equivalent to setting the value to `1`.
 
-| | Setting name | Values |
-| - | - | - |
-| **Environment variable** | `COMPlus_ReadyToRun` or `DOTNET_ReadyToRun` | `1` - enabled<br/>`0` - disabled |
+|                          | Setting name        | Values                           |
+|--------------------------|---------------------|----------------------------------|
+| **Environment variable** | `DOTNET_ReadyToRun` | `1` - enabled<br/>`0` - disabled |
 
 ## Profile-guided optimization
 
 This setting enables dynamic (tiered) profile-guided optimization (PGO) in .NET 6 and later versions.
 
-| | Setting name | Values |
-| - | - | - |
-| **Environment variable** | `DOTNET_TieredPGO` | `1` - enabled<br/>`0` - disabled |
-| **MSBuild property** | `TieredPGO` | `true` - enabled<br/>`false` - disabled |
+|                          | Setting name       | Values                                  |
+|--------------------------|--------------------|-----------------------------------------|
+| **Environment variable** | `DOTNET_TieredPGO` | `1` - enabled<br/>`0` - disabled        |
+| **MSBuild property**     | `TieredPGO`        | `true` - enabled<br/>`false` - disabled |
 
 Profile-guided optimization (PGO) is where the JIT compiler generates optimized code in terms of the types and code paths that are most frequently used. *Dynamic* PGO works hand-in-hand with tiered compilation to further optimize code based on additional instrumentation that's put in place during tier 0.
 

--- a/docs/core/runtime-config/debugging-profiling.md
+++ b/docs/core/runtime-config/debugging-profiling.md
@@ -7,20 +7,18 @@ ms.date: 11/27/2019
 
 This article details the settings you can use to configure .NET debugging and profiling.
 
-[!INCLUDE [complus-prefix](../../../includes/complus-prefix.md)]
-
 > [!NOTE]
-> Starting in .NET 11, profiler environment variables now support both `DOTNET` and `CORECLR` prefixes. The `DOTNET` prefix is the new standard, while `CORECLR` is maintained for backwards compatibility and might be removed in the future.
+> Starting in .NET 11, profiler environment variables support both `DOTNET` and `CORECLR` prefixes. The `DOTNET` prefix is the new standard; `CORECLR` is maintained for backwards compatibility and might be removed in the future.
 
 ## Enable diagnostics
 
 - Configures whether the debugger, the profiler, and EventPipe diagnostics are enabled or disabled.
 - If you omit this setting, diagnostics are enabled. This is equivalent to setting the value to `1`.
 
-| | Setting name | Values |
-| - | - | - |
-| **runtimeconfig.json** | N/A | N/A |
-| **Environment variable** | `COMPlus_EnableDiagnostics` or `DOTNET_EnableDiagnostics` | `1` - enabled<br/>`0` - disabled |
+|                          | Setting name               | Values                           |
+|--------------------------|----------------------------|----------------------------------|
+| **runtimeconfig.json**   | N/A                        | N/A                              |
+| **Environment variable** | `DOTNET_EnableDiagnostics` | `1` - enabled<br/>`0` - disabled |
 
 ## Enable profiling
 
@@ -28,10 +26,10 @@ This article details the settings you can use to configure .NET debugging and pr
 - If you omit this setting, profiling is disabled. This is equivalent to setting the value to `0`.
 - To load a profiler, in addition to enabling profiling, the profiler GUID and profiler location also need to be configured using these settings.
 
-| | Setting name | Values |
-| - | - | - |
-| **runtimeconfig.json** | N/A | N/A |
-| **Environment variable** | `CORECLR_ENABLE_PROFILING` or `DOTNET_ENABLE_PROFILING` | `0` - disabled<br/>`1` - enabled |
+|                          | Setting name              | Values                           |
+|--------------------------|---------------------------|----------------------------------|
+| **runtimeconfig.json**   | N/A                       | N/A                              |
+| **Environment variable** | `DOTNET_ENABLE_PROFILING` | `0` - disabled<br/>`1` - enabled |
 
 ## Profiler GUID
 
@@ -78,20 +76,20 @@ The following table compares perf maps and jit maps.
 | *Perf maps* | Emits `/tmp/perf-<pid>.map`, which contains symbolic information for dynamically generated code.<br/>Emits `/tmp/perfinfo-<pid>.map`, which includes ReadyToRun (R2R) module symbol information and is used by [PerfCollect](../diagnostics/trace-perfcollect-lttng.md). | Perf maps are supported on all Linux kernel versions. |
 | *Jit dumps* | The jit dump format supersedes perf maps and contains more detailed symbolic information. When enabled, jit dumps are output to `/tmp/jit-<pid>.dump` files. | Linux kernel versions 5.4 or higher. |
 
-| | Setting name | Values |
-| - | - | - |
-| **runtimeconfig.json** | N/A | N/A |
-| **Environment variable** | `COMPlus_PerfMapEnabled` or `DOTNET_PerfMapEnabled` | `0` - disabled<br/>`1` - perf maps and jit dumps both enabled<br/>`2` - jit dumps enabled<br/>`3` - perf maps enabled |
+|                        | Setting name | Values |
+|------------------------|--------------|--------|
+| **runtimeconfig.json** | N/A          | N/A    |
+| **Environment variable** | `DOTNET_PerfMapEnabled` | `0` - disabled<br/>`1` - perf maps and jit dumps both enabled<br/>`2` - jit dumps enabled<br/>`3` - perf maps enabled |
 
 ## Perf log markers
 
 - Enables or disables the specified signal to be accepted and ignored as a marker in the perf logs.
 - If you omit this setting, the specified signal is not ignored. This is equivalent to setting the value to `0`.
 
-| | Setting name | Values |
-| - | - | - |
-| **runtimeconfig.json** | N/A | N/A |
-| **Environment variable** | `COMPlus_PerfMapIgnoreSignal` or `DOTNET_PerfMapIgnoreSignal` | `0` - disabled<br/>`1` - enabled |
+|                          | Setting name                 | Values                           |
+|--------------------------|------------------------------|----------------------------------|
+| **runtimeconfig.json**   | N/A                          | N/A                              |
+| **Environment variable** | `DOTNET_PerfMapIgnoreSignal` | `0` - disabled<br/>`1` - enabled |
 
 > [!NOTE]
 > This setting is ignored if [DOTNET_PerfMapEnabled](#export-perf-maps-and-jit-dumps) is omitted or set to `0` (that is, disabled).

--- a/docs/core/runtime-config/garbage-collector.md
+++ b/docs/core/runtime-config/garbage-collector.md
@@ -14,7 +14,7 @@ Settings are arranged into groups on this page. The settings within each group a
 > - These configurations are only read by the runtime when the GC is initialized (usually this means during the process startup time). If you change an environment variable when a process is already running, the change won't be reflected in that process. Settings that can be changed through APIs at run time, such as [latency level](../../standard/garbage-collection/latency.md), are omitted from this page.
 > - Because GC is per process, it rarely ever makes sense to set these configurations at the machine level. For example, you wouldn't want every .NET process on a machine to use server GC or the same heap hard limit.
 > - For number values, use decimal notation for settings in the *runtimeconfig.json* or *runtimeconfig.template.json* file and hexadecimal notation for environment variable settings. For hexadecimal values, you can specify them with or without the "0x" prefix.
-> - If you're using the environment variables, .NET 6 and later versions standardize on the prefix `DOTNET_` instead of `COMPlus_`. However, the `COMPlus_` prefix will continue to work. If you're using a previous version of the .NET runtime, you should still use the `COMPlus_` prefix, for example, `COMPlus_gcServer`.
+> - If you're using the environment variables, .NET 6 and later versions standardize on the prefix `DOTNET_` instead of `COMPlus_`. However, the `COMPlus_` prefix continues to work. If you're using a previous version of the .NET runtime, you should still use the `COMPlus_` prefix, for example, `COMPlus_gcServer`.
 
 ## Ways to specify the configuration
 
@@ -23,7 +23,7 @@ For different versions of the .NET runtime, there are different ways to specify 
 | Config location      | .NET versions this location applies to | Formats  | How it's interpreted                                         |
 | -------------------- | -------------------------------------- | -------- | ------------------------------------------------------------ |
 | runtimeconfig.json file/</br>runtimeconfig.template.json file | .NET (Core)                           | n        | n is interpreted as a decimal value.                         |
-| Environment variable | .NET Framework, .NET (Core)              | 0xn or n | n is interpreted as a hex value in either format             |
+| Environment variable | .NET Framework, .NET              | 0xn or n | n is interpreted as a hex value in either format             |
 | app.config file      | .NET Framework                         | 0xn      | n is interpreted as a hex value<sup>1</sup>                  |
 
 <sup>1</sup> You can specify a value without the `0x` prefix for an app.config file setting, but it's not recommended. On .NET Framework 4.8+, due to a bug, a value specified without the `0x` prefix is interpreted as hexadecimal, but on previous versions of .NET Framework, it's interpreted as decimal. To avoid having to change your config, use the `0x` prefix when specifying a value in your app.config file.
@@ -50,27 +50,11 @@ SET DOTNET_gcServer=1
 SET DOTNET_GCHeapCount=c
 ```
 
-On Windows using .NET 5 or earlier:
-
-```cmd
-SET COMPlus_gcServer=1
-SET COMPlus_GCHeapCount=c
-```
-
-On other operating systems:
-
-For .NET 6 or later versions:
+On other operating systems using .NET 6 or a later version:
 
 ```bash
 export DOTNET_gcServer=1
 export DOTNET_GCHeapCount=c
-```
-
-For .NET 5 and earlier versions:
-
-```bash
-export COMPlus_gcServer=1
-export COMPlus_GCHeapCount=c
 ```
 
 If you're not using .NET Framework, you can also set the value in the *runtimeconfig.json* or *runtimeconfig.template.json* file.
@@ -119,7 +103,6 @@ Use the following settings to select flavors of garbage collection:
 | - | - | - | - |
 | **runtimeconfig.json** | `System.GC.Server` | `false` - workstation<br/>`true` - server | .NET Core 1.0 |
 | **MSBuild property** | `ServerGarbageCollection` | `false` - workstation<br/>`true` - server | .NET Core 1.0 |
-| **Environment variable** | `COMPlus_gcServer` | `0` - workstation<br/>`1` - server | .NET Core 1.0 |
 | **Environment variable** | `DOTNET_gcServer` | `0` - workstation<br/>`1` - server | .NET 6 |
 | **app.config for .NET Framework** | [GCServer](../../framework/configure-apps/file-schema/runtime/gcserver-element.md) | `false` - workstation<br/>`true` - server |  |
 
@@ -169,7 +152,6 @@ Project file:
 | - | - | - | - |
 | **runtimeconfig.json** | `System.GC.Concurrent` | `true` - background GC<br/>`false` - non-concurrent GC | .NET Core 1.0 |
 | **MSBuild property** | `ConcurrentGarbageCollection` | `true` - background GC<br/>`false` - non-concurrent GC | .NET Core 1.0 |
-| **Environment variable** | `COMPlus_gcConcurrent` | `1` - background GC<br/>`0` - non-concurrent GC | .NET Core 1.0 |
 | **Environment variable** | `DOTNET_gcConcurrent` | `1` - background GC<br/>`0` - non-concurrent GC | .NET 6 |
 | **app.config for .NET Framework** | [gcConcurrent](../../framework/configure-apps/file-schema/runtime/gcconcurrent-element.md) | `true` - background GC<br/>`false` - non-concurrent GC |  |
 
@@ -241,7 +223,6 @@ To use a standalone garbage collector instead of the default GC implementation, 
 | | Setting name | Values | Version introduced |
 | - | - | - | - |
 | **runtimeconfig.json** | `System.GC.Name` | *string_name* | .NET 7 |
-| **Environment variable** | `COMPlus_GCName` | *string_name* | .NET Core 2.0 |
 | **Environment variable** | `DOTNET_GCName` | *string_name* | .NET 6 |
 
 ## LOH specific settings
@@ -255,7 +236,6 @@ To use a standalone garbage collector instead of the default GC implementation, 
 | | Setting name | Values | Version introduced |
 | - | - | - | - |
 | **runtimeconfig.json** | N/A | N/A | N/A |
-| **Environment variable** | `COMPlus_gcAllowVeryLargeObjects` | `1` - enabled<br/> `0` - disabled | .NET Core 1.0 |
 | **Environment variable** | `DOTNET_gcAllowVeryLargeObjects` | `1` - enabled<br/> `0` - disabled | .NET 6 |
 | **app.config for .NET Framework** | [gcAllowVeryLargeObjects](../../framework/configure-apps/file-schema/runtime/gcallowverylargeobjects-element.md) | `1` - enabled<br/> `0` - disabled | .NET Framework 4.5 |
 
@@ -269,7 +249,6 @@ To use a standalone garbage collector instead of the default GC implementation, 
 | | Setting name | Values | Version introduced |
 | - | - | - | - |
 | **runtimeconfig.json** | `System.GC.LOHThreshold` | *decimal value* | .NET Core 3.0 |
-| **Environment variable** | `COMPlus_GCLOHThreshold` | *hexadecimal value* | .NET Core 3.0 |
 | **Environment variable** | `DOTNET_GCLOHThreshold` | *hexadecimal value* | .NET 6 |
 | **app.config for .NET Framework** | [GCLOHThreshold](../../framework/configure-apps/file-schema/runtime/gclohthreshold-element.md) | *decimal value* | .NET Framework 4.8 |
 
@@ -327,7 +306,6 @@ The following settings apply to all flavors of the GC:
 | | Setting name | Values | Version introduced |
 | - | - | - | - |
 | **runtimeconfig.json** | `System.GC.HeapHardLimit` | *decimal value* | .NET Core 3.0 |
-| **Environment variable** | `COMPlus_GCHeapHardLimit` | *hexadecimal value* | .NET Core 3.0 |
 | **Environment variable** | `DOTNET_GCHeapHardLimit` | *hexadecimal value* | .NET 6 |
 
 [!INCLUDE [runtimehostconfigurationoption](includes/runtimehostconfigurationoption.md)]
@@ -368,7 +346,6 @@ The following settings apply to all flavors of the GC:
 | | Setting name | Values | Version introduced |
 | - | - | - | - |
 | **runtimeconfig.json** | `System.GC.HeapHardLimitPercent` | *decimal value* | .NET Core 3.0 |
-| **Environment variable** | `COMPlus_GCHeapHardLimitPercent` | *hexadecimal value* | .NET Core 3.0 |
 | **Environment variable** | `DOTNET_GCHeapHardLimitPercent` | *hexadecimal value* | .NET 6 |
 
 [!INCLUDE [runtimehostconfigurationoption](includes/runtimehostconfigurationoption.md)]
@@ -410,19 +387,16 @@ You can specify the GC's heap hard limit on a per-object-heap basis. The differe
 | | Setting name | Values | Version introduced |
 | - | - | - | - |
 | **runtimeconfig.json** | `System.GC.HeapHardLimitSOH` | *decimal value* | .NET 5 |
-| **Environment variable** | `COMPlus_GCHeapHardLimitSOH` | *hexadecimal value* | .NET 5 |
 | **Environment variable** | `DOTNET_GCHeapHardLimitSOH` | *hexadecimal value* | .NET 6 |
 
 | | Setting name | Values | Version introduced |
 | - | - | - | - |
 | **runtimeconfig.json** | `System.GC.HeapHardLimitLOH` | *decimal value* | .NET 5 |
-| **Environment variable** | `COMPlus_GCHeapHardLimitLOH` | *hexadecimal value* | .NET 5 |
 | **Environment variable** | `DOTNET_GCHeapHardLimitLOH` | *hexadecimal value* | .NET 6 |
 
 | | Setting name | Values | Version introduced |
 | - | - | - | - |
 | **runtimeconfig.json** | `System.GC.HeapHardLimitPOH` | *decimal value* | .NET 5 |
-| **Environment variable** | `COMPlus_GCHeapHardLimitPOH` | *hexadecimal value* | .NET 5 |
 | **Environment variable** | `DOTNET_GCHeapHardLimitPOH` | *hexadecimal value* | .NET 6 |
 
 These configuration settings don't have specific MSBuild properties. However, you can add a `RuntimeHostConfigurationOption` MSBuild item instead. Use the *runtimeconfig.json* setting name as the value of the `Include` attribute. For an example, see [MSBuild properties](index.md#msbuild-properties).
@@ -442,19 +416,16 @@ You can specify the GC's heap hard limit on a per-object-heap basis. The differe
 | | Setting name | Values | Version introduced |
 | - | - | - | - |
 | **runtimeconfig.json** | `System.GC.HeapHardLimitSOHPercent` | *decimal value* | .NET 5 |
-| **Environment variable** | `COMPlus_GCHeapHardLimitSOHPercent` | *hexadecimal value* | .NET 5 |
 | **Environment variable** | `DOTNET_GCHeapHardLimitSOHPercent` | *hexadecimal value* | .NET 6 |
 
 | | Setting name | Values | Version introduced |
 | - | - | - | - |
 | **runtimeconfig.json** | `System.GC.HeapHardLimitLOHPercent` | *decimal value* | .NET 5 |
-| **Environment variable** | `COMPlus_GCHeapHardLimitLOHPercent` | *hexadecimal value* | .NET 5 |
 | **Environment variable** | `DOTNET_GCHeapHardLimitLOHPercent` | *hexadecimal value* | .NET 6 |
 
 | | Setting name | Values | Version introduced |
 | - | - | - | - |
 | **runtimeconfig.json** | `System.GC.HeapHardLimitPOHPercent` | *decimal value* | .NET 5 |
-| **Environment variable** | `COMPlus_GCHeapHardLimitPOHPercent` | *hexadecimal value* | .NET 5 |
 | **Environment variable** | `DOTNET_GCHeapHardLimitPOHPercent` | *hexadecimal value* | .NET 6 |
 
 These configuration settings don't have specific MSBuild properties. However, you can add a `RuntimeHostConfigurationOption` MSBuild item instead. Use the *runtimeconfig.json* setting name as the value of the `Include` attribute. For an example, see [MSBuild properties](index.md#msbuild-properties).
@@ -471,7 +442,6 @@ These configuration settings don't have specific MSBuild properties. However, yo
 | | Setting name | Values | Version introduced |
 | - | - | - | - |
 | **runtimeconfig.json** | N/A | N/A | N/A |
-| **Environment variable** | `COMPlus_GCLargePages` | `0` - disabled<br/>`1` - enabled | .NET Core 3.0 |
 | **Environment variable** | `DOTNET_GCLargePages` | `0` - disabled<br/>`1` - enabled | .NET 6 |
 
 ### Region range
@@ -521,7 +491,6 @@ The high memory load threshold can be adjusted by the `DOTNET_GCHighMemPercent` 
 | | Setting name | Values | Version introduced |
 | - | - | - | - |
 | **runtimeconfig.json** | `System.GC.HighMemoryPercent` | *decimal value* | .NET 5 |
-| **Environment variable** | `COMPlus_GCHighMemPercent` | *hexadecimal value* | .NET Core 3.0<br/>.NET Framework 4.7.2 |
 | **Environment variable** | `DOTNET_GCHighMemPercent` | *hexadecimal value* | .NET 6 |
 
 [!INCLUDE [runtimehostconfigurationoption](includes/runtimehostconfigurationoption.md)]
@@ -538,7 +507,6 @@ The high memory load threshold can be adjusted by the `DOTNET_GCHighMemPercent` 
 | - | - | - | - |
 | **runtimeconfig.json** | `System.GC.RetainVM` | `false` - release to OS<br/>`true` - put on standby | .NET Core 1.0 |
 | **MSBuild property** | `RetainVMGarbageCollection` | `false` - release to OS<br/>`true` - put on standby | .NET Core 1.0 |
-| **Environment variable** | `COMPlus_GCRetainVM` | `0` - release to OS<br/>`1` - put on standby | .NET Core 1.0 |
 | **Environment variable** | `DOTNET_GCRetainVM` | `0` - release to OS<br/>`1` - put on standby | .NET 6 |
 
 #### Examples
@@ -587,7 +555,6 @@ Project file:
 | | Setting name | Values | Version introduced |
 | - | - | - | - |
 | **runtimeconfig.json** | `System.GC.ConserveMemory` | `0` - `9` | .NET 6 |
-| **Environment variable** | `COMPlus_GCConserveMemory` | `0` -`9` | .NET Framework 4.8 |
 | **Environment variable** | `DOTNET_GCConserveMemory` | `0` -`9` | .NET 6 |
 | **app.config for .NET Framework** | [GCConserveMemory](../../framework/configure-apps/file-schema/runtime/gcconservememory-element.md) | `0` -`9` | .NET Framework 4.8 |
 
@@ -631,7 +598,6 @@ For more information about the first 3 settings, see the [Middle ground between 
 | | Setting name | Values | Version introduced |
 | - | - | - | - |
 | **runtimeconfig.json** | `System.GC.HeapCount` | *decimal value* | .NET Core 3.0 |
-| **Environment variable** | `COMPlus_GCHeapCount` | *hexadecimal value* | .NET Core 3.0 |
 | **Environment variable** | `DOTNET_GCHeapCount` | *hexadecimal value* | .NET 6 |
 | **app.config for .NET Framework** | [GCHeapCount](../../framework/configure-apps/file-schema/runtime/gcheapcount-element.md) | *decimal value* | .NET Framework 4.6.2 |
 
@@ -673,7 +639,6 @@ For more information about the first 3 settings, see the [Middle ground between 
 | | Setting name | Values | Version introduced |
 | - | - | - | - |
 | **runtimeconfig.json** | `System.GC.NoAffinitize` | `false` - affinitize<br/>`true` - don't affinitize | .NET Core 3.0 |
-| **Environment variable** | `COMPlus_GCNoAffinitize` | `0` - affinitize<br/>`1` - don't affinitize | .NET Core 3.0 |
 | **Environment variable** | `DOTNET_GCNoAffinitize` | `0` - affinitize<br/>`1` - don't affinitize | .NET 6 |
 | **app.config for .NET Framework** | [GCNoAffinitize](../../framework/configure-apps/file-schema/runtime/gcnoaffinitize-element.md) | `false` - affinitize<br/>`true` - don't affinitize | .NET Framework 4.6.2 |
 
@@ -713,7 +678,6 @@ For more information about the first 3 settings, see the [Middle ground between 
 | | Setting name | Values | Version introduced |
 | - | - | - | - |
 | **runtimeconfig.json** | `System.GC.HeapAffinitizeMask` | *decimal value* | .NET Core 3.0 |
-| **Environment variable** | `COMPlus_GCHeapAffinitizeMask` | *hexadecimal value* | .NET Core 3.0 |
 | **Environment variable** | `DOTNET_GCHeapAffinitizeMask` | *hexadecimal value* | .NET 6 |
 | **app.config for .NET Framework** | [GCHeapAffinitizeMask](../../framework/configure-apps/file-schema/runtime/gcheapaffinitizemask-element.md) | *decimal value* | .NET Framework 4.6.2 |
 
@@ -756,7 +720,6 @@ For more information about the first 3 settings, see the [Middle ground between 
 | | Setting name | Values | Version introduced |
 | - | - | - | - |
 | **runtimeconfig.json** | `System.GC.HeapAffinitizeRanges` | Comma-separated list of processor numbers or ranges of processor numbers.<br/>Unix example: "1-10,12,50-52,70"<br/>Windows example: "0:1-10,0:12,1:50-52,1:7" | .NET Core 3.0 |
-| **Environment variable** | `COMPlus_GCHeapAffinitizeRanges` | Comma-separated list of processor numbers or ranges of processor numbers.<br/>Unix example: "1-10,12,50-52,70"<br/>Windows example: "0:1-10,0:12,1:50-52,1:7" | .NET Core 3.0 |
 | **Environment variable** | `DOTNET_GCHeapAffinitizeRanges` | Comma-separated list of processor numbers or ranges of processor numbers.<br/>Unix example: "1-10,12,50-52,70"<br/>Windows example: "0:1-10,0:12,1:50-52,1:7" | .NET 6 |
 
 [!INCLUDE [runtimehostconfigurationoption](includes/runtimehostconfigurationoption.md)]
@@ -801,7 +764,6 @@ For more information about the first 3 settings, see the [Middle ground between 
 | | Setting name | Values | Version introduced |
 | - | - | - | - |
 | **runtimeconfig.json** | `System.GC.CpuGroup` | `false` - disabled<br/>`true` - enabled | .NET 5 |
-| **Environment variable** | `COMPlus_GCCpuGroup` | `0` - disabled<br/>`1` - enabled | .NET Core 1.0 |
 | **Environment variable** | `DOTNET_GCCpuGroup` | `0` - disabled<br/>`1` - enabled | .NET 6 |
 | **app.config for .NET Framework** | [GCCpuGroup](../../framework/configure-apps/file-schema/runtime/gccpugroup-element.md) | `false` - disabled<br/>`true` - enabled |  |
 
@@ -861,9 +823,9 @@ Three settings are provided to adjust what the formula calculates and modify the
   |--------------------------|----------------------------|-----------|--------------------|
   | **runtimeconfig.json** | `System.GC.DGen0GrowthPercent` | *decimal value* | .NET 10 |
   | **Environment variable** | `DOTNET_GCDGen0GrowthPercent` | *hexadecimal value* | .NET 10 |
-  
+
   [!INCLUDE [runtimehostconfigurationoption](includes/runtimehostconfigurationoption.md)]
-  
+
   So if `f` calculates 0.474 and this setting is 200, the multiplier becomes `0.474 * 200% = 0.948` before the clamping is applied.
 
 - The maximum clamping value in permil.
@@ -883,8 +845,7 @@ Three settings are provided to adjust what the formula calculates and modify the
   |--------------------------|----------------------------|-----------|--------------------|
   | **runtimeconfig.json** | `System.GC.DGen0GrowthMinFactor` | *decimal value* | .NET 10 |
   | **Environment variable** | `DOTNET_GCDGen0GrowthMinFactor` | *hexadecimal value* | .NET 10 |
-  
+
   [!INCLUDE [runtimehostconfigurationoption](includes/runtimehostconfigurationoption.md)]
-  
+
   If this value is 200, the minimum clamping value is `200 * 0.001 = 0.2`.
-  

--- a/docs/core/runtime-config/index.md
+++ b/docs/core/runtime-config/index.md
@@ -112,9 +112,7 @@ MSBuild properties for configuring the behavior of the runtime are noted in the 
 
 ## Environment variables
 
-Environment variables can be used to supply some runtime configuration information. Configuration knobs specified as environment variables generally have the prefix **DOTNET_**.
-
-[!INCLUDE [complus-prefix](../../../includes/complus-prefix.md)]
+Environment variables can be used to supply some runtime configuration information. Configuration knobs specified as environment variables generally have the prefix `DOTNET_`. (For .NET Framework runtime configuration, use the `COMPlus_` prefix instead.)
 
 You can define environment variables from the Windows Control Panel, at the command line, or programmatically by calling the <xref:System.Environment.SetEnvironmentVariable(System.String,System.String)?displayProperty=nameWithType> method on both Windows and Unix-based systems.
 

--- a/docs/core/runtime-config/threading.md
+++ b/docs/core/runtime-config/threading.md
@@ -7,18 +7,16 @@ ms.date: 11/04/2021
 
 This article details the settings you can use to configure threading in .NET.
 
-[!INCLUDE [complus-prefix](../../../includes/complus-prefix.md)]
-
 ## Use all CPU groups on Windows
 
 - On machines that have multiple CPU groups, this setting configures whether components such as the thread pool use all CPU groups or only the primary CPU group of the process. The setting also affects what <xref:System.Environment.ProcessorCount?displayProperty=nameWithType> returns.
 - When this setting is enabled, all CPU groups are used and threads are also [automatically distributed across CPU groups](#assign-threads-to-cpu-groups-on-windows) by default.
 - This setting is enabled by default on Windows 11 and later versions, and disabled by default on Windows 10 and earlier versions. For this setting to take effect when enabled, the GC must also be configured to use all CPU groups; for more information, see [GC CPU groups](./garbage-collector.md#cpu-groups).
 
-| | Setting name | Values |
-| - | - | - |
-| **runtimeconfig.json** | N/A | N/A |
-| **Environment variable** | `COMPlus_Thread_UseAllCpuGroups` or `DOTNET_Thread_UseAllCpuGroups` | `0` - disabled<br/>`1` - enabled |
+|                          | Setting name                    | Values                           |
+|--------------------------|---------------------------------|----------------------------------|
+| **runtimeconfig.json**   | N/A                             | N/A                              |
+| **Environment variable** | `DOTNET_Thread_UseAllCpuGroups` | `0` - disabled<br/>`1` - enabled |
 
 ## Assign threads to CPU groups on Windows
 
@@ -26,10 +24,10 @@ This article details the settings you can use to configure threading in .NET.
 - When this setting is enabled, new threads are assigned to a CPU group in a way that tries to fully populate a CPU group that is already in use before utilizing a new CPU group.
 - This setting is enabled by default.
 
-| | Setting name | Values |
-| - | - | - |
-| **runtimeconfig.json** | N/A | N/A |
-| **Environment variable** | `COMPlus_Thread_AssignCpuGroups` or `DOTNET_Thread_AssignCpuGroups` | `0` - disabled<br/>`1` - enabled |
+|                          | Setting name                    | Values                           |
+|--------------------------|---------------------------------|----------------------------------|
+| **runtimeconfig.json**   | N/A                             | N/A                              |
+| **Environment variable** | `DOTNET_Thread_AssignCpuGroups` | `0` - disabled<br/>`1` - enabled |
 
 ## Minimum threads
 

--- a/docs/core/runtime-config/wpf.md
+++ b/docs/core/runtime-config/wpf.md
@@ -7,8 +7,6 @@ ms.date: 09/08/2023
 
 This article details the settings you can use to configure Windows Presentation Framework (WPF) in .NET.
 
-[!INCLUDE [complus-prefix](../../../includes/complus-prefix.md)]
-
 ## Hardware acceleration in RDP
 
 - Configures whether hardware acceleration is used for WPF apps that are accessed through Remote Desktop Protocol (RDP). Hardware acceleration refers to the use of a computer's graphics processing unit (GPU) to speed up the rendering of graphics and visual effects in an application. This can result in improved performance and more seamless, responsive graphics.

--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -1,16 +1,35 @@
 ---
 title: .NET environment variables
 description: Learn about the environment variables that you can use to configure the .NET SDK, .NET CLI, and .NET runtime.
-ms.date: 11/08/2023
+ms.date: 11/20/2025
 ---
 
 # .NET environment variables
 
-**This article applies to:** ✔️ .NET 6 SDK and later versions
-
 In this article, you'll learn about the environment variables used by .NET. Some environment variables are used by the .NET runtime, while others are only used by the .NET SDK and .NET CLI. Some environment variables are used by all three components.
 
 ## .NET runtime environment variables
+
+This section defines the following environment variables:
+
+- [`DOTNET_SYSTEM_NET_HTTP_*`](#dotnet_system_net_http_)
+- [`DOTNET_SYSTEM_GLOBALIZATION_*`](#dotnet_system_globalization_)
+- [`DOTNET_SYSTEM_GLOBALIZATION_USENLS`](#dotnet_system_globalization_usenls)
+- [`DOTNET_SYSTEM_NET_SOCKETS_*`](#dotnet_system_net_sockets_)
+- [`DOTNET_SYSTEM_NET_DISABLEIPV6`](#dotnet_system_net_disableipv6)
+- [`DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER`](#dotnet_system_net_http_usesocketshttphandler)
+- [`DOTNET_RUNNING_IN_CONTAINER` and `DOTNET_RUNNING_IN_CONTAINERS`](#dotnet_running_in_container-and-dotnet_running_in_containers)
+- [`DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION`](#dotnet_system_console_allow_ansi_color_redirection)
+- [`DOTNET_SYSTEM_DIAGNOSTICS` and related variables](#dotnet_system_diagnostics-and-related-variables)
+- [`DOTNET_DiagnosticPorts`](#dotnet_diagnosticports)
+- [`DOTNET_DefaultDiagnosticPortSuspend`](#dotnet_defaultdiagnosticportsuspend)
+- [`DOTNET_EnableDiagnostics`](#dotnet_enablediagnostics)
+- [`DOTNET_EnableDiagnostics_IPC`](#dotnet_enablediagnostics_ipc)
+- [`DOTNET_EnableDiagnostics_Debugger`](#dotnet_enablediagnostics_debugger)
+- [`DOTNET_EnableDiagnostics_Profiler`](#dotnet_enablediagnostics_profiler)
+- [EventPipe variables](#eventpipe-variables)
+
+For more information about configuring the .NET runtime, see [.NET runtime configuration settings](../runtime-config/index.md).
 
 ### `DOTNET_SYSTEM_NET_HTTP_*`
 
@@ -162,6 +181,43 @@ See [EventPipe environment variables](../diagnostics/eventpipe.md#trace-using-en
 - `DOTNET_EventPipeOutputStreaming`: When set to `1`, enables streaming to the output file while the app is running. By default trace information is accumulated in a circular buffer and the contents are written at app shutdown.
 
 ## .NET SDK and CLI environment variables
+
+This section describes the following environment variables:
+
+- [`DOTNET_ROOT`, `DOTNET_ROOT(x86)`, `DOTNET_ROOT_X86`, `DOTNET_ROOT_X64`](#dotnet_root-dotnet_rootx86-dotnet_root_x86-dotnet_root_x64)
+- [`DOTNET_HOST_PATH`](#dotnet_host_path)
+- [`DOTNET_LAUNCH_PROFILE`](#dotnet_launch_profile)
+- [`NUGET_PACKAGES`](#nuget_packages)
+- [`DOTNET_SERVICING`](#dotnet_servicing)
+- [`DOTNET_NOLOGO`](#dotnet_nologo)
+- [`DOTNET_CLI_PERF_LOG`](#dotnet_cli_perf_log)
+- [`DOTNET_GENERATE_ASPNET_CERTIFICATE`](#dotnet_generate_aspnet_certificate)
+- [`DOTNET_ADD_GLOBAL_TOOLS_TO_PATH`](#dotnet_add_global_tools_to_path)
+- [`DOTNET_CLI_TELEMETRY_OPTOUT`](#dotnet_cli_telemetry_optout)
+- [`DOTNET_SKIP_FIRST_TIME_EXPERIENCE`](#dotnet_skip_first_time_experience)
+- [`DOTNET_MULTILEVEL_LOOKUP`](#dotnet_multilevel_lookup)
+- [`DOTNET_ROLL_FORWARD`](#dotnet_roll_forward)
+- [`DOTNET_ROLL_FORWARD_TO_PRERELEASE`](#dotnet_roll_forward_to_prerelease)
+- [`DOTNET_CLI_FORCE_UTF8_ENCODING`](#dotnet_cli_force_utf8_encoding)
+- [`DOTNET_CLI_UI_LANGUAGE`](#dotnet_cli_ui_language)
+- [`DOTNET_DISABLE_GUI_ERRORS`](#dotnet_disable_gui_errors)
+- [`DOTNET_ADDITIONAL_DEPS`](#dotnet_additional_deps)
+- [`DOTNET_RUNTIME_ID`](#dotnet_runtime_id)
+- [`DOTNET_SHARED_STORE`](#dotnet_shared_store)
+- [`DOTNET_STARTUP_HOOKS`](#dotnet_startup_hooks)
+- [`DOTNET_BUNDLE_EXTRACT_BASE_DIR`](#dotnet_bundle_extract_base_dir)
+- [`DOTNET_CLI_HOME`](#dotnet_cli_home)
+- [`DOTNET_CLI_CONTEXT_*`](#dotnet_cli_context_)
+- [`DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE`](#dotnet_cli_workload_update_notify_disable)
+- [`DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_INTERVAL_HOURS`](#dotnet_cli_workload_update_notify_interval_hours)
+- [`DOTNET_SKIP_WORKLOAD_INTEGRITY_CHECK`](#dotnet_skip_workload_integrity_check)
+- [`DOTNET_TOOLS_ALLOW_MANIFEST_IN_ROOT`](#dotnet_tools_allow_manifest_in_root)
+- [`DOTNET_HOST_TRACE`](#dotnet_host_trace)
+- [`COREHOST_TRACE`](#corehost_trace)
+- [`SuppressNETCoreSdkPreviewMessage`](#suppressnetcoresdkpreviewmessage)
+- [Configure MSBuild in the .NET CLI](#configure-msbuild-in-the-net-cli)
+- [`DOTNET_NEW_PREFERRED_LANG`](#dotnet_new_preferred_lang)
+- [`dotnet watch` environment variables](#dotnet-watch-environment-variables)
 
 ### `DOTNET_ROOT`, `DOTNET_ROOT(x86)`, `DOTNET_ROOT_X86`, `DOTNET_ROOT_X64`
 

--- a/includes/complus-prefix.md
+++ b/includes/complus-prefix.md
@@ -1,2 +1,0 @@
-> [!NOTE]
-> .NET 6 standardizes on the prefix `DOTNET_` instead of `COMPlus_` for environment variables that configure .NET run-time behavior. However, the `COMPlus_` prefix will continue to work. If you're using a previous version of the .NET runtime, you should still use the `COMPlus_` prefix for environment variables.


### PR DESCRIPTION
- The DOTNET_ prefix was introduced 4 years ago in .NET 6, so we can assume most users are already using the new prefix.
- Adds a note to the core/runtime-config/index.md file to note that .NET Framework still uses the COMPLUS_ prefix.
- Adds two indexes to H3s in the core/tools/environment-variables.md article.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

<details><summary><strong>Toggle expand/collapse</strong></summary><br/>

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/debug-highcpu.md](https://github.com/dotnet/docs/blob/b1a6b92ea0f7fbd7f16cccb2a84764191dae28a3/docs/core/diagnostics/debug-highcpu.md) | [Debug high CPU usage in .NET Core](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/debug-highcpu?branch=pr-en-us-50077) |
| [docs/core/diagnostics/debug-stackoverflow.md](https://github.com/dotnet/docs/blob/b1a6b92ea0f7fbd7f16cccb2a84764191dae28a3/docs/core/diagnostics/debug-stackoverflow.md) | [Debugging StackOverflow errors](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/debug-stackoverflow?branch=pr-en-us-50077) |
| [docs/core/diagnostics/diagnostic-port.md](https://github.com/dotnet/docs/blob/b1a6b92ea0f7fbd7f16cccb2a84764191dae28a3/docs/core/diagnostics/diagnostic-port.md) | [Diagnostic ports](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/diagnostic-port?branch=pr-en-us-50077) |
| [docs/core/diagnostics/diagnostics-in-containers.md](https://github.com/dotnet/docs/blob/b1a6b92ea0f7fbd7f16cccb2a84764191dae28a3/docs/core/diagnostics/diagnostics-in-containers.md) | [Collect diagnostics in Linux containers](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/diagnostics-in-containers?branch=pr-en-us-50077) |
| [docs/core/diagnostics/eventpipe.md](https://github.com/dotnet/docs/blob/b1a6b92ea0f7fbd7f16cccb2a84764191dae28a3/docs/core/diagnostics/eventpipe.md) | [docs/core/diagnostics/eventpipe](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/eventpipe?branch=pr-en-us-50077) |
| [docs/core/diagnostics/trace-perfcollect-lttng.md](https://github.com/dotnet/docs/blob/b1a6b92ea0f7fbd7f16cccb2a84764191dae28a3/docs/core/diagnostics/trace-perfcollect-lttng.md) | [Trace .NET applications with PerfCollect](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/trace-perfcollect-lttng?branch=pr-en-us-50077) |
| [docs/core/docker/build-container.md](https://github.com/dotnet/docs/blob/b1a6b92ea0f7fbd7f16cccb2a84764191dae28a3/docs/core/docker/build-container.md) | [Tutorial: Containerize a .NET app](https://review.learn.microsoft.com/en-us/dotnet/core/docker/build-container?branch=pr-en-us-50077) |
| [docs/core/runtime-config/compilation.md](https://github.com/dotnet/docs/blob/b1a6b92ea0f7fbd7f16cccb2a84764191dae28a3/docs/core/runtime-config/compilation.md) | [Compilation config settings](https://review.learn.microsoft.com/en-us/dotnet/core/runtime-config/compilation?branch=pr-en-us-50077) |
| [docs/core/runtime-config/debugging-profiling.md](https://github.com/dotnet/docs/blob/b1a6b92ea0f7fbd7f16cccb2a84764191dae28a3/docs/core/runtime-config/debugging-profiling.md) | [Runtime configuration options for debugging and profiling](https://review.learn.microsoft.com/en-us/dotnet/core/runtime-config/debugging-profiling?branch=pr-en-us-50077) |
| [docs/core/runtime-config/garbage-collector.md](https://github.com/dotnet/docs/blob/b1a6b92ea0f7fbd7f16cccb2a84764191dae28a3/docs/core/runtime-config/garbage-collector.md) | [docs/core/runtime-config/garbage-collector](https://review.learn.microsoft.com/en-us/dotnet/core/runtime-config/garbage-collector?branch=pr-en-us-50077) |
| [docs/core/runtime-config/index.md](https://github.com/dotnet/docs/blob/b1a6b92ea0f7fbd7f16cccb2a84764191dae28a3/docs/core/runtime-config/index.md) | [.NET runtime configuration settings](https://review.learn.microsoft.com/en-us/dotnet/core/runtime-config/index?branch=pr-en-us-50077) |
| [docs/core/runtime-config/threading.md](https://github.com/dotnet/docs/blob/b1a6b92ea0f7fbd7f16cccb2a84764191dae28a3/docs/core/runtime-config/threading.md) | [Threading config settings](https://review.learn.microsoft.com/en-us/dotnet/core/runtime-config/threading?branch=pr-en-us-50077) |
| [docs/core/runtime-config/wpf.md](https://github.com/dotnet/docs/blob/b1a6b92ea0f7fbd7f16cccb2a84764191dae28a3/docs/core/runtime-config/wpf.md) | [Runtime configuration options for WPF](https://review.learn.microsoft.com/en-us/dotnet/core/runtime-config/wpf?branch=pr-en-us-50077) |
| [docs/core/tools/dotnet-environment-variables.md](https://github.com/dotnet/docs/blob/b1a6b92ea0f7fbd7f16cccb2a84764191dae28a3/docs/core/tools/dotnet-environment-variables.md) | [.NET environment variables](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables?branch=pr-en-us-50077) |

</details>


<!-- PREVIEW-TABLE-END -->