### PR TITLE
Don't unconditionally yield return default

### DIFF
--- a/docs/csharp/tour-of-csharp/tutorials/snippets/PatternMatching/patterns.cs
+++ b/docs/csharp/tour-of-csharp/tutorials/snippets/PatternMatching/patterns.cs
@@ -132,7 +132,7 @@ static IEnumerable<object?> TransactionRecordType(string inputText)
                 yield return new Deposit(amount, parts[2]);
             else if (transactionType?.ToUpper() is "WITHDRAWAL")
                 yield return new Withdrawal(amount, parts[2]);
-        } 
+        }
     }
 }
 // </ParseToRecord>

--- a/docs/csharp/tour-of-csharp/tutorials/snippets/PatternMatching/patterns.cs
+++ b/docs/csharp/tour-of-csharp/tutorials/snippets/PatternMatching/patterns.cs
@@ -132,8 +132,7 @@ static IEnumerable<object?> TransactionRecordType(string inputText)
                 yield return new Deposit(amount, parts[2]);
             else if (transactionType?.ToUpper() is "WITHDRAWAL")
                 yield return new Withdrawal(amount, parts[2]);
-        }
-        yield return default;
+        } 
     }
 }
 // </ParseToRecord>


### PR DESCRIPTION
If the parse fails, don't add a new item to the returned enumeration.

That was boilerplate code that should have been removed.

Fixes #50825