### PR TITLE
Update mstest0018.md

### DIFF
--- a/docs/core/testing/mstest-analyzers/mstest0018.md
+++ b/docs/core/testing/mstest-analyzers/mstest0018.md
@@ -36,18 +36,16 @@ The "data source" member referenced:
 - should exist on the specified type (current class if no type is specified)
 - should not have overloads
 - should be of the same kind (method or property) as the `DataSourceType` property
-- should be `public`
 - should be `static`
 - should not be generic
 - should be parameterless
-- should return `IEnumerable<object[]>`, `IEnumerable<Tuple<T,...>>` or `IEnumerable<ValueTuple<,...>>`
+- should return `IEnumerable<object[]>`, `IEnumerable<Tuple<T,...>>`, or `IEnumerable<ValueTuple<,...>>`
 
 The "display name" member referenced:
 
 - should exist on the specified type (current class if no type is specified)
 - should not have overloads
 - should be a method
-- should be `public`
 - should be `static`
 - should not be generic
 - should return `string`
@@ -60,7 +58,7 @@ public static string GetDisplayName(MethodInfo methodInfo, object[] data)
 {
     return string.Format("{0} ({1})", methodInfo.Name, string.Join(",", data));
 }
-```
+
 
 ## How to fix violations
 

--- a/docs/core/testing/mstest-analyzers/mstest0018.md
+++ b/docs/core/testing/mstest-analyzers/mstest0018.md
@@ -58,7 +58,7 @@ public static string GetDisplayName(MethodInfo methodInfo, object[] data)
 {
     return string.Format("{0} ({1})", methodInfo.Name, string.Join(",", data));
 }
-
+```
 
 ## How to fix violations
 


### PR DESCRIPTION
This PR updates the MSTEST0018 analyzer documentation to remove the outdated requirement that members referenced in [DynamicData] must be public.

Changes made

Removed “should be public” from both the data source and display name member rule lists.

Aligned the rule description with the current MSTest v3 behavior.

Reason for change
MSTest v3 no longer requires [DynamicData] members to be public.
The documentation previously reflected the older MSTest v2 behavior, which is now obsolete.

Related issue
Fixes #49663

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/mstest-analyzers/mstest0018.md](https://github.com/dotnet/docs/blob/b341c4b57157904c099d4c0e86a8967e5be72745/docs/core/testing/mstest-analyzers/mstest0018.md) | [MSTEST0018: DynamicData should be valid](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0018?branch=pr-en-us-50138) |


<!-- PREVIEW-TABLE-END -->