### PR TITLE
Link operators `==` and `!=` overloading to the records page

### DIFF
--- a/docs/csharp/language-reference/builtin-types/record.md
+++ b/docs/csharp/language-reference/builtin-types/record.md
@@ -124,7 +124,7 @@ To implement value equality, the compiler synthesizes several methods, including
 
 * An override of <xref:System.Object.GetHashCode?displayProperty=nameWithType>. This method can be declared explicitly.
 
-* Overrides of operators `==` and `!=`. It's an error if the operators are declared explicitly.
+* Overrides of [operator `==`](../operators/equality-operators#equality-operator-) and [operator `!=`](../operators/equality-operators#inequality-operator-). It's an error if the operators are declared explicitly.
 
 * If the record type is derived from a base record type, `protected override Type EqualityContract { get; };`. This property can be declared explicitly. For more information, see [Equality in inheritance hierarchies](#equality-in-inheritance-hierarchies).
 
@@ -263,4 +263,5 @@ For more information about these features, see the following feature proposal no
 - [Design guidelines - Choosing between class and struct](../../../standard/design-guidelines/choosing-between-class-and-struct.md)
 - [Design guidelines - Struct design](../../../standard/design-guidelines/struct.md)
 - [The C# type system](../../fundamentals/types/index.md)
+- [Operator overloading](../operators/operator-overloading.md)
 - [`with` expression](../operators/with-expression.md)

--- a/docs/csharp/language-reference/builtin-types/record.md
+++ b/docs/csharp/language-reference/builtin-types/record.md
@@ -124,7 +124,7 @@ To implement value equality, the compiler synthesizes several methods, including
 
 * An override of <xref:System.Object.GetHashCode?displayProperty=nameWithType>. This method can be declared explicitly.
 
-* Overrides of [operator `==`](../operators/equality-operators#equality-operator-) and [operator `!=`](../operators/equality-operators#inequality-operator-). It's an error if the operators are declared explicitly.
+* Overrides of [operator `==`](../operators/equality-operators.md#equality-operator-) and [operator `!=`](../operators/equality-operators.md#inequality-operator-). It's an error if the operators are declared explicitly.
 
 * If the record type is derived from a base record type, `protected override Type EqualityContract { get; };`. This property can be declared explicitly. For more information, see [Equality in inheritance hierarchies](#equality-in-inheritance-hierarchies).
 


### PR DESCRIPTION
As per the issue - the page of `records` was missing a handy link to overloading the operators of equality and inequality.
This pull request closes #49903 by adding embedded links to equality and inequality operators themself, and adds the "Operator overloading" page to "See also" section.

The issue also mentions adding links to `GetHashCode` and `Equals`, but those are already embedded in the page in the same section, so I didn't see a reason to duplicate those links.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/builtin-types/record.md](https://github.com/dotnet/docs/blob/a1136edd684480824968215ab3d227b125d7e2dd/docs/csharp/language-reference/builtin-types/record.md) | [Records (C# reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/record?branch=pr-en-us-50226) |


<!-- PREVIEW-TABLE-END -->