### PR TITLE
Update file-based apps reference article

### DIFF
--- a/docs/core/sdk/file-based-apps.md
+++ b/docs/core/sdk/file-based-apps.md
@@ -208,6 +208,8 @@ List user secrets for file-based apps:
 dotnet user-secrets list --file file.cs
 ```
 
+The `dotnet user-secrets list` command prints the value of your secrets. Don't put this command in scripts that run in public contexts.
+
 For more information, see [Safe storage of app secrets in development](/aspnet/core/security/app-secrets).
 
 ## Launch profiles

--- a/docs/core/sdk/file-based-apps.md
+++ b/docs/core/sdk/file-based-apps.md
@@ -70,7 +70,7 @@ Run a file-based app by using the `dotnet run` command with the `--file` option:
 dotnet run --file file.cs
 ```
 
-Or use the `dotnet run` command:
+Or use the `dotnet run` command followed by the name of the file:
 
 ```dotnetcli
 dotnet run file.cs
@@ -90,7 +90,7 @@ It's recommended to pass arguments to your application by placing them after `--
 dotnet run file.cs -- arg1 arg2
 ```
 
-Arguments after `--` are passed to your application. Without `--`, arguments go to the `dotnet run` command:
+Without `--`, arguments go to the `dotnet run` command:
 
 ```dotnetcli
 dotnet run file.cs arg1 arg2
@@ -114,17 +114,13 @@ Remove build artifacts by using the `dotnet clean` command:
 dotnet clean file.cs
 ```
 
-Deletes cache for file-based apps in a directory:
+Delete cache for file-based apps in a directory:
 
 ```dotnetcli
 dotnet clean file-based-apps
 ```
 
-Use the `--days` option to specify how many days an artifact folder needs to be unused before removal:
-
-```dotnetcli
-dotnet clean file-based-apps --days 21
-```
+Use the `--days` option with the preceding command to specify how many days an artifact folder needs to be unused before removal. The default number of days is 30.
 
 ### Publish applications
 
@@ -136,7 +132,7 @@ Use the `dotnet publish` command to create an independent executable:
 dotnet publish file.cs
 ```
 
-The default location of the executable is an `artifacts` directory next to the .cs file, with a subdirectory named after the application.
+The default location of the executable is an `artifacts` directory next to the `.cs` file, with a subdirectory named after the application.
 
 ### Package as tool
 
@@ -339,7 +335,7 @@ The SDK caches build outputs based on:
 
 - Source file content.
 - Directive configuration.
-- SDK version.- Implicit build files existence and content.
+- SDK version. Implicit build files existence and content.
 
 Caching improves build performance but can cause confusion when:
 

--- a/docs/core/sdk/file-based-apps.md
+++ b/docs/core/sdk/file-based-apps.md
@@ -104,9 +104,9 @@ Compile your file-based app by using the `dotnet build` command:
 dotnet build file.cs
 ```
 
-The SDK generates a virtual project and builds your application. The default path for the build output is `C:\Users\<username>\AppData\Local\Temp\dotnet\runfile\<appname>-<appfilesha>\bin\debug\`.
+The SDK generates a virtual project and builds your application. By default, the build output goes to the system's temporary directory under `<temp>/dotnet/runfile/<appname>-<appfilesha>/bin/<configuration>/`.
 
-Use the `--output` option with the `dotnet build` command to specify a different path. Alternatively, set the `OutoutPath` property in the file by using the directive: `#:property OutputPath=./output`.
+Use the `--output` option with the `dotnet build` command to specify a different path. To define a new default output path, set the `OutputPath` property at the top of your file by using the directive: `#:property OutputPath=./output`.
 
 ### Clean build outputs
 
@@ -154,7 +154,7 @@ Convert your file-based app to a traditional project by using the `dotnet projec
 dotnet project convert file.cs
 ```
 
-This command makes a copy of the `.cs` file and creates a `.csproj` file with equivalent SDK and properties. The `#:` directives are removed, and turned into elements in the corresponding `.csproj` file. The original `.cs` file is left untouched.
+This command makes a copy of the `.cs` file and creates a `.csproj` file with equivalent SDK items, properties, and package references based on the original file's `#:` directives.  Both files are placed in a directory named for the application next to the original `.cs` file, which is left untouched.
 
 ### Restore dependencies
 
@@ -182,7 +182,7 @@ Different SDKs include other file types:
 
 ## Native AOT publishing
 
