### PR TITLE
Fix method name in extension.md

### DIFF
--- a/docs/csharp/language-reference/keywords/extension.md
+++ b/docs/csharp/language-reference/keywords/extension.md
@@ -42,7 +42,7 @@ The following example shows an extension method using the `this` modifier:
 
 :::code language="csharp" source="./snippets/ExtensionMethods.cs" id="ExtensionMethod":::
 
-You can call the `Add` method from any other method as though it was a member of the `IEnumerable<int>` interface:
+You can call the `AddValue` method from any other method as though it was a member of the `IEnumerable<int>` interface:
 
 :::code language="csharp" source="./snippets/ExtensionMethods.cs" id="UseExtensionMethod":::
 


### PR DESCRIPTION
The method name is AddValue in the snippet, not Add.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/extension.md](https://github.com/dotnet/docs/blob/f04cdd6d02a62fd365006cbbe9399d803c09084a/docs/csharp/language-reference/keywords/extension.md) | [Extension declaration (C# Reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/extension?branch=pr-en-us-51938) |

<!-- PREVIEW-TABLE-END -->