### PR TITLE
Update default-probing.md

### DIFF
--- a/docs/core/dependency-loading/default-probing.md
+++ b/docs/core/dependency-loading/default-probing.md
@@ -31,6 +31,10 @@ There are two main scenarios for populating the properties depending on whether 
 Additionally, the *\*.deps.json* files for any referenced frameworks are similarly parsed.
 
 The environment variable `DOTNET_ADDITIONAL_DEPS` can be used to add additional dependencies.  `dotnet.exe` also contains an optional `--additional-deps` parameter to set this value on application startup.
+> [!NOTE]
+> The `DOTNET_ADDITIONAL_DEPS` environment variable and the `--additional-deps` command-line option are **ignored for self-contained applications**.  
+> These options only apply to **framework-dependent applications**.  
+> For more information, see [Framework-dependent vs self-contained deployments](../deploying/index.md).
 
 The `APP_PATHS` property is not populated by default and is omitted for most applications.
 

--- a/docs/core/dependency-loading/default-probing.md
+++ b/docs/core/dependency-loading/default-probing.md
@@ -32,8 +32,8 @@ Additionally, the *\*.deps.json* files for any referenced frameworks are similar
 
 The environment variable `DOTNET_ADDITIONAL_DEPS` can be used to add additional dependencies.  `dotnet.exe` also contains an optional `--additional-deps` parameter to set this value on application startup.
 > [!NOTE]
-> The `DOTNET_ADDITIONAL_DEPS` environment variable and the `--additional-deps` command-line option are **ignored for self-contained applications**.  
-> These options only apply to **framework-dependent applications**.  
+> The `DOTNET_ADDITIONAL_DEPS` environment variable and the `--additional-deps` command-line option only apply to **framework-dependent applications**.
+> These options are **ignored for self-contained applications**. 
 > For more information, see [Framework-dependent vs self-contained deployments](../deploying/index.md).
 
 The `APP_PATHS` property is not populated by default and is omitted for most applications.

--- a/docs/core/dependency-loading/default-probing.md
+++ b/docs/core/dependency-loading/default-probing.md
@@ -31,9 +31,10 @@ There are two main scenarios for populating the properties depending on whether 
 Additionally, the *\*.deps.json* files for any referenced frameworks are similarly parsed.
 
 The environment variable `DOTNET_ADDITIONAL_DEPS` can be used to add additional dependencies.  `dotnet.exe` also contains an optional `--additional-deps` parameter to set this value on application startup.
+
 > [!NOTE]
 > The `DOTNET_ADDITIONAL_DEPS` environment variable and the `--additional-deps` command-line option only apply to **framework-dependent applications**.
-> These options are **ignored for self-contained applications**. 
+> These options are **ignored for self-contained applications**.
 > For more information, see [Framework-dependent vs self-contained deployments](../deploying/index.md).
 
 The `APP_PATHS` property is not populated by default and is omitted for most applications.


### PR DESCRIPTION
Fixes #48014

Added a clarification note stating that the DOTNET_ADDITIONAL_DEPS environment variable and the --additional-deps command-line option are ignored for self-contained applications. 
These options only apply to framework-dependent applications. This note improves documentation accuracy and helps developers understand the limitation of additional dependencies in self-contained deployments.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/dependency-loading/default-probing.md](https://github.com/dotnet/docs/blob/a9fb74936cd521e918f798775a1014714fa758b9/docs/core/dependency-loading/default-probing.md) | [Default probing](https://review.learn.microsoft.com/en-us/dotnet/core/dependency-loading/default-probing?branch=pr-en-us-50134) |


<!-- PREVIEW-TABLE-END -->