### PR TITLE
Add file-based apps reference

### DIFF
--- a/docs/core/sdk/file-based-apps.md
+++ b/docs/core/sdk/file-based-apps.md
@@ -1,0 +1,349 @@
+---
+title: File-based C# apps
+description: Learn how to create, build, and run C# applications from a single file without a project file.
+ms.date: 12/05/2025
+ai-usage: ai-assisted
+---
+# File-based C# apps
+
+**This article applies to:** ✔️ .NET 10 SDK and later versions
+
+File-based apps let you build, run, and publish .NET applications from a single C# file without creating a traditional project file. This approach simplifies development for scripts, utilities, and small applications. The .NET SDK automatically generates the necessary project configuration based on directives in your source file.
+
+## Overview
+
+File-based apps offer a lightweight alternative to traditional .NET projects. Instead of maintaining separate `.csproj` files, you embed configuration directly in your C# source file using special directives. The .NET CLI processes these directives to build and run your application.
+
+Key benefits include:
+
+- Reduced boilerplate for simple applications
+- Self-contained source files with embedded configuration
+- Native AOT publishing enabled by default
+- Automatic packaging as .NET tools
+
+## Supported directives
+
+File-based apps use directives prefixed with `#:` to configure the build. Place these directives at the top of your C# file.
+
+### `#:package`
+
+Adds a NuGet package reference to your application.
+
+```csharp
+#:package Newtonsoft.Json
+#:package Serilog version="3.1.1"
+```
+
+### `#:property`
+
+Sets an MSBuild property value.
+
+```csharp
+#:property TargetFramework=net9.0
+#:property PublishAot=false
+```
+
+### `#:sdk`
+
+Specifies the SDK to use. Defaults to `Microsoft.NET.Sdk`.
+
+```csharp
+#:sdk Microsoft.NET.Sdk.Web
+```
+
+### `#:project`
+
+References another project file.
+
+```csharp
+#:project ../SharedLibrary/SharedLibrary.csproj
+```
+
+## CLI commands
+
+The .NET CLI provides full support for file-based apps through familiar commands.
+
+### Run applications
+
+Run a file-based app directly:
+
+```dotnetcli
+dotnet run file.cs
+```
+
+Or use the shorthand syntax:
+
+```dotnetcli
+dotnet file.cs
+```
+
+#### Pass arguments
+
+Pass arguments to your application in several ways:
+
+```dotnetcli
+dotnet run file.cs -- arg1 arg2
+```
+
+Arguments after `--` are passed to your application. Without `--`, arguments go to the `dotnet run` command:
+
+```dotnetcli
+dotnet run file.cs arg1 arg2
+```
+
+With the shorthand syntax, all arguments go to your application:
+
+```dotnetcli
+dotnet file.cs arg1 arg2
+```
+
+### Restore dependencies
+
+Restore NuGet packages referenced in your file:
+
+```dotnetcli
+dotnet restore file.cs
+```
+
+Restore runs implicitly when you build or run your application.
+
+### Build applications
+
+Compile your file-based app:
+
+```dotnetcli
+dotnet build file.cs
+```
+
+The SDK generates a temporary project and builds your application.
+
+### Publish applications
+
+Create a deployment package:
+
+```dotnetcli
+dotnet publish file.cs
+```
+
+File-based apps enable native AOT publishing by default, producing optimized, self-contained executables.
+
+### Package as tool
+
+Package your file-based app as a .NET tool:
+
+```dotnetcli
+dotnet pack file.cs
+```
+
+File-based apps set `PackAsTool=true` by default.
+
+### Convert to project
+
+Convert your file-based app to a traditional project:
+
+```dotnetcli
+dotnet project convert file.cs
+```
+
+This command creates a `.csproj` file with equivalent configuration.
+
+### Clean build outputs
+
+Remove build artifacts:
+
+```dotnetcli
+dotnet clean file.cs
+```
+
+Clean all file-based apps in a directory:
+
+```dotnetcli
+dotnet clean file-based-apps
+```
+
+## Default included items
+
+File-based apps automatically include specific file types for compilation and packaging.
+
+### Standard includes
+
+By default, the following items are included:
+
+- The single C# file itself
+- ResX resource files in the same directory
+
+### SDK-specific includes
+
+Different SDKs include additional file types:
+
+- `Microsoft.NET.Sdk.Web` includes `*.json` configuration files
+- Other specialized SDKs might include additional patterns
+
+## Native AOT publishing
+
+File-based apps enable native ahead-of-time (AOT) compilation by default. This produces optimized, self-contained executables with faster startup and smaller memory footprint.
+
+Disable native AOT if needed:
+
+```csharp
+#:property PublishAot=false
+```
+
+For more information about native AOT, see [Native AOT deployment](../deploying/native-aot/index.md).
+
+## User secrets
+
+File-based apps generate a stable user secrets ID based on a hash of the full file path. This lets you store sensitive configuration separately from your source code.
+
+Access user secrets the same way as traditional projects:
+
+```dotnetcli
+dotnet user-secrets set "ApiKey" "your-secret-value" --project file.cs
+```
+
+For more information, see [Safe storage of app secrets in development](/aspnet/core/security/app-secrets).
+
+## Shell execution
+
+Enable direct execution of file-based apps on Unix-like systems using a shebang line and executable permissions.
+
+Add a shebang at the top of your file:
+
+```csharp
+#!/usr/bin/env dotnet
+#:package Spectre.Console
+
+using Spectre.Console;
+
+AnsiConsole.MarkupLine("[green]Hello, World![/]");
+```
+
+Make the file executable:
+
+```bash
+chmod +x file.cs
+```
+
+Run directly:
+
+```bash
+./file.cs
+```
+
+## Implicit build files
+
+File-based apps respect MSBuild and NuGet configuration files in the same directory or parent directories. These files affect how the SDK builds your application.
+
+### `Directory.Build.props`
+
+Defines MSBuild properties that apply to all projects in a directory tree. File-based apps inherit these properties.
+
+### `Directory.Build.targets`
+
+Defines MSBuild targets and custom build logic. File-based apps execute these targets during build.
+
+### `Directory.Packages.props`
+
+Enables central package management for NuGet dependencies. File-based apps can use centrally managed package versions.
+
+### `nuget.config`
+
+Configures NuGet package sources and settings. File-based apps use these configurations when restoring packages.
+
+### `global.json`
+
+Specifies the .NET SDK version to use. File-based apps respect this version selection.
+
+Be mindful of these files when organizing your file-based apps. They can unexpectedly affect build behavior.
+
+## Build caching
+
+The .NET SDK caches build outputs to improve performance on subsequent builds. File-based apps participate in this caching system.
+
+### Cache behavior
+
+Build outputs are cached based on:
+
+- Source file content
+- Directive configuration
+- SDK version
+- Implicit build files
+
+### Cache impacts
+
+Caching improves build performance but can cause confusion:
+
+- Changes to implicit build files might not trigger rebuilds
+- Moving files to different directories might not invalidate cache
+
+### Workarounds
+
+Force a clean build to bypass cache:
+
+```dotnetcli
+dotnet clean file.cs
+dotnet build file.cs
+```
+
+Or delete the `obj` and `bin` directories manually.
+
+## Folder layout recommendations
+
+Organize your file-based apps carefully to avoid conflicts with traditional projects and implicit build files.
+
+### Avoid project file cones
+
+Don't place file-based apps within the directory structure of a `.csproj` project. The project file's implicit build files and settings can interfere with your file-based app.
+
+❌ **Not recommended:**
+
+```
+MyProject/
+├── MyProject.csproj
+├── Program.cs
+└── scripts/
+    └── utility.cs  // File-based app - bad location
+```
+
+✅ **Recommended:**
+
+```
+MyProject/
+├── MyProject.csproj
+└── Program.cs
+scripts/
+└── utility.cs  // File-based app - good location
+```
+
+### Be mindful of implicit files
+
+Implicit build files in parent directories affect all file-based apps in subdirectories. Create isolated directories for file-based apps when you need different build configurations.
+
+❌ **Not recommended:**
+
+```
+repo/
+├── Directory.Build.props  // Affects everything below
+├── app1.cs
+└── app2.cs
+```
+
+✅ **Recommended:**
+
+```
+repo/
+├── Directory.Build.props
+├── projects/
+│   └── MyProject.csproj
+└── scripts/
+    ├── Directory.Build.props  // Isolated configuration
+    ├── app1.cs
+    └── app2.cs
+```
+
+## See also
+
+- [.NET CLI overview](index.md)
+- [dotnet run command](dotnet-run.md)
+- [dotnet build command](dotnet-build.md)
+- [Native AOT deployment](../deploying/native-aot/index.md)

