### PR TITLE
Fix typo: keep private field as UInt16 in CLS compliance 

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.clscompliant/cs/public2.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.clscompliant/cs/public2.cs
@@ -5,7 +5,7 @@ using System;
 
 public class Person
 {
-   private Int16 personAge = 0;
+   private UInt16 personAge = 0;
 
    public Int16 Age
    { get { return personAge; } }

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.clscompliant/cs/public2.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.clscompliant/cs/public2.cs
@@ -7,7 +7,6 @@ public class Person
 {
    private UInt16 personAge = 0;
 
-   public Int16 Age
-   { get { return personAge; } }
+   public Int16 Age => (Int16)personAge; 
 }
 // </Snippet2>


### PR DESCRIPTION
Hi 🌹 thanks for your great works.

## Summary
Fixed the code in the CLS compliance documentation where the private field was incorrectly changed to `Int16`.

The documentation states:
> "You don't have to change the type of the private `personAge` field."

However, the code example in `public2.cs` showed both the private and public members changed to `Int16`, which contradicts the documentation.

## Fix
Changed `private Int16 personAge` back to `private UInt16 personAge` .

Fixes issue: #49691 