### PR TITLE
fix: change to correct directory needed

### DIFF
--- a/docs/ai/quickstarts/chat-local-model.md
+++ b/docs/ai/quickstarts/chat-local-model.md
@@ -59,6 +59,12 @@ Complete the following steps to create a .NET console app that connects to your 
     dotnet new console -o LocalAI
     ```
 
+1. Navigate to the directory you created for the app:
+
+    ```dotnetcli
+    cd LocalAI
+    ```
+
 1. Add the [OllamaSharp](https://www.nuget.org/packages/OllamaSharp) package to your app:
 
     ```dotnetcli

--- a/docs/ai/quickstarts/chat-local-model.md
+++ b/docs/ai/quickstarts/chat-local-model.md
@@ -59,7 +59,7 @@ Complete the following steps to create a .NET console app that connects to your 
     dotnet new console -o LocalAI
     ```
 
-1. Navigate to the directory you created for the app:
+1. Change directory into the app folder:
 
     ```dotnetcli
     cd LocalAI


### PR DESCRIPTION
## Summary

The **Create the .NET app** section at https://learn.microsoft.com/en-us/dotnet/ai/quickstarts/chat-local-model lacks a necessary step whereby you'll need to navigate to the new directory.

I have added the required step.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/ai/quickstarts/chat-local-model.md](https://github.com/dotnet/docs/blob/97c1106222e434759cc824882e506121a7761902/docs/ai/quickstarts/chat-local-model.md) | [Chat with a local AI model using .NET](https://review.learn.microsoft.com/en-us/dotnet/ai/quickstarts/chat-local-model?branch=pr-en-us-51838) |


<!-- PREVIEW-TABLE-END -->