### PR TITLE
Make it more explicit that test runner selection is for .NET 10+

### DIFF
--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -16,6 +16,9 @@ ai-usage: ai-assisted
 
 The `dotnet test` command builds the solution and runs the tests with either VSTest or Microsoft Testing Platform (MTP). The test runner you use determines the available command-line options and behavior.
 
+> [!NOTE]
+> Test runner selection is available starting with .NET 10 SDK. In .NET 6, .NET 7, .NET 8, and .NET 9, tests are always executed with VSTest.
+
 ### Choosing a test runner
 
 To enable MTP, you need to specify the test runner in the [`global.json`](global-json.md) file. Here are examples of how to configure the test runner:
@@ -47,7 +50,7 @@ To enable MTP, you need to specify the test runner in the [`global.json`](global
 
 The available command-line options, behavior, and capabilities differ depending on which test runner you use:
 
-- **[dotnet test with VSTest](dotnet-test-vstest.md)** - The traditional test platform, available in .NET 6 SDK and later. Provides comprehensive test discovery, filtering, and result reporting capabilities.
+- **[dotnet test with VSTest](dotnet-test-vstest.md)** - The traditional test platform, available in .NET 6 SDK and later. This is the default and only test runner for .NET 6, .NET 7, .NET 8, and .NET 9. Provides comprehensive test discovery, filtering, and result reporting capabilities.
 
 - **[dotnet test with MTP](dotnet-test-mtp.md)** - The modern testing platform, available in .NET 10 SDK and later. Offers faster test execution and more flexible test module selection.
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -50,7 +50,7 @@ To enable MTP, you need to specify the test runner in the [`global.json`](global
 
 The available command-line options, behavior, and capabilities differ depending on which test runner you use:
 
-- **[dotnet test with VSTest](dotnet-test-vstest.md)** - The traditional test platform, available in .NET 6 SDK and later. This is the default and only test runner for .NET 6, .NET 7, .NET 8, and .NET 9. Provides comprehensive test discovery, filtering, and result reporting capabilities.
+- **[dotnet test with VSTest](dotnet-test-vstest.md)** - The traditional test platform, available in .NET 6 SDK and later. This is the default and only test runner in versions earlier than .NET 10 SDK. Provides comprehensive test discovery, filtering, and result reporting capabilities.
 
 - **[dotnet test with MTP](dotnet-test-mtp.md)** - The modern testing platform, available in .NET 10 SDK and later. Offers faster test execution and more flexible test module selection.
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -17,7 +17,7 @@ ai-usage: ai-assisted
 The `dotnet test` command builds the solution and runs the tests with either VSTest or Microsoft Testing Platform (MTP). The test runner you use determines the available command-line options and behavior.
 
 > [!NOTE]
-> Test runner selection is available starting with .NET 10 SDK. In .NET 6, .NET 7, .NET 8, and .NET 9, tests are always executed with VSTest.
+> Test runner selection is available starting with .NET 10 SDK. In earlier versions of .NET, tests are always executed with VSTest.
 
 ### Choosing a test runner
 


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-test.md](https://github.com/dotnet/docs/blob/87e2763f740103e97b19b79c357a3e63f499e508/docs/core/tools/dotnet-test.md) | [dotnet test](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-test?branch=pr-en-us-50976) |


<!-- PREVIEW-TABLE-END -->