### PR TITLE
Prefer `dotnet file` to `dotnet run file`

### DIFF
--- a/docs/csharp/fundamentals/program-structure/top-level-statements.md
+++ b/docs/csharp/fundamentals/program-structure/top-level-statements.md
@@ -1,7 +1,7 @@
 ---
 title: "Top-level statements - programs without Main methods"
 description: Learn about top-level statements. You can create programs without the ceremony of a Program class and a Main method.
-ms.date: 06/23/2025
+ms.date: 01/12/2026
 helpviewer_keywords:
   - "C# language, top-level statements"
   - "C# language, Main method"
@@ -34,7 +34,7 @@ A project can have any number of source code files that don't have top-level sta
 
 ## No other entry points
 
-You can write a `Main` method explicitly, but it can't function as an entry point. The compiler issues the following warning:
+You can explicitly write a `Main` method, but it can't function as an entry point. The compiler issues the following warning:
 
 > CS7022 The entry point of the program is global code; ignoring 'Main()' entry point.
 
@@ -42,7 +42,7 @@ In a project with top-level statements, you can't use the [-main](../../language
 
 ## `using` directives
 
-For the single file containing top-level statements `using` directives must come first in that file, as in this example:
+For the single file containing top-level statements, `using` directives must come first in that file, as in this example:
 
 :::code language="csharp" source="snippets/top-level-statements-1/Program.cs":::
 
@@ -64,7 +64,7 @@ Top-level statements can reference the `args` variable to access any command-lin
 
 ## `await`
 
-You can call an async method by using `await`. For example:
+Use `await` to call an async method. For example:
 
 :::code language="csharp" source="snippets/top-level-statements-4/Program.cs":::
 
@@ -76,7 +76,7 @@ To return an `int` value when the application ends, use the `return` statement a
 
 ## Implicit entry point method
 
-The compiler generates a method to serve as the program entry point for a project with top-level statements. The signature of the method depends on whether the top-level statements contain the `await` keyword or the `return` statement. The following table shows what the method signature would look like, using the method name `Main` in the table for convenience.
+The compiler generates a method to serve as the program entry point for a project with top-level statements. The signature of the method depends on whether the top-level statements contain the `await` keyword or the `return` statement. The following table shows what the method signature looks like, using the method name `Main` in the table for convenience.
 
 | Top-level code contains | Implicit `Main` signature                    |
 |-------------------------|----------------------------------------------|
@@ -85,7 +85,7 @@ The compiler generates a method to serve as the program entry point for a projec
 | `return`                | `static int Main(string[] args)`             |
 | No `await` or `return`  | `static void Main(string[] args)`            |
 
-Beginning with C# 14, programs can be [*file-based apps*](./index.md#building-and-running-c-programs), where a single file contains the program. You run *file-based apps* with the command `dotnet <file.cs>`, or using the `#!/usr/bin/env dotnet` directive as the first line (unix shells only).
+Starting with C# 14, programs can be [*file-based apps*](./index.md#building-and-running-c-programs), where a single file contains the program. You run *file-based apps* by using the command `dotnet <file.cs>`, or by using the `#!/usr/bin/env dotnet` directive as the first line (Unix shells only).
 
 ## C# language specification
 

--- a/docs/csharp/fundamentals/program-structure/top-level-statements.md
+++ b/docs/csharp/fundamentals/program-structure/top-level-statements.md
@@ -85,7 +85,7 @@ The compiler generates a method to serve as the program entry point for a projec
 | `return`                | `static int Main(string[] args)`             |
 | No `await` or `return`  | `static void Main(string[] args)`            |
 
-Beginning with C# 14, programs can be [*file-based apps*](./index.md#building-and-running-c-programs), where a single file contains the program. You run *file-based apps* with the command `dotnet run <file.cs>`, or using the `#!/usr/local/share/dotnet/dotnet run` directive as the first line (unix shells only).
+Beginning with C# 14, programs can be [*file-based apps*](./index.md#building-and-running-c-programs), where a single file contains the program. You run *file-based apps* with the command `dotnet <file.cs>`, or using the `#!/usr/bin/env dotnet` directive as the first line (unix shells only).
 
 ## C# language specification
 

--- a/docs/csharp/fundamentals/tutorials/file-based-programs.md
+++ b/docs/csharp/fundamentals/tutorials/file-based-programs.md
@@ -42,10 +42,10 @@ You build a file-based program that writes text as ASCII art. The app is contain
 1. Save the file. Then, open the integrated terminal in Visual Studio Code and type:
 
    ```dotnetcli
-   dotnet run AsciiArt.cs
+   dotnet AsciiArt.cs
    ```
 
-The first time you run this program, the `dotnet` host builds the executable from your source file, stores build artifacts in a temporary folder, and then runs the created executable. You can verify this experience by typing `dotnet run AsciiArt.cs` again. This time, the `dotnet` host determines that the executable is current and runs the executable without building it again. You don't see any build output.
+The first time you run this program, the `dotnet` host builds the executable from your source file, stores build artifacts in a temporary folder, and then runs the created executable. You can verify this experience by typing `dotnet AsciiArt.cs` again. This time, the `dotnet` host determines that the executable is current and runs the executable without building it again. You don't see any build output.
 
 The preceding steps demonstrate that file-based apps aren't script files. They're C# source files that the `dotnet` host builds by using a generated project file in a temporary folder. One of the lines of output displayed when you build the program should look something like this (on Windows):
 
@@ -67,9 +67,9 @@ File-based apps are regular C# programs. The only limitation is that you must wr
 
 > [!NOTE]
 >
