### PR TITLE
Update linux-alpine for Alpine 3.23

### DIFF
--- a/docs/core/install/linux-alpine.md
+++ b/docs/core/install/linux-alpine.md
@@ -34,8 +34,6 @@ The following table is a list of currently supported .NET releases and the versi
 
 # [.NET 10](#tab/dotnet10)
 
-[!INCLUDE [linux-release-wait](includes/linux-release-wait.md)]
-
 [!INCLUDE [linux-apk-install-100](includes/linux-install-100-apk.md)]
 
 # [.NET 9](#tab/dotnet9)

--- a/docs/core/install/linux-alpine.md
+++ b/docs/core/install/linux-alpine.md
@@ -3,7 +3,7 @@ title: Install .NET on Alpine
 description: Learn about which versions of .NET SDK and .NET Runtime are supported, and how to install .NET on Alpine.
 author: adegeo
 ms.author: adegeo
-ms.date: 11/07/2025
+ms.date: 12/11/2025
 ms.custom: linux-related-content
 ---
 
@@ -23,6 +23,7 @@ The following table is a list of currently supported .NET releases and the versi
 
 | Alpine | Supported Version | Available in Package Manager |
 |--------|-------------------|------------------------------|
+| 3.23   | 10, 9, 8          | 10, 9, 8                     |
 | 3.22   | 10, 9, 8          | 9, 8                         |
 | 3.21   | 9, 8              | 9, 8                         |
 | 3.20   | 9, 8              | 8, 6                         |


### PR DESCRIPTION
## Summary

Adds 3.23 to to the list of Alpine versions, including mention that dotnet10 is packaged.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/linux-alpine.md](https://github.com/dotnet/docs/blob/ec754eddaa695096190226a035a2d35db519d03b/docs/core/install/linux-alpine.md) | [Install the .NET SDK or the .NET Runtime on Alpine](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-alpine?branch=pr-en-us-50545) |


<!-- PREVIEW-TABLE-END -->