### PR TITLE
Document explicitly that resource files are considered trusted

### DIFF
--- a/docs/core/extensions/resources.md
+++ b/docs/core/extensions/resources.md
@@ -57,6 +57,9 @@ You can then retrieve resources for the current UI culture or for a specific cul
 
 - The <xref:System.Resources.ResXResourceSet> class, which enables you to retrieve all the items in an XML resource file into memory.
 
+> [!NOTE]
+> In general, resource files (.resx and .resources) within .NET are considered part of the application deployment and are assumed to be trustworthy, much like configuration. Components which operate over such files are free to rely on this assumption. Developers therefore should not process untrustworthy resource files unless they're using an API explicitly documented as being safe for use with untrusted data.
+
 ## See also
 
 - <xref:System.Globalization.CultureInfo>

--- a/docs/core/extensions/resources.md
+++ b/docs/core/extensions/resources.md
@@ -58,7 +58,7 @@ You can then retrieve resources for the current UI culture or for a specific cul
 - The <xref:System.Resources.ResXResourceSet> class, which enables you to retrieve all the items in an XML resource file into memory.
 
 > [!NOTE]
-> In general, resource files (.resx and .resources) within .NET are considered part of the application deployment and are assumed to be trustworthy, much like configuration. Components which operate over such files are free to rely on this assumption. Developers therefore should not process untrustworthy resource files unless they're using an API explicitly documented as being safe for use with untrusted data.
+> In general, resource files (.resx and .resources) within .NET are considered part of the application deployment and are assumed to be trustworthy, much like configuration. Components that operate over such files are free to rely on this assumption. You shouldn't process untrustworthy resource files unless you're using an API that's explicitly documented as being safe for use with untrusted data.
 
 ## See also
 


### PR DESCRIPTION
Augments [Note that DeserializingResourceReader should not be used with untrusted data (dotnet/dotnet-api-docs#12198)](https://github.com/dotnet/dotnet-api-docs/pull/12198#issuecomment-3712828260) with a central statement that resources are considered trusted.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/resources.md](https://github.com/dotnet/docs/blob/e8e34ab9971793ba7f3e404d71eacc6d2bd842e4/docs/core/extensions/resources.md) | [Resources in .NET apps](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/resources?branch=pr-en-us-50972) |


<!-- PREVIEW-TABLE-END -->