-File-based apps enable native ahead-of-time (AOT) compilation by default. This feature produces optimized, self-contained executables with faster startup, and a smaller memory footprint.
+File-based apps enable native ahead-of-time (AOT) compilation by default. This feature produces optimized, self-contained executables with faster startup and a smaller memory footprint.
 
 If you need to disable native AOT, use the following setting:
 
@@ -301,7 +301,7 @@ Run directly:
 ```
 
 > [!NOTE]
-> Adding a shebang requires that you use `LF` line endings instead of `CRLF` and that the file doesn't contain a BOM.
+> Use `LF` line endings instead of `CRLF` when you add a shebang. Don't include a BOM in the file.
 
 ## Implicit build files
 
@@ -338,7 +338,7 @@ The SDK caches build outputs based on:
 - Source file content.
 - Directive configuration.
 - SDK version.
-- Implicit build files existence and content.
+- Implicit build file existence and content.
 
 Caching improves build performance but can cause confusion when:
 

--- a/docs/core/sdk/file-based-apps.md
+++ b/docs/core/sdk/file-based-apps.md
@@ -106,7 +106,7 @@ dotnet build file.cs
 
 The SDK generates a virtual project and builds your application. The default path for the build output is `C:\Users\<username>\AppData\Local\Temp\dotnet\runfile\<appname>-<appfilesha>\bin\debug\`.
 
-Use the `--output` option with the `dotnet build` command to specify a different path. Alternatively, set the `OutoutPath` property in the file-based app by using the directive: `#:property OutputPath=./output`
+Use the `--output` option with the `dotnet build` command to specify a different path. Alternatively, set the `OutoutPath` property in the file by using the directive: `#:property OutputPath=./output`.
 
 ### Clean build outputs
 

--- a/docs/core/sdk/file-based-apps.md
+++ b/docs/core/sdk/file-based-apps.md
@@ -104,7 +104,9 @@ Compile your file-based app by using the `dotnet build` command:
 dotnet build file.cs
 ```
 
-The SDK generates a virtual project and builds your application. The default path for the build output is `C:\Users\<username>\AppData\Local\Temp\dotnet\runfile\<appname>-<appfilesha>\bin\debug\`. Use the `--output` option to specify a different path.
+The SDK generates a virtual project and builds your application. The default path for the build output is `C:\Users\<username>\AppData\Local\Temp\dotnet\runfile\<appname>-<appfilesha>\bin\debug\`.
+
+Use the `--output` option with the `dotnet build` command to specify a different path. Alternatively, set the `OutoutPath` property in the file-based app by using the directive: `#:property OutputPath=./output`
 
 ### Clean build outputs
 
@@ -132,7 +134,7 @@ Use the `dotnet publish` command to create an independent executable:
 dotnet publish file.cs
 ```
 
-The default location of the executable is an `artifacts` directory next to the `.cs` file, with a subdirectory named after the application. Use the `--output` option to specify a different path.
+The default location of the executable is an `artifacts` directory next to the `.cs` file, with a subdirectory named after the application. Use the `--output` option with the `dotnet publish` command to specify a different path.
 
 ### Package as tool
 
@@ -152,7 +154,7 @@ Convert your file-based app to a traditional project by using the `dotnet projec
 dotnet project convert file.cs
 ```
 
-The command makes a copy of the `.cs` file and creates a `.csproj` file with equivalent SDK and properties. The `#:` directives are removed, and turned into elements in the corresponding `.csproj` file. The original `.cs` file is left untouched.
+This command makes a copy of the `.cs` file and creates a `.csproj` file with equivalent SDK and properties. The `#:` directives are removed, and turned into elements in the corresponding `.csproj` file. The original `.cs` file is left untouched.
 
 ### Restore dependencies
 

--- a/docs/core/sdk/file-based-apps.md
+++ b/docs/core/sdk/file-based-apps.md
@@ -84,7 +84,7 @@ dotnet file.cs
 
 #### Pass arguments
 
-It's recommended to pass arguments to your application by placing them after `--`:
+Pass arguments to your application by placing them after `--`:
 
 ```dotnetcli
 dotnet run file.cs -- arg1 arg2
@@ -104,7 +104,7 @@ Compile your file-based app by using the `dotnet build` command:
 dotnet build file.cs
 ```
 
