### PR TITLE
docs: add DefaultTraceListener entry to trace listeners table

### DIFF
--- a/docs/framework/configure-apps/file-schema/trace-debug/add-element-for-listeners-for-trace.md
+++ b/docs/framework/configure-apps/file-schema/trace-debug/add-element-for-listeners-for-trace.md
@@ -78,7 +78,9 @@ Adds a listener to the **Listeners** collection.
 |<xref:System.Diagnostics.EventLogTraceListener?displayProperty=nameWithType>|The name of the name of an existing event log source.|  
 |<xref:System.Diagnostics.EventSchemaTraceListener?displayProperty=nameWithType>|The name of the file that the <xref:System.Diagnostics.EventSchemaTraceListener> writes to.|  
 |<xref:System.Diagnostics.TextWriterTraceListener?displayProperty=nameWithType>|The name of the file that the <xref:System.Diagnostics.TextWriterTraceListener> writes to.|  
-|<xref:System.Diagnostics.XmlWriterTraceListener?displayProperty=nameWithType>|The name of the file that the <xref:System.Diagnostics.XmlWriterTraceListener> writes to.|  
+|<xref:System.Diagnostics.XmlWriterTraceListener?displayProperty=nameWithType>|The name of the file that the <xref:System.Diagnostics.XmlWriterTraceListener> writes to.|
+|xref:System.Diagnostics.DefaultTraceListener?displayProperty=nameWithType|The default trace listener that outputs messages to the Visual Studio Output window or debugger. This listener is automatically included in the `Trace.Listeners` collection unless explicitly removed in the configuration.|
+
   
 ## Example  
 


### PR DESCRIPTION
### Summary
Added the missing `DefaultTraceListener` entry to the trace listeners table in the `.NET Framework` configuration documentation.

### Why
The table listing available trace listener classes did not include `DefaultTraceListener`, which caused confusion for users trying to configure it using `app.config`. This listener is automatically included by default in the `Trace.Listeners` collection, but users may want to reference it explicitly in configuration files.

### Change
- Added a new row for `DefaultTraceListener` to the trace listener table in `add-element-for-listeners-for-trace.md`.
- Clarified its purpose and default behavior in debugging and tracing scenarios.

### Related Issue
Fixes #48559

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/configure-apps/file-schema/trace-debug/add-element-for-listeners-for-trace.md](https://github.com/dotnet/docs/blob/0f1e282e3dd56eb2baeb5eb14d0b73903e983a43/docs/framework/configure-apps/file-schema/trace-debug/add-element-for-listeners-for-trace.md) | [\<add> Element for \<listeners> for \<trace>](https://review.learn.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/trace-debug/add-element-for-listeners-for-trace?branch=pr-en-us-50120) |


<!-- PREVIEW-TABLE-END -->