### PR TITLE
Add link to System.Drawing.Point

### DIFF
--- a/docs/csharp/whats-new/tutorials/extension-members.md
+++ b/docs/csharp/whats-new/tutorials/extension-members.md
@@ -31,7 +31,7 @@ In this tutorial, you:
 
 ## Create the sample application
 
-Start by creating a console application that demonstrates both traditional extension methods and the new extension members syntax.
+Start by creating a console application that demonstrates both traditional extension methods and the new extension members syntax. You'll create extensions for the <xref:System.Drawing.Point?displayProperty=fullName> type. This type is typically used in [WPF](~/dotnet/desktop/wpf/index.md) applications.
 
 1. Create a new console application:
 

--- a/docs/csharp/whats-new/tutorials/extension-members.md
+++ b/docs/csharp/whats-new/tutorials/extension-members.md
@@ -31,7 +31,7 @@ In this tutorial, you:
 
 ## Create the sample application
 
-Start by creating a console application that demonstrates both traditional extension methods and the new extension members syntax. You'll create extensions for the <xref:System.Drawing.Point?displayProperty=fullName> type. This type is typically used in [WPF](~/dotnet/desktop/wpf/index.md) applications.
+Start by creating a console application that demonstrates both traditional extension methods and the new extension members syntax. You'll create extensions for the <xref:System.Drawing.Point?displayProperty=fullName> type. This type comes from the `System.Drawing` namespace and is typically used in Windows Forms applications.
 
 1. Create a new console application:
 


### PR DESCRIPTION
Fixes #50363

Some readers weren't familiar with System.Drawing.Point. Add a link and a summary to the type.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/whats-new/tutorials/extension-members.md](https://github.com/dotnet/docs/blob/31467dd2278487b2fbd9766098f8756e79063c78/docs/csharp/whats-new/tutorials/extension-members.md) | [Tutorial: Explore extension members in C# 14](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/tutorials/extension-members?branch=pr-en-us-51318) |


<!-- PREVIEW-TABLE-END -->