### PR TITLE
Update MTP option names

### DIFF
--- a/docs/core/testing/microsoft-testing-platform-architecture-services.md
+++ b/docs/core/testing/microsoft-testing-platform-architecture-services.md
@@ -179,9 +179,9 @@ The options you can choose from include:
 
 ```dotnetcli
 --diagnostic                             Enable the diagnostic logging. The default log level is 'Trace'. The file will be written in the output directory with the name log_[MMddHHssfff].diag
---diagnostic-filelogger-synchronouswrite Force the built-in file logger to write the log synchronously. Useful for scenario where you don't want to lose any log (i.e. in case of crash). Note that this is slowing down the test execution.
+--diagnostic-synchronous-write Force the built-in file logger to write the log synchronously. Useful for scenario where you don't want to lose any log (i.e. in case of crash). Note that this is slowing down the test execution.
 --diagnostic-output-directory            Output directory of the diagnostic logging, if not specified the file will be generated inside the default 'TestResults' directory.
---diagnostic-output-fileprefix           Prefix for the log file name that will replace '[log]_.'
+--diagnostic-file-prefix           Prefix for the log file name that will replace '[log]_.'
 --diagnostic-verbosity                   Define the level of the verbosity for the --diagnostic. The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'
 ```
 

--- a/docs/core/testing/microsoft-testing-platform-extensions-diagnostics.md
+++ b/docs/core/testing/microsoft-testing-platform-extensions-diagnostics.md
@@ -16,9 +16,9 @@ The following [platform options](./microsoft-testing-platform-intro.md#options) 
 
 - `--info`
 - `--diagnostic`
-- `⁠-⁠-⁠diagnostic-⁠filelogger-⁠synchronouswrite`
+- `--diagnostic-synchronous-write`
 - `--diagnostic-verbosity`
-- `--diagnostic-output-fileprefix`
+- `--diagnostic-file-prefix`
 - `--diagnostic-output-directory`
 
 You can also enable the diagnostics logs using the environment variables:

--- a/docs/core/testing/microsoft-testing-platform-intro.md
+++ b/docs/core/testing/microsoft-testing-platform-intro.md
@@ -227,7 +227,7 @@ The list below described only the platform options. To see the specific options 
 
   Enables the diagnostic logging. The default log level is `Trace`. The file is written in the output directory with the following name format, `log_[MMddHHssfff].diag`.
 
-- **`--diagnostic-filelogger-synchronouswrite`**
+- **`--diagnostic-synchronous-write`**
 
   Forces the built-in file logger to synchronously write logs. Useful for scenarios where you don't want to lose any log entries (if the process crashes). This does slow down the test execution.
 
@@ -235,7 +235,7 @@ The list below described only the platform options. To see the specific options 
 
   The output directory of the diagnostic logging, if not specified the file is generated in the default _TestResults_ directory.
 
-- **`--diagnostic-output-fileprefix`**
+- **`--diagnostic-file-prefix`**
 
   The prefix for the log file name. Defaults to `"log_"`.
 

--- a/docs/core/testing/microsoft-testing-platform-intro.md
+++ b/docs/core/testing/microsoft-testing-platform-intro.md
@@ -237,7 +237,7 @@ The list below described only the platform options. To see the specific options 
 
 - **`--diagnostic-file-prefix`**
 
-  The prefix for the log file name. Defaults to `"log_"`.
+  The prefix for the log file name. Defaults to `"log"`.
 
 - **`--diagnostic-verbosity`**
 


### PR DESCRIPTION
This pull request updates the documentation for Microsoft Testing Platform diagnostic command-line options to use the correct and consistent option names.

Documentation improvements:

* Updated the option names in the list to use the correct forms, such as changing `--diagnostic-filelogger-synchronouswrite` to `--diagnostic-synchronous-write` and `--diagnostic-output-fileprefix` to `--diagnostic-file-prefix` in the `microsoft-testing-platform-extensions-diagnostics.md` documentation.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/microsoft-testing-platform-architecture-services.md](https://github.com/dotnet/docs/blob/5342ae60e09d23fa79f1e5de07dc0fc8482bfbc8/docs/core/testing/microsoft-testing-platform-architecture-services.md) | [Microsoft.Testing.Platform Services](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-architecture-services?branch=pr-en-us-50905) |
| [docs/core/testing/microsoft-testing-platform-extensions-diagnostics.md](https://github.com/dotnet/docs/blob/5342ae60e09d23fa79f1e5de07dc0fc8482bfbc8/docs/core/testing/microsoft-testing-platform-extensions-diagnostics.md) | [Microsoft.Testing.Platform diagnostics extensions](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-extensions-diagnostics?branch=pr-en-us-50905) |
| [docs/core/testing/microsoft-testing-platform-intro.md](https://github.com/dotnet/docs/blob/5342ae60e09d23fa79f1e5de07dc0fc8482bfbc8/docs/core/testing/microsoft-testing-platform-intro.md) | [Microsoft.Testing.Platform overview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-intro?branch=pr-en-us-50905) |


<!-- PREVIEW-TABLE-END -->