### PR TITLE
Add note about forever-running foreground thread not terminating test run in MSTest 4 with MTP

### DIFF
--- a/docs/core/testing/unit-testing-mstest-migration-v3-v4.md
+++ b/docs/core/testing/unit-testing-mstest-migration-v3-v4.md
@@ -204,7 +204,7 @@ In v4, and when running with Microsoft.Testing.Platform, AppDomains are disabled
 However, the feature remains available. If you have scenarios requiring it, add the `DisableAppDomain` setting in runsettings.
 
 > [!IMPORTANT]
-> When AppDomain isolation is enabled, MSTest unloads the AppDomain after all tests finish, which aborts all the threads associated with the AppDomain, including foreground threads. As a result, if you had a foreground thread running forever in MSTest 3.x, the test run will complete successfully. The same scenario will hang in MSTest 4.x, which is a more correct behavior since the process should not exit when a foreground thread is still running.
+> When AppDomain isolation is enabled, MSTest unloads the AppDomain after all tests finish, which aborts all the threads associated with the AppDomain, including foreground threads. As a result, if you had a foreground thread running forever in MSTest v3, the test run will complete successfully. The same scenario will hang in MSTest v4, which is a more correct behavior since the process should not exit when a foreground thread is still running.
 
 ### TestContext throws when used incorrectly
 

--- a/docs/core/testing/unit-testing-mstest-migration-v3-v4.md
+++ b/docs/core/testing/unit-testing-mstest-migration-v3-v4.md
@@ -204,7 +204,7 @@ In v4, and when running with Microsoft.Testing.Platform, AppDomains are disabled
 However, the feature remains available. If you have scenarios requiring it, add the `DisableAppDomain` setting in runsettings.
 
 > [!IMPORTANT]
-> When AppDomain isolation is enabled, we will unload the AppDomain after all tests finished. This means that all threads associated with the AppDomain will get aborted, including foreground threads. As a result, if you had a foreground thread running forever in MSTest 3.x, the test run will complete successfully. The same scenario will hang in MSTest 4.x, which is a more correct behavior since the process should not exit when a foreground thread is still running.
+> When AppDomain isolation is enabled, MSTest unloads the AppDomain after all tests finish, which aborts all the threads associated with the AppDomain, including foreground threads. As a result, if you had a foreground thread running forever in MSTest 3.x, the test run will complete successfully. The same scenario will hang in MSTest 4.x, which is a more correct behavior since the process should not exit when a foreground thread is still running.
 
 ### TestContext throws when used incorrectly
 

--- a/docs/core/testing/unit-testing-mstest-migration-v3-v4.md
+++ b/docs/core/testing/unit-testing-mstest-migration-v3-v4.md
@@ -204,7 +204,7 @@ In v4, and when running with Microsoft.Testing.Platform, AppDomains are disabled
 However, the feature remains available. If you have scenarios requiring it, add the `DisableAppDomain` setting in runsettings.
 
 > [!IMPORTANT]
-> When AppDomain isolation is enabled, MSTest unloads the AppDomain after all tests finish, which aborts all the threads associated with the AppDomain, including foreground threads. As a result, if you had a foreground thread running forever in MSTest v3, the test run will complete successfully. The same scenario will hang in MSTest v4, which is a more correct behavior since the process should not exit when a foreground thread is still running.
+> When AppDomain isolation is enabled, MSTest unloads the AppDomain after all tests finish, which aborts all the threads associated with the AppDomain, including foreground threads. As a result, if you had a foreground thread running forever in MSTest v3, the test run will complete successfully. The same scenario will hang in MSTest v4, which is ideal behavior because the process shouldn't exit when a foreground thread is still running.
 
 ### TestContext throws when used incorrectly
 

--- a/docs/core/testing/unit-testing-mstest-migration-v3-v4.md
+++ b/docs/core/testing/unit-testing-mstest-migration-v3-v4.md
@@ -203,6 +203,9 @@ In v4, and when running with Microsoft.Testing.Platform, AppDomains are disabled
 
 However, the feature remains available. If you have scenarios requiring it, add the `DisableAppDomain` setting in runsettings.
 
+> [!IMPORTANT]
+> When AppDomain isolation is enabled, we will unload the AppDomain after all tests finished. This means that all threads associated with the AppDomain will get aborted, including foreground threads. As a result, if you had a foreground thread running forever in MSTest 3.x, the test run will complete successfully. The same scenario will hang in MSTest 4.x, which is a more correct behavior since the process should not exit when a foreground thread is still running.
+
 ### TestContext throws when used incorrectly
 
 The `TestContext` type is passed to AssemblyInitialize, ClassInitialize, and to tests, but available information at each stage is different. Now, an exception is thrown when accessing a property related to a test run information as part of `AssemblyInitialize` or `ClassInitialize`.


### PR DESCRIPTION
See https://github.com/microsoft/testfx/issues/7314


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-mstest-migration-v3-v4.md](https://github.com/dotnet/docs/blob/40529fe3f8a86b220d51751db1c33f42fef805d2/docs/core/testing/unit-testing-mstest-migration-v3-v4.md) | [Migrate from MSTest v3 to v4](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-migration-v3-v4?branch=pr-en-us-51713) |


<!-- PREVIEW-TABLE-END -->