### PR TITLE
Add note about RID being ignored when publishing for solution

### DIFF
--- a/docs/core/tools/dotnet-publish.md
+++ b/docs/core/tools/dotnet-publish.md
@@ -204,7 +204,7 @@ For more information, see the following resources:
 
   > [!NOTE]
   > Publishing can be done on the *solution* level and on the single *project* level. When publishing from the *solution* level by specifying the optional `<SOLUTION>` parameter or leaving it default, MSBuild first compiles the output into the `publish` directory **without** any symbols. This means that later compilations done by MSBuild, based on the initial compilation, will still not include any details for specified `<RUNTIME_IDENTIFIER>`.
-  
+  >
   > This is expected behavior. To avoid this behavior either publish for a single project by specifying the optional `<PROJECT>` parameter for your RID or specify RIDs directly in the project config by adding the [`<RuntimeIdentifiers>`](../project-sdk/msbuild-props.md#runtimeidentifiers) property.
 
 - [!INCLUDE [tl](includes/cli-tl.md)]

--- a/docs/core/tools/dotnet-publish.md
+++ b/docs/core/tools/dotnet-publish.md
@@ -202,6 +202,9 @@ For more information, see the following resources:
 
   Publishes the application for a given runtime. For a list of Runtime Identifiers (RIDs), see the [RID catalog](../rid-catalog.md). For more information, see [.NET application publishing overview](../deploying/index.md). If you use this option, use `--self-contained` or `--no-self-contained` also.
 
+  **Note**, that publishing can be done on the *solution* level and on the single *project* level. When publishing from the *solution* level (by specifying optional `<SOLUTION>` parameter or leaving it default) MSBuild first compiles the output into `publish` directory **without** any symbols, which means that later compilations done by MSBuild, based on the initial compilation, will still not include any details for specified `<RUNTIME_IDENTIFIER>`.
+  <br/>This is expected behavior, and to avoid it either publish for a single project (by specifying optional `<PROJECT>` parameter) regarding your RID, or specify RIDs directly in the project config by adding [`<RuntimeIdentifiers>`](../project-sdk/msbuild-props.md#runtimeidentifiers) property. 
+
 - [!INCLUDE [tl](includes/cli-tl.md)]
 
 - [!INCLUDE [use-current-runtime](includes/cli-use-current-runtime.md)]

--- a/docs/core/tools/dotnet-publish.md
+++ b/docs/core/tools/dotnet-publish.md
@@ -202,8 +202,10 @@ For more information, see the following resources:
 
   Publishes the application for a given runtime. For a list of Runtime Identifiers (RIDs), see the [RID catalog](../rid-catalog.md). For more information, see [.NET application publishing overview](../deploying/index.md). If you use this option, use `--self-contained` or `--no-self-contained` also.
 
-  **Note**, that publishing can be done on the *solution* level and on the single *project* level. When publishing from the *solution* level (by specifying optional `<SOLUTION>` parameter or leaving it default) MSBuild first compiles the output into `publish` directory **without** any symbols, which means that later compilations done by MSBuild, based on the initial compilation, will still not include any details for specified `<RUNTIME_IDENTIFIER>`.
-  <br/>This is expected behavior, and to avoid it either publish for a single project (by specifying optional `<PROJECT>` parameter) regarding your RID, or specify RIDs directly in the project config by adding [`<RuntimeIdentifiers>`](../project-sdk/msbuild-props.md#runtimeidentifiers) property. 
+  > [!NOTE]
+  > Publishing can be done on the *solution* level and on the single *project* level. When publishing from the *solution* level by specifying the optional `<SOLUTION>` parameter or leaving it default, MSBuild first compiles the output into the `publish` directory **without** any symbols. This means that later compilations done by MSBuild, based on the initial compilation, will still not include any details for specified `<RUNTIME_IDENTIFIER>`.
+  
+  > This is expected behavior. To avoid this behavior either publish for a single project by specifying the optional `<PROJECT>` parameter for your RID or specify RIDs directly in the project config by adding the [`<RuntimeIdentifiers>`](../project-sdk/msbuild-props.md#runtimeidentifiers) property.
 
 - [!INCLUDE [tl](includes/cli-tl.md)]
 


### PR DESCRIPTION
This pull request fixes #50258, by adding the note about RIDs (specified by `-r` param) being "ignored" when publishing for the whole solution.
Instead, what is also suggested in the added note, publishing should be done per project regarding specific RIDs details or by specifying RIDs per project using (linked in the note) `<RuntimeIdentifiers>` property in the config.

I didn't make the note by markdown `> [!NOTE]`, because I wasn't sure about the layout of bullet points already there, so let me know in comments in case this would be a good idea.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-publish.md](https://github.com/dotnet/docs/blob/c39e7add3b515c3f1c4a08929731c592c8461886/docs/core/tools/dotnet-publish.md) | [dotnet publish](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-publish?branch=pr-en-us-51417) |


<!-- PREVIEW-TABLE-END -->