--- a/docs/core/sdk/file-based-apps.md
+++ b/docs/core/sdk/file-based-apps.md
@@ -8,22 +8,20 @@ ai-usage: ai-assisted
 
 **This article applies to:** ✔️ .NET 10 SDK and later versions
 
-File-based apps let you build, run, and publish .NET applications from a single C# file without creating a traditional project file. This approach simplifies development for scripts, utilities, and small applications. The .NET SDK automatically generates the necessary project configuration based on directives in your source file.
-
-## Overview
-
-File-based apps offer a lightweight alternative to traditional .NET projects. Instead of maintaining separate `.csproj` files, you embed configuration directly in your C# source file using special directives. The .NET CLI processes these directives to build and run your application.
+File-based apps let you build, run, and publish .NET applications from a single C# file without creating a traditional project file. They offer a lightweight alternative to traditional .NET projects. This approach simplifies development for scripts, utilities, and small applications. The .NET SDK automatically generates the necessary project configuration based on the directives in your source file.
 
 Key benefits include:
 
-- Reduced boilerplate for simple applications
-- Self-contained source files with embedded configuration
-- Native AOT publishing enabled by default
-- Automatic packaging as .NET tools
+- Reduced boilerplate for simple applications.
+- Self-contained source files with embedded configuration.
+- Native AOT publishing enabled by default.
+- Automatic packaging as .NET tools.
+
+In this article, learn more about how to use file-based apps successfully.
 
 ## Supported directives
 
