### PR TITLE
Update F# interactive documentation with security notes

### DIFF
--- a/docs/fsharp/tools/fsharp-interactive/index.md
+++ b/docs/fsharp/tools/fsharp-interactive/index.md
@@ -169,6 +169,11 @@ Examples:
 #r "nuget:fsharp.data,6.6.0,usepackagetargets=true"
 ```
 
+> [!IMPORTANT]
+> Referencing packages with `#r` carries the same security considerations as any other form of package reference.
+> Only include dependencies from sources you trust.
+> [NuGet documentation](https://learn.microsoft.com/nuget/concepts/security-best-practices) describes best practices for securing your software supply chain.
+
 ### Specifying a package source
 
 You can also specify a package source with the `#i` command. The following examples specify remote and local sources:

--- a/docs/fsharp/tools/fsharp-interactive/index.md
+++ b/docs/fsharp/tools/fsharp-interactive/index.md
@@ -173,7 +173,7 @@ Examples:
 > Referencing packages with `#r` carries the same security considerations as any other form of package reference.
 > Only include dependencies from sources you trust.
 >
-> [NuGet documentation](https://learn.microsoft.com/nuget/concepts/security-best-practices) describes best practices for securing your software supply chain.
+> [NuGet documentation](/nuget/concepts/security-best-practices) describes best practices for securing your software supply chain.
 
 ### Specifying a package source
 

--- a/docs/fsharp/tools/fsharp-interactive/index.md
+++ b/docs/fsharp/tools/fsharp-interactive/index.md
@@ -172,6 +172,7 @@ Examples:
 > [!IMPORTANT]
 > Referencing packages with `#r` carries the same security considerations as any other form of package reference.
 > Only include dependencies from sources you trust.
+>
 > [NuGet documentation](https://learn.microsoft.com/nuget/concepts/security-best-practices) describes best practices for securing your software supply chain.
 
 ### Specifying a package source


### PR DESCRIPTION
Added important security considerations for referencing packages in F#.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/tools/fsharp-interactive/index.md](https://github.com/dotnet/docs/blob/016b77a0db561526a761b562426fc5329f45cdc1/docs/fsharp/tools/fsharp-interactive/index.md) | [Interactive programming with F\#](https://review.learn.microsoft.com/en-us/dotnet/fsharp/tools/fsharp-interactive/index?branch=pr-en-us-51277) |


<!-- PREVIEW-TABLE-END -->