### PR TITLE
Updated documentation to publish file based application

### DIFF
--- a/docs/core/tutorials/publishing-with-visual-studio-code.md
+++ b/docs/core/tutorials/publishing-with-visual-studio-code.md
@@ -108,3 +108,31 @@ In this tutorial, you published a console app. In the next tutorial, you create 
 
 > [!div class="nextstepaction"]
 > [Create a .NET class library using Visual Studio Code](library-with-visual-studio-code.md)
+
+## Publish a file-based (single-file) app
+
+The default publishing process creates a framework-dependent deployment, which requires
+the .NET runtime to be installed on the target machine. You can also publish a *file-based*
+app as a single executable that includes the .NET runtime.
+
+To publish a single-file, self-contained app, run the following command:
+
+```dotnetcli
+dotnet publish -c Release -r win-x64 --self-contained true /p:PublishSingleFile=true
+
+Replace win-x64 with the appropriate runtime identifier (RID) for your target platform,
+such as linux-x64 or osx-arm64.
+
+Inspect the file-based output
+
+After publishing, the output is located in:
+bin/Release/net8.0/win-x64/publish/
+
+In this folder, you’ll find a single executable file:
+
+HelloWorld.exe (Windows)
+
+HelloWorld (Linux or macOS)
+
+This executable contains the application, its dependencies, and the .NET runtime. You can
+copy this file to another machine and run it without installing .NET.

--- a/docs/core/tutorials/publishing-with-visual-studio-code.md
+++ b/docs/core/tutorials/publishing-with-visual-studio-code.md
@@ -96,19 +96,6 @@ In the following steps, you'll look at the files created by the publish process.
 
    1. Enter a name in response to the prompt, and press <kbd>Enter</kbd> to exit.
 
-## Additional resources
-
-- [.NET application publishing overview](../deploying/index.md)
-- [`dotnet publish`](../tools/dotnet-publish.md)
-- [Use the .NET SDK in continuous integration (CI) environments](../../devops/dotnet-cli-and-continuous-integration.md)
-
-## Next steps
-
-In this tutorial, you published a console app. In the next tutorial, you create a class library.
-
-> [!div class="nextstepaction"]
-> [Create a .NET class library using Visual Studio Code](library-with-visual-studio-code.md)
-
 ## Publish a file-based (single-file) app
 
 The default publishing process creates a framework-dependent deployment, which requires
@@ -119,6 +106,7 @@ To publish a single-file, self-contained app, run the following command:
 
 ```dotnetcli
 dotnet publish -c Release -r win-x64 --self-contained true /p:PublishSingleFile=true
+```
 
 Replace win-x64 with the appropriate runtime identifier (RID) for your target platform,
 such as linux-x64 or osx-arm64.
@@ -136,3 +124,16 @@ HelloWorld (Linux or macOS)
 
 This executable contains the application, its dependencies, and the .NET runtime. You can
 copy this file to another machine and run it without installing .NET.
+
+## Additional resources
+
+- [.NET application publishing overview](../deploying/index.md)
+- [`dotnet publish`](../tools/dotnet-publish.md)
+- [Use the .NET SDK in continuous integration (CI) environments](../../devops/dotnet-cli-and-continuous-integration.md)
+
+## Next steps
+
+In this tutorial, you published a console app. In the next tutorial, you create a class library.
+
+> [!div class="nextstepaction"]
+> [Create a .NET class library using Visual Studio Code](library-with-visual-studio-code.md)


### PR DESCRIPTION
## Summary

This PR updates the "Publish a .NET console application using Visual Studio Code"
tutorial to include instructions for publishing a file-based (single-file)
self-contained app using the .NET CLI.

Fixes #Issue_Number (if available): Fixes #50725


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tutorials/publishing-with-visual-studio-code.md](https://github.com/dotnet/docs/blob/7cafa57ee97080e2752b12eaee25698fa3248ad5/docs/core/tutorials/publishing-with-visual-studio-code.md) | [Tutorial: Publish a .NET console application using Visual Studio Code](https://review.learn.microsoft.com/en-us/dotnet/core/tutorials/publishing-with-visual-studio-code?branch=pr-en-us-50904) |


<!-- PREVIEW-TABLE-END -->