-File-based apps use directives prefixed with `#:` to configure the build. Place these directives at the top of your C# file.
+File-based apps use directives prefixed with `#:` to configure the build and run your application. Supported directives include: `#:package`, `#:project`, `#:property`, and `#:sdk`. Place these directives at the top of your C# file.
 
 ### `#:package`
 
@@ -34,12 +32,20 @@ Adds a NuGet package reference to your application.
 #:package Serilog version="3.1.1"
 ```
 
-### `#:property`
+### `#:project`
 
-Sets an MSBuild property value.
+References another project file.
 
 ```csharp
-#:property TargetFramework=net9.0
+#:project ../SharedLibrary/SharedLibrary.csproj
+```
+
+### `#:property`
+
+Sets a MSBuild property value.
+
+```csharp
+#:property TargetFramework=net10.0
 #:property PublishAot=false
 ```
 
@@ -51,21 +57,13 @@ Specifies the SDK to use. Defaults to `Microsoft.NET.Sdk`.
 #:sdk Microsoft.NET.Sdk.Web
 ```
 
-### `#:project`
-
-References another project file.
-
-```csharp
-#:project ../SharedLibrary/SharedLibrary.csproj
-```
-
 ## CLI commands
 
 The .NET CLI provides full support for file-based apps through familiar commands.
 
 ### Run applications
 
-Run a file-based app directly:
+Run a file-based app directly using the `dotnet run` command:
 
 ```dotnetcli
 dotnet run file.cs
@@ -97,19 +95,9 @@ With the shorthand syntax, all arguments go to your application:
 dotnet file.cs arg1 arg2
 ```
 
-### Restore dependencies
-
-Restore NuGet packages referenced in your file:
-
-```dotnetcli
-dotnet restore file.cs
-```
-
-Restore runs implicitly when you build or run your application.
-
 ### Build applications
 
