### PR TITLE
Add link to extension members guide for Enum types

### DIFF
--- a/docs/csharp/language-reference/builtin-types/enum.md
+++ b/docs/csharp/language-reference/builtin-types/enum.md
@@ -97,6 +97,6 @@ For more information, see the following sections of the [C# language specificati
 - [Enumeration format strings](../../../standard/base-types/enumeration-format-strings.md)
 - [Design guidelines - Enum design](../../../standard/design-guidelines/enum.md)
 - [Design guidelines - Enum naming conventions](../../../standard/design-guidelines/names-of-classes-structs-and-interfaces.md#naming-enumerations)
-- [Design guidelines - Enum extension members](../../programming-guide/classes-and-structs/how-to-create-a-new-method-for-an-enumeration.md)
+- [C# programming guide - Enum extension members](../../programming-guide/classes-and-structs/how-to-create-a-new-method-for-an-enumeration.md)
 - [`switch` expression](../operators/switch-expression.md)
 - [`switch` statement](../statements/selection-statements.md#the-switch-statement)

--- a/docs/csharp/language-reference/builtin-types/enum.md
+++ b/docs/csharp/language-reference/builtin-types/enum.md
@@ -97,5 +97,6 @@ For more information, see the following sections of the [C# language specificati
 - [Enumeration format strings](../../../standard/base-types/enumeration-format-strings.md)
 - [Design guidelines - Enum design](../../../standard/design-guidelines/enum.md)
 - [Design guidelines - Enum naming conventions](../../../standard/design-guidelines/names-of-classes-structs-and-interfaces.md#naming-enumerations)
+- [Design guidelines - Enum extension members](../../programming-guide/classes-and-structs/how-to-create-a-new-method-for-an-enumeration.md)
 - [`switch` expression](../operators/switch-expression.md)
 - [`switch` statement](../statements/selection-statements.md#the-switch-statement)


### PR DESCRIPTION
## Summary

- This PR adds a link to the extension members guide for `Enum` types in the `See also` section of the `Enumeration types` article.

Fixes #50384


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/builtin-types/enum.md](https://github.com/dotnet/docs/blob/3e1d67be23a2c3428c3378d921562b1e217493d4/docs/csharp/language-reference/builtin-types/enum.md) | [Enumeration types (C# reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/enum?branch=pr-en-us-50582) |


<!-- PREVIEW-TABLE-END -->