### PR TITLE
Document that dump collection isn't supported on mobile platforms

### DIFF
--- a/docs/core/diagnostics/collect-dumps-crash.md
+++ b/docs/core/diagnostics/collect-dumps-crash.md
@@ -8,6 +8,9 @@ ms.date: 12/13/2022
 
 Configuring your application to collect a dump on crash is done by setting specific environment variables. This is helpful when you want to get an understanding of why a crash happened. For example, capturing a dump when an exception is thrown helps you identify an issue by examining the state of the app when it crashed.
 
+> [!NOTE]
+> Dump collection isn't supported on mobile platforms (Android and iOS).
+
 The following table shows the environment variables you can configure for collecting dumps on a crash.
 
 | Environment variable | Description | Default value |

--- a/docs/core/diagnostics/dumps.md
+++ b/docs/core/diagnostics/dumps.md
@@ -13,6 +13,9 @@ A dump is a file that contains a snapshot of the process at the time the dump wa
 Dumps can be collected in a variety of ways depending on which platform your app is running on.
 
 > [!NOTE]
+> Dump collection isn't supported on mobile platforms (Android and iOS). The Mono runtime used on these platforms doesn't support memory dump generation.
+
+> [!NOTE]
 > Dumps might contain sensitive information because they can contain the full memory of the running process. Handle them with any security restrictions and guidance in mind.
 
 * You can use environment variables to configure your application to [collect a dump on a crash](collect-dumps-crash.md).

--- a/docs/core/diagnostics/faq-dumps.yml
+++ b/docs/core/diagnostics/faq-dumps.yml
@@ -59,6 +59,11 @@ sections:
             On macOS the use of `ptrace` requires the host of the target process to be properly entitled. For information about the minimum required entitlements, see [Default entitlements](../install/macos-notarization-issues.md#default-entitlements).
 
       - question: |
+          Why can't I collect dumps on Android or iOS?
+        answer: |
+          Dump collection isn't supported on mobile platforms (Android and iOS). These platforms use the Mono runtime, which doesn't support memory dump generation.
+
+      - question: |
           Where can I learn more about how I can leverage dumps to help diagnose problems in my .NET application?
         answer: |
           Here are some additional resources:


### PR DESCRIPTION
## Summary

Add notes to dumps.md, collect-dumps-crash.md, and a new FAQ entry stating that dump collection isn't supported on Android and iOS because the Mono runtime doesn't support memory dump generation.

Fixes dotnet/diagnostics#5098


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/collect-dumps-crash.md](https://github.com/dotnet/docs/blob/b062d2071f803fa5db35d6b70cdc2ea53cb8b31a/docs/core/diagnostics/collect-dumps-crash.md) | [Collect dumps on crash](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/collect-dumps-crash?branch=pr-en-us-51765) |
| [docs/core/diagnostics/dumps.md](https://github.com/dotnet/docs/blob/b062d2071f803fa5db35d6b70cdc2ea53cb8b31a/docs/core/diagnostics/dumps.md) | [Dumps - .NET](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/dumps?branch=pr-en-us-51765) |
| [docs/core/diagnostics/faq-dumps.yml](https://github.com/dotnet/docs/blob/b062d2071f803fa5db35d6b70cdc2ea53cb8b31a/docs/core/diagnostics/faq-dumps.yml) | [FAQ for dumps](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/faq-dumps?branch=pr-en-us-51765) |

<!-- PREVIEW-TABLE-END -->