-Compile your file-based app:
+Compile your file-based app using the `dotnet build` command:
 
 ```dotnetcli
 dotnet build file.cs
@@ -117,39 +105,9 @@ dotnet build file.cs
 
 The SDK generates a temporary project and builds your application.
 
-### Publish applications
-
-Create a deployment package:
-
-```dotnetcli
-dotnet publish file.cs
-```
-
-File-based apps enable native AOT publishing by default, producing optimized, self-contained executables.
-
-### Package as tool
-
-Package your file-based app as a .NET tool:
-
-```dotnetcli
-dotnet pack file.cs
-```
-
-File-based apps set `PackAsTool=true` by default.
-
-### Convert to project
-
-Convert your file-based app to a traditional project:
-
-```dotnetcli
-dotnet project convert file.cs
-```
-
-This command creates a `.csproj` file with equivalent configuration.
-
 ### Clean build outputs
 
-Remove build artifacts:
+Remove build artifacts using the `dotnet clean` command:
 
 ```dotnetcli
 dotnet clean file.cs
@@ -161,27 +119,63 @@ Clean all file-based apps in a directory:
 dotnet clean file-based-apps
 ```
 
+### Publish applications
+
+Create a deployment package using the `dotnet publish` command:
+
+```dotnetcli
+dotnet publish file.cs
+```
+
+File-based apps enable native AOT publishing by default, producing optimized, self-contained executables.
+
+### Package as tool
+
+Package your file-based app as a .NET tool using the `dotnet pack` command:
+
+```dotnetcli
+dotnet pack file.cs
+```
+
+File-based apps set `PackAsTool=true` by default.
+
+### Convert to project
+
+Convert your file-based app to a traditional project using the `dotnet project convert` command:
+
+```dotnetcli
+dotnet project convert file.cs
+```
+
+This command creates a `.csproj` file with equivalent SDK and properties. All `#` directives are removed from the `.cs` files and turned into elements in the corresponding `.csproj` files.
+
+### Restore dependencies
+
+Restore NuGet packages referenced in your file using the `dotnet restore` command:
+
+```dotnetcli
+dotnet restore file.cs
+```
+
+Restore runs implicitly when you build or run your application.
+
 ## Default included items
 
 File-based apps automatically include specific file types for compilation and packaging.
 
-### Standard includes
-
 By default, the following items are included:
 
-- The single C# file itself
-- ResX resource files in the same directory
+- The single C# file itself.
+- ResX resource files in the same directory.
 
-### SDK-specific includes
+Different SDKs include other file types:
 
-Different SDKs include additional file types:
-
-- `Microsoft.NET.Sdk.Web` includes `*.json` configuration files
-- Other specialized SDKs might include additional patterns
+- `Microsoft.NET.Sdk.Web` includes `*.json` configuration files.
+- Other specialized SDKs might include other patterns.
 
 ## Native AOT publishing
 
-File-based apps enable native ahead-of-time (AOT) compilation by default. This produces optimized, self-contained executables with faster startup and smaller memory footprint.
+File-based apps enable native ahead-of-time (AOT) compilation by default. This feature produces optimized, self-contained executables with faster startup, and a smaller memory footprint.
 
 If you need to disable native AOT, use the following setting:
 
@@ -232,7 +226,7 @@ Run directly:
 
 ## Implicit build files
 
-File-based apps respect MSBuild and NuGet configuration files in the same directory or parent directories. These files affect how the SDK builds your application.
+File-based apps respect MSBuild and NuGet configuration files in the same directory or parent directories. These files affect how the SDK builds your application. Be mindful of these files when organizing your file-based apps.
 
 ### `Directory.Build.props`
 
@@ -254,8 +248,6 @@ Configures NuGet package sources and settings. File-based apps use these configu
 
 Specifies the .NET SDK version to use. File-based apps respect this version selection.
 
