### PR TITLE
Document TestContext.ManagedType breaking change in MSTest v4

### DIFF
--- a/docs/core/testing/unit-testing-mstest-migration-v3-v4.md
+++ b/docs/core/testing/unit-testing-mstest-migration-v3-v4.md
@@ -108,7 +108,7 @@ If you had usages of `[Timeout(TestTimeout.Infinite)]`, update them to `[Timeout
 
 ### TestContext.ManagedType is now removed
 
-The property `TestContext.ManagedType` is removed. You must use `TestContext.FullyQualifiedTestClassName ` instead.
+The property `TestContext.ManagedType` is removed. You must use `TestContext.FullyQualifiedTestClassName` instead.
 
 ### Types not intended for public consumption are made internal or removed
 

--- a/docs/core/testing/unit-testing-mstest-migration-v3-v4.md
+++ b/docs/core/testing/unit-testing-mstest-migration-v3-v4.md
@@ -106,6 +106,10 @@ If you have calls to `TestContext.Properties.Contains`, update them to `TestCont
 This enum only had a single member, `Infinite`, whose value was `int.MaxValue`.
 If you had usages of `[Timeout(TestTimeout.Infinite)]`, update them to `[Timeout(int.MaxValue)]`.
 
+### TestContext.ManagedType is now removed
+
+The property `TestContext.ManagedType` is removed. You must use `TestContext.FullyQualifiedTestClassName ` instead.
+
 ### Types not intended for public consumption are made internal or removed
 
 - `Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface.ObjectModel.ITestMethod` is made internal.

--- a/docs/core/testing/unit-testing-mstest-migration-v3-v4.md
+++ b/docs/core/testing/unit-testing-mstest-migration-v3-v4.md
@@ -108,7 +108,7 @@ If you had usages of `[Timeout(TestTimeout.Infinite)]`, update them to `[Timeout
 
 ### TestContext.ManagedType is now removed
 
-The property `TestContext.ManagedType` is removed. You must use `TestContext.FullyQualifiedTestClassName` instead.
+The property `TestContext.ManagedType` is removed. Use `TestContext.FullyQualifiedTestClassName` instead.
 
 ### Types not intended for public consumption are made internal or removed
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/testfx/issues/6703

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-mstest-migration-v3-v4.md](https://github.com/dotnet/docs/blob/a2227e8221f0e396aea0aedbff84667da01d544d/docs/core/testing/unit-testing-mstest-migration-v3-v4.md) | [Migrate from MSTest v3 to v4](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-migration-v3-v4?branch=pr-en-us-50999) |


<!-- PREVIEW-TABLE-END -->