### PR TITLE
Fix formatting for dotnet-gcdump --dsrouter command

### DIFF
--- a/docs/core/diagnostics/dotnet-gcdump.md
+++ b/docs/core/diagnostics/dotnet-gcdump.md
@@ -127,7 +127,7 @@ dotnet-gcdump collect [-h|--help] [-p|--process-id <pid>] [-o|--output <gcdump-f
   
   By default, dotnet-gcdump listens at the specified address. You can request dotnet-gcdump to connect instead by appending `,connect` after the address. For example, `--diagnostic-port /foo/tool1.socket,connect` will connect to a .NET runtime process that's listening to the `/foo/tool1.socket` Unix domain socket.
 
-- **`--dsrouter {ios|ios-sim|android|android-emu}**
+- **`--dsrouter <ios|ios-sim|android|android-emu>`**
 
   Starts [dotnet-dsrouter](dotnet-dsrouter.md) and connects to it. Requires [dotnet-dsrouter](dotnet-dsrouter.md) to be installed. Run `dotnet-dsrouter -h` for more information.
 


### PR DESCRIPTION
## Summary

It was missing the closing backtick and the options should be enclosed in <> rather than {}


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/dotnet-gcdump.md](https://github.com/dotnet/docs/blob/f921babf598aed843aecc461fe334d9aa380cee1/docs/core/diagnostics/dotnet-gcdump.md) | [docs/core/diagnostics/dotnet-gcdump](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-gcdump?branch=pr-en-us-50583) |

<!-- PREVIEW-TABLE-END -->