### PR TITLE
Remove linux-release-wait include from Ubuntu install doc

### DIFF
--- a/docs/core/install/linux-ubuntu-install.md
+++ b/docs/core/install/linux-ubuntu-install.md
@@ -12,8 +12,6 @@ zone_pivot_groups: ubuntu-install-set-one
 
 This article discusses how to install .NET on Ubuntu.
 
-[!INCLUDE [linux-release-wait](includes/linux-release-wait.md)]
-
 [!INCLUDE [linux-intro-sdk-vs-runtime](includes/linux-intro-sdk-vs-runtime.md)]
 
 [!INCLUDE [linux-install-package-manager-x64-vs-arm-ubuntu](includes/linux-install-package-manager-x64-vs-arm-ubuntu.md)]


### PR DESCRIPTION
Removed the linux-release-wait include from the installation guide.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/linux-ubuntu-install.md](https://github.com/dotnet/docs/blob/7afded486f84428ab524f55e7f6cc3eaf3e5d324/docs/core/install/linux-ubuntu-install.md) | [Install .NET SDK or .NET Runtime on Ubuntu](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu-install?branch=pr-en-us-50692) |

<!-- PREVIEW-TABLE-END -->