### PR TITLE
Fix typo in coding conventions for indentation

### DIFF
--- a/docs/csharp/fundamentals/coding-style/coding-conventions.md
+++ b/docs/csharp/fundamentals/coding-style/coding-conventions.md
@@ -335,7 +335,7 @@ namespace CoolStuff.AwesomeFeature
 
 In general, use the following format for code samples:
 
-- Use four spaces for indentation. Don't use tabs.
+- Use four spaces for indentation. Don't use tab characters.
 - Align code consistently to improve readability.
 - Limit lines to 65 characters to enhance code readability on docs, especially on mobile screens.
 - Improve clarity and user experience by breaking long statements into multiple lines.


### PR DESCRIPTION
Fix for issue - French typo where the word "onglet" is used instead of "tabulation" #50903

## Summary

When translated to French, the wordings were misleading.
Hence, changed "tabs" to "tab characters".

Closes #50903 




<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/fundamentals/coding-style/coding-conventions.md](https://github.com/dotnet/docs/blob/145eb7c36eb7629552dea50995998e692e5f0bbc/docs/csharp/fundamentals/coding-style/coding-conventions.md) | [Common C# code conventions](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions?branch=pr-en-us-50910) |

<!-- PREVIEW-TABLE-END -->