### PR TITLE
Fixed broken URL for `What's new in ASP.NET Core for .NET 11` link

### DIFF
--- a/docs/core/whats-new/dotnet-11/overview.md
+++ b/docs/core/whats-new/dotnet-11/overview.md
@@ -35,7 +35,7 @@ For more information, see [What's new in the SDK for .NET 11](sdk.md).
 
 ## ASP.NET Core
 
-For information about what's new in ASP.NET Core, see [What's new in ASP.NET Core for .NET 11](/aspnet/core/release-notes/aspnetcore-11.0).
+For information about what's new in ASP.NET Core, see [What's new in ASP.NET Core for .NET 11](/aspnet/core/release-notes/aspnetcore-11).
 
 ## C# 15
 


### PR DESCRIPTION
## Summary

What it says on the tin.

The link to the asp.net document had 11.0 in the URL, but the page just has 11.

Only change is the link in the page, which is now to: https://learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-11, which is the correct URL of the existing page.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/whats-new/dotnet-11/overview.md](https://github.com/dotnet/docs/blob/28dd8594afa05c808c4635f94e0e5dd2c8cb7d33/docs/core/whats-new/dotnet-11/overview.md) | [What's new in .NET 11](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-11/overview?branch=pr-en-us-51727) |

<!-- PREVIEW-TABLE-END -->