-Be mindful of these files when organizing your file-based apps. They can unexpectedly affect build behavior.
-
 ## Build caching
 
 The .NET SDK caches build outputs to improve performance on subsequent builds. File-based apps participate in this caching system.
@@ -269,23 +261,25 @@ The SDK caches build outputs based on:
 - SDK version
 - Implicit build files
 
-### Cache impacts
-
 Caching improves build performance but can cause confusion:
 
-- Changes to implicit build files might not trigger rebuilds
-- Moving files to different directories might not invalidate cache
+- Changes to implicit build files might not trigger rebuilds.
+- Moving files to different directories might not invalidate cache.
 
 ### Workarounds
 
-Force a clean build to bypass cache:
+- Run a full build using the `--no-cache` flag:
 
-```dotnetcli
-dotnet clean file.cs
-dotnet build file.cs
-```
+  ```dotnetcli
+  dotnet build file.cs --no-cache
+  ```
 
-Or delete the `obj` and `bin` directories manually.
+- Force a clean build to bypass cache:
+
+  ```dotnetcli
+  dotnet clean file.cs
+  dotnet build file.cs
+  ```
 
 ## Folder layout recommendations
 

--- a/docs/core/sdk/file-based-apps.md
+++ b/docs/core/sdk/file-based-apps.md
@@ -344,6 +344,6 @@ repo/
 ## See also
 
 - [.NET SDK overview](../sdk.md)
-- [dotnet run command](../toolsdotnet-run.md)
-- [dotnet build command](../toolsdotnet-build.md)
+- [dotnet run command](../tools/dotnet-run.md)
+- [dotnet build command](../tools/dotnet-build.md)
 - [Native AOT deployment](../deploying/native-aot/index.md)

--- a/docs/core/sdk/file-based-apps.md
+++ b/docs/core/sdk/file-based-apps.md
@@ -197,6 +197,69 @@ dotnet user-secrets set "ApiKey" "your-secret-value" --project file.cs
 
 For more information, see [Safe storage of app secrets in development](/aspnet/core/security/app-secrets).
 
+## Launch profiles
+
+File-based apps support launch profiles for configuring how the application runs during development. Instead of placing launch profiles in `Properties/launchSettings.json`, file-based apps can use a flat launch settings file named `[ApplicationName].run.json` in the same directory as the source file.
+
+### Flat launch settings file
+
+Create a launch settings file named after your application. For example, if your file-based app is `app.cs`, create `app.run.json` in the same directory:
+
+```json
+{
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}
+```
+
+### Multiple file-based apps
+
+When you have multiple file-based apps in the same directory, each app can have its own launch settings file:
+
+```Directory
+📁 myapps/
+├── foo.cs
+├── foo.run.json
+├── bar.cs
+└── bar.run.json
+```
+
+### Profile selection
+
+The .NET CLI selects launch profiles using the following priority:
+
+1. The profile specified by the `--launch-profile` option.
+1. The profile specified by the `DOTNET_LAUNCH_PROFILE` environment variable.
+1. The first profile defined in the launch settings file.
+
+To run with a specific profile:
+
+```dotnetcli
+dotnet run app.cs --launch-profile https
+```
+
+### Traditional launch settings
+
+File-based apps also support the traditional `Properties/launchSettings.json` file. If both files exist, the traditional location takes priority. If both files are present, the .NET CLI logs a warning to clarify which file is used.
+
 ## Shell execution
 
 Enable direct execution of file-based apps on Unix-like systems by using a shebang line and executable permissions.
@@ -263,8 +326,8 @@ The SDK caches build outputs based on:
 
 Caching improves build performance but can cause confusion when:
 
-- Changes to implicit build files might not trigger rebuilds.
-- Moving files to different directories might not invalidate cache.
+- Changes to implicit build files don't trigger rebuilds.
+- Moving files to different directories doesn't invalidate cache.
 
 ### Workarounds
 

--- a/docs/core/sdk/file-based-apps.md
+++ b/docs/core/sdk/file-based-apps.md
@@ -1,10 +1,10 @@
 ---
