### PR TITLE
Fix Azure Container Apps identity assign CLI flag

### DIFF
--- a/docs/azure/sdk/authentication/user-assigned-managed-identity.md
+++ b/docs/azure/sdk/authentication/user-assigned-managed-identity.md
@@ -110,7 +110,7 @@ The Azure CLI provides different commands to assign a user-assigned managed iden
     az containerapp identity assign \
         --resource-group <resource-group-name> \
         --name <containerapp-name> \
-        --identities <user-assigned-identity-resource-id>
+        --user-assigned <user-assigned-identity-resource-id>
     ```
 
     For Azure Virtual Machines, use the Azure CLI command [`az vm identity assign`](/cli/azure/vm/identity#az-vm-identity-assign):


### PR DESCRIPTION
Change `--identities` to `--user-assigned` for the `az containerapp identity assign` command to match the correct Azure CLI syntax. Related to comment at https://github.com/MicrosoftDocs/azure-dev-docs-pr/pull/8451/changes#r2800873605

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/azure/sdk/authentication/user-assigned-managed-identity.md](https://github.com/dotnet/docs/blob/414c48b6dc5dac7170a0dffc26867ef55c2ea892/docs/azure/sdk/authentication/user-assigned-managed-identity.md) | [docs/azure/sdk/authentication/user-assigned-managed-identity](https://review.learn.microsoft.com/en-us/dotnet/azure/sdk/authentication/user-assigned-managed-identity?branch=pr-en-us-51740) |

<!-- PREVIEW-TABLE-END -->