### PR TITLE
Document float and float32 scientific notation more thoroughly

### DIFF
--- a/docs/fsharp/language-reference/literals.md
+++ b/docs/fsharp/language-reference/literals.md
@@ -23,9 +23,9 @@ The following table shows the literal types in F#. Characters that represent dig
 |unativeint|native pointer as an unsigned natural number|un|`0x00002D3Fun`|
 |int64|signed 64-bit integer|L|`86L`|
 |uint64|unsigned 64-bit natural number|UL|`86UL`|
-|single, float32|32-bit floating point number|F or f|`4.14F` or `4.14f` or `2.3E+32F` or `2.3e+32F` or `2.3E+32f` or `2.3e+32f` or `2.3E-32F` or `2.3e-32F` or `2.3E-32f` or `2.3e-32f` or `infinityf` or `-infinityf`|
+|single, float32|32-bit floating point number|F or f|`4.14F` or `4.14f` or `2.3e+32f` or `2.3e-32f` or `infinityf` or `-infinityf`|
 |||lf|`0x00000000lf`|
-|float; double|64-bit floating point number|none|`4.14` or `2.3E+32` or `2.3e+32` or `2.3E-32` or `2.3e-32` or `infinity` or `-infinity`|
+|float; double|64-bit floating point number|none|`4.14` or `2.3E+32` or `2.3e+32` or `2.3e-32` or `infinity` or `-infinity`|
 |||LF|`0x0000000000000000LF`|
 |bigint|integer not limited to 64-bit representation|I|`9999999999999999999999999999I`|
 |decimal|fractional number represented as a fixed point or rational number|M or m|`0.7833M` or `0.7833m`|

--- a/docs/fsharp/language-reference/literals.md
+++ b/docs/fsharp/language-reference/literals.md
@@ -23,9 +23,9 @@ The following table shows the literal types in F#. Characters that represent dig
 |unativeint|native pointer as an unsigned natural number|un|`0x00002D3Fun`|
 |int64|signed 64-bit integer|L|`86L`|
 |uint64|unsigned 64-bit natural number|UL|`86UL`|
-|single, float32|32-bit floating point number|F or f|`4.14F` or `4.14f` or `infinityf` or `-infinityf`|
+|single, float32|32-bit floating point number|F or f|`4.14F` or `4.14f` or `2.3E+32F` or `2.3e+32F` or `2.3E+32f` or `2.3e+32f` or `2.3E-32F` or `2.3e-32F` or `2.3E-32f` or `2.3e-32f` or `infinityf` or `-infinityf`|
 |||lf|`0x00000000lf`|
-|float; double|64-bit floating point number|none|`4.14` or `2.3E+32` or `2.3e+32` or `infinity` or `-infinity`|
+|float; double|64-bit floating point number|none|`4.14` or `2.3E+32` or `2.3e+32` or `2.3E-32` or `2.3e-32` or `infinity` or `-infinity`|
 |||LF|`0x0000000000000000LF`|
 |bigint|integer not limited to 64-bit representation|I|`9999999999999999999999999999I`|
 |decimal|fractional number represented as a fixed point or rational number|M or m|`0.7833M` or `0.7833m`|


### PR DESCRIPTION
## Summary

F# language reference was missing documentation about the fact that you can have `float32` literals with scientific notation, and that both `float` and `float32` scientific notation literals can use `-` instead of `+` in the exponent portion (i.e. `2.3e+6` and `2.3e-6` both work).

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/literals.md](https://github.com/dotnet/docs/blob/f90daa0c3467140fc28224d2c8cac10f67f98ac9/docs/fsharp/language-reference/literals.md) | [docs/fsharp/language-reference/literals](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/literals?branch=pr-en-us-50208) |


<!-- PREVIEW-TABLE-END -->