-> Support for `#!` directives applies on Unix platforms only. There's no similar directive for Windows to directly execute a C# program. On Windows, you must use `dotnet run` on the command line.
+> Support for `#!` directives applies on Unix platforms only. There's no similar directive for Windows to directly execute a C# program. On Windows, you must use `dotnet` on the command line.
 
-On Unix, you can run file-based apps directly. Instead of using `dotnet run`, you type the source file name on the command line. You need to make two changes:
+On Unix, you can run file-based apps directly. Instead of using `dotnet`, you type the source file name on the command line. You need to make two changes:
 
 1. Set *execute* permissions on the source file:
 
@@ -80,7 +80,7 @@ On Unix, you can run file-based apps directly. Instead of using `dotnet run`, yo
 1. Add a shebang (`#!`) directive as the first line of the `AsciiArt.cs` file:
 
    ```csharp
-   #!/usr/local/share/dotnet/dotnet run
+   #!/usr/local/share/dotnet/dotnet
    ```
 
 The location of `dotnet` can be different on different Unix installations. Use the command `which dotnet` to locate the `dotnet` host in your environment.
@@ -116,7 +116,7 @@ Now, write all arguments on the command line to the output.
 1. You can run this version by typing the following command:
 
    ```dotnetcli
-   dotnet run AsciiArt.cs -- This is the command line.
+   dotnet AsciiArt.cs -- This is the command line.
    ```
 
    The `--` option indicates that all following command arguments should be passed to the AsciiArt program. The arguments `This is the command line.` are passed as an array of strings, where each string is one word: `This`, `is`, `the`, `command`, and `line.`.
@@ -156,13 +156,13 @@ The preceding code handles command line arguments correctly. Now, add the code t
    By using bash:
 
    ```bash
-   cat input.txt | dotnet run AsciiArt.cs
+   cat input.txt | dotnet AsciiArt.cs
    ```
 
    Or, by using PowerShell:
 
    ```powershell
-   Get-Content input.txt | dotnet run AsciiArt.cs
+   Get-Content input.txt | dotnet AsciiArt.cs
    ```
 
 Now your program can accept either command line arguments or standard input.

--- a/docs/csharp/fundamentals/tutorials/file-based-programs.md
+++ b/docs/csharp/fundamentals/tutorials/file-based-programs.md
@@ -1,7 +1,7 @@
 ---
 title: Build file-based apps
 description: File-based apps are command line utilities that are built and execute without a project file. The build and run commands are implicit. New syntax supports project settings in source.
-ms.date: 12/12/2025
+ms.date: 01/12/2026
 ms.topic: tutorial
 ai-usage: ai-assisted
 #customer intent: As a developer, I want to build utilities so that more work is automated.

--- a/docs/csharp/fundamentals/tutorials/file-based-programs.md
+++ b/docs/csharp/fundamentals/tutorials/file-based-programs.md
@@ -69,7 +69,7 @@ File-based apps are regular C# programs. The only limitation is that you must wr
 >
 > Support for `#!` directives applies on Unix platforms only. There's no similar directive for Windows to directly execute a C# program. On Windows, you must use `dotnet` on the command line.
 
-On Unix, you can run file-based apps directly. Instead of using `dotnet`, you type the source file name on the command line. You need to make two changes:
+On Unix, run file-based apps directly by typing just the source file name. Instead of using `dotnet AsciiArt.cs`, type the source file name on the command line. You need to make two changes:
 
 1. Set *execute* permissions on the source file:
 

--- a/docs/csharp/fundamentals/tutorials/snippets/file-based-programs/AsciiArt
+++ b/docs/csharp/fundamentals/tutorials/snippets/file-based-programs/AsciiArt
@@ -1,4 +1,4 @@
-#!/usr/local/share/dotnet/dotnet run
+#!/usr/bin/env dotnet
 
 #:package Colorful.Console@1.2.15
 #:package System.CommandLine@2.0.0

--- a/docs/csharp/fundamentals/tutorials/snippets/file-based-programs/AsciiArt.cs
+++ b/docs/csharp/fundamentals/tutorials/snippets/file-based-programs/AsciiArt.cs
@@ -1,4 +1,4 @@
-#!/usr/bin/env dotnet run
+#!/usr/bin/env dotnet
 
 // <ColorfulPackage>
 #:package Colorful.Console@1.2.15

--- a/docs/csharp/tour-of-csharp/snippets/file-based-programs/hello-world.cs
+++ b/docs/csharp/tour-of-csharp/snippets/file-based-programs/hello-world.cs
@@ -1,2 +1,3 @@
-#!/usr/local/share/dotnet/dotnet run
+#!/usr/bin/env dotnet
+
 Console.WriteLine("Hello, World!");


### PR DESCRIPTION
Fixes #50259

Replace instances of `dotnet run file.cs` with `dotnet file.cs`. Make a similar change for the `#!` directive.

While here, do a freshness edit pass.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/fundamentals/program-structure/top-level-statements.md](https://github.com/dotnet/docs/blob/ee5840509539b78f2391ea9b252367a86a52966f/docs/csharp/fundamentals/program-structure/top-level-statements.md) | [Top-level statements - programs without `Main` methods](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/program-structure/top-level-statements?branch=pr-en-us-51029) |
| [docs/csharp/fundamentals/tutorials/file-based-programs.md](https://github.com/dotnet/docs/blob/ee5840509539b78f2391ea9b252367a86a52966f/docs/csharp/fundamentals/tutorials/file-based-programs.md) | [Tutorial: Build file-based C# programs](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/tutorials/file-based-programs?branch=pr-en-us-51029) |


<!-- PREVIEW-TABLE-END -->