### PR TITLE
Update note on XSLT support in .NET versions

### DIFF
--- a/docs/standard/data/xml/how-to-perform-an-xslt-transformation-by-using-an-assembly.md
+++ b/docs/standard/data/xml/how-to-perform-an-xslt-transformation-by-using-an-assembly.md
@@ -10,7 +10,7 @@ ms.assetid: 76ee440b-d134-4f8f-8262-b917ad6dcbf6
 # How to: Perform an XSLT transformation by using an assembly
 
 > [!NOTE]
-> Script blocks are supported only in .NET Framework. They are _not_ supported on .NET Core or .NET 5 or later.
+> Script blocks and the XSLT compiler are supported only in .NET Framework. They are _not_ supported on .NET Core or .NET 5 or later, and assemblies compiled using xsltc.exe cannot be loaded into .NET Core or .NET 5 or later.
 
 The XSLT compiler (xsltc.exe) compiles XSLT style sheets and generates an assembly. The assembly can be passed directly into the <xref:System.Xml.Xsl.XslCompiledTransform.Load(System.Type)?displayProperty=nameWithType> method.  
   

--- a/docs/standard/data/xml/how-to-perform-an-xslt-transformation-by-using-an-assembly.md
+++ b/docs/standard/data/xml/how-to-perform-an-xslt-transformation-by-using-an-assembly.md
@@ -10,8 +10,7 @@ ms.assetid: 76ee440b-d134-4f8f-8262-b917ad6dcbf6
 # How to: Perform an XSLT transformation by using an assembly
 
 > [!NOTE]
-> Script blocks and the XSLT compiler are supported only in .NET Framework. They are _not_ supported on .NET, and assemblies compiled using xsltc.exe cannot be referenced in .NET. For more information about .NET and .NET Framework, see [Introduction to .NET - 
-.NET ecosystem](../../../core/introduction.md#net-ecosystem).
+> Script blocks and the XSLT compiler are supported only in .NET Framework. They are _not_ supported on .NET, and assemblies compiled using xsltc.exe cannot be referenced in .NET. For more information about .NET and .NET Framework, see [Introduction to .NET - .NET ecosystem](../../../core/introduction.md#net-ecosystem).
 
 The XSLT compiler (xsltc.exe) compiles XSLT style sheets and generates an assembly. The assembly can be passed directly into the <xref:System.Xml.Xsl.XslCompiledTransform.Load(System.Type)?displayProperty=nameWithType> method.  
   

--- a/docs/standard/data/xml/how-to-perform-an-xslt-transformation-by-using-an-assembly.md
+++ b/docs/standard/data/xml/how-to-perform-an-xslt-transformation-by-using-an-assembly.md
@@ -10,7 +10,8 @@ ms.assetid: 76ee440b-d134-4f8f-8262-b917ad6dcbf6
 # How to: Perform an XSLT transformation by using an assembly
 
 > [!NOTE]
-> Script blocks and the XSLT compiler are supported only in .NET Framework. They are _not_ supported on .NET Core or .NET 5 or later, and assemblies compiled using xsltc.exe cannot be loaded into .NET Core or .NET 5 or later.
+> Script blocks and the XSLT compiler are supported only in .NET Framework. They are _not_ supported on .NET, and assemblies compiled using xsltc.exe cannot be referenced in .NET. For more information about .NET and .NET Framework, see [Introduction to .NET - 
+.NET ecosystem](../../../core/introduction.md#net-ecosystem).
 
 The XSLT compiler (xsltc.exe) compiles XSLT style sheets and generates an assembly. The assembly can be passed directly into the <xref:System.Xml.Xsl.XslCompiledTransform.Load(System.Type)?displayProperty=nameWithType> method.  
   


### PR DESCRIPTION
Clarified note about script blocks and XSLT compiler support across .NET versions.

I received a question about this from a customer, citing that the documentation was misleading. They tried using xsltc.exe to create an assembly with .NET Framework and then load that into .NET 10 for processing and found it has a dependency on System.Data.SqlXml.dll.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/data/xml/how-to-perform-an-xslt-transformation-by-using-an-assembly.md](https://github.com/dotnet/docs/blob/8399bf4f976684700c9103b6d77f7909d2ae5821/docs/standard/data/xml/how-to-perform-an-xslt-transformation-by-using-an-assembly.md) | [How to: Perform an XSLT transformation by using an assembly](https://review.learn.microsoft.com/en-us/dotnet/standard/data/xml/how-to-perform-an-xslt-transformation-by-using-an-assembly?branch=pr-en-us-51850) |


<!-- PREVIEW-TABLE-END -->