### PR TITLE
Update title and description for global tool documentation

### DIFF
--- a/docs/fundamentals/apicompat/global-tool.md
+++ b/docs/fundamentals/apicompat/global-tool.md
@@ -1,10 +1,10 @@
 ---
-title: Microsoft.DotNet.ApiCompat.Tool global tool
-description: Learn about the Microsoft.DotNet.ApiCompat.Tool global tool, which performs API compatibility checks on assemblies and packages.
+title: Microsoft.DotNet.ApiCompat.Tool tool
+description: Learn about the Microsoft.DotNet.ApiCompat.Tool tool, which performs API compatibility checks on assemblies and packages.
 ms.date: 11/29/2023
 ---
 
-# Microsoft.DotNet.ApiCompat.Tool global tool
+# Microsoft.DotNet.ApiCompat.Tool tool
 
 The Microsoft.DotNet.ApiCompat.Tool tool lets you perform API compatibility checks outside of MSBuild. The tool has two modes:
 

--- a/docs/fundamentals/apicompat/global-tool.md
+++ b/docs/fundamentals/apicompat/global-tool.md
@@ -1,10 +1,10 @@
 ---
-title: Microsoft.DotNet.ApiCompat.Tool tool
-description: Learn about the Microsoft.DotNet.ApiCompat.Tool tool, which performs API compatibility checks on assemblies and packages.
+title: Microsoft.DotNet.ApiCompat.Tool API compatibility tool
+description: Learn about the Microsoft.DotNet.ApiCompat.Tool API compatibility tool, which performs API compatibility checks on assemblies and packages.
 ms.date: 11/29/2023
 ---
 
-# Microsoft.DotNet.ApiCompat.Tool tool
+# Microsoft.DotNet.ApiCompat.Tool API compatibility tool
 
 The Microsoft.DotNet.ApiCompat.Tool tool lets you perform API compatibility checks outside of MSBuild. The tool has two modes:
 


### PR DESCRIPTION
The APICompat tool is a .NET CLI tool. It is _not_ a "global" tool.

`--global` is a flag the user _may_ specify at install time, but this tool can be installed globally or locally. .NET CLI tools are not "global" or "local". They are just tools.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/apicompat/global-tool.md](https://github.com/dotnet/docs/blob/c9e33d78af903876892c729aec64918a72f276b6/docs/fundamentals/apicompat/global-tool.md) | [Microsoft.DotNet.ApiCompat.Tool API compatibility tool](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/global-tool?branch=pr-en-us-51721) |


<!-- PREVIEW-TABLE-END -->