### PR TITLE
Update title to BinaryReader.ReadString

### DIFF
--- a/docs/core/compatibility/9.0.md
+++ b/docs/core/compatibility/9.0.md
@@ -38,7 +38,7 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 | [API obsoletions with custom diagnostic IDs](core-libraries/9.0/obsolete-apis-with-custom-diagnostics.md)                                                 | Source incompatible        | (Multiple)         |
 | [Ambiguous overload resolution affecting StringValues implicit operators](core-libraries/9.0/ambiguous-overload.md)                                      | Source incompatible        | GA                 |
 | [BigInteger maximum length](core-libraries/9.0/biginteger-limit.md)                                                                                       | Behavioral change          | Preview 6          |
-| [BinaryReader.GetString() returns "\uFFFD" on malformed sequences](core-libraries/9.0/binaryreader.md)                                                    | Behavioral change          | Preview 7          |
+| [BinaryReader.ReadString() returns "\uFFFD" on malformed sequences](core-libraries/9.0/binaryreader.md)                                                    | Behavioral change          | Preview 7          |
 | [C# overload resolution prefers `params` span-type overloads](core-libraries/9.0/params-overloads.md)                                                     | Source incompatible        |                    |
 | [Creating type of array of System.Void not allowed](core-libraries/9.0/type-instance.md)                                                                  | Behavioral change          | Preview 1          |
 | [Default `Equals()` and `GetHashCode()` throw for types marked with `InlineArrayAttribute`](core-libraries/9.0/inlinearrayattribute.md)                   | Behavioral change          | Preview 6          |

--- a/docs/core/compatibility/core-libraries/9.0/binaryreader.md
+++ b/docs/core/compatibility/core-libraries/9.0/binaryreader.md
@@ -1,5 +1,5 @@
 ---
-title: "Breaking change:BinaryReader.ReadString() returns '\uFFFD' on malformed sequences"
+title: "Breaking change: BinaryReader.ReadString() returns '\uFFFD' on malformed sequences"
 description: Learn about the .NET 9 breaking change in core .NET libraries where BinaryReader.ReadString() returns "\uFFFD" on malformed encoded string sequences.
 ms.date: 10/03/2024
 ---

--- a/docs/core/compatibility/core-libraries/9.0/binaryreader.md
+++ b/docs/core/compatibility/core-libraries/9.0/binaryreader.md
@@ -1,9 +1,9 @@
 ---
-title: "Breaking change:BinaryReader.GetString() returns '\uFFFD' on malformed sequences"
-description: Learn about the .NET 9 breaking change in core .NET libraries where BinaryReader.GetString() returns "\uFFFD" on malformed encoded string sequences.
+title: "Breaking change:BinaryReader.ReadString() returns '\uFFFD' on malformed sequences"
+description: Learn about the .NET 9 breaking change in core .NET libraries where BinaryReader.ReadString() returns "\uFFFD" on malformed encoded string sequences.
 ms.date: 10/03/2024
 ---
-# BinaryReader.GetString() returns "\uFFFD" on malformed sequences
+# BinaryReader.ReadString() returns "\uFFFD" on malformed sequences
 
 A a minor breaking change was introduced that only affects malformed encoded payloads.
 

--- a/docs/core/compatibility/toc.yml
+++ b/docs/core/compatibility/toc.yml
@@ -248,7 +248,7 @@ items:
                 href: core-libraries/9.0/obsolete-apis-with-custom-diagnostics.md
               - name: BigInteger maximum length
                 href: core-libraries/9.0/biginteger-limit.md
-              - name: BinaryReader.GetString() returns "/uFFFD" on malformed sequences
+              - name: BinaryReader.ReadString() returns "/uFFFD" on malformed sequences
                 href: core-libraries/9.0/binaryreader.md
               - name: C# overload resolution prefers `params` span-type overloads
                 href: core-libraries/9.0/params-overloads.md


### PR DESCRIPTION
## Summary

The title of the breaking change for `BinaryReader.ReadString` was `BinaryReader.GetString`, even though the code referred to `System.IO.BinaryReader.ReadString`

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/9.0.md](https://github.com/dotnet/docs/blob/19ee106153e490bfbc1bd579a1a935a90538bb5f/docs/core/compatibility/9.0.md) | [Breaking changes in .NET 9](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/9.0?branch=pr-en-us-50988) |
| [docs/core/compatibility/core-libraries/9.0/binaryreader.md](https://github.com/dotnet/docs/blob/19ee106153e490bfbc1bd579a1a935a90538bb5f/docs/core/compatibility/core-libraries/9.0/binaryreader.md) | [BinaryReader.ReadString() returns "\uFFFD" on malformed sequences](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/9.0/binaryreader?branch=pr-en-us-50988) |
| [docs/core/compatibility/toc.yml](https://github.com/dotnet/docs/blob/19ee106153e490bfbc1bd579a1a935a90538bb5f/docs/core/compatibility/toc.yml) | [docs/core/compatibility/toc](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/toc?branch=pr-en-us-50988) |


<!-- PREVIEW-TABLE-END -->