### PR TITLE
docs: fix System.CommandLine tab-completion example to use RootCommand

### DIFF
--- a/docs/standard/commandline/snippets/tab-completion/csharp/Program.cs
+++ b/docs/standard/commandline/snippets/tab-completion/csharp/Program.cs
@@ -3,7 +3,13 @@ using System.CommandLine;
 using System.CommandLine.Completions;
 using System.CommandLine.Parsing;
 
-new DateCommand().Parse(args).Invoke();
+var rootCommand = new RootCommand("Sample app with tab-completion")
+{
+    new DateCommand()
+};
+
+await rootCommand.Parse(args).InvokeAsync();
+
 
 class DateCommand : Command
 {


### PR DESCRIPTION
### Summary
Fixed the tab-completion example in `how-to-enable-tab-completion.md` by updating the sample code to use `RootCommand` instead of `Command`.

### Changes
- Wrapped the command in a `RootCommand`.
- Updated the invocation to use `rootCommand.Parse(args).InvokeAsync()`.
- Verified that tab-completion and help now work correctly.

### Why
Fixes #48478 — the original code used `.Parse(args).Invoke()` on a `Command`, which prevented tab-completion and help from working as intended.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
