### PR TITLE
Update MSTest v4 migration documentation

### DIFF
--- a/docs/core/testing/unit-testing-mstest-migration-v3-v4.md
+++ b/docs/core/testing/unit-testing-mstest-migration-v3-v4.md
@@ -3,7 +3,7 @@ title: MSTest migration from v3 to v4
 description: Learn about migrating to MSTest v4.
 author: Youssef1313
 ms.author: ygerges
-ms.date: 07/22/2025
+ms.date: 12/11/2025
 ---
 
 # Migrate from MSTest v3 to v4
@@ -98,6 +98,20 @@ public static void ClassCleanup(TestContext testContext)
 ### TestContext.Properties is now IDictionary<string, object>
 
 Previously, `TestContext.Properties` was an `IDictionary`. To provide better typing, it's now `IDictionary<string, object>`.
+
+#### Accessing non-existing property
+
+Accessing a non-existing property in the dictionary will now throw `KeyNotFoundException` rather than returning null.
+
+```csharp
+// in MSTest 3.x
+var value = TestContext.Properties["NonExistent"]; // Returns null
+
+// in MSTest 4.x
+var value = TestContext.Properties["NonExistent"]; // Throws KeyNotFoundException
+```
+
+To check for existence of a property, use `TryGetValue` or `ContainsKey` methods.
 
 If you have calls to `TestContext.Properties.Contains`, update them to `TestContext.Properties.ContainsKey`.
 


### PR DESCRIPTION
Updated the date for MSTest v4 migration and added information about accessing non-existing properties in TestContext.Properties.

Related https://github.com/microsoft/testfx/issues/6952


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-mstest-migration-v3-v4.md](https://github.com/dotnet/docs/blob/cd65f4be351f05df6ea064b690a2f87123d7ecb3/docs/core/testing/unit-testing-mstest-migration-v3-v4.md) | [docs/core/testing/unit-testing-mstest-migration-v3-v4](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-migration-v3-v4?branch=pr-en-us-50543) |

<!-- PREVIEW-TABLE-END -->