### PR TITLE
Update I Am Alive diagnostics and recovery details

### DIFF
--- a/docs/orleans/implementation/cluster-management.md
+++ b/docs/orleans/implementation/cluster-management.md
@@ -111,9 +111,9 @@ In addition to `IMembershipTable`, each silo participates in a fully distributed
 
     In addition to heartbeats sent between silos, each silo periodically updates an "I Am Alive" timestamp in its table row. This serves two purposes:
 
-    1. **Diagnostics**: Provides system administrators a simple way to check cluster liveness and determine when a silo was last active. The timestamp is typically updated every 5 minutes.
+    1. **Diagnostics**: Provides system administrators a simple way to check cluster liveness and determine when a silo was last active. The timestamp is by default updated every 30 seconds.
 
-    1. **Disaster recovery**: If a silo hasn't updated its timestamp for several periods (configured via `NumMissedTableIAmAliveLimit`), new silos ignore it during startup connectivity checks. This allows the cluster to recover from scenarios where silos crashed without proper cleanup.
+    1. **Disaster recovery**: If a silo hasn't updated its timestamp for several periods (configured via `NumMissedTableIAmAliveLimit`, default: 3), new silos ignore it during startup connectivity checks. This allows the cluster to recover from scenarios where silos crashed without proper cleanup.
 
 ### Membership table
 


### PR DESCRIPTION
Updated the default timestamp update interval for diagnostics from 5 minutes to 30 seconds and added default value for missed timestamp limit.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/implementation/cluster-management.md](https://github.com/dotnet/docs/blob/300754efe5d0cbd844fea90dbb7c29ccbc49fa6c/docs/orleans/implementation/cluster-management.md) | [Cluster management in Orleans](https://review.learn.microsoft.com/en-us/dotnet/orleans/implementation/cluster-management?branch=pr-en-us-50087) |

<!-- PREVIEW-TABLE-END -->