### PR TITLE
Update NuGet auditing details for dotnet restore

### DIFF
--- a/docs/core/tools/dotnet-restore.md
+++ b/docs/core/tools/dotnet-restore.md
@@ -199,15 +199,18 @@ Starting in .NET 8, `dotnet restore` includes NuGet security auditing. This audi
 
 To opt out of the security auditing, set the `<NuGetAudit>` MSBuild property to `false` in your project file.
 
-To retrieve the known vulnerability dataset from the NuGet.org central registry, define the following in the *nuget.config* file:
+Starting in .NET 9, [`auditSources`](/nuget/reference/nuget-config-file#auditsources) can be used in addition to [`packageSources`](/nuget/reference/nuget-config-file#packagesources) to get vulnerability data. If no audit sources are provided, `dotnet restore` uses package sources instead. NuGet audits any source as long as the source provides the [`VulnerabilityInfo` resource](/nuget/api/vulnerability-info).
+
+To list NuGet.org as an audit source, define the following in the *nuget.config* file:
 
 ```xml
-<packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-</packageSources>
+<configuration>
+    <auditSources>
+        <clear />
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    </auditSources>
+</configuration>
 ```
-
-NuGet.org is the only package source that provides a vulnerability dataset for NuGet auditing. However, NuGet audits any source as long as the source provides the [`VulnerabilityInfo` resource](/nuget/api/vulnerability-info).
 
 You can configure the level at which auditing will fail by setting the `<NuGetAuditLevel>` MSBuild property. Possible values are `low`, `moderate`, `high`, and `critical`. For example if you only want to see moderate, high, and critical advisories, you can set the property to `moderate`.
 

--- a/docs/core/tools/dotnet-restore.md
+++ b/docs/core/tools/dotnet-restore.md
@@ -199,7 +199,7 @@ Starting in .NET 8, `dotnet restore` includes NuGet security auditing. This audi
 
 To opt out of the security auditing, set the `<NuGetAudit>` MSBuild property to `false` in your project file.
 
-Starting in .NET 9, [`auditSources`](/nuget/reference/nuget-config-file#auditsources) can be used in addition to [`packageSources`](/nuget/reference/nuget-config-file#packagesources) to get vulnerability data. If no audit sources are provided, `dotnet restore` uses package sources instead. NuGet audits any source as long as the source provides the [`VulnerabilityInfo` resource](/nuget/api/vulnerability-info).
+To get vulnerability data, starting in .NET 9, you can use [`auditSources`](/nuget/reference/nuget-config-file#auditsources) in addition to [`packageSources`](/nuget/reference/nuget-config-file#packagesources). If no audit sources are provided, `dotnet restore` uses package sources instead. NuGet audits any source as long as the source provides the [`VulnerabilityInfo` resource](/nuget/api/vulnerability-info).
 
 To list NuGet.org as an audit source, define the following in the *nuget.config* file:
 


### PR DESCRIPTION
## Summary

This pull request updates the documentation for NuGet security auditing in the context of `dotnet restore`, focusing on new configuration options available in .NET 9 and clarifying how vulnerability data sources are specified.

NuGet security auditing configuration:

* Added documentation for the new `auditSources` element in `nuget.config`, available starting in .NET 9, which allows specifying sources for vulnerability data separately from package sources. If no audit sources are defined, package sources are used by default.
* Provided an updated example for listing NuGet.org as an audit source using the `auditSources` configuration block.
* Clarified that NuGet audits any source as long as it provides the `VulnerabilityInfo` resource, and removed outdated information about package sources.

Contributes to #39212 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-restore.md](https://github.com/dotnet/docs/blob/f9ffec2d7276f5fb0088d049f9f0c789b36f32d5/docs/core/tools/dotnet-restore.md) | [dotnet restore](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-restore?branch=pr-en-us-50367) |


<!-- PREVIEW-TABLE-END -->