### PR TITLE
Update MCP Server project template install instructions

### DIFF
--- a/docs/ai/quickstarts/build-mcp-server.md
+++ b/docs/ai/quickstarts/build-mcp-server.md
@@ -26,11 +26,11 @@ In this quickstart, you create a minimal Model Context Protocol (MCP) server usi
 1. In a terminal window, install the MCP Server template:
 
    ```bash
-   dotnet new install Microsoft.Extensions.AI.Templates
+   dotnet new install Microsoft.McpServer.ProjectTemplates
    ```
 
     > [!NOTE]
-    > .NET 10.0 SDK (Preview 6 or later) is required to install `Microsoft.Extensions.AI.Templates`.
+    > .NET 10.0 SDK (Preview 6 or later) is required to install `Microsoft.McpServer.ProjectTemplates`.
 
 1. Create a new MCP server app with the `dotnet new mcpserver` command:
 


### PR DESCRIPTION
With [Introduce local vs. remote mcpserver template option (dotnet/extensions#7168)](https://github.com/dotnet/extensions/pull/7168), the mcpserver project template has been moved to a new package [Microsoft.McpServer.ProjectTemplates](https://www.nuget.org/packages/Microsoft.McpServer.ProjectTemplates).

This updates the only reference to the project template with the new installation instructions.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/ai/quickstarts/build-mcp-server.md](https://github.com/dotnet/docs/blob/a37f7acbf1206878a081e7ecbddef53695ba581a/docs/ai/quickstarts/build-mcp-server.md) | [Create a minimal MCP server using C# and publish to NuGet](https://review.learn.microsoft.com/en-us/dotnet/ai/quickstarts/build-mcp-server?branch=pr-en-us-50714) |

<!-- PREVIEW-TABLE-END -->