### PR TITLE
Document concurrency issues with file-based apps

### DIFF
--- a/docs/core/sdk/file-based-apps.md
+++ b/docs/core/sdk/file-based-apps.md
@@ -363,6 +363,9 @@ Caching improves build performance but can cause confusion when:
 - Changes to implicit build files don't trigger rebuilds.
 - Moving files to different directories doesn't invalidate cache.
 
+> [!NOTE]
+> Concurrent invocations of a file-based app (i.e. running more than one instance of the same file-based app in parallel) can cause errors due to contention over the build output files. To avoid this, first build the file-based app via `dotnet build file.cs` before starting the concurrent instances via `dotnet run file.cs --no-build`.
+
 ### Workarounds
 
 - Clear cache artifacts for file-based apps by using the following command:

--- a/docs/core/sdk/file-based-apps.md
+++ b/docs/core/sdk/file-based-apps.md
@@ -364,7 +364,7 @@ Caching improves build performance but can cause confusion when:
 - Moving files to different directories doesn't invalidate cache.
 
 > [!NOTE]
-> Concurrent invocations of a file-based app (i.e. running more than one instance of the same file-based app in parallel) can cause errors due to contention over the build output files. To avoid this, first build the file-based app via `dotnet build file.cs` before starting the concurrent instances via `dotnet run file.cs --no-build`.
+> Concurrent invocations of a file-based app (for example, running more than one instance of the same file-based app in parallel) can cause errors due to contention over the build output files. To avoid this, first build the file-based app via `dotnet build file.cs` before starting the concurrent instances via `dotnet run file.cs --no-build`.
 
 ### Workarounds
 


### PR DESCRIPTION
Add note about concurrent invocations causing errors.

From dotnet/sdk#52773


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/sdk/file-based-apps.md](https://github.com/dotnet/docs/blob/ad7b02f46aebf882e6046ab2f9b138cca86108c9/docs/core/sdk/file-based-apps.md) | [docs/core/sdk/file-based-apps](https://review.learn.microsoft.com/en-us/dotnet/core/sdk/file-based-apps?branch=pr-en-us-51435) |


<!-- PREVIEW-TABLE-END -->