### PR TITLE
[UUF] Remove duplicate ErrObject.Raise entry

### DIFF
--- a/docs/visual-basic/language-reference/runtime-library-members.md
+++ b/docs/visual-basic/language-reference/runtime-library-members.md
@@ -508,7 +508,6 @@ The `Microsoft.VisualBasic` namespace contains the classes, modules, constants, 
 - <xref:Microsoft.VisualBasic.ErrObject.LastDllError%2A>
 - <xref:Microsoft.VisualBasic.ErrObject.Number%2A>
 - <xref:Microsoft.VisualBasic.ErrObject.Raise%2A>
-- <xref:Microsoft.VisualBasic.ErrObject.Raise%2A>
 
 ## Microsoft.VisualBasic.FileSystem Module
 


### PR DESCRIPTION
Removed duplicate entry for Microsoft.VisualBasic.ErrObject.Raise.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/visual-basic/language-reference/runtime-library-members.md](https://github.com/dotnet/docs/blob/8992445953bfdffce9d4e95f7d192ee8bd77a40c/docs/visual-basic/language-reference/runtime-library-members.md) | [Visual Basic Runtime Library Members](https://review.learn.microsoft.com/en-us/dotnet/visual-basic/language-reference/runtime-library-members?branch=pr-en-us-50748) |

<!-- PREVIEW-TABLE-END -->