### PR TITLE
Update MSTest analyzers for 4.1 release

### DIFF
--- a/docs/core/testing/mstest-analyzers/mstest0001.md
+++ b/docs/core/testing/mstest-analyzers/mstest0001.md
@@ -23,7 +23,7 @@ dev_langs:
 | **Category**                        | Performance                                        |
 | **Fix is breaking or non-breaking** | Non-breaking                                       |
 | **Enabled by default**              | Yes                                                |
-| **Default severity**                | Warning starting with 4.0.0, Info before           |
+| **Default severity**                | Info (Warning in 4.0)                              |
 | **Introduced in version**           | 3.2.0                                              |
 | **Is there a code fix**             | No                                                 |
 

--- a/docs/core/testing/mstest-analyzers/mstest0023.md
+++ b/docs/core/testing/mstest-analyzers/mstest0023.md
@@ -20,7 +20,7 @@ ms.author: amauryleve
 | **Category**                        | Usage                                    |
 | **Fix is breaking or non-breaking** | Non-breaking                             |
 | **Enabled by default**              | Yes                                      |
-| **Default severity**                | Warning starting with 4.0.0, Info before |
+| **Default severity**                | Info (Warning in 4.0)                    |
 | **Introduced in version**           | 3.4.0                                    |
 | **Is there a code fix**             | No                                       |
 

--- a/docs/core/testing/mstest-analyzers/mstest0037.md
+++ b/docs/core/testing/mstest-analyzers/mstest0037.md
@@ -13,16 +13,16 @@ ms.author: ygerges
 ---
 # MSTEST0037: Use proper 'Assert' methods
 
-| Property                            | Value                                                                  |
-|-------------------------------------|------------------------------------------------------------------------|
-| **Rule ID**                         | MSTEST0037                                                             |
-| **Title**                           | Use proper 'Assert' methods                                            |
-| **Category**                        | Usage                                                                  |
-| **Fix is breaking or non-breaking** | Non-breaking                                                           |
-| **Enabled by default**              | Yes                                                                    |
-| **Default severity**                | Warning starting with 4.0.0, Info before                               |
-| **Introduced in version**           | 3.7.0                                                                  |
-| **Is there a code fix**             | Yes                                                                    |
+| Property                            | Value                        |
+|-------------------------------------|------------------------------|
+| **Rule ID**                         | MSTEST0037                   |
+| **Title**                           | Use proper 'Assert' methods  |
+| **Category**                        | Usage                        |
+| **Fix is breaking or non-breaking** | Non-breaking                 |
+| **Enabled by default**              | Yes                          |
+| **Default severity**                | Info (Warning in 4.0)        |
+| **Introduced in version**           | 3.7.0                        |
+| **Is there a code fix**             | Yes                          |
 
 ## Cause
 

--- a/docs/core/testing/mstest-analyzers/mstest0045.md
+++ b/docs/core/testing/mstest-analyzers/mstest0045.md
@@ -20,7 +20,7 @@ ms.author: amauryleve
 | **Category**                        | Usage                                    |
 | **Fix is breaking or non-breaking** | Non-breaking                             |
 | **Enabled by default**              | Yes                                      |
-| **Default severity**                | Warning starting with 4.0.0, Info before |
+| **Default severity**                | Info (Warning in 4.0)                    |
 | **Introduced in version**           | 3.10.0                                   |
 | **Is there a code fix**             | Yes                                      |
 

--- a/docs/core/testing/mstest-analyzers/mstest0062.md
+++ b/docs/core/testing/mstest-analyzers/mstest0062.md
@@ -19,11 +19,11 @@ dev_langs:
 | Property                            | Value                                              |
 |-------------------------------------|----------------------------------------------------|
 | **Rule ID**                         | MSTEST0062                                         |
-| **Title**                           | Avoid out and ref parameters in test methods      |
+| **Title**                           | Avoid out and ref parameters in test methods       |
 | **Category**                        | Usage                                              |
 | **Fix is breaking or non-breaking** | Non-breaking                                       |
 | **Enabled by default**              | Yes                                                |
-| **Default severity**                | Info                                               |
+| **Default severity**                | Warning                                            |
 | **Introduced in version**           | 4.1.0                                              |
 | **Is there a code fix**             | Yes                                                |
 

