### PR TITLE
Document supported target frameworks for testing platform

### DIFF
--- a/docs/core/testing/microsoft-testing-platform-intro.md
+++ b/docs/core/testing/microsoft-testing-platform-intro.md
@@ -45,7 +45,7 @@ The main driving factors for the evolution of the new testing platform are detai
 
 ## Supported target frameworks
 
-Microsoft.Testing.Platform supports .NET (.NET 8 SDK and later), .NET Framework (versions 4.6.2 and later), and targets NETStandard 2.0 for maximum compatiblity with other runtimes.
+Microsoft.Testing.Platform supports .NET (.NET 8 SDK and later), .NET Framework (versions 4.6.2 and later), and targets NETStandard 2.0 for maximum compatibility with other runtimes.
 
 ## Run and debug tests
 

--- a/docs/core/testing/microsoft-testing-platform-intro.md
+++ b/docs/core/testing/microsoft-testing-platform-intro.md
@@ -43,6 +43,10 @@ The main driving factors for the evolution of the new testing platform are detai
 * xUnit.net. For more information, see [Microsoft Testing Platform (xUnit.net v3)](https://xunit.net/docs/getting-started/v3/microsoft-testing-platform) and [Microsoft Testing Platform (xUnit.net v2)](https://xunit.net/docs/getting-started/v2/microsoft-testing-platform) from the xUnit.net documentation.
 * TUnit: entirely constructed on top of the `Microsoft.Testing.Platform`, for more information, see [TUnit documentation](https://tunit.dev/).
 
+## Supported target frameworks
+
+Microsoft.Testing.Platform supports both .NET (NET8+) and .NET Framework (4.6.2+), and targets NETStandard 2.0 for maximum compatiblity with other runtimes.
+
 ## Run and debug tests
 
 `Microsoft.Testing.Platform` test projects are built as executables that can be run (or debugged) directly. There's no extra test running console or command. The app exits with a nonzero exit code if there's an error, which is typical for most executables. For more information on the known exit codes, see [Microsoft.Testing.Platform exit codes](microsoft-testing-platform-exit-codes.md).

--- a/docs/core/testing/microsoft-testing-platform-intro.md
+++ b/docs/core/testing/microsoft-testing-platform-intro.md
@@ -45,7 +45,7 @@ The main driving factors for the evolution of the new testing platform are detai
 
 ## Supported target frameworks
 
-Microsoft.Testing.Platform supports both .NET (NET8+) and .NET Framework (4.6.2+), and targets NETStandard 2.0 for maximum compatiblity with other runtimes.
+Microsoft.Testing.Platform supports .NET (.NET 8 SDK and later), .NET Framework (versions 4.6.2 and later), and targets NETStandard 2.0 for maximum compatiblity with other runtimes.
 
 ## Run and debug tests
 


### PR DESCRIPTION
MTP is often mentioned to not support .net framework, add short note about being supported.

https://github.com/stryker-mutator/stryker-net/issues/3094#issuecomment-3837394468

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/microsoft-testing-platform-intro.md](https://github.com/dotnet/docs/blob/a8a49d9594775cd85738944d07ba697a424720ad/docs/core/testing/microsoft-testing-platform-intro.md) | [Microsoft.Testing.Platform overview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-intro?branch=pr-en-us-51433) |


<!-- PREVIEW-TABLE-END -->