### PR TITLE
Fix grammatical error in method parameters documentation

### DIFF
--- a/docs/csharp/language-reference/keywords/method-parameters.md
+++ b/docs/csharp/language-reference/keywords/method-parameters.md
@@ -57,7 +57,7 @@ You apply one of the following modifiers to a parameter declaration to pass argu
 - [`ref readonly`](#ref-readonly-modifier): The argument must be initialized before calling the method. The method can't assign a new value to the parameter.
 - [`in`](#in-parameter-modifier): The argument must be initialized before calling the method. The method can't assign a new value to the parameter. The compiler might create a temporary variable to hold a copy of the argument to `in` parameters.
 
-A parameter that is passed by reference is a *reference variable*. It doesn't have its own value. Instead, it refers to a different variable called its *referrent*. Reference variables can be [ref reassigned](../operators/assignment-operator.md#ref-assignment), which changes its referrent.
+A parameter that is passed by reference is a *reference variable*. It doesn't have its own value. Instead, it refers to a different variable called its *referent*. Reference variables can be [ref reassigned](../operators/assignment-operator.md#ref-assignment), which changes its referent.
 
 Members of a class can't have signatures that differ only by `ref`, `ref readonly`, `in`, or `out`. A compiler error occurs if the only difference between two members of a type is that one of them has a `ref` parameter and the other has an `out`, `ref readonly`, or `in` parameter. However, methods can be overloaded when one method has a `ref`, `ref readonly`, `in`, or `out` parameter and the other has a parameter that is passed by value, as shown in the following example. In other situations that require signature matching, such as hiding or overriding, `in`, `ref`, `ref readonly`, and `out` are part of the signature and don't match each other.
 

--- a/docs/csharp/language-reference/keywords/method-parameters.md
+++ b/docs/csharp/language-reference/keywords/method-parameters.md
@@ -57,7 +57,7 @@ You apply one of the following modifiers to a parameter declaration to pass argu
 - [`ref readonly`](#ref-readonly-modifier): The argument must be initialized before calling the method. The method can't assign a new value to the parameter.
 - [`in`](#in-parameter-modifier): The argument must be initialized before calling the method. The method can't assign a new value to the parameter. The compiler might create a temporary variable to hold a copy of the argument to `in` parameters.
 
-A parameter that is passed by reference is a *reference variable*. It doesn't have it's own value. Instead, it refers to a different variable called its *referrent*. Reference variables can be [ref reassigned](../operators/assignment-operator.md#ref-assignment), which changes its referrent.
+A parameter that is passed by reference is a *reference variable*. It doesn't have its own value. Instead, it refers to a different variable called its *referrent*. Reference variables can be [ref reassigned](../operators/assignment-operator.md#ref-assignment), which changes its referrent.
 
 Members of a class can't have signatures that differ only by `ref`, `ref readonly`, `in`, or `out`. A compiler error occurs if the only difference between two members of a type is that one of them has a `ref` parameter and the other has an `out`, `ref readonly`, or `in` parameter. However, methods can be overloaded when one method has a `ref`, `ref readonly`, `in`, or `out` parameter and the other has a parameter that is passed by value, as shown in the following example. In other situations that require signature matching, such as hiding or overriding, `in`, `ref`, `ref readonly`, and `out` are part of the signature and don't match each other.
 

--- a/docs/csharp/language-reference/operators/assignment-operator.md
+++ b/docs/csharp/language-reference/operators/assignment-operator.md
@@ -43,7 +43,7 @@ In the preceding example, the [local reference variable](../statements/declarati
 
 The left-hand operand of `ref` assignment can be a [local reference variable](../statements/declarations.md#reference-variables), a [`ref` field](../builtin-types/ref-struct.md#ref-fields), and a [`ref`](../keywords/ref.md), [`out`](../keywords/method-parameters.md#out-parameter-modifier), or [`in`](../keywords/method-parameters.md#in-parameter-modifier) method parameter. Both operands must be of the same type.
 
-A `ref` assignment means that a reference variable has a different referrent. It's no longer referring to its previous referrent. Using `ref =` on a `ref` parameter means the parameter no longer refers to its argument. Any actions that modify the state of the object after ref reassigning it make those modifications to the new item. For example, consider the following method:
+A `ref` assignment means that a reference variable has a different referent. It's no longer referring to its previous referent. Using `ref =` on a `ref` parameter means the parameter no longer refers to its argument. Any actions that modify the state of the object after ref reassigning it make those modifications to the new item. For example, consider the following method:
 
 :::code language="csharp" source="snippets/shared/AssignmentOperator.cs" id="SnippetRefReassignAndModify":::
 


### PR DESCRIPTION
Corrected the phrase "it's own value" to "its own value" for grammatical accuracy.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/method-parameters.md](https://github.com/dotnet/docs/blob/078baa51f1bd36ef05468be65a4eb93040a4399e/docs/csharp/language-reference/keywords/method-parameters.md) | [Method parameters and modifiers](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/method-parameters?branch=pr-en-us-50114) |
| [docs/csharp/language-reference/operators/assignment-operator.md](https://github.com/dotnet/docs/blob/078baa51f1bd36ef05468be65a4eb93040a4399e/docs/csharp/language-reference/operators/assignment-operator.md) | ["Assignment operators - assign an expression to a variable"](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/assignment-operator?branch=pr-en-us-50114) |


<!-- PREVIEW-TABLE-END -->