-title: File-based C# apps
+title: File-based apps
 description: Learn how to create, build, and run C# applications from a single file without a project file.
 ms.date: 12/05/2025
 ai-usage: ai-assisted
 ---
-# File-based C# apps
+# File-based apps
 
 **This article applies to:** ✔️ .NET 10 SDK and later versions
 
@@ -183,7 +183,7 @@ Different SDKs include additional file types:
 
 File-based apps enable native ahead-of-time (AOT) compilation by default. This produces optimized, self-contained executables with faster startup and smaller memory footprint.
 
-Disable native AOT if needed:
+If you need to disable native AOT, use the following setting:
 
 ```csharp
 #:property PublishAot=false
@@ -193,7 +193,7 @@ For more information about native AOT, see [Native AOT deployment](../deploying/
 
 ## User secrets
 
-File-based apps generate a stable user secrets ID based on a hash of the full file path. This lets you store sensitive configuration separately from your source code.
+File-based apps generate a stable user secrets ID based on a hash of the full file path. This ID lets you store sensitive configuration separately from your source code.
 
 Access user secrets the same way as traditional projects:
 
@@ -205,7 +205,7 @@ For more information, see [Safe storage of app secrets in development](/aspnet/c
 
 ## Shell execution
 
-Enable direct execution of file-based apps on Unix-like systems using a shebang line and executable permissions.
+Enable direct execution of file-based apps on Unix-like systems by using a shebang line and executable permissions.
 
 Add a shebang at the top of your file:
 
@@ -262,7 +262,7 @@ The .NET SDK caches build outputs to improve performance on subsequent builds. F
 
 ### Cache behavior
 
-Build outputs are cached based on:
+The SDK caches build outputs based on:
 
 - Source file content
 - Directive configuration
@@ -343,7 +343,7 @@ repo/
 
 ## See also
 
-- [.NET CLI overview](index.md)
-- [dotnet run command](dotnet-run.md)
-- [dotnet build command](dotnet-build.md)
+- [.NET SDK overview](../sdk.md)
+- [dotnet run command](../toolsdotnet-run.md)
+- [dotnet build command](../toolsdotnet-build.md)
 - [Native AOT deployment](../deploying/native-aot/index.md)

--- a/docs/core/sdk/file-based-apps.md
+++ b/docs/core/sdk/file-based-apps.md
@@ -21,7 +21,7 @@ In this article, learn how to create, configure, and work with file-based apps e
 
 ## Supported directives
 
-File-based apps use directives prefixed with `#:` to configure the build and run your application. Supported directives include: `#:package`, `#:project`, `#:property`, and `#:sdk`. Place these directives at the top of your C# file.
+File-based apps use directives prefixed with `#:` to configure the build and run the application. Supported directives include: `#:package`, `#:project`, `#:property`, and `#:sdk`. Place these directives at the top of the C# file.
 
 ### `#:package`
 
@@ -34,7 +34,7 @@ Adds a NuGet package reference to your application.
 
 ### `#:project`
 
-References another project file.
+References another project file or directory that contains a project file.
 
 ```csharp
 #:project ../SharedLibrary/SharedLibrary.csproj
@@ -42,7 +42,7 @@ References another project file.
 
 ### `#:property`
 
-Sets the MSBuild property value.
+Sets an MSBuild property value.
 
 ```csharp
 #:property TargetFramework=net10.0
@@ -89,7 +89,7 @@ Arguments after `--` are passed to your application. Without `--`, arguments go 
 dotnet run file.cs arg1 arg2
 ```
 
-With the shorthand syntax, all arguments go to your application:
+However, with the shorthand syntax, all arguments go to your application:
 
 ```dotnetcli
 dotnet file.cs arg1 arg2
@@ -147,7 +147,7 @@ Convert your file-based app to a traditional project by using the `dotnet projec
 dotnet project convert file.cs
 ```
 
-This command creates a `.csproj` file with equivalent SDK and properties. All `#` directives are removed from the `.cs` files and turned into elements in the corresponding `.csproj` files.
+This command creates a `.csproj` file with equivalent SDK and properties. All `#` directives are removed from the `.cs` file and turned into elements in the corresponding `.csproj` file.
 
 ### Restore dependencies
 
