### PR TITLE
Update CA2264 documentation for clarity

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca2264.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca2264.md
@@ -22,11 +22,11 @@ dev_langs:
 
 ## Cause
 
-When a value that's known to never be null is passed to `ArgumentNullException.ThrowIfNull()`, an exception is never thrown, making the statement a no-op.
+A value that's known to never be null is passed to `ArgumentNullException.ThrowIfNull()`.
 
 ## Rule description
 
-`ArgumentNullException.ThrowIfNull` throws when the passed argument is `null`. Certain constructs like non-nullable structs (except for <xref:System.Nullable%601>), type parameters known to be non-nullable structs, 'nameof()' expressions, and 'new' expressions are known to never be null, so `ArgumentNullException.ThrowIfNull` will never throw.
+`ArgumentNullException.ThrowIfNull` throws when the passed argument is `null`. Certain constructs like non-nullable structs (except for <xref:System.Nullable%601>), type parameters known to be non-nullable structs, 'nameof()' expressions, and 'new' expressions are known to never be null, so `ArgumentNullException.ThrowIfNull` will never throw. Thus, calling `ArgumentNullException.ThrowIfNull` is unnecessary.
 
 In the case of a struct, since `ArgumentNullException.ThrowIfNull` accepts an `object?`, the struct is boxed, which causes an additional performance penalty.
 
@@ -77,3 +77,7 @@ dotnet_diagnostic.CA2264.severity = none
 ```
 
 For more information, see [How to suppress code analysis warnings](../suppress-warnings.md).
+
+## See also
+
+- [CA1871: Do not pass a nullable struct to 'ArgumentNullException.ThrowIfNull](ca1871.md)


### PR DESCRIPTION
Fixes #51028.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca2264.md](https://github.com/dotnet/docs/blob/c46d9140a35f04827e2340afc4443fc3753eccf9/docs/fundamentals/code-analysis/quality-rules/ca2264.md) | [CA2264: Do not pass a non-nullable value to 'ArgumentNullException.ThrowIfNull'](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2264?branch=pr-en-us-51043) |

<!-- PREVIEW-TABLE-END -->