### PR TITLE
[UUF] Use H2 headings instead of H3

### DIFF
--- a/docs/core/extensions/httpclient-latency-extensions.md
+++ b/docs/core/extensions/httpclient-latency-extensions.md
@@ -12,7 +12,7 @@ The <xref:Microsoft.Extensions.DependencyInjection.HttpClientLatencyTelemetryExt
 extension enables collection of detailed timing information for outgoing HTTP calls with no changes to calling code.
 It plugs into the existing `HttpClientFactory` pipeline to capture stage timings across the request lifecycle, record
 HTTP protocol details, measure garbage collection impact where the runtime exposes that data, and emit a uniform
-telemetry shape suitable for performance analysis and tuning.Enable them by calling `AddHttpClientLatencyTelemetry()` extension method.
+telemetry shape suitable for performance analysis and tuning. Enable this telemetry by calling the `AddHttpClientLatencyTelemetry()` extension method.
 The built‑in handler creates an `ILatencyContext` per outbound request and populates measures by the time the inner
 pipeline completes. Consume them after `await base.SendAsync(...)` in a later delegating handler (added after telemetry)
 and export to your metrics backend. Example:
@@ -24,6 +24,8 @@ Register extension method:
 Access the context:
 
 :::code language="csharp" source="snippets/http/latency/HttpLatencyExportHandler.cs" range="4-23" highlight="12,15":::
+
+## Add the package
 
 ### [.NET CLI](#tab/dotnet-cli)
 
@@ -41,7 +43,7 @@ dotnet add package Microsoft.Extensions.Http.Diagnostics --version 9.10.0
 
 For more information, see [dotnet package add](../tools/dotnet-package-add.md) or [Manage package dependencies in .NET applications](../tools/dependencies.md).
 
-### Register HTTP client latency telemetry
+## Register HTTP client latency telemetry
 
 To add HTTP client latency telemetry to your application, call the <xref:Microsoft.Extensions.DependencyInjection.HttpClientLatencyTelemetryExtensions.AddHttpClientLatencyTelemetry*> extension method when configuring your services:
 
@@ -49,7 +51,7 @@ To add HTTP client latency telemetry to your application, call the <xref:Microso
 
 This registration adds a `DelegatingHandler` to all HTTP clients created through <xref:System.Net.Http.IHttpClientFactory>, collecting detailed latency information for each request.
 
-### Configure telemetry options
+## Configure telemetry options
 
 You configure telemetry collection through the <xref:Microsoft.Extensions.Http.Latency.HttpClientLatencyTelemetryOptions> ([standard options pattern](options.md)).
 You can supply values either with a delegate or by binding configuration (for example, `appsettings.json`).
@@ -57,7 +59,7 @@ The options instance is resolved once per handler pipeline so changes apply to n
 
 :::code language="csharp" source="snippets/http/latency/Program.cs" range="23-31" highlight="1-5,8,9":::
 
-### Configuration options
+## Configuration options
 
 The <xref:Microsoft.Extensions.Http.Latency.HttpClientLatencyTelemetryOptions> class offers the following settings:
 
@@ -65,11 +67,11 @@ The <xref:Microsoft.Extensions.Http.Latency.HttpClientLatencyTelemetryOptions> c
 |--------------------------------|---------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
 | EnableDetailedLatencyBreakdown | Boolean | `true`  | Enables fine-grained phase timing for each HttpClient request (for example, connection establishment, headers sent, first byte, completion) to produce a breakdown of total latency. Adds a small extra CPU/time measurement cost, no wire overhead. | Set to `false` only in very high-throughput scenarios where minimal overhead is required and total duration alone is sufficient. |
 
-### Collected telemetry data
+## Collected telemetry data
 
 When HTTP client latency telemetry is enabled, it captures phase timestamps, selected measures (where supported), and protocol attributes used for performance analysis.
 
-#### Timing checkpoints
+### Timing checkpoints
 
 Timestamps are recorded for key stages of the HTTP request lifecycle:
 
@@ -83,7 +85,7 @@ Timestamps are recorded for key stages of the HTTP request lifecycle:
 | Response headers        | Http.ResponseHeadersStart  | Http.ResponseHeadersEnd    | First byte to completion of header parsing.             |
 | Response content        | Http.ResponseContentStart  | Http.ResponseContentEnd    | Reading full response body (to completion or disposal). |
 
-#### Measures (platform dependent)
+### Measures (platform dependent)
 
 Measures quantify latency contributors that raw phase checkpoints cannot (GC pause overlap, connection churn, other
 accumulated counts or durations). They are collected in an in‑memory latency context created when you call
@@ -100,7 +102,7 @@ to a histogram and connection initiations to a counter, optionally dimensioned b
 | Http.GCPauseTime         | Total GC pause duration overlapping the request.                        |
 | Http.ConnectionInitiated | Emitted when a new underlying connection (not pooled reuse) is created. |
 
-#### Tags
+### Tags
 
 Use tags to attach stable categorical dimensions to each request so you can segment, filter, and aggregate metrics
 and logs without reprocessing raw data. They are low‑cardinality classification labels (not timings) captured
@@ -130,7 +132,7 @@ For example:
 
 :::code language="csharp" source="snippets/http/latency/Program.cs" range="58-75" highlight="10,13,16":::
 
-### Platform considerations
+## Platform considerations
 
 HTTP client latency telemetry runs on all supported targets (.NET 9, .NET 8, .NET Standard 2.0, and .NET Framework 4.6.2).
 Core timing checkpoints are always collected. The GC pause metric (Http.GCPauseTime) is emitted only when running on .NET 8 or .NET 9.


### PR DESCRIPTION
Updated section headers and improved clarity in documentation regarding HTTP client latency telemetry.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/httpclient-latency-extensions.md](https://github.com/dotnet/docs/blob/6dd3fb0343560416b8adcf41efcf4a4c1791b34a/docs/core/extensions/httpclient-latency-extensions.md) | [HTTP client latency telemetry in .NET](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/httpclient-latency-extensions?branch=pr-en-us-50736) |

<!-- PREVIEW-TABLE-END -->