### PR TITLE
Remove note stating that DATAS setting doesn't have a specific MSBuild property

### DIFF
--- a/docs/core/runtime-config/garbage-collector.md
+++ b/docs/core/runtime-config/garbage-collector.md
@@ -786,8 +786,6 @@ For more information about the first 3 settings, see the [Middle ground between 
 | **MSBuild property** | `GarbageCollectionAdaptationMode` | `1` - enabled<br/> `0` - disabled | .NET 8 |
 | **runtimeconfig.json**   | `System.GC.DynamicAdaptationMode` | `1` - enabled<br/> `0` - disabled | .NET 8 |
 
-[!INCLUDE [runtimehostconfigurationoption](includes/runtimehostconfigurationoption.md)]
-
 #### Target TCP
 
 DATAS uses the Throughput Cost Percentage (TCP) as the memory cost measurement on throughput. It takes into consideration both GC pauses and how much allocations have to wait. Usually, GC pauses dominates, so you can use the "% pause time in GC" to approximate this cost. There are two transient cases where the allocation wait time can dominate:


### PR DESCRIPTION
## Summary

DATAS **does** have it's own MSBuild property. It is even listed in the table above:

<img width="1160" height="769" alt="image" src="https://github.com/user-attachments/assets/17e30948-ea09-4c30-83b5-608100fc327b" />



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/runtime-config/garbage-collector.md](https://github.com/dotnet/docs/blob/3bcc5ad669b38de326a4dbe1d6ab505bd6fa5dd1/docs/core/runtime-config/garbage-collector.md) | [Runtime configuration options for garbage collection](https://review.learn.microsoft.com/en-us/dotnet/core/runtime-config/garbage-collector?branch=pr-en-us-51540) |

<!-- PREVIEW-TABLE-END -->