--- a/docs/core/testing/mstest-analyzers/mstest0063.md
+++ b/docs/core/testing/mstest-analyzers/mstest0063.md
@@ -71,7 +71,7 @@ public class MyTestClass
 
 Ensure your test class has a valid constructor. A valid constructor must be:
 
-1. Declared as `public`
+1. Declared as `public`.
 1. Either parameterless or accepts a single <xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestContext> parameter
 
 ### Parameterless constructor

--- a/docs/core/testing/mstest-analyzers/mstest0063.md
+++ b/docs/core/testing/mstest-analyzers/mstest0063.md
@@ -72,7 +72,7 @@ public class MyTestClass
 Ensure your test class has a valid constructor. A valid constructor must be:
 
 1. Declared as `public`
-1. Either parameterless or accept a single <xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestContext> parameter
+1. Either parameterless or accepts a single <xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestContext> parameter
 
 ### Parameterless constructor
 

--- a/docs/core/testing/mstest-analyzers/mstest0063.md
+++ b/docs/core/testing/mstest-analyzers/mstest0063.md
@@ -72,7 +72,7 @@ public class MyTestClass
 Ensure your test class has a valid constructor. A valid constructor must be:
 
 1. Declared as `public`.
-1. Either parameterless or accepts a single <xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestContext> parameter
+1. Either parameterless or accepts a single <xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestContext> parameter.
 
 ### Parameterless constructor
 

--- a/docs/core/testing/mstest-analyzers/mstest0063.md
+++ b/docs/core/testing/mstest-analyzers/mstest0063.md
@@ -1,0 +1,174 @@
+---
+title: "MSTEST0063: Test classes should have valid constructors"
+description: "Learn about code analysis rule MSTEST0063: Test classes should have valid constructors"
+ms.date: 02/04/2026
+f1_keywords:
+- MSTEST0063
+- TestClassConstructorShouldBeValidAnalyzer
+helpviewer_keywords:
+- TestClassConstructorShouldBeValidAnalyzer
+- MSTEST0063
+author: evangelink
+ms.author: amauryleve
+ai-usage: ai-assisted
+dev_langs:
+- CSharp
+---
+# MSTEST0063: Test classes should have valid constructors
+
+| Property                            | Value                                              |
+|-------------------------------------|----------------------------------------------------|
+| **Rule ID**                         | MSTEST0063                                         |
+| **Title**                           | Test classes should have valid constructors        |
+| **Category**                        | Usage                                              |
+| **Fix is breaking or non-breaking** | Non-breaking                                       |
+| **Enabled by default**              | Yes                                                |
+| **Default severity**                | Warning                                            |
+| **Introduced in version**           | 4.1.0                                              |
+| **Is there a code fix**             | No                                                 |
+
+## Cause
+
+A test class doesn't have a valid constructor. Valid constructors are `public` and either parameterless or have a single parameter of type <xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestContext>.
+
+## Rule description
+
+Test classes must have a public constructor that is either parameterless or accepts a single <xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestContext> parameter. This allows the test framework to instantiate the test class properly.
+
+Constructors that are non-public, have parameters of unsupported types, or have multiple parameters aren't valid and prevent the test framework from creating instances of the test class.
+
+```csharp
+[TestClass]
+public class MyTestClass
+{
+    private MyTestClass() // Violation - constructor is not public
+    {
+    }
+}
+```
+
+```csharp
+[TestClass]
+public class MyTestClass
+{
+    public MyTestClass(string value) // Violation - parameter type is not supported
+    {
+    }
+}
+```
+
+```csharp
+[TestClass]
+public class MyTestClass
+{
+    public MyTestClass(TestContext testContext, int value) // Violation - multiple parameters
+    {
+    }
+}
+```
+
+## How to fix violations
+
+Ensure your test class has a valid constructor. A valid constructor must be:
+
+1. Declared as `public`
+1. Either parameterless or accept a single <xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestContext> parameter
+
+### Parameterless constructor
+
+```csharp
+[TestClass]
+public class MyTestClass
+{
+    public MyTestClass()
+    {
+    }
+
+    [TestMethod]
+    public void TestMethod()
+    {
+    }
+}
+```
+
+### Constructor with TestContext
+
+```csharp
+[TestClass]
+public class MyTestClass
+{
+    private readonly TestContext _testContext;
+
+    public MyTestClass(TestContext testContext)
+    {
+        _testContext = testContext;
+    }
+
+    [TestMethod]
+    public void TestMethod()
+    {
+        _testContext.WriteLine("Test is running...");
+    }
+}
+```
+
+### Implicit parameterless constructor
+
+If you don't define any constructor, the compiler generates a public parameterless constructor automatically:
+
+```csharp
+[TestClass]
+public class MyTestClass
+{
+    [TestMethod]
+    public void TestMethod()
+    {
+    }
+}
+```
+
+### Valid and invalid constructors together
+
+If your test class has multiple constructors, at least one must be valid:
+
+```csharp
+[TestClass]
+public class MyTestClass
+{
+    public MyTestClass() // Valid - this makes the class valid
+    {
+    }
+
+    private MyTestClass(int x) // Invalid, but ignored because a valid constructor exists
+    {
+    }
+
+    [TestMethod]
+    public void TestMethod()
+    {
+    }
+}
+```
+
+## When to suppress warnings
+
+Don't suppress warnings from this rule. Test classes without valid constructors can't be instantiated by the test framework, and the tests won't run.
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable MSTEST0063
+// The code that's violating the rule is on this line.
+#pragma warning restore MSTEST0063
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none` in the [configuration file](../../../fundamentals/code-analysis/configuration-files.md).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0063.severity = none
+```
+
+For more information, see [How to suppress code analysis warnings](../../../fundamentals/code-analysis/suppress-warnings.md).

