### PR TITLE
Remove indication that self-contained option accepts true/false

### DIFF
--- a/includes/cli-no-self-contained.md
+++ b/includes/cli-no-self-contained.md
@@ -1,7 +1,7 @@
 ---
-ms.date: 10/01/2025
+ms.date: 12/03/2025
 ms.topic: include
 ---
 **`--no-self-contained`**
 
-Equivalent to `--self-contained false`.
+Publish your application as a framework dependent application. A compatible .NET runtime must be installed on the target machine to run your application.

--- a/includes/cli-no-self-contained.md
+++ b/includes/cli-no-self-contained.md
@@ -4,4 +4,4 @@ ms.topic: include
 ---
 **`--no-self-contained`**
 
-Publish your application as a framework dependent application. A compatible .NET runtime must be installed on the target machine to run your application.
+Publish your application as a framework-dependent application. A compatible .NET runtime must be installed on the target machine to run your application.

--- a/includes/cli-self-contained.md
+++ b/includes/cli-self-contained.md
@@ -1,7 +1,7 @@
 ---
-ms.date: 10/01/2025
+ms.date: 12/03/2025
 ms.topic: include
 ---
 **`--sc|--self-contained`**
 
-Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine. The default is `true`.
+Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.


### PR DESCRIPTION
## Summary

This pull request updates documentation for .NET CLI publishing options to clarify the behavior of the `--self-contained` and `--no-self-contained` options so they don't indicate true/false can be passed. 

