### PR TITLE
Clarify JsonException behavior in documentation

### DIFF
--- a/docs/standard/serialization/system-text-json/converters-how-to.md
+++ b/docs/standard/serialization/system-text-json/converters-how-to.md
@@ -107,8 +107,6 @@ The JSON value could not be converted to System.Object.
 Path: $.Date | LineNumber: 1 | BytePositionInLine: 37.
 ```
 
-If you do provide a message (for example, `throw new JsonException("Error occurred")`), the serializer still sets the <xref:System.Text.Json.JsonException.Path>, <xref:System.Text.Json.JsonException.LineNumber>, and <xref:System.Text.Json.JsonException.BytePositionInLine> properties.
-
 ### NotSupportedException
 
 If you throw a `NotSupportedException`, you always get the path information in the message. If you provide a message, the path information is appended to it. For example, the statement `throw new NotSupportedException("Error occurred.")` produces an error message like the following example:


### PR DESCRIPTION
When a message is provided in the `JsonException` the serializer **does not** set the Path, LineNumber and BytePositionInLine properties.

This is easily demonstrated by this simple converter that always throws a `JsonException`.

**Program.cs**
```c#
using System;
using System.IO;
using System.Text.Json;
using System.Text.Json.Serialization;

string?[] messages = [null, "Conversion to FileInfo failed"];
foreach (var message in messages)
{
    try
    {
        var options = new JsonSerializerOptions { Converters = { new FileInfoJsonConverter(message) } };
        _ = JsonSerializer.Deserialize<FileInfo>("0", options);
    }
    catch (Exception exception)
    {
        var result = exception.Message.Contains("LineNumber:") ? "✅" : "❌";
        Console.WriteLine($"{result} {exception.Message}");
    }
}


internal class FileInfoJsonConverter(string? message) : JsonConverter<FileInfo>
{
    public override FileInfo Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
        => throw new JsonException(message);
    
    public override void Write(Utf8JsonWriter writer, FileInfo value, JsonSerializerOptions options)
        => throw new NotImplementedException();
}
```

The result of `dotnet run Program.cs` is clear.

When no message is set: JSON source information is included in the exception message. 

> ✅ The JSON value could not be converted to System.IO.FileInfo. Path: $ | LineNumber: 0 | BytePositionInLine: 1.

When an explicit message is set, JSON source information is **not** included in the exception message.

> ❌ Conversion to FileInfo failed

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/serialization/system-text-json/converters-how-to.md](https://github.com/dotnet/docs/blob/515030e78622046f096e3072deda035421a93246/docs/standard/serialization/system-text-json/converters-how-to.md) | [How to write custom converters for JSON serialization (marshalling) in .NET](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/converters-how-to?branch=pr-en-us-51726) |

<!-- PREVIEW-TABLE-END -->