### PR TITLE
Passing properties to the dotnet run command works.

### DIFF
--- a/docs/core/tools/dotnet-run.md
+++ b/docs/core/tools/dotnet-run.md
@@ -21,6 +21,7 @@ dotnet run [<applicationArguments>]
   [-f|--framework <FRAMEWORK>] [--force] [--interactive]
   [-lp|--launch-profile <NAME>] [--no-build] [--no-cache]
   [--no-dependencies] [--no-launch-profile] [--no-restore] [--os <OS>]
+  [-p|--property:<PROPERTYNAME>=<VALUE>]
   [--project <PATH>] [-r|--runtime <RUNTIME_IDENTIFIER>]
   [--sc|--self-contained] [--tl:[auto|on|off]] [-v|--verbosity <LEVEL>]
   [[--] [application arguments]]
@@ -31,9 +32,6 @@ dotnet run -h|--help
 ## Description
 
 The `dotnet run` command provides a convenient option to run your application from the source code with one command. It's useful for fast iterative development from the command line. The command depends on the [`dotnet build`](dotnet-build.md) command to build the code. Any requirements for the build apply to `dotnet run` as well.
-
-> [!NOTE]
-> `dotnet run` doesn't respect arguments like `/property:property=value`, which are respected by `dotnet build`.
 
 Output files are written into the default location, which is `bin/<configuration>/<target>`. For example if you have a `netcoreapp2.1` application and you run `dotnet run`, the output is placed in `bin/Debug/netcoreapp2.1`. Files are overwritten as needed. Temporary files are placed in the `obj` directory.
 


### PR DESCRIPTION
## Summary

Passing properties to the dotnet run command works, so add -p|--property to
the list of valid arguments, and remove the notice saying it doesn't work.

It's already listed as a valid argument further down on this page: https://github.com/dotnet/docs/commit/9b0663a92b0e2430b16ffb2f36061e43de29fd15

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-run.md](https://github.com/dotnet/docs/blob/baf72ed77ee986f3b4d60f21f863c3943ef3b3ed/docs/core/tools/dotnet-run.md) | [docs/core/tools/dotnet-run](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-run?branch=pr-en-us-51285) |

<!-- PREVIEW-TABLE-END -->