### PR TITLE
Change section headers in logging.md

### DIFF
--- a/docs/core/extensions/logging.md
+++ b/docs/core/extensions/logging.md
@@ -503,7 +503,7 @@ public void Test(string id)
 
 Exception logging is provider-specific.
 
-### Default log level
+## Default log level
 
 If the default log level isn't set, the default log level value is `Information`.
 
@@ -526,7 +526,7 @@ using IHost host = builder.Build();
 await host.RunAsync();
 ```
 
-### Filter function
+## Filter function
 
 A filter function is invoked for all providers and categories that don't have rules assigned to them by configuration or code:
 


### PR DESCRIPTION
Updated section headers from '###' to '##' for consistency.




<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/logging.md](https://github.com/dotnet/docs/blob/9706ef108774363825cd85ab96a36be354f7e904/docs/core/extensions/logging.md) | [Logging in C# and .NET](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/logging?branch=pr-en-us-50743) |

<!-- PREVIEW-TABLE-END -->