### PR TITLE
Fix spelling of "passed"

### DIFF
--- a/docs/core/compatibility/core-libraries/10.0/filepatternmatch-stem-nonnullable.md
+++ b/docs/core/compatibility/core-libraries/10.0/filepatternmatch-stem-nonnullable.md
@@ -48,7 +48,7 @@ The previous nullability annotations were inaccurate, and a `null` value for the
 
 ## Recommended action
 
-If a possibly null value was passed in for the `stem` argument, review usage and update the call site to ensure `stem` can't be paTssed in as `null`.
+If a possibly null value was passed in for the `stem` argument, review usage and update the call site to ensure `stem` can't be passed in as `null`.
 
 If you applied nullability warning suppressions when consuming the `FilePatternMatch.Stem` property, you can remove those suppressions.
 


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/core-libraries/10.0/filepatternmatch-stem-nonnullable.md](https://github.com/dotnet/docs/blob/50271c0c22071790b02a38cfa72d396e089bd0c6/docs/core/compatibility/core-libraries/10.0/filepatternmatch-stem-nonnullable.md) | [FilePatternMatch.Stem changed to non-nullable](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/10.0/filepatternmatch-stem-nonnullable?branch=pr-en-us-51176) |

<!-- PREVIEW-TABLE-END -->