### PR TITLE
Revert "Fix DisposeAsync pattern: remove incorrect Dispose(false) call"

### DIFF
--- a/docs/standard/garbage-collection/implementing-disposeasync.md
+++ b/docs/standard/garbage-collection/implementing-disposeasync.md
@@ -42,12 +42,18 @@ The `public` parameterless `DisposeAsync()` method is called implicitly in an `a
 public async ValueTask DisposeAsync()
 {
     // Perform async cleanup.
-    await DisposeAsyncCore().ConfigureAwait(false);
+    await DisposeAsyncCore();
+
+    // Dispose of unmanaged resources.
+    Dispose(false);
 
     // Suppress finalization.
     GC.SuppressFinalize(this);
 }
 ```
+
+> [!NOTE]
+> One primary difference in the async dispose pattern compared to the dispose pattern, is that the call from <xref:System.IAsyncDisposable.DisposeAsync> to the `Dispose(bool)` overload method is given `false` as an argument. When implementing the <xref:System.IDisposable.Dispose?displayProperty=nameWithType> method, however, `true` is passed instead. This helps ensure functional equivalence with the synchronous dispose pattern, and further ensures that finalizer code paths still get invoked. In other words, the `DisposeAsyncCore()` method will dispose of managed resources asynchronously, so you don't want to dispose of them synchronously as well. Therefore, call `Dispose(false)` instead of `Dispose(true)`.
 
 ### The `DisposeAsyncCore` method
 

--- a/docs/standard/garbage-collection/implementing-disposeasync.md
+++ b/docs/standard/garbage-collection/implementing-disposeasync.md
@@ -42,7 +42,7 @@ The `public` parameterless `DisposeAsync()` method is called implicitly in an `a
 public async ValueTask DisposeAsync()
 {
     // Perform async cleanup.
-    await DisposeAsyncCore();
+    await DisposeAsyncCore().ConfigureAwait(false);
 
     // Dispose of unmanaged resources.
     Dispose(false);

--- a/docs/standard/garbage-collection/snippets/dispose-async/ExampleConjunctiveDisposable.cs
+++ b/docs/standard/garbage-collection/snippets/dispose-async/ExampleConjunctiveDisposable.cs
@@ -13,6 +13,7 @@
     {
         await DisposeAsyncCore().ConfigureAwait(false);
 
+        Dispose(disposing: false);
         GC.SuppressFinalize(this);
     }
 


### PR DESCRIPTION
Reverts dotnet/docs#50900
Fixes #51019.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/garbage-collection/implementing-disposeasync.md](https://github.com/dotnet/docs/blob/a25b430aa2648826c6cc7660fed0ceb1208e03e7/docs/standard/garbage-collection/implementing-disposeasync.md) | [Implement a DisposeAsync method](https://review.learn.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-disposeasync?branch=pr-en-us-51024) |


<!-- PREVIEW-TABLE-END -->