### PR TITLE
Add Meziantou.Analyzer to third-party analyzers list

### DIFF
--- a/docs/fundamentals/code-analysis/overview.md
+++ b/docs/fundamentals/code-analysis/overview.md
@@ -250,7 +250,7 @@ If your project uses the legacy project file format, that is, it doesn't referen
 
 ## Third-party analyzers
 
-In addition to the official .NET analyzers, you can also install third party analyzers, such as [StyleCop](https://www.nuget.org/packages/StyleCop.Analyzers/), [Roslynator](https://www.nuget.org/packages/Roslynator.Analyzers/), [XUnit Analyzers](https://www.nuget.org/packages/xunit.analyzers/), and [Sonar Analyzer](https://www.nuget.org/packages/SonarAnalyzer.CSharp/).
+In addition to the official .NET analyzers, you can also install third party analyzers, such as [StyleCop](https://www.nuget.org/packages/StyleCop.Analyzers/), [Roslynator](https://www.nuget.org/packages/Roslynator.Analyzers/), [Meziantou.Analyzer](https://www.nuget.org/packages/Meziantou.Analyzer/), [XUnit Analyzers](https://www.nuget.org/packages/xunit.analyzers/), and [Sonar Analyzer](https://www.nuget.org/packages/SonarAnalyzer.CSharp/).
 
 ## See also
 


### PR DESCRIPTION
## Summary

Adds another semi-popular analyzer library to the list of third-party analyzers.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/overview.md](https://github.com/dotnet/docs/blob/2b4d7d164f78b11344dcf2a791f87e0165966866/docs/fundamentals/code-analysis/overview.md) | [Overview of .NET source code analysis](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/overview?branch=pr-en-us-50236) |

<!-- PREVIEW-TABLE-END -->