### PR TITLE
Correct Median calculation in Extensions.cs

### DIFF
--- a/docs/csharp/language-reference/keywords/snippets/Extensions.cs
+++ b/docs/csharp/language-reference/keywords/snippets/Extensions.cs
@@ -45,7 +45,7 @@ public static class NumericSequences
                 if (count % 2 == 0)
                 {
                     // Even number of elements: average the two middle elements
-                    return (sortedList[middleIndex - 1] + sortedList[middleIndex]);
+                    return (sortedList[middleIndex - 1] + sortedList[middleIndex]) / 2;
                 }
                 else
                 {


### PR DESCRIPTION
Fix calculation (divide by 2) of average for even number of elements.


