### PR TITLE
Updated formatting for CA5351 to match

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca5351.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5351.md
@@ -1,11 +1,11 @@
 ---
-title: Rule CA5351 Do Not Use Broken Cryptographic Algorithms (code analysis)
-description: "Learn about code analysis rule Rule CA5351 Do Not Use Broken Cryptographic Algorithms"
+title: CA5351: Do Not Use Broken Cryptographic Algorithms (code analysis)
+description: "Learn about code analysis rule CA5351: Do Not Use Broken Cryptographic Algorithms"
 ms.date: 11/04/2016
 f1_keywords:
 - CA5351
 ---
-# CA5351 Do Not Use Broken Cryptographic Algorithms
+# CA5351: Do Not Use Broken Cryptographic Algorithms
 
 | Property                            | Value                                      |
 |-------------------------------------|--------------------------------------------|

--- a/docs/fundamentals/code-analysis/quality-rules/ca5351.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca5351.md
@@ -1,5 +1,5 @@
 ---
-title: CA5351: Do Not Use Broken Cryptographic Algorithms (code analysis)
+title: "CA5351: Do Not Use Broken Cryptographic Algorithms (code analysis)"
 description: "Learn about code analysis rule CA5351: Do Not Use Broken Cryptographic Algorithms"
 ms.date: 11/04/2016
 f1_keywords:


### PR DESCRIPTION
## Summary

I noticed that CA5351 did not have a colon (`:`) after the rule ID in its title like all of the other pages.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca5351.md](https://github.com/dotnet/docs/blob/51ff4077f8eea9f432a95ac5a50c4dc3db3b6c46/docs/fundamentals/code-analysis/quality-rules/ca5351.md) | [CA5351: Do Not Use Broken Cryptographic Algorithms](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca5351?branch=pr-en-us-50987) |


<!-- PREVIEW-TABLE-END -->