--- a/docs/core/testing/mstest-analyzers/overview.md
+++ b/docs/core/testing/mstest-analyzers/overview.md
@@ -111,6 +111,7 @@ Rules that help ensure your test classes and methods are properly structured and
 - [MSTEST0056](mstest0056.md) - TestMethodAttribute should set DisplayName correctly
 - [MSTEST0057](mstest0057.md) - TestMethodAttribute should propagate source information
 - [MSTEST0060](mstest0060.md) - Duplicate TestMethodAttribute
+- [MSTEST0063](mstest0063.md) - Test class should have valid constructor
 
 Related documentation: [Write tests with MSTest](../unit-testing-mstest-writing-tests.md), [Attributes](../unit-testing-mstest-writing-tests-attributes.md)
 
@@ -276,6 +277,7 @@ Related documentation: [Configure MSTest](../unit-testing-mstest-configure.md), 
 | [MSTEST0060](mstest0060.md) | Usage | Duplicate TestMethodAttribute | Warning |
 | [MSTEST0061](mstest0061.md) | Usage | Use OSCondition attribute instead of runtime check | Info |
 | [MSTEST0062](mstest0062.md) | Usage | Avoid out/ref test method parameters | Warning |
+| [MSTEST0063](mstest0063.md) | Usage | Test class should have valid constructor | Warning |
 
 \* Escalated to Error in `Recommended` and `All` modes.
 

--- a/docs/core/testing/mstest-analyzers/usage-rules.md
+++ b/docs/core/testing/mstest-analyzers/usage-rules.md
@@ -58,6 +58,7 @@ Usage rules support proper usage of MSTest attributes, methods, and patterns. Th
 | [MSTEST0060](mstest0060.md) | Duplicate TestMethodAttribute. | Warning | Yes |
 | [MSTEST0061](mstest0061.md) | Use OSCondition attribute instead of runtime check. | Info | Yes |
 | [MSTEST0062](mstest0062.md) | Avoid out/ref test method parameters. | Warning | Yes |
+| [MSTEST0063](mstest0063.md) | Test class should have valid constructor. | Warning | No |
 
 \* Escalated to Error in `Recommended` and `All` modes.
 
@@ -70,6 +71,7 @@ Ensure your test classes, methods, and fixtures follow MSTest requirements:
 - **[MSTEST0002](mstest0002.md)**: Test class layout requirements (for example, public, non-static).
 - **[MSTEST0003](mstest0003.md)**: Test method layout requirements (⚠️ escalated to Error).
 - **[MSTEST0030](mstest0030.md)**: Methods with [TestMethod] must be in a [TestClass].
