### PR TITLE
Create What's new for .NET 11, Preview 1

### DIFF
--- a/.github/prompts/whats-new-net.md
+++ b/.github/prompts/whats-new-net.md
@@ -2,14 +2,14 @@ When you're assigned an issue where one label includes the word "Release" and yo
 
 ## Task
 
-You'll update 4 articles. For .NET 10, you update these:
+You'll update 4 articles. For .NET 11, you create or update these:
 
-- https://github.com/dotnet/docs/blob/main/docs/core/whats-new/dotnet-10/overview.md
-- https://github.com/dotnet/docs/blob/main/docs/core/whats-new/dotnet-10/runtime.md
-- https://github.com/dotnet/docs/blob/main/docs/core/whats-new/dotnet-10/libraries.md
-- https://github.com/dotnet/docs/blob/main/docs/core/whats-new/dotnet-10/sdk.md
+- https://github.com/dotnet/docs/blob/main/docs/core/whats-new/dotnet-11/overview.md
+- https://github.com/dotnet/docs/blob/main/docs/core/whats-new/dotnet-11/runtime.md
+- https://github.com/dotnet/docs/blob/main/docs/core/whats-new/dotnet-11/libraries.md
+- https://github.com/dotnet/docs/blob/main/docs/core/whats-new/dotnet-11/sdk.md
 
-For other releases, replace "dotnet-10" in the preceding paths with the correct release. For example, use "dotnet-11" for the ".NET 11" releases.
+For other releases, replace "dotnet-11" in the preceding paths with the correct release. For example, use "dotnet-10" for the ".NET 10" releases.
 
 ## Source material
 

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -151,6 +151,21 @@ items:
         items:
           - name: Breaking changes
             href: ../core/compatibility/11.md?toc=/dotnet/fundamentals/toc.json&bc=/dotnet/breadcrumb/toc.json
+      - name: .NET 11
+        items:
+          - name: What's new
+            items:
+              - name: Overview
+                href: ../core/whats-new/dotnet-11/overview.md
+                displayName: whats new, what's new
+              - name: Runtime
+                href: ../core/whats-new/dotnet-11/runtime.md
+              - name: Libraries
+                href: ../core/whats-new/dotnet-11/libraries.md
+              - name: SDK
+                href: ../core/whats-new/dotnet-11/sdk.md
+          - name: Breaking changes
+            href: ../core/compatibility/11.md?toc=/dotnet/fundamentals/toc.json&bc=/dotnet/breadcrumb/toc.json
       - name: .NET 10
         items:
           - name: What's new


### PR DESCRIPTION
This builds the What's New for .NET 11, preview 1.

Use https://github.com/BillWagner/docs/blob/02f6404c3796021db7bfee8fd20a24c8164fb5ae/.github/prompts/whats-new-net.md to read the current release notes and build the What's new pages.

In the first commit, the TOC and the prompt have been updated.

Fixes #51579

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/prompts/whats-new-net.md](https://github.com/dotnet/docs/blob/02f6404c3796021db7bfee8fd20a24c8164fb5ae/.github/prompts/whats-new-net.md) | [.github/prompts/whats-new-net](https://review.learn.microsoft.com/en-us/dotnet/.github/prompts/whats-new-net?branch=pr-en-us-51577) |
| [docs/fundamentals/toc.yml](https://github.com/dotnet/docs/blob/02f6404c3796021db7bfee8fd20a24c8164fb5ae/docs/fundamentals/toc.yml) | [docs/fundamentals/toc](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/toc?branch=pr-en-us-51577) |

<!-- PREVIEW-TABLE-END -->