### PR TITLE
Remove invalid issue numbers from metadata

### DIFF
--- a/.github/agents/breakingchange.agent.md
+++ b/.github/agents/breakingchange.agent.md
@@ -16,20 +16,22 @@ Start with this header (replace placeholders):
 
 ```
 ---
-title: "Breaking change - <Concise descriptive title>"
+title: "Breaking change: <Concise descriptive title>"
 description: "Learn about the breaking change in <product/version without preview> where <brief description>."
 ms.date: <Today's date in MM/DD/YYYY format>
 ai-usage: ai-assisted
 ---
 ```
 
-> **Note:** Use today's date in the format MM/DD/YYYY. This date cannot be earlier than 11/12/2025.
+> **Note:**
+> - Use today's date in the format MM/DD/YYYY. This date cannot be earlier than 01/12/2026.
+> - Do NOT include ms.custom metadata with an issue number.
 
 Then, include these sections in this order:
 
 ### 1. H1 Title
 
-- Use the header title, but remove "Breaking change - ".
+- Use the header title, but remove "Breaking change: ".
 
 **Intro paragraph:**
 Summarize the breaking change.

--- a/docs/core/compatibility/core-libraries/8.0/system-io-packaging-case-insensitive-uri.md
+++ b/docs/core/compatibility/core-libraries/8.0/system-io-packaging-case-insensitive-uri.md
@@ -3,7 +3,6 @@ title: "Breaking change: Package part URIs are now compared case-insensitively i
 description: "Learn about the breaking change in .NET 8 where System.IO.Packaging now compares package part URIs case-insensitively to align with the OPC specification."
 ms.date: 09/29/2024
 ai-usage: ai-generated
-ms.custom: https://github.com/dotnet/runtime/issues/112783
 ---
 
 # Package part URIs are now compared case-insensitively in System.IO.Packaging

--- a/docs/core/compatibility/deployment/8.0/opensuse-sles-openssl3-dependency.md
+++ b/docs/core/compatibility/deployment/8.0/opensuse-sles-openssl3-dependency.md
@@ -2,7 +2,6 @@
 title: "Breaking change: .NET packages for openSUSE and SLES depend on OpenSSL 3.x"
 description: "Learn about the breaking change in .NET 8 where .NET packages for openSUSE and SLES distributions now depend on OpenSSL 3.x instead of OpenSSL 1.x."
 ms.date: 01/05/2026
-ms.custom: https://github.com/dotnet/runtime/issues/122653
 ai-usage: ai-assisted
 ---
 # .NET packages for openSUSE and SLES depend on OpenSSL 3.x

--- a/docs/core/compatibility/sdk/10.0/dnx-ps1-removed.md
+++ b/docs/core/compatibility/sdk/10.0/dnx-ps1-removed.md
@@ -3,7 +3,6 @@ title: "Breaking change - dnx.ps1 file is no longer included in .NET SDK"
 description: "Learn about the breaking change in .NET 10 where the dnx.ps1 script is no longer included in Windows versions of the .NET SDK."
 ms.date: 10/13/2025
 ai-usage: ai-assisted
-ms.custom: https://github.com/dotnet/docs/issues/497988
 ---
 
 # dnx.ps1 file is no longer included in .NET SDK


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/agents/breakingchange.agent.md](https://github.com/dotnet/docs/blob/0688ec26c331c3cf54d4c9db89f3d41dc3a22676/.github/agents/breakingchange.agent.md) | ["Breaking change: <Concise descriptive title>"](https://review.learn.microsoft.com/en-us/dotnet/.github/agents/breakingchange.agent?branch=pr-en-us-51033) |
| [docs/core/compatibility/core-libraries/8.0/system-io-packaging-case-insensitive-uri.md](https://github.com/dotnet/docs/blob/0688ec26c331c3cf54d4c9db89f3d41dc3a22676/docs/core/compatibility/core-libraries/8.0/system-io-packaging-case-insensitive-uri.md) | [Package part URIs are now compared case-insensitively in System.IO.Packaging](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/8.0/system-io-packaging-case-insensitive-uri?branch=pr-en-us-51033) |
| [docs/core/compatibility/deployment/8.0/opensuse-sles-openssl3-dependency.md](https://github.com/dotnet/docs/blob/0688ec26c331c3cf54d4c9db89f3d41dc3a22676/docs/core/compatibility/deployment/8.0/opensuse-sles-openssl3-dependency.md) | [docs/core/compatibility/deployment/8.0/opensuse-sles-openssl3-dependency](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/deployment/8.0/opensuse-sles-openssl3-dependency?branch=pr-en-us-51033) |
| [docs/core/compatibility/sdk/10.0/dnx-ps1-removed.md](https://github.com/dotnet/docs/blob/0688ec26c331c3cf54d4c9db89f3d41dc3a22676/docs/core/compatibility/sdk/10.0/dnx-ps1-removed.md) | [dnx.ps1 file is no longer included in .NET SDK](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/10.0/dnx-ps1-removed?branch=pr-en-us-51033) |

<!-- PREVIEW-TABLE-END -->