### PR TITLE
Fix grammatical error in expression trees documentation

### DIFF
--- a/docs/csharp/advanced-topics/expression-trees/expression-trees-interpreting.md
+++ b/docs/csharp/advanced-topics/expression-trees/expression-trees-interpreting.md
@@ -198,7 +198,7 @@ In this expression, you encounter nodes of all these types:
 1. Conditional (the `? :` expression)
 1. Method Call Expression (calling `Range()` and `Aggregate()`)
 
-One way to modify the visitor algorithm is to keep executing it, and write the node type every time you reach your `default` clause. After a few iterations, you've see each of the potential nodes. Then, you have all you need. The result would be something like this:
+One way to modify the visitor algorithm is to keep executing it, and write the node type every time you reach your `default` clause. After a few iterations, you've seen all the potential nodes. At that point, you have everything you need. The result would be something like this:
 
 :::code language="csharp" source="snippets/Visitors2.cs" id="UpdatedVisitor":::
 


### PR DESCRIPTION
Corrected the verb tense from 'see' to 'seen' for grammatical accuracy. And some minor changes to make the sentence more polished.

Fixes #51410



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/advanced-topics/expression-trees/expression-trees-interpreting.md](https://github.com/dotnet/docs/blob/728314c942854304eb7453091ddd101b19375f05/docs/csharp/advanced-topics/expression-trees/expression-trees-interpreting.md) | [Interpret expressions](https://review.learn.microsoft.com/en-us/dotnet/csharp/advanced-topics/expression-trees/expression-trees-interpreting?branch=pr-en-us-51413) |

<!-- PREVIEW-TABLE-END -->