### PR TITLE
Typo in Service discovery in .NET page

### DIFF
--- a/docs/core/extensions/service-discovery.md
+++ b/docs/core/extensions/service-discovery.md
@@ -116,7 +116,7 @@ The configuration resolver is configured using the <xref:Microsoft.Extensions.Se
 
 - **ApplyHostNameMetadata**: A delegate used to determine if host name metadata should be applied to resolved endpoints. It defaults to a function that returns `false`.
 
-To configure these options, you can call the <xref:Microsoft.Extensions.ContextualOptionsServiceCollectionExtensions.Configure*> extension method on the `IServiceCollection` within your application's `Startup` class or `Program` file:
+To configure these options, you can call the <xref:Microsoft.Extensions.DependencyInjection.OptionsServiceCollectionExtensions.Configure*> extension method on the `IServiceCollection` within your application's `Startup` class or `Program` file:
 
 ```csharp
 var builder = WebApplication.CreateBuilder(args);

--- a/docs/core/extensions/service-discovery.md
+++ b/docs/core/extensions/service-discovery.md
@@ -116,7 +116,7 @@ The configuration resolver is configured using the <xref:Microsoft.Extensions.Se
 
 - **ApplyHostNameMetadata**: A delegate used to determine if host name metadata should be applied to resolved endpoints. It defaults to a function that returns `false`.
 
-To configure these options, you can use the `Configure` extension method on the `IServiceCollection` within your application's `Startup` class or `Program` file:
+To configure these options, you can call the <xref:Microsoft.Extensions.ContextualOptionsServiceCollectionExtensions.Configure*> extension method on the `IServiceCollection` within your application's `Startup` class or `Program` file:
 
 ```csharp
 var builder = WebApplication.CreateBuilder(args);

--- a/docs/core/extensions/service-discovery.md
+++ b/docs/core/extensions/service-discovery.md
@@ -121,7 +121,7 @@ To configure these options, you can use the `Configure` extension method on the 
 ```csharp
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.Configure<ConfigurationServiceEndPointResolverOptions>(
+builder.Services.Configure<ConfigurationServiceEndpointProviderOptions>(
     static options =>
     {
         options.SectionName = "MyServiceEndpoints";


### PR DESCRIPTION
### Describe the issue or suggestion

Type of issue
Typo

Description
While reading the article, there is a sentence that reads "The configuration resolver is configured using the **ConfigurationServiceEndpointProviderOptions** class..".

However, the code snippet below is using **ConfigurationServiceEndPointResolverOptions** class, which is not available in the namespace.

I believe, the code snippet should be updated to fix the class name to **ConfigurationServiceEndpointProviderOptions**:

```csharp
builder.Services.Configure<ConfigurationServiceEndpointProviderOptions>(
  ..
);
```

### Page URL
https://learn.microsoft.com/en-us/dotnet/core/extensions/service-discovery?tabs=dotnet-cli#configuration

### Content source URL
https://github.com/dotnet/docs/blob/main/docs/core/extensions/service-discovery.md

Fixes #51424

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/service-discovery.md](https://github.com/dotnet/docs/blob/6aa2f1af1569f3debfe9855cd1343f129ddab327/docs/core/extensions/service-discovery.md) | [Service discovery in .NET](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/service-discovery?branch=pr-en-us-51425) |


<!-- PREVIEW-TABLE-END -->