### PR TITLE
Remove trailing periods from option descriptions

### DIFF
--- a/docs/standard/commandline/snippets/define-symbols/csharp/Program.cs
+++ b/docs/standard/commandline/snippets/define-symbols/csharp/Program.cs
@@ -40,12 +40,12 @@ class Program
         // <defineoptions>
         Option<int> delayOption = new("--delay", "-d")
         {
-            Description = "An option whose argument is parsed as an int.",
+            Description = "An option whose argument is parsed as an int",
             DefaultValueFactory = parseResult => 42,
         };
         Option<string> messageOption = new("--message", "-m")
         {
-            Description = "An option whose argument is parsed as a string."
+            Description = "An option whose argument is parsed as a string"
         };
 
         RootCommand rootCommand = new();
@@ -88,7 +88,7 @@ class Program
         // <parseerrors>
         Option<string> verbosityOption = new("--verbosity", "-v")
         {
-            Description = "Set the verbosity level.",
+            Description = "Set the verbosity level",
         };
         verbosityOption.AcceptOnlyFromAmong("quiet", "minimal", "normal", "detailed", "diagnostic");
         RootCommand rootCommand = new() { verbosityOption };

--- a/docs/standard/commandline/snippets/global-options/csharp/Program.cs
+++ b/docs/standard/commandline/snippets/global-options/csharp/Program.cs
@@ -66,7 +66,7 @@ class Program1
         // Add -q as a separate option for quiet verbosity.
         Option<bool> quietOption = new("-q")
         {
-            Description = "Set verbosity to quiet (shorthand for --verbosity quiet).",
+            Description = "Set verbosity to quiet (shorthand for --verbosity quiet)",
             Recursive = true
         };
 


### PR DESCRIPTION
## Summary

The built-in options do not have trailing periods:

- https://github.com/dotnet/command-line-api/blob/cf5fd8d696450a48d3cc75a7a1792d34b5303f88/src/System.CommandLine/Properties/Resources.resx#L208
- https://github.com/dotnet/command-line-api/blob/cf5fd8d696450a48d3cc75a7a1792d34b5303f88/src/System.CommandLine/Properties/Resources.resx#L157

This PR aligns the example options with the convention set by the built-in options.

I did not touch the example arguments. There are no built-in arguments, so I'm unsure of the convention.

Note that there is one example option which contains two sentences. I left that one as-is:

- https://github.com/dotnet/docs/blob/f00deb9aacc83e48617de597d64bbc5cc4cf25a2/docs/standard/commandline/snippets/global-options/csharp/Program.cs#L53