### PR TITLE
Disambiguate distributed tracing documentation

### DIFF
--- a/docs/core/diagnostics/distributed-tracing.md
+++ b/docs/core/diagnostics/distributed-tracing.md
@@ -15,6 +15,10 @@ process, which then makes several queries to a database. Using distributed traci
 engineers to distinguish if any of those steps failed, how long each step took, and potentially
 logging messages produced by each step as it ran.
 
+> [!NOTE]
+> The term 'tracing' can have multiple meanings in older .NET APIs. This document focuses on distributed tracing. For information
+> on logging and older tracing APIs, see [Logging and tracing](./logging-tracing.md).
+
 ## Getting started for .NET app developers
 
 Key .NET libraries are instrumented to produce distributed tracing information automatically. However, this information needs to be collected and stored so that it will be available for review later.


### PR DESCRIPTION
## Summary

Add a note to the beginning of the distributed tracing doc to also point to the logging and tracing doc. There's already a link from logging and tracing here, so making the link bidirectional so the relationship is clear regardless of which entrypoint the reader found.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/distributed-tracing.md](https://github.com/dotnet/docs/blob/387c5a670483a0e0ed176dbd72347521fd0ce435/docs/core/diagnostics/distributed-tracing.md) | [.NET distributed tracing](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/distributed-tracing?branch=pr-en-us-51397) |

<!-- PREVIEW-TABLE-END -->