### PR TITLE
[typo] Add missing space to syslib0057.md

### DIFF
--- a/docs/fundamentals/syslib-diagnostics/syslib0057.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib0057.md
@@ -19,7 +19,7 @@ While this method was easy to use, it created issues where user-supplied data wa
 
 Use a different API to load certificate content, depending on the intended content type.
 
-A new class called <xref:System.Security.Cryptography.X509Certificates.X509CertificateLoader>can be used to load X.509 or PKCS12 content:
+A new class called <xref:System.Security.Cryptography.X509Certificates.X509CertificateLoader> can be used to load X.509 or PKCS12 content:
 
 - If you're loading X.509 content, use `X509CertificateLoader.LoadCertificate` or `X509CertificateLoader.LoadCertificateFromFile`.
 - If you're loading PKCS12 content, use `X509CertificateLoader.LoadPkcs12`, `X509CertificateLoader.LoadPkcs12FromFile`, `X509CertificateLoader.LoadPkcs12Collection`, or `X509CertificateLoader.LoadPkcs12CollectionFromFile`.


### PR DESCRIPTION
Hello @gewarren @BillWagner, thanks for maintaining these docs.
Looks like this typo was introduced in #46261.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/syslib-diagnostics/syslib0057.md](https://github.com/dotnet/docs/blob/5aa392ea584dd00f3a3c0827fe791e1f2ab02f45/docs/fundamentals/syslib-diagnostics/syslib0057.md) | [SYSLIB0057: X509Certificate2 and X509Certificate constructors for binary and file content are obsolete](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib0057?branch=pr-en-us-51580) |

<!-- PREVIEW-TABLE-END -->