### PR TITLE
Add note about running dotnet-format only against trusted code

### DIFF
--- a/docs/core/tools/dotnet-format.md
+++ b/docs/core/tools/dotnet-format.md
@@ -35,7 +35,7 @@ dotnet format -h|--help
 The MSBuild project or solution to run code formatting on. If a project or solution file is not specified, MSBuild searches the current working directory for a file that has a file extension that ends in *proj* or *sln*, and uses that file.
 
 > [!CAUTION]
-> dotnet-format may restore, compile, and run analyzers from the specified project or solution.  Make sure to only invoke the tool against trusted code.
+> dotnet format may restore, compile, and run analyzers from the specified project or solution. Only invoke the tool against trusted code.
 
 ## Options
 

--- a/docs/core/tools/dotnet-format.md
+++ b/docs/core/tools/dotnet-format.md
@@ -34,8 +34,8 @@ dotnet format -h|--help
 
 The MSBuild project or solution to run code formatting on. If a project or solution file is not specified, MSBuild searches the current working directory for a file that has a file extension that ends in *proj* or *sln*, and uses that file.
 
-> [!WARNING]
-> dotnet-format may restore, compile, and run analyzers on the specified project or solution.  Make sure to only invoke the tool against trusted code.
+> [!CAUTION]
+> dotnet-format may restore, compile, and run analyzers from the specified project or solution.  Make sure to only invoke the tool against trusted code.
 
 ## Options
 

--- a/docs/core/tools/dotnet-format.md
+++ b/docs/core/tools/dotnet-format.md
@@ -34,6 +34,9 @@ dotnet format -h|--help
 
 The MSBuild project or solution to run code formatting on. If a project or solution file is not specified, MSBuild searches the current working directory for a file that has a file extension that ends in *proj* or *sln*, and uses that file.
 
+> [!WARNING]
+> dotnet-format may restore, compile, and run analyzers on the specified project or solution.  Make sure to only invoke the tool against trusted code.
+
 ## Options
 
 None of the options below are required for the `dotnet format` command to succeed, but you can use them to further customize what is formatted and by which rules.


### PR DESCRIPTION
## Summary

Add a note that dotnet-format should be only invoked against trusted code (outcome of a security review).


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-format.md](https://github.com/dotnet/docs/blob/8f6345c9b5f967b878b7676558b50a9c58c6dbae/docs/core/tools/dotnet-format.md) | [docs/core/tools/dotnet-format](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-format?branch=pr-en-us-50539) |


<!-- PREVIEW-TABLE-END -->