### PR TITLE
Add new diagnostics for `with`

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/array-declaration-errors.md
+++ b/docs/csharp/language-reference/compiler-messages/array-declaration-errors.md
@@ -43,6 +43,12 @@ f1_keywords:
  - "CS9215"
  - "CS9222"
  - "CS9332"
+ - "CS9354"
+ - "CS9355"
+ - "CS9356"
+ - "CS9357"
+ - "CS9358"
+ - "CS9359"
 helpviewer_keywords:
  - "CS0022"
  - "CS0178"
@@ -85,7 +91,13 @@ helpviewer_keywords:
  - "CS9215"
  - "CS9222"
  - "CS9332"
-ms.date: 11/07/2025
+ - "CS9354"
+ - "CS9355"
+ - "CS9356"
+ - "CS9357"
+ - "CS9358"
+ - "CS9359"
+ms.date: 02/04/2026
 ai-usage: ai-assisted
 ---
 # Resolve errors and warnings in array and collection declarations and initialization expressions
@@ -129,6 +141,12 @@ That's by design. The text closely matches the text of the compiler error / warn
 - [**CS9215**](#invalid-collection-initializer): *Collection expression type 'type' must have an instance or extension method 'Add' that can be called with a single argument.*
 - [**CS9222**](#invalid-collection-initializer): *Collection initializer results in an infinite chain of instantiations of collection 'type'.*
 - [**CS9332**](#invalid-collection-initializer): *Cannot use '..' spread operator in the filter expression of a catch clause.*
+- [**CS9354**](#invalid-collection-initializer): *'with(...)' element must be the first element*
+- [**CS9355**](#invalid-collection-initializer): *'with(...)' elements are not supported for type 'type'*
+- [**CS9356**](#invalid-collection-initializer): *'with(...)' element arguments cannot be dynamic*
+- [**CS9357**](#invalid-collection-initializer): *'with(...)' element for a read-only interface must be empty if present*
+- [**CS9358**](#invalid-collection-initializer): *Element type of this collection may not be a ref struct or a type parameter allowing ref structs*
+- [**CS9359**](#invalid-collection-initializer): *No overload for method 'method' takes 'number' 'with(...)' element arguments*
 
 In addition, the following warnings are covered in this article:
 
@@ -171,6 +189,12 @@ To access array elements correctly, follow these indexing rules. For more inform
 - **CS9215**: *Collection expression type 'type' must have an instance or extension method 'Add' that can be called with a single argument.*
 - **CS9222**: *Collection initializer results in an infinite chain of instantiations of collection 'type'.*
 - **CS9332**: *Cannot use '..' spread operator in the filter expression of a catch clause.*
+- **CS9354**: *'with(...)' element must be the first element*
+- **CS9355**: *'with(...)' elements are not supported for type 'type'*
+- **CS9356**: *'with(...)' element arguments cannot be dynamic*
+- **CS9357**: *'with(...)' element for a read-only interface must be empty if present*
+- **CS9358**: *Element type of this collection may not be a ref struct or a type parameter allowing ref structs*
+- **CS9359**: *No overload for method 'method' takes 'number' 'with(...)' element arguments*
 
 The compiler might also generate the following warnings:
 
@@ -195,6 +219,12 @@ To create valid collection initializers, follow these rules. For more informatio
 - Implement enumeration patterns (like `GetEnumerator`) for spread operator support (**CS9212**).
 - Avoid circular dependencies in collection initialization (**CS9222**).
 - Don't use the spread operator in catch clause filter expressions (**CS9332**).
+- Place the `with(...)` element first in collection expressions (**CS9354**).
+- Use `with(...)` elements only with types that support collection expression arguments (**CS9355**).
+- Don't use dynamic arguments in `with(...)` elements (**CS9356**).
+- Use empty `with()` for read-only interface types (**CS9357**).
+- Don't use ref struct types as element types in collections that don't support them (**CS9358**).
+- Match the number of `with(...)` arguments to available constructor overloads (**CS9359**).
 
 ## Invalid array rank
 

--- a/docs/csharp/language-reference/toc.yml
+++ b/docs/csharp/language-reference/toc.yml
@@ -616,13 +616,12 @@ items:
       CS0820, CS0826, CS0846, CS1062, CS1063, CS1064, CS1552, CS1586, CS1920, CS1921,
       CS1925, CS1950, CS1954, CS3007, CS3016, CS9174, CS9176, CS9185, CS9186, CS9187,
       CS9188, CS9203, CS9208, CS9209, CS9210, CS9212, CS9213, CS9214, CS9215, CS9222,
-      CS9332
+      CS9332, CS9354, CS9355, CS9356, CS9357, CS9358, CS9359
   - name: Inline arrays
     href: ./compiler-messages/inline-array-errors.md
     displayName: >
       CS9125, CS9164, CS9165, CS9166, CS9167, CS9168, CS9169, CS9172, CS9173, CS9180,
-      CS9181, CS9182, CS9183, CS9184, CS9259, CS9354, CS9355, CS9356, CS9357, CS9358,
-      CS9359
+      CS9181, CS9182, CS9183, CS9184, CS9259
   - name: Lambda expressions
     href: ./compiler-messages/lambda-expression-errors.md
     displayName: >

--- a/docs/csharp/language-reference/toc.yml
+++ b/docs/csharp/language-reference/toc.yml
@@ -621,7 +621,8 @@ items:
     href: ./compiler-messages/inline-array-errors.md
     displayName: >
       CS9125, CS9164, CS9165, CS9166, CS9167, CS9168, CS9169, CS9172, CS9173, CS9180,
-      CS9181, CS9182, CS9183, CS9184, CS9259
+      CS9181, CS9182, CS9183, CS9184, CS9259, CS9354, CS9355, CS9356, CS9357, CS9358,
+      CS9359
   - name: Lambda expressions
     href: ./compiler-messages/lambda-expression-errors.md
     displayName: >

--- a/docs/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error.md
+++ b/docs/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error.md
@@ -1,7 +1,7 @@
 ---
 title: "Sorry, we don't have specifics on this error"
 description: "List of possible resources for compiler errors and warnings that haven't been documented yet."
-ms.date: 05/23/2025
+ms.date: 02/04/2026
 f1_keywords:
   - "CS0190"
   - "CS0257"
@@ -48,6 +48,7 @@ f1_keywords:
   - "CS2045"
   - "CS2046"
   - "CS3028"
+  # C# 5 diagnostics
   - "CS4001"
   - "CS4003"
   - "CS4005"
@@ -75,6 +76,7 @@ f1_keywords:
   - "CS4031"
   - "CS4034"
   - "CS4036"
+  # C# 6 diagnostics
   - "CS7006"
   - "CS7012"
   - "CS7013"
@@ -203,6 +205,7 @@ f1_keywords:
   - "CS8111"
   - "CS8112"
   - "CS8113"
+  # C# 7.0 diagnostics
   - "CS8115"
   - "CS8116"
   - "CS8117"
@@ -231,6 +234,7 @@ f1_keywords:
   - "CS8190"
   - "CS8191"
   - "CS8197"
+  # C# 7.0 diagnostics
   - "CS8199"
   - "CS8202"
   - "CS8204"
@@ -238,6 +242,7 @@ f1_keywords:
   - "CS8206"
   - "CS8208"
   - "CS8209"
+  # C# 7.1 diagnostics
   - "CS8300"
   - "CS8301"
   - "CS8305"
@@ -246,6 +251,7 @@ f1_keywords:
   - "CS8309"
   - "CS8310"
   - "CS8312"
+  # C# 7.2 diagnostics
   - "CS8321"
   - "CS8323"
   - "CS8328"
@@ -278,6 +284,7 @@ f1_keywords:
   - "CS8386"
   - "CS8387"
   - "CS8389"
+  # C# 7.3 diagnostics
   - "CS8412"
   - "CS8413"
   - "CS8414"
@@ -327,6 +334,7 @@ f1_keywords:
   - "CS8715"
   - "CS8716"
   - "CS8750"
+  # C# 9 diagnostics start here
   - "CS8751"
   - "CS8752"
   - "CS8753"
@@ -456,12 +464,6 @@ f1_keywords:
   - "CS9351"
   - "CS9352"
   - "CS9353"
-  - "CS9354"
-  - "CS9355"
-  - "CS9356"
-  - "CS9357"
-  - "CS9358"
-  - "CS9359"
 helpviewer_keywords:
   - "errors [C#], additional information"
 ---


### PR DESCRIPTION
Fixes #51441

The feature for collection expression arguments adds these six diagnostic codes.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-messages/array-declaration-errors.md](https://github.com/dotnet/docs/blob/f687592b7716164625be471f070964b207943dd1/docs/csharp/language-reference/compiler-messages/array-declaration-errors.md) | [Resolve errors and warnings in array and collection declarations and initialization expressions](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/array-declaration-errors?branch=pr-en-us-51514) |
| [docs/csharp/language-reference/toc.yml](https://github.com/dotnet/docs/blob/f687592b7716164625be471f070964b207943dd1/docs/csharp/language-reference/toc.yml) | [docs/csharp/language-reference/toc](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/toc?branch=pr-en-us-51514) |
| [docs/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error.md](https://github.com/dotnet/docs/blob/f687592b7716164625be471f070964b207943dd1/docs/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error.md) | [Coming in C# 15](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error?branch=pr-en-us-51514) |


<!-- PREVIEW-TABLE-END -->