### PR TITLE
Clarify `sizeof` rules for unsafe code blocks

### DIFF
--- a/docs/csharp/language-reference/operators/sizeof.md
+++ b/docs/csharp/language-reference/operators/sizeof.md
@@ -38,7 +38,7 @@ In [unsafe](../keywords/unsafe.md) code, you can use `sizeof` on any non-`void` 
 
 - The size of a reference or pointer type is the size of a reference or pointer, not the size of the object it might refer to.
 - The size of a value type, unmanaged or not, is the size of such a value.
-- The size of a `ref struct` type is the size of value. The size of every `ref` field is the size of a reference or pointer, not the size of the value it refers to.
+- The size of a `ref struct` type is the size of the value. The size of every `ref` field is the size of a reference or pointer, not the size of the value it refers to.
 
 The following example demonstrates the usage of the `sizeof` operator:
 

--- a/docs/csharp/language-reference/operators/sizeof.md
+++ b/docs/csharp/language-reference/operators/sizeof.md
@@ -10,7 +10,7 @@ helpviewer_keywords:
 ---
 # sizeof operator - determine the memory needs for a given type
 
-The `sizeof` operator returns the number of bytes occupied by a variable of a given type. In safe code, the argument to the `sizeof` operator must be the name of a built-in [unmanaged type](../builtin-types/unmanaged-types.md).
+The `sizeof` operator returns the number of bytes occupied by a variable of a given type. In safe code, the argument to the `sizeof` operator must be the name of a built-in [unmanaged type](../builtin-types/unmanaged-types.md) whose size is not platform-dependent.
 
 [!INCLUDE[csharp-version-note](../includes/initial-version.md)]
 
@@ -32,12 +32,13 @@ The expressions presented in the following table are evaluated at compile time t
 | `sizeof(decimal)` | 16             |
 | `sizeof(bool)`    |  1             |
 
-The size of a built-in, unmanaged type is a compile-time constant.
+The size of the types in the preceding table is a compile-time constant.
 
-In [unsafe](../keywords/unsafe.md) code, you can use `sizeof` as follows:
+In [unsafe](../keywords/unsafe.md) code, you can use `sizeof` on any non-`void` type, including types constructed from type parameters.
 
-- A type parameter that is [constrained](../../programming-guide/generics/constraints-on-type-parameters.md#unmanaged-constraint) to be an unmanaged type returns the size of that unmanaged type at runtime.
-- A managed type or a pointer type returns the size of the reference or pointer, not the size of the object it refers to.
+- The size of a reference or pointer type is the size of a reference or pointer, not the size of the object it might refer to.
+- The size of a value type, unmanaged or not, is the size of such a value.
+- The size of a `ref struct` type is the size of value. The size of every `ref` field is the size of a reference or pointer, not the size of the value it refers to.
 
 The following example demonstrates the usage of the `sizeof` operator:
 

--- a/docs/csharp/language-reference/operators/sizeof.md
+++ b/docs/csharp/language-reference/operators/sizeof.md
@@ -1,7 +1,7 @@
 ---
 title: "sizeof operator - determine the storage needs for a type"
 description: "Learn about the C# `sizeof` operator that returns the memory amount occupied by a variable of a given type."
-ms.date: 01/20/2026
+ms.date: 02/06/2026
 f1_keywords: 
   - "sizeof_CSharpKeyword"
   - "sizeof"

--- a/docs/csharp/language-reference/operators/snippets/shared/SizeOfOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/SizeOfOperator.cs
@@ -20,6 +20,9 @@ public class SizeOfOperator
         unsafe
         {
             Console.WriteLine(sizeof(Point*));  // output: 8
+            Console.WriteLine(sizeof(nint));  // output: 8 on 64-bit, 4 on 32-bit
+            Console.WriteLine(sizeof(nuint)); // output: 8 on 64-bit, 4 on 32-bit
+            Console.WriteLine(sizeof(Span<int>));  // output: 16 on 64-bit, 12 on 32-bit
         }
     }
 


### PR DESCRIPTION
Some rules regarding nint, nuint, and ref struct types wasn't as clear as it should be. Add examples for `nint`, `nuint`, and `Span<T>`.

Fixes #51281

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/sizeof.md](https://github.com/dotnet/docs/blob/7aed72cf24d83994c0f1211134c3f11bb9e28b99/docs/csharp/language-reference/operators/sizeof.md) | [sizeof operator - determine the memory needs for a given type](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/sizeof?branch=pr-en-us-51543) |


<!-- PREVIEW-TABLE-END -->