### PR TITLE
Document --bl parameter for dotnet build

### DIFF
--- a/docs/core/tools/dotnet-build.md
+++ b/docs/core/tools/dotnet-build.md
@@ -15,7 +15,7 @@ ms.date: 09/24/2025
 
 ```dotnetcli
 dotnet build [<PROJECT>|<SOLUTION>|<FILE>] [-a|--arch <ARCHITECTURE>]
-    [--artifacts-path <ARTIFACTS_DIR>]
+    [--artifacts-path <ARTIFACTS_DIR>]  [-bl|--binaryLogger:<FILE>]
     [-c|--configuration <CONFIGURATION>] [--disable-build-servers]
     [-f|--framework <FRAMEWORK>] [--force] [--interactive]
     [--no-dependencies] [--no-incremental] [--no-restore] [--nologo]
@@ -23,7 +23,7 @@ dotnet build [<PROJECT>|<SOLUTION>|<FILE>] [-a|--arch <ARCHITECTURE>]
     [-p|--property:<PROPERTYNAME>=<VALUE>] [-r|--runtime <RUNTIME_IDENTIFIER>]
     [--sc|--self-contained] [--source <SOURCE>]
     [--tl:[auto|on|off]] [ --ucr|--use-current-runtime]
-    [-v|--verbosity <LEVEL>] [-bl|--binaryLogger:<FILE>] [--version-suffix <VERSION_SUFFIX>]
+    [-v|--verbosity <LEVEL>] [--version-suffix <VERSION_SUFFIX>]
 
 dotnet build -h|--help
 ```
@@ -90,8 +90,8 @@ Running `dotnet build` is equivalent to running `dotnet msbuild -restore`; howev
   [MSBuild Structured Log Viewer](https://msbuildlog.com).
 
   ```dotnetcli
-  dotnet build --bl
-  dotnet build --bl:build-log.binlog
+  dotnet build -bl
+  dotnet build -bl:build-log.binlog
   ```
 
 - [!INCLUDE [configuration](../../../includes/cli-configuration.md)]
@@ -206,4 +206,3 @@ Running `dotnet build` is equivalent to running `dotnet msbuild -restore`; howev
   ```dotnetcli
   dotnet build -p:Version=1.2.3.4
   ```
-

--- a/docs/core/tools/dotnet-build.md
+++ b/docs/core/tools/dotnet-build.md
@@ -23,7 +23,7 @@ dotnet build [<PROJECT>|<SOLUTION>|<FILE>] [-a|--arch <ARCHITECTURE>]
     [-p|--property:<PROPERTYNAME>=<VALUE>] [-r|--runtime <RUNTIME_IDENTIFIER>]
     [--sc|--self-contained] [--source <SOURCE>]
     [--tl:[auto|on|off]] [ --ucr|--use-current-runtime]
-    [-v|--verbosity <LEVEL>] [--version-suffix <VERSION_SUFFIX>]
+    [-v|--verbosity <LEVEL>] [-bl|--binaryLogger:<FILE>] [--version-suffix <VERSION_SUFFIX>]
 
 dotnet build -h|--help
 ```
@@ -80,6 +80,19 @@ Running `dotnet build` is equivalent to running `dotnet msbuild -restore`; howev
 - [!INCLUDE [arch](../../../includes/cli-arch.md)]
 
 - [!INCLUDE [artifacts-path](../../../includes/cli-artifacts-path.md)]
+
+- **`-bl|--binaryLogger:<FILE>`**
+
+  Enables the binary logger and optionally specifies the output file name.  
+  If no file name is provided, the default is `msbuild.binlog` in the current directory.
+
+  The binary log contains detailed build information and can be opened with the
+  [MSBuild Structured Log Viewer](https://msbuildlog.com).
+
+  ```dotnetcli
+  dotnet build --bl
+  dotnet build --bl:build-log.binlog
+  ```
 
 - [!INCLUDE [configuration](../../../includes/cli-configuration.md)]
 
@@ -193,3 +206,4 @@ Running `dotnet build` is equivalent to running `dotnet msbuild -restore`; howev
   ```dotnetcli
   dotnet build -p:Version=1.2.3.4
   ```
+


### PR DESCRIPTION
Fixes #50115

## Description
Added documentation for the `--bl` parameter which enables binary logging for the `dotnet build` command.

## Changes
- Added `--bl[:<FILE>]` parameter documentation in the Options section
- Included description of functionality and default behavior
- Added usage examples showing both `--bl` and `--bl:build-log.binlog` syntax
- Referenced MSBuild Structured Log Viewer for viewing binlog files

## Additional Context
This parameter was already functional but undocumented. The documentation follows the existing style and format of other parameters in the file.

## Checklist
- Followed contributing guidelines
- Documentation follows existing formatting style
- References related issue #50115

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-build.md](https://github.com/dotnet/docs/blob/666da2fb8b09ebfcbbfc1d3a074a6c7ca04c1946/docs/core/tools/dotnet-build.md) | [dotnet build](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-build?branch=pr-en-us-50249) |


<!-- PREVIEW-TABLE-END -->