### PR TITLE
Update syntax.md

### DIFF
--- a/docs/standard/commandline/syntax.md
+++ b/docs/standard/commandline/syntax.md
@@ -99,6 +99,34 @@ When you configure an option, you specify the option name including the prefix:
 :::code language="csharp" source="snippets/define-symbols/csharp/Program.cs" id="defineoptions" :::
 
 To add an option to a command and recursively to all of its subcommands, use the `System.CommandLine.Symbol.Recursive` property.
+### Global options and verbosity
+
+Some command-line tools define *global options* that apply to all commands and subcommands.  
+For example, the .NET CLI provides a global `--verbosity` (short form `-v`) option to control the level of output detail.
+
+You can define a global option by adding it to the root command so that it’s available to all subcommands:
+
+```csharp
+using System.CommandLine;
+
+var verbosityOption = new Option<string>(
+    aliases: new[] { "-v", "--verbosity" },
+    description: "Set the verbosity level (quiet, minimal, normal, detailed, diagnostic)")
+{
+    Arity = ArgumentArity.ZeroOrOne
+};
+
+var rootCommand = new RootCommand("Sample app");
+rootCommand.AddGlobalOption(verbosityOption);
+
+rootCommand.SetHandler((string verbosity) =>
+{
+    verbosity ??= "diagnostic"; // Treat bare "-v" as Diagnostic
+    Console.WriteLine($"Verbosity set to: {verbosity}");
+}, verbosityOption);
+
+rootCommand.Invoke(args);
+
 
 ### Required Options
 


### PR DESCRIPTION
### 📝 **PR Description**

**Summary**
Adds a concise example demonstrating how to define and use a global `--verbosity` (`-v`) option with System.CommandLine.

**Changes made**
- Added a new “Global options and verbosity” subsection under the Options section.
- Included sample code showing how to declare a global option using `AddGlobalOption`.
- Documented accepted verbosity values and short/long form examples.

**Reason for change**
The syntax overview previously described options but did not explain how to define global options or handle verbosity behavior.  
This update adds practical, minimal guidance consistent with .NET CLI design.

**Related issue**
Fixes #49437


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/commandline/syntax.md](https://github.com/dotnet/docs/blob/87466ae2864da08f9eaf7c723d44ea720d05d3f7/docs/standard/commandline/syntax.md) | [Syntax overview: Commands, options, and arguments](https://review.learn.microsoft.com/en-us/dotnet/standard/commandline/syntax?branch=pr-en-us-50139) |

<!-- PREVIEW-TABLE-END -->