### PR TITLE
Unhyphenate run-time

### DIFF
--- a/docs/core/testing/mstest-analyzers/mstest0050.md
+++ b/docs/core/testing/mstest-analyzers/mstest0050.md
@@ -40,4 +40,4 @@ Ensure that global test fixture methods follow the required layout.
 
 ## When to suppress warnings
 
-Don't suppress warnings from this rule. Invalid global test fixture methods will not execute at run-time.
+Don't suppress warnings from this rule. Invalid global test fixture methods will not execute at runtime.

--- a/docs/framework/windows-workflow-foundation/samples/non-generic-foreach.md
+++ b/docs/framework/windows-workflow-foundation/samples/non-generic-foreach.md
@@ -40,7 +40,7 @@ public class ForEach : NativeActivity
  The <xref:System.Activities.ActivityAction> of type <xref:System.Object>, which is executed for each element in the collection. Each individual element is passed into the Body through its `Argument` property.
 
  Values (optional)
- The collection of elements that are iterated over. Ensuring that all elements of the collection are of compatible types is done at run-time.
+ The collection of elements that are iterated over. Ensuring that all elements of the collection are of compatible types is done at runtime.
 
 ## Example of Using ForEach
 

--- a/docs/framework/windows-workflow-foundation/samples/non-generic-parallelforeach.md
+++ b/docs/framework/windows-workflow-foundation/samples/non-generic-parallelforeach.md
@@ -45,7 +45,7 @@ Body (optional)\
 The <xref:System.Activities.ActivityAction> of type <xref:System.Object>, which is executed for each element in the collection. Each individual element is passed into the Body through its Argument property.
 
 Values (optional)\
-The collection of elements that are iterated over. Ensuring that all elements of the collection are of compatible types is done at run-time.
+The collection of elements that are iterated over. Ensuring that all elements of the collection are of compatible types is done at runtime.
 
 CompletionCondition (optional)\
 The <xref:System.Activities.Statements.ParallelForEach%601.CompletionCondition%2A> property is evaluated after any iteration completes. If it evaluates to `true`, then the scheduled pending iterations are canceled. If this property is not set, all activities in the Branches collection execute until completion.

--- a/docs/fsharp/language-reference/literals.md
+++ b/docs/fsharp/language-reference/literals.md
@@ -39,10 +39,10 @@ The following table shows the literal types in F#. Characters that represent dig
 
 Values that are intended to be constants can be marked with the [Literal](https://fsharp.github.io/fsharp-core-docs/reference/fsharp-core-literalattribute.html) attribute.
 
-This attribute has the effect of causing a value to be compiled as a constant. In the following example, both `x` and `y` below are immutable values, but `x` is evaluated at run-time, whereas `y` is a compile-time constant.
+This attribute has the effect of causing a value to be compiled as a constant. In the following example, both `x` and `y` below are immutable values, but `x` is evaluated at runtime, whereas `y` is a compile-time constant.
 
 ```fsharp
-let x = "a" + "b" // evaluated at run-time
+let x = "a" + "b" // evaluated at runtime
 
 [<Literal>]
 let y = "a" + "b" // evaluated at compile-time

--- a/docs/standard/commandline/how-to-enable-tab-completion.md
+++ b/docs/standard/commandline/how-to-enable-tab-completion.md
@@ -44,7 +44,7 @@ Once the user's shell is set up and the executable is registered, completions wi
 
 For *cmd.exe* on Windows (the Windows Command Prompt) there is no pluggable tab completion mechanism, so no shim script is available. For other shells, [look for a GitHub issue that is labeled `Area-Completions`](https://github.com/dotnet/command-line-api/issues?q=is%3Aissue+is%3Aopen+label%3A%22Area-Completions%22). If you don't find an issue, you can [open a new one](https://github.com/dotnet/command-line-api/issues).
 
-## Get tab completion values at run-time
+## Get tab completion values at runtime
 
 The following code shows an app that retrieves values for tab completion dynamically at runtime. The code gets a list of the next two weeks of dates following the current date. The list is provided to the `--date` option by calling `CompletionSources.Add`:
 


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/mstest-analyzers/mstest0050.md](https://github.com/dotnet/docs/blob/2fa8721e1ce855fab912e9944637eb03a69e8a5e/docs/core/testing/mstest-analyzers/mstest0050.md) | [MSTEST0050: Global test fixture should be valid](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0050?branch=pr-en-us-50358) |
| [docs/framework/windows-workflow-foundation/samples/non-generic-foreach.md](https://github.com/dotnet/docs/blob/2fa8721e1ce855fab912e9944637eb03a69e8a5e/docs/framework/windows-workflow-foundation/samples/non-generic-foreach.md) | ["Non-Generic ForEach"](https://review.learn.microsoft.com/en-us/dotnet/framework/windows-workflow-foundation/samples/non-generic-foreach?branch=pr-en-us-50358) |
| [docs/framework/windows-workflow-foundation/samples/non-generic-parallelforeach.md](https://github.com/dotnet/docs/blob/2fa8721e1ce855fab912e9944637eb03a69e8a5e/docs/framework/windows-workflow-foundation/samples/non-generic-parallelforeach.md) | [Non-generic ParallelForEach](https://review.learn.microsoft.com/en-us/dotnet/framework/windows-workflow-foundation/samples/non-generic-parallelforeach?branch=pr-en-us-50358) |
| [docs/fsharp/language-reference/literals.md](https://github.com/dotnet/docs/blob/2fa8721e1ce855fab912e9944637eb03a69e8a5e/docs/fsharp/language-reference/literals.md) | [docs/fsharp/language-reference/literals](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/literals?branch=pr-en-us-50358) |
| [docs/standard/commandline/how-to-enable-tab-completion.md](https://github.com/dotnet/docs/blob/2fa8721e1ce855fab912e9944637eb03a69e8a5e/docs/standard/commandline/how-to-enable-tab-completion.md) | [Tab completion for System.CommandLine](https://review.learn.microsoft.com/en-us/dotnet/standard/commandline/how-to-enable-tab-completion?branch=pr-en-us-50358) |

<!-- PREVIEW-TABLE-END -->