### PR TITLE
Clarify where method comes from

### DIFF
--- a/docs/core/extensions/configuration-providers.md
+++ b/docs/core/extensions/configuration-providers.md
@@ -125,11 +125,14 @@ The previous configuration file loads the following keys with `value`:
 
 ### INI configuration provider
 
-The <xref:Microsoft.Extensions.Configuration.Ini.IniConfigurationProvider> class loads configuration from an INI file at runtime. Install the [`Microsoft.Extensions.Configuration.Ini`](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.Ini)  NuGet package.
+The <xref:Microsoft.Extensions.Configuration.Ini.IniConfigurationProvider> class loads configuration from an INI file at runtime.
 
 The following code clears all the configuration providers and adds the `IniConfigurationProvider` with two INI files as the source:
 
 :::code language="csharp" source="snippets/configuration/console-ini/Program.cs" range="1-12,19-23" highlight="7-11":::
+
+> [!NOTE]
+> You must install the [`Microsoft.Extensions.Configuration.Ini`](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.Ini) NuGet package to have access to the <xref:Microsoft.Extensions.Configuration.IniConfigurationExtensions.AddIniFile*> method.
 
 An example *appsettings.ini* file with various configuration settings follows:
 


### PR DESCRIPTION
Fixes #50737 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/configuration-providers.md](https://github.com/dotnet/docs/blob/c3849a785f4700b7566e4b277ab67f0da0b54776/docs/core/extensions/configuration-providers.md) | [Configuration providers in .NET](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/configuration-providers?branch=pr-en-us-51456) |

<!-- PREVIEW-TABLE-END -->