+- **[MSTEST0063](mstest0063.md)**: Test class constructor validation.
 
 ### Lifecycle methods
 

--- a/docs/navigate/devops-testing/toc.yml
+++ b/docs/navigate/devops-testing/toc.yml
@@ -243,6 +243,8 @@ items:
                         href: ../../core/testing/mstest-analyzers/mstest0061.md
                       - name: MSTEST0062
                         href: ../../core/testing/mstest-analyzers/mstest0062.md
+                      - name: MSTEST0063
+                        href: ../../core/testing/mstest-analyzers/mstest0063.md
               - name: Migration
                 items:
                   - name: Migrate from MSTest v1 to v3


### PR DESCRIPTION
## Summary

Add missing rule documentation and update severity of some rules following release of MSTest 4.1

Fixes https://github.com/microsoft/testfx/issues/7337

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/mstest-analyzers/mstest0001.md](https://github.com/dotnet/docs/blob/7b0fef319ff1b6bf38514b48a21d134dd6fb9aa0/docs/core/testing/mstest-analyzers/mstest0001.md) | [MSTEST0001: Explicitly enable or disable tests parallelization](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0001?branch=pr-en-us-51464) |
| [docs/core/testing/mstest-analyzers/mstest0023.md](https://github.com/dotnet/docs/blob/7b0fef319ff1b6bf38514b48a21d134dd6fb9aa0/docs/core/testing/mstest-analyzers/mstest0023.md) | ["MSTEST0023: Do not negate boolean assertions"](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0023?branch=pr-en-us-51464) |
| [docs/core/testing/mstest-analyzers/mstest0037.md](https://github.com/dotnet/docs/blob/7b0fef319ff1b6bf38514b48a21d134dd6fb9aa0/docs/core/testing/mstest-analyzers/mstest0037.md) | [MSTEST0037: Use proper 'Assert' methods](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0037?branch=pr-en-us-51464) |
| [docs/core/testing/mstest-analyzers/mstest0045.md](https://github.com/dotnet/docs/blob/7b0fef319ff1b6bf38514b48a21d134dd6fb9aa0/docs/core/testing/mstest-analyzers/mstest0045.md) | [MSTEST0045: Use cooperative cancellation for timeout](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0045?branch=pr-en-us-51464) |
| [docs/core/testing/mstest-analyzers/mstest0062.md](https://github.com/dotnet/docs/blob/7b0fef319ff1b6bf38514b48a21d134dd6fb9aa0/docs/core/testing/mstest-analyzers/mstest0062.md) | [docs/core/testing/mstest-analyzers/mstest0062](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0062?branch=pr-en-us-51464) |
| [docs/core/testing/mstest-analyzers/mstest0063.md](https://github.com/dotnet/docs/blob/7b0fef319ff1b6bf38514b48a21d134dd6fb9aa0/docs/core/testing/mstest-analyzers/mstest0063.md) | [MSTEST0063: Test classes should have valid constructors](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0063?branch=pr-en-us-51464) |
| [docs/core/testing/mstest-analyzers/overview.md](https://github.com/dotnet/docs/blob/7b0fef319ff1b6bf38514b48a21d134dd6fb9aa0/docs/core/testing/mstest-analyzers/overview.md) | [MSTest code analysis](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/overview?branch=pr-en-us-51464) |
| [docs/core/testing/mstest-analyzers/usage-rules.md](https://github.com/dotnet/docs/blob/7b0fef319ff1b6bf38514b48a21d134dd6fb9aa0/docs/core/testing/mstest-analyzers/usage-rules.md) | [MSTest usage rules](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/usage-rules?branch=pr-en-us-51464) |
| [docs/navigate/devops-testing/toc.yml](https://github.com/dotnet/docs/blob/7b0fef319ff1b6bf38514b48a21d134dd6fb9aa0/docs/navigate/devops-testing/toc.yml) | [docs/navigate/devops-testing/toc](https://review.learn.microsoft.com/en-us/dotnet/navigate/devops-testing/toc?branch=pr-en-us-51464) |


<!-- PREVIEW-TABLE-END -->