### PR TITLE
Fix URL for ASP.NET Core 11.0 release notes

### DIFF
--- a/docs/whats-new/index.yml
+++ b/docs/whats-new/index.yml
@@ -15,7 +15,7 @@ landingContent:
     - text: .NET 11
       url: ../core/whats-new/dotnet-11/overview.md
     - text: ASP.NET Core 11.0
-      url: /aspnet/core/release-notes/aspnetcore-11.0
+      url: /aspnet/core/release-notes/aspnetcore-11
 - title: .NET 10 release updates
   linkLists:
   - linkListType: whats-new


### PR DESCRIPTION
This is the same as https://github.com/dotnet/docs/pull/51966, in which I accidentally set up the incorrect base branch, so it didn't merge into `main`. Sorry about that.

cc: @BillWagner 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/whats-new/index.yml](https://github.com/dotnet/docs/blob/17bc8a84039a8fce242b7b797a70d9229ad7ad8b/docs/whats-new/index.yml) | [.NET - what's new?](https://review.learn.microsoft.com/en-us/dotnet/whats-new/index?branch=pr-en-us-51977) |

<!-- PREVIEW-TABLE-END -->