### PR TITLE
Remove remaining trailing periods from option descriptions

### DIFF
--- a/docs/standard/commandline/snippets/customize-help/csharp/Program.cs
+++ b/docs/standard/commandline/snippets/customize-help/csharp/Program.cs
@@ -18,7 +18,7 @@ class Program
         // <original>
         Option<FileInfo> fileOption = new("--file")
         {
-            Description = "The file to print out.",
+            Description = "The file to print out",
         };
         Option<bool> lightModeOption = new("--light-mode")
         {
@@ -44,7 +44,7 @@ class Program
     {
         Option<FileInfo> fileOption = new("--file")
         {
-            Description = "The file to print out.",
+            Description = "The file to print out",
         };
         Option<bool> lightModeOption = new("--light-mode")
         {
@@ -79,7 +79,7 @@ class Program
     {
         Option<FileInfo> fileOption = new("--file")
         {
-            Description = "The file to print out.",
+            Description = "The file to print out",
         };
         Option<bool> lightModeOption = new("--light-mode")
         {

--- a/docs/standard/commandline/snippets/get-started-tutorial/csharp/Stage0/Program.cs
+++ b/docs/standard/commandline/snippets/get-started-tutorial/csharp/Stage0/Program.cs
@@ -11,7 +11,7 @@ class Program
         // <symbols>
         Option<FileInfo> fileOption = new("--file")
         {
-            Description = "The file to read and display on the console."
+            Description = "The file to read and display on the console"
         };
 
         RootCommand rootCommand = new("Sample app for System.CommandLine");

--- a/docs/standard/commandline/snippets/get-started-tutorial/csharp/Stage1/Program.cs
+++ b/docs/standard/commandline/snippets/get-started-tutorial/csharp/Stage1/Program.cs
@@ -10,7 +10,7 @@ class Program
         // <option>
         Option<FileInfo> fileOption = new("--file")
         {
-            Description = "The file to read and display on the console."
+            Description = "The file to read and display on the console"
         };
 
         RootCommand rootCommand = new("Sample app for System.CommandLine");

--- a/docs/standard/commandline/snippets/get-started-tutorial/csharp/Stage2/Program.cs
+++ b/docs/standard/commandline/snippets/get-started-tutorial/csharp/Stage2/Program.cs
@@ -9,23 +9,23 @@ class Program
     {
         Option<FileInfo> fileOption = new("--file")
         {
-            Description = "The file to read and display on the console."
+            Description = "The file to read and display on the console"
         };
 
         // <options>
         Option<int> delayOption = new("--delay")
         {
-            Description = "Delay between lines, specified as milliseconds per character in a line.",
+            Description = "Delay between lines, specified as milliseconds per character in a line",
             DefaultValueFactory = parseResult => 42
         };
         Option<ConsoleColor> fgcolorOption = new("--fgcolor")
         {
-            Description = "Foreground color of text displayed on the console.",
+            Description = "Foreground color of text displayed on the console",
             DefaultValueFactory = parseResult => ConsoleColor.White
         };
         Option<bool> lightModeOption = new("--light-mode")
         {
-            Description = "Background color of text displayed on the console: default is black, light mode is white."
+            Description = "Background color of text displayed on the console: default is black, light mode is white"
         };
         // </options>
 

--- a/docs/standard/commandline/snippets/get-started-tutorial/csharp/Stage3/Program.cs
+++ b/docs/standard/commandline/snippets/get-started-tutorial/csharp/Stage3/Program.cs
@@ -35,23 +35,23 @@ class Program
 
         Option<int> delayOption = new("--delay")
         {
-            Description = "Delay between lines, specified as milliseconds per character in a line.",
+            Description = "Delay between lines, specified as milliseconds per character in a line",
             DefaultValueFactory = parseResult => 42
         };
         Option<ConsoleColor> fgcolorOption = new("--fgcolor")
         {
-            Description = "Foreground color of text displayed on the console.",
+            Description = "Foreground color of text displayed on the console",
             DefaultValueFactory = parseResult => ConsoleColor.White
         };
         Option<bool> lightModeOption = new("--light-mode")
         {
-            Description = "Background color of text displayed on the console: default is black, light mode is white."
+            Description = "Background color of text displayed on the console: default is black, light mode is white"
         };
 
         // <optionsandargs>
         Option<string[]> searchTermsOption = new("--search-terms")
         {
-            Description = "Strings to search for when deleting entries.",
+            Description = "Strings to search for when deleting entries",
             Required = true,
             AllowMultipleArgumentsPerToken = true
         };

--- a/docs/standard/commandline/snippets/handle-termination/csharp/Program.cs
+++ b/docs/standard/commandline/snippets/handle-termination/csharp/Program.cs
@@ -7,7 +7,7 @@ class Program
     {
         Option<string> urlOption = new("--url")
         {
-            Description = "A URL."
+            Description = "A URL"
         };
         RootCommand rootCommand = new("Handle termination example") { urlOption };
 

--- a/docs/standard/commandline/snippets/model-binding/csharp/ParseArgument.cs
+++ b/docs/standard/commandline/snippets/model-binding/csharp/ParseArgument.cs
@@ -10,7 +10,7 @@ class Program
         // <delayOption>
         Option<int> delayOption = new("--delay")
         {
-            Description = "An option whose argument is parsed as an int.",
+            Description = "An option whose argument is parsed as an int",
             CustomParser = result =>
             {
                 if (!result.Tokens.Any())

--- a/docs/standard/commandline/snippets/model-binding/csharp/Program.cs
+++ b/docs/standard/commandline/snippets/model-binding/csharp/Program.cs
@@ -22,11 +22,11 @@ class Program
         // <intandstring>
         Option<int> delayOption = new("--delay")
         {
-            Description = "An option whose argument is parsed as an int."
+            Description = "An option whose argument is parsed as an int"
         };
         Option<string> messageOption = new("--message")
         {
-            Description = "An option whose argument is parsed as a string."
+            Description = "An option whose argument is parsed as a string"
         };
 
         RootCommand rootCommand = new("Parameter binding example")
@@ -62,11 +62,11 @@ class Program
         {
             new Option<int>("--delay")
             {
-                Description = "An option whose argument is parsed as an int."
+                Description = "An option whose argument is parsed as an int"
             },
             new Option<string>("--message")
             {
-                Description = "An option whose argument is parsed as a string."
+                Description = "An option whose argument is parsed as a string"
             }
         };
         // </collectioninitializersyntax>


### PR DESCRIPTION
## Summary

Similar to https://github.com/dotnet/docs/pull/50808