### PR TITLE
Improve command-line argument processing

### DIFF
--- a/docs/core/tutorials/creating-app-with-plugin-support.md
+++ b/docs/core/tutorials/creating-app-with-plugin-support.md
@@ -3,7 +3,7 @@ title: Create a .NET Core application with plugins
 description: Learn how to create a .NET Core application that supports plugins.
 author: jkoritzinsky
 ms.author: jekoritz
-ms.date: 11/20/2024
+ms.date: 02/04/2026
 ---
 
 # Create a .NET Core application with plugins
@@ -235,7 +235,9 @@ Now, open the *HelloPlugin.csproj* file. It should look similar to the following
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
 </Project>
@@ -265,7 +267,7 @@ The `<Private>false</Private>` element is important. This tells MSBuild to not c
 
 Similarly, the `<ExcludeAssets>runtime</ExcludeAssets>` element is also important if the `PluginBase` references other packages. This setting has the same effect as `<Private>false</Private>` but works on package references that the `PluginBase` project or one of its dependencies may include.
 
-Now that the `HelloPlugin` project is complete, you should update the `AppWithPlugin` project to know where the `HelloPlugin` plugin can be found. After the `// Paths to plugins to load` comment, add `@"HelloPlugin\bin\Debug\net5.0\HelloPlugin.dll"` (this path could be different based on the .NET Core version you use) as an element of the `pluginPaths` array.
+Now that the `HelloPlugin` project is complete, you should update the `AppWithPlugin` project to know where the `HelloPlugin` plugin can be found. After the `// Paths to plugins to load` comment, add `@"HelloPlugin\bin\Debug\net10.0\HelloPlugin.dll"` (this path could be different based on the .NET Core version you use) as an element of the `pluginPaths` array.
 
 ## Plugin with library dependencies
 
@@ -291,7 +293,7 @@ This prevents the `A.PluginBase` assemblies from being copied to the output dire
 
 ## Plugin target framework recommendations
 
-Because plugin dependency loading uses the *.deps.json* file, there is a gotcha related to the plugin's target framework. Specifically, your plugins should target a runtime, such as .NET 5, instead of a version of .NET Standard. The *.deps.json* file is generated based on which framework the project targets, and since many .NET Standard-compatible packages ship reference assemblies for building against .NET Standard and implementation assemblies for specific runtimes, the *.deps.json* may not correctly see implementation assemblies, or it may grab the .NET Standard version of an assembly instead of the .NET Core version you expect.
+Because plugin dependency loading uses the *.deps.json* file, there is a gotcha related to the plugin's target framework. Specifically, your plugins should target a runtime, such as .NET 10, instead of a version of .NET Standard. The *.deps.json* file is generated based on which framework the project targets, and since many .NET Standard-compatible packages ship reference assemblies for building against .NET Standard and implementation assemblies for specific runtimes, the *.deps.json* may not correctly see implementation assemblies, or it may grab the .NET Standard version of an assembly instead of the .NET Core version you expect.
 
 ## Plugin framework references
 

--- a/docs/core/tutorials/creating-app-with-plugin-support.md
+++ b/docs/core/tutorials/creating-app-with-plugin-support.md
@@ -81,6 +81,13 @@ namespace AppWithPlugin
                     {
                         Console.WriteLine($"-- {commandName} --");
 
+                        // Skip command-line switches/flags (arguments starting with '/' or '-')
+                        if (commandName.StartsWith("/") || commandName.StartsWith("-"))
+                        {
+                            Console.WriteLine($"Skipping command-line flag: {commandName}");
+                            continue;
+                        }
+
                         // Execute the command with the name passed as an argument.
 
                         Console.WriteLine();
@@ -138,8 +145,8 @@ Replace the `// Execute the command with the name passed as an argument` comment
 ICommand command = commands.FirstOrDefault(c => c.Name == commandName);
 if (command == null)
 {
-    Console.WriteLine("No such command is known.");
-    return;
+    Console.WriteLine($"No such command is known: {commandName}");
+    continue;
 }
 
 command.Execute();


### PR DESCRIPTION
Update command-line argument handling and error message.

## Summary

The code was using return when a command wasn't found, which exits the entire loop and prevents processing of subsequent commands.

Solutions Applied:

1.	Added flag detection: Check if the argument starts with / or - (common command-line flag prefixes) and skip it with continue instead of trying to find it as a command.

2.	Changed return to continue: When a command is not found, use continue to skip only the current iteration and move to the next command in the list, rather than exiting the entire method.

3.	Improved error messages: Added the actual command name to error messages for better debugging.
This way, /d (and other flags) will be skipped, and valid commands in the args array will still be processed.


Fixes #48281



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tutorials/creating-app-with-plugin-support.md](https://github.com/dotnet/docs/blob/6ccbd472d9d2631adfe51920560dd09d2f2723d9/docs/core/tutorials/creating-app-with-plugin-support.md) | [Create a .NET Core application with plugins](https://review.learn.microsoft.com/en-us/dotnet/core/tutorials/creating-app-with-plugin-support?branch=pr-en-us-51415) |


<!-- PREVIEW-TABLE-END -->