@@ -175,7 +175,7 @@ Different SDKs include other file types:
 
 ## Native AOT publishing
 
-File-based apps enable native ahead-of-time (AOT) compilation by default. This feature produces optimized, self-contained executables with faster startup, and a smaller memory footprint.
+File-based apps enable native ahead-of-time (AOT) compilation by default. This feature produces optimized, self-contained executables with faster startup and a smaller memory footprint.
 
 If you need to disable native AOT, use the following setting:
 
@@ -291,21 +291,21 @@ Don't place file-based apps within the directory structure of a `.csproj` projec
 
 ❌ **Not recommended:**
 
-```
-MyProject/
+```Directory
+📁 MyProject/
 ├── MyProject.csproj
 ├── Program.cs
-└── scripts/
+└──📁 scripts/
     └── utility.cs  // File-based app - bad location
 ```
 
 ✅ **Recommended:**
 
-```
-MyProject/
+```Directory
+📁 MyProject/
 ├── MyProject.csproj
 └── Program.cs
-scripts/
+📁 scripts/
 └── utility.cs  // File-based app - good location
 ```
 
@@ -315,8 +315,8 @@ Implicit build files in parent directories affect all file-based apps in subdire
 
 ❌ **Not recommended:**
 
-```
-repo/
+```Directory
+📁 repo/
 ├── Directory.Build.props  // Affects everything below
 ├── app1.cs
 └── app2.cs
@@ -324,12 +324,12 @@ repo/
 
 ✅ **Recommended:**
 
-```
-repo/
+```Directory
+📁 repo/
 ├── Directory.Build.props
-├── projects/
+├──📁 projects/
 │   └── MyProject.csproj
-└── scripts/
+└──📁 scripts/
     ├── Directory.Build.props  // Isolated configuration
     ├── app1.cs
     └── app2.cs

--- a/docs/core/sdk/file-based-apps.md
+++ b/docs/core/sdk/file-based-apps.md
@@ -17,7 +17,7 @@ Key benefits include:
 - Native AOT publishing enabled by default.
 - Automatic packaging as .NET tools.
 
-In this article, learn more about how to use file-based apps successfully.
+In this article, learn how to create, configure, and work with file-based apps effectively.
 
 ## Supported directives
 
@@ -63,7 +63,7 @@ The .NET CLI provides full support for file-based apps through familiar commands
 
 ### Run applications
 
-Run a file-based app directly using the `dotnet run` command:
+Run a file-based app directly by using the `dotnet run` command:
 
 ```dotnetcli
 dotnet run file.cs
@@ -97,7 +97,7 @@ dotnet file.cs arg1 arg2
 
 ### Build applications
 
-Compile your file-based app using the `dotnet build` command:
+Compile your file-based app by using the `dotnet build` command:
 
 ```dotnetcli
 dotnet build file.cs
@@ -107,7 +107,7 @@ The SDK generates a temporary project and builds your application.
 
 ### Clean build outputs
 
-Remove build artifacts using the `dotnet clean` command:
+Remove build artifacts by using the `dotnet clean` command:
 
 ```dotnetcli
 dotnet clean file.cs
@@ -121,7 +121,7 @@ dotnet clean file-based-apps
 
 ### Publish applications
 
-Create a deployment package using the `dotnet publish` command:
+Create a deployment package by using the `dotnet publish` command:
 
 ```dotnetcli
 dotnet publish file.cs
@@ -131,7 +131,7 @@ File-based apps enable native AOT publishing by default, producing optimized, se
 
 ### Package as tool
 
-Package your file-based app as a .NET tool using the `dotnet pack` command:
+Package your file-based app as a .NET tool by using the `dotnet pack` command:
 
 ```dotnetcli
 dotnet pack file.cs
@@ -141,7 +141,7 @@ File-based apps set `PackAsTool=true` by default.
 
 ### Convert to project
 
-Convert your file-based app to a traditional project using the `dotnet project convert` command:
+Convert your file-based app to a traditional project by using the `dotnet project convert` command:
 
 ```dotnetcli
 dotnet project convert file.cs
