### PR TITLE
Add API obsoletions for .NET 10 into overview

### DIFF
--- a/docs/core/compatibility/10.md
+++ b/docs/core/compatibility/10.md
@@ -39,7 +39,7 @@ If you're migrating an app to .NET 10, the breaking changes listed here might af
 
 | Title | Type of change    |
 |-------|-------------------|
-| [API obsoletions ](docs/core/compatibility/core-libraries/10.0/obsolete-apis.md) | Source incompatible |
+| [API obsoletions](core-libraries/10.0/obsolete-apis.md) | Source incompatible |
 | [ActivitySource.CreateActivity and ActivitySource.StartActivity behavior change](core-libraries/10.0/activity-sampling.md) | Behavioral change |
 | [Arm64 SVE nonfaulting loads require mask](core-libraries/10.0/sve-nonfaulting-loads-mask-parameter.md) | Binary/source incompatible |
 | [BufferedStream.WriteByte no longer performs implicit flush](core-libraries/10.0/bufferedstream-writebyte-flush.md) | Behavioral change |

--- a/docs/core/compatibility/10.md
+++ b/docs/core/compatibility/10.md
@@ -39,6 +39,7 @@ If you're migrating an app to .NET 10, the breaking changes listed here might af
 
 | Title | Type of change    |
 |-------|-------------------|
+| [API obsoletions ](docs/core/compatibility/core-libraries/10.0/obsolete-apis.md) | Source incompatible |
 | [ActivitySource.CreateActivity and ActivitySource.StartActivity behavior change](core-libraries/10.0/activity-sampling.md) | Behavioral change |
 | [Arm64 SVE nonfaulting loads require mask](core-libraries/10.0/sve-nonfaulting-loads-mask-parameter.md) | Binary/source incompatible |
 | [BufferedStream.WriteByte no longer performs implicit flush](core-libraries/10.0/bufferedstream-writebyte-flush.md) | Behavioral change |


### PR DESCRIPTION
## Summary

Describe your changes here.
The API obsoletions were added into the overview page of the .NET 10 breaking changes

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/10.md](https://github.com/dotnet/docs/blob/2b4a9cd586869a32e5cb66745387b1d36577d922/docs/core/compatibility/10.md) | [Breaking changes in .NET 10](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/10?branch=pr-en-us-51325) |


<!-- PREVIEW-TABLE-END -->