### PR TITLE
Replace semicolon with at character in dotnet install page

### DIFF
--- a/docs/core/install/templates.md
+++ b/docs/core/install/templates.md
@@ -31,11 +31,14 @@ To install a template package from the default NuGet feed, use the `dotnet new i
 dotnet new install Microsoft.DotNet.Web.Spa.ProjectTemplates
 ```
 
-To install a template package from the default NuGet feed with a specific version, use the `dotnet new install {package-id}::{version}` command:
+To install a template package from the default NuGet feed with a specific version, use the `dotnet new install {package-id}@{version}` command:
 
 ```dotnetcli
-dotnet new install Microsoft.DotNet.Web.Spa.ProjectTemplates::2.2.6
+dotnet new install Microsoft.DotNet.Web.Spa.ProjectTemplates@2.2.6
 ```
+
+> [!NOTE]
+> The colon separator `::` was depracated in favor of the `@` character in .NET 9.0.200 SDK.
 
 ### Local NuGet package
 


### PR DESCRIPTION
This pull request closes #51564.
It replaces `::` operator, for the `dotnet install` version, with the `@` character, as specified in https://learn.microsoft.com/dotnet/core/tools/dotnet-new-install article.
Also, the NOTE is added so that for the time being of `::` deprecation this operator is still mentioned but explicitly described as deprecated.

I decided to go with the same approach that is done in the page I linked above to replace the `::` operator completely and mention it only in the NOTE, instead of keeping it and mentioning the new alternate `@` operator.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/templates.md](https://github.com/dotnet/docs/blob/da6367af7ceb5c78b48f769766c9808386167949/docs/core/install/templates.md) | [Manage .NET project and item templates](https://review.learn.microsoft.com/en-us/dotnet/core/install/templates?branch=pr-en-us-51755) |

<!-- PREVIEW-TABLE-END -->