### PR TITLE
Fix typo in F# pattern matching code example

### DIFF
--- a/docs/fsharp/language-reference/pattern-matching.md
+++ b/docs/fsharp/language-reference/pattern-matching.md
@@ -289,7 +289,7 @@ let len (str: string | null) =
 Similarly, you can use new dedicated nullability related [patterns](./active-patterns.md):
 
 ```fsharp
-let let str =       // str is inferred to be `string | null`
+let len str =       // str is inferred to be `string | null`
     match str with
     | Null -> -1
     | NonNull (s: string) -> s.Length


### PR DESCRIPTION
## Summary

Simply fixes a tiny typo in an F# code sample.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/pattern-matching.md](https://github.com/dotnet/docs/blob/3b85eba77485fdbf3035c155c317e30fde73c7e7/docs/fsharp/language-reference/pattern-matching.md) | [Pattern Matching](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/pattern-matching?branch=pr-en-us-50284) |

<!-- PREVIEW-TABLE-END -->