### PR TITLE
fix: add missing semicolon to Previous behavior example

### DIFF
--- a/docs/core/compatibility/networking/10.0/uri-length-limits-removed.md
+++ b/docs/core/compatibility/networking/10.0/uri-length-limits-removed.md
@@ -18,7 +18,7 @@ Methods that create <xref:System.Uri> instances (constructors and <xref:System.U
 Previously, it wasn't possible to create a <xref:System.Uri> instance whose length exceeded around 65,000 characters. Code like the following example threw a <xref:System.UriFormatException> with the message "Invalid URI: The Uri string is too long."
 
 ```csharp
-new Uri($"https://host/{new string('a', 100_000)}")
+new Uri($"https://host/{new string('a', 100_000)}");
 ```
 
 ## New behavior


### PR DESCRIPTION
## Summary

when copying from the "Previous behavior" code sample, I noted a compilation error due to a missing semicolon.

- Add the missing semicolon


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/networking/10.0/uri-length-limits-removed.md](https://github.com/dotnet/docs/blob/4422fab7954586eeb9835199191dcc10b6d305df/docs/core/compatibility/networking/10.0/uri-length-limits-removed.md) | [`Uri` length limits removed](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/networking/10.0/uri-length-limits-removed?branch=pr-en-us-50893) |

<!-- PREVIEW-TABLE-END -->