### PR TITLE
Remove sdk mention from supported versions

### DIFF
--- a/docs/core/testing/microsoft-testing-platform-intro.md
+++ b/docs/core/testing/microsoft-testing-platform-intro.md
@@ -45,7 +45,7 @@ The main driving factors for the evolution of the new testing platform are detai
 
 ## Supported target frameworks
 
-Microsoft.Testing.Platform supports .NET (.NET 8 SDK and later), .NET Framework (versions 4.6.2 and later), and targets NETStandard 2.0 for maximum compatibility with other runtimes.
+Microsoft.Testing.Platform supports .NET (.NET 8 and later), .NET Framework (versions 4.6.2 and later), and targets NETStandard 2.0 for maximum compatibility with other runtimes.
 
 ## Run and debug tests
 


### PR DESCRIPTION
## Summary

Just .NET 8 is more appropriate here. SDK suggests that Microsoft.Testing.Platform is tied to the SDK, and the other entries in the sentence also don't mention SDKs


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/microsoft-testing-platform-intro.md](https://github.com/dotnet/docs/blob/c58c018b5a229fca7d05e4ddcf4e91c04303a383/docs/core/testing/microsoft-testing-platform-intro.md) | [Microsoft.Testing.Platform overview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-intro?branch=pr-en-us-51539) |

<!-- PREVIEW-TABLE-END -->