### PR TITLE
Add missing reflection and sdk changes to .NET 10 overview

### DIFF
--- a/docs/core/compatibility/10.md
+++ b/docs/core/compatibility/10.md
@@ -109,6 +109,7 @@ See [Breaking changes in EF Core 10](/ef/core/what-is-new/ef-core-10.0/breaking-
 | Title | Type of change    | Introduced version |
 |-------|-------------------|--------------------|
 | [More restricted annotations on InvokeMember/FindMembers/DeclaredMembers](reflection/10/ireflect-damt-annotations.md) | Behavioral/source incompatible | |
+| [Type.MakeGenericSignatureType argument validation](reflection/10/makegeneric-signaturetype-validation.md) | Behavioral change | |
 
 ## SDK and MSBuild
 
@@ -120,6 +121,7 @@ See [Breaking changes in EF Core 10](/ef/core/what-is-new/ef-core-10.0/breaking-
 | [Default workload configuration from 'loose manifests' to 'workload sets' mode](sdk/10.0/default-workload-config.md) | Behavioral change |
 | [Code coverage EnableDynamicNativeInstrumentation defaults to false](sdk/10.0/code-coverage-dynamic-native-instrumentation.md) | Behavioral change |
 | [dnx.ps1 file is no longer included in .NET SDK](sdk/10.0/dnx-ps1-removed.md) | Source incompatible |
+| [Double quotes in file-level directives are disallowed](sdk/10.0/file-level-directive-double-quotes.md) | Source incompatible |
 | [`dotnet new sln` defaults to SLNX file format](sdk/10.0/dotnet-new-sln-slnx-default.md) | Behavioral change |
 | [`dotnet package list` performs restore](sdk/10.0/dotnet-package-list-restore.md) | Behavioral change |
 | [`dotnet restore` audits transitive packages](sdk/10.0/nugetaudit-transitive-packages.md) | Behavioral change |


### PR DESCRIPTION
## Summary

Describe your changes here.
Some missing breaking changes on .NET 10 reflection and sdk were added

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/10.md](https://github.com/dotnet/docs/blob/fd71addea220cc138ae1b2c258c2e00a39b0dc93/docs/core/compatibility/10.md) | [Breaking changes in .NET 10](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/10?branch=pr-en-us-51406) |

<!-- PREVIEW-TABLE-END -->