### PR TITLE
Update installation command for .NET 9 runtime

### DIFF
--- a/docs/core/install/linux-snap-runtime.md
+++ b/docs/core/install/linux-snap-runtime.md
@@ -34,10 +34,10 @@ Your Linux distribution might already include snap. Try running `snap` from a te
 The following steps install the .NET 9 runtime snap package:
 
 01. Open a terminal.
-01. Use `snap install` to install the .NET Runtime snap package. For example, the following command installs the .NET 8 runtime.
+01. Use `snap install` to install the .NET Runtime snap package. For example, the following command installs the .NET 9 runtime.
 
     ```bash
-    sudo snap install dotnet-runtime-80
+    sudo snap install dotnet-runtime-90
     ```
 
 Each .NET Runtime is published as an individual snap package. The following table lists the packages:


### PR DESCRIPTION
mentioned at subheader "The following steps install the .NET 9 runtime snap package:"

then showed an example of installing .NET 8 runtime



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/linux-snap-runtime.md](https://github.com/dotnet/docs/blob/292ddd776f649447bd6a25cbdd74c18068e31535/docs/core/install/linux-snap-runtime.md) | [Install .NET Runtime with Snap](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-snap-runtime?branch=pr-en-us-51554) |

<!-- PREVIEW-TABLE-END -->