### PR TITLE
Update supported .NET versions for Ubuntu 24.04 and 22.04

### DIFF
--- a/docs/core/install/linux-ubuntu-install.md
+++ b/docs/core/install/linux-ubuntu-install.md
@@ -136,7 +136,7 @@ The following versions of .NET are supported or available for Ubuntu 24.04:
 
 | Supported .NET versions | Available in<br>built-in Ubuntu feed | [Available in<br>backports<br>Ubuntu feed](linux-ubuntu-decision.md#ubuntu-net-backports-package-repository) | [Available in<br>Microsoft feed](linux-ubuntu-decision.md#register-the-microsoft-package-repository) |
 |-------------------------|--------------------------------------|-----------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
-| 10.0, 9.0, 8.0          | 8.0                                  | 9.0, 7.0, 6.0                                                                                       |None                                                                                         |
+| 10.0, 9.0, 8.0          | 8.0                                  | 10.0, 9.0, 7.0, 6.0                                                                                       |None                                                                                         |
 
 When an [Ubuntu version](https://wiki.ubuntu.com/Releases) falls out of support, .NET is no longer supported with that version.
 
@@ -192,7 +192,7 @@ The following versions of .NET are supported or available for Ubuntu 22.04:
 
 | Supported .NET versions | Available in<br>built-in Ubuntu feed | [Available in<br>.NET backports<br>Ubuntu feed](linux-ubuntu-decision.md#ubuntu-net-backports-package-repository) | [Available in<br>Microsoft feed](linux-ubuntu-decision.md#register-the-microsoft-package-repository) |
 |-------------------------|--------------------------------------|----------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
-| 10.0, 9.0, 8.0          | 8.0, 7.0, 6.0                        | 9.0                                                                                                      | 8.0, 7.0, 6.0, 3.1                |
+| 10.0, 9.0, 8.0          | 8.0, 7.0, 6.0                        | 10.0 9.0                                                                                                      | 8.0, 7.0, 6.0, 3.1                |
 
 [!INCLUDE [linux-ubuntu-feed-sdk-note](includes/linux-ubuntu-feed-sdk-note.md)]
 


### PR DESCRIPTION
## Summary

.NET 10 is available in backport feed for weeks now, this should be updated

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/linux-ubuntu-install.md](https://github.com/dotnet/docs/blob/081691f843feee75b5ad42406b2e0595c3e9b724/docs/core/install/linux-ubuntu-install.md) | [Install .NET SDK or .NET Runtime on Ubuntu](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu-install?branch=pr-en-us-50224) |

<!-- PREVIEW-TABLE-END -->