### PR TITLE
Refactor the first static constructor example

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/snippets/constructors/Program.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/snippets/constructors/Program.cs
@@ -25,7 +25,10 @@ public class Adult : Person
    public Adult(string lastName, string firstName) : base(lastName, firstName)
    { }
 
-   static Adult() => minimumAge = 18;
+   static Adult()
+   {
+       minimumAge = 18;
+   }
 
    // Remaining implementation of Adult class.
 }


### PR DESCRIPTION
## Summary

Refactor the first static constructor example to demonstrate we can initialize static fields in two ways.

For more information about the discussion between me and Bill, see #50089.

Fixes #50089
