### PR TITLE
Clarify the use of `sizeof` in safe and unsafe contexts

### DIFF
--- a/docs/csharp/language-reference/operators/sizeof.md
+++ b/docs/csharp/language-reference/operators/sizeof.md
@@ -1,7 +1,7 @@
 ---
 title: "sizeof operator - determine the storage needs for a type"
 description: "Learn about the C# `sizeof` operator that returns the memory amount occupied by a variable of a given type."
-ms.date: 02/06/2025
+ms.date: 12/16/2025
 f1_keywords: 
   - "sizeof_CSharpKeyword"
   - "sizeof"
@@ -10,7 +10,7 @@ helpviewer_keywords:
 ---
 # sizeof operator - determine the memory needs for a given type
 
-The `sizeof` operator returns the number of bytes occupied by a variable of a given type. In safe code, the argument to the `sizeof` operator must be the name of an [unmanaged type](../builtin-types/unmanaged-types.md) or a type parameter that is [constrained](../../programming-guide/generics/constraints-on-type-parameters.md#unmanaged-constraint) to be an unmanaged type. Unmanaged types include all numeric types, enum types, and tuple and struct types where all members are unmanaged types.
+The `sizeof` operator returns the number of bytes occupied by a variable of a given type. In safe code, the argument to the `sizeof` operator must be the name of a builtin [unmanaged type](../builtin-types/unmanaged-types.md).
 
 The expressions presented in the following table are evaluated in compile time to the corresponding constant values and don't require an unsafe context:
 
@@ -30,15 +30,18 @@ The expressions presented in the following table are evaluated in compile time t
 | `sizeof(decimal)` | 16             |
 | `sizeof(bool)`    |  1             |
 
-In unsafe code, the argument to `sizeof` can include pointer types and managed types, including unconstrained type parameters. Examples include `object` and `string`.
+The size of a builtin unmanaged type is a compile time constant.
+
+In [unsafe](../keywords/unsafe.md) code you can use `sizeof` as follows:
+
+- A type parameter that is constrained](../../programming-guide/generics/constraints-on-type-parameters.md#unmanaged-constraint) to be an unmanaged type returns the size of that unmanaged type at runtime.
+- A managed type or a pointer type returns the size of the reference or pointer, not the size of the object it refers to.
 
 The following example demonstrates the usage of the `sizeof` operator:
 
 :::code language="csharp" source="./snippets/shared/SizeOfOperator.cs":::
 
 The `sizeof` operator returns the number of bytes allocated by the common language runtime in managed memory. For [struct](../builtin-types/struct.md) types, that value includes any padding, as the preceding example demonstrates. The result of the `sizeof` operator might differ from the result of the <xref:System.Runtime.InteropServices.Marshal.SizeOf%2A?displayProperty=nameWithType> method, which returns the size of a type in *unmanaged* memory.
-
-In unsafe code, when the argument is a managed type, the `sizeof` operator returns the size of a reference, not the number of bytes allocated for an instance of that type.
 
 > [!IMPORTANT]
 >

--- a/docs/csharp/language-reference/operators/sizeof.md
+++ b/docs/csharp/language-reference/operators/sizeof.md
@@ -30,7 +30,7 @@ The expressions presented in the following table are evaluated at compile time t
 | `sizeof(decimal)` | 16             |
 | `sizeof(bool)`    |  1             |
 
-The size of a built-in unmanaged type is a compile-time constant.
+The size of a built-in, unmanaged type is a compile-time constant.
 
 In [unsafe](../keywords/unsafe.md) code, you can use `sizeof` as follows:
 

--- a/docs/csharp/language-reference/operators/sizeof.md
+++ b/docs/csharp/language-reference/operators/sizeof.md
@@ -10,9 +10,9 @@ helpviewer_keywords:
 ---
 # sizeof operator - determine the memory needs for a given type
 
-The `sizeof` operator returns the number of bytes occupied by a variable of a given type. In safe code, the argument to the `sizeof` operator must be the name of a builtin [unmanaged type](../builtin-types/unmanaged-types.md).
+The `sizeof` operator returns the number of bytes occupied by a variable of a given type. In safe code, the argument to the `sizeof` operator must be the name of a built-in [unmanaged type](../builtin-types/unmanaged-types.md).
 
-The expressions presented in the following table are evaluated in compile time to the corresponding constant values and don't require an unsafe context:
+The expressions presented in the following table are evaluated at compile time to the corresponding constant values and don't require an unsafe context:
 
 | Expression        | Constant value |
 |-------------------|----------------|
@@ -30,11 +30,11 @@ The expressions presented in the following table are evaluated in compile time t
 | `sizeof(decimal)` | 16             |
 | `sizeof(bool)`    |  1             |
 
-The size of a builtin unmanaged type is a compile time constant.
+The size of a built-in unmanaged type is a compile-time constant.
 
-In [unsafe](../keywords/unsafe.md) code you can use `sizeof` as follows:
+In [unsafe](../keywords/unsafe.md) code, you can use `sizeof` as follows:
 
-- A type parameter that is constrained](../../programming-guide/generics/constraints-on-type-parameters.md#unmanaged-constraint) to be an unmanaged type returns the size of that unmanaged type at runtime.
+- A type parameter that is [constrained](../../programming-guide/generics/constraints-on-type-parameters.md#unmanaged-constraint) to be an unmanaged type returns the size of that unmanaged type at runtime.
 - A managed type or a pointer type returns the size of the reference or pointer, not the size of the object it refers to.
 
 The following example demonstrates the usage of the `sizeof` operator:


### PR DESCRIPTION
Fixes #50239 

In addition, rework the unsafe description to provide a more holistic view of the behavior and the rules.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/sizeof.md](https://github.com/dotnet/docs/blob/4fda2b9fb90942f4893e733ce137a92653a9ee6c/docs/csharp/language-reference/operators/sizeof.md) | [sizeof operator - determine the memory needs for a given type](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/sizeof?branch=pr-en-us-50601) |


<!-- PREVIEW-TABLE-END -->