### PR TITLE
Fix method references in Socket class overview

### DIFF
--- a/docs/fundamentals/networking/sockets/sockets-overview.md
+++ b/docs/fundamentals/networking/sockets/sockets-overview.md
@@ -23,7 +23,7 @@ The <xref:System.Net.Sockets> namespace contains a managed, cross-platform socke
 
 The <xref:System.Net.Sockets.Socket> class is a managed-code version of the socket services provided relying on native interoperability with Linux, macOS, or Windows. In most cases, the `Socket` class methods simply marshal data into their native counterparts and handle any necessary security checks.
 
-The `Socket` class supports two basic modes, synchronous and asynchronous. In synchronous mode, calls to functions that perform network operations (such as <xref:System.Net.Sockets.Socket.SendAsync%2A> and <xref:System.Net.Sockets.Socket.ReceiveAsync%2A>) wait until the operation completes before returning control to the calling program. In asynchronous mode, these calls return immediately.
+The `Socket` class supports two basic modes, synchronous and asynchronous. In synchronous mode, calls to functions that perform network operations (such as <xref:System.Net.Sockets.Socket.Send%2A> and <xref:System.Net.Sockets.Socket.Receive%2A>) wait until the operation completes before returning control to the calling program. In asynchronous mode, these calls return immediately.
 
 ## See also
 


### PR DESCRIPTION
## Summary

Updated the documentation to reference the correct synchronous methods (`Socket.Send` and `Socket.Receive`) instead of their asynchronous counterparts (`Socket.SendAsync` and `Socket.ReceiveAsync`) when describing synchronous mode operation.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/networking/sockets/sockets-overview.md](https://github.com/dotnet/docs/blob/449327e9f6063aac75fe80ed5177f6690ff8ca54/docs/fundamentals/networking/sockets/sockets-overview.md) | [Sockets in .NET](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/networking/sockets/sockets-overview?branch=pr-en-us-51848) |

<!-- PREVIEW-TABLE-END -->