### PR TITLE
Remove duplicated breaking changes from 9.0 Overview

### DIFF
--- a/docs/core/compatibility/9.0.md
+++ b/docs/core/compatibility/9.0.md
@@ -106,7 +106,6 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 | [`dotnet watch` incompatible with Hot Reload for old frameworks](sdk/9.0/dotnet-watch.md) | Behavioral change   | RC 1               |
 | [`dotnet workload` commands output change](sdk/9.0/dotnet-workload-output.md)             | Behavioral change   | Preview 1          |
 | [`installer` repo version no longer documented](sdk/9.0/productcommits-versions.md)       | Behavioral change   | Preview 5          |
-| [MSBuild custom culture resource handling](sdk/10.0/msbuild-custom-culture.md)            | Behavioral change   | 9.0.200/9.0.300    |
 | [New default RID used when targeting .NET Framework](sdk/9.0/default-rid.md)              | Source incompatible | GA                 |
 | [Terminal Logger is default](sdk/9.0/terminal-logger.md)                                  | Behavioral change   | Preview 1          |
 | [Version requirements for .NET 9 SDK](sdk/9.0/version-requirements.md)                    | Source incompatible | GA                 |

--- a/docs/core/compatibility/9.0.md
+++ b/docs/core/compatibility/9.0.md
@@ -106,6 +106,7 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 | [`dotnet watch` incompatible with Hot Reload for old frameworks](sdk/9.0/dotnet-watch.md) | Behavioral change   | RC 1               |
 | [`dotnet workload` commands output change](sdk/9.0/dotnet-workload-output.md)             | Behavioral change   | Preview 1          |
 | [`installer` repo version no longer documented](sdk/9.0/productcommits-versions.md)       | Behavioral change   | Preview 5          |
+| [MSBuild custom culture resource handling](sdk/10.0/msbuild-custom-culture.md)            | Behavioral change   | 9.0.200/9.0.300    |
 | [New default RID used when targeting .NET Framework](sdk/9.0/default-rid.md)              | Source incompatible | GA                 |
 | [Terminal Logger is default](sdk/9.0/terminal-logger.md)                                  | Behavioral change   | Preview 1          |
 | [Version requirements for .NET 9 SDK](sdk/9.0/version-requirements.md)                    | Source incompatible | GA                 |

--- a/docs/core/compatibility/9.0.md
+++ b/docs/core/compatibility/9.0.md
@@ -91,7 +91,6 @@ If you're migrating an app to .NET 9, the breaking changes listed here might aff
 
 | Title                                                                                              | Type of change      | Introduced version |
 |----------------------------------------------------------------------------------------------------|---------------------|--------------------|
-| [API obsoletions](core-libraries/9.0/obsolete-apis-with-custom-diagnostics.md)                     | Source incompatible | Preview 6          |
 | [HttpClient metrics report `server.port` unconditionally](networking/9.0/server-port-attribute.md) | Behavioral change   | Preview 7          |
 | [HttpClientFactory logging redacts header values by default](networking/9.0/redact-headers.md)     | Behavioral change   | RC 1               |
 | [HttpClientFactory uses SocketsHttpHandler as primary handler](networking/9.0/default-handler.md)  | Behavioral change   | Preview 6          |


### PR DESCRIPTION
## Summary
The API Obsoletions in the Networking section is already linked in Core .NET libraries:
https://learn.microsoft.com/en-us/dotnet/core/compatibility/9.0#core-net-libraries

Describe your changes here.
The duplicated entry has been removed

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/9.0.md](https://github.com/dotnet/docs/blob/f914bf66068f81a76ba93bf81f921ad3ff183084/docs/core/compatibility/9.0.md) | [Breaking changes in .NET 9](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/9.0?branch=pr-en-us-51211) |


<!-- PREVIEW-TABLE-END -->