### PR TITLE
Update documentation for ContinuousIntegrationBuild property

### DIFF
--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -690,9 +690,6 @@ C# compiler options, such as `LangVersion` and `Nullable`, can also be specified
 
 The `ContinuousIntegrationBuild` property indicates whether a build is executing on a continuous integration (CI) server. When set to `true`, this property enables settings that only apply to official builds as opposed to local builds on a developer machine. For example, stored file paths are normalized for official builds. But on a local development machine, the debugger isn't able to find local source files if file paths are normalized.
 
-> [!NOTE]
-> Currently, setting this property to `true` works only if you add either a specific [SourceLink](https://github.com/dotnet/sourcelink) provider package reference or a `<SourceRoot Include="$(MyDirectory)" />` item. For more information, see [dotnet/roslyn issue 55860](https://github.com/dotnet/roslyn/issues/55860).
-
 You can use your CI system's variable to conditionally set the `ContinuousIntegrationBuild` property. For example, the variable name for Azure Pipelines is `TF_BUILD`:
 
 ```xml


### PR DESCRIPTION
Remove outdated note.

Source Link is included in .NET SDK since version 8.0 and ContinuousIntegrationBuild works without any additional configuration.

Related issue: https://github.com/dotnet/roslyn/issues/55860

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/project-sdk/msbuild-props.md](https://github.com/dotnet/docs/blob/07c338842dd70c9ff1473cbce223ee79698d248e/docs/core/project-sdk/msbuild-props.md) | [docs/core/project-sdk/msbuild-props](https://review.learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props?branch=pr-en-us-51831) |

<!-- PREVIEW-TABLE-END -->