@@ -151,7 +151,7 @@ This command creates a `.csproj` file with equivalent SDK and properties. All `#
 
 ### Restore dependencies
 
-Restore NuGet packages referenced in your file using the `dotnet restore` command:
+Restore NuGet packages referenced in your file by using the `dotnet restore` command:
 
 ```dotnetcli
 dotnet restore file.cs
@@ -268,7 +268,7 @@ Caching improves build performance but can cause confusion:
 
 ### Workarounds
 
-- Run a full build using the `--no-cache` flag:
+- Run a full build by using the `--no-cache` flag:
 
   ```dotnetcli
   dotnet build file.cs --no-cache

--- a/docs/core/sdk/file-based-apps.md
+++ b/docs/core/sdk/file-based-apps.md
@@ -42,7 +42,7 @@ References another project file.
 
 ### `#:property`
 
-Sets a MSBuild property value.
+Sets the MSBuild property value.
 
 ```csharp
 #:property TargetFramework=net10.0
@@ -256,12 +256,12 @@ The .NET SDK caches build outputs to improve performance on subsequent builds. F
 
 The SDK caches build outputs based on:
 
-- Source file content
-- Directive configuration
-- SDK version
-- Implicit build files
+- Source file content.
+- Directive configuration.
+- SDK version.
+- Implicit build files.
 
-Caching improves build performance but can cause confusion:
+Caching improves build performance but can cause confusion when:
 
 - Changes to implicit build files might not trigger rebuilds.
 - Moving files to different directories might not invalidate cache.

--- a/docs/navigate/tools-diagnostics/toc.yml
+++ b/docs/navigate/tools-diagnostics/toc.yml
@@ -9,6 +9,8 @@ items:
         href: ../../core/sdk.md
       - name: Environment variables
         href: ../../core/tools/dotnet-environment-variables.md
+      - name: File-based apps
+        href: ../../core/sdk/file-based-apps.md
       - name: dotnet-install scripts
         href: ../../core/tools/dotnet-install-script.md
       - name: global.json overview


### PR DESCRIPTION
## Summary

This pull request adds comprehensive documentation for file-based C# apps in the .NET SDK, targeting .NET 10 and later. It explains how developers can create, build, and run single-file C# applications without a traditional project file, including supported directives, CLI usage, publishing, caching, and best practices for folder layout. Additionally, the new documentation is integrated into the navigation sidebar for easy access.

**Documentation addition:**

* Added a new file, `docs/core/sdk/file-based-apps.md`, detailing the concept, usage, supported directives, CLI commands, publishing options, caching behavior, and folder layout recommendations for file-based C# apps in .NET 10+. This includes examples and guidance for native AOT publishing, user secrets, shell execution, and handling implicit build files.

**Navigation update:**

* Updated `docs/navigate/tools-diagnostics/toc.yml` to include a link to the new "File-based apps" documentation in the SDK section, making the topic discoverable from the sidebar.

Fixes #49957
Fixes #49929


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/sdk/file-based-apps.md](https://github.com/dotnet/docs/blob/bf6adbf3a7551fdeadc9440c9f538b7686eac62a/docs/core/sdk/file-based-apps.md) | [File-based apps](https://review.learn.microsoft.com/en-us/dotnet/core/sdk/file-based-apps?branch=pr-en-us-50371) |
| [docs/navigate/tools-diagnostics/toc.yml](https://github.com/dotnet/docs/blob/bf6adbf3a7551fdeadc9440c9f538b7686eac62a/docs/navigate/tools-diagnostics/toc.yml) | [docs/navigate/tools-diagnostics/toc](https://review.learn.microsoft.com/en-us/dotnet/navigate/tools-diagnostics/toc?branch=pr-en-us-50371) |


<!-- PREVIEW-TABLE-END -->