### PR TITLE
Add the doc for newly added publish-related property PublishReferencesSymbols

### DIFF
--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -530,7 +530,7 @@ When this property is `true`, XML documentation files for the project's referenc
 
 ### PublishReferencesSymbols
 
-When this property is `true`, symbol files (also known as PDB files) for the project's references are copied to the publish directory, instead of just run-time assets like DLL files. This property defaults to `true`.
+When this property is `true`, symbol files (also known as PDB files) for the project's references are copied to the publish directory, instead of just runtime assets like DLL files. This property defaults to `true`.
 
 ### PublishRelease
 

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -530,7 +530,7 @@ When this property is `true`, XML documentation files for the project's referenc
 
 ### PublishReferencesSymbols
 
-When this property is `true`, symbol files (also known as PDB files) for the project's references are copied to the publish directory. This property defaults to `true`.
+When this property is `true`, symbol files (also known as PDB files) for the project's references are copied to the publish directory, instead of just run-time assets like DLL files. This property defaults to `true`.
 
 ### PublishRelease
 

--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -370,6 +370,7 @@ The following MSBuild properties are documented in this section:
 - [PublishDocumentationFile](#publishdocumentationfile)
 - [PublishDocumentationFiles](#publishdocumentationfiles)
 - [PublishReferencesDocumentationFiles](#publishreferencesdocumentationfiles)
+- [PublishReferencesSymbols](#publishreferencessymbols)
 - [PublishRelease](#publishrelease)
 - [PublishSelfContained](#publishselfcontained)
 - [RollForward](#rollforward)
@@ -526,6 +527,10 @@ This property is an enablement flag for several other properties that control wh
 ### PublishReferencesDocumentationFiles
 
 When this property is `true`, XML documentation files for the project's references are copied to the publish directory, instead of just run-time assets like DLL files. This property defaults to `true`.
+
+### PublishReferencesSymbols
+
+When this property is `true`, symbol files (also known as PDB files) for the project's references are copied to the publish directory. This property defaults to `true`.
 
 ### PublishRelease
 


### PR DESCRIPTION
## Summary

https://github.com/dotnet/sdk/pull/49707 added a new publish-related property `PublishReferencesSymbols`. Add the corresponding doc.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/project-sdk/msbuild-props.md](https://github.com/dotnet/docs/blob/cb00d3cd45f08467cfb0ac54c0f33c3149c21886/docs/core/project-sdk/msbuild-props.md) | [MSBuild reference for .NET SDK projects](https://review.learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props?branch=pr-en-us-50255) |


<!-- PREVIEW-TABLE-END -->