### PR TITLE
[MSTest] Do not use var when type is not explicit

### DIFF
--- a/docs/core/testing/snippets/unit-testing-using-mstest/csharp/PrimeService.Tests/PrimeService_IsPrimeShould.cs
+++ b/docs/core/testing/snippets/unit-testing-using-mstest/csharp/PrimeService.Tests/PrimeService_IsPrimeShould.cs
@@ -16,7 +16,7 @@ namespace Prime.UnitTests.Services
         [TestMethod]
         public void IsPrime_InputIs1_ReturnFalse()
         {
-            var result = _primeService.IsPrime(1);
+            bool result = _primeService.IsPrime(1);
 
             Assert.IsFalse(result, $"1 should not be prime");
         }
@@ -28,7 +28,7 @@ namespace Prime.UnitTests.Services
         [DataRow(1)]
         public void IsPrime_ValuesLessThan2_ReturnFalse(int value)
         {
-            var result = _primeService.IsPrime(value);
+            bool result = _primeService.IsPrime(value);
 
             Assert.IsFalse(result, $"{value} should not be prime");
         }

--- a/docs/core/testing/unit-testing-mstest-writing-tests-lifecycle.md
+++ b/docs/core/testing/unit-testing-mstest-writing-tests-lifecycle.md
@@ -105,7 +105,7 @@ public class ClassLifecycleExample
     [TestMethod]
     public async Task GetUsers_ReturnsSuccess()
     {
-        var response = await _client!.GetAsync("/users");
+        HttpResponseMessage response = await _client!.GetAsync("/users");
         Assert.IsTrue(response.IsSuccessStatusCode);
     }
 }
@@ -232,7 +232,7 @@ public class TestLevelSetupExample
     [TestMethod]
     public void Add_TwoNumbers_ReturnsSum()
     {
-        var result = _calculator!.Add(2, 3);
+        int result = _calculator!.Add(2, 3);
         Assert.AreEqual(5, result);
     }
 }
@@ -293,7 +293,7 @@ public class TestLevelCleanupExample
     [TestMethod]
     public async Task GetData_ReturnsSuccess()
     {
-        var response = await _client!.GetAsync("https://example.com");
+        HttpResponseMessage response = await _client!.GetAsync("https://example.com");
         Assert.IsTrue(response.IsSuccessStatusCode);
     }
 }

--- a/docs/core/testing/unit-testing-mstest-writing-tests.md
+++ b/docs/core/testing/unit-testing-mstest-writing-tests.md
@@ -30,7 +30,7 @@ public class CalculatorTests
         var calculator = new Calculator();
 
         // Act
-        var result = calculator.Add(2, 3);
+        int result = calculator.Add(2, 3);
 
         // Assert
         Assert.AreEqual(5, result);
@@ -99,7 +99,7 @@ public class CalculatorTests
     internal void Add_WithTestInput_ReturnsExpected(TestInput input)
     {
         var calculator = new Calculator();
-        var result = calculator.Add(input.Value, 1);
+        int result = calculator.Add(input.Value, 1);
         Assert.AreEqual(input.Value + 1, result);
     }
 }


### PR DESCRIPTION
## Summary

Apply feedback about usage of `var` in MSTest docs.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-mstest-writing-tests-lifecycle.md](https://github.com/dotnet/docs/blob/9d4e1f4c5b39763e7962a76c983e98c72bd8ead5/docs/core/testing/unit-testing-mstest-writing-tests-lifecycle.md) | [MSTest lifecycle](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-writing-tests-lifecycle?branch=pr-en-us-51752) |
| [docs/core/testing/unit-testing-mstest-writing-tests.md](https://github.com/dotnet/docs/blob/9d4e1f4c5b39763e7962a76c983e98c72bd8ead5/docs/core/testing/unit-testing-mstest-writing-tests.md) | [Write tests with MSTest](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-writing-tests?branch=pr-en-us-51752) |

<!-- PREVIEW-TABLE-END -->