-The SDK generates a virtual project and builds your application. The default path for the build output is `./bin/<configuration>/<framework>/`. Use the `--output` option to specify a different path.
+The SDK generates a virtual project and builds your application. The default path for the build output is `C:\Users\<username>\AppData\Local\Temp\dotnet\runfile\<appname>-<appfilesha>\bin\debug\`. Use the `--output` option to specify a different path.
 
 ### Clean build outputs
 
@@ -132,7 +132,7 @@ Use the `dotnet publish` command to create an independent executable:
 dotnet publish file.cs
 ```
 
-The default location of the executable is an `artifacts` directory next to the `.cs` file, with a subdirectory named after the application.
+The default location of the executable is an `artifacts` directory next to the `.cs` file, with a subdirectory named after the application. Use the `--output` option to specify a different path.
 
 ### Package as tool
 
@@ -152,7 +152,7 @@ Convert your file-based app to a traditional project by using the `dotnet projec
 dotnet project convert file.cs
 ```
 
-This command creates a `.csproj` file with equivalent SDK and properties. The command removes all `#:` directives from the `.cs` file and turns them into elements in the corresponding `.csproj` file.
+The command makes a copy of the `.cs` file and creates a `.csproj` file with equivalent SDK and properties. The `#:` directives are removed, and turned into elements in the corresponding `.csproj` file. The original `.cs` file is left untouched.
 
 ### Restore dependencies
 
@@ -180,7 +180,7 @@ Different SDKs include other file types:
 
 ## Native AOT publishing
 
-File-based apps enable native ahead-of-time (AOT) compilation by default. This feature produces optimized, self-contained executables with faster startup and a smaller memory footprint.
+File-based apps enable native ahead-of-time (AOT) compilation by default. This feature produces optimized, self-contained executables with faster startup, and a smaller memory footprint.
 
 If you need to disable native AOT, use the following setting:
 
@@ -327,7 +327,7 @@ Specifies the .NET SDK version to use. File-based apps respect this version sele
 
 ## Build caching
 
-The .NET SDK caches build outputs to improve performance on subsequent builds. This caching system is unique to file-based apps.
+The .NET SDK caches build outputs to improve performance on subsequent invocations of `dotnet run`. This caching system is unique to file-based apps.
 
 ### Cache behavior
 
@@ -335,7 +335,8 @@ The SDK caches build outputs based on:
 
 - Source file content.
 - Directive configuration.
-- SDK version. Implicit build files existence and content.
+- SDK version.
+- Implicit build files existence and content.
 
 Caching improves build performance but can cause confusion when:
 


### PR DESCRIPTION
## Summary

Address comments from review feedback in: https://github.com/dotnet/docs/pull/50371

This pull request updates the documentation for file-based .NET apps, focusing on clarifying CLI usage, improving explanations of build and caching behavior, and providing more precise instructions for advanced scenarios. The changes aim to make the documentation more accurate and user-friendly by refining command syntax, clarifying default behaviors, and adding details on cache management and publishing.

**CLI Command Usage and Syntax Improvements:**
- Clarified how to run file-based apps with `dotnet run`, emphasizing the use of the `--file` option and providing updated examples for passing arguments, including the recommended use of `--` to separate app arguments.
- Updated instructions for cleaning build artifacts, including new options like `--days` for cache cleanup and clarified the difference between deleting artifacts for a single file and a directory.
- Improved explanations and examples for publishing (noting default native AOT publishing and how to disable it), packaging as a tool, and converting to a project, including details on default locations and how to override default behaviors.

**NuGet and SDK Reference Syntax:**
- Updated NuGet package reference syntax from `#:package Serilog version="3.1.1"` to `#:package Serilog@3.1.1` for consistency, and added an example for referencing a specific SDK version.

**User Secrets and Advanced Features:**
- Updated user secrets commands to use the `--file` option instead of `--project`, and added an example for listing secrets.
- Added a note about shebang requirements, specifying line endings and BOM constraints.

**Build Output and Caching Behavior:**
- Clarified that the SDK generates a "virtual project" (not just a temporary one), and specified the default build output path with instructions for customizing it.
- Expanded and clarified the section on build caching, emphasizing that the caching system is unique to file-based apps, and detailed what factors affect cache keys. Added explicit instructions for clearing cache artifacts.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/sdk/file-based-apps.md](https://github.com/dotnet/docs/blob/62d4c617a0039a33be3fd7cfe7ec07ed45ffcc53/docs/core/sdk/file-based-apps.md) | [File-based apps](https://review.learn.microsoft.com/en-us/dotnet/core/sdk/file-based-apps?branch=pr-en-us-50604) |


<!-- PREVIEW-TABLE-END -->