### PR TITLE
Clarify precedence groups.

### DIFF
--- a/docs/csharp/language-reference/operators/arithmetic-operators.md
+++ b/docs/csharp/language-reference/operators/arithmetic-operators.md
@@ -199,10 +199,10 @@ You also use the `+=` and `-=` operators to subscribe to and unsubscribe from an
 
 The following list orders arithmetic operators in groups from highest precedence to lowest precedence:
 
-- ([Primary](./index.md#operator-precedence)) operators: postfix increment `x++` and decrement `x--`.
-- ([Unary](./index.md#operator-precedence)) operators: Prefix increment `++x` and decrement `--x` operators, and unary `+` and `-` operators.
+- ([Primary](./index.md#operator-precedence)) operators: postfix increment `x++` and decrement `x--` operators.
+- ([Unary](./index.md#operator-precedence)) operators: prefix increment `++x` and decrement `--x` operators, and unary `+` and `-` operators.
 - ([Multiplicative](./index.md#operator-precedence)) operators: `*`, `/`, and `%` operators.
-- ([Additive](./index.md#operator-precedence)) operators: Additive `+` and `-` operators.
+- ([Additive](./index.md#operator-precedence)) operators: binary `+` and `-` operators.
 
 Binary arithmetic operators are left-associative. That is, the compiler evaluates operators with the same precedence level from left to right.
 

--- a/docs/csharp/language-reference/operators/arithmetic-operators.md
+++ b/docs/csharp/language-reference/operators/arithmetic-operators.md
@@ -197,12 +197,12 @@ You also use the `+=` and `-=` operators to subscribe to and unsubscribe from an
 
 ## Operator precedence and associativity
 
-The following list orders arithmetic operators from highest precedence to lowest precedence:
+The following list orders arithmetic operators in groups from highest precedence to lowest precedence:
 
-- Postfix increment `x++` and decrement `x--` operators
-- Prefix increment `++x` and decrement `--x` operators, and unary `+` and `-` operators
-- Multiplicative `*`, `/`, and `%` operators
-- Additive `+` and `-` operators
+- ([Primary](./index.md#operator-precedence)) operators: postfix increment `x++` and decrement `x--`.
+- ([Unary](./index.md#operator-precedence)) operators: Prefix increment `++x` and decrement `--x` operators, and unary `+` and `-` operators.
+- ([Multiplicative](./index.md#operator-precedence)) operators: `*`, `/`, and `%` operators.
+- ([Additive](./index.md#operator-precedence)) operators: Additive `+` and `-` operators.
 
 Binary arithmetic operators are left-associative. That is, the compiler evaluates operators with the same precedence level from left to right.
 

--- a/docs/csharp/language-reference/operators/bitwise-and-shift-operators.md
+++ b/docs/csharp/language-reference/operators/bitwise-and-shift-operators.md
@@ -151,13 +151,13 @@ Because of [numeric promotions](~/_csharpstandard/standard/expressions.md#1247-n
 
 ## Operator precedence
 
-The following list orders bitwise and shift operators from highest precedence to lowest precedence:
+The following list orders bitwise and shift operators in groups from highest precedence to lowest precedence:
 
-- Bitwise complement operator `~`
-- Shift operators `<<`, `>>`, and `>>>`
-- Logical AND operator `&`
-- Logical exclusive OR operator `^`
-- Logical OR operator `|`
+- ([Unary](./index.md#operator-precedence)) operators: Bitwise complement operator `~`.
+- ([Shift](./index.md#operator-precedence)) operators: Shift operators `<<`, `>>`, and `>>>`.
+- ([Logical AND](./index.md#operator-precedence)) operators: `&`.
+- ([Logical XOR](./index.md#operator-precedence)) operators: Logical exclusive OR `^`.
+- ([Logical OR](./index.md#operator-precedence)) operators: `|`.
 
 Use parentheses, `()`, to change the order of evaluation from the default operator precedence:
 

--- a/docs/csharp/language-reference/operators/bitwise-and-shift-operators.md
+++ b/docs/csharp/language-reference/operators/bitwise-and-shift-operators.md
@@ -155,9 +155,9 @@ The following list orders bitwise and shift operators in groups from highest pre
 
 - ([Unary](./index.md#operator-precedence)) operators: Bitwise complement operator `~`.
 - ([Shift](./index.md#operator-precedence)) operators: Shift operators `<<`, `>>`, and `>>>`.
-- ([Logical AND](./index.md#operator-precedence)) operators: `&`.
-- ([Logical XOR](./index.md#operator-precedence)) operators: Logical exclusive OR `^`.
-- ([Logical OR](./index.md#operator-precedence)) operators: `|`.
+- ([Bitwise logical AND](./index.md#operator-precedence)) operators: `&`.
+- ([Bitwise logical XOR](./index.md#operator-precedence)) operators: Logical exclusive OR `^`.
+- ([Bitwise logical OR](./index.md#operator-precedence)) operators: `|`.
 
 Use parentheses, `()`, to change the order of evaluation from the default operator precedence:
 

--- a/docs/csharp/language-reference/operators/boolean-logical-operators.md
+++ b/docs/csharp/language-reference/operators/boolean-logical-operators.md
@@ -167,14 +167,14 @@ The `&`, `|`, and `^` operators support compound assignment, as the following ex
 
 ## Operator precedence
 
-The following list orders logical operators starting from the highest precedence to the lowest:
+The following list orders logical operators in groups starting from the highest precedence to the lowest:
 
-- Logical negation operator `!`
-- Logical AND operator `&`
-- Logical exclusive OR operator `^`
-- Logical OR operator `|`
-- Conditional logical AND operator `&&`
-- Conditional logical OR operator `||`
+- ([Primary](./index.md#operator-precedence)) operators: Logical negation operator `!`.
+- ([Logical AND](./index.md#operator-precedence)) operators: `&`.
+- ([Logical XOR](./index.md#operator-precedence)) operators: Logical exclusive OR operator `^`.
+- ([Logical OR](./index.md#operator-precedence)) operators: `|`.
+- ([Conditional AND](./index.md#operator-precedence)) operators: `&&`.
+- ([Conditional OR](./index.md#operator-precedence)) operators: `||`.
 
 Use parentheses, `()`, to change the order of evaluation imposed by operator precedence:
 

--- a/docs/csharp/language-reference/operators/boolean-logical-operators.md
+++ b/docs/csharp/language-reference/operators/boolean-logical-operators.md
@@ -170,9 +170,9 @@ The `&`, `|`, and `^` operators support compound assignment, as the following ex
 The following list orders logical operators in groups starting from the highest precedence to the lowest:
 
 - ([Primary](./index.md#operator-precedence)) operators: Logical negation operator `!`.
-- ([Logical AND](./index.md#operator-precedence)) operators: `&`.
-- ([Logical XOR](./index.md#operator-precedence)) operators: Logical exclusive OR operator `^`.
-- ([Logical OR](./index.md#operator-precedence)) operators: `|`.
+- ([Boolean logical AND](./index.md#operator-precedence)) operators: `&`.
+- ([Boolean logical XOR](./index.md#operator-precedence)) operators: Logical exclusive OR operator `^`.
+- ([Boolean logical OR](./index.md#operator-precedence)) operators: `|`.
 - ([Conditional AND](./index.md#operator-precedence)) operators: `&&`.
 - ([Conditional OR](./index.md#operator-precedence)) operators: `||`.
 

--- a/docs/csharp/language-reference/operators/index.md
+++ b/docs/csharp/language-reference/operators/index.md
@@ -56,7 +56,7 @@ You can use an [expression body definition](../../programming-guide/statements-e
 
 ## Operator precedence
 
-In an expression with multiple operators, the operators with higher precedence are evaluated before the operators with lower precedence. In the following example, the multiplication is performed first because it has higher precedence than addition:
+In an expression with multiple operators, the operators with higher precedence are evaluated before the operators with lower precedence. Operands of the same precedence are evaluated in lexical order. In the following example, the multiplication is performed first because it has higher precedence than addition:
 
 ```csharp
 var a = 2 + 2 * 2;

--- a/docs/csharp/language-reference/operators/index.md
+++ b/docs/csharp/language-reference/operators/index.md
@@ -56,7 +56,7 @@ You can use an [expression body definition](../../programming-guide/statements-e
 
 ## Operator precedence
 
-In an expression with multiple operators, the operators with higher precedence are evaluated before the operators with lower precedence. Operands of the same precedence are evaluated in lexical order. In the following example, the multiplication is performed first because it has higher precedence than addition:
+In an expression with multiple operators, the operators with higher precedence are evaluated before the operators with lower precedence. Operators of the same precedence are evaluated in lexical order. In the following example, the multiplication is performed first because it has higher precedence than addition:
 
 ```csharp
 var a = 2 + 2 * 2;

--- a/docs/csharp/language-reference/operators/pointer-related-operators.md
+++ b/docs/csharp/language-reference/operators/pointer-related-operators.md
@@ -154,13 +154,13 @@ For information about the behavior of those operators for operands of other type
 
 ## Operator precedence
 
-The following list orders pointer related operators starting from the highest precedence to the lowest:
+The following list orders pointer related operators in groups starting from the highest precedence to the lowest:
 
-- Postfix increment `x++` and decrement `x--` operators and the `->` and `[]` operators
-- Prefix increment `++x` and decrement `--x` operators and the `&` and `*` operators
-- Additive `+` and `-` operators
-- Comparison `<`, `>`, `<=`, and `>=` operators
-- Equality `==` and `!=` operators
+- ([Primary](./index.md#operator-precedence)) operators: Postfix increment `x++` and decrement `x--` operators and the `->` and `[]` operators.
+- ([Unary](./index.md#operator-precedence)) operators: Prefix increment `++x` and decrement `--x` operators and the address-of `&` and indirection `*` operators.
+- ([Additive](./index.md#operator-precedence)) operators: `+` and `-` operators.
+- ([Relational and type testing](./index.md#operator-precedence)) operators: Comparison `<`, `>`, `<=`, and `>=` operators.
+- ([Equality](./index.md#operator-precedence)) operators: `==` and `!=` operators.
 
 Use parentheses, `()`, to change the order of evaluation imposed by operator precedence.
 

--- a/docs/csharp/language-reference/operators/pointer-related-operators.md
+++ b/docs/csharp/language-reference/operators/pointer-related-operators.md
@@ -156,10 +156,10 @@ For information about the behavior of those operators for operands of other type
 
 The following list orders pointer related operators in groups starting from the highest precedence to the lowest:
 
-- ([Primary](./index.md#operator-precedence)) operators: Postfix increment `x++` and decrement `x--` operators and the `->` and `[]` operators.
-- ([Unary](./index.md#operator-precedence)) operators: Prefix increment `++x` and decrement `--x` operators and the address-of `&` and indirection `*` operators.
-- ([Additive](./index.md#operator-precedence)) operators: `+` and `-` operators.
-- ([Relational and type testing](./index.md#operator-precedence)) operators: Comparison `<`, `>`, `<=`, and `>=` operators.
+- ([Primary](./index.md#operator-precedence)) operators: postfix increment `x++` and decrement `x--` operators and the `->` and `[]` operators.
+- ([Unary](./index.md#operator-precedence)) operators: prefix increment `++x` and decrement `--x` operators and the address-of `&` and indirection `*` operators.
+- ([Additive](./index.md#operator-precedence)) operators: binary `+` and `-` operators.
+- ([Relational and type-testing](./index.md#operator-precedence)) operators: comparison `<`, `>`, `<=`, and `>=` operators.
 - ([Equality](./index.md#operator-precedence)) operators: `==` and `!=` operators.
 
 Use parentheses, `()`, to change the order of evaluation imposed by operator precedence.


### PR DESCRIPTION
Fixes #50888

Readers had misinterpreted the list of operator precedence as an absolute list, rather than a list of groups.

Clarify that within the same group, operators are evaluated in lexical order. Clarify that each list is a group with the same precedence.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/arithmetic-operators.md](https://github.com/dotnet/docs/blob/6e15b406d1892dec7b3bf63f20cbb46596a14ed6/docs/csharp/language-reference/operators/arithmetic-operators.md) | [Arithmetic operators (C# reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/arithmetic-operators?branch=pr-en-us-51408) |
| [docs/csharp/language-reference/operators/bitwise-and-shift-operators.md](https://github.com/dotnet/docs/blob/6e15b406d1892dec7b3bf63f20cbb46596a14ed6/docs/csharp/language-reference/operators/bitwise-and-shift-operators.md) | [Bitwise and shift operators (C# reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/bitwise-and-shift-operators?branch=pr-en-us-51408) |
| [docs/csharp/language-reference/operators/boolean-logical-operators.md](https://github.com/dotnet/docs/blob/6e15b406d1892dec7b3bf63f20cbb46596a14ed6/docs/csharp/language-reference/operators/boolean-logical-operators.md) | ["Boolean logical operators - the boolean and, or, not, and xor operators"](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/boolean-logical-operators?branch=pr-en-us-51408) |
| [docs/csharp/language-reference/operators/index.md](https://github.com/dotnet/docs/blob/6e15b406d1892dec7b3bf63f20cbb46596a14ed6/docs/csharp/language-reference/operators/index.md) | [C# operators and expressions](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/index?branch=pr-en-us-51408) |
| [docs/csharp/language-reference/operators/pointer-related-operators.md](https://github.com/dotnet/docs/blob/6e15b406d1892dec7b3bf63f20cbb46596a14ed6/docs/csharp/language-reference/operators/pointer-related-operators.md) | [Pointer related operators - take the address of variables, dereference storage locations, and access memory locations](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/pointer-related-operators?branch=pr-en-us-51408) |


<!-- PREVIEW-TABLE-END -->