### PR TITLE
Remove AzureAIInferenceChatClient link from ichatclient.md

### DIFF
--- a/docs/ai/ichatclient.md
+++ b/docs/ai/ichatclient.md
@@ -170,7 +170,6 @@ The following sample implements `IChatClient` to show the general structure.
 
 For more realistic, concrete implementations of `IChatClient`, see:
 
-- [AzureAIInferenceChatClient.cs](https://github.com/dotnet/extensions/blob/main/src/Libraries/Microsoft.Extensions.AI.AzureAIInference/AzureAIInferenceChatClient.cs)
 - [OpenAIChatClient.cs](https://github.com/dotnet/extensions/blob/main/src/Libraries/Microsoft.Extensions.AI.OpenAI/OpenAIChatClient.cs)
 - [Microsoft.Extensions.AI chat clients](https://github.com/dotnet/extensions/tree/main/src/Libraries/Microsoft.Extensions.AI/ChatCompletion)
 


### PR DESCRIPTION
Removed link to AzureAIInferenceChatClient.cs from documentation.

See https://github.com/dotnet/extensions/pull/7096.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/ai/ichatclient.md](https://github.com/dotnet/docs/blob/4997b4a8998ac94d918e39936ae9de145d6a6362/docs/ai/ichatclient.md) | [Use the IChatClient interface](https://review.learn.microsoft.com/en-us/dotnet/ai/ichatclient?branch=pr-en-us-50703) |

<!-- PREVIEW-TABLE-END -->