### PR TITLE
Improve `\` in `string` literal to show both effects

### DIFF
--- a/docs/fsharp/language-reference/strings.md
+++ b/docs/fsharp/language-reference/strings.md
@@ -50,7 +50,7 @@ let xmlFragment1 = @"<book author=""Milton, John"" title=""Paradise Lost"">"
 let xmlFragment2 = """<book author="Milton, John" title="Paradise Lost">"""
 ```
 
-In code, strings that have line breaks are accepted and the line breaks are interpreted as the newline encoding used in source, unless a backslash character is the last character before the line break. Leading white space on the next line is ignored when the backslash character is used. The following code produces a string `str1` that has value `"abc\ndef"` and a string `str2` that has value `"abcdef"`.
+In code, strings that have line breaks are accepted and the line breaks are interpreted as the newline encoding used in source, unless a backslash character is the last character before the line break. Leading white space on the next line is ignored when the backslash character is used. The following code produces a string `str1` that has value `"abc\n     def"` and a string `str2` that has value `"abcdef"`.
 
 [!code-fsharp[Main](~/samples/snippets/fsharp/lang-ref-1/snippet1001.fs)]
 

--- a/samples/snippets/fsharp/lang-ref-1/snippet1001.fs
+++ b/samples/snippets/fsharp/lang-ref-1/snippet1001.fs
@@ -1,7 +1,7 @@
 let str1 =
     "abc
-def"
+     def"
 
 let str2 =
     "abc\
-def"
+     def"


### PR DESCRIPTION
## Summary

The existing example shows that the backslash removes the newline character in the string, however the string literal still (technically unnecessarily) de-indents the beginning of the next line of code to the first column.

I have an intermediate amount of F# experience, but I come across this syntax rarely and skimmed the docs to jog my memory. I saw the code example and the way it was formatted implied to me that the `\` wouldn't strip the leading whitespace on the next line if it were there.

I think it would be clearer to show two nearly identical string literals, without and with the backslash, and call out that the former includes both the newline and leading spaces, while the latter has neither.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/strings.md](https://github.com/dotnet/docs/blob/e966ccf5084a08c5de811f78c42c1cbb950bfaee/docs/fsharp/language-reference/strings.md) | [Strings](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/strings?branch=pr-en-us-50820) |

<!-- PREVIEW-TABLE-END -->