### PR TITLE
Typo fix for partial constructors in C# 14

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/constructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/constructors.md
@@ -62,7 +62,7 @@ A class can also have **both** an Instance and Static constructor defined, and t
 
 ## Partial constructors
 
-Beginning with C# 14, you can declare *partial constructors* in a partial class or struct. Any partial constructor must have a *defining declaration* and an *implementing declaration*. The signatures of the declaring and implementing partial constructors must match according to the rules of [partial members](./partial-classes-and-methods.md#partial-members). The defining declaration of the partial constructor can't use the `: base()` or `: this()` constructor initializer. You add any constructor initializer must be added on the implementing declaration.
+Beginning with C# 14, you can declare *partial constructors* in a partial class or struct. Any partial constructor must have a *defining declaration* and an *implementing declaration*. The signatures of the declaring and implementing partial constructors must match according to the rules of [partial members](./partial-classes-and-methods.md#partial-members). The defining declaration of the partial constructor can't use the `: base()` or `: this()` constructor initializer. Any constructor initializer must be added on the implementing declaration.
 
 ## See also
 


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/classes-and-structs/constructors.md](https://github.com/dotnet/docs/blob/e4782e1e15c2a9e5d184e35b5b630c0d8f41c2c1/docs/csharp/programming-guide/classes-and-structs/constructors.md) | [docs/csharp/programming-guide/classes-and-structs/constructors](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/constructors?branch=pr-en-us-50375) |

<!-- PREVIEW-TABLE-END -->