### PR TITLE
Fix URL for ASP.NET Core 11.0 release notes

### DIFF
--- a/docs/whats-new/index.yml
+++ b/docs/whats-new/index.yml
@@ -15,7 +15,7 @@ landingContent:
     - text: .NET 11
       url: ../core/whats-new/dotnet-11/overview.md
     - text: ASP.NET Core 11.0
-      url: /aspnet/core/release-notes/aspnetcore-11.0
+      url: /aspnet/core/release-notes/aspnetcore-11
 - title: .NET 10 release updates
   linkLists:
   - linkListType: whats-new


### PR DESCRIPTION
The correct URL is https://learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-11, not https://learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-11.0.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/whats-new/index.yml](https://github.com/dotnet/docs/blob/89cc3e3094affe969cd97e7eedb0abc3b1e93d8b/docs/whats-new/index.yml) | [docs/whats-new/index](https://review.learn.microsoft.com/en-us/dotnet/whats-new/index?branch=pr-en-us-51966) |

<!-- PREVIEW-TABLE-END -->