### PR TITLE
Modify .NET version options in BC issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/02-breaking-change.yml
+++ b/.github/ISSUE_TEMPLATE/02-breaking-change.yml
@@ -23,7 +23,7 @@ body:
       options:
         - .NET 8
         - .NET 9
-        - .NET 10 
+        - .NET 10
         - .NET 11 Preview 1
         - .NET 11 Preview 2
         - .NET 11 Preview 3

--- a/.github/ISSUE_TEMPLATE/02-breaking-change.yml
+++ b/.github/ISSUE_TEMPLATE/02-breaking-change.yml
@@ -23,14 +23,17 @@ body:
       options:
         - .NET 8
         - .NET 9
-        - .NET 10 RC 1
-        - .NET 10 RC 2
-        - .NET 10 GA
+        - .NET 10 
         - .NET 11 Preview 1
         - .NET 11 Preview 2
         - .NET 11 Preview 3
         - .NET 11 Preview 4
         - .NET 11 Preview 5
+        - .NET 11 Preview 6
+        - .NET 11 Preview 7
+        - .NET 11 RC 1
+        - .NET 11 RC 2
+        - .NET 11 GA
         - Other (please put exact version in description textbox)
     validations:
       required: true


### PR DESCRIPTION
Updated .NET version options for breaking change template.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/ISSUE_TEMPLATE/02-breaking-change.yml](https://github.com/dotnet/docs/blob/c92731f6ce82c8cf262a885f8e35fa2a9fa7e708/.github/ISSUE_TEMPLATE/02-breaking-change.yml) | ["[Breaking change]: "](https://review.learn.microsoft.com/en-us/dotnet/.github/ISSUE_TEMPLATE/02-breaking-change?branch=pr-en-us-51392) |


<!-- PREVIEW-TABLE-END -->